### PR TITLE
AccessControl: scope Zanzana-merged permissions by resource, not action prefix

### DIFF
--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
@@ -188,20 +188,16 @@ func (r *ZanzanaPermissionResolver) searchAllUsers(ctx context.Context, signedIn
 	return result, nil
 }
 
-func scopeFromAction(action, name string) string {
-	parts := strings.SplitN(action, ":", 2)
-	if parts[0] == "" {
-		return name
-	}
-	return ac.Scope(parts[0], "uid", name)
+// resourceScope scopes an object by the resource type Zanzana listed it under
+// (e.g. "folders:uid:abc"), not by the action prefix, so permission actions like
+// "folders.permissions:read" stay scoped on "folders:uid:<uid>".
+func resourceScope(resource, name string) string {
+	return ac.Scope(resource, "uid", name)
 }
 
-func allScopeFromAction(action string) string {
-	parts := strings.SplitN(action, ":", 2)
-	if parts[0] == "" {
-		return "*"
-	}
-	return ac.Scope(parts[0], "*")
+// resourceWildcardScope is the org-wide scope for the listed resource ("folders:*").
+func resourceWildcardScope(resource string) string {
+	return ac.Scope(resource, "*")
 }
 
 // folderScopeForLegacyRBAC returns a legacy RBAC scope for folder-scoped access (folders:uid:<uid>).
@@ -269,7 +265,7 @@ func (r *ZanzanaPermissionResolver) listPermissions(ctx context.Context, namespa
 			}
 			appendIfMatches(ac.Permission{
 				Action: action,
-				Scope:  allScopeFromAction(action),
+				Scope:  resourceWildcardScope(resource),
 			})
 			// Generic dashboard list grants org-wide dashboard access; legacy RBAC also records
 			// folder wildcard for the same action (see SearchUsersPermissions / Reduce).
@@ -280,16 +276,16 @@ func (r *ZanzanaPermissionResolver) listPermissions(ctx context.Context, namespa
 		} else {
 			appendIfMatches(ac.Permission{
 				Action: action,
-				Scope:  allScopeFromAction(action),
+				Scope:  resourceWildcardScope(resource),
 			})
 		}
 	}
 
-	// Convert Items to legacy scopes (e.g. dashboards:uid:<name>).
+	// Items are objects of the listed resource type, scoped by that resource.
 	for _, item := range resp.Items {
 		appendIfMatches(ac.Permission{
 			Action: action,
-			Scope:  scopeFromAction(action, item),
+			Scope:  resourceScope(resource, item),
 		})
 	}
 

--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver_test.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver_test.go
@@ -650,3 +650,121 @@ func TestLegacyZanzanaParity(t *testing.T) {
 		})
 	}
 }
