### PR TITLE
authz/zanzana: translate K8s-native permissions to OpenFGA tuples

### DIFF
--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -192,6 +192,10 @@ func IsGroupResourceRelation(relation string) bool {
 	return isValidRelation(relation, RelationsGroupResource)
 }
 
+func IsResourceRelation(relation string) bool {
+	return isValidRelation(relation, RelationsResource)
+}
+
 func IsSubresourceRelation(relation string) bool {
 	return isValidRelation(relation, RelationsSubresource)
 }
@@ -316,13 +320,19 @@ func translateK8sNativeToTuple(subject, action, kind, name string) (*openfgav1.T
 		return nil, false
 	}
 
-	_, verb, ok := strings.Cut(action, kind+":")
-	if !ok || !IsGroupResourceRelation(verb) {
+	before, verb, ok := strings.Cut(action, kind+":")
+	if !ok || before != "" || !IsGroupResourceRelation(verb) {
 		return nil, false
 	}
 
 	if name == "*" {
 		return NewGroupResourceTuple(subject, verb, group, resource, ""), true
+	}
+
+	// A named instance maps to the "resource" type, which has no "create" relation
+	// (you can't create an already-named instance). Drop verbs that aren't valid there.
+	if !IsResourceRelation(verb) {
+		return nil, false
 	}
 	return NewResourceTuple(subject, verb, group, resource, "", name), true
 }

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -273,7 +273,7 @@ func TranslateToResourceTuple(subject string, action, kind, name string) (*openf
 	translation, ok := resourceTranslations[kind]
 
 	if !ok {
-		return nil, false
+		return translateK8sNativeToTuple(subject, action, kind, name)
 	}
 
 	m, ok := translation.mapping[action]
@@ -301,6 +301,30 @@ func TranslateToResourceTuple(subject string, action, kind, name string) (*openf
 	}
 
 	return NewTypedTuple(translation.typ, subject, m.relation, name), true
+}
+
+// translateK8sNativeToTuple is the fallback for TranslateToResourceTuple when the scope kind
+// is not in resourceTranslations. It handles K8s-native format permissions whose kind is
+// "{group}/{resource}" (e.g. "notifications.alerting.grafana.app/alertmanagerimports") and
+// whose action is "{kind}:{verb}".
+//
+// Wildcard scope (name=="*") maps to a group_resource-level tuple; specific names map to
+// a resource-level tuple.
+func translateK8sNativeToTuple(subject, action, kind, name string) (*openfgav1.TupleKey, bool) {
+	group, resource, ok := strings.Cut(kind, "/")
+	if !ok {
+		return nil, false
+	}
+
+	_, verb, ok := strings.Cut(action, kind+":")
+	if !ok || !IsGroupResourceRelation(verb) {
+		return nil, false
+	}
+
+	if name == "*" {
+		return NewGroupResourceTuple(subject, verb, group, resource, ""), true
+	}
+	return NewResourceTuple(subject, verb, group, resource, "", name), true
 }
 
 func MergeFolderResourceTuples(a, b *openfgav1.TupleKey) {

--- a/pkg/services/authz/zanzana/common/tuple_test.go
+++ b/pkg/services/authz/zanzana/common/tuple_test.go
@@ -165,3 +165,77 @@ func TestTranslateToResourceTuple(t *testing.T) {
 		})
 	}
 }
