### PR TITLE
Storage: wire KVRemoteIndexStore behind index_snapshot_storage_kv toggle

### DIFF
--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -396,7 +396,7 @@ func createBaselineServer(t *testing.T, dbType, dbConnStr string, testNamespaces
 	docBuilders, err := InitializeDocumentBuilders(cfg)
 	require.NoError(t, err)
 	require.NoError(t, err)
-	searchOpts, err := search.NewSearchOptions(features, cfg, docBuilders, nil, nil)
+	searchOpts, err := search.NewSearchOptions(features, cfg, docBuilders, nil, nil, nil)
 	require.NoError(t, err)
 	cfg.DisablePruner = dbType == "sqlite3"
 	eDB, err := sql.ProvideResourceDB(cfg, nil)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -680,6 +680,7 @@ type Cfg struct {
 	MinFileIndexBuildVersion                   string        // Minimum version of Grafana that built the file-based index. If index was built with older Grafana, it will be rebuilt asynchronously.
 	IndexSnapshotEnabled                       bool          // Enable remote index snapshots
 	IndexSnapshotBucketURL                     string        // Go CDK bucket URL for snapshot storage (s3://, gs://, azblob://, mem://, file:///)
+	IndexSnapshotStorageKV                     bool          // Store snapshots in the same KV used by the storage backend instead of an object-storage bucket. Mutually exclusive with index_snapshot_bucket_url; requires enable_kv_leases.
 	IndexSnapshotThreshold                     int           // Min doc count to use remote snapshots (must be >= IndexFileThreshold, default: 5000)
 	IndexSnapshotMaxAge                        time.Duration // Max snapshot age before deletion (must be >= MaxFileIndexAge, default: 7d)
 	IndexSnapshotCleanupGracePeriod            time.Duration // Time a new snapshot must exist before its predecessor in the same Grafana-version group is eligible for cleanup (default: 30m)

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -261,6 +261,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	// Index snapshot settings
 	cfg.IndexSnapshotEnabled = section.Key("index_snapshot_enabled").MustBool(false)
 	cfg.IndexSnapshotBucketURL = section.Key("index_snapshot_bucket_url").String()
+	cfg.IndexSnapshotStorageKV = section.Key("index_snapshot_storage_kv").MustBool(false)
 	cfg.IndexSnapshotThreshold = section.Key("index_snapshot_threshold").MustInt(5000)
 	if cfg.IndexSnapshotThreshold < cfg.IndexFileThreshold {
 		cfg.Logger.Warn("index_snapshot_threshold is smaller than index_file_threshold, overriding", "configured", cfg.IndexSnapshotThreshold, "index_file_threshold", cfg.IndexFileThreshold)

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -162,7 +162,7 @@ func newClient(opts options.StorageOptions,
 		return resource.NewResourceClient(conn, indexConn, cfg, features, tracer)
 
 	default:
-		searchOptions, err := search.NewSearchOptions(features, cfg, docs, indexMetrics, nil)
+		searchOptions, err := search.NewSearchOptions(features, cfg, docs, indexMetrics, nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -668,7 +668,7 @@ func newRetryTestResourceServerWithSearch(t *testing.T, backend resource.Storage
 		},
 	}
 
-	searchOpts, err := search.NewSearchOptions(featuremgmt.WithFeatures(), cfg, docBuilders, nil, nil)
+	searchOpts, err := search.NewSearchOptions(featuremgmt.WithFeatures(), cfg, docBuilders, nil, nil, nil)
 	require.NoError(t, err)
 
 	return resource.NewResourceServer(resource.ResourceServerOptions{

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -145,6 +145,16 @@ type KVBackend interface {
 	StorageBackend
 	resourcepb.DiagnosticsServer //nolint:staticcheck
 	ResourceServerStopper
+
+	// KV returns the underlying KV store. Exposed so other subsystems
+	// (e.g. search snapshot storage) can share the same store rather than
+	// opening a second connection.
+	KV() KV
+
+	// LeaseManager returns the lease manager used by this backend, or nil
+	// if leases are disabled. Exposed so other subsystems can share the
+	// same manager and avoid running a second heartbeat loop.
+	LeaseManager() *lease.Manager
 }
 
 type KVBackendOptions struct {
@@ -468,6 +478,17 @@ func (k *kvStorageBackend) initPruner(ctx context.Context) error {
 	k.historyPruner = pruner
 	k.historyPruner.Start(ctx)
 	return nil
+}
+
+// KV returns the KV store backing this storage backend. See KVBackend.KV.
+func (b *kvStorageBackend) KV() KV {
+	return b.kv
+}
+
+// LeaseManager returns the lease manager owned by this backend, or nil
+// if leases are disabled. See KVBackend.LeaseManager.
+func (b *kvStorageBackend) LeaseManager() *lease.Manager {
+	return b.leaseManager
 }
 
 func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -79,6 +79,31 @@ func TestNewKvStorageBackend(t *testing.T) {
 	assert.NotNil(t, backend.snowflake)
 }
 
+// TestKvStorageBackend_Accessors verifies that KV() returns the configured
+// store and that LeaseManager() reflects whether EnableKVLeases is set.
+// These accessors let other subsystems (e.g. KV-backed search snapshots)
+// share the backend's KV store and lease manager rather than opening
+// their own.
+func TestKvStorageBackend_Accessors(t *testing.T) {
+	t.Run("KV returns configured store", func(t *testing.T) {
+		backend := setupTestStorageBackend(t)
+		assert.Same(t, backend.kv, backend.KV())
+	})
+
+	t.Run("LeaseManager is nil when leases are disabled", func(t *testing.T) {
+		backend := setupTestStorageBackend(t)
+		assert.Nil(t, backend.LeaseManager())
+	})
+
+	t.Run("LeaseManager is non-nil when leases are enabled", func(t *testing.T) {
+		backend := setupTestStorageBackend(t, func(o *KVBackendOptions) {
+			o.EnableKVLeases = true
+			o.Holder = "test-holder"
+		})
+		assert.NotNil(t, backend.LeaseManager())
+	})
+}
+
 func TestKvStorageBackend_WriteEvent_Success(t *testing.T) {
 	backend := setupTestStorageBackend(t)
 	ctx := context.Background()

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -1117,7 +1117,7 @@ func newConfiguredSnapshotBackend(t *testing.T, bucketURL string) (*bleveBackend
 	cfg.IndexSnapshotBucketURL = bucketURL
 
 	metrics := resource.ProvideIndexMetrics(prometheus.NewRegistry())
-	opts, err := NewSearchOptions(featuremgmt.WithFeatures(), cfg, nil, metrics, nil)
+	opts, err := NewSearchOptions(featuremgmt.WithFeatures(), cfg, nil, metrics, nil, nil)
 	require.NoError(t, err)
 	be, ok := opts.Backend.(*bleveBackend)
 	require.True(t, ok)

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -38,12 +38,17 @@ const (
 	DefaultSnapshotCleanupGracePeriod = 30 * time.Minute
 )
 
+// NewSearchOptions builds the SearchOptions used by the resource server.
+// snapshotStore is optional: when non-nil it replaces the RemoteIndexStore
+// that would otherwise be built from cfg.IndexSnapshotBucketURL. Used by
+// the SQL wiring layer to inject a KV-backed store.
 func NewSearchOptions(
 	features featuremgmt.FeatureToggles,
 	cfg *setting.Cfg,
 	docs resource.DocumentBuilderSupplier,
 	indexMetrics *resource.BleveIndexMetrics,
 	ownsIndexFn func(key resource.NamespacedResource) (bool, error),
+	snapshotStore RemoteIndexStore,
 ) (resource.SearchOptions, error) {
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if cfg.EnableSearch || features.IsEnabledGlobally(featuremgmt.FlagProvisioning) {
@@ -76,7 +81,7 @@ func NewSearchOptions(
 			}
 		}
 
-		snapshot, err := buildSnapshotOptions(cfg, minVersion)
+		snapshot, err := buildSnapshotOptions(cfg, minVersion, snapshotStore)
 		if err != nil {
 			return resource.SearchOptions{}, err
 		}
@@ -143,22 +148,55 @@ func snapshotLockHeartbeat(ttl time.Duration) time.Duration {
 	return hb
 }
 
-// buildSnapshotOptions opens the configured object-storage bucket and wraps it
-// as a RemoteIndexStore. Returns a zero SnapshotOptions (Store==nil) when the
-// feature is not enabled, so the backend short-circuits all new paths.
-func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (SnapshotOptions, error) {
-	if !cfg.IndexSnapshotEnabled || cfg.IndexSnapshotBucketURL == "" {
+// buildSnapshotOptions builds a SnapshotOptions from cfg.
+//
+// All non-Store fields (MinDocCount, MaxIndexAge, UploadInterval, etc.)
+// are taken from cfg regardless. injectedStore overrides only the Store
+// field: if non-nil it is used directly; otherwise the function opens
+// the object-storage bucket configured in cfg.IndexSnapshotBucketURL
+// and wraps it as a BucketRemoteIndexStore. Returns a zero
+// SnapshotOptions (Store==nil) when snapshots are disabled, so the
+// backend short-circuits all new paths.
+func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version, injectedStore RemoteIndexStore) (SnapshotOptions, error) {
+	if !cfg.IndexSnapshotEnabled {
 		return SnapshotOptions{}, nil
 	}
 
+	store := injectedStore
+	if store == nil {
+		if cfg.IndexSnapshotBucketURL == "" {
+			return SnapshotOptions{}, nil
+		}
+		var err error
+		store, err = buildBucketSnapshotStore(cfg)
+		if err != nil {
+			return SnapshotOptions{}, err
+		}
+	}
+
+	return SnapshotOptions{
+		Store:              store,
+		MinDocCount:        int64(cfg.IndexSnapshotThreshold),
+		MaxIndexAge:        cfg.IndexSnapshotMaxAge,
+		MinBuildVersion:    minBuildVersion,
+		UploadInterval:     DefaultSnapshotUploadInterval,
+		MinDocChanges:      DefaultSnapshotMinDocChanges,
+		CleanupGracePeriod: cleanupGracePeriodOrDefault(cfg.IndexSnapshotCleanupGracePeriod),
+		CleanupInterval:    DefaultSnapshotCleanupInterval,
+	}, nil
+}
+
+// buildBucketSnapshotStore opens the configured object-storage bucket
+// and wraps it as a BucketRemoteIndexStore.
+func buildBucketSnapshotStore(cfg *setting.Cfg) (RemoteIndexStore, error) {
 	bucket, err := blob.OpenBucket(context.Background(), cfg.IndexSnapshotBucketURL)
 	if err != nil {
-		return SnapshotOptions{}, fmt.Errorf("opening snapshot bucket %q: %w", cfg.IndexSnapshotBucketURL, err)
+		return nil, fmt.Errorf("opening snapshot bucket %q: %w", cfg.IndexSnapshotBucketURL, err)
 	}
 
 	lockBackend, err := snapshotLockBackendForBucket(bucket, cfg.IndexSnapshotBucketURL)
 	if err != nil {
-		return SnapshotOptions{}, fmt.Errorf("snapshot lock backend options: %w", err)
+		return nil, fmt.Errorf("snapshot lock backend options: %w", err)
 	}
 
 	ownerBase := cfg.InstanceID
@@ -170,7 +208,7 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 	}
 	lockOwnerSuffix, err := ulid.New(ulid.Now(), rand.Reader)
 	if err != nil {
-		return SnapshotOptions{}, fmt.Errorf("creating lock owner suffix: %w", err)
+		return nil, fmt.Errorf("creating lock owner suffix: %w", err)
 	}
 	// Include a per-process ULID suffix to avoid owner collisions across instances
 	// that share the same configured instance_id/instance_name.
@@ -182,22 +220,13 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 		HeartbeatInterval: snapshotLockHeartbeat(lockTTL),
 	}
 
-	return SnapshotOptions{
-		Store: NewBucketRemoteIndexStore(BucketRemoteIndexStoreConfig{
-			Bucket:      bucket,
-			LockBackend: lockBackend,
-			LockOwner:   owner,
-			BuildLock:   lockOpts,
-			CleanupLock: lockOpts,
-		}),
-		MinDocCount:        int64(cfg.IndexSnapshotThreshold),
-		MaxIndexAge:        cfg.IndexSnapshotMaxAge,
-		MinBuildVersion:    minBuildVersion,
-		UploadInterval:     DefaultSnapshotUploadInterval,
-		MinDocChanges:      DefaultSnapshotMinDocChanges,
-		CleanupGracePeriod: cleanupGracePeriodOrDefault(cfg.IndexSnapshotCleanupGracePeriod),
-		CleanupInterval:    DefaultSnapshotCleanupInterval,
-	}, nil
+	return NewBucketRemoteIndexStore(BucketRemoteIndexStoreConfig{
+		Bucket:      bucket,
+		LockBackend: lockBackend,
+		LockOwner:   owner,
+		BuildLock:   lockOpts,
+		CleanupLock: lockOpts,
+	}), nil
 }
 
 func snapshotLockBackendForBucket(bucket *blob.Bucket, bucketURL string) (lockBackend, error) {

--- a/pkg/storage/unified/search/options_test.go
+++ b/pkg/storage/unified/search/options_test.go
@@ -89,7 +89,7 @@ func TestBuildSnapshotOptionsGating(t *testing.T) {
 		cfg.IndexSnapshotEnabled = false
 		cfg.IndexSnapshotBucketURL = "://not-a-valid-url"
 
-		snapshot, err := buildSnapshotOptions(cfg, nil)
+		snapshot, err := buildSnapshotOptions(cfg, nil, nil)
 		require.NoError(t, err)
 		assert.Nil(t, snapshot.Store)
 	})
@@ -99,7 +99,7 @@ func TestBuildSnapshotOptionsGating(t *testing.T) {
 		cfg.IndexSnapshotEnabled = true
 		cfg.IndexSnapshotBucketURL = ""
 
-		snapshot, err := buildSnapshotOptions(cfg, nil)
+		snapshot, err := buildSnapshotOptions(cfg, nil, nil)
 		require.NoError(t, err)
 		assert.Nil(t, snapshot.Store)
 	})
@@ -109,7 +109,7 @@ func TestBuildSnapshotOptionsGating(t *testing.T) {
 		cfg.IndexSnapshotEnabled = true
 		cfg.IndexSnapshotBucketURL = fileBucketURL(t, t.TempDir())
 
-		snapshot, err := buildSnapshotOptions(cfg, nil)
+		snapshot, err := buildSnapshotOptions(cfg, nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, snapshot.Store)
 	})
@@ -119,11 +119,47 @@ func TestBuildSnapshotOptionsGating(t *testing.T) {
 		cfg.IndexSnapshotEnabled = true
 		cfg.IndexSnapshotBucketURL = "mem://snapshot-test"
 
-		snapshot, err := buildSnapshotOptions(cfg, nil)
+		snapshot, err := buildSnapshotOptions(cfg, nil, nil)
 		require.Error(t, err)
 		assert.Nil(t, snapshot.Store)
 		assert.Contains(t, err.Error(), "unsupported blob provider")
 	})
+}
+
+func TestBuildSnapshotOptionsInjectedStore(t *testing.T) {
+	t.Run("injected store overrides bucket URL and is used as-is", func(t *testing.T) {
+		cfg := snapshotOptionsTestCfg(t)
+		cfg.IndexSnapshotEnabled = true
+		// Bucket URL is intentionally set to ensure the injected store takes precedence.
+		cfg.IndexSnapshotBucketURL = fileBucketURL(t, t.TempDir())
+		cfg.IndexSnapshotThreshold = 12345
+		cfg.IndexSnapshotMaxAge = 7 * 24 * time.Hour
+
+		injected := &fakeRemoteIndexStore{}
+		snapshot, err := buildSnapshotOptions(cfg, nil, injected)
+		require.NoError(t, err)
+		assert.Same(t, injected, snapshot.Store)
+		// Non-Store fields still come from cfg.
+		assert.Equal(t, int64(12345), snapshot.MinDocCount)
+		assert.Equal(t, 7*24*time.Hour, snapshot.MaxIndexAge)
+	})
+
+	t.Run("injected store is ignored when snapshots are disabled", func(t *testing.T) {
+		cfg := snapshotOptionsTestCfg(t)
+		cfg.IndexSnapshotEnabled = false
+
+		injected := &fakeRemoteIndexStore{}
+		snapshot, err := buildSnapshotOptions(cfg, nil, injected)
+		require.NoError(t, err)
+		assert.Nil(t, snapshot.Store)
+	})
+}
+
+// fakeRemoteIndexStore is a stand-in RemoteIndexStore used to verify that
+// buildSnapshotOptions wires an injected store through as-is. Methods
+// are unimplemented because the test never exercises them.
+type fakeRemoteIndexStore struct {
+	RemoteIndexStore
 }
 
 func TestBuildSnapshotOptionsFileBucketUsesProcessLocalLocks(t *testing.T) {
@@ -131,7 +167,7 @@ func TestBuildSnapshotOptionsFileBucketUsesProcessLocalLocks(t *testing.T) {
 	cfg.IndexSnapshotEnabled = true
 	cfg.IndexSnapshotBucketURL = fileBucketURL(t, t.TempDir())
 
-	snapshot, err := buildSnapshotOptions(cfg, nil)
+	snapshot, err := buildSnapshotOptions(cfg, nil, nil)
 	require.NoError(t, err)
 
 	ns := resource.NamespacedResource{Namespace: "default", Group: "dashboard.grafana.app", Resource: "dashboards"}
@@ -153,7 +189,7 @@ func TestNewSearchOptionsPassesFileSnapshotStoreToBleveBackend(t *testing.T) {
 	cfg.IndexSnapshotBucketURL = fileBucketURL(t, t.TempDir())
 
 	metrics := resource.ProvideIndexMetrics(prometheus.NewRegistry())
-	opts, err := NewSearchOptions(featuremgmt.WithFeatures(), cfg, nil, metrics, nil)
+	opts, err := NewSearchOptions(featuremgmt.WithFeatures(), cfg, nil, metrics, nil, nil)
 	require.NoError(t, err)
 
 	backend, ok := opts.Backend.(*bleveBackend)

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -374,7 +374,15 @@ func (s *service) registerServer(provider grpcserver.Provider) error {
 		return err
 	}
 
-	searchOptions, err := search.NewSearchOptions(s.features, s.cfg, s.docBuilders, s.indexMetrics, s.OwnsIndex)
+	var snapshotStore search.RemoteIndexStore
+	if s.cfg.IndexSnapshotEnabled && s.cfg.IndexSnapshotStorageKV {
+		snapshotStore, err = buildKVSnapshotStore(s.cfg, s.backend, s.log)
+		if err != nil {
+			return err
+		}
+	}
+
+	searchOptions, err := search.NewSearchOptions(s.features, s.cfg, s.docBuilders, s.indexMetrics, s.OwnsIndex, snapshotStore)
 	if err != nil {
 		return err
 	}
@@ -574,4 +582,41 @@ func (s *service) registerUnifiedResourceServer(provider grpcserver.Provider, se
 	resourcepb.RegisterResourceIndexServer(srv, handler)
 	resourcepb.RegisterManagedObjectIndexServer(srv, handler)
 	_, _ = grpcserver.ProvideReflectionService(s.cfg, provider)
+}
+
+// buildKVSnapshotStore wires a KVRemoteIndexStore that shares the KV
+// store and lease manager with the storage backend. The caller is
+// responsible for ensuring cfg.IndexSnapshotStorageKV is true. This
+// function validates the remaining preconditions and fails loudly so
+// misconfiguration is caught at process start rather than at the first
+// snapshot operation.
+func buildKVSnapshotStore(cfg *setting.Cfg, backend resource.StorageBackend, logger log.Logger) (search.RemoteIndexStore, error) {
+	if cfg.IndexSnapshotBucketURL != "" {
+		return nil, fmt.Errorf("index_snapshot_storage_kv and index_snapshot_bucket_url are mutually exclusive")
+	}
+	if !cfg.EnableKVLeases {
+		return nil, fmt.Errorf("index_snapshot_storage_kv requires enable_kv_leases")
+	}
+
+	kvBackend, ok := backend.(resource.KVBackend)
+	if !ok {
+		return nil, fmt.Errorf("index_snapshot_storage_kv requires a KV-backed storage backend (got %T)", backend)
+	}
+
+	leaseMgr := kvBackend.LeaseManager()
+	if leaseMgr == nil {
+		// Defensive: enable_kv_leases above should already have triggered
+		// lease manager creation in the backend.
+		return nil, fmt.Errorf("storage backend has no lease manager; cannot use index_snapshot_storage_kv")
+	}
+
+	store, err := search.NewKVRemoteIndexStore(search.KVRemoteIndexStoreConfig{
+		KV:           kvBackend.KV(),
+		LeaseManager: leaseMgr,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("building KV remote index store: %w", err)
+	}
+	logger.Info("using KV-backed snapshot store for search indexes")
+	return store, nil
 }

--- a/pkg/storage/unified/sql/service_test.go
+++ b/pkg/storage/unified/sql/service_test.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	badger "github.com/dgraph-io/badger/v4"
 	authnlib "github.com/grafana/authlib/authn"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -17,10 +18,13 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
 	"github.com/grafana/grafana/pkg/services/grpcserver/interceptors"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/lease"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
@@ -252,4 +256,80 @@ func TestNewGrpcAuthenticator(t *testing.T) {
 		_, err := authn(ctxWithToken)
 		require.Error(t, err)
 	})
+}
+
+// nonKVBackend embeds StorageBackend (a nil interface) so it satisfies
+// StorageBackend at compile time without implementing KVBackend. Used to
+// exercise the "backend doesn't expose KV / lease manager" branch.
+type nonKVBackend struct {
+	resource.StorageBackend
+}
+
+// stubKVBackend embeds KVBackend (a nil interface) so unrelated methods
+// are forwarded to the nil interface but never called. KV() and
+// LeaseManager() return the values the test wires in.
+type stubKVBackend struct {
+	resource.KVBackend
+	kv  resource.KV
+	mgr *lease.Manager
+}
+
+func (s *stubKVBackend) KV() resource.KV              { return s.kv }
+func (s *stubKVBackend) LeaseManager() *lease.Manager { return s.mgr }
+
+func TestBuildKVSnapshotStore(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	t.Run("rejects when index_snapshot_bucket_url is also set", func(t *testing.T) {
+		cfg := &setting.Cfg{
+			IndexSnapshotBucketURL: "file:///tmp/snapshot",
+			EnableKVLeases:         true,
+		}
+		_, err := buildKVSnapshotStore(cfg, &stubKVBackend{}, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("rejects when enable_kv_leases is off", func(t *testing.T) {
+		cfg := &setting.Cfg{}
+		_, err := buildKVSnapshotStore(cfg, &stubKVBackend{}, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires enable_kv_leases")
+	})
+
+	t.Run("rejects when backend is not a KVBackend", func(t *testing.T) {
+		cfg := &setting.Cfg{EnableKVLeases: true}
+		_, err := buildKVSnapshotStore(cfg, &nonKVBackend{}, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires a KV-backed storage backend")
+	})
+
+	t.Run("rejects when backend has no lease manager", func(t *testing.T) {
+		cfg := &setting.Cfg{EnableKVLeases: true}
+		backend := &stubKVBackend{kv: newTestKV(t)}
+		_, err := buildKVSnapshotStore(cfg, backend, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no lease manager")
+	})
+
+	t.Run("constructs store when everything is wired", func(t *testing.T) {
+		cfg := &setting.Cfg{EnableKVLeases: true}
+		store := newTestKV(t)
+		mgr := lease.NewManager(store, "test-holder", nil)
+		t.Cleanup(mgr.Stop)
+		backend := &stubKVBackend{kv: store, mgr: mgr}
+
+		got, err := buildKVSnapshotStore(cfg, backend, logger)
+		require.NoError(t, err)
+		assert.NotNil(t, got)
+	})
+}
+
+func newTestKV(t *testing.T) resource.KV {
+	t.Helper()
+	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	return kv.NewBadgerKV(db)
 }

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -172,7 +172,7 @@ func newTestResourceServerWithSearch(t *testing.T, backend resource.StorageBacke
 
 	// Create search options
 	features := featuremgmt.WithFeatures()
-	searchOpts, err := search.NewSearchOptions(features, cfg, docBuilders, nil, nil)
+	searchOpts, err := search.NewSearchOptions(features, cfg, docBuilders, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Create ResourceServer with search enabled


### PR DESCRIPTION
Lets search snapshots use the same KV store as the resource data instead of an object-storage bucket. Turned on with `index_snapshot_storage_kv=true`; requires `enable_kv_leases=true`.

When the toggle is on, the SQL wiring layer pulls the KV store and lease manager off the storage backend (via two new accessors on `KVBackend`) and builds a `KVRemoteIndexStore`, passing it to `NewSearchOptions` through a new optional parameter.

Validation runs at startup: rejects `index_snapshot_bucket_url` and `index_snapshot_storage_kv` set together, requires `enable_kv_leases`, requires a KV-backed storage backend.
