### PR TITLE
Provisioning: Enable README rendering by default

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -89,6 +89,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `panelTitleSearch`                | Search for dashboards using panel title                                                                |
 | `refactorVariablesTimeRange`      | Refactor time range variables flow to reduce number of API calls made when query variables are chained |
 | `faroDatasourceSelector`          | Enable the data source selector within the Frontend Apps section of the Frontend Observability         |
+| `provisioning.readmes`            | Render the README.md of a Git Sync provisioned folder inline below its dashboards list                 |
 | `externalServiceAccounts`         | Automatic service account and token setup for plugins                                                  |
 | `dashboardFiltersOverview`        | Enables the dashboard filters overview pane                                                            |
 | `feedbackButton`                  | Enables the feedback button in the dashboard edit sidebar                                              |

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -458,10 +458,10 @@ export const useFlagProvisioningGitConventions = (options?: ReactFlagEvaluationO
  *
  * **Details:**
  * - flag key: `provisioning.readmes`
- * - default value: `false`
+ * - default value: `true`
  */
 export const useFlagProvisioningReadmes = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("provisioning.readmes", false, options).value;
+  return useFlag("provisioning.readmes", true, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -281,9 +281,9 @@ var (
 		{
 			Name:        "provisioning.readmes",
 			Description: "Render the README.md of a Git Sync provisioned folder inline below its dashboards list",
-			Stage:       FeatureStageExperimental,
+			Stage:       FeatureStagePublicPreview,
 			Owner:       grafanaAppPlatformSquad,
-			Expression:  "false",
+			Expression:  "true", // enabled by default
 			Generate:    Generate{React: true},
 		},
 		{

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -30,7 +30,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-11-22,provisioning,GA,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,provisioningFolderMetadata,GA,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,provisioningExport,experimental,@grafana/grafana-app-platform-squad,false,true,false
-2026-05-22,provisioning.readmes,experimental,@grafana/grafana-app-platform-squad,false,false,true
+2026-05-22,provisioning.readmes,preview,@grafana/grafana-app-platform-squad,false,false,true
 2026-06-09,provisioning.gitConventions,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2023-12-06,grafanaAPIServerEnsureKubectlAccess,experimental,@grafana/grafana-app-platform-squad,true,true,false
 2023-07-21,awsAsyncQueryCaching,GA,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4081,15 +4081,18 @@
     {
       "metadata": {
         "name": "provisioning.readmes",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1781078230859",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-06-10 07:57:10.859008 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Render the README.md of a Git Sync provisioned folder inline below its dashboards list",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/grafana-app-platform-squad",
         "frontend": true,
-        "expression": "false"
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
## Summary

Promotes the `provisioning.readmes` feature toggle from `experimental` to `PublicPreview` and enables it by default. Git Sync provisioned folders will render their `README.md` inline below the dashboards list out of the box, starting with v13.1.0 builds.

## Changes

- `pkg/services/featuremgmt/registry.go`: stage `experimental` → `PublicPreview`, `Expression: "false"` → `"true"`
- Regenerated artifacts via `make gen-feature-toggles`:
  - `toggles_gen.csv` (stage `experimental` → `preview`)
  - `toggles_gen.json` (stage + `expression: "true"`)
  - `packages/grafana-runtime/.../openfeature.gen.ts` (default value `false` → `true`)
  - `docs/.../feature-toggles/index.md` (moved into the default-on table)

## Why PublicPreview

`toggles_gen_test.go` enforces that only `PublicPreview`, `GA`, or `Deprecated` features may be enabled by default. `PublicPreview` is the natural next step from `experimental` — enabled by default while still maturing — without overstating maturity by jumping straight to GA.

## Testing

- `go test ./pkg/services/featuremgmt/...` passes
- `make gen-feature-toggles` regenerates cleanly with no further diff

## Checklist

- [x] Generated files regenerated and committed
- [x] Documentation (feature-toggles index) updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)