### PR TITLE
[release-13.0.3] Provisioning: Consistently use request context in Connector.Connect

### DIFF
--- a/pkg/registry/apis/provisioning/connection_repositories.go
+++ b/pkg/registry/apis/provisioning/connection_repositories.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,10 +48,10 @@ func (*connectionRepositoriesConnector) NewConnectOptions() (runtime.Object, boo
 }
 
 func (c *connectionRepositoriesConnector) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
-	logger := logging.FromContext(ctx).With("logger", "connection-repositories-connector", "connection_name", name)
-	ctx = logging.Context(ctx, logger)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := logging.FromContext(ctx).With("logger", "connection-repositories-connector", "connection_name", name)
+		ctx := logging.Context(ctx, logger)
 
-	return WithTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			responder.Error(apierrors.NewMethodNotSupported(provisioning.ConnectionResourceInfo.GroupResource(), r.Method))
 			return
@@ -92,7 +91,7 @@ func (c *connectionRepositoriesConnector) Connect(ctx context.Context, name stri
 		}
 
 		responder.Object(http.StatusOK, result)
-	}), 30*time.Second), nil
+	}), nil
 }
 
 var (

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,12 +82,10 @@ func (c *filesConnector) getRepo(ctx context.Context, method, name string) (repo
 
 // TODO: document the synchronous write and delete on the API Spec
 func (c *filesConnector) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
-	logger := logging.FromContext(ctx).With("logger", "files-connector", "repository_name", name)
-	ctx = logging.Context(ctx, logger)
-
-	return WithTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.handleRequest(ctx, name, r, responder, logger)
-	}), 30*time.Second), nil
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := logging.FromContext(ctx).With("logger", "files-connector", "repository_name", name)
+		c.handleRequest(logging.Context(ctx, logger), name, r, responder, logger)
+	}), nil
 }
 
 // handleRequest processes the HTTP request for files operations.
@@ -119,7 +116,7 @@ func (c *filesConnector) handleRequest(ctx context.Context, name string, r *http
 	}
 
 	logger = logger.With("url", r.URL.Path, "ref", opts.Ref, "message", opts.Message)
-	ctx = logging.Context(r.Context(), logger)
+	ctx = logging.Context(ctx, logger)
 
 	// Handle directory listing separately
 	isDir := safepath.IsDir(opts.Path)

--- a/pkg/registry/apis/provisioning/history.go
+++ b/pkg/registry/apis/provisioning/history.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,6 +18,10 @@ import (
 
 type historySubresource struct {
 	repoGetter RepoGetter
+}
+
+func NewHistorySubresource(repoGetter RepoGetter) *historySubresource {
+	return &historySubresource{repoGetter: repoGetter}
 }
 
 func (h *historySubresource) New() runtime.Object {
@@ -53,22 +56,23 @@ func (h *historySubresource) NewConnectOptions() (runtime.Object, bool, string) 
 }
 
 func (h *historySubresource) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
-	logger := logging.FromContext(ctx).With("logger", "history-subresource")
-	ctx = logging.Context(ctx, logger)
-	repo, err := h.repoGetter.GetRepository(ctx, name)
-	if err != nil {
-		logger.Debug("failed to find repository", "error", err)
-		return nil, err
-	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := logging.FromContext(ctx).With("logger", "history-subresource")
+		ctx := logging.Context(ctx, logger)
 
-	return WithTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query()
 		ref := query.Get("ref")
-
 		// Reject unvalidated refs before they reach any backend. Empty is allowed
 		// and defaulted by the backend to the configured branch.
 		if !git.IsValidRef(ref) {
 			responder.Error(repository.ErrInvalidRef)
+			return
+		}
+
+		repo, err := h.repoGetter.GetRepository(ctx, name)
+		if err != nil {
+			logger.Debug("failed to find repository", "error", err)
+			responder.Error(err)
 			return
 		}
 
@@ -90,7 +94,7 @@ func (h *historySubresource) Connect(ctx context.Context, name string, opts runt
 		}
 
 		logger = logger.With("ref", ref, "path", filePath)
-		ctx = logging.Context(r.Context(), logger)
+		ctx = logging.Context(ctx, logger)
 
 		// TODO: Add history pagination
 		commits, err := versioned.History(ctx, filePath, ref)
@@ -101,5 +105,5 @@ func (h *historySubresource) Connect(ctx context.Context, name string, opts runt
 		}
 
 		responder.Object(http.StatusOK, &provisioning.HistoryList{Items: commits})
-	}), 30*time.Second), nil
+	}), nil
 }

