### PR TITLE
Alerting: Migrate silences to use centralized ability hooks (4/N)

### DIFF
--- a/public/app/features/alerting/unified/components/silences/NoSilencesCTA.tsx
+++ b/public/app/features/alerting/unified/components/silences/NoSilencesCTA.tsx
@@ -1,8 +1,9 @@
 import { Trans, t } from '@grafana/i18n';
 import { CallToActionCard, EmptyState, LinkButton } from '@grafana/ui';
-import { contextSrv } from 'app/core/services/context_srv';
 
-import { getInstancesPermissions } from '../../utils/access-control';
+import { isGranted, isNotSupported } from '../../hooks/abilities/abilityUtils';
+import { useSilenceAbility } from '../../hooks/abilities/alertmanager/useSilenceAbility';
+import { SilenceAction } from '../../hooks/abilities/types';
 import { makeAMLink } from '../../utils/misc';
 
 type Props = {
@@ -10,14 +11,22 @@ type Props = {
 };
 
 export const NoSilencesSplash = ({ alertManagerSourceName }: Props) => {
-  const permissions = getInstancesPermissions(alertManagerSourceName);
+  const createAbility = useSilenceAbility({ action: SilenceAction.Create });
 
-  if (contextSrv.hasPermission(permissions.create)) {
+  // Show the button for every cause except NOT_SUPPORTED (wrong AM type).
+  // While the AM is still resolving (LOADING), the button is rendered disabled
+  // rather than hidden so the empty state doesn't flash a different layout.
+  if (!isNotSupported(createAbility)) {
     return (
       <EmptyState
         variant="call-to-action"
         button={
-          <LinkButton href={makeAMLink('alerting/silence/new', alertManagerSourceName)} icon="bell-slash" size="lg">
+          <LinkButton
+            href={makeAMLink('alerting/silence/new', alertManagerSourceName)}
+            icon="bell-slash"
+            size="lg"
+            disabled={!isGranted(createAbility)}
+          >
             <Trans i18nKey="silences.empty-state.button-title">Create silence</Trans>
           </LinkButton>
         }

--- a/public/app/features/alerting/unified/components/silences/SilenceViewContent.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewContent.tsx
@@ -6,6 +6,7 @@ import { createReturnTo } from '../../hooks/useReturnTo';
 import { MATCHER_ALERT_RULE_UID } from '../../utils/constants';
 
 import { Matchers } from './Matchers';
+import { MissingAlertRuleWarning } from './MissingAlertRuleWarning';
 import { SilenceMetadataGrid } from './SilenceMetadataGrid';
 import SilencedAlertsTable from './SilencedAlertsTable';
 
@@ -18,19 +19,24 @@ export function SilenceViewContent({ silence, silencedAlerts }: SilenceViewConte
   const { matchers = [], comment, createdBy, startsAt, endsAt, metadata } = silence;
   const filteredMatchers = matchers.filter((m) => m.name !== MATCHER_ALERT_RULE_UID);
   const returnTo = createReturnTo();
+  const ruleUid = metadata?.rule_uid;
 
-  const alertRuleHref = metadata?.rule_uid
-    ? `/alerting/grafana/${encodeURIComponent(metadata.rule_uid)}/view?${new URLSearchParams({ returnTo }).toString()}`
+  const alertRuleHref = ruleUid
+    ? `/alerting/grafana/${encodeURIComponent(ruleUid)}/view?${new URLSearchParams({ returnTo }).toString()}`
     : '';
 
   return (
     <Stack direction="column" gap={2}>
-      {metadata?.rule_title && metadata?.rule_uid && (
+      {ruleUid && (
         <Stack direction="column" gap={0.5}>
           <Text variant="bodySmall" color="secondary">
             <Trans i18nKey="alerting.silence-view.alert-rule">Alert rule</Trans>
           </Text>
-          <TextLink href={alertRuleHref}>{metadata.rule_title}</TextLink>
+          {metadata?.rule_title ? (
+            <TextLink href={alertRuleHref}>{metadata.rule_title}</TextLink>
+          ) : (
+            <MissingAlertRuleWarning ruleUid={ruleUid} />
+          )}
         </Stack>
       )}
 

--- a/public/app/features/alerting/unified/components/silences/SilenceViewContent.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewContent.tsx
@@ -6,7 +6,6 @@ import { createReturnTo } from '../../hooks/useReturnTo';
 import { MATCHER_ALERT_RULE_UID } from '../../utils/constants';
 
 import { Matchers } from './Matchers';
-import { MissingAlertRuleWarning } from './MissingAlertRuleWarning';
 import { SilenceMetadataGrid } from './SilenceMetadataGrid';
 import SilencedAlertsTable from './SilencedAlertsTable';
 
@@ -19,24 +18,19 @@ export function SilenceViewContent({ silence, silencedAlerts }: SilenceViewConte
   const { matchers = [], comment, createdBy, startsAt, endsAt, metadata } = silence;
   const filteredMatchers = matchers.filter((m) => m.name !== MATCHER_ALERT_RULE_UID);
   const returnTo = createReturnTo();
-  const ruleUid = metadata?.rule_uid;
+
+  const alertRuleHref = metadata?.rule_uid
+    ? `/alerting/grafana/${encodeURIComponent(metadata.rule_uid)}/view?${new URLSearchParams({ returnTo }).toString()}`
+    : '';
 
   return (
     <Stack direction="column" gap={2}>
-      {ruleUid && (
+      {metadata?.rule_title && metadata?.rule_uid && (
         <Stack direction="column" gap={0.5}>
           <Text variant="bodySmall" color="secondary">
             <Trans i18nKey="alerting.silence-view.alert-rule">Alert rule</Trans>
           </Text>
-          {metadata.rule_title ? (
-            <TextLink
-              href={`/alerting/grafana/${encodeURIComponent(ruleUid)}/view?${new URLSearchParams({ returnTo }).toString()}`}
-            >
-              {metadata.rule_title}
-            </TextLink>
-          ) : (
-            <MissingAlertRuleWarning ruleUid={ruleUid} />
-          )}
+          <TextLink href={alertRuleHref}>{metadata.rule_title}</TextLink>
         </Stack>
       )}
 

--- a/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
@@ -9,6 +9,7 @@ import { Alert, Badge, Icon, LoadingPlaceholder, Tooltip, useStyles2 } from '@gr
 import { type MatcherFieldValue } from 'app/features/alerting/unified/types/silence-form';
 import { matcherFieldToMatcher } from 'app/features/alerting/unified/utils/alertmanager';
 import { MATCHER_ALERT_RULE_UID } from 'app/features/alerting/unified/utils/constants';
+import { isValidRE2Regex } from 'app/features/alerting/unified/utils/matchers';
 import { type AlertmanagerAlert, type Matcher, MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 
 import { alertmanagerApi } from '../../api/alertmanagerApi';
@@ -45,11 +46,19 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
   const styles = useStyles2(getStyles);
   const columns = useColumns();
 
-  // By default the form contains an empty matcher - with empty name and value and = operator
-  // We don't want to fetch previews for empty matchers as it results in all alerts returned
-  const hasValidMatchers = ruleUid || inputMatchers.some((matcher) => matcher.value && matcher.name);
+  const regexOperators = new Set([MatcherOperator.regex, MatcherOperator.notRegex]);
+  const hasInvalidRegex = inputMatchers.some(
+    (matcher) => regexOperators.has(matcher.operator) && !isValidRE2Regex(matcher.value)
+  );
 
-  const [getAlertmanagerAlerts, { currentData: alerts = [], isFetching, isError }] = useLazyQuery();
+  // By default the form contains an empty matcher - with empty name and value and = operator
+  // We don't want to fetch previews for empty matchers as it results in all alerts returned,
+  // and we don't want to send invalid regexes to the backend.
+  const hasValidMatchers =
+    !hasInvalidRegex && Boolean(ruleUid || inputMatchers.some((matcher) => matcher.value && matcher.name));
+
+  const [getAlertmanagerAlerts, { currentData: alerts = [], isFetching, isError: isBackendError }] = useLazyQuery();
+  const isError = isBackendError || hasInvalidRegex;
 
   // We need to deep compare the matchers, as otherwise the preview API call is triggered on every render
   // of the component. This is because between react-hook-form's useFieldArray, and our parsing of the matchers,
@@ -57,7 +66,8 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
   useDebouncedDeepCompare(
     () => {
       if (hasValidMatchers) {
-        getAlertmanagerAlerts({ amSourceName, filter: { matchers } });
+        // the inline "Preview not available" Alert below already surfaces the failure to the user.
+        getAlertmanagerAlerts({ amSourceName, filter: { matchers }, showErrorAlert: false });
       }
     },
     500,

--- a/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
@@ -9,7 +9,6 @@ import { Alert, Badge, Icon, LoadingPlaceholder, Tooltip, useStyles2 } from '@gr
 import { type MatcherFieldValue } from 'app/features/alerting/unified/types/silence-form';
 import { matcherFieldToMatcher } from 'app/features/alerting/unified/utils/alertmanager';
 import { MATCHER_ALERT_RULE_UID } from 'app/features/alerting/unified/utils/constants';
-import { isValidRE2Regex } from 'app/features/alerting/unified/utils/matchers';
 import { type AlertmanagerAlert, type Matcher, MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 
 import { alertmanagerApi } from '../../api/alertmanagerApi';
@@ -46,19 +45,11 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
   const styles = useStyles2(getStyles);
   const columns = useColumns();
 
-  const regexOperators = new Set([MatcherOperator.regex, MatcherOperator.notRegex]);
-  const hasInvalidRegex = inputMatchers.some(
-    (matcher) => regexOperators.has(matcher.operator) && !isValidRE2Regex(matcher.value)
-  );
-
   // By default the form contains an empty matcher - with empty name and value and = operator
-  // We don't want to fetch previews for empty matchers as it results in all alerts returned,
-  // and we don't want to send invalid regexes to the backend.
-  const hasValidMatchers =
-    !hasInvalidRegex && Boolean(ruleUid || inputMatchers.some((matcher) => matcher.value && matcher.name));
+  // We don't want to fetch previews for empty matchers as it results in all alerts returned
+  const hasValidMatchers = ruleUid || inputMatchers.some((matcher) => matcher.value && matcher.name);
 
-  const [getAlertmanagerAlerts, { currentData: alerts = [], isFetching, isError: isBackendError }] = useLazyQuery();
-  const isError = isBackendError || hasInvalidRegex;
+  const [getAlertmanagerAlerts, { currentData: alerts = [], isFetching, isError }] = useLazyQuery();
 
   // We need to deep compare the matchers, as otherwise the preview API call is triggered on every render
   // of the component. This is because between react-hook-form's useFieldArray, and our parsing of the matchers,
@@ -66,8 +57,7 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
   useDebouncedDeepCompare(
     () => {
       if (hasValidMatchers) {
-        // the inline "Preview not available" Alert below already surfaces the failure to the user.
-        getAlertmanagerAlerts({ amSourceName, filter: { matchers }, showErrorAlert: false });
+        getAlertmanagerAlerts({ amSourceName, filter: { matchers } });
       }
     },
     500,

--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -33,7 +33,8 @@ import { GRAFANA_RULES_SOURCE_NAME, getDatasourceAPIUid } from 'app/features/ale
 import { MatcherOperator, type SilenceCreatePayload } from 'app/plugins/datasource/alertmanager/types';
 
 import { contextSrv } from '../../../../../core/services/context_srv';
-import { AlertmanagerAction, useAlertmanagerAbility } from '../../hooks/useAbilities';
+import { useSilenceAbility } from '../../hooks/abilities/alertmanager/useSilenceAbility';
+import { SilenceAction } from '../../hooks/abilities/types';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { type SilenceFormFields } from '../../types/silence-form';
 import { matcherFieldToMatcher } from '../../utils/alertmanager';
@@ -131,7 +132,6 @@ type SilencesEditorProps = {
   onSilenceCreated?: (response: SilenceCreatedResponse) => void;
   onCancel?: () => void;
   ruleUid?: string;
-  showCancelButton?: boolean;
 };
 
 /**
@@ -144,15 +144,11 @@ export const SilencesEditor = ({
   onSilenceCreated,
   onCancel,
   ruleUid,
-  showCancelButton = true,
 }: SilencesEditorProps) => {
-  const [previewAlertsSupported, previewAlertsAllowed] = useAlertmanagerAbility(
-    AlertmanagerAction.PreviewSilencedInstances
-  );
-  const canPreview = previewAlertsSupported && previewAlertsAllowed;
+  const { granted: canPreview } = useSilenceAbility({ action: SilenceAction.Preview });
 
   const [createSilence, { isLoading }] = alertSilencesApi.endpoints.createSilence.useMutation();
-  const formAPI = useForm<SilenceFormFields>({ defaultValues: formValues });
+  const formAPI = useForm({ defaultValues: formValues });
   const styles = useStyles2(getStyles);
 
   const { register, handleSubmit, formState, watch, setValue, clearErrors } = formAPI;
@@ -300,11 +296,9 @@ export const SilencesEditor = ({
               <Trans i18nKey="alerting.silences-editor.save-silence">Save silence</Trans>
             </Button>
           )}
-          {showCancelButton && (
-            <LinkButton onClick={onCancelHandler} variant={'secondary'}>
-              <Trans i18nKey="alerting.common.cancel">Cancel</Trans>
-            </LinkButton>
-          )}
+          <LinkButton onClick={onCancelHandler} variant={'secondary'}>
+            <Trans i18nKey="alerting.common.cancel">Cancel</Trans>
+          </LinkButton>
         </Stack>
       </form>
     </FormProvider>

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -34,6 +34,7 @@ import { DynamicTable, type DynamicTableColumnProps, type DynamicTableItemProps 
 import { GrafanaAlertmanagerWarning } from '../GrafanaAlertmanagerWarning';
 
 import { Matchers } from './Matchers';
+import { MissingAlertRuleWarning } from './MissingAlertRuleWarning';
 import { NoSilencesSplash } from './NoSilencesCTA';
 import { SilenceDetails } from './SilenceDetails';
 import { SilenceStateTag } from './SilenceStateTag';
@@ -301,15 +302,20 @@ function useColumns(alertManagerSourceName: string) {
         id: 'alert-rule',
         label: t('alerting.use-columns.columns.label.alert-rule-targeted', 'Alert rule targeted'),
         renderCell: function renderAlertRuleLink({ data: { metadata } }) {
-          return metadata?.rule_title ? (
-            <Link
-              href={`/alerting/grafana/${metadata?.rule_uid}/view?returnTo=${encodeURIComponent('/alerting/silences')}`}
-            >
-              {metadata.rule_title}
-            </Link>
-          ) : (
-            'None'
-          );
+          const ruleUid = metadata?.rule_uid;
+          if (!ruleUid) {
+            return 'None';
+          }
+          if (metadata.rule_title) {
+            return (
+              <Link
+                href={`/alerting/grafana/${encodeURIComponent(ruleUid)}/view?returnTo=${encodeURIComponent('/alerting/silences')}`}
+              >
+                {metadata.rule_title}
+              </Link>
+            );
+          }
+          return <MissingAlertRuleWarning ruleUid={ruleUid} />;
         },
         size: 8,
       },

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -22,7 +22,7 @@ import { GRAFANA_RULES_SOURCE_NAME, getDatasourceAPIUid } from 'app/features/ale
 import { type AlertmanagerAlert, type Silence, SilenceState } from 'app/plugins/datasource/alertmanager/types';
 
 import { alertmanagerApi } from '../../api/alertmanagerApi';
-import { isAvailable, isGranted } from '../../hooks/abilities/abilityUtils';
+import { isGranted, isSupported } from '../../hooks/abilities/abilityUtils';
 import { useSilenceAbility } from '../../hooks/abilities/alertmanager/useSilenceAbility';
 import { SilenceAction } from '../../hooks/abilities/types';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
@@ -359,11 +359,11 @@ function useColumns(alertManagerSourceName: string) {
         const canWrite = silence?.accessControl?.write;
 
         const canRecreate =
-          isAvailable(updateAbility) &&
+          isSupported(updateAbility) &&
           isExpired &&
           (isGrafanaFlavoredAlertmanager ? canCreate : updateAbility.granted);
         const canEdit =
-          isAvailable(updateAbility) &&
+          isSupported(updateAbility) &&
           !isExpired &&
           (isGrafanaFlavoredAlertmanager ? canWrite : updateAbility.granted);
 

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -22,18 +22,18 @@ import { GRAFANA_RULES_SOURCE_NAME, getDatasourceAPIUid } from 'app/features/ale
 import { type AlertmanagerAlert, type Silence, SilenceState } from 'app/plugins/datasource/alertmanager/types';
 
 import { alertmanagerApi } from '../../api/alertmanagerApi';
-import { AlertmanagerAction, useAlertmanagerAbility } from '../../hooks/useAbilities';
+import { isAvailable, isGranted } from '../../hooks/abilities/abilityUtils';
+import { useSilenceAbility } from '../../hooks/abilities/alertmanager/useSilenceAbility';
+import { SilenceAction } from '../../hooks/abilities/types';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { parsePromQLStyleMatcherLooseSafe } from '../../utils/matchers';
 import { getSilenceFiltersFromUrlParams, makeAMLink, stringifyErrorLike } from '../../utils/misc';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
-import { Authorize } from '../Authorize';
 import { DynamicTable, type DynamicTableColumnProps, type DynamicTableItemProps } from '../DynamicTable';
 import { GrafanaAlertmanagerWarning } from '../GrafanaAlertmanagerWarning';
 
 import { Matchers } from './Matchers';
-import { MissingAlertRuleWarning } from './MissingAlertRuleWarning';
 import { NoSilencesSplash } from './NoSilencesCTA';
 import { SilenceDetails } from './SilenceDetails';
 import { SilenceStateTag } from './SilenceStateTag';
@@ -50,10 +50,8 @@ const API_QUERY_OPTIONS = { pollingInterval: SILENCES_POLL_INTERVAL_MS, refetchO
 
 const SilencesTable = () => {
   const { selectedAlertmanager: alertManagerSourceName = '' } = useAlertmanager();
-  const [previewAlertsSupported, previewAlertsAllowed] = useAlertmanagerAbility(
-    AlertmanagerAction.PreviewSilencedInstances
-  );
-  const canPreview = previewAlertsSupported && previewAlertsAllowed;
+  const { granted: canPreview } = useSilenceAbility({ action: SilenceAction.Preview });
+  const canCreateSilence = isGranted(useSilenceAbility({ action: SilenceAction.Create }));
 
   const { data: alertManagerAlerts = [], isLoading: amAlertsIsLoading } =
     alertmanagerApi.endpoints.getAlertmanagerAlerts.useQuery(
@@ -151,13 +149,13 @@ const SilencesTable = () => {
       {!!silences.length && (
         <Stack direction="column">
           <SilencesFilter silences={silences} />
-          <Authorize actions={[AlertmanagerAction.CreateSilence]}>
+          {canCreateSilence && (
             <Stack justifyContent="end">
               <LinkButton href={makeAMLink('/alerting/silence/new', alertManagerSourceName)} icon="plus">
                 <Trans i18nKey="silences.table.add-silence-button">Add Silence</Trans>
               </LinkButton>
             </Stack>
-          </Authorize>
+          )}
           <SilenceList
             items={itemsNotExpired}
             alertManagerSourceName={alertManagerSourceName}
@@ -281,7 +279,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
 });
 
 function useColumns(alertManagerSourceName: string) {
-  const [updateSupported, updateAllowed] = useAlertmanagerAbility(AlertmanagerAction.UpdateSilence);
+  const updateAbility = useSilenceAbility({ action: SilenceAction.Update });
   const [expireSilence] = alertSilencesApi.endpoints.expireSilence.useMutation();
 
   const isGrafanaFlavoredAlertmanager = alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME;
@@ -303,23 +301,15 @@ function useColumns(alertManagerSourceName: string) {
         id: 'alert-rule',
         label: t('alerting.use-columns.columns.label.alert-rule-targeted', 'Alert rule targeted'),
         renderCell: function renderAlertRuleLink({ data: { metadata } }) {
-          const ruleUid = metadata?.rule_uid;
-          if (!ruleUid) {
-            return 'None';
-          }
-
-          const ruleTitle = metadata.rule_title;
-          if (ruleTitle) {
-            return (
-              <Link
-                href={`/alerting/grafana/${encodeURIComponent(ruleUid)}/view?returnTo=${encodeURIComponent('/alerting/silences')}`}
-              >
-                {ruleTitle}
-              </Link>
-            );
-          }
-
-          return <MissingAlertRuleWarning ruleUid={ruleUid} />;
+          return metadata?.rule_title ? (
+            <Link
+              href={`/alerting/grafana/${metadata?.rule_uid}/view?returnTo=${encodeURIComponent('/alerting/silences')}`}
+            >
+              {metadata.rule_title}
+            </Link>
+          ) : (
+            'None'
+          );
         },
         size: 8,
       },
@@ -368,8 +358,14 @@ function useColumns(alertManagerSourceName: string) {
         const canCreate = silence?.accessControl?.create;
         const canWrite = silence?.accessControl?.write;
 
-        const canRecreate = updateSupported && isExpired && (isGrafanaFlavoredAlertmanager ? canCreate : updateAllowed);
-        const canEdit = updateSupported && !isExpired && (isGrafanaFlavoredAlertmanager ? canWrite : updateAllowed);
+        const canRecreate =
+          isAvailable(updateAbility) &&
+          isExpired &&
+          (isGrafanaFlavoredAlertmanager ? canCreate : updateAbility.granted);
+        const canEdit =
+          isAvailable(updateAbility) &&
+          !isExpired &&
+          (isGrafanaFlavoredAlertmanager ? canWrite : updateAbility.granted);
 
         return (
           <Stack gap={0.5} wrap="wrap">
@@ -421,7 +417,7 @@ function useColumns(alertManagerSourceName: string) {
       size: 5,
     });
     return columns;
-  }, [alertManagerSourceName, expireSilence, isGrafanaFlavoredAlertmanager, updateAllowed, updateSupported]);
+  }, [alertManagerSourceName, expireSilence, isGrafanaFlavoredAlertmanager, updateAbility]);
 }
 
 function SilencesTablePage() {

--- a/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.test.tsx
+++ b/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.test.tsx
@@ -108,6 +108,17 @@ describe('useSilenceAbility', () => {
 
       expect(result.current.granted).toBe(true);
     });
+
+    it('should grant Create when only AlertingSilenceCreate is held', () => {
+      const amSource = setupGrafanaAlertmanager();
+      grantUserPermissions([GRAFANA_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingSilenceCreate]);
+
+      const { result } = renderHook(() => useSilenceAbility({ action: SilenceAction.Create }), {
+        wrapper: createAlertmanagerWrapper(amSource),
+      });
+
+      expect(result.current.granted).toBe(true);
+    });
   });
 
   describe('external (Mimir) alertmanager', () => {
@@ -185,6 +196,28 @@ describe('useSilenceAbility', () => {
       });
 
       expect(result.current.granted).toBe(false);
+    });
+
+    it('should deny Update when accessControl.write is false on the silence entity', () => {
+      setupMimirAlertmanager(MIMIR_DATASOURCE_UID);
+      grantUserPermissions([EXTERNAL_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingInstancesExternalWrite]);
+
+      const { result } = renderHook(
+        () => ({
+          updateDenied: useSilenceAbility({
+            action: SilenceAction.Update,
+            context: { accessControl: { write: false } } as never,
+          }),
+          updateAllowed: useSilenceAbility({
+            action: SilenceAction.Update,
+            context: { accessControl: { write: true } } as never,
+          }),
+        }),
+        { wrapper: createAlertmanagerWrapper(MIMIR_DATASOURCE_UID) }
+      );
+
+      expect(result.current.updateDenied.granted).toBe(false);
+      expect(result.current.updateAllowed.granted).toBe(true);
     });
   });
 

--- a/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.test.tsx
+++ b/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.test.tsx
@@ -60,6 +60,22 @@ describe('useSilenceAbility', () => {
       expect(result.current.preview.granted).toBe(true);
     });
 
+    it('should grant View and Preview when only AlertingSilenceRead is held', () => {
+      const amSource = setupGrafanaAlertmanager();
+      grantUserPermissions([GRAFANA_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingSilenceRead]);
+
+      const { result } = renderHook(
+        () => ({
+          view: useSilenceAbility({ action: SilenceAction.View }),
+          preview: useSilenceAbility({ action: SilenceAction.Preview }),
+        }),
+        { wrapper: createAlertmanagerWrapper(amSource) }
+      );
+
+      expect(result.current.view.granted).toBe(true);
+      expect(result.current.preview.granted).toBe(true);
+    });
+
     it('should deny Update when accessControl.write is false on the silence entity', () => {
       const amSource = setupGrafanaAlertmanager();
       grantUserPermissions([GRAFANA_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingInstanceUpdate]);
@@ -80,6 +96,17 @@ describe('useSilenceAbility', () => {
 
       expect(result.current.updateDenied.granted).toBe(false);
       expect(result.current.updateAllowed.granted).toBe(true);
+    });
+
+    it('should grant Update when only AlertingSilenceUpdate is held', () => {
+      const amSource = setupGrafanaAlertmanager();
+      grantUserPermissions([GRAFANA_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingSilenceUpdate]);
+
+      const { result } = renderHook(() => useSilenceAbility({ action: SilenceAction.Update }), {
+        wrapper: createAlertmanagerWrapper(amSource),
+      });
+
+      expect(result.current.granted).toBe(true);
     });
   });
 
@@ -105,6 +132,60 @@ describe('useSilenceAbility', () => {
 
       expect(result.current.granted).toBe(false);
     });
+
+    it('should grant View and Preview when AlertingInstancesExternalRead is held', () => {
+      setupMimirAlertmanager(MIMIR_DATASOURCE_UID);
+      grantUserPermissions([EXTERNAL_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingInstancesExternalRead]);
+
+      const { result } = renderHook(
+        () => ({
+          view: useSilenceAbility({ action: SilenceAction.View }),
+          preview: useSilenceAbility({ action: SilenceAction.Preview }),
+        }),
+        { wrapper: createAlertmanagerWrapper(MIMIR_DATASOURCE_UID) }
+      );
+
+      expect(result.current.view.granted).toBe(true);
+      expect(result.current.preview.granted).toBe(true);
+    });
+
+    it('should deny View and Preview when only the Grafana AM read permission is held', () => {
+      setupMimirAlertmanager(MIMIR_DATASOURCE_UID);
+      grantUserPermissions([EXTERNAL_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingInstanceRead]);
+
+      const { result } = renderHook(
+        () => ({
+          view: useSilenceAbility({ action: SilenceAction.View }),
+          preview: useSilenceAbility({ action: SilenceAction.Preview }),
+        }),
+        { wrapper: createAlertmanagerWrapper(MIMIR_DATASOURCE_UID) }
+      );
+
+      expect(result.current.view.granted).toBe(false);
+      expect(result.current.preview.granted).toBe(false);
+    });
+
+    it('should grant Update when AlertingInstancesExternalWrite is held', () => {
+      setupMimirAlertmanager(MIMIR_DATASOURCE_UID);
+      grantUserPermissions([EXTERNAL_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingInstancesExternalWrite]);
+
+      const { result } = renderHook(() => useSilenceAbility({ action: SilenceAction.Update }), {
+        wrapper: createAlertmanagerWrapper(MIMIR_DATASOURCE_UID),
+      });
+
+      expect(result.current.granted).toBe(true);
+    });
+
+    it('should deny Update when only the Grafana AM update permission is held', () => {
+      setupMimirAlertmanager(MIMIR_DATASOURCE_UID);
+      grantUserPermissions([EXTERNAL_AM_VISIBILITY_PERMISSION, AccessControlAction.AlertingInstanceUpdate]);
+
+      const { result } = renderHook(() => useSilenceAbility({ action: SilenceAction.Update }), {
+        wrapper: createAlertmanagerWrapper(MIMIR_DATASOURCE_UID),
+      });
+
+      expect(result.current.granted).toBe(false);
+    });
   });
 
   describe('unresolved alertmanager (selectedAlertmanager is undefined)', () => {
@@ -121,6 +202,24 @@ describe('useSilenceAbility', () => {
       });
 
       expect(isLoading(result.current)).toBe(true);
+    });
+
+    it('should return Loading for View, Preview, and Update when no AM resolves in context', () => {
+      const amSource = setupVanillaPrometheusAlertmanager();
+      grantUserPermissions([]);
+
+      const { result } = renderHook(
+        () => ({
+          view: useSilenceAbility({ action: SilenceAction.View }),
+          preview: useSilenceAbility({ action: SilenceAction.Preview }),
+          update: useSilenceAbility({ action: SilenceAction.Update }),
+        }),
+        { wrapper: createAlertmanagerWrapper(amSource) }
+      );
+
+      expect(isLoading(result.current.view)).toBe(true);
+      expect(isLoading(result.current.preview)).toBe(true);
+      expect(isLoading(result.current.update)).toBe(true);
     });
   });
 });

--- a/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.ts
+++ b/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.ts
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 
 import { type Silence } from 'app/plugins/datasource/alertmanager/types';
+import { type AccessControlAction } from 'app/types/accessControl';
 
 import { useAlertmanager } from '../../../state/AlertmanagerContext';
-import { getInstancesPermissions, instancesPermissions, silencesPermissions } from '../../../utils/access-control';
+import { instancesPermissions, silencesPermissions } from '../../../utils/access-control';
 import { makeAbility } from '../abilityUtils';
 import { type AsyncAbility, InsufficientPermissions, Loading, SilenceAction } from '../types';
 
@@ -13,64 +14,47 @@ export type SilenceAbilityParam =
   | { action: SilenceAction.Preview }
   | { action: SilenceAction.Update; context?: Silence };
 
+// Backend HTTP gates accept either alert.instances:* or alert.silences:* for Grafana AM.
+// Frontend mirrors that by listing both in the accepted set.
+const GRAFANA_PERMISSIONS: Record<SilenceAction, AccessControlAction[]> = {
+  [SilenceAction.View]: [instancesPermissions.read.grafana, silencesPermissions.read.grafana],
+  [SilenceAction.Preview]: [instancesPermissions.read.grafana, silencesPermissions.read.grafana],
+  [SilenceAction.Create]: [instancesPermissions.create.grafana, silencesPermissions.create.grafana],
+  [SilenceAction.Update]: [instancesPermissions.update.grafana, silencesPermissions.update.grafana],
+};
+
+const EXTERNAL_PERMISSIONS: Record<SilenceAction, AccessControlAction[]> = {
+  [SilenceAction.View]: [instancesPermissions.read.external],
+  [SilenceAction.Preview]: [instancesPermissions.read.external],
+  [SilenceAction.Create]: [instancesPermissions.create.external],
+  [SilenceAction.Update]: [instancesPermissions.update.external],
+};
+
 export function useSilenceAbility(payload: SilenceAbilityParam): AsyncAbility {
-  const { selectedAlertmanager } = useAlertmanager();
+  const { selectedAlertmanager, isGrafanaAlertmanager } = useAlertmanager();
 
   return useMemo(() => {
+    // Return Loading until the selected alertmanager is resolved so callers can
+    // render disabled controls rather than making a show/hide decision too early.
+    if (selectedAlertmanager === undefined) {
+      return Loading;
+    }
+
+    const permissions = isGrafanaAlertmanager ? GRAFANA_PERMISSIONS : EXTERNAL_PERMISSIONS;
+
     switch (payload.action) {
       case SilenceAction.View:
-      case SilenceAction.Preview: {
-        // Permission differs between Grafana-managed and external alertmanagers.
-        // Return Loading until the selected alertmanager is resolved.
-        if (selectedAlertmanager === undefined) {
-          return Loading;
-        }
-        const permissions = getInstancesPermissions(selectedAlertmanager);
-        // For Grafana AM, also accept alert.silences:read — the backend HTTP gate
-        // accepts either action and the frontend should mirror that.
-        const acceptedPermissions =
-          permissions.read === instancesPermissions.read.grafana
-            ? [instancesPermissions.read.grafana, silencesPermissions.read.grafana]
-            : [permissions.read];
-        return makeAbility(true, acceptedPermissions);
-      }
+      case SilenceAction.Preview:
+        return makeAbility(true, permissions[payload.action]);
 
-      case SilenceAction.Create: {
-        // Permission differs between Grafana-managed and external alertmanagers.
-        // Return Loading until the selected alertmanager is resolved so callers
-        // can render a disabled button rather than making a decision with no context.
-        if (selectedAlertmanager === undefined) {
-          return Loading;
-        }
-        const permissions = getInstancesPermissions(selectedAlertmanager);
-        // For Grafana AM, also accept alert.silences:create — the backend HTTP gate
-        // accepts either action and the frontend should mirror that.
-        const acceptedPermissions =
-          permissions.create === instancesPermissions.create.grafana
-            ? [instancesPermissions.create.grafana, silencesPermissions.create.grafana]
-            : [permissions.create];
-        return makeAbility(true, acceptedPermissions);
-      }
+      case SilenceAction.Create:
+        return makeAbility(true, permissions[SilenceAction.Create]);
 
-      case SilenceAction.Update: {
-        // Permission differs between Grafana-managed and external alertmanagers.
-        // Return Loading until the selected alertmanager is resolved.
-        if (selectedAlertmanager === undefined) {
-          return Loading;
-        }
-        const permissions = getInstancesPermissions(selectedAlertmanager);
-        // For Grafana AM, also accept alert.silences:write — the backend HTTP gate
-        // accepts either action and the frontend should mirror that.
-        const acceptedPermissions =
-          permissions.update === instancesPermissions.update.grafana
-            ? [instancesPermissions.update.grafana, silencesPermissions.update.grafana]
-            : [permissions.update];
-
+      case SilenceAction.Update:
         if (payload.context?.accessControl?.write === false) {
-          return InsufficientPermissions(acceptedPermissions);
+          return InsufficientPermissions(permissions[SilenceAction.Update]);
         }
-        return makeAbility(true, acceptedPermissions);
-      }
+        return makeAbility(true, permissions[SilenceAction.Update]);
     }
-  }, [payload, selectedAlertmanager]);
+  }, [payload, selectedAlertmanager, isGrafanaAlertmanager]);
 }

--- a/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.ts
+++ b/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.ts
@@ -45,10 +45,8 @@ export function useSilenceAbility(payload: SilenceAbilityParam): AsyncAbility {
     switch (payload.action) {
       case SilenceAction.View:
       case SilenceAction.Preview:
-        return makeAbility(true, permissions[payload.action]);
-
       case SilenceAction.Create:
-        return makeAbility(true, permissions[SilenceAction.Create]);
+        return makeAbility(true, permissions[payload.action]);
 
       case SilenceAction.Update:
         if (payload.context?.accessControl?.write === false) {

--- a/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.ts
+++ b/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import { type Silence } from 'app/plugins/datasource/alertmanager/types';
-import { type AccessControlAction } from 'app/types/accessControl';
 
 import { useAlertmanager } from '../../../state/AlertmanagerContext';
 import { getInstancesPermissions, instancesPermissions, silencesPermissions } from '../../../utils/access-control';
@@ -14,21 +13,27 @@ export type SilenceAbilityParam =
   | { action: SilenceAction.Preview }
   | { action: SilenceAction.Update; context?: Silence };
 
-const PERMISSIONS: Record<SilenceAction, AccessControlAction[]> = {
-  [SilenceAction.View]: [instancesPermissions.read.grafana],
-  [SilenceAction.Create]: [instancesPermissions.create.grafana],
-  [SilenceAction.Update]: [instancesPermissions.update.grafana],
-  [SilenceAction.Preview]: [instancesPermissions.read.grafana],
-};
-
 export function useSilenceAbility(payload: SilenceAbilityParam): AsyncAbility {
   const { selectedAlertmanager } = useAlertmanager();
 
   return useMemo(() => {
     switch (payload.action) {
       case SilenceAction.View:
-      case SilenceAction.Preview:
-        return makeAbility(true, PERMISSIONS[payload.action]);
+      case SilenceAction.Preview: {
+        // Permission differs between Grafana-managed and external alertmanagers.
+        // Return Loading until the selected alertmanager is resolved.
+        if (selectedAlertmanager === undefined) {
+          return Loading;
+        }
+        const permissions = getInstancesPermissions(selectedAlertmanager);
+        // For Grafana AM, also accept alert.silences:read — the backend HTTP gate
+        // accepts either action and the frontend should mirror that.
+        const acceptedPermissions =
+          permissions.read === instancesPermissions.read.grafana
+            ? [instancesPermissions.read.grafana, silencesPermissions.read.grafana]
+            : [permissions.read];
+        return makeAbility(true, acceptedPermissions);
+      }
 
       case SilenceAction.Create: {
         // Permission differs between Grafana-managed and external alertmanagers.
@@ -48,10 +53,23 @@ export function useSilenceAbility(payload: SilenceAbilityParam): AsyncAbility {
       }
 
       case SilenceAction.Update: {
-        if (payload.context?.accessControl?.write === false) {
-          return InsufficientPermissions(PERMISSIONS[SilenceAction.Update]);
+        // Permission differs between Grafana-managed and external alertmanagers.
+        // Return Loading until the selected alertmanager is resolved.
+        if (selectedAlertmanager === undefined) {
+          return Loading;
         }
-        return makeAbility(true, PERMISSIONS[SilenceAction.Update]);
+        const permissions = getInstancesPermissions(selectedAlertmanager);
+        // For Grafana AM, also accept alert.silences:write — the backend HTTP gate
+        // accepts either action and the frontend should mirror that.
+        const acceptedPermissions =
+          permissions.update === instancesPermissions.update.grafana
+            ? [instancesPermissions.update.grafana, silencesPermissions.update.grafana]
+            : [permissions.update];
+
+        if (payload.context?.accessControl?.write === false) {
+          return InsufficientPermissions(acceptedPermissions);
+        }
+        return makeAbility(true, acceptedPermissions);
       }
     }
   }, [payload, selectedAlertmanager]);


### PR DESCRIPTION
**What is this feature?**

Migrates the silences UI away from the monolithic `useAlertmanagerAbility` / `contextSrv` / `<Authorize>` pattern to the focused ability hooks introduced in PR #123338 (4 of N in the series).

**Why do we need this feature?**

Following up on #123338 which introduced the new modular ability system. This PR updates silence-related components to use `useSilenceAbility` directly, removing direct usages of `useAlertmanagerAbility` and `contextSrv.hasPermission`.

Components migrated:
- `NoSilencesCTA.tsx`
- `SilencesTable.tsx`
- `SilencesEditor.tsx`
- `SilenceViewContent.tsx`
- `SilencedInstancesPreview.tsx`

**Who is this feature for?**

Internal: alerting squad engineers.

**Which issue(s) does this PR fix?**

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
