### PR TITLE
Alerting: Rules app search endpoints

### DIFF
--- a/apps/alerting/rules/definitions/alerting-manifest.yaml
+++ b/apps/alerting/rules/definitions/alerting-manifest.yaml
@@ -69,9 +69,6 @@ spec:
         ExpressionMap:
           additionalProperties:
             $ref: '#/components/schemas/Expression'
-          description: |-
-            TODO: validate that only one can specify source=true
-            & struct.MinFields(1) This doesn't work in Cue <v0.12.0 as per
           type: object
         IntervalTrigger:
           additionalProperties: false
@@ -100,8 +97,6 @@ spec:
           - KeepLast
           type: string
         NotificationSettings:
-          description: 'TODO(@moustafab): this should be imported from the notifications
-            package'
           oneOf:
           - $ref: '#/components/schemas/SimplifiedRouting'
           - $ref: '#/components/schemas/NamedRoutingTree'
@@ -203,7 +198,6 @@ spec:
         TemplateString:
           type: string
         TimeIntervalRef:
-          description: 'TODO(@moustafab): validate regex for time interval ref'
           type: string
         spec:
           additionalProperties: false
@@ -318,9 +312,6 @@ spec:
         ExpressionMap:
           additionalProperties:
             $ref: '#/components/schemas/Expression'
-          description: |-
-            TODO: validate that only one can specify source=true
-            & struct.MinFields(1) This doesn't work in Cue <v0.12.0 as per
           type: object
         IntervalTrigger:
           additionalProperties: false
@@ -331,7 +322,6 @@ spec:
           - interval
           type: object
         MetricName:
-          description: 'TODO(@moustafab): validate the metric name regex'
           pattern: ^[a-zA-Z_:][a-zA-Z0-9_:]*$
           type: string
         OperatorState:
@@ -547,4 +537,543 @@ spec:
       scope: Namespaced
       userReadable: false
     name: v0alpha1
+    routes:
+      namespaced:
+        /search:
+          get:
+            operationId: getSearchRules
+            parameters:
+            - in: query
+              name: continueToken
+              schema:
+                type: string
+            - in: query
+              name: dashboardUID
+              schema:
+                type: string
+            - in: query
+              name: datasourceUIDs
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: folders
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: groups
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: labels
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: limit
+              schema:
+                type: integer
+            - in: query
+              name: metric
+              schema:
+                type: string
+            - in: query
+              name: names
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: notificationType
+              schema:
+                type: string
+            - in: query
+              name: panelID
+              schema:
+                type: integer
+            - in: query
+              name: paused
+              schema:
+                type: boolean
+            - in: query
+              name: q
+              schema:
+                type: string
+            - in: query
+              name: receiver
+              schema:
+                type: string
+            - in: query
+              name: routingTree
+              schema:
+                type: string
+            - in: query
+              name: sort
+              schema:
+                $ref: '#/components/schemas/RuleSearchSortField'
+            - in: query
+              name: targetDatasourceUID
+              schema:
+                type: string
+            - in: query
+              name: type
+              schema:
+                type: string
+            responses:
+              default:
+                content:
+                  application/json:
+                    schema:
+                      additionalProperties: false
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        items:
+                          items:
+                            $ref: '#/components/schemas/getSearchRulesRuleHit'
+                          type: array
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          properties:
+                            continue:
+                              type: string
+                            remainingItemCount:
+                              type: integer
+                            resourceVersion:
+                              type: string
+                            selfLink:
+                              type: string
+                          type: object
+                          x-grafana-app-uses-kubernetes-list-metadata: true
+                      required:
+                      - items
+                      - apiVersion
+                      - kind
+                      - metadata
+                      type: object
+                description: Default OK response
+        /search/alertrules:
+          get:
+            operationId: getSearchAlertRules
+            parameters:
+            - in: query
+              name: continueToken
+              schema:
+                type: string
+            - in: query
+              name: dashboardUID
+              schema:
+                type: string
+            - in: query
+              name: datasourceUIDs
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: folders
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: groups
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: labels
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: limit
+              schema:
+                type: integer
+            - in: query
+              name: names
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: notificationType
+              schema:
+                type: string
+            - in: query
+              name: panelID
+              schema:
+                type: integer
+            - in: query
+              name: paused
+              schema:
+                type: boolean
+            - in: query
+              name: q
+              schema:
+                type: string
+            - in: query
+              name: receiver
+              schema:
+                type: string
+            - in: query
+              name: routingTree
+              schema:
+                type: string
+            - in: query
+              name: sort
+              schema:
+                $ref: '#/components/schemas/RuleSearchSortField'
+            responses:
+              default:
+                content:
+                  application/json:
+                    schema:
+                      additionalProperties: false
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        items:
+                          items:
+                            $ref: '#/components/schemas/getSearchAlertRulesAlertRuleHit'
+                          type: array
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          properties:
+                            continue:
+                              type: string
+                            remainingItemCount:
+                              type: integer
+                            resourceVersion:
+                              type: string
+                            selfLink:
+                              type: string
+                          type: object
+                          x-grafana-app-uses-kubernetes-list-metadata: true
+                      required:
+                      - items
+                      - apiVersion
+                      - kind
+                      - metadata
+                      type: object
+                description: Default OK response
+        /search/recordingrules:
+          get:
+            operationId: getSearchRecordingRules
+            parameters:
+            - in: query
+              name: continueToken
+              schema:
+                type: string
+            - in: query
+              name: datasourceUIDs
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: folders
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: groups
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: labels
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: limit
+              schema:
+                type: integer
+            - in: query
+              name: metric
+              schema:
+                type: string
+            - in: query
+              name: names
+              schema:
+                items:
+                  type: string
+                type: array
+            - in: query
+              name: paused
+              schema:
+                type: boolean
+            - in: query
+              name: q
+              schema:
+                type: string
+            - in: query
+              name: sort
+              schema:
+                $ref: '#/components/schemas/RuleSearchSortField'
+            - in: query
+              name: targetDatasourceUID
+              schema:
+                type: string
+            responses:
+              default:
+                content:
+                  application/json:
+                    schema:
+                      additionalProperties: false
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        items:
+                          items:
+                            $ref: '#/components/schemas/getSearchRecordingRulesRecordingRuleHit'
+                          type: array
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          properties:
+                            continue:
+                              type: string
+                            remainingItemCount:
+                              type: integer
+                            resourceVersion:
+                              type: string
+                            selfLink:
+                              type: string
+                          type: object
+                          x-grafana-app-uses-kubernetes-list-metadata: true
+                      required:
+                      - items
+                      - apiVersion
+                      - kind
+                      - metadata
+                      type: object
+                description: Default OK response
+      schemas:
+        getSearchAlertRulesAlertRuleHit:
+          additionalProperties: false
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              type: object
+            dashboardUID:
+              type: string
+            datasourceUIDs:
+              items:
+                type: string
+              type: array
+            folder:
+              type: string
+            for:
+              type: string
+            group:
+              type: string
+            interval:
+              type: string
+            keepFiringFor:
+              type: string
+            labels:
+              additionalProperties:
+                type: string
+              type: object
+            name:
+              type: string
+            notificationType:
+              type: string
+            panelID:
+              type: integer
+            paused:
+              type: boolean
+            receiver:
+              type: string
+            routingTree:
+              type: string
+            title:
+              type: string
+            type:
+              $ref: '#/components/schemas/getSearchAlertRulesRuleSearchType'
+          required:
+          - type
+          - name
+          - title
+          - folder
+          type: object
+        getSearchAlertRulesRuleSearchType:
+          enum:
+          - alertrule
+          - recordingrule
+          type: string
+        getSearchRecordingRulesRecordingRuleHit:
+          additionalProperties: false
+          properties:
+            datasourceUIDs:
+              items:
+                type: string
+              type: array
+            folder:
+              type: string
+            group:
+              type: string
+            interval:
+              type: string
+            labels:
+              additionalProperties:
+                type: string
+              type: object
+            metric:
+              type: string
+            name:
+              type: string
+            paused:
+              type: boolean
+            targetDatasourceUID:
+              type: string
+            title:
+              type: string
+            type:
+              $ref: '#/components/schemas/getSearchRecordingRulesRuleSearchType'
+          required:
+          - type
+          - name
+          - title
+          - folder
+          type: object
+        getSearchRecordingRulesRuleSearchType:
+          enum:
+          - alertrule
+          - recordingrule
+          type: string
+        getSearchRulesAlertRuleHit:
+          additionalProperties: false
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              type: object
+            dashboardUID:
+              type: string
+            datasourceUIDs:
+              items:
+                type: string
+              type: array
+            folder:
+              type: string
+            for:
+              type: string
+            group:
+              type: string
+            interval:
+              type: string
+            keepFiringFor:
+              type: string
+            labels:
+              additionalProperties:
+                type: string
+              type: object
+            name:
+              type: string
+            notificationType:
+              type: string
+            panelID:
+              type: integer
+            paused:
+              type: boolean
+            receiver:
+              type: string
+            routingTree:
+              type: string
+            title:
+              type: string
+            type:
+              $ref: '#/components/schemas/getSearchRulesRuleSearchType'
+          required:
+          - type
+          - name
+          - title
+          - folder
+          type: object
+        getSearchRulesRecordingRuleHit:
+          additionalProperties: false
+          properties:
+            datasourceUIDs:
+              items:
+                type: string
+              type: array
+            folder:
+              type: string
+            group:
+              type: string
+            interval:
+              type: string
+            labels:
+              additionalProperties:
+                type: string
+              type: object
+            metric:
+              type: string
+            name:
+              type: string
+            paused:
+              type: boolean
+            targetDatasourceUID:
+              type: string
+            title:
+              type: string
+            type:
+              $ref: '#/components/schemas/getSearchRulesRuleSearchType'
+          required:
+          - type
+          - name
+          - title
+          - folder
+          type: object
+        getSearchRulesRuleHit:
+          description: RuleHit is the cross-kind union returned by /search.
+          oneOf:
+          - $ref: '#/components/schemas/AlertRuleHit'
+          - $ref: '#/components/schemas/RecordingRuleHit'
+        getSearchRulesRuleSearchType:
+          enum:
+          - alertrule
+          - recordingrule
+          type: string
     served: true

--- a/apps/alerting/rules/definitions/alertrule.rules.alerting.grafana.app.yaml
+++ b/apps/alerting/rules/definitions/alertrule.rules.alerting.grafana.app.yaml
@@ -60,9 +60,6 @@ spec:
                   required:
                   - model
                   type: object
-                description: |-
-                  TODO: validate that only one can specify source=true
-                  & struct.MinFields(1) This doesn't work in Cue <v0.12.0 as per
                 type: object
               for:
                 type: string
@@ -83,8 +80,6 @@ spec:
                 - KeepLast
                 type: string
               notificationSettings:
-                description: 'TODO(@moustafab): this should be imported from the notifications
-                  package'
                 oneOf:
                 - not:
                     anyOf:
@@ -103,8 +98,6 @@ spec:
                 properties:
                   activeTimeIntervals:
                     items:
-                      description: 'TODO(@moustafab): validate regex for time interval
-                        ref'
                       type: string
                     type: array
                   groupBy:
@@ -119,8 +112,6 @@ spec:
                     type: string
                   muteTimeIntervals:
                     items:
-                      description: 'TODO(@moustafab): validate regex for time interval
-                        ref'
                       type: string
                     type: array
                   receiver:

--- a/apps/alerting/rules/definitions/recordingrule.rules.alerting.grafana.app.yaml
+++ b/apps/alerting/rules/definitions/recordingrule.rules.alerting.grafana.app.yaml
@@ -49,16 +49,12 @@ spec:
                   required:
                   - model
                   type: object
-                description: |-
-                  TODO: validate that only one can specify source=true
-                  & struct.MinFields(1) This doesn't work in Cue <v0.12.0 as per
                 type: object
               labels:
                 additionalProperties:
                   type: string
                 type: object
               metric:
-                description: 'TODO(@moustafab): validate the metric name regex'
                 pattern: ^[a-zA-Z_:][a-zA-Z0-9_:]*$
                 type: string
               paused:

