### PR TITLE
Alerting: Return merge stats from convert Alertmanager import API

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -142,7 +142,7 @@ type ConvertPrometheusSrv struct {
 
 type Alertmanager interface {
 	DeleteExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, identifier string) error
-	SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace bool, dryRun bool) (merge.RenameResources, error)
+	SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace bool, dryRun bool) (merge.MergeResult, error)
 	GetAlertmanagerConfiguration(ctx context.Context, org int64, withAutogen bool) (apimodels.GettableUserConfig, error)
 	IsExternalAMSyncConfiguredForOrg(ctx context.Context, orgID int64) (bool, error)
 }
@@ -644,34 +644,41 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostAlertmanagerConfig(c 
 		return errorToResponse(err)
 	}
 
-	renamed, err := srv.am.SaveAndApplyExtraConfiguration(c.Req.Context(), c.GetOrgID(), c.SignedInUser, srv.importsAuthz, ec, replace, dryRun)
+	result, err := srv.am.SaveAndApplyExtraConfiguration(c.Req.Context(), c.GetOrgID(), c.SignedInUser, srv.importsAuthz, ec, replace, dryRun)
 	if err != nil {
 		logger.Error("Failed to save alertmanager configuration", "error", err, "identifier", identifier)
 		return errorToResponse(fmt.Errorf("failed to save alertmanager configuration: %w", err))
 	}
 
-	// Convert merge.RenameResources to API RenameResources type
-	var apiRenamed *apimodels.RenameResources
-	if len(renamed.Receivers) > 0 || len(renamed.TimeIntervals) > 0 {
-		apiRenamed = &apimodels.RenameResources{
-			Receivers:     renamed.Receivers,
-			TimeIntervals: renamed.TimeIntervals,
-		}
-	}
+	apiResp := buildConvertResponse(result)
 
 	if dryRun {
 		logger.Info("Dry run: alertmanager configuration validated successfully", "identifier", identifier, "replace", replace)
-		return response.JSON(http.StatusOK, apimodels.ConvertAlertmanagerResponse{
-			Status:          "success",
-			RenameResources: apiRenamed,
-		})
+		return response.JSON(http.StatusOK, apiResp)
 	}
 
 	logger.Info("Successfully updated alertmanager configuration with imported Prometheus config", "identifier", identifier, "replace", replace)
-	return response.JSON(http.StatusAccepted, apimodels.ConvertAlertmanagerResponse{
-		Status:          "success",
-		RenameResources: apiRenamed,
-	})
+	return response.JSON(http.StatusAccepted, apiResp)
+}
+
+func buildConvertResponse(result merge.MergeResult) apimodels.ConvertAlertmanagerResponse {
+	resp := apimodels.ConvertAlertmanagerResponse{
+		Status: "success",
+		Stats: &apimodels.MergeStats{
+			AddedRoute:           result.AddedRoute,
+			AddedReceivers:       result.AddedReceivers,
+			AddedTimeIntervals:   result.AddedTimeIntervals,
+			AddedTemplates:       result.AddedTemplates,
+			AddedInhibitionRules: result.AddedInhibitionRules,
+		},
+	}
+	if len(result.Receivers) > 0 || len(result.TimeIntervals) > 0 {
+		resp.RenameResources = &apimodels.RenameResources{
+			Receivers:     result.Receivers,
+			TimeIntervals: result.TimeIntervals,
+		}
+	}
+	return resp
 }
 
 func (srv *ConvertPrometheusSrv) RouteConvertPrometheusGetAlertmanagerConfig(c *contextmodel.ReqContext) response.Response {

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -1964,9 +1964,9 @@ type mockAlertmanager struct {
 	mock.Mock
 }
 
-func (m *mockAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace bool, dryRun bool) (merge.RenameResources, error) {
+func (m *mockAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace bool, dryRun bool) (merge.MergeResult, error) {
 	args := m.Called(ctx, org, user, authz, extraConfig, replace, dryRun)
-	return args.Get(0).(merge.RenameResources), args.Error(1)
+	return args.Get(0).(merge.MergeResult), args.Error(1)
 }
 
 func (m *mockAlertmanager) GetAlertmanagerConfiguration(ctx context.Context, org int64, withAutogen bool) (apimodels.GettableUserConfig, error) {
@@ -1997,7 +1997,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 			return extraConfig.Identifier == identifier &&
 				len(extraConfig.TemplateFiles) == 1 &&
 				extraConfig.TemplateFiles["test.tmpl"] == "{{ define \"test\" }}Hello{{ end }}"
-		}), false, false).Return(merge.RenameResources{}, nil).Once()
+		}), false, false).Return(merge.MergeResult{}, nil).Once()
 
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configIdentifierHeader, identifier)
@@ -2030,7 +2030,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM.On("IsExternalAMSyncConfiguredForOrg", mock.Anything, int64(1)).Return(false, nil).Maybe()
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig v1.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), false, false).Return(merge.RenameResources{}, nil)
+		}), false, false).Return(merge.MergeResult{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies, featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2060,7 +2060,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM.On("IsExternalAMSyncConfiguredForOrg", mock.Anything, int64(1)).Return(false, nil).Maybe()
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig v1.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), true, false).Return(merge.RenameResources{}, nil)
+		}), true, false).Return(merge.MergeResult{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies, featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2090,7 +2090,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM.On("IsExternalAMSyncConfiguredForOrg", mock.Anything, int64(1)).Return(false, nil).Maybe()
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig v1.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), false, true).Return(merge.RenameResources{}, nil)
+		}), false, true).Return(merge.MergeResult{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies, featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2113,24 +2113,31 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM.AssertExpectations(t)
 	})
 
