### PR TITLE
[release-13.0.3] Unified Storage: ANALYZE resource_history before backfill on Postgres

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -269,6 +269,7 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		watchBufferSize:         opts.WatchBufferSize,
 		storageMetrics:          opts.storageMetrics,
 		bulkLock:                &bulkLock{running: make(map[string]bool)},
+		analyzeBulkRowThreshold: analyzeResourceHistoryRowThreshold,
 		simulatedNetworkLatency: opts.SimulatedNetworkLatency,
 		migrationParquetBuffer:  opts.MigrationParquetBuffer,
 		tmpDir:                  opts.TmpDir,
@@ -308,6 +309,10 @@ type backend struct {
 	db         db.DB
 	dialect    sqltemplate.Dialect
 	bulkLock   *bulkLock
+
+	// analyzeBulkRowThreshold is the number of rows bulk-loaded into resource_history
+	// above which ANALYZE runs before the backfill. Overridable in tests.
+	analyzeBulkRowThreshold int
 
 	// -- Storage Services
 

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -35,6 +35,10 @@ var (
 const (
 	bulkHistoryInsertSQLiteMaxRows  = 8
 	bulkHistoryInsertDefaultMaxRows = 1000
+
+	// analyzeResourceHistoryRowThreshold is the number of rows bulk-loaded into
+	// resource_history to trigger an ANALYZE before the resource backfill.
+	analyzeResourceHistoryRowThreshold = 10000
 )
 
 // noRollbackTx wraps a db.Tx but makes Rollback() a no-op.
@@ -294,6 +298,11 @@ func (b *backend) processBulkWithTx(ctx context.Context, tx db.Tx, setting resou
 		}
 	}
 
+	// Refresh planner stats so syncCollection's self-join avoids a nested-loop plan.
+	if err := b.analyzeResourceHistoryForBackfill(ctx, tx, rsp.Processed); err != nil {
+		return rollbackWithError(err)
+	}
+
 	// Now update the resource table from history
 	for _, key := range setting.Collection {
 		k := fmt.Sprintf("%s/%s/%s", key.Namespace, key.Group, key.Resource)
@@ -337,6 +346,22 @@ func (b *backend) processBulkWithTx(ctx context.Context, tx db.Tx, setting resou
 		}
 	}
 	return nil
+}
+
+// analyzeResourceHistoryForBackfill exists because syncCollection's self-join would otherwise
+// run against stale statistics: resource_history was just bulk-loaded in this same transaction,
+// so the planner still sees it as empty and picks an O(n^2) nested-loop plan that never finishes
+// on large rebuilds.
+func (b *backend) analyzeResourceHistoryForBackfill(ctx context.Context, tx db.ContextExecer, processed int64) error {
+	if b.dialect.DialectName() != "postgres" || processed < int64(b.analyzeBulkRowThreshold) {
+		return nil
+	}
+	table, err := b.dialect.Ident("resource_history")
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, "ANALYZE "+table)
+	return err
 }
 
 func (b *backend) insertHistoryBatch(ctx context.Context, tx db.ContextExecer, batch []*resourcepb.BulkRequest, rv *bulkRV, rsp *resourcepb.BulkResponse) error {

--- a/pkg/storage/unified/sql/backend_bulk_test.go
+++ b/pkg/storage/unified/sql/backend_bulk_test.go
@@ -2,12 +2,54 @@ package sql
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	unitest "github.com/grafana/grafana/pkg/storage/unified/testing"
+	"github.com/grafana/grafana/pkg/util/testutil"
 )
