### PR TITLE
Folders: Fix flaky cascade delete toggle test

### DIFF
--- a/pkg/registry/apis/folders/cascade_delete_test.go
+++ b/pkg/registry/apis/folders/cascade_delete_test.go
@@ -16,7 +16,7 @@ import (
 var featureFlagsProvider = oftesting.NewTestProvider()
 
 func TestMain(m *testing.M) {
-	if err := openfeature.SetProvider(featureFlagsProvider); err != nil {
+	if err := openfeature.SetProviderAndWait(featureFlagsProvider); err != nil {
 		panic(err)
 	}
 	os.Exit(m.Run())


### PR DESCRIPTION
**What is this feature?**

Fixes a flaky unit test. `TestMain` in `cascade_delete_test.go` used `openfeature.SetProvider`, which initializes the feature-flag provider asynchronously. While the provider sat in `NotReadyState`, flag evaluation returned the default value (`false`) instead of the configured in-memory flag, so `TestKubernetesFolderCascadeDeleteEnabled/enabled_when_toggle_on` intermittently failed. Switching to `SetProviderAndWait` ensures the provider is ready before any test runs.

**Why do we need this feature?**

The test flaked in CI (`require.True` failing as "Should be true"), blocking unrelated work. The fix removes the startup race.

Failing CI job: https://github.com/grafana/grafana/actions/runs/27141546442/job/80108377844

**Who is this feature for?**

Grafana developers / CI stability.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

One-line change. Verified with `go test -run TestKubernetesFolderCascadeDeleteEnabled -count=50 ./pkg/registry/apis/folders/` (50/50 pass; was flaky before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)