-	t.Run("should return rename information when resources are renamed", func(t *testing.T) {
+	t.Run("should return rename and stats information about the merge", func(t *testing.T) {
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configIdentifierHeader, identifier)
 		mockAM := &mockAlertmanager{}
 		mockAM.On("IsExternalAMSyncConfiguredForOrg", mock.Anything, int64(1)).Return(false, nil).Maybe()
 
-		expectedRenames := merge.RenameResources{
-			Receivers: map[string]string{
-				"default": "default-test-config",
+		expectedResult := merge.MergeResult{
+			RenameResources: merge.RenameResources{
+				Receivers: map[string]string{
+					"default": "default-test-config",
+				},
+				TimeIntervals: map[string]string{
+					"weekdays": "weekdays-test-config",
+				},
 			},
-			TimeIntervals: map[string]string{
-				"weekdays": "weekdays-test-config",
-			},
+			AddedRoute:           identifier,
+			AddedReceivers:       []string{"default-test-config"},
+			AddedTimeIntervals:   []string{"weekdays-test-config"},
+			AddedTemplates:       []string{"test.tmpl"},
+			AddedInhibitionRules: []string{"rule-1"},
 		}
 
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig v1.ExtraConfiguration) bool {
 			return extraConfig.Identifier == identifier
-		}), false, false).Return(expectedRenames, nil)
+		}), false, false).Return(expectedResult, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies, featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2147,9 +2154,17 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		err := json.Unmarshal(response.Body(), &resp)
 		require.NoError(t, err)
 		require.Equal(t, "success", resp.Status)
+
 		require.NotNil(t, resp.RenameResources)
 		require.Equal(t, "default-test-config", resp.RenameResources.Receivers["default"])
 		require.Equal(t, "weekdays-test-config", resp.RenameResources.TimeIntervals["weekdays"])
+
+		require.NotNil(t, resp.Stats)
+		require.Equal(t, identifier, resp.Stats.AddedRoute)
+		require.Equal(t, []string{"default-test-config"}, resp.Stats.AddedReceivers)
+		require.Equal(t, []string{"weekdays-test-config"}, resp.Stats.AddedTimeIntervals)
+		require.Equal(t, []string{"test.tmpl"}, resp.Stats.AddedTemplates)
+		require.Equal(t, []string{"rule-1"}, resp.Stats.AddedInhibitionRules)
 
 		mockAM.AssertExpectations(t)
 	})

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -318,6 +318,8 @@ type ConvertAlertmanagerResponse struct {
 	Error     string `json:"error"`
 	// RenameResources contains information about renamed resources during configuration merge
 	RenameResources *RenameResources `json:"rename_resources,omitempty"`
+	// Stats contains information about what was added during configuration merge
+	Stats *MergeStats `json:"stats,omitempty"`
 }
 
 // RenameResources describes which resources were renamed to avoid conflicts
@@ -326,6 +328,20 @@ type RenameResources struct {
 	Receivers map[string]string `json:"receivers,omitempty"`
 	// TimeIntervals maps old time interval names to new time interval names
 	TimeIntervals map[string]string `json:"time_intervals,omitempty"`
+}
+
+// MergeStats describes which resources were added during configuration merge.
+type MergeStats struct {
+	// AddedRoute is the identifier of the routing sub-tree added to the configuration
+	AddedRoute string `json:"added_route,omitempty"`
+	// AddedReceivers contains the names of receivers added (post-rename if renamed)
+	AddedReceivers []string `json:"added_receivers,omitempty"`
+	// AddedTimeIntervals contains the names of time intervals added (post-rename if renamed)
+	AddedTimeIntervals []string `json:"added_time_intervals,omitempty"`
+	// AddedTemplates contains the names of templates added
+	AddedTemplates []string `json:"added_templates,omitempty"`
+	// AddedInhibitionRules contains the names of inhibition rules added
+	AddedInhibitionRules []string `json:"added_inhibition_rules,omitempty"`
 }
 
 // swagger:parameters RouteConvertPrometheusPostAlertmanagerConfig

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -89,11 +89,11 @@ func (moa *MultiOrgAlertmanager) PrepareConfig(
 		if err := moa.Crypto.DecryptExtraConfigs(ctx, prepared); err != nil {
 			return alertingNotify.NotificationsConfiguration{}, fmt.Errorf("failed to decrypt external configurations: %w", err)
 		}
-		mergeResult, err := merge.MergeExtraConfig(ctx, prepared, models.ProvenanceConvertedPrometheus)
+		mergedConfig, _, err := merge.MergeExtraConfig(ctx, prepared, models.ProvenanceConvertedPrometheus)
 		if err != nil {
 			return alertingNotify.NotificationsConfiguration{}, fmt.Errorf("failed to merge external configuration: %w", err)
 		}
-		prepared = &mergeResult.Config
+		prepared = &mergedConfig
 	}
 
 	config := prepared.AlertmanagerConfig
@@ -379,7 +379,7 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 		}
 	}
 
-	mergeResult, err := merge.MergeExtraConfig(ctx, cfg, models.ProvenanceConvertedPrometheus)
+	_, mergeResult, err := merge.MergeExtraConfig(ctx, cfg, models.ProvenanceConvertedPrometheus)
 	if err != nil {
 		return merge.RenameResources{}, fmt.Errorf("cannot merge imported configuration into Grafana: %w", err)
 	}
@@ -451,7 +451,7 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 		return []v1.ExtraConfiguration{extraConfig}, nil
 	}
 
-	renamed, err := moa.modifyAndApplyExtraConfiguration(ctx, org, modifyFunc, dryRun)
+	result, err := moa.modifyAndApplyExtraConfiguration(ctx, org, modifyFunc, dryRun)
 	if err != nil {
 		return merge.RenameResources{}, err
 	}
@@ -461,7 +461,7 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 	} else {
 		moa.logger.Info("Applied alertmanager configuration with extra config", "org", org, "identifier", extraConfig.Identifier)
 	}
-	return renamed, nil
+	return result, nil
 }
 
 // DeleteExtraConfiguration deletes an ExtraConfiguration by its identifier while preserving the main AlertmanagerConfig.

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -355,63 +355,63 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 	org int64,
 	modifyFn func([]v1.ExtraConfiguration) ([]v1.ExtraConfiguration, error),
 	dryRun bool,
