### PR TITLE
Hide org subtitle in frontend for single-org users

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -945,6 +945,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/utils/isRecord.ts @grafana/dashboards-squad
 /public/app/core/utils/kbn* @grafana/grafana-frontend-platform
 /public/app/core/utils/navBarItem-translations.ts @grafana/grafana-frontend-navigation
+/public/app/core/utils/configurationSubtitle* @grafana/grafana-frontend-navigation
 /public/app/core/utils/object* @grafana/grafana-frontend-platform
 /public/app/core/utils/query* @grafana/grafana-datasources-core-services
 /public/app/core/utils/richHistory* @grafana/datapro

--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -1,8 +1,9 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
-
 import { type NavModelItem, type GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
+
+import { shouldShowConfigurationSubtitle } from 'app/core/utils/configurationSubtitle';
 
 import { PageInfo } from '../PageInfo/PageInfo';
 
@@ -21,6 +22,7 @@ export interface Props {
 export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEditTitle }: Props) {
   const styles = useStyles2(getStyles);
   const sub = subTitle ?? navItem.subTitle;
+  const visibleSub = shouldShowConfigurationSubtitle(sub) ? sub : undefined;
 
   return (
     <div className={styles.pageHeader}>
@@ -40,7 +42,7 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEd
         </div>
         <div className={styles.actions}>{actions}</div>
       </div>
-      {sub && <div className={styles.subTitle}>{sub}</div>}
+      {visibleSub && <div className={styles.subTitle}>{visibleSub}</div>}
     </div>
   );
 }

