### PR TITLE
Alerting: promote staged Prometheus/Mimir import into main Grafana Alertmanager config

### DIFF
--- a/pkg/services/ngalert/accesscontrol/alertmanager_imports.go
+++ b/pkg/services/ngalert/accesscontrol/alertmanager_imports.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 )
 
 // AlertmanagerImportsAccess implements notifier.ExtraConfigAuthz using RBAC.
@@ -46,4 +47,29 @@ func (s *AlertmanagerImportsAccess) AuthorizeDelete(ctx context.Context, user id
 			models.ScopeAlertmanagerImportsProvider.GetResourceScopeUID(identifier),
 		),
 	), func() string { return "delete alertmanager import" })
+}
+
+// AuthorizePromote checks create/write permissions for every notification resource type
+// present in the import. Only the types that are actually present are checked.
+func (s *AlertmanagerImportsAccess) AuthorizePromote(ctx context.Context, user identity.Requester, result merge.MergeResult) error {
+	var evals []ac.Evaluator
+	if len(result.AddedReceivers) > 0 {
+		evals = append(evals, ac.EvalPermission(ac.ActionAlertingReceiversCreate))
+	}
+	if result.AddedRoute != "" {
+		evals = append(evals, ac.EvalPermission(ac.ActionAlertingManagedRoutesCreate))
+	}
+	if len(result.AddedTemplates) > 0 {
+		evals = append(evals, ac.EvalPermission(ac.ActionAlertingNotificationsTemplatesWrite))
+	}
+	if len(result.AddedTimeIntervals) > 0 {
+		evals = append(evals, ac.EvalPermission(ac.ActionAlertingNotificationsTimeIntervalsWrite))
+	}
+	if len(result.AddedInhibitionRules) > 0 {
+		evals = append(evals, ac.EvalPermission(ac.ActionAlertingNotificationsInhibitionRulesWrite))
+	}
+	if len(evals) == 0 {
+		return nil
+	}
+	return s.HasAccessOrError(ctx, user, ac.EvalAll(evals...), func() string { return "promote alertmanager import" })
 }