--- a/apps/alerting/rules/kinds/alertRule.cue
+++ b/apps/alerting/rules/kinds/alertRule.cue
@@ -11,7 +11,7 @@ alertRuleKind: {
 
 alertRulev0alpha1: alertRuleKind & {
 	schema: {
-		spec: v0alpha1.AlertRuleSpec
+		spec: v0alpha1.#AlertRuleSpec
 	}
 	validation: {
 		operations: [

--- a/apps/alerting/rules/kinds/manifest.cue
+++ b/apps/alerting/rules/kinds/manifest.cue
@@ -14,6 +14,7 @@ manifest: {
 				recordingRulev0alpha1,
 				ruleSequencev0alpha1,
 			]
+			routes: searchRoutes
 		}
 	}
 	roles: {}

--- a/apps/alerting/rules/kinds/recordingRule.cue
+++ b/apps/alerting/rules/kinds/recordingRule.cue
@@ -11,7 +11,7 @@ recordingRuleKind: {
 
 recordingRulev0alpha1: recordingRuleKind & {
 	schema: {
-		spec: v0alpha1.RecordingRuleSpec
+		spec: v0alpha1.#RecordingRuleSpec
 	}
 	validation: {
 		operations: [

--- a/apps/alerting/rules/kinds/searchRoutes.cue
+++ b/apps/alerting/rules/kinds/searchRoutes.cue
@@ -55,7 +55,7 @@ searchRoutes: {
 					query: #alertRuleSearchQuery
 				}
 				response: {
-					items: [...v0alpha1.#AlertRuleHit]
+					items: [...v0alpha1.#RuleHit]
 				}
 				responseMetadata: {
 					typeMeta: true
@@ -71,7 +71,7 @@ searchRoutes: {
 					query: #recordingRuleSearchQuery
 				}
 				response: {
-					items: [...v0alpha1.#RecordingRuleHit]
+					items: [...v0alpha1.#RuleHit]
 				}
 				responseMetadata: {
 					typeMeta: true

--- a/apps/alerting/rules/kinds/searchRoutes.cue
+++ b/apps/alerting/rules/kinds/searchRoutes.cue
@@ -1,0 +1,99 @@
+package kinds
+
+import (
+	"github.com/grafana/grafana/apps/alerting/rules/kinds/v0alpha1"
+)
+
+// Generic pagination params shared by any paginated search endpoint.
+#paginationQuery: {
+	limit?:         int64
+	continueToken?: string
+}
+
+#commonSearchQuery: {
+	#paginationQuery
+	q?: string
+	names?: [...string]
+	folders?: [...string]
+	groups?: [...string]
+	paused?: bool
+	datasourceUIDs?: [...string]
+	labels?: [...string]
+	sort?: v0alpha1.#RuleSearchSortField
+}
+
+#alertRuleSearchQuery: {
+	#commonSearchQuery
+	dashboardUID?:     string
+	panelID?:          int64
+	receiver?:         string
+	notificationType?: string
+	routingTree?:      string
+}
+
+#recordingRuleSearchQuery: {
+	#commonSearchQuery
+	metric?:              string
+	targetDatasourceUID?: string
+}
+
+// The cross-kind query is a pure superset of the per-kind queries plus the
+// type discriminator used to optionally narrow results to a single kind.
+#ruleSearchQuery: {
+	#alertRuleSearchQuery
+	#recordingRuleSearchQuery
+	type?: string
+}
+
+searchRoutes: {
+	namespaced: {
+		"/search/alertrules": {
+			GET: {
+				// These search routes are experimental and subject to change without deprecation until stabilized
+				name: "getSearchAlertRules"
+				request: {
+					query: #alertRuleSearchQuery
+				}
+				response: {
+					items: [...v0alpha1.#AlertRuleHit]
+				}
+				responseMetadata: {
+					typeMeta: true
+					listMeta: true
+				}
+			}
+		}
+		"/search/recordingrules": {
+			GET: {
+				// These search routes are experimental and subject to change without deprecation until stabilized
+				name: "getSearchRecordingRules"
+				request: {
+					query: #recordingRuleSearchQuery
+				}
+				response: {
+					items: [...v0alpha1.#RecordingRuleHit]
+				}
+				responseMetadata: {
+					typeMeta: true
+					listMeta: true
+				}
+			}
+		}
+		"/search": {
+			GET: {
+				// These search routes are experimental and subject to change without deprecation until stabilized
+				name: "getSearchRules"
+				request: {
+					query: #ruleSearchQuery
+				}
+				response: {
+					items: [...v0alpha1.#RuleHit]
+				}
+				responseMetadata: {
+					typeMeta: true
+					listMeta: true
+				}
+			}
+		}
+	}
+}

--- a/apps/alerting/rules/kinds/searchRoutes.cue
+++ b/apps/alerting/rules/kinds/searchRoutes.cue
@@ -55,7 +55,7 @@ searchRoutes: {
 					query: #alertRuleSearchQuery
 				}
 				response: {
-					items: [...v0alpha1.#RuleHit]
+					items: [...v0alpha1.#AlertRuleHit]
 				}
 				responseMetadata: {
 					typeMeta: true
@@ -71,7 +71,7 @@ searchRoutes: {
 					query: #recordingRuleSearchQuery
 				}
 				response: {
-					items: [...v0alpha1.#RuleHit]
+					items: [...v0alpha1.#RecordingRuleHit]
 				}
 				responseMetadata: {
 					typeMeta: true

--- a/apps/alerting/rules/kinds/v0alpha1/alertRule_spec.cue
+++ b/apps/alerting/rules/kinds/v0alpha1/alertRule_spec.cue
@@ -5,11 +5,13 @@ import "strings"
 NoDataState:  *"NoData" | "Ok" | "Alerting" | "KeepLast"
 ExecErrState: *"Error" | "Ok" | "Alerting" | "KeepLast"
 
-#TimeIntervalRef: string // TODO(@moustafab): validate regex for time interval ref
+// TODO(@moustafab): validate regex for time interval ref
+
+#TimeIntervalRef: string
 
 // FIXME: the For and KeepFiringFor types should be using the AlertRulePromDuration type, but there seems to be an issue with the generator
 
-AlertRuleSpec: #RuleSpec & {
+#AlertRuleSpec: #RuleSpec & {
 	annotations?: {
 		[string]: TemplateString
 	}
@@ -49,4 +51,5 @@ AlertRuleSpec: #RuleSpec & {
 }
 
 // TODO(@moustafab): this should be imported from the notifications package
+
 #NotificationSettings: #SimplifiedRouting | #NamedRoutingTree

--- a/apps/alerting/rules/kinds/v0alpha1/recordingRule_spec.cue
+++ b/apps/alerting/rules/kinds/v0alpha1/recordingRule_spec.cue
@@ -1,9 +1,10 @@
 package v0alpha1
 
-RecordingRuleSpec: #RuleSpec & {
+#RecordingRuleSpec: #RuleSpec & {
 	metric:              #MetricName
 	targetDatasourceUID: #DatasourceUID
 }
 
 // TODO(@moustafab): validate the metric name regex
+
 #MetricName: string & =~"^[a-zA-Z_:][a-zA-Z0-9_:]*$"

--- a/apps/alerting/rules/kinds/v0alpha1/rule_spec.cue
+++ b/apps/alerting/rules/kinds/v0alpha1/rule_spec.cue
@@ -32,9 +32,11 @@ TemplateString: string
 }
 
 // TODO: validate that only one can specify source=true
+// & struct.MinFields(1) This doesn't work in Cue <v0.12.0 as per
+
 #ExpressionMap: {
 	[string]: #Expression
-} // & struct.MinFields(1) This doesn't work in Cue <v0.12.0 as per
+}
 
 #Expression: {
 	// The type of query if this is a query expression

--- a/apps/alerting/rules/kinds/v0alpha1/searchResults.cue
+++ b/apps/alerting/rules/kinds/v0alpha1/searchResults.cue
@@ -1,0 +1,39 @@
+package v0alpha1
+
+#RuleSearchSortField: "title" | "-title" | "group" | "-group" @cog(kind="enum",memberNames="TitleAsc|TitleDesc|GroupAsc|GroupDesc")
+
+#RuleSearchType: "alertrule" | "recordingrule" @cog(kind="enum",memberNames="AlertRule|RecordingRule")
+
+_ruleHitBase: {
+	name:      string
+	title:     string
+	folder:    string
+	group?:    string
+	interval?: string
+	paused?:   bool
+	labels?: [string]: string
+	datasourceUIDs?: [...string]
+}
+
+#AlertRuleHit: {
+	_ruleHitBase
+	type: #RuleSearchType & "alertrule"
+	annotations?: [string]: string
+	"for"?:            string
+	keepFiringFor?:    string
+	dashboardUID?:     string
+	panelID?:          int64
+	receiver?:         string
+	notificationType?: string
+	routingTree?:      string
+}
+
+#RecordingRuleHit: {
+	_ruleHitBase
+	type:                 #RuleSearchType & "recordingrule"
+	metric?:              string
+	targetDatasourceUID?: string
+}
+
+// RuleHit is the cross-kind union returned by /search.
+#RuleHit: #AlertRuleHit | #RecordingRuleHit

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/alertrule_spec_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/alertrule_spec_gen.go
@@ -57,7 +57,6 @@ func (AlertRuleExecErrState) OpenAPIModelName() string {
 	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.AlertRuleExecErrState"
 }
 
-// TODO(@moustafab): this should be imported from the notifications package
 // +k8s:openapi-gen=true
 type AlertRuleNotificationSettings = AlertRuleSimplifiedRoutingOrNamedRoutingTree
 
@@ -103,7 +102,6 @@ func (AlertRuleNotificationSettingsType) OpenAPIModelName() string {
 	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.AlertRuleNotificationSettingsType"
 }
 
-// TODO(@moustafab): validate regex for time interval ref
 // +k8s:openapi-gen=true
 type AlertRuleTimeIntervalRef string
 
@@ -125,8 +123,6 @@ func (AlertRuleNamedRoutingTree) OpenAPIModelName() string {
 	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.AlertRuleNamedRoutingTree"
 }
 
-// TODO: validate that only one can specify source=true
-// & struct.MinFields(1) This doesn't work in Cue <v0.12.0 as per
 // +k8s:openapi-gen=true
 type AlertRuleExpressionMap map[string]AlertRuleExpression
 

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/client_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/client_gen.go
@@ -1,0 +1,103 @@
+package v0alpha1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type CustomRouteClient struct {
+	resource.CustomRouteClient
+}
+
+func NewCustomRouteClient(client resource.CustomRouteClient) *CustomRouteClient {
+	return &CustomRouteClient{client}
+}
+
+func NewCustomRouteClientFromGenerator(generator resource.ClientGenerator, defaultNamespace string) (*CustomRouteClient, error) {
+	client, err := generator.GetCustomRouteClient(schema.GroupVersion{
+		Group:   "rules.alerting.grafana.app",
+		Version: "v0alpha1",
+	}, defaultNamespace)
+	if err != nil {
+		return nil, err
+	}
+	return NewCustomRouteClient(client), nil
+}
+
+type GetSearchAlertRulesRequest struct {
+	Params  GetSearchAlertRulesRequestParams
+	Headers http.Header
+}
+
+func (c *CustomRouteClient) GetSearchAlertRules(ctx context.Context, namespace string, request GetSearchAlertRulesRequest) (*GetSearchAlertRulesResponse, error) {
+	params := url.Values{}
+	resp, err := c.NamespacedRequest(ctx, namespace, resource.CustomRouteRequestOptions{
+		Path:    "/search/alertrules",
+		Verb:    "GET",
+		Query:   params,
+		Headers: request.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cast := GetSearchAlertRulesResponse{}
+	err = json.Unmarshal(resp, &cast)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response bytes into GetSearchAlertRulesResponse: %w", err)
+	}
+	return &cast, nil
+}
+
+type GetSearchRecordingRulesRequest struct {
+	Params  GetSearchRecordingRulesRequestParams
+	Headers http.Header
+}
+
+func (c *CustomRouteClient) GetSearchRecordingRules(ctx context.Context, namespace string, request GetSearchRecordingRulesRequest) (*GetSearchRecordingRulesResponse, error) {
+	params := url.Values{}
+	resp, err := c.NamespacedRequest(ctx, namespace, resource.CustomRouteRequestOptions{
+		Path:    "/search/recordingrules",
+		Verb:    "GET",
+		Query:   params,
+		Headers: request.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cast := GetSearchRecordingRulesResponse{}
+	err = json.Unmarshal(resp, &cast)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response bytes into GetSearchRecordingRulesResponse: %w", err)
+	}
+	return &cast, nil
+}
+
+type GetSearchRulesRequest struct {
+	Params  GetSearchRulesRequestParams
+	Headers http.Header
+}
+
+func (c *CustomRouteClient) GetSearchRules(ctx context.Context, namespace string, request GetSearchRulesRequest) (*GetSearchRulesResponse, error) {
+	params := url.Values{}
+	resp, err := c.NamespacedRequest(ctx, namespace, resource.CustomRouteRequestOptions{
+		Path:    "/search",
+		Verb:    "GET",
+		Query:   params,
+		Headers: request.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cast := GetSearchRulesResponse{}
+	err = json.Unmarshal(resp, &cast)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response bytes into GetSearchRulesResponse: %w", err)
+	}
+	return &cast, nil
+}

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchalertrules_request_params_object_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchalertrules_request_params_object_gen.go
@@ -1,0 +1,37 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type GetSearchAlertRulesRequestParamsObject struct {
+	metav1.TypeMeta                  `json:",inline"`
+	GetSearchAlertRulesRequestParams `json:",inline"`
+}
+
+func NewGetSearchAlertRulesRequestParamsObject() *GetSearchAlertRulesRequestParamsObject {
+	return &GetSearchAlertRulesRequestParamsObject{}
+}
+
+func (o *GetSearchAlertRulesRequestParamsObject) DeepCopyObject() runtime.Object {
+	dst := NewGetSearchAlertRulesRequestParamsObject()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetSearchAlertRulesRequestParamsObject) DeepCopyInto(dst *GetSearchAlertRulesRequestParamsObject) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	dstGetSearchAlertRulesRequestParams := GetSearchAlertRulesRequestParams{}
+	_ = resource.CopyObjectInto(&dstGetSearchAlertRulesRequestParams, &o.GetSearchAlertRulesRequestParams)
+}
+
+func (GetSearchAlertRulesRequestParamsObject) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesRequestParamsObject"
+}
+
+var _ runtime.Object = NewGetSearchAlertRulesRequestParamsObject()

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchalertrules_request_params_types_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchalertrules_request_params_types_gen.go
@@ -1,0 +1,45 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+type GetSearchAlertRulesRequestRuleSearchSortField string
+
+const (
+	GetSearchAlertRulesRequestRuleSearchSortFieldTitleAsc  GetSearchAlertRulesRequestRuleSearchSortField = "title"
+	GetSearchAlertRulesRequestRuleSearchSortFieldTitleDesc GetSearchAlertRulesRequestRuleSearchSortField = "-title"
+	GetSearchAlertRulesRequestRuleSearchSortFieldGroupAsc  GetSearchAlertRulesRequestRuleSearchSortField = "group"
+	GetSearchAlertRulesRequestRuleSearchSortFieldGroupDesc GetSearchAlertRulesRequestRuleSearchSortField = "-group"
+)
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchAlertRulesRequestRuleSearchSortField.
+func (GetSearchAlertRulesRequestRuleSearchSortField) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesRequestRuleSearchSortField"
+}
+
+type GetSearchAlertRulesRequestParams struct {
+	DashboardUID     *string                                        `json:"dashboardUID,omitempty"`
+	PanelID          *int64                                         `json:"panelID,omitempty"`
+	Receiver         *string                                        `json:"receiver,omitempty"`
+	NotificationType *string                                        `json:"notificationType,omitempty"`
+	Q                *string                                        `json:"q,omitempty"`
+	Names            []string                                       `json:"names,omitempty"`
+	Folders          []string                                       `json:"folders,omitempty"`
+	Groups           []string                                       `json:"groups,omitempty"`
+	Paused           *bool                                          `json:"paused,omitempty"`
+	DatasourceUIDs   []string                                       `json:"datasourceUIDs,omitempty"`
+	Labels           []string                                       `json:"labels,omitempty"`
+	Limit            *int64                                         `json:"limit,omitempty"`
+	RoutingTree      *string                                        `json:"routingTree,omitempty"`
+	Sort             *GetSearchAlertRulesRequestRuleSearchSortField `json:"sort,omitempty"`
+	ContinueToken    *string                                        `json:"continueToken,omitempty"`
+}
+
+// NewGetSearchAlertRulesRequestParams creates a new GetSearchAlertRulesRequestParams object.
+func NewGetSearchAlertRulesRequestParams() *GetSearchAlertRulesRequestParams {
+	return &GetSearchAlertRulesRequestParams{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchAlertRulesRequestParams.
+func (GetSearchAlertRulesRequestParams) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesRequestParams"
+}

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchalertrules_response_body_types_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchalertrules_response_body_types_gen.go
@@ -1,0 +1,66 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+// +k8s:openapi-gen=true
+type GetSearchAlertRulesAlertRuleHit struct {
+	Type             GetSearchAlertRulesRuleSearchType `json:"type"`
+	Annotations      map[string]string                 `json:"annotations,omitempty"`
+	For              *string                           `json:"for,omitempty"`
+	KeepFiringFor    *string                           `json:"keepFiringFor,omitempty"`
+	DashboardUID     *string                           `json:"dashboardUID,omitempty"`
+	PanelID          *int64                            `json:"panelID,omitempty"`
+	Receiver         *string                           `json:"receiver,omitempty"`
+	NotificationType *string                           `json:"notificationType,omitempty"`
+	Name             string                            `json:"name"`
+	Title            string                            `json:"title"`
+	Folder           string                            `json:"folder"`
+	Group            *string                           `json:"group,omitempty"`
+	Interval         *string                           `json:"interval,omitempty"`
+	Paused           *bool                             `json:"paused,omitempty"`
+	Labels           map[string]string                 `json:"labels,omitempty"`
+	RoutingTree      *string                           `json:"routingTree,omitempty"`
+	DatasourceUIDs   []string                          `json:"datasourceUIDs,omitempty"`
+}
+
+// NewGetSearchAlertRulesAlertRuleHit creates a new GetSearchAlertRulesAlertRuleHit object.
+func NewGetSearchAlertRulesAlertRuleHit() *GetSearchAlertRulesAlertRuleHit {
+	return &GetSearchAlertRulesAlertRuleHit{
+		Type: GetSearchAlertRulesRuleSearchTypeAlertRule,
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchAlertRulesAlertRuleHit.
+func (GetSearchAlertRulesAlertRuleHit) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesAlertRuleHit"
+}
+
+// +k8s:openapi-gen=true
+type GetSearchAlertRulesRuleSearchType string
+
+const (
+	GetSearchAlertRulesRuleSearchTypeAlertRule     GetSearchAlertRulesRuleSearchType = "alertrule"
+	GetSearchAlertRulesRuleSearchTypeRecordingRule GetSearchAlertRulesRuleSearchType = "recordingrule"
+)
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchAlertRulesRuleSearchType.
+func (GetSearchAlertRulesRuleSearchType) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesRuleSearchType"
+}
+
+// +k8s:openapi-gen=true
+type GetSearchAlertRulesBody struct {
+	Items []GetSearchAlertRulesAlertRuleHit `json:"items"`
+}
+
+// NewGetSearchAlertRulesBody creates a new GetSearchAlertRulesBody object.
+func NewGetSearchAlertRulesBody() *GetSearchAlertRulesBody {
+	return &GetSearchAlertRulesBody{
+		Items: []GetSearchAlertRulesAlertRuleHit{},
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchAlertRulesBody.
+func (GetSearchAlertRulesBody) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesBody"
+}

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchalertrules_response_object_types_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchalertrules_response_object_types_gen.go
@@ -1,0 +1,43 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type GetSearchAlertRulesResponse struct {
+	metav1.TypeMeta         `json:",inline"`
+	metav1.ListMeta         `json:"metadata"`
+	GetSearchAlertRulesBody `json:",inline"`
+}
+
+func NewGetSearchAlertRulesResponse() *GetSearchAlertRulesResponse {
+	return &GetSearchAlertRulesResponse{}
+}
+
+func (t *GetSearchAlertRulesBody) DeepCopyInto(dst *GetSearchAlertRulesBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *GetSearchAlertRulesResponse) DeepCopyObject() runtime.Object {
+	dst := NewGetSearchAlertRulesResponse()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetSearchAlertRulesResponse) DeepCopyInto(dst *GetSearchAlertRulesResponse) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ListMeta.DeepCopyInto(&dst.ListMeta)
+	o.GetSearchAlertRulesBody.DeepCopyInto(&dst.GetSearchAlertRulesBody)
+}
+
+func (GetSearchAlertRulesResponse) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesResponse"
+}
+
+var _ runtime.Object = NewGetSearchAlertRulesResponse()

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrecordingrules_request_params_object_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrecordingrules_request_params_object_gen.go
@@ -1,0 +1,37 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type GetSearchRecordingRulesRequestParamsObject struct {
+	metav1.TypeMeta                      `json:",inline"`
+	GetSearchRecordingRulesRequestParams `json:",inline"`
+}
+
+func NewGetSearchRecordingRulesRequestParamsObject() *GetSearchRecordingRulesRequestParamsObject {
+	return &GetSearchRecordingRulesRequestParamsObject{}
+}
+
+func (o *GetSearchRecordingRulesRequestParamsObject) DeepCopyObject() runtime.Object {
+	dst := NewGetSearchRecordingRulesRequestParamsObject()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetSearchRecordingRulesRequestParamsObject) DeepCopyInto(dst *GetSearchRecordingRulesRequestParamsObject) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	dstGetSearchRecordingRulesRequestParams := GetSearchRecordingRulesRequestParams{}
+	_ = resource.CopyObjectInto(&dstGetSearchRecordingRulesRequestParams, &o.GetSearchRecordingRulesRequestParams)
+}
+
+func (GetSearchRecordingRulesRequestParamsObject) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesRequestParamsObject"
+}
+
+var _ runtime.Object = NewGetSearchRecordingRulesRequestParamsObject()

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrecordingrules_request_params_types_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrecordingrules_request_params_types_gen.go
@@ -1,0 +1,42 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+type GetSearchRecordingRulesRequestRuleSearchSortField string
+
+const (
+	GetSearchRecordingRulesRequestRuleSearchSortFieldTitleAsc  GetSearchRecordingRulesRequestRuleSearchSortField = "title"
+	GetSearchRecordingRulesRequestRuleSearchSortFieldTitleDesc GetSearchRecordingRulesRequestRuleSearchSortField = "-title"
+	GetSearchRecordingRulesRequestRuleSearchSortFieldGroupAsc  GetSearchRecordingRulesRequestRuleSearchSortField = "group"
+	GetSearchRecordingRulesRequestRuleSearchSortFieldGroupDesc GetSearchRecordingRulesRequestRuleSearchSortField = "-group"
+)
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRecordingRulesRequestRuleSearchSortField.
+func (GetSearchRecordingRulesRequestRuleSearchSortField) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesRequestRuleSearchSortField"
+}
+
+type GetSearchRecordingRulesRequestParams struct {
+	Metric              *string                                            `json:"metric,omitempty"`
+	Q                   *string                                            `json:"q,omitempty"`
+	Names               []string                                           `json:"names,omitempty"`
+	Folders             []string                                           `json:"folders,omitempty"`
+	Groups              []string                                           `json:"groups,omitempty"`
+	Paused              *bool                                              `json:"paused,omitempty"`
+	DatasourceUIDs      []string                                           `json:"datasourceUIDs,omitempty"`
+	Labels              []string                                           `json:"labels,omitempty"`
+	Limit               *int64                                             `json:"limit,omitempty"`
+	TargetDatasourceUID *string                                            `json:"targetDatasourceUID,omitempty"`
+	Sort                *GetSearchRecordingRulesRequestRuleSearchSortField `json:"sort,omitempty"`
+	ContinueToken       *string                                            `json:"continueToken,omitempty"`
+}
+
+// NewGetSearchRecordingRulesRequestParams creates a new GetSearchRecordingRulesRequestParams object.
+func NewGetSearchRecordingRulesRequestParams() *GetSearchRecordingRulesRequestParams {
+	return &GetSearchRecordingRulesRequestParams{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRecordingRulesRequestParams.
+func (GetSearchRecordingRulesRequestParams) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesRequestParams"
+}

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrecordingrules_response_body_types_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrecordingrules_response_body_types_gen.go
@@ -1,0 +1,60 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+// +k8s:openapi-gen=true
+type GetSearchRecordingRulesRecordingRuleHit struct {
+	Type                GetSearchRecordingRulesRuleSearchType `json:"type"`
+	Metric              *string                               `json:"metric,omitempty"`
+	Name                string                                `json:"name"`
+	Title               string                                `json:"title"`
+	Folder              string                                `json:"folder"`
+	Group               *string                               `json:"group,omitempty"`
+	Interval            *string                               `json:"interval,omitempty"`
+	Paused              *bool                                 `json:"paused,omitempty"`
+	Labels              map[string]string                     `json:"labels,omitempty"`
+	TargetDatasourceUID *string                               `json:"targetDatasourceUID,omitempty"`
+	DatasourceUIDs      []string                              `json:"datasourceUIDs,omitempty"`
+}
+
+// NewGetSearchRecordingRulesRecordingRuleHit creates a new GetSearchRecordingRulesRecordingRuleHit object.
+func NewGetSearchRecordingRulesRecordingRuleHit() *GetSearchRecordingRulesRecordingRuleHit {
+	return &GetSearchRecordingRulesRecordingRuleHit{
+		Type: GetSearchRecordingRulesRuleSearchTypeRecordingRule,
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRecordingRulesRecordingRuleHit.
+func (GetSearchRecordingRulesRecordingRuleHit) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesRecordingRuleHit"
+}
+
+// +k8s:openapi-gen=true
+type GetSearchRecordingRulesRuleSearchType string
+
+const (
+	GetSearchRecordingRulesRuleSearchTypeAlertRule     GetSearchRecordingRulesRuleSearchType = "alertrule"
+	GetSearchRecordingRulesRuleSearchTypeRecordingRule GetSearchRecordingRulesRuleSearchType = "recordingrule"
+)
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRecordingRulesRuleSearchType.
+func (GetSearchRecordingRulesRuleSearchType) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesRuleSearchType"
+}
+
+// +k8s:openapi-gen=true
+type GetSearchRecordingRulesBody struct {
+	Items []GetSearchRecordingRulesRecordingRuleHit `json:"items"`
+}
+
+// NewGetSearchRecordingRulesBody creates a new GetSearchRecordingRulesBody object.
+func NewGetSearchRecordingRulesBody() *GetSearchRecordingRulesBody {
+	return &GetSearchRecordingRulesBody{
+		Items: []GetSearchRecordingRulesRecordingRuleHit{},
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRecordingRulesBody.
+func (GetSearchRecordingRulesBody) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesBody"
+}

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrecordingrules_response_object_types_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrecordingrules_response_object_types_gen.go
@@ -1,0 +1,43 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type GetSearchRecordingRulesResponse struct {
+	metav1.TypeMeta             `json:",inline"`
+	metav1.ListMeta             `json:"metadata"`
+	GetSearchRecordingRulesBody `json:",inline"`
+}
+
+func NewGetSearchRecordingRulesResponse() *GetSearchRecordingRulesResponse {
+	return &GetSearchRecordingRulesResponse{}
+}
+
+func (t *GetSearchRecordingRulesBody) DeepCopyInto(dst *GetSearchRecordingRulesBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *GetSearchRecordingRulesResponse) DeepCopyObject() runtime.Object {
+	dst := NewGetSearchRecordingRulesResponse()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetSearchRecordingRulesResponse) DeepCopyInto(dst *GetSearchRecordingRulesResponse) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ListMeta.DeepCopyInto(&dst.ListMeta)
+	o.GetSearchRecordingRulesBody.DeepCopyInto(&dst.GetSearchRecordingRulesBody)
+}
+
+func (GetSearchRecordingRulesResponse) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesResponse"
+}
+
+var _ runtime.Object = NewGetSearchRecordingRulesResponse()

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrules_request_params_object_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrules_request_params_object_gen.go
@@ -1,0 +1,37 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type GetSearchRulesRequestParamsObject struct {
+	metav1.TypeMeta             `json:",inline"`
+	GetSearchRulesRequestParams `json:",inline"`
+}
+
+func NewGetSearchRulesRequestParamsObject() *GetSearchRulesRequestParamsObject {
+	return &GetSearchRulesRequestParamsObject{}
+}
+
+func (o *GetSearchRulesRequestParamsObject) DeepCopyObject() runtime.Object {
+	dst := NewGetSearchRulesRequestParamsObject()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetSearchRulesRequestParamsObject) DeepCopyInto(dst *GetSearchRulesRequestParamsObject) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	dstGetSearchRulesRequestParams := GetSearchRulesRequestParams{}
+	_ = resource.CopyObjectInto(&dstGetSearchRulesRequestParams, &o.GetSearchRulesRequestParams)
+}
+
+func (GetSearchRulesRequestParamsObject) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesRequestParamsObject"
+}
+
+var _ runtime.Object = NewGetSearchRulesRequestParamsObject()

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrules_request_params_types_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrules_request_params_types_gen.go
@@ -1,0 +1,48 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+type GetSearchRulesRequestRuleSearchSortField string
+
+const (
+	GetSearchRulesRequestRuleSearchSortFieldTitleAsc  GetSearchRulesRequestRuleSearchSortField = "title"
+	GetSearchRulesRequestRuleSearchSortFieldTitleDesc GetSearchRulesRequestRuleSearchSortField = "-title"
+	GetSearchRulesRequestRuleSearchSortFieldGroupAsc  GetSearchRulesRequestRuleSearchSortField = "group"
+	GetSearchRulesRequestRuleSearchSortFieldGroupDesc GetSearchRulesRequestRuleSearchSortField = "-group"
+)
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRulesRequestRuleSearchSortField.
+func (GetSearchRulesRequestRuleSearchSortField) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesRequestRuleSearchSortField"
+}
+
+type GetSearchRulesRequestParams struct {
+	Type                *string                                   `json:"type,omitempty"`
+	DashboardUID        *string                                   `json:"dashboardUID,omitempty"`
+	PanelID             *int64                                    `json:"panelID,omitempty"`
+	Receiver            *string                                   `json:"receiver,omitempty"`
+	NotificationType    *string                                   `json:"notificationType,omitempty"`
+	Q                   *string                                   `json:"q,omitempty"`
+	Limit               *int64                                    `json:"limit,omitempty"`
+	Metric              *string                                   `json:"metric,omitempty"`
+	Names               []string                                  `json:"names,omitempty"`
+	Folders             []string                                  `json:"folders,omitempty"`
+	Groups              []string                                  `json:"groups,omitempty"`
+	Paused              *bool                                     `json:"paused,omitempty"`
+	DatasourceUIDs      []string                                  `json:"datasourceUIDs,omitempty"`
+	Labels              []string                                  `json:"labels,omitempty"`
+	RoutingTree         *string                                   `json:"routingTree,omitempty"`
+	Sort                *GetSearchRulesRequestRuleSearchSortField `json:"sort,omitempty"`
+	ContinueToken       *string                                   `json:"continueToken,omitempty"`
+	TargetDatasourceUID *string                                   `json:"targetDatasourceUID,omitempty"`
+}
+
+// NewGetSearchRulesRequestParams creates a new GetSearchRulesRequestParams object.
+func NewGetSearchRulesRequestParams() *GetSearchRulesRequestParams {
+	return &GetSearchRulesRequestParams{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRulesRequestParams.
+func (GetSearchRulesRequestParams) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesRequestParams"
+}

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrules_response_body_types_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrules_response_body_types_gen.go
@@ -1,0 +1,173 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	json "encoding/json"
+)
+
+// RuleHit is the cross-kind union returned by /search.
+// +k8s:openapi-gen=true
+type GetSearchRulesRuleHit = GetSearchRulesAlertRuleHitOrRecordingRuleHit
+
+// NewGetSearchRulesRuleHit creates a new GetSearchRulesRuleHit object.
+func NewGetSearchRulesRuleHit() *GetSearchRulesRuleHit {
+	return NewGetSearchRulesAlertRuleHitOrRecordingRuleHit()
+}
+
+// +k8s:openapi-gen=true
+type GetSearchRulesAlertRuleHit struct {
+	Type             GetSearchRulesRuleSearchType `json:"type"`
+	Annotations      map[string]string            `json:"annotations,omitempty"`
+	For              *string                      `json:"for,omitempty"`
+	KeepFiringFor    *string                      `json:"keepFiringFor,omitempty"`
+	DashboardUID     *string                      `json:"dashboardUID,omitempty"`
+	PanelID          *int64                       `json:"panelID,omitempty"`
+	Receiver         *string                      `json:"receiver,omitempty"`
+	NotificationType *string                      `json:"notificationType,omitempty"`
+	Name             string                       `json:"name"`
+	Title            string                       `json:"title"`
+	Folder           string                       `json:"folder"`
+	Group            *string                      `json:"group,omitempty"`
+	Interval         *string                      `json:"interval,omitempty"`
+	Paused           *bool                        `json:"paused,omitempty"`
+	Labels           map[string]string            `json:"labels,omitempty"`
+	RoutingTree      *string                      `json:"routingTree,omitempty"`
+	DatasourceUIDs   []string                     `json:"datasourceUIDs,omitempty"`
+}
+
+// NewGetSearchRulesAlertRuleHit creates a new GetSearchRulesAlertRuleHit object.
+func NewGetSearchRulesAlertRuleHit() *GetSearchRulesAlertRuleHit {
+	return &GetSearchRulesAlertRuleHit{
+		Type: GetSearchRulesRuleSearchTypeAlertRule,
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRulesAlertRuleHit.
+func (GetSearchRulesAlertRuleHit) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesAlertRuleHit"
+}
+
+// +k8s:openapi-gen=true
+type GetSearchRulesRuleSearchType string
+
+const (
+	GetSearchRulesRuleSearchTypeAlertRule     GetSearchRulesRuleSearchType = "alertrule"
+	GetSearchRulesRuleSearchTypeRecordingRule GetSearchRulesRuleSearchType = "recordingrule"
+)
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRulesRuleSearchType.
+func (GetSearchRulesRuleSearchType) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesRuleSearchType"
+}
+
+// +k8s:openapi-gen=true
+type GetSearchRulesRecordingRuleHit struct {
+	Type                GetSearchRulesRuleSearchType `json:"type"`
+	Metric              *string                      `json:"metric,omitempty"`
+	Name                string                       `json:"name"`
+	Title               string                       `json:"title"`
+	Folder              string                       `json:"folder"`
+	Group               *string                      `json:"group,omitempty"`
+	Interval            *string                      `json:"interval,omitempty"`
+	Paused              *bool                        `json:"paused,omitempty"`
+	Labels              map[string]string            `json:"labels,omitempty"`
+	TargetDatasourceUID *string                      `json:"targetDatasourceUID,omitempty"`
+	DatasourceUIDs      []string                     `json:"datasourceUIDs,omitempty"`
+}
+
+// NewGetSearchRulesRecordingRuleHit creates a new GetSearchRulesRecordingRuleHit object.
+func NewGetSearchRulesRecordingRuleHit() *GetSearchRulesRecordingRuleHit {
+	return &GetSearchRulesRecordingRuleHit{
+		Type: GetSearchRulesRuleSearchTypeRecordingRule,
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRulesRecordingRuleHit.
+func (GetSearchRulesRecordingRuleHit) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesRecordingRuleHit"
+}
+
+// +k8s:openapi-gen=true
+type GetSearchRulesBody struct {
+	Items []GetSearchRulesRuleHit `json:"items"`
+}
+
+// NewGetSearchRulesBody creates a new GetSearchRulesBody object.
+func NewGetSearchRulesBody() *GetSearchRulesBody {
+	return &GetSearchRulesBody{
+		Items: []GetSearchRulesRuleHit{},
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRulesBody.
+func (GetSearchRulesBody) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesBody"
+}
+
+// +k8s:openapi-gen=true
+type GetSearchRulesAlertRuleHitOrRecordingRuleHit struct {
+	AlertRuleHit     *GetSearchRulesAlertRuleHit     `json:"AlertRuleHit,omitempty"`
+	RecordingRuleHit *GetSearchRulesRecordingRuleHit `json:"RecordingRuleHit,omitempty"`
+}
+
+// NewGetSearchRulesAlertRuleHitOrRecordingRuleHit creates a new GetSearchRulesAlertRuleHitOrRecordingRuleHit object.
+func NewGetSearchRulesAlertRuleHitOrRecordingRuleHit() *GetSearchRulesAlertRuleHitOrRecordingRuleHit {
+	return &GetSearchRulesAlertRuleHitOrRecordingRuleHit{}
+}
+
+// MarshalJSON implements a custom JSON marshalling logic to encode `GetSearchRulesAlertRuleHitOrRecordingRuleHit` as JSON.
+func (resource GetSearchRulesAlertRuleHitOrRecordingRuleHit) MarshalJSON() ([]byte, error) {
+	if resource.AlertRuleHit != nil {
+		return json.Marshal(resource.AlertRuleHit)
+	}
+	if resource.RecordingRuleHit != nil {
+		return json.Marshal(resource.RecordingRuleHit)
+	}
+
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON implements a custom JSON unmarshalling logic to decode `GetSearchRulesAlertRuleHitOrRecordingRuleHit` from JSON.
+func (resource *GetSearchRulesAlertRuleHitOrRecordingRuleHit) UnmarshalJSON(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+
+	// FIXME: this is wasteful, we need to find a more efficient way to unmarshal this.
+	parsedAsMap := make(map[string]interface{})
+	if err := json.Unmarshal(raw, &parsedAsMap); err != nil {
+		return err
+	}
+
+	discriminator, found := parsedAsMap["type"]
+	if !found {
+		return nil
+	}
+
+	switch discriminator {
+	case "alertrule":
+		var getSearchRulesAlertRuleHit GetSearchRulesAlertRuleHit
+		if err := json.Unmarshal(raw, &getSearchRulesAlertRuleHit); err != nil {
+			return err
+		}
+
+		resource.AlertRuleHit = &getSearchRulesAlertRuleHit
+		return nil
+	case "recordingrule":
+		var getSearchRulesRecordingRuleHit GetSearchRulesRecordingRuleHit
+		if err := json.Unmarshal(raw, &getSearchRulesRecordingRuleHit); err != nil {
+			return err
+		}
+
+		resource.RecordingRuleHit = &getSearchRulesRecordingRuleHit
+		return nil
+	}
+
+	return nil
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRulesAlertRuleHitOrRecordingRuleHit.
+func (GetSearchRulesAlertRuleHitOrRecordingRuleHit) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesAlertRuleHitOrRecordingRuleHit"
+}

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrules_response_object_types_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/getsearchrules_response_object_types_gen.go
@@ -1,0 +1,43 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type GetSearchRulesResponse struct {
+	metav1.TypeMeta    `json:",inline"`
+	metav1.ListMeta    `json:"metadata"`
+	GetSearchRulesBody `json:",inline"`
+}
+
+func NewGetSearchRulesResponse() *GetSearchRulesResponse {
+	return &GetSearchRulesResponse{}
+}
+
+func (t *GetSearchRulesBody) DeepCopyInto(dst *GetSearchRulesBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *GetSearchRulesResponse) DeepCopyObject() runtime.Object {
+	dst := NewGetSearchRulesResponse()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetSearchRulesResponse) DeepCopyInto(dst *GetSearchRulesResponse) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.ListMeta.DeepCopyInto(&dst.ListMeta)
+	o.GetSearchRulesBody.DeepCopyInto(&dst.GetSearchRulesBody)
+}
+
+func (GetSearchRulesResponse) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesResponse"
+}
+
+var _ runtime.Object = NewGetSearchRulesResponse()

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/recordingrule_spec_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/recordingrule_spec_gen.go
@@ -23,12 +23,9 @@ type RecordingRulePromDuration string
 // +k8s:openapi-gen=true
 type RecordingRuleTemplateString string
 
-// TODO(@moustafab): validate the metric name regex
 // +k8s:openapi-gen=true
 type RecordingRuleMetricName string
 
-// TODO: validate that only one can specify source=true
-// & struct.MinFields(1) This doesn't work in Cue <v0.12.0 as per
 // +k8s:openapi-gen=true
 type RecordingRuleExpressionMap map[string]RecordingRuleExpression
 

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/zz_openapi_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/zz_openapi_gen.go
@@ -20,6 +20,17 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		AlertRuleSpec{}.OpenAPIModelName():                                schema_pkg_apis_alerting_v0alpha1_AlertRuleSpec(ref),
 		AlertRuleStatus{}.OpenAPIModelName():                              schema_pkg_apis_alerting_v0alpha1_AlertRuleStatus(ref),
 		AlertRulestatusOperatorState{}.OpenAPIModelName():                 schema_pkg_apis_alerting_v0alpha1_AlertRulestatusOperatorState(ref),
+		GetSearchAlertRulesAlertRuleHit{}.OpenAPIModelName():              schema_pkg_apis_alerting_v0alpha1_GetSearchAlertRulesAlertRuleHit(ref),
+		GetSearchAlertRulesBody{}.OpenAPIModelName():                      schema_pkg_apis_alerting_v0alpha1_GetSearchAlertRulesBody(ref),
+		GetSearchAlertRulesResponse{}.OpenAPIModelName():                  schema_pkg_apis_alerting_v0alpha1_GetSearchAlertRulesResponse(ref),
+		GetSearchRecordingRulesBody{}.OpenAPIModelName():                  schema_pkg_apis_alerting_v0alpha1_GetSearchRecordingRulesBody(ref),
+		GetSearchRecordingRulesRecordingRuleHit{}.OpenAPIModelName():      schema_pkg_apis_alerting_v0alpha1_GetSearchRecordingRulesRecordingRuleHit(ref),
+		GetSearchRecordingRulesResponse{}.OpenAPIModelName():              schema_pkg_apis_alerting_v0alpha1_GetSearchRecordingRulesResponse(ref),
+		GetSearchRulesAlertRuleHit{}.OpenAPIModelName():                   schema_pkg_apis_alerting_v0alpha1_GetSearchRulesAlertRuleHit(ref),
+		GetSearchRulesAlertRuleHitOrRecordingRuleHit{}.OpenAPIModelName(): schema_pkg_apis_alerting_v0alpha1_GetSearchRulesAlertRuleHitOrRecordingRuleHit(ref),
+		GetSearchRulesBody{}.OpenAPIModelName():                           schema_pkg_apis_alerting_v0alpha1_GetSearchRulesBody(ref),
+		GetSearchRulesRecordingRuleHit{}.OpenAPIModelName():               schema_pkg_apis_alerting_v0alpha1_GetSearchRulesRecordingRuleHit(ref),
+		GetSearchRulesResponse{}.OpenAPIModelName():                       schema_pkg_apis_alerting_v0alpha1_GetSearchRulesResponse(ref),
 		RecordingRule{}.OpenAPIModelName():                                schema_pkg_apis_alerting_v0alpha1_RecordingRule(ref),
 		RecordingRuleExpression{}.OpenAPIModelName():                      schema_pkg_apis_alerting_v0alpha1_RecordingRuleExpression(ref),
 		RecordingRuleIntervalTrigger{}.OpenAPIModelName():                 schema_pkg_apis_alerting_v0alpha1_RecordingRuleIntervalTrigger(ref),
@@ -605,6 +616,746 @@ func schema_pkg_apis_alerting_v0alpha1_AlertRulestatusOperatorState(ref common.R
 				Required: []string{"lastEvaluation", "state"},
 			},
 		},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchAlertRulesAlertRuleHit(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"annotations": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+					"for": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"keepFiringFor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"dashboardUID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"panelID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
+					"receiver": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"notificationType": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"title": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"folder": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"interval": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"paused": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"labels": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+					"routingTree": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"datasourceUIDs": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"type", "name", "title", "folder"},
+			},
+		},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchAlertRulesBody(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref(GetSearchAlertRulesAlertRuleHit{}.OpenAPIModelName()),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+		},
+		Dependencies: []string{
+			GetSearchAlertRulesAlertRuleHit{}.OpenAPIModelName()},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchAlertRulesResponse(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Default: map[string]interface{}{},
+							Ref:     ref(metav1.ListMeta{}.OpenAPIModelName()),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref(GetSearchAlertRulesAlertRuleHit{}.OpenAPIModelName()),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"metadata", "items"},
+			},
+		},
+		Dependencies: []string{
+			GetSearchAlertRulesAlertRuleHit{}.OpenAPIModelName(), metav1.ListMeta{}.OpenAPIModelName()},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchRecordingRulesBody(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref(GetSearchRecordingRulesRecordingRuleHit{}.OpenAPIModelName()),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+		},
+		Dependencies: []string{
+			GetSearchRecordingRulesRecordingRuleHit{}.OpenAPIModelName()},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchRecordingRulesRecordingRuleHit(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"metric": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"title": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"folder": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"interval": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"paused": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"labels": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+					"targetDatasourceUID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"datasourceUIDs": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"type", "name", "title", "folder"},
+			},
+		},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchRecordingRulesResponse(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Default: map[string]interface{}{},
+							Ref:     ref(metav1.ListMeta{}.OpenAPIModelName()),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref(GetSearchRecordingRulesRecordingRuleHit{}.OpenAPIModelName()),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"metadata", "items"},
+			},
+		},
+		Dependencies: []string{
+			GetSearchRecordingRulesRecordingRuleHit{}.OpenAPIModelName(), metav1.ListMeta{}.OpenAPIModelName()},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchRulesAlertRuleHit(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"annotations": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+					"for": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"keepFiringFor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"dashboardUID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"panelID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
+					"receiver": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"notificationType": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"title": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"folder": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"interval": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"paused": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"labels": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+					"routingTree": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"datasourceUIDs": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"type", "name", "title", "folder"},
+			},
+		},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchRulesAlertRuleHitOrRecordingRuleHit(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"AlertRuleHit": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref(GetSearchRulesAlertRuleHit{}.OpenAPIModelName()),
+						},
+					},
+					"RecordingRuleHit": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref(GetSearchRulesRecordingRuleHit{}.OpenAPIModelName()),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			GetSearchRulesAlertRuleHit{}.OpenAPIModelName(), GetSearchRulesRecordingRuleHit{}.OpenAPIModelName()},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchRulesBody(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref(GetSearchRulesAlertRuleHitOrRecordingRuleHit{}.OpenAPIModelName()),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+		},
+		Dependencies: []string{
+			GetSearchRulesAlertRuleHitOrRecordingRuleHit{}.OpenAPIModelName()},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchRulesRecordingRuleHit(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"metric": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"title": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"folder": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"interval": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"paused": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"labels": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+					"targetDatasourceUID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"datasourceUIDs": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"type", "name", "title", "folder"},
+			},
+		},
+	}
+}
+
+func schema_pkg_apis_alerting_v0alpha1_GetSearchRulesResponse(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Default: map[string]interface{}{},
+							Ref:     ref(metav1.ListMeta{}.OpenAPIModelName()),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref(GetSearchRulesAlertRuleHitOrRecordingRuleHit{}.OpenAPIModelName()),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"metadata", "items"},
+			},
+		},
+		Dependencies: []string{
+			GetSearchRulesAlertRuleHitOrRecordingRuleHit{}.OpenAPIModelName(), metav1.ListMeta{}.OpenAPIModelName()},
 	}
 }
 

