### PR TITLE
Search: auto-create vector backfill jobs from the reconciler

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -380,15 +380,10 @@ type ResourceServerOptions struct {
 	// the RPC then returns Unimplemented.
 	Embedder *embedder.Embedder
 
-	// VectorBackfiller, when non-nil, is launched in a background
-	// goroutine after Init. The server tracks it in its WaitGroup so
-	// Stop blocks until it returns. nil = backfill feature off.
-	VectorBackfiller Runnable
-
-	// VectorReconciler, when non-nil, is launched alongside the
-	// backfiller; the server attaches its own broadcaster to it before
-	// starting Run so the reconciler's watch path lights up. nil =
-	// reconciler feature off.
+	// VectorReconciler, when non-nil, is launched after Init; the server
+	// attaches its own broadcaster to it before starting Run so the
+	// reconciler's watch path lights up. The reconciler owns the
+	// backfiller and runs it. nil = reconciler feature off.
 	VectorReconciler BroadcasterConsumer
 }
 
@@ -539,7 +534,6 @@ func NewUninitializedResourceServer(opts ResourceServerOptions) (*server, error)
 		quotasConfig:                   opts.QuotasConfig,
 		artificialSuccessfulWriteDelay: opts.Search.IndexMinUpdateInterval,
 		bookmarkFrequency:              opts.BookmarkFrequency,
-		vectorBackfiller:               opts.VectorBackfiller,
 		vectorWriteReconciler:          opts.VectorReconciler,
 	}
 
@@ -646,9 +640,8 @@ type server struct {
 
 	bookmarkFrequency time.Duration
 
-	// Async vector indexers (backfiller + reconciler).
-	// Started in Init, joined in Stop via indexersWG.
-	vectorBackfiller      Runnable
+	// Vector reconciler (which owns the backfiller). Started in Init,
+	// joined in Stop via indexersWG.
 	vectorWriteReconciler BroadcasterConsumer
 	indexersWG            sync.WaitGroup
 }
@@ -685,18 +678,11 @@ func (s *server) Init(ctx context.Context) error {
 	return s.initErr
 }
 
