### PR TITLE
Frontend Logging: Remove unused trace handling from JS agent receiver

### DIFF
--- a/pkg/api/frontendlogging/grafana_javascript_agent_payload.go
+++ b/pkg/api/frontendlogging/grafana_javascript_agent_payload.go
@@ -196,7 +196,7 @@ func SpanToKeyVal(s ptrace.Span) *KeyVal {
 		KeyValAdd(kv, "timestamp", s.StartTimestamp().AsTime().String())
 	}
 	if s.EndTimestamp() > 0 {
-		KeyValAdd(kv, "end_timestamp", s.StartTimestamp().AsTime().String())
+		KeyValAdd(kv, "end_timestamp", s.EndTimestamp().AsTime().String())
 	}
 	KeyValAdd(kv, "kind", "span")
 	KeyValAdd(kv, "traceID", traceIDHex)

--- a/pkg/api/frontendlogging/grafana_javascript_agent_payload_test.go
+++ b/pkg/api/frontendlogging/grafana_javascript_agent_payload_test.go
@@ -1,0 +1,38 @@
+package frontendlogging
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestSpanToKeyValUsesEndTimestamp(t *testing.T) {
+	start := time.Date(2026, time.June, 16, 10, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Second)
+
+	span := ptrace.NewSpan()
+	span.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	span.SetEndTimestamp(pcommon.NewTimestampFromTime(end))
+
+	kv := SpanToKeyVal(span)
+
+	endTimestamp, ok := kv.Get("end_timestamp")
+	if !ok {
+		t.Fatal("expected end_timestamp to be set")
+	}
+
+	if got, want := endTimestamp, end.String(); got != want {
+		t.Fatalf("unexpected end_timestamp: got %q, want %q", got, want)
+	}
+
+	startTimestamp, ok := kv.Get("timestamp")
+	if !ok {
+		t.Fatal("expected timestamp to be set")
+	}
+
+	if got, want := startTimestamp, start.String(); got != want {
+		t.Fatalf("unexpected timestamp: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
**What is this feature?**

  `SpanToKeyVal` in `pkg/api/frontendlogging/grafana_javascript_agent_payload.go`
  populated the `end_timestamp` field from the span's `StartTimestamp()` instead of
  `EndTimestamp()` — a copy/paste bug. This fixes it to use `EndTimestamp()` and adds
  a unit test covering both timestamp fields.

  **Why do we need this feature?**

  Frontend trace-span logs reported the wrong end time (equal to the start time),
  making span durations look like zero and breaking downstream analysis.

  **Who is this feature for?**

  Users relying on frontend (Faro) trace-span logging in Grafana.

  **Which issue(s) does this PR fix?**:

  Fixes #105003

  **Special notes for your reviewer:**

  - One-line fix; the existing `if s.EndTimestamp() > 0` guard preserves prior behavior for unset/zero end timestamps.
  - The package had no tests before; added `TestSpanToKeyVal` which fails on the old code and passes with the fix.