### PR TITLE
Pyroscope: Add Profile ID query editor input

### DIFF
--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.test.tsx
@@ -120,7 +120,7 @@ describe('QueryEditor', () => {
     setup();
     await openOptions();
     expect(screen.getByText(/Metric/)).toBeDefined();
-    expect(screen.getByText(/Profile/)).toBeDefined();
+    expect(screen.getByText(/^Profile$/)).toBeDefined();
     expect(screen.getByText(/Both/)).toBeDefined();
 
     expect(screen.getByText(/Group by/)).toBeDefined();
@@ -130,7 +130,7 @@ describe('QueryEditor', () => {
     setup({ props: { app: CoreApp.Dashboard } });
     await openOptions();
     expect(screen.getByText(/Metric/)).toBeDefined();
-    expect(screen.getByText(/Profile/)).toBeDefined();
+    expect(screen.getByText(/^Profile$/)).toBeDefined();
     expect(screen.queryAllByText(/Both/).length).toBe(0);
   });
 });

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
@@ -55,6 +55,9 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
   if (query.spanSelector?.length) {
     collapsedInfo.push(`Span ID: ${query.spanSelector.join(', ')}`);
   }
+  if (query.profileIdSelector?.length) {
+    collapsedInfo.push(`Profile ID: ${query.profileIdSelector.join(', ')}`);
+  }
   if (query.maxNodes) {
     collapsedInfo.push(`Max nodes: ${query.maxNodes}`);
   }
@@ -126,6 +129,19 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
                 onQueryChange({
                   ...query,
                   spanSelector: event.currentTarget.value !== '' ? [event.currentTarget.value] : [],
+                });
+              }}
+            />
+          </EditorField>
+          <EditorField label={'Profile ID'} tooltip={<>Sets the profile ID from which to load a single profile.</>}>
+            <Input
+              value={query.profileIdSelector || ['']}
+              type="string"
+              placeholder="a1b2c3d4e5f6"
+              onChange={(event: React.SyntheticEvent<HTMLInputElement>) => {
+                onQueryChange({
+                  ...query,
+                  profileIdSelector: event.currentTarget.value !== '' ? [event.currentTarget.value] : [],
                 });
               }}
             />


### PR DESCRIPTION
**What is this feature?**

Adds a "Profile ID" input to the Pyroscope query editor options, sitting alongside the existing "Span ID" and "Max Nodes" fields. It is bound to the query's `profileIdSelector`, so a profile id can be entered (or read/edited) directly in the UI, and it appears in the collapsed options summary.

**Why do we need this feature?**

`profileIdSelector` was already supported by the query model and the backend (`GetProfile`), but there was no way to see or edit it from the query editor. This matters especially together with profile exemplars: when an exemplar link opens a `profile` query, the profile id now lands in a visible, editable input instead of being hidden in the query JSON.

**Who is this feature for?**

Grafana users querying a specific profile by id in Explore and dashboards.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- This is the **frontend** half of the work; the **backend** counterpart (clickable exemplar → profile flame graph link) is in a separate PR per the FE/BE PR convention.
- The input mirrors the existing "Span ID" field (single value mapped to the `profileIdSelector` array). Note the backend precedence: when both `spanSelector` and `profileIdSelector` are set, the span profile path takes precedence.
- Adjusted two existing `QueryEditor` test matchers from `/Profile/` to `/^Profile$/` so they target the "Profile" query-type radio and don't collide with the new "Profile ID" label.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.