### PR TITLE
Provisioning: Generalize selective export to any supported kind

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -60,32 +60,30 @@ func ExportResources(ctx context.Context, options provisioning.ExportJobOptions,
 // (manager-identity skip, conversion shim, UID regeneration) but resolves
 // items via Get rather than listing the namespace.
 //
-// The admission validator restricts Resources to unmanaged Dashboards; this
-// function trusts that constraint and short-circuits anything else with a
-// recorded warning so a misconfigured caller surfaces in the job summary
-// rather than silently failing.
+// Each reference is resolved against the configured set of supported kinds, so
+// any provisioning-managed kind can be exported, not just dashboards. The
+// admission validator (P0.9) is expected to reject unsupported references up
+// front; if one still reaches the worker it is recorded as an error so a
+// misconfigured caller surfaces in the job summary rather than silently
+// failing.
 func ExportSpecificResources(ctx context.Context, options provisioning.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, generateNewUIDs bool) error {
 	progress.SetMessage(ctx, "start selective resource export")
 
-	// ForKind resolves the preferred version when Version is empty.
-	dashboardGVK := schema.GroupVersionKind{
-		Group: resources.DashboardKind.Group,
-		Kind:  resources.DashboardKind.Kind,
-	}
-	dashClient, dashGVR, err := clients.ForKind(ctx, dashboardGVK)
-	if err != nil {
-		return fmt.Errorf("get dashboard client: %w", err)
-	}
-	shim := newDashboardConversionShim(dashGVR, clients)
+	supported := clients.SupportedResources()
+
+	// The dashboard conversion shim is built lazily on first use so exports that
+	// contain no dashboards don't pay for a dashboard discovery lookup.
+	var dashboardShim conversionShim
 
 	for _, ref := range options.Resources {
+		gvk, ok := resolveSupportedKind(supported, ref)
 		// Leave the action unset on the error paths below: the recorder
 		// treats FileActionIgnored results as non-fatal, and we want the
 		// caller's bad/unresolvable reference to escalate the job state.
-		result := jobs.NewGroupKindResult(ref.Name, resources.DashboardKind.Group, resources.DashboardKind.Kind)
+		result := jobs.NewGroupKindResult(ref.Name, gvk.Group, gvk.Kind)
 
-		if ref.Kind != "" && ref.Kind != resources.DashboardKind.Kind {
-			result.WithError(fmt.Errorf("resource %s/%s is not a %s", ref.Kind, ref.Name, resources.DashboardKind.Kind))
+		if !ok {
+			result.WithError(fmt.Errorf("resource %s/%s has unsupported kind %q (group %q)", ref.Kind, ref.Name, ref.Kind, ref.Group))
 			progress.Record(ctx, result.Build())
 			if err := progress.TooManyErrors(); err != nil {
 				return err
@@ -93,12 +91,33 @@ func ExportSpecificResources(ctx context.Context, options provisioning.ExportJob
 			continue
 		}
 
-		item, err := dashClient.Get(ctx, ref.Name, metav1.GetOptions{})
+		// ForKind resolves the preferred version when Version is empty.
+		client, gvr, err := clients.ForKind(ctx, gvk)
+		if err != nil {
+			result.WithError(fmt.Errorf("get client for %s/%s: %w", gvk.Group, gvk.Kind, err))
+			progress.Record(ctx, result.Build())
+			if err := progress.TooManyErrors(); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Dashboards need the conversion shim to preserve their original stored
+		// apiVersion; other kinds are exported as returned.
+		var shim conversionShim
+		if gvr.GroupResource() == resources.DashboardResource.GroupResource() {
+			if dashboardShim == nil {
+				dashboardShim = newDashboardConversionShim(gvr, clients)
+			}
+			shim = dashboardShim
+		}
+
+		item, err := client.Get(ctx, ref.Name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				result.WithError(fmt.Errorf("dashboard %q not found", ref.Name))
+				result.WithError(fmt.Errorf("%s %q not found", gvk.Kind, ref.Name))
 			} else {
-				result.WithError(fmt.Errorf("get dashboard %q: %w", ref.Name, err))
+				result.WithError(fmt.Errorf("get %s %q: %w", gvk.Kind, ref.Name, err))
 			}
 			progress.Record(ctx, result.Build())
 			if err := progress.TooManyErrors(); err != nil {
@@ -113,6 +132,33 @@ func ExportSpecificResources(ctx context.Context, options provisioning.ExportJob
 	}
 
 	return nil
+}
+
+// resolveSupportedKind maps a ResourceRef onto a supported GroupVersionKind. The
+// Version is left empty so ForKind resolves the preferred version via discovery.
+// When the ref omits the group, the kind is matched against the supported set,
+// which keeps callers that only set Kind working. Folders are excluded because
+// they are exported separately via ExportFolders, not as individual resources.
+// The returned bool is false when no supported, non-folder resource matches.
+func resolveSupportedKind(supported []resources.SupportedResource, ref provisioning.ResourceRef) (schema.GroupVersionKind, bool) {
+	if ref.Kind == "" {
+		return schema.GroupVersionKind{Group: ref.Group, Kind: ref.Kind}, false
+	}
+
+	for _, r := range supported {
+		if r.GroupKind == resources.FolderKind.GroupKind() {
+			continue
+		}
+		if r.Kind != ref.Kind {
+			continue
+		}
+		if ref.Group != "" && ref.Group != r.Group {
+			continue
+		}
+		return schema.GroupVersionKind{Group: r.Group, Kind: r.Kind}, true
+	}
+
+	return schema.GroupVersionKind{Group: ref.Group, Kind: ref.Kind}, false
 }
 
 func exportResource(ctx context.Context,

--- a/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
@@ -72,6 +72,17 @@ func dashboardGVK() schema.GroupVersionKind {
 	}
 }
 
+// supportedDashboardAndFolder mirrors the default provisioning configuration:
+// Folder and Dashboard are supported. Selective export must resolve Dashboard
+// refs against this set and reject Folder refs (folders are exported via
+// ExportFolders, not as individual resources).
+func supportedDashboardAndFolder() []resources.SupportedResource {
+	return []resources.SupportedResource{
+		{GroupKind: resources.FolderKind.GroupKind()},
+		{GroupKind: resources.DashboardKind.GroupKind()},
+	}
+}
+
 func TestExportSpecificResources_Success(t *testing.T) {
 	dashClient := &mockGetByName{items: map[string]*unstructured.Unstructured{
 		"dash-1": dashboardObject("dash-1"),
@@ -79,6 +90,7 @@ func TestExportSpecificResources_Success(t *testing.T) {
 	}}
 
 	resourceClients := resources.NewMockResourceClients(t)
+	resourceClients.On("SupportedResources").Return(supportedDashboardAndFolder())
 	resourceClients.On("ForKind", mock.Anything, dashboardGVK()).
 		Return(dashClient, resources.DashboardResource, nil)
 
@@ -120,6 +132,7 @@ func TestExportSpecificResources_ManagedDashboardError(t *testing.T) {
 	}}
 
 	resourceClients := resources.NewMockResourceClients(t)
+	resourceClients.On("SupportedResources").Return(supportedDashboardAndFolder())
 	resourceClients.On("ForKind", mock.Anything, dashboardGVK()).
 		Return(dashClient, resources.DashboardResource, nil)
 
@@ -152,6 +165,7 @@ func TestExportSpecificResources_NotFoundRecordsError(t *testing.T) {
 	dashClient := &mockGetByName{items: map[string]*unstructured.Unstructured{}}
 
 	resourceClients := resources.NewMockResourceClients(t)
+	resourceClients.On("SupportedResources").Return(supportedDashboardAndFolder())
 	resourceClients.On("ForKind", mock.Anything, dashboardGVK()).
 		Return(dashClient, resources.DashboardResource, nil)
 
@@ -185,6 +199,7 @@ func TestExportSpecificResources_GetErrorRecordsError(t *testing.T) {
 	}
 
 	resourceClients := resources.NewMockResourceClients(t)
+	resourceClients.On("SupportedResources").Return(supportedDashboardAndFolder())
 	resourceClients.On("ForKind", mock.Anything, dashboardGVK()).
 		Return(dashClient, resources.DashboardResource, nil)
 
@@ -211,6 +226,7 @@ func TestExportSpecificResources_NewUIDsSetsRandomName(t *testing.T) {
 	}}
 
 	resourceClients := resources.NewMockResourceClients(t)
+	resourceClients.On("SupportedResources").Return(supportedDashboardAndFolder())
 	resourceClients.On("ForKind", mock.Anything, dashboardGVK()).
 		Return(dashClient, resources.DashboardResource, nil)
 
@@ -236,23 +252,23 @@ func TestExportSpecificResources_NewUIDsSetsRandomName(t *testing.T) {
 	require.NotEqual(t, "original-uid", writtenName, "generateNewUIDs=true should have rewritten the object name")
 }
 
-func TestExportSpecificResources_NonDashboardKindIsErroredAndSkipped(t *testing.T) {
-	// ForKind still gets called once at the top of ExportSpecificResources so
-	// the shim can be prepared, even though no dashboards end up being fetched.
+func TestExportSpecificResources_FolderKindIsErroredAndSkipped(t *testing.T) {
+	// Folders are a supported provisioning kind but are exported via
+	// ExportFolders, not selectively as individual resources. A Folder ref is
+	// rejected before any client is resolved, so ForKind is never called.
 	resourceClients := resources.NewMockResourceClients(t)
-	resourceClients.On("ForKind", mock.Anything, dashboardGVK()).
-		Return(&mockGetByName{items: map[string]*unstructured.Unstructured{}}, resources.DashboardResource, nil)
+	resourceClients.On("SupportedResources").Return(supportedDashboardAndFolder())
 
 	repoResources := resources.NewMockRepositoryResources(t)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
 	progress.On("SetMessage", mock.Anything, "start selective resource export").Return()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		// A non-Dashboard kind is a caller mistake (admission would normally
-		// reject it); if it still reaches the worker, fail the item rather
-		// than quietly warn so the job surfaces the bad input. The action is
-		// NOT Ignored because the recorder silently discards errors on
-		// ignored results — we need this one to escalate the job state.
+		// A folder ref is a caller mistake (admission would normally reject
+		// it); if it still reaches the worker, fail the item rather than
+		// quietly warn so the job surfaces the bad input. The action is NOT
+		// Ignored because the recorder silently discards errors on ignored
+		// results — we need this one to escalate the job state.
 		return r.Name() == "folder-ref" && r.Action() != repository.FileActionIgnored && r.Error() != nil
 	})).Return()
 	progress.On("TooManyErrors").Return(nil).Once()
@@ -263,5 +279,75 @@ func TestExportSpecificResources_NonDashboardKindIsErroredAndSkipped(t *testing.
 
 	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, false)
 	require.NoError(t, err)
+	resourceClients.AssertNotCalled(t, "ForKind", mock.Anything, mock.Anything)
 	repoResources.AssertNotCalled(t, "WriteResourceFileFromObject", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestExportSpecificResources_UnsupportedKindIsErroredAndSkipped(t *testing.T) {
+	// A kind that is not in the supported set (e.g. Playlist when only
+	// dashboards and folders are configured) is rejected without resolving a
+	// client.
+	resourceClients := resources.NewMockResourceClients(t)
+	resourceClients.On("SupportedResources").Return(supportedDashboardAndFolder())
+
+	repoResources := resources.NewMockRepositoryResources(t)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, "start selective resource export").Return()
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Name() == "playlist-1" && r.Action() != repository.FileActionIgnored && r.Error() != nil
+	})).Return()
+	progress.On("TooManyErrors").Return(nil).Once()
+
+	options := provisioningV0.ExportJobOptions{
+		Resources: []provisioningV0.ResourceRef{{Name: "playlist-1", Kind: "Playlist", Group: "playlist.grafana.app"}},
+	}
+
+	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, false)
+	require.NoError(t, err)
+	resourceClients.AssertNotCalled(t, "ForKind", mock.Anything, mock.Anything)
+	repoResources.AssertNotCalled(t, "WriteResourceFileFromObject", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestExportSpecificResources_SupportedNonDashboardKind(t *testing.T) {
+	// A non-dashboard supported kind resolves its own client (no conversion
+	// shim) and is exported like any other resource.
+	const group = "playlist.grafana.app"
+	playlistGVK := schema.GroupVersionKind{Group: group, Kind: "Playlist"}
+	playlistGVR := schema.GroupVersionResource{Group: group, Version: "v0alpha1", Resource: "playlists"}
+
+	playlist := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": group + "/v0alpha1",
+		"kind":       "Playlist",
+		"metadata":   map[string]any{"name": "playlist-1"},
+	}}
+	playlistClient := &mockGetByName{items: map[string]*unstructured.Unstructured{"playlist-1": playlist}}
+
+	resourceClients := resources.NewMockResourceClients(t)
+	resourceClients.On("SupportedResources").Return([]resources.SupportedResource{
+		{GroupKind: resources.FolderKind.GroupKind()},
+		{GroupKind: resources.DashboardKind.GroupKind()},
+		{GroupKind: playlistGVK.GroupKind()},
+	})
+	resourceClients.On("ForKind", mock.Anything, playlistGVK).
+		Return(playlistClient, playlistGVR, nil)
+
+	repoResources := resources.NewMockRepositoryResources(t)
+	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
+		return obj.GetName() == "playlist-1"
+	}), mock.Anything).Return("playlist-1.json", nil)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, "start selective resource export").Return()
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Name() == "playlist-1" && r.Action() == repository.FileActionCreated
+	})).Return()
+	progress.On("TooManyErrors").Return(nil).Once()
+
+	options := provisioningV0.ExportJobOptions{
+		Resources: []provisioningV0.ResourceRef{{Name: "playlist-1", Kind: "Playlist", Group: group}},
+	}
+
+	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, false)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

