### PR TITLE
chore(mt-annotations): add legacy ID to support migration

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1798,6 +1798,9 @@ store_backend = legacy-sql
 # Retention TTL for annotations - old data will be cleaned up
 retention_ttl = 2160h
 
+# Generate and persist grafana.app/deprecatedInternalID labels for legacy API compatibility.
+enable_deprecated_internal_id = false
+
 # gRPC server address for remote annotation storage (only used when store_backend = "grpc")
 grpc_address = localhost:9090
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1798,8 +1798,8 @@ store_backend = legacy-sql
 # Retention TTL for annotations - old data will be cleaned up
 retention_ttl = 2160h
 
-# Generate and persist grafana.app/deprecatedInternalID labels for legacy API compatibility.
-enable_deprecated_internal_id = false
+# Generate and persist grafana.app/legacyID labels for legacy API compatibility.
+enable_legacy_id = false
 
 # gRPC server address for remote annotation storage (only used when store_backend = "grpc")
 grpc_address = localhost:9090

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1727,8 +1727,8 @@ default_datasource_uid =
 # Retention TTL for annotations - old data will be cleaned up
 ;retention_ttl = 2160h
 
-# Generate and persist grafana.app/deprecatedInternalID labels for legacy API compatibility.
-;enable_deprecated_internal_id = false
+# Generate and persist grafana.app/legacyID labels for legacy API compatibility.
+;enable_legacy_id = false
 
 # gRPC server address for remote annotation storage (only used when store_backend = "grpc")
 ;grpc_address = localhost:9090

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1727,6 +1727,9 @@ default_datasource_uid =
 # Retention TTL for annotations - old data will be cleaned up
 ;retention_ttl = 2160h
 
+# Generate and persist grafana.app/deprecatedInternalID labels for legacy API compatibility.
+;enable_deprecated_internal_id = false
+
 # gRPC server address for remote annotation storage (only used when store_backend = "grpc")
 ;grpc_address = localhost:9090
 

