### PR TITLE
Search: Normalize root folder UID to fix root dashboard search during rollout

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -637,8 +637,13 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 		// hijacks the "name" query param to only search for shared dashboard UIDs
 		names = append(names, dashboardUIDs...)
 	} else if folder != "" {
-		// A root folder UID ("general" or the legacy "") is expanded to match
-		// both root sentinels by the search backend, so pass it through unchanged.
+		// Collapse the canonical "general" root sentinel to the legacy empty
+		// value before querying. A search backend on the same version expands
+		// "" back to both root sentinels, but the backend is deployed separately
+		// and may lag this API server; an un-upgraded backend only matches the
+		// "" that root-parented resources are still indexed with, so normalizing
+		// here keeps root search working across the rollout skew.
+		folder = foldermodel.ToLegacyFolderUID(folder)
 		searchRequest.Options.Fields = append(searchRequest.Options.Fields, &resourcepb.Requirement{
 			Key:      "folder",
 			Operator: string(selection.Equals),

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -936,12 +936,12 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 				Federated: []*resourcepb.ResourceKey{folderKey},
 			},
 		},
-		"root folder is passed through for the search backend to expand": {
+		"canonical root folder is collapsed to the legacy empty sentinel": {
 			queryString: "folder=general",
 			expected: &resourcepb.ResourceSearchRequest{
 				Options: &resourcepb.ListOptions{
 					Key:    dashboardKey,
-					Fields: []*resourcepb.Requirement{{Key: "folder", Operator: "=", Values: []string{"general"}}},
+					Fields: []*resourcepb.Requirement{{Key: "folder", Operator: "=", Values: []string{""}}},
 				},
 				Query:     "",
 				Limit:     50,


### PR DESCRIPTION
**What is this feature?**

On the dashboard search API, this collapses the canonical `general` root-folder UID back to the legacy empty (`""`) value before issuing the search request, restoring the normalization that PR #125681 had moved into the unified search backend.

**Why do we need this feature?**

PR #125681 made the API server pass `general` through and rely on the search backend to expand a root filter to both sentinels, but the search backend deploys separately and can lag this API server; while skewed, an un-upgraded backend never expands `general` and only matches the `""` that root-parented dashboards are still indexed with, so searching the root folder returns zero dashboards (only folders appear). Sending `""` works in both the skewed and fully-upgraded states, since an up-to-date backend still expands `""` to both sentinels.

**Who is this feature for?**

Any Grafana / Grafana Cloud user browsing or searching dashboards in the root ("General") folder during a rollout where the search backend and API server are on different versions.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

The same passthrough pattern from #125681 also exists in `dashboard_service.go` (`buildDashboardSearchRequest`) and `folderimpl/unifiedstore.go` (`GetChildren`); those have the identical rollout-skew exposure but are out of scope here. Validated by temporarily disabling the backend expansion and confirming the PR's `TestBleveSearchRootFolderExpansion` reproduces the empty-result symptom.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.