### PR TITLE
Dashboards: Trim whitespace from UID on import

### DIFF
--- a/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.tsx
@@ -108,6 +108,7 @@ export const ImportDashboardFormV2 = ({
             <Input
               disabled
               {...register('k8s.name', {
+                setValueAs: (v) => (typeof v === 'string' ? v.trim() : v),
                 validate: async (v) => (!v ? true : await validateUid(String(v))),
               })}
               addonAfter={
@@ -121,6 +122,7 @@ export const ImportDashboardFormV2 = ({
           ) : (
             <Input
               {...register('k8s.name', {
+                setValueAs: (v) => (typeof v === 'string' ? v.trim() : v),
                 validate: async (v) => (!v ? true : await validateUid(String(v))),
               })}
             />

--- a/public/app/features/manage-dashboards/import/components/ImportForm.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportForm.tsx
@@ -109,7 +109,10 @@ export function ImportForm({
             {!uidReset ? (
               <Input
                 disabled
-                {...register('uid', { validate: async (v: string) => await validateUid(v) })}
+                {...register('uid', {
+                  setValueAs: (v: string) => (typeof v === 'string' ? v.trim() : v),
+                  validate: async (v: string) => await validateUid(v),
+                })}
                 addonAfter={
                   !uidReset && (
                     <Button onClick={onUidReset}>
@@ -119,7 +122,13 @@ export function ImportForm({
                 }
               />
             ) : (
-              <Input {...register('uid', { required: true, validate: async (v: string) => await validateUid(v) })} />
+              <Input
+                {...register('uid', {
+                  required: true,
+                  setValueAs: (v: string) => (typeof v === 'string' ? v.trim() : v),
+                  validate: async (v: string) => await validateUid(v),
+                })}
+              />
             )}
           </>
         </Field>

--- a/public/app/features/manage-dashboards/import/components/ImportForm.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportForm.tsx
@@ -110,7 +110,7 @@ export function ImportForm({
               <Input
                 disabled
                 {...register('uid', {
-                  setValueAs: (v: string) => (typeof v === 'string' ? v.trim() : v),
+                  setValueAs: (v) => (typeof v === 'string' ? v.trim() : v),
                   validate: async (v: string) => await validateUid(v),
                 })}
                 addonAfter={
@@ -125,7 +125,7 @@ export function ImportForm({
               <Input
                 {...register('uid', {
                   required: true,
-                  setValueAs: (v: string) => (typeof v === 'string' ? v.trim() : v),
+                  setValueAs: (v) => (typeof v === 'string' ? v.trim() : v),
                   validate: async (v: string) => await validateUid(v),
                 })}
               />

--- a/public/app/features/manage-dashboards/import/components/ImportOverviewV2.test.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportOverviewV2.test.tsx
@@ -258,5 +258,27 @@ describe('ImportOverviewV2', () => {
       const savedData = saveDashboard.mock.calls[0][0];
       expect(savedData.k8s?.name).toBe('custom-uid');
     });
+
+    it('trims uid before save', async () => {
+      const layout = defaultGridLayoutKind();
+      renderCmp(layout, 'resource-uid');
+
+      await user.click(screen.getByRole('button', { name: /change uid/i }));
+
+      const uidField = document.querySelector('input[name="k8s.name"]') as HTMLInputElement;
+      await user.clear(uidField);
+      await user.type(uidField, '  custom-uid  ');
+
+      const datasourcePicker = screen.getByTestId('datasource-picker-prometheus');
+      await user.type(datasourcePicker, 'prom-uid');
+      await user.click(screen.getByRole('button', { name: /import/i }));
+
+      await waitFor(() => {
+        expect(saveDashboard).toHaveBeenCalled();
+      });
+
+      const savedData = saveDashboard.mock.calls[0][0];
+      expect(savedData.k8s?.name).toBe('custom-uid');
+    });
   });
 });


### PR DESCRIPTION
**What is this feature?**

Trim whitespace from the UID field in the dashboard import forms (v1 + v2).

with spaces:
<img width="1148" height="574" alt="image" src="https://github.com/user-attachments/assets/aba8dc81-4868-4b6d-9b38-17d1911d3be7" />

