### PR TITLE
ci: use grafana-writer

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -48,7 +48,7 @@ jobs:
           version: ${{ inputs.version }}
       - run: echo "WORK_BRANCH=bump-version/${RUN_ID}/${VERSION}" >> "$GITHUB_ENV"
       # Pre-create the branch on the remote so kminehart has a target ref to commit to.
-      - if: ${{ inputs.push }}
+      - if: ${{ inputs.push == true || inputs.push == 'true' }}
         name: Pre-create branch on remote
         env:
           GH_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
@@ -58,7 +58,7 @@ jobs:
             --method POST \
             -f "ref=refs/heads/${WORK_BRANCH}" \
             -f "sha=${BASE_SHA}"
-      - if: ${{ inputs.push }}
+      - if: ${{ inputs.push == true || inputs.push == 'true' }}
         name: Commit bump-version changes
         uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
         with:
@@ -68,7 +68,7 @@ jobs:
           file_pattern: "**"
         env:
           GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
-      - if: ${{ inputs.push }}
+      - if: ${{ inputs.push == true || inputs.push == 'true' }}
         name: Create PR
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,29 +18,67 @@ jobs:
   bump-version:
     runs-on: ubuntu-arm64-small
     permissions:
-      contents: write
+      id-token: write
+      contents: read
       pull-requests: write
+    env:
+      VERSION: ${{ inputs.version }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      REF_NAME: ${{ github.ref_name }}
+      RUN_ID: ${{ github.run_id }}
     steps:
+      # grafana/grafana is too large for GitHub's pre-receive workflow-file scan to
+      # finish within its timeout, so every push is rejected with "workflows scope may
+      # be required" -- even when no workflow files are touched. workflows:write tells
+      # GitHub to skip that scan. grafana-writer is the only app installed with that
+      # scope here. Commits go through the Git Data API via planetscale/ghcommit-action
+      # so they're automatically signed under grafana-writer[bot]'s identity, satisfying
+      # upcoming required_signatures rules.
+      - name: Get GitHub App token
+        id: get-writer-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        with:
+          github_app: grafana-writer
+          permission_set: ${{ startsWith(github.ref_name, 'release-') && 'release-writer' || 'release-writer-main' }}
       - name: Checkout Grafana
         uses: actions/checkout@v5
       - name: Update package.json versions
         uses: ./pkg/build/actions/bump-version
         with:
           version: ${{ inputs.version }}
+      - run: echo "WORK_BRANCH=bump-version/${RUN_ID}/${VERSION}" >> "$GITHUB_ENV"
+      # Pre-create the branch on the remote so planetscale has a target ref to commit to.
       - if: ${{ inputs.push }}
-        name: Push & Create PR
+        name: Pre-create branch on remote
         env:
-          VERSION: ${{ inputs.version }}
-          DRY_RUN: ${{ inputs.dry_run }}
-          REF_NAME: ${{ github.ref_name }}
-          RUN_ID: ${{ github.run_id }}
+          GH_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse "origin/${REF_NAME}")
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            --method POST \
+            -f "ref=refs/heads/${WORK_BRANCH}" \
+            -f "sha=${BASE_SHA}"
+      - if: ${{ inputs.push }}
+        name: Commit bump-version changes
+        uses: planetscale/ghcommit-action@57a6c787385af407a557374c794a09273aaebfd7
+        with:
+          commit_message: "bump version ${{ env.VERSION }}"
+          repo: ${{ github.repository }}
+          branch: ${{ env.WORK_BRANCH }}
+          file_pattern: "**"
+        env:
+          GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
+      - if: ${{ inputs.push }}
+        name: Create PR
+        env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local --add --bool push.autoSetupRemote true
-          git checkout -b "bump-version/${RUN_ID}/${VERSION}"
-          git add .
-          git commit -m "bump version ${VERSION}"
-          git push
-          gh pr create --dry-run="$DRY_RUN" -l "type/ci" -l "no-changelog" --draft -B "$REF_NAME" --title "Release: Bump version to ${VERSION}" --body "Updated version to ${VERSION}"
+          gh pr create \
+            --dry-run="$DRY_RUN" \
+            -l "type/ci" \
+            -l "no-changelog" \
+            --draft \
+            -B "$REF_NAME" \
+            -H "$WORK_BRANCH" \
+            --title "Release: Bump version to ${VERSION}" \
+            --body "Updated version to ${VERSION}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,7 +31,7 @@ jobs:
       # finish within its timeout, so every push is rejected with "workflows scope may
       # be required" -- even when no workflow files are touched. workflows:write tells
       # GitHub to skip that scan. grafana-writer is the only app installed with that
