### PR TITLE
A11y: Announce Card isSelected state with a meaningful name

### DIFF
--- a/packages/grafana-ui/src/components/Card/Card.test.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.test.tsx
@@ -130,5 +130,11 @@ describe('Card', () => {
 
       expect(screen.queryByRole('radio')).not.toBeInTheDocument();
     });
+
+    it('Should fall back to a generic name for selectable cards without heading content', () => {
+      render(<Card noMargin isSelected={false} />);
+
+      expect(screen.getByRole('radio', { name: 'option' })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Card/Card.test.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.test.tsx
@@ -110,8 +110,6 @@ describe('Card', () => {
         </Card>
       );
 
-      // The selection state must be exposed to assistive tech, named after the card heading so
-      // multiple selectable cards are distinguishable (not a generic, repeated "option").
       expect(screen.getByRole('radio', { name: 'My Option' })).toBeInTheDocument();
       expect(screen.getByRole('radio', { name: 'My Option' })).toBeChecked();
 

--- a/packages/grafana-ui/src/components/Card/Card.test.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.test.tsx
@@ -110,8 +110,10 @@ describe('Card', () => {
         </Card>
       );
 
-      expect(screen.getByRole('radio')).toBeInTheDocument();
-      expect(screen.getByRole('radio')).toBeChecked();
+      // The selection state must be exposed to assistive tech, named after the card heading so
+      // multiple selectable cards are distinguishable (not a generic, repeated "option").
+      expect(screen.getByRole('radio', { name: 'My Option' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'My Option' })).toBeChecked();
 
       rerender(
         <Card noMargin isSelected={false}>
@@ -119,8 +121,8 @@ describe('Card', () => {
         </Card>
       );
 
-      expect(screen.getByRole('radio')).toBeInTheDocument();
-      expect(screen.getByRole('radio')).not.toBeChecked();
+      expect(screen.getByRole('radio', { name: 'My Option' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'My Option' })).not.toBeChecked();
 
       rerender(
         <Card noMargin>

--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -131,6 +131,7 @@ const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & 
   };
   const optionLabel = t('grafana-ui.card.option', 'option');
   const headingId = useId();
+  const hasHeadingContent = React.Children.count(children) > 0;
 
   return (
     <div data-testid={selectors.components.Card.heading} className={cx(styles.heading, className)}>
@@ -147,7 +148,12 @@ const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & 
       )}
       {/* Input must be readonly because we are providing a value for the checked prop with no onChange handler */}
       {isSelected !== undefined && (
-        <input aria-labelledby={headingId} aria-label={optionLabel} type="radio" checked={isSelected} readOnly />
+        <input
+          {...(hasHeadingContent ? { 'aria-labelledby': headingId } : { 'aria-label': optionLabel })}
+          type="radio"
+          checked={isSelected}
+          readOnly
+        />
       )}
     </div>
   );

--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -130,8 +130,6 @@ const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & 
     isSelected: undefined,
   };
   const optionLabel = t('grafana-ui.card.option', 'option');
-  // Name the selection radio after the heading content so assistive tech announces which card is
-  // selected, rather than a generic "option" repeated for every selectable card in a list.
   const headingId = useId();
 
   return (

--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { memo, cloneElement, type FC, useMemo, useContext, type ReactNode } from 'react';
+import { memo, cloneElement, type FC, useId, useMemo, useContext, type ReactNode } from 'react';
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -130,22 +130,27 @@ const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & 
     isSelected: undefined,
   };
   const optionLabel = t('grafana-ui.card.option', 'option');
+  // Name the selection radio after the heading content so assistive tech announces which card is
+  // selected, rather than a generic "option" repeated for every selectable card in a list.
+  const headingId = useId();
 
   return (
     <div data-testid={selectors.components.Card.heading} className={cx(styles.heading, className)}>
       {href ? (
-        <a href={href} className={styles.linkHack} aria-label={ariaLabel} onClick={onClick}>
+        <a id={headingId} href={href} className={styles.linkHack} aria-label={ariaLabel} onClick={onClick}>
           {children}
         </a>
       ) : onClick ? (
-        <button onClick={onClick} className={styles.linkHack} aria-label={ariaLabel} type="button">
+        <button id={headingId} onClick={onClick} className={styles.linkHack} aria-label={ariaLabel} type="button">
           {children}
         </button>
       ) : (
-        <>{children}</>
+        <span id={headingId}>{children}</span>
       )}
       {/* Input must be readonly because we are providing a value for the checked prop with no onChange handler */}
-      {isSelected !== undefined && <input aria-label={optionLabel} type="radio" checked={isSelected} readOnly />}
+      {isSelected !== undefined && (
+        <input aria-labelledby={headingId} aria-label={optionLabel} type="radio" checked={isSelected} readOnly />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description

The `Card` component in `@grafana/ui` renders a readonly radio for its `isSelected` state so it is exposed to assistive technology. However, the radio's accessible name was a hardcoded generic `"option"` that is not connected to the card's content.

This PR names the selection radio after the card heading via `aria-labelledby`, so assistive tech announces e.g. `"My Option, radio button, checked"`. The generic label is kept only as a fallback for cards without heading text.

## Related Issue
Resolves #126087

## Screenshots

I used macOS' VoiceOver tool. 

| Before | After |
|---|---|
| <img width="1074" height="996" alt="image" src="https://github.com/user-attachments/assets/f1763f60-bb57-40b1-8644-8211316e9a65" /> | <img width="1017" height="991" alt="image" src="https://github.com/user-attachments/assets/3f6b6a5d-a684-4ea1-bc05-ca3762a39ff5" /> |
