### PR TITLE
Dashboards: Fix variable query editor fields resetting on unrelated re-render

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/components/QueryEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryEditor.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { type DataSourceApi, LoadingState, type TimeRange } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
@@ -25,15 +27,19 @@ export function QueryEditor({
   onQueryChange,
   timeRange,
 }: QueryEditorProps) {
-  let queryWithDefaults;
-  if (typeof query === 'string') {
-    queryWithDefaults = query || (datasource.variables?.getDefaultQuery?.() ?? '');
-  } else {
-    queryWithDefaults = {
+  // Keep a stable reference across renders. The underlying query editors re-initialize their
+  // internal state from this prop via useEffect, so a fresh object on every render would wipe
+  // out in-flight edits (e.g. typing a variable into a label filter) whenever the parent
+  // re-renders for an unrelated reason.
+  const queryWithDefaults = useMemo(() => {
+    if (typeof query === 'string') {
+      return query || (datasource.variables?.getDefaultQuery?.() ?? '');
+    }
+    return {
       ...datasource.variables?.getDefaultQuery?.(),
       ...query,
     };
-  }
+  }, [query, datasource]);
 
   if (VariableQueryEditor && isLegacyQueryEditor(VariableQueryEditor, datasource)) {
     return (


### PR DESCRIPTION
**What is this feature?**

Fixes a bug in the dashboard variable query editor where fields the user had already entered (metric, label filters, etc.) could be unexpectedly cleared while editing — for example, after typing in the Regex field and blurring it.

`QueryEditor` rebuilt `queryWithDefaults` as a new object on every render and passed it as the `query` prop to the data source variable editor. Data source editors (e.g. Prometheus) re-initialize their internal state from this prop via `useEffect(..., [query])`, so a fresh reference each render made that effect re-run on every parent re-render. The Regex field's `onChange` calls `variable.setState(...)`, which re-renders the parent, hands the editor a new `query` reference, and causes it to re-initialize from the last-persisted query — discarding any in-flight edits that hadn't been persisted yet.

This PR memoizes `queryWithDefaults` so the `query` prop keeps a stable reference and only changes when the query or data source actually changes.

**Why do we need this feature?**

Users lose work in the variable editor: values they just entered silently reset, which is confusing and makes the editor feel unreliable.

**Who is this feature for?**

Anyone editing query variables on a dashboard, particularly with the Prometheus data source's "Label values" builder.

**Which issue(s) does this PR fix?**:

Fixes #125984

**Special notes for your reviewer:**

- Verified manually against a live Prometheus data source: with the fix, the metric no longer resets after blurring the Regex field; without it, it does.
- This mitigates an unstable-prop + `useEffect`-driven state-sync interaction. A more resilient long-term fix belongs in the `@grafana/prometheus` variable editor (it shouldn't discard local state on a new `query` reference) and/or its `&& label` persistence guard — both live in the `grafana-prometheus-datasource` repo and are out of scope here.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)