### PR TITLE
fix: ID 260585: [Programmatic Access - Simon - Rate then Sum]: Label "Rang...

### DIFF
--- a/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch
+++ b/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/esm/components/VisualQueryBuilder/components/OperationParamEditor.js b/dist/esm/components/VisualQueryBuilder/components/OperationParamEditor.js
+index 007f995a2c395726ea12cb389912bf5d15d031b7..b2434ef0276b7e9111383c591e9eaa2739ce344f 100644
+--- a/dist/esm/components/VisualQueryBuilder/components/OperationParamEditor.js
++++ b/dist/esm/components/VisualQueryBuilder/components/OperationParamEditor.js
+@@ -100,7 +100,7 @@ function SelectInputParamEditor({
+   return /* @__PURE__ */ React.createElement(EditorStack, { gap: 0.5, direction: "row", alignItems: "center" }, /* @__PURE__ */ React.createElement(
+     Select,
+     {
+-      id: getOperationParamId(operationId, index),
++      inputId: getOperationParamId(operationId, index),
+       value: valueOption,
+       options: selectOptions,
+       placeholder: paramDef.placeholder,

--- a/package.json
+++ b/package.json
@@ -289,7 +289,7 @@
     "@grafana/llm": "1.0.8",
     "@grafana/monaco-logql": "^0.0.8",
     "@grafana/o11y-ds-frontend": "workspace:*",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/prometheus": "13.1.2",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "^8.2.6",
@@ -468,7 +468,9 @@
     "@types/slate/immutable": "^4.0.0",
     "@types/slate-react/immutable": "^4.0.0",
     "ws": "^8.20.1",
-    "js-cookie": "^3.0.7"
+    "js-cookie": "^3.0.7",
+    "@grafana/plugin-ui@npm:^0.13.0": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
+    "@grafana/plugin-ui@npm:^0.13.1": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
   },
   "workspaces": {
     "packages": [

--- a/packages/grafana-o11y-ds-frontend/package.json
+++ b/packages/grafana-o11y-ds-frontend/package.json
@@ -43,7 +43,7 @@
     "@emotion/css": "11.13.5",
     "@grafana/data": "13.1.0-pre",
     "@grafana/e2e-selectors": "13.1.0-pre",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/runtime": "13.1.0-pre",
     "@grafana/ui": "13.1.0-pre",
     "react-use": "17.6.0",

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -46,7 +46,7 @@
     "@grafana/data": "13.1.0-pre",
     "@grafana/e2e-selectors": "13.1.0-pre",
     "@grafana/i18n": "13.1.0-pre",
-    "@grafana/plugin-ui": "0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/ui": "13.1.0-pre",
     "@react-awesome-query-builder/ui": "6.6.15",
     "lodash": "4.18.1",

--- a/public/app/plugins/datasource/azuremonitor/package.json
+++ b/public/app/plugins/datasource/azuremonitor/package.json
@@ -8,7 +8,7 @@
     "@grafana/azure-sdk": "0.1.0",
     "@grafana/data": "13.1.0-pre",
     "@grafana/i18n": "13.1.0-pre",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/runtime": "13.1.0-pre",
     "@grafana/schema": "13.1.0-pre",
     "@grafana/ui": "13.1.0-pre",

--- a/public/app/plugins/datasource/cloud-monitoring/package.json
+++ b/public/app/plugins/datasource/cloud-monitoring/package.json
@@ -7,7 +7,7 @@
     "@emotion/css": "11.13.5",
     "@grafana/data": "13.1.0-pre",
     "@grafana/google-sdk": "0.6.0",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/runtime": "13.1.0-pre",
     "@grafana/schema": "13.1.0-pre",
     "@grafana/ui": "13.1.0-pre",

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@grafana/data": "13.1.0-pre",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/runtime": "13.1.0-pre",
     "@grafana/sql": "13.1.0-pre",
     "@grafana/ui": "13.1.0-pre",

--- a/public/app/plugins/datasource/influxdb/package.json
+++ b/public/app/plugins/datasource/influxdb/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@grafana/data": "13.1.0-pre",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/runtime": "13.1.0-pre",
     "@grafana/sql": "13.1.0-pre",
     "@grafana/ui": "13.1.0-pre",

--- a/public/app/plugins/datasource/jaeger/package.json
+++ b/public/app/plugins/datasource/jaeger/package.json
@@ -8,7 +8,7 @@
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/o11y-ds-frontend": "workspace:*",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/runtime": "workspace:*",
     "@grafana/ui": "workspace:*",
     "react": "18.3.1",

--- a/public/app/plugins/datasource/mssql/package.json
+++ b/public/app/plugins/datasource/mssql/package.json
@@ -7,7 +7,7 @@
     "@emotion/css": "11.13.5",
     "@grafana/data": "13.1.0-pre",
     "@grafana/i18n": "13.1.0-pre",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/runtime": "13.1.0-pre",
     "@grafana/sql": "13.1.0-pre",
     "@grafana/ui": "13.1.0-pre",

--- a/public/app/plugins/datasource/mysql/package.json
+++ b/public/app/plugins/datasource/mysql/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@grafana/data": "13.1.0-pre",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/runtime": "13.1.0-pre",
     "@grafana/sql": "13.1.0-pre",
     "@grafana/ui": "13.1.0-pre",

--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -10,7 +10,7 @@
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/lezer-traceql": "0.0.25",
     "@grafana/o11y-ds-frontend": "workspace:*",
-    "@grafana/plugin-ui": "^0.13.1",
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch",
     "@grafana/runtime": "workspace:*",
     "@grafana/schema": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1788,7 +1788,7 @@ __metadata:
     "@grafana/e2e-selectors": "npm:13.1.0-pre"
     "@grafana/i18n": "npm:13.1.0-pre"
     "@grafana/plugin-configs": "npm:13.1.0-pre"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/runtime": "npm:13.1.0-pre"
     "@grafana/schema": "npm:13.1.0-pre"
     "@grafana/test-utils": "workspace:*"
@@ -1831,7 +1831,7 @@ __metadata:
     "@grafana/data": "npm:13.1.0-pre"
     "@grafana/e2e-selectors": "npm:13.1.0-pre"
     "@grafana/plugin-configs": "npm:13.1.0-pre"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/runtime": "npm:13.1.0-pre"
     "@grafana/sql": "npm:13.1.0-pre"
     "@grafana/ui": "npm:13.1.0-pre"
@@ -1968,7 +1968,7 @@ __metadata:
     "@grafana/data": "npm:13.1.0-pre"
     "@grafana/e2e-selectors": "npm:13.1.0-pre"
     "@grafana/plugin-configs": "npm:13.1.0-pre"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/runtime": "npm:13.1.0-pre"
     "@grafana/sql": "npm:13.1.0-pre"
     "@grafana/ui": "npm:13.1.0-pre"
@@ -2003,7 +2003,7 @@ __metadata:
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-configs": "workspace:*"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/runtime": "workspace:*"
     "@grafana/ui": "workspace:*"
     "@testing-library/dom": "npm:10.4.1"
@@ -2072,7 +2072,7 @@ __metadata:
     "@grafana/e2e-selectors": "npm:13.1.0-pre"
     "@grafana/i18n": "npm:13.1.0-pre"
     "@grafana/plugin-configs": "npm:13.1.0-pre"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/runtime": "npm:13.1.0-pre"
     "@grafana/sql": "npm:13.1.0-pre"
     "@grafana/ui": "npm:13.1.0-pre"
@@ -2102,7 +2102,7 @@ __metadata:
     "@grafana/data": "npm:13.1.0-pre"
     "@grafana/e2e-selectors": "npm:13.1.0-pre"
     "@grafana/plugin-configs": "npm:13.1.0-pre"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/runtime": "npm:13.1.0-pre"
     "@grafana/sql": "npm:13.1.0-pre"
     "@grafana/ui": "npm:13.1.0-pre"
@@ -2196,7 +2196,7 @@ __metadata:
     "@grafana/e2e-selectors": "npm:13.1.0-pre"
     "@grafana/google-sdk": "npm:0.6.0"
     "@grafana/plugin-configs": "npm:13.1.0-pre"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/runtime": "npm:13.1.0-pre"
     "@grafana/schema": "npm:13.1.0-pre"
     "@grafana/ui": "npm:13.1.0-pre"
@@ -2238,7 +2238,7 @@ __metadata:
     "@grafana/lezer-traceql": "npm:0.0.25"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-configs": "npm:13.1.0-pre"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/runtime": "workspace:*"
     "@grafana/schema": "workspace:*"
     "@grafana/ui": "workspace:*"
@@ -2702,7 +2702,7 @@ __metadata:
     "@emotion/css": "npm:11.13.5"
     "@grafana/data": "npm:13.1.0-pre"
     "@grafana/e2e-selectors": "npm:13.1.0-pre"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/runtime": "npm:13.1.0-pre"
     "@grafana/ui": "npm:13.1.0-pre"
     "@rollup/plugin-dynamic-import-vars": "npm:2.1.5"
@@ -2785,7 +2785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/plugin-ui@npm:0.13.1, @grafana/plugin-ui@npm:^0.13.0, @grafana/plugin-ui@npm:^0.13.1":
+"@grafana/plugin-ui@npm:0.13.1":
   version: 0.13.1
   resolution: "@grafana/plugin-ui@npm:0.13.1"
   dependencies:
@@ -2814,6 +2814,38 @@ __metadata:
     react-dom: ^18.2.0
     rxjs: ^7.8.1
   checksum: 10/472131fe0034ae6a5bd7ea86dcc34c160e2e932f4876d8cc5cadefa1cf85a1039d505ebf2f60ff92f2fb13bdfa6fcaf7ffeefbf1391345cbb8441db98bc81c87
+  languageName: node
+  linkType: hard
+
+"@grafana/plugin-ui@patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch":
+  version: 0.13.1
+  resolution: "@grafana/plugin-ui@patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch::version=0.13.1&hash=49c701"
+  dependencies:
+    "@emotion/css": "npm:^11.11.2"
+    "@hello-pangea/dnd": "npm:^17.0.0"
+    "@react-awesome-query-builder/ui": "npm:^6.6.4"
+    "@types/prismjs": "npm:^1.26.4"
+    chance: "npm:^1.1.7"
+    lodash: "npm:^4.17.21"
+    prismjs: "npm:^1.30.0"
+    react-calendar: "npm:^4.8.0"
+    react-popper-tooltip: "npm:^4.4.2"
+    react-use: "npm:^17.3.1"
+    react-virtualized-auto-sizer: "npm:^1.0.6"
+    sql-formatter-plus: "npm:^1.3.6"
+    uuid: "npm:^11.0.0"
+  peerDependencies:
+    "@grafana/data": ">=10.4.0"
+    "@grafana/e2e-selectors": ">=10.4.0"
+    "@grafana/runtime": ">=10.4.0"
+    "@grafana/ui": ">=10.4.0"
+    "@testing-library/jest-dom": ">=5.16.5"
+    "@testing-library/react": ">=15.0.2"
+    "@testing-library/user-event": ">=14.5.2"
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    rxjs: ^7.8.1
+  checksum: 10/99b43e1003223bd3a94661ac76c4e93fec00bdce8c4c739b2862ddbf039ce6e89e225b1aba9f508e297a5d35fb912791b703f34feeb8fee316592ff1aa11d92c
   languageName: node
   linkType: hard
 
@@ -3004,7 +3036,7 @@ __metadata:
     "@grafana/data": "npm:13.1.0-pre"
     "@grafana/e2e-selectors": "npm:13.1.0-pre"
     "@grafana/i18n": "npm:13.1.0-pre"
-    "@grafana/plugin-ui": "npm:0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/ui": "npm:13.1.0-pre"
     "@react-awesome-query-builder/ui": "npm:6.6.15"
     "@rollup/plugin-dynamic-import-vars": "npm:2.1.5"
@@ -18581,7 +18613,7 @@ __metadata:
     "@grafana/monaco-logql": "npm:^0.0.8"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-e2e": "npm:3.7.1-canary.2604.25387292549.0"
-    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@grafana/plugin-ui": "patch:@grafana/plugin-ui@npm%3A0.13.1#~/.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch"
     "@grafana/prometheus": "npm:13.1.2"
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": "npm:^8.2.6"


### PR DESCRIPTION
## Summary

The "Range" label in the Prometheus query builder (and other operation param labels) was not associated with its combo box due to a bug in `@grafana/plugin-ui` v0.13.1.


## Root cause

The "Range" label in the Prometheus query builder (and other operation param labels) was not associated with its combo box due to a bug in `@grafana/plugin-ui` v0.13.1.

In `dist/esm/components/VisualQueryBuilder/components/OperationParamEditor.js`, the `SelectInputParamEditor` function renders a `Select` component with an `id` prop:

```js
Select, { id: getOperationParamId(operationId, index), ... }
```

In `@grafana/ui`'s `Select` (which wraps react-select), the `id` prop sets the HTML id on the container element, while `inputId` sets the id on the actual `<input>` element inside the combobox. The corresponding `<label htmlFor={getOperationParamId(id, paramIndex)}>` in `OperationEditorBody.js` references the same generated ID, but since that ID was placed on the container div (not the input), the label was not associated with the input. React-select then auto-generated its own id (`react-select-8-input`), leaving the combobox without a proper label.


## What changed

Created a yarn patch for `@grafana/plugin-ui@npm:0.13.1` that changes `id:` to `inputId:` in `SelectInputParamEditor` within `dist/esm/components/VisualQueryBuilder/components/OperationParamEditor.js`.

**Patch file:** `.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch`

The change:
```diff
- id: getOperationParamId(operationId, index),
+ inputId: getOperationParamId(operationId, index),
```

The `inputId` prop passes the id down to react-select's internal `<input>` element, allowing the `<label htmlFor>` in `OperationEditorBody.js` to correctly associate with the combobox input. This fixes the accessibility issue for the "Range" select, the "Query pattern" select, the "Quantile" select, and any other operation parameter rendered as a `SelectInputParamEditor`.

**Files changed:**
- `.yarn/patches/@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch` (new patch file)
- `package.json` (updated dependency + resolutions to use patched version)
- `yarn.lock` (updated to reference patched package)
- Sub-package `package.json` files updated by `yarn patch-commit` (o11y-ds-frontend, grafana-sql, azuremonitor, cloud-monitoring, grafana-postgresql-datasource, influxdb, jaeger, mssql, mysql, tempo)


## Issue

Fixes #66347

Issue: https://github.com/grafana/grafana/issues/66347


## Diffstat

```
.../@grafana-plugin-ui-npm-0.13.1-5ecb6359c4.patch | 13 +++++
 package.json | 6 ++-
 packages/grafana-o11y-ds-frontend/package.json | 2 +-
 packages/grafana-sql/package.json | 2 +-
 .../plugins/datasource/azuremonitor/package.json | 2 +-
 .../datasource/cloud-monitoring/package.json | 2 +-
 .../grafana-postgresql-datasource/package.json | 2 +-
 .../app/plugins/datasource/influxdb/package.json | 2 +-
 public/app/plugins/datasource/jaeger/package.json | 2 +-
 public/app/plugins/datasource/mssql/package.json | 2 +-
 public/app/plugins/datasource/mysql/package.json | 2 +-
 public/app/plugins/datasource/tempo/package.json | 2 +-
 yarn.lock | 56 +++++++++++++++++-----
 13 files changed, 71 insertions(+), 24 deletions(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.