### PR TITLE
Ephemeral Instances: Pass comment id for reactions on progress

### DIFF
--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -33,6 +33,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ID: ${{ github.event.comment.id }}
           REPO_NAME: ${{ github.event.repository.name }}
           REPO_ID: ${{ github.event.repository.id }}
           REPO_OWNER: ${{ github.repository_owner }}
@@ -52,6 +53,7 @@ jobs:
             -f pr-author="$PR_AUTHOR" \
             -f pr-html-url="$PR_HTML_URL" \
             -f comment-body="$COMMENT_BODY" \
+            -f comment-id="$COMMENT_ID" \
             -f triggering-actor="$TRIGGERING_ACTOR"
 
       - name: Dispatch (pr-closed)


### PR DESCRIPTION
The workflow for the Ephemeral Instances now optionall takes in a comment-id which can be used by the workflow to react with 👀 , 🚀 , 😞  on the `/deploy-to-hg` comment to signal whether the build is in progress, succeeded or failed.