--- a/pkg/services/ngalert/accesscontrol/alertmanager_imports_test.go
+++ b/pkg/services/ngalert/accesscontrol/alertmanager_imports_test.go
@@ -8,6 +8,7 @@ import (
 
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 )
 
 func TestAlertmanagerImportsAccess_AuthorizeCreate(t *testing.T) {
@@ -94,6 +95,112 @@ func TestAlertmanagerImportsAccess_AuthorizeUpdate(t *testing.T) {
 			fake := &recordingAccessControlFake{}
 			svc := NewAlertmanagerImportsAccess(fake)
 			err := svc.AuthorizeUpdate(context.Background(), newUser(tc.permissions...), tc.identifier)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAlertmanagerImportsAccess_AuthorizePromote(t *testing.T) {
+	testCases := []struct {
+		name        string
+		permissions []ac.Permission
+		result      merge.MergeResult
+		expectedErr bool
+	}{
+		{
+			name:        "no resources succeeds without any permissions",
+			result:      merge.MergeResult{},
+			expectedErr: false,
+		},
+		{
+			name:        "HasReceivers with receivers:create succeeds",
+			permissions: []ac.Permission{{Action: ac.ActionAlertingReceiversCreate}},
+			result:      merge.MergeResult{AddedReceivers: []string{"x"}},
+			expectedErr: false,
+		},
+		{
+			name:        "HasReceivers without receivers:create fails",
+			result:      merge.MergeResult{AddedReceivers: []string{"x"}},
+			expectedErr: true,
+		},
+		{
+			name:        "HasRoutes with routes:create succeeds",
+			permissions: []ac.Permission{{Action: ac.ActionAlertingManagedRoutesCreate}},
+			result:      merge.MergeResult{AddedRoute: "x"},
+			expectedErr: false,
+		},
+		{
+			name:        "HasRoutes without routes:create fails",
+			result:      merge.MergeResult{AddedRoute: "x"},
+			expectedErr: true,
+		},
+		{
+			name:        "HasTemplates with templates:write succeeds",
+			permissions: []ac.Permission{{Action: ac.ActionAlertingNotificationsTemplatesWrite}},
+			result:      merge.MergeResult{AddedTemplates: []string{"x"}},
+			expectedErr: false,
+		},
+		{
+			name:        "HasTemplates without templates:write fails",
+			result:      merge.MergeResult{AddedTemplates: []string{"x"}},
+			expectedErr: true,
+		},
+		{
+			name:        "HasTimeIntervals with time-intervals:write succeeds",
+			permissions: []ac.Permission{{Action: ac.ActionAlertingNotificationsTimeIntervalsWrite}},
+			result:      merge.MergeResult{AddedTimeIntervals: []string{"x"}},
+			expectedErr: false,
+		},
+		{
+			name:        "HasTimeIntervals without time-intervals:write fails",
+			result:      merge.MergeResult{AddedTimeIntervals: []string{"x"}},
+			expectedErr: true,
+		},
+		{
+			name:        "HasInhibitionRules with inhibition-rules:write succeeds",
+			permissions: []ac.Permission{{Action: ac.ActionAlertingNotificationsInhibitionRulesWrite}},
+			result:      merge.MergeResult{AddedInhibitionRules: []string{"x"}},
+			expectedErr: false,
+		},
+		{
+			name:        "HasInhibitionRules without inhibition-rules:write fails",
+			result:      merge.MergeResult{AddedInhibitionRules: []string{"x"}},
+			expectedErr: true,
+		},
+		{
+			name: "all resources with all permissions succeeds",
+			permissions: []ac.Permission{
+				{Action: ac.ActionAlertingReceiversCreate},
+				{Action: ac.ActionAlertingManagedRoutesCreate},
+				{Action: ac.ActionAlertingNotificationsTemplatesWrite},
+				{Action: ac.ActionAlertingNotificationsTimeIntervalsWrite},
+				{Action: ac.ActionAlertingNotificationsInhibitionRulesWrite},
+			},
+			result:      merge.MergeResult{AddedReceivers: []string{"x"}, AddedRoute: "x", AddedTemplates: []string{"x"}, AddedTimeIntervals: []string{"x"}, AddedInhibitionRules: []string{"x"}},
+			expectedErr: false,
+		},
+		{
+			name: "all resources with one permission missing fails",
+			permissions: []ac.Permission{
+				{Action: ac.ActionAlertingReceiversCreate},
+				{Action: ac.ActionAlertingManagedRoutesCreate},
+				{Action: ac.ActionAlertingNotificationsTemplatesWrite},
+				{Action: ac.ActionAlertingNotificationsTimeIntervalsWrite},
+			},
+			result:      merge.MergeResult{AddedReceivers: []string{"x"}, AddedRoute: "x", AddedTemplates: []string{"x"}, AddedTimeIntervals: []string{"x"}, AddedInhibitionRules: []string{"x"}},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &recordingAccessControlFake{}
+			svc := NewAlertmanagerImportsAccess(fake)
+			err := svc.AuthorizePromote(context.Background(), newUser(tc.permissions...), tc.result)
 			if tc.expectedErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -67,6 +67,8 @@ const (
 	configForceReplaceHeader = "X-Grafana-Alerting-Config-Force-Replace"
 	// dryRunHeader if specified, will validate the configuration without saving it
 	dryRunHeader = "X-Grafana-Alerting-Dry-Run"
+	// promoteHeader if specified, will promote the merge imported configuration into Grafana and save. This is a one-off operation
+	promoteHeader = "X-Grafana-Alerting-Promote"
 
 	// versionMessageHeader is the header that specifies an optional message for rule versions.
 	versionMessageHeader = "X-Grafana-Alerting-Version-Message"
@@ -142,7 +144,7 @@ type ConvertPrometheusSrv struct {
 
 type Alertmanager interface {
 	DeleteExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, identifier string) error
-	SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace bool, dryRun bool) (merge.MergeResult, error)
+	SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace, dryRun, promote bool) (merge.MergeResult, error)
 	GetAlertmanagerConfiguration(ctx context.Context, org int64, withAutogen bool) (apimodels.GettableUserConfig, error)
 	IsExternalAMSyncConfiguredForOrg(ctx context.Context, orgID int64) (bool, error)
 }
@@ -621,11 +623,18 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostAlertmanagerConfig(c 
 		return errorToResponse(err)
 	}
 
+	promote, err := parseBooleanHeader(c.Req.Header.Get(promoteHeader), promoteHeader)
+	if err != nil {
+		logger.Error("Failed to parse promote header", "error", err)
+		return errorToResponse(err)
+	}
+
 	identifier, err := parseConfigIdentifierHeader(c)
 	if err != nil {
 		logger.Error("Failed to parse config identifier header", "error", err)
 		return errorToResponse(err)
 	}
+	logger = logger.New("identifier", identifier)
 
 	ec := v1.ExtraConfiguration{
 		Identifier:         identifier,
@@ -634,7 +643,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostAlertmanagerConfig(c 
 	}
 	err = ec.Validate()
 	if err != nil {
-		logger.Error("Invalid alertmanager configuration", "error", err, "identifier", identifier)
+		logger.Error("Invalid alertmanager configuration", "error", err)
 		return errorToResponse(err)
 	}
 
@@ -644,20 +653,24 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostAlertmanagerConfig(c 
 		return errorToResponse(err)
 	}
 
-	result, err := srv.am.SaveAndApplyExtraConfiguration(c.Req.Context(), c.GetOrgID(), c.SignedInUser, srv.importsAuthz, ec, replace, dryRun)
+	result, err := srv.am.SaveAndApplyExtraConfiguration(c.Req.Context(), c.GetOrgID(), c.SignedInUser, srv.importsAuthz, ec, replace, dryRun, promote)
 	if err != nil {
-		logger.Error("Failed to save alertmanager configuration", "error", err, "identifier", identifier)
+		logger.Error("Failed to save alertmanager configuration", "error", err)
 		return errorToResponse(fmt.Errorf("failed to save alertmanager configuration: %w", err))
 	}
 
 	apiResp := buildConvertResponse(result)
 
+	logCtx := append(result.LogContext(), "replace", replace)
 	if dryRun {
-		logger.Info("Dry run: alertmanager configuration validated successfully", "identifier", identifier, "replace", replace)
+		logger.Debug("Dry run: alertmanager configuration validated successfully", logCtx...)
 		return response.JSON(http.StatusOK, apiResp)
 	}
-
-	logger.Info("Successfully updated alertmanager configuration with imported Prometheus config", "identifier", identifier, "replace", replace)
+	if promote {
+		logger.Info("Successfully imported and promoted alertmanager configuration", logCtx...)
+	} else {
+		logger.Info("Successfully updated alertmanager configuration with imported Prometheus config", logCtx...)
+	}
 	return response.JSON(http.StatusAccepted, apiResp)
 }
 

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -1964,8 +1964,8 @@ type mockAlertmanager struct {
 	mock.Mock
 }
 
-func (m *mockAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace bool, dryRun bool) (merge.MergeResult, error) {
-	args := m.Called(ctx, org, user, authz, extraConfig, replace, dryRun)
+func (m *mockAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace, dryRun, promote bool) (merge.MergeResult, error) {
+	args := m.Called(ctx, org, user, authz, extraConfig, replace, dryRun, promote)
 	return args.Get(0).(merge.MergeResult), args.Error(1)
 }
 
@@ -1997,7 +1997,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 			return extraConfig.Identifier == identifier &&
 				len(extraConfig.TemplateFiles) == 1 &&
 				extraConfig.TemplateFiles["test.tmpl"] == "{{ define \"test\" }}Hello{{ end }}"
-		}), false, false).Return(merge.MergeResult{}, nil).Once()
+		}), false, false, false).Return(merge.MergeResult{}, nil).Once()
 
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configIdentifierHeader, identifier)
@@ -2030,7 +2030,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM.On("IsExternalAMSyncConfiguredForOrg", mock.Anything, int64(1)).Return(false, nil).Maybe()
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig v1.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), false, false).Return(merge.MergeResult{}, nil)
+		}), false, false, false).Return(merge.MergeResult{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies, featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2060,7 +2060,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM.On("IsExternalAMSyncConfiguredForOrg", mock.Anything, int64(1)).Return(false, nil).Maybe()
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig v1.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), true, false).Return(merge.MergeResult{}, nil)
+		}), true, false, false).Return(merge.MergeResult{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies, featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2090,7 +2090,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM.On("IsExternalAMSyncConfiguredForOrg", mock.Anything, int64(1)).Return(false, nil).Maybe()
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig v1.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), false, true).Return(merge.MergeResult{}, nil)
+		}), false, true, false).Return(merge.MergeResult{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies, featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2137,7 +2137,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig v1.ExtraConfiguration) bool {
 			return extraConfig.Identifier == identifier
-		}), false, false).Return(expectedResult, nil)
+		}), false, false, false).Return(expectedResult, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies, featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -356,6 +356,9 @@ type RouteConvertPrometheusPostAlertmanagerConfigParams struct {
 	// If true, validates the configuration without saving it
 	// in: header
 	DryRun bool `json:"x-grafana-alerting-dry-run"`
+	// If true, immediately promotes the configuration into the main Grafana config, making it editable via regular APIs.
+	// in: header
+	Promote bool `json:"x-grafana-alerting-promote"`
 	// Alertmanager configuration including routing rules, receivers, and template files
 	// in:body
 	Body AlertmanagerUserConfig

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -27,6 +27,7 @@ type ExtraConfigAuthz interface {
 	AuthorizeCreate(ctx context.Context, user identity.Requester) error
 	AuthorizeUpdate(ctx context.Context, user identity.Requester, identifier string) error
 	AuthorizeDelete(ctx context.Context, user identity.Requester, identifier string) error
+	AuthorizePromote(ctx context.Context, user identity.Requester, result merge.MergeResult) error
 }
 
 var (
@@ -350,11 +351,15 @@ func (moa *MultiOrgAlertmanager) gettableUserConfigFromAMConfigString(ctx contex
 
 // modifyAndApplyExtraConfiguration is a helper function that loads the current configuration,
 // applies a modification function to the ExtraConfigs, and saves the result.
+// If promote is true, the saved config is immediately promoted into the main Grafana config.
 func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 	ctx context.Context,
 	org int64,
+	user identity.Requester,
+	authz ExtraConfigAuthz,
 	modifyFn func([]v1.ExtraConfiguration) ([]v1.ExtraConfiguration, error),
 	dryRun bool,
+	promote bool,
 ) (merge.MergeResult, error) {
 	currentCfg, err := moa.configStore.GetLatestAlertmanagerConfiguration(ctx, org)
 	if err != nil {
@@ -379,7 +384,11 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 		}
 	}
 
-	_, mergeResult, err := merge.MergeExtraConfig(ctx, cfg, models.ProvenanceConvertedPrometheus)
+	provenance := models.ProvenanceConvertedPrometheus
+	if promote {
+		provenance = models.ProvenanceNone
+	}
+	mergedConfig, mergeResult, err := merge.MergeExtraConfig(ctx, cfg, provenance)
 	if err != nil {
 		return merge.MergeResult{}, fmt.Errorf("cannot merge imported configuration into Grafana: %w", err)
 	}
@@ -387,6 +396,12 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 	if dryRun {
 		moa.logger.Debug("Dry run: extra configuration validated successfully", "org", org)
 		return mergeResult, nil
+	}
+	if promote {
+		if err := authz.AuthorizePromote(ctx, user, mergeResult); err != nil {
+			return merge.MergeResult{}, err
+		}
+		cfg = &mergedConfig
 	}
 
 	am, err := moa.AlertmanagerFor(org)
@@ -406,7 +421,7 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 		return merge.MergeResult{}, AlertmanagerConfigRejectedError{err}
 	}
 
-	moa.logger.Info("Applied alertmanager configuration with extra config", "org", org)
+	moa.logger.Info("Applied alertmanager configuration with extra config", "org", org, "promoted", promote)
 	return mergeResult, nil
 }
 
@@ -451,7 +466,7 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 		return []v1.ExtraConfiguration{extraConfig}, nil
 	}
 
