### PR TITLE
IAM: Fix LDAP-asserted role not written to k8s user spec.role

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -295,10 +295,11 @@ func (s *UserSync) SyncUserHook(ctx context.Context, id *authn.Identity, _ *auth
 		return nil
 	}
 
-	// Auth proxy keys the role asserted in the header by DefaultOrgID but never sets OrgID,
+	// Auth proxy and LDAP key the asserted role by DefaultOrgID but never set OrgID,
 	// so GetOrgRole() looks up key 0 and resolves to RoleNone. Align OrgID to DefaultOrgID so the
 	// asserted role is written to the k8s user's Spec.Role on create/update.
-	if id.OrgID == 0 && id.AuthenticatedBy == login.AuthProxyAuthModule &&
+	if id.OrgID == 0 &&
+		(id.AuthenticatedBy == login.AuthProxyAuthModule || id.AuthenticatedBy == login.LDAPAuthModule) &&
 		s.openFeatureClient.Boolean(ctx, featuremgmt.FlagKubernetesUsersRedirect, false, openfeature.TransactionContext(ctx)) {
 		id.OrgID = s.cfg.DefaultOrgID()
 	}

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -2332,7 +2332,7 @@ func TestUserSync_createUser_PassesOrgRoleAsDefaultOrgRole(t *testing.T) {
 	}
 }
 
-func TestUserSync_SyncUserHook_AuthProxyAlignsOrgIDForK8sRole(t *testing.T) {
+func TestUserSync_SyncUserHook_AlignsOrgIDForK8sRole(t *testing.T) {
 	tests := []struct {
 		name                    string
 		authenticatedBy         string
@@ -2344,6 +2344,18 @@ func TestUserSync_SyncUserHook_AuthProxyAlignsOrgIDForK8sRole(t *testing.T) {
 			authenticatedBy:         login.AuthProxyAuthModule,
 			kubernetesUsersRedirect: true,
 			wantDefaultOrgRole:      "Editor",
+		},
+		{
+			name:                    "ldap with flag enabled aligns OrgID so the asserted role is written",
+			authenticatedBy:         login.LDAPAuthModule,
+			kubernetesUsersRedirect: true,
+			wantDefaultOrgRole:      "Editor",
+		},
+		{
+			name:                    "ldap with flag disabled leaves OrgID unaligned so the role resolves to None",
+			authenticatedBy:         login.LDAPAuthModule,
+			kubernetesUsersRedirect: false,
+			wantDefaultOrgRole:      "None",
 		},
 		{
 			name:                    "auth proxy with flag disabled leaves OrgID unaligned so the role resolves to None",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Users created or updated via LDAP with a role mapped from their LDAP groups now have that role persisted to their Kubernetes user resource (`spec.role`), which `toSignedInUser` reads downstream to set the org role.

**Why do we need this feature?**
LDAP keys the asserted role into `identity.OrgRoles` by `DefaultOrgID`, but never sets `identity.OrgID`. As a result `GetOrgRole()` looked up key 0, returned `RoleNone`, and the k8s user was created with `spec.role: "None"` — leaving the user with no permissions when `kubernetesUsersRedirect` is enabled. The auth proxy hit the same bug (fixed in #125829). This extends the guard to `LDAPAuthModule`.

**Who is this feature for?**
all LDAP users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