-      # scope here. Commits go through the Git Data API via planetscale/ghcommit-action
+      # scope here. Commits go through the Git Data API via kminehart/ghcommit-action
       # so they're automatically signed under grafana-writer[bot]'s identity, satisfying
       # upcoming required_signatures rules.
       - name: Get GitHub App token
@@ -47,7 +47,7 @@ jobs:
         with:
           version: ${{ inputs.version }}
       - run: echo "WORK_BRANCH=bump-version/${RUN_ID}/${VERSION}" >> "$GITHUB_ENV"
-      # Pre-create the branch on the remote so planetscale has a target ref to commit to.
+      # Pre-create the branch on the remote so kminehart has a target ref to commit to.
       - if: ${{ inputs.push }}
         name: Pre-create branch on remote
         env:
@@ -60,7 +60,7 @@ jobs:
             -f "sha=${BASE_SHA}"
       - if: ${{ inputs.push }}
         name: Commit bump-version changes
-        uses: planetscale/ghcommit-action@57a6c787385af407a557374c794a09273aaebfd7
+        uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
         with:
           commit_message: "bump version ${{ env.VERSION }}"
           repo: ${{ github.repository }}

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -28,14 +28,17 @@ jobs:
       group: create-release-tag-${{ inputs.tag }}
       cancel-in-progress: false
     steps:
-      # The default GITHUB_TOKEN can't create tag refs that would trigger other
-      # workflows (e.g. publish-technical-documentation-release.yml on push:tags),
-      # so use an app token that isn't subject to that restriction.
+      # grafana/grafana is large enough that GitHub's pre-receive workflow-file scan
+      # exceeds its server-side timeout on any ref creation here. The push/API call is
+      # then rejected with "workflows scope may be required" regardless of whether
+      # workflow files were actually touched. workflows:write tells GitHub to skip the
+      # scan. grafana-writer is the only app installed with that scope on grafana/grafana;
+      # no bot lacking it can create refs (branches or tags) in this repo.
       - name: Get GitHub App token
         id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          github_app: grafana-pr-automation
