### PR TITLE
Provisioning: Generalize the job admission validator

### DIFF
--- a/apps/provisioning/pkg/jobs/validator.go
+++ b/apps/provisioning/pkg/jobs/validator.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -15,8 +16,10 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
-// ValidateJob performs validation on the Job specification and returns an error if validation fails
-func ValidateJob(job *provisioning.Job) error {
+// ValidateJob performs validation on the Job specification and returns an error if validation fails.
+// supportedResources is the configured set of resource types provisioning can manage; export-style
+// job options (push and migrate) are validated against it.
+func ValidateJob(job *provisioning.Job, supportedResources []provisioning.SupportedResource) error {
 	list := field.ErrorList{}
 
 	// Validate action is specified
@@ -42,7 +45,7 @@ func ValidateJob(job *provisioning.Job) error {
 		if job.Spec.Push == nil {
 			list = append(list, field.Required(field.NewPath("spec", "push"), "push options required for push action"))
 		} else {
-			list = append(list, validateExportJobOptions(job.Spec.Push)...)
+			list = append(list, validateExportJobOptions(job.Spec.Push, supportedResources)...)
 		}
 
 	case provisioning.JobActionPullRequest:
@@ -55,7 +58,7 @@ func ValidateJob(job *provisioning.Job) error {
 		if job.Spec.Migrate == nil {
 			list = append(list, field.Required(field.NewPath("spec", "migrate"), "migrate options required for migrate action"))
 		} else {
-			list = append(list, validateMigrateJobOptions(job.Spec.Migrate)...)
+			list = append(list, validateMigrateJobOptions(job.Spec.Migrate, supportedResources)...)
 		}
 
 	case provisioning.JobActionDelete:
@@ -98,7 +101,7 @@ func toError(name string, list field.ErrorList) error {
 }
 
 // validateExportJobOptions validates export (push) job options
-func validateExportJobOptions(opts *provisioning.ExportJobOptions) field.ErrorList {
+func validateExportJobOptions(opts *provisioning.ExportJobOptions, supportedResources []provisioning.SupportedResource) field.ErrorList {
 	list := field.ErrorList{}
 
 	// Validate branch name if specified
@@ -117,27 +120,28 @@ func validateExportJobOptions(opts *provisioning.ExportJobOptions) field.ErrorLi
 
 	// Empty Resources is valid: the worker falls back to exporting every
 	// unmanaged resource (legacy behavior).
-	list = append(list, validateExportResourceRefs(field.NewPath("spec", "push", "resources"), opts.Resources)...)
+	list = append(list, validateExportResourceRefs(field.NewPath("spec", "push", "resources"), opts.Resources, supportedResources)...)
 
 	return list
 }
 
 // validateMigrateJobOptions validates migrate job options
-func validateMigrateJobOptions(opts *provisioning.MigrateJobOptions) field.ErrorList {
+func validateMigrateJobOptions(opts *provisioning.MigrateJobOptions, supportedResources []provisioning.SupportedResource) field.ErrorList {
 	list := field.ErrorList{} //nolint:prealloc
 
 	// Empty Resources is valid: the worker falls back to migrating every
 	// unmanaged resource (legacy behavior).
-	list = append(list, validateExportResourceRefs(field.NewPath("spec", "migrate", "resources"), opts.Resources)...)
+	list = append(list, validateExportResourceRefs(field.NewPath("spec", "migrate", "resources"), opts.Resources, supportedResources)...)
 
 	return list
 }
 
-// validateExportResourceRefs enforces the rules shared by export-style
-// resource lists (push and migrate): name + kind required, only Dashboard is
-// supported, and a non-empty group must match the dashboard group.
-func validateExportResourceRefs(base *field.Path, refs []provisioning.ResourceRef) field.ErrorList {
+// validateExportResourceRefs enforces the rules shared by export-style resource
+// lists (push and migrate): name + kind are required, and each kind/group must
+// match an active entry in the configured supported-resource set.
+func validateExportResourceRefs(base *field.Path, refs []provisioning.ResourceRef, supportedResources []provisioning.SupportedResource) field.ErrorList {
 	list := field.ErrorList{}
+	supported := activeExportResources(supportedResources)
 	for i, r := range refs {
 		path := base.Index(i)
 		if r.Name == "" {
@@ -145,16 +149,59 @@ func validateExportResourceRefs(base *field.Path, refs []provisioning.ResourceRe
 		}
 		if r.Kind == "" {
 			list = append(list, field.Required(path.Child("kind"), "resource kind is required"))
-		} else if r.Kind != resources.DashboardKind.Kind {
-			list = append(list, field.Invalid(path.Child("kind"), r.Kind,
-				fmt.Sprintf("only %s is supported for export", resources.DashboardKind.Kind)))
+			continue
 		}
-		if r.Group != "" && r.Group != resources.DashboardResource.Group {
+
+		// A non-empty group must match the group registered for that kind.
+		var kindOK, groupOK bool
+		for _, s := range supported {
+			if s.Kind != r.Kind {
+				continue
+			}
+			kindOK = true
+			if r.Group == "" || r.Group == s.Group {
+				groupOK = true
+				break
+			}
+		}
+		switch {
+		case !kindOK:
+			list = append(list, field.Invalid(path.Child("kind"), r.Kind,
+				fmt.Sprintf("kind is not supported for export; supported kinds: %s", strings.Join(supportedKinds(supported), ", "))))
+		case !groupOK:
 			list = append(list, field.Invalid(path.Child("group"), r.Group,
-				fmt.Sprintf("only %s is supported for export", resources.DashboardResource.Group)))
+				fmt.Sprintf("group %q is not supported for kind %s", r.Group, r.Kind)))
 		}
 	}
 	return list
+}
+
+// activeExportResources returns the active subset of the configured supported
+// resources. When none are configured it falls back to the dashboard-only
+// default, preserving the legacy export behavior.
+func activeExportResources(supportedResources []provisioning.SupportedResource) []provisioning.SupportedResource {
+	active := make([]provisioning.SupportedResource, 0, len(supportedResources))
+	for _, r := range supportedResources {
+		if !r.Disabled {
+			active = append(active, r)
+		}
+	}
+	if len(active) == 0 {
+		return []provisioning.SupportedResource{{
+			Group: resources.DashboardResource.Group,
+			Kind:  resources.DashboardKind.Kind,
+		}}
+	}
+	return active
+}
+
+// supportedKinds returns the kinds in supported, for use in error messages.
+func supportedKinds(supported []provisioning.SupportedResource) []string {
+	kinds := make([]string, 0, len(supported))
+	for _, r := range supported {
+		kinds = append(kinds, r.Kind)
+	}
+	return kinds
 }
 
 // validateDeleteJobOptions validates delete job options
@@ -227,11 +274,16 @@ func validateMoveJobOptions(opts *provisioning.MoveJobOptions) field.ErrorList {
 }
 
 // AdmissionValidator handles validation for Job resources during admission
-type AdmissionValidator struct{}
+type AdmissionValidator struct {
+	// supportedResources is the configured set of resource types provisioning can manage,
+	// used to validate export-style (push and migrate) job options.
+	supportedResources []provisioning.SupportedResource
+}
 
-// NewAdmissionValidator creates a new job admission validator
-func NewAdmissionValidator() *AdmissionValidator {
-	return &AdmissionValidator{}
+// NewAdmissionValidator creates a new job admission validator. supportedResources is the
+// configured set of resource types provisioning can manage.
+func NewAdmissionValidator(supportedResources []provisioning.SupportedResource) *AdmissionValidator {
+	return &AdmissionValidator{supportedResources: supportedResources}
 }
 
 // Validate validates Job resources during admission
@@ -252,7 +304,7 @@ func (v *AdmissionValidator) Validate(ctx context.Context, a admission.Attribute
 		return fmt.Errorf("expected job, got %T", obj)
 	}
 
-	return ValidateJob(job)
+	return ValidateJob(job, v.supportedResources)
 }
 
 // HistoricJobAdmissionValidator handles validation for HistoricJob resources during admission.

--- a/apps/provisioning/pkg/jobs/validator_test.go
+++ b/apps/provisioning/pkg/jobs/validator_test.go
@@ -16,10 +16,11 @@ import (
 
 func TestValidateJob(t *testing.T) {
 	tests := []struct {
-		name          string
-		job           *provisioning.Job
-		wantErr       bool
-		validateError func(t *testing.T, err error)
+		name               string
+		job                *provisioning.Job
+		supportedResources []provisioning.SupportedResource
+		wantErr            bool
+		validateError      func(t *testing.T, err error)
 	}{
 		{
 			name: "valid pull job",
@@ -461,7 +462,7 @@ func TestValidateJob(t *testing.T) {
 			wantErr: true,
 			validateError: func(t *testing.T, err error) {
 				require.Contains(t, err.Error(), "spec.migrate.resources[0].kind")
-				require.Contains(t, err.Error(), "only Dashboard is supported")
+				require.Contains(t, err.Error(), "kind is not supported for export")
 			},
 		},
 		{
@@ -714,7 +715,7 @@ func TestValidateJob(t *testing.T) {
 			wantErr: true,
 			validateError: func(t *testing.T, err error) {
 				require.Contains(t, err.Error(), "spec.push.resources[0].kind")
-				require.Contains(t, err.Error(), "only Dashboard is supported")
+				require.Contains(t, err.Error(), "kind is not supported for export")
 			},
 		},
 		{
@@ -732,6 +733,104 @@ func TestValidateJob(t *testing.T) {
 			wantErr: true,
 			validateError: func(t *testing.T, err error) {
 				require.Contains(t, err.Error(), "spec.push.resources[0].group")
+			},
+		},
+		{
+			name: "push action with configured non-dashboard kind",
+			job: &provisioning.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+				Spec: provisioning.JobSpec{
+					Action:     provisioning.JobActionPush,
+					Repository: "test-repo",
+					Push: &provisioning.ExportJobOptions{
+						Resources: []provisioning.ResourceRef{
+							{Name: "pl-1", Kind: "Playlist"},
+							{Name: "pl-2", Kind: "Playlist", Group: "playlist.grafana.app"},
+						},
+					},
+				},
+			},
+			supportedResources: []provisioning.SupportedResource{
+				{Group: "playlist.grafana.app", Kind: "Playlist"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "migrate action with configured non-dashboard kind",
+			job: &provisioning.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+				Spec: provisioning.JobSpec{
+					Action:     provisioning.JobActionMigrate,
+					Repository: "test-repo",
+					Migrate: &provisioning.MigrateJobOptions{
+						Resources: []provisioning.ResourceRef{{Name: "pl-1", Kind: "Playlist", Group: "playlist.grafana.app"}},
+					},
+				},
+			},
+			supportedResources: []provisioning.SupportedResource{
+				{Group: "playlist.grafana.app", Kind: "Playlist"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "push action with kind absent from configured set",
+			job: &provisioning.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+				Spec: provisioning.JobSpec{
+					Action:     provisioning.JobActionPush,
+					Repository: "test-repo",
+					Push: &provisioning.ExportJobOptions{
+						Resources: []provisioning.ResourceRef{{Name: "dash-1", Kind: "Dashboard"}},
+					},
+				},
+			},
+			supportedResources: []provisioning.SupportedResource{
+				{Group: "playlist.grafana.app", Kind: "Playlist"},
+			},
+			wantErr: true,
+			validateError: func(t *testing.T, err error) {
+				require.Contains(t, err.Error(), "spec.push.resources[0].kind")
+				require.Contains(t, err.Error(), "kind is not supported for export")
+			},
+		},
+		{
+			name: "push action with disabled supported kind is rejected",
+			job: &provisioning.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+				Spec: provisioning.JobSpec{
+					Action:     provisioning.JobActionPush,
+					Repository: "test-repo",
+					Push: &provisioning.ExportJobOptions{
+						Resources: []provisioning.ResourceRef{{Name: "pl-1", Kind: "Playlist"}},
+					},
+				},
+			},
+			supportedResources: []provisioning.SupportedResource{
+				{Group: "playlist.grafana.app", Kind: "Playlist", Disabled: true},
+			},
+			wantErr: true,
+			validateError: func(t *testing.T, err error) {
+				require.Contains(t, err.Error(), "spec.push.resources[0].kind")
+			},
+		},
+		{
+			name: "migrate action with wrong group for configured kind",
+			job: &provisioning.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+				Spec: provisioning.JobSpec{
+					Action:     provisioning.JobActionMigrate,
+					Repository: "test-repo",
+					Migrate: &provisioning.MigrateJobOptions{
+						Resources: []provisioning.ResourceRef{{Name: "pl-1", Kind: "Playlist", Group: "wrong.grafana.app"}},
+					},
+				},
+			},
+			supportedResources: []provisioning.SupportedResource{
+				{Group: "playlist.grafana.app", Kind: "Playlist"},
+			},
+			wantErr: true,
+			validateError: func(t *testing.T, err error) {
+				require.Contains(t, err.Error(), "spec.migrate.resources[0].group")
 			},
 		},
 		{
@@ -808,7 +907,7 @@ func TestValidateJob(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateJob(tt.job)
+			err := ValidateJob(tt.job, tt.supportedResources)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.validateError != nil {
@@ -887,7 +986,7 @@ func TestAdmissionValidator_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v := NewAdmissionValidator()
+			v := NewAdmissionValidator(nil)
 
 			var obj runtime.Object
 			if tt.obj != nil {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -749,7 +749,15 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	b.admissionHandler.RegisterMutator(provisioning.ConnectionResourceInfo.GetName(), connection.NewAdmissionMutator(b.connectionFactory))
 	b.admissionHandler.RegisterValidator(provisioning.ConnectionResourceInfo.GetName(), connCombinedValidator)
 	// Jobs validator (no mutator needed)
-	b.admissionHandler.RegisterValidator(provisioning.JobResourceInfo.GetName(), appjobs.NewAdmissionValidator())
+	jobSupportedResources := make([]provisioning.SupportedResource, 0, len(b.supportedResources))
+	for _, r := range b.supportedResources {
+		jobSupportedResources = append(jobSupportedResources, provisioning.SupportedResource{
+			Group:    r.Group,
+			Kind:     r.Kind,
+			Disabled: !r.IsActive(),
+		})
+	}
+	b.admissionHandler.RegisterValidator(provisioning.JobResourceInfo.GetName(), appjobs.NewAdmissionValidator(jobSupportedResources))
 	b.admissionHandler.RegisterValidator(provisioning.HistoricJobResourceInfo.GetName(), appjobs.NewHistoricJobAdmissionValidator())
 
 	jobStore, err := grafanaregistry.NewCompleteRegistryStore(opts.Scheme, provisioning.JobResourceInfo, opts.OptsGetter)

--- a/pkg/tests/apis/provisioning/jobs/job_validation_configured_resources_test.go
+++ b/pkg/tests/apis/provisioning/jobs/job_validation_configured_resources_test.go
@@ -34,14 +34,11 @@ func TestIntegrationProvisioning_JobValidationConfiguredResources(t *testing.T) 
 	})
 	ctx := context.Background()
 
+	// The job admission validator only requires a non-empty repository name; it does not check
+	// repository existence (that happens later, in the jobs connector / worker). Creating Job
+	// objects directly through the resource client exercises admission in isolation, so no real
+	// repository is needed.
 	const repo = "job-validation-configured-resources"
-	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1,
-	})
 
 	tests := []struct {
 		name         string

--- a/pkg/tests/apis/provisioning/jobs/job_validation_configured_resources_test.go
+++ b/pkg/tests/apis/provisioning/jobs/job_validation_configured_resources_test.go
@@ -1,0 +1,161 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+)
+
+// TestIntegrationProvisioning_JobValidationConfiguredResources verifies that the job admission
+// validator honors the configured supported-resource set ([provisioning] resources) rather than a
+// hardcoded dashboard-only rule: a kind added purely through configuration is accepted for export,
+// while kinds outside the active set (unknown or declared-but-disabled) are rejected. This mirrors
+// the config-driven settings test added alongside the supported-resource set.
+func TestIntegrationProvisioning_JobValidationConfiguredResources(t *testing.T) {
+	helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
+		// example.grafana.app/Example is added purely through config (it need not be served:
+		// admission validates the configured descriptor without discovery). playlist is declared
+		// but disabled, so it must not be accepted for export.
+		opts.ProvisioningResources = []string{
+			"folder.grafana.app/Folder:folder",
+			"dashboard.grafana.app/Dashboard:folder",
+			"example.grafana.app/Example",
+			"playlist.grafana.app/Playlist:disabled",
+		}
+	})
+	ctx := context.Background()
+
+	const repo = "job-validation-configured-resources"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:               repo,
+		SyncTarget:         "folder",
+		Copies:             map[string]string{},
+		ExpectedDashboards: 0,
+		ExpectedFolders:    1,
+	})
+
+	tests := []struct {
+		name         string
+		jobSpec      map[string]interface{}
+		wantAccepted bool
+		expectedErr  string
+	}{
+		{
+			name: "push job with config-added kind is accepted",
+			jobSpec: map[string]interface{}{
+				"action":     string(provisioning.JobActionPush),
+				"repository": repo,
+				"push": map[string]interface{}{
+					"resources": []map[string]interface{}{
+						{"name": "ex-1", "kind": "Example", "group": "example.grafana.app"},
+					},
+				},
+			},
+			wantAccepted: true,
+		},
+		{
+			name: "push job with config-added kind and no group is accepted",
+			jobSpec: map[string]interface{}{
+				"action":     string(provisioning.JobActionPush),
+				"repository": repo,
+				"push": map[string]interface{}{
+					"resources": []map[string]interface{}{
+						{"name": "ex-1", "kind": "Example"},
+					},
+				},
+			},
+			wantAccepted: true,
+		},
+		{
+			name: "migrate job with config-added kind is accepted",
+			jobSpec: map[string]interface{}{
+				"action":     string(provisioning.JobActionMigrate),
+				"repository": repo,
+				"migrate": map[string]interface{}{
+					"resources": []map[string]interface{}{
+						{"name": "ex-1", "kind": "Example", "group": "example.grafana.app"},
+					},
+				},
+			},
+			wantAccepted: true,
+		},
+		{
+			name: "push job with disabled configured kind is rejected",
+			jobSpec: map[string]interface{}{
+				"action":     string(provisioning.JobActionPush),
+				"repository": repo,
+				"push": map[string]interface{}{
+					"resources": []map[string]interface{}{
+						{"name": "pl-1", "kind": "Playlist"},
+					},
+				},
+			},
+			expectedErr: "spec.push.resources[0].kind: Invalid value: \"Playlist\": kind is not supported for export",
+		},
+		{
+			name: "push job with unconfigured kind is rejected",
+			jobSpec: map[string]interface{}{
+				"action":     string(provisioning.JobActionPush),
+				"repository": repo,
+				"push": map[string]interface{}{
+					"resources": []map[string]interface{}{
+						{"name": "panel-1", "kind": "LibraryPanel"},
+					},
+				},
+			},
+			expectedErr: "spec.push.resources[0].kind: Invalid value: \"LibraryPanel\": kind is not supported for export",
+		},
+		{
+			name: "push job with wrong group for config-added kind is rejected",
+			jobSpec: map[string]interface{}{
+				"action":     string(provisioning.JobActionPush),
+				"repository": repo,
+				"push": map[string]interface{}{
+					"resources": []map[string]interface{}{
+						{"name": "ex-1", "kind": "Example", "group": "wrong.grafana.app"},
+					},
+				},
+			},
+			expectedErr: "spec.push.resources[0].group: Invalid value: \"wrong.grafana.app\": group \"wrong.grafana.app\" is not supported for kind Example",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name := fmt.Sprintf("test-job-configured-%d", i)
+			jobObj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "provisioning.grafana.app/v0alpha1",
+					"kind":       "Job",
+					"metadata": map[string]interface{}{
+						"name":      name,
+						"namespace": "default",
+					},
+					"spec": tt.jobSpec,
+				},
+			}
+
+			_, err := helper.Jobs.Resource.Create(ctx, jobObj, metav1.CreateOptions{})
+			if tt.wantAccepted {
+				require.NoError(t, err, "job referencing a configured kind should pass admission")
+				// Best-effort cleanup: the job controller reconciles the new job concurrently, so a
+				// delete can race with a status update. Admission acceptance is the assertion here.
+				_ = helper.Jobs.Resource.Delete(ctx, name, metav1.DeleteOptions{})
+				return
+			}
+
+			require.Error(t, err, "job referencing an unsupported kind should be rejected")
+			statusError := helper.RequireApiErrorStatus(err, metav1.StatusReasonInvalid, http.StatusUnprocessableEntity)
+			require.Contains(t, statusError.Message, tt.expectedErr, "error message should contain expected validation message")
+		})
+	}
+}

--- a/pkg/tests/apis/provisioning/jobs/job_validation_test.go
+++ b/pkg/tests/apis/provisioning/jobs/job_validation_test.go
@@ -152,20 +152,22 @@ func TestIntegrationProvisioning_JobValidation(t *testing.T) {
 			expectedErr: "spec.migrate: Required value: migrate options required for migrate action",
 		},
 		{
-			name: "push job with non-Dashboard resource kind",
+			// Playlist is declared but disabled in the default config, so it is not part of
+			// the active supported set and must be rejected for export.
+			name: "push job with disabled resource kind",
 			jobSpec: map[string]interface{}{
 				"action":     string(provisioning.JobActionPush),
 				"repository": repo,
 				"push": map[string]interface{}{
 					"resources": []map[string]interface{}{
-						{"name": "some-folder", "kind": "Folder"},
+						{"name": "playlist-1", "kind": "Playlist"},
 					},
 				},
 			},
-			expectedErr: "spec.push.resources[0].kind: Invalid value: \"Folder\": only Dashboard is supported for export",
+			expectedErr: "spec.push.resources[0].kind: Invalid value: \"Playlist\": kind is not supported for export",
 		},
 		{
-			name: "push job with non-dashboard resource group",
+			name: "push job with wrong group for supported kind",
 			jobSpec: map[string]interface{}{
 				"action":     string(provisioning.JobActionPush),
 				"repository": repo,
@@ -175,7 +177,7 @@ func TestIntegrationProvisioning_JobValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "spec.push.resources[0].group: Invalid value: \"folder.grafana.app\": only dashboard.grafana.app is supported for export",
+			expectedErr: "spec.push.resources[0].group: Invalid value: \"folder.grafana.app\": group \"folder.grafana.app\" is not supported for kind Dashboard",
 		},
 		{
 			name: "push job with resource missing name",
@@ -224,13 +226,14 @@ func TestIntegrationProvisioning_JobValidation(t *testing.T) {
 				"push": map[string]interface{}{
 					"resources": []map[string]interface{}{
 						{"name": "dash-1", "kind": "Dashboard"},
-						{"name": "some-folder", "kind": "Folder"},
+						{"name": "playlist-1", "kind": "Playlist"},
 					},
 				},
 			},
-			expectedErr: "spec.push.resources[1].kind: Invalid value: \"Folder\": only Dashboard is supported for export",
+			expectedErr: "spec.push.resources[1].kind: Invalid value: \"Playlist\": kind is not supported for export",
 		},
 		{
+			// Kind matching is case-sensitive: "dashboard" does not match the supported "Dashboard".
 			name: "push job with lowercase dashboard kind",
 			jobSpec: map[string]interface{}{
 				"action":     string(provisioning.JobActionPush),
@@ -241,9 +244,10 @@ func TestIntegrationProvisioning_JobValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "spec.push.resources[0].kind: Invalid value: \"dashboard\": only Dashboard is supported for export",
+			expectedErr: "spec.push.resources[0].kind: Invalid value: \"dashboard\": kind is not supported for export",
 		},
 		{
+			// LibraryPanel is declared but disabled in the default config.
 			name: "push job with LibraryPanel kind",
 			jobSpec: map[string]interface{}{
 				"action":     string(provisioning.JobActionPush),
@@ -254,7 +258,7 @@ func TestIntegrationProvisioning_JobValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "spec.push.resources[0].kind: Invalid value: \"LibraryPanel\": only Dashboard is supported for export",
+			expectedErr: "spec.push.resources[0].kind: Invalid value: \"LibraryPanel\": kind is not supported for export",
 		},
 	}
 


### PR DESCRIPTION
## Summary

`validateExportResourceRefs` (shared by **push** and **migrate** job options) hard-rejected anything that wasn't a `Dashboard`/dashboard group, so job-driven flows for any newly-supported kind failed at admission.

This generalizes the job admission validator to check each resource ref's `Kind`/`Group` against the **configured supported-resource set** (the flag-aware set introduced in P0.1, #125856) instead of the hardcoded dashboard constants.

Fixes grafana/git-ui-sync-project#1175 (Prep P0.9). Pairs with P0.6 (grafana/git-ui-sync-project#1172).

## Changes

- **`apps/provisioning/pkg/jobs/validator.go`**
  - `validateExportResourceRefs` now validates `Kind`/`Group` against the supported set:
    - kind not in the active set → invalid on `.kind` (message lists supported kinds)
    - non-empty group that doesn't match the registered group for that kind → invalid on `.group`
  - The supported set is injected into the job `AdmissionValidator` and threaded through `ValidateJob(job, supportedResources)`.
  - **Backward-compatible fallback**: when no set is configured (nil/empty/all-disabled), it falls back to the dashboard-only default, preserving legacy behavior. Disabled resources are filtered out.
- **`pkg/registry/apis/provisioning/register.go`**
  - Wires the builder's `supportedResources` into `NewAdmissionValidator`, converting to the apps-module `provisioning.SupportedResource` DTO (same conversion `routes.go` already uses).
- **`apps/provisioning/pkg/jobs/validator_test.go`**
  - Updated existing assertions for the new error messages.
  - Added cases: configured non-dashboard kind (valid), kind absent from set (rejected), disabled kind (rejected), group mismatch for a configured kind (rejected).

## Testing

- `go test ./apps/provisioning/pkg/jobs/` — pass
- `go build ./pkg/registry/apis/provisioning/` — pass
- `gofmt` + `go vet ./pkg/jobs/` — clean

## Checklist

- [x] Tests added/updated
- [x] No breaking changes (legacy dashboard-only behavior preserved when no set is configured)
- [ ] Documentation updated (n/a — internal admission behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)