### PR TITLE
[release-13.0.3] Dashboards: preserve datasource name through v2 export/import

### DIFF
--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -28,7 +28,13 @@ import { createConstantVariableAdapter } from '../../../variables/constant/adapt
 import { createDataSourceVariableAdapter } from '../../../variables/datasource/adapter';
 import { createQueryVariableAdapter } from '../../../variables/query/adapter';
 
-import { makeExportableV1, makeExportableV2, type LibraryElementExport, ExportLabel } from './exporters';
+import {
+  makeExportableV1,
+  makeExportableV2,
+  type LibraryElementExport,
+  ExportLabel,
+  ExportDatasourceName,
+} from './exporters';
 
 jest.mock('@grafana/data', () => ({
   ...jest.requireActual('@grafana/data'),
@@ -761,6 +767,35 @@ describe('dashboard exporter v2', () => {
     expect(annotationQuery.spec.query.labels?.[ExportLabel]).toBe('prometheus-4');
   });
 
+  it('should assign the original datasource name as an export label during export', async () => {
+    const { dashboard } = await setup();
+
+    const panel = dashboard.elements['panel-1'];
+    if (panel.kind !== 'Panel') {
+      throw new Error('Panel should be a Panel');
+    }
+    const panelQuery = panel.spec.data.spec.queries[0];
+    expect(panelQuery.spec.query.labels?.[ExportDatasourceName]).toBe('Production Prometheus');
+
+    const queryVariable = dashboard.variables.find(
+      (variable) => variable.kind === 'QueryVariable'
+    ) as QueryVariableKind;
+    expect(queryVariable.spec.query.labels?.[ExportDatasourceName]).toBe('Production Prometheus');
+
+    const groupByVariable = dashboard.variables.find(
+      (variable) => variable.kind === 'GroupByVariable'
+    ) as GroupByVariableKind;
+    expect(groupByVariable.labels?.[ExportDatasourceName]).toBe('Staging Prometheus');
+
+    const adhocVariable = dashboard.variables.find(
+      (variable) => variable.kind === 'AdhocVariable'
+    ) as AdhocVariableKind;
+    expect(adhocVariable.labels?.[ExportDatasourceName]).toBe('Dev Prometheus');
+
+    const annotationQuery = dashboard.annotations[0];
+    expect(annotationQuery.spec.query.labels?.[ExportDatasourceName]).toBe('Annotations Prometheus');
+  });
+
   it('should not remove datasource ref from panel that uses a datasource variable', async () => {
     const { dashboard } = await setup();
     const panel = dashboard.elements['panel-using-datasource-var'];
@@ -929,4 +964,26 @@ stubs['grafana'] = {
     name: 'grafana',
     builtIn: true,
   },
+} as DataSourceInstanceSettings;
+
+// Stubs used by v2 schema fixtures — each datasource UID maps to a distinct display name
+// so we can assert that the original name is preserved through export.
+stubs['datasource1'] = {
+  name: 'Production Prometheus',
+  meta: { id: 'prometheus', info: { version: '1.2.1' }, name: 'Prometheus' },
+} as DataSourceInstanceSettings;
+
+stubs['datasource2'] = {
+  name: 'Staging Prometheus',
+  meta: { id: 'prometheus', info: { version: '1.2.1' }, name: 'Prometheus' },
+} as DataSourceInstanceSettings;
+
+stubs['datasource3'] = {
+  name: 'Dev Prometheus',
+  meta: { id: 'prometheus', info: { version: '1.2.1' }, name: 'Prometheus' },
+} as DataSourceInstanceSettings;
+
+stubs['uid'] = {
+  name: 'Annotations Prometheus',
+  meta: { id: 'grafana-testdata-datasource', info: { version: '1.2.1' }, name: 'TestData' },
 } as DataSourceInstanceSettings;

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -32,6 +32,10 @@ import { isConstant } from '../../../variables/guard';
 // E.g. if a dashboard has two datasources with the same type, the export label will be used to distinguish them.
 export const ExportLabel = 'grafana.app/export-label';
 
+// This label is used to store the original datasource display name when exporting a V2 dashboard.
+// The importer surfaces it in the datasource picker so users can tell which original datasource each input refers to.
+export const ExportDatasourceName = 'grafana.app/export-datasource-name';
+
 export interface InputUsage {
   libraryPanels?: LibraryPanelRef[];
 }
@@ -435,9 +439,12 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
       return;
     }
 
+    const datasourceName = getDatasourceDisplayName(datasourceUid);
+
     dataQueryKind.labels = {
       ...(dataQueryKind.labels ?? {}),
       [ExportLabel]: getLabel(dataQueryKind.group, datasourceUid),
+      ...(datasourceName ? { [ExportDatasourceName]: datasourceName } : {}),
     };
 
     dataQueryKind.datasource = undefined;
@@ -454,9 +461,12 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
       return;
     }
 
+    const datasourceName = getDatasourceDisplayName(datasourceUid);
+
     variable.labels = {
       ...(variable.labels ?? {}),
       [ExportLabel]: getLabel(variable.group, datasourceUid),
+      ...(datasourceName ? { [ExportDatasourceName]: datasourceName } : {}),
     };
     variable.datasource = undefined;
   };
@@ -472,6 +482,14 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     }
 
     return false;