--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,7 +86,7 @@ func (c *jobsConnector) Connect(
 	opts runtime.Object,
 	responder rest.Responder,
 ) (http.Handler, error) {
-	return WithTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		prefix := fmt.Sprintf("/%s/jobs/", name)
 		idx := strings.Index(r.URL.Path, prefix)
 
@@ -114,7 +113,7 @@ func (c *jobsConnector) Connect(
 		}
 
 		c.handleCreateJob(ctx, r, name, spec, responder)
-	}), 30*time.Second), nil
+	}), nil
 }
 
 // handleGetJob serves GET requests for job history — either a single job by
@@ -172,7 +171,7 @@ func (c *jobsConnector) handleCreateJob(ctx context.Context, r *http.Request, na
 	}
 
 	if spec.Action == provisioning.JobActionPull {
-		if err := c.authorizeAdminJob(r.Context(), cfg); err != nil {
+		if err := c.authorizeAdminJob(ctx, cfg); err != nil {
 			responder.Error(err)
 			return
 		}
@@ -183,7 +182,7 @@ func (c *jobsConnector) handleCreateJob(ctx context.Context, r *http.Request, na
 		return
 	}
 
-	if err := c.authorizeJob(r.Context(), repo, cfg, spec); err != nil {
+	if err := c.authorizeJob(ctx, repo, cfg, spec); err != nil {
 		responder.Error(err)
 		return
 	}
@@ -277,7 +276,7 @@ func (c *jobsConnector) handleOrphanCleanupJob(ctx context.Context, r *http.Requ
 		return
 	}
 
-	if err := c.authorizeAdminJob(r.Context(), &provisioning.Repository{
+	if err := c.authorizeAdminJob(ctx, &provisioning.Repository{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ns},
 	}); err != nil {
 		responder.Error(err)

--- a/pkg/registry/apis/provisioning/list.go
+++ b/pkg/registry/apis/provisioning/list.go
@@ -2,9 +2,7 @@ package provisioning
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -18,6 +16,10 @@ import (
 type listConnector struct {
 	getter RepoGetter
 	lister resources.ResourceLister
+}
+
+func NewListConnector(getter RepoGetter, lister resources.ResourceLister) *listConnector {
+	return &listConnector{getter: getter, lister: lister}
 }
 
 func (*listConnector) New() runtime.Object {
@@ -43,12 +45,8 @@ func (*listConnector) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 func (s *listConnector) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
-	ns, ok := request.NamespaceFrom(ctx)
-	if !ok {
-		return nil, fmt.Errorf("missing namespace")
-	}
-
-	return WithTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ns := request.NamespaceValue(ctx)
 		// TODO: Add pagination to resource lister
 		rsp, err := s.lister.List(ctx, ns, name)
 		if err != nil {
@@ -56,7 +54,7 @@ func (s *listConnector) Connect(ctx context.Context, name string, opts runtime.O
 		} else {
 			responder.Object(200, rsp)
 		}
-	}), 30*time.Second), nil
+	}), nil
 }
 
 var (

--- a/pkg/registry/apis/provisioning/refs.go
+++ b/pkg/registry/apis/provisioning/refs.go
@@ -44,17 +44,19 @@ func (*refsConnector) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 func (c *refsConnector) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
-	logger := logging.FromContext(ctx).With("logger", "refs-connector", "repository_name", name)
-	ctx = logging.Context(ctx, logger)
-	repo, err := c.getter.GetRepository(ctx, name)
-	if err != nil {
-		logger.Debug("failed to find repository", "error", err)
-		return nil, err
-	}
-
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := logging.FromContext(ctx).With("logger", "refs-connector", "repository_name", name)
+		ctx = logging.Context(ctx, logger)
+
 		if r.Method != http.MethodGet {
 			responder.Error(apierrors.NewMethodNotSupported(provisioning.RepositoryResourceInfo.GroupResource(), r.Method))
+			return
+		}
+
+		repo, err := c.getter.GetRepository(ctx, name)
+		if err != nil {
+			logger.Debug("failed to find repository", "error", err)
+			responder.Error(err)
 			return
 		}
 

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -764,14 +764,14 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 
 	storage[provisioning.ConnectionResourceInfo.StoragePath()] = connectionsStore
 	storage[provisioning.ConnectionResourceInfo.StoragePath("status")] = connectionStatusStorage
-	storage[provisioning.ConnectionResourceInfo.StoragePath("repositories")] = NewConnectionRepositoriesConnector(b)
+	storage[provisioning.ConnectionResourceInfo.StoragePath("repositories")] = WithTimeout(NewConnectionRepositoriesConnector(b), 30*time.Second)
 
 	// TODO: Add some logic so that the connectors can registered themselves and we don't have logic all over the place
 	testTester := repository.NewTester(b.repoValidator, existingReposValidator)
 
 	// TODO: Remove this connector when we deprecate the test endpoint
 	// We should use fieldErrors from status instead.
-	storage[provisioning.RepositoryResourceInfo.StoragePath("test")] = NewTestConnector(b, testTester)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("test")] = WithTimeout(NewTestConnector(b, testTester), 30*time.Second)
 	// The files subresource handles GET/POST/PUT/DELETE in a single connector
 	// and the appropriate role fallback differs per verb: reads should fall
 	// back to Viewer, writes to Editor. A static accessWithEditor would over-
@@ -781,16 +781,12 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	// connector via ProvisioningAuthorizer.AuthorizeResource, and repository-
 	// level operations remain Admin-gated by authorizeRepositorySubresource.
 	filesAccess := auth.NewVerbAwareAccessChecker(b.accessWithViewer, b.accessWithEditor)
-	storage[provisioning.RepositoryResourceInfo.StoragePath("files")] = NewFilesConnector(b, b.parsers, b.clients, filesAccess, b.folderMetadataEnabled, b.folderAPIVersion)
-	storage[provisioning.RepositoryResourceInfo.StoragePath("refs")] = NewRefsConnector(b)
-	storage[provisioning.RepositoryResourceInfo.StoragePath("resources")] = &listConnector{
-		getter: b,
-		lister: b.resourceLister,
-	}
-	storage[provisioning.RepositoryResourceInfo.StoragePath("history")] = &historySubresource{
-		repoGetter: b,
-	}
-	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = NewJobsConnector(b, b, b, jobHistory, b.access, b.clients, b.folderMetadataEnabled)
+
+	storage[provisioning.RepositoryResourceInfo.StoragePath("files")] = WithTimeout(NewFilesConnector(b, b.parsers, b.clients, filesAccess, b.folderMetadataEnabled, b.folderAPIVersion), 30*time.Second)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("refs")] = WithTimeout(NewRefsConnector(b), 30*time.Second)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("resources")] = WithTimeout(NewListConnector(b, b.resourceLister), 30*time.Second)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("history")] = WithTimeout(NewHistorySubresource(b), 30*time.Second)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = WithTimeout(NewJobsConnector(b, b, b, jobHistory, b.access, b.clients, b.folderMetadataEnabled), 30*time.Second)
 
 	// Add any extra storage
 	for _, extra := range b.extras {

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
@@ -96,15 +95,15 @@ func (*testConnector) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Object, responder rest.Responder) (http.Handler, error) {
-	ns, ok := request.NamespaceFrom(ctx)
-	if !ok {
-		return nil, fmt.Errorf("missing namespace")
-	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ns, ok := request.NamespaceFrom(ctx)
+		if !ok {
+			responder.Error(k8serrors.NewBadRequest("missing namespace"))
+			return
+		}
 
-	logger := logging.FromContext(ctx).With("logger", "test-connector", "repository_name", name, "namespace", ns)
-	ctx = logging.Context(ctx, logger)
-
-	return WithTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := logging.FromContext(ctx).With("logger", "test-connector", "repository_name", name, "namespace", ns)
+		ctx = logging.Context(ctx, logger)
 		body, err := readBody(r, defaultMaxBodySize)
 		if err != nil {
 			responder.Error(err)
@@ -311,7 +310,7 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 		}
 
 		responder.Object(rsp.Code, rsp)
-	}), 30*time.Second), nil
+	}), nil
 }
 
 var (

--- a/pkg/registry/apis/provisioning/test_test.go
+++ b/pkg/registry/apis/provisioning/test_test.go
@@ -36,11 +36,12 @@ func TestTestConnector_RequiresNewTokenWhenURLChanges(t *testing.T) {
 	)
 
 	responder := &testResponder{}
-	handler, err := connector.Connect(request.WithNamespace(context.Background(), "default"), "test", nil, responder)
+	ctx := request.WithNamespace(context.Background(), "default")
+	handler, err := connector.Connect(ctx, "test", nil, responder)
 	require.NoError(t, err)
 
 	body := `{"spec":{"title":"Test Repo","type":"github","github":{"url":"https://github.com/grafana/new","branch":"main"}}}`
-	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body)))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body)).WithContext(ctx))
 
 	require.Error(t, responder.err)
 	status := responder.err.(apierrors.APIStatus).Status()