+
+func TestAnalyzeResourceHistoryForBackfill(t *testing.T) {
+	t.Run("postgres above threshold issues ANALYZE", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+		b.dialect = sqltemplate.PostgreSQL
+		b.SQLMock.ExpectExec(`ANALYZE`).WillReturnResult(sqlmock.NewResult(0, 0))
+
+		require.NoError(t, b.analyzeResourceHistoryForBackfill(ctx, b.db, analyzeResourceHistoryRowThreshold))
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+	})
+
+	t.Run("failed ANALYZE returns the error", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+		b.dialect = sqltemplate.PostgreSQL
+		b.SQLMock.ExpectExec(`ANALYZE`).WillReturnError(errTest)
+
+		require.ErrorIs(t, b.analyzeResourceHistoryForBackfill(ctx, b.db, analyzeResourceHistoryRowThreshold), errTest)
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+	})
+
+	t.Run("postgres below threshold skips ANALYZE", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+		b.dialect = sqltemplate.PostgreSQL
+
+		require.NoError(t, b.analyzeResourceHistoryForBackfill(ctx, b.db, analyzeResourceHistoryRowThreshold-1))
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+	})
+
+	t.Run("non-postgres skips ANALYZE", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+		b.dialect = sqltemplate.SQLite
+
+		require.NoError(t, b.analyzeResourceHistoryForBackfill(ctx, b.db, analyzeResourceHistoryRowThreshold*10))
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+	})
+}
 
 func TestBackendInsertHistoryBatch(t *testing.T) {
 	b, ctx := setupBackendTest(t)
@@ -45,5 +87,56 @@ func newSQLBulkRequest(name string, action resourcepb.BulkRequest_Action, value 
 		},
 		Action: action,
 		Value:  value,
+	}
+}
+
+// TestIntegrationBulkProcessAnalyzesResourceHistory exercises the bulk migration path,
+// including the ANALYZE that runs before the resource backfill. The row threshold is
+// lowered so the path is hit with a handful of rows instead of the production default.
+func TestIntegrationBulkProcessAnalyzesResourceHistory(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	t.Cleanup(db.CleanupTestDB)
+
+	ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+
+	storageBackend, _ := newTestBackend(t, GarbageCollectionConfig{})
+	b := storageBackend.(*backend)
+	b.analyzeBulkRowThreshold = 1 // trigger ANALYZE with a small load
+
+	key := &resourcepb.ResourceKey{
+		Namespace: "default",
+		Group:     "shorturl.grafana.app",
+		Resource:  "shorturls",
+	}
+	iter := unitest.ToBulkIterator([]*resourcepb.BulkRequest{
+		newSQLBulkRequest("item-1", resourcepb.BulkRequest_ADDED, []byte(`{"apiVersion":"shorturl.grafana.app/v1beta1","kind":"ShortURL","metadata":{"name":"item-1","namespace":"default"},"spec":{"path":"d/a"}}`)),
+		newSQLBulkRequest("item-2", resourcepb.BulkRequest_ADDED, []byte(`{"apiVersion":"shorturl.grafana.app/v1beta1","kind":"ShortURL","metadata":{"name":"item-2","namespace":"default"},"spec":{"path":"d/b"}}`)),
+		newSQLBulkRequest("item-3", resourcepb.BulkRequest_ADDED, []byte(`{"apiVersion":"shorturl.grafana.app/v1beta1","kind":"ShortURL","metadata":{"name":"item-3","namespace":"default"},"spec":{"path":"d/c"}}`)),
+	})
+
+	resp := b.ProcessBulk(ctx, resource.BulkSettings{
+		Collection: []*resourcepb.ResourceKey{key},
+	}, iter)
+	require.Nil(t, resp.Error)
+	require.Equal(t, int64(3), resp.Processed)
+
+	// The backfill must have populated the resource table from history.
+	server, err := resource.NewResourceServer(resource.ResourceServerOptions{Backend: storageBackend})
+	require.NoError(t, err)
+	listResp, err := server.List(ctx, &resourcepb.ListRequest{
+		Source:  resourcepb.ListRequest_STORE,
+		Options: &resourcepb.ListOptions{Key: key},
+	})
+	require.NoError(t, err)
+	require.Nil(t, listResp.Error)
+	require.Len(t, listResp.Items, 3)
+
+	// On Postgres the ANALYZE must have refreshed statistics: a freshly created table
+	// reports reltuples=0/-1, so a positive estimate proves the ANALYZE ran.
+	if b.dialect.DialectName() == "postgres" {
+		var reltuples float64
+		row := b.db.QueryRowContext(ctx, `SELECT reltuples FROM pg_class WHERE relname = 'resource_history'`)
+		require.NoError(t, row.Scan(&reltuples))
+		require.Greater(t, reltuples, float64(0))
 	}
 }

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -1628,6 +1628,12 @@ func toBulkIterator(items []*resourcepb.BulkRequest) *sliceBulkRequestIterator {
 	return &sliceBulkRequestIterator{ix: -1, items: items}
 }
 
+// ToBulkIterator returns a BulkRequestIterator over the given requests, for use by
+// bulk-processing tests in other packages.
+func ToBulkIterator(items []*resourcepb.BulkRequest) resource.BulkRequestIterator {
+	return toBulkIterator(items)
+}
+
 func (s *sliceBulkRequestIterator) Next() bool {
 	s.ix++
 	return s.ix < len(s.items)


### PR DESCRIPTION
Backport befec0d6161d16a0df9e00f55b4c7310e013469b from #126055

---

**What is this feature?**

During the legacy-to-unified storage migration, `processBulkWithTx` bulk-loads `resource_history` and then runs the `resource` backfill (a self-join over `resource_history`) in the same transaction. This adds an `ANALYZE "resource_history"` before the backfill, gated to Postgres and to large loads (>= 10k rows).

**Why do we need this feature?**

On Postgres the table was just populated inside the same uncommitted transaction, so the planner still estimates it as empty (`reltuples=0`) and picks an O(n^2) nested-loop plan that re-runs the GROUP BY aggregate per row; on large instances the backfill can run for hours. Refreshing statistics first flips the plan to a hash/merge join (reproduced: a 200k-row backfill went from >120s timeout to ~300ms). Other engines materialize the subquery once and are unaffected, so the change is Postgres-only.

**Who is this feature for?**

Operators upgrading large Grafana instances to unified storage.

**Which issue(s) does this PR fix?**:

Ticket: https://github.com/grafana/support-escalations/issues/22686

**Special notes for your reviewer:**

Backend-only change. The `ANALYZE` error is propagated rather than swallowed because a failed statement aborts the whole Postgres transaction anyway, and the failures that can occur here (timeout, cancellation, resource exhaustion) would also doom the heavier backfill.

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