-) (merge.RenameResources, error) {
+) (merge.MergeResult, error) {
 	currentCfg, err := moa.configStore.GetLatestAlertmanagerConfiguration(ctx, org)
 	if err != nil {
-		return merge.RenameResources{}, fmt.Errorf("failed to get current configuration: %w", err)
+		return merge.MergeResult{}, fmt.Errorf("failed to get current configuration: %w", err)
 	}
 
 	cfg, err := Load([]byte(currentCfg.AlertmanagerConfiguration))
 	if err != nil {
-		return merge.RenameResources{}, fmt.Errorf("failed to unmarshal current alertmanager configuration: %w", err)
+		return merge.MergeResult{}, fmt.Errorf("failed to unmarshal current alertmanager configuration: %w", err)
 	}
 
 	cfg.ExtraConfigs, err = modifyFn(cfg.ExtraConfigs)
 	if err != nil {
-		return merge.RenameResources{}, fmt.Errorf("failed to apply extra configuration: %w", err)
+		return merge.MergeResult{}, fmt.Errorf("failed to apply extra configuration: %w", err)
 	}
 
 	if len(cfg.ManagedRoutes) > 0 {
 		for _, c := range cfg.ExtraConfigs {
 			if _, ok := cfg.ManagedRoutes[c.Identifier]; ok {
-				return merge.RenameResources{}, ErrIdentifierAlreadyExists.Build(errutil.TemplateData{Public: map[string]interface{}{"Identifier": c.Identifier}})
+				return merge.MergeResult{}, ErrIdentifierAlreadyExists.Build(errutil.TemplateData{Public: map[string]interface{}{"Identifier": c.Identifier}})
 			}
 		}
 	}
 
 	_, mergeResult, err := merge.MergeExtraConfig(ctx, cfg, models.ProvenanceConvertedPrometheus)
 	if err != nil {
-		return merge.RenameResources{}, fmt.Errorf("cannot merge imported configuration into Grafana: %w", err)
+		return merge.MergeResult{}, fmt.Errorf("cannot merge imported configuration into Grafana: %w", err)
 	}
 
 	if dryRun {
 		moa.logger.Debug("Dry run: extra configuration validated successfully", "org", org)
-		return mergeResult.RenameResources, nil
+		return mergeResult, nil
 	}
 
 	am, err := moa.AlertmanagerFor(org)
 	if err != nil {
 		// It's okay if the alertmanager isn't ready yet, we're changing its config anyway.
 		if !errors.Is(err, ErrAlertmanagerNotReady) {
-			return merge.RenameResources{}, err
+			return merge.MergeResult{}, err
 		}
 	}
 
 	if err := moa.Crypto.EncryptExtraConfigs(ctx, cfg); err != nil {
-		return merge.RenameResources{}, fmt.Errorf("failed to encrypt external configurations: %w", err)
+		return merge.MergeResult{}, fmt.Errorf("failed to encrypt external configurations: %w", err)
 	}
 
 	if err := moa.saveAndApplyConfig(ctx, org, am, cfg); err != nil {
 		moa.logger.Error("Unable to save and apply alertmanager configuration with extra config", "error", err, "org", org)
-		return merge.RenameResources{}, AlertmanagerConfigRejectedError{err}
+		return merge.MergeResult{}, AlertmanagerConfigRejectedError{err}
 	}
 
 	moa.logger.Info("Applied alertmanager configuration with extra config", "org", org)
-	return mergeResult.RenameResources, nil
+	return mergeResult, nil
 }
 
 // SaveAndApplyExtraConfiguration adds or replaces an ExtraConfiguration while preserving the main AlertmanagerConfig.
