### PR TITLE
Provisioning: Show folder README panel in empty provisioned folders

### DIFF
--- a/public/app/features/browse-dashboards/components/BrowseView.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.test.tsx
@@ -187,6 +187,25 @@ describe('browse-dashboards BrowseView', () => {
       });
     }
 
+    function mockReadmeMissing() {
+      jest.spyOn(useFolderReadmeModule, 'useFolderReadme').mockReturnValue({
+        repository: {
+          name: 'r',
+          target: 'folder',
+          title: 'r',
+          type: 'github',
+          url: 'https://github.com/o/r',
+          branch: 'main',
+          workflows: [],
+        } as never,
+        folder: undefined,
+        readmePath: 'README.md',
+        status: 'missing',
+        markdownContent: undefined,
+        refetch: jest.fn(),
+      });
+    }
+
     afterEach(() => {
       act(() => {
         setTestFlags({});
@@ -257,7 +276,7 @@ describe('browse-dashboards BrowseView', () => {
       expect(screen.queryByText('README.md')).not.toBeInTheDocument();
     });
 
-    it('does not append the README row for empty folders', async () => {
+    it('appends the README panel for empty provisioned folders', async () => {
       setTestFlags({ 'provisioning.readmes': true });
       mockReadme();
 
@@ -272,7 +291,25 @@ describe('browse-dashboards BrowseView', () => {
       );
 
       expect(await screen.findByText('Create dashboard')).toBeInTheDocument();
-      expect(screen.queryByText('README.md')).not.toBeInTheDocument();
+      expect(await screen.findByText('README.md')).toBeInTheDocument();
+    });
+
+    it('shows the Add README CTA for empty provisioned folders without a README', async () => {
+      setTestFlags({ 'provisioning.readmes': true });
+      mockReadmeMissing();
+
+      render(
+        <BrowseView
+          permissions={mockPermissions}
+          folderUID={folderB_empty.item.uid}
+          isProvisionedFolder
+          width={WIDTH}
+          height={HEIGHT}
+        />
+      );
+
+      expect(await screen.findByText('Create dashboard')).toBeInTheDocument();
+      expect(await screen.findByRole('link', { name: /Add README/i })).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/browse-dashboards/components/BrowseView.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.test.tsx
@@ -182,6 +182,7 @@ describe('browse-dashboards BrowseView', () => {
         folder: undefined,
         readmePath: 'README.md',
         status: 'ok',
+        isLoading: false,
         markdownContent,
         refetch: jest.fn(),
       });
@@ -201,6 +202,7 @@ describe('browse-dashboards BrowseView', () => {
         folder: undefined,
         readmePath: 'README.md',
         status: 'missing',
+        isLoading: false,
         markdownContent: undefined,
         refetch: jest.fn(),
       });

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -1,11 +1,14 @@
+import { css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useCallback, useMemo } from 'react';
 
+import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { CallToActionCard, EmptyState, LinkButton, TextLink } from '@grafana/ui';
+import { CallToActionCard, EmptyState, LinkButton, TextLink, useStyles2 } from '@grafana/ui';
 import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
+import { FolderReadmePanel } from 'app/features/provisioning/components/Folders/FolderReadmePanel';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
 import { useSearchStateManager } from 'app/features/search/state/SearchStateManager';
 import { type DashboardViewItem } from 'app/features/search/types';
@@ -149,6 +152,7 @@ export function BrowseView({
   );
 
   const provisioningReadmesEnabled = useBooleanFlagValue('provisioning.readmes', false);
+  const styles = useStyles2(getStyles);
 
   const flatTreeWithReadme = useMemo(() => {
     if (!provisioningReadmesEnabled || !isProvisionedFolder || !folderUID || flatTree.length === 0) {
@@ -181,7 +185,7 @@ export function BrowseView({
 
   if (status === 'fulfilled' && flatTree.length === 0) {
     return (
-      <div style={{ width }}>
+      <div className={styles.emptyState} style={{ width }}>
         {canSelect ? (
           <EmptyState
             variant="call-to-action"
@@ -219,6 +223,7 @@ export function BrowseView({
             }
           />
         )}
+        {provisioningReadmesEnabled && isProvisionedFolder && folderUID && <FolderReadmePanel folderUID={folderUID} />}
       </div>
     );
   }
@@ -260,3 +265,11 @@ function hasSelectedDescendants(
     return hasSelectedDescendants(v, childrenByParentUID, selectedItems);
   });
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  emptyState: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  }),
+});

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -152,7 +152,7 @@ export function BrowseView({
   );
 
   const provisioningReadmesEnabled = useBooleanFlagValue('provisioning.readmes', false);
-  const showReadme = provisioningReadmesEnabled && isProvisionedFolder && !!folderUID;
+  const showReadme = provisioningReadmesEnabled && isProvisionedFolder && folderUID;
   const styles = useStyles2(getStyles);
 
   const flatTreeWithReadme = useMemo(() => {
@@ -224,7 +224,7 @@ export function BrowseView({
             }
           />
         )}
-        {showReadme && folderUID && <FolderReadmePanel folderUID={folderUID} />}
+        {showReadme && <FolderReadmePanel folderUID={folderUID} />}
       </div>
     );
   }

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -152,10 +152,11 @@ export function BrowseView({
   );
 
   const provisioningReadmesEnabled = useBooleanFlagValue('provisioning.readmes', false);
+  const showReadme = provisioningReadmesEnabled && isProvisionedFolder && !!folderUID;
   const styles = useStyles2(getStyles);
 
   const flatTreeWithReadme = useMemo(() => {
-    if (!provisioningReadmesEnabled || !isProvisionedFolder || !folderUID || flatTree.length === 0) {
+    if (!showReadme || flatTree.length === 0) {
       return flatTree;
     }
 
@@ -167,7 +168,7 @@ export function BrowseView({
         isOpen: false,
       },
     ];
-  }, [flatTree, isProvisionedFolder, folderUID, provisioningReadmesEnabled]);
+  }, [flatTree, showReadme, folderUID]);
 
   const isItemLoaded = useCallback(
     (itemIndex: number) => {
@@ -223,7 +224,7 @@ export function BrowseView({
             }
           />
         )}
-        {provisioningReadmesEnabled && isProvisionedFolder && folderUID && <FolderReadmePanel folderUID={folderUID} />}
+        {showReadme && folderUID && <FolderReadmePanel folderUID={folderUID} />}
       </div>
     );
   }

--- a/public/app/features/provisioning/components/Folders/FolderReadmePanel.test.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadmePanel.test.tsx
@@ -40,6 +40,7 @@ function setReadmeResult(overrides: Partial<UseFolderReadmeResult> = {}) {
     folder: mockFolder,
     readmePath: 'dashboards/team-a/README.md',
     status: 'ok',
+    isLoading: false,
     markdownContent: '# Hello\n\nThis is a README.',
     refetch: jest.fn(),
     ...overrides,
@@ -190,20 +191,19 @@ describe('FolderReadmePanel', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders nothing while the repository view is loading', () => {
-    setReadmeResult({ status: 'loading' });
+  it('shows a loading indicator while the repository view is loading', () => {
+    setReadmeResult({ status: 'loading', isLoading: true, repository: undefined });
 
-    const { container } = render(<FolderReadmePanel folderUID="test-folder" />);
-    expect(container).toBeEmptyDOMElement();
+    render(<FolderReadmePanel folderUID="test-folder" />);
+    expect(screen.getByTestId('Spinner')).toBeInTheDocument();
+    expect(screen.getByText('README.md')).toBeInTheDocument();
   });
 
-  it('shows a spinner while the README itself is loading', () => {
-    // When status is 'loading', the panel returns null — the layout shows the
-    // dashboards list as-is while loading; the panel appears once data arrives.
-    setReadmeResult({ status: 'loading', markdownContent: undefined });
+  it('shows a loading indicator while the README file is loading', () => {
+    setReadmeResult({ status: 'loading', isLoading: true, markdownContent: undefined });
 
-    const { container } = render(<FolderReadmePanel folderUID="test-folder" />);
-    expect(container).toBeEmptyDOMElement();
+    render(<FolderReadmePanel folderUID="test-folder" />);
+    expect(screen.getByTestId('Spinner')).toBeInTheDocument();
   });
 
   it('renders an empty README without the parse-error message', () => {

--- a/public/app/features/provisioning/components/Folders/FolderReadmePanel.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadmePanel.tsx
@@ -5,7 +5,7 @@ import { useIntersection } from 'react-use';
 
 import { type GrafanaTheme2, renderMarkdown, textUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Button, Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Icon, LinkButton, Spinner, Stack, Text, useStyles2 } from '@grafana/ui';
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 
 import { type FolderReadmeStatus, useFolderReadme } from '../../hooks/useFolderReadme';
@@ -25,8 +25,8 @@ interface Props {
  * Header shows the file name + an Edit pencil that opens the host editor;
  * the body either renders the markdown or shows an "Add README" empty state.
  *
- * Returns null and triggers no data fetching when the `provisioning.readmes`
- * OpenFeature toggle is off or when the folder isn't provisioned.
+ * Returns null when the `provisioning.readmes` toggle is off or a loaded folder
+ * isn't provisioned; shows a spinner while loading.
  */
 export function FolderReadmePanel({ folderUID }: Props) {
   const provisioningReadmesEnabled = useBooleanFlagValue('provisioning.readmes', false);
@@ -38,7 +38,7 @@ export function FolderReadmePanel({ folderUID }: Props) {
 
 function FolderReadmePanelContent({ folderUID }: Props) {
   const styles = useStyles2(getStyles);
-  const { repository, folder, readmePath, status, markdownContent, refetch } = useFolderReadme(folderUID);
+  const { repository, folder, readmePath, status, isLoading, markdownContent, refetch } = useFolderReadme(folderUID);
 
   const sectionRef = useRef<HTMLElement>(null);
   const intersection = useIntersection(sectionRef, { threshold: 0.5 });
@@ -58,27 +58,31 @@ function FolderReadmePanelContent({ folderUID }: Props) {
     FolderReadmeEvents.panelViewed({ repositoryType: repository.type, status });
   }, [intersection, repository, status]);
 
-  if (!repository || status === 'loading') {
+  if (!isLoading && !repository) {
     return null;
   }
 
-  const editUrl = getRepoEditFileUrl({
-    repoType: repository.type,
-    url: repository.url,
-    branch: repository.branch,
-    filePath: readmePath,
-    pathPrefix: repository.path,
-  });
+  const editUrl = repository
+    ? getRepoEditFileUrl({
+        repoType: repository.type,
+        url: repository.url,
+        branch: repository.branch,
+        filePath: readmePath,
+        pathPrefix: repository.path,
+      })
+    : undefined;
 
   const folderTitle = folder?.spec?.title ?? '';
-  const newFileUrl = getRepoNewFileUrl({
-    repoType: repository.type,
-    url: repository.url,
-    branch: repository.branch,
-    filePath: readmePath,
-    pathPrefix: repository.path,
-    template: buildReadmeTemplate(folderTitle),
-  });
+  const newFileUrl = repository
+    ? getRepoNewFileUrl({
+        repoType: repository.type,
+        url: repository.url,
+        branch: repository.branch,
+        filePath: readmePath,
+        pathPrefix: repository.path,
+        template: buildReadmeTemplate(folderTitle),
+      })
+    : undefined;
 
   return (
     <section
@@ -109,7 +113,7 @@ function FolderReadmePanelContent({ folderUID }: Props) {
             tooltip={t('browse-dashboards.readme.edit-tooltip', 'Edit README')}
             aria-label={t('browse-dashboards.readme.edit-tooltip', 'Edit README')}
             onClick={() => {
-              FolderReadmeEvents.editClicked({ repositoryType: repository.type });
+              repository && FolderReadmeEvents.editClicked({ repositoryType: repository.type });
             }}
           />
         )}
@@ -129,15 +133,22 @@ function FolderReadmePanelContent({ folderUID }: Props) {
 }
 
 interface ReadmeBodyProps {
-  status: Exclude<FolderReadmeStatus, 'loading'>;
+  status: FolderReadmeStatus;
   markdownContent: string | undefined;
-  repository: RepositoryView;
+  repository: RepositoryView | undefined;
   readmePath: string;
   newFileUrl: string | undefined;
   refetch: () => void;
 }
 
 function ReadmeBody({ status, markdownContent, repository, readmePath, newFileUrl, refetch }: ReadmeBodyProps) {
+  if (status === 'loading' || !repository) {
+    return (
+      <Stack justifyContent="center">
+        <Spinner size="lg" />
+      </Stack>
+    );
+  }
   switch (status) {
     case 'ok':
       return markdownContent !== undefined ? (

--- a/public/app/features/provisioning/hooks/useFolderReadme.ts
+++ b/public/app/features/provisioning/hooks/useFolderReadme.ts
@@ -15,6 +15,8 @@ export interface UseFolderReadmeResult {
   /** Path of the README relative to the repository's configured root. */
   readmePath: string;
   status: FolderReadmeStatus;
+  /** True while fetching, unlike `status === 'loading'` which a non-provisioned folder reports forever. */
+  isLoading: boolean;
   /** Markdown body of the README, or undefined when not loaded successfully. */
   markdownContent: string | undefined;
   refetch: () => void;
@@ -52,8 +54,10 @@ export function useFolderReadme(folderUID: string): UseFolderReadmeResult {
       : skipToken
   );
 
+  const isLoading = isRepoLoading || isFileLoading;
+
   let status: FolderReadmeStatus;
-  if (isRepoLoading || isFileLoading) {
+  if (isLoading) {
     status = 'loading';
   } else if (error && isFetchError(error) && error.status === 404) {
     status = 'missing';
@@ -85,6 +89,7 @@ export function useFolderReadme(folderUID: string): UseFolderReadmeResult {
     folder,
     readmePath,
     status,
+    isLoading,
     markdownContent,
     refetch,
   };


### PR DESCRIPTION
**What is this feature?**

Renders the inline `FolderReadmePanel` (README.md content or "Add README" CTA) in provisioned folders that have no dashboards or subfolders. Previously the README panel only appeared when a folder had at least one child item.

**Why do we need this feature?**

Empty provisioned folders showed only the "Create dashboard" empty state with no way to view or create a README. This made the README feature incomplete for newly created folders that hadn't been populated with dashboards yet.

**Who is this feature for?**

Teams using Git-provisioned folders who want to document folder contents via README.md before adding dashboards.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1160