### PR TITLE
Notifications: Onboard datapro team

### DIFF
--- a/.github/team-notifications-config.json
+++ b/.github/team-notifications-config.json
@@ -60,6 +60,21 @@
         "fr_notify": true,
         "fr_weekly": true
       }
+    },
+    {
+      "name": "datapro",
+      "kickoff_date": "2026-06-08",
+      "adoption_date": "2025-06-08",
+      "codeowners_teams": [
+        "@grafana/datapro"
+      ],
+      "area_labels": ["area/explore", "area/transformations", "area/correlations", "area/expressions"],
+      "enabled": {
+        "pr_notify": true,
+        "pr_weekly": true,
+        "fr_notify": true,
+        "fr_weekly": true
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Onboards the DataPro team (`@grafana/datapro`) to the community notifications system. All four notification types are enabled (PR real-time + weekly digest, FR real-time + weekly digest).

- Codeowners: `@grafana/datapro`
- Area labels: `area/explore`, `area/transformations`, `area/correlations`, `area/expressions`
- Adoption date set to one year before kickoff so the first weekly digest catches older items.

## Follow-up

After merge, a vault admin needs to add the `datapro` team entry to the `slack-channels` / `map` secret so notifications can be routed to the team channel. The channel ID will be shared in `#proj-community-contributions`.