### PR TITLE
test: Migrate E2E to page objects (PR #2)

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/AGENTS.md
+++ b/e2e-playwright/dashboard-new-layouts/AGENTS.md
@@ -13,8 +13,10 @@ All page objects live in `page-objects/` and are re-exported from `page-objects/
 | `PageObject`       | `PageObject.ts`        | _(abstract base — not used directly)_     | Shared constructor (`page`, `dashboardPage`, `selectors`) |
 | `Controls`         | `Controls.ts`          | Top nav bar (edit, save, ...)             | `enterEditMode()`                                         |
 | `Toolbar`          | `Toolbar.ts`           | Vertical icon bar (options, outline, add) | `openDashboardOptions()`                                  |
-| `Sidebar`          | `Sidebar.ts`           | Slide-out container                       | `.dashboardOptions` sub-object                            |
+| `Sidebar`          | `Sidebar.ts`           | Slide-out container                       | `.dashboardOptions`, `.panelOptions` sub-objects          |
 | `DashboardOptions` | `Sidebar.ts` (private) | Dashboard options pane inside sidebar     | `getTitleInput()`, `getDescriptionTextarea()`             |
+| `PanelOptions`     | `Sidebar.ts` (private) | Panel options pane inside sidebar         | `getTitleInput()`, `getDescriptionTextarea()`             |
+| `Panel`            | `Panel.ts`             | A dashboard panel in the edit canvas      | `getHeaderByTitle()`, `selectByTitle()`, `deselectAll()`  |
 
 > This table grows as specs are migrated — only methods needed by migrated specs exist.
 
@@ -130,9 +132,10 @@ await expect(titleInput).toHaveValue(newTitle);
 
 ## Migration Status
 
-| Spec                                   | Status      |
-| -------------------------------------- | ----------- |
-| `dashboards-title-description.spec.ts` | Migrated    |
-| 25 remaining specs                     | Not started |
+| Spec                                              | Status      |
+| ------------------------------------------------- | ----------- |
+| `dashboards-title-description.spec.ts`            | Migrated    |
+| `dashboards-edit-panel-title-description.spec.ts` | Migrated    |
+| 24 remaining specs                                | Not started |
 
 See [`_page_objects_strategy.md`](./_page_objects_strategy.md) for the full migration plan.

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-title-description.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-title-description.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
-import { flows } from './utils';
+import { Controls, Panel, Sidebar } from './page-objects';
 
 test.use({
   featureToggles: {
@@ -21,32 +21,31 @@ test.describe(
     test('can edit panel title and description', async ({ gotoDashboardPage, selectors, page }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
 
-      await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
+      const controls = new Controls(page, dashboardPage, selectors);
+      const panel = new Panel(page, dashboardPage, selectors);
+      const sidebar = new Sidebar(page, dashboardPage, selectors);
 
-      const oldTitle = 'No Data Points Warning';
-      const firstPanelTitle = dashboardPage
-        .getByGrafanaSelector(selectors.components.Panels.Panel.headerContainer)
-        .first()
-        .locator('h2')
-        .first();
-      await expect(firstPanelTitle).toHaveText(oldTitle);
+      await controls.enterEditMode();
 
-      const newDescription = 'A description of this panel';
-      await flows.changePanelDescription(dashboardPage, selectors, oldTitle, newDescription);
+      const oldTitle = /^No Data Points Warning$/;
+      await panel.selectByTitle(oldTitle);
 
-      const newTitle = 'New Panel Title';
-      await flows.changePanelTitle(dashboardPage, selectors, oldTitle, newTitle);
+      const titleInput = sidebar.panelOptions.getTitleInput();
+      await expect(titleInput).toHaveValue(oldTitle);
 
-      // Check that new title is reflected in panel header
-      const updatedPanelTitle = dashboardPage
-        .getByGrafanaSelector(selectors.components.Panels.Panel.headerContainer)
-        .first()
-        .locator('h2')
-        .first();
-      await expect(updatedPanelTitle).toHaveText(newTitle);
+      const newTitle = `New panel title (${Date.now()})`;
+      await titleInput.fill(newTitle);
+
+      const newDescription = `New panel description (${Date.now()})`;
+      await sidebar.panelOptions.getDescriptionTextarea().fill(newDescription);
+
+      await expect(panel.getHeaderByTitle(oldTitle)).toBeHidden();
+
+      const header = panel.getHeaderByTitle(newTitle);
+      await expect(header).toBeVisible();
 
       // Reveal description tooltip and check that its value is as expected
-      const descriptionIcon = page.locator('[data-testid="title-items-container"] > span').first();
+      const descriptionIcon = header.locator('[data-testid="title-items-container"] > span').first();
       await descriptionIcon.hover();
       await expect(page.getByRole('tooltip')).toHaveText(newDescription);
     });

--- a/e2e-playwright/dashboard-new-layouts/page-objects/Panel.ts
+++ b/e2e-playwright/dashboard-new-layouts/page-objects/Panel.ts
@@ -1,0 +1,27 @@
+import { test } from '@playwright/test';
+
+import { PageObject } from './PageObject';
+
+// A dashboard panel: header, title, and selection within the edit canvas
+export class Panel extends PageObject {
+  getHeaderByTitle(title: string | RegExp) {
+    return this.dashboardPage
+      .getByGrafanaSelector(this.selectors.components.Panels.Panel.headerContainer)
+      .filter({ hasText: title })
+      .first();
+  }
+
+  async selectByTitle(title: string | RegExp) {
+    await test.step(`Select panel "${title}"`, async () => {
+      await this.getHeaderByTitle(title).click();
+    });
+  }
+
+  async deselectAll() {
+    await test.step('Deselect all panels', async () => {
+      await this.dashboardPage
+        .getByGrafanaSelector(this.selectors.pages.Dashboard.Controls)
+        .click({ position: { x: 0, y: 0 } });
+    });
+  }
+}

--- a/e2e-playwright/dashboard-new-layouts/page-objects/Sidebar.ts
+++ b/e2e-playwright/dashboard-new-layouts/page-objects/Sidebar.ts
@@ -7,10 +7,12 @@ import { PageObject } from './PageObject';
 // Right side sidebar (open pane): Dashboard options, Panel options, Content outline, etc.
 export class Sidebar extends PageObject {
   public dashboardOptions: DashboardOptions;
+  public panelOptions: PanelOptions;
 
   constructor(page: Page, dashboardPage: DashboardPage, selectors: E2ESelectorGroups) {
     super(page, dashboardPage, selectors);
     this.dashboardOptions = new DashboardOptions(page, dashboardPage, selectors);
+    this.panelOptions = new PanelOptions(page, dashboardPage, selectors);
   }
 }
 
@@ -26,6 +28,20 @@ class DashboardOptions extends PageObject {
       .getByGrafanaSelector(
         this.selectors.components.PanelEditor.OptionsPane.fieldLabel('dashboard-options Description')
       )
+      .locator('textarea');
+  }
+}
+
+class PanelOptions extends PageObject {
+  getTitleInput() {
+    return this.dashboardPage.getByGrafanaSelector(
+      this.selectors.components.PanelEditor.OptionsPane.fieldInput('Title')
+    );
+  }
+
+  getDescriptionTextarea() {
+    return this.dashboardPage
+      .getByGrafanaSelector(this.selectors.components.PanelEditor.OptionsPane.fieldLabel('panel-options Description'))
       .locator('textarea');
   }
 }

--- a/e2e-playwright/dashboard-new-layouts/page-objects/index.ts
+++ b/e2e-playwright/dashboard-new-layouts/page-objects/index.ts
@@ -1,3 +1,4 @@
 export { Controls } from './Controls';
 export { Toolbar } from './Toolbar';
 export { Sidebar } from './Sidebar';
+export { Panel } from './Panel';

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -5,47 +5,21 @@ import { type DashboardPage, type E2ESelectorGroups, expect } from '@grafana/plu
 
 import testV2Dashboard from '../dashboards/TestV2Dashboard.json';
 
-const deselectPanels = async (dashboardPage: DashboardPage, selectors: E2ESelectorGroups) => {
-  await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Controls).click({
-    position: { x: 0, y: 0 },
-  });
-};
+import { Panel, Sidebar } from './page-objects';
 
 export const flows = {
-  deselectPanels,
   async changePanelTitle(
     dashboardPage: DashboardPage,
     selectors: E2ESelectorGroups,
     oldPanelTitle: string,
     newPanelTitle: string
   ) {
-    await deselectPanels(dashboardPage, selectors);
-    await dashboardPage
-      .getByGrafanaSelector(selectors.components.Panels.Panel.headerContainer)
-      .filter({ hasText: oldPanelTitle })
-      .first()
-      .click();
-    await dashboardPage
-      .getByGrafanaSelector(selectors.components.PanelEditor.OptionsPane.fieldInput('Title'))
-      .fill(newPanelTitle);
-  },
-  async changePanelDescription(
-    dashboardPage: DashboardPage,
-    selectors: E2ESelectorGroups,
-    panelTitle: string,
-    newDescription: string
-  ) {
-    await deselectPanels(dashboardPage, selectors);
-    const panelTitleRegex = new RegExp(`^${panelTitle}$`);
-    await dashboardPage
-      .getByGrafanaSelector(selectors.components.Panels.Panel.headerContainer)
-      .filter({ hasText: panelTitleRegex })
-      .first()
-      .click();
-    const descriptionTextArea = dashboardPage
-      .getByGrafanaSelector(selectors.components.PanelEditor.OptionsPane.fieldLabel('panel-options Description'))
-      .locator('textarea');
-    await descriptionTextArea.fill(newDescription);
+    const page = dashboardPage.ctx.page;
+    const panel = new Panel(page, dashboardPage, selectors);
+    const sidebar = new Sidebar(page, dashboardPage, selectors);
+    await panel.deselectAll();
+    await panel.selectByTitle(oldPanelTitle);
+    await sidebar.panelOptions.getTitleInput().fill(newPanelTitle);
   },
   async newEditPaneVariableClick(dashboardPage: DashboardPage, selectors: E2ESelectorGroups) {
     await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();


### PR DESCRIPTION
This PR continues the migration to page objects started in https://github.com/grafana/grafana/pull/123402 

### Key changes

- New `Panel` page object
- New `PanelOptions` sub-object on the existing `Sidebar` page object
- Migration of [dashboards-edit-panel-title-description.spec.ts](https://github.com/grafana/grafana/blob/main/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-title-description.spec.ts)
- Update of the `changePanelTitle` and `changePanelDescription` flows in [utils.ts](https://github.com/grafana/grafana/blob/main/e2e-playwright/dashboard-new-layouts/utils.ts)
- Update of [AGENTS.md](https://github.com/grafana/grafana/blob/main/e2e-playwright/dashboard-new-layouts/AGENTS.md)
