### PR TITLE
Provisioning: Add logs for outbound git operations

### DIFF
--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -95,7 +95,8 @@ func (r *gitRepository) GetCurrentBranch() string {
 }
 
 func (r *gitRepository) GetDefaultBranch(ctx context.Context) (string, error) {
-	ctx, _ = r.withGitContext(ctx, "")
+	ctx, logger := r.withGitContext(ctx, "")
+	logger.Info("outbound git operation", "operation", "get_default_branch")
 
 	// Get all refs to find the default branch
 	refs, err := r.client.ListRefs(ctx)
@@ -179,7 +180,8 @@ func isValidGitURL(gitURL string) bool {
 
 // Test implements provisioning.Repository.
 func (r *gitRepository) Test(ctx context.Context) (*provisioning.TestResults, error) {
-	ctx, _ = r.withGitContext(ctx, "")
+	ctx, logger := r.withGitContext(ctx, "")
+	logger.Info("outbound git operation", "operation", "test")
 
 	t := string(r.config.Spec.Type)
 
@@ -339,7 +341,8 @@ func (r *gitRepository) Test(ctx context.Context) (*provisioning.TestResults, er
 
 // Read implements provisioning.Repository.
 func (r *gitRepository) Read(ctx context.Context, filePath, ref string) (*repository.FileInfo, error) {
-	ctx, _ = r.withGitContext(ctx, ref)
+	ctx, logger := r.withGitContext(ctx, ref)
+	logger.Info("outbound git operation", "operation", "read", "path", filePath)
 	finalPath := safepath.Join(r.gitConfig.Path, filePath)
 
 	// Resolve ref to commit hash
@@ -393,7 +396,8 @@ func (r *gitRepository) Read(ctx context.Context, filePath, ref string) (*reposi
 }
 
 func (r *gitRepository) ReadTree(ctx context.Context, ref string) ([]repository.FileTreeEntry, error) {
-	ctx, _ = r.withGitContext(ctx, ref)
+	ctx, logger := r.withGitContext(ctx, ref)
+	logger.Info("outbound git operation", "operation", "read_tree")
 
 	// Resolve ref to commit hash
 	refHash, err := r.resolveRefToHash(ctx, ref)
@@ -441,7 +445,8 @@ func (r *gitRepository) Create(ctx context.Context, path, ref string, data []byt
 	if ref == "" {
 		ref = r.gitConfig.Branch
 	}
-	ctx, _ = r.withGitContext(ctx, ref)
+	ctx, logger := r.withGitContext(ctx, ref)
+	logger.Info("outbound git operation", "operation", "create", "path", path)
 	branchRef, err := r.ensureBranchExists(ctx, ref)
 	if err != nil {
 		return err
@@ -486,7 +491,8 @@ func (r *gitRepository) Update(ctx context.Context, path, ref string, data []byt
 	if ref == "" {
 		ref = r.gitConfig.Branch
 	}
-	ctx, _ = r.withGitContext(ctx, ref)
+	ctx, logger := r.withGitContext(ctx, ref)
+	logger.Info("outbound git operation", "operation", "update", "path", path)
 
 	// Check if trying to update a directory
 	if safepath.IsDir(path) {
@@ -533,7 +539,8 @@ func (r *gitRepository) Write(ctx context.Context, path string, ref string, data
 		ref = r.gitConfig.Branch
 	}
 
-	ctx, _ = r.withGitContext(ctx, ref)
+	ctx, logger := r.withGitContext(ctx, ref)
+	logger.Info("outbound git operation", "operation", "write", "path", path)
 	info, err := r.Read(ctx, path, ref)
 	if err != nil && !(errors.Is(err, repository.ErrFileNotFound)) {
 		return fmt.Errorf("check if file exists before writing: %w", err)
@@ -553,7 +560,8 @@ func (r *gitRepository) Delete(ctx context.Context, path, ref, comment string) e
 	if ref == "" {
 		ref = r.gitConfig.Branch
 	}
-	ctx, _ = r.withGitContext(ctx, ref)
+	ctx, logger := r.withGitContext(ctx, ref)
+	logger.Info("outbound git operation", "operation", "delete", "path", path)
 
 	branchRef, err := r.ensureBranchExists(ctx, ref)
 	if err != nil {
@@ -576,7 +584,8 @@ func (r *gitRepository) Move(ctx context.Context, oldPath, newPath, ref, comment
 	if ref == "" {
 		ref = r.gitConfig.Branch
 	}
-	ctx, _ = r.withGitContext(ctx, ref)
+	ctx, logger := r.withGitContext(ctx, ref)
+	logger.Info("outbound git operation", "operation", "move", "old_path", oldPath, "new_path", newPath)
 
 	branchRef, err := r.ensureBranchExists(ctx, ref)
 	if err != nil {
@@ -667,7 +676,8 @@ func (r *gitRepository) History(_ context.Context, _ string, _ string) ([]provis
 }
 
 func (r *gitRepository) ListRefs(ctx context.Context) ([]provisioning.RefItem, error) {
-	ctx, _ = r.withGitContext(ctx, "")
+	ctx, logger := r.withGitContext(ctx, "")
+	logger.Info("outbound git operation", "operation", "list_refs")
 	refs, err := r.client.ListRefs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list refs: %w", err)
@@ -689,7 +699,8 @@ func (r *gitRepository) ListRefs(ctx context.Context) ([]provisioning.RefItem, e
 }
 
 func (r *gitRepository) LatestRef(ctx context.Context) (string, error) {
-	ctx, _ = r.withGitContext(ctx, "")
+	ctx, logger := r.withGitContext(ctx, "")
+	logger.Info("outbound git operation", "operation", "latest_ref")
 	branchRef, err := r.client.GetRef(ctx, fmt.Sprintf("refs/heads/%s", r.gitConfig.Branch))
 	if err != nil {
 		return "", fmt.Errorf("get branch ref: %w", err)
@@ -707,6 +718,7 @@ func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]r
 	}
 
 	ctx, logger := r.withGitContext(ctx, ref)
+	logger.Info("outbound git operation", "operation", "compare_files")
 
 	// Resolve base ref to hash
 	var baseHash hash.Hash
@@ -839,7 +851,8 @@ func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]r
 
 func (r *gitRepository) Stage(ctx context.Context, opts repository.StageOptions) (repository.StagedRepository, error) {
 	ctx = ensureRetryContext(ctx)
-	ctx, _ = r.withGitContext(ctx, "")
+	ctx, logger := r.withGitContext(ctx, "")
+	logger.Info("outbound git operation", "operation", "stage")
 	return NewStagedGitRepository(ctx, r, opts)
 }
 
@@ -1037,7 +1050,13 @@ func (r *gitRepository) withGitContext(ctx context.Context, ref string) (context
 	if ref == "" {
 		ref = r.gitConfig.Branch
 	}
-	logger = logger.With(slog.Group("git_repository", "url", r.gitConfig.URL, "ref", ref, "nanogit", true))
+	logger = logger.With(slog.Group("git_repository",
+		"url", r.gitConfig.URL,
+		"ref", ref,
+		"namespace", r.config.Namespace,
+		"repository_name", r.config.Name,
+		"nanogit", true,
+	))
 	ctx = logging.Context(ctx, logger)
 	// We want to ensure we don't add multiple git_repository keys. With doesn't deduplicate the keys...
 	ctx = context.WithValue(ctx, containsGitKey, true)

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -96,7 +96,7 @@ func (r *gitRepository) GetCurrentBranch() string {
 
 func (r *gitRepository) GetDefaultBranch(ctx context.Context) (string, error) {
 	ctx, logger := r.withGitContext(ctx, "")
-	logger.Info("outbound git operation", "operation", "get_default_branch")
+	logger.Info("get default branch")
 
 	// Get all refs to find the default branch
 	refs, err := r.client.ListRefs(ctx)
@@ -181,7 +181,7 @@ func isValidGitURL(gitURL string) bool {
 // Test implements provisioning.Repository.
 func (r *gitRepository) Test(ctx context.Context) (*provisioning.TestResults, error) {
 	ctx, logger := r.withGitContext(ctx, "")
-	logger.Info("outbound git operation", "operation", "test")
+	logger.Info("test repository connection")
 
 	t := string(r.config.Spec.Type)
 
@@ -342,7 +342,7 @@ func (r *gitRepository) Test(ctx context.Context) (*provisioning.TestResults, er
 // Read implements provisioning.Repository.
 func (r *gitRepository) Read(ctx context.Context, filePath, ref string) (*repository.FileInfo, error) {
 	ctx, logger := r.withGitContext(ctx, ref)
-	logger.Info("outbound git operation", "operation", "read", "path", filePath)
+	logger.Info("read repository path", "path", filePath)
 	finalPath := safepath.Join(r.gitConfig.Path, filePath)
 
 	// Resolve ref to commit hash
@@ -397,7 +397,7 @@ func (r *gitRepository) Read(ctx context.Context, filePath, ref string) (*reposi
 
 func (r *gitRepository) ReadTree(ctx context.Context, ref string) ([]repository.FileTreeEntry, error) {
 	ctx, logger := r.withGitContext(ctx, ref)
-	logger.Info("outbound git operation", "operation", "read_tree")
+	logger.Info("read repository tree")
 
 	// Resolve ref to commit hash
 	refHash, err := r.resolveRefToHash(ctx, ref)
@@ -446,7 +446,7 @@ func (r *gitRepository) Create(ctx context.Context, path, ref string, data []byt
 		ref = r.gitConfig.Branch
 	}
 	ctx, logger := r.withGitContext(ctx, ref)
-	logger.Info("outbound git operation", "operation", "create", "path", path)
+	logger.Info("create repository path", "path", path)
 	branchRef, err := r.ensureBranchExists(ctx, ref)
 	if err != nil {
 		return err
@@ -492,7 +492,7 @@ func (r *gitRepository) Update(ctx context.Context, path, ref string, data []byt
 		ref = r.gitConfig.Branch
 	}
 	ctx, logger := r.withGitContext(ctx, ref)
-	logger.Info("outbound git operation", "operation", "update", "path", path)
+	logger.Info("update repository path", "path", path)
 
 	// Check if trying to update a directory
 	if safepath.IsDir(path) {
@@ -540,7 +540,7 @@ func (r *gitRepository) Write(ctx context.Context, path string, ref string, data
 	}
 
 	ctx, logger := r.withGitContext(ctx, ref)
-	logger.Info("outbound git operation", "operation", "write", "path", path)
+	logger.Info("write repository path", "path", path)
 	info, err := r.Read(ctx, path, ref)
 	if err != nil && !(errors.Is(err, repository.ErrFileNotFound)) {
 		return fmt.Errorf("check if file exists before writing: %w", err)
@@ -561,7 +561,7 @@ func (r *gitRepository) Delete(ctx context.Context, path, ref, comment string) e
 		ref = r.gitConfig.Branch
 	}
 	ctx, logger := r.withGitContext(ctx, ref)
-	logger.Info("outbound git operation", "operation", "delete", "path", path)
+	logger.Info("delete repository path", "path", path)
 
 	branchRef, err := r.ensureBranchExists(ctx, ref)
 	if err != nil {
@@ -585,7 +585,7 @@ func (r *gitRepository) Move(ctx context.Context, oldPath, newPath, ref, comment
 		ref = r.gitConfig.Branch
 	}
 	ctx, logger := r.withGitContext(ctx, ref)
-	logger.Info("outbound git operation", "operation", "move", "old_path", oldPath, "new_path", newPath)
+	logger.Info("move repository path", "old_path", oldPath, "new_path", newPath)
 
 	branchRef, err := r.ensureBranchExists(ctx, ref)
 	if err != nil {
@@ -677,7 +677,7 @@ func (r *gitRepository) History(_ context.Context, _ string, _ string) ([]provis
 
 func (r *gitRepository) ListRefs(ctx context.Context) ([]provisioning.RefItem, error) {
 	ctx, logger := r.withGitContext(ctx, "")
-	logger.Info("outbound git operation", "operation", "list_refs")
+	logger.Info("list refs")
 	refs, err := r.client.ListRefs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list refs: %w", err)
@@ -700,7 +700,7 @@ func (r *gitRepository) ListRefs(ctx context.Context) ([]provisioning.RefItem, e
 
 func (r *gitRepository) LatestRef(ctx context.Context) (string, error) {
 	ctx, logger := r.withGitContext(ctx, "")
-	logger.Info("outbound git operation", "operation", "latest_ref")
+	logger.Info("get latest ref")
 	branchRef, err := r.client.GetRef(ctx, fmt.Sprintf("refs/heads/%s", r.gitConfig.Branch))
 	if err != nil {
 		return "", fmt.Errorf("get branch ref: %w", err)
@@ -718,7 +718,7 @@ func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]r
 	}
 
 	ctx, logger := r.withGitContext(ctx, ref)
-	logger.Info("outbound git operation", "operation", "compare_files")
+	logger.Info("compare files")
 
 	// Resolve base ref to hash
 	var baseHash hash.Hash
@@ -852,7 +852,7 @@ func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]r
 func (r *gitRepository) Stage(ctx context.Context, opts repository.StageOptions) (repository.StagedRepository, error) {
 	ctx = ensureRetryContext(ctx)
 	ctx, logger := r.withGitContext(ctx, "")
-	logger.Info("outbound git operation", "operation", "stage")
+	logger.Info("stage repository")
 	return NewStagedGitRepository(ctx, r, opts)
 }
 

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -5057,9 +5057,8 @@ func TestGitRepository_AuditLog(t *testing.T) {
 	require.NoError(t, err)
 
 	output := buf.String()
-	require.Contains(t, output, `"operation":"list_refs"`)
+	require.Contains(t, output, `"msg":"list refs"`)
 	require.Contains(t, output, `"namespace":"my-ns"`)
 	require.Contains(t, output, `"repository_name":"my-repo"`)
 	require.Contains(t, output, `"url":"https://git.example.com/owner/repo.git"`)
-	require.Contains(t, output, "outbound git operation")
 }

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -1,13 +1,16 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -4986,4 +4989,77 @@ func TestGitRepository_GetCurrentBranch(t *testing.T) {
 			require.Equal(t, tt.expectedBranch, branch)
 		})
 	}
+}
+
+func TestWithGitContext_AuditFields(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, nil)
+	logger := logging.NewSLogLogger(handler)
+
+	ctx := logging.Context(context.Background(), logger)
+
+	gitRepo := &gitRepository{
+		config: &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-repo",
+				Namespace: "test-ns",
+			},
+			Spec: provisioning.RepositorySpec{
+				Type: provisioning.GitRepositoryType,
+			},
+		},
+		gitConfig: RepositoryConfig{
+			URL:    "https://git.example.com/owner/repo.git",
+			Branch: "main",
+		},
+	}
+
+	_, enrichedLogger := gitRepo.withGitContext(ctx, "main")
+	enrichedLogger.Info("test log")
+
+	output := buf.String()
+	require.Contains(t, output, `"namespace":"test-ns"`)
+	require.Contains(t, output, `"repository_name":"test-repo"`)
+	require.Contains(t, output, `"url":"https://git.example.com/owner/repo.git"`)
+	require.Contains(t, output, `"ref":"main"`)
+}
+
+func TestGitRepository_AuditLog(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, nil)
+	logger := logging.NewSLogLogger(handler)
+
+	ctx := logging.Context(context.Background(), logger)
+
+	mockClient := &mocks.FakeClient{}
+	mockClient.ListRefsReturns([]nanogit.Ref{
+		{Name: "refs/heads/main", Hash: hash.Hash{}},
+	}, nil)
+
+	gitRepo := &gitRepository{
+		client: mockClient,
+		config: &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-repo",
+				Namespace: "my-ns",
+			},
+			Spec: provisioning.RepositorySpec{
+				Type: provisioning.GitRepositoryType,
+			},
+		},
+		gitConfig: RepositoryConfig{
+			URL:    "https://git.example.com/owner/repo.git",
+			Branch: "main",
+		},
+	}
+
+	_, err := gitRepo.ListRefs(ctx)
+	require.NoError(t, err)
+
+	output := buf.String()
+	require.Contains(t, output, `"operation":"list_refs"`)
+	require.Contains(t, output, `"namespace":"my-ns"`)
+	require.Contains(t, output, `"repository_name":"my-repo"`)
+	require.Contains(t, output, `"url":"https://git.example.com/owner/repo.git"`)
+	require.Contains(t, output, "outbound git operation")
 }

--- a/apps/provisioning/pkg/repository/git/staged.go
+++ b/apps/provisioning/pkg/repository/git/staged.go
@@ -205,7 +205,7 @@ func (r *stagedGitRepository) Move(ctx context.Context, oldPath, newPath, ref, m
 
 func (r *stagedGitRepository) Push(ctx context.Context) error {
 	ctx, logger := r.withGitContext(ctx, "")
-	logger.Info("outbound git operation", "operation", "push")
+	logger.Info("push repository")
 
 	if r.opts.Timeout > 0 {
 		var cancel context.CancelFunc

--- a/apps/provisioning/pkg/repository/git/staged.go
+++ b/apps/provisioning/pkg/repository/git/staged.go
@@ -204,6 +204,9 @@ func (r *stagedGitRepository) Move(ctx context.Context, oldPath, newPath, ref, m
 }
 
 func (r *stagedGitRepository) Push(ctx context.Context) error {
+	ctx, logger := r.withGitContext(ctx, "")
+	logger.Info("outbound git operation", "operation", "push")
+
 	if r.opts.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, r.opts.Timeout)


### PR DESCRIPTION
**What is this feature?**

Adds some additional logs for outbound git operations

**Why do we need this feature?**

Gives better visibility on the git operations performed by the Provisioning feature. 

**Who is this feature for?**

Maintainers of the provisioning feature, and OnPrem users which are interested in having more insights on which operations are performed by the feature, and when
