### PR TITLE
Storage: export ToSnowflakeRV and SubtractDurationFromSnowflake

### DIFF
--- a/pkg/storage/unified/resource/eventstore.go
+++ b/pkg/storage/unified/resource/eventstore.go
@@ -304,9 +304,9 @@ func snowflakeFromTime(t time.Time) int64 {
 	return (t.UnixMilli() - snowflake.Epoch) << (snowflake.NodeBits + snowflake.StepBits)
 }
 
-// subtractDurationFromSnowflake subtracts a duration from a snowflake ID by
+// SubtractDurationFromSnowflake subtracts a duration from a snowflake ID by
 // converting it to time, subtracting the duration, and converting back to a snowflake ID
-func subtractDurationFromSnowflake(snowflakeID int64, duration time.Duration) int64 {
+func SubtractDurationFromSnowflake(snowflakeID int64, duration time.Duration) int64 {
 	// Extract timestamp from snowflake (returns milliseconds since epoch)
 	timestamp := snowflake.ID(snowflakeID).Time()
 	// Convert to time.Time

--- a/pkg/storage/unified/resource/eventstore_test.go
+++ b/pkg/storage/unified/resource/eventstore_test.go
@@ -774,7 +774,7 @@ func TestSubtractDurationFromSnowflake(t *testing.T) {
 			baseSnowflake := snowflakeFromTime(baseTime)
 
 			// Subtract the duration
-			resultSnowflake := subtractDurationFromSnowflake(baseSnowflake, tt.addTime)
+			resultSnowflake := SubtractDurationFromSnowflake(baseSnowflake, tt.addTime)
 
 			// Convert back to timestamp and verify
 			// Extract timestamp from the result snowflake
@@ -848,8 +848,8 @@ func testListKeysSinceWithSnowflakeTime(t *testing.T, ctx context.Context, store
 		require.NoError(t, err)
 	}
 
-	// List events since 90 minutes ago using subtractDurationFromSnowflake
-	sinceRV := subtractDurationFromSnowflake(snowflakeFromTime(now), 90*time.Minute)
+	// List events since 90 minutes ago using SubtractDurationFromSnowflake
+	sinceRV := SubtractDurationFromSnowflake(snowflakeFromTime(now), 90*time.Minute)
 	retrievedEvents := make([]string, 0) //nolint:prealloc
 	for eventKey, err := range store.ListKeysSince(ctx, sinceRV, SortOrderAsc) {
 		require.NoError(t, err)
@@ -865,8 +865,8 @@ func testListKeysSinceWithSnowflakeTime(t *testing.T, ctx context.Context, store
 	require.NoError(t, err)
 	assert.Equal(t, "test-3", evt2.Name)
 
-	// List events since 30 minutes ago using subtractDurationFromSnowflake
-	sinceRV = subtractDurationFromSnowflake(snowflakeFromTime(now), 30*time.Minute)
+	// List events since 30 minutes ago using SubtractDurationFromSnowflake
+	sinceRV = SubtractDurationFromSnowflake(snowflakeFromTime(now), 30*time.Minute)
 	retrievedEvents = make([]string, 0) //nolint:prealloc
 	for eventKey, err := range store.ListKeysSince(ctx, sinceRV, SortOrderAsc) {
 		require.NoError(t, err)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -761,12 +761,15 @@ func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName 
 	return cutoffTimestamp
 }
 
-// toSnowflakeRV converts a microsecond RV to snowflake format if needed.
-// This ensures the KV backend is compatible with both RV formats during the
-// backend transition period.
+// ToSnowflakeRV converts a microsecond RV to snowflake format if needed,
+// leaving values that are already snowflake (or <= 0) unchanged. This keeps
+// the KV backend compatible with both RV formats during the backend
+// transition period, and lets callers outside this package canonicalize RVs
+// to a single encoding for comparison independent of which backend produced
+// them.
 //
 // TODO: remove when compatibility with SQL backend is no longer needed.
-func toSnowflakeRV(rv int64) int64 {
+func ToSnowflakeRV(rv int64) int64 {
 	if rv > 0 && !IsSnowflake(rv) {
 		return rvmanager.SnowflakeFromRV(rv)
 	}
@@ -884,7 +887,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv
 		return 0, apierrors.NewBadRequest(err.Error())
 	}
 
-	event.PreviousRV = toSnowflakeRV(event.PreviousRV)
+	event.PreviousRV = ToSnowflakeRV(event.PreviousRV)
 
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.WriteEvent", trace.WithAttributes(
 		attribute.String("event_type", event.Type.String()),
@@ -1193,7 +1196,7 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 		return &BackendReadResponse{Error: &resourcepb.ErrorResult{Code: http.StatusBadRequest, Message: "missing key"}}
 	}
 
-	req.ResourceVersion = toSnowflakeRV(req.ResourceVersion)
+	req.ResourceVersion = ToSnowflakeRV(req.ResourceVersion)
 
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.ReadResource", trace.WithAttributes(
 		attribute.String("namespace", req.Key.Namespace),
@@ -1282,7 +1285,7 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 		return 0, fmt.Errorf("missing options or key in ListRequest")
 	}
 
-	req.ResourceVersion = toSnowflakeRV(req.ResourceVersion)
+	req.ResourceVersion = ToSnowflakeRV(req.ResourceVersion)
 
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.ListIterator", trace.WithAttributes(
 		attribute.String("namespace", req.Options.Key.Namespace),
@@ -1316,7 +1319,7 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 			listOptions.ContinueNamespace = token.Namespace
 		}
 		listOptions.ContinueName = token.Name
-		listOptions.ResourceVersion = toSnowflakeRV(token.ResourceVersion)
+		listOptions.ResourceVersion = ToSnowflakeRV(token.ResourceVersion)
 	}
 
 	// We set the listRV to the last event resource version.
@@ -1577,7 +1580,7 @@ func (k *kvStorageBackend) ListModifiedSince(ctx context.Context, key Namespaced
 		}
 	}
 
-	sinceRv = toSnowflakeRV(sinceRv)
+	sinceRv = ToSnowflakeRV(sinceRv)
 
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.ListModifiedSince", trace.WithAttributes(
 		attribute.String("namespace", key.Namespace),
@@ -1615,7 +1618,7 @@ func (k *kvStorageBackend) ListModifiedSince(ctx context.Context, key Namespaced
 		if skipLookback {
 			effectiveRv = sinceRv
 		} else {
-			effectiveRv = subtractDurationFromSnowflake(sinceRv, k.searchLookback)
+			effectiveRv = SubtractDurationFromSnowflake(sinceRv, k.searchLookback)
 		}
 	}
 
@@ -1798,7 +1801,7 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 		return 0, err
 	}
 	key := req.Options.Key
