### PR TITLE
Provisioning: Render repository stats generically (P0.8)

### DIFF
--- a/public/app/features/provisioning/Repository/RepositoryListItem.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryListItem.tsx
@@ -5,13 +5,14 @@ import { type GrafanaTheme2, dateTimeFormatTimeAgo } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Badge, Card, LinkButton, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
-import { type Repository, type ResourceCount } from 'app/api/clients/provisioning/v0alpha1';
+import { type Repository } from 'app/api/clients/provisioning/v0alpha1';
 
 import { RepoIcon } from '../Shared/RepoIcon';
 import { StatusBadge } from '../Shared/StatusBadge';
 import { PROVISIONING_URL } from '../constants';
 import { formatRepoUrl, getRepoHrefForProvider } from '../utils/git';
 import { getIsReadOnlyWorkflows } from '../utils/repository';
+import { getResourceLabel, getResourceListUrl } from '../utils/resourceKinds';
 
 import { SyncRepository } from './SyncRepository';
 
@@ -84,9 +85,12 @@ export function RepositoryListItem({ repository }: Props) {
                   fill="outline"
                   size="md"
                   variant="secondary"
-                  href={getListURL(repository, stat)}
+                  href={getResourceListUrl(stat.group, stat.resource, {
+                    repoName: name,
+                    syncTarget: spec?.sync.target,
+                  })}
                 >
-                  {stat.count} {stat.resource}
+                  {stat.count} {getResourceLabel(stat.group, stat.resource)}
                 </LinkButton>
               ))}
             </Stack>
@@ -120,17 +124,6 @@ export function RepositoryListItem({ repository }: Props) {
       </Card.Actions>
     </Card>
   );
-}
-
-// Helper function
-function getListURL(repo: Repository, stats: ResourceCount): string {
-  if (stats.resource === 'playlists') {
-    return '/playlists';
-  }
-  if (repo.spec?.sync.target === 'folder') {
-    return `/dashboards/f/${repo.metadata?.name}`;
-  }
-  return '/dashboards';
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -3,8 +3,20 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useMemo } from 'react';
 
 import { textUtil, type GrafanaTheme2 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
-import { Box, Card, type CellProps, Grid, InteractiveTable, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
+import {
+  Box,
+  Card,
+  type CellProps,
+  Grid,
+  Icon,
+  type IconName,
+  InteractiveTable,
+  LinkButton,
+  Stack,
+  Text,
+  useStyles2,
+} from '@grafana/ui';
 import { type Repository, type ResourceCount } from 'app/api/clients/provisioning/v0alpha1';
 
 import { RecentJobs } from '../Job/RecentJobs';
@@ -12,6 +24,7 @@ import { QuotaLimitNote } from '../Shared/QuotaLimitNote';
 import { MissingFolderMetadataBanner } from '../components/Folders/MissingFolderMetadataBanner';
 import { hasMissingFolderMetadata } from '../utils/folderMetadata';
 import { isQuotaReachedOrExceeded } from '../utils/quota';
+import { getResourceIcon, getResourceLabel, getResourceListUrl } from '../utils/resourceKinds';
 import { formatTimestamp } from '../utils/time';
 
 import { RepositoryHealthCard } from './RepositoryHealthCard';
@@ -42,7 +55,12 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
         id: 'Resource',
         header: 'Resource Type',
         cell: ({ row: { original } }: StatCell<'resource'>) => {
-          return <span>{original.resource}</span>;
+          return (
+            <Stack direction="row" gap={1} alignItems="center">
+              <Icon name={getResourceIcon(original.group, original.resource)} />
+              <span>{getResourceLabel(original.group, original.resource)}</span>
+            </Stack>
+          );
         },
         size: 'auto',
       },
@@ -57,6 +75,47 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
     ],
     []
   );