@@ -70,11 +71,12 @@ func TestTestConnector_AllowsURLChangeWithNewToken(t *testing.T) {
 		&testConnectorDeps{repo: oldRepo, repoFactory: repoFactory},
 		repository.NewTester(),
 	)
-	handler, err := connector.Connect(request.WithNamespace(context.Background(), "default"), "test", nil, responder)
+	ctx := request.WithNamespace(context.Background(), "default")
+	handler, err := connector.Connect(ctx, "test", nil, responder)
 	require.NoError(t, err)
 
 	body := `{"spec":{"title":"Test Repo","type":"github","github":{"url":"https://github.com/grafana/new","branch":"main"}},"secure":{"token":{"create":"new-token"}}}`
-	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body)))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body)).WithContext(ctx))
 
 	require.NoError(t, responder.err)
 	assert.Equal(t, http.StatusOK, responder.statusCode)
@@ -103,11 +105,12 @@ func TestTestConnector_AllowsUnchangedURLWithoutNewToken(t *testing.T) {
 		&testConnectorDeps{repo: oldRepo, repoFactory: repoFactory},
 		repository.NewTester(),
 	)
-	handler, err := connector.Connect(request.WithNamespace(context.Background(), "default"), "test", nil, responder)
+	ctx := request.WithNamespace(context.Background(), "default")
+	handler, err := connector.Connect(ctx, "test", nil, responder)
 	require.NoError(t, err)
 
 	body := `{"spec":{"title":"Updated Title","type":"github","github":{"url":"https://github.com/grafana/repo","branch":"main"}}}`
