### PR TITLE
QueryEditor: Remove queryEditorNextMultiSelect feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1406,11 +1406,6 @@ export interface FeatureToggles {
   */
   queryEditorNext?: boolean;
   /**
-  * Enables multi-select UX (card checkboxes and bulk-actions footer) in the next query editor
-  * @default false
-  */
-  queryEditorNextMultiSelect?: boolean;
-  /**
   * Enables team APIs in the app platform
   * @default false
   */

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -34,7 +34,6 @@ declare module "@openfeature/core" {
     | "dashboardSectionVariables"
     | "globalDashboardVariables"
     | "queryEditorNext"
-    | "queryEditorNextMultiSelect"
     | "managedPluginsV2"
     | "analyticsFramework"
     | "grafana.scenesFlickeringFix"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -83,8 +83,6 @@ export const FlagKeys = {
   ProvisioningFolderMetadata: "provisioningFolderMetadata",
   /** Enables next generation query editor experience */
   QueryEditorNext: "queryEditorNext",
-  /** Enables multi-select UX (card checkboxes and bulk-actions footer) in the next query editor */
-  QueryEditorNextMultiSelect: "queryEditorNextMultiSelect",
   /** Store query history in browser IndexedDB instead of server-side */
   QueryHistoryLocalOnly: "queryHistory.localOnly",
   /** Replace the Query History drawer with a new Recent Queries modal UI */
@@ -486,17 +484,6 @@ export const useFlagProvisioningFolderMetadata = (options?: ReactFlagEvaluationO
  */
 export const useFlagQueryEditorNext = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("queryEditorNext", false, options).value;
-};
-
-/**
- * Enables multi-select UX (card checkboxes and bulk-actions footer) in the next query editor
- *
- * **Details:**
- * - flag key: `queryEditorNextMultiSelect`
- * - default value: `false`
- */
-export const useFlagQueryEditorNextMultiSelect = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("queryEditorNextMultiSelect", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2541,14 +2541,6 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:        "queryEditorNextMultiSelect",
-			Description: "Enables multi-select UX (card checkboxes and bulk-actions footer) in the next query editor",
-			Stage:       FeatureStageExperimental,
-			Generate:    Generate{LegacyFrontend: true, React: true},
-			Owner:       grafanaDataProSquad,
-			Expression:  "false",
-		},
-		{
 			Name:         "kubernetesTeamsApi",
 			Description:  "Enables team APIs in the app platform",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -296,7 +296,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-01-14,alertingSyncDispatchTimer,experimental,@grafana/alerting-squad,false,true,false
 2026-05-22,queryWithAssistant,experimental,@grafana/data-sources-plugins,false,false,true
 2026-05-22,queryEditorNext,privatePreview,@grafana/datapro,false,false,true
-2026-05-22,queryEditorNextMultiSelect,experimental,@grafana/datapro,false,false,true
 2026-05-22,kubernetesTeamsApi,experimental,@grafana/identity-access-team,false,false,false
 2026-05-22,kubernetesTeamsRedirect,experimental,@grafana/identity-access-team,false,false,false
 2026-05-22,kubernetesUsersApi,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4180,7 +4180,8 @@
       "metadata": {
         "name": "queryEditorNextMultiSelect",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "deletionTimestamp": "2026-06-09T16:30:59Z"
       },
       "spec": {
         "description": "Enables multi-select UX (card checkboxes and bulk-actions footer) in the next query editor",

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.test.tsx
@@ -3,7 +3,6 @@ import { screen } from '@testing-library/react';
 import { AlertState, type DataSourceInstanceSettings } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
-import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { QueryEditorType } from '../../../constants';
 import { renderWithQueryEditorProvider } from '../../testUtils';
@@ -44,14 +43,6 @@ function createAlertRule(overrides: Partial<AlertRule> = {}): AlertRule {
 }
 
 describe('SidebarFooter', () => {
-  beforeAll(() => {
-    setTestFlags({ queryEditorNextMultiSelect: true });
-  });
-
-  afterAll(() => {
-    setTestFlags();
-  });
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -210,35 +201,6 @@ describe('SidebarFooter', () => {
       });
 
       expect(screen.queryByRole('toolbar', { name: /bulk actions/i })).not.toBeInTheDocument();
-    });
-  });
-
-  describe('with queryEditorNextMultiSelect flag off', () => {
-    beforeAll(() => {
-      setTestFlags({ queryEditorNextMultiSelect: false });
-    });
-
-    afterAll(() => {
-      setTestFlags({ queryEditorNextMultiSelect: true });
-    });
-
-    it('should hide the select button', () => {
-      renderWithQueryEditorProvider(<SidebarFooter />);
-
-      expect(screen.getByText('0 items')).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /select multiple items/i })).not.toBeInTheDocument();
-    });
-
-    it('still renders the bulk actions bar in the footer when items are selected in multi-select mode', () => {
-      renderWithQueryEditorProvider(<SidebarFooter />, {
-        queries: [
-          { refId: 'A', datasource: { type: 'test', uid: 'test' } },
-          { refId: 'B', datasource: { type: 'test', uid: 'test' } },
-        ],
-        uiStateOverrides: { selectedQueryRefIds: ['A', 'B'], multiSelectMode: true },
-      });
-
-      expect(screen.getByRole('toolbar', { name: /bulk actions/i })).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
@@ -1,5 +1,4 @@
 import { css, keyframes } from '@emotion/css';
-import { useBooleanFlagValue } from '@openfeature/react-sdk';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -21,7 +20,6 @@ export function SidebarFooter() {
   const { alertRules } = useAlertingContext();
   const { cardType, setMultiSelectMode, selectedQueryRefIds, selectedTransformationIds, multiSelectMode } =
     useQueryEditorUIContext();
-  const isMultiSelectEnabled = useBooleanFlagValue('queryEditorNextMultiSelect', false);
   const styles = useStyles2(getStyles);
 
   const isAlertView = cardType === QueryEditorType.Alert;
@@ -68,7 +66,7 @@ export function SidebarFooter() {
             <Text weight="medium" variant="bodySmall">
               {suffixText}
             </Text>
-            {!isAlertView && isMultiSelectEnabled && (
+            {!isAlertView && (
               <Button
                 fill="text"
                 size="sm"


### PR DESCRIPTION
Removes the `queryEditorNextMultiSelect` toggle and graduates multi-select to always-on in the next query editor.

- Deleted toggle from `registry.go` and regenerated toggle files
- Removed the flag check in `SidebarFooter.tsx`
- Cleaned up flag setup in `SidebarFooter.test.tsx`

Close: DPOR-115