### PR TITLE
fix: Transformations: Clearer conditions in filter by values

### DIFF
--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
@@ -66,63 +66,64 @@ describe('FilterByValueTransformerEditor', () => {
       type: FilterByValueType.include,
     });
   });
-});
-it('hides conditions field when there is 0 or 1 filter', () => {
-  const onChangeMock = jest.fn();
-  const input: DataFrame[] = [
-    {
-      fields: [{ name: 'field1', type: FieldType.string, config: {}, values: [] }],
-      length: 0,
-    },
-  ];
 
-  // Test with 0 filters
-  const { queryByText, rerender } = render(
-    <FilterByValueTransformerEditor
-      input={input}
-      options={{ type: FilterByValueType.include, match: FilterByValueMatch.all, filters: [] }}
-      onChange={onChangeMock}
-    />
-  );
-  expect(queryByText('Conditions')).not.toBeInTheDocument();
+  it('hides conditions field when there is 0 or 1 filter', () => {
+    const onChangeMock = jest.fn();
+    const input: DataFrame[] = [
+      {
+        fields: [{ name: 'field1', type: FieldType.string, config: {}, values: [] }],
+        length: 0,
+      },
+    ];
 
-  // Test with 1 filter
-  rerender(
-    <FilterByValueTransformerEditor
-      input={input}
-      options={{
-        type: FilterByValueType.include,
-        match: FilterByValueMatch.all,
-        filters: [{ fieldName: 'test', config: { id: ValueMatcherID.isNull, options: {} } }],
-      }}
-      onChange={onChangeMock}
-    />
-  );
-  expect(queryByText('Conditions')).not.toBeInTheDocument();
-});
+    // Test with 0 filters
+    const { queryByText, rerender } = render(
+      <FilterByValueTransformerEditor
+        input={input}
+        options={{ type: FilterByValueType.include, match: FilterByValueMatch.all, filters: [] }}
+        onChange={onChangeMock}
+      />
+    );
+    expect(queryByText('Conditions')).not.toBeInTheDocument();
 
-it('shows conditions field when there are more than 1 filter', () => {
-  const onChangeMock = jest.fn();
-  const input: DataFrame[] = [
-    {
-      fields: [{ name: 'field1', type: FieldType.string, config: {}, values: [] }],
-      length: 0,
-    },
-  ];
+    // Test with 1 filter
+    rerender(
+      <FilterByValueTransformerEditor
+        input={input}
+        options={{
+          type: FilterByValueType.include,
+          match: FilterByValueMatch.all,
+          filters: [{ fieldName: 'test', config: { id: ValueMatcherID.isNull, options: {} } }],
+        }}
+        onChange={onChangeMock}
+      />
+    );
+    expect(queryByText('Conditions')).not.toBeInTheDocument();
+  });
 
-  const { getByText } = render(
-    <FilterByValueTransformerEditor
-      input={input}
-      options={{
-        type: FilterByValueType.include,
-        match: FilterByValueMatch.all,
-        filters: [
-          { fieldName: 'test1', config: { id: ValueMatcherID.isNull, options: {} } },
-          { fieldName: 'test2', config: { id: ValueMatcherID.isNull, options: {} } },
-        ],
-      }}
-      onChange={onChangeMock}
-    />
-  );
-  expect(getByText('Conditions')).toBeInTheDocument();
+  it('shows conditions field when there are more than 1 filter', () => {
+    const onChangeMock = jest.fn();
+    const input: DataFrame[] = [
+      {
+        fields: [{ name: 'field1', type: FieldType.string, config: {}, values: [] }],
+        length: 0,
+      },
+    ];
+
+    const { getByText } = render(
+      <FilterByValueTransformerEditor
+        input={input}
+        options={{
+          type: FilterByValueType.include,
+          match: FilterByValueMatch.all,
+          filters: [
+            { fieldName: 'test1', config: { id: ValueMatcherID.isNull, options: {} } },
+            { fieldName: 'test2', config: { id: ValueMatcherID.isNull, options: {} } },
+          ],
+        }}
+        onChange={onChangeMock}
+      />
+    );
+    expect(getByText('Conditions')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

The `Conditions` (match all/any) radio button group in the Filter by Values transformation editor was always visible, even when there was only one filter. With a single filter, "match all" vs "match any" is meaningless, which confused users.


## Root cause

The `Conditions` (match all/any) radio button group in the Filter by Values transformation editor was always visible, even when there was only one filter. With a single filter, "match all" vs "match any" is meaningless, which confused users.

The fix was already applied to `FilterByValueTransformerEditor` in a prior commit (2ad00f99bf). The component conditionally renders the `Conditions` field only when `options.filters.length > 1`.

The issue with the test file was that the two tests verifying this behavior were placed outside the `describe('FilterByValueTransformerEditor', ...)` block - they were top-level `it` calls in the module. This is syntactically valid but structurally wrong; the tests should be grouped with the rest of the editor tests.


## What changed

- `public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx`: Moved the two tests (`hides conditions field when there is 0 or 1 filter` and `shows conditions field when there are more than 1 filter`) inside the `describe('FilterByValueTransformerEditor', ...)` block and fixed their indentation. No logic was changed.

The component behavior itself (the actual feature fix) lives in `FilterByValueTransformerEditor` - the JSX conditional `{options.filters.length > 1 && <InlineField label="Conditions" ...>}` - which was already correct.


## Issue

Fixes #97239

Issue: https://github.com/grafana/grafana/issues/97239


## Diffstat

```
.../FilterByValueTransformerEditor.test.tsx | 111 +++++++++++----------
 1 file changed, 56 insertions(+), 55 deletions(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.