-	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body)))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body)).WithContext(ctx))
 
 	require.NoError(t, responder.err)
 	assert.Equal(t, http.StatusOK, responder.statusCode)

--- a/pkg/registry/apis/provisioning/timeout.go
+++ b/pkg/registry/apis/provisioning/timeout.go
@@ -4,18 +4,73 @@ import (
 	"context"
 	"net/http"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 )
 
-// WithTimeout adds a timeout context to the request
-func WithTimeout(h http.Handler, timeout time.Duration) http.Handler {
+// WithTimeoutFunc adds a timeout context to the request
+func WithTimeoutFunc(f http.HandlerFunc, timeout time.Duration) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		ctxWithTimeout, cancel := context.WithTimeout(r.Context(), timeout)
 		defer cancel()
-		h.ServeHTTP(w, r.WithContext(ctx))
+		f.ServeHTTP(w, r.WithContext(ctxWithTimeout))
 	})
 }
 
-// WithTimeoutFunc adds a timeout context to the request
-func WithTimeoutFunc(f func(w http.ResponseWriter, r *http.Request), timeout time.Duration) func(w http.ResponseWriter, r *http.Request) {
-	return WithTimeout(http.HandlerFunc(f), timeout).ServeHTTP
+// WithTimeout adds a timeout context to the request
+func WithTimeout(s rest.Storage, timeout time.Duration) rest.Storage {
+	c, ok := s.(rest.Connecter)
+	if !ok {
+		return s
+	}
+
+	return &timeoutConnector{Storage: s, Connecter: c, timeout: timeout}
 }
+
+type timeoutConnector struct {
+	rest.Storage
+	rest.Connecter
+	timeout time.Duration
+}
+
+// Connect attaches a bound ctx to the existing request context
+func (t *timeoutConnector) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The k8s library does not copy over the namespace to the request context so we need to manually copy it over
+		// https://github.com/kubernetes/apiserver/blob/release-1.36/pkg/endpoints/handlers/rest.go#L189-L190
+		ns := request.NamespaceValue(ctx)
+		reqCtx := request.WithNamespace(r.Context(), ns)
+
+		boundCtx, cancel := context.WithTimeout(reqCtx, t.timeout)
+		defer cancel()
+		handler, err := t.Connecter.Connect(boundCtx, name, opts, responder)
+		if err != nil {
+			responder.Error(err)
+			return
+		}
+		handler.ServeHTTP(w, r.WithContext(boundCtx))
+	}), nil
+}
+
+// Functions that implement the rest.StorageMetadata
+func (t *timeoutConnector) ProducesMIMETypes(verb string) []string {
+	if m, ok := t.Connecter.(rest.StorageMetadata); ok {
+		return m.ProducesMIMETypes(verb)
+	}
+	return nil
+}
+
+func (t *timeoutConnector) ProducesObject(verb string) any {
+	if m, ok := t.Connecter.(rest.StorageMetadata); ok {
+		return m.ProducesObject(verb)
+	}
+	return nil
+}
+
+var (
+	_ rest.Storage         = (*timeoutConnector)(nil)
+	_ rest.Connecter       = (*timeoutConnector)(nil)
+	_ rest.StorageMetadata = (*timeoutConnector)(nil)
+)

