### PR TITLE
Alerting: fix missing requester context in alertmanager datasource proxy

### DIFF
--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/datasource/validation"
 	"github.com/grafana/grafana/pkg/api/pluginproxy"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -131,7 +132,7 @@ func (p *DataSourceProxyService) proxyDatasourceRequest(c *contextmodel.ReqConte
 	}
 
 	hc := pluginproxy.HTTPContext{
-		Req:  c.Req,
+		Req:  c.Req.WithContext(identity.WithRequester(c.Req.Context(), c.SignedInUser)),
 		Resp: c.Resp,
 
 		UserToken: c.UserToken,

--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/datasource/validation"
 	"github.com/grafana/grafana/pkg/api/pluginproxy"
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -132,7 +131,7 @@ func (p *DataSourceProxyService) proxyDatasourceRequest(c *contextmodel.ReqConte
 	}
 
 	hc := pluginproxy.HTTPContext{
-		Req:  c.Req.WithContext(identity.WithRequester(c.Req.Context(), c.SignedInUser)),
+		Req:  c.Req,
 		Resp: c.Resp,
 
 		UserToken: c.UserToken,

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -134,7 +134,7 @@ func (p *AlertingProxy) withReq(
 	extractor func(*response.NormalResponse) (any, error),
 	headers map[string]string,
 ) response.Response {
-	req, err := http.NewRequest(method, u.String(), body)
+	req, err := http.NewRequestWithContext(ctx.Req.Context(), method, u.String(), body)
 	if err != nil {
 		return ErrResp(http.StatusBadRequest, err, "")
 	}

--- a/pkg/services/ngalert/api/util_test.go
+++ b/pkg/services/ngalert/api/util_test.go
@@ -1,18 +1,23 @@
 package api
 
 import (
+	"context"
 	"math/rand"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/auth"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/datasourceproxy"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	models2 "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -177,6 +182,57 @@ func (r *recordingConditionValidator) Validate(_ eval.EvaluationContext, conditi
 }
 
 var _ ConditionValidator = &recordingConditionValidator{}
+
+// TestAlertingProxy_withReq_propagatesRequestContext verifies that withReq carries
+// the original request context (including identity) into the new request it creates
+// for the upstream datasource proxy.
+func TestAlertingProxy_withReq_propagatesRequestContext(t *testing.T) {
+	signedInUser := &user.SignedInUser{OrgID: 1, UserID: 1}
+
+	httpReq := httptest.NewRequest(http.MethodGet, "http://upstream/api/v1/alerts", nil)
+	httpReq = httpReq.WithContext(identity.WithRequester(httpReq.Context(), signedInUser))
+	httpReq = web.SetURLParams(httpReq, map[string]string{":DatasourceUID": "test-uid"})
+
+	ctx := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Req:  httpReq,
+			Resp: web.NewResponseWriter(http.MethodGet, httptest.NewRecorder()),
+		},
+		SignedInUser: signedInUser,
+		Logger:       log.NewNopLogger(),
+	}
+
+	var capturedCtx context.Context
+	cache := &contextCapturingCacheService{
+		onGetByUID: func(c context.Context) { capturedCtx = c },
+	}
+	proxy := &AlertingProxy{
+		DataProxy: &datasourceproxy.DataSourceProxyService{DataSourceCache: cache},
+	}
+
+	u, err := url.Parse("http://upstream/api/v1/alerts")
+	require.NoError(t, err)
+	proxy.withReq(ctx, http.MethodGet, u, nil, nil, nil)
+
+	require.NotNil(t, capturedCtx, "GetDatasourceByUID should have been called")
+	_, err = identity.GetRequester(capturedCtx)
+	require.NoError(t, err, "request context forwarded to datasource proxy must carry the identity")
+}
+
+type contextCapturingCacheService struct {
+	onGetByUID func(context.Context)
+}
+
+func (c *contextCapturingCacheService) GetDatasource(_ context.Context, _ int64, _ identity.Requester, _ bool) (*datasources.DataSource, error) {
+	return nil, datasources.ErrDataSourceNotFound
+}
+
+func (c *contextCapturingCacheService) GetDatasourceByUID(ctx context.Context, _ string, _ identity.Requester, _ bool) (*datasources.DataSource, error) {
+	if c.onGetByUID != nil {
+		c.onGetByUID(ctx)
+	}
+	return nil, datasources.ErrDataSourceNotFound
+}
 
 func TestIsPrometheusCompatible(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
## Summary

- `withReq` in the alerting proxy creates a fresh `http.NewRequest(method, url, body)` — this gives the new request `context.Background()`, discarding all values from the original request context, including the identity set by the auth middleware.
- `NewDataSourceProxy` (changed in #125752) now calls `identity.GetRequester(ctx.Req.Context())` to get the caller identity. For the alertmanager proxy path this context is blank, causing `"Failed creating data source proxy: failed to get requester from context"`.
- Fix: use `http.NewRequestWithContext(ctx.Req.Context(), ...)` so identity, tracing spans, and cancellation all propagate correctly into the upstream proxy request. The response interception (`NormalResponse`/`safeMacaronWrapper`) is unaffected — it operates on the response writer, not the context.

## Why only alertmanager?

Regular datasource proxy requests use the original `c.Req` from the web framework, whose context carries the identity. The alertmanager proxy intentionally constructs a new `*http.Request` to rewrite the URL for the upstream alertmanager — and that construction was dropping the context entirely.

## Test plan

- [ ] `go test ./pkg/services/datasourceproxy/... ./pkg/services/ngalert/api/... ./pkg/api/pluginproxy/...` — all pass
- [ ] Verify `GET /api/alertmanager/{uid}/config/api/v1/alerts` (and other alertmanager proxy endpoints) no longer return `"Failed creating data source proxy"`