--- a/apps/alerting/rules/pkg/apis/manifestdata/alerting_manifest.go
+++ b/apps/alerting/rules/pkg/apis/manifestdata/alerting_manifest.go
@@ -20,10 +20,10 @@ import (
 )
 
 var (
-	rawSchemaAlertRulev0alpha1         = []byte(`{"AlertRule":{"properties":{"spec":{"$ref":"#/components/schemas/spec"},"status":{"$ref":"#/components/schemas/status"}},"required":["spec"]},"DatasourceUID":{"pattern":"^[a-zA-Z0-9_-]+$","type":"string"},"ExecErrState":{"enum":["Error","Ok","Alerting","KeepLast"],"type":"string"},"Expression":{"additionalProperties":false,"properties":{"datasourceUID":{"$ref":"#/components/schemas/DatasourceUID","description":"The UID of the datasource to run this expression against. If omitted, the expression will be run against the ` + "`" + `__expr__` + "`" + ` datasource"},"model":{"additionalProperties":{},"type":"object"},"queryType":{"description":"The type of query if this is a query expression","type":"string"},"relativeTimeRange":{"$ref":"#/components/schemas/RelativeTimeRange"},"source":{"description":"Used to mark the expression to be used as the final source for the rule evaluation\nOnly one expression in a rule can be marked as the source\nFor AlertRules, this is the expression that will be evaluated against the alerting condition\nFor RecordingRules, this is the expression that will be recorded","type":"boolean"}},"required":["model"],"type":"object"},"ExpressionMap":{"additionalProperties":{"$ref":"#/components/schemas/Expression"},"description":"TODO: validate that only one can specify source=true\n\u0026 struct.MinFields(1) This doesn't work in Cue \u003cv0.12.0 as per","type":"object"},"IntervalTrigger":{"additionalProperties":false,"properties":{"interval":{"$ref":"#/components/schemas/PromDuration"}},"required":["interval"],"type":"object"},"NamedRoutingTree":{"additionalProperties":false,"properties":{"routingTree":{"type":"string"},"type":{"$ref":"#/components/schemas/NotificationSettingsType"}},"required":["type","routingTree"],"type":"object"},"NoDataState":{"enum":["NoData","Ok","Alerting","KeepLast"],"type":"string"},"NotificationSettings":{"description":"TODO(@moustafab): this should be imported from the notifications package","oneOf":[{"$ref":"#/components/schemas/SimplifiedRouting"},{"$ref":"#/components/schemas/NamedRoutingTree"}]},"NotificationSettingsType":{"enum":["SimplifiedRouting","NamedRoutingTree"],"type":"string"},"OperatorState":{"additionalProperties":false,"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"additionalProperties":true,"description":"details contains any extra information that is operator-specific","type":"object"},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"PanelRef":{"additionalProperties":false,"properties":{"dashboardUID":{"minLength":1,"pattern":"^[a-zA-Z0-9_-]+$","type":"string"},"panelID":{"exclusiveMinimum":true,"minimum":0,"type":"integer"}},"required":["dashboardUID","panelID"],"type":"object"},"PromDuration":{"not":{"pattern":"hmuµn"},"pattern":"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|0)$","type":"string"},"PromDurationWMillis":{"pattern":"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$","type":"string"},"RelativeTimeRange":{"additionalProperties":false,"properties":{"from":{"$ref":"#/components/schemas/PromDurationWMillis"},"to":{"$ref":"#/components/schemas/PromDurationWMillis"}},"required":["from","to"],"type":"object"},"SimplifiedRouting":{"additionalProperties":false,"properties":{"activeTimeIntervals":{"items":{"$ref":"#/components/schemas/TimeIntervalRef"},"type":"array"},"groupBy":{"items":{"type":"string"},"type":"array"},"groupInterval":{"$ref":"#/components/schemas/PromDuration"},"groupWait":{"$ref":"#/components/schemas/PromDuration"},"muteTimeIntervals":{"items":{"$ref":"#/components/schemas/TimeIntervalRef"},"type":"array"},"receiver":{"type":"string"},"repeatInterval":{"$ref":"#/components/schemas/PromDuration"},"type":{"$ref":"#/components/schemas/NotificationSettingsType"}},"required":["type","receiver"],"type":"object"},"TemplateString":{"type":"string"},"TimeIntervalRef":{"description":"TODO(@moustafab): validate regex for time interval ref","type":"string"},"spec":{"additionalProperties":false,"properties":{"annotations":{"additionalProperties":{"$ref":"#/components/schemas/TemplateString"},"type":"object"},"execErrState":{"$ref":"#/components/schemas/ExecErrState","default":"Error"},"expressions":{"$ref":"#/components/schemas/ExpressionMap"},"for":{"type":"string"},"keepFiringFor":{"type":"string"},"labels":{"additionalProperties":{"$ref":"#/components/schemas/TemplateString"},"type":"object"},"missingSeriesEvalsToResolve":{"minimum":0,"type":"integer"},"noDataState":{"$ref":"#/components/schemas/NoDataState","default":"NoData"},"notificationSettings":{"$ref":"#/components/schemas/NotificationSettings"},"panelRef":{"$ref":"#/components/schemas/PanelRef"},"paused":{"type":"boolean"},"title":{"type":"string"},"trigger":{"$ref":"#/components/schemas/IntervalTrigger"}},"required":["title","trigger","noDataState","execErrState","expressions"],"type":"object"},"status":{"additionalProperties":false,"properties":{"additionalFields":{"additionalProperties":true,"description":"additionalFields is reserved for future use","type":"object"},"operatorStates":{"additionalProperties":{"$ref":"#/components/schemas/OperatorState"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
+	rawSchemaAlertRulev0alpha1         = []byte(`{"AlertRule":{"properties":{"spec":{"$ref":"#/components/schemas/spec"},"status":{"$ref":"#/components/schemas/status"}},"required":["spec"]},"DatasourceUID":{"pattern":"^[a-zA-Z0-9_-]+$","type":"string"},"ExecErrState":{"enum":["Error","Ok","Alerting","KeepLast"],"type":"string"},"Expression":{"additionalProperties":false,"properties":{"datasourceUID":{"$ref":"#/components/schemas/DatasourceUID","description":"The UID of the datasource to run this expression against. If omitted, the expression will be run against the ` + "`" + `__expr__` + "`" + ` datasource"},"model":{"additionalProperties":{},"type":"object"},"queryType":{"description":"The type of query if this is a query expression","type":"string"},"relativeTimeRange":{"$ref":"#/components/schemas/RelativeTimeRange"},"source":{"description":"Used to mark the expression to be used as the final source for the rule evaluation\nOnly one expression in a rule can be marked as the source\nFor AlertRules, this is the expression that will be evaluated against the alerting condition\nFor RecordingRules, this is the expression that will be recorded","type":"boolean"}},"required":["model"],"type":"object"},"ExpressionMap":{"additionalProperties":{"$ref":"#/components/schemas/Expression"},"type":"object"},"IntervalTrigger":{"additionalProperties":false,"properties":{"interval":{"$ref":"#/components/schemas/PromDuration"}},"required":["interval"],"type":"object"},"NamedRoutingTree":{"additionalProperties":false,"properties":{"routingTree":{"type":"string"},"type":{"$ref":"#/components/schemas/NotificationSettingsType"}},"required":["type","routingTree"],"type":"object"},"NoDataState":{"enum":["NoData","Ok","Alerting","KeepLast"],"type":"string"},"NotificationSettings":{"oneOf":[{"$ref":"#/components/schemas/SimplifiedRouting"},{"$ref":"#/components/schemas/NamedRoutingTree"}]},"NotificationSettingsType":{"enum":["SimplifiedRouting","NamedRoutingTree"],"type":"string"},"OperatorState":{"additionalProperties":false,"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"additionalProperties":true,"description":"details contains any extra information that is operator-specific","type":"object"},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"PanelRef":{"additionalProperties":false,"properties":{"dashboardUID":{"minLength":1,"pattern":"^[a-zA-Z0-9_-]+$","type":"string"},"panelID":{"exclusiveMinimum":true,"minimum":0,"type":"integer"}},"required":["dashboardUID","panelID"],"type":"object"},"PromDuration":{"not":{"pattern":"hmuµn"},"pattern":"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|0)$","type":"string"},"PromDurationWMillis":{"pattern":"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$","type":"string"},"RelativeTimeRange":{"additionalProperties":false,"properties":{"from":{"$ref":"#/components/schemas/PromDurationWMillis"},"to":{"$ref":"#/components/schemas/PromDurationWMillis"}},"required":["from","to"],"type":"object"},"SimplifiedRouting":{"additionalProperties":false,"properties":{"activeTimeIntervals":{"items":{"$ref":"#/components/schemas/TimeIntervalRef"},"type":"array"},"groupBy":{"items":{"type":"string"},"type":"array"},"groupInterval":{"$ref":"#/components/schemas/PromDuration"},"groupWait":{"$ref":"#/components/schemas/PromDuration"},"muteTimeIntervals":{"items":{"$ref":"#/components/schemas/TimeIntervalRef"},"type":"array"},"receiver":{"type":"string"},"repeatInterval":{"$ref":"#/components/schemas/PromDuration"},"type":{"$ref":"#/components/schemas/NotificationSettingsType"}},"required":["type","receiver"],"type":"object"},"TemplateString":{"type":"string"},"TimeIntervalRef":{"type":"string"},"spec":{"additionalProperties":false,"properties":{"annotations":{"additionalProperties":{"$ref":"#/components/schemas/TemplateString"},"type":"object"},"execErrState":{"$ref":"#/components/schemas/ExecErrState","default":"Error"},"expressions":{"$ref":"#/components/schemas/ExpressionMap"},"for":{"type":"string"},"keepFiringFor":{"type":"string"},"labels":{"additionalProperties":{"$ref":"#/components/schemas/TemplateString"},"type":"object"},"missingSeriesEvalsToResolve":{"minimum":0,"type":"integer"},"noDataState":{"$ref":"#/components/schemas/NoDataState","default":"NoData"},"notificationSettings":{"$ref":"#/components/schemas/NotificationSettings"},"panelRef":{"$ref":"#/components/schemas/PanelRef"},"paused":{"type":"boolean"},"title":{"type":"string"},"trigger":{"$ref":"#/components/schemas/IntervalTrigger"}},"required":["title","trigger","noDataState","execErrState","expressions"],"type":"object"},"status":{"additionalProperties":false,"properties":{"additionalFields":{"additionalProperties":true,"description":"additionalFields is reserved for future use","type":"object"},"operatorStates":{"additionalProperties":{"$ref":"#/components/schemas/OperatorState"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
 	versionSchemaAlertRulev0alpha1     app.VersionSchema
 	_                                  = json.Unmarshal(rawSchemaAlertRulev0alpha1, &versionSchemaAlertRulev0alpha1)
-	rawSchemaRecordingRulev0alpha1     = []byte(`{"DatasourceUID":{"pattern":"^[a-zA-Z0-9_-]+$","type":"string"},"Expression":{"additionalProperties":false,"properties":{"datasourceUID":{"$ref":"#/components/schemas/DatasourceUID","description":"The UID of the datasource to run this expression against. If omitted, the expression will be run against the ` + "`" + `__expr__` + "`" + ` datasource"},"model":{"additionalProperties":{},"type":"object"},"queryType":{"description":"The type of query if this is a query expression","type":"string"},"relativeTimeRange":{"$ref":"#/components/schemas/RelativeTimeRange"},"source":{"description":"Used to mark the expression to be used as the final source for the rule evaluation\nOnly one expression in a rule can be marked as the source\nFor AlertRules, this is the expression that will be evaluated against the alerting condition\nFor RecordingRules, this is the expression that will be recorded","type":"boolean"}},"required":["model"],"type":"object"},"ExpressionMap":{"additionalProperties":{"$ref":"#/components/schemas/Expression"},"description":"TODO: validate that only one can specify source=true\n\u0026 struct.MinFields(1) This doesn't work in Cue \u003cv0.12.0 as per","type":"object"},"IntervalTrigger":{"additionalProperties":false,"properties":{"interval":{"$ref":"#/components/schemas/PromDuration"}},"required":["interval"],"type":"object"},"MetricName":{"description":"TODO(@moustafab): validate the metric name regex","pattern":"^[a-zA-Z_:][a-zA-Z0-9_:]*$","type":"string"},"OperatorState":{"additionalProperties":false,"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"additionalProperties":true,"description":"details contains any extra information that is operator-specific","type":"object"},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"PromDuration":{"not":{"pattern":"hmuµn"},"pattern":"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|0)$","type":"string"},"PromDurationWMillis":{"pattern":"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$","type":"string"},"RecordingRule":{"properties":{"spec":{"$ref":"#/components/schemas/spec"},"status":{"$ref":"#/components/schemas/status"}},"required":["spec"]},"RelativeTimeRange":{"additionalProperties":false,"properties":{"from":{"$ref":"#/components/schemas/PromDurationWMillis"},"to":{"$ref":"#/components/schemas/PromDurationWMillis"}},"required":["from","to"],"type":"object"},"TemplateString":{"type":"string"},"spec":{"additionalProperties":false,"properties":{"expressions":{"$ref":"#/components/schemas/ExpressionMap"},"labels":{"additionalProperties":{"$ref":"#/components/schemas/TemplateString"},"type":"object"},"metric":{"$ref":"#/components/schemas/MetricName"},"paused":{"type":"boolean"},"targetDatasourceUID":{"$ref":"#/components/schemas/DatasourceUID"},"title":{"type":"string"},"trigger":{"$ref":"#/components/schemas/IntervalTrigger"}},"required":["title","trigger","metric","expressions","targetDatasourceUID"],"type":"object"},"status":{"additionalProperties":false,"properties":{"additionalFields":{"additionalProperties":true,"description":"additionalFields is reserved for future use","type":"object"},"operatorStates":{"additionalProperties":{"$ref":"#/components/schemas/OperatorState"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
+	rawSchemaRecordingRulev0alpha1     = []byte(`{"DatasourceUID":{"pattern":"^[a-zA-Z0-9_-]+$","type":"string"},"Expression":{"additionalProperties":false,"properties":{"datasourceUID":{"$ref":"#/components/schemas/DatasourceUID","description":"The UID of the datasource to run this expression against. If omitted, the expression will be run against the ` + "`" + `__expr__` + "`" + ` datasource"},"model":{"additionalProperties":{},"type":"object"},"queryType":{"description":"The type of query if this is a query expression","type":"string"},"relativeTimeRange":{"$ref":"#/components/schemas/RelativeTimeRange"},"source":{"description":"Used to mark the expression to be used as the final source for the rule evaluation\nOnly one expression in a rule can be marked as the source\nFor AlertRules, this is the expression that will be evaluated against the alerting condition\nFor RecordingRules, this is the expression that will be recorded","type":"boolean"}},"required":["model"],"type":"object"},"ExpressionMap":{"additionalProperties":{"$ref":"#/components/schemas/Expression"},"type":"object"},"IntervalTrigger":{"additionalProperties":false,"properties":{"interval":{"$ref":"#/components/schemas/PromDuration"}},"required":["interval"],"type":"object"},"MetricName":{"pattern":"^[a-zA-Z_:][a-zA-Z0-9_:]*$","type":"string"},"OperatorState":{"additionalProperties":false,"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"additionalProperties":true,"description":"details contains any extra information that is operator-specific","type":"object"},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"PromDuration":{"not":{"pattern":"hmuµn"},"pattern":"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|0)$","type":"string"},"PromDurationWMillis":{"pattern":"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$","type":"string"},"RecordingRule":{"properties":{"spec":{"$ref":"#/components/schemas/spec"},"status":{"$ref":"#/components/schemas/status"}},"required":["spec"]},"RelativeTimeRange":{"additionalProperties":false,"properties":{"from":{"$ref":"#/components/schemas/PromDurationWMillis"},"to":{"$ref":"#/components/schemas/PromDurationWMillis"}},"required":["from","to"],"type":"object"},"TemplateString":{"type":"string"},"spec":{"additionalProperties":false,"properties":{"expressions":{"$ref":"#/components/schemas/ExpressionMap"},"labels":{"additionalProperties":{"$ref":"#/components/schemas/TemplateString"},"type":"object"},"metric":{"$ref":"#/components/schemas/MetricName"},"paused":{"type":"boolean"},"targetDatasourceUID":{"$ref":"#/components/schemas/DatasourceUID"},"title":{"type":"string"},"trigger":{"$ref":"#/components/schemas/IntervalTrigger"}},"required":["title","trigger","metric","expressions","targetDatasourceUID"],"type":"object"},"status":{"additionalProperties":false,"properties":{"additionalFields":{"additionalProperties":true,"description":"additionalFields is reserved for future use","type":"object"},"operatorStates":{"additionalProperties":{"$ref":"#/components/schemas/OperatorState"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
 	versionSchemaRecordingRulev0alpha1 app.VersionSchema
 	_                                  = json.Unmarshal(rawSchemaRecordingRulev0alpha1, &versionSchemaRecordingRulev0alpha1)
 	rawSchemaRuleSequencev0alpha1      = []byte(`{"IntervalTrigger":{"additionalProperties":false,"properties":{"interval":{"$ref":"#/components/schemas/PromDuration"}},"required":["interval"],"type":"object"},"OperatorState":{"additionalProperties":false,"properties":{"descriptiveState":{"description":"descriptiveState is an optional more descriptive state field which has no requirements on format","type":"string"},"details":{"additionalProperties":true,"description":"details contains any extra information that is operator-specific","type":"object"},"lastEvaluation":{"description":"lastEvaluation is the ResourceVersion last evaluated","type":"string"},"state":{"description":"state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.","enum":["success","in_progress","failed"],"type":"string"}},"required":["lastEvaluation","state"],"type":"object"},"PromDuration":{"not":{"pattern":"hmuµn"},"pattern":"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|0)$","type":"string"},"RuleRef":{"additionalProperties":false,"properties":{"name":{"$ref":"#/components/schemas/RuleUID","description":"name is the metadata.name of an AlertRule or RecordingRule resource."}},"required":["name"],"type":"object"},"RuleSequence":{"properties":{"spec":{"$ref":"#/components/schemas/spec"},"status":{"$ref":"#/components/schemas/status"}},"required":["spec"]},"RuleUID":{"pattern":"^[a-zA-Z0-9_-]+$","type":"string"},"spec":{"additionalProperties":false,"properties":{"alertingRules":{"items":{"$ref":"#/components/schemas/RuleRef"},"type":"array"},"recordingRules":{"items":{"$ref":"#/components/schemas/RuleRef"},"type":"array"},"trigger":{"$ref":"#/components/schemas/IntervalTrigger"}},"required":["trigger","recordingRules"],"type":"object"},"status":{"additionalProperties":false,"properties":{"additionalFields":{"additionalProperties":true,"description":"additionalFields is reserved for future use","type":"object"},"operatorStates":{"additionalProperties":{"$ref":"#/components/schemas/OperatorState"},"description":"operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.","type":"object"}},"type":"object"}}`)
@@ -125,9 +125,1358 @@ var appManifestData = app.ManifestData{
 				},
 			},
 			Routes: app.ManifestVersionRoutes{
-				Namespaced: map[string]spec3.PathProps{},
-				Cluster:    map[string]spec3.PathProps{},
-				Schemas:    map[string]spec.Schema{},
+				Namespaced: map[string]spec3.PathProps{
+					"/search": {
+						Get: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "getSearchRules",
+
+								Parameters: []*spec3.Parameter{
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "continueToken",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "dashboardUID",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "datasourceUIDs",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "folders",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "groups",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "labels",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "limit",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"integer"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "metric",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "names",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "notificationType",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "panelID",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"integer"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "paused",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"boolean"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "q",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "receiver",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "routingTree",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "sort",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+
+													Ref: spec.MustCreateRef("#/components/schemas/RuleSearchSortField"),
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "targetDatasourceUID",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "type",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
+
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"apiVersion": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																			},
+																		},
+																		"items": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"array"},
+																				Items: &spec.SchemaOrArray{
+																					Schema: &spec.Schema{
+																						SchemaProps: spec.SchemaProps{
+
+																							Ref: spec.MustCreateRef("#/components/schemas/getSearchRulesRuleHit"),
+																						}},
+																				},
+																			},
+																		},
+																		"kind": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																			},
+																		},
+																		"metadata": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"object"},
+																				Properties: map[string]spec.Schema{
+																					"continue": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"string"},
+																						},
+																					},
+																					"remainingItemCount": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"integer"},
+																						},
+																					},
+																					"resourceVersion": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"string"},
+																						},
+																					},
+																					"selfLink": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"string"},
+																						},
+																					},
+																				},
+																			},
+																			VendorExtensible: spec.VendorExtensible{
+																				Extensions: spec.Extensions{
+																					"x-grafana-app-uses-kubernetes-list-metadata": true,
+																				},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"items",
+																		"apiVersion",
+																		"kind",
+																		"metadata",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+					},
+					"/search/alertrules": {
+						Get: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "getSearchAlertRules",
+
+								Parameters: []*spec3.Parameter{
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "continueToken",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "dashboardUID",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "datasourceUIDs",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "folders",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "groups",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "labels",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "limit",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"integer"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "names",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "notificationType",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "panelID",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"integer"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "paused",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"boolean"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "q",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "receiver",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "routingTree",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "sort",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+
+													Ref: spec.MustCreateRef("#/components/schemas/RuleSearchSortField"),
+												},
+											},
+										},
+									},
+								},
+
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"apiVersion": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																			},
+																		},
+																		"items": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"array"},
+																				Items: &spec.SchemaOrArray{
+																					Schema: &spec.Schema{
+																						SchemaProps: spec.SchemaProps{
+
+																							Ref: spec.MustCreateRef("#/components/schemas/getSearchAlertRulesAlertRuleHit"),
+																						}},
+																				},
+																			},
+																		},
+																		"kind": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																			},
+																		},
+																		"metadata": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"object"},
+																				Properties: map[string]spec.Schema{
+																					"continue": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"string"},
+																						},
+																					},
+																					"remainingItemCount": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"integer"},
+																						},
+																					},
+																					"resourceVersion": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"string"},
+																						},
+																					},
+																					"selfLink": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"string"},
+																						},
+																					},
+																				},
+																			},
+																			VendorExtensible: spec.VendorExtensible{
+																				Extensions: spec.Extensions{
+																					"x-grafana-app-uses-kubernetes-list-metadata": true,
+																				},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"items",
+																		"apiVersion",
+																		"kind",
+																		"metadata",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+					},
+					"/search/recordingrules": {
+						Get: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "getSearchRecordingRules",
+
+								Parameters: []*spec3.Parameter{
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "continueToken",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "datasourceUIDs",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "folders",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "groups",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "labels",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "limit",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"integer"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "metric",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "names",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "paused",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"boolean"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "q",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "sort",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+
+													Ref: spec.MustCreateRef("#/components/schemas/RuleSearchSortField"),
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "targetDatasourceUID",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
+
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"apiVersion": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																			},
+																		},
+																		"items": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"array"},
+																				Items: &spec.SchemaOrArray{
+																					Schema: &spec.Schema{
+																						SchemaProps: spec.SchemaProps{
+
+																							Ref: spec.MustCreateRef("#/components/schemas/getSearchRecordingRulesRecordingRuleHit"),
+																						}},
+																				},
+																			},
+																		},
+																		"kind": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																			},
+																		},
+																		"metadata": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"object"},
+																				Properties: map[string]spec.Schema{
+																					"continue": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"string"},
+																						},
+																					},
+																					"remainingItemCount": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"integer"},
+																						},
+																					},
+																					"resourceVersion": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"string"},
+																						},
+																					},
+																					"selfLink": {
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"string"},
+																						},
+																					},
+																				},
+																			},
+																			VendorExtensible: spec.VendorExtensible{
+																				Extensions: spec.Extensions{
+																					"x-grafana-app-uses-kubernetes-list-metadata": true,
+																				},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"items",
+																		"apiVersion",
+																		"kind",
+																		"metadata",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+					},
+				},
+				Cluster: map[string]spec3.PathProps{},
+				Schemas: map[string]spec.Schema{
+					"getSearchAlertRulesAlertRuleHit": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"annotations": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										AdditionalProperties: &spec.SchemaOrBool{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
+								"dashboardUID": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"datasourceUIDs": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												}},
+										},
+									},
+								},
+								"folder": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"for": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"group": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"interval": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"keepFiringFor": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"labels": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										AdditionalProperties: &spec.SchemaOrBool{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
+								"name": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"notificationType": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"panelID": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"integer"},
+									},
+								},
+								"paused": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"boolean"},
+									},
+								},
+								"receiver": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"routingTree": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"title": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"type": {
+									SchemaProps: spec.SchemaProps{
+
+										Ref: spec.MustCreateRef("#/components/schemas/getSearchAlertRulesRuleSearchType"),
+									},
+								},
+							},
+							Required: []string{
+								"type",
+								"name",
+								"title",
+								"folder",
+							},
+						},
+					},
+					"getSearchAlertRulesRuleSearchType": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"string"},
+							Enum: []interface{}{
+								"alertrule",
+								"recordingrule",
+							},
+						},
+					},
+					"getSearchRecordingRulesRecordingRuleHit": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"datasourceUIDs": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												}},
+										},
+									},
+								},
+								"folder": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"group": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"interval": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"labels": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										AdditionalProperties: &spec.SchemaOrBool{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
+								"metric": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"name": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"paused": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"boolean"},
+									},
+								},
+								"targetDatasourceUID": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"title": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"type": {
+									SchemaProps: spec.SchemaProps{
+
+										Ref: spec.MustCreateRef("#/components/schemas/getSearchRecordingRulesRuleSearchType"),
+									},
+								},
+							},
+							Required: []string{
+								"type",
+								"name",
+								"title",
+								"folder",
+							},
+						},
+					},
+					"getSearchRecordingRulesRuleSearchType": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"string"},
+							Enum: []interface{}{
+								"alertrule",
+								"recordingrule",
+							},
+						},
+					},
+					"getSearchRulesAlertRuleHit": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"annotations": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										AdditionalProperties: &spec.SchemaOrBool{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
+								"dashboardUID": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"datasourceUIDs": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												}},
+										},
+									},
+								},
+								"folder": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"for": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"group": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"interval": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"keepFiringFor": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"labels": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										AdditionalProperties: &spec.SchemaOrBool{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
+								"name": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"notificationType": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"panelID": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"integer"},
+									},
+								},
+								"paused": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"boolean"},
+									},
+								},
+								"receiver": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"routingTree": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"title": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"type": {
+									SchemaProps: spec.SchemaProps{
+
+										Ref: spec.MustCreateRef("#/components/schemas/getSearchRulesRuleSearchType"),
+									},
+								},
+							},
+							Required: []string{
+								"type",
+								"name",
+								"title",
+								"folder",
+							},
+						},
+					},
+					"getSearchRulesRecordingRuleHit": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							Properties: map[string]spec.Schema{
+								"datasourceUIDs": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												}},
+										},
+									},
+								},
+								"folder": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"group": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"interval": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"labels": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"object"},
+										AdditionalProperties: &spec.SchemaOrBool{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
+								"metric": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"name": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"paused": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"boolean"},
+									},
+								},
+								"targetDatasourceUID": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"title": {
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"string"},
+									},
+								},
+								"type": {
+									SchemaProps: spec.SchemaProps{
+
+										Ref: spec.MustCreateRef("#/components/schemas/getSearchRulesRuleSearchType"),
+									},
+								},
+							},
+							Required: []string{
+								"type",
+								"name",
+								"title",
+								"folder",
+							},
+						},
+					},
+					"getSearchRulesRuleHit": {
+						SchemaProps: spec.SchemaProps{
+
+							Description: "RuleHit is the cross-kind union returned by /search.",
+						},
+					},
+					"getSearchRulesRuleSearchType": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"string"},
+							Enum: []interface{}{
+								"alertrule",
+								"recordingrule",
+							},
+						},
+					},
+				},
 			},
 		},
 	},
@@ -154,7 +1503,11 @@ func ManifestGoTypeAssociator(kind, version string) (goType resource.Kind, exist
 	return goType, exists
 }
 
-var customRouteToGoResponseType = map[string]any{}
+var customRouteToGoResponseType = map[string]any{
+	"v0alpha1||<namespace>/search|GET":                v0alpha1.GetSearchRulesResponse{},
+	"v0alpha1||<namespace>/search/alertrules|GET":     v0alpha1.GetSearchAlertRulesResponse{},
+	"v0alpha1||<namespace>/search/recordingrules|GET": v0alpha1.GetSearchRecordingRulesResponse{},
+}
 
 // ManifestCustomRouteResponsesAssociator returns the associated response go type for a given kind, version, custom route path, and method, if one exists.
 // kind may be empty for custom routes which are not kind subroutes. Leading slashes are removed from subroute paths.

--- a/apps/alerting/rules/pkg/app/app.go
+++ b/apps/alerting/rules/pkg/app/app.go
@@ -57,7 +57,8 @@ func New(cfg app.Config) (app.App, error) {
 				},
 			},
 		},
-		ManagedKinds: managedKinds,
+		ManagedKinds:          managedKinds,
+		VersionedCustomRoutes: buildSearchRoutes(runtimeCfg),
 	}
 
 	a, err := simple.NewApp(c)
@@ -71,6 +72,26 @@ func New(cfg app.Config) (app.App, error) {
 	}
 
 	return a, nil