--- a/pkg/registry/apis/provisioning/timeout_test.go
+++ b/pkg/registry/apis/provisioning/timeout_test.go
@@ -1,48 +1,261 @@
 package provisioning
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 )
 
-func TestWithTimeout(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		select {
-		case <-r.Context().Done():
+// fakeConnector implements rest.Connecter used to drive timeoutConnecter
+// without pulling in any real connector's dependencies.
+type fakeConnector struct {
+	mu sync.Mutex
+
+	handler    http.Handler
+	connectErr error
+
+	// StorageMetadata forwarding inputs. fakeConnecter always implements
+	// rest.StorageMetadata; leaving these zero models the "inner has no
+	// metadata to report" case.
+	mimes []string
+	obj   any
+
+	connectCalls int
+	receivedCtx  context.Context
+}
+
+func (f *fakeConnector) New() runtime.Object                               { return nil }
+func (f *fakeConnector) Destroy()                                          {}
+func (f *fakeConnector) ConnectMethods() []string                          { return []string{http.MethodGet} }
+func (f *fakeConnector) NewConnectOptions() (runtime.Object, bool, string) { return nil, false, "" }
+
+func (f *fakeConnector) Connect(ctx context.Context, _ string, _ runtime.Object, _ rest.Responder) (http.Handler, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.connectCalls++
+	f.receivedCtx = ctx
+	if f.connectErr != nil {
+		return nil, f.connectErr
+	}
+	return f.handler, nil
+}
+
+func (f *fakeConnector) ProducesMIMETypes(string) []string { return f.mimes }
+func (f *fakeConnector) ProducesObject(string) any         { return f.obj }
+
+// recordingResponder captures whatever a handler reports.
+type recordingResponder struct {
+	mu      sync.Mutex
+	err     error
+	obj     any
+	code    int
+	written bool
+}
+
+func (r *recordingResponder) Error(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
+	r.written = true
+}
+
+func (r *recordingResponder) Object(statusCode int, obj runtime.Object) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.code = statusCode
+	r.obj = obj
+	r.written = true
+}
+
+func TestWithTimeout_RunsInnerHandler(t *testing.T) {
+	called := false
+	inner := &fakeConnector{
+		handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusTeapot)
+		}),
+	}
+
+	wrapped := WithTimeout(inner, 30*time.Second).(rest.Connecter)
+	h, err := wrapped.Connect(context.Background(), "repo", nil, &recordingResponder{})
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.True(t, called, "wrapper should invoke the inner handler")
+	require.Equal(t, http.StatusTeapot, rr.Code, "inner handler's response should pass through")
+}
+
+// TestWithTimeout_PreservesRequestContext locks down the request-anchored
+// design: boundCtx must descend from r.Context() (so filter-populated values
+// like userInfo/requestInfo survive), and the namespace from the outer Connect
+// ctx must be forwarded onto the bound ctx.
+func TestWithTimeout_PreservesRequestContext(t *testing.T) {
+	type filterKey struct{}
+
+	var observedDeadline bool
+	var observedFilterValue any
+	var observedNamespace string
+	var observedNamespaceOK bool
+
+	inner := &fakeConnector{
+		handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			_, observedDeadline = r.Context().Deadline()
+			observedFilterValue = r.Context().Value(filterKey{})
+			observedNamespace, observedNamespaceOK = request.NamespaceFrom(r.Context())
+		}),
+	}
+
+	// Mirror production: the outer Connect ctx has a namespace (k8s adds it in
+	// ConnectResource) but no filter-added values. The inbound request has the
+	// filter-added values but not the namespace.
+	connectCtx := request.WithNamespace(context.Background(), "ns-from-connect")
+
+	wrapped := WithTimeout(inner, 30*time.Second).(rest.Connecter)
+	h, err := wrapped.Connect(connectCtx, "repo", nil, &recordingResponder{})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(context.WithValue(req.Context(), filterKey{}, "from-filter"))
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.True(t, observedDeadline,
+		"inner handler should see a deadline on r.Context() (wrapper bounded it with timeout)")
+	require.Equal(t, "from-filter", observedFilterValue,
+		"values on the inbound request's context must survive — boundCtx descends from r.Context()")
+	require.True(t, observedNamespaceOK,
+		"namespace from the outer Connect ctx must reach the inner handler")
+	require.Equal(t, "ns-from-connect", observedNamespace,
+		"namespace forwarded onto boundCtx must match the one on the Connect ctx")
+}
+
+func TestWithTimeout_HandlerSeesTimeoutCancellation(t *testing.T) {
+	const timeout = 20 * time.Millisecond
+	inner := &fakeConnector{}
+
+	// The handler blocks until r.Context() is canceled and reports which kind
+	// of cancellation it saw via the response status. 504 means the deadline
+	// fired (what we want); 500 would mean some other cancellation cause.
+	inner.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		if errors.Is(r.Context().Err(), context.DeadlineExceeded) {
 			w.WriteHeader(http.StatusGatewayTimeout)
-		case <-time.After(50 * time.Millisecond):
-			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
 		}
 	})
 