-	result, err := moa.modifyAndApplyExtraConfiguration(ctx, org, modifyFunc, dryRun)
+	result, err := moa.modifyAndApplyExtraConfiguration(ctx, org, user, authz, modifyFunc, dryRun, false)
 	if err != nil {
 		return merge.MergeResult{}, err
 	}
@@ -479,7 +494,7 @@ func (moa *MultiOrgAlertmanager) DeleteExtraConfiguration(ctx context.Context, o
 		return filtered, nil
 	}
 
-	_, err := moa.modifyAndApplyExtraConfiguration(ctx, org, modifyFunc, false)
+	_, err := moa.modifyAndApplyExtraConfiguration(ctx, org, user, authz, modifyFunc, false, false)
 	return err
 }
 

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -85,7 +85,7 @@ func (moa *MultiOrgAlertmanager) PrepareConfig(
 	}
 
 	//nolint:staticcheck // not yet migrated to OpenFeature
-	if moa.featureManager.IsEnabledGlobally(featuremgmt.FlagAlertingImportAlertmanagerAPI) && moa.featureManager.IsEnabledGlobally(featuremgmt.FlagAlertingMultiplePolicies) {
+	if len(prepared.ExtraConfigs) > 0 && moa.featureManager.IsEnabledGlobally(featuremgmt.FlagAlertingImportAlertmanagerAPI) && moa.featureManager.IsEnabledGlobally(featuremgmt.FlagAlertingMultiplePolicies) {
 		if err := moa.Crypto.DecryptExtraConfigs(ctx, prepared); err != nil {
 			return alertingNotify.NotificationsConfiguration{}, fmt.Errorf("failed to decrypt external configurations: %w", err)
 		}

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -426,7 +426,8 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 }
 
 // SaveAndApplyExtraConfiguration adds or replaces an ExtraConfiguration while preserving the main AlertmanagerConfig.
-func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace bool, dryRun bool) (merge.MergeResult, error) {
+// If promote is true, the configuration is immediately promoted into the main config before saving.
+func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace, dryRun, promote bool) (merge.MergeResult, error) {
 	modifyFunc := func(configs []v1.ExtraConfiguration) ([]v1.ExtraConfiguration, error) {
 		if replace {
 			// When replacing all configs, authorize deletion for each config with a different identifier.
@@ -466,7 +467,7 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 		return []v1.ExtraConfiguration{extraConfig}, nil
 	}
 
-	result, err := moa.modifyAndApplyExtraConfiguration(ctx, org, user, authz, modifyFunc, dryRun, false)
+	result, err := moa.modifyAndApplyExtraConfiguration(ctx, org, user, authz, modifyFunc, dryRun, promote)
 	if err != nil {
 		return merge.MergeResult{}, err
 	}
@@ -474,7 +475,7 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 	if dryRun {
 		moa.logger.Info("Dry run: validated alertmanager configuration with extra config", "org", org, "identifier", extraConfig.Identifier)
 	} else {
-		moa.logger.Info("Applied alertmanager configuration with extra config", "org", org, "identifier", extraConfig.Identifier)
+		moa.logger.Info("Applied alertmanager configuration with extra config", "org", org, "identifier", extraConfig.Identifier, "promoted", promote)
 	}
 	return result, nil
 }

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -392,16 +392,15 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 	if err != nil {
 		return merge.MergeResult{}, fmt.Errorf("cannot merge imported configuration into Grafana: %w", err)
 	}
-
-	if dryRun {
-		moa.logger.Debug("Dry run: extra configuration validated successfully", "org", org)
-		return mergeResult, nil
-	}
 	if promote {
 		if err := authz.AuthorizePromote(ctx, user, mergeResult); err != nil {
 			return merge.MergeResult{}, err
 		}
 		cfg = &mergedConfig
+	}
+	if dryRun {
+		moa.logger.Debug("Dry run: extra configuration validated successfully", "org", org)
+		return mergeResult, nil
 	}
 
 	am, err := moa.AlertmanagerFor(org)

--- a/pkg/services/ngalert/notifier/alertmanager_config_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config_test.go
@@ -69,7 +69,7 @@ func TestMultiOrgAlertmanager_SaveAndApplyExtraConfiguration(t *testing.T) {
   receiver: test-receiver`,
 		}
 
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, 999, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, 999, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false, false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to get current configuration")
 	})
@@ -88,7 +88,7 @@ receivers:
   - name: test-receiver`,
 		}
 
-		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false)
+		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false, false)
 		require.NoError(t, err)
 		require.Empty(t, renamed.Receivers, "no renaming should occur")
 		require.Empty(t, renamed.TimeIntervals, "no renaming should occur")
