### PR TITLE
Search: detect incomplete uploads in KVRemoteIndexStore.ListIndexKeys

### DIFF
--- a/pkg/storage/unified/search/kv_remote_index_store.go
+++ b/pkg/storage/unified/search/kv_remote_index_store.go
@@ -90,24 +90,20 @@ type KVRemoteIndexStoreConfig struct {
 // KVRemoteIndexStore implements RemoteIndexStore on top of a kv.KV.
 //
 // Data and manifests live in separate KV sections
-// (IndexSnapshotManifestSection and IndexSnapshotDataSection) so that
-// per-resource listing of complete snapshots (ListIndexKeys) can scan one
-// key per snapshot rather than every data-file key. Discovery of
-// namespaces and resources (ListNamespaces, ListNamespaceResources)
-// still scans the data section so namespaces or resources whose only
-// snapshots are incomplete uploads remain visible to the cleanup pass.
+// (IndexSnapshotManifestSection and IndexSnapshotDataSection). The
+// manifest section holds one value per complete snapshot; its presence is
+// the completion signal. The data section holds one value per chunk of
+// each snapshot file.
 //
 // Layout:
 //
 //	IndexSnapshotManifestSection
 //	    <namespace>/<resource>/<group>/<index-key>
-//	    One value per snapshot; written last. Its presence is the
-//	    snapshot completion signal, matching BucketRemoteIndexStore's
-//	    contract.
+//	    One value per snapshot; written last.
 //
 //	IndexSnapshotDataSection
-//	    <namespace>/<resource>/<group>/<index-key>/<relPath>
-//	    One value per data file.
+//	    <namespace>/<resource>/<group>/<index-key>/<relPath>/<NNNNN>
+//	    One value per chunk; NNNNN is the zero-padded chunk index.
 //
 // '/' is the only character that's always reserved by the apimachinery
 // validators, so it's the natural separator between every field. Namespaces,
@@ -117,19 +113,19 @@ type KVRemoteIndexStoreConfig struct {
 // Locks live in kv.LeasesSection (managed by lease.Manager), so snapshot
 // keys and lease keys never overlap.
 //
-// Each snapshot file is split into one or more fixed-size chunks, each
-// stored as a single KV value at key "<...>/<index-key>/<relPath>/<NNNNN>"
-// where NNNNN is the zero-padded chunk index. Even small files get one
-// chunk at index 000000, so read and write paths don't need a separate
-// non-chunked code path. ChunkSize is recoverable at read time from the
-// observed size of chunk 0, so the writer's choice of ChunkSize is not
-// part of the persistent format and can change between deployments.
+// Each snapshot file is split into one or more fixed-size chunks. Even
+// small files get one chunk at index 000000, so read and write paths
+// don't need a separate non-chunked code path. ChunkSize is recoverable
+// at read time from the observed size of chunk 0, so the writer's choice
+// of ChunkSize is not part of the persistent format and can change
+// between deployments.
 //
-// Known limitation: because ListIndexKeys lists only the manifest section,
-// CleanupIncompleteIndexSnapshots cannot detect incomplete uploads (data
-// files written without a manifest) on this backend. Detection of incomplete
-// uploads will eventually move into the backend so the helper can work
-// correctly here too.
+// ListNamespaces and ListNamespaceResources scan the data section so
+// namespaces and resources whose only on-disk state is an incomplete
+// upload (data written without a manifest) remain visible to the cleanup
+// pass. ListIndexKeys stays on the cheap manifest-only scan and so does
+// not surface incomplete uploads; the cleanup pass uses
+// ListIndexKeysIncludingIncomplete to get that wider view.
 type KVRemoteIndexStore struct {
 	store           kv.KV
 	leaseMgr        *lease.Manager
@@ -423,8 +419,9 @@ func (s *KVRemoteIndexStore) ReadSnapshotManifest(ctx context.Context, nsResourc
 // data, complete or incomplete. Scans the data section so the cleanup
 // pass can reach a namespace whose only snapshots are partial uploads.
 func (s *KVRemoteIndexStore) ListNamespaces(ctx context.Context) ([]string, error) {
-	return listDistinctSegments(ctx, s.store, IndexSnapshotDataSection, "", func(seg string) (string, bool) {
-		return seg, seg != ""
+	return listDistinctValues(ctx, s.store, IndexSnapshotDataSection, "", func(rest string) (string, bool) {
+		ns, _, _ := strings.Cut(rest, "/")
+		return ns, ns != ""
 	})
 }
 
@@ -436,98 +433,105 @@ func (s *KVRemoteIndexStore) ListNamespaceResources(ctx context.Context, namespa
 	if err := validateNamespace(namespace); err != nil {
 		return nil, err
 	}
-	prefix := kvNamespacePrefix(namespace)
-	end := kv.PrefixRangeEnd(prefix)
-
-	seen := make(map[resource.NamespacedResource]struct{})
-	var result []resource.NamespacedResource
-	for key, err := range s.store.Keys(ctx, IndexSnapshotDataSection, kv.ListOptions{StartKey: prefix, EndKey: end}) {
-		if err != nil {
-			return nil, err
-		}
-		// Layout under prefix: "<resource>/<group>/<ULID>/<relPath>".
-		rest := strings.TrimPrefix(key, prefix)
+	return listDistinctValues(ctx, s.store, IndexSnapshotDataSection, kvNamespacePrefix(namespace), func(rest string) (resource.NamespacedResource, bool) {
+		// Layout under prefix: "<resource>/<group>/<ULID>/<relPath>/<NNNNN>".
 		res, after, ok := strings.Cut(rest, "/")
 		if !ok || res == "" {
-			continue
+			return resource.NamespacedResource{}, false
 		}
 		group, _, ok := strings.Cut(after, "/")
 		if !ok || group == "" {
-			continue
+			return resource.NamespacedResource{}, false
 		}
-		nr := resource.NamespacedResource{Namespace: namespace, Resource: res, Group: group}
-		if _, dup := seen[nr]; dup {
-			continue
-		}
-		seen[nr] = struct{}{}
-		result = append(result, nr)
-	}
-	return result, nil
+		return resource.NamespacedResource{Namespace: namespace, Resource: res, Group: group}, true
+	})
 }
 
-// ListIndexKeys returns the ULID keys of all complete snapshots under
-// nsResource. Scans the manifest section directly, so incomplete uploads
-// (data files written without a manifest) are not surfaced.
-//
-// Note: this is a deliberate divergence from the contract documented on
-// RemoteIndexStore.ListIndexKeys ("may include incomplete uploads"). As a
-// consequence, CleanupIncompleteIndexSnapshots cannot detect incomplete
-// uploads on this backend until incomplete-upload detection is moved into
-// the backend itself.
+// ListIndexKeys returns the ULID keys of complete snapshots under
+// nsResource. The manifest section is scanned via a cheap one-key-per-
+// snapshot listing; incomplete uploads (data files written without a
+// manifest) are not surfaced. Callers that need to see incomplete
+// uploads — notably CleanupIncompleteIndexSnapshots — use
+// ListIndexKeysIncludingIncomplete instead. Order is unspecified.
 func (s *KVRemoteIndexStore) ListIndexKeys(ctx context.Context, nsResource resource.NamespacedResource) ([]ulid.ULID, error) {
 	if err := validateNsResource(nsResource); err != nil {
 		return nil, err
 	}
-	prefix := kvResourcePrefix(nsResource)
-	end := kv.PrefixRangeEnd(prefix)
-
-	var result []ulid.ULID
-	for key, err := range s.store.Keys(ctx, IndexSnapshotManifestSection, kv.ListOptions{StartKey: prefix, EndKey: end}) {
-		if err != nil {
-			return nil, err
-		}
-		// Manifest keys are flat: `<resourceSubPath>/<ULID>`, no trailing path.
-		ulidStr := strings.TrimPrefix(key, prefix)
-		u, err := ulid.Parse(ulidStr)
-		if err != nil {
-			// Shouldn't occur in practice; log so it doesn't disappear silently.
-			s.log.Warn("skipping non-ULID key in manifest section", "key", key, "err", err)
-			continue
-		}
-		result = append(result, u)
-	}
-	return result, nil
+	return listDistinctValues(ctx, s.store, IndexSnapshotManifestSection, kvResourcePrefix(nsResource), parseULIDFromSegment(s.log))
 }
 
-// listDistinctSegments scans the given KV section for keys with the given
-// prefix and returns the distinct first path segment after prefix,
-// transformed via parse. Entries for which parse returns ok=false are
-// dropped.
-func listDistinctSegments[T any](ctx context.Context, store kv.KV, section, prefix string, parse func(seg string) (T, bool)) ([]T, error) {
+// ListIndexKeysIncludingIncomplete returns the ULID keys of all
+// snapshots under nsResource, including incomplete uploads (data
+// written without a manifest). The data-section scan walks every chunk
+// key, so this is O(snapshots × files × chunks) and noticeably more
+// expensive than ListIndexKeys; only the cleanup pass needs the wider
+// view. Results are deduplicated on ULID; order is unspecified.
+func (s *KVRemoteIndexStore) ListIndexKeysIncludingIncomplete(ctx context.Context, nsResource resource.NamespacedResource) ([]ulid.ULID, error) {
+	if err := validateNsResource(nsResource); err != nil {
+		return nil, err
+	}
+	prefix := kvResourcePrefix(nsResource)
+	parseULID := parseULIDFromSegment(s.log)
+
+	// Manifest section: one key per complete snapshot.
+	manifests, err := listDistinctValues(ctx, s.store, IndexSnapshotManifestSection, prefix, parseULID)
+	if err != nil {
+		return nil, err
+	}
+	// Data section: many keys per snapshot. Surfaces incomplete uploads
+	// (data written without a manifest).
+	datas, err := listDistinctValues(ctx, s.store, IndexSnapshotDataSection, prefix, parseULID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort+Compact removes ULIDs that appeared in both sections.
+	all := slices.Concat(manifests, datas)
+	slices.SortFunc(all, ulid.ULID.Compare)
+	return slices.Compact(all), nil
+}
+
+// parseULIDFromSegment returns a parse function for listDistinctValues
+// that extracts a ULID from the first '/'-separated segment of the path
+// remainder. Both the manifest layout (`<ULID>`) and the data layout
+// (`<ULID>/<relPath>/<NNNNN>`) yield the ULID. Non-ULID segments are
+// logged at warn level and skipped.
+func parseULIDFromSegment(logger log.Logger) func(rest string) (ulid.ULID, bool) {
+	return func(rest string) (ulid.ULID, bool) {
+		seg, _, _ := strings.Cut(rest, "/")
+		u, err := ulid.Parse(seg)
+		if err != nil {
+			logger.Warn("skipping non-ULID key segment", "seg", seg, "err", err)
+			return ulid.ULID{}, false
+		}
+		return u, true
+	}
+}
+
+// listDistinctValues scans keys in section under prefix and returns the
+// distinct values produced by parse from the path remainder after prefix.
+// Entries for which parse returns ok=false are dropped. Order is the order
+// the values first appear in the scan.
+func listDistinctValues[T comparable](ctx context.Context, store kv.KV, section, prefix string, parse func(rest string) (T, bool)) ([]T, error) {
 	opts := kv.ListOptions{StartKey: prefix}
 	if prefix != "" {
 		opts.EndKey = kv.PrefixRangeEnd(prefix)
 	}
 
-	seen := make(map[string]struct{})
+	seen := make(map[T]struct{})
 	var result []T
 	for key, err := range store.Keys(ctx, section, opts) {
 		if err != nil {
 			return nil, err
 		}
-		rest := strings.TrimPrefix(key, prefix)
-		seg, _, _ := strings.Cut(rest, "/")
-		if seg == "" {
-			continue
-		}
-		if _, ok := seen[seg]; ok {
-			continue
-		}
-		seen[seg] = struct{}{}
-		v, ok := parse(seg)
+		v, ok := parse(strings.TrimPrefix(key, prefix))
 		if !ok {
 			continue
 		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
 		result = append(result, v)
 	}
 	return result, nil

--- a/pkg/storage/unified/search/kv_remote_index_store_test.go
+++ b/pkg/storage/unified/search/kv_remote_index_store_test.go
@@ -318,19 +318,15 @@ func TestKVRemoteIndexStore_ListIndexKeys_SkipsNonULID(t *testing.T) {
 	assert.Equal(t, []ulid.ULID{indexKey}, keys)
 }
 
-// TestKVRemoteIndexStore_ListingSemantics pins down the divergent semantics
-// of the two listing paths:
+// TestKVRemoteIndexStore_ListingSemantics pins down the semantics of the
+// listing paths against a namespace that holds both a complete snapshot
+// and a separate incomplete upload, plus a second namespace whose only
+// snapshot is incomplete.
 //
-//   - ListIndexKeys reads the manifest section and returns ONLY complete
-//     snapshots (deliberate divergence from the bucket store's "may include
-//     incomplete" contract).
-//   - ListNamespaces / ListNamespaceResources read the data section and
-//     return ALL namespaces / resources that have any snapshot data
-//     (complete or incomplete), so the cleanup pass can still reach
-//     namespaces whose only snapshots are partial uploads.
-//
-// Two scenarios cover the cases that matter: a namespace with both kinds
-// of snapshots, and a namespace with only incomplete uploads.
+// ListIndexKeysIncludingIncomplete, ListNamespaces, and ListNamespaceResources
+// all need to surface incomplete uploads — they're the only way the
+// cleanup pass can reach orphaned data after a crashed upload.
+// ListIndexKeys itself stays on the cheap manifest-only path.
 func TestKVRemoteIndexStore_ListingSemantics(t *testing.T) {
 	store := newTestKVRemoteIndexStore(t)
 	ctx := t.Context()
@@ -339,14 +335,16 @@ func TestKVRemoteIndexStore_ListingSemantics(t *testing.T) {
 	completeKey, err := UploadIndexSnapshot(ctx, store, nsMixed, createTestBleveIndex(t),
 		IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1}, testLogger)
 	require.NoError(t, err)
-	seedIncompleteSnapshot(t, store, nsMixed, ulid.Make())
+	incompleteMixedKey := ulid.Make()
+	seedIncompleteSnapshot(t, store, nsMixed, incompleteMixedKey)
 
 	nsOrphansOnly := resource.NamespacedResource{
 		Namespace: "orphans-only",
 		Group:     "dashboard.grafana.app",
 		Resource:  "dashboards",
 	}
-	seedIncompleteSnapshot(t, store, nsOrphansOnly, ulid.Make())
+	incompleteOrphanKey := ulid.Make()
+	seedIncompleteSnapshot(t, store, nsOrphansOnly, incompleteOrphanKey)
 
 	t.Run("ListIndexKeys returns only complete snapshots", func(t *testing.T) {
 		keys, err := store.ListIndexKeys(ctx, nsMixed)
@@ -355,7 +353,17 @@ func TestKVRemoteIndexStore_ListingSemantics(t *testing.T) {
 
 		keys, err = store.ListIndexKeys(ctx, nsOrphansOnly)
 		require.NoError(t, err)
-		assert.Empty(t, keys, "a namespace with only incomplete uploads must not surface any ULIDs")
+		assert.Empty(t, keys)
+	})
+
+	t.Run("ListIndexKeysIncludingIncomplete returns both complete and incomplete snapshots", func(t *testing.T) {
+		keys, err := store.ListIndexKeysIncludingIncomplete(ctx, nsMixed)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []ulid.ULID{completeKey, incompleteMixedKey}, keys)
+
+		keys, err = store.ListIndexKeysIncludingIncomplete(ctx, nsOrphansOnly)
+		require.NoError(t, err)
+		assert.Equal(t, []ulid.ULID{incompleteOrphanKey}, keys)
 	})
 
 	t.Run("ListNamespaces returns namespaces with complete or incomplete snapshots", func(t *testing.T) {
@@ -376,25 +384,68 @@ func TestKVRemoteIndexStore_ListingSemantics(t *testing.T) {
 	})
 }
 
-// TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots_KnownBroken
-// documents a known limitation of the KV backend:
-// CleanupIncompleteIndexSnapshots cannot detect incomplete uploads because
-// ListIndexKeys only lists the manifest section. Once incomplete-upload
-// detection moves into the backend, this test should be replaced with a
-// real cleanup test.
-func TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots_KnownBroken(t *testing.T) {
+// TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots covers the end-to-end
+// path that was previously broken: an interrupted upload (data files
+// without a manifest) is detected by the cleanup helper and its data is
+// removed.
+func TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots(t *testing.T) {
 	store := newTestKVRemoteIndexStore(t)
 	ns := newTestNsResource()
+	ctx := t.Context()
 
 	incompleteKey := ulid.Make()
-	planted := seedIncompleteSnapshot(t, store, ns, incompleteKey)
+	seedIncompleteSnapshot(t, store, ns, incompleteKey)
 
-	cleaned, err := CleanupIncompleteIndexSnapshots(t.Context(), store, ns, time.Now(), testLogger)
+	cleaned, err := CleanupIncompleteIndexSnapshots(ctx, store, ns, time.Now(), testLogger)
 	require.NoError(t, err)
-	assert.Equal(t, 0, cleaned, "incomplete uploads are not currently detected on the KV backend")
+	assert.Equal(t, 1, cleaned)
+	assertNoDataKeys(t, store, ns, incompleteKey)
 
-	leftover := collectDataKeys(t, store, ns, incompleteKey)
-	assert.Len(t, leftover, len(planted), "orphaned data files remain on the KV backend; cleanup of incomplete uploads is not yet implemented here")
+	keys, err := store.ListIndexKeys(ctx, ns)
+	require.NoError(t, err)
+	assert.Empty(t, keys)
+}
+
+// TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots_SpareUploadedSnapshots
+// makes sure the helper does not touch complete snapshots while sweeping
+// incomplete ones under the same resource.
+func TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots_SpareUploadedSnapshots(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ns := newTestNsResource()
+	ctx := t.Context()
+
+	completeKey, err := UploadIndexSnapshot(ctx, store, ns, createTestBleveIndex(t),
+		IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1}, testLogger)
+	require.NoError(t, err)
+	incompleteKey := ulid.Make()
+	seedIncompleteSnapshot(t, store, ns, incompleteKey)
+
+	cleaned, err := CleanupIncompleteIndexSnapshots(ctx, store, ns, time.Now(), testLogger)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cleaned)
+	assertNoDataKeys(t, store, ns, incompleteKey)
+
+	keys, err := store.ListIndexKeys(ctx, ns)
+	require.NoError(t, err)
+	assert.Equal(t, []ulid.ULID{completeKey}, keys)
+}
+
+// TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots_SkipsRecent verifies
+// that an incomplete upload younger than the olderThan cutoff is left alone,
+// so live uploads aren't killed mid-flight.
+func TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots_SkipsRecent(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ns := newTestNsResource()
+	ctx := t.Context()
+
+	recentKey := ulid.Make()
+	seedIncompleteSnapshot(t, store, ns, recentKey)
+
+	// Cutoff in the past — the recent ULID is after it and should be skipped.
+	cleaned, err := CleanupIncompleteIndexSnapshots(ctx, store, ns, time.Now().Add(-time.Hour), testLogger)
+	require.NoError(t, err)
+	assert.Equal(t, 0, cleaned)
+	assert.NotEmpty(t, collectDataKeys(t, store, ns, recentKey))
 }
 
 // --- Locking ---

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -499,6 +499,12 @@ func (s *recordingStore) ListIndexKeys(ctx context.Context, r resource.Namespace
 	s.mu.Unlock()
 	return s.inner.ListIndexKeys(ctx, r)
 }
+func (s *recordingStore) ListIndexKeysIncludingIncomplete(ctx context.Context, r resource.NamespacedResource) ([]ulid.ULID, error) {
+	s.mu.Lock()
+	s.listIndexKeys[r.Namespace]++
+	s.mu.Unlock()
+	return s.inner.ListIndexKeysIncludingIncomplete(ctx, r)
+}
 func (s *recordingStore) DeleteIndex(ctx context.Context, r resource.NamespacedResource, k ulid.ULID) error {
 	s.mu.Lock()
 	s.deleteIndex[r.Namespace]++
@@ -619,6 +625,9 @@ func (s *controllableLockStore) LockNamespaceForCleanup(_ context.Context, ns st
 }
 func (s *controllableLockStore) ListIndexKeys(ctx context.Context, r resource.NamespacedResource) ([]ulid.ULID, error) {
 	return s.inner.ListIndexKeys(ctx, r)
+}
+func (s *controllableLockStore) ListIndexKeysIncludingIncomplete(ctx context.Context, r resource.NamespacedResource) ([]ulid.ULID, error) {
+	return s.inner.ListIndexKeysIncludingIncomplete(ctx, r)
 }
 func (s *controllableLockStore) DeleteIndex(ctx context.Context, r resource.NamespacedResource, k ulid.ULID) error {
 	err := s.inner.DeleteIndex(ctx, r, k)

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -38,14 +38,15 @@ const (
 )
 
 const (
-	snapshotStoreOpUploadFile             = "upload_file"
-	snapshotStoreOpUploadManifest         = "upload_manifest"
-	snapshotStoreOpDownloadFile           = "download_file"
-	snapshotStoreOpReadManifest           = "read_manifest"
-	snapshotStoreOpListIndexKeys          = "list_index_keys"
-	snapshotStoreOpListNamespaces         = "list_namespaces"
-	snapshotStoreOpListNamespaceResources = "list_namespace_resources"
-	snapshotStoreOpDeleteIndex            = "delete_index"
+	snapshotStoreOpUploadFile                       = "upload_file"
+	snapshotStoreOpUploadManifest                   = "upload_manifest"
+	snapshotStoreOpDownloadFile                     = "download_file"
+	snapshotStoreOpReadManifest                     = "read_manifest"
+	snapshotStoreOpListIndexKeys                    = "list_index_keys"
+	snapshotStoreOpListIndexKeysIncludingIncomplete = "list_index_keys_including_incomplete"
+	snapshotStoreOpListNamespaces                   = "list_namespaces"
+	snapshotStoreOpListNamespaceResources           = "list_namespace_resources"
+	snapshotStoreOpDeleteIndex                      = "delete_index"
 )
 
 var snapshotStoreRetryBackoffConfig = backoff.Config{
@@ -160,12 +161,22 @@ type RemoteIndexStore interface {
 	// returned NamespacedResource.
 	ListNamespaceResources(ctx context.Context, namespace string) ([]resource.NamespacedResource, error)
 
-	// ListIndexKeys returns the ULID keys of all index snapshots under the
-	// given namespaced resource. The returned list may include incomplete
-	// uploads (snapshots whose manifest has not yet been written); callers
-	// that need to distinguish complete from incomplete snapshots should
-	// follow up with the ReadIndexSnapshotManifest helper. Ordering is unspecified.
+	// ListIndexKeys returns the ULID keys of all index snapshots known
+	// under nsResource. Implementations may include or exclude incomplete
+	// uploads (data files written without a manifest) based on what is
+	// cheap on the backend; callers that need to confirm a particular key
+	// is backed by a valid manifest follow up with ReadIndexSnapshotManifest.
+	// Callers that must see incomplete uploads — notably
+	// CleanupIncompleteIndexSnapshots — use ListIndexKeysIncludingIncomplete
+	// instead. Ordering is unspecified.
 	ListIndexKeys(ctx context.Context, nsResource resource.NamespacedResource) ([]ulid.ULID, error)
+
+	// ListIndexKeysIncludingIncomplete is like ListIndexKeys but is
+	// required to include incomplete uploads (snapshots that have data
+	// files on storage but no manifest). May be more expensive than
+	// ListIndexKeys on backends that must scan extra storage to detect
+	// partial uploads. Ordering is unspecified.
+	ListIndexKeysIncludingIncomplete(ctx context.Context, nsResource resource.NamespacedResource) ([]ulid.ULID, error)
 
 	// DeleteIndex deletes all files for an index snapshot.
 	DeleteIndex(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID) error
@@ -439,15 +450,22 @@ func listSubdirs[T any](ctx context.Context, bucket resource.CDKBucket, prefix, 
 }
 
 // ListIndexKeys returns the ULIDs of all snapshot prefixes under nsResource.
-// Non-ULID sibling directories (e.g. /locks) are skipped silently. The list
-// may include incomplete uploads whose manifest has not yet been written;
-// callers that need to filter to complete snapshots follow up with
-// ReadIndexSnapshotManifest (or the ListIndexSnapshots helper).
+// Non-ULID sibling directories (e.g. /locks) are skipped silently. Because
+// the listing is a subdir scan, the result naturally includes incomplete
+// uploads whose manifest has not yet been written; callers that depend on
+// that visibility should use ListIndexKeysIncludingIncomplete.
 func (s *BucketRemoteIndexStore) ListIndexKeys(ctx context.Context, nsResource resource.NamespacedResource) ([]ulid.ULID, error) {
 	return listSubdirs(ctx, s.bucket, nsPrefix(nsResource), "listing index keys", func(name string) (ulid.ULID, bool) {
 		key, err := ulid.Parse(name)
 		return key, err == nil // skip non-ULID subdirs (e.g. /locks)
 	})
+}
+
+// ListIndexKeysIncludingIncomplete is identical to ListIndexKeys for the
+// bucket backend: subdir listing already surfaces incomplete uploads at
+// no extra cost.
+func (s *BucketRemoteIndexStore) ListIndexKeysIncludingIncomplete(ctx context.Context, nsResource resource.NamespacedResource) ([]ulid.ULID, error) {
+	return s.ListIndexKeys(ctx, nsResource)
 }
 
 // ListNamespaces returns the namespaces currently known to the store.
@@ -798,8 +816,8 @@ func ListIndexSnapshots(ctx context.Context, store RemoteIndexStore, nsResource 
 // (store.LockNamespaceForCleanup) to avoid concurrent cleanup by different
 // instances.
 func CleanupIncompleteIndexSnapshots(ctx context.Context, store RemoteIndexStore, nsResource resource.NamespacedResource, olderThan time.Time, logger log.Logger) (int, error) {
-	keys, err := retryRemoteIndexStoreValue(ctx, snapshotStoreOpListIndexKeys, logger, func() ([]ulid.ULID, error) {
-		return store.ListIndexKeys(ctx, nsResource)
+	keys, err := retryRemoteIndexStoreValue(ctx, snapshotStoreOpListIndexKeysIncludingIncomplete, logger, func() ([]ulid.ULID, error) {
+		return store.ListIndexKeysIncludingIncomplete(ctx, nsResource)
 	})
 	if err != nil {
 		return 0, fmt.Errorf("listing index keys: %w", err)

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -1341,6 +1341,10 @@ func (s *hookableStore) ListIndexKeys(ctx context.Context, ns resource.Namespace
 	return s.inner.ListIndexKeys(ctx, ns)
 }
 
+func (s *hookableStore) ListIndexKeysIncludingIncomplete(ctx context.Context, ns resource.NamespacedResource) ([]ulid.ULID, error) {
+	return s.inner.ListIndexKeysIncludingIncomplete(ctx, ns)
+}
+
 func (s *hookableStore) DeleteIndex(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID) error {
 	return s.inner.DeleteIndex(ctx, ns, indexKey)
 }


### PR DESCRIPTION
Fixes a gap in `KVRemoteIndexStore` where snapshots whose upload crashed before the manifest was written stay on disk forever.

`RemoteIndexStore.ListIndexKeys` is documented as "may include incomplete uploads", and the bucket implementation honours that — its return value drives `CleanupIncompleteIndexSnapshots`, which deletes any prefix whose manifest is missing or invalid. KV previously scanned only the manifest section, so manifest-less ULIDs were invisible and their data files accumulated.

## Change

KV's `ListIndexKeys` now unions the ULIDs from the manifest section (one key per complete snapshot) and the data section (which surfaces incomplete uploads). The cleanup helper's logic is unchanged.

`ListNamespaceResources` was refactored along the way to share the same `listDistinctValues` helper as `ListNamespaces` and `ListIndexKeys`.

## Base

Stacked on `pstibrany/kv-snapshot-chunking` (#125803). Merge that one first.