+  };
+
+  const getDatasourceDisplayName = (datasourceUid: string): string | undefined => {
+    const settings = getDataSourceSrv().getInstanceSettings(datasourceUid);
+    if (!settings || settings.meta?.builtIn) {
+      return undefined;
+    }
+    return settings.name;
   };
 
   const getLabel = (datasourceGroup: string, datasourceUid: string) => {

--- a/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.test.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.test.tsx
@@ -117,6 +117,82 @@ describe('ImportDashboardFormV2', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('renders the original datasource name on the field label when label and name differ', () => {
+    const inputs: DashboardInputs = {
+      ...mockInputs,
+      dataSources: [
+        {
+          name: 'mysql-1',
+          label: 'mysql-1 (Production MySQL)',
+          pluginId: 'mysql',
+          type: InputType.DataSource,
+          description: 'mysql data source — originally "Production MySQL"',
+          info: 'Select a mysql data source',
+          value: '',
+        },
+        {
+          name: 'mysql-2',
+          label: 'mysql-2 (Reports MySQL)',
+          pluginId: 'mysql',
+          type: InputType.DataSource,
+          description: 'mysql data source — originally "Reports MySQL"',
+          info: 'Select a mysql data source',
+          value: '',
+        },
+      ],
+    };
+
+    renderForm(false, inputs);
+
+    expect(screen.getByText('mysql-1 (Production MySQL)')).toBeInTheDocument();
+    expect(screen.getByText('mysql-2 (Reports MySQL)')).toBeInTheDocument();
+  });
+
+  it('pre-selects the datasource picker when a matching datasource exists on the instance', () => {
+    const inputs: DashboardInputs = {
+      ...mockInputs,
+      dataSources: [
+        {
+          name: 'mysql-1',
+          label: 'mysql-1 (Production MySQL)',
+          pluginId: 'mysql',
+          type: InputType.DataSource,
+          description: 'mysql data source — originally "Production MySQL"',
+          info: 'Select a mysql data source',
+          value: '',
+          matchedDatasource: { uid: 'ds-prod', name: 'Production MySQL', type: 'mysql' },
+        },
+      ],
+    };
+
+    renderForm(false, inputs);
+
+    const picker = screen.getByTestId('datasource-picker-mysql') as HTMLInputElement;
+    expect(picker.value).toBe('ds-prod');
+  });
+
+  it('leaves the datasource picker empty when no matching datasource exists', () => {
+    const inputs: DashboardInputs = {
+      ...mockInputs,
+      dataSources: [
+        {
+          name: 'mysql-1',
+          label: 'mysql-1 (Production MySQL)',
+          pluginId: 'mysql',
+          type: InputType.DataSource,
+          description: 'mysql data source — originally "Production MySQL"',
+          info: 'Select a mysql data source',
+          value: '',
+        },
+      ],
+    };
+
+    renderForm(false, inputs);
+
+    const picker = screen.getByTestId('datasource-picker-mysql') as HTMLInputElement;
+    expect(picker.value).toBe('');
+  });
+
   it('renders UID field as read-only first and enables editing after clicking change uid', async () => {
     const user = userEvent.setup();
     renderForm(false, mockInputs, 'existing-uid');

--- a/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.tsx
@@ -38,7 +38,14 @@ export const ImportDashboardFormV2 = ({
 }: Props) => {
   const [isSubmitted, setSubmitted] = useState(false);
   const [uidReset, setUidReset] = useState(false);
-  const [selectedDataSources, setSelectedDataSources] = useState<Record<string, DatasourceSelection>>({});
+  const [selectedDataSources, setSelectedDataSources] = useState<Record<string, DatasourceSelection>>(() =>
+    Object.fromEntries(
+      inputs.dataSources
+        .filter((input) => input.matchedDatasource)
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        .map((input) => [`datasource-${input.name}`, input.matchedDatasource!])
+    )
+  );
 
   /*
     This useEffect is needed for overwriting a dashboard. It
@@ -75,11 +82,16 @@ export const ImportDashboardFormV2 = ({
         />
       </Field>
 
-      <Field label={t('dashboard-scene.import-dashboard-form-v2.label-folder', 'Folder')} noMargin>
+      <Field
+        label={t('dashboard-scene.import-dashboard-form-v2.label-folder', 'Folder')}
+        htmlFor="dashboard-import-folder"
+        noMargin
+      >
         <Controller
           render={({ field: { ref, value, onChange, ...field } }) => (
             <FolderPicker
               {...field}
+              id="dashboard-import-folder"
               onChange={(uid, title) => {
                 onChange(uid, title);
               }}
@@ -133,8 +145,9 @@ export const ImportDashboardFormV2 = ({
 
           return (
             <Field
-              label={input.name}
+              label={input.label}
               description={input.description}
+              htmlFor={dataSourceOption}
               key={dataSourceOption}
               invalid={!!errors[dataSourceOption]}
               error={errors[dataSourceOption] ? 'Please select a data source' : undefined}
@@ -142,9 +155,11 @@ export const ImportDashboardFormV2 = ({
             >
               <Controller<ImportFormDataV2, FieldPath<ImportFormDataV2>>
                 name={dataSourceOption}
+                defaultValue={input.matchedDatasource}
                 render={({ field: { ref, ...field } }) => (
                   <DataSourcePicker
                     {...field}
+                    inputId={dataSourceOption}
                     noDefault={true}
                     placeholder={input.info}
                     pluginId={input.pluginId}

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { type Dashboard, type Panel, type VariableModel } from '@grafana/schema/dist/esm/veneer/dashboard.types';
 import { ExportFormat } from 'app/features/dashboard/api/types';
-import { ExportLabel } from 'app/features/dashboard-scene/scene/export/exporters';
+import { ExportDatasourceName, ExportLabel } from 'app/features/dashboard-scene/scene/export/exporters';
 
 import { type DashboardInputs, type ImportDashboardDTO, type ImportFormDataV2, InputType } from '../../types';
 
@@ -338,6 +338,132 @@ describe('extractV2Inputs', () => {
   it('should handle empty dashboard gracefully', async () => {
     const result = await extractV2Inputs({});
     expect(result).toEqual(emptyInputs);
+  });
+
+  it('surfaces the original datasource name on the input label', async () => {
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'QueryVariable',
+          spec: {
+            name: 'var1',
+            query: {
+              group: 'mysql',
+              labels: { [ExportLabel]: 'mysql-1', [ExportDatasourceName]: 'Production MySQL' },
+            },
+          },
+        },
+        {
+          kind: 'QueryVariable',
+          spec: {
+            name: 'var2',
+            query: {
+              group: 'mysql',
+              labels: { [ExportLabel]: 'mysql-2', [ExportDatasourceName]: 'Reports MySQL' },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = await extractV2Inputs(dashboard);
+
+    expect(result.dataSources).toHaveLength(2);
+    expect(result.dataSources[0].name).toBe('mysql-1');
+    expect(result.dataSources[0].label).toBe('mysql-1 (Production MySQL)');
+    expect(result.dataSources[0].description).toBe('Select a mysql data source');
+    expect(result.dataSources[1].name).toBe('mysql-2');
+    expect(result.dataSources[1].label).toBe('mysql-2 (Reports MySQL)');
+  });
+
+  it('pre-selects the datasource when its name matches an existing one of the same plugin type', async () => {
+    mockGetDataSourceSrv.getList.mockReturnValueOnce([
+      { uid: 'ds-prod', name: 'Production MySQL', type: 'mysql' },
+      { uid: 'ds-stage', name: 'Staging MySQL', type: 'mysql' },
+    ]);
+
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'QueryVariable',
+          spec: {
+            name: 'var1',
+            query: {
+              group: 'mysql',
+              labels: { [ExportLabel]: 'mysql-1', [ExportDatasourceName]: 'Production MySQL' },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = await extractV2Inputs(dashboard);
+
+    expect(result.dataSources[0].matchedDatasource).toEqual({
+      uid: 'ds-prod',
+      name: 'Production MySQL',
+      type: 'mysql',
+    });
+  });
+
+  it('does not pre-select a datasource when no name matches', async () => {
+    mockGetDataSourceSrv.getList.mockReturnValueOnce([{ uid: 'ds-stage', name: 'Staging MySQL', type: 'mysql' }]);
+
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'QueryVariable',
+          spec: {
+            name: 'var1',
+            query: {
+              group: 'mysql',
+              labels: { [ExportLabel]: 'mysql-1', [ExportDatasourceName]: 'Production MySQL' },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = await extractV2Inputs(dashboard);
+
+    expect(result.dataSources[0].matchedDatasource).toBeUndefined();
+  });
+
+  it('does not pre-select when no original name is present', async () => {
+    mockGetDataSourceSrv.getList.mockReturnValueOnce([{ uid: 'ds-prod', name: 'Production MySQL', type: 'mysql' }]);
+
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'QueryVariable',
+          spec: { name: 'var1', query: { group: 'mysql', labels: { [ExportLabel]: 'mysql-1' } } },
+        },
+      ],
+    };
+
+    const result = await extractV2Inputs(dashboard);
+
+    expect(result.dataSources[0].matchedDatasource).toBeUndefined();
+  });
+
+  it('falls back to the export label when no datasource name is present', async () => {
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'QueryVariable',
+          spec: { name: 'var1', query: { group: 'mysql', labels: { [ExportLabel]: 'mysql-1' } } },
+        },
+      ],
+    };
+
+    const result = await extractV2Inputs(dashboard);
+    expect(result.dataSources[0].label).toBe('mysql-1');
+    expect(result.dataSources[0].description).toBe('Select a mysql data source');
   });
 
   it('should keep distinct datasource labels', async () => {
@@ -823,7 +949,7 @@ describe('applyV2Inputs', () => {
                     spec: {
                       query: {
                         group: 'prometheus',
-                        labels: { [ExportLabel]: 'prometheus-1' },
+                        labels: { [ExportLabel]: 'prometheus-1', [ExportDatasourceName]: 'Original Prometheus' },
                         datasource: { name: 'old-ds' },
                       },
                     },
@@ -840,7 +966,7 @@ describe('applyV2Inputs', () => {
           spec: {
             query: {
               group: 'prometheus',
-              labels: { [ExportLabel]: 'prometheus-1' },
+              labels: { [ExportLabel]: 'prometheus-1', [ExportDatasourceName]: 'Original Prometheus' },
               datasource: { name: 'old-ds' },
             },
           },
@@ -852,7 +978,7 @@ describe('applyV2Inputs', () => {
           spec: {
             query: {
               group: 'prometheus',
-              labels: { [ExportLabel]: 'prometheus-1' },
+              labels: { [ExportLabel]: 'prometheus-1', [ExportDatasourceName]: 'Original Prometheus' },
               datasource: { name: 'old-ds' },
             },
           },
@@ -881,6 +1007,14 @@ describe('applyV2Inputs', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const querySpec = updatedQuery?.spec as any;
     expect(querySpec?.query?.datasource?.name).toBe('ds-uid');
+
+    // export-only labels must be stripped after applying inputs
+    expect(updatedAnnotation.spec.query?.labels?.[ExportLabel]).toBeUndefined();
+    expect(updatedAnnotation.spec.query?.labels?.[ExportDatasourceName]).toBeUndefined();
+    expect(updatedVariable.spec.query?.labels?.[ExportLabel]).toBeUndefined();
+    expect(updatedVariable.spec.query?.labels?.[ExportDatasourceName]).toBeUndefined();
+    expect(querySpec?.query?.labels?.[ExportLabel]).toBeUndefined();
+    expect(querySpec?.query?.labels?.[ExportDatasourceName]).toBeUndefined();
   });
 
   it('uses datasource labels to keep selections independent', () => {
@@ -1350,6 +1484,41 @@ describe('replaceDatasourcesInDashboard', () => {
       expect(variable).toBeDefined();
       expect(variable?.datasource?.name).toBe(expectedDs);
     });
+
+    it('strips export-only labels after replacing the datasource', () => {
+      const variable = createAdhocVariable('loki', 'old-loki-uid');
+      // @ts-ignore - using minimal test schema
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [{ ...variable, labels: { [ExportLabel]: 'loki', [ExportDatasourceName]: 'Original Loki' } }],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+      const updated = getAdhocVariable(result);
+
+      expect(updated?.datasource?.name).toBe('new-loki-uid');
+      // labels held only export-only keys, so the object is omitted entirely
+      expect(updated?.labels).toBeUndefined();
+    });
+
+    it('keeps non-export labels while stripping export-only ones', () => {
+      const variable = createAdhocVariable('loki', 'old-loki-uid');
+      // @ts-ignore - using minimal test schema
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          {
+            ...variable,
+            labels: { [ExportLabel]: 'loki', [ExportDatasourceName]: 'Original Loki', team: 'observability' },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+      const updated = getAdhocVariable(result);
+
+      expect(updated?.labels).toEqual({ team: 'observability' });
+    });
   });
 
   describe('GroupBy variable', () => {
@@ -1383,6 +1552,24 @@ describe('replaceDatasourcesInDashboard', () => {
 
       expect(variable).toBeDefined();
       expect(variable?.datasource?.name).toBe(expectedDs);
+    });
+
+    it('strips export-only labels after replacing the datasource', () => {
+      const variable = createGroupByVariable('prometheus', 'old-prom-uid');
+      // @ts-ignore - using minimal test schema
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          { ...variable, labels: { [ExportLabel]: 'prometheus', [ExportDatasourceName]: 'Original Prometheus' } },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+      const updated = getGroupByVariable(result);
+
+      expect(updated?.datasource?.name).toBe('new-prom-uid');
+      // labels held only export-only keys, so the object is omitted entirely
+      expect(updated?.labels).toBeUndefined();
     });
   });
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -6,7 +6,7 @@ import { type AnnotationQueryKind, type Spec as DashboardV2Spec } from '@grafana
 import { isRecord } from 'app/core/utils/isRecord';
 import { ExportFormat } from 'app/features/dashboard/api/types';
 import { isDashboardV1Resource, isDashboardV2Resource, isDashboardV2Spec } from 'app/features/dashboard/api/utils';
-import { ExportLabel } from 'app/features/dashboard-scene/scene/export/exporters';
+import { ExportDatasourceName, ExportLabel } from 'app/features/dashboard-scene/scene/export/exporters';
 
 import { type LibraryElementExport } from '../../../dashboard/components/DashExportModal/DashboardExporter';
 import { getLibraryPanel } from '../../../library-panels/state/api';
@@ -73,6 +73,14 @@ function getExportLabel(labels?: { [ExportLabel]?: string }): string | undefined
   }
 
   return labels[ExportLabel];
+}
+
+function getExportDatasourceName(labels?: { [ExportDatasourceName]?: string }): string | undefined {
+  if (!labels) {
+    return undefined;
+  }
+
+  return labels[ExportDatasourceName];
 }
 
 /**
@@ -210,21 +218,32 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
   }
 
   const dsTypes: { [label: string]: string } = {};
+  const dsNames: { [label: string]: string } = {};
+
+  const recordDatasource = (
+    exportLabel: string | undefined,
+    dsType: string | undefined,
+    dsName: string | undefined
+  ) => {
+    if (!exportLabel || !dsType) {
+      return;
+    }
+    dsTypes[exportLabel] = dsType;
+    if (dsName && !dsNames[exportLabel]) {
+      dsNames[exportLabel] = dsName;
+    }
+  };
 
   if (dashboard.variables) {
     for (const variable of dashboard.variables) {
       if (variable.kind === 'QueryVariable') {
-        const dsType = variable.spec.query?.group;
-        const exportLabel = getExportLabel(variable.spec.query.labels);
-        if (dsType && exportLabel) {
-          dsTypes[exportLabel] = dsType;
-        }
+        recordDatasource(
+          getExportLabel(variable.spec.query.labels),
+          variable.spec.query?.group,
+          getExportDatasourceName(variable.spec.query.labels)
+        );
       } else if (variable.kind === 'AdhocVariable' || variable.kind === 'GroupByVariable') {
-        const dsType = variable.group;
-        const exportLabel = getExportLabel(variable.labels);
-        if (dsType && exportLabel) {
-          dsTypes[exportLabel] = dsType;
-        }
+        recordDatasource(getExportLabel(variable.labels), variable.group, getExportDatasourceName(variable.labels));
       }
     }
   }
@@ -236,11 +255,11 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
         continue;
       }
 
-      const dsType = annotation.spec.query?.group;
-      const exportLabel = getExportLabel(annotation.spec.query.labels);
-      if (dsType && exportLabel) {
-        dsTypes[exportLabel] = dsType;
-      }
+      recordDatasource(
+        getExportLabel(annotation.spec.query.labels),
+        annotation.spec.query?.group,
+        getExportDatasourceName(annotation.spec.query.labels)
+      );
     }
   }
 
@@ -249,11 +268,11 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
       if (element.kind === 'Panel' && element.spec.data?.kind === 'QueryGroup') {
         for (const query of element.spec.data.spec.queries) {
           if (query.kind === 'PanelQuery') {
-            const dsType = query.spec.query?.group;
-            const exportLabel = getExportLabel(query.spec.query.labels);
-            if (dsType && exportLabel) {
-              dsTypes[exportLabel] = dsType;
-            }
+            recordDatasource(
+              getExportLabel(query.spec.query.labels),
+              query.spec.query?.group,
+              getExportDatasourceName(query.spec.query.labels)
+            );
           }
         }
       }
@@ -271,14 +290,26 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
     }
 
     const dsInfo = getDataSourceSrv().getList({ pluginId: dsType });
+    const originalName = dsNames[label];
+    const matchedDatasource = originalName ? dsInfo.find((ds) => ds.name === originalName) : undefined;
+    const prompt = dsInfo.length > 0 ? `Select a ${dsType} data source` : `No ${dsType} data sources found`;
     inputs.dataSources.push({
       name: label,
-      label: label,
-      info: dsInfo.length > 0 ? `Select a ${dsType} data source` : `No ${dsType} data sources found`,
-      description: `${dsType} data source`,
+      label: originalName ? `${label} (${originalName})` : label,
+      info: prompt,
+      description: prompt,
       value: '',
       type: InputType.DataSource,
       pluginId: dsType,
+      ...(matchedDatasource
+        ? {
+            matchedDatasource: {
+              uid: matchedDatasource.uid,
+              type: matchedDatasource.type,
+              name: matchedDatasource.name,
+            },
+          }
+        : {}),
     });
   }
 
@@ -400,9 +431,10 @@ function replaceAnnotationDatasources(
       return annotation;
     }
 
-    // remove export label
+    // remove export labels
     if (annotation.spec.query?.labels) {
       delete annotation.spec.query.labels[ExportLabel];
+      delete annotation.spec.query.labels[ExportDatasourceName];
     }
 
     return {
@@ -434,9 +466,10 @@ function replaceVariableDatasources(
         return variable;
       }
 
-      // remove export label
+      // remove export labels
       if (variable.spec.query?.labels) {
         delete variable.spec.query.labels[ExportLabel];
+        delete variable.spec.query.labels[ExportDatasourceName];
       }
 
       return {
@@ -485,9 +518,16 @@ function replaceVariableDatasources(
         return variable;
       }
 
+      // Drop export-only labels.
+      const { labels, ...variableWithoutLabels } = variable;
+      const remainingLabels = { ...labels };
+      delete remainingLabels[ExportLabel];
+      delete remainingLabels[ExportDatasourceName];
+
       return {
-        ...variable,
+        ...variableWithoutLabels,
         datasource: { name: ds.uid },
+        ...(Object.keys(remainingLabels).length > 0 && { labels: remainingLabels }),
       };
     }
 
@@ -518,9 +558,10 @@ function replaceElementDatasources(
               return query;
             }
 
-            // remove export label
+            // remove export labels
             if (query.spec.query?.labels) {
               delete query.spec.query.labels[ExportLabel];
+              delete query.spec.query.labels[ExportDatasourceName];
             }
 
             return {

--- a/public/app/features/manage-dashboards/types.ts
+++ b/public/app/features/manage-dashboards/types.ts
@@ -74,6 +74,10 @@ export interface DashboardInput {
 
 export interface DataSourceInput extends DashboardInput {
   pluginId: string;
+  // A datasource on the importing instance whose name matches the original
+  // exported datasource name. Used to pre-select the import picker so users
+  // don't have to manually pick a same-named datasource.
+  matchedDatasource?: DatasourceSelection;
 }
 
 export interface LibraryPanelInput {


### PR DESCRIPTION
Backport c3f8912b9d0ddb5765cbe14d3c671afd6a680107 from #125824

---

Before:
<img width="649" height="844" alt="image" src="https://github.com/user-attachments/assets/f5da7858-045a-4e7e-bd01-cc91da9968bc" />


After:
<img width="670" height="722" alt="image" src="https://github.com/user-attachments/assets/0f36fbdf-d336-4b04-a9db-ab163ee38a00" />

## Summary

Improves the v2 dashboard import experience when a dashboard references multiple datasources of the same type (e.g. several MySQL instances). Previously, the import form's datasource picker showed only the generic type label (`mysql`, `mysql`, `mysql`) with no way to tell the inputs apart — confusing when re-importing a dashboard or installing one from a colleague.

Customer-reported pain point: importing a dashboard with several MySQL datasources gives a picker that lists the type but not the name, so the user can't map inputs to the original datasources.

This PR addresses that across four small, additive changes:

1. **Carry the original datasource name through the export.** The v2 exporter writes a new `grafana.app/export-datasource-name` label alongside the existing `grafana.app/export-label`, capturing the display name of each referenced datasource.
2. **Show the original name in the import picker label.** The import form now renders `mysql-1 (Production MySQL)` instead of just `mysql-1`, so each input is identifiable at a glance.
3. **Auto-select a matching datasource.** If the importing instance has a datasource with the same name and plugin type as the original, the picker is pre-selected — saving manual clicks in the common case of re-importing onto the origin instance or a similarly-named environment.

All changes are scoped to v2 dashboards. The v1 export already preserves the original datasource name (`label: ds.name`), so v1 is unaffected.

## How it works

- **Export** (`makeExportableV2` in `public/app/features/dashboard-scene/scene/export/exporters.ts`): for every panel query, query/ad-hoc/group-by variable, and annotation, looks up the datasource by UID via `getDataSourceSrv().getInstanceSettings()` and writes `name` to the new label. Built-in datasources and unresolved UIDs are skipped — behaviour unchanged in those cases.
- **Import** (`extractV2Inputs` in `public/app/features/manage-dashboards/import/utils/inputs.ts`):
  - Reads the new label, composes `<exportLabel> (<originalName>)` as the picker field label.
  - Tracks panel titles per export label and exposes them as `usedByPanels` on the input.
  - Looks up a same-plugin-type datasource by exact name match and attaches it as `matchedDatasource` for pre-selection.
- **Form** (`ImportDashboardFormV2.tsx`):
  - Primes `selectedDataSources` state and `Controller.defaultValue` from `matchedDatasource` so the pre-fill participates in form validation and submission like any user-driven pick.
- **Strip on apply** (`applyV2Inputs`): the new label is deleted alongside the existing export label so the saved dashboard does not retain export-only metadata.

## Compatibility

- The new label is purely additive. Older clients ignoring it see no behaviour change.
- Dashboards exported before this change have no `grafana.app/export-datasource-name` label, so import falls back to the previous behaviour (generic `mysql-1` label, no tooltip, no auto-select).
- No schema, migration, or feature flag required.

## Test plan

- [x] `yarn jest public/app/features/dashboard-scene/scene/export/exporters.test.ts` — 34 tests pass, including new assertions that all four v2 export sites (panel query, query variable, ad-hoc, group-by, annotation) write the original name.
- [x] `yarn jest public/app/features/manage-dashboards/import/utils/inputs.test.ts` — 75 tests pass, covering: friendly label composition, panel-usage collection (with dedup and untitled-panel fallback), auto-match found / missing / no-name cases, and label stripping in `applyV2Inputs`.
- [x] `yarn jest public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.test.tsx` — 8 tests pass, covering: friendly label rendering, tooltip presence/absence, and picker pre-selection from `matchedDatasource`.
- [x] `yarn typecheck` clean for changed files.
- [x] `yarn eslint` clean for changed files.
- [ ] Manual: export a v2 dashboard with multiple MySQL datasources, import it back on the same instance — verify the picker is pre-filled
- [ ] Manual: import the same export on a fresh instance with no matching datasource — verify the picker is empty but the friendly label
- [ ] Manual: import an older dashboard exported before this change — verify the import works exactly as before (no regressions).