-	req.ResourceVersion = toSnowflakeRV(req.ResourceVersion)
+	req.ResourceVersion = ToSnowflakeRV(req.ResourceVersion)
 
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.ListHistory", trace.WithAttributes(
 		attribute.String("namespace", key.Namespace),
@@ -1815,7 +1818,7 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 		if err != nil {
 			return 0, fmt.Errorf("invalid continue token: %w", err)
 		}
-		lastSeenRV = toSnowflakeRV(token.ResourceVersion)
+		lastSeenRV = ToSnowflakeRV(token.ResourceVersion)
 	}
 
 	// Generate a new resource version for the list

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -1296,7 +1296,7 @@ func seedBackend(t *testing.T, backend *kvStorageBackend, ctx context.Context, n
 	// whose latest RV is slightly before sinceRv. Add these to each
 	// expectation's changes map so the test can validate them.
 	for _, expect := range expectations {
-		lookbackRv := subtractDurationFromSnowflake(expect.rv, backend.searchLookback)
+		lookbackRv := SubtractDurationFromSnowflake(expect.rv, backend.searchLookback)
 		for name, mr := range allResources {
 			if _, ok := expect.changes[name]; ok {
 				continue // already expected


### PR DESCRIPTION
> **Stacked PR (1/3)** — review/merge bottom-up:
> 1. **#126004 — export RV helpers (this PR)**
> 2. #126005 — `CreateBackfillJob` in the vector store
> 3. #126006 — auto-create backfill jobs from the reconciler

**What is this feature?**

Exports two existing RV helpers in `pkg/storage/unified/resource` (rename only, no logic change):

- `ToSnowflakeRV(rv)` — converts a microsecond RV to snowflake format, leaving snowflake (or `<= 0`) values unchanged.
- `SubtractDurationFromSnowflake(rv, d)` — shifts a snowflake RV earlier by a duration.

**Why do we need this feature?**

Unified Storage runs two backends with different resource-version encodings: the KV backend uses snowflake IDs, the legacy SQL backend uses microseconds. The reconciler and backfiller (later PRs in this stack) compare RVs in memory, so they need to canonicalize both sides to a single encoding — independent of which backend produced the value — for those comparisons to hold across a SQL↔KV backend swap. Exporting these helpers lets the `search/embed` packages reuse the canonical conversion instead of reimplementing it.

**Who is this feature for?**

Grafana developers working on Unified Storage vector indexing. No user-facing change.

**Which issue(s) does this PR fix?**:

Part of grafana/search-and-storage-team#823 — Automatically create backfilling jobs

**Special notes for your reviewer:**

- Pure rename/export — the function bodies are unchanged, so behavior is identical. Internal call sites were updated to the exported names.
- Bottom of a 3-PR stack; the consumers are in #126005 and #126006.