-func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace bool, dryRun bool) (merge.RenameResources, error) {
+func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz ExtraConfigAuthz, extraConfig v1.ExtraConfiguration, replace bool, dryRun bool) (merge.MergeResult, error) {
 	modifyFunc := func(configs []v1.ExtraConfiguration) ([]v1.ExtraConfiguration, error) {
 		if replace {
 			// When replacing all configs, authorize deletion for each config with a different identifier.
@@ -453,7 +453,7 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 
 	result, err := moa.modifyAndApplyExtraConfiguration(ctx, org, modifyFunc, dryRun)
 	if err != nil {
-		return merge.RenameResources{}, err
+		return merge.MergeResult{}, err
 	}
 
 	if dryRun {

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -38,7 +38,7 @@ func (e ImportedConfigRevision) GetReceivers(uids []string) ([]*models.Receiver,
 		return nil, nil
 	}
 	original := e.rev.Config.AlertmanagerConfig.GetReceivers()
-	merged, _ := merge.Receivers(original, e.importedConfig.GetReceivers(), e.identifier)
+	merged, _, _ := merge.Receivers(original, e.importedConfig.GetReceivers(), e.identifier)
 
 	capacity := len(uids)
 	if capacity == 0 {
@@ -78,7 +78,7 @@ func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]v1.MuteTimeInterval, e
 	grafanaTime := e.rev.Config.AlertmanagerConfig.TimeIntervals
 
 	// Merge to get the renames map (only renamed if name collision occurs)
-	_, renames := merge.TimeIntervals(
+	_, renames, _ := merge.TimeIntervals(
 		grafanaMute,
 		grafanaTime,
 		importedMute,
@@ -114,7 +114,7 @@ func (e ImportedConfigRevision) ReceiverUseByName() map[string]int {
 	}
 	m := make(map[string]int)
 	receiverUseCounts([]*v1.Route{e.importedConfig.Route}, m)
-	_, renames := merge.Receivers(e.rev.Config.AlertmanagerConfig.GetReceivers(), e.importedConfig.GetReceivers(), e.identifier)
+	_, renames, _ := merge.Receivers(e.rev.Config.AlertmanagerConfig.GetReceivers(), e.importedConfig.GetReceivers(), e.identifier)
 	for original, renamed := range renames {
 		if cnt, ok := m[original]; ok {
 			delete(m, original)

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -24,38 +24,59 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-// MergeResult represents the result of merging two Alertmanager configurations.
-// It contains the unified configuration and maps of renamed receivers and time intervals.
-type MergeResult struct {
-	Config v1.AMConfigV1
-	RenameResources
-	Identifier string
-}
-
+// RenameResources describes which incoming resources were renamed to avoid conflicts with existing ones.
+// In each map the key is the original incoming name and the value is the new name assigned during the merge.
 type RenameResources struct {
 	Receivers     map[string]string
 	TimeIntervals map[string]string
 }
 
-// LogContext returns key-value pairs describing any receiver or time-interval renames the
-// merge produced, suitable for structured logging. Returns nil when nothing was renamed.
+// MergeResult describes what changed during a merge: which resources were added and which were renamed.
+type MergeResult struct {
+	RenameResources
+	// AddedRoute is the identifier of the routing sub-tree added to the configuration.
+	AddedRoute string
+	// AddedReceivers contains receivers added to the merged config. If the receiver was renamed, this list contains the new name.
+	AddedReceivers []string
+	// AddedTimeIntervals contains time intervals added to the merged config. If the time interval was renamed, this list contains the new name.
+	AddedTimeIntervals   []string
+	AddedTemplates       []string
+	AddedInhibitionRules []string
+}
+
+// LogContext returns key-value pairs describing what changed during the merge, suitable for structured logging.
+// Returns nil when nothing was added or renamed.
 func (m MergeResult) LogContext() []any {
-	if len(m.Receivers) == 0 && len(m.TimeIntervals) == 0 {
+	if len(m.Receivers) == 0 && len(m.TimeIntervals) == 0 &&
+		len(m.AddedReceivers) == 0 && len(m.AddedTimeIntervals) == 0 &&
+		len(m.AddedTemplates) == 0 && len(m.AddedInhibitionRules) == 0 {
 		return nil
 	}
-	logCtx := make([]any, 0, 6)
-	logCtx = append(logCtx, "identifier", m.Identifier)
+	logCtx := make([]any, 0, 12)
+	logCtx = append(logCtx, "route", m.AddedRoute)
+	if len(m.AddedReceivers) > 0 {
+		logCtx = append(logCtx, "receivers", fmt.Sprintf("%v", m.AddedReceivers))
+	}
+	if len(m.AddedTimeIntervals) > 0 {
+		logCtx = append(logCtx, "timeIntervals", fmt.Sprintf("%v", m.AddedTimeIntervals))
+	}
+	if len(m.AddedTemplates) > 0 {
+		logCtx = append(logCtx, "templates", fmt.Sprintf("%v", m.AddedTemplates))
+	}
+	if len(m.AddedInhibitionRules) > 0 {
+		logCtx = append(logCtx, "inhibitionRules", fmt.Sprintf("%v", m.AddedInhibitionRules))
+	}
 	if len(m.Receivers) > 0 {
 		rcvBuilder := strings.Builder{}
 		for from, to := range m.Receivers {
-			fmt.Fprintf(&rcvBuilder, "'%s'->'%s',", from, to)
+			_, _ = fmt.Fprintf(&rcvBuilder, "'%s'->'%s',", from, to)
 		}
 		logCtx = append(logCtx, "renamedReceivers", fmt.Sprintf("[%s]", rcvBuilder.String()[0:rcvBuilder.Len()-1]))
 	}
 	if len(m.TimeIntervals) > 0 {
 		intervalBuilder := strings.Builder{}
 		for from, to := range m.TimeIntervals {
-			fmt.Fprintf(&intervalBuilder, "'%s'->'%s',", from, to)
+			_, _ = fmt.Fprintf(&intervalBuilder, "'%s'->'%s',", from, to)
 		}
 		logCtx = append(logCtx, "renamedTimeIntervals", fmt.Sprintf("[%s]", intervalBuilder.String()[0:intervalBuilder.Len()-1]))
 	}
@@ -86,27 +107,27 @@ func (m MergeResult) LogContext() []any {
 //     - All inhibit rules from the extra configuration are copied to the result
 //
 // provenance is applied to templates and inhibition rules produced by the merge.
-func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1, provenance models.Provenance) (MergeResult, error) {
+func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1, provenance models.Provenance) (v1.AMConfigV1, MergeResult, error) {
 	if len(cfg.ExtraConfigs) == 0 {
-		return MergeResult{Config: *cfg}, nil
+		return *cfg, MergeResult{}, nil
 	}
 	// support only one config for now
 	mimirCfg := cfg.ExtraConfigs[0]
 	if err := mimirCfg.Validate(); err != nil {
-		return MergeResult{}, fmt.Errorf("invalid extra configuration: %w", err)
+		return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("invalid extra configuration: %w", err)
 	}
 	mcfg, err := mimirCfg.GetAlertmanagerConfig()
 	if err != nil {
-		return MergeResult{}, fmt.Errorf("failed to get mimir alertmanager config: %w", err)
+		return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("failed to get mimir alertmanager config: %w", err)
 	}
 
 	if _, ok := cfg.ManagedRoutes[mimirCfg.Identifier]; ok || mimirCfg.Identifier == models.DefaultRoutingTreeName {
-		return MergeResult{}, fmt.Errorf("cannot merge because config %s because it conflicts with existing managed route", mimirCfg.Identifier)
+		return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("cannot merge because config %s because it conflicts with existing managed route", mimirCfg.Identifier)
 	}
 
-	mergedReceivers, renamedReceivers := Receivers(cfg.AlertmanagerConfig.Receivers, mcfg.Receivers, mimirCfg.Identifier)
+	mergedReceivers, renamedReceivers, addedReceivers := Receivers(cfg.AlertmanagerConfig.Receivers, mcfg.Receivers, mimirCfg.Identifier)
 
-	mergedTimeIntervals, renamedTimeIntervals := TimeIntervals(
+	mergedTimeIntervals, renamedTimeIntervals, addedTimeIntervals := TimeIntervals(
 		cfg.AlertmanagerConfig.MuteTimeIntervals,
 		cfg.AlertmanagerConfig.TimeIntervals,
 		mcfg.MuteTimeIntervals,
@@ -114,43 +135,41 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1, provenance models.P
 		mimirCfg.Identifier,
 	)
 
-	renamed := RenameResources{
-		Receivers:     renamedReceivers,
-		TimeIntervals: renamedTimeIntervals,
-	}
-
 	managedRoutes := make(v1.ManagedRoutes, len(cfg.ManagedRoutes)+1)
 	{
 		maps.Copy(managedRoutes, cfg.ManagedRoutes)
 		extraRoute := mcfg.Route
-		RenameResourceUsagesInRoutes([]*v1.Route{extraRoute}, renamed)
+		RenameResourceUsagesInRoutes([]*v1.Route{extraRoute}, RenameResources{Receivers: renamedReceivers, TimeIntervals: renamedTimeIntervals})
 		managedRoutes[mimirCfg.Identifier] = extraRoute
 	}
 
+	var addedInhibitionRules []string
 	managedInhibitionRules := make(v1.ManagedInhibitionRules, len(mcfg.InhibitRules)+len(cfg.ManagedInhibitionRules))
 	{
 		maps.Copy(managedInhibitionRules, cfg.ManagedInhibitionRules)
 		importedRules, err := BuildManagedInhibitionRules(mimirCfg.Identifier, mcfg.InhibitRules, v1.Provenance(provenance))
 		if err != nil {
-			return MergeResult{}, fmt.Errorf("failed to build managed inhibition rules for imported configuration: %w", err)
+			return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("failed to build managed inhibition rules for imported configuration: %w", err)
 		}
+		addedInhibitionRules = slices.Collect(maps.Keys(importedRules))
 		maps.Copy(managedInhibitionRules, importedRules)
 	}
 
+	var addedTemplates []string
 	templates := make(map[v1.ResourceUID]v1.TemplateGroup, len(cfg.Templates)+len(mimirCfg.TemplateFiles))
 	{
 		maps.Copy(templates, cfg.Templates)
 		for name, content := range mimirCfg.TemplateFiles {
 			tmpl := v1.NewTemplateGroup(name, content, v1.TemplateKindMimir, provenance)
 			if _, ok := templates[tmpl.UID]; ok {
-				return MergeResult{}, fmt.Errorf("template [%s] of %s kind already exists", name, v1.TemplateKindMimir)
+				return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("template [%s] of %s kind already exists", name, v1.TemplateKindMimir)
 			}
 			templates[tmpl.UID] = tmpl
+			addedTemplates = append(addedTemplates, name)
 		}
 	}
 
-	return MergeResult{
-		Config: v1.AMConfigV1{
+	return v1.AMConfigV1{
 			ExtraConfigs: cfg.ExtraConfigs[1:],
 			Templates:    templates,
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
@@ -165,38 +184,40 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1, provenance models.P
 			},
 			ManagedRoutes:          managedRoutes,
 			ManagedInhibitionRules: managedInhibitionRules,
-		},
-		RenameResources: renamed,
-		Identifier:      mimirCfg.Identifier,
-	}, nil
+		}, MergeResult{
+			RenameResources:      RenameResources{Receivers: renamedReceivers, TimeIntervals: renamedTimeIntervals},
+			AddedRoute:           mimirCfg.Identifier,
+			AddedReceivers:       addedReceivers,
+			AddedTimeIntervals:   addedTimeIntervals,
+			AddedTemplates:       addedTemplates,
+			AddedInhibitionRules: addedInhibitionRules,
+		}, nil
 }
 
 // DeduplicateResources merges existing and incoming resources (receivers and time intervals) and ensures unique names by applying suffixes. Returns renamed resources for tracking adjustments made.
 func DeduplicateResources(a, b v1.PostableApiAlertingConfig, suffix string) RenameResources {
-	_, renamedReceivers := Receivers(a.Receivers, b.Receivers, suffix)
-
-	_, renamedTimeIntervals := TimeIntervals(
+	_, renamedReceivers, _ := Receivers(a.Receivers, b.Receivers, suffix)
+	_, renamedTimeIntervals, _ := TimeIntervals(
 		a.MuteTimeIntervals,
 		a.TimeIntervals,
 		b.MuteTimeIntervals,
 		b.TimeIntervals,
 		suffix,
 	)
-	return RenameResources{
-		Receivers:     renamedReceivers,
-		TimeIntervals: renamedTimeIntervals,
-	}
+	return RenameResources{Receivers: renamedReceivers, TimeIntervals: renamedTimeIntervals}
 }
 
 // TimeIntervals merges existing and incoming time intervals and mute intervals, ensuring unique names by applying suffixes.
-// It returns a merged list of time intervals and a map of renamed interval names for tracking adjustments made. Mute time intervals are converted to time intervals.
+// It returns a merged list of time intervals, a map of renamed interval names for tracking adjustments made, and the final
+// names of the incoming intervals (post-rename) in their original order (mute intervals first, then time intervals).
+// Mute time intervals are converted to time intervals.
 func TimeIntervals(
 	existingMuteIntervals []v1.MuteTimeInterval,
 	existingTimeIntervals []v1.TimeInterval,
 	incomingMuteIntervals []v1.MuteTimeInterval,
 	incomingTimeIntervals []v1.TimeInterval,
 	suffix string,
-) ([]v1.TimeInterval, map[string]string) {
+) ([]v1.TimeInterval, map[string]string, []string) {
 	// combine all incoming intervals into a single list
 	incomingAll := make([]v1.TimeInterval, 0, len(incomingTimeIntervals)+len(incomingMuteIntervals))
 	for _, interval := range incomingMuteIntervals {
@@ -211,6 +232,7 @@ func TimeIntervals(
 	}
 	result = append(result, existingTimeIntervals...)
 	renames := make(map[string]string)
+	added := make([]string, 0, len(incomingAll))
 	for idx, interval := range incomingAll {
 		curName := interval.Name
 		if i, ok := usedNames[curName]; ok && i != idx { // if the name is already used by another interval, append a suffix.
@@ -219,9 +241,10 @@ func TimeIntervals(
 			usedNames[newName] = idx
 			interval.Name = newName
 		}
+		added = append(added, interval.Name)
 		result = append(result, interval)
 	}
-	return result, renames
+	return result, renames, added
 }
 
 func createIndexTimeIntervals(
@@ -271,14 +294,16 @@ func RenameResourceUsagesInRoutes(routes []*v1.Route, renames RenameResources) {
 }
 
 // Receivers merges two lists of PostableApiReceiver objects, ensuring unique names by appending a suffix if necessary.
-// It returns the combined list of receivers and a map of renamed original names to their new unique names.
+// It returns the combined list of receivers, a map of renamed original names to their new unique names, and the incoming
+// receivers in their original order after any renames have been applied.
 // The items of the existing list are added to the result list as is whereas the items of incoming list are copied (shallow copy)
 // and renamed if necessary.
-func Receivers(existing, incoming []*v1.PostableApiReceiver, suffix string) ([]*v1.PostableApiReceiver, map[string]string) {
+func Receivers(existing, incoming []*v1.PostableApiReceiver, suffix string) ([]*v1.PostableApiReceiver, map[string]string, []string) {
 	result := make([]*v1.PostableApiReceiver, 0, len(existing)+len(incoming))
 	result = append(result, existing...)
 	usedNames := createIndexReceivers(existing, incoming)
 	renames := make(map[string]string)
+	added := make([]string, 0, len(incoming))
 	for idx, r := range incoming {
 		if r == nil {
 			continue
@@ -290,9 +315,10 @@ func Receivers(existing, incoming []*v1.PostableApiReceiver, suffix string) ([]*
 			cpy.Name = newName
 			usedNames[cpy.Name] = i
 		}
+		added = append(added, cpy.Name)
 		result = append(result, &cpy)
 	}
-	return result, renames
+	return result, renames, added
 }
 
 func createIndexReceivers(existing, incoming []*v1.PostableApiReceiver) map[string]int {

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -41,6 +43,7 @@ func TestReceivers(t *testing.T) {
 		incoming        []*v1.PostableApiReceiver
 		expected        []*v1.PostableApiReceiver
 		expectedRenames map[string]string
+		expectedAdded   []string
 	}{
 		{
 			name: "should append copies of incoming to existing",
@@ -57,6 +60,7 @@ func TestReceivers(t *testing.T) {
 				r3,
 			},
 			expectedRenames: map[string]string{},
+			expectedAdded:   []string{"r1", "r3"},
 		},
 		{
 			name: "should rename incoming if there is existing",
@@ -73,6 +77,7 @@ func TestReceivers(t *testing.T) {
 			expectedRenames: map[string]string{
 				"r2": "r2" + suffix,
 			},
+			expectedAdded: []string{"r2" + suffix},
 		},
 		{
 			name: "should rename incoming if there is existing after dedup",
@@ -91,6 +96,7 @@ func TestReceivers(t *testing.T) {
 			expectedRenames: map[string]string{
 				"r2": "r2" + suffix + "_01",
 			},
+			expectedAdded: []string{"r2" + suffix + "_01"},
 		},
 		{
 			name: "should keep names unique across both sets",
@@ -111,6 +117,7 @@ func TestReceivers(t *testing.T) {
 			expectedRenames: map[string]string{
 				"r2": "r2" + suffix + "_02",
 			},
+			expectedAdded: []string{"r2" + suffix + "_02", "r2" + suffix + "_01"},
 		},
 	}
 	for _, tc := range testCases {
@@ -123,9 +130,10 @@ func TestReceivers(t *testing.T) {
 				incomingNames = append(incomingNames, r.Name)
 			}
 
-			actual, actualRenames := Receivers(tc.existing, tc.incoming, suffix)
+			actual, actualRenames, actualAdded := Receivers(tc.existing, tc.incoming, suffix)
 			require.Len(t, actual, len(tc.expected))
 			assert.EqualValues(t, tc.expectedRenames, actualRenames)
+			assert.Equal(t, tc.expectedAdded, actualAdded)
 			for i := range tc.expected {
 				assert.EqualValues(t, tc.expected[i], actual[i])
 				if i < len(tc.existing) {
@@ -174,6 +182,7 @@ func TestTimeIntervals(t *testing.T) {
 		incomingTimeIntervals []v1.TimeInterval
 		expected              []v1.TimeInterval
 		expectedRenames       map[string]string
+		expectedAdded         []string
 	}{
 		{
 			name: "should append copies of incoming to existing time intervals",
@@ -196,6 +205,7 @@ func TestTimeIntervals(t *testing.T) {
 				ti("ti4"),
 			},
 			expectedRenames: map[string]string{},
+			expectedAdded:   []string{"mti3", "ti4"},
 		},
 		{
 			name: "should rename incoming if there is existing",
@@ -221,6 +231,7 @@ func TestTimeIntervals(t *testing.T) {
 				"ti2":  "ti2" + suffix,
 				"mti1": "mti1" + suffix,
 			},
+			expectedAdded: []string{"ti2" + suffix, "mti1" + suffix},
 		},
 		{
 			name: "should rename incoming if there is existing after dedup",
@@ -246,6 +257,7 @@ func TestTimeIntervals(t *testing.T) {
 				"ti1" + suffix: "ti1" + suffix + suffix,
 				"ti1":          "ti1" + suffix + "_01",
 			},
+			expectedAdded: []string{"ti1" + suffix + "_01", "ti1" + suffix + suffix},
 		},
 		{
 			name: "should rename dupe among incoming",
@@ -266,6 +278,7 @@ func TestTimeIntervals(t *testing.T) {
 			expectedRenames: map[string]string{
 				"ti2": "ti2" + suffix + "_01",
 			},
+			expectedAdded: []string{"ti2" + suffix, "ti2" + suffix + "_01"},
 		},
 		{
 			name: "should ensure uniqueness across existing and incoming",
@@ -292,6 +305,7 @@ func TestTimeIntervals(t *testing.T) {
 			expectedRenames: map[string]string{
 				"ti1": "ti1" + suffix + "_02",
 			},
+			expectedAdded: []string{"ti1" + suffix + "_01", "ti1" + suffix + "_02", "ti2"},
 		},
 	}
 	for _, tc := range testCases {
@@ -310,9 +324,10 @@ func TestTimeIntervals(t *testing.T) {
 				incomingNames = append(incomingNames, r.Name)
 			}
 
-			actualTimeIntervals, actualRenames := TimeIntervals(tc.existingMuteIntervals, tc.existingTimeIntervals, tc.incomingMuteIntervals, tc.incomingTimeIntervals, suffix)
+			actualTimeIntervals, actualRenames, actualAdded := TimeIntervals(tc.existingMuteIntervals, tc.existingTimeIntervals, tc.incomingMuteIntervals, tc.incomingTimeIntervals, suffix)
 			assert.Equal(t, tc.expected, actualTimeIntervals)
 			assert.EqualValues(t, tc.expectedRenames, actualRenames)
+			assert.Equal(t, tc.expectedAdded, actualAdded)
 
 			// check that existing and incoming lists are not changed
 			var names []string
@@ -399,7 +414,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		return v1.ManagedRoutes{identifier: route}, inhibitRules
 	}
 
-	assertResult := func(t *testing.T, expected, actual MergeResult) {
+	assertConfig := func(t *testing.T, expected, actual v1.AMConfigV1) {
 		t.Helper()
 		diff := cmp.Diff(expected, actual,
 			cmpopts.IgnoreUnexported(commoncfg.ProxyConfig{}, labels.Matcher{}),
@@ -420,7 +435,7 @@ func TestMergeExtraConfig(t *testing.T) {
 			}),
 		)
 		if !assert.Empty(t, diff) {
-			data, err := yaml.Marshal(actual.Config)
+			data, err := yaml.Marshal(actual)
 			require.NoError(t, err)
 			t.Fatalf("YAML:\n%v", string(data))
 		}
@@ -428,57 +443,47 @@ func TestMergeExtraConfig(t *testing.T) {
 
 	t.Run("should merge all resources, no renames", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
-		result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
 		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirConfig, RenameResources{})
-		assertResult(t, MergeResult{
-			Config: v1.AMConfigV1{
-				AlertmanagerConfig:     *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) { p.Global = nil }),
-				ManagedRoutes:          expectedRoutes,
-				ManagedInhibitionRules: expectedInhibitRules,
-			},
-			Identifier: identifier,
-		}, result)
+		assertConfig(t, v1.AMConfigV1{
+			AlertmanagerConfig:     *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) { p.Global = nil }),
+			ManagedRoutes:          expectedRoutes,
+			ManagedInhibitionRules: expectedInhibitRules,
+		}, config)
 	})
 
 	t.Run("should populate intervals by defaults", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirNoIntervals)
-		result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
 		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirNoIntervals, RenameResources{})
-		assertResult(t, MergeResult{
-			Config: v1.AMConfigV1{
-				AlertmanagerConfig:     *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) { p.Global = nil }),
-				ManagedRoutes:          expectedRoutes,
-				ManagedInhibitionRules: expectedInhibitRules,
-			},
-			Identifier: identifier,
-		}, result)
+		assertConfig(t, v1.AMConfigV1{
+			AlertmanagerConfig:     *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) { p.Global = nil }),
+			ManagedRoutes:          expectedRoutes,
+			ManagedInhibitionRules: expectedInhibitRules,
+		}, config)
 	})
 
 	t.Run("should rename receivers and refactor usages", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirWithExtraReceiver)
-		result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
-		renames := RenameResources{Receivers: map[string]string{"grafana-default-email": "grafana-default-email" + identifier}}
-		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirWithExtraReceiver, renames)
-		assertResult(t, MergeResult{
-			Config: v1.AMConfigV1{
-				AlertmanagerConfig: *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) {
-					p.Global = nil
-					p.Receivers = append(p.Receivers, &v1.PostableApiReceiver{
-						Receiver: definition.Receiver{Name: "grafana-default-email" + identifier},
-					})
-				}),
-				ManagedRoutes:          expectedRoutes,
-				ManagedInhibitionRules: expectedInhibitRules,
-			},
-			RenameResources: renames,
-			Identifier:      identifier,
-		}, result)
+		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirWithExtraReceiver,
+			RenameResources{Receivers: map[string]string{"grafana-default-email": "grafana-default-email" + identifier}})
+		assertConfig(t, v1.AMConfigV1{
+			AlertmanagerConfig: *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) {
+				p.Global = nil
+				p.Receivers = append(p.Receivers, &v1.PostableApiReceiver{
+					Receiver: definition.Receiver{Name: "grafana-default-email" + identifier},
+				})
+			}),
+			ManagedRoutes:          expectedRoutes,
+			ManagedInhibitionRules: expectedInhibitRules,
+		}, config)
 	})
 
 	t.Run("should append index suffix if rename still collides", func(t *testing.T) {
@@ -488,86 +493,78 @@ func TestMergeExtraConfig(t *testing.T) {
 			})
 		})
 		input := withExtra(t, grafana, fullMimirWithOnlyExtraReceiver)
-		result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
-		renames := RenameResources{Receivers: map[string]string{"grafana-default-email": "grafana-default-email" + identifier + "_01"}}
-		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirWithOnlyExtraReceiver, renames)
-		assertResult(t, MergeResult{
-			Config: v1.AMConfigV1{
-				AlertmanagerConfig: *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) {
-					p.Global = nil
-					p.Receivers = append(p.Receivers,
-						&v1.PostableApiReceiver{Receiver: definition.Receiver{Name: "grafana-default-email" + identifier}},
-						&v1.PostableApiReceiver{Receiver: definition.Receiver{Name: "grafana-default-email" + identifier + "_01"}},
-					)
-				}),
-				ManagedRoutes:          expectedRoutes,
-				ManagedInhibitionRules: expectedInhibitRules,
-			},
-			RenameResources: renames,
-			Identifier:      identifier,
-		}, result)
+		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirWithOnlyExtraReceiver,
+			RenameResources{Receivers: map[string]string{"grafana-default-email": "grafana-default-email" + identifier + "_01"}})
+		assertConfig(t, v1.AMConfigV1{
+			AlertmanagerConfig: *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) {
+				p.Global = nil
+				p.Receivers = append(p.Receivers,
+					&v1.PostableApiReceiver{Receiver: definition.Receiver{Name: "grafana-default-email" + identifier}},
+					&v1.PostableApiReceiver{Receiver: definition.Receiver{Name: "grafana-default-email" + identifier + "_01"}},
+				)
+			}),
+			ManagedRoutes:          expectedRoutes,
+			ManagedInhibitionRules: expectedInhibitRules,
+		}, config)
 	})
 
 	t.Run("should rename time intervals and refactor usages", func(t *testing.T) {
 		// fullMimirSwappedIntervals has mute_time_intervals=[ti-1] and time_intervals=[ti-2, mti-1],
 		// intentionally swapping names to verify uniqueness is enforced across both fields.
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirSwappedIntervals)
-		result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
-		renames := RenameResources{TimeIntervals: map[string]string{"ti-1": "ti-1" + identifier, "mti-1": "mti-1" + identifier}}
-		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirSwappedIntervals, renames)
-		assertResult(t, MergeResult{
-			Config: v1.AMConfigV1{
-				AlertmanagerConfig: *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) {
-					p.Global = nil
-					// Keep mti-1 and ti-1 from base; mti-2 is absent in fullMimirSwappedIntervals.
-					// Incoming: mute ti-1 (renamed) → ti-1+id, time ti-2 (no conflict), time mti-1 (renamed) → mti-1+id.
-					p.TimeIntervals = []v1.TimeInterval{
-						p.TimeIntervals[0], // mti-1 (existing mute, folded)
-						p.TimeIntervals[1], // ti-1
-						{Name: "ti-1" + identifier},
-						p.TimeIntervals[3], // ti-2 (incoming time, no conflict)
-						{Name: "mti-1" + identifier},
-					}
-				}),
-				ManagedRoutes:          expectedRoutes,
-				ManagedInhibitionRules: expectedInhibitRules,
-			},
-			RenameResources: renames,
-			Identifier:      identifier,
-		}, result)
+		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirSwappedIntervals,
+			RenameResources{TimeIntervals: map[string]string{"ti-1": "ti-1" + identifier, "mti-1": "mti-1" + identifier}})
+		assertConfig(t, v1.AMConfigV1{
+			AlertmanagerConfig: *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) {
+				p.Global = nil
+				// Keep mti-1 and ti-1 from base; mti-2 is absent in fullMimirSwappedIntervals.
+				// Incoming: mute ti-1 (renamed) → ti-1+id, time ti-2 (no conflict), time mti-1 (renamed) → mti-1+id.
+				p.TimeIntervals = []v1.TimeInterval{
+					p.TimeIntervals[0], // mti-1 (existing mute, folded)
+					p.TimeIntervals[1], // ti-1
+					{Name: "ti-1" + identifier},
+					p.TimeIntervals[3], // ti-2 (incoming time, no conflict)
+					{Name: "mti-1" + identifier},
+				}
+			}),
+			ManagedRoutes:          expectedRoutes,
+			ManagedInhibitionRules: expectedInhibitRules,
+		}, config)
 	})
 
 	t.Run("should not modify the base Grafana config", func(t *testing.T) {
 		g := load(t, fullGrafanaConfig)
 		input := withExtra(t, g, fullMimirConfig)
-		_, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 		assert.Equal(t, load(t, fullGrafanaConfig), g)
 	})
 
 	t.Run("should return base config unchanged if no extra configs", func(t *testing.T) {
 		input := v1.AMConfigV1{AlertmanagerConfig: *load(t, fullGrafanaConfig)}
-		result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
-		assert.Equal(t, input, result.Config)
+		assert.Equal(t, input, config)
 	})
 
 	t.Run("should fail if identifier is empty", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
 			e.Identifier = ""
 		})