@@ -123,7 +123,7 @@ receivers:
 		}
 
 		// Call with dryRun=true
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, true)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, true, false)
 		require.NoError(t, err)
 
 		// Verify configuration was NOT saved
@@ -148,7 +148,7 @@ receivers:
   - name: original-receiver`,
 		}
 
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, originalConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, originalConfig, false, false, false)
 		require.NoError(t, err)
 
 		// Now replace it
@@ -161,7 +161,7 @@ receivers:
   - name: updated-receiver`,
 		}
 
-		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, updatedConfig, false, false)
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, updatedConfig, false, false, false)
 		require.NoError(t, err)
 
 		// Verify only one config exists with updated content
@@ -191,7 +191,7 @@ receivers:
 			}`,
 		}
 
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, firstConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, firstConfig, false, false, false)
 		require.NoError(t, err)
 
 		secondConfig := v1.ExtraConfiguration{
@@ -208,13 +208,13 @@ receivers:
 			}`,
 		}
 
-		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, secondConfig, false, false)
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, secondConfig, false, false, false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "multiple extra configurations are not supported")
 		require.ErrorContains(t, err, "first-config")
 
 		t.Run("replaces if replace=true", func(t *testing.T) {
-			_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, secondConfig, true, false)
+			_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, secondConfig, true, false, false)
 			require.NoError(t, err)
 
 			gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false)
@@ -271,7 +271,7 @@ receivers:
   - name: original-receiver`,
 		}
 
-		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, originalConfig, false, false)
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, originalConfig, false, false, false)
 		require.ErrorIs(t, err, ErrIdentifierAlreadyExists)
 	})
 }
@@ -294,7 +294,7 @@ receivers:
   - name: test-receiver`,
 		}
 
-		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false)
+		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false, false)
 		require.NoError(t, err)
 		require.Empty(t, renamed.Receivers, "no renaming should occur")
 		require.Empty(t, renamed.TimeIntervals, "no renaming should occur")
@@ -347,7 +347,7 @@ receivers:
 		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
 
 		authz := stubExtraConfigAuthz{createErr: errors.New("forbidden")}
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, validConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, validConfig, false, false, false)
 		require.Error(t, err)
 
 		// Verify no config was saved.
@@ -361,12 +361,12 @@ receivers:
 		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
 
 		// Save the config first with noop authz.
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, validConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, validConfig, false, false, false)
 		require.NoError(t, err)
 
 		// Try updating with update denied.
 		authz := stubExtraConfigAuthz{updateErr: errors.New("forbidden")}
-		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, validConfig, false, false)
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, validConfig, false, false, false)
 		require.Error(t, err)
 	})
 
@@ -382,7 +382,7 @@ receivers:
 receivers:
   - name: test-receiver`,
 		}
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, configA, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, configA, false, false, false)
 		require.NoError(t, err)
 
 		// Try to save config B with replace=true, but delete is denied.
@@ -394,7 +394,7 @@ receivers:
   - name: test-receiver`,
 		}
 		authz := stubExtraConfigAuthz{deleteErr: errors.New("forbidden")}
-		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, configB, true, false)
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, configB, true, false, false)
 		require.Error(t, err)
 	})
 