The selective-export job controller (`ExportSpecificResources`) hardcoded the Dashboard GVK and rejected any other kind. This generalizes UID→resource resolution so **any supported provisioning kind** can be selectively exported, not just dashboards.

Prep work for generic resource type support (part of #1166, issue #1172). Pairs with the P0.9 admission validator.

The bulk **move** and **delete** job controllers were already generic — they resolve `ResourceRef` → path via `FindResourcePath`/`ForKind` for arbitrary GVKs — so no change was needed there. The only dashboard-restricted controller was selective export.

## Changes

- `ExportSpecificResources` resolves each `ResourceRef` against `clients.SupportedResources()` (new `resolveSupportedKind` helper) instead of assuming `Dashboard`. Matches by kind, and by group when the ref provides one.
- Per-ref `ForKind` client resolution rather than a single shared dashboard client.
- The dashboard conversion shim (preserves the original stored `apiVersion`) is built **lazily** and applied only when the resolved resource is the dashboard resource; other kinds export as returned.
- Folders remain excluded — they are exported separately via `ExportFolders`, not as individual resources.
- Unsupported refs are recorded as errors (escalating the job) rather than silently ignored, consistent with existing fail-loud behavior.

## Testing

- `go test ./pkg/registry/apis/provisioning/jobs/export/` — all pass.
- Existing dashboard tests updated with `SupportedResources` mock setup.
- New tests: folder ref rejected before client resolution, unsupported kind rejected, and a non-dashboard supported kind (Playlist) exports correctly without the shim.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (n/a)
- [x] No breaking changes
- [x] Backend-only (frontend changes, if any, in a separate PR per repo convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)