### PR TITLE
`iam`: Correctly map datasource permissions

### DIFF
--- a/pkg/registry/apis/iam/datasourcek8s/k8s.go
+++ b/pkg/registry/apis/iam/datasourcek8s/k8s.go
@@ -1,6 +1,10 @@
 package datasourcek8s
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
 
 // K8sDatasourceAPIGroup returns the k8s API group for a Grafana datasource type
 func K8sDatasourceAPIGroup(dsType string) string {
@@ -72,12 +76,19 @@ func LegacyDatasourceAction(dsType string, action *string) {
 
 // LegacyDatasourceScopeAndActionToK8s converts legacy datasource scope and action to k8s form
 func LegacyDatasourceScopeAndActionToK8s(datasourceType, scope, action string) (string, string) {
-	if datasourceType == "" {
+	kind, _, uid := accesscontrol.SplitScope(scope)
+	if kind != "datasources" {
 		return scope, action
 	}
-	if uid, ok := strings.CutPrefix(scope, "datasources:uid:"); ok {
-		scope = LegacyUIDScopeToK8s(datasourceType, uid)
+	if uid == "*" {
+		// datasource type is not set for wildcard scopes, we use "*" instead
+		datasourceType = "*"
+	} else if datasourceType == "" {
+		// datasource type is not set, this should be an error
+		return scope, action
 	}
+
+	scope = LegacyUIDScopeToK8s(datasourceType, uid)
 	if converted, ok := legacyActionToK8s(datasourceType, action); ok {
 		action = converted
 	}

--- a/pkg/registry/apis/iam/datasourcek8s/k8s.go
+++ b/pkg/registry/apis/iam/datasourcek8s/k8s.go
@@ -84,7 +84,7 @@ func LegacyDatasourceScopeAndActionToK8s(datasourceType, scope, action string) (
 		// datasource type is not set for wildcard scopes, we use "*" instead
 		datasourceType = "*"
 	} else if datasourceType == "" {
-		// datasource type is not set, this should be an error
+		// TODO: datasource type is not set, this should be an error
 		return scope, action
 	}
 

--- a/pkg/registry/apis/iam/datasourcek8s/k8s_test.go
+++ b/pkg/registry/apis/iam/datasourcek8s/k8s_test.go
@@ -38,6 +38,10 @@ func TestLegacyDatasourceScopeAndActionToK8s(t *testing.T) {
 	scope, action = LegacyDatasourceScopeAndActionToK8s("loki", "datasources:uid:abc", "datasources:read")
 	assert.Equal(t, "loki.datasource.grafana.app/datasources:abc", scope)
 	assert.Equal(t, "loki.datasource.grafana.app/datasources:get", action)
+
+	scope, action = LegacyDatasourceScopeAndActionToK8s("*", "datasources:*", "datasources.permissions:write")
+	assert.Equal(t, "*.datasource.grafana.app/datasources:*", scope)
+	assert.Equal(t, "*.datasource.grafana.app/datasources:set_permissions", action)
 }
 
 func TestLegacyDatasourceAction(t *testing.T) {


### PR DESCRIPTION
## Why the change

The conversion of legacy datasource permissions to their k8s form did not correctly handle all scope shapes. In particular, wildcard datasource scopes (`datasources:*`) were not mapped, and scope parsing relied on string prefix checks that were fragile.

## Summary

- Use `accesscontrol.SplitScope` to parse the legacy scope instead of manual prefix matching.
- Only convert scopes whose kind is `datasources`, leaving everything else untouched.
- Map the wildcard scope `datasources:*` to the wildcard k8s group/resource by using `*` as the datasource type.
- Keep returning the original scope/action when the datasource type is unknown for a non-wildcard scope.
- Add a test covering the wildcard scope + `datasources.permissions:write` action.

Fixes: https://github.com/grafana/identity-access-team/issues/2088
