### PR TITLE
Search: add CreateBackfillJob and EnsureResourcePartition to the vector store

### DIFF
--- a/pkg/storage/unified/resource/search_vector_test.go
+++ b/pkg/storage/unified/resource/search_vector_test.go
@@ -103,6 +103,10 @@ func (f *fakeVectorBackend) TryAcquireReconcilerLock(context.Context) (func(), b
 func (f *fakeVectorBackend) ListIncompleteBackfillJobs(context.Context, string) ([]vector.BackfillJob, error) {
 	return nil, nil
 }
+func (f *fakeVectorBackend) EnsureResourcePartition(context.Context, string) error { return nil }
+func (f *fakeVectorBackend) CreateBackfillJob(_ context.Context, _, _ string, _ int64) error {
+	return nil
+}
 func (f *fakeVectorBackend) UpdateBackfillJobCheckpoint(context.Context, int64, string, string) error {
 	return nil
 }

--- a/pkg/storage/unified/search/embed/backfill/fakes_test.go
+++ b/pkg/storage/unified/search/embed/backfill/fakes_test.go
@@ -270,6 +270,10 @@ func (f *fakeVector) SetLatestRV(context.Context, int64) error   { return nil }
 func (f *fakeVector) TryAcquireReconcilerLock(context.Context) (func(), bool, error) {
 	return func() {}, true, nil
 }
+func (f *fakeVector) EnsureResourcePartition(context.Context, string) error { return nil }
+func (f *fakeVector) CreateBackfillJob(_ context.Context, _, _ string, _ int64) error {
+	return nil
+}
 func (f *fakeVector) ListIncompleteBackfillJobs(_ context.Context, model string) ([]vector.BackfillJob, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -307,6 +307,10 @@ func (f *fakeVector) SetLatestRV(_ context.Context, rv int64) error {
 func (f *fakeVector) ListIncompleteBackfillJobs(context.Context, string) ([]vector.BackfillJob, error) {
 	return nil, nil
 }
+func (f *fakeVector) EnsureResourcePartition(context.Context, string) error { return nil }
+func (f *fakeVector) CreateBackfillJob(context.Context, string, string, int64) error {
+	return nil
+}
 func (f *fakeVector) UpdateBackfillJobCheckpoint(context.Context, int64, string, string) error {
 	return nil
 }

--- a/pkg/storage/unified/search/vector/data/vector_backfill_jobs_create.sql
+++ b/pkg/storage/unified/search/vector/data/vector_backfill_jobs_create.sql
@@ -1,0 +1,5 @@
+INSERT INTO vector_backfill_jobs
+    ({{ .Ident "model" }}, {{ .Ident "resource" }}, {{ .Ident "stopping_rv" }}, {{ .Ident "is_complete" }})
+    VALUES ({{ .Arg .Model }}, {{ .Arg .Resource }}, {{ .Arg .StoppingRV }}, FALSE)
+    ON CONFLICT ({{ .Ident "model" }}, {{ .Ident "resource" }}) DO NOTHING
+;

--- a/pkg/storage/unified/search/vector/integration_test.go
+++ b/pkg/storage/unified/search/vector/integration_test.go
@@ -89,6 +89,8 @@ func cleanIntegrationState(t *testing.T, engine *xorm.Engine) {
 		`DELETE FROM vector_promoted WHERE namespace LIKE 'integration-test%'`)
 	_, _ = engine.DB().ExecContext(ctx,
 		`UPDATE vector_latest_rv SET latest_rv = 0 WHERE id = 1`)
+	_, _ = engine.DB().ExecContext(ctx,
+		`DELETE FROM vector_backfill_jobs WHERE model = $1`, testModel)
 }
 
 func TestIntegrationVectorUpsertAndSearch(t *testing.T) {
@@ -387,6 +389,21 @@ func TestIntegrationVectorGetLatestRV(t *testing.T) {
 	assert.Equal(t, int64(100), rv)
 }
 
+func TestIntegrationVectorCreateBackfillJob(t *testing.T) {
+	backend, _, ctx := setupIntegrationTest(t)
+
+	require.NoError(t, backend.CreateBackfillJob(ctx, testModel, testResource, 100))
+
+	// Second insert for the same (model, resource) is a no-op (ON CONFLICT
+	// DO NOTHING): the original row is preserved, not overwritten with 200.
+	require.NoError(t, backend.CreateBackfillJob(ctx, testModel, testResource, 200))
+
+	jobs, err := backend.ListIncompleteBackfillJobs(ctx, testModel)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1, "exactly one job exists after the conflicting insert")
+	assert.Equal(t, int64(100), jobs[0].StoppingRV, "original stopping_rv preserved")
+}
+
 func TestIntegrationVectorReconcilerLock(t *testing.T) {
 	backend, _, ctx := setupIntegrationTest(t)
 
@@ -480,4 +497,46 @@ func makeEmbedding(a, b float32) []float32 {
 	e[0] = a
 	e[1] = b
 	return e
+}
+
+func TestEnsureResourcePartition_RejectsUnsafeResource(t *testing.T) {
+	b := &pgvectorBackend{}
+	for _, res := range []string{"", "Dashboards", "dash-boards", "a.b", "drop;table", "with space"} {
+		require.Error(t, b.EnsureResourcePartition(context.Background(), res),
+			"resource %q must be rejected", res)
+	}
+}
+
+func TestIntegrationVectorEnsureResourcePartition(t *testing.T) {
+	backend, engine, ctx := setupIntegrationTest(t)
+	pg := backend.(*pgvectorBackend)
+
+	const res = "testpartition"
+	leaf := subtreeName(res)
+	idx := leaf + "_metadata_idx"
+	drop := func() { _, _ = engine.DB().ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, leaf)) }
+	drop()
+	t.Cleanup(drop)
+
+	// Absent before creation.
+	ready, err := pg.resourcePartitionReady(ctx, leaf, idx)
+	require.NoError(t, err)
+	require.False(t, ready)
+
+	// Create it: partition + metadata index both present.
+	require.NoError(t, backend.EnsureResourcePartition(ctx, res))
+	ready, err = pg.resourcePartitionReady(ctx, leaf, idx)
+	require.NoError(t, err)
+	assert.True(t, ready, "leaf attached as partition and metadata index present")
+
+	// Heals a missing index: drop it, retry must recreate it.
+	_, err = engine.DB().ExecContext(ctx, fmt.Sprintf(`DROP INDEX IF EXISTS %s`, idx))
+	require.NoError(t, err)
+	require.NoError(t, backend.EnsureResourcePartition(ctx, res))
+	ready, err = pg.resourcePartitionReady(ctx, leaf, idx)
+	require.NoError(t, err)
+	assert.True(t, ready, "missing index recreated on retry")
+
+	// Idempotent: a second call (fast path) is a no-op, no error.
+	require.NoError(t, backend.EnsureResourcePartition(ctx, res))
 }

--- a/pkg/storage/unified/search/vector/pgvector.go
+++ b/pkg/storage/unified/search/vector/pgvector.go
@@ -416,6 +416,95 @@ func (b *pgvectorBackend) ListIncompleteBackfillJobs(ctx context.Context, model 
 	return out, nil
 }
 
+// EnsureResourcePartition creates the embeddings_<resource> partition leaf and
+// its metadata index. The per-resource advisory lock serializes the attach
+// (ACCESS EXCLUSIVE on the parent) so concurrent replicas don't race it.
+func (b *pgvectorBackend) EnsureResourcePartition(ctx context.Context, resource string) error {
+	// resource is interpolated unquoted into the DDL below; reject anything
+	// sanitizeIdentifier would alter to keep it injection-safe.
+	if resource == "" || sanitizeIdentifier(resource) != resource {
+		return fmt.Errorf("ensure partition: unsafe resource %q", resource)
+	}
+	leaf := subtreeName(resource) // embeddings_<resource>
+	idx := leaf + "_metadata_idx"
+
+	// Fast path: skip the lock + DDL only when BOTH leaf and index exist.
+	// Checking the index too lets a retry finish a prior attempt that created
+	// the leaf but failed before the index.
+	ready, err := b.resourcePartitionReady(ctx, leaf, idx)
+	if err != nil {
+		return fmt.Errorf("check partition %s: %w", leaf, err)
+	}
+	if ready {
+		return nil
+	}
+
+	conn, err := b.db.SqlDB().Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("ensure partition conn: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	lockName := "vectorpartition_" + resource
+	if _, err := conn.ExecContext(ctx,
+		"SELECT pg_advisory_lock(hashtext($1)::bigint)", lockName); err != nil {
+		return fmt.Errorf("ensure partition lock: %w", err)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(context.Background(),
+			"SELECT pg_advisory_unlock(hashtext($1)::bigint)", lockName)
+	}()
+
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf(
+		`CREATE TABLE IF NOT EXISTS %s PARTITION OF %s FOR VALUES IN ('%s')`,
+		leaf, unifiedParent, resource,
+	)); err != nil {
+		return fmt.Errorf("create partition %s: %w", leaf, err)
+	}
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf(
+		`CREATE INDEX IF NOT EXISTS %s ON %s USING GIN (metadata)`,
+		idx, leaf,
+	)); err != nil {
+		return fmt.Errorf("create metadata index on %s: %w", leaf, err)
+	}
+	return nil
+}
+
+// resourcePartitionReady reports whether leaf is attached as a partition of
+// the parent (pg_inherits, not to_regclass, so a same-named unrelated table
+// can't match) AND its metadata index exists.
+func (b *pgvectorBackend) resourcePartitionReady(ctx context.Context, leaf, idx string) (bool, error) {
+	var ready bool
+	err := b.db.QueryRowContext(ctx, `
+		SELECT
+			EXISTS (
+				SELECT 1 FROM pg_inherits i
+				JOIN pg_class c ON c.oid = i.inhrelid
+				JOIN pg_class p ON p.oid = i.inhparent
+				WHERE p.relname = $1 AND c.relname = $2
+			)
+			AND EXISTS (
+				SELECT 1 FROM pg_class WHERE relname = $3 AND relkind = 'i'
+			)`, unifiedParent, leaf, idx).Scan(&ready)
+	if err != nil {
+		return false, err
+	}
+	return ready, nil
+}
+
+func (b *pgvectorBackend) CreateBackfillJob(ctx context.Context, model, resource string, stoppingRV int64) error {
+	req := &sqlVectorBackfillJobsCreateRequest{
+		SQLTemplate: sqltemplate.New(b.dialect),
+		Model:       model,
+		Resource:    resource,
+		StoppingRV:  stoppingRV,
+	}
+	if _, err := dbutil.Exec(ctx, b.db, sqlVectorBackfillJobsCreate, req); err != nil {
+		return fmt.Errorf("create backfill job (%s,%s): %w", model, resource, err)
+	}
+	return nil
+}
+
 func (b *pgvectorBackend) UpdateBackfillJobCheckpoint(ctx context.Context, id int64, lastSeenKey string, lastErr string) error {
 	req := &sqlVectorBackfillJobsUpdateRequest{
 		SQLTemplate: sqltemplate.New(b.dialect),

--- a/pkg/storage/unified/search/vector/queries.go
+++ b/pkg/storage/unified/search/vector/queries.go
@@ -36,6 +36,7 @@ var (
 	sqlVectorCollectionExists            = mustTemplate("vector_collection_exists.sql")
 	sqlVectorCollectionSearch            = mustTemplate("vector_collection_search.sql")
 	sqlVectorBackfillJobsList            = mustTemplate("vector_backfill_jobs_list.sql")
+	sqlVectorBackfillJobsCreate          = mustTemplate("vector_backfill_jobs_create.sql")
 	sqlVectorBackfillJobsUpdate          = mustTemplate("vector_backfill_jobs_update.sql")
 	sqlVectorBackfillJobsSetError        = mustTemplate("vector_backfill_jobs_set_error.sql")
 	sqlVectorBackfillJobsComplete        = mustTemplate("vector_backfill_jobs_complete.sql")
@@ -156,6 +157,26 @@ func (r *sqlVectorBackfillJobsListRequest) Validate() error {
 func (r *sqlVectorBackfillJobsListRequest) Results() (*sqlVectorBackfillJobsListResponse, error) {
 	cp := *r.Response
 	return &cp, nil
+}
+
+type sqlVectorBackfillJobsCreateRequest struct {
+	sqltemplate.SQLTemplate
+	Model      string
+	Resource   string
+	StoppingRV int64
+}
+
+func (r *sqlVectorBackfillJobsCreateRequest) Validate() error {
+	if r.Model == "" {
+		return fmt.Errorf("missing model")
+	}
+	if r.Resource == "" {
+		return fmt.Errorf("missing resource")
+	}
+	if r.StoppingRV <= 0 {
+		return fmt.Errorf("stopping_rv must be positive")
+	}
+	return nil
 }
 
 type sqlVectorBackfillJobsUpdateRequest struct {

--- a/pkg/storage/unified/search/vector/queries_test.go
+++ b/pkg/storage/unified/search/vector/queries_test.go
@@ -103,6 +103,17 @@ func TestVectorQueries(t *testing.T) {
 					},
 				},
 			},
+			sqlVectorBackfillJobsCreate: {
+				{
+					Name: "simple",
+					Data: &sqlVectorBackfillJobsCreateRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Model:       "text-embedding-005",
+						Resource:    "dashboards",
+						StoppingRV:  12345,
+					},
+				},
+			},
 			sqlVectorBackfillJobsUpdate: {
 				{
 					Name: "simple",

--- a/pkg/storage/unified/search/vector/store.go
+++ b/pkg/storage/unified/search/vector/store.go
@@ -75,6 +75,13 @@ type VectorBackend interface {
 	// own. Operators add rows via SQL migrations; the resource embedder drains them.
 	ListIncompleteBackfillJobs(ctx context.Context, model string) ([]BackfillJob, error)
 
+	// EnsureResourcePartition creates the embeddings_<resource> partition leaf (idempotent).
+	EnsureResourcePartition(ctx context.Context, resource string) error
+
+	// CreateBackfillJob creates a backfill job for (model, resource, stoppingRV).
+	// No-op if a job already exists for (model, resource).
+	CreateBackfillJob(ctx context.Context, model, resource string, stoppingRV int64) error
+
 	// UpdateBackfillJobCheckpoint writes the cursor + optional error after
 	// each processed resource. Best-effort — race with another writer is
 	// acceptable since the resource embedder is single-goroutine.

--- a/pkg/storage/unified/search/vector/testdata/postgres--vector_backfill_jobs_create-simple.sql
+++ b/pkg/storage/unified/search/vector/testdata/postgres--vector_backfill_jobs_create-simple.sql
@@ -1,0 +1,5 @@
+INSERT INTO vector_backfill_jobs
+    ("model", "resource", "stopping_rv", "is_complete")
+    VALUES ('text-embedding-005', 'dashboards', 12345, FALSE)
+    ON CONFLICT ("model", "resource") DO NOTHING
+;


### PR DESCRIPTION
> **Stacked PR (2/3)** — base: #126004 (merged)
> 1. #126004 — export RV helpers (merged)
> 2. **#126005 — vector store: CreateBackfillJob + EnsureResourcePartition (this PR)**
> 3. #126006 — auto-create backfill jobs from the reconciler

**What is this feature?**

Adds two methods to the `VectorBackend` interface and its pgvector implementation:

- **`CreateBackfillJob(ctx, model, resource, stoppingRV) error`** — inserts a row into `vector_backfill_jobs` with `INSERT ... ON CONFLICT (model, resource) DO NOTHING`. Idempotent; a no-op when a job already exists for that `(model, resource)`.
- **`EnsureResourcePartition(ctx, resource) error`** — creates the `embeddings_<resource>` partition leaf (and its metadata GIN index) if absent. Advisory-locked so concurrent reconcilers don't race the DDL, with a fast-path existence check that skips the lock when the leaf + index already exist. Idempotent.

Includes the SQL templates, snapshot testdata, query structs + unit test, and integration tests for both. Test fakes implementing `VectorBackend` get stubs so dependent packages compile.

**Why do we need this feature?**

The reconciler (next PR, #126006) provisions a resource's vector storage on its first write: it creates the partition leaf so upserts have somewhere to route, and a backfill job so historical rows get embedded. These two backend primitives are that mechanism. Both are idempotent so the reconciler can call them on every first-seen event without coordination.

**Who is this feature for?**

Grafana developers; enables the automatic provisioning shipped in #126006. No user-facing change on its own.

**Which issue(s) does this PR fix?**:

Part of grafana/search-and-storage-team#823 — Automatically create backfilling jobs

**Special notes for your reviewer:**

- The interface methods + impl + SQL live here; the `EnsureResourcePartition` / `CreateBackfillJob` **stubs** in the three test fakes (`resource/search_vector_test.go`, `backfill/fakes_test.go`, `reconciler/fakes_test.go`) also ride in this PR purely so those packages compile once the interface gains the methods. Their real usage is exercised in #126006.