@@ -403,7 +403,7 @@ receivers:
 		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
 
 		// Save config first.
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, validConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, validConfig, false, false, false)
 		require.NoError(t, err)
 
 		// Try to delete with delete denied.

--- a/pkg/services/ngalert/notifier/alertmanager_config_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
@@ -30,11 +31,15 @@ func (noopExtraConfigAuthz) AuthorizeUpdate(_ context.Context, _ identity.Reques
 func (noopExtraConfigAuthz) AuthorizeDelete(_ context.Context, _ identity.Requester, _ string) error {
 	return nil
 }
+func (noopExtraConfigAuthz) AuthorizePromote(_ context.Context, _ identity.Requester, _ merge.MergeResult) error {
+	return nil
+}
 
 type stubExtraConfigAuthz struct {
-	createErr error
-	updateErr error
-	deleteErr error
+	createErr  error
+	updateErr  error
+	deleteErr  error
+	promoteErr error
 }
 
 func (s stubExtraConfigAuthz) AuthorizeCreate(_ context.Context, _ identity.Requester) error {
@@ -45,6 +50,9 @@ func (s stubExtraConfigAuthz) AuthorizeUpdate(_ context.Context, _ identity.Requ
 }
 func (s stubExtraConfigAuthz) AuthorizeDelete(_ context.Context, _ identity.Requester, _ string) error {
 	return s.deleteErr
+}
+func (s stubExtraConfigAuthz) AuthorizePromote(_ context.Context, _ identity.Requester, _ merge.MergeResult) error {
+	return s.promoteErr
 }
 
 func TestMultiOrgAlertmanager_SaveAndApplyExtraConfiguration(t *testing.T) {

--- a/pkg/services/ngalert/notifier/alertmanager_config_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config_test.go
@@ -224,6 +224,86 @@ receivers:
 		})
 	})
 
