### PR TITLE
Pyroscope: Link exemplars to their profile flame graph

### DIFF
--- a/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar.go
@@ -109,3 +109,36 @@ func CreateExemplarFrame(labels map[string]string, exemplars []*Exemplar, exempl
 	}
 	return frame
 }
+
+// AddProfileDataLink attaches an internal data link to the "Id" field of a profile exemplar frame so that
+// clicking an exemplar in Explore opens the individual profile as a flame graph in a split pane. The clicked
+// exemplar's profile id is resolved at navigation time via the ${__value.raw} interpolation variable.
+//
+// The link only manifests in consumers that render exemplars with Grafana's standard timeseries panel (Explore,
+// dashboards). The Profiles Drilldown app builds its own exemplar interactions and does not read these links.
+func AddProfileDataLink(frame *data.Frame, datasourceUID, datasourceName, labelSelector, profileTypeID string) {
+	idField, _ := frame.FieldByName("Id")
+	if idField == nil {
+		return
+	}
+	if idField.Config == nil {
+		idField.Config = &data.FieldConfig{}
+	}
+	idField.Config.Links = append(idField.Config.Links, data.DataLink{
+		Title: "View profile",
+		Internal: &data.InternalDataLink{
+			DatasourceUID:  datasourceUID,
+			DatasourceName: datasourceName,
+			Query: map[string]any{
+				"queryType":         "profile",
+				"labelSelector":     labelSelector,
+				"profileTypeId":     profileTypeID,
+				"profileIdSelector": []string{"${__value.raw}"},
+				"groupBy":           []string{},
+				"heatmapType":       "individual",
+				"includeExemplars":  false,
+				"includeHeatmap":    false,
+			},
+		},
+	})
+}

--- a/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar_test.go
@@ -37,6 +37,43 @@ func TestCreateExemplarFrame_ProfileType(t *testing.T) {
 	require.Equal(t, "profile-1", row[2]) // Should use ProfileId for profile type
 }
 
+func TestAddProfileDataLink(t *testing.T) {
+	exemplars := []*Exemplar{
+		{ProfileId: "profile-1", Value: 1.0, Timestamp: 100, Labels: map[string]string{"pod": "pod-1"}},
+	}
+	frame := CreateExemplarFrame(map[string]string{"service": "api"}, exemplars, ExemplarTypeProfile, "short")
+
+	AddProfileDataLink(frame, "ds-uid", "Pyroscope", `{service="api"}`, "cpu")
+
+	idField, _ := frame.FieldByName("Id")
+	require.NotNil(t, idField)
+	require.NotNil(t, idField.Config)
+	require.Len(t, idField.Config.Links, 1)
+
+	link := idField.Config.Links[0]
+	require.Equal(t, "View profile", link.Title)
+	require.NotNil(t, link.Internal)
+	require.Equal(t, "ds-uid", link.Internal.DatasourceUID)
+	require.Equal(t, "Pyroscope", link.Internal.DatasourceName)
+
+	query, ok := link.Internal.Query.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "profile", query["queryType"])
+	require.Equal(t, `{service="api"}`, query["labelSelector"])
+	require.Equal(t, "cpu", query["profileTypeId"])
+	require.Equal(t, []string{"${__value.raw}"}, query["profileIdSelector"])
+}
+
+func TestAddProfileDataLink_NoIdField(t *testing.T) {
+	// Should be a no-op (not panic) when there is no Id field.
+	frame := CreateExemplarFrame(map[string]string{}, []*Exemplar{}, ExemplarTypeProfile, "short")
+	idField, _ := frame.FieldByName("Id")
+	idField.Name = "NotId"
+	require.NotPanics(t, func() {
+		AddProfileDataLink(frame, "ds-uid", "Pyroscope", "{}", "cpu")
+	})
+}
+
 func TestCreateExemplarFrame_SpanType(t *testing.T) {
 	exemplars := []*Exemplar{
 		{

--- a/pkg/tsdb/grafana-pyroscope-datasource/query.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query.go
@@ -137,6 +137,12 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 				logger.Error("Querying SelectSeries()", "err", err, "function", logEntrypoint())
 				return err
 			}
+			// Make profile exemplars clickable: each exemplar links to its individual profile's flame graph.
+			for _, f := range frames {
+				if f.Name == "exemplar" {
+					exemplar.AddProfileDataLink(f, pCtx.DataSourceInstanceSettings.UID, pCtx.DataSourceInstanceSettings.Name, labelSelector, profileTypeId)
+				}
+			}
 			response.Frames = append(response.Frames, frames...)
 
 			return nil


### PR DESCRIPTION
**What is this feature?**

When profile exemplars are returned for a metrics/series query, the backend now attaches an internal data link to each exemplar's `Id` field. Clicking an exemplar in Explore opens that individual profile as a flame graph in a split pane. The clicked exemplar's profile id is resolved at navigation time via the `${__value.raw}` interpolation variable, and the link runs a `profile` query (`profileIdSelector: ["<id>"]`) against the same Pyroscope datasource.

The link is constructed in Go using the plugin SDK's `InternalDataLink`, which is explicitly intended "to allow Explore links to be constructed in the backend".

**Why do we need this feature?**

Profiles exemplars are fully interactive in the Profiles Drilldown app but were a dead-end in Explore: exemplar markers rendered, but there was no way to jump from an exemplar to the profile it represents. This closes that gap and brings exemplar interactivity to Explore (and, for free, to dashboard timeseries panels).

**Who is this feature for?**

Grafana users investigating profiles via exemplars in Explore and dashboards.

**Special notes for your reviewer:**

- This is the **backend** half of the work; a separate frontend PR adds a "Profile ID" query-editor input (kept separate per the FE/BE PR convention).
- The link only manifests in consumers that render exemplars with Grafana's standard timeseries panel (Explore). The Profiles Drilldown app builds its own exemplar interactions and ignores `field.config.links`, so it is unaffected.
- Exemplars are only emitted when the `profilesExemplars` feature toggle is enabled (gated in `query.go`), so this behavior is implicitly behind that toggle.
- Unit tests added in `exemplar_test.go`.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)