### PR TITLE
Storage: Revert no-op check in client

### DIFF
--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -6,6 +6,7 @@
 package apistore
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -640,10 +641,11 @@ func (s *Storage) GuaranteedUpdate(
 	ctx, span := tracer.Start(ctx, "apistore.Storage.GuaranteedUpdate")
 	defer span.End()
 	var (
-		res         storage.ResponseMeta
-		updatedObj  runtime.Object
-		existingObj runtime.Object
-		err         error
+		res           storage.ResponseMeta
+		updatedObj    runtime.Object
+		existingObj   runtime.Object
+		existingBytes []byte
+		err           error
 	)
 	req := &resourcepb.UpdateRequest{}
 	req.Key, err = s.getKey(key)
@@ -702,6 +704,7 @@ func (s *Storage) GuaranteedUpdate(
 			return s.Create(ctx, key, updatedObj, destination, 0)
 		}
 
+		existingBytes = readResponse.Value
 		existingObj, err = s.convertToObject(ctx, readResponse.Value, s.newFunc())
 		if err != nil {
 			return err
@@ -734,29 +737,34 @@ func (s *Storage) GuaranteedUpdate(
 			return s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_MODIFIED, key, updatedObj, destination)
 		}
 
+		// Only update (for real) if the bytes have changed
+		var rv uint64
 		req.Value = v.raw.Bytes()
-		req.ResourceVersion = readResponse.ResourceVersion
-		updateResponse, err := s.store.Update(ctx, req) // Also does RBAC check
-		if err != nil {
-			err = resource.GetError(resource.AsErrorResult(err))
-		} else if updateResponse.Error != nil {
-			if attempt < MaxUpdateAttempts && updateResponse.Error.Code == http.StatusConflict {
-				continue // try the read again
+		if !bytes.Equal(req.Value, existingBytes) {
+			req.ResourceVersion = readResponse.ResourceVersion
+			updateResponse, err := s.store.Update(ctx, req)
+			if err != nil {
+				err = resource.GetError(resource.AsErrorResult(err))
+			} else if updateResponse.Error != nil {
+				if attempt < MaxUpdateAttempts && updateResponse.Error.Code == http.StatusConflict {
+					continue // try the read again
+				}
+				err = resource.GetError(updateResponse.Error)
 			}
-			err = resource.GetError(updateResponse.Error)
-		}
 
-		// Cleanup secure values
-		if err = v.finish(ctx, err, s.opts.SecureValues); err != nil {
-			return err
+			// Cleanup secure values
+			if err = v.finish(ctx, err, s.opts.SecureValues); err != nil {
+				return err
+			}
+
+			rv = uint64(updateResponse.ResourceVersion)
 		}
 
 		if _, err := s.convertToObject(ctx, req.Value, destination); err != nil {
 			return err
 		}
 
-		if updateResponse.ResourceVersion > 0 {
-			rv := uint64(updateResponse.ResourceVersion)
+		if rv > 0 {
 			if err := s.versioner.UpdateObject(destination, rv); err != nil {
 				return err
 			}

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -316,11 +316,6 @@ func doFolderTests(t *testing.T, helper *apis.K8sTestHelper) *apis.K8sTestHelper
 			GVR:  gvr,
 		})
 
-		clientViewer := helper.GetResourceClient(apis.ResourceClientArgs{
-			User: helper.Org1.Viewer,
-			GVR:  gvr,
-		})
-
 		// Create the folder "test"
 		first, err := client.Resource.Create(context.Background(),
 			helper.LoadYAMLOrJSONFile("testdata/folder-test-create.yaml"),
@@ -338,16 +333,6 @@ func doFolderTests(t *testing.T, helper *apis.K8sTestHelper) *apis.K8sTestHelper
 			)
 			require.NoError(t, err)
 			uids = append(uids, out.GetName())
-
-			// Update with same body will keep the same RV
-			again, err := client.Resource.Update(context.Background(), out, metav1.UpdateOptions{})
-			require.NoError(t, err)
-			require.Equal(t, out.GetResourceVersion(), again.GetResourceVersion())
-
-			// Viewer should not be able to edit the same folder
-			_, err = clientViewer.Resource.Update(context.Background(), out, metav1.UpdateOptions{})
-			require.Error(t, err)
-			require.True(t, apierrors.IsForbidden(err))
 		}
 		slices.Sort(uids) // make list compare stable
 


### PR DESCRIPTION
**What is this feature?**

This PR partially reverts changes made for US client in https://github.com/grafana/grafana/pull/125440, re-adding the check on byte updates when incrementing RV.

**Why do we need this feature?**

While the server side is being fully applied, having the client side still doing this check will remove the inter-dependencies on deployments and resource versions between client and server environments. 