+          github_app: grafana-writer
       - name: Create annotated tag
         env:
           TAG: ${{ inputs.tag }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -229,6 +229,7 @@ jobs:
           commit_message: "Update changelog"
           repo: ${{ github.repository }}
           branch: ${{ env.WORK_BRANCH }}
+          empty: "true"
           file_pattern: CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
@@ -252,6 +253,7 @@ jobs:
           commit_message: "Update version to ${{ env.VERSION }}"
           repo: ${{ github.repository }}
           branch: ${{ env.WORK_BRANCH }}
+          empty: "true"
           file_pattern: "package.json lerna.json packages/** public/** e2e-playwright/test-plugins/**"
         env:
           GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
@@ -268,6 +270,7 @@ jobs:
           commit_message: "Update yarn.lock for ${{ env.VERSION }}"
           repo: ${{ github.repository }}
           branch: ${{ env.WORK_BRANCH }}
+          empty: "true"
           file_pattern: yarn.lock
         env:
           GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
@@ -283,6 +286,7 @@ jobs:
           commit_message: "Regenerate CUE schemas for ${{ env.VERSION }}"
           repo: ${{ github.repository }}
           branch: ${{ env.WORK_BRANCH }}
+          empty: "true"
           file_pattern: "**"
         env:
           GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Checkout Grafana target branch #checkout the target branch to base the release branch on
         uses: actions/checkout@v5
         with:
-          token: ${{ steps.get-writer-app-token.outputs.token }} # used only for fetching; commits go via planetscale API
+          token: ${{ steps.get-writer-app-token.outputs.token }} # used only for fetching; commits go via kminehart API
           ref: ${{ env.RELEASE_BRANCH }}
           fetch-tags: true
           fetch-depth: 0
@@ -156,7 +156,7 @@ jobs:
           go-version-file: .grafana-main/go.mod
           cache: false
 
-      # planetscale/ghcommit-action commits to an existing remote branch; it doesn't
+      # kminehart/ghcommit-action commits to an existing remote branch; it doesn't
       # create the branch itself. Pre-create the ref at the release branch's HEAD via
       # the Git Data API so subsequent commits have a target.
       - name: Pre-create branch on remote
@@ -213,7 +213,7 @@ jobs:
       - name: "Prettify CHANGELOG.md"
         if: ${{ inputs.changelog == true || inputs.changelog == 'true' }}
         run: npx prettier --write CHANGELOG.md
-      # All commits go through planetscale/ghcommit-action, which uses the Git Data API.
+      # All commits go through kminehart/ghcommit-action, which uses the Git Data API.
       # Two reasons we have to do this rather than a normal git push:
       #   1. Commits made via the Git Data API with a GitHub App installation token are
       #      automatically signed by GitHub under the App's identity (grafana-writer[bot]),
@@ -224,7 +224,7 @@ jobs:
       #      scan; the API path piggybacks on the same authorization.
       - name: Commit CHANGELOG.md
         if: ${{ inputs.changelog == true || inputs.changelog == 'true' }}
-        uses: planetscale/ghcommit-action@57a6c787385af407a557374c794a09273aaebfd7
+        uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
         with:
           commit_message: "Update changelog"
           repo: ${{ github.repository }}
@@ -247,7 +247,7 @@ jobs:
           yarn prettier:write
       - name: Commit version bumps
         if: ${{ (inputs.bump == true || inputs.bump == 'true') && !contains(inputs.version, '+security') }}
-        uses: planetscale/ghcommit-action@57a6c787385af407a557374c794a09273aaebfd7
+        uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
         with:
           commit_message: "Update version to ${{ env.VERSION }}"
           repo: ${{ github.repository }}
@@ -263,7 +263,7 @@ jobs:
         run: yarn install
       - name: Commit yarn.lock
         if: ${{ (inputs.bump == true || inputs.bump == 'true') && !contains(inputs.version, '+security') }}
-        uses: planetscale/ghcommit-action@57a6c787385af407a557374c794a09273aaebfd7
+        uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
         with:
           commit_message: "Update yarn.lock for ${{ env.VERSION }}"
           repo: ${{ github.repository }}
@@ -278,7 +278,7 @@ jobs:
         run: make gen-cue
       - name: Commit gen-cue changes
         if: ${{ !contains(inputs.version, '+security') }}
-        uses: planetscale/ghcommit-action@57a6c787385af407a557374c794a09273aaebfd7
+        uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
         with:
           commit_message: "Regenerate CUE schemas for ${{ env.VERSION }}"
           repo: ${{ github.repository }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -109,17 +109,30 @@ jobs:
         with:
           github_app: grafana-pr-automation
           permission_set: ${{ startsWith(github.ref_name, 'release-') && 'release' || 'main' }}
-      - name: Get GitHub App token
+      # The grafana repo is large enough that GitHub's pre-receive scan for workflow-file
+      # modifications ("Restricts updates to workflow files" system rule) consistently
+      # exceeds its server-side timeout on any push -- regardless of whether the push
+      # actually touches workflow files. When the scan times out, GitHub fails closed and
+      # rejects the push with "workflows scope may be required". Granting workflows:write
+      # tells GitHub to skip the scan entirely (the caller is already authorized to modify
+      # workflow files), which is the only documented way to push to this repo from a bot.
+      # grafana-writer is the only app installed with that scope; grafana-pr-automation
+      # cannot push at all because of this.
+      - name: Get GitHub App token (writer)
         id: get-writer-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          github_app: grafana-pr-automation
+          github_app: grafana-writer
           permission_set: ${{ startsWith(github.ref_name, 'release-') && 'release-writer' || 'release-writer-main' }}
-      - run: echo "RELEASE_BRANCH=release-${VERSION}" >> "$GITHUB_ENV"
+      - run: |
+          {
+            echo "RELEASE_BRANCH=release-${VERSION}"
+            echo "WORK_BRANCH=release/${RUN_NUMBER}/${VERSION}"
+          } >> "$GITHUB_ENV"
       - name: Checkout Grafana target branch #checkout the target branch to base the release branch on
         uses: actions/checkout@v5
         with:
-          token: ${{ steps.get-writer-app-token.outputs.token }} # use the writer token which can push
+          token: ${{ steps.get-writer-app-token.outputs.token }} # used only for fetching; commits go via planetscale API
           ref: ${{ env.RELEASE_BRANCH }}
           fetch-tags: true
           fetch-depth: 0
@@ -142,20 +155,10 @@ jobs:
         with:
           go-version-file: .grafana-main/go.mod
           cache: false
-      - name: Configure git user
-        run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local --add --bool push.autoSetupRemote true
 
-      - name: Create branch
-        run: git checkout -b "release/${RUN_NUMBER}/${VERSION}"
-      # Pre-create the new branch on the remote pointing at the release branch's HEAD.
-      # Using the REST API rather than `git push` because git push triggers the
-      # "Restricts updates to workflow files" pre-receive scan, which times out on
-      # branches that diverge significantly from the default branch. The API path
-      # may bypass that scan since it's a direct ref creation pointing at an
-      # already-existing commit.
+      # planetscale/ghcommit-action commits to an existing remote branch; it doesn't
+      # create the branch itself. Pre-create the ref at the release branch's HEAD via
+      # the Git Data API so subsequent commits have a target.
       - name: Pre-create branch on remote
         env:
           GH_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
@@ -163,7 +166,7 @@ jobs:
           BASE_SHA=$(git rev-parse "origin/${RELEASE_BRANCH}")
           gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
             --method POST \
-            -f "ref=refs/heads/release/${RUN_NUMBER}/${VERSION}" \
+            -f "ref=refs/heads/${WORK_BRANCH}" \
             -f "sha=${BASE_SHA}"
 
       - name: Generate changelog
@@ -174,7 +177,7 @@ jobs:
           previous: ${{inputs.previous_version}}
           target: v${{ env.VERSION }}
           output_file: changelog_items.md
-          github_token: ${{  steps.get-github-app-token.outputs.token }}
+          github_token: ${{ steps.get-github-app-token.outputs.token }}
       - name: Patch CHANGELOG.md
         if: ${{ inputs.changelog == true || inputs.changelog == 'true' }}
         run: |
@@ -210,12 +213,26 @@ jobs:
       - name: "Prettify CHANGELOG.md"
         if: ${{ inputs.changelog == true || inputs.changelog == 'true' }}
         run: npx prettier --write CHANGELOG.md
-      - name: Commit & push CHANGELOG.md
+      # All commits go through planetscale/ghcommit-action, which uses the Git Data API.
+      # Two reasons we have to do this rather than a normal git push:
+      #   1. Commits made via the Git Data API with a GitHub App installation token are
+      #      automatically signed by GitHub under the App's identity (grafana-writer[bot]),
+      #      with a Verified signature -- satisfying upcoming required_signatures rules.
+      #   2. Regular git push to grafana/grafana hits the pre-receive workflow-file scan
+      #      timeout (the repo is too large for the scan to finish in time), causing
+      #      pushes to be rejected. The grafana-writer token's workflows:write skips that
+      #      scan; the API path piggybacks on the same authorization.
+      - name: Commit CHANGELOG.md
         if: ${{ inputs.changelog == true || inputs.changelog == 'true' }}
-        run: |
-          git add CHANGELOG.md
-          git commit --allow-empty -m "Update changelog" CHANGELOG.md
-          git push
+        uses: planetscale/ghcommit-action@57a6c787385af407a557374c794a09273aaebfd7
+        with:
+          commit_message: "Update changelog"
+          repo: ${{ github.repository }}
+          branch: ${{ env.WORK_BRANCH }}
+          file_pattern: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
+
       # Remove the main checkout before lerna runs so nx doesn't see duplicate plugin
       # package.json files across .grafana-main and the release-branch tree.
       - name: Remove main checkout before bump
@@ -228,35 +245,47 @@ jobs:
           npm version patch --no-git-tag-version
           yarn run lerna version patch --no-push --no-git-tag-version --force-publish --exact --yes
           yarn prettier:write
-      - name: Commit & push version bumps
+      - name: Commit version bumps
         if: ${{ (inputs.bump == true || inputs.bump == 'true') && !contains(inputs.version, '+security') }}
-        run: |
-          git add package.json lerna.json packages public
-          test -e e2e-playwright/test-plugins && git add e2e-playwright/test-plugins
-          git commit --allow-empty -m "Update version to $VERSION"
-          git push
+        uses: planetscale/ghcommit-action@57a6c787385af407a557374c794a09273aaebfd7
+        with:
+          commit_message: "Update version to ${{ env.VERSION }}"
+          repo: ${{ github.repository }}
+          branch: ${{ env.WORK_BRANCH }}
+          file_pattern: "package.json lerna.json packages/** public/** e2e-playwright/test-plugins/**"
+        env:
+          GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
+
       # Second yarn install: refresh yarn.lock with the new workspace package refs
-      # produced by lerna. Committed/pushed separately to keep the push small.
+      # produced by lerna. Committed separately to keep each commit small.
       - name: Update yarn.lock for new package versions
         if: ${{ (inputs.bump == true || inputs.bump == 'true') && !contains(inputs.version, '+security') }}
         run: yarn install
-      - name: Commit & push yarn.lock
+      - name: Commit yarn.lock
         if: ${{ (inputs.bump == true || inputs.bump == 'true') && !contains(inputs.version, '+security') }}
-        run: |
-          git add yarn.lock
-          git commit --allow-empty -m "Update yarn.lock for $VERSION"
-          git push
+        uses: planetscale/ghcommit-action@57a6c787385af407a557374c794a09273aaebfd7
+        with:
+          commit_message: "Update yarn.lock for ${{ env.VERSION }}"
+          repo: ${{ github.repository }}
+          branch: ${{ env.WORK_BRANCH }}
+          file_pattern: yarn.lock
+        env:
+          GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
 
       - name: make gen-cue
         if: ${{ !contains(inputs.version, '+security') }}
         shell: bash
         run: make gen-cue
-      - name: Commit & push gen-cue changes
+      - name: Commit gen-cue changes
         if: ${{ !contains(inputs.version, '+security') }}
-        run: |
-          git add .
-          git commit --allow-empty -m "Regenerate CUE schemas for $VERSION"
-          git push
+        uses: planetscale/ghcommit-action@57a6c787385af407a557374c794a09273aaebfd7
+        with:
+          commit_message: "Regenerate CUE schemas for ${{ env.VERSION }}"
+          repo: ${{ github.repository }}
+          branch: ${{ env.WORK_BRANCH }}
+          file_pattern: "**"
+        env:
+          GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
       - name: Create PR
         env:
           GH_TOKEN: ${{ github.token }}
@@ -272,5 +301,6 @@ jobs:
             --draft \
             --dry-run="$DRY_RUN" \
             -B "${RELEASE_BRANCH}" \
+            -H "${WORK_BRANCH}" \
             --title "Release: $VERSION" \
             --body "These code changes must be merged after a release is complete"


### PR DESCRIPTION
This uses a specific app just for writing the contents. A separate app is used for creating the pull request.

Using my fork of this action which pins the Dockerfile base image via digest https://github.com/planetscale/ghcommit-action/pull/139 until it's merged upstream.