+	t.Run("promote merges extra config into main config", func(t *testing.T) {
+		mam := setupMam(t, nil)
+		ctx := context.Background()
+		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
+
+		identifier := "promoted-config"
+		extraConfig := v1.ExtraConfiguration{
+			Identifier:    identifier,
+			TemplateFiles: map[string]string{"promoted.tmpl": `{{ define "promoted" }}Promoted{{ end }}`},
+			AlertmanagerConfig: `route:
+  receiver: promoted-receiver
+receivers:
+  - name: promoted-receiver`,
+		}
+
+		result, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false, true)
+		require.NoError(t, err)
+		require.Equal(t, identifier, result.AddedRoute)
+		require.Contains(t, result.AddedReceivers, "promoted-receiver")
+		require.Contains(t, result.AddedTemplates, "promoted.tmpl")
+
+		gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false)
+		require.NoError(t, err)
+		// Promoted config is merged into main config, so ExtraConfigs should be empty.
+		require.Empty(t, gettableConfig.ExtraConfigs)
+		// The promoted receiver should appear in the main alertmanager config.
+		receiverNames := make([]string, 0, len(gettableConfig.AlertmanagerConfig.Receivers))
+		for _, r := range gettableConfig.AlertmanagerConfig.Receivers {
+			receiverNames = append(receiverNames, r.Name)
+		}
+		require.Contains(t, receiverNames, "promoted-receiver")
+
+		// Promoted resources must not be provisioned (ProvenanceNone), so they remain editable.
+		rawCfg, err := mam.configStore.GetLatestAlertmanagerConfiguration(ctx, orgID)
+		require.NoError(t, err)
+		cfg, err := Load([]byte(rawCfg.AlertmanagerConfiguration))
+		require.NoError(t, err)
+		for _, tmpl := range cfg.Templates {
+			if tmpl.Title == "promoted.tmpl" {
+				require.Equal(t, models.ProvenanceNone, tmpl.Provenance,
+					"promoted template must have ProvenanceNone, not provisioned")
+				return
+			}
+		}
+		t.Fatal("promoted.tmpl not found in raw config templates")
+	})
+
+	t.Run("non-promoted extra config templates are provisioned", func(t *testing.T) {
+		mam := setupMam(t, nil)
+		ctx := context.Background()
+		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
+
+		extraConfig := v1.ExtraConfiguration{
+			Identifier:    "imported-config",
+			TemplateFiles: map[string]string{"imported.tmpl": `{{ define "imported" }}Imported{{ end }}`},
+			AlertmanagerConfig: `route:
+  receiver: imported-receiver
+receivers:
+  - name: imported-receiver`,
+		}
+
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false, false)
+		require.NoError(t, err)
+
+		// Non-promoted templates stay in ExtraConfigs and are not merged into cfg.Templates.
+		gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false)
+		require.NoError(t, err)
+		require.Len(t, gettableConfig.ExtraConfigs, 1)
+
+		// The merged (runtime) config still carries the template with ConvertedPrometheus provenance.
+		rawCfg, err := mam.configStore.GetLatestAlertmanagerConfiguration(ctx, orgID)
+		require.NoError(t, err)
+		cfg, err := Load([]byte(rawCfg.AlertmanagerConfiguration))
+		require.NoError(t, err)
+		// Raw config should have no templates at the top level — they live in ExtraConfigs.
+		for _, tmpl := range cfg.Templates {
+			require.NotEqual(t, "imported.tmpl", tmpl.Title, "non-promoted template must not appear in top-level Templates")
+		}
+	})
+
 	t.Run("fail to create extra configuration with identifier that used in managed routes", func(t *testing.T) {
 		mam := setupMam(t, nil)
 		ctx := context.Background()
@@ -396,6 +476,20 @@ receivers:
 		authz := stubExtraConfigAuthz{deleteErr: errors.New("forbidden")}
 		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, configB, true, false, false)
 		require.Error(t, err)
+	})
+
+	t.Run("SaveAndApply promote=true: AuthorizePromote denied", func(t *testing.T) {
+		mam := setupMam(t, nil)
+		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
+
+		authz := stubExtraConfigAuthz{promoteErr: errors.New("forbidden")}
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, validConfig, false, false, true)
+		require.Error(t, err)
+
+		// Verify no config was saved.
+		gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false)
+		require.NoError(t, err)
+		require.Len(t, gettableConfig.ExtraConfigs, 0)
 	})
 
 	t.Run("Delete: AuthorizeDelete denied", func(t *testing.T) {

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -124,7 +124,7 @@ receivers:
         smarthost: 'smtp.gmail.com:587'
         auth_username: 'grafana@example.com'
         auth_password: 'another-secret-password'`,
-	}, false, false)
+	}, false, false, false)
 	require.NoError(t, err)
 
 	savedConfig, err := moa.configStore.GetLatestAlertmanagerConfiguration(context.Background(), am.(*alertmanager).Base.TenantID())

--- a/pkg/services/ngalert/notifier/external_am_syncer_test.go
+++ b/pkg/services/ngalert/notifier/external_am_syncer_test.go
@@ -474,7 +474,7 @@ func TestSyncExternalAMs_IdentifierMismatchClassifiedOnMetric(t *testing.T) {
 	_, err := moa.SaveAndApplyExtraConfiguration(seedCtx, 1, seedUser, syncBypassAuthz{}, v1.ExtraConfiguration{
 		Identifier:         "existing-uid",
 		AlertmanagerConfig: amConfig,
-	}, false, false)
+	}, false, false, false)
 	require.NoError(t, err)
 	rowsBefore := len(cs.historicConfigs[1])
 

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 
 	alertingNotify "github.com/grafana/alerting/notify"
 
@@ -408,6 +409,10 @@ func (syncBypassAuthz) AuthorizeDelete(context.Context, identity.Requester, stri
 	return nil
 }
 
+func (syncBypassAuthz) AuthorizePromote(context.Context, identity.Requester, merge.MergeResult) error {
+	return nil
+}
+
 // syncExternalAMConfigForOrgs runs the external Alertmanager fetch for each
 // non-disabled org whose Alertmanager instance has already been created, and
 // persists any changed configs via SaveAndApplyExtraConfiguration.
@@ -441,7 +446,7 @@ func (moa *MultiOrgAlertmanager) syncExternalAMConfigForOrgs(ctx context.Context
 		// External sync is system-driven, so we use a service identity and a no-op
 		// authz: there is no end-user request to authorize against.
 		svcCtx, svcUser := identity.WithServiceIdentity(ctx, orgID)
-		if _, err := moa.SaveAndApplyExtraConfiguration(svcCtx, orgID, svcUser, syncBypassAuthz{}, *ec, false /*replace*/, false /*dryRun*/); err != nil {
+		if _, err := moa.SaveAndApplyExtraConfiguration(svcCtx, orgID, svcUser, syncBypassAuthz{}, *ec, false /*replace*/, false /*dryRun*/, false /*promote*/); err != nil {
 			reason := classifySyncError(err)
 			moa.logger.Warn("Failed to save external AM configuration", "org_id", orgID, "reason", reason, "error", err)
 			moa.metrics.ExternalAMConfigSyncFailures.WithLabelValues(fmt.Sprintf("%d", orgID), reason).Inc()

--- a/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
@@ -376,6 +376,243 @@ receivers:
 		})
 	})
 
+	t.Run("promote imports configuration into main Grafana config", func(t *testing.T) {
+		identifier := "test-promote-main"
+
+		amConfig := apimodels.AlertmanagerUserConfig{
+			AlertmanagerConfig: `
+route:
+  receiver: promoted-webhook
+receivers:
+  - name: promoted-webhook
+    webhook_configs:
+      - url: 'http://127.0.0.1:8080/webhook'
+`,
+			TemplateFiles: map[string]string{
+				"promoted.tmpl": `{{ define "promoted" }}Promoted{{ end }}`,
+			},
+		}
+
+		rawResp, status, _ := apiClient.RawConvertPrometheusPostAlertmanagerConfig(t, amConfig, map[string]string{
+			"Content-Type":                         "application/yaml",
+			"X-Grafana-Alerting-Config-Identifier": identifier,
+			"X-Grafana-Alerting-Promote":           "true",
+		})
+		requireStatusCode(t, http.StatusAccepted, status, "")
+		require.Equal(t, "success", rawResp.Status)
+		require.NotNil(t, rawResp.Stats)
+		require.Equal(t, identifier, rawResp.Stats.AddedRoute)
+		require.Contains(t, rawResp.Stats.AddedReceivers, "promoted-webhook")
+		require.Contains(t, rawResp.Stats.AddedTemplates, "promoted.tmpl")
+
+		// Promoted config must not be stored in ExtraConfigs.
+		_, status, _ = apiClient.RawConvertPrometheusGetAlertmanagerConfig(t, map[string]string{
+			"X-Grafana-Alerting-Config-Identifier": identifier,
+		})
+		requireStatusCode(t, http.StatusNotFound, status, "")
+
+		// Promoted receiver and template must appear in the main Grafana alertmanager config.
+		mainConfig, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
+		requireStatusCode(t, http.StatusOK, status, "")
+		require.Empty(t, mainConfig.ExtraConfigs)
+		var receiverNames []string
+		for _, r := range mainConfig.AlertmanagerConfig.Receivers {
+			receiverNames = append(receiverNames, r.Name)
+		}
+		require.Contains(t, receiverNames, "promoted-webhook")
+		require.Contains(t, mainConfig.TemplateFiles, "promoted.tmpl")
+
+		// Promoted template must be accessible via the provisioning templates API with no provenance —
+		// meaning it is not locked and can be edited through regular APIs.
+		templates, status, _ := apiClient.GetTemplatesWithStatus(t)
+		requireStatusCode(t, http.StatusOK, status, "")
+		var found *apimodels.NotificationTemplate
+		for i := range templates {
+			if templates[i].Name == "promoted.tmpl" {
+				found = &templates[i]
+				break
+			}
+		}
+		require.NotNil(t, found, "promoted.tmpl must appear in the provisioning templates API")
+		require.Empty(t, found.Provenance, "promoted template must have no provenance (not locked)")
+	})
+
+	t.Run("dry-run with promote validates but does not save", func(t *testing.T) {
+		identifier := "test-dryrun-promote"
+
+		amConfig := apimodels.AlertmanagerUserConfig{
+			AlertmanagerConfig: `
+route:
+  receiver: dryrun-promote-receiver
+receivers:
+  - name: dryrun-promote-receiver
+    webhook_configs:
+      - url: 'http://127.0.0.1:8080/dryrun'
+`,
+		}
+
+		_, status, body := apiClient.RawConvertPrometheusPostAlertmanagerConfig(t, amConfig, map[string]string{
+			"Content-Type":                         "application/yaml",
+			"X-Grafana-Alerting-Config-Identifier": identifier,
+			"X-Grafana-Alerting-Dry-Run":           "true",
+			"X-Grafana-Alerting-Promote":           "true",
+		})
+		requireStatusCode(t, http.StatusOK, status, body) // dry-run returns 200
+		rawResp := apimodels.ConvertAlertmanagerResponse{}
+		require.NoError(t, json.Unmarshal([]byte(body), &rawResp))
+		require.Equal(t, "success", rawResp.Status)
+		require.NotNil(t, rawResp.Stats)
+		require.Equal(t, identifier, rawResp.Stats.AddedRoute)
+		require.Contains(t, rawResp.Stats.AddedReceivers, "dryrun-promote-receiver")
+
+		// Nothing must be saved — neither in ExtraConfigs nor in the main config.
+		_, status, _ = apiClient.RawConvertPrometheusGetAlertmanagerConfig(t, map[string]string{
+			"X-Grafana-Alerting-Config-Identifier": identifier,
+		})
+		requireStatusCode(t, http.StatusNotFound, status, "")
+
+		mainConfig, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
+		requireStatusCode(t, http.StatusOK, status, "")
+		var receiverNames []string
+		for _, r := range mainConfig.AlertmanagerConfig.Receivers {
+			receiverNames = append(receiverNames, r.Name)
+		}
+		require.NotContains(t, receiverNames, "dryrun-promote-receiver")
+	})
+
+	t.Run("promote blocks re-import with same identifier", func(t *testing.T) {
+		identifier := "test-promote-reimport"
+
+		amConfig := apimodels.AlertmanagerUserConfig{
+			AlertmanagerConfig: `
+route:
+  receiver: reimport-receiver
+receivers:
+  - name: reimport-receiver
+    webhook_configs:
+      - url: 'http://127.0.0.1:8080/reimport'
+`,
+		}
+		headers := map[string]string{
+			"Content-Type":                         "application/yaml",
+			"X-Grafana-Alerting-Config-Identifier": identifier,
+			"X-Grafana-Alerting-Promote":           "true",
+		}
+
+		_, status, _ := apiClient.RawConvertPrometheusPostAlertmanagerConfig(t, amConfig, headers)
+		requireStatusCode(t, http.StatusAccepted, status, "")
+
+		// Re-importing with the same identifier must fail: the identifier is now locked in ManagedRoutes.
+		_, status, body := apiClient.RawConvertPrometheusPostAlertmanagerConfig(t, amConfig, headers)
+		requireStatusCode(t, http.StatusBadRequest, status, body)
+	})
+
+	t.Run("promote with replace removes pre-existing ExtraConfig", func(t *testing.T) {
+		identifierA := "test-promote-replace-a"
+		identifierB := "test-promote-replace-b"
+
+		// Step 1: import config A without promote.
+		_, status, _ := apiClient.RawConvertPrometheusPostAlertmanagerConfig(t, apimodels.AlertmanagerUserConfig{
+			AlertmanagerConfig: `
+route:
+  receiver: replace-a-receiver
+receivers:
+  - name: replace-a-receiver
+    webhook_configs:
+      - url: 'http://127.0.0.1:8080/a'
+`,
+		}, map[string]string{
+			"Content-Type":                         "application/yaml",
+			"X-Grafana-Alerting-Config-Identifier": identifierA,
+		})
+		requireStatusCode(t, http.StatusAccepted, status, "")
+
+		// Verify A is in ExtraConfigs.
+		_, status, _ = apiClient.RawConvertPrometheusGetAlertmanagerConfig(t, map[string]string{
+			"X-Grafana-Alerting-Config-Identifier": identifierA,
+		})
+		requireStatusCode(t, http.StatusOK, status, "")
+
+		// Step 2: import config B with promote=true and replace=true.
+		rawResp, status, _ := apiClient.RawConvertPrometheusPostAlertmanagerConfig(t, apimodels.AlertmanagerUserConfig{
+			AlertmanagerConfig: `
+route:
+  receiver: replace-b-receiver
+receivers:
+  - name: replace-b-receiver
+    webhook_configs:
+      - url: 'http://127.0.0.1:8080/b'
+`,
+		}, map[string]string{
+			"Content-Type":                            "application/yaml",
+			"X-Grafana-Alerting-Config-Identifier":    identifierB,
+			"X-Grafana-Alerting-Promote":              "true",
+			"X-Grafana-Alerting-Config-Force-Replace": "true",
+		})
+		requireStatusCode(t, http.StatusAccepted, status, "")
+		require.Equal(t, identifierB, rawResp.Stats.AddedRoute)
+
+		// Config A must be gone from ExtraConfigs (replaced and promoted away).
+		_, status, _ = apiClient.RawConvertPrometheusGetAlertmanagerConfig(t, map[string]string{
+			"X-Grafana-Alerting-Config-Identifier": identifierA,
+		})
+		requireStatusCode(t, http.StatusNotFound, status, "")
+
+		// Config B is promoted, so it must not be in ExtraConfigs either.
+		_, status, _ = apiClient.RawConvertPrometheusGetAlertmanagerConfig(t, map[string]string{
+			"X-Grafana-Alerting-Config-Identifier": identifierB,
+		})
+		requireStatusCode(t, http.StatusNotFound, status, "")
+
+		// B's receiver must be in the main config; A's must not.
+		mainConfig, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
+		requireStatusCode(t, http.StatusOK, status, "")
+		require.Empty(t, mainConfig.ExtraConfigs)
+		var receiverNames []string
+		for _, r := range mainConfig.AlertmanagerConfig.Receivers {
+			receiverNames = append(receiverNames, r.Name)
+		}
+		require.Contains(t, receiverNames, "replace-b-receiver")
+		require.NotContains(t, receiverNames, "replace-a-receiver")
+	})
+
+	t.Run("promote preserves rename result when receiver conflicts with existing", func(t *testing.T) {
+		identifier := "test-promote-rename"
+
+		// Import a config with a receiver named "opsgenie", which conflicts with the
+		// pre-existing receiver created by EnsureReceiver at the top of this test.
+		rawResp, status, _ := apiClient.RawConvertPrometheusPostAlertmanagerConfig(t, apimodels.AlertmanagerUserConfig{
+			AlertmanagerConfig: `
+route:
+  receiver: opsgenie
+receivers:
+  - name: opsgenie
+    webhook_configs:
+      - url: 'http://127.0.0.1:8080/opsgenie'
+`,
+		}, map[string]string{
+			"Content-Type":                         "application/yaml",
+			"X-Grafana-Alerting-Config-Identifier": identifier,
+			"X-Grafana-Alerting-Promote":           "true",
+		})
+		requireStatusCode(t, http.StatusAccepted, status, "")
+		require.Equal(t, "success", rawResp.Status)
+		require.NotNil(t, rawResp.RenameResources, "conflicting receiver must produce a rename result")
+		require.Contains(t, rawResp.RenameResources.Receivers, "opsgenie")
+
+		renamedName := rawResp.RenameResources.Receivers["opsgenie"]
+		require.NotEmpty(t, renamedName)
+
+		// The renamed receiver must appear in the main config under its new name.
+		mainConfig, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
+		requireStatusCode(t, http.StatusOK, status, "")
+		var receiverNames []string
+		for _, r := range mainConfig.AlertmanagerConfig.Receivers {
+			receiverNames = append(receiverNames, r.Name)
+		}
+		require.Contains(t, receiverNames, renamedName)
+	})
+
 	t.Run("dry-run should not create configuration", func(t *testing.T) {
 		identifier := "config"
 		// Create first configuration

--- a/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
@@ -415,7 +415,7 @@ receivers:
 		mainConfig, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
 		requireStatusCode(t, http.StatusOK, status, "")
 		require.Empty(t, mainConfig.ExtraConfigs)
-		var receiverNames []string
+		receiverNames := make([]string, 0, len(mainConfig.AlertmanagerConfig.Receivers))
 		for _, r := range mainConfig.AlertmanagerConfig.Receivers {
 			receiverNames = append(receiverNames, r.Name)
 		}
@@ -473,7 +473,7 @@ receivers:
 
 		mainConfig, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
 		requireStatusCode(t, http.StatusOK, status, "")
-		var receiverNames []string
+		receiverNames := make([]string, 0, len(mainConfig.AlertmanagerConfig.Receivers))
 		for _, r := range mainConfig.AlertmanagerConfig.Receivers {
 			receiverNames = append(receiverNames, r.Name)
 		}
@@ -568,7 +568,7 @@ receivers:
 		mainConfig, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
 		requireStatusCode(t, http.StatusOK, status, "")
 		require.Empty(t, mainConfig.ExtraConfigs)
-		var receiverNames []string
+		receiverNames := make([]string, 0, len(mainConfig.AlertmanagerConfig.Receivers))
 		for _, r := range mainConfig.AlertmanagerConfig.Receivers {
 			receiverNames = append(receiverNames, r.Name)
 		}
@@ -606,7 +606,7 @@ receivers:
 		// The renamed receiver must appear in the main config under its new name.
 		mainConfig, status, _ := apiClient.GetAlertmanagerConfigWithStatus(t)
 		requireStatusCode(t, http.StatusOK, status, "")
-		var receiverNames []string
+		receiverNames := make([]string, 0, len(mainConfig.AlertmanagerConfig.Receivers))
 		for _, r := range mainConfig.AlertmanagerConfig.Receivers {
 			receiverNames = append(receiverNames, r.Name)
 		}


### PR DESCRIPTION
## Summary

Adds a **promote** flag to the existing import endpoint that permanently merges a staged `ExtraConfiguration` (imported Prometheus/Mimir alertmanager config) into the main Grafana Alertmanager configuration, making all its resources editable via regular APIs.

### Background

The existing staging flow stores a Mimir Alertmanager config as `ExtraConfiguration` blob. Promote converts that configuration into first-class Grafana-managed resources that can then be edited or deleted via the standard APIs.

### What changes

**`POST /api/convert/prometheus/config/v1/alertmanager`** — new `X-Grafana-Alerting-Promote: true` header

When set, the endpoint merges the imported config into the main Grafana Alertmanager config (instead of storing it as an `ExtraConfiguration` blob):
- Receivers, time intervals, templates, inhibition rules, and the managed route are folded into the respective Grafana resources
- the config (if exists) is removed from `ExtraConfigs`. 
- the operation is not revertable. All imported resources need to be removed manually.

**Dry-run + promote**

Both flags can be combined. Authorization is checked before the dry-run early return, so `dry-run + promote` validates the merge *and* the caller's permissions without persisting anything.

**Authorization** 
- the promote operation requires user to have create permissions for all created resources, e.g. if the config has only a receiver and a route, only permissions  `receivers:create`, `managed-routes:create` are required. 

**Re-import guard**
After a successful promote the identifier lands in `ManagedRoutes`. A subsequent import with the same identifier returns `400 ErrIdentifierAlreadyExists`.

### Response

202 with:
- `stats` — `added_route`, `added_receivers`, `added_templates`, `added_time_intervals`, `added_inhibition_rules`
- `rename_resources` — receiver/time-interval renames applied to resolve name collisions (present only when renames occurred)

### Known bug
- The configuration that contains Inhibition rules will fail to be promoted due to invalid UID generated by the merge function. This will be addressed in a follow-up PR.