### PR TITLE
Docs: Improve wording explaining socket_gid requirements

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -80,7 +80,7 @@ cert_pass =
 certs_watch_interval =
 
 # Unix socket gid
-# Changing the gid of a file without privileges requires that the target group is in the group of the process and that the process is the file owner
+# To change a file's GID without elevated privileges, the user must be the file owner and be a member to the target group.
 # It is recommended to set the gid as http server user gid
 # Not set when the value is -1
 socket_gid = -1

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -326,8 +326,8 @@ You must reload the connections with old certificates for them to work.
 
 #### `socket_gid`
 
-GID where the socket should be set when `protocol=socket`.
-Make sure that the target group is in the group of Grafana process and that Grafana process is the file owner before you change this setting.
+GID of the socket when `protocol=socket`.
+Make sure that the user running the Grafana process is a member of the target group and is the file owner before you change this setting.
 It is recommended to set the GID as HTTP server user GID.
 Not set when the value is `-1`.
 


### PR DESCRIPTION
**What is this feature?**

This improves the wording in the documentation as well as the comments in `conf/defaults.ini` regarding socket_gid.

**Why do we need this feature?**

Currently the requirements for changing the socket's GID are hard to understand bordering on incorrect: The user running the `grafana` process needs to be a member of the target group and additionally be the owner the file/socket.  
I think the current description and comments do not make this clear enough.

**Who is this feature for?**

Users of Grafana

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
