### PR TITLE
IAM: Serve org users lookup using the new APIs in single-org mode

### DIFF
--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/searchusers/sortopts"
@@ -145,6 +146,31 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrg(c *contextmodel.ReqContext) respo
 // 500: internalServerError
 
 func (hs *HTTPServer) GetOrgUsersForCurrentOrgLookup(c *contextmodel.ReqContext) response.Response {
+	// Single-org with users in unified storage: the legacy org_user/user join is
+	// empty, so read the shared users via the k8s-redirected user search instead.
+	if hs.Cfg.RBAC.SingleOrganization && hs.Features.IsEnabledGlobally(featuremgmt.FlagKubernetesUsersApi) {
+		searchResult, err := hs.userService.Search(c.Req.Context(), &user.SearchUsersQuery{
+			SignedInUser: c.SignedInUser,
+			OrgID:        c.GetOrgID(),
+			Query:        c.Query("query"),
+			Limit:        c.QueryInt("limit"),
+		})
+		if err != nil {
+			return response.Error(http.StatusInternalServerError, "Failed to get users for current organization", err)
+		}
+
+		result := make([]*dtos.UserLookupDTO, 0, len(searchResult.Users))
+		for _, u := range searchResult.Users {
+			result = append(result, &dtos.UserLookupDTO{
+				UID:       u.UID,
+				UserID:    u.ID,
+				Login:     u.Login,
+				AvatarURL: u.AvatarURL,
+			})
+		}
+		return response.JSON(http.StatusOK, result)
+	}
+
 	orgUsersResult, err := hs.searchOrgUsersHelper(c, &org.SearchOrgUsersQuery{
 		OrgID:                    c.GetOrgID(),
 		Query:                    c.Query("query"),

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/open-feature/go-sdk/openfeature"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -146,10 +148,11 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrg(c *contextmodel.ReqContext) respo
 // 500: internalServerError
 
 func (hs *HTTPServer) GetOrgUsersForCurrentOrgLookup(c *contextmodel.ReqContext) response.Response {
+	ctx := c.Req.Context()
 	// Single-org with users in unified storage: the legacy org_user/user join is
 	// empty, so read the shared users via the k8s-redirected user search instead.
-	if hs.Cfg.RBAC.SingleOrganization && hs.Features.IsEnabledGlobally(featuremgmt.FlagKubernetesUsersApi) {
-		searchResult, err := hs.userService.Search(c.Req.Context(), &user.SearchUsersQuery{
+	if hs.Cfg.RBAC.SingleOrganization && ofClient.Boolean(ctx, featuremgmt.FlagKubernetesUsersRedirect, false, openfeature.TransactionContext(ctx)) {
+		searchResult, err := hs.userService.Search(ctx, &user.SearchUsersQuery{
 			SignedInUser: c.SignedInUser,
 			OrgID:        c.GetOrgID(),
 			Query:        c.Query("query"),
@@ -161,11 +164,15 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrgLookup(c *contextmodel.ReqContext)
 
 		result := make([]*dtos.UserLookupDTO, 0, len(searchResult.Users))
 		for _, u := range searchResult.Users {
+			avatarURL := u.AvatarURL
+			if avatarURL == "" {
+				avatarURL = dtos.GetGravatarUrl(hs.Cfg, u.Email)
+			}
 			result = append(result, &dtos.UserLookupDTO{
 				UID:       u.UID,
 				UserID:    u.ID,
 				Login:     u.Login,
-				AvatarURL: u.AvatarURL,
+				AvatarURL: avatarURL,
 			})
 		}
 		return response.JSON(http.StatusOK, result)


### PR DESCRIPTION
## What

`GET /api/org/users/lookup` (used by the UserPicker when adding folder/dashboard/team permissions) joins the legacy `org_user`/`user` SQL tables. When users are served from unified storage (`kubernetesUsersApi`), those tables are empty, so the picker returns no users.

This routes the lookup through the already-k8s-redirected `userService.Search`, which reads the shared users, **gated on `single_organization`**. It falls back to the legacy org-scoped SQL search otherwise, so it's a no-op for non-migrated and multi-org deployments.

## Why single-org only

`userService.Search` is not scoped by `org_user` membership the way the legacy join is, so "all users == org users" only holds for single-organization deployments. Multi-org keeps the legacy path to avoid surfacing the wrong user set.

## Scope / follow-up

`orgService.SearchOrgUsers` itself remains an unmigrated legacy path (other callers, e.g. the full Org Users admin page, still read empty legacy SQL when users live in unified storage). This PR fixes the lookup consumed by the permissions UI; migrating `SearchOrgUsers` to be org-membership aware against unified storage is the broader follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)