+
+  // Derive the "view" actions from the repository's stats, routing and labelling
+  // each kind through its descriptor. Kinds that resolve to the same destination
+  // (e.g. dashboards + folders under a folder-synced repo) collapse into one
+  // button, and unknown kinds fall back gracefully.
+  const viewLinks = useMemo(() => {
+    const ctx = { repoName, syncTarget: repo.spec?.sync.target };
+    const folderUrl = `/dashboards/f/${repoName}`;
+    const links = new Map<string, { href: string; icon: IconName; label: string }>();
+
+    for (const stat of status?.stats ?? []) {
+      const href = getResourceListUrl(stat.group, stat.resource, ctx);
+      if (links.has(href)) {
+        continue;
+      }
+      // When the destination is the repository's own folder, keep the familiar
+      // folder framing rather than a per-kind label.
+      const isRepoFolder = repo.spec?.sync.target === 'folder' && href === folderUrl;
+      links.set(href, {
+        href,
+        icon: isRepoFolder ? 'folder-open' : getResourceIcon(stat.group, stat.resource),
+        label: isRepoFolder
+          ? t('provisioning.repository-overview.view-folder', 'View Folder')
+          : getResourceLabel(stat.group, stat.resource),
+      });
+    }
+
+    // Always offer at least the folder/dashboards view, preserving prior behavior
+    // when a repository reports no stats yet.
+    if (links.size === 0) {
+      const href = getResourceListUrl(undefined, undefined, ctx);
+      links.set(href, {
+        href,
+        icon: 'folder-open',
+        label: t('provisioning.repository-overview.view-folder', 'View Folder'),
+      });
+    }
+
+    return [...links.values()];
+  }, [repoName, repo.spec?.sync.target, status?.stats]);
+
   return (
     <Box padding={2}>
       <Stack direction="column" gap={2}>
@@ -84,9 +143,11 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                 )}
               </Card.Description>
               <Card.Actions className={styles.actions}>
-                <LinkButton size="md" href={getFolderURL(repo)} icon="folder-open" variant="secondary">
-                  <Trans i18nKey="provisioning.repository-overview.view-folder">View Folder</Trans>
-                </LinkButton>
+                {viewLinks.map((link) => (
+                  <LinkButton key={link.href} size="md" href={link.href} icon={link.icon} variant="secondary">
+                    {link.label}
+                  </LinkButton>
+                ))}
               </Card.Actions>
             </Card>
           </div>
@@ -160,13 +221,6 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
       </Stack>
     </Box>
   );