+
+func TestTranslateToResourceTuple_K8sNativeFallback(t *testing.T) {
+	t.Run("wildcard scope produces group_resource tuple", func(t *testing.T) {
+		tuple, ok := TranslateToResourceTuple(
+			"role:fixed_tKsnflM69PHBFvDKdlsuXVvdwG0#assignee",
+			"notifications.alerting.grafana.app/alertmanagerimports:create",
+			"notifications.alerting.grafana.app/alertmanagerimports",
+			"*",
+		)
+		require.True(t, ok)
+		require.Equal(t, "role:fixed_tKsnflM69PHBFvDKdlsuXVvdwG0#assignee", tuple.User)
+		require.Equal(t, "create", tuple.Relation)
+		require.Equal(t, "group_resource:notifications.alerting.grafana.app/alertmanagerimports", tuple.Object)
+	})
+
+	t.Run("specific name produces resource tuple", func(t *testing.T) {
+		tuple, ok := TranslateToResourceTuple(
+			"user:u001",
+			"notifications.alerting.grafana.app/alertmanagerimports:get",
+			"notifications.alerting.grafana.app/alertmanagerimports",
+			"import-abc",
+		)
+		require.True(t, ok)
+		require.Equal(t, "user:u001", tuple.User)
+		require.Equal(t, "get", tuple.Relation)
+		require.Equal(t, "resource:notifications.alerting.grafana.app/alertmanagerimports/import-abc", tuple.Object)
+	})
+
+	t.Run("all verbs map correctly", func(t *testing.T) {
+		cases := []struct {
+			verb     string
+			relation string
+		}{
+			{"get", "get"},
+			{"create", "create"},
+			{"update", "update"},
+			{"delete", "delete"},
+			{"get_permissions", "get_permissions"},
+			{"set_permissions", "set_permissions"},
+		}
+		for _, c := range cases {
+			action := "myapp.ext.grafana.com/widgets:" + c.verb
+			kind := "myapp.ext.grafana.com/widgets"
+			tuple, ok := TranslateToResourceTuple("user:u001", action, kind, "*")
+			require.True(t, ok, "verb %s", c.verb)
+			require.Equal(t, c.relation, tuple.Relation, "verb %s", c.verb)
+		}
+	})
+
+	t.Run("unknown verb returns false", func(t *testing.T) {
+		_, ok := TranslateToResourceTuple(
+			"user:u001",
+			"notifications.alerting.grafana.app/alertmanagerimports:watch",
+			"notifications.alerting.grafana.app/alertmanagerimports",
+			"*",
+		)
+		require.False(t, ok)
+	})
+
+	t.Run("non-k8s kind without slash returns false", func(t *testing.T) {
+		_, ok := TranslateToResourceTuple("user:u001", "unknown:read", "unknown", "*")
+		require.False(t, ok)
+	})
+
+	t.Run("action not matching kind prefix returns false", func(t *testing.T) {
+		_, ok := TranslateToResourceTuple(
+			"user:u001",
+			"other.group/other:get",
+			"notifications.alerting.grafana.app/alertmanagerimports",
+			"*",
+		)
+		require.False(t, ok)
+	})
+}

--- a/pkg/services/authz/zanzana/common/tuple_test.go
+++ b/pkg/services/authz/zanzana/common/tuple_test.go
@@ -214,10 +214,43 @@ func TestTranslateToResourceTuple_K8sNativeFallback(t *testing.T) {
 		}
 	})
 