-	tests := []struct {
-		name       string
-		timeout    time.Duration
-		wantStatus int
-	}{
-		{
-			name:       "request completes",
-			timeout:    100 * time.Millisecond,
-			wantStatus: http.StatusOK,
-		},
-		{
-			name:       "request times out",
-			timeout:    10 * time.Millisecond,
-			wantStatus: http.StatusGatewayTimeout,
-		},
-	}
+	wrapped := WithTimeout(inner, timeout).(rest.Connecter)
+	h, err := wrapped.Connect(context.Background(), "repo", nil, &recordingResponder{})
+	require.NoError(t, err)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			r := httptest.NewRequest("GET", "/", nil)
-			WithTimeout(handler, tt.timeout).ServeHTTP(w, r)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
 
-			if w.Code != tt.wantStatus {
-				t.Errorf("withTimeout() status = %v, want %v", w.Code, tt.wantStatus)
-			}
-		})
-	}
+	require.Equal(t, http.StatusGatewayTimeout, rr.Code,
+		"inner handler should observe context.DeadlineExceeded once timeout fires")
 }
+
+func TestWithTimeout_PropagatesConnectError(t *testing.T) {
+	want := errors.New("inner refused")
+	inner := &fakeConnector{connectErr: want}
+
+	wrapped := WithTimeout(inner, 30*time.Second).(rest.Connecter)
+	responder := &recordingResponder{}
+	h, err := wrapped.Connect(context.Background(), "repo", nil, responder)
+
+	require.NoError(t, err, "outer Connect should succeed; inner runs at request time")
+	require.NotNil(t, h, "outer Connect should always return a handler")
+
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	require.ErrorIs(t, responder.err, want, "inner Connect error should reach responder.Error")
+}
+
+// TestWithTimeoutFunc covers the standalone helper used by routes.go for
+// extra (non-k8s-subresource) endpoints. The wrapper must put a deadline on
+// r.Context() and the wrapped handler must observe cancellation when it
+// blocks past the timeout.
+func TestWithTimeoutFunc(t *testing.T) {
+	t.Run("sets a deadline on r.Context()", func(t *testing.T) {
+		const timeout = 50 * time.Millisecond
+		var observed time.Duration
+		var hasDeadline bool
+
+		before := time.Now()
+		h := WithTimeoutFunc(func(_ http.ResponseWriter, r *http.Request) {
+			deadline, ok := r.Context().Deadline()
+			hasDeadline = ok
+			if ok {
+				observed = deadline.Sub(before)
+			}
+		}, timeout)
+
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+		require.True(t, hasDeadline, "wrapped handler should see a deadline on r.Context()")
+		require.InDelta(t, timeout, observed, float64(20*time.Millisecond),
+			"deadline should be ~%s from now, got %s", timeout, observed)
+	})
+
+	t.Run("handler observes timeout cancellation", func(t *testing.T) {
+		const timeout = 20 * time.Millisecond
+
+		h := WithTimeoutFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+			if errors.Is(r.Context().Err(), context.DeadlineExceeded) {
+				w.WriteHeader(http.StatusGatewayTimeout)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}, timeout)
+
+		rr := httptest.NewRecorder()
+		start := time.Now()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+		elapsed := time.Since(start)
+
+		require.Equal(t, http.StatusGatewayTimeout, rr.Code,
+			"handler should observe context.DeadlineExceeded once timeout fires")
+		require.GreaterOrEqual(t, elapsed, timeout,
+			"handler should not return before the timeout fires")
+		require.Less(t, elapsed, 500*time.Millisecond,
+			"handler should return promptly after the timeout, took %s", elapsed)
+	})
+}
+
+func TestWithTimeout_ForwardsStorageMetadata(t *testing.T) {
+	// Zero fields on the inner: wrapper should forward to ProducesMIMETypes /
+	// ProducesObject and return whatever the inner returns (nil here).
+	empty := &fakeConnector{handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})}
+	wrapped := WithTimeout(empty, 30*time.Second).(rest.StorageMetadata)
+
+	require.Nil(t, wrapped.ProducesMIMETypes(http.MethodGet))
+	require.Nil(t, wrapped.ProducesObject(http.MethodGet))
+
+	// Populated metadata: wrapper should pass the values through unchanged.
+	populated := &fakeConnector{
+		handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		mimes:   []string{"application/test"},
+		obj:     "the-object",
+	}
+	wrapped = WithTimeout(populated, time.Second).(rest.StorageMetadata)
+
+	require.Equal(t, []string{"application/test"}, wrapped.ProducesMIMETypes(http.MethodGet))
+	require.Equal(t, "the-object", wrapped.ProducesObject(http.MethodGet))
+}
+
+var (
+	_ rest.Storage         = (*fakeConnector)(nil)
+	_ rest.Connecter       = (*fakeConnector)(nil)
+	_ rest.StorageMetadata = (*fakeConnector)(nil)
+)

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -146,12 +146,7 @@ func ProvideWebhooksWithImages(
 
 			screenshotRenderer := pullrequest.NewScreenshotRenderer(renderer, blobstore)
 			render := NewRenderConnector(blobstore, b)
-			webhook := NewWebhookConnector(
-				isPublic,
-				b,
-				screenshotRenderer,
-				registry,
-			)
+			webhook := NewWebhookConnector(isPublic, b, screenshotRenderer, registry)
 
 			evaluator := pullrequest.NewEvaluator(screenshotRenderer, parsers, urls, registry)
 			commenter := pullrequest.NewCommenter(cfg.ProvisioningAllowImageRendering)

--- a/pkg/registry/apis/provisioning/webhooks/render.go
+++ b/pkg/registry/apis/provisioning/webhooks/render.go
@@ -104,7 +104,7 @@ func (c *renderConnector) PostProcessOpenAPI(oas *spec3.OpenAPI) error {
 }
 
 func (c *renderConnector) UpdateStorage(storage map[string]rest.Storage) error {
-	storage[provisioning.RepositoryResourceInfo.StoragePath("render")] = c
+	storage[provisioning.RepositoryResourceInfo.StoragePath("render")] = provisioningapis.WithTimeout(c, 20*time.Second)
 	return nil
 }
 
@@ -114,8 +114,8 @@ func (c *renderConnector) Connect(
 	opts runtime.Object,
 	responder rest.Responder,
 ) (http.Handler, error) {
-	namespace := request.NamespaceValue(ctx)
-	return provisioningapis.WithTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		namespace := request.NamespaceValue(ctx)
 		prefix := fmt.Sprintf("/%s/render", name)
 		idx := strings.Index(r.URL.Path, prefix)
 		if idx == -1 {
@@ -169,7 +169,7 @@ func (c *renderConnector) Connect(
 				},
 			})
 		}
