### PR TITLE
fix: Prometheus: Fetch new labels ater the cursor moves out of the limit i...

### DIFF
--- a/.yarn/patches/@grafana-prometheus-npm-13.1.2-ee1c5a3113.patch
+++ b/.yarn/patches/@grafana-prometheus-npm-13.1.2-ee1c5a3113.patch
@@ -1,0 +1,56 @@
+diff --git a/dist/cjs/components/metrics-browser/MetricSelector.cjs b/dist/cjs/components/metrics-browser/MetricSelector.cjs
+index 76c32e789c5846c10ef3f245ab799f8b7709eac4..ce9bad4fdd81a97781bd6df98cf08cb3a71a877a 100644
+--- a/dist/cjs/components/metrics-browser/MetricSelector.cjs
++++ b/dist/cjs/components/metrics-browser/MetricSelector.cjs
+@@ -17,6 +17,7 @@ function MetricSelector() {
+   const styles$1 = ui.useStyles2(styles.getStylesMetricSelector);
+   const [metricSearchTerm, setMetricSearchTerm] = React.useState("");
+   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = MetricsBrowserContext.useMetricsBrowser();
++  const [seriesLimitInput, setSeriesLimitInput] = React.useState(String(seriesLimit));
+   const filteredMetrics = React.useMemo(() => {
+     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
+   }, [metrics, selectedMetric, metricSearchTerm]);
+@@ -56,12 +57,13 @@ function MetricSelector() {
+     /* @__PURE__ */ jsxRuntime.jsx("div", { children: /* @__PURE__ */ jsxRuntime.jsx(
+       ui.Input,
+       {
+-        onChange: (e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10)),
++        onChange: (e) => setSeriesLimitInput(e.currentTarget.value),
++        onBlur: (e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10)),
+         "aria-label": i18n.t(
+           "grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint",
+           "Limit results from series endpoint"
+         ),
+-        value: seriesLimit,
++        value: seriesLimitInput,
+         "data-testid": e2eSelectors.selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit
+       }
+     ) }),
+diff --git a/dist/esm/components/metrics-browser/MetricSelector.mjs b/dist/esm/components/metrics-browser/MetricSelector.mjs
+index c805c870b40aeb8c33dc4ce82b2a9d3d8e7f27d5..b91e76c07fa4f8241df5df6a18f22d5785b0140e 100644
+--- a/dist/esm/components/metrics-browser/MetricSelector.mjs
++++ b/dist/esm/components/metrics-browser/MetricSelector.mjs
+@@ -13,6 +13,7 @@ function MetricSelector() {
+   const styles = useStyles2(getStylesMetricSelector);
+   const [metricSearchTerm, setMetricSearchTerm] = useState("");
+   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = useMetricsBrowser();
++  const [seriesLimitInput, setSeriesLimitInput] = useState(String(seriesLimit));
+   const filteredMetrics = useMemo(() => {
+     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
+   }, [metrics, selectedMetric, metricSearchTerm]);
+@@ -52,12 +53,13 @@ function MetricSelector() {
+     /* @__PURE__ */ jsx("div", { children: /* @__PURE__ */ jsx(
+       Input,
+       {
+-        onChange: (e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10)),
++        onChange: (e) => setSeriesLimitInput(e.currentTarget.value),
++        onBlur: (e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10)),
+         "aria-label": t(
+           "grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint",
+           "Limit results from series endpoint"
+         ),
+-        value: seriesLimit,
++        value: seriesLimitInput,
+         "data-testid": selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit
+       }
+     ) }),

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "@grafana/monaco-logql": "^0.0.8",
     "@grafana/o11y-ds-frontend": "workspace:*",
     "@grafana/plugin-ui": "^0.13.1",
-    "@grafana/prometheus": "13.1.2",
+    "@grafana/prometheus": "patch:@grafana/prometheus@npm%3A13.1.2#./.yarn/patches/@grafana-prometheus-npm-13.1.2-ee1c5a3113.patch",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "^8.2.6",
     "@grafana/scenes-react": "^8.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2868,6 +2868,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grafana/prometheus@patch:@grafana/prometheus@npm%3A13.1.2#./.yarn/patches/@grafana-prometheus-npm-13.1.2-ee1c5a3113.patch::locator=grafana%40workspace%3A.":
