### PR TITLE
Hide org subtitle server-side for single-org users

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/navtree"
 	"github.com/grafana/grafana/pkg/services/org"
 	pref "github.com/grafana/grafana/pkg/services/preference"
 	"github.com/grafana/grafana/pkg/setting"
@@ -110,6 +111,13 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		return nil, err
 	}
 
+	orgCount := hs.getUserOrgCount(c, userID)
+	if orgCount <= 1 {
+		if cfgNode := navTree.FindById(navtree.NavIDCfg); cfgNode != nil {
+			cfgNode.SubTitle = ""
+		}
+	}
+
 	weekStart := ""
 	if prefs.WeekStart != nil {
 		weekStart = *prefs.WeekStart
@@ -135,7 +143,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 			OrgId:                      c.GetOrgID(),
 			OrgName:                    c.OrgName,
 			OrgRole:                    c.GetOrgRole(),
-			OrgCount:                   hs.getUserOrgCount(c, userID),
+			OrgCount:                   orgCount,
 			GravatarUrl:                dtos.GetGravatarUrl(hs.Cfg, c.GetEmail()),
 			IsGrafanaAdmin:             c.IsGrafanaAdmin,
 			Theme:                      theme.ID,


### PR DESCRIPTION
## Summary
- Clear the configuration nav subtitle in index view data when the user belongs to only one organization
- Ensures the Administration page does not show a redundant Organization subheading on initial page load

Split from #126030 for MT service compatibility (backend review).

## Test plan
- [ ] Log in as a user with a single organization and confirm the Administration page no longer shows Organization subtitle on initial load
- [ ] Log in as a user with multiple organizations and confirm the subtitle still appears