### PR TITLE
Provisioning: Enforce naming convention for provisioning.gitConventions flag

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -293,7 +293,7 @@ var (
 			RequiresRestart: true,
 			Owner:           grafanaAppPlatformSquad,
 			Expression:      "false",
-			Generate:        Generate{LegacyGo: true, React: true},
+			Generate:        Generate{Go: true, React: true},
 		},
 		{
 			Name:            "grafanaAPIServerEnsureKubectlAccess",


### PR DESCRIPTION
## Summary

Follow-up to #125986. That PR registered the `provisioning.gitConventions` feature flag with `Generate.LegacyGo`, which unintentionally **bypasses** the feature-flag naming-convention check.

In `verifyFlagName` (`pkg/services/featuremgmt/toggles_gen_test.go`), the `component.flagName` dotted-namespace requirement only applies to non-legacy flags:

```go
isLegacy := flag.Generate.LegacyFrontend || flag.Generate.LegacyGo
if !isLegacy && !strings.Contains(name, ".") {
    return fmt.Errorf("flag name %q must be in the format of component.flagName", name)
}
```

Because the flag used `LegacyGo`, it was treated as legacy and the check never ran. The name happens to be dotted, but the convention was not actually being enforced.

## Change

Switch the codegen target from `LegacyGo` to `Go`:

```go
Generate: Generate{Go: true, React: true}
```

`Go` is the modern Go codegen target (the comment at `toggles_gen_test.go:370` notes it exists specifically "to enforce new naming conventions"). With it, `isLegacy` is `false`, so the dotted-name rule is genuinely enforced — and the flag passes legitimately.

## Notes

- **Generated output is byte-identical**: both `LegacyGo` and `Go` emit the same `FlagProvisioningGitConventions` Go constant, and the React/OpenFeature generation is unchanged. Only `registry.go` changes; no regenerated files differ.
- `make gen-feature-toggles` passes (`go test ./pkg/services/featuremgmt/...`).

## Checklist

- [x] Feature-toggle tests pass
- [x] No generated-file changes (output identical)
- [x] No breaking changes — flag default stays off

🤖 Generated with [Claude Code](https://claude.com/claude-code)