+  version: 13.1.2
+  resolution: "@grafana/prometheus@patch:@grafana/prometheus@npm%3A13.1.2#./.yarn/patches/@grafana-prometheus-npm-13.1.2-ee1c5a3113.patch::version=13.1.2&hash=adcdc4&locator=grafana%40workspace%3A."
+  dependencies:
+    "@emotion/css": "npm:11.13.5"
+    "@floating-ui/react": "npm:0.27.19"
+    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@hello-pangea/dnd": "npm:18.0.1"
+    "@leeoniya/ufuzzy": "npm:1.0.19"
+    "@lezer/common": "npm:1.5.2"
+    "@lezer/highlight": "npm:1.2.3"
+    "@lezer/lr": "npm:1.4.8"
+    "@prometheus-io/lezer-promql": "npm:0.307.3"
+    "@types/debounce-promise": "npm:3.1.9"
+    "@types/lodash": "npm:4.17.20"
+    "@types/react": "npm:18.3.18"
+    "@types/react-dom": "npm:18.3.5"
+    "@types/react-highlight-words": "npm:0.20.0"
+    "@types/semver": "npm:7.7.1"
+    "@types/uuid": "npm:10.0.0"
+    debounce-promise: "npm:3.1.2"
+    lodash: "npm:^4.17.23"
+    moment: "npm:2.30.1"
+    moment-timezone: "npm:0.5.47"
+    monaco-editor: "npm:0.34.1"
+    monaco-promql: "npm:1.8.0"
+    pluralize: "npm:8.0.0"
+    prismjs: "npm:1.30.0"
+    react-highlight-words: "npm:0.21.0"
+    react-use: "npm:17.6.0"
+    react-window: "npm:1.8.11"
+    rxjs: "npm:7.8.2"
+    semver: "npm:7.7.3"
+    uuid: "npm:11.1.0"
+  peerDependencies:
+    "@grafana/assistant": ">=0.1.0"
+    "@grafana/data": ">=11.5.0"
+    "@grafana/e2e-selectors": ">=11.5.0"
+    "@grafana/i18n": ">=12.3.0"
+    "@grafana/runtime": ">=11.5.0"
+    "@grafana/schema": ">=11.5.0"
+    "@grafana/ui": ">=11.5.0"
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  peerDependenciesMeta:
+    "@grafana/assistant":
+      optional: true
+  checksum: 10/709b1430f142e487dcdf807b3e6bb20586b86ff6f8597a68aeaf8525e7d2aa2afcadff6bb0848d8d58f4d12a3090b568896dff1ae25d96dce4d48833ff34d981
+  languageName: node
+  linkType: hard
+
 "@grafana/react-data-grid@npm:7.0.0-beta.57":
   version: 7.0.0-beta.57
   resolution: "@grafana/react-data-grid@npm:7.0.0-beta.57"
@@ -18582,7 +18633,7 @@ __metadata:
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-e2e": "npm:3.7.1-canary.2604.25387292549.0"
     "@grafana/plugin-ui": "npm:^0.13.1"
-    "@grafana/prometheus": "npm:13.1.2"
+    "@grafana/prometheus": "patch:@grafana/prometheus@npm%3A13.1.2#./.yarn/patches/@grafana-prometheus-npm-13.1.2-ee1c5a3113.patch"
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": "npm:^8.2.6"
     "@grafana/scenes-react": "npm:^8.2.6"


### PR DESCRIPTION
## Summary

The `MetricSelector` component in `@grafana/prometheus@13.1.2` used an `onChange` handler on the series limit `<Input>` that called `setSeriesLimit` directly on every keystroke.


## Root cause

The `MetricSelector` component in `@grafana/prometheus@13.1.2` used an `onChange` handler on the series limit `<Input>` that called `setSeriesLimit` directly on every keystroke. `setSeriesLimit` updates shared context state, which in turn triggers `useDebounce` in `useMetricsLabelsValues.ts` to fire a backend fetch (with a 300 ms delay). This meant typing "5000" into the input triggered four debounced fetch requests instead of one.

The component lives in the external `@grafana/prometheus` npm package. It was originally developed in this repo as `packages/grafana-prometheus`, published as `@grafana/prometheus@13.1.2`, and then removed from the repo in PR #123035.


## What changed

A yarn patch was applied to `@grafana/prometheus@13.1.2` that modifies `MetricSelector` in both the ESM and CJS builds:

- **`dist/esm/components/metrics-browser/MetricSelector.mjs`** - Added local state `seriesLimitInput` (a string copy of the current `seriesLimit`). Changed the series limit `Input` to update local state only on `onChange`, and to call `setSeriesLimit` (the context setter that triggers the fetch) on `onBlur` instead.
- **`dist/cjs/components/metrics-browser/MetricSelector.cjs`** - Same change for the CommonJS build.

The patch is registered in:
- `.yarn/patches/@grafana-prometheus-npm-13.1.2-ee1c5a3113.patch`
- `package.json` `dependencies` - changed from `"13.1.2"` to the patch reference
- `yarn.lock` - updated automatically by `yarn install --mode=update-lockfile`


## Issue

Fixes #120727

Issue: https://github.com/grafana/grafana/issues/120727


## Diffstat

```
...@grafana-prometheus-npm-13.1.2-ee1c5a3113.patch | 56 ++++++++++++++++++++++
 package.json | 2 +-
 yarn.lock | 53 +++++++++++++++++++-
 3 files changed, 109 insertions(+), 2 deletions(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.