### PR TITLE
Live: remove live routes when max_connections is 0

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -89,6 +89,11 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 		keyPrefix:         "gf_live",
 	}
 
+	if cfg.LiveMaxConnections == 0 {
+		logger.Debug("Grafana Live is disabled (max_connections=0)")
+		return g, nil
+	}
+
 	if cfg.LiveHAPrefix != "" {
 		// Once this is deployed across all waves in grafana cloud, we can remove the configured LiveHAPrefix
 		// This is OK because the channel prefix now starts with the full stack identifier

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -91,7 +91,6 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 
 	if cfg.LiveMaxConnections == 0 {
 		logger.Debug("Grafana Live is disabled (max_connections=0)")
-		return g, nil
 	}
 
 	if cfg.LiveHAPrefix != "" {
@@ -396,15 +395,16 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 		pushPipelineWSHandler.ServeHTTP(ctx.Resp, r)
 	}
 
-	routeRegister.Group("/api/live", func(group routing.RouteRegister) {
-		group.Get("/ws", g.websocketHandler)
-	}, middleware.ReqSignedIn, requestmeta.SetSLOGroup(requestmeta.SLOGroupNone))
+	if cfg.LiveMaxConnections > 0 {
+		routeRegister.Group("/api/live", func(group routing.RouteRegister) {
+			group.Get("/ws", g.websocketHandler)
+		}, middleware.ReqSignedIn, requestmeta.SetSLOGroup(requestmeta.SLOGroupNone))
 
-	routeRegister.Group("/api/live", func(group routing.RouteRegister) {
-		group.Get("/push/:streamId", g.pushWebsocketHandler)
-		group.Get("/pipeline/push/*", g.pushPipelineWebsocketHandler)
-	}, middleware.ReqOrgAdmin, requestmeta.SetSLOGroup(requestmeta.SLOGroupNone))
-
+		routeRegister.Group("/api/live", func(group routing.RouteRegister) {
+			group.Get("/push/:streamId", g.pushWebsocketHandler)
+			group.Get("/pipeline/push/*", g.pushPipelineWebsocketHandler)
+		}, middleware.ReqOrgAdmin, requestmeta.SetSLOGroup(requestmeta.SLOGroupNone))
+	}
 	g.registerUsageMetrics()
 
 	return g, nil

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -395,7 +395,7 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 		pushPipelineWSHandler.ServeHTTP(ctx.Resp, r)
 	}
 
-	if cfg.LiveMaxConnections > 0 {
+	if cfg.LiveMaxConnections != 0 {
 		routeRegister.Group("/api/live", func(group routing.RouteRegister) {
 			group.Get("/ws", g.websocketHandler)
 		}, middleware.ReqSignedIn, requestmeta.SetSLOGroup(requestmeta.SLOGroupNone))

--- a/pkg/services/live/live_test.go
+++ b/pkg/services/live/live_test.go
@@ -345,6 +345,19 @@ func Test_handleOnSubscribe_IDTokenExpiration(t *testing.T) {
 	})
 }
 
+func Test_DisabledWhenMaxConnectionsIsZero(t *testing.T) {
+	cfg := setting.NewCfg()
+	cfg.LiveMaxConnections = 0
+
+	g, err := setupLiveService(cfg, t)
+	require.NoError(t, err)
+	require.NotNil(t, g)
+
+	t.Run("grafana live is disabled", func(t *testing.T) {
+		assert.Equal(t, cfg, g.Cfg)
+	})
+}
+
 func setupLiveService(cfg *setting.Cfg, t *testing.T) (*GrafanaLive, error) {
 	if cfg == nil {
 		cfg = setting.NewCfg()

--- a/pkg/services/live/live_test.go
+++ b/pkg/services/live/live_test.go
@@ -351,11 +351,19 @@ func Test_DisabledWhenMaxConnectionsIsZero(t *testing.T) {
 
 	g, err := setupLiveService(cfg, t)
 	require.NoError(t, err)
-	require.NotNil(t, g)
 
-	t.Run("grafana live is disabled", func(t *testing.T) {
-		assert.Equal(t, cfg, g.Cfg)
-	})
+	testPaths := []string{
+		"/api/live/ws",
+		"/api/live/push/:streamId",
+		"/api/live/pipeline/push/*",
+	}
+
+	// Because we skipped registering these endpoints they should not exist 
+	// on the router registry. Grafana's engine will natively 404 on them.
+	for _, path := range testPaths {
+		require.False(t, g.RouteRegister.HasRoute(path), 
+			"Path %s should not be registered when live is disabled", path,
+	}
 }
 
 func setupLiveService(cfg *setting.Cfg, t *testing.T) (*GrafanaLive, error) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Disable live when max_connections is set to 0.


```
[live]
# max_connections to Grafana Live WebSocket endpoint per Grafana server instance. See Grafana Live docs
# if you are planning to make it higher than default 100 since this can require some OS and infrastructure
# tuning. 0 disables Live, -1 means unlimited connections.
max_connections = 0
```

**Why do we need this feature?**

Corrects bug where setting live.max_connections to 0 does not disable live

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #72072
Fixes #120890

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