--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
+
 import { type NavModelItem, type GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 

--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 
 import { type NavModelItem, type GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
-
 import { shouldShowConfigurationSubtitle } from 'app/core/utils/configurationSubtitle';
 
 import { PageInfo } from '../PageInfo/PageInfo';

--- a/public/app/core/reducers/navModel.test.ts
+++ b/public/app/core/reducers/navModel.test.ts
@@ -1,4 +1,5 @@
 import { type NavIndex } from '@grafana/data';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { reducerTester } from '../../../test/core/redux/reducerTester';
 
@@ -42,6 +43,7 @@ describe('navModelReducer', () => {
 
   describe('when updateConfigurationSubtitle is dispatched', () => {
     it('then state should be correct', () => {
+      contextSrv.user.orgCount = 2;
       const originalCfg = { id: 'cfg', subTitle: 'Organization: Org 1', text: 'Configuration' };
       const datasources = { id: 'datasources', text: 'Data Sources' };
       const correlations = { id: 'correlations', text: 'Correlations' };
@@ -76,6 +78,44 @@ describe('navModelReducer', () => {
       reducerTester<NavIndex>()
         .givenReducer(navIndexReducer, { ...initialState })
         .whenActionIsDispatched(updateConfigurationSubtitle(newOrgName))
+        .thenStateShouldEqual(expectedState);
+    });
+
+    it('then it should not set organization subtitle when user belongs to a single org', () => {
+      contextSrv.user.orgCount = 1;
+
+      const originalCfg = { id: 'cfg', subTitle: 'Organization: Org 1', text: 'Configuration' };
+      const datasources = { id: 'datasources', text: 'Data Sources' };
+      const correlations = { id: 'correlations', text: 'Correlations' };
+      const users = { id: 'users', text: 'Users' };
+      const teams = { id: 'teams', text: 'Teams' };
+      const plugins = { id: 'plugins', text: 'Plugins' };
+      const orgsettings = { id: 'org-settings', text: 'Preferences' };
+
+      const initialState = {
+        cfg: { ...originalCfg, children: [datasources, users, teams, plugins, orgsettings] },
+        datasources: { ...datasources, parentItem: originalCfg },
+        correlations: { ...correlations, parentItem: originalCfg },
+        users: { ...users, parentItem: originalCfg },
+        teams: { ...teams, parentItem: originalCfg },
+        plugins: { ...plugins, parentItem: originalCfg },
+        'org-settings': { ...orgsettings, parentItem: originalCfg },
+      };
+
+      const newCfg = { ...originalCfg, subTitle: '' };
+      const expectedState = {
+        cfg: { ...newCfg, children: [datasources, users, teams, plugins, orgsettings] },
+        datasources: { ...datasources, parentItem: newCfg },
+        correlations: { ...correlations, parentItem: newCfg },
+        users: { ...users, parentItem: newCfg },
+        teams: { ...teams, parentItem: newCfg },
+        plugins: { ...plugins, parentItem: newCfg },
+        'org-settings': { ...orgsettings, parentItem: newCfg },
+      };
+
+      reducerTester<NavIndex>()
+        .givenReducer(navIndexReducer, { ...initialState })
+        .whenActionIsDispatched(updateConfigurationSubtitle('Org 2'))
         .thenStateShouldEqual(expectedState);
     });
   });

--- a/public/app/core/reducers/navModel.ts
+++ b/public/app/core/reducers/navModel.ts
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash';
 
 import { type NavIndex, type NavModel, type NavModelItem } from '@grafana/data';
 import config from 'app/core/config';
+import { getConfigurationSubtitle } from 'app/core/utils/configurationSubtitle';
 
 import { getNavSubTitle, getNavTitle } from '../utils/navBarItem-translations';
 
@@ -111,7 +112,7 @@ export const navIndexReducer = (state: NavIndex = initialState, action: AnyActio
 
     return { ...state, ...newPages };
   } else if (updateConfigurationSubtitle.match(action)) {
-    const subTitle = `Organization: ${action.payload}`;
+    const subTitle = getConfigurationSubtitle(action.payload);
 
     return {
       ...state,

--- a/public/app/core/utils/configurationSubtitle.test.ts
+++ b/public/app/core/utils/configurationSubtitle.test.ts
@@ -1,0 +1,39 @@
+import { contextSrv } from 'app/core/services/context_srv';
+
+import { getConfigurationSubtitle, shouldShowConfigurationSubtitle } from './configurationSubtitle';
+
+describe('configurationSubtitle', () => {
+  beforeEach(() => {
+    contextSrv.user.orgCount = 2;
+  });
+
+  describe('getConfigurationSubtitle', () => {
+    it('returns organization subtitle when user belongs to multiple orgs', () => {
+      expect(getConfigurationSubtitle('Main Org.')).toBe('Organization: Main Org.');
+    });
+
+    it('returns empty string when user belongs to a single org', () => {
+      contextSrv.user.orgCount = 1;
+
+      expect(getConfigurationSubtitle('Main Org.')).toBe('');
+    });
+  });
+
+  describe('shouldShowConfigurationSubtitle', () => {
+    it('returns false for organization subtitle when user belongs to a single org', () => {
+      contextSrv.user.orgCount = 1;
+
+      expect(shouldShowConfigurationSubtitle('Organization: Main Org.')).toBe(false);
+    });
+
+    it('returns true for organization subtitle when user belongs to multiple orgs', () => {
+      expect(shouldShowConfigurationSubtitle('Organization: Main Org.')).toBe(true);
+    });
+
+    it('returns true for non-organization subtitles regardless of org count', () => {
+      contextSrv.user.orgCount = 1;
+
+      expect(shouldShowConfigurationSubtitle('Manage default preferences and settings across Grafana')).toBe(true);
+    });
+  });
+});

--- a/public/app/core/utils/configurationSubtitle.ts
+++ b/public/app/core/utils/configurationSubtitle.ts
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+import { contextSrv } from 'app/core/services/context_srv';
+
+const ORG_SUBTITLE_PREFIX = 'Organization:';
+
+export function getConfigurationSubtitle(orgName: string): string {
+  if (contextSrv.user.orgCount <= 1) {
+    return '';
+  }
+
+  return `${ORG_SUBTITLE_PREFIX} ${orgName}`;
+}
+
+export function shouldShowConfigurationSubtitle(subTitle?: ReactNode): boolean {
+  if (!subTitle) {
+    return false;
+  }
+
+  if (contextSrv.user.orgCount <= 1 && typeof subTitle === 'string' && subTitle.startsWith(ORG_SUBTITLE_PREFIX)) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- Add shared configurationSubtitle helpers used by PageHeader and the navModel reducer
- Hide the Organization subheading on the Administration page when the user belongs to only one organization
- Add CODEOWNERS entry for the new utility module

Split from #126030 for MT service compatibility (frontend review).

## Test plan
- [ ] Log in as a user with a single organization and confirm the Administration page no longer shows Organization subtitle
- [ ] Log in as a user with multiple organizations and confirm the subtitle still appears and updates on org switch
- [ ] Run unit tests: configurationSubtitle.test.ts and navModel.test.ts