-		_, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.ErrorContains(t, err, "identifier is required")
 	})
 
 	t.Run("should fail if identifier conflicts with existing managed route", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
 		input.ManagedRoutes = v1.ManagedRoutes{identifier: nil}
-		_, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.ErrorContains(t, err, identifier)
 	})
 
@@ -575,36 +572,75 @@ func TestMergeExtraConfig(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
 			e.Identifier = models.DefaultRoutingTreeName
 		})
-		_, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.ErrorContains(t, err, models.DefaultRoutingTreeName)
+	})
+
+	t.Run("should populate stats with added resource names", func(t *testing.T) {
+		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
+		config, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		require.NoError(t, err)
+
+		assert.Equal(t, identifier, result.AddedRoute)
+		assert.ElementsMatch(t, []string{"recv", "recv2"}, result.AddedReceivers)
+		assert.ElementsMatch(t, []string{"mti-2", "ti-2"}, result.AddedTimeIntervals)
+		assert.Empty(t, result.AddedTemplates)
+		assert.ElementsMatch(t, slices.Collect(maps.Keys(config.ManagedInhibitionRules)), result.AddedInhibitionRules)
+	})
+
+	t.Run("should report renamed receiver in stats", func(t *testing.T) {
+		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirWithExtraReceiver)
+		_, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t, []string{"recv", "recv2", "grafana-default-email" + identifier}, result.AddedReceivers)
+	})
+
+	t.Run("should report added template names in stats", func(t *testing.T) {
+		templateName := "my-template"
+		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
+			e.TemplateFiles = map[string]string{templateName: `{{ define "my-template" }}test{{ end }}`}
+		})
+		_, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{templateName}, result.AddedTemplates)
+	})
+
+	t.Run("should return empty stats when no extra configs", func(t *testing.T) {
+		input := v1.AMConfigV1{AlertmanagerConfig: *load(t, fullGrafanaConfig)}
+		_, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		require.NoError(t, err)
+
+		assert.Equal(t, MergeResult{}, result)
 	})
 
 	t.Run("should add extra route to ManagedRoutes", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
-		result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
-		require.Contains(t, result.Config.ManagedRoutes, identifier)
-		assert.Equal(t, "recv", result.Config.ManagedRoutes[identifier].Receiver)
+		require.Contains(t, config.ManagedRoutes, identifier)
+		assert.Equal(t, "recv", config.ManagedRoutes[identifier].Receiver)
 	})
 
 	t.Run("should preserve existing managed routes in result", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
 		input.ManagedRoutes = v1.ManagedRoutes{"existing-managed": {Receiver: "existing"}}
-		result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
-		assert.Contains(t, result.Config.ManagedRoutes, "existing-managed")
-		assert.Contains(t, result.Config.ManagedRoutes, identifier)
+		assert.Contains(t, config.ManagedRoutes, "existing-managed")
+		assert.Contains(t, config.ManagedRoutes, identifier)
 	})
 
 	t.Run("should add inhibition rules to ManagedInhibitionRules with identifier scope", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
-		result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
-		require.Len(t, result.Config.ManagedInhibitionRules, 1)
-		for _, rule := range result.Config.ManagedInhibitionRules {
+		require.Len(t, config.ManagedInhibitionRules, 1)
+		for _, rule := range config.ManagedInhibitionRules {
 			hasSourceScope := false
 			for _, m := range rule.SourceMatchers {
 				if m.Name == models.NamedRouteLabel && m.Value == identifier {
@@ -631,12 +667,12 @@ func TestMergeExtraConfig(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
 			e.TemplateFiles = map[string]string{templateName: templateContent}
 		})
-		result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
 		expectedUID := v1.TemplateUID(v1.TemplateKindMimir, templateName)
-		require.Contains(t, result.Config.Templates, expectedUID)
-		assert.Equal(t, templateName, result.Config.Templates[expectedUID].Title)
+		require.Contains(t, config.Templates, expectedUID)
+		assert.Equal(t, templateName, config.Templates[expectedUID].Title)
 	})
 
 	t.Run("should fail on duplicate template", func(t *testing.T) {
@@ -649,7 +685,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		input.Templates = map[v1.ResourceUID]v1.TemplateGroup{
 			existingUID: v1.NewTemplateGroup(templateName, templateContent, v1.TemplateKindMimir, models.ProvenanceNone),
 		}
-		_, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.ErrorContains(t, err, templateName)
 	})
 }


### PR DESCRIPTION
## What this PR does

The convert Alertmanager import endpoint now reports what the merge did when folding an imported config into Grafana, so callers (mimirtool / UI) can see how it was applied.

`ConvertAlertmanagerResponse` gains an additive `stats` object listing the resources the merge **added** — the routing sub-tree (`added_route`), receivers, time intervals, templates, and inhibition rules. The existing `rename_resources` field is left untouched and still reports resources renamed to avoid name collisions.

### Backend
- `merge` package: `MergeExtraConfig` now returns the merged config separately from a `MergeResult` that embeds `RenameResources` and records the added resources. `Receivers`/`TimeIntervals` also return the incoming names after any rename, and `LogContext` reports added resources alongside renames.
- `MultiOrgAlertmanager.SaveAndApplyExtraConfiguration` returns `merge.MergeResult`.

## Why

Imports can rename or add resources on collision without telling anyone — surfacing what changed lets the client report it back to the user instead of guessing. The open question this answers: how does a caller learn what an import actually did to their config?

No breaking API change: `rename_resources` is preserved; `stats` is purely additive.
