### PR TITLE
DataFrames: Add characterization tests for joinTabular edge cases

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.test.ts
@@ -347,6 +347,117 @@ describe('align frames', () => {
         ]
       `);
     });
+
+    // Three non-empty frames exercise the iterative merge in joinTabular (the `for (ti = 1...)` loop):
+    // the second merge re-joins frame3 against a left table that is itself a previously
+    // cartesian-expanded join result, which is where the output-column index bookkeeping is most fragile.
+    const f1 = toDataFrame({
+      fields: [
+        { name: 'key', type: FieldType.string, values: ['A', 'A', 'B', 'C'] },
+        { name: 'l', type: FieldType.number, values: [1, 2, 3, 4] },
+      ],
+    });
+    const f2 = toDataFrame({
+      fields: [
+        { name: 'key', type: FieldType.string, values: ['A', 'B', 'B', 'D'] },
+        { name: 'm', type: FieldType.number, values: [10, 20, 30, 40] },
+      ],
+    });
+    const f3 = toDataFrame({
+      fields: [
+        { name: 'key', type: FieldType.string, values: ['A', 'B', 'E'] },
+        { name: 'r', type: FieldType.number, values: [100, 200, 300] },
+      ],
+    });
+
+    it('should perform an outer join across three frames with duplicated join values', () => {
+      const out = joinDataFrames({
+        frames: [f1, f2, f3],
+        joinBy: fieldMatchers.get(FieldMatcherID.byName).get('key'),
+        mode: JoinMode.outerTabular,
+      })!;
+      expect(
+        out.fields.map((f) => ({
+          name: f.name,
+          values: f.values,
+        }))
+      ).toEqual([
+        { name: 'key', values: ['A', 'A', 'B', 'B', 'C', 'D', 'E'] },
+        { name: 'l', values: [1, 2, 3, 3, 4, null, null] },
+        { name: 'm', values: [10, 10, 20, 30, null, 40, null] },
+        { name: 'r', values: [100, 100, 200, 200, null, null, 300] },
+      ]);
+    });
+
+    it('should perform an inner join across three frames with duplicated join values', () => {
+      const out = joinDataFrames({
+        frames: [f1, f2, f3],
+        joinBy: fieldMatchers.get(FieldMatcherID.byName).get('key'),
+        mode: JoinMode.inner,
+      })!;
+      expect(
+        out.fields.map((f) => ({
+          name: f.name,
+          values: f.values,
+        }))
+      ).toEqual([
+        { name: 'key', values: ['A', 'A', 'B', 'B'] },
+        { name: 'l', values: [1, 2, 3, 3] },
+        { name: 'm', values: [10, 10, 20, 30] },
+        { name: 'r', values: [100, 100, 200, 200] },
+      ]);
+    });
+
+    // A null/undefined value in the join column exercises the `v == null` branch in joinTabular:
+    // for outer joins the row is carried as an unmatched-left row; for inner joins it is dropped.
+    const nullKeyLeft = toDataFrame({
+      fields: [
+        { name: 'key', type: FieldType.string, values: ['A', null, 'B'] },
+        { name: 'l', type: FieldType.number, values: [1, 2, 3] },
+      ],
+    });
+    const nullKeyRight = toDataFrame({
+      fields: [
+        { name: 'key', type: FieldType.string, values: ['A', 'B'] },
+        { name: 'r', type: FieldType.number, values: [10, 20] },
+      ],
+    });
+
+    it('should carry a null join value as an unmatched-left row for outer tabular joins', () => {
+      const out = joinDataFrames({
+        frames: [nullKeyLeft, nullKeyRight],
+        joinBy: fieldMatchers.get(FieldMatcherID.byName).get('key'),
+        mode: JoinMode.outerTabular,
+      })!;
+      expect(
+        out.fields.map((f) => ({
+          name: f.name,
+          values: f.values,
+        }))
+      ).toEqual([
+        { name: 'key', values: ['A', 'B', null] },
+        { name: 'l', values: [1, 3, 2] },
+        { name: 'r', values: [10, 20, null] },
+      ]);
+    });
+
+    it('should drop a null join value for inner tabular joins', () => {
+      const out = joinDataFrames({
+        frames: [nullKeyLeft, nullKeyRight],
+        joinBy: fieldMatchers.get(FieldMatcherID.byName).get('key'),
+        mode: JoinMode.inner,
+      })!;
+      expect(
+        out.fields.map((f) => ({
+          name: f.name,
+          values: f.values,
+        }))
+      ).toEqual([
+        { name: 'key', values: ['A', 'B'] },
+        { name: 'l', values: [1, 3] },
+        { name: 'r', values: [10, 20] },
+      ]);
+    });
   });
 
   it('unsorted input keep indexes', () => {


### PR DESCRIPTION
## What

Adds characterization tests for `joinTabular` (the engine behind `JoinMode.inner` and `JoinMode.outerTabular`) covering two paths that were previously untested:

1. **Three+ non-empty tabular frames with duplicate join keys** (outer and inner). This exercises the iterative `for (ti = 1…)` merge that re-joins a frame against a left table which is *itself* a previously cartesian-expanded join result — where the output-column index bookkeeping is most fragile.
2. **`null`/`undefined` in the join column** (the `v == null` branch): carried as an unmatched-left row for outer joins, dropped for inner joins.

## Why

This is **PR 1 of a stacked pair**. A follow-up PR rewrites `joinTabular`'s materialization step to remove a `new Function()` runtime-codegen call (which requires the `'unsafe-eval'` CSP directive). Landing these tests first locks in current behavior so the refactor is provably non-behavior-changing.

No production code changes — the snapshots/expectations were generated against the current implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)