+
+// permScopes returns the scopes the resolver produced for the given action.
+func permScopes(perms []ac.Permission, action string) []string {
+	var out []string
+	for _, p := range perms {
+		if p.Action == action {
+			out = append(out, p.Scope)
+		}
+	}
+	return out
+}
+
+// scopeKind returns the kind segment of a legacy RBAC scope, e.g. "folders" for
+// "folders:uid:abc" and "folders" for "folders:*". "*" has no kind.
+func scopeKind(scope string) string {
+	if scope == "*" {
+		return ""
+	}
+	return strings.SplitN(scope, ":", 2)[0]
+}
+
+// TestListPermissions_ScopeKindFollowsResource checks that, for every supported
+// action, objects are scoped by the resource they belong to (never by the action
+// prefix), so a sub-resource action like "folders.permissions:read" scopes on
+// "folders:uid:<uid>" rather than "folders.permissions:uid:<uid>".
+func TestListPermissions_ScopeKindFollowsResource(t *testing.T) {
+	const (
+		itemUID   = "obj-uid"
+		folderUID = "fold-uid"
+	)
+
+	actions := common.SupportedActions()
+	require.NotEmpty(t, actions)
+
+	for _, entry := range actions {
+		t.Run(entry.Action, func(t *testing.T) {
+			// Cover both code paths: a directly-assigned object and an enclosing folder.
+			resp := &authzv1.ListResponse{
+				Items:   []string{itemUID},
+				Folders: []string{folderUID},
+			}
+			perms, err := zanzanaResolve(resp, entry.Action, "")
+			require.NoError(t, err)
+			require.NotEmpty(t, perms, "action %q produced no permissions", entry.Action)
+
+			scopes := permScopes(perms, entry.Action)
+
+			require.Contains(t, scopes, ac.Scope(entry.Resource, "uid", itemUID),
+				"item must be scoped by the listed resource %q", entry.Resource)
+			require.Contains(t, scopes, ac.Scope("folders", "uid", folderUID),
+				"folder-list entries must be folder-scoped")
+
+			// Every scope kind must be a base resource, never a sub-resource like
+			// "folders.permissions" (which would never match a legacy folders:uid: query).
+			for _, s := range scopes {
+				k := scopeKind(s)
+				require.NotContains(t, k, ".", "scope %q has sub-resource kind %q", s, k)
+			}
+		})
+	}
+}
+
+// TestListPermissions_AllScopeKindFollowsResource asserts the same invariant for
+// org-wide (All=true) grants.
+func TestListPermissions_AllScopeKindFollowsResource(t *testing.T) {
+	for _, entry := range common.SupportedActions() {
+		t.Run(entry.Action, func(t *testing.T) {
+			perms, err := zanzanaResolve(&authzv1.ListResponse{All: true}, entry.Action, "")
+			require.NoError(t, err)
+			require.NotEmpty(t, perms, "action %q produced no permissions for All grant", entry.Action)
+
+			scopes := permScopes(perms, entry.Action)
+			require.Contains(t, scopes, ac.Scope(entry.Resource, "*"),
+				"All grant must produce the %q wildcard", entry.Resource)
+
+			for _, s := range scopes {
+				k := scopeKind(s)
+				require.NotContains(t, k, ".",
+					"All-grant scope %q has sub-resource kind %q", s, k)
+			}
+		})
+	}
+}
+
+// TestListPermissions_PermissionManagementActionsScoping pins how *.permissions:*
+// actions translate: scoped by their base resource, and for dashboards either
+// dashboard-scoped (direct grant) or folder-scoped (inherited from the folder).
+func TestListPermissions_PermissionManagementActionsScoping(t *testing.T) {
+	cases := []struct {
+		name       string
+		action     string
+		resp       *authzv1.ListResponse
+		wantScopes []string
+	}{
+		// Folder permission management is always folder-scoped.
+		{"folder perms on a folder", "folders.permissions:read",
+			&authzv1.ListResponse{Items: []string{"fold1"}}, []string{"folders:uid:fold1"}},
+		{"folder perms write on a folder", "folders.permissions:write",
+			&authzv1.ListResponse{Items: []string{"fold1"}}, []string{"folders:uid:fold1"}},
+
+		// Dashboard permission management: direct grant, folder-inherited, or both.
+		{"dashboard perms on a dashboard", "dashboards.permissions:read",
+			&authzv1.ListResponse{Items: []string{"dash1"}}, []string{"dashboards:uid:dash1"}},
+		{"dashboard perms via a folder", "dashboards.permissions:read",
+			&authzv1.ListResponse{Folders: []string{"fold1"}}, []string{"folders:uid:fold1"}},
+		{"dashboard perms on a dashboard and via a folder", "dashboards.permissions:write",
+			&authzv1.ListResponse{Items: []string{"dash1"}, Folders: []string{"fold1"}},
+			[]string{"dashboards:uid:dash1", "folders:uid:fold1"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			perms, err := zanzanaResolve(tc.resp, tc.action, "")
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.wantScopes, permScopes(perms, tc.action))
+		})
+	}
+}


### PR DESCRIPTION
## What

When merging Zanzana-resolved permissions back into legacy RBAC, the resolver derived a permission's **scope kind from the action prefix**. For sub-resource actions like `folders.permissions:read` this produced `folders.permissions:uid:<uid>` instead of the `folders:uid:<uid>` scope that legacy RBAC actually uses.

This now scopes objects by the **resource type Zanzana listed them under**, which is correct for every action uniformly (regular actions are unaffected; permission-management actions get the right base-resource scope).

## Why

A user granted `admin` on a folder in Zanzana received `folders.permissions:read`/`:write` scoped on `folders.permissions:uid:<uid>`. The folder `canAdmin` check (`EvalPermission(folders.permissions:read, folders:uid:<uid>)`) therefore never matched, so the user could not manage permissions on a folder they administer. The same applied to `dashboards.permissions:*`.

## How

- Replace action-prefix scope derivation (`scopeFromAction`/`allScopeFromAction`) with resource-based helpers (`resourceScope`/`resourceWildcardScope`) in `listPermissions`.
- Folder-list entries remain folder-scoped; directly-assigned items use the listed resource's scope. Dashboard permission management is correctly emitted as either dashboard-scoped (direct grant) or folder-scoped (inherited from the enclosing folder).

## Tests

Table-driven tests over `common.SupportedActions()` assert that the scope kind follows the resource for item, folder, and `All` grants, plus explicit cases for `*.permissions:*` actions (including dashboard-via-folder scoping). Verified to fail on the previous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)