-// startVectorIndexers launches the configured backfiller and
-// reconciler. Both are optional (nil = feature off). The reconciler
-// gets the server's broadcaster via UseBroadcaster before Run; the
-// backfiller doesn't need the watch path.
+// startVectorIndexers launches the vector reconciler (which owns and runs
+// the backfiller). Optional: nil = feature off. The reconciler gets the
+// server's broadcaster via UseBroadcaster before Run so its watch path
+// lights up.
 func (s *server) startVectorIndexers() {
-	if s.vectorBackfiller != nil {
-		s.indexersWG.Go(func() {
-			if err := s.vectorBackfiller.Run(s.ctx); err != nil && !errors.Is(err, context.Canceled) {
-				s.log.Error("vector backfiller stopped", "err", err)
-			}
-		})
-	}
 	if s.vectorWriteReconciler != nil {
 		if s.broadcaster != nil {
 			s.vectorWriteReconciler.UseBroadcaster(s.broadcaster)

--- a/pkg/storage/unified/search/embed/backfill/backfill_test.go
+++ b/pkg/storage/unified/search/embed/backfill/backfill_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -92,9 +93,20 @@ func TestRun_LockUnavailable_SkipsAllWork(t *testing.T) {
 func TestRun_LockAcquired_ReleasedOnReturn(t *testing.T) {
 	vec := newFakeVector()
 	o := newBackfiller(t, newFakeStorage(), vec)
-	require.NoError(t, o.Run(context.Background()))
 
-	assert.Equal(t, 1, vec.lockAttempts)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- o.Run(ctx) }()
+
+	// Run loops on a ticker; wait for the lock, then stop it.
+	require.Eventually(t, func() bool {
+		vec.mu.Lock()
+		defer vec.mu.Unlock()
+		return vec.lockAttempts == 1
+	}, time.Second, time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+
 	assert.Equal(t, 1, vec.lockReleases, "lock must be released when Run returns")
 }
 

--- a/pkg/storage/unified/search/embed/backfill/backfiller.go
+++ b/pkg/storage/unified/search/embed/backfill/backfiller.go
@@ -44,6 +44,9 @@ type Options struct {
 	// Metrics is optional; when nil the backfiller runs without
 	// observability instrumentation (handy for unit tests).
 	Metrics *resource.VectorMetrics
+	// Interval is how often Run re-scans for incomplete jobs (jobs are
+	// created lazily by the reconciler's write path). Defaults to 1m.
+	Interval time.Duration
 }
 
 type VectorBackfiller struct {
@@ -58,7 +61,10 @@ type VectorBackfiller struct {
 	dashboardStats builders.DashboardStats
 	log            log.Logger
 	metrics        *resource.VectorMetrics
+	interval       time.Duration
 }
+
+const defaultBackfillInterval = time.Minute
 
 func NewVectorBackfiller(opts Options) (*VectorBackfiller, error) {
 	if opts.Storage == nil {
@@ -92,6 +98,11 @@ func NewVectorBackfiller(opts Options) (*VectorBackfiller, error) {
 		sorted = append(sorted, builders[k])
 	}
 
+	interval := opts.Interval
+	if interval <= 0 {
+		interval = defaultBackfillInterval
+	}
+
 	return &VectorBackfiller{
 		storage:        opts.Storage,
 		vectorBackend:  opts.VectorBackend,
@@ -101,11 +112,13 @@ func NewVectorBackfiller(opts Options) (*VectorBackfiller, error) {
 		dashboardStats: opts.DashboardStats,
 		log:            log.New("backfill"),
 		metrics:        opts.Metrics,
+		interval:       interval,
 	}, nil
 }
 
-// Run first acquires a Postgres advisory lock so that only one process runs the
-// backfiller at a time.
+// Run acquires a Postgres advisory lock so only one process backfills, then
+// drains incomplete jobs immediately and on every interval tick. The periodic
+// re-scan picks up new jobs from the reconciler.
 func (b *VectorBackfiller) Run(ctx context.Context) error {
 	release, acquired, err := b.vectorBackend.TryAcquireBackfillLock(ctx)
 	if err != nil {
@@ -118,7 +131,16 @@ func (b *VectorBackfiller) Run(ctx context.Context) error {
 	defer release()
 
 	b.runBackfill(ctx)
-	return ctx.Err()
+	t := time.NewTicker(b.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			b.runBackfill(ctx)
+		}
+	}
 }
 
 // runBackfill processes every incomplete vector_backfill_jobs row serially.
@@ -310,7 +332,10 @@ func (b *VectorBackfiller) processBackfillItem(ctx context.Context, job vector.B
 	}()
 
 	rv := iter.ResourceVersion()
-	if rv > job.StoppingRV {
+	// Compare in snowflake space so the bound holds whether the item RV and
+	// the stored stopping_rv came from the kv (snowflake) or legacy sql
+	// (microsecond) backend — e.g. after a SQL<->KV backend swap.
+	if resource.ToSnowflakeRV(rv) > resource.ToSnowflakeRV(job.StoppingRV) {
 		statusLabel = "skipped_rv_past_stopping"
 		return nil
 	}

--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -127,13 +127,16 @@ func (f *fakeStorage) ListModifiedSince(_ context.Context, key resource.Namespac
 		if key.Namespace != "" && c.Key.Namespace != key.Namespace {
 			continue
 		}
+		// latestRv mirrors the real backend's behavior: it's the
+		// absolute latest event RV for this resource, independent
+		// of the sinceRv cutoff applied to the iterator.
+		if c.ResourceVersion > latestRv {
+			latestRv = c.ResourceVersion
+		}
 		if c.ResourceVersion <= sinceRv {
 			continue
 		}
 		matches = append(matches, c)
-		if c.ResourceVersion > latestRv {
-			latestRv = c.ResourceVersion
-		}
 	}
 	itemErr := f.itemErr
 	itemErrI := f.itemErrI
@@ -172,6 +175,18 @@ type fakeVector struct {
 	setLatestRVCalls int
 	setLatestRVErr   error
 	getLatestRVErr   error
+
+	ensuredPartitions  []string
+	ensurePartitionErr error
+
+	backfillJobs      []backfillJobCall
+	createBackfillErr error
+}
+
+type backfillJobCall struct {
+	Model      string
+	Resource   string
+	StoppingRV int64
 }
 
 type deleteCall struct{ Namespace, Model, Resource, UID string }
@@ -307,8 +322,22 @@ func (f *fakeVector) SetLatestRV(_ context.Context, rv int64) error {
 func (f *fakeVector) ListIncompleteBackfillJobs(context.Context, string) ([]vector.BackfillJob, error) {
 	return nil, nil
 }
-func (f *fakeVector) EnsureResourcePartition(context.Context, string) error { return nil }
-func (f *fakeVector) CreateBackfillJob(context.Context, string, string, int64) error {
+func (f *fakeVector) EnsureResourcePartition(_ context.Context, res string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ensurePartitionErr != nil {
+		return f.ensurePartitionErr
+	}
+	f.ensuredPartitions = append(f.ensuredPartitions, res)
+	return nil
+}
+func (f *fakeVector) CreateBackfillJob(_ context.Context, model, res string, stoppingRV int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.createBackfillErr != nil {
+		return f.createBackfillErr
+	}
+	f.backfillJobs = append(f.backfillJobs, backfillJobCall{Model: model, Resource: res, StoppingRV: stoppingRV})
 	return nil
 }
 func (f *fakeVector) UpdateBackfillJobCheckpoint(context.Context, int64, string, string) error {
@@ -331,6 +360,32 @@ func (f *fakeVector) TryAcquireReconcilerLock(context.Context) (func(), bool, er
 		defer f.mu.Unlock()
 		f.lockReleases++
 	}, true, nil
+}
+
+// fakeBackfiller records that Run was invoked and blocks until ctx is
+// cancelled, mirroring the real backfiller's lifetime semantics.
+type fakeBackfiller struct {
+	mu      sync.Mutex
+	runs    int
+	blocked bool
+}
+
+func (f *fakeBackfiller) Run(ctx context.Context) error {
+	f.mu.Lock()
+	f.runs++
+	block := f.blocked
+	f.mu.Unlock()
+	if block {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (f *fakeBackfiller) runCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.runs
 }
 
 // fakeText is a deterministic embedder used by the reconciler. It

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -8,6 +8,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -27,6 +28,12 @@ import (
 )
 
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/search/embed/reconciler")
+
+// Backfiller drains historical resources into the vector index. The
+// reconciler ensures a job exists per builder, then runs it once.
+type Backfiller interface {
+	Run(ctx context.Context) error
+}
 
 const DefaultInterval = time.Minute
 
@@ -79,6 +86,7 @@ type Options struct {
 	VectorBackend     vector.VectorBackend
 	BatchEmbedder     *embedder.BatchEmbedder
 	Builders          []embed.Builder
+	Backfiller        Backfiller
 	Interval          time.Duration
 	LockRetryInterval time.Duration
 	// Metrics is optional; when nil the reconciler runs without
@@ -96,6 +104,7 @@ type Reconciler struct {
 	vectorBackend     vector.VectorBackend
 	batchEmbedder     *embedder.BatchEmbedder
 	builders          map[string]embed.Builder
+	backfiller        Backfiller
 	interval          time.Duration
 	lockRetryInterval time.Duration
 	log               log.Logger
@@ -106,6 +115,9 @@ type Reconciler struct {
 
 	pendingMu sync.Mutex
 	pending   map[string]*pendingEvent
+
+	// ensuredResources tracks provisioned resources (have partition leaf and backfill job)
+	ensuredResources map[string]struct{}
 }
 
 // New constructs the embedding reconciler.
@@ -134,11 +146,13 @@ func New(opts Options) (*Reconciler, error) {
 		vectorBackend:     opts.VectorBackend,
 		batchEmbedder:     opts.BatchEmbedder,
 		builders:          builders,
+		backfiller:        opts.Backfiller,
 		interval:          opts.Interval,
 		lockRetryInterval: opts.LockRetryInterval,
 		log:               log.New("embeddings_reconciler"),
 		metrics:           opts.Metrics,
 		pending:           make(map[string]*pendingEvent),
+		ensuredResources:  make(map[string]struct{}),
 	}, nil
 }
 
@@ -206,6 +220,20 @@ func (s *Reconciler) Run(ctx context.Context) error {
 	}
 	defer release()
 	s.log.Info("reconciler: lock acquired; entering active state")
+
+	// Backfill jobs are created lazily on the write path (the first event for
+	// a resource); the backfiller drains them in the background on its own
+	// advisory lock.
+	if s.backfiller != nil {
+		backfillDone := make(chan struct{})
+		defer func() { <-backfillDone }()
+		go func() {
+			defer close(backfillDone)
+			if err := s.backfiller.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				s.log.Error("reconciler: backfiller stopped", "err", err)
+			}
+		}()
+	}
 
 	// Subscribe before startupReconcile so events between the
 	// startupReconcile snapshot and the subscription join can't slip through;
@@ -288,7 +316,7 @@ func (s *Reconciler) consumeWatchEvents(ctx context.Context, ch <-chan *resource
 				namespace: ev.Key.Namespace,
 				name:      ev.Key.Name,
 				value:     ev.Value,
-				rv:        ev.ResourceVersion,
+				rv:        resource.ToSnowflakeRV(ev.ResourceVersion),
 			})
 			s.log.Debug("reconciler: watch event enqueued",
 				"namespace", ev.Key.Namespace,
@@ -299,9 +327,41 @@ func (s *Reconciler) consumeWatchEvents(ctx context.Context, ch <-chan *resource
 	}
 }
 
+// ensureResourceInitialized provisions a resource's partition leaf + backfill
+// job on its first write event, once per process (idempotent via
+// ensuredResources and the DB row). stoppingRV is the event's RV, bounding the
+// backfill of pre-existing rows for that resource.
+func (s *Reconciler) ensureResourceInitialized(ctx context.Context, b embed.Builder, stoppingRV int64) error {
+	r := b.Resource()
+	if _, ok := s.ensuredResources[r]; ok {
+		return nil
+	}
+
+	if err := s.vectorBackend.EnsureResourcePartition(ctx, r); err != nil {
+		return fmt.Errorf("ensure partition for %q: %w", r, err)
+	}
+
+	if err := s.vectorBackend.CreateBackfillJob(ctx, s.batchEmbedder.Model(), r, stoppingRV); err != nil {
+		return fmt.Errorf("create backfill job for %q: %w", r, err)
+	}
+	s.ensuredResources[r] = struct{}{}
+	return nil
+}
+
+// checkpointRV canonicalizes the persisted checkpoint to snowflake so it
+// compares against event RVs across a SQL<->KV backend swap (a micro
+// checkpoint from the sql backend would otherwise mis-compare).
+func (s *Reconciler) checkpointRV(ctx context.Context) (int64, error) {
+	rv, err := s.vectorBackend.GetLatestRV(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return resource.ToSnowflakeRV(rv), nil
+}
+
 // startupReconcile enqueues changes since the last processed RV.
 func (s *Reconciler) startupReconcile(ctx context.Context) {
-	sinceRv, err := s.vectorBackend.GetLatestRV(ctx)
+	sinceRv, err := s.checkpointRV(ctx)
 	if err != nil {
 		s.log.Error("reconciler: startupReconcile read checkpoint", "err", err)
 		return
@@ -389,7 +449,7 @@ func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, 
 			namespace: mr.Key.Namespace,
 			name:      mr.Key.Name,
 			value:     mr.Value,
-			rv:        mr.ResourceVersion,
+			rv:        resource.ToSnowflakeRV(mr.ResourceVersion),
 		}
 		// Skip iter events that watch has already superseded with a
 		// newer write — re-embedding the older copy would just be
@@ -468,7 +528,7 @@ func (s *Reconciler) processBatch(ctx context.Context, batch []*pendingEvent) {
 	}
 	logger := s.log.FromContext(ctx)
 
-	sinceRv, err := s.vectorBackend.GetLatestRV(ctx)
+	sinceRv, err := s.checkpointRV(ctx)
 	if err != nil {
 		logger.Error("reconciler: read checkpoint", "err", err)
 		s.requeue(batch)
@@ -515,6 +575,7 @@ func (s *Reconciler) processBatch(ctx context.Context, batch []*pendingEvent) {
 // don't accidentally filter out lower-RV events after an earlier batch
 // would have bumped the checkpoint. abort is true if ctx was cancelled
 // mid-loop; the caller should treat all events as un-processed.
+// For new resources, it ensures a partition and backfill job is created
 func (s *Reconciler) processEvents(ctx context.Context, sinceRv int64, batch []*pendingEvent) (maxRv, lowestFailedRv int64, failed, successes []*pendingEvent, abort bool) {
 	logger := s.log.FromContext(ctx)
 	maxRv = sinceRv
@@ -536,6 +597,14 @@ func (s *Reconciler) processEvents(ctx context.Context, sinceRv int64, batch []*
 		// Increment before processing so recordFailure sees the
 		// post-increment value when deciding whether to retry.
 		ev.attempts++
+
+		// Ensure partition + backfill job before processing the event.
+		if err := s.ensureResourceInitialized(ctx, builder, ev.rv); err != nil {
+			logger.Error("reconciler: ensure resource for event",
+				"group", ev.group, "resource", ev.resource, "err", err)
+			lowestFailedRv = s.recordFailure(ev, &failed, lowestFailedRv, logger)
+			continue
+		}
 
 		if err := s.processEvent(ctx, builder, ev); err != nil {
 			logger.Warn("reconciler: process event",

--- a/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
@@ -3,6 +3,7 @@ package reconciler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -23,6 +24,12 @@ import (
 const dashGroup = "dashboard.grafana.app"
 const dashRes = "dashboards"
 const testModel = "test-model"
+
+// testRVBase anchors test RVs to a "now" snowflake RV
+var testRVBase = resource.ToSnowflakeRV(time.Now().UnixMicro())
+
+// snowflakeRV returns a snowflake-format RV offset from testRVBase
+func snowflakeRV(offset int64) int64 { return testRVBase + offset }
 
 // minimalDashboard returns a single-panel dashboard payload that the
 // dashboard extractor will turn into one embed.Item.
@@ -303,11 +310,11 @@ func TestReconciler_Bootstrap_PullsCrossNamespaceEvents(t *testing.T) {
 	// them per-dashboard.
 	st := &fakeStorage{}
 	st.changes = []*resource.ModifiedResource{
-		dashChange(resourcepb.WatchEvent_ADDED, "ns-a", "dash-1", 100, minimalDashboard("dash-1", "Dash 1")),
-		dashChange(resourcepb.WatchEvent_ADDED, "ns-b", "dash-2", 200, minimalDashboard("dash-2", "Dash 2")),
+		dashChange(resourcepb.WatchEvent_ADDED, "ns-a", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")),
+		dashChange(resourcepb.WatchEvent_ADDED, "ns-b", "dash-2", snowflakeRV(200), minimalDashboard("dash-2", "Dash 2")),
 	}
 	vec := newFakeVector()
-	vec.latestRV = 50 // anything below the change RVs
+	vec.latestRV = snowflakeRV(50) // anything below the change RVs
 	s, text := newReconciler(t, st, vec)
 
 	s.startupReconcile(context.Background())
@@ -315,17 +322,17 @@ func TestReconciler_Bootstrap_PullsCrossNamespaceEvents(t *testing.T) {
 
 	require.Len(t, vec.upserts, 2)
 	assert.Equal(t, 2, text.calls)
-	assert.Equal(t, int64(200), vec.latestRV)
+	assert.Equal(t, snowflakeRV(200), vec.latestRV)
 }
 
 func TestReconciler_Bootstrap_FiltersBelowCursor(t *testing.T) {
 	st := &fakeStorage{}
 	st.changes = []*resource.ModifiedResource{
-		dashChange(resourcepb.WatchEvent_ADDED, "ns", "old", 100, minimalDashboard("old", "Old")),
-		dashChange(resourcepb.WatchEvent_ADDED, "ns", "new", 200, minimalDashboard("new", "New")),
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "old", snowflakeRV(100), minimalDashboard("old", "Old")),
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "new", snowflakeRV(200), minimalDashboard("new", "New")),
 	}
 	vec := newFakeVector()
-	vec.latestRV = 150
+	vec.latestRV = snowflakeRV(150)
 	s, _ := newReconciler(t, st, vec)
 
 	s.startupReconcile(context.Background())
@@ -333,7 +340,7 @@ func TestReconciler_Bootstrap_FiltersBelowCursor(t *testing.T) {
 
 	require.Len(t, vec.upserts, 1)
 	assert.Equal(t, "new", vec.upserts[0][0].UID)
-	assert.Equal(t, int64(200), vec.latestRV)
+	assert.Equal(t, snowflakeRV(200), vec.latestRV)
 }
 
 // ---------- Watch path ----------
@@ -427,20 +434,22 @@ func TestReconciler_EnqueueDedup_DeleteOverridesOlderUpsert(t *testing.T) {
 	assert.Equal(t, int64(200), vec.latestRV)
 }
 
-func TestReconciler_CursorFiltersAlreadyProcessedEvents(t *testing.T) {
+// Events at or below the cursor were already processed; they're filtered
+// out and only newer ones embed. The cursor advances to the max.
+func TestReconciler_FiltersEventsAtOrBelowCursor(t *testing.T) {
 	vec := newFakeVector()
-	vec.latestRV = 150
+	vec.latestRV = snowflakeRV(150)
 	s, text := newReconciler(t, &fakeStorage{}, vec)
 
-	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "old", 100, minimalDashboard("old", "Old")))
-	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "new", 200, minimalDashboard("new", "New")))
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "old", snowflakeRV(100), minimalDashboard("old", "Old")))
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "new", snowflakeRV(200), minimalDashboard("new", "New")))
 
 	s.processPending(context.Background())
 
 	assert.Equal(t, 1, text.calls)
 	require.Len(t, vec.upserts, 1)
 	assert.Equal(t, "new", vec.upserts[0][0].UID)
-	assert.Equal(t, int64(200), vec.latestRV)
+	assert.Equal(t, snowflakeRV(200), vec.latestRV)
 }
 
 // ---------- Retry cap ----------
@@ -581,20 +590,20 @@ func TestReconciler_StartupReconcile_FlushesAtBatchSize(t *testing.T) {
 	st := &fakeStorage{}
 	// Emit in DESC order to mirror the real SQL backend.
 	for i := 6; i >= 0; i-- {
-		rv := int64(100 + i*10)
+		rv := snowflakeRV(int64(100 + i*10))
 		name := fmt.Sprintf("dash-%d", i)
 		st.changes = append(st.changes,
 			dashChange(resourcepb.WatchEvent_ADDED, "ns", name, rv, minimalDashboard(name, name)))
 	}
 
 	vec := newFakeVector()
-	vec.latestRV = 50
+	vec.latestRV = snowflakeRV(50)
 	s, _ := newReconciler(t, st, vec)
 
 	s.startupReconcile(context.Background())
 
 	require.Len(t, vec.upserts, 7, "every event must be processed across batched flushes")
-	assert.Equal(t, int64(160), vec.latestRV, "cursor advances to highest RV")
+	assert.Equal(t, snowflakeRV(160), vec.latestRV, "cursor advances to highest RV")
 	assert.Equal(t, 0, s.pendingLen(), "queue is empty after startup")
 	assert.Equal(t, 1, vec.setLatestRVCalls, "cursor advances exactly once at end of startup")
 }
@@ -614,20 +623,20 @@ func TestReconciler_StartupReconcile_DescOrderDoesNotDropEvents(t *testing.T) {
 	st := &fakeStorage{}
 	// Strictly descending RV order, mirroring the real SQL backend.
 	for i := 5; i >= 0; i-- {
-		rv := int64(100 + i*10)
+		rv := snowflakeRV(int64(100 + i*10))
 		name := fmt.Sprintf("dash-%d", i)
 		st.changes = append(st.changes,
 			dashChange(resourcepb.WatchEvent_ADDED, "ns", name, rv, minimalDashboard(name, name)))
 	}
 
 	vec := newFakeVector()
-	vec.latestRV = 50
+	vec.latestRV = snowflakeRV(50)
 	s, _ := newReconciler(t, st, vec)
 
 	s.startupReconcile(context.Background())
 
 	assert.Len(t, vec.upserts, 6, "every event embedded even though batches arrive in DESC order")
-	assert.Equal(t, int64(150), vec.latestRV)
+	assert.Equal(t, snowflakeRV(150), vec.latestRV)
 }
 
 // TestReconciler_StartupReconcile_RequeuesOnCheckpointWriteFailure
@@ -639,21 +648,21 @@ func TestReconciler_StartupReconcile_DescOrderDoesNotDropEvents(t *testing.T) {
 func TestReconciler_StartupReconcile_RequeuesOnCheckpointWriteFailure(t *testing.T) {
 	st := &fakeStorage{}
 	for i := 0; i < 3; i++ {
-		rv := int64(100 + i*10)
+		rv := snowflakeRV(int64(100 + i*10))
 		name := fmt.Sprintf("dash-%d", i)
 		st.changes = append(st.changes,
 			dashChange(resourcepb.WatchEvent_ADDED, "ns", name, rv, minimalDashboard(name, name)))
 	}
 
 	vec := newFakeVector()
-	vec.latestRV = 50
+	vec.latestRV = snowflakeRV(50)
 	vec.setLatestRVErr = fmt.Errorf("transient checkpoint write failure")
 	s, _ := newReconciler(t, st, vec)
 
 	s.startupReconcile(context.Background())
 
 	assert.Len(t, vec.upserts, 3, "embeds succeeded even though the cursor write failed")
-	assert.Equal(t, int64(50), vec.latestRV, "cursor stays at old value when SetLatestRV errors")
+	assert.Equal(t, snowflakeRV(50), vec.latestRV, "cursor stays at old value when SetLatestRV errors")
 	assert.Equal(t, 3, s.pendingLen(), "all processed events re-enqueued for the next cycle to retry the advance")
 }
 
@@ -669,21 +678,21 @@ func TestReconciler_StartupReconcile_DoesNotProcessWatchEvents(t *testing.T) {
 
 	st := &fakeStorage{}
 	for i := 0; i < 4; i++ {
-		rv := int64(100 + i*10)
+		rv := snowflakeRV(int64(100 + i*10))
 		name := fmt.Sprintf("iter-%d", i)
 		st.changes = append(st.changes,
 			dashChange(resourcepb.WatchEvent_ADDED, "ns", name, rv, minimalDashboard(name, name)))
 	}
 
 	vec := newFakeVector()
-	vec.latestRV = 50
+	vec.latestRV = snowflakeRV(50)
 	s, _ := newReconciler(t, st, vec)
 
 	// Pre-seed the global queue with a watch event at a much higher RV
 	// for an unrelated dashboard. If bootstrap incorrectly drained the
 	// global queue, this RV (9999) would become the new cursor and the
 	// remaining iter events would be filtered out.
-	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "watch-only", 9999,
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "watch-only", snowflakeRV(9999),
 		minimalDashboard("watch-only", "Watch Only")))
 
 	s.startupReconcile(context.Background())
@@ -694,14 +703,14 @@ func TestReconciler_StartupReconcile_DoesNotProcessWatchEvents(t *testing.T) {
 		require.NotEmpty(t, batch)
 		assert.NotEqual(t, "watch-only", batch[0].UID, "watch event must not be processed during bootstrap")
 	}
-	assert.Equal(t, int64(130), vec.latestRV, "cursor stays within iter range during bootstrap")
+	assert.Equal(t, snowflakeRV(130), vec.latestRV, "cursor stays within iter range during bootstrap")
 	assert.Equal(t, 1, s.pendingLen(), "watch event remains in global queue for the next cycle")
 
 	// A subsequent processPending (Run's first cycle) drains the watch event.
 	s.processPending(context.Background())
 	require.Len(t, vec.upserts, 5)
 	assert.Equal(t, "watch-only", vec.upserts[4][0].UID)
-	assert.Equal(t, int64(9999), vec.latestRV)
+	assert.Equal(t, snowflakeRV(9999), vec.latestRV)
 }
 
 // TestReconciler_StartupReconcile_SkipsIterEventsSupersededByWatch
@@ -711,15 +720,15 @@ func TestReconciler_StartupReconcile_DoesNotProcessWatchEvents(t *testing.T) {
 func TestReconciler_StartupReconcile_SkipsIterEventsSupersededByWatch(t *testing.T) {
 	st := &fakeStorage{}
 	st.changes = []*resource.ModifiedResource{
-		dashChange(resourcepb.WatchEvent_ADDED, "ns", "shared", 100, minimalDashboard("shared", "v1")),
-		dashChange(resourcepb.WatchEvent_ADDED, "ns", "other", 110, minimalDashboard("other", "Other")),
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "shared", snowflakeRV(100), minimalDashboard("shared", "v1")),
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "other", snowflakeRV(110), minimalDashboard("other", "Other")),
 	}
 	vec := newFakeVector()
-	vec.latestRV = 50
+	vec.latestRV = snowflakeRV(50)
 	s, _ := newReconciler(t, st, vec)
 
 	// Watch already saw a newer write for "shared".
-	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "shared", 500,
+	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "shared", snowflakeRV(500),
 		minimalDashboard("shared", "v2")))
 
 	s.startupReconcile(context.Background())
@@ -886,10 +895,10 @@ func TestReconciler_Run_ContextCancelDuringLockWait(t *testing.T) {
 func TestReconciler_Run_RunsStartupAndCycles(t *testing.T) {
 	st := &fakeStorage{}
 	st.changes = []*resource.ModifiedResource{
-		dashChange(resourcepb.WatchEvent_ADDED, "ns", "startup-1", 100, minimalDashboard("startup-1", "Startup 1")),
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "startup-1", snowflakeRV(100), minimalDashboard("startup-1", "Startup 1")),
 	}
 	vec := newFakeVector()
-	vec.latestRV = 50 // > 0 so startupReconcile actually runs
+	vec.latestRV = snowflakeRV(50) // > 0 so startupReconcile actually runs
 	s, _ := newRunnable(t, st, vec)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -905,7 +914,7 @@ func TestReconciler_Run_RunsStartupAndCycles(t *testing.T) {
 	}, time.Second, time.Millisecond, "startupReconcile should run before the first tick")
 
 	// Now enqueue a tick-driven event and wait for the next cycle.
-	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "live-1", 200, minimalDashboard("live-1", "Live 1")))
+	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "live-1", snowflakeRV(200), minimalDashboard("live-1", "Live 1")))
 	require.Eventually(t, func() bool {
 		vec.mu.Lock()
 		defer vec.mu.Unlock()
@@ -991,7 +1000,7 @@ func TestReconciler_Run_BroadcasterDeliversWatchEvents(t *testing.T) {
 			Name:      "watched",
 		},
 		Value:           minimalDashboard("watched", "Watched"),
-		ResourceVersion: 500,
+		ResourceVersion: snowflakeRV(500),
 	})
 
 	require.Eventually(t, func() bool {
@@ -1047,4 +1056,70 @@ func TestReconciler_Run_BroadcasterSubscribeErrorContinues(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Run did not exit after ctx cancel")
 	}
+}
+
+func TestReconciler_Run_LaunchesBackfiller(t *testing.T) {
+	// Run drives the backfiller and waits for it on shutdown.
+	vec := newFakeVector()
+	bf := &fakeBackfiller{blocked: true}
+	text := &fakeText{dim: 4}
+	s, err := New(Options{
+		Storage:           &fakeStorage{},
+		VectorBackend:     vec,
+		BatchEmbedder:     embedder.NewBatchEmbedder(*newFakeEmbedder(text)),
+		Builders:          []embed.Builder{dashboard.New()},
+		Backfiller:        bf,
+		Interval:          5 * time.Millisecond,
+		LockRetryInterval: 1 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return bf.runCount() == 1
+	}, time.Second, time.Millisecond, "Run should launch the backfiller")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not exit after ctx cancel")
+	}
+}
+
+func TestReconciler_EnsureResourceInitialized_UsesEventRV(t *testing.T) {
+	// Bounds the job by the triggering event's RV; idempotent per process.
+	vec := newFakeVector()
+	s, _ := newReconciler(t, &fakeStorage{}, vec)
+	b := dashboard.New()
+
+	require.NoError(t, s.ensureResourceInitialized(context.Background(), b, snowflakeRV(777)))
+
+	assert.Equal(t, []string{dashRes}, vec.ensuredPartitions)
+	require.Len(t, vec.backfillJobs, 1)
+	assert.Equal(t, dashRes, vec.backfillJobs[0].Resource)
+	assert.Equal(t, testModel, vec.backfillJobs[0].Model)
+	assert.Equal(t, snowflakeRV(777), vec.backfillJobs[0].StoppingRV)
+
+	// Second event for the same resource: no-op (no new partition or job).
+	require.NoError(t, s.ensureResourceInitialized(context.Background(), b, snowflakeRV(999)))
+	assert.Len(t, vec.ensuredPartitions, 1)
+	assert.Len(t, vec.backfillJobs, 1)
+	assert.Equal(t, snowflakeRV(777), vec.backfillJobs[0].StoppingRV)
+}
+
+func TestReconciler_EnsureResourceInitialized_CreateError(t *testing.T) {
+	// A CreateBackfillJob failure surfaces (and leaves the resource unmarked,
+	// so the next event retries).
+	vec := newFakeVector()
+	vec.createBackfillErr = errors.New("db unavailable")
+	s, _ := newReconciler(t, &fakeStorage{}, vec)
+
+	err := s.ensureResourceInitialized(context.Background(), dashboard.New(), snowflakeRV(1))
+	require.Error(t, err)
+	assert.Empty(t, vec.backfillJobs)
 }

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -230,8 +230,7 @@ func withVectorIndexers(opts *ServerOptions, resourceOpts *resource.ResourceServ
 	batchEmbedder := embedder.NewBatchEmbedder(*opts.Embedder)
 	builders := []embed.Builder{dashboard.New()}
 
-	var err error
-	resourceOpts.VectorBackfiller, err = backfill.NewVectorBackfiller(backfill.Options{
+	backfiller, err := backfill.NewVectorBackfiller(backfill.Options{
 		Storage:        opts.Backend,
 		VectorBackend:  opts.VectorBackend,
 		BatchEmbedder:  batchEmbedder,
@@ -248,6 +247,7 @@ func withVectorIndexers(opts *ServerOptions, resourceOpts *resource.ResourceServ
 		VectorBackend: opts.VectorBackend,
 		BatchEmbedder: batchEmbedder,
 		Builders:      builders,
+		Backfiller:    backfiller,
 		Interval:      opts.Cfg.VectorReconcilerInterval,
 		Metrics:       resourceOpts.VectorMetrics,
 	})


### PR DESCRIPTION
> **Stacked PR (3/3)** — base: #126005
> 1. #126004 — export RV helpers (merged)
> 2. #126005 — vector store: CreateBackfillJob + EnsureResourcePartition
> 3. **#126006 — auto-create backfill jobs from the reconciler (this PR)**

**What is this feature?**

Makes the embedding reconciler provision a resource's vector storage automatically, on the **first write event** for that resource:

- `ensureResourceInitialized` (once per process, idempotent via an in-memory set + the DB row): `EnsureResourcePartition` so the upsert has a leaf to route to, then `CreateBackfillJob` bounded by the event's RV so pre-existing rows for that resource get embedded.
- The reconciler **owns the backfiller** and runs it on a loop (`Interval`, default 1m): it drains incomplete jobs immediately and re-scans each tick, so jobs created lazily on the write path get picked up without a restart.
- Event RVs and the persisted checkpoint are canonicalized to snowflake (`resource.ToSnowflakeRV`) at the reconciler/backfiller comparison boundaries, so the cursor and `stopping_rv` stay valid across a SQL↔KV backend swap (the two backends encode RVs differently — snowflake vs microseconds).

There is no startup bootstrap pass: provisioning is purely write-path driven, so the `stopping_rv` always comes from a real backend RV (never fabricated from wall-clock time).

**Why do we need this feature?**

On a fresh vector deployment a resource has no partition leaf and no backfill job, so writes can't be embedded and historical rows are never indexed. This wires the reconciler — which already sees every write — to create both the moment a resource is first written, then the backfiller embeds the history. Idempotent primitives (#126005) mean it's safe to attempt on every first-seen event.

**Who is this feature for?**

Operators and users of vector/semantic search over dashboards in Grafana Cloud — search works on a resource shortly after the first write to it, with no manual setup.

**Which issue(s) does this PR fix?**:

Fixes grafana/search-and-storage-team#823 — Automatically create backfilling jobs

**Special notes for your reviewer:**

- Top of a 3-PR stack; depends on #126005 (`CreateBackfillJob` + `EnsureResourcePartition`).
- Behind the existing vector-indexing config (`VectorIndexingEnabled` + embedding provider); no effect when vector indexing is off.
- Tradeoff: a write-quiet instance won't backfill a resource until its first write lands — acceptable for live instances, and avoids a fabricated startup cursor.
