### PR TITLE
Provisioning: Make strict-validation exemption opt-in

### DIFF
--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -34,20 +34,24 @@ type ParserFactory interface {
 	GetParser(ctx context.Context, repo repository.Reader) (Parser, error)
 }
 
-// strictValidationExemptions lists the GroupResources that receive
+// strictValidationExemptions lists the GroupVersionResources that receive
 // FieldValidation=Ignore on apiserver writes instead of the default Strict.
+//
+// The exemption is version-specific on purpose: only the legacy v1 dashboard is
+// exempt. Newer dashboard versions (v2*) must keep strict validation so their
+// CUE schema is enforced by apiserver admission.
 //
 // FIXME: the dashboard exemption is temporary while we improve validation.
 // New resources must be added here deliberately rather than relying on a
 // hardcoded equality check.
-var strictValidationExemptions = map[schema.GroupResource]struct{}{
-	DashboardResource.GroupResource(): {},
+var strictValidationExemptions = map[schema.GroupVersionResource]struct{}{
+	DashboardResource: {},
 }
 
-// skipsStrictValidation reports whether the given GroupResource is exempt from
-// strict field validation and should be written with FieldValidation=Ignore.
-func skipsStrictValidation(gr schema.GroupResource) bool {
-	_, ok := strictValidationExemptions[gr]
+// skipsStrictValidation reports whether the given GroupVersionResource is exempt
+// from strict field validation and should be written with FieldValidation=Ignore.
+func skipsStrictValidation(gvr schema.GroupVersionResource) bool {
+	_, ok := strictValidationExemptions[gvr]
 	return ok
 }
 
@@ -325,7 +329,7 @@ func (f *ParsedResource) DryRun(ctx context.Context) error {
 	}
 
 	fieldValidation := "Strict"
-	if f.SkipStrictValidation || skipsStrictValidation(f.GVR.GroupResource()) {
+	if f.SkipStrictValidation || skipsStrictValidation(f.GVR) {
 		fieldValidation = "Ignore"
 	}
 
@@ -407,7 +411,7 @@ func (f *ParsedResource) Run(ctx context.Context) error {
 	identitySpan.End()
 
 	fieldValidation := "Strict"
-	if f.SkipStrictValidation || skipsStrictValidation(f.GVR.GroupResource()) {
+	if f.SkipStrictValidation || skipsStrictValidation(f.GVR) {
 		fieldValidation = "Ignore"
 	}
 

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -34,6 +34,23 @@ type ParserFactory interface {
 	GetParser(ctx context.Context, repo repository.Reader) (Parser, error)
 }
 
+// strictValidationExemptions lists the GroupResources that receive
+// FieldValidation=Ignore on apiserver writes instead of the default Strict.
+//
+// FIXME: the dashboard exemption is temporary while we improve validation.
+// New resources must be added here deliberately rather than relying on a
+// hardcoded equality check.
+var strictValidationExemptions = map[schema.GroupResource]struct{}{
+	DashboardResource.GroupResource(): {},
+}
+
+// skipsStrictValidation reports whether the given GroupResource is exempt from
+// strict field validation and should be written with FieldValidation=Ignore.
+func skipsStrictValidation(gr schema.GroupResource) bool {
+	_, ok := strictValidationExemptions[gr]
+	return ok
+}
+
 // Parser is a parser for a given repository
 //
 //go:generate mockery --name Parser --structname MockParser --inpackage --filename parser_mock.go --with-expecter
@@ -308,8 +325,8 @@ func (f *ParsedResource) DryRun(ctx context.Context) error {
 	}
 
 	fieldValidation := "Strict"
-	if f.SkipStrictValidation || f.GVR == DashboardResource {
-		fieldValidation = "Ignore" // FIXME: dashboard exemption is temporary while we improve validation
+	if f.SkipStrictValidation || skipsStrictValidation(f.GVR.GroupResource()) {
+		fieldValidation = "Ignore"
 	}
 
 	// Handle deletion action separately
@@ -390,8 +407,8 @@ func (f *ParsedResource) Run(ctx context.Context) error {
 	identitySpan.End()
 
 	fieldValidation := "Strict"
-	if f.SkipStrictValidation || f.GVR == DashboardResource {
-		fieldValidation = "Ignore" // FIXME: dashboard exemption is temporary while we improve validation
+	if f.SkipStrictValidation || skipsStrictValidation(f.GVR.GroupResource()) {
+		fieldValidation = "Ignore"
 	}
 
 	// Check for ownership conflicts

--- a/pkg/registry/apis/provisioning/resources/parser_test.go
+++ b/pkg/registry/apis/provisioning/resources/parser_test.go
@@ -577,12 +577,20 @@ func TestDryRunDeletePopulatesExisting(t *testing.T) {
 }
 
 func TestSkipsStrictValidation(t *testing.T) {
-	// Behaviour must be identical to the previous hardcoded dashboard check:
-	// only the dashboard resource is exempt from strict validation.
-	require.True(t, skipsStrictValidation(DashboardResource.GroupResource()),
-		"dashboard resource must be exempt from strict validation")
-	require.False(t, skipsStrictValidation(FolderResource.GroupResource()),
+	// Behaviour must be identical to the previous hardcoded dashboard check
+	// (f.GVR == DashboardResource): only the v1 dashboard GVR is exempt.
+	require.True(t, skipsStrictValidation(DashboardResource),
+		"v1 dashboard resource must be exempt from strict validation")
+	require.False(t, skipsStrictValidation(FolderResource),
 		"non-dashboard resources must use strict validation")
+	// The exemption is version-specific: v2 dashboards keep strict validation so
+	// their CUE schema is enforced by apiserver admission.
+	require.False(t, skipsStrictValidation(DashboardResourceV2),
+		"v2 dashboard resource must keep strict validation")
+	require.False(t, skipsStrictValidation(DashboardResourceV2alpha1),
+		"v2alpha1 dashboard resource must keep strict validation")
+	require.False(t, skipsStrictValidation(DashboardResourceV2beta1),
+		"v2beta1 dashboard resource must keep strict validation")
 }
 
 func TestParsedResource_DryRun_FieldValidation(t *testing.T) {
@@ -595,9 +603,14 @@ func TestParsedResource_DryRun_FieldValidation(t *testing.T) {
 		wantFieldValidation string
 	}{
 		{
-			name:                "dashboard resource is exempt and uses Ignore",
+			name:                "v1 dashboard resource is exempt and uses Ignore",
 			gvr:                 DashboardResource,
 			wantFieldValidation: "Ignore",
+		},
+		{
+			name:                "v2 dashboard resource is not exempt and uses Strict",
+			gvr:                 DashboardResourceV2,
+			wantFieldValidation: "Strict",
 		},
 		{
 			name:                "non-dashboard resource uses Strict",

--- a/pkg/registry/apis/provisioning/resources/parser_test.go
+++ b/pkg/registry/apis/provisioning/resources/parser_test.go
@@ -576,6 +576,73 @@ func TestDryRunDeletePopulatesExisting(t *testing.T) {
 	})
 }
 
+func TestSkipsStrictValidation(t *testing.T) {
+	// Behaviour must be identical to the previous hardcoded dashboard check:
+	// only the dashboard resource is exempt from strict validation.
+	require.True(t, skipsStrictValidation(DashboardResource.GroupResource()),
+		"dashboard resource must be exempt from strict validation")
+	require.False(t, skipsStrictValidation(FolderResource.GroupResource()),
+		"non-dashboard resources must use strict validation")
+}
+
+func TestParsedResource_DryRun_FieldValidation(t *testing.T) {
+	notFound := apierrors.NewNotFound(schema.GroupResource{Resource: "test"}, "my-resource")
+
+	tests := []struct {
+		name                string
+		gvr                 schema.GroupVersionResource
+		skipStrict          bool
+		wantFieldValidation string
+	}{
+		{
+			name:                "dashboard resource is exempt and uses Ignore",
+			gvr:                 DashboardResource,
+			wantFieldValidation: "Ignore",
+		},
+		{
+			name:                "non-dashboard resource uses Strict",
+			gvr:                 FolderResource,
+			wantFieldValidation: "Strict",
+		},
+		{
+			name:                "SkipStrictValidation forces Ignore regardless of resource",
+			gvr:                 FolderResource,
+			skipStrict:          true,
+			wantFieldValidation: "Ignore",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockDynamicResourceInterface{}
+			// No existing resource, so DryRun takes the Create path.
+			mockClient.On("Get", mock.Anything, "my-resource", metav1.GetOptions{}, mock.Anything).
+				Return(nil, notFound)
+
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{"name": "my-resource", "namespace": "default"},
+			}}
+			mockClient.On("Create", mock.Anything, obj,
+				mock.MatchedBy(func(opts metav1.CreateOptions) bool {
+					return opts.FieldValidation == tt.wantFieldValidation
+				}), mock.Anything).
+				Return(obj, nil)
+
+			parsed := &ParsedResource{
+				Action:               provisioning.ResourceActionCreate,
+				Obj:                  obj,
+				GVR:                  tt.gvr,
+				SkipStrictValidation: tt.skipStrict,
+				Client:               mockClient,
+				Repo:                 testRepoInfo(),
+			}
+
+			require.NoError(t, parsed.DryRun(context.Background()))
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
 func newParsedResource(client *MockDynamicResourceInterface, opts ...func(*ParsedResource)) *ParsedResource {
 	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "dashboard.grafana.app/v1",

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -932,14 +932,14 @@ func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {
 }
 
 // TestIntegrationProvisioning_DashboardStrictValidationExempted verifies the
-// strict-validation exemption end to end. Dashboards are written with
-// FieldValidation=Ignore (see resources.skipsStrictValidation), so a dashboard
+// strict-validation exemption end to end. The v1 dashboard is written with
+// FieldValidation=Ignore (see resources.skipsStrictValidation), so a v1 dashboard
 // file carrying an unknown field must still provision successfully — the unknown
 // field is dropped rather than rejected. Under FieldValidation=Strict the same
 // file is rejected with a "strict decoding error: unknown field" from the
-// apiserver, so removing the dashboard GroupResource from the exemption list
-// would make both the dry run and the sync below fail. That makes this test a
-// regression guard for the exemption, not just a happy-path check.
+// apiserver, so removing the v1 dashboard GVR from the exemption list would make
+// both the dry run and the sync below fail. That makes this test a regression
+// guard for the exemption, not just a happy-path check.
 func TestIntegrationProvisioning_DashboardStrictValidationExempted(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -931,6 +931,44 @@ func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {
 	require.NoError(t, err, "should delete the resource file")
 }
 
+// TestIntegrationProvisioning_DashboardStrictValidationExempted verifies the
+// strict-validation exemption end to end. Dashboards are written with
+// FieldValidation=Ignore (see resources.skipsStrictValidation), so a dashboard
+// file carrying an unknown field must still provision successfully — the unknown
+// field is dropped rather than rejected. Under FieldValidation=Strict the same
+// file is rejected with a "strict decoding error: unknown field" from the
+// apiserver, so removing the dashboard GroupResource from the exemption list
+// would make both the dry run and the sync below fail. That makes this test a
+// regression guard for the exemption, not just a happy-path check.
+func TestIntegrationProvisioning_DashboardStrictValidationExempted(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	const repo = "dashboard-strict-exempt"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:       repo,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
+		Copies: map[string]string{
+			"../testdata/dashboard-unknown-field.json": "dashboard-unknown-field.json",
+		},
+		ExpectedDashboards: 1,
+		ExpectedFolders:    0,
+	})
+
+	// The dry run through the files endpoint must succeed despite the unknown
+	// field, because dashboards are exempt from strict validation.
+	_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard-unknown-field.json")
+	require.NoError(t, err, "dry run of a dashboard with an unknown field should succeed while dashboards are exempt from strict validation")
+
+	// The dashboard must exist in Grafana after sync.
+	const dashboardUID = "dashboard-unknown-field"
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		assert.NoError(collect, err, "dashboard with an unknown field should have been created via the strict-validation exemption")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard with an unknown field should exist after sync")
+}
+
 func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()

--- a/pkg/tests/apis/provisioning/testdata/dashboard-unknown-field.json
+++ b/pkg/tests/apis/provisioning/testdata/dashboard-unknown-field.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "dashboard.grafana.app/v0alpha1",
+  "apiVersion": "dashboard.grafana.app/v1",
   "kind": "Dashboard",
   "metadata": {
     "name": "dashboard-unknown-field"

--- a/pkg/tests/apis/provisioning/testdata/dashboard-unknown-field.json
+++ b/pkg/tests/apis/provisioning/testdata/dashboard-unknown-field.json
@@ -1,0 +1,11 @@
+{
+  "apiVersion": "dashboard.grafana.app/v0alpha1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "dashboard-unknown-field"
+  },
+  "spec": {
+    "title": "Dashboard With Unknown Field"
+  },
+  "thisIsAnUnknownTopLevelField": "rejected under FieldValidation=Strict, dropped under Ignore"
+}


### PR DESCRIPTION
## Summary

Closes grafana/git-ui-sync-project#1171 (part of grafana/git-ui-sync-project#1166).

The parser forced `FieldValidation=Ignore` only for `DashboardResource` via a hardcoded equality check. This drives the exemption from a small opt-in lookup + predicate containing only the dashboard `GroupResource` today. No new resource exempted; no behaviour change.

Supersedes #125855 (which only had unit tests); that PR will be closed.

## Changes

- Add `strictValidationExemptions` map and `skipsStrictValidation()` predicate in `parser.go`.
- Replace both hardcoded `f.GVR == DashboardResource` checks (in `DryRun` and `Run`) with the predicate.
- Unit tests asserting the `FieldValidation` value per resource (`TestSkipsStrictValidation`, `TestParsedResource_DryRun_FieldValidation`).
- Integration test provisioning a dashboard with an unknown field end to end (`TestIntegrationProvisioning_DashboardStrictValidationExempted`) plus its `testdata/dashboard-unknown-field.json` fixture.

## Testing

- `go test ./pkg/registry/apis/provisioning/resources/` — unit tests pass.
- `go test -tags=integration -run TestIntegrationProvisioning_DashboardStrictValidationExempted ./pkg/tests/apis/provisioning/repository/` — passes.
- Verified the integration test **fails** when the dashboard is removed from the exemption map: strict decoding rejects the unknown field and 0 dashboards sync, so it guards the behaviour rather than just exercising the happy path.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (n/a)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)