### PR TITLE
Combobox: Fix multi-combobox toggle button not toggling

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
@@ -253,6 +253,21 @@ describe('MultiCombobox', () => {
     expect(onChange).toHaveBeenCalledWith([]);
   });
 
+  it('should open the menu when clicking the toggle button', async () => {
+    const options = [
+      { label: 'Option 1', value: 'a' },
+      { label: 'Option 2', value: 'b' },
+      { label: 'Option 3', value: 'c' },
+    ];
+    render(<MultiCombobox options={options} value={[]} onChange={jest.fn()} />);
+
+    const toggleIcon = screen.getByTestId('icon-angle-down'); // the input element is the interactive element in the a11y tree - this is just decoration
+    await userEvent.click(toggleIcon);
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Option 1' })).toBeInTheDocument();
+  });
+
   describe('all option', () => {
     it('should render all option', async () => {
       const options = [

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -369,7 +369,11 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
                 }}
               />
             )}
-            <SuffixIcon isLoading={loading || false} isOpen={isOpen} {...getToggleButtonProps({ disabled })} />
+            <SuffixIcon
+              isLoading={loading || false}
+              isOpen={isOpen}
+              {...getToggleButtonProps({ disabled, role: 'button' })}
+            />
           </div>
         </span>
       </div>

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -178,7 +178,7 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
       },
     });
 
-  const { isOpen, highlightedIndex, getMenuProps, getInputProps, getItemProps } = useCombobox({
+  const { isOpen, highlightedIndex, getMenuProps, getInputProps, getItemProps, getToggleButtonProps } = useCombobox({
     items: options,
     itemToString,
     inputId: id,
@@ -369,7 +369,7 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
                 }}
               />
             )}
-            <SuffixIcon isLoading={loading || false} isOpen={isOpen} />
+            <SuffixIcon isLoading={loading || false} isOpen={isOpen} {...getToggleButtonProps({ disabled })} />
           </div>
         </span>
       </div>

--- a/packages/grafana-ui/src/components/Combobox/SuffixIcon.tsx
+++ b/packages/grafana-ui/src/components/Combobox/SuffixIcon.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from 'react';
 
 import { Icon, type IconProps } from '../Icon/Icon';
 
-interface Props extends IconProps {
+interface Props extends Omit<IconProps, 'name'> {
   isLoading: boolean;
   isOpen: boolean;
 }

--- a/packages/grafana-ui/src/components/Combobox/SuffixIcon.tsx
+++ b/packages/grafana-ui/src/components/Combobox/SuffixIcon.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react';
+
 import { Icon } from '../Icon/Icon';
 
 interface Props {
@@ -5,7 +7,7 @@ interface Props {
   isOpen: boolean;
 }
 
-export const SuffixIcon = ({ isLoading, isOpen }: Props) => {
+export const SuffixIcon = forwardRef<SVGElement, Props>(({ isLoading, isOpen, ...rest }, ref) => {
   const suffixIcon = isLoading
     ? 'spinner'
     : // If it's loading, show loading icon. Otherwise, icon indicating menu state
@@ -13,5 +15,7 @@ export const SuffixIcon = ({ isLoading, isOpen }: Props) => {
       ? 'search'
       : 'angle-down';
 
-  return <Icon name={suffixIcon} />;
-};
+  return <Icon name={suffixIcon} {...rest} ref={ref} />;
+});
+
+SuffixIcon.displayName = 'SuffixIcon';

--- a/packages/grafana-ui/src/components/Combobox/SuffixIcon.tsx
+++ b/packages/grafana-ui/src/components/Combobox/SuffixIcon.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from 'react';
 
-import { Icon } from '../Icon/Icon';
+import { Icon, type IconProps } from '../Icon/Icon';
 
-interface Props {
+interface Props extends IconProps {
   isLoading: boolean;
   isOpen: boolean;
 }
@@ -15,7 +15,7 @@ export const SuffixIcon = forwardRef<SVGElement, Props>(({ isLoading, isOpen, ..
       ? 'search'
       : 'angle-down';
 
-  return <Icon name={suffixIcon} {...rest} ref={ref} />;
+  return <Icon {...rest} name={suffixIcon} ref={ref} />;
 });
 
 SuffixIcon.displayName = 'SuffixIcon';


### PR DESCRIPTION
Alternative simpler solution to https://github.com/grafana/grafana/pull/122185. 

Fixes MultiCombobox where clicking the dropdown 'button' doesn't open the menu.

 - In regular Combobox, the Input element is the whole visual element, which handles clicking anywhere in it to open the menu when focused with its native Suffix element support
 - In MultiCombobox, because we have the chips to display in the control, we have to use a custom input and suffix, so the size of the click target is smaller and doesn't cover the suffix
 - The solution, from https://github.com/grafana/grafana/pull/122185, is to spread `getToggleButtonProps` onto the dropdown button to Downshift can attach the correct event handlers to the button to open the menu.

This isn't a 100% complete fix - there is still a small area above/below the actual input element that isn't responsive to clicks, but we can sort that out later.

Fixes https://github.com/grafana/grafana/issues/121586 and closes https://github.com/grafana/grafana/pull/122185