-}
-
-function getFolderURL(repo: Repository) {
-  if (repo.spec?.sync.target === 'folder') {
-    return `/dashboards/f/${repo.metadata?.name}`;
-  }
-  return '/dashboards';
 }
 
 const getStyles = (theme: GrafanaTheme2) => {

--- a/public/app/features/provisioning/utils/resourceKinds.test.ts
+++ b/public/app/features/provisioning/utils/resourceKinds.test.ts
@@ -1,0 +1,76 @@
+import { getResourceIcon, getResourceLabel, getResourceListUrl, resolveResourceKind } from './resourceKinds';
+
+describe('resourceKinds', () => {
+  describe('resolveResourceKind', () => {
+    it('resolves a known kind by group and resource', () => {
+      expect(resolveResourceKind('dashboard.grafana.app', 'dashboards')?.resource).toBe('dashboards');
+      expect(resolveResourceKind('playlist.grafana.app', 'playlists')?.resource).toBe('playlists');
+    });
+
+    it('resolves by resource alone (resource is the discriminator)', () => {
+      expect(resolveResourceKind(undefined, 'folders')?.group).toBe('folder.grafana.app');
+    });
+
+    it('resolves by group alone when resource is missing', () => {
+      expect(resolveResourceKind('dashboard.grafana.app', undefined)?.resource).toBe('dashboards');
+    });
+
+    it('returns undefined for unknown kinds', () => {
+      expect(resolveResourceKind('unknown.grafana.app', 'widgets')).toBeUndefined();
+      expect(resolveResourceKind(undefined, undefined)).toBeUndefined();
+    });
+  });
+
+  describe('getResourceLabel', () => {
+    it('returns the friendly label for a known kind', () => {
+      expect(getResourceLabel('dashboard.grafana.app', 'dashboards')).toBe('Dashboards');
+      expect(getResourceLabel('playlist.grafana.app', 'playlists')).toBe('Playlists');
+    });
+
+    it('falls back to the raw resource name for unknown kinds', () => {
+      expect(getResourceLabel('unknown.grafana.app', 'widgets')).toBe('widgets');
+    });
+
+    it('falls back to an empty string when nothing is known', () => {
+      expect(getResourceLabel(undefined, undefined)).toBe('');
+    });
+  });
+
+  describe('getResourceIcon', () => {
+    it('returns the kind icon for a known kind', () => {
+      expect(getResourceIcon('folder.grafana.app', 'folders')).toBe('folder');
+      expect(getResourceIcon('playlist.grafana.app', 'playlists')).toBe('presentation-play');
+    });
+
+    it('falls back to a generic icon for unknown kinds', () => {
+      expect(getResourceIcon('unknown.grafana.app', 'widgets')).toBe('apps');
+    });
+  });
+
+  describe('getResourceListUrl', () => {
+    it('routes playlists to the playlists list regardless of sync target', () => {
+      expect(getResourceListUrl('playlist.grafana.app', 'playlists', { repoName: 'repo', syncTarget: 'folder' })).toBe(
+        '/playlists'
+      );
+    });
+
+    it('routes folder-scoped kinds to the repository folder when syncing to a folder', () => {
+      expect(
+        getResourceListUrl('dashboard.grafana.app', 'dashboards', { repoName: 'repo', syncTarget: 'folder' })
+      ).toBe('/dashboards/f/repo');
+    });
+
+    it('routes folder-scoped kinds to the dashboards list for non-folder targets', () => {
+      expect(
+        getResourceListUrl('dashboard.grafana.app', 'dashboards', { repoName: 'repo', syncTarget: 'instance' })
+      ).toBe('/dashboards');
+    });
+
+    it('falls back to the folder/dashboards route for unknown kinds', () => {
+      expect(getResourceListUrl('unknown.grafana.app', 'widgets', { repoName: 'repo', syncTarget: 'folder' })).toBe(
+        '/dashboards/f/repo'
+      );
+      expect(getResourceListUrl(undefined, undefined, { syncTarget: 'instance' })).toBe('/dashboards');
+    });
+  });
+});

--- a/public/app/features/provisioning/utils/resourceKinds.ts
+++ b/public/app/features/provisioning/utils/resourceKinds.ts
@@ -1,0 +1,106 @@
+import { type IconName } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { type RepositorySpec } from 'app/api/clients/provisioning/v0alpha1';
+
+type SyncTarget = RepositorySpec['sync']['target'];
+
+interface ResourceListContext {
+  /** Repository name, used to build folder-scoped routes. */
+  repoName?: string;
+  /** Where the repository syncs its resources. */
+  syncTarget?: SyncTarget;
+}
+
+export interface ResourceKindDescriptor {
+  /** API group, e.g. `dashboard.grafana.app`. */
+  group: string;
+  /** Plural resource name as reported in repository stats, e.g. `dashboards`. */
+  resource: string;
+  /** Icon shown next to the kind in listings and the resource table. */
+  icon: IconName;
+  /** Localized, human-friendly plural label, e.g. "Dashboards". */
+  getLabel: () => string;
+  /** In-app route listing resources of this kind for the given repository. */
+  getListUrl: (ctx: ResourceListContext) => string;
+}
+
+// Folder- and dashboard-scoped kinds live under a repository's folder when the
+// repo syncs to a folder, otherwise under the global dashboards list. Unknown
+// kinds reuse this as the graceful fallback, matching prior behavior.
+function folderScopedListUrl({ repoName, syncTarget }: ResourceListContext): string {
+  if (syncTarget === 'folder' && repoName) {
+    return `/dashboards/f/${repoName}`;
+  }
+  return '/dashboards';
+}
+
+// The single source of per-kind presentation knowledge for repository stats.
+// Adding a new provisioned resource type is one entry here; the listing and
+// overview render it with no further edits.
+const RESOURCE_KINDS: ResourceKindDescriptor[] = [
+  {
+    group: 'folder.grafana.app',
+    resource: 'folders',
+    icon: 'folder',
+    getLabel: () => t('provisioning.resource-kind.folders', 'Folders'),
+    getListUrl: folderScopedListUrl,
+  },
+  {
+    group: 'dashboard.grafana.app',
+    resource: 'dashboards',
+    icon: 'apps',
+    getLabel: () => t('provisioning.resource-kind.dashboards', 'Dashboards'),
+    getListUrl: folderScopedListUrl,
+  },
+  {
+    group: 'playlist.grafana.app',
+    resource: 'playlists',
+    icon: 'presentation-play',
+    getLabel: () => t('provisioning.resource-kind.playlists', 'Playlists'),
+    getListUrl: () => '/playlists',
+  },
+];
+
+/**
+ * Resolve the descriptor for a repository stat entry. Stats are keyed on
+ * group+resource, but `resource` is the discriminator since the API group is
+ * not unique across kinds. Falls back to a group-only match so a stat that
+ * carries only one of the two still resolves. Returns undefined for unknown
+ * kinds — callers fall back gracefully.
+ */
+export function resolveResourceKind(group?: string, resource?: string): ResourceKindDescriptor | undefined {
+  if (resource) {
+    const byResource = RESOURCE_KINDS.filter((kind) => kind.resource === resource);
+    if (byResource.length === 1) {
+      return byResource[0];
+    }
+    if (byResource.length > 1) {
+      return byResource.find((kind) => kind.group === group) ?? byResource[0];
+    }
+  }
+  if (group) {
+    return RESOURCE_KINDS.find((kind) => kind.group === group);
+  }
+  return undefined;
+}
+
+const DEFAULT_RESOURCE_ICON: IconName = 'apps';
+
+/** Friendly plural label for a stat's kind; falls back to the raw resource name. */
+export function getResourceLabel(group?: string, resource?: string): string {
+  return resolveResourceKind(group, resource)?.getLabel() ?? resource ?? '';
+}
+
+/** Icon for a stat's kind; falls back to a generic resource icon. */
+export function getResourceIcon(group?: string, resource?: string): IconName {
+  return resolveResourceKind(group, resource)?.icon ?? DEFAULT_RESOURCE_ICON;
+}
+
+/** In-app listing route for a stat's kind, with a folder/dashboards fallback for unknown kinds. */
+export function getResourceListUrl(
+  group: string | undefined,
+  resource: string | undefined,
+  ctx: ResourceListContext
+): string {
+  return (resolveResourceKind(group, resource) ?? { getListUrl: folderScopedListUrl }).getListUrl(ctx);
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13861,6 +13861,11 @@
       "pure-git-description": "Connect to any Git repository",
       "pure-git-tooltip": "Connects to any Git repository using Smart HTTP protocol v2. Core sync workflow without provider-specific features (webhooks, PR comments, deep links)."
     },
+    "resource-kind": {
+      "dashboards": "Dashboards",
+      "folders": "Folders",
+      "playlists": "Playlists"
+    },
     "resource-tree": {
       "header-hash": "Hash",
       "header-status": "Status",


### PR DESCRIPTION
## Summary

Implements **Prep P0.8** (grafana/git-ui-sync-project#1174), part of grafana/git-ui-sync-project#1166.

Per-repo stats data is kind-agnostic, but the presentation wasn't: `RepositoryListItem.tsx` routed per kind with a hardcoded `if` chain and showed the raw GVR string, and `RepositoryOverview.tsx`'s only action was a hardcoded "View Folder" link that assumed folder-containment.

This drives label/icon/route from a descriptor keyed on `group`+`resource`, with graceful fallback for unknown kinds, so a **new provisioned kind renders correctly with no edits to these files**.

## Changes

### New — `utils/resourceKinds.ts`
A small registry keyed on `group`+`resource`. Each entry carries `group`, `resource`, `icon`, a localized `getLabel()`, and a `getListUrl(ctx)`. Helpers:
- `resolveResourceKind(group, resource)` — `resource` is the discriminator (the API group is not unique); falls back to a group-only match; returns `undefined` for unknown kinds.
- `getResourceLabel` / `getResourceIcon` / `getResourceListUrl` — all degrade gracefully (raw resource string / generic icon / folder-or-dashboards route).
- Registered today: `folders`, `dashboards`, `playlists`. Adding a kind is one entry.

### `RepositoryListItem.tsx`
Replaces the hardcoded `getListURL` if-chain and the raw resource string with descriptor-driven routing + friendly labels.

### `RepositoryOverview.tsx`
- Resource table cell shows a friendly icon + label instead of the raw `resource`.
- The hardcoded "View Folder" action becomes descriptor-driven view links built from the repo's stats (deduped by destination). Folder-synced repos still collapse to a "View Folder" button; the no-stats case preserves the prior fallback button.

## Testing

- New `utils/resourceKinds.test.ts` (13 cases: lookups, routing, label/icon fallbacks).
- Existing Repository suites pass (31 tests total).
- `yarn typecheck`, ESLint and Prettier clean on changed files.
- `make i18n-extract` added `provisioning.resource-kind.{dashboards,folders,playlists}`.

## Notes

- Frontend-only. Behavior is preserved for current kinds (dashboards/folders).
- Playlists is wired into the registry but only surfaces once the backend reports it in repository stats.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes
- [ ] Documentation updated (registry is self-documenting; broader docs land with P0.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)