+	t.Run("create on a specific name returns false", func(t *testing.T) {
+		// The "resource" type has no "create" relation, so a named scope must not
+		// produce a create tuple (it would be invalid against the FGA model).
+		_, ok := TranslateToResourceTuple(
+			"user:u001",
+			"notifications.alerting.grafana.app/alertmanagerimports:create",
+			"notifications.alerting.grafana.app/alertmanagerimports",
+			"import-abc",
+		)
+		require.False(t, ok)
+	})
+
+	t.Run("valid resource verbs map on a specific name", func(t *testing.T) {
+		for _, verb := range []string{"get", "update", "delete", "get_permissions", "set_permissions"} {
+			action := "myapp.ext.grafana.com/widgets:" + verb
+			kind := "myapp.ext.grafana.com/widgets"
+			tuple, ok := TranslateToResourceTuple("user:u001", action, kind, "widget-1")
+			require.True(t, ok, "verb %s", verb)
+			require.Equal(t, verb, tuple.Relation, "verb %s", verb)
+			require.Equal(t, "resource:myapp.ext.grafana.com/widgets/widget-1", tuple.Object, "verb %s", verb)
+		}
+	})
+
 	t.Run("unknown verb returns false", func(t *testing.T) {
 		_, ok := TranslateToResourceTuple(
 			"user:u001",
 			"notifications.alerting.grafana.app/alertmanagerimports:watch",
+			"notifications.alerting.grafana.app/alertmanagerimports",
+			"*",
+		)
+		require.False(t, ok)
+	})
+
+	t.Run("action with extra prefix before kind returns false", func(t *testing.T) {
+		_, ok := TranslateToResourceTuple(
+			"user:u001",
+			"x-notifications.alerting.grafana.app/alertmanagerimports:get",
 			"notifications.alerting.grafana.app/alertmanagerimports",
 			"*",
 		)

--- a/pkg/services/authz/zanzana/server/server_write_test.go
+++ b/pkg/services/authz/zanzana/server/server_write_test.go
@@ -6,10 +6,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 func TestWriteAuthorization(t *testing.T) {
@@ -39,5 +43,103 @@ func TestWriteAuthorization(t *testing.T) {
 	t.Run("allows Write with zanzana:update", func(t *testing.T) {
 		_, err := srv.Write(newContextWithZanzanaUpdatePermission(), req)
 		require.NoError(t, err)
+	})
+}
+
+// TestIntegrationK8sNativePermissionDelegation reproduces the original report:
+// an Admin holding the K8s-native alerting permission could not delegate it
+// because the permission was never translated into an OpenFGA tuple. With the
+// K8s-native fallback in TranslateToResourceTuple the tuple is produced, written,
+// and the delegation check passes.
+func TestIntegrationK8sNativePermissionDelegation(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	const (
+		roleUID         = "r-alerting"
+		saUID           = "sa-admin"
+		alertingGroup   = "notifications.alerting.grafana.app"
+		importsResource = "alertmanagerimports"
+	)
+
+	// The permission exactly as granted to the Admin basic role (see the alerting
+	// RBAC snapshot in pkg/services/ngalert/accesscontrol/testdata).
+	roleTuples, err := zanzana.RoleToTuples(roleUID, []*authzextv1.RolePermission{
+		{
+			Action: "notifications.alerting.grafana.app/alertmanagerimports:create",
+			Scope:  "notifications.alerting.grafana.app/alertmanagerimports:*",
+		},
+	})
+	require.NoError(t, err)
+
+	// Bug 1: before the fallback was added this slice was empty — the permission
+	// was silently dropped and never reached Zanzana.
+	require.Len(t, roleTuples, 1, "K8s-native permission must translate to a tuple")
+	require.Equal(t, common.RelationCreate, roleTuples[0].Relation)
+	require.Equal(t, "group_resource:notifications.alerting.grafana.app/alertmanagerimports", roleTuples[0].Object)
+
+	// Bind the service account (which holds Admin) to the role.
+	saSubject := common.NewTupleEntry(common.TypeServiceAccount, saUID, "")
+	binding := common.NewTuple(saSubject, common.RelationAssignee, common.NewTupleEntry(common.TypeRole, roleUID, ""))
+
+	srv := setupOpenFGAServer(t)
+	setupOpenFGADatabase(t, srv, append(roleTuples, binding))
+
+	check := func(subject string) bool {
+		resp, err := srv.Check(newContextWithNamespace(), &authzv1.CheckRequest{
+			Namespace: namespace,
+			Subject:   subject,
+			Verb:      utils.VerbCreate,
+			Group:     alertingGroup,
+			Resource:  importsResource,
+			Name:      "*",
+		})
+		require.NoError(t, err)
+		return resp.GetAllowed()
+	}
+
+	t.Run("admin SA can delegate the alerting create permission", func(t *testing.T) {
+		require.True(t, check(saSubject))
+	})
+
+	t.Run("unrelated SA cannot", func(t *testing.T) {
+		require.False(t, check(common.NewTupleEntry(common.TypeServiceAccount, "sa-other", "")))
+	})
+}
+
+// TestIntegrationK8sNativeCreateOnNamedScopeRejected guards the bug fixed on top
+// of the PR: a "create" verb scoped to a specific named instance must not produce
+// a "resource"-type tuple, because the FGA "resource" type has no "create" relation
+// (schema_resource.fga) and OpenFGA rejects such a write.
+func TestIntegrationK8sNativeCreateOnNamedScopeRejected(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	srv := setupOpenFGAServer(t)
+	setup(t, srv)
+
+	t.Run("openfga rejects a create relation on the resource type", func(t *testing.T) {
+		_, err := srv.Write(newContextWithZanzanaUpdatePermission(), &authzextv1.WriteRequest{
+			Namespace: namespace,
+			Writes: &authzextv1.WriteRequestWrites{
+				TupleKeys: []*authzextv1.TupleKey{
+					{
+						User:     "user:u001",
+						Relation: common.RelationCreate,
+						Object:   "resource:myapp.ext.grafana.com/widgets/widget-1",
+					},
+				},
+			},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("translation drops create on a named scope so the invalid tuple is never produced", func(t *testing.T) {
+		tuples, err := zanzana.RoleToTuples("r-widgets", []*authzextv1.RolePermission{
+			{
+				Action: "myapp.ext.grafana.com/widgets:create",
+				Scope:  "myapp.ext.grafana.com/widgets:uid:widget-1",
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, tuples)
 	})
 }


### PR DESCRIPTION
## Summary

- `TranslateToResourceTuple` only handled `KindFolders` and `KindDashboards`. Permissions using K8s-native action format (`{group}/{resource}:{verb}`, e.g. `notifications.alerting.grafana.app/alertmanagerimports:create`) were silently dropped and never synced to the OpenFGA store.
- This caused `checkGroupResource` to return `Allowed=false` even when the caller held the permission in the RBAC DB, making `RolePermissionValidator.ValidateUserCanDelegateRole` return a 403 for valid role updates.
- Adds `translateK8sNativeToTuple` as a fallback: splits the scope kind on `/` to extract group/resource, extracts the verb from the action, validates it against `RelationsGroupResource`, and emits a `group_resource` tuple (wildcard scope) or `resource` tuple (specific name).

## Test plan

- [ ] Unit tests added in `TestTranslateToResourceTuple_K8sNativeFallback` covering wildcard scope, specific name, all valid verbs, unknown verb, non-K8s kind, and mismatched action prefix
- [ ] All existing `TestTranslateToResourceTuple` cases still pass
- [ ] After deploying: fixed roles containing K8s-native permissions (e.g. `fixed:alerting.alertmanager-imports:writer`) need to be re-synced to Zanzana so the new group_resource tuples are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)