### PR TITLE
ci: migrate detect-breaking-changes-levitate slack call to send-slack-message v3

### DIFF
--- a/.github/workflows/detect-breaking-changes-levitate.yml
+++ b/.github/workflows/detect-breaking-changes-levitate.yml
@@ -275,9 +275,9 @@ jobs:
       - name: Send Slack Message via Payload
         id: slack
         if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && github.repository == 'grafana/grafana'
-        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
+        uses: grafana/shared-workflows/actions/send-slack-message@952ec381447a2002ff76103395d37bf8b4c7c3f5 # send-slack-message/v3.0.1
         with:
-          channel-id: "C08QATP6AE9"
+          method: chat.postMessage
           payload:  |
             {
               "channel": "C08QATP6AE9",


### PR DESCRIPTION
v1.0.0 of `grafana/shared-workflows/actions/send-slack-message` is broken since [#1957](https://github.com/grafana/shared-workflows/pull/1957) merged 4 days ago — `get-vault-secrets` stopped exporting env vars, and v1.0.0 reads `${{ env.SLACK_BOT_TOKEN }}`. Calls fail with `Error: Need to provide at least one botToken or webhookUrl`.

This bumps to v3.0.1 which pins `get-vault-secrets` transitively. `channel-id` (removed in v2+) is redundant here since the channel is already in the JSON payload.