### PR TITLE
Dashboard: redirect from dashboard settings tabs to sidebar counterparts

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -74,6 +74,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `alertingMultiplePolicies`                   | Enables the ability to create multiple notification policies in alerting                                                                                      | Yes                |
 | `react19`                                    | Whether to use the new React 19 runtime                                                                                                                       | Yes                |
 | `datasources.useNewStackInfoToSettingsCache` | Use the new cache for datasource.StackInfoToSettings, backend flag                                                                                            |                    |
+| `grafana.dashboardSettingsRedesign`          | Redesigns dashboard settings page into Advanced Settings in a modal window                                                                                    | Yes                |
 
 ## Public preview feature toggles
 

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-adhoc-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-adhoc-variables.spec.ts
@@ -31,9 +31,7 @@ test.describe(
         label: 'VariableUnderTest',
       };
 
-      // common steps to add a new variable
-      await flows.newEditPaneVariableClick(dashboardPage, selectors);
-      await flows.newEditPanelCommonVariableInputs(dashboardPage, selectors, variable);
+      await flows.addNewGenericVariable(page, dashboardPage, selectors, variable);
 
       // Select datasource for the ad hoc variable
       const dataSource = 'gdev-loki';

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-custom-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-custom-variables.spec.ts
@@ -56,8 +56,7 @@ test.describe(
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      await flows.newEditPaneVariableClick(dashboardPage, selectors);
-      await flows.newEditPanelCommonVariableInputs(dashboardPage, selectors, {
+      await flows.addNewGenericVariable(page, dashboardPage, selectors, {
         type: 'custom',
         name: 'foo',
         label: 'Foo',
@@ -92,8 +91,7 @@ test.describe(
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      await flows.newEditPaneVariableClick(dashboardPage, selectors);
-      await flows.newEditPanelCommonVariableInputs(dashboardPage, selectors, {
+      await flows.addNewGenericVariable(page, dashboardPage, selectors, {
         type: 'custom',
         name: 'foo',
         label: 'Foo',

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-datasource-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-datasource-variables.spec.ts
@@ -31,9 +31,7 @@ test.describe(
         value: `gdev-${dsType}`,
       };
 
-      // Common steps to add a new variable
-      await flows.newEditPaneVariableClick(dashboardPage, selectors);
-      await flows.newEditPanelCommonVariableInputs(dashboardPage, selectors, variable);
+      await flows.addNewGenericVariable(page, dashboardPage, selectors, variable);
 
       await dashboardPage
         .getByGrafanaSelector(selectors.pages.Dashboard.Settings.Variables.Edit.DatasourceVariable.datasourceSelect)

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-group-by-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-group-by-variables.spec.ts
@@ -30,9 +30,7 @@ test.describe(
         label: 'VariableUnderTest',
       };
 
-      // common steps to add a new variable
-      await flows.newEditPaneVariableClick(dashboardPage, selectors);
-      await flows.newEditPanelCommonVariableInputs(dashboardPage, selectors, variable);
+      await flows.addNewGenericVariable(page, dashboardPage, selectors, variable);
 
       // select datasource for the group by variable
       await dashboardPage

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-query-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-query-variables.spec.ts
@@ -36,9 +36,7 @@ test.describe(
         label: 'VariableUnderTest', // constant doesn't really need a label
       };
 
-      // common steps to add a new variable
-      await flows.newEditPaneVariableClick(dashboardPage, selectors);
-      await flows.newEditPanelCommonVariableInputs(dashboardPage, selectors, variable);
+      await flows.addNewGenericVariable(page, dashboardPage, selectors, variable);
 
       // open the modal query variable editor
       await dashboardPage

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -33,9 +33,7 @@ test.describe(
 
       const variable = variableWithDefaults({ type: 'constant' });
 
-      // common steps to add a new variable
-      await flows.newEditPaneVariableClick(dashboardPage, selectors);
-      await flows.newEditPanelCommonVariableInputs(dashboardPage, selectors, variable);
+      await flows.addNewGenericVariable(page, dashboardPage, selectors, variable);
 
       // set the constant variable value
       const type = 'variable-type Value';
@@ -85,8 +83,7 @@ test.describe(
       const variable = variableWithDefaults({ type: 'interval', value: '1m' });
 
       // common steps to add a new variable
-      await flows.newEditPaneVariableClick(dashboardPage, selectors);
-      await flows.newEditPanelCommonVariableInputs(dashboardPage, selectors, variable);
+      await flows.addNewGenericVariable(page, dashboardPage, selectors, variable);
 
       // enable the auto option
       await page.getByText('Auto option').click();

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -5,21 +5,23 @@ import { type DashboardPage, type E2ESelectorGroups, expect } from '@grafana/plu
 
 import testV2Dashboard from '../dashboards/TestV2Dashboard.json';
 
+import { Controls, Sidebar } from './page-objects';
+
 export const flows = {
-  async newEditPaneVariableClick(dashboardPage: DashboardPage, selectors: E2ESelectorGroups) {
-    await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
-    await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Sidebar.outlineButton).click();
-    await dashboardPage.getByGrafanaSelector(selectors.components.PanelEditor.Outline.item('Variables')).click();
-    await dashboardPage.getByGrafanaSelector(selectors.components.Sidebar.dockToggle).click();
-    await dashboardPage
-      .getByGrafanaSelector(selectors.components.PanelEditor.ElementEditPane.addVariableButton)
-      .click();
-  },
-  async newEditPanelCommonVariableInputs(
+  async addNewGenericVariable(
+    page: Page,
     dashboardPage: DashboardPage,
     selectors: E2ESelectorGroups,
     variable: Variable
   ) {
+    const controls = new Controls(page, dashboardPage, selectors);
+    const sidebar = new Sidebar(page, dashboardPage, selectors);
+
+    await controls.enterEditMode();
+
+    await sidebar.toolbar.clickButton('Add');
+    await dashboardPage.getByGrafanaSelector(selectors.components.Sidebar.addNewVariableButton).click();
+
     await dashboardPage
       .getByGrafanaSelector(selectors.components.PanelEditor.ElementEditPane.variableType(variable.type))
       .click();
@@ -44,8 +46,7 @@ export const flows = {
     }
   },
   async addNewTextBoxVariable(dashboardPage: DashboardPage, variable: Variable) {
-    await flows.newEditPaneVariableClick(dashboardPage, selectors);
-    await flows.newEditPanelCommonVariableInputs(dashboardPage, selectors, variable);
+    await flows.addNewGenericVariable(dashboardPage.ctx.page, dashboardPage, selectors, variable);
     // set the textbox variable value
     const type = 'variable-type Value';
     const fieldLabel = dashboardPage.getByGrafanaSelector(

--- a/e2e-playwright/dashboards-suite/new-constant-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-constant-variable.spec.ts
@@ -7,6 +7,11 @@ test.use({
   featureToggles: {
     dashboardNewLayouts: true,
   },
+  openFeature: {
+    flags: {
+      'grafana.dashboardSettingsRedesign': false,
+    },
+  },
 });
 
 test.describe(

--- a/e2e-playwright/dashboards-suite/new-custom-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-custom-variable.spec.ts
@@ -54,6 +54,11 @@ test.use({
   featureToggles: {
     dashboardNewLayouts: true,
   },
+  openFeature: {
+    flags: {
+      'grafana.dashboardSettingsRedesign': false,
+    },
+  },
 });
 
 test.describe(

--- a/e2e-playwright/dashboards-suite/new-datasource-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-datasource-variable.spec.ts
@@ -7,6 +7,11 @@ test.use({
   featureToggles: {
     dashboardNewLayouts: true,
   },
+  openFeature: {
+    flags: {
+      'grafana.dashboardSettingsRedesign': false,
+    },
+  },
 });
 
 test.describe(

--- a/e2e-playwright/dashboards-suite/new-interval-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-interval-variable.spec.ts
@@ -20,6 +20,11 @@ test.use({
   featureToggles: {
     dashboardNewLayouts: true,
   },
+  openFeature: {
+    flags: {
+      'grafana.dashboardSettingsRedesign': false,
+    },
+  },
 });
 
 test.describe(

--- a/e2e-playwright/dashboards-suite/new-query-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-query-variable.spec.ts
@@ -7,6 +7,11 @@ test.use({
   featureToggles: {
     dashboardNewLayouts: true,
   },
+  openFeature: {
+    flags: {
+      'grafana.dashboardSettingsRedesign': false,
+    },
+  },
 });
 
 test.describe(

--- a/e2e-playwright/dashboards-suite/new-text-box-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-text-box-variable.spec.ts
@@ -7,6 +7,11 @@ test.use({
   featureToggles: {
     dashboardNewLayouts: true,
   },
+  openFeature: {
+    flags: {
+      'grafana.dashboardSettingsRedesign': false,
+    },
+  },
 });
 
 test.describe(

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -756,6 +756,9 @@ export const versionedComponents = {
       addVariableButton: {
         '12.0.0': 'data-testid add variable button',
       },
+      showDependenciesButton: {
+        '13.1.0': 'data-testid show dependencies button',
+      },
       addAnnotationButton: {
         '12.6.0': 'data-testid add annotation button',
       },
@@ -767,11 +770,6 @@ export const versionedComponents = {
       },
       variableLabelInput: {
         '12.0.0': 'data-testid variable label input',
-      },
-      CustomVariable: {
-        customValueInput: {
-          [MIN_GRAFANA_VERSION]: 'data-testid custom-variable-input',
-        },
       },
       AutoGridLayout: {
         minColumnWidth: {

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -90,6 +90,9 @@ export const versionedComponents = {
     configurePanelButton: {
       '13.1.0': 'data-testid edit pane configure panel button',
     },
+    addNewVariableButton: {
+      '13.1.0': 'data-testid edit pane add new variable button',
+    },
   },
   EditPaneHeader: {
     deleteButton: {
@@ -764,6 +767,11 @@ export const versionedComponents = {
       },
       variableLabelInput: {
         '12.0.0': 'data-testid variable label input',
+      },
+      CustomVariable: {
+        customValueInput: {
+          [MIN_GRAFANA_VERSION]: 'data-testid custom-variable-input',
+        },
       },
       AutoGridLayout: {
         minColumnWidth: {

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -63,6 +63,7 @@ declare module "@openfeature/core" {
     | "table.refactorNested"
     | "dataviz.experimentalColorSchemes"
     | "grafana.customizableMegaMenu"
+    | "grafana.dashboardSettingsRedesign"
     | "grafana.growthHomepage";
   export type NumberFlagKey = never;
   export type StringFlagKey = never;

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -45,6 +45,8 @@ export const FlagKeys = {
   GrafanaCustomDashboardTemplates: "grafana.customDashboardTemplates",
   /** Allows users to customise the mega menu by hiding top-level navigation items they are not interested in */
   GrafanaCustomizableMegaMenu: "grafana.customizableMegaMenu",
+  /** Redesigns dashboard settings page into Advanced Settings in a modal window */
+  GrafanaDashboardSettingsRedesign: "grafana.dashboardSettingsRedesign",
   /** Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button) */
   GrafanaEnableScopesFirstMode: "grafana.enableScopesFirstMode",
   /** Enables PLG-focused growth redesign of the unified homepage */
@@ -297,6 +299,17 @@ export const useFlagGrafanaCustomDashboardTemplates = (options?: ReactFlagEvalua
  */
 export const useFlagGrafanaCustomizableMegaMenu = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("grafana.customizableMegaMenu", false, options).value;
+};
+
+/**
+ * Redesigns dashboard settings page into Advanced Settings in a modal window
+ *
+ * **Details:**
+ * - flag key: `grafana.dashboardSettingsRedesign`
+ * - default value: `true`
+ */
+export const useFlagGrafanaDashboardSettingsRedesign = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.dashboardSettingsRedesign", true, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3140,6 +3140,14 @@ var (
 			Generate:     Generate{Go: true},
 		},
 		{
+			Name:        "grafana.dashboardSettingsRedesign",
+			Description: "Redesigns dashboard settings page into Advanced Settings in a modal window",
+			Stage:       FeatureStageGeneralAvailability,
+			Generate:    Generate{React: true},
+			Owner:       grafanaDashboardsSquad,
+			Expression:  "true",
+		},
+		{
 			Name:        "grafana.growthHomepage",
 			Description: "Enables PLG-focused growth redesign of the unified homepage",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -365,5 +365,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-25,grafana.customizableMegaMenu,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-04-20,cujTracking,experimental,@grafana/dashboards-squad,false,false,true
 2026-06-26,auth.tokenRotationGracePeriod,experimental,@grafana/identity-access-team,false,false,false
+2026-06-30,grafana.dashboardSettingsRedesign,GA,@grafana/dashboards-squad,false,false,true
 2026-07-01,grafana.growthHomepage,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-07-01,kubernetesReporting,experimental,@grafana/grafana-operator-experience-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2510,6 +2510,20 @@
     },
     {
       "metadata": {
+        "name": "grafana.dashboardSettingsRedesign",
+        "resourceVersion": "1782823244633",
+        "creationTimestamp": "2026-06-30T12:40:44Z"
+      },
+      "spec": {
+        "description": "Redesigns dashboard settings page into Advanced Settings in a modal window",
+        "stage": "GA",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.dedicatedGrafanaComProxyAPIToken",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2026-05-22T09:03:04Z"

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddButton.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddButton.tsx
@@ -13,12 +13,24 @@ type AddButtonProps = {
   tabIndex?: number;
   // When disabled, callers should set tooltip to explain why.
   disabled?: boolean;
+  testId?: string;
 };
 
-export function AddButton({ icon, label, tooltip, tabIndex, onClick, onKeyDown, className, disabled }: AddButtonProps) {
+export function AddButton({
+  icon,
+  label,
+  tooltip,
+  tabIndex,
+  onClick,
+  onKeyDown,
+  className,
+  disabled,
+  testId,
+}: AddButtonProps) {
   const styles = useStyles2(getStyles);
   return (
     <Button
+      data-testid={testId}
       className={cx(styles.iconButton, className)}
       variant="secondary"
       fill="outline"

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddVariable.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddVariable.tsx
@@ -1,6 +1,7 @@
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useCallback } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type SceneObject } from '@grafana/scenes';
@@ -39,6 +40,7 @@ export function AddVariable({
   return (
     <AddButton
       icon="brackets-curly"
+      testId={selectors.components.Sidebar.addNewVariableButton}
       label={t('dashboard-scene.add-variable.label-variable', 'Variable')}
       onClick={onAddVariableClick}
     />

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardEditableElement.tsx
@@ -17,6 +17,7 @@ import {
 import { DashboardLinksSet } from '../../settings/links/DashboardLinksSet';
 import { DashboardFiltersSet } from '../../settings/variables/DashboardFiltersSet';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+import { VariablesDependenciesButton } from '../../variables/VariablesDependenciesButton';
 
 import { DashboardAnnotationsList } from './DashboardAnnotationsList';
 import { DashboardDescriptionInput, DashboardTitleInput } from './DashboardBasicOptions';
@@ -206,6 +207,16 @@ function useVariablesCategory(dashboard: DashboardScene): OptionsPaneCategoryDes
         render: () => <AddVariableButton dashboard={dashboard} />,
       })
     );
+    if ($variables?.state.variables.length) {
+      category.addItem(
+        new OptionsPaneItemDescriptor({
+          title: '',
+          id: 'dashboard-variables-dependencies',
+          skipField: true,
+          render: () => <VariablesDependenciesButton variables={$variables?.state.variables} isInSidebar />,
+        })
+      );
+    }
 
     return [category];
   }, [$variables, addVariableButtonId, variableListId, dashboard]);

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -5,9 +5,16 @@ import {
   type NavModelItem,
   PageLayoutType,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { t, Trans } from '@grafana/i18n';
+import { config, getDataSourceSrv, locationService } from '@grafana/runtime';
+import { useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
 import { type SceneComponentProps, SceneObjectBase, type VizPanel, dataLayers } from '@grafana/scenes';
+import { Alert, Button } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
+import {
+  HIGHLIGHT_CATEGORY_PARAM_NAME,
+  CATEGORY_PARAM_NAME,
+} from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategory';
 
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
 import { NEW_ANNOTATION_NAME } from '../scene/DashboardDataLayerSet';
@@ -15,6 +22,7 @@ import { type DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { dataLayersToAnnotations } from '../serialization/dataLayersToAnnotations';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
+import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor } from '../utils/utils';
 
 import { EditListViewSceneUrlSync } from './EditListViewSceneUrlSync';
@@ -144,6 +152,40 @@ function AnnotationsSettingsView({ model }: SceneComponentProps<AnnotationsEditV
   const panels = dashboardSceneGraph.getVizPanels(dashboard);
 
   const annotations: AnnotationQuery[] = dataLayersToAnnotations(annotationLayers);
+
+  const isDynamicDashboardsEnabled = config.featureToggles.dashboardNewLayouts;
+  const isSettingsPageRedesignEnabled = useFlagGrafanaDashboardSettingsRedesign();
+
+  const goToSidebar = () => {
+    // close settings and open dashboard sidebar
+    const dashboard = getDashboardSceneFor(model);
+    dashboard.state.editPane.selectObject(dashboard);
+    locationService.partial({
+      editview: null,
+      [HIGHLIGHT_CATEGORY_PARAM_NAME]: 'dashboard-annotations',
+      [CATEGORY_PARAM_NAME]: 'dashboard-annotations',
+    });
+
+    DashboardInteractions.takeMeToSidebarClicked({ item: 'annotations' });
+  };
+  if (isDynamicDashboardsEnabled && isSettingsPageRedesignEnabled) {
+    return (
+      <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
+        <NavToolbarActions dashboard={dashboard} />
+        <Alert
+          severity="info"
+          title={t('dashboard-scene.dashboard-settings.annotations.title-moved', 'Looking for annotations?')}
+        >
+          <Trans i18nKey="dashboard-scene.dashboard-settings.annotations.description-moved">
+            Annotation settings have moved to the dashboard&apos;s sidebar.
+          </Trans>
+          <Button onClick={goToSidebar} fill="text" variant="primary" size="md">
+            <Trans i18nKey="dashboard-scene.dashboard-settings.annotations.button-moved">Take me there</Trans>
+          </Button>
+        </Alert>
+      </Page>
+    );
+  }
 
   if (editIndex != null && editIndex < annotationLayers.length) {
     return (

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
@@ -1,3 +1,4 @@
+import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import { render as RTLRender } from '@testing-library/react';
 import * as React from 'react';
 import { of } from 'rxjs';
@@ -14,9 +15,11 @@ import {
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils, setRunRequest } from '@grafana/runtime';
 import { SceneVariableSet, CustomVariable, VizPanel, AdHocFiltersVariable, SceneTimeRange } from '@grafana/scenes';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
+import { FlagKeys } from '../../../../../packages/grafana-runtime/src/internal/openFeature/openfeature.gen';
 import { DashboardScene } from '../scene/DashboardScene';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { activateFullSceneTree } from '../utils/test-utils';
@@ -24,7 +27,11 @@ import { activateFullSceneTree } from '../utils/test-utils';
 import { VariablesEditView } from './VariablesEditView';
 
 function render(component: React.ReactNode) {
-  return RTLRender(<TestProvider>{component}</TestProvider>);
+  return RTLRender(
+    <TestProvider>
+      <OpenFeatureProvider>{component}</OpenFeatureProvider>
+    </TestProvider>
+  );
 }
 
 setPluginImportUtils({
@@ -73,6 +80,12 @@ const runRequestMock = jest.fn().mockReturnValue(
 setRunRequest(runRequestMock);
 
 describe('VariablesEditView', () => {
+  beforeAll(() => {
+    setTestFlags({ [FlagKeys.GrafanaDashboardSettingsRedesign]: false });
+  });
+  afterAll(() => {
+    setTestFlags({});
+  });
   describe('Dashboard Variables state', () => {
     let dashboard: DashboardScene;
     let variableView: VariablesEditView;
@@ -226,6 +239,7 @@ describe('VariablesEditView', () => {
       expect(queryByText('Provisioned by data source')).not.toBeInTheDocument();
     });
 
+    // remove test when we remove the variable tab in dashboard settings
     it('should show Provisioned by data source section when at least one variable has origin', async () => {
       const variables = variableView.getVariableSet().state.variables;
       const originVariable = new CustomVariable({

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
@@ -14,12 +14,12 @@ import {
 } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils, setRunRequest } from '@grafana/runtime';
+import { FlagKeys } from '@grafana/runtime/internal';
 import { SceneVariableSet, CustomVariable, VizPanel, AdHocFiltersVariable, SceneTimeRange } from '@grafana/scenes';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
-import { FlagKeys } from '../../../../../packages/grafana-runtime/src/internal/openFeature/openfeature.gen';
 import { DashboardScene } from '../scene/DashboardScene';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { activateFullSceneTree } from '../utils/test-utils';

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from 'react';
 
 import { type NavModel, type NavModelItem, PageLayoutType, generateUUID } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { config, locationService } from '@grafana/runtime';
+import { useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
 import {
   type SceneComponentProps,
   SceneObjectBase,
@@ -8,11 +11,17 @@ import {
   type SceneVariables,
   sceneGraph,
 } from '@grafana/scenes';
+import { Alert, Button } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
+import {
+  HIGHLIGHT_CATEGORY_PARAM_NAME,
+  CATEGORY_PARAM_NAME,
+} from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategory';
 
 import { type DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
+import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor } from '../utils/utils';
 import { createUsagesNetwork, transformUsagesToNetwork } from '../variables/utils';
 
@@ -238,6 +247,41 @@ function VariableEditorSettingsListView({ model }: SceneComponentProps<Variables
   const usagesNetwork = useMemo(() => model.getUsagesNetwork(), [model]);
   const usages = useMemo(() => model.getUsages(), [model]);
   const saveModel = model.getSaveModel();
+
+  const isDynamicDashboardsEnabled = config.featureToggles.dashboardNewLayouts;
+  const isSettingsPageRedesignEnabled = useFlagGrafanaDashboardSettingsRedesign();
+
+  const goToSidebar = () => {
+    // close settings and open dashboard sidebar
+    const dashboard = getDashboardSceneFor(model);
+    dashboard.state.editPane.selectObject(dashboard);
+    locationService.partial({
+      editview: null,
+      [HIGHLIGHT_CATEGORY_PARAM_NAME]: 'dashboard-variables',
+      [CATEGORY_PARAM_NAME]: 'dashboard-variables',
+    });
+
+    DashboardInteractions.takeMeToSidebarClicked({ item: 'variables' });
+  };
+
+  if (isDynamicDashboardsEnabled && isSettingsPageRedesignEnabled) {
+    return (
+      <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
+        <NavToolbarActions dashboard={dashboard} />
+        <Alert
+          severity="info"
+          title={t('dashboard-scene.dashboard-settings.variables.title-moved', 'Looking for variable settings?')}
+        >
+          <Trans i18nKey="dashboard-scene.dashboard-settings.variables.description-moved">
+            Variable settings have moved to the dashboard&apos;s sidebar.
+          </Trans>
+          <Button onClick={goToSidebar} fill="text" variant="primary" size="md">
+            <Trans i18nKey="dashboard-scene.dashboard-settings.variables.button-moved">Take me there</Trans>
+          </Button>
+        </Alert>
+      </Page>
+    );
+  }
 
   if (editIndex !== undefined && variables[editIndex]) {
     const variable = variables[editIndex];

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -349,6 +349,11 @@ export const DashboardInteractions = {
   editSessionStarted: (properties: { dashboard_uid?: string; source: 'assistant' | 'user' }) => {
     reportDashboardInteraction('edit_session_started', properties);
   },
+
+  // click "Take me there" button from the dashboard settings for annotations or variables
+  takeMeToSidebarClicked: (properties: { item: 'annotations' | 'variables' }) => {
+    reportDashboardInteraction('take_me_to_sidebar_clicked', properties);
+  },
 };
 
 const reportDashboardInteraction = (

--- a/public/app/features/dashboard-scene/variables/VariablesDependenciesButton.tsx
+++ b/public/app/features/dashboard-scene/variables/VariablesDependenciesButton.tsx
@@ -41,7 +41,7 @@ export const VariablesDependenciesButton = ({ variables, isInSidebar }: Props) =
               reportInteraction('Show variable dependencies');
               showModal();
             }}
-            data-testid={selectors.components.PanelEditor.ElementEditPane.addVariableButton}
+            data-testid={selectors.components.PanelEditor.ElementEditPane.showDependenciesButton}
           >
             <Trans i18nKey="variables.variables-dependencies-button.show-dependencies">Show dependencies</Trans>
           </Button>

--- a/public/app/features/dashboard-scene/variables/VariablesDependenciesButton.tsx
+++ b/public/app/features/dashboard-scene/variables/VariablesDependenciesButton.tsx
@@ -1,5 +1,7 @@
+import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { type SceneVariable, type SceneVariableState } from '@grafana/scenes';
@@ -10,9 +12,10 @@ import { createDependencyEdges, createDependencyNodes, filterNodesWithDependenci
 
 interface Props {
   variables: Array<SceneVariable<SceneVariableState>>;
+  isInSidebar?: boolean;
 }
 
-export const VariablesDependenciesButton = ({ variables }: Props) => {
+export const VariablesDependenciesButton = ({ variables, isInSidebar }: Props) => {
   const nodes = useMemo(() => createDependencyNodes(variables), [variables]);
   const edges = useMemo(() => createDependencyEdges(variables), [variables]);
 
@@ -28,7 +31,21 @@ export const VariablesDependenciesButton = ({ variables }: Props) => {
       edges={edges}
     >
       {({ showModal }) => {
-        return (
+        return isInSidebar ? (
+          <Button
+            className={css({ width: '100%', justifyContent: 'center' })}
+            icon="channel-add"
+            size="sm"
+            variant="secondary"
+            onClick={() => {
+              reportInteraction('Show variable dependencies');
+              showModal();
+            }}
+            data-testid={selectors.components.PanelEditor.ElementEditPane.addVariableButton}
+          >
+            <Trans i18nKey="variables.variables-dependencies-button.show-dependencies">Show dependencies</Trans>
+          </Button>
+        ) : (
           <Button
             onClick={() => {
               reportInteraction('Show variable dependencies');

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx, keyframes } from '@emotion/css';
 import { type ReactNode, useCallback, useEffect, useState, useRef } from 'react';
 import * as React from 'react';
 import { useLocalStorage } from 'react-use';
@@ -28,7 +28,8 @@ export interface OptionsPaneCategoryProps {
   disabledText?: string | React.ReactElement;
 }
 
-const CATEGORY_PARAM_NAME = 'showCategory' as const;
+export const CATEGORY_PARAM_NAME = 'showCategory' as const;
+export const HIGHLIGHT_CATEGORY_PARAM_NAME = 'highlightCategory' as const;
 
 export const OptionsPaneCategory = React.memo(
   ({
@@ -50,9 +51,11 @@ export const OptionsPaneCategory = React.memo(
 
     const isExpandedInitialValue = forceOpen || (savedState?.isExpanded ?? isOpenDefault);
     const [isExpanded, setIsExpanded] = useState(isExpandedInitialValue);
+    const [isHighlighted, setIsHighlighted] = useState(false);
     const ref = useRef<HTMLDivElement>(null);
     const [queryParams, updateQueryParams] = useQueryParams();
     const isOpenFromUrl = queryParams[CATEGORY_PARAM_NAME] === id;
+    const isHighlightedFromUrl = queryParams[HIGHLIGHT_CATEGORY_PARAM_NAME] === id;
 
     // Handle opening by forceOpen param or from URL
     useEffect(() => {
@@ -63,6 +66,32 @@ export const OptionsPaneCategory = React.memo(
         }, 200);
       }
     }, [isExpanded, isOpenFromUrl, forceOpen]);
+
+    // remove effect when feature flag grafanaDasboardSettingsRedesign is removed
+    useEffect(
+      function highlightPaneCategory() {
+        if (!isHighlightedFromUrl) {
+          return;
+        }
+
+        setIsHighlighted(true);
+        setIsExpanded(true);
+
+        const scrollTimeout = window.setTimeout(() => {
+          ref.current?.scrollIntoView();
+        }, 200);
+
+        const highlightTimeout = window.setTimeout(() => setIsHighlighted(false), 2000);
+
+        updateQueryParams({ [HIGHLIGHT_CATEGORY_PARAM_NAME]: undefined }, true);
+
+        return () => {
+          window.clearTimeout(scrollTimeout);
+          window.clearTimeout(highlightTimeout);
+        };
+      },
+      [isHighlightedFromUrl, updateQueryParams]
+    );
 
     const onToggle = useCallback(() => {
       updateQueryParams({ [CATEGORY_PARAM_NAME]: isExpanded ? undefined : id }, true);
@@ -96,6 +125,7 @@ export const OptionsPaneCategory = React.memo(
     const headerStyles = cx(styles.header, {
       [styles.headerExpanded]: isExpanded,
       [styles.headerNested]: isNested,
+      [styles.boxHighlighted]: isHighlighted,
     });
 
     const bodyStyles = cx(styles.body, {
@@ -231,6 +261,28 @@ const getStyles = (theme: GrafanaTheme2) => ({
       background: theme.colors.border.weak,
     },
   }),
+
+  boxHighlighted: css({
+    [theme.transitions.handleMotion('no-preference')]: {
+      animation: `${categoryHighlight(theme)} 2s ease-out forwards`,
+    },
+    [theme.transitions.handleMotion('reduce')]: {
+      backgroundColor: theme.colors.primary.transparent,
+      boxShadow: `inset 0 0 0 1px ${theme.colors.primary.border}`,
+    },
+  }),
 });
+
+const categoryHighlight = (theme: GrafanaTheme2) =>
+  keyframes({
+    '0%': {
+      backgroundColor: theme.colors.primary.transparent,
+      boxShadow: `inset 0 0 0 1px ${theme.colors.primary.border}`,
+    },
+    '100%': {
+      backgroundColor: 'transparent',
+      boxShadow: 'none',
+    },
+  });
 
 const getOptionGroupStorageKey = (id: string) => `${PANEL_EDITOR_UI_STATE_STORAGE_KEY}.optionGroup[${id}]`;

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -68,33 +68,35 @@ export const OptionsPaneCategory = React.memo(
     }, [isExpanded, isOpenFromUrl, forceOpen]);
 
     // remove effect when feature flag grafana.dashboardSettingsRedesign is removed
-    useEffect(
-      function highlightPaneCategory() {
-        if (!isHighlightedFromUrl) {
-          return;
-        }
+    useEffect(() => {
+      if (!isHighlightedFromUrl) {
+        return;
+      }
 
-        setIsHighlighted(true);
-        setIsExpanded(true);
+      setIsHighlighted(true);
+      setIsExpanded(true);
+      updateQueryParams({ [HIGHLIGHT_CATEGORY_PARAM_NAME]: undefined }, true);
+    }, [isHighlightedFromUrl, updateQueryParams]);
 
-        const scrollTimeout = window.setTimeout(() => {
-          ref.current?.scrollIntoView();
-        }, 200);
+    // remove effect when feature flag grafana.dashboardSettingsRedesign is removed
+    useEffect(() => {
+      if (!isHighlighted) {
+        return;
+      }
 
-        // Clear the URL param only after the highlight completes. Clearing it synchronously
-        // flips isHighlightedFromUrl, which re-runs this effect and cancels both timers early.
-        const highlightTimeout = window.setTimeout(() => {
-          setIsHighlighted(false);
-          updateQueryParams({ [HIGHLIGHT_CATEGORY_PARAM_NAME]: undefined }, true);
-        }, 2000);
+      const scrollTimeout = window.setTimeout(() => {
+        ref.current?.scrollIntoView();
+      }, 200);
 
-        return () => {
-          window.clearTimeout(scrollTimeout);
-          window.clearTimeout(highlightTimeout);
-        };
-      },
-      [isHighlightedFromUrl, updateQueryParams]
-    );
+      const highlightTimeout = window.setTimeout(() => {
+        setIsHighlighted(false);
+      }, 2000);
+
+      return () => {
+        window.clearTimeout(scrollTimeout);
+        window.clearTimeout(highlightTimeout);
+      };
+    }, [isHighlighted]);
 
     const onToggle = useCallback(() => {
       updateQueryParams({ [CATEGORY_PARAM_NAME]: isExpanded ? undefined : id }, true);

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -67,7 +67,7 @@ export const OptionsPaneCategory = React.memo(
       }
     }, [isExpanded, isOpenFromUrl, forceOpen]);
 
-    // remove effect when feature flag grafanaDasboardSettingsRedesign is removed
+    // remove effect when feature flag grafana.dashboardSettingsRedesign is removed
     useEffect(
       function highlightPaneCategory() {
         if (!isHighlightedFromUrl) {
@@ -81,9 +81,12 @@ export const OptionsPaneCategory = React.memo(
           ref.current?.scrollIntoView();
         }, 200);
 
-        const highlightTimeout = window.setTimeout(() => setIsHighlighted(false), 2000);
-
-        updateQueryParams({ [HIGHLIGHT_CATEGORY_PARAM_NAME]: undefined }, true);
+        // Clear the URL param only after the highlight completes. Clearing it synchronously
+        // flips isHighlightedFromUrl, which re-runs this effect and cancels both timers early.
+        const highlightTimeout = window.setTimeout(() => {
+          setIsHighlighted(false);
+          updateQueryParams({ [HIGHLIGHT_CATEGORY_PARAM_NAME]: undefined }, true);
+        }, 2000);
 
         return () => {
           window.clearTimeout(scrollTimeout);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6828,6 +6828,18 @@
         "dashboard-not-found": "Dashboard not found"
       }
     },
+    "dashboard-settings": {
+      "annotations": {
+        "button-moved": "Take me there",
+        "description-moved": "Annotation settings have moved to the dashboard's sidebar.",
+        "title-moved": "Looking for annotations?"
+      },
+      "variables": {
+        "button-moved": "Take me there",
+        "description-moved": "Variable settings have moved to the dashboard's sidebar.",
+        "title-moved": "Looking for variable settings?"
+      }
+    },
     "dashboard-side-pane-new": {
       "dashboard-controls": "Dashboard controls"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -16721,6 +16721,9 @@
     "variable-options": {
       "aria-label-toggle-all-values": "Toggle all values"
     },
+    "variables-dependencies-button": {
+      "show-dependencies": "Show dependencies"
+    },
     "variables-unknown-button": {
       "usage-title": "Showing usages for: {{variableId}}",
       "VariablesUnknownButton-tooltip-show-usages": "Show usages"


### PR DESCRIPTION
Solves https://github.com/grafana/grafana/issues/125617 as the first step to the redesign
Feature toggle `grafana.dashboardSettingsRedesign` enabled by default

https://github.com/user-attachments/assets/e3ced96a-6362-49e6-ba85-65162a7625be

Added tracking so we can see
1. what the adoption for variables and annotations in sidebar is
2. reduction in clicks will give us signal that we can replace the settings with the modal

Had to adjust one variable e2e test, so refactored it a bit to use the new page objects