--- a/pkg/registry/apps/annotation/config.go
+++ b/pkg/registry/apps/annotation/config.go
@@ -38,6 +38,10 @@ type Config struct {
 	PostgresTagCacheTTL      time.Duration
 	PostgresTagCacheSize     int
 
+	// EnableDeprecatedInternalID controls whether a grafana.app/deprecatedInternalID
+	// label is generated for new annotations and persisted in the store.
+	EnableDeprecatedInternalID bool
+
 	// CleanupSettings configures annotation pruning for the SQL backend's LifecycleManager.
 	// Zero value (all limits unset) disables cleanup. Not used by memory or gRPC backends.
 	CleanupSettings annotations.CleanupSettings
@@ -46,6 +50,7 @@ type Config struct {
 func (c *Config) AddFlags(flags *pflag.FlagSet) {
 	// TODO: add cleanup flags when the SQL backend is supported in MT.
 	flags.StringVar(&c.StoreBackend, "annotation.store-backend", "memory", "Annotation store backend: memory, grpc, postgres, legacy-sql")
+	flags.BoolVar(&c.EnableDeprecatedInternalID, "annotation.enable-deprecated-internal-id", false, "Generate and persist grafana.app/deprecatedInternalID labels for legacy API compatibility")
 
 	// General lifecycle flags
 	flags.DurationVar(&c.RetentionTTL, "annotation.retention-ttl", defaultRetentionTTL, "Retention TTL for annotations (old data will be cleaned up)")
@@ -72,8 +77,9 @@ func newConfigFromSettings(cfg *setting.Cfg) Config {
 	}
 
 	return Config{
-		StoreBackend: cfg.AnnotationAppPlatform.StoreBackend,
-		RetentionTTL: retentionTTL,
+		StoreBackend:               cfg.AnnotationAppPlatform.StoreBackend,
+		RetentionTTL:               retentionTTL,
+		EnableDeprecatedInternalID: cfg.AnnotationAppPlatform.EnableDeprecatedInternalID,
 
 		GRPCAddress:       cfg.AnnotationAppPlatform.GRPCAddress,
 		GRPCUseTLS:        cfg.AnnotationAppPlatform.GRPCUseTLS,

--- a/pkg/registry/apps/annotation/config.go
+++ b/pkg/registry/apps/annotation/config.go
@@ -38,9 +38,9 @@ type Config struct {
 	PostgresTagCacheTTL      time.Duration
 	PostgresTagCacheSize     int
 
-	// EnableDeprecatedInternalID controls whether a grafana.app/deprecatedInternalID
-	// label is generated for new annotations and persisted in the store.
-	EnableDeprecatedInternalID bool
+	// EnableLegacyID controls whether a grafana.app/legacyID label is generated
+	// for new annotations and persisted in the store.
+	EnableLegacyID bool
 
 	// CleanupSettings configures annotation pruning for the SQL backend's LifecycleManager.
 	// Zero value (all limits unset) disables cleanup. Not used by memory or gRPC backends.
@@ -50,7 +50,7 @@ type Config struct {
 func (c *Config) AddFlags(flags *pflag.FlagSet) {
 	// TODO: add cleanup flags when the SQL backend is supported in MT.
 	flags.StringVar(&c.StoreBackend, "annotation.store-backend", "memory", "Annotation store backend: memory, grpc, postgres, legacy-sql")
-	flags.BoolVar(&c.EnableDeprecatedInternalID, "annotation.enable-deprecated-internal-id", false, "Generate and persist grafana.app/deprecatedInternalID labels for legacy API compatibility")
+	flags.BoolVar(&c.EnableLegacyID, "annotation.enable-legacy-id", false, "Generate and persist grafana.app/legacyID labels for legacy API compatibility")
 
 	// General lifecycle flags
 	flags.DurationVar(&c.RetentionTTL, "annotation.retention-ttl", defaultRetentionTTL, "Retention TTL for annotations (old data will be cleaned up)")
@@ -77,9 +77,9 @@ func newConfigFromSettings(cfg *setting.Cfg) Config {
 	}
 
 	return Config{
-		StoreBackend:               cfg.AnnotationAppPlatform.StoreBackend,
-		RetentionTTL:               retentionTTL,
-		EnableDeprecatedInternalID: cfg.AnnotationAppPlatform.EnableDeprecatedInternalID,
+		StoreBackend:   cfg.AnnotationAppPlatform.StoreBackend,
+		RetentionTTL:   retentionTTL,
+		EnableLegacyID: cfg.AnnotationAppPlatform.EnableLegacyID,
 
 		GRPCAddress:       cfg.AnnotationAppPlatform.GRPCAddress,
 		GRPCUseTLS:        cfg.AnnotationAppPlatform.GRPCUseTLS,

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -30,9 +30,8 @@ import (
 var annotationGR = annotationV0.AnnotationKind().GroupVersionResource().GroupResource()
 
 // maxSafeJSInt is 2^52 - 1. IDs are masked to this range so they remain
-// lossless when serialised to JSON and consumed by JavaScript (which uses
-// IEEE-754 doubles, safe up to 2^53-1). We use 52 bits — not 53 — to match
-// the convention in pkg/storage/unified/apistore/prepare.go.
+// lossless when serialised to JSON and consumed by JavaScript.
+// This follows the convention in pkg/storage/unified/apistore/prepare.go.
 const maxSafeJSInt = (1 << 52) - 1
 
 // toAPIError maps store-layer sentinels to the right k8s apierror so HTTP

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/bwmarrin/snowflake"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,6 +28,12 @@ import (
 )
 
 var annotationGR = annotationV0.AnnotationKind().GroupVersionResource().GroupResource()
+
+// maxSafeJSInt is 2^52 - 1. IDs are masked to this range so they remain
+// lossless when serialised to JSON and consumed by JavaScript (which uses
+// IEEE-754 doubles, safe up to 2^53-1). We use 52 bits — not 53 — to match
+// the convention in pkg/storage/unified/apistore/prepare.go.
+const maxSafeJSInt = (1 << 52) - 1
 
 // toAPIError maps store-layer sentinels to the right k8s apierror so HTTP
 // status + telemetry classification agree. Already-typed apierrors and unknown
@@ -69,6 +76,8 @@ type k8sRESTAdapter struct {
 	accessClient   authtypes.AccessClient
 	folderResolver DashboardFolderResolver
 	installer      *AppInstaller
+
+	snowflakeNode *snowflake.Node
 
 	tracer  trace.Tracer
 	metrics *Metrics
@@ -224,6 +233,17 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 	}
 	annotation.SetCreatedBy(user.GetUID())
 
+	if s.snowflakeNode != nil {
+		meta, err := utils.MetaAccessor(annotation)
+		if err != nil {
+			return nil, apierrors.NewInternalError(err)
+		}
+		if meta.GetDeprecatedInternalID() == 0 {
+			id := s.snowflakeNode.Generate().Int64() & maxSafeJSInt
+			meta.SetDeprecatedInternalID(id)
+		}
+	}
+
 	created, err := s.store.Create(ctx, annotation)
 	if err != nil {
 		return nil, toAPIError(err, annotation.Name)
@@ -362,6 +382,12 @@ func parseFieldSelector(fs fields.Selector, opts *ListOptions) error {
 				return fmt.Errorf("invalid timeEnd value %q: %w", r.Value, err)
 			}
 			opts.To = v
+		case "metadata.deprecatedInternalID":
+			v, err := strconv.ParseInt(r.Value, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid deprecatedInternalID value %q: %w", r.Value, err)
+			}
+			opts.DeprecatedInternalID = v
 		default:
 			return fmt.Errorf("unsupported field selector: %s", r.Field)
 		}

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -233,13 +233,9 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 	annotation.SetCreatedBy(user.GetUID())
 
 	if s.snowflakeNode != nil {
-		meta, err := utils.MetaAccessor(annotation)
-		if err != nil {
-			return nil, apierrors.NewInternalError(err)
-		}
-		if meta.GetDeprecatedInternalID() == 0 { // nolint:staticcheck
+		if getLegacyID(annotation) == 0 {
 			id := s.snowflakeNode.Generate().Int64() & maxSafeJSInt
-			meta.SetDeprecatedInternalID(id) // nolint:staticcheck
+			setLegacyID(annotation, id)
 		}
 	}
 
@@ -381,12 +377,12 @@ func parseFieldSelector(fs fields.Selector, opts *ListOptions) error {
 				return fmt.Errorf("invalid timeEnd value %q: %w", r.Value, err)
 			}
 			opts.To = v
-		case "metadata.deprecatedInternalID":
+		case "metadata.legacyID":
 			v, err := strconv.ParseInt(r.Value, 10, 64)
 			if err != nil {
-				return fmt.Errorf("invalid deprecatedInternalID value %q: %w", r.Value, err)
+				return fmt.Errorf("invalid legacyID value %q: %w", r.Value, err)
 			}
-			opts.DeprecatedInternalID = v
+			opts.LegacyID = v
 		default:
 			return fmt.Errorf("unsupported field selector: %s", r.Field)
 		}

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -238,9 +238,9 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 		if err != nil {
 			return nil, apierrors.NewInternalError(err)
 		}
-		if meta.GetDeprecatedInternalID() == 0 {
+		if meta.GetDeprecatedInternalID() == 0 { // nolint:staticcheck
 			id := s.snowflakeNode.Generate().Int64() & maxSafeJSInt
-			meta.SetDeprecatedInternalID(id)
+			meta.SetDeprecatedInternalID(id) // nolint:staticcheck
 		}
 	}
 

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -20,7 +20,6 @@ import (
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
 // errStore returns a configurable error from every method. Used to verify the
@@ -53,7 +52,7 @@ func (u *updatedObjectInfo) UpdatedObject(_ context.Context, _ runtime.Object) (
 	return u.obj, nil
 }
 
-func newTestAdapterWithDeprecatedID(store Store, ac authtypes.AccessClient) *k8sRESTAdapter {
+func newTestAdapterWithLegacyID(store Store, ac authtypes.AccessClient) *k8sRESTAdapter {
 	adapter := newTestAdapter(store, ac)
 	node, err := snowflake.NewNode(0)
 	if err != nil {
@@ -63,13 +62,10 @@ func newTestAdapterWithDeprecatedID(store Store, ac authtypes.AccessClient) *k8s
 	return adapter
 }
 
-// testGetDeprecatedID is a test helper that extracts the deprecated internal ID
-// from an annotation via MetaAccessor.
-func testGetDeprecatedID(t *testing.T, anno *annotationV0.Annotation) int64 {
+// testGetLegacyID is a test helper that extracts the legacy ID from an annotation.
+func testGetLegacyID(t *testing.T, anno *annotationV0.Annotation) int64 {
 	t.Helper()
-	meta, err := utils.MetaAccessor(anno)
-	require.NoError(t, err)
-	return meta.GetDeprecatedInternalID() // nolint:staticcheck
+	return getLegacyID(anno)
 }
 
 // TestToAPIError covers the helper in isolation: each sentinel maps to the
@@ -176,8 +172,8 @@ func TestK8sAdapter_Create(t *testing.T) {
 		assert.True(t, apierrors.IsAlreadyExists(err), "expected 409 AlreadyExists, got %v", err)
 	})
 
-	t.Run("generates deprecated ID when enabled", func(t *testing.T) {
-		adapter := newTestAdapterWithDeprecatedID(NewMemoryStore(), allowAll)
+	t.Run("generates legacy ID when enabled", func(t *testing.T) {
+		adapter := newTestAdapterWithLegacyID(NewMemoryStore(), allowAll)
 		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
 
 		obj := &annotationV0.Annotation{
@@ -187,30 +183,30 @@ func TestK8sAdapter_Create(t *testing.T) {
 		result, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		id := testGetDeprecatedID(t, result.(*annotationV0.Annotation))
+		id := testGetLegacyID(t, result.(*annotationV0.Annotation))
 		assert.Greater(t, id, int64(0))
 		assert.LessOrEqual(t, id, int64(maxSafeJSInt))
 	})
 
-	t.Run("preserves caller-supplied deprecated ID", func(t *testing.T) {
-		adapter := newTestAdapterWithDeprecatedID(NewMemoryStore(), allowAll)
+	t.Run("preserves caller-supplied legacy ID", func(t *testing.T) {
+		adapter := newTestAdapterWithLegacyID(NewMemoryStore(), allowAll)
 		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
 
 		obj := &annotationV0.Annotation{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "backfilled",
 				Namespace: ns,
-				Labels:    map[string]string{utils.LabelKeyDeprecatedInternalID: "12345"},
+				Labels:    map[string]string{LabelKeyLegacyID: "12345"},
 			},
 			Spec: annotationV0.AnnotationSpec{Text: "backfilled", Time: 1000},
 		}
 		result, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		assert.Equal(t, int64(12345), testGetDeprecatedID(t, result.(*annotationV0.Annotation)))
+		assert.Equal(t, int64(12345), testGetLegacyID(t, result.(*annotationV0.Annotation)))
 	})
 
-	t.Run("no deprecated ID when disabled", func(t *testing.T) {
+	t.Run("no legacy ID when disabled", func(t *testing.T) {
 		adapter := newTestAdapter(NewMemoryStore(), allowAll)
 		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
 
@@ -221,11 +217,11 @@ func TestK8sAdapter_Create(t *testing.T) {
 		result, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		assert.Equal(t, int64(0), testGetDeprecatedID(t, result.(*annotationV0.Annotation)))
+		assert.Equal(t, int64(0), testGetLegacyID(t, result.(*annotationV0.Annotation)))
 	})
 
 	t.Run("generates unique IDs", func(t *testing.T) {
-		adapter := newTestAdapterWithDeprecatedID(NewMemoryStore(), allowAll)
+		adapter := newTestAdapterWithLegacyID(NewMemoryStore(), allowAll)
 		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
 
 		seen := make(map[int64]struct{}, 50)
@@ -237,7 +233,7 @@ func TestK8sAdapter_Create(t *testing.T) {
 			result, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
 			require.NoError(t, err)
 
-			id := testGetDeprecatedID(t, result.(*annotationV0.Annotation))
+			id := testGetLegacyID(t, result.(*annotationV0.Annotation))
 			_, dup := seen[id]
 			assert.False(t, dup, "duplicate ID: %d", id)
 			seen[id] = struct{}{}
@@ -266,7 +262,7 @@ func TestK8sAdapter_List(t *testing.T) {
 
 	setup := func(t *testing.T) (*k8sRESTAdapter, context.Context) {
 		t.Helper()
-		adapter := newTestAdapterWithDeprecatedID(NewMemoryStore(), allowAll)
+		adapter := newTestAdapterWithLegacyID(NewMemoryStore(), allowAll)
 		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
 
 		for _, tc := range []struct {
@@ -280,7 +276,7 @@ func TestK8sAdapter_List(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      tc.name,
 					Namespace: ns,
-					Labels:    map[string]string{utils.LabelKeyDeprecatedInternalID: tc.id},
+					Labels:    map[string]string{LabelKeyLegacyID: tc.id},
 				},
 				Spec: annotationV0.AnnotationSpec{Text: tc.name, Time: 1000},
 			}
@@ -290,10 +286,10 @@ func TestK8sAdapter_List(t *testing.T) {
 		return adapter, ctx
 	}
 
-	t.Run("field selector filters by deprecated ID", func(t *testing.T) {
+	t.Run("field selector filters by legacy ID", func(t *testing.T) {
 		adapter, ctx := setup(t)
 		result, err := adapter.List(ctx, &internalversion.ListOptions{
-			FieldSelector: fields.ParseSelectorOrDie("metadata.deprecatedInternalID=100"),
+			FieldSelector: fields.ParseSelectorOrDie("metadata.legacyID=100"),
 		})
 		require.NoError(t, err)
 		list := result.(*annotationV0.AnnotationList)
@@ -301,10 +297,10 @@ func TestK8sAdapter_List(t *testing.T) {
 		assert.Equal(t, "anno-a", list.Items[0].Name)
 	})
 
-	t.Run("non-matching deprecated ID returns empty", func(t *testing.T) {
+	t.Run("non-matching legacy ID returns empty", func(t *testing.T) {
 		adapter, ctx := setup(t)
 		result, err := adapter.List(ctx, &internalversion.ListOptions{
-			FieldSelector: fields.ParseSelectorOrDie("metadata.deprecatedInternalID=999"),
+			FieldSelector: fields.ParseSelectorOrDie("metadata.legacyID=999"),
 		})
 		require.NoError(t, err)
 		list := result.(*annotationV0.AnnotationList)

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -6,17 +6,21 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/bwmarrin/snowflake"
 	authtypes "github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 	registryrest "k8s.io/apiserver/pkg/registry/rest"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
 // errStore returns a configurable error from every method. Used to verify the
@@ -39,6 +43,34 @@ func (s *errStore) Update(_ context.Context, _ *annotationV0.Annotation) (*annot
 }
 func (s *errStore) Delete(_ context.Context, _, _ string) error { return s.err }
 func (s *errStore) Close() error                                { return nil }
+
+// updatedObjectInfo is a minimal rest.UpdatedObjectInfo for tests that just
+// returns the provided object unchanged.
+type updatedObjectInfo struct{ obj *annotationV0.Annotation }
+
+func (u *updatedObjectInfo) Preconditions() *metav1.Preconditions { return nil }
+func (u *updatedObjectInfo) UpdatedObject(_ context.Context, _ runtime.Object) (runtime.Object, error) {
+	return u.obj, nil
+}
+
+func newTestAdapterWithDeprecatedID(store Store, ac authtypes.AccessClient) *k8sRESTAdapter {
+	adapter := newTestAdapter(store, ac)
+	node, err := snowflake.NewNode(0)
+	if err != nil {
+		panic(err)
+	}
+	adapter.snowflakeNode = node
+	return adapter
+}
+
+// testGetDeprecatedID is a test helper that extracts the deprecated internal ID
+// from an annotation via MetaAccessor.
+func testGetDeprecatedID(t *testing.T, anno *annotationV0.Annotation) int64 {
+	t.Helper()
+	meta, err := utils.MetaAccessor(anno)
+	require.NoError(t, err)
+	return meta.GetDeprecatedInternalID()
+}
 
 // TestToAPIError covers the helper in isolation: each sentinel maps to the
 // matching apierror predicate, wrapped sentinels still classify, already-typed
@@ -127,46 +159,165 @@ func TestK8sAdapter_StoreErrorMapping(t *testing.T) {
 	}
 }
 
-// updatedObjectInfo is a minimal rest.UpdatedObjectInfo for tests that just
-// returns the provided object unchanged.
-type updatedObjectInfo struct{ obj *annotationV0.Annotation }
+func TestK8sAdapter_Create(t *testing.T) {
+	ns := "org-1"
+	allowAll := &fakeAccessClient{fn: func(_ authtypes.BatchCheckItem) bool { return true }}
 
-func (u *updatedObjectInfo) Preconditions() *metav1.Preconditions { return nil }
-func (u *updatedObjectInfo) UpdatedObject(_ context.Context, _ runtime.Object) (runtime.Object, error) {
-	return u.obj, nil
+	t.Run("duplicate returns 409", func(t *testing.T) {
+		adapter := newTestAdapter(NewMemoryStore(), allowAll)
+		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
+
+		obj := &annotationV0.Annotation{ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: ns}}
+		_, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		_, err = adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsAlreadyExists(err), "expected 409 AlreadyExists, got %v", err)
+	})
+
+	t.Run("generates deprecated ID when enabled", func(t *testing.T) {
+		adapter := newTestAdapterWithDeprecatedID(NewMemoryStore(), allowAll)
+		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
+
+		obj := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-anno", Namespace: ns},
+			Spec:       annotationV0.AnnotationSpec{Text: "hello", Time: 1000},
+		}
+		result, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		id := testGetDeprecatedID(t, result.(*annotationV0.Annotation))
+		assert.Greater(t, id, int64(0))
+		assert.LessOrEqual(t, id, int64(maxSafeJSInt))
+	})
+
+	t.Run("preserves caller-supplied deprecated ID", func(t *testing.T) {
+		adapter := newTestAdapterWithDeprecatedID(NewMemoryStore(), allowAll)
+		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
+
+		obj := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backfilled",
+				Namespace: ns,
+				Labels:    map[string]string{utils.LabelKeyDeprecatedInternalID: "12345"},
+			},
+			Spec: annotationV0.AnnotationSpec{Text: "backfilled", Time: 1000},
+		}
+		result, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(12345), testGetDeprecatedID(t, result.(*annotationV0.Annotation)))
+	})
+
+	t.Run("no deprecated ID when disabled", func(t *testing.T) {
+		adapter := newTestAdapter(NewMemoryStore(), allowAll)
+		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
+
+		obj := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-id", Namespace: ns},
+			Spec:       annotationV0.AnnotationSpec{Text: "hello", Time: 1000},
+		}
+		result, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(0), testGetDeprecatedID(t, result.(*annotationV0.Annotation)))
+	})
+
+	t.Run("generates unique IDs", func(t *testing.T) {
+		adapter := newTestAdapterWithDeprecatedID(NewMemoryStore(), allowAll)
+		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
+
+		seen := make(map[int64]struct{}, 50)
+		for i := range 50 {
+			obj := &annotationV0.Annotation{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("anno-%d", i), Namespace: ns},
+				Spec:       annotationV0.AnnotationSpec{Text: "hello", Time: int64(1000 + i)},
+			}
+			result, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			id := testGetDeprecatedID(t, result.(*annotationV0.Annotation))
+			_, dup := seen[id]
+			assert.False(t, dup, "duplicate ID: %d", id)
+			seen[id] = struct{}{}
+		}
+	})
 }
 
 // TestK8sAdapter_Update_StoreErrors covers Update separately because its store
 // error can come from either the pre-fetch Get or the Update call itself.
-func TestK8sAdapter_Update_StoreErrors(t *testing.T) {
+func TestK8sAdapter_Update(t *testing.T) {
 	ns := "org-1"
 	allowAll := &fakeAccessClient{fn: func(_ authtypes.BatchCheckItem) bool { return true }}
-	obj := &annotationV0.Annotation{ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: ns}}
 
 	t.Run("pre-fetch returns NotFound", func(t *testing.T) {
 		adapter := newTestAdapter(&errStore{err: ErrNotFound}, allowAll)
 		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
+		obj := &annotationV0.Annotation{ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: ns}}
 		_, _, err := adapter.Update(ctx, "obj", &updatedObjectInfo{obj: obj}, nil, nil, false, &metav1.UpdateOptions{})
 		assert.True(t, apierrors.IsNotFound(err), "got %v", err)
 	})
 }
 
-// TestMemoryStore_DuplicateCreate is the end-to-end smoke test: a backend that
-// emits ErrAlreadyExists must surface as a 409 at the K8s boundary. Catches
-// regressions where backends drift back to plain fmt.Errorf.
-func TestMemoryStore_DuplicateCreate(t *testing.T) {
+func TestK8sAdapter_List(t *testing.T) {
 	ns := "org-1"
 	allowAll := &fakeAccessClient{fn: func(_ authtypes.BatchCheckItem) bool { return true }}
-	adapter := newTestAdapter(NewMemoryStore(), allowAll)
-	ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
 
-	obj := &annotationV0.Annotation{ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: ns}}
-	_, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
-	require.NoError(t, err)
+	setup := func(t *testing.T) (*k8sRESTAdapter, context.Context) {
+		t.Helper()
+		adapter := newTestAdapterWithDeprecatedID(NewMemoryStore(), allowAll)
+		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
 
-	_, err = adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
-	require.Error(t, err)
-	assert.True(t, apierrors.IsAlreadyExists(err), "expected 409 AlreadyExists, got %v", err)
+		for _, tc := range []struct {
+			name string
+			id   string
+		}{
+			{"anno-a", "100"},
+			{"anno-b", "200"},
+		} {
+			obj := &annotationV0.Annotation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tc.name,
+					Namespace: ns,
+					Labels:    map[string]string{utils.LabelKeyDeprecatedInternalID: tc.id},
+				},
+				Spec: annotationV0.AnnotationSpec{Text: tc.name, Time: 1000},
+			}
+			_, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
+			require.NoError(t, err)
+		}
+		return adapter, ctx
+	}
+
+	t.Run("field selector filters by deprecated ID", func(t *testing.T) {
+		adapter, ctx := setup(t)
+		result, err := adapter.List(ctx, &internalversion.ListOptions{
+			FieldSelector: fields.ParseSelectorOrDie("metadata.deprecatedInternalID=100"),
+		})
+		require.NoError(t, err)
+		list := result.(*annotationV0.AnnotationList)
+		require.Len(t, list.Items, 1)
+		assert.Equal(t, "anno-a", list.Items[0].Name)
+	})
+
+	t.Run("non-matching deprecated ID returns empty", func(t *testing.T) {
+		adapter, ctx := setup(t)
+		result, err := adapter.List(ctx, &internalversion.ListOptions{
+			FieldSelector: fields.ParseSelectorOrDie("metadata.deprecatedInternalID=999"),
+		})
+		require.NoError(t, err)
+		list := result.(*annotationV0.AnnotationList)
+		assert.Empty(t, list.Items)
+	})
+
+	t.Run("no field selector returns all", func(t *testing.T) {
+		adapter, ctx := setup(t)
+		result, err := adapter.List(ctx, &internalversion.ListOptions{})
+		require.NoError(t, err)
+		list := result.(*annotationV0.AnnotationList)
+		assert.Len(t, list.Items, 2)
+	})
 }
 
 // compile-time assertion that errStore implements Store

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -69,7 +69,7 @@ func testGetDeprecatedID(t *testing.T, anno *annotationV0.Annotation) int64 {
 	t.Helper()
 	meta, err := utils.MetaAccessor(anno)
 	require.NoError(t, err)
-	return meta.GetDeprecatedInternalID()
+	return meta.GetDeprecatedInternalID() // nolint:staticcheck
 }
 
 // TestToAPIError covers the helper in isolation: each sentinel maps to the

--- a/pkg/registry/apps/annotation/legacy_id.go
+++ b/pkg/registry/apps/annotation/legacy_id.go
@@ -1,0 +1,40 @@
+package annotation
+
+import (
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// LabelKeyLegacyID is the annotation-specific label key for legacy numeric IDs.
+// This provides backward compatibility with the old annotation API's numeric ID
+// while the platform migrates to Kubernetes-native naming.
+const LabelKeyLegacyID = "grafana.app/legacyID"
+
+// getLegacyID reads the legacy numeric ID from the object's labels.
+// Returns 0 if the label is absent or unparseable.
+func getLegacyID(obj metav1.Object) int64 {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return 0
+	}
+	v, ok := labels[LabelKeyLegacyID]
+	if !ok {
+		return 0
+	}
+	id, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
+// setLegacyID writes the legacy numeric ID label on the object.
+func setLegacyID(obj metav1.Object, id int64) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string, 1)
+	}
+	labels[LabelKeyLegacyID] = strconv.FormatInt(id, 10)
+	obj.SetLabels(labels)
+}

--- a/pkg/registry/apps/annotation/memory_store.go
+++ b/pkg/registry/apps/annotation/memory_store.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
 type memoryStore struct {
@@ -84,8 +83,8 @@ func (m *memoryStore) List(ctx context.Context, namespace string, opts ListOptio
 			continue
 		}
 
-		if opts.DeprecatedInternalID > 0 {
-			if meta, err := utils.MetaAccessor(anno); err != nil || meta.GetDeprecatedInternalID() != opts.DeprecatedInternalID { // nolint:staticcheck
+		if opts.LegacyID > 0 {
+			if getLegacyID(anno) != opts.LegacyID {
 				continue
 			}
 		}

--- a/pkg/registry/apps/annotation/memory_store.go
+++ b/pkg/registry/apps/annotation/memory_store.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
 type memoryStore struct {
@@ -81,6 +82,12 @@ func (m *memoryStore) List(ctx context.Context, namespace string, opts ListOptio
 
 		if opts.CreatedBy != "" && anno.GetCreatedBy() != opts.CreatedBy {
 			continue
+		}
+
+		if opts.DeprecatedInternalID > 0 {
+			if meta, err := utils.MetaAccessor(anno); err != nil || meta.GetDeprecatedInternalID() != opts.DeprecatedInternalID {
+				continue
+			}
 		}
 
 		result = append(result, *anno.DeepCopy())

--- a/pkg/registry/apps/annotation/memory_store.go
+++ b/pkg/registry/apps/annotation/memory_store.go
@@ -85,7 +85,7 @@ func (m *memoryStore) List(ctx context.Context, namespace string, opts ListOptio
 		}
 
 		if opts.DeprecatedInternalID > 0 {
-			if meta, err := utils.MetaAccessor(anno); err != nil || meta.GetDeprecatedInternalID() != opts.DeprecatedInternalID {
+			if meta, err := utils.MetaAccessor(anno); err != nil || meta.GetDeprecatedInternalID() != opts.DeprecatedInternalID { // nolint:staticcheck
 				continue
 			}
 		}

--- a/pkg/registry/apps/annotation/migrations/00003_add_deprecated_internal_id.sql
+++ b/pkg/registry/apps/annotation/migrations/00003_add_deprecated_internal_id.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+ALTER TABLE annotations ADD COLUMN deprecated_internal_id BIGINT;
+CREATE UNIQUE INDEX idx_deprecated_internal_id ON annotations (namespace, deprecated_internal_id)
+  WHERE deprecated_internal_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_deprecated_internal_id;
+ALTER TABLE annotations DROP COLUMN IF EXISTS deprecated_internal_id;

--- a/pkg/registry/apps/annotation/migrations/00003_add_deprecated_internal_id.sql
+++ b/pkg/registry/apps/annotation/migrations/00003_add_deprecated_internal_id.sql
@@ -1,8 +1,0 @@
--- +goose Up
-ALTER TABLE annotations ADD COLUMN deprecated_internal_id BIGINT;
-CREATE INDEX idx_deprecated_internal_id ON annotations (namespace, deprecated_internal_id)
-  WHERE deprecated_internal_id IS NOT NULL;
-
--- +goose Down
-DROP INDEX IF EXISTS idx_deprecated_internal_id;
-ALTER TABLE annotations DROP COLUMN IF EXISTS deprecated_internal_id;

--- a/pkg/registry/apps/annotation/migrations/00003_add_deprecated_internal_id.sql
+++ b/pkg/registry/apps/annotation/migrations/00003_add_deprecated_internal_id.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 ALTER TABLE annotations ADD COLUMN deprecated_internal_id BIGINT;
-CREATE UNIQUE INDEX idx_deprecated_internal_id ON annotations (namespace, deprecated_internal_id)
+CREATE INDEX idx_deprecated_internal_id ON annotations (namespace, deprecated_internal_id)
   WHERE deprecated_internal_id IS NOT NULL;
 
 -- +goose Down

--- a/pkg/registry/apps/annotation/migrations/00003_add_legacy_id.sql
+++ b/pkg/registry/apps/annotation/migrations/00003_add_legacy_id.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+ALTER TABLE annotations ADD COLUMN legacy_id BIGINT;
+CREATE INDEX idx_legacy_id ON annotations (namespace, legacy_id)
+  WHERE legacy_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_legacy_id;
+ALTER TABLE annotations DROP COLUMN IF EXISTS legacy_id;

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -128,7 +127,7 @@ func (s *PostgreSQLStore) Close() error {
 func (s *PostgreSQLStore) Get(ctx context.Context, namespace, name string) (*annotationV0.Annotation, error) {
 	query := `
 		SELECT namespace, name, time, time_end, dashboard_uid, panel_id,
-		       text, tags, scopes, created_by, created_at, deprecated_internal_id
+		       text, tags, scopes, created_by, created_at, legacy_id
 		FROM annotations
 		WHERE namespace = $1 AND name = $2
 		LIMIT 1
@@ -137,18 +136,18 @@ func (s *PostgreSQLStore) Get(ctx context.Context, namespace, name string) (*ann
 	row := s.pool.QueryRow(ctx, query, namespace, name)
 
 	var (
-		ns, n, text          string
-		timeMs, createdAt    int64
-		timeEnd              *int64
-		dashboardUID         *string
-		panelID              *int64
-		tags, scopes         []string
-		createdBy            *string
-		deprecatedInternalID *int64
+		ns, n, text       string
+		timeMs, createdAt int64
+		timeEnd           *int64
+		dashboardUID      *string
+		panelID           *int64
+		tags, scopes      []string
+		createdBy         *string
+		legacyID          *int64
 	)
 
 	err := row.Scan(&ns, &n, &timeMs, &timeEnd, &dashboardUID, &panelID,
-		&text, &tags, &scopes, &createdBy, &createdAt, &deprecatedInternalID)
+		&text, &tags, &scopes, &createdBy, &createdAt, &legacyID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -156,7 +155,7 @@ func (s *PostgreSQLStore) Get(ctx context.Context, namespace, name string) (*ann
 		return nil, fmt.Errorf("failed to scan annotation: %w", err)
 	}
 
-	return rowToAnnotation(ns, n, timeMs, timeEnd, dashboardUID, panelID, text, tags, scopes, createdBy, createdAt, deprecatedInternalID), nil
+	return rowToAnnotation(ns, n, timeMs, timeEnd, dashboardUID, panelID, text, tags, scopes, createdBy, createdAt, legacyID), nil
 }
 
 // Create creates a new annotation
@@ -182,22 +181,20 @@ func (s *PostgreSQLStore) Create(ctx context.Context, anno *annotationV0.Annotat
 	createdBy := anno.GetCreatedBy()
 	createdAt := time.Now().UTC().UnixMilli()
 
-	var deprecatedInternalID *int64
-	if meta, err := utils.MetaAccessor(anno); err == nil {
-		if id := meta.GetDeprecatedInternalID(); id > 0 { // nolint:staticcheck
-			deprecatedInternalID = &id
-		}
+	var legacyID *int64
+	if id := getLegacyID(anno); id > 0 {
+		legacyID = &id
 	}
 
 	query := `
 		INSERT INTO annotations
-		(namespace, name, time, time_end, dashboard_uid, panel_id, text, tags, scopes, created_by, created_at, deprecated_internal_id)
+		(namespace, name, time, time_end, dashboard_uid, panel_id, text, tags, scopes, created_by, created_at, legacy_id)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 	`
 
 	_, err := s.pool.Exec(ctx, query,
 		namespace, name, timeMs, timeEnd, dashboardUID, panelID,
-		text, pq.Array(tags), pq.Array(scopes), createdBy, createdAt, deprecatedInternalID,
+		text, pq.Array(tags), pq.Array(scopes), createdBy, createdAt, legacyID,
 	)
 	if err != nil {
 		// Check for unique constraint violation
@@ -285,23 +282,23 @@ func (s *PostgreSQLStore) List(ctx context.Context, namespace string, opts ListO
 	var results []annotationV0.Annotation
 	for rows.Next() {
 		var (
-			ns, n, text          string
-			timeMs, createdAt    int64
-			timeEnd              *int64
-			dashboardUID         *string
-			panelID              *int64
-			tags, scopes         []string
-			createdBy            *string
-			deprecatedInternalID *int64
+			ns, n, text       string
+			timeMs, createdAt int64
+			timeEnd           *int64
+			dashboardUID      *string
+			panelID           *int64
+			tags, scopes      []string
+			createdBy         *string
+			legacyID          *int64
 		)
 
 		err := rows.Scan(&ns, &n, &timeMs, &timeEnd, &dashboardUID, &panelID,
-			&text, &tags, &scopes, &createdBy, &createdAt, &deprecatedInternalID)
+			&text, &tags, &scopes, &createdBy, &createdAt, &legacyID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan annotation row: %w", err)
 		}
 
-		results = append(results, *rowToAnnotation(ns, n, timeMs, timeEnd, dashboardUID, panelID, text, tags, scopes, createdBy, createdAt, deprecatedInternalID))
+		results = append(results, *rowToAnnotation(ns, n, timeMs, timeEnd, dashboardUID, panelID, text, tags, scopes, createdBy, createdAt, legacyID))
 	}
 
 	if err := rows.Err(); err != nil {
@@ -393,16 +390,16 @@ func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (st
 	}
 
 	// Deprecated internal ID filter
-	if opts.DeprecatedInternalID > 0 {
-		conditions = append(conditions, fmt.Sprintf("deprecated_internal_id = $%d", argNum))
-		args = append(args, opts.DeprecatedInternalID)
+	if opts.LegacyID > 0 {
+		conditions = append(conditions, fmt.Sprintf("legacy_id = $%d", argNum))
+		args = append(args, opts.LegacyID)
 		argNum++
 	}
 
 	// Construct query
 	query := `
 		SELECT namespace, name, time, time_end, dashboard_uid, panel_id,
-		       text, tags, scopes, created_by, created_at, deprecated_internal_id
+		       text, tags, scopes, created_by, created_at, legacy_id
 		FROM annotations
 		WHERE ` + strings.Join(conditions, " AND ") + `
 		ORDER BY time DESC, name
@@ -418,7 +415,7 @@ func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (st
 // rowToAnnotation converts database row values to an Annotation object
 func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
 	dashboardUID *string, panelID *int64, text string, tags, scopes []string,
-	createdBy *string, createdAt int64, deprecatedInternalID *int64) *annotationV0.Annotation {
+	createdBy *string, createdAt int64, legacyID *int64) *annotationV0.Annotation {
 	anno := &annotationV0.Annotation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -444,11 +441,9 @@ func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
 	// Set creation timestamp
 	anno.CreationTimestamp = metav1.NewTime(time.UnixMilli(createdAt))
 
-	// Populate the deprecated internal ID label if the column has a value
-	if deprecatedInternalID != nil && *deprecatedInternalID != 0 {
-		if meta, err := utils.MetaAccessor(anno); err == nil {
-			meta.SetDeprecatedInternalID(*deprecatedInternalID) // nolint:staticcheck
-		}
+	// Populate the legacy ID label if the column has a value
+	if legacyID != nil && *legacyID != 0 {
+		setLegacyID(anno, *legacyID)
 	}
 
 	return anno

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -184,7 +184,7 @@ func (s *PostgreSQLStore) Create(ctx context.Context, anno *annotationV0.Annotat
 
 	var deprecatedInternalID *int64
 	if meta, err := utils.MetaAccessor(anno); err == nil {
-		if id := meta.GetDeprecatedInternalID(); id > 0 {
+		if id := meta.GetDeprecatedInternalID(); id > 0 { // nolint:staticcheck
 			deprecatedInternalID = &id
 		}
 	}
@@ -447,7 +447,7 @@ func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
 	// Populate the deprecated internal ID label if the column has a value
 	if deprecatedInternalID != nil && *deprecatedInternalID != 0 {
 		if meta, err := utils.MetaAccessor(anno); err == nil {
-			meta.SetDeprecatedInternalID(*deprecatedInternalID)
+			meta.SetDeprecatedInternalID(*deprecatedInternalID) // nolint:staticcheck
 		}
 	}
 

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -127,7 +128,7 @@ func (s *PostgreSQLStore) Close() error {
 func (s *PostgreSQLStore) Get(ctx context.Context, namespace, name string) (*annotationV0.Annotation, error) {
 	query := `
 		SELECT namespace, name, time, time_end, dashboard_uid, panel_id,
-		       text, tags, scopes, created_by, created_at
+		       text, tags, scopes, created_by, created_at, deprecated_internal_id
 		FROM annotations
 		WHERE namespace = $1 AND name = $2
 		LIMIT 1
@@ -136,17 +137,18 @@ func (s *PostgreSQLStore) Get(ctx context.Context, namespace, name string) (*ann
 	row := s.pool.QueryRow(ctx, query, namespace, name)
 
 	var (
-		ns, n, text       string
-		timeMs, createdAt int64
-		timeEnd           *int64
-		dashboardUID      *string
-		panelID           *int64
-		tags, scopes      []string
-		createdBy         *string
+		ns, n, text          string
+		timeMs, createdAt    int64
+		timeEnd              *int64
+		dashboardUID         *string
+		panelID              *int64
+		tags, scopes         []string
+		createdBy            *string
+		deprecatedInternalID *int64
 	)
 
 	err := row.Scan(&ns, &n, &timeMs, &timeEnd, &dashboardUID, &panelID,
-		&text, &tags, &scopes, &createdBy, &createdAt)
+		&text, &tags, &scopes, &createdBy, &createdAt, &deprecatedInternalID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -154,7 +156,7 @@ func (s *PostgreSQLStore) Get(ctx context.Context, namespace, name string) (*ann
 		return nil, fmt.Errorf("failed to scan annotation: %w", err)
 	}
 
-	return rowToAnnotation(ns, n, timeMs, timeEnd, dashboardUID, panelID, text, tags, scopes, createdBy, createdAt), nil
+	return rowToAnnotation(ns, n, timeMs, timeEnd, dashboardUID, panelID, text, tags, scopes, createdBy, createdAt, deprecatedInternalID), nil
 }
 
 // Create creates a new annotation
@@ -180,15 +182,22 @@ func (s *PostgreSQLStore) Create(ctx context.Context, anno *annotationV0.Annotat
 	createdBy := anno.GetCreatedBy()
 	createdAt := time.Now().UTC().UnixMilli()
 
+	var deprecatedInternalID *int64
+	if meta, err := utils.MetaAccessor(anno); err == nil {
+		if id := meta.GetDeprecatedInternalID(); id > 0 {
+			deprecatedInternalID = &id
+		}
+	}
+
 	query := `
 		INSERT INTO annotations
-		(namespace, name, time, time_end, dashboard_uid, panel_id, text, tags, scopes, created_by, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		(namespace, name, time, time_end, dashboard_uid, panel_id, text, tags, scopes, created_by, created_at, deprecated_internal_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 	`
 
 	_, err := s.pool.Exec(ctx, query,
 		namespace, name, timeMs, timeEnd, dashboardUID, panelID,
-		text, pq.Array(tags), pq.Array(scopes), createdBy, createdAt,
+		text, pq.Array(tags), pq.Array(scopes), createdBy, createdAt, deprecatedInternalID,
 	)
 	if err != nil {
 		// Check for unique constraint violation
@@ -276,22 +285,23 @@ func (s *PostgreSQLStore) List(ctx context.Context, namespace string, opts ListO
 	var results []annotationV0.Annotation
 	for rows.Next() {
 		var (
-			ns, n, text       string
-			timeMs, createdAt int64
-			timeEnd           *int64
-			dashboardUID      *string
-			panelID           *int64
-			tags, scopes      []string
-			createdBy         *string
+			ns, n, text          string
+			timeMs, createdAt    int64
+			timeEnd              *int64
+			dashboardUID         *string
+			panelID              *int64
+			tags, scopes         []string
+			createdBy            *string
+			deprecatedInternalID *int64
 		)
 
 		err := rows.Scan(&ns, &n, &timeMs, &timeEnd, &dashboardUID, &panelID,
-			&text, &tags, &scopes, &createdBy, &createdAt)
+			&text, &tags, &scopes, &createdBy, &createdAt, &deprecatedInternalID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan annotation row: %w", err)
 		}
 
-		results = append(results, *rowToAnnotation(ns, n, timeMs, timeEnd, dashboardUID, panelID, text, tags, scopes, createdBy, createdAt))
+		results = append(results, *rowToAnnotation(ns, n, timeMs, timeEnd, dashboardUID, panelID, text, tags, scopes, createdBy, createdAt, deprecatedInternalID))
 	}
 
 	if err := rows.Err(); err != nil {
@@ -382,10 +392,17 @@ func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (st
 		argNum++
 	}
 
+	// Deprecated internal ID filter
+	if opts.DeprecatedInternalID > 0 {
+		conditions = append(conditions, fmt.Sprintf("deprecated_internal_id = $%d", argNum))
+		args = append(args, opts.DeprecatedInternalID)
+		argNum++
+	}
+
 	// Construct query
 	query := `
 		SELECT namespace, name, time, time_end, dashboard_uid, panel_id,
-		       text, tags, scopes, created_by, created_at
+		       text, tags, scopes, created_by, created_at, deprecated_internal_id
 		FROM annotations
 		WHERE ` + strings.Join(conditions, " AND ") + `
 		ORDER BY time DESC, name
@@ -401,7 +418,7 @@ func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (st
 // rowToAnnotation converts database row values to an Annotation object
 func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
 	dashboardUID *string, panelID *int64, text string, tags, scopes []string,
-	createdBy *string, createdAt int64) *annotationV0.Annotation {
+	createdBy *string, createdAt int64, deprecatedInternalID *int64) *annotationV0.Annotation {
 	anno := &annotationV0.Annotation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -426,6 +443,13 @@ func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
 
 	// Set creation timestamp
 	anno.CreationTimestamp = metav1.NewTime(time.UnixMilli(createdAt))
+
+	// Populate the deprecated internal ID label if the column has a value
+	if deprecatedInternalID != nil && *deprecatedInternalID != 0 {
+		if meta, err := utils.MetaAccessor(anno); err == nil {
+			meta.SetDeprecatedInternalID(*deprecatedInternalID)
+		}
+	}
 
 	return anno
 }

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -110,7 +110,7 @@ func NewAppInstaller(
 	}
 
 	var sfNode *snowflake.Node
-	if cfg.EnableDeprecatedInternalID {
+	if cfg.EnableLegacyID {
 		node, err := snowflake.NewNode(rand.Int64N(1024))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create snowflake node: %w", err)

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -5,9 +5,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"math/rand/v2"
 	"os"
 	"sync"
 
+	"github.com/bwmarrin/snowflake"
 	authtypes "github.com/grafana/authlib/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
@@ -107,11 +109,21 @@ func NewAppInstaller(
 		installer.startCleanup(ctx, lifecycleMgr, cfg.RetentionTTL)
 	}
 
+	var sfNode *snowflake.Node
+	if cfg.EnableDeprecatedInternalID {
+		node, err := snowflake.NewNode(rand.Int64N(1024))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create snowflake node: %w", err)
+		}
+		sfNode = node
+	}
+
 	installer.k8sAdapter = &k8sRESTAdapter{
 		store:          instrumentedStore,
 		accessClient:   accessClient,
 		folderResolver: folderResolver,
 		installer:      installer,
+		snowflakeNode:  sfNode,
 		tracer:         installer.tracer,
 		metrics:        installer.metrics,
 		logger:         logger,

--- a/pkg/registry/apps/annotation/search_handler.go
+++ b/pkg/registry/apps/annotation/search_handler.go
@@ -131,9 +131,9 @@ func listOptionsFromQueryParams(queryParams url.Values) ListOptions {
 		opts.CreatedBy = v
 	}
 
-	if v := queryParams.Get("deprecatedInternalID"); v != "" {
+	if v := queryParams.Get("legacyID"); v != "" {
 		if id, err := strconv.ParseInt(v, 10, 64); err == nil && id > 0 {
-			opts.DeprecatedInternalID = id
+			opts.LegacyID = id
 		}
 	}
 

--- a/pkg/registry/apps/annotation/search_handler.go
+++ b/pkg/registry/apps/annotation/search_handler.go
@@ -131,5 +131,11 @@ func listOptionsFromQueryParams(queryParams url.Values) ListOptions {
 		opts.CreatedBy = v
 	}
 
+	if v := queryParams.Get("deprecatedInternalID"); v != "" {
+		if id, err := strconv.ParseInt(v, 10, 64); err == nil && id > 0 {
+			opts.DeprecatedInternalID = id
+		}
+	}
+
 	return opts
 }

--- a/pkg/registry/apps/annotation/sql_adapter.go
+++ b/pkg/registry/apps/annotation/sql_adapter.go
@@ -243,8 +243,11 @@ func (a *sqlAdapter) toK8sResource(item *annotations.ItemDTO, namespace string) 
 		anno.Spec.PanelID = &item.PanelID
 	}
 
-	if item.UserUID != "" {
-		if m, err := utils.MetaAccessor(anno); err == nil {
+	if m, err := utils.MetaAccessor(anno); err == nil {
+		if item.ID > 0 {
+			m.SetDeprecatedInternalID(item.ID)
+		}
+		if item.UserUID != "" {
 			m.SetCreatedBy(claims.NewTypeID(claims.TypeUser, item.UserUID))
 		}
 	}

--- a/pkg/registry/apps/annotation/sql_adapter.go
+++ b/pkg/registry/apps/annotation/sql_adapter.go
@@ -243,10 +243,10 @@ func (a *sqlAdapter) toK8sResource(item *annotations.ItemDTO, namespace string) 
 		anno.Spec.PanelID = &item.PanelID
 	}
 
+	if item.ID > 0 {
+		setLegacyID(anno, item.ID)
+	}
 	if m, err := utils.MetaAccessor(anno); err == nil {
-		if item.ID > 0 {
-			m.SetDeprecatedInternalID(item.ID) // nolint:staticcheck
-		}
 		if item.UserUID != "" {
 			m.SetCreatedBy(claims.NewTypeID(claims.TypeUser, item.UserUID))
 		}

--- a/pkg/registry/apps/annotation/sql_adapter.go
+++ b/pkg/registry/apps/annotation/sql_adapter.go
@@ -245,7 +245,7 @@ func (a *sqlAdapter) toK8sResource(item *annotations.ItemDTO, namespace string) 
 
 	if m, err := utils.MetaAccessor(anno); err == nil {
 		if item.ID > 0 {
-			m.SetDeprecatedInternalID(item.ID)
+			m.SetDeprecatedInternalID(item.ID) // nolint:staticcheck
 		}
 		if item.UserUID != "" {
 			m.SetCreatedBy(claims.NewTypeID(claims.TypeUser, item.UserUID))

--- a/pkg/registry/apps/annotation/storage.go
+++ b/pkg/registry/apps/annotation/storage.go
@@ -39,6 +39,9 @@ type ListOptions struct {
 	TagsMatchAny   bool
 	Scopes         []string
 	ScopesMatchAny bool
+
+	// DeprecatedInternalID filters by the legacy numeric ID
+	DeprecatedInternalID int64
 }
 
 type AnnotationList struct {

--- a/pkg/registry/apps/annotation/storage.go
+++ b/pkg/registry/apps/annotation/storage.go
@@ -40,8 +40,8 @@ type ListOptions struct {
 	Scopes         []string
 	ScopesMatchAny bool
 
-	// DeprecatedInternalID filters by the legacy numeric ID
-	DeprecatedInternalID int64
+	// LegacyID filters by the legacy numeric ID
+	LegacyID int64
 }
 
 type AnnotationList struct {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1135,18 +1135,18 @@ type AnnotationAppPlatformSettings struct {
 	PostgresTagCacheTTL      time.Duration // TTL for tag query cache
 	PostgresTagCacheSize     int           // Size of the tag query cache
 
-	// EnableDeprecatedInternalID controls whether a grafana.app/deprecatedInternalID
-	// label is generated for new annotations.
-	EnableDeprecatedInternalID bool
+	// EnableLegacyID controls whether a grafana.app/legacyID label is generated
+	// for new annotations.
+	EnableLegacyID bool
 }
 
 func loadAnnotationAppPlatformSettings(cfg *ini.File) AnnotationAppPlatformSettings {
 	appPlatformSection := cfg.Section("annotations.app_platform")
 	return AnnotationAppPlatformSettings{
-		Enabled:                    appPlatformSection.Key("enabled").MustBool(false),
-		StoreBackend:               appPlatformSection.Key("store_backend").MustString("legacy-sql"),
-		RetentionTTL:               appPlatformSection.Key("retention_ttl").MustDuration(2160 * time.Hour),
-		EnableDeprecatedInternalID: appPlatformSection.Key("enable_deprecated_internal_id").MustBool(false),
+		Enabled:        appPlatformSection.Key("enabled").MustBool(false),
+		StoreBackend:   appPlatformSection.Key("store_backend").MustString("legacy-sql"),
+		RetentionTTL:   appPlatformSection.Key("retention_ttl").MustDuration(2160 * time.Hour),
+		EnableLegacyID: appPlatformSection.Key("enable_legacy_id").MustBool(false),
 
 		GRPCAddress:       appPlatformSection.Key("grpc_address").MustString("localhost:9090"),
 		GRPCUseTLS:        appPlatformSection.Key("grpc_use_tls").MustBool(false),

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1134,14 +1134,19 @@ type AnnotationAppPlatformSettings struct {
 	PostgresConnMaxLifetime  time.Duration // Maximum lifetime of a connection
 	PostgresTagCacheTTL      time.Duration // TTL for tag query cache
 	PostgresTagCacheSize     int           // Size of the tag query cache
+
+	// EnableDeprecatedInternalID controls whether a grafana.app/deprecatedInternalID
+	// label is generated for new annotations.
+	EnableDeprecatedInternalID bool
 }
 
 func loadAnnotationAppPlatformSettings(cfg *ini.File) AnnotationAppPlatformSettings {
 	appPlatformSection := cfg.Section("annotations.app_platform")
 	return AnnotationAppPlatformSettings{
-		Enabled:      appPlatformSection.Key("enabled").MustBool(false),
-		StoreBackend: appPlatformSection.Key("store_backend").MustString("legacy-sql"),
-		RetentionTTL: appPlatformSection.Key("retention_ttl").MustDuration(2160 * time.Hour),
+		Enabled:                    appPlatformSection.Key("enabled").MustBool(false),
+		StoreBackend:               appPlatformSection.Key("store_backend").MustString("legacy-sql"),
+		RetentionTTL:               appPlatformSection.Key("retention_ttl").MustDuration(2160 * time.Hour),
+		EnableDeprecatedInternalID: appPlatformSection.Key("enable_deprecated_internal_id").MustBool(false),
 
 		GRPCAddress:       appPlatformSection.Key("grpc_address").MustString("localhost:9090"),
 		GRPCUseTLS:        appPlatformSection.Key("grpc_use_tls").MustBool(false),


### PR DESCRIPTION
Adds a  `legacyID` field as a label to the annotation resource to support migrations from the legacy API to the newer app platform API. When enabled via the `annotations.app_platform.enable_legacy_id` config, new annotations receive a unique generated snowflake ID and  backfilled records can supply their legacy numeric ID, facilitating the mapping between numeric IDs and k8s resource names during migration. This follows an existing pattern present in unistore and applies it to the annotations API.

This PR also adds the capability to filter by `legacyID` to the List and Search endpoints so that the corresponding k8s resource name can be easily retrieved for a given legacy ID.