### PR TITLE
Annotations: Fix alerting cleanup ignoring max_annotations_to_keep (issue #125991)

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1079,7 +1079,7 @@ func (cfg *Cfg) readAnnotationSettings() error {
 	}
 
 	alertingAnnotations := cfg.Raw.Section("unified_alerting.state_history.annotations")
-	if alertingAnnotations.Key("max_age").Value() == "" && section.Key("max_annotations_to_keep").Value() == "" {
+	if alertingAnnotations.Key("max_age").Value() == "" && alertingAnnotations.Key("max_annotations_to_keep").Value() == "" {
 		// Although this section is not documented anymore, we decided to keep it to avoid potential data-loss when user upgrades Grafana and does not change the setting.
 		// TODO delete some time after Grafana 11.
 		alertingSection := cfg.Raw.Section("alerting")

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -818,3 +818,92 @@ func TestDynamicSection(t *testing.T) {
 		assert.Equal(t, value, ds.section.Key(key).String())
 	})
 }
+
+func TestReadAnnotationSettings(t *testing.T) {
+	t.Run("alerting cleanup uses unified_alerting.state_history.annotations when only max_annotations_to_keep is set", func(t *testing.T) {
+		// Regression test: previously, `readAnnotationSettings` checked the
+		// `max_annotations_to_keep` key against the parent `[annotations]`
+		// section, so this configuration silently fell back to the deprecated
+		// `[alerting]` branch and produced MaxCount=0.
+		f := ini.Empty()
+		sec, err := f.NewSection("unified_alerting.state_history.annotations")
+		require.NoError(t, err)
+		_, err = sec.NewKey("max_annotations_to_keep", "10000")
+		require.NoError(t, err)
+
+		cfg := NewCfg()
+		cfg.Raw = f
+		require.NoError(t, cfg.readAnnotationSettings())
+
+		require.Equal(t, int64(10000), cfg.AlertingAnnotationCleanupSetting.MaxCount)
+		require.Equal(t, time.Duration(0), cfg.AlertingAnnotationCleanupSetting.MaxAge)
+	})
+
+	t.Run("alerting cleanup reads max_age from unified_alerting.state_history.annotations", func(t *testing.T) {
+		f := ini.Empty()
+		sec, err := f.NewSection("unified_alerting.state_history.annotations")
+		require.NoError(t, err)
+		_, err = sec.NewKey("max_age", "30d")
+		require.NoError(t, err)
+
+		cfg := NewCfg()
+		cfg.Raw = f
+		require.NoError(t, cfg.readAnnotationSettings())
+
+		require.Equal(t, 30*24*time.Hour, cfg.AlertingAnnotationCleanupSetting.MaxAge)
+		require.Equal(t, int64(0), cfg.AlertingAnnotationCleanupSetting.MaxCount)
+	})
+
+	t.Run("alerting cleanup reads both max_age and max_annotations_to_keep from unified_alerting.state_history.annotations", func(t *testing.T) {
+		f := ini.Empty()
+		sec, err := f.NewSection("unified_alerting.state_history.annotations")
+		require.NoError(t, err)
+		_, err = sec.NewKey("max_age", "30d")
+		require.NoError(t, err)
+		_, err = sec.NewKey("max_annotations_to_keep", "5000")
+		require.NoError(t, err)
+
+		cfg := NewCfg()
+		cfg.Raw = f
+		require.NoError(t, cfg.readAnnotationSettings())
+
+		require.Equal(t, 30*24*time.Hour, cfg.AlertingAnnotationCleanupSetting.MaxAge)
+		require.Equal(t, int64(5000), cfg.AlertingAnnotationCleanupSetting.MaxCount)
+	})
+
+	t.Run("alerting cleanup falls back to deprecated [alerting] section when unified_alerting.state_history.annotations is empty", func(t *testing.T) {
+		f := ini.Empty()
+		sec, err := f.NewSection("alerting")
+		require.NoError(t, err)
+		_, err = sec.NewKey("max_annotation_age", "15d")
+		require.NoError(t, err)
+		_, err = sec.NewKey("max_annotations_to_keep", "1000")
+		require.NoError(t, err)
+
+		cfg := NewCfg()
+		cfg.Raw = f
+		require.NoError(t, cfg.readAnnotationSettings())
+
+		require.Equal(t, 15*24*time.Hour, cfg.AlertingAnnotationCleanupSetting.MaxAge)
+		require.Equal(t, int64(1000), cfg.AlertingAnnotationCleanupSetting.MaxCount)
+	})
+
+	t.Run("dashboard and API cleanup read from their own sections regardless of alerting fallback", func(t *testing.T) {
+		f := ini.Empty()
+		dash, err := f.NewSection("annotations.dashboard")
+		require.NoError(t, err)
+		_, err = dash.NewKey("max_annotations_to_keep", "100")
+		require.NoError(t, err)
+		api, err := f.NewSection("annotations.api")
+		require.NoError(t, err)
+		_, err = api.NewKey("max_age", "7d")
+		require.NoError(t, err)
+
+		cfg := NewCfg()
+		cfg.Raw = f
+		require.NoError(t, cfg.readAnnotationSettings())
+
+		require.Equal(t, int64(100), cfg.DashboardAnnotationCleanupSettings.MaxCount)
+		require.Equal(t, 7*24*time.Hour, cfg.APIAnnotationCleanupSettings.MaxAge)
+	})
+}


### PR DESCRIPTION
## Summary

`readAnnotationSettings` in `pkg/setting/setting.go` checks `max_annotations_to_keep` against the parent `[annotations]` INI section when deciding whether to fall
back to the deprecated `[alerting]` block. The intent — clear from the surrounding code — is to read it from `[unified_alerting.state_history.annotations]`, the same
section as `max_age`. The misread silently sends correctly-configured installs down the deprecated branch and produces `MaxCount=0`, so alerting annotations are never
cleaned up by count unless `max_age` is also set.

This PR is a minimal correctness fix: read both keys from `alertingAnnotations`. No behavior change for users who relied on the deprecated `[alerting]` keys, and
dashboard/API cleanup are untouched.

## Scoped intentionally

The deprecated `[alerting] max_annotation_age` / `max_annotations_to_keep` fallback (introduced in #83266) carries a `TODO delete some time after Grafana 11` comment.
We're now well past Grafana 11, so removing the fallback entirely is a reasonable next step — but it's a user-visible change for anyone still on the deprecated keys,
and worth a separate decision/PR. This PR keeps the fallback in place and only fixes the misread. Happy to follow up with a removal PR if maintainers prefer.

## Test plan

- [x] `go test ./pkg/setting/...` passes locally.
- [ ] New `TestReadAnnotationSettings` covers:
  - the previously buggy path (only `max_annotations_to_keep` set in `[unified_alerting.state_history.annotations]`)
  - `max_age` only in the same section
  - both keys set in the same section
  - fallback to deprecated `[alerting]` when neither key is set in the new section
  - dashboard / API sections unaffected by the alerting fallback

Fixes #125991

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

bug fix. See above description

**Why do we need this feature?**

Fixes a bug

**Who is this feature for?**

Relevant for people who manage/host Grafana OSS

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #125991
