### PR TITLE
Map legacy `data_source.version` to k8s ResourceVersion

### DIFF
--- a/pkg/registry/apis/datasource/converter/converter.go
+++ b/pkg/registry/apis/datasource/converter/converter.go
@@ -58,6 +58,9 @@ func (r *Converter) AsDataSource(ds *datasources.DataSource) (*datasourceV0.Data
 		Spec:   datasourceV0.UnstructuredSpec{},
 		Secure: ToInlineSecureValues(ds.UID, maps.Keys(ds.SecureJsonData)),
 	}
+	if ds.Version > 0 {
+		obj.ResourceVersion = strconv.FormatInt(int64(ds.Version), 10)
+	}
 	obj.UID = gapiutil.CalculateClusterWideUID(obj)
 	obj.Spec.SetTitle(ds.Name).
 		SetAccess(string(ds.Access)).
@@ -75,25 +78,18 @@ func (r *Converter) AsDataSource(ds *datasources.DataSource) (*datasourceV0.Data
 		obj.Spec.SetJSONData(ds.JsonData.Interface())
 	}
 
-	rv := int64(0)
 	if !ds.Created.IsZero() {
 		obj.CreationTimestamp = metav1.NewTime(ds.Created)
-		rv = ds.Created.UnixMilli()
 	}
 
 	// Only mark updated if the times have actually changed
 	if !ds.Updated.IsZero() {
-		rv = ds.Updated.UnixMilli()
-		delta := rv - obj.CreationTimestamp.UnixMilli()
+		delta := ds.Updated.UnixMilli() - obj.CreationTimestamp.UnixMilli()
 		if delta > 1500 {
 			obj.Annotations = map[string]string{
 				utils.AnnoKeyUpdatedTimestamp: ds.Updated.UTC().Format(time.RFC3339),
 			}
 		}
-	}
-
-	if rv > 0 {
-		obj.ResourceVersion = strconv.FormatInt(rv, 10)
 	}
 
 	if ds.APIVersion != "" {
@@ -175,6 +171,7 @@ func (r *Converter) ToUpdateCommand(ds *datasourceV0.DataSource) (*datasources.U
 		return nil, err
 	}
 
+	version, _ := strconv.Atoi(ds.ResourceVersion)
 	cmd := &datasources.UpdateDataSourceCommand{
 		Name:  ds.Spec.Title(),
 		UID:   ds.Name,
@@ -192,7 +189,7 @@ func (r *Converter) ToUpdateCommand(ds *datasourceV0.DataSource) (*datasources.U
 		ReadOnly:        ds.Spec.ReadOnly(),
 
 		// The only field different than add
-		Version: int(ds.Generation),
+		Version: version,
 	}
 
 	jsonData := ds.Spec.JSONData()

--- a/pkg/registry/apis/datasource/converter/testdata/convert-dto-empty-to-resource.json
+++ b/pkg/registry/apis/datasource/converter/testdata/convert-dto-empty-to-resource.json
@@ -3,7 +3,7 @@
     "name": "unique-identifier",
     "namespace": "org-0",
     "uid": "YpaSG5GQAdxtLZtF6BqQWCeYXOhbVi5C4Cg4oILnJC0X",
-    "resourceVersion": "1015203600000",
+    "resourceVersion": "8",
     "generation": 8,
     "creationTimestamp": "2002-03-04T01:00:00Z",
     "labels": {

--- a/pkg/registry/apis/datasource/converter/testdata/convert-dto-testdata-to-resource.json
+++ b/pkg/registry/apis/datasource/converter/testdata/convert-dto-testdata-to-resource.json
@@ -4,7 +4,7 @@
     "name": "unique-identifier",
     "namespace": "org-0",
     "uid": "YpaSG5GQAdxtLZtF6BqQWCeYXOhbVi5C4Cg4oILnJC0X",
-    "resourceVersion": "1083805200000",
+    "resourceVersion": "2",
     "generation": 2,
     "creationTimestamp": "2002-03-04T01:00:00Z",
     "labels": {

--- a/pkg/registry/apis/datasource/converter/testdata/convert-resource-full-to-cmd-update-roundtrip.json
+++ b/pkg/registry/apis/datasource/converter/testdata/convert-resource-full-to-cmd-update-roundtrip.json
@@ -3,6 +3,7 @@
     "name": "cejobd88i85j4d",
     "namespace": "org-0",
     "uid": "boDNh7zU3nXj46rOXIJI7r44qaxjs8yy9I9dOj1MyBoX",
+    "resourceVersion": "2",
     "generation": 2
   },
   "spec": {

--- a/pkg/registry/apis/datasource/converter/testdata/convert-resource-full.json
+++ b/pkg/registry/apis/datasource/converter/testdata/convert-resource-full.json
@@ -3,7 +3,7 @@
     "name": "cejobd88i85j4d",
     "namespace": "default",
     "uid": "IGIUtEQS21DtLpBG2rSGfuDoUX8cwsGrtb5aXauYeA4X",
-    "resourceVersion": "1745320815000",
+    "resourceVersion": "2",
     "generation": 2,
     "creationTimestamp": "2025-04-22T11:20:11Z",
     "labels": {
@@ -27,7 +27,11 @@
     }
   },
   "secure": {
-    "password": { "create": "XXXX" },
-    "extra": { "remove": true }
+    "password": {
+      "create": "XXXX"
+    },
+    "extra": {
+      "remove": true
+    }
   }
 }

--- a/pkg/registry/apis/datasource/legacy_store.go
+++ b/pkg/registry/apis/datasource/legacy_store.go
@@ -147,7 +147,7 @@ func (s *legacyStorage) Update(ctx context.Context, name string, objInfo rest.Up
 		return nil, false, fmt.Errorf("expected a datasource object")
 	}
 
-	oldDS, ok := obj.(*v0alpha1.DataSource)
+	oldDS, ok := old.(*v0alpha1.DataSource)
 	if !ok {
 		return nil, false, fmt.Errorf("expected a datasource object (old)")
 	}
@@ -178,6 +178,9 @@ func (s *legacyStorage) Update(ctx context.Context, name string, objInfo rest.Up
 
 	// Keep all the old secure values
 	if len(oldDS.Secure) > 0 {
+		if ds.Secure == nil {
+			ds.Secure = map[string]common.InlineSecureValue{}
+		}
 		for k, v := range oldDS.Secure {
 			_, found := ds.Secure[k]
 			if !found {

--- a/pkg/tests/apis/datasource/testdata_test.go
+++ b/pkg/tests/apis/datasource/testdata_test.go
@@ -85,6 +85,7 @@ func TestIntegrationTestDatasource(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "test", out.GetName())
 	require.Equal(t, expectedAPIVersion, out.GetAPIVersion())
+	require.Equal(t, "1", out.GetResourceVersion())
 
 	t.Run("get", func(t *testing.T) {
 		out, err := client.Get(ctx, "test", metav1.GetOptions{})
@@ -105,7 +106,8 @@ func TestIntegrationTestDatasource(t *testing.T) {
 			Object: map[string]any{
 				"apiVersion": "grafana-testdata-datasource.datasource.grafana.app/v0alpha1",
 				"metadata": map[string]any{
-					"name": "test",
+					"name":            "test",
+					"resourceVersion": out.GetResourceVersion(),
 				},
 				"spec": map[string]any{
 					"title":     "test",
@@ -131,6 +133,7 @@ func TestIntegrationTestDatasource(t *testing.T) {
 		}, metav1.UpdateOptions{})
 		require.NoError(t, err)
 		require.Equal(t, "test", out.GetName())
+		require.Equal(t, "2", out.GetResourceVersion())
 		require.Equal(t, expectedAPIVersion, out.GetAPIVersion())
 
 		ds, err := datasourceV0alpha1.FromUnstructured(out)


### PR DESCRIPTION
We're currently mapping `data_source.updated` to the k8s object metadata ResourceVersion field.

This is not going to work while we're still using legacy storage.

Also, we weren't converting to and from legacy version <-> k8s resource version in the frontend.

This PR fixes those issues.

Accompanying PR for the UI: #126158 
