### PR TITLE
Storage: add SQL tables and SqlKV sections for snapshot index storage

### DIFF
--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -452,12 +452,10 @@ func (w *sqlWriteCloser) Close() error {
 
 	keyPath := getKeyPath(w.section, w.key)
 
-	// Do regular kv save: simple key_path + value insert with conflict check.
-	// Used for sections that map to dedicated key-value tables (resource_events,
-	// pending_tenant_deletions, kv_leases, search_snapshot_manifest,
-	// search_snapshot_data). DataSection still goes through the
-	// resource_history-specific path below until the legacy columns are dropped.
-	if w.section == EventsSection || w.section == PendingDeleteSection || w.section == LeasesSection || w.section == SearchSnapshotManifestSection || w.section == SearchSnapshotDataSection {
+	// Do regular kv save for sections that map to dedicated key-value tables.
+	// DataSection still goes through the resource_history-specific path below
+	// until the legacy columns are dropped.
+	if w.section != DataSection {
 		query, args := qb.buildUpsertQuery(keyPath, value)
 		_, err := w.kv.conn(w.ctx).ExecContext(w.ctx, query, args...)
 		if err != nil {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -22,12 +22,25 @@ import (
 )
 
 const (
-	DataSection           = "unified/data"
-	EventsSection         = "unified/events"
-	LastImportTimeSection = "unified/lastimport"
-	PendingDeleteSection  = "unified/pendingdelete"
-	LeasesSection         = "unified/leases"
+	DataSection                   = "unified/data"
+	EventsSection                 = "unified/events"
+	LastImportTimeSection         = "unified/lastimport"
+	PendingDeleteSection          = "unified/pendingdelete"
+	LeasesSection                 = "unified/leases"
+	SearchSnapshotManifestSection = "search/snapshot-manifest"
+	SearchSnapshotDataSection     = "search/snapshot-data"
 )
+
+// validSaveSections is the set of sections accepted by SqlKV.Save.
+var validSaveSections = map[string]bool{
+	DataSection:                   true,
+	EventsSection:                 true,
+	PendingDeleteSection:          true,
+	LastImportTimeSection:         true,
+	LeasesSection:                 true,
+	SearchSnapshotManifestSection: true,
+	SearchSnapshotDataSection:     true,
+}
 
 var _ KV = &SqlKV{}
 
@@ -104,6 +117,10 @@ func (k *SqlKV) getQueryBuilder(section string) (*queryBuilder, error) {
 		tableName = "pending_tenant_deletions"
 	case LeasesSection:
 		tableName = "kv_leases"
+	case SearchSnapshotManifestSection:
+		tableName = "search_snapshot_manifest"
+	case SearchSnapshotDataSection:
+		tableName = "search_snapshot_data"
 	default:
 		return nil, fmt.Errorf("invalid section: %s", section)
 	}
@@ -382,7 +399,7 @@ func (k *SqlKV) Save(ctx context.Context, section string, key string) (io.WriteC
 	if key == "" {
 		return nil, fmt.Errorf("key is required")
 	}
-	if section != DataSection && section != EventsSection && section != PendingDeleteSection && section != LastImportTimeSection && section != LeasesSection {
+	if !validSaveSections[section] {
 		return nil, fmt.Errorf("invalid section: %s", section)
 	}
 
@@ -437,9 +454,10 @@ func (w *sqlWriteCloser) Close() error {
 
 	// Do regular kv save: simple key_path + value insert with conflict check.
 	// Used for sections that map to dedicated key-value tables (resource_events,
-	// pending_tenant_deletions, kv_leases). DataSection still goes through the
+	// pending_tenant_deletions, kv_leases, search_snapshot_manifest,
+	// search_snapshot_data). DataSection still goes through the
 	// resource_history-specific path below until the legacy columns are dropped.
-	if w.section == EventsSection || w.section == PendingDeleteSection || w.section == LeasesSection {
+	if w.section == EventsSection || w.section == PendingDeleteSection || w.section == LeasesSection || w.section == SearchSnapshotManifestSection || w.section == SearchSnapshotDataSection {
 		query, args := qb.buildUpsertQuery(keyPath, value)
 		_, err := w.kv.conn(w.ctx).ExecContext(w.ctx, query, args...)
 		if err != nil {

--- a/pkg/storage/unified/search/kv_remote_index_store.go
+++ b/pkg/storage/unified/search/kv_remote_index_store.go
@@ -26,11 +26,11 @@ const (
 	// KVRemoteIndexStore stores snapshot manifests. Separate from the
 	// data section so listing complete snapshots only requires scanning
 	// manifest keys (one per snapshot) rather than every data file key.
-	IndexSnapshotManifestSection = "index-snapshot-manifest"
+	IndexSnapshotManifestSection = kv.SearchSnapshotManifestSection
 
 	// IndexSnapshotDataSection is the KV section under which
 	// KVRemoteIndexStore stores per-file snapshot data.
-	IndexSnapshotDataSection = "index-snapshot-data"
+	IndexSnapshotDataSection = kv.SearchSnapshotDataSection
 
 	// defaultKVLockTTL matches BucketRemoteIndexStore's default lock TTL.
 	defaultKVLockTTL = 3 * time.Minute

--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -253,6 +253,30 @@ func initResourceTables(mg *migrator.Migrator) string {
 	mg.AddMigration("create table "+kv_leases_table.Name, migrator.NewAddTableMigration(kv_leases_table))
 	mg.AddMigration("Change key_path collation of kv_leases in postgres", migrator.NewRawSQLMigration("").Postgres(`ALTER TABLE kv_leases ALTER COLUMN key_path TYPE VARCHAR(2048) COLLATE "C";`))
 
+	// Tables backing the search/snapshot-manifest and search/snapshot-data
+	// KV sections used by KVRemoteIndexStore. The data section stores
+	// arbitrary binary index chunks, so both tables use a binary blob
+	// column rather than a TEXT one.
+	search_snapshot_manifest_table := migrator.Table{
+		Name: "search_snapshot_manifest",
+		Columns: []*migrator.Column{
+			{Name: "key_path", Type: migrator.DB_NVarchar, Length: 2048, Nullable: false, IsPrimaryKey: true, IsLatin: true},
+			{Name: "value", Type: migrator.DB_LongBlob, Nullable: false},
+		},
+	}
+	mg.AddMigration("create table "+search_snapshot_manifest_table.Name, migrator.NewAddTableMigration(search_snapshot_manifest_table))
+	mg.AddMigration("Change key_path collation of search_snapshot_manifest in postgres", migrator.NewRawSQLMigration("").Postgres(`ALTER TABLE search_snapshot_manifest ALTER COLUMN key_path TYPE VARCHAR(2048) COLLATE "C";`))
+
+	search_snapshot_data_table := migrator.Table{
+		Name: "search_snapshot_data",
+		Columns: []*migrator.Column{
+			{Name: "key_path", Type: migrator.DB_NVarchar, Length: 2048, Nullable: false, IsPrimaryKey: true, IsLatin: true},
+			{Name: "value", Type: migrator.DB_LongBlob, Nullable: false},
+		},
+	}
+	mg.AddMigration("create table "+search_snapshot_data_table.Name, migrator.NewAddTableMigration(search_snapshot_data_table))
+	mg.AddMigration("Change key_path collation of search_snapshot_data in postgres", migrator.NewRawSQLMigration("").Postgres(`ALTER TABLE search_snapshot_data ALTER COLUMN key_path TYPE VARCHAR(2048) COLLATE "C";`))
+
 	return marker
 }
 

--- a/pkg/storage/unified/testing/sqlkv_search_sections_test.go
+++ b/pkg/storage/unified/testing/sqlkv_search_sections_test.go
@@ -1,0 +1,97 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// TestIntegrationSQLKVSearchSnapshotSections verifies that SqlKV routes
+// the search/snapshot-manifest and search/snapshot-data sections to
+// their dedicated tables and round-trips arbitrary binary values. The
+// data section stores Bleve index chunks, which are not UTF-8 safe and
+// can reach the default 10 MiB chunk size. Runs against every supported
+// database in CI so Postgres BYTEA, MySQL LONGBLOB, and SQLite BLOB are
+// all covered.
+func TestIntegrationSQLKVSearchSnapshotSections(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	t.Cleanup(db.CleanupTestDB)
+
+	store := newSQLKVForTest(t)
+
+	cases := []struct {
+		name  string
+		value []byte
+	}{
+		{
+			// Includes NUL and high bytes — would silently truncate or
+			// fail on a TEXT column.
+			name:  "small_binary",
+			value: []byte{0x00, 0x01, 0xff, 0xfe, 'a', 'b', 'c', 0x00, 0xde, 0xad},
+		},
+		{
+			// Matches defaultKVChunkSize in the search package.
+			name:  "10MiB_binary",
+			value: bytes.Repeat([]byte{0xde, 0xad, 0xbe, 0xef}, 10*1024*1024/4),
+		},
+	}
+
+	for _, section := range []string{kv.SearchSnapshotManifestSection, kv.SearchSnapshotDataSection} {
+		for _, c := range cases {
+			t.Run(section+"/"+c.name, func(t *testing.T) {
+				ctx := t.Context()
+				key := "ns/res/group/01HQABCDEFGHJKMNPQRSTVWXYZ/000000"
+
+				w, err := store.Save(ctx, section, key)
+				require.NoError(t, err)
+				n, err := w.Write(c.value)
+				require.NoError(t, err)
+				assert.Equal(t, len(c.value), n)
+				require.NoError(t, w.Close())
+
+				r, err := store.Get(ctx, section, key)
+				require.NoError(t, err)
+				got, err := io.ReadAll(r)
+				require.NoError(t, err)
+				require.NoError(t, r.Close())
+				assert.True(t, bytes.Equal(c.value, got), "round-tripped value should match original bytes")
+
+				// Listing only returns keys from this section's table.
+				var found []string
+				for k, err := range store.Keys(ctx, section, kv.ListOptions{}) {
+					require.NoError(t, err)
+					found = append(found, k)
+				}
+				assert.Equal(t, []string{key}, found)
+
+				require.NoError(t, store.Delete(ctx, section, key))
+				_, err = store.Get(ctx, section, key)
+				require.ErrorIs(t, err, kv.ErrNotFound)
+			})
+		}
+	}
+}
+
+func newSQLKVForTest(t *testing.T) resource.KV {
+	t.Helper()
+	ctx := context.Background()
+	dbstore := db.InitTestDB(t)
+	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
+	require.NoError(t, err)
+	dbConn, err := eDB.Init(ctx)
+	require.NoError(t, err)
+	store, err := kv.NewSQLKV(dbConn.SqlDB(), dbConn.DriverName())
+	require.NoError(t, err)
+	return store
+}


### PR DESCRIPTION
Adds the storage backing required for `KVRemoteIndexStore` to run against a SQL database. `SqlKV` previously rejected the two sections that `KVRemoteIndexStore` uses, so the store only worked against the in-memory KV.

Two new tables `search_snapshot_manifest` and `search_snapshot_data` (mirroring the `kv_leases` shape) plus two new section constants in `SqlKV`. The `value` column is `LongBlob` rather than `MediumText` because snapshot data chunks are arbitrary binary — `MediumText` on Postgres is unsafe for non-UTF-8 bytes.
