### PR TITLE
PanelEditorNext: Render library panel modals

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/LibraryPanelEditModals.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/LibraryPanelEditModals.tsx
@@ -1,7 +1,6 @@
 import { type SceneComponentProps } from '@grafana/scenes';
 
 import { UnlinkModal } from '../scene/UnlinkModal';
-import { getLibraryPanelBehavior } from '../utils/utils';
 
 import { type PanelEditor } from './PanelEditor';
 import { SaveLibraryVizPanelModal } from './SaveLibraryVizPanelModal';
@@ -10,8 +9,7 @@ import { SaveLibraryVizPanelModal } from './SaveLibraryVizPanelModal';
 // PanelEditor, so they render here to avoid code duplication.
 export function LibraryPanelEditModals({ model }: SceneComponentProps<PanelEditor>) {
   const { showLibraryPanelSaveModal, showLibraryPanelUnlinkModal } = model.useState();
-  const panel = model.getPanel();
-  const libraryPanel = getLibraryPanelBehavior(panel);
+  const libraryPanel = model.getLibraryPanelBehavior();
 
   if (!libraryPanel) {
     return null;

--- a/public/app/features/dashboard-scene/panel-edit/LibraryPanelEditModals.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/LibraryPanelEditModals.tsx
@@ -1,0 +1,39 @@
+import { type SceneComponentProps } from '@grafana/scenes';
+
+import { UnlinkModal } from '../scene/UnlinkModal';
+import { getLibraryPanelBehavior } from '../utils/utils';
+
+import { type PanelEditor } from './PanelEditor';
+import { SaveLibraryVizPanelModal } from './SaveLibraryVizPanelModal';
+
+// Both panel editor renderers (v1 and PanelEditNext) open these modals by toggling state on the
+// PanelEditor, so they render here to avoid code duplication.
+export function LibraryPanelEditModals({ model }: SceneComponentProps<PanelEditor>) {
+  const { showLibraryPanelSaveModal, showLibraryPanelUnlinkModal } = model.useState();
+  const panel = model.getPanel();
+  const libraryPanel = getLibraryPanelBehavior(panel);
+
+  if (!libraryPanel) {
+    return null;
+  }
+
+  return (
+    <>
+      {showLibraryPanelSaveModal && (
+        <SaveLibraryVizPanelModal
+          libraryPanel={libraryPanel}
+          onDismiss={model.onDismissLibraryPanelSaveModal}
+          onConfirm={model.onConfirmSaveLibraryPanel}
+          onDiscard={model.onDiscard}
+        />
+      )}
+      {showLibraryPanelUnlinkModal && (
+        <UnlinkModal
+          onDismiss={model.onDismissUnlinkLibraryPanelModal}
+          onConfirm={model.onConfirmUnlinkLibraryPanel}
+          isOpen
+        />
+      )}
+    </>
+  );
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelEditorRendererNext.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelEditorRendererNext.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+
+import { VizPanel } from '@grafana/scenes';
+
+import { LibraryPanelBehavior } from '../../scene/LibraryPanelBehavior';
+import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
+import { buildPanelEditScene } from '../PanelEditor';
+
+import { PanelEditorRendererNext } from './PanelEditorRendererNext';
+import { usePanelEditorShell } from './hooks';
+
+jest.mock('./hooks', () => ({
+  usePanelEditorShell: jest.fn(),
+}));
+
+jest.mock('../../scene/NavToolbarActions', () => ({
+  NavToolbarActions: () => <div data-testid="nav-toolbar" />,
+}));
+
+jest.mock('./VizAndDataPaneNext', () => ({
+  VizAndDataPaneNext: () => <div data-testid="viz-and-data-pane" />,
+}));
+
+jest.mock('app/features/library-panels/state/api', () => ({
+  ...jest.requireActual('app/features/library-panels/state/api'),
+  getConnectedDashboards: jest.fn().mockResolvedValue([]),
+}));
+
+// The splitter / options-pane shell is irrelevant to the modals under test, so it is stubbed out.
+// The cast mirrors the scene-hook mocking pattern in the sibling VizAndDataPaneNext.test.tsx.
+const shell = {
+  dashboard: {},
+  optionsPane: undefined,
+  splitter: {
+    containerProps: { className: '' },
+    primaryProps: { className: '' },
+    secondaryProps: { className: '' },
+    splitterProps: { className: '' },
+    splitterState: { collapsed: false },
+    onToggleCollapse: jest.fn(),
+  },
+} as unknown as ReturnType<typeof usePanelEditorShell>;
+
+function setupLibraryPanelEditor() {
+  const panel = new VizPanel({ key: 'lib-panel-1', pluginId: 'text' });
+  panel.setState({
+    $behaviors: [
+      new LibraryPanelBehavior({
+        isLoaded: true,
+        uid: 'uid',
+        name: 'libraryPanelName',
+        _loadedPanel: { uid: 'uid', name: 'libraryPanelName', model: { type: 'text' }, type: 'panel', version: 1 },
+      }),
+    ],
+  });
+  new DashboardGridItem({ body: panel });
+  return buildPanelEditScene(panel);
+}
+
+describe('PanelEditorRendererNext', () => {
+  beforeEach(() => {
+    jest.mocked(usePanelEditorShell).mockReturnValue(shell);
+  });
+
+  it('shows the update modal when the save library panel flow is triggered', async () => {
+    const editor = setupLibraryPanelEditor();
+    editor.onSaveLibraryPanel();
+
+    render(<PanelEditorRendererNext model={editor} />);
+
+    expect(await screen.findByRole('dialog', { name: 'Save library panel' })).toBeInTheDocument();
+  });
+
+  it('shows the unlink modal when the unlink flow is triggered', () => {
+    const editor = setupLibraryPanelEditor();
+    editor.onUnlinkLibraryPanel();
+
+    render(<PanelEditorRendererNext model={editor} />);
+
+    expect(screen.getByRole('dialog', { name: 'Do you really want to unlink this panel?' })).toBeInTheDocument();
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelEditorRendererNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelEditorRendererNext.tsx
@@ -7,12 +7,15 @@ import { type SceneComponentProps } from '@grafana/scenes';
 import { Spinner, ToolbarButton, useStyles2 } from '@grafana/ui';
 
 import { NavToolbarActions } from '../../scene/NavToolbarActions';
+import { LibraryPanelEditModals } from '../LibraryPanelEditModals';
 import { type PanelEditor } from '../PanelEditor';
 import { scrollReflowMediaCondition } from '../useScrollReflowLimit';
 
 import { VizAndDataPaneNext } from './VizAndDataPaneNext';
 import { usePanelEditorShell } from './hooks';
 
+// v2 panel editor (PanelEditNext). The classic ../PanelEditorRenderer.tsx renders the same
+// PanelEditor scene, so keep user-facing features in sync across both until v1 is removed.
 export function PanelEditorRendererNext({ model }: SceneComponentProps<PanelEditor>) {
   const { dashboard, optionsPane, splitter } = usePanelEditorShell(model);
   const { containerProps, primaryProps, secondaryProps, splitterProps, splitterState, onToggleCollapse } = splitter;
@@ -22,6 +25,7 @@ export function PanelEditorRendererNext({ model }: SceneComponentProps<PanelEdit
   return (
     <div className={styles.container}>
       <NavToolbarActions dashboard={dashboard} />
+      <LibraryPanelEditModals model={model} />
       <div
         {...containerProps}
         className={cx(containerProps.className, styles.content)}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -27,6 +27,7 @@ import { vizSuggestionsTracker } from 'app/features/panel/components/VizTypePick
 
 import { DashboardEditActionEvent, EDIT_PANE_COLLAPSED_KEY } from '../edit-pane/shared';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
+import { type LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from '../scene/UnconfiguredPanel';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { type DashboardLayoutItem, isDashboardLayoutItem } from '../scene/types/DashboardLayoutItem';
@@ -337,6 +338,10 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
 
     // Remember that we have done changes
     this._changesHaveBeenMade = true;
+  }
+
+  public getLibraryPanelBehavior(): LibraryPanelBehavior | undefined {
+    return getLibraryPanelBehavior(this.getPanel());
   }
 
   public onSaveLibraryPanel = () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
@@ -10,15 +10,17 @@ import { MIN_SUGGESTIONS_PANE_WIDTH } from 'app/features/panel/suggestions/const
 
 import { useEditPaneCollapsed } from '../edit-pane/shared';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
-import { UnlinkModal } from '../scene/UnlinkModal';
-import { getDashboardSceneFor, getLibraryPanelBehavior } from '../utils/utils';
+import { getDashboardSceneFor } from '../utils/utils';
 
+import { LibraryPanelEditModals } from './LibraryPanelEditModals';
 import { PanelEditPanelWrapper } from './PanelEditPanelWrapper';
 import { type PanelEditor } from './PanelEditor';
-import { SaveLibraryVizPanelModal } from './SaveLibraryVizPanelModal';
 import { useSnappingSplitter } from './splitter/useSnappingSplitter';
 import { scrollReflowMediaCondition, useScrollReflowLimit } from './useScrollReflowLimit';
 
+// v1 panel editor. PanelEditNext/PanelEditorRendererNext.tsx is the v2 version and renders the same
+// PanelEditor scene, so anything the user can see here (modals, panes, toolbar actions) needs to
+// exist there too until we drop v1.
 export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>) {
   const dashboard = getDashboardSceneFor(model);
   const { optionsPane } = model.useState();
@@ -82,9 +84,8 @@ export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>)
 
 function VizAndDataPane({ model }: SceneComponentProps<PanelEditor>) {
   const dashboard = getDashboardSceneFor(model);
-  const { dataPane, showLibraryPanelSaveModal, showLibraryPanelUnlinkModal, tableView } = model.useState();
+  const { dataPane, tableView } = model.useState();
   const panel = model.getPanel();
-  const libraryPanel = getLibraryPanelBehavior(panel);
   const { controls } = dashboard.useState();
   const styles = useStyles2(getStyles);
 
@@ -118,21 +119,7 @@ function VizAndDataPane({ model }: SceneComponentProps<PanelEditor>) {
         <div {...primaryProps}>
           <PanelEditPanelWrapper panel={panel} tableView={tableView} dashboard={dashboard} />
         </div>
-        {showLibraryPanelSaveModal && libraryPanel && (
-          <SaveLibraryVizPanelModal
-            libraryPanel={libraryPanel}
-            onDismiss={model.onDismissLibraryPanelSaveModal}
-            onConfirm={model.onConfirmSaveLibraryPanel}
-            onDiscard={model.onDiscard}
-          ></SaveLibraryVizPanelModal>
-        )}
-        {showLibraryPanelUnlinkModal && libraryPanel && (
-          <UnlinkModal
-            onDismiss={model.onDismissUnlinkLibraryPanelModal}
-            onConfirm={model.onConfirmUnlinkLibraryPanel}
-            isOpen
-          />
-        )}
+        <LibraryPanelEditModals model={model} />
         {dataPane && (
           <>
             <div {...splitterProps} />


### PR DESCRIPTION
## Description
Fixes DPRO-113: in the PanelEditNext (v2) panel editor, clicking "Save library panel" or "Unlink library panel" did nothing because the v2 renderer never mounted the corresponding modals. The classic (v1) editor rendered them, but the v2 renderer was missing the wiring.

## Changes
* Extract the library panel save/unlink modal rendering into a shared `LibraryPanelEditModals` component.
* Add a regression test at the renderer layer (`PanelEditorRendererNext.test.tsx`).

## Risks
N/A

## Demo

https://github.com/user-attachments/assets/7e023a1f-0bf2-4c7b-b38b-e0fd9b9a2855

## Testing Instructions
* Enable the `queryEditorNext` feature flag.
* Add a Library Panel to a dashboard, then edit it.
* Click **Save library panel** → the update modal should appear; **Update all** saves the panel.
* Click **Unlink library panel** → the unlink confirmation modal should appear.

## Reviewer Checklist
- [x] Tests are added where applicable
- [x] Issue is linked to PR
- [ ] Code pulled and tested
- [x] Code is meaningfully improved if applicable