+}
+
+// buildSearchRoutes wires the rule search handlers (provided by the registry)
+// to their namespaced custom routes. Routes whose handler is unset are skipped
+// so manifest validation without a backing instance does not register nil
+// handlers.
+func buildSearchRoutes(cfg config.RuntimeConfig) map[string]simple.AppVersionRouteHandlers {
+	handlers := simple.AppVersionRouteHandlers{}
+	add := func(path string, handler simple.AppCustomRouteHandler) {
+		if handler != nil {
+			handlers[simple.AppVersionRoute{Namespaced: true, Path: path, Method: simple.AppCustomRouteMethodGet}] = handler
+		}
+	}
+	add("/search", cfg.SearchRulesHandler)
+	add("/search/alertrules", cfg.SearchAlertRulesHandler)
+	add("/search/recordingrules", cfg.SearchRecordingRulesHandler)
+	if len(handlers) == 0 {
+		return nil
+	}
+	return map[string]simple.AppVersionRouteHandlers{"v0alpha1": handlers}
 }
 
 func buildKindValidator(kind resource.Kind, cfg config.RuntimeConfig, md app.ManifestData) (*simple.Validator, error) {

--- a/apps/alerting/rules/pkg/app/config/runtime.go
+++ b/apps/alerting/rules/pkg/app/config/runtime.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/grafana/grafana-app-sdk/simple"
+
 	"github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 )
 
@@ -46,4 +48,10 @@ type RuntimeConfig struct {
 	// watches all namespaces (on-prem default); in cloud it must be the stack
 	// namespace, else the all-namespace watch is rejected as a mismatch.
 	WatchNamespace string
+	// Search route handlers, built by the registry with access to the alerting
+	// services. They back the /search, /search/alertrules and
+	// /search/recordingrules namespaced custom routes.
+	SearchRulesHandler          simple.AppCustomRouteHandler
+	SearchAlertRulesHandler     simple.AppCustomRouteHandler
+	SearchRecordingRulesHandler simple.AppCustomRouteHandler
 }

--- a/apps/alerting/rules/plugin/src/generated/alertrule/v0alpha1/types.spec.gen.ts
+++ b/apps/alerting/rules/plugin/src/generated/alertrule/v0alpha1/types.spec.gen.ts
@@ -34,7 +34,6 @@ export enum ExecErrState {
 
 export const defaultExecErrState = (): ExecErrState => (ExecErrState.Error);
 
-// TODO(@moustafab): this should be imported from the notifications package
 export type NotificationSettings = SimplifiedRouting | NamedRoutingTree;
 
 export const defaultNotificationSettings = (): NotificationSettings => (defaultSimplifiedRouting());
@@ -62,7 +61,6 @@ export enum NotificationSettingsType {
 
 export const defaultNotificationSettingsType = (): NotificationSettingsType => (NotificationSettingsType.SimplifiedRouting);
 
-// TODO(@moustafab): validate regex for time interval ref
 export type TimeIntervalRef = string;
 
 export const defaultTimeIntervalRef = (): TimeIntervalRef => ("");
@@ -77,8 +75,6 @@ export const defaultNamedRoutingTree = (): NamedRoutingTree => ({
 	routingTree: "",
 });
 
-// TODO: validate that only one can specify source=true
-// & struct.MinFields(1) This doesn't work in Cue <v0.12.0 as per
 export type ExpressionMap = Record<string, Expression>;
 
 export const defaultExpressionMap = (): ExpressionMap => ({});

--- a/apps/alerting/rules/plugin/src/generated/recordingrule/v0alpha1/types.spec.gen.ts
+++ b/apps/alerting/rules/plugin/src/generated/recordingrule/v0alpha1/types.spec.gen.ts
@@ -16,13 +16,10 @@ export type TemplateString = string;
 
 export const defaultTemplateString = (): TemplateString => ("");
 
-// TODO(@moustafab): validate the metric name regex
 export type MetricName = string;
 
 export const defaultMetricName = (): MetricName => ("");
 
-// TODO: validate that only one can specify source=true
-// & struct.MinFields(1) This doesn't work in Cue <v0.12.0 as per
 export type ExpressionMap = Record<string, Expression>;
 
 export const defaultExpressionMap = (): ExpressionMap => ({});

--- a/pkg/registry/apps/alerting/rules/alertrule/export.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/export.go
@@ -1,0 +1,13 @@
+package alertrule
+
+import (
+	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// ConvertToK8sResource converts a domain alert rule into its v0alpha1 resource
+// representation. It is exported for reuse by the rule search handlers.
+func ConvertToK8sResource(orgID int64, rule *ngmodels.AlertRule, provenance ngmodels.Provenance, namespaceMapper request.NamespaceMapper) (*model.AlertRule, error) {
+	return convertToK8sResource(orgID, rule, provenance, namespaceMapper)
+}

--- a/pkg/registry/apps/alerting/rules/recordingrule/export.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/export.go
@@ -1,0 +1,13 @@
+package recordingrule
+
+import (
+	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// ConvertToK8sResource converts a domain recording rule into its v0alpha1
+// resource representation. It is exported for reuse by the rule search handlers.
+func ConvertToK8sResource(orgID int64, rule *ngmodels.AlertRule, provenance ngmodels.Provenance, namespaceMapper request.NamespaceMapper) (*model.RecordingRule, error) {
+	return convertToK8sResource(orgID, rule, provenance, namespaceMapper)
+}

--- a/pkg/registry/apps/alerting/rules/register.go
+++ b/pkg/registry/apps/alerting/rules/register.go
@@ -228,6 +228,8 @@ func (a *AppInstaller) GetAuthorizer() authorizer.Authorizer {
 				return alertrule.Authorize(ctx, authz, a)
 			case rulesequence.ResourceInfo.GroupResource().Resource:
 				return rulesequence.Authorize(ctx, authz, a)
+			case search.RouteResource:
+				return search.Authorize(ctx, authz, a)
 			}
 			return authorizer.DecisionNoOpinion, "", nil
 		},

--- a/pkg/registry/apps/alerting/rules/register.go
+++ b/pkg/registry/apps/alerting/rules/register.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/alertrule"
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/recordingrule"
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/rulesequence"
+	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/search"
 	"github.com/grafana/grafana/pkg/services/apiserver/appinstaller"
 	reqns "github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/ngalert"
@@ -64,6 +65,8 @@ func RegisterAppInstaller(
 
 	membershipIndex := rulesequence_app.NewMembershipIndex()
 
+	searchHandler := search.NewHandler(*ng.Api.AlertRules, reqns.GetNamespaceMapper(cfg))
+
 	appSpecificConfig := rulesAppConfig.RuntimeConfig{
 		FolderValidator:               newFolderValidator(ng),
 		BaseEvaluationInterval:        ng.Cfg.UnifiedAlerting.BaseInterval,
@@ -72,6 +75,9 @@ func RegisterAppInstaller(
 		MembershipResolver:            membershipIndex,
 		NotificationSettingsValidator: newNotificationSettingsValidator(ng),
 		WatchNamespace:                watchNamespace(cfg),
+		SearchRulesHandler:            searchHandler.SearchRules,
+		SearchAlertRulesHandler:       searchHandler.SearchAlertRules,
+		SearchRecordingRulesHandler:   searchHandler.SearchRecordingRules,
 	}
 
 	provider := simple.NewAppProvider(rulesManifest.LocalManifest(), appSpecificConfig, rulesApp.New)

--- a/pkg/registry/apps/alerting/rules/register.go
+++ b/pkg/registry/apps/alerting/rules/register.go
@@ -32,7 +32,9 @@ import (
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	apistore "github.com/grafana/grafana/pkg/storage/unified/apistore"
+	unifiedresource "github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
 var (
@@ -51,6 +53,8 @@ type AppInstaller struct {
 func RegisterAppInstaller(
 	cfg *setting.Cfg,
 	ng *ngalert.AlertNG,
+	unifiedClient unifiedresource.ResourceClient,
+	dual dualwrite.Service,
 	_ resource.ClientGenerator, // retained for Wire compatibility; membership resolution now uses a watch-backed index
 ) (*AppInstaller, error) {
 	if ng.IsDisabled() {
@@ -65,7 +69,14 @@ func RegisterAppInstaller(
 
 	membershipIndex := rulesequence_app.NewMembershipIndex()
 
-	searchHandler := search.NewHandler(*ng.Api.AlertRules, reqns.GetNamespaceMapper(cfg))
+	// Search routes through a dual-writer-aware client per kind: the legacy
+	// backend (provisioning service) serves modes 0-2, the unified client 3+.
+	legacySearch := search.NewLegacyClient(*ng.Api.AlertRules)
+	searchAdapter := dualwrite.NewSearchAdapter(dual)
+	searchHandler := search.NewHandler(
+		unifiedresource.NewSearchClient(searchAdapter, alertrule.ResourceInfo.GroupResource(), unifiedClient, legacySearch),
+		unifiedresource.NewSearchClient(searchAdapter, recordingrule.ResourceInfo.GroupResource(), unifiedClient, legacySearch),
+	)
 
 	appSpecificConfig := rulesAppConfig.RuntimeConfig{
 		FolderValidator:               newFolderValidator(ng),

--- a/pkg/registry/apps/alerting/rules/register_test.go
+++ b/pkg/registry/apps/alerting/rules/register_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/services/ngalert"
+	"github.com/grafana/grafana/pkg/services/ngalert/api"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/stretchr/testify/require"
@@ -41,9 +43,9 @@ func TestRegisterAppInstaller_UnifiedAlertingEnabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			enabled := tt.enabled
 			cfg := &setting.Cfg{UnifiedAlerting: setting.UnifiedAlertingSettings{Enabled: &enabled}}
-			ng := &ngalert.AlertNG{Cfg: cfg}
+			ng := &ngalert.AlertNG{Cfg: cfg, Api: &api.API{AlertRules: &provisioning.AlertRuleService{}}}
 
-			inst, err := RegisterAppInstaller(cfg, ng, nil)
+			inst, err := RegisterAppInstaller(cfg, ng, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/registry/apps/alerting/rules/search/authorize.go
+++ b/pkg/registry/apps/alerting/rules/search/authorize.go
@@ -1,0 +1,34 @@
+package search
+
+import (
+	"context"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+// RouteResource is the resource segment of the namespaced search routes
+// (/search, /search/alertrules, /search/recordingrules), as seen by the
+// apiserver authorizer.
+const RouteResource = "search"
+
+// Authorize gates the rule search routes on rule-read access, consistent with
+// listing rules. Per-folder/per-rule access is still enforced by each backend
+// (the provisioning service for legacy, the access client for unified), so this
+// is the coarse route-level check.
+func Authorize(ctx context.Context, ac accesscontrol.AccessControl, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+	if attr.GetResource() != RouteResource {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return authorizer.DecisionDeny, "valid user is required", err
+	}
+	ok, err := ac.Evaluate(ctx, user, accesscontrol.EvalPermission(accesscontrol.ActionAlertingRuleRead))
+	if ok {
+		return authorizer.DecisionAllow, "", nil
+	}
+	return authorizer.DecisionDeny, "", err
+}

--- a/pkg/registry/apps/alerting/rules/search/authorize_test.go
+++ b/pkg/registry/apps/alerting/rules/search/authorize_test.go
@@ -1,0 +1,82 @@
+package search
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+type mockAttributes struct {
+	authorizer.Attributes
+	resource string
+}
+
+func (m *mockAttributes) GetResource() string { return m.resource }
+
+type mockAccessControl struct {
+	accesscontrol.AccessControl
+	evaluateFunc func(ctx context.Context, user identity.Requester, evaluator accesscontrol.Evaluator) (bool, error)
+}
+
+func (m *mockAccessControl) Evaluate(ctx context.Context, user identity.Requester, evaluator accesscontrol.Evaluator) (bool, error) {
+	return m.evaluateFunc(ctx, user, evaluator)
+}
+
+func TestAuthorize(t *testing.T) {
+	viewer := func() context.Context {
+		return identity.WithRequester(context.Background(), &identity.StaticRequester{
+			OrgID:   1,
+			UserID:  1,
+			OrgRole: identity.RoleViewer,
+		})
+	}
+
+	t.Run("non-search resource yields no opinion without evaluating", func(t *testing.T) {
+		ac := &mockAccessControl{evaluateFunc: func(context.Context, identity.Requester, accesscontrol.Evaluator) (bool, error) {
+			t.Fatal("should not evaluate access for a non-search resource")
+			return false, nil
+		}}
+		decision, _, err := Authorize(viewer(), ac, &mockAttributes{resource: "alertrules"})
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionNoOpinion, decision)
+	})
+
+	t.Run("search with rule-read permission allows", func(t *testing.T) {
+		var evaluated string
+		ac := &mockAccessControl{evaluateFunc: func(_ context.Context, _ identity.Requester, e accesscontrol.Evaluator) (bool, error) {
+			evaluated = e.String()
+			return true, nil
+		}}
+		decision, _, err := Authorize(viewer(), ac, &mockAttributes{resource: RouteResource})
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+		assert.Contains(t, evaluated, accesscontrol.ActionAlertingRuleRead)
+	})
+
+	t.Run("search without rule-read permission denies", func(t *testing.T) {
+		ac := &mockAccessControl{evaluateFunc: func(context.Context, identity.Requester, accesscontrol.Evaluator) (bool, error) {
+			return false, nil
+		}}
+		decision, _, err := Authorize(viewer(), ac, &mockAttributes{resource: RouteResource})
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+	})
+
+	t.Run("missing user denies", func(t *testing.T) {
+		ac := &mockAccessControl{evaluateFunc: func(context.Context, identity.Requester, accesscontrol.Evaluator) (bool, error) {
+			t.Fatal("should not evaluate access without a requester")
+			return false, nil
+		}}
+		decision, reason, err := Authorize(context.Background(), ac, &mockAttributes{resource: RouteResource})
+		require.Error(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+		assert.True(t, strings.Contains(reason, "valid user is required"))
+	})
+}

--- a/pkg/registry/apps/alerting/rules/search/fields.go
+++ b/pkg/registry/apps/alerting/rules/search/fields.go
@@ -9,11 +9,15 @@ const (
 	fieldTitle          = resource.SEARCH_FIELD_TITLE
 	fieldFolder         = resource.SEARCH_FIELD_FOLDER
 	fieldGroup          = "group"
+	fieldInterval       = "interval"
 	fieldPaused         = "paused"
 	fieldType           = "type"
 	fieldLabels         = "labels"
 	fieldDatasourceUIDs = "datasourceUIDs"
 
+	fieldAnnotations         = "annotations"
+	fieldFor                 = "for"
+	fieldKeepFiringFor       = "keepFiringFor"
 	fieldDashboardUID        = "dashboardUID"
 	fieldPanelID             = "panelID"
 	fieldReceiver            = "receiver"
@@ -26,6 +30,8 @@ const (
 // resultColumns are the columns every search result table carries, in order.
 // Kind-specific columns are empty for the other kind.
 var resultColumns = []string{
-	fieldType, fieldTitle, fieldFolder, fieldGroup, fieldPaused, fieldLabels, fieldDatasourceUIDs,
-	fieldDashboardUID, fieldPanelID, fieldMetric, fieldTargetDatasourceUID,
+	fieldType, fieldTitle, fieldFolder, fieldGroup, fieldInterval, fieldPaused, fieldLabels, fieldDatasourceUIDs,
+	fieldAnnotations, fieldFor, fieldKeepFiringFor,
+	fieldDashboardUID, fieldPanelID, fieldReceiver, fieldNotificationType, fieldRoutingTree,
+	fieldMetric, fieldTargetDatasourceUID,
 }

--- a/pkg/registry/apps/alerting/rules/search/fields.go
+++ b/pkg/registry/apps/alerting/rules/search/fields.go
@@ -1,0 +1,29 @@
+package search
+
+import "github.com/grafana/grafana/pkg/storage/unified/resource"
+
+// Search request requirement keys and result column names shared by the legacy
+// and unified backends (and the unified document builder). Title and folder
+// reuse the standard search fields; the rest are rule-specific.
+const (
+	fieldTitle          = resource.SEARCH_FIELD_TITLE
+	fieldFolder         = resource.SEARCH_FIELD_FOLDER
+	fieldGroup          = "group"
+	fieldPaused         = "paused"
+	fieldType           = "type"
+	fieldLabels         = "labels"
+	fieldDatasourceUIDs = "datasourceUIDs"
+
+	fieldDashboardUID        = "dashboardUID"
+	fieldPanelID             = "panelID"
+	fieldReceiver            = "receiver"
+	fieldNotificationType    = "notificationType"
+	fieldRoutingTree         = "routingTree"
+	fieldMetric              = "metric"
+	fieldTargetDatasourceUID = "targetDatasourceUID"
+)
+
+// resultColumns are the columns every search result table carries, in order.
+var resultColumns = []string{
+	fieldType, fieldTitle, fieldFolder, fieldGroup, fieldPaused, fieldLabels, fieldDatasourceUIDs,
+}

--- a/pkg/registry/apps/alerting/rules/search/fields.go
+++ b/pkg/registry/apps/alerting/rules/search/fields.go
@@ -24,6 +24,8 @@ const (
 )
 
 // resultColumns are the columns every search result table carries, in order.
+// Kind-specific columns are empty for the other kind.
 var resultColumns = []string{
 	fieldType, fieldTitle, fieldFolder, fieldGroup, fieldPaused, fieldLabels, fieldDatasourceUIDs,
+	fieldDashboardUID, fieldPanelID, fieldMetric, fieldTargetDatasourceUID,
 }

--- a/pkg/registry/apps/alerting/rules/search/fields.go
+++ b/pkg/registry/apps/alerting/rules/search/fields.go
@@ -6,6 +6,7 @@ import "github.com/grafana/grafana/pkg/storage/unified/resource"
 // and unified backends (and the unified document builder). Title and folder
 // reuse the standard search fields; the rest are rule-specific.
 const (
+	fieldName           = resource.SEARCH_FIELD_NAME
 	fieldTitle          = resource.SEARCH_FIELD_TITLE
 	fieldFolder         = resource.SEARCH_FIELD_FOLDER
 	fieldGroup          = "group"

--- a/pkg/registry/apps/alerting/rules/search/legacy_search.go
+++ b/pkg/registry/apps/alerting/rules/search/legacy_search.go
@@ -90,6 +90,19 @@ func ruleKey(namespace string, r *ngmodels.AlertRule) *resourcepb.ResourceKey {
 func ruleCells(r *ngmodels.AlertRule) [][]byte {
 	labels, _ := json.Marshal(r.Labels)
 	datasources, _ := json.Marshal(sourceDatasourceUIDs(r))
+
+	var dashboardUID, panelID, metric, targetDatasourceUID string
+	if r.DashboardUID != nil {
+		dashboardUID = *r.DashboardUID
+	}
+	if r.PanelID != nil {
+		panelID = strconv.FormatInt(*r.PanelID, 10)
+	}
+	if r.Record != nil {
+		metric = r.Record.Metric
+		targetDatasourceUID = r.Record.TargetDatasourceUID
+	}
+
 	return [][]byte{
 		[]byte(ruleType(r)),
 		[]byte(r.Title),
@@ -98,6 +111,10 @@ func ruleCells(r *ngmodels.AlertRule) [][]byte {
 		[]byte(strconv.FormatBool(r.IsPaused)),
 		labels,
 		datasources,
+		[]byte(dashboardUID),
+		[]byte(panelID),
+		[]byte(metric),
+		[]byte(targetDatasourceUID),
 	}
 }
 

--- a/pkg/registry/apps/alerting/rules/search/legacy_search.go
+++ b/pkg/registry/apps/alerting/rules/search/legacy_search.go
@@ -1,0 +1,164 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"google.golang.org/grpc"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/alertrule"
+	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/recordingrule"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// legacyClient implements resourcepb.ResourceIndexClient over the provisioning
+// AlertRuleService (the ngalert SQL store). It is the legacy half of the
+// dual-writer-aware search router; selector-expressible filters are pushed to
+// the service and the rest (free-text title, label matchers, source datasource)
+// are applied in memory, mirroring the unified backend's result shape.
+type legacyClient struct {
+	resourcepb.ResourceIndexClient
+	service provisioning.AlertRuleService
+	logger  log.Logger
+}
+
+func NewLegacyClient(service provisioning.AlertRuleService) *legacyClient {
+	return &legacyClient{service: service, logger: log.New("alerting.rules.search.legacy")}
+}
+
+func (c *legacyClient) Search(ctx context.Context, req *resourcepb.ResourceSearchRequest, _ ...grpc.CallOption) (*resourcepb.ResourceSearchResponse, error) {
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	f := extractFilters(req)
+	rules, _, _, err := c.service.ListAlertRules(ctx, user, provisioning.ListAlertRulesOptions{
+		RuleType:                  ruleTypeForRequest(req),
+		GroupFilter:               includeFilter(f.groups),
+		FolderFilter:              includeFilter(f.folders),
+		PausedFilter:              provisioning.ListRuleBoolFilter{Value: f.paused},
+		DashboardFilter:           stringFilter(f.dashboardUID),
+		PanelIDFilter:             stringFilter(f.panelID),
+		NotificationTypeFilter:    stringFilter(f.notificationType),
+		ReceiverFilter:            stringFilter(f.receiver),
+		RoutingTreeFilter:         stringFilter(f.routingTree),
+		MetricFilter:              stringFilter(f.metric),
+		TargetDatasourceUIDFilter: stringFilter(f.targetDatasourceUID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := rules[:0]
+	for _, r := range rules {
+		if !matchText(r, f.text) || !matchLabels(r, f.labels) || !matchDatasources(r, f.datasourceUIDs) {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	sortRules(filtered, f.sortField, f.sortDesc)
+
+	total := len(filtered)
+	page := applyOffset(filtered, req.Offset, req.Limit)
+
+	table := &resourcepb.ResourceTable{Columns: resultColumnDefinitions()}
+	for _, r := range page {
+		table.Rows = append(table.Rows, &resourcepb.ResourceTableRow{
+			Key:   ruleKey(req.Options.GetKey().GetNamespace(), r),
+			Cells: ruleCells(r),
+		})
+	}
+	return &resourcepb.ResourceSearchResponse{Results: table, TotalHits: int64(total)}, nil
+}
+
+func ruleKey(namespace string, r *ngmodels.AlertRule) *resourcepb.ResourceKey {
+	res := alertrule.ResourceInfo
+	if r.Type() == ngmodels.RuleTypeRecording {
+		res = recordingrule.ResourceInfo
+	}
+	gr := res.GroupResource()
+	return &resourcepb.ResourceKey{Namespace: namespace, Group: gr.Group, Resource: gr.Resource, Name: r.UID}
+}
+
+// ruleCells encodes the result columns for a rule, in resultColumns order.
+func ruleCells(r *ngmodels.AlertRule) [][]byte {
+	labels, _ := json.Marshal(r.Labels)
+	datasources, _ := json.Marshal(sourceDatasourceUIDs(r))
+	return [][]byte{
+		[]byte(ruleType(r)),
+		[]byte(r.Title),
+		[]byte(r.NamespaceUID),
+		[]byte(r.RuleGroup),
+		[]byte(strconv.FormatBool(r.IsPaused)),
+		labels,
+		datasources,
+	}
+}
+
+func ruleType(r *ngmodels.AlertRule) string {
+	if r.Type() == ngmodels.RuleTypeRecording {
+		return "recordingrule"
+	}
+	return "alertrule"
+}
+
+func ruleTypeForRequest(req *resourcepb.ResourceSearchRequest) ngmodels.RuleTypeFilter {
+	resourceName := req.Options.GetKey().GetResource()
+	// A federated request (cross-kind /search) carries the other kind too.
+	if len(req.Federated) > 0 {
+		return ngmodels.RuleTypeFilterAll
+	}
+	if resourceName == recordingrule.ResourceInfo.GroupResource().Resource {
+		return ngmodels.RuleTypeFilterRecording
+	}
+	return ngmodels.RuleTypeFilterAlerting
+}
+
+func resultColumnDefinitions() []*resourcepb.ResourceTableColumnDefinition {
+	cols := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(resultColumns))
+	for _, name := range resultColumns {
+		cols = append(cols, &resourcepb.ResourceTableColumnDefinition{
+			Name: name,
+			Type: resourcepb.ResourceTableColumnDefinition_STRING,
+		})
+	}
+	return cols
+}
+
+func applyOffset(rules []*ngmodels.AlertRule, offset, limit int64) []*ngmodels.AlertRule {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > int64(len(rules)) {
+		offset = int64(len(rules))
+	}
+	rules = rules[offset:]
+	if limit > 0 && int64(len(rules)) > limit {
+		rules = rules[:limit]
+	}
+	return rules
+}
+
+// sourceDatasourceUIDs returns the distinct source datasource UIDs referenced by
+// the rule's query expressions (excluding server-side expression datasources).
+func sourceDatasourceUIDs(r *ngmodels.AlertRule) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, q := range r.Data {
+		if _, server := serverSideDatasourceUIDs[q.DatasourceUID]; server || q.DatasourceUID == "" {
+			continue
+		}
+		if _, ok := seen[q.DatasourceUID]; ok {
+			continue
+		}
+		seen[q.DatasourceUID] = struct{}{}
+		out = append(out, q.DatasourceUID)
+	}
+	return out
+}

--- a/pkg/registry/apps/alerting/rules/search/legacy_search.go
+++ b/pkg/registry/apps/alerting/rules/search/legacy_search.go
@@ -42,6 +42,7 @@ func (c *legacyClient) Search(ctx context.Context, req *resourcepb.ResourceSearc
 	f := extractFilters(req)
 	rules, _, _, err := c.service.ListAlertRules(ctx, user, provisioning.ListAlertRulesOptions{
 		RuleType:                  ruleTypeForRequest(req),
+		RuleUIDs:                  f.names,
 		GroupFilter:               includeFilter(f.groups),
 		FolderFilter:              includeFilter(f.folders),
 		PausedFilter:              provisioning.ListRuleBoolFilter{Value: f.paused},
@@ -107,6 +108,7 @@ func ruleCells(r *ngmodels.AlertRule) [][]byte {
 	}
 	receiver, notificationType, routingTree := notificationFields(r.NotificationSettings)
 
+	// TODO: see if there is a safer way to make sure the ordering of cells matches the resultColumns definition, without relying on manual maintenance of this function when columns are added/removed/reshuffled.
 	return [][]byte{
 		[]byte(ruleType(r)),
 		[]byte(r.Title),

--- a/pkg/registry/apps/alerting/rules/search/legacy_search.go
+++ b/pkg/registry/apps/alerting/rules/search/legacy_search.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
+	"time"
 
+	prom_model "github.com/prometheus/common/model"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -89,6 +91,7 @@ func ruleKey(namespace string, r *ngmodels.AlertRule) *resourcepb.ResourceKey {
 // ruleCells encodes the result columns for a rule, in resultColumns order.
 func ruleCells(r *ngmodels.AlertRule) [][]byte {
 	labels, _ := json.Marshal(r.Labels)
+	annotations, _ := json.Marshal(r.Annotations)
 	datasources, _ := json.Marshal(sourceDatasourceUIDs(r))
 
 	var dashboardUID, panelID, metric, targetDatasourceUID string
@@ -102,20 +105,54 @@ func ruleCells(r *ngmodels.AlertRule) [][]byte {
 		metric = r.Record.Metric
 		targetDatasourceUID = r.Record.TargetDatasourceUID
 	}
+	receiver, notificationType, routingTree := notificationFields(r.NotificationSettings)
 
 	return [][]byte{
 		[]byte(ruleType(r)),
 		[]byte(r.Title),
 		[]byte(r.NamespaceUID),
 		[]byte(r.RuleGroup),
+		[]byte(promDuration(time.Duration(r.IntervalSeconds) * time.Second)),
 		[]byte(strconv.FormatBool(r.IsPaused)),
 		labels,
 		datasources,
+		annotations,
+		[]byte(promDurationOrEmpty(r.For)),
+		[]byte(promDurationOrEmpty(r.KeepFiringFor)),
 		[]byte(dashboardUID),
 		[]byte(panelID),
+		[]byte(receiver),
+		[]byte(notificationType),
+		[]byte(routingTree),
 		[]byte(metric),
 		[]byte(targetDatasourceUID),
 	}
+}
+
+func promDuration(d time.Duration) string {
+	return prom_model.Duration(d).String()
+}
+
+func promDurationOrEmpty(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	return promDuration(d)
+}
+
+// notificationFields maps the rule's notification settings to the receiver,
+// notification type, and routing tree displayed on a hit.
+func notificationFields(ns *ngmodels.NotificationSettings) (receiver, notificationType, routingTree string) {
+	if ns == nil {
+		return "", "", ""
+	}
+	if ns.ContactPointRouting != nil {
+		return ns.ContactPointRouting.Receiver, string(ngmodels.NotificationSettingsTypeSimplifiedRouting), ""
+	}
+	if ns.PolicyRouting != nil {
+		return "", string(ngmodels.NotificationSettingsTypeNamedRoutingTree), ns.PolicyRouting.Policy
+	}
+	return "", "", ""
 }
 
 func ruleType(r *ngmodels.AlertRule) string {

--- a/pkg/registry/apps/alerting/rules/search/query.go
+++ b/pkg/registry/apps/alerting/rules/search/query.go
@@ -17,6 +17,7 @@ import (
 // unified backends each decode the request in their own way.
 type filters struct {
 	text                string
+	names               []string
 	folders             []string
 	groups              []string
 	datasourceUIDs      []string
@@ -39,6 +40,8 @@ func extractFilters(req *resourcepb.ResourceSearchRequest) filters {
 	if opts != nil {
 		for _, r := range opts.Fields {
 			switch r.Key {
+			case fieldName:
+				f.names = r.Values
 			case fieldFolder:
 				f.folders = r.Values
 			case fieldLabels:

--- a/pkg/registry/apps/alerting/rules/search/query.go
+++ b/pkg/registry/apps/alerting/rules/search/query.go
@@ -1,0 +1,259 @@
+package search
+
+import (
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/expr"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+)
+
+// parseParams decodes the request query string into the generated (superset)
+// request params type, so the handler input matches the documented API.
+func parseParams(v url.Values) model.GetSearchRulesRequestParams {
+	p := model.GetSearchRulesRequestParams{
+		Q:                   strPtr(v, "q"),
+		Folders:             v["folders"],
+		Groups:              v["groups"],
+		DatasourceUIDs:      v["datasourceUIDs"],
+		Labels:              v["labels"],
+		ContinueToken:       strPtr(v, "continueToken"),
+		Type:                strPtr(v, "type"),
+		DashboardUID:        strPtr(v, "dashboardUID"),
+		Receiver:            strPtr(v, "receiver"),
+		NotificationType:    strPtr(v, "notificationType"),
+		RoutingTree:         strPtr(v, "routingTree"),
+		Metric:              strPtr(v, "metric"),
+		TargetDatasourceUID: strPtr(v, "targetDatasourceUID"),
+	}
+	if s := v.Get("paused"); s != "" {
+		if b, err := strconv.ParseBool(s); err == nil {
+			p.Paused = &b
+		}
+	}
+	if s := v.Get("limit"); s != "" {
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil && n >= 0 {
+			p.Limit = &n
+		}
+	}
+	if s := v.Get("panelID"); s != "" {
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			p.PanelID = &n
+		}
+	}
+	if s := v.Get("sort"); s != "" {
+		f := model.GetSearchRulesRequestRuleSearchSortField(s)
+		p.Sort = &f
+	}
+	return p
+}
+
+func strPtr(v url.Values, key string) *string {
+	if s := v.Get(key); s != "" {
+		return &s
+	}
+	return nil
+}
+
+func strVal(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func limit(p model.GetSearchRulesRequestParams) int64 {
+	if p.Limit == nil {
+		return 0
+	}
+	return *p.Limit
+}
+
+func panelID(p model.GetSearchRulesRequestParams) string {
+	if p.PanelID == nil {
+		return ""
+	}
+	return strconv.FormatInt(*p.PanelID, 10)
+}
+
+// sortSpec splits a sort field value into the field name and descending flag
+// ("-title" -> "title", desc).
+func sortSpec(field *model.GetSearchRulesRequestRuleSearchSortField) (string, bool) {
+	if field == nil {
+		return "", false
+	}
+	s := string(*field)
+	return strings.TrimPrefix(s, "-"), strings.HasPrefix(s, "-")
+}
+
+type labelMatcher struct {
+	key   string
+	value string
+	op    matcherOp
+}
+
+type matcherOp int
+
+const (
+	matchEquals matcherOp = iota
+	matchNotEquals
+	matchExists
+	matchNotExists
+)
+
+func parseLabelMatchers(raw []string) []labelMatcher {
+	matchers := make([]labelMatcher, 0, len(raw))
+	for _, s := range raw {
+		if s == "" {
+			continue
+		}
+		matchers = append(matchers, parseLabelMatcher(s))
+	}
+	return matchers
+}
+
+func parseLabelMatcher(s string) labelMatcher {
+	if rest, ok := strings.CutPrefix(s, "!"); ok {
+		return labelMatcher{key: rest, op: matchNotExists}
+	}
+	if k, v, ok := strings.Cut(s, "!="); ok {
+		return labelMatcher{key: k, value: v, op: matchNotEquals}
+	}
+	if k, v, ok := strings.Cut(s, "="); ok {
+		return labelMatcher{key: k, value: v, op: matchEquals}
+	}
+	return labelMatcher{key: s, op: matchExists}
+}
+
+func matchText(r *ngmodels.AlertRule, text string) bool {
+	if text == "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(r.Title), strings.ToLower(text))
+}
+
+// matchLabels returns true when every matcher holds against the rule labels.
+func matchLabels(r *ngmodels.AlertRule, matchers []labelMatcher) bool {
+	for _, m := range matchers {
+		v, ok := r.Labels[m.key]
+		switch m.op {
+		case matchExists:
+			if !ok {
+				return false
+			}
+		case matchNotExists:
+			if ok {
+				return false
+			}
+		case matchEquals:
+			if !ok || v != m.value {
+				return false
+			}
+		case matchNotEquals:
+			if ok && v == m.value {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// serverSideDatasourceUIDs are the synthetic datasources used for expression
+// nodes; they are never user-facing query datasources.
+var serverSideDatasourceUIDs = map[string]struct{}{
+	expr.DatasourceUID:    {},
+	expr.OldDatasourceUID: {},
+	expr.MLDatasourceUID:  {},
+}
+
+// matchDatasources returns true when the rule references any of the requested
+// source datasources in its query expressions.
+func matchDatasources(r *ngmodels.AlertRule, uids []string) bool {
+	if len(uids) == 0 {
+		return true
+	}
+	have := make(map[string]struct{}, len(r.Data))
+	for _, q := range r.Data {
+		if _, server := serverSideDatasourceUIDs[q.DatasourceUID]; server || q.DatasourceUID == "" {
+			continue
+		}
+		have[q.DatasourceUID] = struct{}{}
+	}
+	for _, want := range uids {
+		if _, ok := have[want]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func sortRules(rules []*ngmodels.AlertRule, field string, desc bool) {
+	var less func(a, b *ngmodels.AlertRule) bool
+	switch field {
+	case "group":
+		// Compound key keeps each group together and in evaluation order.
+		less = func(a, b *ngmodels.AlertRule) bool {
+			if a.NamespaceUID != b.NamespaceUID {
+				return a.NamespaceUID < b.NamespaceUID
+			}
+			if a.RuleGroup != b.RuleGroup {
+				return a.RuleGroup < b.RuleGroup
+			}
+			if a.RuleGroupIndex != b.RuleGroupIndex {
+				return a.RuleGroupIndex < b.RuleGroupIndex
+			}
+			return a.Title < b.Title
+		}
+	default:
+		less = func(a, b *ngmodels.AlertRule) bool {
+			if a.Title != b.Title {
+				return a.Title < b.Title
+			}
+			return a.UID < b.UID
+		}
+	}
+	sort.SliceStable(rules, func(i, j int) bool {
+		if desc {
+			return less(rules[j], rules[i])
+		}
+		return less(rules[i], rules[j])
+	})
+}
+
+// paginate slices the (already filtered and sorted) rules using an offset
+// encoded in the continue token. It returns the page and the token for the
+// next page, which is empty when the last page is reached.
+func paginate(rules []*ngmodels.AlertRule, continueToken string, limit int64) ([]*ngmodels.AlertRule, string) {
+	offset := 0
+	if continueToken != "" {
+		if n, err := strconv.Atoi(continueToken); err == nil && n > 0 {
+			offset = n
+		}
+	}
+	if offset > len(rules) {
+		offset = len(rules)
+	}
+	rules = rules[offset:]
+	if limit <= 0 || int64(len(rules)) <= limit {
+		return rules, ""
+	}
+	return rules[:limit], strconv.Itoa(offset + int(limit))
+}
+
+func includeFilter(values []string) provisioning.ListRuleStringFilter {
+	if len(values) == 0 {
+		return provisioning.ListRuleStringFilter{}
+	}
+	return provisioning.ListRuleStringFilter{Include: values}
+}
+
+func stringFilter(value string) provisioning.ListRuleStringFilter {
+	if value == "" {
+		return provisioning.ListRuleStringFilter{}
+	}
+	return provisioning.ListRuleStringFilter{Include: []string{value}}
+}

--- a/pkg/registry/apps/alerting/rules/search/query.go
+++ b/pkg/registry/apps/alerting/rules/search/query.go
@@ -5,8 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/selection"
-
+	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 	"github.com/grafana/grafana/pkg/expr"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
@@ -42,8 +41,8 @@ func extractFilters(req *resourcepb.ResourceSearchRequest) filters {
 			switch r.Key {
 			case fieldFolder:
 				f.folders = r.Values
-			case fieldGroup:
-				f.groups = r.Values
+			case fieldLabels:
+				f.labels = append(f.labels, requirementToLabelMatchers(r)...)
 			case fieldDatasourceUIDs:
 				f.datasourceUIDs = r.Values
 			case fieldPaused:
@@ -68,8 +67,11 @@ func extractFilters(req *resourcepb.ResourceSearchRequest) filters {
 				f.targetDatasourceUID = firstValue(r.Values)
 			}
 		}
+		// Group is carried as a controlled metadata label.
 		for _, r := range opts.Labels {
-			f.labels = append(f.labels, requirementToMatcher(r))
+			if r.Key == model.GroupLabelKey {
+				f.groups = r.Values
+			}
 		}
 	}
 	if len(req.SortBy) > 0 {
@@ -116,38 +118,46 @@ func parseLabelMatcher(s string) labelMatcher {
 	return labelMatcher{key: s, op: matchExists}
 }
 
-// requirementToMatcher / matcherToRequirement translate a label matcher to and
-// from a ResourceSearchRequest label requirement so it survives the request.
-func requirementToMatcher(r *resourcepb.Requirement) labelMatcher {
-	m := labelMatcher{key: r.Key, value: firstValue(r.Values)}
-	switch selection.Operator(r.Operator) {
-	case selection.NotEquals:
-		m.op = matchNotEquals
-	case selection.Exists:
-		m.op = matchExists
-	case selection.DoesNotExist:
-		m.op = matchNotExists
-	default:
-		m.op = matchEquals
-	}
-	return m
-}
-
-func matcherToRequirement(m labelMatcher) *resourcepb.Requirement {
-	r := &resourcepb.Requirement{Key: m.key}
+// labelMatcherRequirement / requirementToLabelMatchers translate label matchers
+// to and from a requirement on the indexed "labels" field, using flattened
+// "key"/"key=value" terms and in/notin operators so a matcher survives the
+// request and resolves the same way on both backends.
+func labelMatcherRequirement(m labelMatcher) *resourcepb.Requirement {
+	r := &resourcepb.Requirement{Key: fieldLabels, Operator: "in"}
 	switch m.op {
+	case matchEquals:
+		r.Values = []string{m.key + "=" + m.value}
 	case matchNotEquals:
-		r.Operator = string(selection.NotEquals)
-		r.Values = []string{m.value}
+		r.Operator = "notin"
+		r.Values = []string{m.key + "=" + m.value}
 	case matchExists:
-		r.Operator = string(selection.Exists)
+		r.Values = []string{m.key}
 	case matchNotExists:
-		r.Operator = string(selection.DoesNotExist)
-	default:
-		r.Operator = string(selection.Equals)
-		r.Values = []string{m.value}
+		r.Operator = "notin"
+		r.Values = []string{m.key}
 	}
 	return r
+}
+
+func requirementToLabelMatchers(r *resourcepb.Requirement) []labelMatcher {
+	negated := r.Operator == "notin" || r.Operator == "!="
+	out := make([]labelMatcher, 0, len(r.Values))
+	for _, term := range r.Values {
+		if k, v, ok := strings.Cut(term, "="); ok {
+			op := matchEquals
+			if negated {
+				op = matchNotEquals
+			}
+			out = append(out, labelMatcher{key: k, value: v, op: op})
+			continue
+		}
+		op := matchExists
+		if negated {
+			op = matchNotExists
+		}
+		out = append(out, labelMatcher{key: term, op: op})
+	}
+	return out
 }
 
 func matchText(r *ngmodels.AlertRule, text string) bool {

--- a/pkg/registry/apps/alerting/rules/search/query.go
+++ b/pkg/registry/apps/alerting/rules/search/query.go
@@ -1,93 +1,89 @@
 package search
 
 import (
-	"net/url"
 	"sort"
 	"strconv"
 	"strings"
 
-	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"k8s.io/apimachinery/pkg/selection"
+
 	"github.com/grafana/grafana/pkg/expr"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
-// parseParams decodes the request query string into the generated (superset)
-// request params type, so the handler input matches the documented API.
-func parseParams(v url.Values) model.GetSearchRulesRequestParams {
-	p := model.GetSearchRulesRequestParams{
-		Q:                   strPtr(v, "q"),
-		Folders:             v["folders"],
-		Groups:              v["groups"],
-		DatasourceUIDs:      v["datasourceUIDs"],
-		Labels:              v["labels"],
-		ContinueToken:       strPtr(v, "continueToken"),
-		Type:                strPtr(v, "type"),
-		DashboardUID:        strPtr(v, "dashboardUID"),
-		Receiver:            strPtr(v, "receiver"),
-		NotificationType:    strPtr(v, "notificationType"),
-		RoutingTree:         strPtr(v, "routingTree"),
-		Metric:              strPtr(v, "metric"),
-		TargetDatasourceUID: strPtr(v, "targetDatasourceUID"),
-	}
-	if s := v.Get("paused"); s != "" {
-		if b, err := strconv.ParseBool(s); err == nil {
-			p.Paused = &b
-		}
-	}
-	if s := v.Get("limit"); s != "" {
-		if n, err := strconv.ParseInt(s, 10, 64); err == nil && n >= 0 {
-			p.Limit = &n
-		}
-	}
-	if s := v.Get("panelID"); s != "" {
-		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
-			p.PanelID = &n
-		}
-	}
-	if s := v.Get("sort"); s != "" {
-		f := model.GetSearchRulesRequestRuleSearchSortField(s)
-		p.Sort = &f
-	}
-	return p
+// filters is the backend-neutral view of a ResourceSearchRequest used by the
+// legacy backend. The handler encodes these into the request; the legacy and
+// unified backends each decode the request in their own way.
+type filters struct {
+	text                string
+	folders             []string
+	groups              []string
+	datasourceUIDs      []string
+	labels              []labelMatcher
+	paused              *bool
+	dashboardUID        string
+	panelID             string
+	receiver            string
+	notificationType    string
+	routingTree         string
+	metric              string
+	targetDatasourceUID string
+	sortField           string
+	sortDesc            bool
 }
 
-func strPtr(v url.Values, key string) *string {
-	if s := v.Get(key); s != "" {
-		return &s
+func extractFilters(req *resourcepb.ResourceSearchRequest) filters {
+	f := filters{text: req.Query}
+	opts := req.Options
+	if opts != nil {
+		for _, r := range opts.Fields {
+			switch r.Key {
+			case fieldFolder:
+				f.folders = r.Values
+			case fieldGroup:
+				f.groups = r.Values
+			case fieldDatasourceUIDs:
+				f.datasourceUIDs = r.Values
+			case fieldPaused:
+				if len(r.Values) == 1 {
+					if b, err := strconv.ParseBool(r.Values[0]); err == nil {
+						f.paused = &b
+					}
+				}
+			case fieldDashboardUID:
+				f.dashboardUID = firstValue(r.Values)
+			case fieldPanelID:
+				f.panelID = firstValue(r.Values)
+			case fieldReceiver:
+				f.receiver = firstValue(r.Values)
+			case fieldNotificationType:
+				f.notificationType = firstValue(r.Values)
+			case fieldRoutingTree:
+				f.routingTree = firstValue(r.Values)
+			case fieldMetric:
+				f.metric = firstValue(r.Values)
+			case fieldTargetDatasourceUID:
+				f.targetDatasourceUID = firstValue(r.Values)
+			}
+		}
+		for _, r := range opts.Labels {
+			f.labels = append(f.labels, requirementToMatcher(r))
+		}
 	}
-	return nil
+	if len(req.SortBy) > 0 {
+		f.sortField = req.SortBy[0].Field
+		f.sortDesc = req.SortBy[0].Desc
+	}
+	return f
 }
 
-func strVal(p *string) string {
-	if p == nil {
+func firstValue(values []string) string {
+	if len(values) == 0 {
 		return ""
 	}
-	return *p
-}
-
-func limit(p model.GetSearchRulesRequestParams) int64 {
-	if p.Limit == nil {
-		return 0
-	}
-	return *p.Limit
-}
-
-func panelID(p model.GetSearchRulesRequestParams) string {
-	if p.PanelID == nil {
-		return ""
-	}
-	return strconv.FormatInt(*p.PanelID, 10)
-}
-
-// sortSpec splits a sort field value into the field name and descending flag
-// ("-title" -> "title", desc).
-func sortSpec(field *model.GetSearchRulesRequestRuleSearchSortField) (string, bool) {
-	if field == nil {
-		return "", false
-	}
-	s := string(*field)
-	return strings.TrimPrefix(s, "-"), strings.HasPrefix(s, "-")
+	return values[0]
 }
 
 type labelMatcher struct {
@@ -105,17 +101,8 @@ const (
 	matchNotExists
 )
 
-func parseLabelMatchers(raw []string) []labelMatcher {
-	matchers := make([]labelMatcher, 0, len(raw))
-	for _, s := range raw {
-		if s == "" {
-			continue
-		}
-		matchers = append(matchers, parseLabelMatcher(s))
-	}
-	return matchers
-}
-
+// parseLabelMatcher parses a "labels" query value: key=value, key!=value, key
+// (exists) or !key (not exists).
 func parseLabelMatcher(s string) labelMatcher {
 	if rest, ok := strings.CutPrefix(s, "!"); ok {
 		return labelMatcher{key: rest, op: matchNotExists}
@@ -127,6 +114,40 @@ func parseLabelMatcher(s string) labelMatcher {
 		return labelMatcher{key: k, value: v, op: matchEquals}
 	}
 	return labelMatcher{key: s, op: matchExists}
+}
+
+// requirementToMatcher / matcherToRequirement translate a label matcher to and
+// from a ResourceSearchRequest label requirement so it survives the request.
+func requirementToMatcher(r *resourcepb.Requirement) labelMatcher {
+	m := labelMatcher{key: r.Key, value: firstValue(r.Values)}
+	switch selection.Operator(r.Operator) {
+	case selection.NotEquals:
+		m.op = matchNotEquals
+	case selection.Exists:
+		m.op = matchExists
+	case selection.DoesNotExist:
+		m.op = matchNotExists
+	default:
+		m.op = matchEquals
+	}
+	return m
+}
+
+func matcherToRequirement(m labelMatcher) *resourcepb.Requirement {
+	r := &resourcepb.Requirement{Key: m.key}
+	switch m.op {
+	case matchNotEquals:
+		r.Operator = string(selection.NotEquals)
+		r.Values = []string{m.value}
+	case matchExists:
+		r.Operator = string(selection.Exists)
+	case matchNotExists:
+		r.Operator = string(selection.DoesNotExist)
+	default:
+		r.Operator = string(selection.Equals)
+		r.Values = []string{m.value}
+	}
+	return r
 }
 
 func matchText(r *ngmodels.AlertRule, text string) bool {
@@ -194,7 +215,7 @@ func matchDatasources(r *ngmodels.AlertRule, uids []string) bool {
 func sortRules(rules []*ngmodels.AlertRule, field string, desc bool) {
 	var less func(a, b *ngmodels.AlertRule) bool
 	switch field {
-	case "group":
+	case fieldGroup:
 		// Compound key keeps each group together and in evaluation order.
 		less = func(a, b *ngmodels.AlertRule) bool {
 			if a.NamespaceUID != b.NamespaceUID {
@@ -222,26 +243,6 @@ func sortRules(rules []*ngmodels.AlertRule, field string, desc bool) {
 		}
 		return less(rules[i], rules[j])
 	})
-}
-
-// paginate slices the (already filtered and sorted) rules using an offset
-// encoded in the continue token. It returns the page and the token for the
-// next page, which is empty when the last page is reached.
-func paginate(rules []*ngmodels.AlertRule, continueToken string, limit int64) ([]*ngmodels.AlertRule, string) {
-	offset := 0
-	if continueToken != "" {
-		if n, err := strconv.Atoi(continueToken); err == nil && n > 0 {
-			offset = n
-		}
-	}
-	if offset > len(rules) {
-		offset = len(rules)
-	}
-	rules = rules[offset:]
-	if limit <= 0 || int64(len(rules)) <= limit {
-		return rules, ""
-	}
-	return rules[:limit], strconv.Itoa(offset + int(limit))
 }
 
 func includeFilter(values []string) provisioning.ListRuleStringFilter {

--- a/pkg/registry/apps/alerting/rules/search/query_test.go
+++ b/pkg/registry/apps/alerting/rules/search/query_test.go
@@ -22,8 +22,9 @@ func TestParseLabelMatcher(t *testing.T) {
 	}
 	for in, want := range tests {
 		assert.Equal(t, want, parseLabelMatcher(in), in)
-		// matchers must survive the round trip through a request requirement.
-		assert.Equal(t, want, requirementToMatcher(matcherToRequirement(want)), in)
+		// matchers must survive the round trip through the labels-field requirement.
+		got := requirementToLabelMatchers(labelMatcherRequirement(want))
+		require.Equal(t, []labelMatcher{want}, got, in)
 	}
 }
 

--- a/pkg/registry/apps/alerting/rules/search/query_test.go
+++ b/pkg/registry/apps/alerting/rules/search/query_test.go
@@ -8,29 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/alertrule"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
-
-func TestParseParams(t *testing.T) {
-	v, err := url.ParseQuery("q=cpu&folders=f1&folders=f2&groups=g1&paused=true&limit=10&sort=-group&type=alertrule&labels=team%3Da&labels=!__grafana_origin&datasourceUIDs=ds1&panelID=7")
-	require.NoError(t, err)
-
-	p := parseParams(v)
-
-	assert.Equal(t, "cpu", strVal(p.Q))
-	assert.Equal(t, []string{"f1", "f2"}, p.Folders)
-	assert.Equal(t, []string{"g1"}, p.Groups)
-	require.NotNil(t, p.Paused)
-	assert.True(t, *p.Paused)
-	assert.Equal(t, int64(10), limit(p))
-	assert.Equal(t, "alertrule", strVal(p.Type))
-	assert.Equal(t, []string{"ds1"}, p.DatasourceUIDs)
-	assert.Equal(t, "7", panelID(p))
-
-	field, desc := sortSpec(p.Sort)
-	assert.Equal(t, "group", field)
-	assert.True(t, desc)
-}
 
 func TestParseLabelMatcher(t *testing.T) {
 	tests := map[string]labelMatcher{
@@ -41,20 +22,21 @@ func TestParseLabelMatcher(t *testing.T) {
 	}
 	for in, want := range tests {
 		assert.Equal(t, want, parseLabelMatcher(in), in)
+		// matchers must survive the round trip through a request requirement.
+		assert.Equal(t, want, requirementToMatcher(matcherToRequirement(want)), in)
 	}
 }
 
 func TestMatchLabels(t *testing.T) {
 	rule := &ngmodels.AlertRule{Labels: map[string]string{"team": "a", "__grafana_origin": "plugin/x"}}
 
-	assert.True(t, matchLabels(rule, parseLabelMatchers([]string{"team=a"})))
-	assert.False(t, matchLabels(rule, parseLabelMatchers([]string{"team=b"})))
-	assert.True(t, matchLabels(rule, parseLabelMatchers([]string{"team!=b"})))
-	// plugin-owned via existence check
-	assert.True(t, matchLabels(rule, parseLabelMatchers([]string{"__grafana_origin"})))
-	assert.False(t, matchLabels(rule, parseLabelMatchers([]string{"!__grafana_origin"})))
+	assert.True(t, matchLabels(rule, []labelMatcher{parseLabelMatcher("team=a")}))
+	assert.False(t, matchLabels(rule, []labelMatcher{parseLabelMatcher("team=b")}))
+	assert.True(t, matchLabels(rule, []labelMatcher{parseLabelMatcher("team!=b")}))
+	assert.True(t, matchLabels(rule, []labelMatcher{parseLabelMatcher("__grafana_origin")}))
+	assert.False(t, matchLabels(rule, []labelMatcher{parseLabelMatcher("!__grafana_origin")}))
 	// all matchers must hold (AND)
-	assert.False(t, matchLabels(rule, parseLabelMatchers([]string{"team=a", "missing"})))
+	assert.False(t, matchLabels(rule, []labelMatcher{parseLabelMatcher("team=a"), parseLabelMatcher("missing")}))
 }
 
 func TestMatchDatasources(t *testing.T) {
@@ -67,7 +49,6 @@ func TestMatchDatasources(t *testing.T) {
 	assert.True(t, matchDatasources(rule, []string{"ds1"}))
 	assert.True(t, matchDatasources(rule, []string{"other", "ds1"}))
 	assert.False(t, matchDatasources(rule, []string{"other"}))
-	// the server-side expression datasource is never matchable
 	assert.False(t, matchDatasources(rule, []string{expr.DatasourceUID}))
 }
 
@@ -78,52 +59,88 @@ func TestSortRules(t *testing.T) {
 		{Title: "c", NamespaceUID: "f1", RuleGroup: "g0", RuleGroupIndex: 1},
 	}
 
-	sortRules(rules, "group", false)
-	// g0 sorts before g1; within g1 the group index is preserved.
+	sortRules(rules, fieldGroup, false)
 	assert.Equal(t, []string{"c", "a", "b"}, titles(rules))
 
-	sortRules(rules, "title", false)
+	sortRules(rules, fieldTitle, false)
 	assert.Equal(t, []string{"a", "b", "c"}, titles(rules))
 
-	sortRules(rules, "title", true)
+	sortRules(rules, fieldTitle, true)
 	assert.Equal(t, []string{"c", "b", "a"}, titles(rules))
 }
 
-func TestPaginate(t *testing.T) {
-	rules := make([]*ngmodels.AlertRule, 5)
-	for i := range rules {
-		rules[i] = &ngmodels.AlertRule{UID: string(rune('a' + i))}
+// TestBuildSearchRequestExtractRoundTrip verifies the handler-built request can
+// be decoded back into the same filters by the legacy backend.
+func TestBuildSearchRequestExtractRoundTrip(t *testing.T) {
+	q := url.Values{
+		"q":              {"cpu"},
+		"folders":        {"f1", "f2"},
+		"groups":         {"g1"},
+		"paused":         {"true"},
+		"datasourceUIDs": {"ds1", "ds2"},
+		"labels":         {"team=a", "!__grafana_origin"},
+		"sort":           {"-group"},
+		"receiver":       {"slack"},
+	}
+	req, offset, err := buildSearchRequest(q, "default", alertrule.ResourceInfo.GroupResource(), nil)
+	require.NoError(t, err)
+	assert.Zero(t, offset)
+
+	f := extractFilters(req)
+	assert.Equal(t, "cpu", f.text)
+	assert.Equal(t, []string{"f1", "f2"}, f.folders)
+	assert.Equal(t, []string{"g1"}, f.groups)
+	assert.Equal(t, []string{"ds1", "ds2"}, f.datasourceUIDs)
+	assert.Equal(t, "slack", f.receiver)
+	require.NotNil(t, f.paused)
+	assert.True(t, *f.paused)
+	assert.Equal(t, fieldGroup, f.sortField)
+	assert.True(t, f.sortDesc)
+	assert.ElementsMatch(t, []labelMatcher{
+		{key: "team", value: "a", op: matchEquals},
+		{key: "__grafana_origin", op: matchNotExists},
+	}, f.labels)
+}
+
+// TestCellsParseRoundTrip verifies a rule encoded into table cells decodes back
+// into the expected hit.
+func TestCellsParseRoundTrip(t *testing.T) {
+	rule := &ngmodels.AlertRule{
+		UID:          "uid1",
+		Title:        "cpu high",
+		NamespaceUID: "folder1",
+		RuleGroup:    "group1",
+		IsPaused:     true,
+		Labels:       map[string]string{"team": "a"},
+		Data:         []ngmodels.AlertQuery{{DatasourceUID: "ds1"}, {DatasourceUID: expr.DatasourceUID}},
 	}
 
-	page, token := paginate(rules, "", 2)
-	assert.Len(t, page, 2)
-	assert.Equal(t, "2", token)
-
-	page, token = paginate(rules, token, 2)
-	assert.Equal(t, []string{"c", "d"}, uids(page))
-	assert.Equal(t, "4", token)
-
-	page, token = paginate(rules, token, 2)
-	assert.Equal(t, []string{"e"}, uids(page))
-	assert.Empty(t, token, "last page has no continue token")
-
-	page, token = paginate(rules, "", 0)
-	assert.Len(t, page, 5, "limit 0 returns everything")
-	assert.Empty(t, token)
+	resp := &resourcepb.ResourceSearchResponse{
+		TotalHits: 1,
+		Results: &resourcepb.ResourceTable{
+			Columns: resultColumnDefinitions(),
+			Rows:    []*resourcepb.ResourceTableRow{{Key: ruleKey("default", rule), Cells: ruleCells(rule)}},
+		},
+	}
+	hits := parseResults(resp)
+	require.Len(t, hits, 1)
+	h := hits[0]
+	assert.Equal(t, "uid1", h.Name)
+	assert.EqualValues(t, "alertrule", h.Type)
+	assert.Equal(t, "cpu high", h.Title)
+	assert.Equal(t, "folder1", h.Folder)
+	require.NotNil(t, h.Group)
+	assert.Equal(t, "group1", *h.Group)
+	require.NotNil(t, h.Paused)
+	assert.True(t, *h.Paused)
+	assert.Equal(t, map[string]string{"team": "a"}, h.Labels)
+	assert.Equal(t, []string{"ds1"}, h.DatasourceUIDs)
 }
 
 func titles(rules []*ngmodels.AlertRule) []string {
 	out := make([]string, len(rules))
 	for i, r := range rules {
 		out[i] = r.Title
-	}
-	return out
-}
-
-func uids(rules []*ngmodels.AlertRule) []string {
-	out := make([]string, len(rules))
-	for i, r := range rules {
-		out[i] = r.UID
 	}
 	return out
 }

--- a/pkg/registry/apps/alerting/rules/search/query_test.go
+++ b/pkg/registry/apps/alerting/rules/search/query_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -107,13 +108,19 @@ func TestBuildSearchRequestExtractRoundTrip(t *testing.T) {
 // into the expected hit.
 func TestCellsParseRoundTrip(t *testing.T) {
 	rule := &ngmodels.AlertRule{
-		UID:          "uid1",
-		Title:        "cpu high",
-		NamespaceUID: "folder1",
-		RuleGroup:    "group1",
-		IsPaused:     true,
-		Labels:       map[string]string{"team": "a"},
-		Data:         []ngmodels.AlertQuery{{DatasourceUID: "ds1"}, {DatasourceUID: expr.DatasourceUID}},
+		UID:             "uid1",
+		Title:           "cpu high",
+		NamespaceUID:    "folder1",
+		RuleGroup:       "group1",
+		IntervalSeconds: 60,
+		For:             5 * time.Minute,
+		IsPaused:        true,
+		Labels:          map[string]string{"team": "a"},
+		Annotations:     map[string]string{"summary": "cpu is high"},
+		Data:            []ngmodels.AlertQuery{{DatasourceUID: "ds1"}, {DatasourceUID: expr.DatasourceUID}},
+		NotificationSettings: &ngmodels.NotificationSettings{
+			ContactPointRouting: &ngmodels.ContactPointRouting{Receiver: "slack"},
+		},
 	}
 
 	resp := &resourcepb.ResourceSearchResponse{
@@ -136,6 +143,15 @@ func TestCellsParseRoundTrip(t *testing.T) {
 	assert.True(t, *h.Paused)
 	assert.Equal(t, map[string]string{"team": "a"}, h.Labels)
 	assert.Equal(t, []string{"ds1"}, h.DatasourceUIDs)
+	require.NotNil(t, h.Interval)
+	assert.Equal(t, "1m", *h.Interval)
+	require.NotNil(t, h.For)
+	assert.Equal(t, "5m", *h.For)
+	assert.Equal(t, map[string]string{"summary": "cpu is high"}, h.Annotations)
+	require.NotNil(t, h.Receiver)
+	assert.Equal(t, "slack", *h.Receiver)
+	require.NotNil(t, h.NotificationType)
+	assert.Equal(t, "SimplifiedRouting", *h.NotificationType)
 }
 
 func titles(rules []*ngmodels.AlertRule) []string {

--- a/pkg/registry/apps/alerting/rules/search/query_test.go
+++ b/pkg/registry/apps/alerting/rules/search/query_test.go
@@ -1,0 +1,129 @@
+package search
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/expr"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func TestParseParams(t *testing.T) {
+	v, err := url.ParseQuery("q=cpu&folders=f1&folders=f2&groups=g1&paused=true&limit=10&sort=-group&type=alertrule&labels=team%3Da&labels=!__grafana_origin&datasourceUIDs=ds1&panelID=7")
+	require.NoError(t, err)
+
+	p := parseParams(v)
+
+	assert.Equal(t, "cpu", strVal(p.Q))
+	assert.Equal(t, []string{"f1", "f2"}, p.Folders)
+	assert.Equal(t, []string{"g1"}, p.Groups)
+	require.NotNil(t, p.Paused)
+	assert.True(t, *p.Paused)
+	assert.Equal(t, int64(10), limit(p))
+	assert.Equal(t, "alertrule", strVal(p.Type))
+	assert.Equal(t, []string{"ds1"}, p.DatasourceUIDs)
+	assert.Equal(t, "7", panelID(p))
+
+	field, desc := sortSpec(p.Sort)
+	assert.Equal(t, "group", field)
+	assert.True(t, desc)
+}
+
+func TestParseLabelMatcher(t *testing.T) {
+	tests := map[string]labelMatcher{
+		"team=a":            {key: "team", value: "a", op: matchEquals},
+		"team!=a":           {key: "team", value: "a", op: matchNotEquals},
+		"__grafana_origin":  {key: "__grafana_origin", op: matchExists},
+		"!__grafana_origin": {key: "__grafana_origin", op: matchNotExists},
+	}
+	for in, want := range tests {
+		assert.Equal(t, want, parseLabelMatcher(in), in)
+	}
+}
+
+func TestMatchLabels(t *testing.T) {
+	rule := &ngmodels.AlertRule{Labels: map[string]string{"team": "a", "__grafana_origin": "plugin/x"}}
+
+	assert.True(t, matchLabels(rule, parseLabelMatchers([]string{"team=a"})))
+	assert.False(t, matchLabels(rule, parseLabelMatchers([]string{"team=b"})))
+	assert.True(t, matchLabels(rule, parseLabelMatchers([]string{"team!=b"})))
+	// plugin-owned via existence check
+	assert.True(t, matchLabels(rule, parseLabelMatchers([]string{"__grafana_origin"})))
+	assert.False(t, matchLabels(rule, parseLabelMatchers([]string{"!__grafana_origin"})))
+	// all matchers must hold (AND)
+	assert.False(t, matchLabels(rule, parseLabelMatchers([]string{"team=a", "missing"})))
+}
+
+func TestMatchDatasources(t *testing.T) {
+	rule := &ngmodels.AlertRule{Data: []ngmodels.AlertQuery{
+		{DatasourceUID: "ds1"},
+		{DatasourceUID: expr.DatasourceUID},
+	}}
+
+	assert.True(t, matchDatasources(rule, nil))
+	assert.True(t, matchDatasources(rule, []string{"ds1"}))
+	assert.True(t, matchDatasources(rule, []string{"other", "ds1"}))
+	assert.False(t, matchDatasources(rule, []string{"other"}))
+	// the server-side expression datasource is never matchable
+	assert.False(t, matchDatasources(rule, []string{expr.DatasourceUID}))
+}
+
+func TestSortRules(t *testing.T) {
+	rules := []*ngmodels.AlertRule{
+		{Title: "b", NamespaceUID: "f1", RuleGroup: "g1", RuleGroupIndex: 2},
+		{Title: "a", NamespaceUID: "f1", RuleGroup: "g1", RuleGroupIndex: 1},
+		{Title: "c", NamespaceUID: "f1", RuleGroup: "g0", RuleGroupIndex: 1},
+	}
+
+	sortRules(rules, "group", false)
+	// g0 sorts before g1; within g1 the group index is preserved.
+	assert.Equal(t, []string{"c", "a", "b"}, titles(rules))
+
+	sortRules(rules, "title", false)
+	assert.Equal(t, []string{"a", "b", "c"}, titles(rules))
+
+	sortRules(rules, "title", true)
+	assert.Equal(t, []string{"c", "b", "a"}, titles(rules))
+}
+
+func TestPaginate(t *testing.T) {
+	rules := make([]*ngmodels.AlertRule, 5)
+	for i := range rules {
+		rules[i] = &ngmodels.AlertRule{UID: string(rune('a' + i))}
+	}
+
+	page, token := paginate(rules, "", 2)
+	assert.Len(t, page, 2)
+	assert.Equal(t, "2", token)
+
+	page, token = paginate(rules, token, 2)
+	assert.Equal(t, []string{"c", "d"}, uids(page))
+	assert.Equal(t, "4", token)
+
+	page, token = paginate(rules, token, 2)
+	assert.Equal(t, []string{"e"}, uids(page))
+	assert.Empty(t, token, "last page has no continue token")
+
+	page, token = paginate(rules, "", 0)
+	assert.Len(t, page, 5, "limit 0 returns everything")
+	assert.Empty(t, token)
+}
+
+func titles(rules []*ngmodels.AlertRule) []string {
+	out := make([]string, len(rules))
+	for i, r := range rules {
+		out[i] = r.Title
+	}
+	return out
+}
+
+func uids(rules []*ngmodels.AlertRule) []string {
+	out := make([]string, len(rules))
+	for i, r := range rules {
+		out[i] = r.UID
+	}
+	return out
+}

--- a/pkg/registry/apps/alerting/rules/search/query_test.go
+++ b/pkg/registry/apps/alerting/rules/search/query_test.go
@@ -122,7 +122,7 @@ func TestCellsParseRoundTrip(t *testing.T) {
 			Rows:    []*resourcepb.ResourceTableRow{{Key: ruleKey("default", rule), Cells: ruleCells(rule)}},
 		},
 	}
-	hits := parseResults(resp)
+	hits := parseAlertRuleHits(resp)
 	require.Len(t, hits, 1)
 	h := hits[0]
 	assert.Equal(t, "uid1", h.Name)

--- a/pkg/registry/apps/alerting/rules/search/search.go
+++ b/pkg/registry/apps/alerting/rules/search/search.go
@@ -45,11 +45,27 @@ func (h *Handler) clientFor(primary schema.GroupResource) resourcepb.ResourceInd
 }
 
 func (h *Handler) SearchAlertRules(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
-	return h.search(ctx, w, req, alertrule.ResourceInfo.GroupResource(), nil)
+	resp, next, err := h.run(ctx, req, alertrule.ResourceInfo.GroupResource(), nil)
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, &model.GetSearchAlertRulesResponse{
+		TypeMeta:                listTypeMeta,
+		ListMeta:                metav1.ListMeta{Continue: next},
+		GetSearchAlertRulesBody: model.GetSearchAlertRulesBody{Items: parseAlertRuleHits(resp)},
+	})
 }
 
 func (h *Handler) SearchRecordingRules(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
-	return h.search(ctx, w, req, recordingrule.ResourceInfo.GroupResource(), nil)
+	resp, next, err := h.run(ctx, req, recordingrule.ResourceInfo.GroupResource(), nil)
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, &model.GetSearchRecordingRulesResponse{
+		TypeMeta:                    listTypeMeta,
+		ListMeta:                    metav1.ListMeta{Continue: next},
+		GetSearchRecordingRulesBody: model.GetSearchRecordingRulesBody{Items: parseRecordingRuleHits(resp)},
+	})
 }
 
 func (h *Handler) SearchRules(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
@@ -64,36 +80,46 @@ func (h *Handler) SearchRules(ctx context.Context, w app.CustomRouteResponseWrit
 		primary = recordingrule.ResourceInfo.GroupResource()
 		federated = nil
 	}
-	return h.search(ctx, w, req, primary, federated)
-}
-
-func (h *Handler) search(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest, primary schema.GroupResource, federated []schema.GroupResource) error {
-	namespace := req.ResourceIdentifier.Namespace
-	searchReq, offset, err := buildSearchRequest(req.URL.Query(), namespace, primary, federated)
-	if err != nil {
-		return apierrors.NewBadRequest(err.Error())
-	}
-
-	resp, err := h.clientFor(primary).Search(ctx, searchReq)
+	resp, next, err := h.run(ctx, req, primary, federated)
 	if err != nil {
 		return err
 	}
-	if resp.Error != nil {
-		return apierrors.NewInternalError(errorFromResult(resp.Error))
-	}
-
-	items := parseResults(resp)
-	next := ""
-	if offset+int64(len(items)) < resp.TotalHits {
-		next = strconv.FormatInt(offset+int64(len(items)), 10)
-	}
-
 	return writeJSON(w, &model.GetSearchRulesResponse{
-		TypeMeta:           metav1.TypeMeta{APIVersion: model.GroupVersion.String(), Kind: "RuleSearchResults"},
+		TypeMeta:           listTypeMeta,
 		ListMeta:           metav1.ListMeta{Continue: next},
-		GetSearchRulesBody: model.GetSearchRulesBody{Items: items},
+		GetSearchRulesBody: model.GetSearchRulesBody{Items: parseRuleHits(resp)},
 	})
 }
+
+// run builds the search request, dispatches to the mode-routed client for the
+// primary kind, and computes the next page token.
+func (h *Handler) run(ctx context.Context, req *app.CustomRouteRequest, primary schema.GroupResource, federated []schema.GroupResource) (*resourcepb.ResourceSearchResponse, string, error) {
+	searchReq, offset, err := buildSearchRequest(req.URL.Query(), req.ResourceIdentifier.Namespace, primary, federated)
+	if err != nil {
+		return nil, "", apierrors.NewBadRequest(err.Error())
+	}
+	resp, err := h.clientFor(primary).Search(ctx, searchReq)
+	if err != nil {
+		return nil, "", err
+	}
+	if resp.Error != nil {
+		return nil, "", apierrors.NewInternalError(errorFromResult(resp.Error))
+	}
+	next := ""
+	if rows := rowCount(resp); offset+rows < resp.TotalHits {
+		next = strconv.FormatInt(offset+rows, 10)
+	}
+	return resp, next, nil
+}
+
+func rowCount(resp *resourcepb.ResourceSearchResponse) int64 {
+	if resp.Results == nil {
+		return 0
+	}
+	return int64(len(resp.Results.Rows))
+}
+
+var listTypeMeta = metav1.TypeMeta{APIVersion: model.GroupVersion.String(), Kind: "RuleSearchResults"}
 
 func resourceKey(namespace string, gr schema.GroupResource) *resourcepb.ResourceKey {
 	return &resourcepb.ResourceKey{Namespace: namespace, Group: gr.Group, Resource: gr.Resource}
@@ -154,44 +180,154 @@ func buildSearchRequest(q url.Values, namespace string, primary schema.GroupReso
 	return req, offset, nil
 }
 
-// parseResults turns the search response table into typed rule hits, reading
-// cells by column name so it works for both the legacy and unified backends.
-func parseResults(resp *resourcepb.ResourceSearchResponse) []model.GetSearchRulesRuleHit {
+// rowReader reads cells from a search result table by column name.
+type rowReader struct {
+	idx map[string]int
+	row *resourcepb.ResourceTableRow
+}
+
+func newRowReaders(resp *resourcepb.ResourceSearchResponse) []rowReader {
 	if resp.Results == nil {
-		return []model.GetSearchRulesRuleHit{}
+		return nil
 	}
 	idx := map[string]int{}
 	for i, c := range resp.Results.Columns {
 		idx[c.Name] = i
 	}
-	cell := func(row *resourcepb.ResourceTableRow, name string) []byte {
-		if i, ok := idx[name]; ok && i < len(row.Cells) {
-			return row.Cells[i]
-		}
-		return nil
-	}
-
-	hits := make([]model.GetSearchRulesRuleHit, 0, len(resp.Results.Rows))
+	readers := make([]rowReader, 0, len(resp.Results.Rows))
 	for _, row := range resp.Results.Rows {
-		hit := model.GetSearchRulesRuleHit{
-			Type:   model.GetSearchRulesRuleSearchType(cell(row, fieldType)),
-			Name:   row.Key.GetName(),
-			Title:  string(cell(row, fieldTitle)),
-			Folder: string(cell(row, fieldFolder)),
+		readers = append(readers, rowReader{idx: idx, row: row})
+	}
+	return readers
+}
+
+func (r rowReader) str(name string) string {
+	if i, ok := r.idx[name]; ok && i < len(r.row.Cells) {
+		return string(r.row.Cells[i])
+	}
+	return ""
+}
+
+func (r rowReader) strPtr(name string) *string {
+	if v := r.str(name); v != "" {
+		return &v
+	}
+	return nil
+}
+
+func (r rowReader) boolPtr(name string) *bool {
+	if v := r.str(name); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return &b
 		}
-		if g := string(cell(row, fieldGroup)); g != "" {
-			hit.Group = &g
+	}
+	return nil
+}
+
+func (r rowReader) int64Ptr(name string) *int64 {
+	if v := r.str(name); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return &n
 		}
-		if p := string(cell(row, fieldPaused)); p != "" {
-			if b, err := strconv.ParseBool(p); err == nil {
-				hit.Paused = &b
+	}
+	return nil
+}
+
+func (r rowReader) labels() map[string]string {
+	var out map[string]string
+	if i, ok := r.idx[fieldLabels]; ok && i < len(r.row.Cells) && len(r.row.Cells[i]) > 0 {
+		_ = json.Unmarshal(r.row.Cells[i], &out)
+	}
+	return out
+}
+
+func (r rowReader) datasourceUIDs() []string {
+	var out []string
+	if i, ok := r.idx[fieldDatasourceUIDs]; ok && i < len(r.row.Cells) && len(r.row.Cells[i]) > 0 {
+		_ = json.Unmarshal(r.row.Cells[i], &out)
+	}
+	return out
+}
+
+func parseAlertRuleHits(resp *resourcepb.ResourceSearchResponse) []model.GetSearchAlertRulesAlertRuleHit {
+	rows := newRowReaders(resp)
+	hits := make([]model.GetSearchAlertRulesAlertRuleHit, 0, len(rows))
+	for _, r := range rows {
+		hits = append(hits, model.GetSearchAlertRulesAlertRuleHit{
+			Type:             model.GetSearchAlertRulesRuleSearchType(r.str(fieldType)),
+			Name:             r.row.Key.GetName(),
+			Title:            r.str(fieldTitle),
+			Folder:           r.str(fieldFolder),
+			Group:            r.strPtr(fieldGroup),
+			Paused:           r.boolPtr(fieldPaused),
+			Labels:           r.labels(),
+			DatasourceUIDs:   r.datasourceUIDs(),
+			DashboardUID:     r.strPtr(fieldDashboardUID),
+			PanelID:          r.int64Ptr(fieldPanelID),
+			Receiver:         r.strPtr(fieldReceiver),
+			NotificationType: r.strPtr(fieldNotificationType),
+			RoutingTree:      r.strPtr(fieldRoutingTree),
+		})
+	}
+	return hits
+}
+
+func parseRecordingRuleHits(resp *resourcepb.ResourceSearchResponse) []model.GetSearchRecordingRulesRecordingRuleHit {
+	rows := newRowReaders(resp)
+	hits := make([]model.GetSearchRecordingRulesRecordingRuleHit, 0, len(rows))
+	for _, r := range rows {
+		hits = append(hits, model.GetSearchRecordingRulesRecordingRuleHit{
+			Type:                model.GetSearchRecordingRulesRuleSearchType(r.str(fieldType)),
+			Name:                r.row.Key.GetName(),
+			Title:               r.str(fieldTitle),
+			Folder:              r.str(fieldFolder),
+			Group:               r.strPtr(fieldGroup),
+			Paused:              r.boolPtr(fieldPaused),
+			Labels:              r.labels(),
+			DatasourceUIDs:      r.datasourceUIDs(),
+			Metric:              r.strPtr(fieldMetric),
+			TargetDatasourceUID: r.strPtr(fieldTargetDatasourceUID),
+		})
+	}
+	return hits
+}
+
+// parseRuleHits builds the cross-kind union, discriminating each row by its
+// type column into the matching variant.
+func parseRuleHits(resp *resourcepb.ResourceSearchResponse) []model.GetSearchRulesRuleHit {
+	rows := newRowReaders(resp)
+	hits := make([]model.GetSearchRulesRuleHit, 0, len(rows))
+	for _, r := range rows {
+		hit := model.GetSearchRulesRuleHit{}
+		if r.str(fieldType) == "recordingrule" {
+			hit.RecordingRuleHit = &model.GetSearchRulesRecordingRuleHit{
+				Type:                model.GetSearchRulesRuleSearchTypeRecordingRule,
+				Name:                r.row.Key.GetName(),
+				Title:               r.str(fieldTitle),
+				Folder:              r.str(fieldFolder),
+				Group:               r.strPtr(fieldGroup),
+				Paused:              r.boolPtr(fieldPaused),
+				Labels:              r.labels(),
+				DatasourceUIDs:      r.datasourceUIDs(),
+				Metric:              r.strPtr(fieldMetric),
+				TargetDatasourceUID: r.strPtr(fieldTargetDatasourceUID),
 			}
-		}
-		if l := cell(row, fieldLabels); len(l) > 0 {
-			_ = json.Unmarshal(l, &hit.Labels)
-		}
-		if d := cell(row, fieldDatasourceUIDs); len(d) > 0 {
-			_ = json.Unmarshal(d, &hit.DatasourceUIDs)
+		} else {
+			hit.AlertRuleHit = &model.GetSearchRulesAlertRuleHit{
+				Type:             model.GetSearchRulesRuleSearchTypeAlertRule,
+				Name:             r.row.Key.GetName(),
+				Title:            r.str(fieldTitle),
+				Folder:           r.str(fieldFolder),
+				Group:            r.strPtr(fieldGroup),
+				Paused:           r.boolPtr(fieldPaused),
+				Labels:           r.labels(),
+				DatasourceUIDs:   r.datasourceUIDs(),
+				DashboardUID:     r.strPtr(fieldDashboardUID),
+				PanelID:          r.int64Ptr(fieldPanelID),
+				Receiver:         r.strPtr(fieldReceiver),
+				NotificationType: r.strPtr(fieldNotificationType),
+				RoutingTree:      r.strPtr(fieldRoutingTree),
+			}
 		}
 		hits = append(hits, hit)
 	}

--- a/pkg/registry/apps/alerting/rules/search/search.go
+++ b/pkg/registry/apps/alerting/rules/search/search.go
@@ -155,6 +155,7 @@ func buildSearchRequest(q url.Values, namespace string, primary schema.GroupReso
 			req.Options.Fields = append(req.Options.Fields, &resourcepb.Requirement{Key: field, Operator: "in", Values: vals})
 		}
 	}
+	add(fieldName, q["names"]...)
 	add(fieldFolder, q["folders"]...)
 	add(fieldDatasourceUIDs, q["datasourceUIDs"]...)
 	add(fieldDashboardUID, q.Get("dashboardUID"))

--- a/pkg/registry/apps/alerting/rules/search/search.go
+++ b/pkg/registry/apps/alerting/rules/search/search.go
@@ -4,210 +4,219 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana-app-sdk/app"
 
 	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/alertrule"
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/recordingrule"
-	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
-	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
-// Handler serves the rule search custom routes. It queries rules through the
-// provisioning service (legacy storage) and applies the filters that cannot be
-// expressed as field/label selectors (free-text title, rule-label matchers and
-// source datasource) plus sorting and pagination in memory.
+const defaultLimit = 100
+
+// Handler serves the rule search custom routes. It builds a ResourceSearchRequest
+// from the query string and delegates to a dual-writer-aware search client that
+// routes to the legacy or unified backend based on the resource's storage mode.
+// One router per kind is held because the dual-writer mode is per resource.
 type Handler struct {
-	service    provisioning.AlertRuleService
-	namespacer request.NamespaceMapper
-	logger     log.Logger
+	alertRules     resourcepb.ResourceIndexClient
+	recordingRules resourcepb.ResourceIndexClient
+	logger         log.Logger
 }
 
-func NewHandler(service provisioning.AlertRuleService, namespacer request.NamespaceMapper) *Handler {
-	return &Handler{
-		service:    service,
-		namespacer: namespacer,
-		logger:     log.New("alerting.rules.search"),
+func NewHandler(alertRules, recordingRules resourcepb.ResourceIndexClient) *Handler {
+	return &Handler{alertRules: alertRules, recordingRules: recordingRules, logger: log.New("alerting.rules.search")}
+}
+
+// clientFor selects the router for the primary resource being searched.
+func (h *Handler) clientFor(primary schema.GroupResource) resourcepb.ResourceIndexClient {
+	if primary.Resource == recordingrule.ResourceInfo.GroupResource().Resource {
+		return h.recordingRules
 	}
+	return h.alertRules
 }
 
 func (h *Handler) SearchAlertRules(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
-	page, err := h.collect(ctx, req, ngmodels.RuleTypeFilterAlerting)
-	if err != nil {
-		return err
-	}
-	items := make([]model.GetSearchAlertRulesAlertRuleHit, 0, len(page.rules))
-	for _, r := range page.rules {
-		obj, err := alertrule.ConvertToK8sResource(page.orgID, r, page.provenances[r.UID], h.namespacer)
-		if err != nil {
-			h.skip(ctx, r, err)
-			continue
-		}
-		var spec model.GetSearchAlertRulesAlertRuleSpec
-		if err := reencode(obj.Spec, &spec); err != nil {
-			h.skip(ctx, r, err)
-			continue
-		}
-		items = append(items, model.GetSearchAlertRulesAlertRuleHit{Metadata: obj.ObjectMeta, Spec: spec})
-	}
-	return writeJSON(w, &model.GetSearchAlertRulesResponse{
-		TypeMeta:                listTypeMeta,
-		ListMeta:                metav1.ListMeta{Continue: page.continueToken},
-		GetSearchAlertRulesBody: model.GetSearchAlertRulesBody{Items: items},
-	})
+	return h.search(ctx, w, req, alertrule.ResourceInfo.GroupResource(), nil)
 }
 
 func (h *Handler) SearchRecordingRules(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
-	page, err := h.collect(ctx, req, ngmodels.RuleTypeFilterRecording)
-	if err != nil {
-		return err
-	}
-	items := make([]model.GetSearchRecordingRulesRecordingRuleHit, 0, len(page.rules))
-	for _, r := range page.rules {
-		obj, err := recordingrule.ConvertToK8sResource(page.orgID, r, page.provenances[r.UID], h.namespacer)
-		if err != nil {
-			h.skip(ctx, r, err)
-			continue
-		}
-		var spec model.GetSearchRecordingRulesRecordingRuleSpec
-		if err := reencode(obj.Spec, &spec); err != nil {
-			h.skip(ctx, r, err)
-			continue
-		}
-		items = append(items, model.GetSearchRecordingRulesRecordingRuleHit{Metadata: obj.ObjectMeta, Spec: spec})
-	}
-	return writeJSON(w, &model.GetSearchRecordingRulesResponse{
-		TypeMeta:                    listTypeMeta,
-		ListMeta:                    metav1.ListMeta{Continue: page.continueToken},
-		GetSearchRecordingRulesBody: model.GetSearchRecordingRulesBody{Items: items},
-	})
+	return h.search(ctx, w, req, recordingrule.ResourceInfo.GroupResource(), nil)
 }
 
 func (h *Handler) SearchRules(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
-	page, err := h.collect(ctx, req, ngmodels.RuleTypeFilterAll)
+	// Cross-kind: search alert rules with recording rules federated. A type
+	// query param can still narrow to a single kind.
+	primary := alertrule.ResourceInfo.GroupResource()
+	federated := []schema.GroupResource{recordingrule.ResourceInfo.GroupResource()}
+	switch req.URL.Query().Get("type") {
+	case "alertrule":
+		federated = nil
+	case "recordingrule":
+		primary = recordingrule.ResourceInfo.GroupResource()
+		federated = nil
+	}
+	return h.search(ctx, w, req, primary, federated)
+}
+
+func (h *Handler) search(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest, primary schema.GroupResource, federated []schema.GroupResource) error {
+	namespace := req.ResourceIdentifier.Namespace
+	searchReq, offset, err := buildSearchRequest(req.URL.Query(), namespace, primary, federated)
+	if err != nil {
+		return apierrors.NewBadRequest(err.Error())
+	}
+
+	resp, err := h.clientFor(primary).Search(ctx, searchReq)
 	if err != nil {
 		return err
 	}
-	items := make([]model.GetSearchRulesRuleHit, 0, len(page.rules))
-	for _, r := range page.rules {
-		hit, err := h.crossKindHit(page.orgID, r, page.provenances[r.UID])
-		if err != nil {
-			h.skip(ctx, r, err)
-			continue
-		}
-		items = append(items, hit)
+	if resp.Error != nil {
+		return apierrors.NewInternalError(errorFromResult(resp.Error))
 	}
+
+	items := parseResults(resp)
+	next := ""
+	if offset+int64(len(items)) < resp.TotalHits {
+		next = strconv.FormatInt(offset+int64(len(items)), 10)
+	}
+
 	return writeJSON(w, &model.GetSearchRulesResponse{
-		TypeMeta:           listTypeMeta,
-		ListMeta:           metav1.ListMeta{Continue: page.continueToken},
+		TypeMeta:           metav1.TypeMeta{APIVersion: model.GroupVersion.String(), Kind: "RuleSearchResults"},
+		ListMeta:           metav1.ListMeta{Continue: next},
 		GetSearchRulesBody: model.GetSearchRulesBody{Items: items},
 	})
 }
 
-// crossKindHit builds an untyped (spec union) hit for the cross-kind endpoint.
-func (h *Handler) crossKindHit(orgID int64, r *ngmodels.AlertRule, provenance ngmodels.Provenance) (model.GetSearchRulesRuleHit, error) {
-	if r.Type() == ngmodels.RuleTypeRecording {
-		obj, err := recordingrule.ConvertToK8sResource(orgID, r, provenance, h.namespacer)
-		if err != nil {
-			return model.GetSearchRulesRuleHit{}, err
+func resourceKey(namespace string, gr schema.GroupResource) *resourcepb.ResourceKey {
+	return &resourcepb.ResourceKey{Namespace: namespace, Group: gr.Group, Resource: gr.Resource}
+}
+
+func buildSearchRequest(q url.Values, namespace string, primary schema.GroupResource, federated []schema.GroupResource) (*resourcepb.ResourceSearchRequest, int64, error) {
+	limit := int64(defaultLimit)
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			limit = n
 		}
-		return model.GetSearchRulesRuleHit{Metadata: obj.ObjectMeta, Spec: obj.Spec}, nil
 	}
-	obj, err := alertrule.ConvertToK8sResource(orgID, r, provenance, h.namespacer)
-	if err != nil {
-		return model.GetSearchRulesRuleHit{}, err
-	}
-	return model.GetSearchRulesRuleHit{Metadata: obj.ObjectMeta, Spec: obj.Spec}, nil
-}
-
-// resultPage is the filtered, sorted and paginated rule set plus the context
-// needed to render hits.
-type resultPage struct {
-	rules         []*ngmodels.AlertRule
-	provenances   map[string]ngmodels.Provenance
-	orgID         int64
-	continueToken string
-}
-
-func (h *Handler) collect(ctx context.Context, req *app.CustomRouteRequest, ruleType ngmodels.RuleTypeFilter) (resultPage, error) {
-	user, err := identity.GetRequester(ctx)
-	if err != nil {
-		return resultPage{}, apierrors.NewUnauthorized(err.Error())
-	}
-	info, err := request.NamespaceInfoFrom(ctx, true)
-	if err != nil {
-		return resultPage{}, apierrors.NewBadRequest(err.Error())
-	}
-
-	params := parseParams(req.URL.Query())
-	if ruleType == ngmodels.RuleTypeFilterAll {
-		switch strVal(params.Type) {
-		case "alertrule":
-			ruleType = ngmodels.RuleTypeFilterAlerting
-		case "recordingrule":
-			ruleType = ngmodels.RuleTypeFilterRecording
-		case "":
-		default:
-			return resultPage{}, apierrors.NewBadRequest("invalid type: must be one of alertrule, recordingrule")
+	var offset int64
+	if v := q.Get("continueToken"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			offset = n
 		}
 	}
 
-	// Server-side (selector-backed) filters narrow the set; the remaining
-	// filters and ordering are applied in memory, so we fetch the full set.
-	rules, provenances, _, err := h.service.ListAlertRules(ctx, user, provisioning.ListAlertRulesOptions{
-		RuleType:                  ruleType,
-		GroupFilter:               includeFilter(params.Groups),
-		FolderFilter:              includeFilter(params.Folders),
-		PausedFilter:              provisioning.ListRuleBoolFilter{Value: params.Paused},
-		DashboardFilter:           stringFilter(strVal(params.DashboardUID)),
-		PanelIDFilter:             stringFilter(panelID(params)),
-		NotificationTypeFilter:    stringFilter(strVal(params.NotificationType)),
-		ReceiverFilter:            stringFilter(strVal(params.Receiver)),
-		RoutingTreeFilter:         stringFilter(strVal(params.RoutingTree)),
-		MetricFilter:              stringFilter(strVal(params.Metric)),
-		TargetDatasourceUIDFilter: stringFilter(strVal(params.TargetDatasourceUID)),
-	})
-	if err != nil {
-		return resultPage{}, err
+	req := &resourcepb.ResourceSearchRequest{
+		Options: &resourcepb.ListOptions{Key: resourceKey(namespace, primary)},
+		Query:   q.Get("q"),
+		Limit:   limit,
+		Offset:  offset,
+	}
+	for _, gr := range federated {
+		req.Federated = append(req.Federated, resourceKey(namespace, gr))
 	}
 
-	matchers := parseLabelMatchers(params.Labels)
-	filtered := rules[:0]
-	for _, r := range rules {
-		if !matchText(r, strVal(params.Q)) || !matchLabels(r, matchers) || !matchDatasources(r, params.DatasourceUIDs) {
-			continue
+	add := func(field string, values ...string) {
+		vals := nonEmpty(values)
+		if len(vals) > 0 {
+			req.Options.Fields = append(req.Options.Fields, &resourcepb.Requirement{Key: field, Operator: "in", Values: vals})
 		}
-		filtered = append(filtered, r)
 	}
-
-	field, desc := sortSpec(params.Sort)
-	sortRules(filtered, field, desc)
-
-	page, token := paginate(filtered, strVal(params.ContinueToken), limit(params))
-	return resultPage{rules: page, provenances: provenances, orgID: info.OrgID, continueToken: token}, nil
+	add(fieldFolder, q["folders"]...)
+	add(fieldGroup, q["groups"]...)
+	add(fieldDatasourceUIDs, q["datasourceUIDs"]...)
+	add(fieldDashboardUID, q.Get("dashboardUID"))
+	add(fieldPanelID, q.Get("panelID"))
+	add(fieldReceiver, q.Get("receiver"))
+	add(fieldNotificationType, q.Get("notificationType"))
+	add(fieldRoutingTree, q.Get("routingTree"))
+	add(fieldMetric, q.Get("metric"))
+	add(fieldTargetDatasourceUID, q.Get("targetDatasourceUID"))
+	if v := q.Get("paused"); v != "" {
+		req.Options.Fields = append(req.Options.Fields, &resourcepb.Requirement{Key: fieldPaused, Operator: "=", Values: []string{v}})
+	}
+	for _, l := range q["labels"] {
+		if l != "" {
+			req.Options.Labels = append(req.Options.Labels, matcherToRequirement(parseLabelMatcher(l)))
+		}
+	}
+	if s := q.Get("sort"); s != "" {
+		desc := s[0] == '-'
+		req.SortBy = []*resourcepb.ResourceSearchRequest_Sort{{Field: trimSortPrefix(s), Desc: desc}}
+	}
+	return req, offset, nil
 }
 
-func (h *Handler) skip(ctx context.Context, r *ngmodels.AlertRule, err error) {
-	h.logger.FromContext(ctx).Warn("skipping rule that failed conversion", "uid", r.UID, "error", err)
+// parseResults turns the search response table into typed rule hits, reading
+// cells by column name so it works for both the legacy and unified backends.
+func parseResults(resp *resourcepb.ResourceSearchResponse) []model.GetSearchRulesRuleHit {
+	if resp.Results == nil {
+		return []model.GetSearchRulesRuleHit{}
+	}
+	idx := map[string]int{}
+	for i, c := range resp.Results.Columns {
+		idx[c.Name] = i
+	}
+	cell := func(row *resourcepb.ResourceTableRow, name string) []byte {
+		if i, ok := idx[name]; ok && i < len(row.Cells) {
+			return row.Cells[i]
+		}
+		return nil
+	}
+
+	hits := make([]model.GetSearchRulesRuleHit, 0, len(resp.Results.Rows))
+	for _, row := range resp.Results.Rows {
+		hit := model.GetSearchRulesRuleHit{
+			Type:   model.GetSearchRulesRuleSearchType(cell(row, fieldType)),
+			Name:   row.Key.GetName(),
+			Title:  string(cell(row, fieldTitle)),
+			Folder: string(cell(row, fieldFolder)),
+		}
+		if g := string(cell(row, fieldGroup)); g != "" {
+			hit.Group = &g
+		}
+		if p := string(cell(row, fieldPaused)); p != "" {
+			if b, err := strconv.ParseBool(p); err == nil {
+				hit.Paused = &b
+			}
+		}
+		if l := cell(row, fieldLabels); len(l) > 0 {
+			_ = json.Unmarshal(l, &hit.Labels)
+		}
+		if d := cell(row, fieldDatasourceUIDs); len(d) > 0 {
+			_ = json.Unmarshal(d, &hit.DatasourceUIDs)
+		}
+		hits = append(hits, hit)
+	}
+	return hits
 }
 
-var listTypeMeta = metav1.TypeMeta{APIVersion: model.GroupVersion.String(), Kind: "RuleSearchResults"}
-
-// reencode copies src into dst via JSON. The per-kind hit specs are generated
-// as route-local types that are JSON-identical to the canonical rule specs.
-func reencode(src any, dst any) error {
-	b, err := json.Marshal(src)
-	if err != nil {
-		return err
+func nonEmpty(values []string) []string {
+	out := values[:0]
+	for _, v := range values {
+		if v != "" {
+			out = append(out, v)
+		}
 	}
-	return json.Unmarshal(b, dst)
+	return out
+}
+
+func trimSortPrefix(s string) string {
+	if len(s) > 0 && s[0] == '-' {
+		return s[1:]
+	}
+	return s
+}
+
+func errorFromResult(e *resourcepb.ErrorResult) error {
+	return &apierrors.StatusError{ErrStatus: metav1.Status{Status: metav1.StatusFailure, Message: e.Message, Code: e.Code}}
 }
 
 func writeJSON(w app.CustomRouteResponseWriter, obj any) error {

--- a/pkg/registry/apps/alerting/rules/search/search.go
+++ b/pkg/registry/apps/alerting/rules/search/search.go
@@ -156,7 +156,6 @@ func buildSearchRequest(q url.Values, namespace string, primary schema.GroupReso
 		}
 	}
 	add(fieldFolder, q["folders"]...)
-	add(fieldGroup, q["groups"]...)
 	add(fieldDatasourceUIDs, q["datasourceUIDs"]...)
 	add(fieldDashboardUID, q.Get("dashboardUID"))
 	add(fieldPanelID, q.Get("panelID"))
@@ -168,9 +167,15 @@ func buildSearchRequest(q url.Values, namespace string, primary schema.GroupReso
 	if v := q.Get("paused"); v != "" {
 		req.Options.Fields = append(req.Options.Fields, &resourcepb.Requirement{Key: fieldPaused, Operator: "=", Values: []string{v}})
 	}
+	// Group is a controlled metadata label, matched via the label selector.
+	if groups := nonEmpty(q["groups"]); len(groups) > 0 {
+		req.Options.Labels = append(req.Options.Labels, &resourcepb.Requirement{Key: model.GroupLabelKey, Operator: "in", Values: groups})
+	}
+	// Rule labels are matched against the indexed labels field as flattened
+	// "key"/"key=value" terms.
 	for _, l := range q["labels"] {
 		if l != "" {
-			req.Options.Labels = append(req.Options.Labels, matcherToRequirement(parseLabelMatcher(l)))
+			req.Options.Fields = append(req.Options.Fields, labelMatcherRequirement(parseLabelMatcher(l)))
 		}
 	}
 	if s := q.Get("sort"); s != "" {

--- a/pkg/registry/apps/alerting/rules/search/search.go
+++ b/pkg/registry/apps/alerting/rules/search/search.go
@@ -1,0 +1,217 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana-app-sdk/app"
+
+	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/alertrule"
+	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/recordingrule"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+)
+
+// Handler serves the rule search custom routes. It queries rules through the
+// provisioning service (legacy storage) and applies the filters that cannot be
+// expressed as field/label selectors (free-text title, rule-label matchers and
+// source datasource) plus sorting and pagination in memory.
+type Handler struct {
+	service    provisioning.AlertRuleService
+	namespacer request.NamespaceMapper
+	logger     log.Logger
+}
+
+func NewHandler(service provisioning.AlertRuleService, namespacer request.NamespaceMapper) *Handler {
+	return &Handler{
+		service:    service,
+		namespacer: namespacer,
+		logger:     log.New("alerting.rules.search"),
+	}
+}
+
+func (h *Handler) SearchAlertRules(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
+	page, err := h.collect(ctx, req, ngmodels.RuleTypeFilterAlerting)
+	if err != nil {
+		return err
+	}
+	items := make([]model.GetSearchAlertRulesAlertRuleHit, 0, len(page.rules))
+	for _, r := range page.rules {
+		obj, err := alertrule.ConvertToK8sResource(page.orgID, r, page.provenances[r.UID], h.namespacer)
+		if err != nil {
+			h.skip(ctx, r, err)
+			continue
+		}
+		var spec model.GetSearchAlertRulesAlertRuleSpec
+		if err := reencode(obj.Spec, &spec); err != nil {
+			h.skip(ctx, r, err)
+			continue
+		}
+		items = append(items, model.GetSearchAlertRulesAlertRuleHit{Metadata: obj.ObjectMeta, Spec: spec})
+	}
+	return writeJSON(w, &model.GetSearchAlertRulesResponse{
+		TypeMeta:                listTypeMeta,
+		ListMeta:                metav1.ListMeta{Continue: page.continueToken},
+		GetSearchAlertRulesBody: model.GetSearchAlertRulesBody{Items: items},
+	})
+}
+
+func (h *Handler) SearchRecordingRules(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
+	page, err := h.collect(ctx, req, ngmodels.RuleTypeFilterRecording)
+	if err != nil {
+		return err
+	}
+	items := make([]model.GetSearchRecordingRulesRecordingRuleHit, 0, len(page.rules))
+	for _, r := range page.rules {
+		obj, err := recordingrule.ConvertToK8sResource(page.orgID, r, page.provenances[r.UID], h.namespacer)
+		if err != nil {
+			h.skip(ctx, r, err)
+			continue
+		}
+		var spec model.GetSearchRecordingRulesRecordingRuleSpec
+		if err := reencode(obj.Spec, &spec); err != nil {
+			h.skip(ctx, r, err)
+			continue
+		}
+		items = append(items, model.GetSearchRecordingRulesRecordingRuleHit{Metadata: obj.ObjectMeta, Spec: spec})
+	}
+	return writeJSON(w, &model.GetSearchRecordingRulesResponse{
+		TypeMeta:                    listTypeMeta,
+		ListMeta:                    metav1.ListMeta{Continue: page.continueToken},
+		GetSearchRecordingRulesBody: model.GetSearchRecordingRulesBody{Items: items},
+	})
+}
+
+func (h *Handler) SearchRules(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
+	page, err := h.collect(ctx, req, ngmodels.RuleTypeFilterAll)
+	if err != nil {
+		return err
+	}
+	items := make([]model.GetSearchRulesRuleHit, 0, len(page.rules))
+	for _, r := range page.rules {
+		hit, err := h.crossKindHit(page.orgID, r, page.provenances[r.UID])
+		if err != nil {
+			h.skip(ctx, r, err)
+			continue
+		}
+		items = append(items, hit)
+	}
+	return writeJSON(w, &model.GetSearchRulesResponse{
+		TypeMeta:           listTypeMeta,
+		ListMeta:           metav1.ListMeta{Continue: page.continueToken},
+		GetSearchRulesBody: model.GetSearchRulesBody{Items: items},
+	})
+}
+
+// crossKindHit builds an untyped (spec union) hit for the cross-kind endpoint.
+func (h *Handler) crossKindHit(orgID int64, r *ngmodels.AlertRule, provenance ngmodels.Provenance) (model.GetSearchRulesRuleHit, error) {
+	if r.Type() == ngmodels.RuleTypeRecording {
+		obj, err := recordingrule.ConvertToK8sResource(orgID, r, provenance, h.namespacer)
+		if err != nil {
+			return model.GetSearchRulesRuleHit{}, err
+		}
+		return model.GetSearchRulesRuleHit{Metadata: obj.ObjectMeta, Spec: obj.Spec}, nil
+	}
+	obj, err := alertrule.ConvertToK8sResource(orgID, r, provenance, h.namespacer)
+	if err != nil {
+		return model.GetSearchRulesRuleHit{}, err
+	}
+	return model.GetSearchRulesRuleHit{Metadata: obj.ObjectMeta, Spec: obj.Spec}, nil
+}
+
+// resultPage is the filtered, sorted and paginated rule set plus the context
+// needed to render hits.
+type resultPage struct {
+	rules         []*ngmodels.AlertRule
+	provenances   map[string]ngmodels.Provenance
+	orgID         int64
+	continueToken string
+}
+
+func (h *Handler) collect(ctx context.Context, req *app.CustomRouteRequest, ruleType ngmodels.RuleTypeFilter) (resultPage, error) {
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return resultPage{}, apierrors.NewUnauthorized(err.Error())
+	}
+	info, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		return resultPage{}, apierrors.NewBadRequest(err.Error())
+	}
+
+	params := parseParams(req.URL.Query())
+	if ruleType == ngmodels.RuleTypeFilterAll {
+		switch strVal(params.Type) {
+		case "alertrule":
+			ruleType = ngmodels.RuleTypeFilterAlerting
+		case "recordingrule":
+			ruleType = ngmodels.RuleTypeFilterRecording
+		case "":
+		default:
+			return resultPage{}, apierrors.NewBadRequest("invalid type: must be one of alertrule, recordingrule")
+		}
+	}
+
+	// Server-side (selector-backed) filters narrow the set; the remaining
+	// filters and ordering are applied in memory, so we fetch the full set.
+	rules, provenances, _, err := h.service.ListAlertRules(ctx, user, provisioning.ListAlertRulesOptions{
+		RuleType:                  ruleType,
+		GroupFilter:               includeFilter(params.Groups),
+		FolderFilter:              includeFilter(params.Folders),
+		PausedFilter:              provisioning.ListRuleBoolFilter{Value: params.Paused},
+		DashboardFilter:           stringFilter(strVal(params.DashboardUID)),
+		PanelIDFilter:             stringFilter(panelID(params)),
+		NotificationTypeFilter:    stringFilter(strVal(params.NotificationType)),
+		ReceiverFilter:            stringFilter(strVal(params.Receiver)),
+		RoutingTreeFilter:         stringFilter(strVal(params.RoutingTree)),
+		MetricFilter:              stringFilter(strVal(params.Metric)),
+		TargetDatasourceUIDFilter: stringFilter(strVal(params.TargetDatasourceUID)),
+	})
+	if err != nil {
+		return resultPage{}, err
+	}
+
+	matchers := parseLabelMatchers(params.Labels)
+	filtered := rules[:0]
+	for _, r := range rules {
+		if !matchText(r, strVal(params.Q)) || !matchLabels(r, matchers) || !matchDatasources(r, params.DatasourceUIDs) {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+
+	field, desc := sortSpec(params.Sort)
+	sortRules(filtered, field, desc)
+
+	page, token := paginate(filtered, strVal(params.ContinueToken), limit(params))
+	return resultPage{rules: page, provenances: provenances, orgID: info.OrgID, continueToken: token}, nil
+}
+
+func (h *Handler) skip(ctx context.Context, r *ngmodels.AlertRule, err error) {
+	h.logger.FromContext(ctx).Warn("skipping rule that failed conversion", "uid", r.UID, "error", err)
+}
+
+var listTypeMeta = metav1.TypeMeta{APIVersion: model.GroupVersion.String(), Kind: "RuleSearchResults"}
+
+// reencode copies src into dst via JSON. The per-kind hit specs are generated
+// as route-local types that are JSON-identical to the canonical rule specs.
+func reencode(src any, dst any) error {
+	b, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, dst)
+}
+
+func writeJSON(w app.CustomRouteResponseWriter, obj any) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	return json.NewEncoder(w).Encode(obj)
+}

--- a/pkg/registry/apps/alerting/rules/search/search.go
+++ b/pkg/registry/apps/alerting/rules/search/search.go
@@ -238,9 +238,9 @@ func (r rowReader) int64Ptr(name string) *int64 {
 	return nil
 }
 
-func (r rowReader) labels() map[string]string {
+func (r rowReader) jsonMap(name string) map[string]string {
 	var out map[string]string
-	if i, ok := r.idx[fieldLabels]; ok && i < len(r.row.Cells) && len(r.row.Cells[i]) > 0 {
+	if i, ok := r.idx[name]; ok && i < len(r.row.Cells) && len(r.row.Cells[i]) > 0 {
 		_ = json.Unmarshal(r.row.Cells[i], &out)
 	}
 	return out
@@ -264,9 +264,13 @@ func parseAlertRuleHits(resp *resourcepb.ResourceSearchResponse) []model.GetSear
 			Title:            r.str(fieldTitle),
 			Folder:           r.str(fieldFolder),
 			Group:            r.strPtr(fieldGroup),
+			Interval:         r.strPtr(fieldInterval),
 			Paused:           r.boolPtr(fieldPaused),
-			Labels:           r.labels(),
+			Labels:           r.jsonMap(fieldLabels),
 			DatasourceUIDs:   r.datasourceUIDs(),
+			Annotations:      r.jsonMap(fieldAnnotations),
+			For:              r.strPtr(fieldFor),
+			KeepFiringFor:    r.strPtr(fieldKeepFiringFor),
 			DashboardUID:     r.strPtr(fieldDashboardUID),
 			PanelID:          r.int64Ptr(fieldPanelID),
 			Receiver:         r.strPtr(fieldReceiver),
@@ -287,8 +291,9 @@ func parseRecordingRuleHits(resp *resourcepb.ResourceSearchResponse) []model.Get
 			Title:               r.str(fieldTitle),
 			Folder:              r.str(fieldFolder),
 			Group:               r.strPtr(fieldGroup),
+			Interval:            r.strPtr(fieldInterval),
 			Paused:              r.boolPtr(fieldPaused),
-			Labels:              r.labels(),
+			Labels:              r.jsonMap(fieldLabels),
 			DatasourceUIDs:      r.datasourceUIDs(),
 			Metric:              r.strPtr(fieldMetric),
 			TargetDatasourceUID: r.strPtr(fieldTargetDatasourceUID),
@@ -311,8 +316,9 @@ func parseRuleHits(resp *resourcepb.ResourceSearchResponse) []model.GetSearchRul
 				Title:               r.str(fieldTitle),
 				Folder:              r.str(fieldFolder),
 				Group:               r.strPtr(fieldGroup),
+				Interval:            r.strPtr(fieldInterval),
 				Paused:              r.boolPtr(fieldPaused),
-				Labels:              r.labels(),
+				Labels:              r.jsonMap(fieldLabels),
 				DatasourceUIDs:      r.datasourceUIDs(),
 				Metric:              r.strPtr(fieldMetric),
 				TargetDatasourceUID: r.strPtr(fieldTargetDatasourceUID),
@@ -324,9 +330,13 @@ func parseRuleHits(resp *resourcepb.ResourceSearchResponse) []model.GetSearchRul
 				Title:            r.str(fieldTitle),
 				Folder:           r.str(fieldFolder),
 				Group:            r.strPtr(fieldGroup),
+				Interval:         r.strPtr(fieldInterval),
 				Paused:           r.boolPtr(fieldPaused),
-				Labels:           r.labels(),
+				Labels:           r.jsonMap(fieldLabels),
 				DatasourceUIDs:   r.datasourceUIDs(),
+				Annotations:      r.jsonMap(fieldAnnotations),
+				For:              r.strPtr(fieldFor),
+				KeepFiringFor:    r.strPtr(fieldKeepFiringFor),
 				DashboardUID:     r.strPtr(fieldDashboardUID),
 				PanelID:          r.int64Ptr(fieldPanelID),
 				Receiver:         r.strPtr(fieldReceiver),

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -849,7 +849,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
-	rulesAppInstaller, err := rules.RegisterAppInstaller(cfg, alertNG, clientGenerator)
+	rulesAppInstaller, err := rules.RegisterAppInstaller(cfg, alertNG, resourceClient, dualwriteService, clientGenerator)
 	if err != nil {
 		return nil, err
 	}
@@ -1583,7 +1583,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	rulesAppInstaller, err := rules.RegisterAppInstaller(cfg, alertNG, clientGenerator)
+	rulesAppInstaller, err := rules.RegisterAppInstaller(cfg, alertNG, resourceClient, dualwriteService, clientGenerator)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -94,9 +94,11 @@ type ListRuleBoolFilter struct {
 }
 
 type ListAlertRulesOptions struct {
-	RuleType                  models.RuleTypeFilter
-	Limit                     int64
-	ContinueToken             string
+	RuleType      models.RuleTypeFilter
+	Limit         int64
+	ContinueToken string
+	// RuleUIDs restricts the results to rules with these UIDs (metadata.name).
+	RuleUIDs                  []string
 	GroupFilter               ListRuleStringFilter
 	FolderFilter              ListRuleStringFilter
 	TitleFilter               ListRuleStringFilter
@@ -213,6 +215,7 @@ func (service *AlertRuleService) ListAlertRules(ctx context.Context, user identi
 	q := models.ListAlertRulesExtendedQuery{
 		ListAlertRulesQuery: models.ListAlertRulesQuery{
 			OrgID:                            user.GetOrgID(),
+			RuleUIDs:                         opts.RuleUIDs,
 			RuleGroups:                       opts.GroupFilter.Include,
 			ExcludeRuleGroups:                opts.GroupFilter.Exclude,
 			RuleGroupExists:                  opts.GroupFilter.Exists,

--- a/pkg/storage/unified/search/builders/alertingrules.go
+++ b/pkg/storage/unified/search/builders/alertingrules.go
@@ -2,6 +2,7 @@ package builders
 
 import (
 	"context"
+	"encoding/json"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -17,28 +18,46 @@ import (
 // is a known label key matched via IndexableDocument.Labels.
 const (
 	ruleSearchType                = "type"
+	ruleSearchInterval            = "interval"
 	ruleSearchPaused              = "paused"
 	ruleSearchLabels              = "labels"
+	ruleSearchAnnotations         = "annotations"
+	ruleSearchFor                 = "for"
+	ruleSearchKeepFiringFor       = "keepFiringFor"
 	ruleSearchDatasourceUIDs      = "datasourceUIDs"
 	ruleSearchDashboardUID        = "dashboardUID"
 	ruleSearchPanelID             = "panelID"
+	ruleSearchReceiver            = "receiver"
+	ruleSearchNotificationType    = "notificationType"
+	ruleSearchRoutingTree         = "routingTree"
 	ruleSearchMetric              = "metric"
 	ruleSearchTargetDatasourceUID = "targetDatasourceUID"
 )
 
 func ruleSearchColumnDefinitions() []*resourcepb.ResourceTableColumnDefinition {
 	filterable := &resourcepb.ResourceTableColumnDefinition_Properties{Filterable: true}
+	str := func(name string) *resourcepb.ResourceTableColumnDefinition {
+		return &resourcepb.ResourceTableColumnDefinition{Name: name, Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: filterable}
+	}
 	return []*resourcepb.ResourceTableColumnDefinition{
-		{Name: ruleSearchType, Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: filterable},
+		str(ruleSearchType),
+		str(ruleSearchInterval),
 		{Name: ruleSearchPaused, Type: resourcepb.ResourceTableColumnDefinition_BOOLEAN, Properties: filterable},
 		// The rule's own (spec) labels, indexed as "key" and "key=value" terms
 		// so label matchers (equals and existence) resolve against them.
 		{Name: ruleSearchLabels, Type: resourcepb.ResourceTableColumnDefinition_STRING, IsArray: true, Properties: filterable},
+		// annotations is display-only, carried as the JSON-encoded map.
+		str(ruleSearchAnnotations),
+		str(ruleSearchFor),
+		str(ruleSearchKeepFiringFor),
 		{Name: ruleSearchDatasourceUIDs, Type: resourcepb.ResourceTableColumnDefinition_STRING, IsArray: true, Properties: filterable},
-		{Name: ruleSearchDashboardUID, Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: filterable},
+		str(ruleSearchDashboardUID),
 		{Name: ruleSearchPanelID, Type: resourcepb.ResourceTableColumnDefinition_INT64, Properties: filterable},
-		{Name: ruleSearchMetric, Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: filterable},
-		{Name: ruleSearchTargetDatasourceUID, Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: filterable},
+		str(ruleSearchReceiver),
+		str(ruleSearchNotificationType),
+		str(ruleSearchRoutingTree),
+		str(ruleSearchMetric),
+		str(ruleSearchTargetDatasourceUID),
 	}
 }
 
@@ -82,6 +101,7 @@ func (alertRuleSearchBuilder) BuildDocument(ctx context.Context, key *resourcepb
 		return nil, err
 	}
 	doc.Fields[ruleSearchType] = "alertrule"
+	doc.Fields[ruleSearchInterval] = string(rule.Spec.Trigger.Interval)
 	var uids []string
 	for _, e := range rule.Spec.Expressions {
 		if e.DatasourceUID != nil {
@@ -94,9 +114,28 @@ func (alertRuleSearchBuilder) BuildDocument(ctx context.Context, key *resourcepb
 	if rule.Spec.Paused != nil {
 		doc.Fields[ruleSearchPaused] = *rule.Spec.Paused
 	}
+	if rule.Spec.For != nil {
+		doc.Fields[ruleSearchFor] = *rule.Spec.For
+	}
+	if rule.Spec.KeepFiringFor != nil {
+		doc.Fields[ruleSearchKeepFiringFor] = *rule.Spec.KeepFiringFor
+	}
+	if a := annotationsJSON(rule.Spec.Annotations); a != "" {
+		doc.Fields[ruleSearchAnnotations] = a
+	}
 	if rule.Spec.PanelRef != nil {
 		doc.Fields[ruleSearchDashboardUID] = rule.Spec.PanelRef.DashboardUID
 		doc.Fields[ruleSearchPanelID] = rule.Spec.PanelRef.PanelID
+	}
+	if ns := rule.Spec.NotificationSettings; ns != nil {
+		switch {
+		case ns.SimplifiedRouting != nil:
+			doc.Fields[ruleSearchReceiver] = ns.SimplifiedRouting.Receiver
+			doc.Fields[ruleSearchNotificationType] = string(rulesv0alpha1.AlertRuleNotificationSettingsTypeSimplifiedRouting)
+		case ns.NamedRoutingTree != nil:
+			doc.Fields[ruleSearchRoutingTree] = ns.NamedRoutingTree.RoutingTree
+			doc.Fields[ruleSearchNotificationType] = string(rulesv0alpha1.AlertRuleNotificationSettingsTypeNamedRoutingTree)
+		}
 	}
 	if terms := labelTerms(rule.Spec.Labels); len(terms) > 0 {
 		doc.Fields[ruleSearchLabels] = terms
@@ -113,6 +152,7 @@ func (recordingRuleSearchBuilder) BuildDocument(ctx context.Context, key *resour
 		return nil, err
 	}
 	doc.Fields[ruleSearchType] = "recordingrule"
+	doc.Fields[ruleSearchInterval] = string(rule.Spec.Trigger.Interval)
 	var uids []string
 	for _, e := range rule.Spec.Expressions {
 		if e.DatasourceUID != nil {
@@ -163,4 +203,21 @@ func labelTerms[T ~string](labels map[string]T) []string {
 		out = append(out, k, k+"="+string(v))
 	}
 	return out
+}
+
+// annotationsJSON encodes rule annotations as a JSON object string for display,
+// or "" when there are none.
+func annotationsJSON[T ~string](annotations map[string]T) string {
+	if len(annotations) == 0 {
+		return ""
+	}
+	m := make(map[string]string, len(annotations))
+	for k, v := range annotations {
+		m[k] = string(v)
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }

--- a/pkg/storage/unified/search/builders/alertingrules.go
+++ b/pkg/storage/unified/search/builders/alertingrules.go
@@ -1,0 +1,166 @@
+package builders
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	rulesv0alpha1 "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// Rule search field/column names. These must match the keys the alerting rule
+// search handler uses when building ResourceSearchRequests so the legacy and
+// unified backends are interchangeable. Group is intentionally not a column: it
+// is a known label key matched via IndexableDocument.Labels.
+const (
+	ruleSearchType                = "type"
+	ruleSearchPaused              = "paused"
+	ruleSearchLabels              = "labels"
+	ruleSearchDatasourceUIDs      = "datasourceUIDs"
+	ruleSearchDashboardUID        = "dashboardUID"
+	ruleSearchPanelID             = "panelID"
+	ruleSearchMetric              = "metric"
+	ruleSearchTargetDatasourceUID = "targetDatasourceUID"
+)
+
+func ruleSearchColumnDefinitions() []*resourcepb.ResourceTableColumnDefinition {
+	filterable := &resourcepb.ResourceTableColumnDefinition_Properties{Filterable: true}
+	return []*resourcepb.ResourceTableColumnDefinition{
+		{Name: ruleSearchType, Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: filterable},
+		{Name: ruleSearchPaused, Type: resourcepb.ResourceTableColumnDefinition_BOOLEAN, Properties: filterable},
+		// The rule's own (spec) labels, indexed as "key" and "key=value" terms
+		// so label matchers (equals and existence) resolve against them.
+		{Name: ruleSearchLabels, Type: resourcepb.ResourceTableColumnDefinition_STRING, IsArray: true, Properties: filterable},
+		{Name: ruleSearchDatasourceUIDs, Type: resourcepb.ResourceTableColumnDefinition_STRING, IsArray: true, Properties: filterable},
+		{Name: ruleSearchDashboardUID, Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: filterable},
+		{Name: ruleSearchPanelID, Type: resourcepb.ResourceTableColumnDefinition_INT64, Properties: filterable},
+		{Name: ruleSearchMetric, Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: filterable},
+		{Name: ruleSearchTargetDatasourceUID, Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: filterable},
+	}
+}
+
+// serverSideDatasourceUIDs are synthetic expression datasources, never a
+// user-facing query datasource.
+var serverSideDatasourceUIDs = map[string]struct{}{
+	expr.DatasourceUID:    {},
+	expr.OldDatasourceUID: {},
+	expr.MLDatasourceUID:  {},
+}
+
+func GetAlertRuleSearchBuilder() (resource.DocumentBuilderInfo, error) {
+	fields, err := resource.NewSearchableDocumentFields(ruleSearchColumnDefinitions())
+	return resource.DocumentBuilderInfo{
+		GroupResource: schema.GroupResource{Group: rulesv0alpha1.AlertRuleKind().Group(), Resource: rulesv0alpha1.AlertRuleKind().Plural()},
+		Fields:        fields,
+		Builder:       new(alertRuleSearchBuilder),
+	}, err
+}
+
+func GetRecordingRuleSearchBuilder() (resource.DocumentBuilderInfo, error) {
+	fields, err := resource.NewSearchableDocumentFields(ruleSearchColumnDefinitions())
+	return resource.DocumentBuilderInfo{
+		GroupResource: schema.GroupResource{Group: rulesv0alpha1.RecordingRuleKind().Group(), Resource: rulesv0alpha1.RecordingRuleKind().Plural()},
+		Fields:        fields,
+		Builder:       new(recordingRuleSearchBuilder),
+	}, err
+}
+
+var (
+	_ resource.DocumentBuilder = new(alertRuleSearchBuilder)
+	_ resource.DocumentBuilder = new(recordingRuleSearchBuilder)
+)
+
+type alertRuleSearchBuilder struct{}
+
+func (alertRuleSearchBuilder) BuildDocument(ctx context.Context, key *resourcepb.ResourceKey, rv int64, value []byte) (*resource.IndexableDocument, error) {
+	rule := &rulesv0alpha1.AlertRule{}
+	doc, err := NewIndexableDocumentFromValue(key, rv, value, rule, rulesv0alpha1.AlertRuleKind())
+	if err != nil {
+		return nil, err
+	}
+	doc.Fields[ruleSearchType] = "alertrule"
+	var uids []string
+	for _, e := range rule.Spec.Expressions {
+		if e.DatasourceUID != nil {
+			uids = appendSourceUID(uids, string(*e.DatasourceUID))
+		}
+	}
+	if len(uids) > 0 {
+		doc.Fields[ruleSearchDatasourceUIDs] = uids
+	}
+	if rule.Spec.Paused != nil {
+		doc.Fields[ruleSearchPaused] = *rule.Spec.Paused
+	}
+	if rule.Spec.PanelRef != nil {
+		doc.Fields[ruleSearchDashboardUID] = rule.Spec.PanelRef.DashboardUID
+		doc.Fields[ruleSearchPanelID] = rule.Spec.PanelRef.PanelID
+	}
+	if terms := labelTerms(rule.Spec.Labels); len(terms) > 0 {
+		doc.Fields[ruleSearchLabels] = terms
+	}
+	return doc, nil
+}
+
+type recordingRuleSearchBuilder struct{}
+
+func (recordingRuleSearchBuilder) BuildDocument(ctx context.Context, key *resourcepb.ResourceKey, rv int64, value []byte) (*resource.IndexableDocument, error) {
+	rule := &rulesv0alpha1.RecordingRule{}
+	doc, err := NewIndexableDocumentFromValue(key, rv, value, rule, rulesv0alpha1.RecordingRuleKind())
+	if err != nil {
+		return nil, err
+	}
+	doc.Fields[ruleSearchType] = "recordingrule"
+	var uids []string
+	for _, e := range rule.Spec.Expressions {
+		if e.DatasourceUID != nil {
+			uids = appendSourceUID(uids, string(*e.DatasourceUID))
+		}
+	}
+	if len(uids) > 0 {
+		doc.Fields[ruleSearchDatasourceUIDs] = uids
+	}
+	if rule.Spec.Paused != nil {
+		doc.Fields[ruleSearchPaused] = *rule.Spec.Paused
+	}
+	if rule.Spec.Metric != "" {
+		doc.Fields[ruleSearchMetric] = string(rule.Spec.Metric)
+	}
+	if rule.Spec.TargetDatasourceUID != "" {
+		doc.Fields[ruleSearchTargetDatasourceUID] = string(rule.Spec.TargetDatasourceUID)
+	}
+	if terms := labelTerms(rule.Spec.Labels); len(terms) > 0 {
+		doc.Fields[ruleSearchLabels] = terms
+	}
+	return doc, nil
+}
+
+func appendSourceUID(uids []string, uid string) []string {
+	if uid == "" {
+		return uids
+	}
+	if _, server := serverSideDatasourceUIDs[uid]; server {
+		return uids
+	}
+	for _, existing := range uids {
+		if existing == uid {
+			return uids
+		}
+	}
+	return append(uids, uid)
+}
+
+// labelTerms flattens the rule's spec labels into searchable terms: a bare
+// "key" term (for existence matchers) and a "key=value" term (for equality).
+func labelTerms[T ~string](labels map[string]T) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(labels)*2)
+	for k, v := range labels {
+		out = append(out, k, k+"="+string(v))
+	}
+	return out
+}

--- a/pkg/storage/unified/search/builders/document.go
+++ b/pkg/storage/unified/search/builders/document.go
@@ -83,7 +83,17 @@ func All(sql db.DB, sprinkles DashboardStats) ([]resource.DocumentBuilderInfo, e
 		return nil, err
 	}
 
-	return []resource.DocumentBuilderInfo{dashboards, users, extGroupMappings, teams, teamBindings}, nil
+	alertRules, err := GetAlertRuleSearchBuilder()
+	if err != nil {
+		return nil, err
+	}
+
+	recordingRules, err := GetRecordingRuleSearchBuilder()
+	if err != nil {
+		return nil, err
+	}
+
+	return []resource.DocumentBuilderInfo{dashboards, users, extGroupMappings, teams, teamBindings, alertRules, recordingRules}, nil
 }
 
 // NewIndexableDocumentFromValue parses provided bytes value into object, and initializes IndexableDocument from it.

--- a/pkg/tests/apis/alerting/rules/search/grouping_test.go
+++ b/pkg/tests/apis/alerting/rules/search/grouping_test.go
@@ -1,0 +1,147 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/apiserver/rest"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/tests/api/alerting"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/apis/alerting/rules/common"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+const groupSortFolder = "group-sort-folder"
+
+// TestIntegrationRuleSearchGroupSort verifies the cross-kind search interleaves
+// the two rule kinds by group (ascending and descending) rather than grouping by
+// kind.
+//
+// TODO: rules are seeded through the legacy provisioning API here because the
+// k8s create path rejects a preset group label, and provisioning is the only
+// way to land rules in specific groups today. That ties this test to the
+// legacy-read dual-writer modes (0-2): provisioning writes to the SQL store,
+// which the unified read path (mode 3+) would not see without a background sync.
+// Once storage access moves behind the k8s client and setting the group at
+// create time is allowed, seed via the k8s client instead and extend this to the
+// unified modes.
+func TestIntegrationRuleSearchGroupSort(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	for _, mode := range []rest.DualWriterMode{rest.Mode0, rest.Mode2} {
+		t.Run(fmt.Sprintf("dualWriterMode=%d", mode), func(t *testing.T) {
+			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+					"alertrules.rules.alerting.grafana.app":     {DualWriterMode: mode},
+					"recordingrules.rules.alerting.grafana.app": {DualWriterMode: mode},
+				},
+			})
+			runGroupSortTests(t, helper)
+		})
+	}
+}
+
+func runGroupSortTests(t *testing.T, helper *apis.K8sTestHelper) {
+	ctx := context.Background()
+	common.CreateTestFolder(t, helper, groupSortFolder)
+	legacyClient := alerting.NewAlertingLegacyAPIClient(helper.GetListenerAddress(), "admin", "admin")
+
+	// Group names sort group-1 < group-2 < group-3 < group-4. Titles are in the
+	// reverse order so a group-sorted result is distinguishable from a
+	// title-sorted one, and the kinds alternate per group.
+	seedAlertRuleGroup(t, legacyClient, "group-1", "zulu")
+	seedRecordingRuleGroup(t, legacyClient, "group-2", "yankee", "metric_two")
+	seedAlertRuleGroup(t, legacyClient, "group-3", "xray")
+	seedRecordingRuleGroup(t, legacyClient, "group-4", "whiskey", "metric_four")
+
+	rc := helper.Org1.Admin.RESTClient(t, &v0alpha1.GroupVersion)
+	search := func(t *testing.T, sort string) v0alpha1.GetSearchRulesResponse {
+		t.Helper()
+		raw, err := rc.Get().
+			AbsPath("apis", v0alpha1.APIGroup, v0alpha1.APIVersion, "namespaces", "default", "search").
+			Param("sort", sort).
+			DoRaw(ctx)
+		require.NoError(t, err)
+		var resp v0alpha1.GetSearchRulesResponse
+		require.NoError(t, json.Unmarshal(raw, &resp))
+		return resp
+	}
+
+	t.Run("ascending group order interleaves kinds", func(t *testing.T) {
+		resp := search(t, "group")
+		require.Equal(t, []string{"zulu", "yankee", "xray", "whiskey"}, crossKindTitles(resp))
+		require.Equal(t, []string{"alertrule", "recordingrule", "alertrule", "recordingrule"}, crossKindKinds(resp))
+	})
+
+	t.Run("descending group order interleaves kinds", func(t *testing.T) {
+		resp := search(t, "-group")
+		require.Equal(t, []string{"whiskey", "xray", "yankee", "zulu"}, crossKindTitles(resp))
+		require.Equal(t, []string{"recordingrule", "alertrule", "recordingrule", "alertrule"}, crossKindKinds(resp))
+	})
+}
+
+func seedAlertRuleGroup(t *testing.T, client alerting.LegacyApiClient, group, title string) {
+	t.Helper()
+	base := ngmodels.RuleGen.With(
+		ngmodels.RuleMuts.WithUniqueUID(),
+		ngmodels.RuleMuts.WithNamespaceUID(groupSortFolder),
+		ngmodels.RuleMuts.WithIntervalMatching(10*time.Second),
+	).Generate()
+
+	rule := provisionedRule(base, title, group)
+	createRuleGroup(t, client, group, rule)
+}
+
+func seedRecordingRuleGroup(t *testing.T, client alerting.LegacyApiClient, group, title, metric string) {
+	t.Helper()
+	base := ngmodels.RuleGen.With(
+		ngmodels.RuleMuts.WithUniqueUID(),
+		ngmodels.RuleMuts.WithNamespaceUID(groupSortFolder),
+		ngmodels.RuleMuts.WithAllRecordingRules(),
+		ngmodels.RuleMuts.WithIntervalMatching(10*time.Second),
+	).Generate()
+
+	rule := provisionedRule(base, title, group)
+	rule.Record = &apimodels.Record{Metric: metric, From: "A", TargetDatasourceUID: base.Data[0].DatasourceUID}
+	createRuleGroup(t, client, group, rule)
+}
+
+func provisionedRule(base ngmodels.AlertRule, title, group string) apimodels.ProvisionedAlertRule {
+	return apimodels.ProvisionedAlertRule{
+		UID:       base.UID,
+		Title:     title,
+		OrgID:     1,
+		FolderUID: groupSortFolder,
+		RuleGroup: group,
+		Condition: "A",
+		Data: []apimodels.AlertQuery{{
+			RefID:             "A",
+			DatasourceUID:     base.Data[0].DatasourceUID,
+			Model:             base.Data[0].Model,
+			RelativeTimeRange: apimodels.RelativeTimeRange{From: apimodels.Duration(5 * time.Minute), To: 0},
+		}},
+		NoDataState:  apimodels.NoData,
+		ExecErrState: apimodels.ErrorErrState,
+	}
+}
+
+func createRuleGroup(t *testing.T, client alerting.LegacyApiClient, group string, rule apimodels.ProvisionedAlertRule) {
+	t.Helper()
+	_, status, body := client.CreateOrUpdateRuleGroupProvisioning(t, apimodels.AlertRuleGroup{
+		Title:     group,
+		FolderUID: groupSortFolder,
+		Interval:  10,
+		Rules:     []apimodels.ProvisionedAlertRule{rule},
+	})
+	require.Equalf(t, 200, status, "seeding group %s: %s", group, body)
+}

--- a/pkg/tests/apis/alerting/rules/search/search_test.go
+++ b/pkg/tests/apis/alerting/rules/search/search_test.go
@@ -106,6 +106,18 @@ func runRuleSearchTests(t *testing.T, helper *apis.K8sTestHelper) {
 		}
 	})
 
+	t.Run("alert rules: filter by name (uid)", func(t *testing.T) {
+		all := searchAlert(t, nil).Items
+		require.GreaterOrEqual(t, len(all), 2)
+		want := []string{all[0].Name, all[1].Name}
+		got := searchAlert(t, url.Values{"names": want})
+		gotNames := make([]string, 0, len(got.Items))
+		for _, h := range got.Items {
+			gotNames = append(gotNames, h.Name)
+		}
+		require.ElementsMatch(t, want, gotNames)
+	})
+
 	t.Run("alert rules: free-text title filter", func(t *testing.T) {
 		require.ElementsMatch(t, []string{"cpu usage high", "memory usage high"}, alertTitles(searchAlert(t, url.Values{"q": {"usage"}})))
 	})

--- a/pkg/tests/apis/alerting/rules/search/search_test.go
+++ b/pkg/tests/apis/alerting/rules/search/search_test.go
@@ -58,6 +58,7 @@ func runRuleSearchTests(t *testing.T, helper *apis.K8sTestHelper) {
 	createAlertRule(t, ctx, alertClient, "memory usage high", true, map[string]string{"team": "b"}, "ds-loki")
 	createAlertRule(t, ctx, alertClient, "disk low", false, map[string]string{"team": "a"}, "ds-prom")
 	createRecordingRule(t, ctx, recClient, "cpu recording", "ds-prom")
+	createRecordingRule(t, ctx, recClient, "disk recording", "ds-prom")
 
 	rc := helper.Org1.Admin.RESTClient(t, &v0alpha1.GroupVersion)
 	getRaw := func(t *testing.T, path string, params url.Values) []byte {
@@ -136,17 +137,27 @@ func runRuleSearchTests(t *testing.T, helper *apis.K8sTestHelper) {
 	})
 
 	t.Run("recording rules: returns all recording rules", func(t *testing.T) {
-		resp := searchRecording(t, nil)
-		require.Len(t, resp.Items, 1)
-		require.Equal(t, "cpu recording", resp.Items[0].Title)
+		require.ElementsMatch(t, []string{"cpu recording", "disk recording"}, recordingTitles(searchRecording(t, nil)))
 	})
 
 	t.Run("cross-kind: returns both kinds", func(t *testing.T) {
-		require.Len(t, searchCrossKind(t, nil).Items, 4)
+		require.Len(t, searchCrossKind(t, nil).Items, 5)
 	})
 
 	t.Run("cross-kind: type narrowing", func(t *testing.T) {
-		require.Equal(t, []string{"cpu recording"}, crossKindTitles(searchCrossKind(t, url.Values{"type": {"recordingrule"}})))
+		require.ElementsMatch(t, []string{"cpu recording", "disk recording"}, crossKindTitles(searchCrossKind(t, url.Values{"type": {"recordingrule"}})))
+	})
+
+	t.Run("cross-kind: interleaved by title", func(t *testing.T) {
+		// Sorting the union by title mixes the two kinds rather than grouping
+		// them: the recordings land between alert rules.
+		asc := searchCrossKind(t, url.Values{"sort": {"title"}})
+		require.Equal(t, []string{"cpu recording", "cpu usage high", "disk low", "disk recording", "memory usage high"}, crossKindTitles(asc))
+		require.Equal(t, []string{"recordingrule", "alertrule", "alertrule", "recordingrule", "alertrule"}, crossKindKinds(asc))
+
+		desc := searchCrossKind(t, url.Values{"sort": {"-title"}})
+		require.Equal(t, []string{"memory usage high", "disk recording", "disk low", "cpu usage high", "cpu recording"}, crossKindTitles(desc))
+		require.Equal(t, []string{"alertrule", "recordingrule", "alertrule", "alertrule", "recordingrule"}, crossKindKinds(desc))
 	})
 
 	t.Run("consistency: search matches list", func(t *testing.T) {
@@ -164,6 +175,14 @@ func alertTitles(resp v0alpha1.GetSearchAlertRulesResponse) []string {
 	return out
 }
 
+func recordingTitles(resp v0alpha1.GetSearchRecordingRulesResponse) []string {
+	out := make([]string, 0, len(resp.Items))
+	for _, h := range resp.Items {
+		out = append(out, h.Title)
+	}
+	return out
+}
+
 // crossKindTitles reads the title from whichever variant of the union hit is set.
 func crossKindTitles(resp v0alpha1.GetSearchRulesResponse) []string {
 	out := make([]string, 0, len(resp.Items))
@@ -173,6 +192,21 @@ func crossKindTitles(resp v0alpha1.GetSearchRulesResponse) []string {
 			out = append(out, h.AlertRuleHit.Title)
 		case h.RecordingRuleHit != nil:
 			out = append(out, h.RecordingRuleHit.Title)
+		}
+	}
+	return out
+}
+
+// crossKindKinds reports the kind of each union hit, in order, so a test can
+// assert the two kinds are interleaved rather than grouped.
+func crossKindKinds(resp v0alpha1.GetSearchRulesResponse) []string {
+	out := make([]string, 0, len(resp.Items))
+	for _, h := range resp.Items {
+		switch {
+		case h.AlertRuleHit != nil:
+			out = append(out, "alertrule")
+		case h.RecordingRuleHit != nil:
+			out = append(out, "recordingrule")
 		}
 	}
 	return out

--- a/pkg/tests/apis/alerting/rules/search/search_test.go
+++ b/pkg/tests/apis/alerting/rules/search/search_test.go
@@ -60,7 +60,7 @@ func runRuleSearchTests(t *testing.T, helper *apis.K8sTestHelper) {
 	createRecordingRule(t, ctx, recClient, "cpu recording", "ds-prom")
 
 	rc := helper.Org1.Admin.RESTClient(t, &v0alpha1.GroupVersion)
-	do := func(t *testing.T, path string, params url.Values) searchResponse {
+	getRaw := func(t *testing.T, path string, params url.Values) []byte {
 		t.Helper()
 		segments := []string{"apis", v0alpha1.APIGroup, v0alpha1.APIVersion, "namespaces", "default", "search"}
 		if path != "" {
@@ -74,95 +74,97 @@ func runRuleSearchTests(t *testing.T, helper *apis.K8sTestHelper) {
 		}
 		raw, err := req.DoRaw(ctx)
 		require.NoError(t, err)
-		var resp searchResponse
-		require.NoError(t, json.Unmarshal(raw, &resp))
+		return raw
+	}
+	searchAlert := func(t *testing.T, params url.Values) v0alpha1.GetSearchAlertRulesResponse {
+		var resp v0alpha1.GetSearchAlertRulesResponse
+		require.NoError(t, json.Unmarshal(getRaw(t, "alertrules", params), &resp))
 		return resp
 	}
-	search := func(t *testing.T, path string, params url.Values) []searchHit {
-		return do(t, path, params).Items
+	searchRecording := func(t *testing.T, params url.Values) v0alpha1.GetSearchRecordingRulesResponse {
+		var resp v0alpha1.GetSearchRecordingRulesResponse
+		require.NoError(t, json.Unmarshal(getRaw(t, "recordingrules", params), &resp))
+		return resp
+	}
+	searchCrossKind := func(t *testing.T, params url.Values) v0alpha1.GetSearchRulesResponse {
+		var resp v0alpha1.GetSearchRulesResponse
+		require.NoError(t, json.Unmarshal(getRaw(t, "", params), &resp))
+		return resp
 	}
 
 	t.Run("alert rules: returns all alert rules", func(t *testing.T) {
-		hits := search(t, "alertrules", nil)
-		require.Len(t, hits, 3)
+		require.Len(t, searchAlert(t, nil).Items, 3)
 	})
 
 	t.Run("alert rules: free-text title filter", func(t *testing.T) {
-		hits := search(t, "alertrules", url.Values{"q": {"usage"}})
-		require.ElementsMatch(t, []string{"cpu usage high", "memory usage high"}, titles(hits))
+		require.ElementsMatch(t, []string{"cpu usage high", "memory usage high"}, alertTitles(searchAlert(t, url.Values{"q": {"usage"}})))
 	})
 
 	t.Run("alert rules: label matcher", func(t *testing.T) {
-		hits := search(t, "alertrules", url.Values{"labels": {"team=a"}})
-		require.ElementsMatch(t, []string{"cpu usage high", "disk low"}, titles(hits))
+		require.ElementsMatch(t, []string{"cpu usage high", "disk low"}, alertTitles(searchAlert(t, url.Values{"labels": {"team=a"}})))
 	})
 
 	t.Run("alert rules: source datasource filter", func(t *testing.T) {
-		hits := search(t, "alertrules", url.Values{"datasourceUIDs": {"ds-loki"}})
-		require.Equal(t, []string{"memory usage high"}, titles(hits))
+		require.Equal(t, []string{"memory usage high"}, alertTitles(searchAlert(t, url.Values{"datasourceUIDs": {"ds-loki"}})))
 	})
 
 	t.Run("alert rules: paused filter", func(t *testing.T) {
-		hits := search(t, "alertrules", url.Values{"paused": {"true"}})
-		require.Equal(t, []string{"memory usage high"}, titles(hits))
+		require.Equal(t, []string{"memory usage high"}, alertTitles(searchAlert(t, url.Values{"paused": {"true"}})))
 	})
 
 	t.Run("alert rules: sort by title descending", func(t *testing.T) {
-		hits := search(t, "alertrules", url.Values{"sort": {"-title"}})
-		require.Equal(t, []string{"memory usage high", "disk low", "cpu usage high"}, titles(hits))
+		require.Equal(t, []string{"memory usage high", "disk low", "cpu usage high"}, alertTitles(searchAlert(t, url.Values{"sort": {"-title"}})))
 	})
 
 	t.Run("alert rules: pagination", func(t *testing.T) {
-		first := do(t, "alertrules", url.Values{"sort": {"title"}, "limit": {"2"}})
-		require.Len(t, first.Items, 2)
-		require.Equal(t, []string{"cpu usage high", "disk low"}, titles(first.Items))
-		require.NotEmpty(t, first.Metadata.Continue)
+		first := searchAlert(t, url.Values{"sort": {"title"}, "limit": {"2"}})
+		require.Equal(t, []string{"cpu usage high", "disk low"}, alertTitles(first))
+		require.NotEmpty(t, first.Continue)
 
-		second := do(t, "alertrules", url.Values{"sort": {"title"}, "limit": {"2"}, "continueToken": {first.Metadata.Continue}})
-		require.Equal(t, []string{"memory usage high"}, titles(second.Items))
-		require.Empty(t, second.Metadata.Continue)
+		second := searchAlert(t, url.Values{"sort": {"title"}, "limit": {"2"}, "continueToken": {first.Continue}})
+		require.Equal(t, []string{"memory usage high"}, alertTitles(second))
+		require.Empty(t, second.Continue)
 	})
 
 	t.Run("recording rules: returns all recording rules", func(t *testing.T) {
-		hits := search(t, "recordingrules", nil)
-		require.Equal(t, []string{"cpu recording"}, titles(hits))
+		resp := searchRecording(t, nil)
+		require.Len(t, resp.Items, 1)
+		require.Equal(t, "cpu recording", resp.Items[0].Title)
 	})
 
 	t.Run("cross-kind: returns both kinds", func(t *testing.T) {
-		hits := search(t, "", nil)
-		require.Len(t, hits, 4)
+		require.Len(t, searchCrossKind(t, nil).Items, 4)
 	})
 
 	t.Run("cross-kind: type narrowing", func(t *testing.T) {
-		hits := search(t, "", url.Values{"type": {"recordingrule"}})
-		require.Equal(t, []string{"cpu recording"}, titles(hits))
+		require.Equal(t, []string{"cpu recording"}, crossKindTitles(searchCrossKind(t, url.Values{"type": {"recordingrule"}})))
 	})
 
 	t.Run("consistency: search matches list", func(t *testing.T) {
 		list, err := alertClient.List(ctx, v1.ListOptions{})
 		require.NoError(t, err)
-		hits := search(t, "alertrules", nil)
-		require.Len(t, hits, len(list.Items))
+		require.Len(t, searchAlert(t, nil).Items, len(list.Items))
 	})
 }
 
-// searchHit / searchResponse decode the summary rule hit returned by search.
-type searchHit struct {
-	Type   string `json:"type"`
-	Name   string `json:"name"`
-	Title  string `json:"title"`
-	Folder string `json:"folder"`
-}
-
-type searchResponse struct {
-	Metadata v1.ListMeta `json:"metadata"`
-	Items    []searchHit `json:"items"`
-}
-
-func titles(hits []searchHit) []string {
-	out := make([]string, 0, len(hits))
-	for _, h := range hits {
+func alertTitles(resp v0alpha1.GetSearchAlertRulesResponse) []string {
+	out := make([]string, 0, len(resp.Items))
+	for _, h := range resp.Items {
 		out = append(out, h.Title)
+	}
+	return out
+}
+
+// crossKindTitles reads the title from whichever variant of the union hit is set.
+func crossKindTitles(resp v0alpha1.GetSearchRulesResponse) []string {
+	out := make([]string, 0, len(resp.Items))
+	for _, h := range resp.Items {
+		switch {
+		case h.AlertRuleHit != nil:
+			out = append(out, h.AlertRuleHit.Title)
+		case h.RecordingRuleHit != nil:
+			out = append(out, h.RecordingRuleHit.Title)
+		}
 	}
 	return out
 }

--- a/pkg/tests/apis/alerting/rules/search/search_test.go
+++ b/pkg/tests/apis/alerting/rules/search/search_test.go
@@ -34,7 +34,7 @@ func TestIntegrationRuleSearch(t *testing.T) {
 	// Search reads through the provisioning service (the ngalert SQL store), so
 	// results must be correct whichever dual-writer mode the rule resources run
 	// in. Legacy is written (and authoritative) in modes 0-3.
-	for _, mode := range []rest.DualWriterMode{rest.Mode0, rest.Mode2} {
+	for _, mode := range []rest.DualWriterMode{rest.Mode0, rest.Mode2, rest.Mode3} {
 		t.Run(fmt.Sprintf("dualWriterMode=%d", mode), func(t *testing.T) {
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
@@ -177,6 +177,7 @@ func createAlertRule(t *testing.T, ctx context.Context, client *apis.TypedClient
 
 	rule := &v0alpha1.AlertRule{
 		ObjectMeta: v1.ObjectMeta{
+			Name:        base.UID,
 			Namespace:   "default",
 			Annotations: map[string]string{v0alpha1.FolderAnnotationKey: searchFolder},
 		},
@@ -205,6 +206,7 @@ func createRecordingRule(t *testing.T, ctx context.Context, client *apis.TypedCl
 
 	rule := &v0alpha1.RecordingRule{
 		ObjectMeta: v1.ObjectMeta{
+			Name:        base.UID,
 			Namespace:   "default",
 			Annotations: map[string]string{v0alpha1.FolderAnnotationKey: searchFolder},
 		},

--- a/pkg/tests/apis/alerting/rules/search/search_test.go
+++ b/pkg/tests/apis/alerting/rules/search/search_test.go
@@ -146,11 +146,12 @@ func runRuleSearchTests(t *testing.T, helper *apis.K8sTestHelper) {
 	})
 }
 
-// searchHit / searchResponse decode the relevant parts of the generated
-// response shape (metadata + spec) regardless of rule kind.
+// searchHit / searchResponse decode the summary rule hit returned by search.
 type searchHit struct {
-	Metadata v1.ObjectMeta  `json:"metadata"`
-	Spec     map[string]any `json:"spec"`
+	Type   string `json:"type"`
+	Name   string `json:"name"`
+	Title  string `json:"title"`
+	Folder string `json:"folder"`
 }
 
 type searchResponse struct {
@@ -161,9 +162,7 @@ type searchResponse struct {
 func titles(hits []searchHit) []string {
 	out := make([]string, 0, len(hits))
 	for _, h := range hits {
-		if title, ok := h.Spec["title"].(string); ok {
-			out = append(out, title)
-		}
+		out = append(out, h.Title)
 	}
 	return out
 }

--- a/pkg/tests/apis/alerting/rules/search/search_test.go
+++ b/pkg/tests/apis/alerting/rules/search/search_test.go
@@ -1,0 +1,239 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/apis/alerting/rules/common"
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}
+
+const searchFolder = "search-folder"
+
+func TestIntegrationRuleSearch(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	helper := common.GetTestHelper(t)
+	common.CreateTestFolder(t, helper, searchFolder)
+
+	alertClient := common.NewAlertRuleClient(t, helper.Org1.Admin)
+	recClient := common.NewRecordingRuleClient(t, helper.Org1.Admin)
+
+	createAlertRule(t, ctx, alertClient, "cpu usage high", false, map[string]string{"team": "a"}, "ds-prom")
+	createAlertRule(t, ctx, alertClient, "memory usage high", true, map[string]string{"team": "b"}, "ds-loki")
+	createAlertRule(t, ctx, alertClient, "disk low", false, map[string]string{"team": "a"}, "ds-prom")
+	createRecordingRule(t, ctx, recClient, "cpu recording", "ds-prom")
+
+	rc := helper.Org1.Admin.RESTClient(t, &v0alpha1.GroupVersion)
+	do := func(t *testing.T, path string, params url.Values) searchResponse {
+		t.Helper()
+		segments := []string{"apis", v0alpha1.APIGroup, v0alpha1.APIVersion, "namespaces", "default", "search"}
+		if path != "" {
+			segments = append(segments, path)
+		}
+		req := rc.Get().AbsPath(segments...)
+		for k, vals := range params {
+			for _, v := range vals {
+				req = req.Param(k, v)
+			}
+		}
+		raw, err := req.DoRaw(ctx)
+		require.NoError(t, err)
+		var resp searchResponse
+		require.NoError(t, json.Unmarshal(raw, &resp))
+		return resp
+	}
+	search := func(t *testing.T, path string, params url.Values) []searchHit {
+		return do(t, path, params).Items
+	}
+
+	t.Run("alert rules: returns all alert rules", func(t *testing.T) {
+		hits := search(t, "alertrules", nil)
+		require.Len(t, hits, 3)
+	})
+
+	t.Run("alert rules: free-text title filter", func(t *testing.T) {
+		hits := search(t, "alertrules", url.Values{"q": {"usage"}})
+		require.ElementsMatch(t, []string{"cpu usage high", "memory usage high"}, titles(hits))
+	})
+
+	t.Run("alert rules: label matcher", func(t *testing.T) {
+		hits := search(t, "alertrules", url.Values{"labels": {"team=a"}})
+		require.ElementsMatch(t, []string{"cpu usage high", "disk low"}, titles(hits))
+	})
+
+	t.Run("alert rules: source datasource filter", func(t *testing.T) {
+		hits := search(t, "alertrules", url.Values{"datasourceUIDs": {"ds-loki"}})
+		require.Equal(t, []string{"memory usage high"}, titles(hits))
+	})
+
+	t.Run("alert rules: paused filter", func(t *testing.T) {
+		hits := search(t, "alertrules", url.Values{"paused": {"true"}})
+		require.Equal(t, []string{"memory usage high"}, titles(hits))
+	})
+
+	t.Run("alert rules: sort by title descending", func(t *testing.T) {
+		hits := search(t, "alertrules", url.Values{"sort": {"-title"}})
+		require.Equal(t, []string{"memory usage high", "disk low", "cpu usage high"}, titles(hits))
+	})
+
+	t.Run("alert rules: pagination", func(t *testing.T) {
+		first := do(t, "alertrules", url.Values{"sort": {"title"}, "limit": {"2"}})
+		require.Len(t, first.Items, 2)
+		require.Equal(t, []string{"cpu usage high", "disk low"}, titles(first.Items))
+		require.NotEmpty(t, first.Metadata.Continue)
+
+		second := do(t, "alertrules", url.Values{"sort": {"title"}, "limit": {"2"}, "continueToken": {first.Metadata.Continue}})
+		require.Equal(t, []string{"memory usage high"}, titles(second.Items))
+		require.Empty(t, second.Metadata.Continue)
+	})
+
+	t.Run("recording rules: returns all recording rules", func(t *testing.T) {
+		hits := search(t, "recordingrules", nil)
+		require.Equal(t, []string{"cpu recording"}, titles(hits))
+	})
+
+	t.Run("cross-kind: returns both kinds", func(t *testing.T) {
+		hits := search(t, "", nil)
+		require.Len(t, hits, 4)
+	})
+
+	t.Run("cross-kind: type narrowing", func(t *testing.T) {
+		hits := search(t, "", url.Values{"type": {"recordingrule"}})
+		require.Equal(t, []string{"cpu recording"}, titles(hits))
+	})
+
+	t.Run("consistency: search matches list", func(t *testing.T) {
+		list, err := alertClient.List(ctx, v1.ListOptions{})
+		require.NoError(t, err)
+		hits := search(t, "alertrules", nil)
+		require.Len(t, hits, len(list.Items))
+	})
+}
+
+// searchHit / searchResponse decode the relevant parts of the generated
+// response shape (metadata + spec) regardless of rule kind.
+type searchHit struct {
+	Metadata v1.ObjectMeta  `json:"metadata"`
+	Spec     map[string]any `json:"spec"`
+}
+
+type searchResponse struct {
+	Metadata v1.ListMeta `json:"metadata"`
+	Items    []searchHit `json:"items"`
+}
+
+func titles(hits []searchHit) []string {
+	out := make([]string, 0, len(hits))
+	for _, h := range hits {
+		if title, ok := h.Spec["title"].(string); ok {
+			out = append(out, title)
+		}
+	}
+	return out
+}
+
+func createAlertRule(t *testing.T, ctx context.Context, client *apis.TypedClient[v0alpha1.AlertRule, v0alpha1.AlertRuleList], title string, paused bool, labels map[string]string, dsUID string) {
+	t.Helper()
+	base := ngmodels.RuleGen.With(
+		ngmodels.RuleMuts.WithUniqueUID(),
+		ngmodels.RuleMuts.WithNamespaceUID(searchFolder),
+		ngmodels.RuleMuts.WithIntervalMatching(10*time.Second),
+	).Generate()
+
+	rule := &v0alpha1.AlertRule{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace:   "default",
+			Annotations: map[string]string{v0alpha1.FolderAnnotationKey: searchFolder},
+		},
+		Spec: v0alpha1.AlertRuleSpec{
+			Title:        title,
+			Paused:       new(paused),
+			Labels:       templateLabels(labels),
+			Expressions:  alertExpressions(base, dsUID),
+			Trigger:      v0alpha1.AlertRuleIntervalTrigger{Interval: "10s"},
+			NoDataState:  "NoData",
+			ExecErrState: "Error",
+		},
+	}
+	_, err := client.Create(ctx, rule, v1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func createRecordingRule(t *testing.T, ctx context.Context, client *apis.TypedClient[v0alpha1.RecordingRule, v0alpha1.RecordingRuleList], title, dsUID string) {
+	t.Helper()
+	base := ngmodels.RuleGen.With(
+		ngmodels.RuleMuts.WithUniqueUID(),
+		ngmodels.RuleMuts.WithNamespaceUID(searchFolder),
+		ngmodels.RuleMuts.WithAllRecordingRules(),
+		ngmodels.RuleMuts.WithIntervalMatching(10*time.Second),
+	).Generate()
+
+	rule := &v0alpha1.RecordingRule{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace:   "default",
+			Annotations: map[string]string{v0alpha1.FolderAnnotationKey: searchFolder},
+		},
+		Spec: v0alpha1.RecordingRuleSpec{
+			Title:               title,
+			Metric:              v0alpha1.RecordingRuleMetricName(base.Record.Metric),
+			TargetDatasourceUID: v0alpha1.RecordingRuleDatasourceUID(dsUID),
+			Expressions: v0alpha1.RecordingRuleExpressionMap{
+				"A": {
+					QueryType:     new(base.Data[0].QueryType),
+					DatasourceUID: new(v0alpha1.RecordingRuleDatasourceUID(dsUID)),
+					Model:         base.Data[0].Model,
+					Source:        new(true),
+					RelativeTimeRange: &v0alpha1.RecordingRuleRelativeTimeRange{
+						From: v0alpha1.RecordingRulePromDurationWMillis("5m"),
+						To:   v0alpha1.RecordingRulePromDurationWMillis("0s"),
+					},
+				},
+			},
+			Trigger: v0alpha1.RecordingRuleIntervalTrigger{Interval: "10s"},
+		},
+	}
+	_, err := client.Create(ctx, rule, v1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func alertExpressions(base ngmodels.AlertRule, dsUID string) v0alpha1.AlertRuleExpressionMap {
+	return v0alpha1.AlertRuleExpressionMap{
+		"A": {
+			QueryType:     new(base.Data[0].QueryType),
+			DatasourceUID: new(v0alpha1.AlertRuleDatasourceUID(dsUID)),
+			Model:         base.Data[0].Model,
+			Source:        new(true),
+			RelativeTimeRange: &v0alpha1.AlertRuleRelativeTimeRange{
+				From: v0alpha1.AlertRulePromDurationWMillis("5m"),
+				To:   v0alpha1.AlertRulePromDurationWMillis("0s"),
+			},
+		},
+	}
+}
+
+func templateLabels(labels map[string]string) map[string]v0alpha1.AlertRuleTemplateString {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make(map[string]v0alpha1.AlertRuleTemplateString, len(labels))
+	for k, v := range labels {
+		out[k] = v0alpha1.AlertRuleTemplateString(v)
+	}
+	return out
+}

--- a/pkg/tests/apis/alerting/rules/search/search_test.go
+++ b/pkg/tests/apis/alerting/rules/search/search_test.go
@@ -96,6 +96,15 @@ func runRuleSearchTests(t *testing.T, helper *apis.K8sTestHelper) {
 		require.Len(t, searchAlert(t, nil).Items, 3)
 	})
 
+	t.Run("alert rules: compact-view fields populated", func(t *testing.T) {
+		// interval is a config field common to both backends; assert it round
+		// trips consistently regardless of storage mode.
+		for _, h := range searchAlert(t, nil).Items {
+			require.NotNil(t, h.Interval, h.Title)
+			require.Equal(t, "10s", *h.Interval, h.Title)
+		}
+	})
+
 	t.Run("alert rules: free-text title filter", func(t *testing.T) {
 		require.ElementsMatch(t, []string{"cpu usage high", "memory usage high"}, alertTitles(searchAlert(t, url.Values{"q": {"usage"}})))
 	})

--- a/pkg/tests/apis/alerting/rules/search/search_test.go
+++ b/pkg/tests/apis/alerting/rules/search/search_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"testing"
 	"time"
@@ -11,9 +12,12 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/apiserver/rest"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/apis/alerting/rules/common"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -27,8 +31,24 @@ const searchFolder = "search-folder"
 func TestIntegrationRuleSearch(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
+	// Search reads through the provisioning service (the ngalert SQL store), so
+	// results must be correct whichever dual-writer mode the rule resources run
+	// in. Legacy is written (and authoritative) in modes 0-3.
+	for _, mode := range []rest.DualWriterMode{rest.Mode0, rest.Mode2} {
+		t.Run(fmt.Sprintf("dualWriterMode=%d", mode), func(t *testing.T) {
+			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+					"alertrules.rules.alerting.grafana.app":     {DualWriterMode: mode},
+					"recordingrules.rules.alerting.grafana.app": {DualWriterMode: mode},
+				},
+			})
+			runRuleSearchTests(t, helper)
+		})
+	}
+}
+
+func runRuleSearchTests(t *testing.T, helper *apis.K8sTestHelper) {
 	ctx := context.Background()
-	helper := common.GetTestHelper(t)
 	common.CreateTestFolder(t, helper, searchFolder)
 
 	alertClient := common.NewAlertRuleClient(t, helper.Org1.Admin)

--- a/pkg/tests/apis/openapi_snapshots/rules.alerting.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/rules.alerting.grafana.app-v0alpha1.json
@@ -2862,6 +2862,483 @@
           }
         }
       ]
+    },
+    "/apis/rules.alerting.grafana.app/v0alpha1/namespaces/{namespace}/search": {
+      "get": {
+        "operationId": "getSearchRules",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesResponse"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesResponse"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "continueToken",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "dashboardUID",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "datasourceUIDs",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "folders",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "groups",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "labels",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "metric",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "names",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "notificationType",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "panelID",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "paused",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "q",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "receiver",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "routingTree",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "sort",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "targetDatasourceUID",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "type",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/rules.alerting.grafana.app/v0alpha1/namespaces/{namespace}/search/alertrules": {
+      "get": {
+        "operationId": "getSearchAlertRules",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesResponse"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesResponse"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "continueToken",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "dashboardUID",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "datasourceUIDs",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "folders",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "groups",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "labels",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "names",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "notificationType",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "panelID",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "paused",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "q",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "receiver",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "routingTree",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "sort",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/rules.alerting.grafana.app/v0alpha1/namespaces/{namespace}/search/recordingrules": {
+      "get": {
+        "operationId": "getSearchRecordingRules",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesResponse"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesResponse"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "continueToken",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "datasourceUIDs",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "folders",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "groups",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "labels",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "metric",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "names",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "paused",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "q",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "sort",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "targetDatasourceUID",
+          "in": "query",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
     }
   },
   "components": {
@@ -2947,7 +3424,6 @@
         "additionalProperties": false
       },
       "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.AlertRuleExpressionMap": {
-        "description": "TODO: validate that only one can specify source=true\n\u0026 struct.MinFields(1) This doesn't work in Cue \u003cv0.12.0 as per",
         "type": "object",
         "additionalProperties": {
           "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.AlertRuleExpression"
@@ -3034,7 +3510,6 @@
         ]
       },
       "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.AlertRuleNotificationSettings": {
-        "description": "TODO(@moustafab): this should be imported from the notifications package",
         "oneOf": [
           {
             "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.AlertRuleSimplifiedRouting"
@@ -3253,8 +3728,244 @@
         "type": "string"
       },
       "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.AlertRuleTimeIntervalRef": {
-        "description": "TODO(@moustafab): validate regex for time interval ref",
         "type": "string"
+      },
+      "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesAlertRuleHit": {
+        "type": "object",
+        "required": [
+          "type",
+          "name",
+          "title",
+          "folder"
+        ],
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "dashboardUID": {
+            "type": "string"
+          },
+          "datasourceUIDs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "folder": {
+            "type": "string"
+          },
+          "for": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "interval": {
+            "type": "string"
+          },
+          "keepFiringFor": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "notificationType": {
+            "type": "string"
+          },
+          "panelID": {
+            "type": "integer"
+          },
+          "paused": {
+            "type": "boolean"
+          },
+          "receiver": {
+            "type": "string"
+          },
+          "routingTree": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesRuleSearchType"
+          }
+        }
+      },
+      "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesResponse": {
+        "type": "object",
+        "required": [
+          "items",
+          "apiVersion",
+          "kind",
+          "metadata"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesAlertRuleHit"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ]
+          }
+        }
+      },
+      "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchAlertRulesRuleSearchType": {
+        "type": "string",
+        "enum": [
+          "alertrule",
+          "recordingrule"
+        ]
+      },
+      "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesRecordingRuleHit": {
+        "type": "object",
+        "required": [
+          "type",
+          "name",
+          "title",
+          "folder"
+        ],
+        "properties": {
+          "datasourceUIDs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "folder": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "interval": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "metric": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "paused": {
+            "type": "boolean"
+          },
+          "targetDatasourceUID": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesRuleSearchType"
+          }
+        }
+      },
+      "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesResponse": {
+        "type": "object",
+        "required": [
+          "items",
+          "apiVersion",
+          "kind",
+          "metadata"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesRecordingRuleHit"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ]
+          }
+        }
+      },
+      "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRecordingRulesRuleSearchType": {
+        "type": "string",
+        "enum": [
+          "alertrule",
+          "recordingrule"
+        ]
+      },
+      "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesResponse": {
+        "type": "object",
+        "required": [
+          "items",
+          "apiVersion",
+          "kind",
+          "metadata"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesRuleHit"
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ]
+          }
+        }
+      },
+      "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.GetSearchRulesRuleHit": {
+        "description": "RuleHit is the cross-kind union returned by /search."
       },
       "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.RecordingRule": {
         "type": "object",
@@ -3328,7 +4039,6 @@
         "additionalProperties": false
       },
       "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.RecordingRuleExpressionMap": {
-        "description": "TODO: validate that only one can specify source=true\n\u0026 struct.MinFields(1) This doesn't work in Cue \u003cv0.12.0 as per",
         "type": "object",
         "additionalProperties": {
           "$ref": "#/components/schemas/com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.RecordingRuleExpression"
@@ -3390,7 +4100,6 @@
         ]
       },
       "com.github.grafana.grafana.apps.alerting.rules.pkg.apis.alerting.v0alpha1.RecordingRuleMetricName": {
-        "description": "TODO(@moustafab): validate the metric name regex",
         "type": "string",
         "pattern": "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
       },


### PR DESCRIPTION
## What

Adds search endpoints to the alerting **rules** app for `AlertRule` and `RecordingRule`:

- `GET …/namespaces/{ns}/search/alertrules`
- `GET …/namespaces/{ns}/search/recordingrules`
- `GET …/namespaces/{ns}/search` — cross-kind; its query is a superset of the per-kind ones, and results interleave both kinds by sort order.

### Mode-routed backends
Search is dual-writer-mode aware via `resource.NewSearchClient`: the **legacy** backend (a `ResourceIndexClient` over the provisioning `AlertRuleService`) serves modes 0–2, and the **unified** search index serves modes 3+. The handler translates the HTTP query into a `ResourceSearchRequest` and massages the columnar `ResourceSearchResponse` into typed hits. The `ResourceIndexClient` backends stay config-only; orchestration lives in the handler.

### Filters, sort, fields
- **Filters:** `q` (free-text title), `folders`, `groups`, `paused`, `datasourceUIDs` (source datasources from `spec.expressions`), `labels` (rule spec-label matchers incl. existence checks), per-kind (`dashboardUID`/`panelID`/`receiver`/`notificationType`/`routingTree` for alerts; `metric`/`targetDatasourceUID` for recording), and `names` (rule UID).
- **Sort:** `title` and `group` (asc/desc); the cross-kind endpoint interleaves both kinds rather than grouping them.
- **Hits** are per-kind objects (`AlertRuleHit`/`RecordingRuleHit`) with a discriminated union for the cross-kind endpoint, carrying the fields needed for the Prometheus compact rule view **excluding state/health** (interval, annotations, for/keepFiringFor, notification settings, …).
- The unified path indexes rules via new document builders (rule spec-labels indexed as a field).

### Authorization
The namespaced search routes are gated on rule-read access (`ActionAlertingRuleRead`) at the apiserver authorizer, consistent with listing rules; per-folder/per-rule filtering stays enforced by each backend.

### Tests
e2e under dual-writer modes **0, 2 and 3** (legacy + unified federated search): filters, sort interleaving in both directions, pagination, name filtering. Group-sort is seeded via the provisioning API (legacy-read modes) — see the TODO in `grouping_test.go`. Plus unit tests for query encoding, table round-trips, and route authorization.

## Out of scope

State/health filtering and hydration are intentionally **not** in this PR — they require joining the ruler's runtime data, which is a separate effort. The `names` (UID) filter is kept as the seam for a future ruler↔search join, though we don't expect to use it yet.

## Generator workaround — resolved

An earlier revision stripped doc comments from the rule spec CUE to work around an **app-sdk codegen bug**: doc comments on schema definitions referenced by custom-route request/response types broke manifest Go generation (`string literal not terminated`).

That bug is fixed upstream in **grafana-app-sdk v0.56.2** (grafana/grafana-app-sdk#1421), which is now on `main`. The workaround commit and its revert have been dropped; the CUE comments are restored — with dev-note comments (TODOs/FIXMEs) restructured onto standalone lines so they no longer leak into generated field descriptions — and all artifacts are regenerated with v0.56.2. `make generate` is a no-op against the committed output.

Upstream: grafana/grafana-app-sdk#1421 (bug: grafana/grafana-app-sdk#1420)

## Status

Ready for review.
