### PR TITLE
Provisioning: Validate branch/commit/pull request options against repository type

### DIFF
--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -173,6 +173,8 @@ func validateWorkflowOptions(cfg *provisioning.Repository) field.ErrorList {
 			list = append(list, field.Invalid(field.NewPath("spec", "pullRequest"),
 				cfg.Spec.PullRequest, "pull request options are not supported on git repositories"))
 		}
+	default:
+		// Hosting providers (github, githubEnterprise, bitbucket, gitlab) support all options.
 	}
 
 	return list

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -86,9 +86,9 @@ func (v *RepositoryValidator) Validate(ctx context.Context, cfg *provisioning.Re
 			cfg.Spec.Git, "Git config only valid when type is git"))
 	}
 
-	// Branch and commit options are only meaningful for the branch workflow, which
-	// is not supported on local repositories. Reject them to avoid silently storing
-	// configuration that can never take effect.
+	// Branch, commit and pull request options are only meaningful for the branch
+	// workflow, which is not supported on local repositories. Reject them to avoid
+	// silently storing configuration that can never take effect.
 	if cfg.Spec.Type == provisioning.LocalRepositoryType {
 		if cfg.Spec.Branch != nil {
 			list = append(list, field.Invalid(field.NewPath("spec", "branch"),
@@ -97,6 +97,10 @@ func (v *RepositoryValidator) Validate(ctx context.Context, cfg *provisioning.Re
 		if cfg.Spec.Commit != nil {
 			list = append(list, field.Invalid(field.NewPath("spec", "commit"),
 				cfg.Spec.Commit, "commit options are not supported on local repositories"))
+		}
+		if cfg.Spec.PullRequest != nil {
+			list = append(list, field.Invalid(field.NewPath("spec", "pullRequest"),
+				cfg.Spec.PullRequest, "pull request options are not supported on local repositories"))
 		}
 	}
 

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -86,6 +86,20 @@ func (v *RepositoryValidator) Validate(ctx context.Context, cfg *provisioning.Re
 			cfg.Spec.Git, "Git config only valid when type is git"))
 	}
 
+	// Branch and commit options are only meaningful for the branch workflow, which
+	// is not supported on local repositories. Reject them to avoid silently storing
+	// configuration that can never take effect.
+	if cfg.Spec.Type == provisioning.LocalRepositoryType {
+		if cfg.Spec.Branch != nil {
+			list = append(list, field.Invalid(field.NewPath("spec", "branch"),
+				cfg.Spec.Branch, "branch options are not supported on local repositories"))
+		}
+		if cfg.Spec.Commit != nil {
+			list = append(list, field.Invalid(field.NewPath("spec", "commit"),
+				cfg.Spec.Commit, "commit options are not supported on local repositories"))
+		}
+	}
+
 	for _, w := range cfg.Spec.Workflows {
 		switch w {
 		case provisioning.WriteWorkflow: // valid; no fall thru

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -104,6 +104,13 @@ func (v *RepositoryValidator) Validate(ctx context.Context, cfg *provisioning.Re
 		}
 	}
 
+	// Pull requests are a hosting-provider feature. Plain git repositories support the
+	// branch workflow but cannot open pull requests, so reject pull request options.
+	if cfg.Spec.Type == provisioning.GitRepositoryType && cfg.Spec.PullRequest != nil {
+		list = append(list, field.Invalid(field.NewPath("spec", "pullRequest"),
+			cfg.Spec.PullRequest, "pull request options are not supported on git repositories"))
+	}
+
 	for _, w := range cfg.Spec.Workflows {
 		switch w {
 		case provisioning.WriteWorkflow: // valid; no fall thru

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -86,30 +86,7 @@ func (v *RepositoryValidator) Validate(ctx context.Context, cfg *provisioning.Re
 			cfg.Spec.Git, "Git config only valid when type is git"))
 	}
 
-	// Branch, commit and pull request options are only meaningful for the branch
-	// workflow, which is not supported on local repositories. Reject them to avoid
-	// silently storing configuration that can never take effect.
-	if cfg.Spec.Type == provisioning.LocalRepositoryType {
-		if cfg.Spec.Branch != nil {
-			list = append(list, field.Invalid(field.NewPath("spec", "branch"),
-				cfg.Spec.Branch, "branch options are not supported on local repositories"))
-		}
-		if cfg.Spec.Commit != nil {
-			list = append(list, field.Invalid(field.NewPath("spec", "commit"),
-				cfg.Spec.Commit, "commit options are not supported on local repositories"))
-		}
-		if cfg.Spec.PullRequest != nil {
-			list = append(list, field.Invalid(field.NewPath("spec", "pullRequest"),
-				cfg.Spec.PullRequest, "pull request options are not supported on local repositories"))
-		}
-	}
-
-	// Pull requests are a hosting-provider feature. Plain git repositories support the
-	// branch workflow but cannot open pull requests, so reject pull request options.
-	if cfg.Spec.Type == provisioning.GitRepositoryType && cfg.Spec.PullRequest != nil {
-		list = append(list, field.Invalid(field.NewPath("spec", "pullRequest"),
-			cfg.Spec.PullRequest, "pull request options are not supported on git repositories"))
-	}
+	list = append(list, validateWorkflowOptions(cfg)...)
 
 	for _, w := range cfg.Spec.Workflows {
 		switch w {
@@ -163,6 +140,39 @@ func (v *RepositoryValidator) Validate(ctx context.Context, cfg *provisioning.Re
 
 	if cfg.Spec.Webhook != nil && cfg.Spec.Webhook.BaseURL != "" {
 		list = append(list, validateWebhookBaseURL(cfg.Spec.Webhook.BaseURL)...)
+	}
+
+	return list
+}
+
+// validateWorkflowOptions rejects branch, commit and pull request options on repository
+// types that cannot use them. These options are only meaningful for the branch workflow
+// (git-only), and pull requests additionally require a hosting provider. Rejecting them
+// avoids silently storing configuration that can never take effect.
+func validateWorkflowOptions(cfg *provisioning.Repository) field.ErrorList {
+	var list field.ErrorList
+
+	switch cfg.Spec.Type {
+	case provisioning.LocalRepositoryType:
+		// Local repositories support neither the branch workflow nor pull requests.
+		if cfg.Spec.Branch != nil {
+			list = append(list, field.Invalid(field.NewPath("spec", "branch"),
+				cfg.Spec.Branch, "branch options are not supported on local repositories"))
+		}
+		if cfg.Spec.Commit != nil {
+			list = append(list, field.Invalid(field.NewPath("spec", "commit"),
+				cfg.Spec.Commit, "commit options are not supported on local repositories"))
+		}
+		if cfg.Spec.PullRequest != nil {
+			list = append(list, field.Invalid(field.NewPath("spec", "pullRequest"),
+				cfg.Spec.PullRequest, "pull request options are not supported on local repositories"))
+		}
+	case provisioning.GitRepositoryType:
+		// Plain git supports the branch workflow but cannot open pull requests.
+		if cfg.Spec.PullRequest != nil {
+			list = append(list, field.Invalid(field.NewPath("spec", "pullRequest"),
+				cfg.Spec.PullRequest, "pull request options are not supported on git repositories"))
+		}
 	}
 
 	return list

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -275,38 +275,61 @@ func TestValidator_Validate(t *testing.T) {
 			},
 		},
 		{
-			name: "branch and commit options for local repository",
+			name: "pull request options for local repository",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Finalizers: []string{CleanFinalizer},
 					},
 					Spec: provisioning.RepositorySpec{
-						Title:  "Test Repo",
-						Type:   provisioning.LocalRepositoryType,
-						Branch: &provisioning.BranchOptions{NameTemplate: "{{title}}"},
-						Commit: &provisioning.CommitOptions{SingleResourceMessageTemplate: "{{title}}"},
+						Title:       "Test Repo",
+						Type:        provisioning.LocalRepositoryType,
+						PullRequest: &provisioning.PullRequestOptions{TitleTemplate: "{{title}}"},
 					},
 				}
 			}(),
-			expectedErrs: 2,
+			expectedErrs: 1,
 			validateError: func(t *testing.T, errors field.ErrorList) {
-				require.Contains(t, errors.ToAggregate().Error(), "branch options are not supported on local repositories")
-				require.Contains(t, errors.ToAggregate().Error(), "commit options are not supported on local repositories")
+				require.Equal(t, "spec.pullRequest", errors[0].Field)
+				require.Contains(t, errors.ToAggregate().Error(), "pull request options are not supported on local repositories")
 			},
 		},
 		{
-			name: "branch and commit options allowed for git repository",
+			name: "branch, commit and pull request options for local repository",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Finalizers: []string{CleanFinalizer},
 					},
 					Spec: provisioning.RepositorySpec{
-						Title:  "Test Repo",
-						Type:   provisioning.GitHubRepositoryType,
-						Branch: &provisioning.BranchOptions{NameTemplate: "{{title}}"},
-						Commit: &provisioning.CommitOptions{SingleResourceMessageTemplate: "{{title}}"},
+						Title:       "Test Repo",
+						Type:        provisioning.LocalRepositoryType,
+						Branch:      &provisioning.BranchOptions{NameTemplate: "{{title}}"},
+						Commit:      &provisioning.CommitOptions{SingleResourceMessageTemplate: "{{title}}"},
+						PullRequest: &provisioning.PullRequestOptions{TitleTemplate: "{{title}}"},
+					},
+				}
+			}(),
+			expectedErrs: 3,
+			validateError: func(t *testing.T, errors field.ErrorList) {
+				require.Contains(t, errors.ToAggregate().Error(), "branch options are not supported on local repositories")
+				require.Contains(t, errors.ToAggregate().Error(), "commit options are not supported on local repositories")
+				require.Contains(t, errors.ToAggregate().Error(), "pull request options are not supported on local repositories")
+			},
+		},
+		{
+			name: "branch, commit and pull request options allowed for git repository",
+			repository: func() *provisioning.Repository {
+				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
+					Spec: provisioning.RepositorySpec{
+						Title:       "Test Repo",
+						Type:        provisioning.GitHubRepositoryType,
+						Branch:      &provisioning.BranchOptions{NameTemplate: "{{title}}"},
+						Commit:      &provisioning.CommitOptions{SingleResourceMessageTemplate: "{{title}}"},
+						PullRequest: &provisioning.PullRequestOptions{TitleTemplate: "{{title}}"},
 					},
 				}
 			}(),

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -235,6 +235,84 @@ func TestValidator_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "branch options for local repository",
+			repository: func() *provisioning.Repository {
+				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
+					Spec: provisioning.RepositorySpec{
+						Title:  "Test Repo",
+						Type:   provisioning.LocalRepositoryType,
+						Branch: &provisioning.BranchOptions{NameTemplate: "{{title}}"},
+					},
+				}
+			}(),
+			expectedErrs: 1,
+			validateError: func(t *testing.T, errors field.ErrorList) {
+				require.Equal(t, "spec.branch", errors[0].Field)
+				require.Contains(t, errors.ToAggregate().Error(), "branch options are not supported on local repositories")
+			},
+		},
+		{
+			name: "commit options for local repository",
+			repository: func() *provisioning.Repository {
+				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
+					Spec: provisioning.RepositorySpec{
+						Title:  "Test Repo",
+						Type:   provisioning.LocalRepositoryType,
+						Commit: &provisioning.CommitOptions{SingleResourceMessageTemplate: "{{title}}"},
+					},
+				}
+			}(),
+			expectedErrs: 1,
+			validateError: func(t *testing.T, errors field.ErrorList) {
+				require.Equal(t, "spec.commit", errors[0].Field)
+				require.Contains(t, errors.ToAggregate().Error(), "commit options are not supported on local repositories")
+			},
+		},
+		{
+			name: "branch and commit options for local repository",
+			repository: func() *provisioning.Repository {
+				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
+					Spec: provisioning.RepositorySpec{
+						Title:  "Test Repo",
+						Type:   provisioning.LocalRepositoryType,
+						Branch: &provisioning.BranchOptions{NameTemplate: "{{title}}"},
+						Commit: &provisioning.CommitOptions{SingleResourceMessageTemplate: "{{title}}"},
+					},
+				}
+			}(),
+			expectedErrs: 2,
+			validateError: func(t *testing.T, errors field.ErrorList) {
+				require.Contains(t, errors.ToAggregate().Error(), "branch options are not supported on local repositories")
+				require.Contains(t, errors.ToAggregate().Error(), "commit options are not supported on local repositories")
+			},
+		},
+		{
+			name: "branch and commit options allowed for git repository",
+			repository: func() *provisioning.Repository {
+				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
+					Spec: provisioning.RepositorySpec{
+						Title:  "Test Repo",
+						Type:   provisioning.GitHubRepositoryType,
+						Branch: &provisioning.BranchOptions{NameTemplate: "{{title}}"},
+						Commit: &provisioning.CommitOptions{SingleResourceMessageTemplate: "{{title}}"},
+					},
+				}
+			}(),
+			expectedErrs: 0,
+		},
+		{
 			name: "invalid workflow in the list",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -318,7 +318,7 @@ func TestValidator_Validate(t *testing.T) {
 			},
 		},
 		{
-			name: "branch, commit and pull request options allowed for git repository",
+			name: "branch, commit and pull request options allowed for github repository",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
@@ -330,6 +330,43 @@ func TestValidator_Validate(t *testing.T) {
 						Branch:      &provisioning.BranchOptions{NameTemplate: "{{title}}"},
 						Commit:      &provisioning.CommitOptions{SingleResourceMessageTemplate: "{{title}}"},
 						PullRequest: &provisioning.PullRequestOptions{TitleTemplate: "{{title}}"},
+					},
+				}
+			}(),
+			expectedErrs: 0,
+		},
+		{
+			name: "pull request options for git repository",
+			repository: func() *provisioning.Repository {
+				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
+					Spec: provisioning.RepositorySpec{
+						Title:       "Test Repo",
+						Type:        provisioning.GitRepositoryType,
+						PullRequest: &provisioning.PullRequestOptions{TitleTemplate: "{{title}}"},
+					},
+				}
+			}(),
+			expectedErrs: 1,
+			validateError: func(t *testing.T, errors field.ErrorList) {
+				require.Equal(t, "spec.pullRequest", errors[0].Field)
+				require.Contains(t, errors.ToAggregate().Error(), "pull request options are not supported on git repositories")
+			},
+		},
+		{
+			name: "branch and commit options allowed for git repository",
+			repository: func() *provisioning.Repository {
+				return &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{CleanFinalizer},
+					},
+					Spec: provisioning.RepositorySpec{
+						Title:  "Test Repo",
+						Type:   provisioning.GitRepositoryType,
+						Branch: &provisioning.BranchOptions{NameTemplate: "{{title}}"},
+						Commit: &provisioning.CommitOptions{SingleResourceMessageTemplate: "{{title}}"},
 					},
 				}
 			}(),

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -439,6 +439,35 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			expectedErr: "pull request options are not supported on local repositories",
 		},
 		{
+			name: "should error if pull request options are set on a git repository",
+			repo: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "provisioning.grafana.app/v0alpha1",
+				"kind":       "Repository",
+				"metadata": map[string]any{
+					"name":      "git-repo-with-pull-request-options",
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"title": "Git Repo With Pull Request Options",
+					"type":  string(provisioning.GitRepositoryType),
+					"sync": map[string]any{
+						"enabled": false,
+						"target":  "folder",
+					},
+					"git": map[string]any{
+						"url":    "https://github.com/grafana/grafana-git-sync-demo.git",
+						"branch": "main",
+					},
+					"pullRequest": map[string]any{
+						"titleTemplate": "{{title}}",
+					},
+					// Empty workflows to avoid the token/connection requirement
+					"workflows": []string{},
+				},
+			}},
+			expectedErr: "pull request options are not supported on git repositories",
+		},
+		{
 			name: "should error if unknown finalizer is set",
 			repo: func() *unstructured.Unstructured {
 				localTmp := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), map[string]any{

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -412,6 +412,33 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			expectedErr: "commit options are not supported on local repositories",
 		},
 		{
+			name: "should error if pull request options are set on a local repository",
+			repo: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "provisioning.grafana.app/v0alpha1",
+				"kind":       "Repository",
+				"metadata": map[string]any{
+					"name":      "local-repo-with-pull-request-options",
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"title": "Local Repo With Pull Request Options",
+					"type":  string(provisioning.LocalRepositoryType),
+					"sync": map[string]any{
+						"enabled": false,
+						"target":  "folder",
+					},
+					"local": map[string]any{
+						"path": helper.ProvisioningPath,
+					},
+					"pullRequest": map[string]any{
+						"titleTemplate": "{{title}}",
+					},
+					"workflows": []string{},
+				},
+			}},
+			expectedErr: "pull request options are not supported on local repositories",
+		},
+		{
 			name: "should error if unknown finalizer is set",
 			repo: func() *unstructured.Unstructured {
 				localTmp := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), map[string]any{

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -358,6 +358,60 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			expectedErr: "cannot have both remove and release orphan resources finalizers",
 		},
 		{
+			name: "should error if branch options are set on a local repository",
+			repo: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "provisioning.grafana.app/v0alpha1",
+				"kind":       "Repository",
+				"metadata": map[string]any{
+					"name":      "local-repo-with-branch-options",
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"title": "Local Repo With Branch Options",
+					"type":  string(provisioning.LocalRepositoryType),
+					"sync": map[string]any{
+						"enabled": false,
+						"target":  "folder",
+					},
+					"local": map[string]any{
+						"path": helper.ProvisioningPath,
+					},
+					"branch": map[string]any{
+						"nameTemplate": "{{title}}",
+					},
+					"workflows": []string{},
+				},
+			}},
+			expectedErr: "branch options are not supported on local repositories",
+		},
+		{
+			name: "should error if commit options are set on a local repository",
+			repo: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "provisioning.grafana.app/v0alpha1",
+				"kind":       "Repository",
+				"metadata": map[string]any{
+					"name":      "local-repo-with-commit-options",
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"title": "Local Repo With Commit Options",
+					"type":  string(provisioning.LocalRepositoryType),
+					"sync": map[string]any{
+						"enabled": false,
+						"target":  "folder",
+					},
+					"local": map[string]any{
+						"path": helper.ProvisioningPath,
+					},
+					"commit": map[string]any{
+						"singleResourceMessageTemplate": "{{title}}",
+					},
+					"workflows": []string{},
+				},
+			}},
+			expectedErr: "commit options are not supported on local repositories",
+		},
+		{
 			name: "should error if unknown finalizer is set",
 			repo: func() *unstructured.Unstructured {
 				localTmp := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), map[string]any{


### PR DESCRIPTION
## Summary

`spec.branch` (`BranchOptions`), `spec.commit` (`CommitOptions`) and `spec.pullRequest` (`PullRequestOptions`) only make sense for certain repository types, but nothing validated that — inert configuration could be silently stored. This adds validation so unsupported options are rejected with a clear error.

The rules follow what each type can actually do:

| Option | local | git (plain) | github / hosted |
| --- | :---: | :---: | :---: |
| `spec.branch` | ❌ | ✅ | ✅ |
| `spec.commit` | ❌ | ✅ | ✅ |
| `spec.pullRequest` | ❌ | ❌ | ✅ |

- **local** supports neither the branch workflow nor pull requests, so all three are rejected.
- **plain git** supports the branch workflow (so branch/commit are fine) but cannot open pull requests — it does not implement `RepositoryWithURLs` and cannot generate a PR URL — so `spec.pullRequest` is rejected.
- **github (and other hosting providers)** support all three.

## Changes

- **`apps/provisioning/pkg/repository/validator.go`**: `RepositoryValidator.Validate` now rejects branch/commit/pull request options on `local`, and pull request options on plain `git`.
- **`apps/provisioning/pkg/repository/validator_test.go`**: unit cases for each option per type, including allowed combinations (regression guards).
- **`pkg/tests/apis/provisioning/repository/repository_test.go`**: integration cases in `TestIntegrationProvisioning_RepositoryValidation` asserting the API server rejects the unsupported combinations.

## Testing

- `go test ./apps/provisioning/pkg/repository/ -run TestValidator_Validate` — pass
- `go test ./pkg/tests/apis/provisioning/repository/ -run TestIntegrationProvisioning_RepositoryValidation` — pass
- `gofmt` / `go vet` clean on changed files

## Checklist

- [x] Tests added/updated
- [x] No breaking changes (rejects previously-accepted-but-inert config; these types could not use the options anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)