-	}), 20*time.Second), nil
+	}), nil
 }
 
 var (

--- a/pkg/registry/apis/provisioning/webhooks/webhook.go
+++ b/pkg/registry/apis/provisioning/webhooks/webhook.go
@@ -92,7 +92,7 @@ func (s *webhookConnector) Authorize(ctx context.Context, a authorizer.Attribute
 }
 
 func (s *webhookConnector) UpdateStorage(storage map[string]rest.Storage) error {
-	storage[provisioning.RepositoryResourceInfo.StoragePath("webhook")] = s
+	storage[provisioning.RepositoryResourceInfo.StoragePath("webhook")] = provisioningapis.WithTimeout(s, 30*time.Second)
 	return nil
 }
 
@@ -111,23 +111,11 @@ func (s *webhookConnector) PostProcessOpenAPI(oas *spec3.OpenAPI) error {
 }
 
 func (s *webhookConnector) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
-	namespace := request.NamespaceValue(ctx)
-	ctx, _, err := identity.WithProvisioningIdentity(ctx, namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get the repository with the worker identity (since the request user is likely anonymous).
-	// Reject the request early if the repository is not healthy
-	repo, err := s.core.GetHealthyRepository(ctx, name)
-	if err != nil {
-		return nil, err
-	}
-
-	return provisioningapis.WithTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, span := tracing.Start(r.Context(), "provisioning.webhook.handle")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := tracing.Start(ctx, "provisioning.webhook.handle")
 		defer span.End()
 
+		namespace := request.NamespaceValue(ctx)
 		span.SetAttributes(
 			attribute.String("repository", name),
 			attribute.String("namespace", namespace),
@@ -135,6 +123,27 @@ func (s *webhookConnector) Connect(ctx context.Context, name string, opts runtim
 
 		logger := logging.FromContext(ctx).With("logger", "webhook-connector", "repo", name)
 		ctx = logging.Context(ctx, logger)
+
+		// Switch to the worker identity (the request user is likely anonymous), then
+		// fetch the repository under that identity. Both calls run against the
+		// timeout-bounded ctx so they can't hang past the connector's SLA.
+		var err error
+		ctx, _, err = identity.WithProvisioningIdentity(ctx, namespace)
+		if err != nil {
+			span.RecordError(err)
+			responder.Error(err)
+			return
+		}
+
+		// Get the repository with the worker identity. Reject the request early if
+		// the repository is not healthy.
+		repo, err := s.core.GetHealthyRepository(ctx, name)
+		if err != nil {
+			span.RecordError(err)
+			responder.Error(err)
+			return
+		}
+
 		if !s.webhooksEnabled {
 			responder.Error(errors.NewBadRequest("webhooks are not enabled"))
 			return
@@ -192,7 +201,7 @@ func (s *webhookConnector) Connect(ctx context.Context, name string, opts runtim
 		}
 
 		responder.Object(rsp.Code, rsp)
-	}), 30*time.Second), nil
+	}), nil
 }
 
 // statusPatcher is the subset of the status patcher API used by updateLastEvent.


### PR DESCRIPTION
Backport 5c0da4693cbb2901657ae20a9f748640bacbe978 from #125475

---

**What is this feature?**
Consistently use the correct context when running `connectors.Connect`. Now all connectors registered as a path in `register.go` will by default, be wrapped by the `TimeoutConnector`. The `TimeoutConnector` creates a context w/ timeout and calls the actual connector below the hood. 

**Why do we need this feature?**
Respect the timeouts 

**Who is this feature for?**
All connectors in the provisioning app

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1089

**Special notes for your reviewer:**
In the [k8s api](https://github.com/kubernetes/apiserver/blob/release-1.36/pkg/endpoints/handlers/rest.go#L189-L191), the request context isn't properly copying the namespace from the original context into the request context so we have to manually copy it. 

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
