### PR TITLE
Navigation: Populate starred nav section client-side

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -957,11 +957,6 @@
       "count": 3
     }
   },
-  "public/app/core/reducers/navBarTree.ts": {
-    "@grafana/no-locale-compare": {
-      "count": 2
-    }
-  },
   "public/app/core/services/ResponseQueue.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -11,6 +11,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { ScrollContainer, useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { setBookmark } from 'app/core/reducers/navBarTree';
+import { useSyncStarredItemsInNav } from 'app/features/stars/hooks';
 import { useDispatch, useSelector } from 'app/types/store';
 
 import { MegaMenuExtensionPoint } from './MegaMenuExtensionPoint';
@@ -35,6 +36,7 @@ export const MegaMenu = memo(
     const state = chrome.useState();
     const [patchPreferences] = usePatchUserPreferencesMutation();
     const pinnedItems = usePinnedItems();
+    useSyncStarredItemsInNav();
 
     // Remove profile + help from tree
     const navItems = navTree

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -36,7 +36,7 @@ export const MegaMenu = memo(
     const state = chrome.useState();
     const [patchPreferences] = usePatchUserPreferencesMutation();
     const pinnedItems = usePinnedItems();
-    const { isLoading: starredItemsLoading } = useSyncStarredItemsInNav();
+    const { isLoading: starredItemsLoading, isError: starredItemsError } = useSyncStarredItemsInNav();
 
     // Remove profile + help from tree
     const navItems = navTree
@@ -120,6 +120,7 @@ export const MegaMenu = memo(
                     activeItem={activeItem}
                     onPin={onPinItem}
                     loadingChildren={link.id === 'starred' && starredItemsLoading}
+                    childrenLoadError={link.id === 'starred' && starredItemsError}
                   />
                 ))}
               </ul>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -36,7 +36,7 @@ export const MegaMenu = memo(
     const state = chrome.useState();
     const [patchPreferences] = usePatchUserPreferencesMutation();
     const pinnedItems = usePinnedItems();
-    useSyncStarredItemsInNav();
+    const { isLoading: starredItemsLoading } = useSyncStarredItemsInNav();
 
     // Remove profile + help from tree
     const navItems = navTree
@@ -119,6 +119,7 @@ export const MegaMenu = memo(
                     onClick={state.megaMenuDocked ? undefined : onClose}
                     activeItem={activeItem}
                     onPin={onPinItem}
+                    loadingChildren={link.id === 'starred' && starredItemsLoading}
                   />
                 ))}
               </ul>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -24,11 +24,22 @@ interface Props {
   isPinned: (id?: string) => boolean;
   /** Section-level only: children are being fetched, show placeholders instead of the empty message */
   loadingChildren?: boolean;
+  /** Section-level only: fetching children failed, show an error instead of the empty message */
+  childrenLoadError?: boolean;
 }
 
 const MAX_DEPTH = 2;
 
-export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPinned, loadingChildren }: Props) {
+export function MegaMenuItem({
+  link,
+  activeItem,
+  level = 0,
+  onClick,
+  onPin,
+  isPinned,
+  loadingChildren,
+  childrenLoadError,
+}: Props) {
   const { chrome } = useGrafana();
   const state = chrome.useState();
   const menuIsDocked = state.megaMenuDocked;
@@ -39,7 +50,8 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
     `grafana.navigation.expanded[${link.text}]`,
     Boolean(hasActiveChild)
   );
-  const showExpandButton = level < MAX_DEPTH && Boolean(linkHasChildren(link) || link.emptyMessage || loadingChildren);
+  const showExpandButton =
+    level < MAX_DEPTH && Boolean(linkHasChildren(link) || link.emptyMessage || loadingChildren || childrenLoadError);
   const item = useRef<HTMLLIElement>(null);
 
   const styles = useStyles2(getStyles);
@@ -165,6 +177,10 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
               <Skeleton width={120} />
               <Skeleton width={90} />
             </Box>
+          ) : childrenLoadError ? (
+            <div className={styles.emptyMessage} aria-live="polite">
+              {t('navigation.megamenu-item.children-error', 'Failed to load items')}
+            </div>
           ) : (
             <div className={styles.emptyMessage} aria-live="polite">
               {link.emptyMessage}

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -1,12 +1,13 @@
 import { css, cx } from '@emotion/css';
 import { useEffect, useRef } from 'react';
 import * as React from 'react';
+import Skeleton from 'react-loading-skeleton';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { useLocalStorage } from 'react-use';
 
 import { FeatureState, type GrafanaTheme2, type NavModelItem, toIconName } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { useStyles2, Text, IconButton, Icon, Stack, FeatureBadge } from '@grafana/ui';
+import { useStyles2, Text, IconButton, Icon, Stack, FeatureBadge, Box } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
 import { Indent } from '../../Indent/Indent';
@@ -21,11 +22,13 @@ interface Props {
   level?: number;
   onPin: (item: NavModelItem) => void;
   isPinned: (id?: string) => boolean;
+  /** Section-level only: children are being fetched, show placeholders instead of the empty message */
+  loadingChildren?: boolean;
 }
 
 const MAX_DEPTH = 2;
 
-export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPinned }: Props) {
+export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPinned, loadingChildren }: Props) {
   const { chrome } = useGrafana();
   const state = chrome.useState();
   const menuIsDocked = state.megaMenuDocked;
@@ -36,7 +39,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
     `grafana.navigation.expanded[${link.text}]`,
     Boolean(hasActiveChild)
   );
-  const showExpandButton = level < MAX_DEPTH && Boolean(linkHasChildren(link) || link.emptyMessage);
+  const showExpandButton = level < MAX_DEPTH && Boolean(linkHasChildren(link) || link.emptyMessage || loadingChildren);
   const item = useRef<HTMLLIElement>(null);
 
   const styles = useStyles2(getStyles);
@@ -147,6 +150,21 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
                   isPinned={isPinned}
                 />
               ))
+          ) : loadingChildren ? (
+            <Box
+              display="flex"
+              direction="column"
+              gap={0.5}
+              padding={1}
+              paddingLeft={6}
+              aria-live="polite"
+              aria-label={t('navigation.megamenu-item.loading-aria-label', 'Loading {{sectionName}}', {
+                sectionName: link.text,
+              })}
+            >
+              <Skeleton width={120} />
+              <Skeleton width={90} />
+            </Box>
           ) : (
             <div className={styles.emptyMessage} aria-live="polite">
               {link.emptyMessage}

--- a/public/app/core/reducers/navBarTree.test.ts
+++ b/public/app/core/reducers/navBarTree.test.ts
@@ -1,6 +1,6 @@
 import { type NavModelItem } from '@grafana/data';
 
-import { ID_PREFIX, navTreeReducer, setStarred, updateDashboardName } from './navBarTree';
+import { ID_PREFIX, navTreeReducer, setStarred, setStarredItems, updateDashboardName } from './navBarTree';
 
 function buildState(starredChildren: NavModelItem[] = []): NavModelItem[] {
   return [
@@ -58,6 +58,69 @@ describe('navBarTree reducer', () => {
       const starred = next.find((n) => n.id === 'starred');
       const names = starred?.children?.map((c) => c.text);
       expect(names).toEqual(['Beta', 'Charlie', 'Zulu']);
+    });
+  });
+
+  describe('setStarredItems', () => {
+    it('replaces children with sorted items', () => {
+      const state = buildState([{ id: ID_PREFIX + 'old', text: 'Old Dash', url: '/d/old' }]);
+      const next = navTreeReducer(
+        state,
+        setStarredItems({
+          uids: ['c', 'a', 'b'],
+          items: [
+            { id: 'c', title: 'Charlie', url: '/d/c' },
+            { id: 'a', title: 'Alpha', url: '/d/a' },
+            { id: 'b', title: 'Beta', url: '/d/b' },
+          ],
+        })
+      );
+      const starred = next.find((n) => n.id === 'starred');
+      expect(starred?.children).toHaveLength(3);
+      expect(starred?.children?.map((c) => c.text)).toEqual(['Alpha', 'Beta', 'Charlie']);
+      expect(starred?.children?.map((c) => c.id)).toEqual(['starred/a', 'starred/b', 'starred/c']);
+    });
+
+    it('clears previous children', () => {
+      const state = buildState([
+        { id: ID_PREFIX + 'x', text: 'X', url: '/d/x' },
+        { id: ID_PREFIX + 'y', text: 'Y', url: '/d/y' },
+      ]);
+      const next = navTreeReducer(state, setStarredItems({ uids: [], items: [] }));
+      const starred = next.find((n) => n.id === 'starred');
+      expect(starred?.children).toEqual([]);
+    });
+
+    it('keeps the existing child for a starred uid missing from the search response', () => {
+      const state = buildState([{ id: ID_PREFIX + 'fresh', text: 'Fresh Dash', url: '/d/fresh' }]);
+      const next = navTreeReducer(
+        state,
+        setStarredItems({
+          uids: ['a', 'fresh'],
+          items: [{ id: 'a', title: 'Alpha', url: '/d/a' }],
+        })
+      );
+      const starred = next.find((n) => n.id === 'starred');
+      expect(starred?.children?.map((c) => c.text)).toEqual(['Alpha', 'Fresh Dash']);
+    });
+
+    it('drops unstarred uids even when search misses them', () => {
+      const state = buildState([{ id: ID_PREFIX + 'gone', text: 'Gone Dash', url: '/d/gone' }]);
+      const next = navTreeReducer(
+        state,
+        setStarredItems({ uids: ['a'], items: [{ id: 'a', title: 'Alpha', url: '/d/a' }] })
+      );
+      const starred = next.find((n) => n.id === 'starred');
+      expect(starred?.children?.map((c) => c.text)).toEqual(['Alpha']);
+    });
+
+    it('no-ops when starred section is missing', () => {
+      const state = [{ id: 'home', text: 'Home', url: '/' }];
+      const next = navTreeReducer(
+        state,
+        setStarredItems({ uids: ['a'], items: [{ id: 'a', title: 'A', url: '/d/a' }] })
+      );
+      expect(next).toEqual(state);
     });
   });
 });

--- a/public/app/core/reducers/navBarTree.ts
+++ b/public/app/core/reducers/navBarTree.ts
@@ -24,6 +24,14 @@ function translateNav(navTree: NavModelItem[]): NavModelItem[] {
 // this matches the prefix set in the backend navtree
 export const ID_PREFIX = 'starred/';
 
+export interface StarredNavItem {
+  id: string;
+  title: string;
+  url: string;
+}
+// Single shared collator avoids per-call Intl.Collator construction
+const collator = new Intl.Collator();
+
 const navTreeSlice = createSlice({
   name: 'navBarTree',
   initialState: () => translateNav(config.bootData?.navTree ?? []),
@@ -42,7 +50,7 @@ const navTreeSlice = createSlice({
             url,
           };
           starredItems.children.push(newStarredItem);
-          starredItems.children.sort((a, b) => a.text.localeCompare(b.text));
+          starredItems.children.sort((a, b) => collator.compare(a.text, b.text));
         } else {
           const index = starredItems.children?.findIndex((item) => item.id === ID_PREFIX + id) ?? -1;
           if (index > -1) {
@@ -80,7 +88,7 @@ const navTreeSlice = createSlice({
         if (navItem) {
           navItem.text = title;
           navItem.url = url;
-          starredItems.children?.sort((a, b) => a.text.localeCompare(b.text));
+          starredItems.children?.sort((a, b) => collator.compare(a.text, b.text));
         }
       }
     },
@@ -91,8 +99,33 @@ const navTreeSlice = createSlice({
         state.splice(pluginItemIndex, 1);
       }
     },
+    setStarredItems: (state, action: PayloadAction<{ uids: string[]; items: StarredNavItem[] }>) => {
+      const starred = state.find((n) => n.id === 'starred');
+      if (!starred) {
+        return;
+      }
+      const { uids, items } = action.payload;
+      const found = new Map(items.map((item) => [item.id, item]));
+      const existing = new Map((starred.children ?? []).map((child) => [child.id, child]));
+      const children: NavModelItem[] = [];
+      for (const uid of uids) {
+        const item = found.get(uid);
+        if (item) {
+          children.push({ id: ID_PREFIX + uid, text: item.title, url: item.url });
+        } else {
+          // The search index is eventually consistent, so a freshly starred dashboard may
+          // be missing from the response — keep the optimistic entry added by setStarred
+          const prev = existing.get(ID_PREFIX + uid);
+          if (prev) {
+            children.push(prev);
+          }
+        }
+      }
+      starred.children = children.sort((a, b) => collator.compare(a.text, b.text));
+    },
   },
 });
 
-export const { setStarred, removePluginFromNavTree, updateDashboardName, setBookmark } = navTreeSlice.actions;
+export const { setStarred, setStarredItems, removePluginFromNavTree, updateDashboardName, setBookmark } =
+  navTreeSlice.actions;
 export const navTreeReducer = navTreeSlice.reducer;

--- a/public/app/core/reducers/navBarTree.ts
+++ b/public/app/core/reducers/navBarTree.ts
@@ -113,8 +113,11 @@ const navTreeSlice = createSlice({
         if (item) {
           children.push({ id: ID_PREFIX + uid, text: item.title, url: item.url });
         } else {
-          // The search index is eventually consistent, so a freshly starred dashboard may
-          // be missing from the response — keep the optimistic entry added by setStarred
+          // A starred uid can be missing from the search response when the eventually
+          // consistent index hasn't caught up with a fresh star yet, or when the dashboard
+          // was deleted. Keep the already-rendered entry (e.g. the optimistic one from
+          // setStarred) so a just-starred item doesn't vanish; a deleted dashboard has no
+          // entry to keep and is dropped on the next full page load either way.
           const prev = existing.get(ID_PREFIX + uid);
           if (prev) {
             children.push(prev);

--- a/public/app/features/stars/hooks.test.tsx
+++ b/public/app/features/stars/hooks.test.tsx
@@ -22,13 +22,14 @@ setupMockServer();
 
 /** Renders the hook plus a read-only component that reflects Redux starred state */
 const TestHarness = () => {
-  const { isLoading } = useSyncStarredItemsInNav();
+  const { isLoading, isError } = useSyncStarredItemsInNav();
   const navTree = useSelector((state) => state.navBarTree);
   const starred = navTree.find((item) => item.id === 'starred');
 
   return (
     <>
       <span data-testid="loading-state">{String(isLoading)}</span>
+      <span data-testid="error-state">{String(isError)}</span>
       <ul data-testid="starred-list">
         {starred?.children?.map((child) => (
           <li key={child.id} data-testid={`synced-${child.id}`}>
@@ -143,6 +144,22 @@ describe('useSyncStarredItemsInNav', () => {
       await waitFor(() => {
         expect(screen.getByTestId('loading-state')).toHaveTextContent('false');
       });
+    });
+
+    it('reports an error and leaves the nav untouched when search fails', async () => {
+      const mockSearcher = setupSearchMock([]);
+      mockSearcher.search.mockRejectedValue(new Error('search unavailable'));
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      render(<TestHarness />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('error-state')).toHaveTextContent('true');
+      });
+
+      // Loading resolved instead of spinning forever, and no items were dispatched
+      expect(screen.getByTestId('loading-state')).toHaveTextContent('false');
+      expect(screen.getByTestId('starred-list').children).toHaveLength(0);
     });
   });
 });

--- a/public/app/features/stars/hooks.ts
+++ b/public/app/features/stars/hooks.ts
@@ -113,6 +113,7 @@ export const useUpdateNavStarredItems = () => {
   };
 };
 
+// Matches the backend cap on starred nav children in bootData (buildStarredItemsNavLinks)
 const STARRED_NAV_CAP = 50;
 
 /**

--- a/public/app/features/stars/hooks.ts
+++ b/public/app/features/stars/hooks.ts
@@ -121,10 +121,11 @@ const STARRED_NAV_CAP = 50;
  * Replaces whatever the backend shipped in bootData (which is empty in dual-writer mode 5).
  */
 export const useSyncStarredItemsInNav = () => {
-  const { data: uids, isLoading } = useStarredItems('dashboard.grafana.app', 'Dashboard');
+  const { data: uids, isLoading, isError } = useStarredItems('dashboard.grafana.app', 'Dashboard');
   // Initialized from the stars query so a remount with a warm RTK cache doesn't
   // flash a loading state — the nav tree is already correct from the prior sync
   const [hasSynced, setHasSynced] = useState(!isLoading);
+  const [searchFailed, setSearchFailed] = useState(false);
 
   // Stable identity so the effect doesn't re-fire when the array ref changes but content is identical
   const uidKey = useMemo(() => {
@@ -142,6 +143,7 @@ export const useSyncStarredItemsInNav = () => {
     if (uidKey === '') {
       dispatch(setStarredItems({ uids: [], items: [] }));
       setHasSynced(true);
+      setSearchFailed(false);
       return;
     }
 
@@ -161,11 +163,13 @@ export const useSyncStarredItemsInNav = () => {
         }
         dispatch(setStarredItems({ uids: names, items }));
         setHasSynced(true);
+        setSearchFailed(false);
       })
       .catch((err) => {
         console.error('Failed to sync starred items to nav', err);
-        // Fall back to the empty message rather than showing a loading state forever
+        // Resolve the loading state rather than showing it forever
         setHasSynced(true);
+        setSearchFailed(true);
       });
 
     return () => {
@@ -173,5 +177,5 @@ export const useSyncStarredItemsInNav = () => {
     };
   }, [uidKey, isLoading]);
 
-  return { isLoading: isLoading || !hasSynced };
+  return { isLoading: isLoading || !hasSynced, isError: isError || searchFailed };
 };

--- a/public/app/features/stars/hooks.ts
+++ b/public/app/features/stars/hooks.ts
@@ -1,5 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/query';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import {
   useGetStarsQuery as useLegacyGetStarsQuery,
@@ -121,6 +121,9 @@ const STARRED_NAV_CAP = 50;
  */
 export const useSyncStarredItemsInNav = () => {
   const { data: uids, isLoading } = useStarredItems('dashboard.grafana.app', 'Dashboard');
+  // Initialized from the stars query so a remount with a warm RTK cache doesn't
+  // flash a loading state — the nav tree is already correct from the prior sync
+  const [hasSynced, setHasSynced] = useState(!isLoading);
 
   // Stable identity so the effect doesn't re-fire when the array ref changes but content is identical
   const uidKey = useMemo(() => {
@@ -137,6 +140,7 @@ export const useSyncStarredItemsInNav = () => {
 
     if (uidKey === '') {
       dispatch(setStarredItems({ uids: [], items: [] }));
+      setHasSynced(true);
       return;
     }
 
@@ -155,13 +159,18 @@ export const useSyncStarredItemsInNav = () => {
           items.push({ id: row.uid, title: row.name, url: row.url });
         }
         dispatch(setStarredItems({ uids: names, items }));
+        setHasSynced(true);
       })
       .catch((err) => {
         console.error('Failed to sync starred items to nav', err);
+        // Fall back to the empty message rather than showing a loading state forever
+        setHasSynced(true);
       });
 
     return () => {
       cancelled = true;
     };
   }, [uidKey, isLoading]);
+
+  return { isLoading: isLoading || !hasSynced };
 };

--- a/public/app/features/stars/hooks.ts
+++ b/public/app/features/stars/hooks.ts
@@ -1,5 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/query';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import {
   useGetStarsQuery as useLegacyGetStarsQuery,
@@ -9,8 +9,9 @@ import {
 import { locationUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { useAddStarMutation, useRemoveStarMutation, useListStarsQuery } from 'app/api/clients/collections/v1alpha1';
-import { setStarred } from 'app/core/reducers/navBarTree';
+import { setStarred, setStarredItems, type StarredNavItem } from 'app/core/reducers/navBarTree';
 import { contextSrv } from 'app/core/services/context_srv';
+import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { dispatch } from 'app/store/store';
 
 type StarItemArgs = {
@@ -110,4 +111,57 @@ export const useUpdateNavStarredItems = () => {
     const url = locationUtil.assureBaseUrl(`/d/${id}`);
     return dispatch(setStarred({ id, title, url, isStarred }));
   };
+};
+
+const STARRED_NAV_CAP = 50;
+
+/**
+ * Sync starred dashboards into the nav tree on mount and when the star set changes.
+ * Replaces whatever the backend shipped in bootData (which is empty in dual-writer mode 5).
+ */
+export const useSyncStarredItemsInNav = () => {
+  const { data: uids, isLoading } = useStarredItems('dashboard.grafana.app', 'Dashboard');
+
+  // Stable identity so the effect doesn't re-fire when the array ref changes but content is identical
+  const uidKey = useMemo(() => {
+    if (!uids) {
+      return undefined;
+    }
+    return [...uids].sort().join(',');
+  }, [uids]);
+
+  useEffect(() => {
+    if (isLoading || uidKey === undefined) {
+      return;
+    }
+
+    if (uidKey === '') {
+      dispatch(setStarredItems({ uids: [], items: [] }));
+      return;
+    }
+
+    const names = uidKey.split(',').slice(0, STARRED_NAV_CAP);
+    let cancelled = false;
+
+    getGrafanaSearcher()
+      .search({ name: names, kind: ['dashboard'] })
+      .then((response) => {
+        if (cancelled) {
+          return;
+        }
+        const items: StarredNavItem[] = [];
+        for (let i = 0; i < response.view.length; i++) {
+          const row = response.view.get(i);
+          items.push({ id: row.uid, title: row.name, url: row.url });
+        }
+        dispatch(setStarredItems({ uids: names, items }));
+      })
+      .catch((err) => {
+        console.error('Failed to sync starred items to nav', err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [uidKey, isLoading]);
 };

--- a/public/app/features/stars/useSyncStarredItemsInNav.test.tsx
+++ b/public/app/features/stars/useSyncStarredItemsInNav.test.tsx
@@ -22,18 +22,21 @@ setupMockServer();
 
 /** Renders the hook plus a read-only component that reflects Redux starred state */
 const TestHarness = () => {
-  useSyncStarredItemsInNav();
+  const { isLoading } = useSyncStarredItemsInNav();
   const navTree = useSelector((state) => state.navBarTree);
   const starred = navTree.find((item) => item.id === 'starred');
 
   return (
-    <ul data-testid="starred-list">
-      {starred?.children?.map((child) => (
-        <li key={child.id} data-testid={`synced-${child.id}`}>
-          {child.text}
-        </li>
-      ))}
-    </ul>
+    <>
+      <span data-testid="loading-state">{String(isLoading)}</span>
+      <ul data-testid="starred-list">
+        {starred?.children?.map((child) => (
+          <li key={child.id} data-testid={`synced-${child.id}`}>
+            {child.text}
+          </li>
+        ))}
+      </ul>
+    </>
   );
 };
 
@@ -88,6 +91,9 @@ describe('useSyncStarredItemsInNav', () => {
 
       render(<TestHarness />);
 
+      // Loading until the stars query and search round-trip complete
+      expect(screen.getByTestId('loading-state')).toHaveTextContent('true');
+
       await waitFor(() => {
         expect(mockSearcher.search).toHaveBeenCalledWith({
           name: starredDashboards.map((d) => d.uid).sort(),
@@ -101,6 +107,8 @@ describe('useSyncStarredItemsInNav', () => {
           expect(screen.getByTestId(`synced-starred/${dash.uid}`)).toBeInTheDocument();
         });
       }
+
+      expect(screen.getByTestId('loading-state')).toHaveTextContent('false');
     });
 
     it('dispatches empty items when no stars exist', async () => {
@@ -130,6 +138,11 @@ describe('useSyncStarredItemsInNav', () => {
 
       // Search should NOT be called when there are no stars
       expect(mockSearcher.search).not.toHaveBeenCalled();
+
+      // Loading resolves even without a search round-trip
+      await waitFor(() => {
+        expect(screen.getByTestId('loading-state')).toHaveTextContent('false');
+      });
     });
   });
 });

--- a/public/app/features/stars/useSyncStarredItemsInNav.test.tsx
+++ b/public/app/features/stars/useSyncStarredItemsInNav.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
+
+import { config, setBackendSrv } from '@grafana/runtime';
+import server, { setupMockServer } from '@grafana/test-utils/server';
+import { getFolderFixtures } from '@grafana/test-utils/unstable';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { getGrafanaSearcher } from 'app/features/search/service/searcher';
+import { useSelector } from 'app/types/store';
+
+import { useSyncStarredItemsInNav } from './hooks';
+
+jest.mock('app/features/search/service/searcher');
+
+const mockedGetGrafanaSearcher = jest.mocked(getGrafanaSearcher);
+
+const [_, { dashbdD, folderA_dashbdD }] = getFolderFixtures();
+// The starred fixtures are: dashbdD.item.uid, folderA_dashbdD.item.uid
+const starredDashboards = [dashbdD.item, folderA_dashbdD.item];
+
+setBackendSrv(backendSrv);
+setupMockServer();
+
+/** Renders the hook plus a read-only component that reflects Redux starred state */
+const TestHarness = () => {
+  useSyncStarredItemsInNav();
+  const navTree = useSelector((state) => state.navBarTree);
+  const starred = navTree.find((item) => item.id === 'starred');
+
+  return (
+    <ul data-testid="starred-list">
+      {starred?.children?.map((child) => (
+        <li key={child.id} data-testid={`synced-${child.id}`}>
+          {child.text}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+function setupSearchMock(items: Array<{ uid: string; name: string; url: string }>) {
+  const view = {
+    length: items.length,
+    get: (i: number) => items[i],
+    dataFrame: { fields: [], length: items.length },
+  };
+  const mockSearcher = {
+    search: jest.fn().mockResolvedValue({
+      view,
+      totalRows: items.length,
+      isItemLoaded: () => true,
+      loadMoreItems: () => Promise.resolve(),
+    }),
+    starred: jest.fn(),
+    tags: jest.fn(),
+    getSortOptions: jest.fn(),
+    getLocationInfo: jest.fn(),
+    getFolderViewSort: jest.fn().mockReturnValue('name_sort'),
+  };
+  mockedGetGrafanaSearcher.mockReturnValue(mockSearcher);
+  return mockSearcher;
+}
+
+const fixtures: Array<[string, Parameters<typeof testWithFeatureToggles>[0]]> = [
+  ['starsFromAPIServer enabled', { enable: ['starsFromAPIServer'] }],
+  ['starsFromAPIServer disabled', {}],
+];
+
+describe('useSyncStarredItemsInNav', () => {
+  describe.each(fixtures)('%s', (_title, featureToggleSetup) => {
+    testWithFeatureToggles(featureToggleSetup);
+
+    beforeEach(() => {
+      // Provide a starred section in the nav tree so the reducer has a target
+      config.bootData.navTree = [
+        { id: 'home', text: 'Home', url: '/' },
+        { id: 'starred', text: 'Starred', children: [] },
+      ];
+    });
+
+    it('populates the starred nav section with metadata from search', async () => {
+      const mockSearcher = setupSearchMock(
+        starredDashboards.map((d) => ({
+          uid: d.uid,
+          name: d.title,
+          url: `/d/${d.uid}`,
+        }))
+      );
+
+      render(<TestHarness />);
+
+      await waitFor(() => {
+        expect(mockSearcher.search).toHaveBeenCalledWith({
+          name: starredDashboards.map((d) => d.uid).sort(),
+          kind: ['dashboard'],
+        });
+      });
+
+      // Verify items appeared in the nav tree (sorted alphabetically)
+      for (const dash of starredDashboards) {
+        await waitFor(() => {
+          expect(screen.getByTestId(`synced-starred/${dash.uid}`)).toBeInTheDocument();
+        });
+      }
+    });
+
+    it('dispatches empty items when no stars exist', async () => {
+      const { http, HttpResponse } = await import('msw');
+      server.use(
+        // Legacy empty
+        http.get('/api/user/stars', () => HttpResponse.json([])),
+        // App platform empty
+        http.get('/apis/collections.grafana.app/v1alpha1/namespaces/:namespace/stars', () =>
+          HttpResponse.json({
+            kind: 'StarsList',
+            apiVersion: 'collections.grafana.app/v1alpha1',
+            metadata: { resourceVersion: '1' },
+            items: [],
+          })
+        )
+      );
+
+      const mockSearcher = setupSearchMock([]);
+
+      render(<TestHarness />);
+
+      await waitFor(() => {
+        const list = screen.getByTestId('starred-list');
+        expect(list.children).toHaveLength(0);
+      });
+
+      // Search should NOT be called when there are no stars
+      expect(mockSearcher.search).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12248,6 +12248,7 @@
       "undock": "Undock menu"
     },
     "megamenu-item": {
+      "children-error": "Failed to load items",
       "collapse-aria-label": "Collapse section: {{sectionName}}",
       "expand-aria-label": "Expand section: {{sectionName}}",
       "loading-aria-label": "Loading {{sectionName}}"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12249,7 +12249,8 @@
     },
     "megamenu-item": {
       "collapse-aria-label": "Collapse section: {{sectionName}}",
-      "expand-aria-label": "Expand section: {{sectionName}}"
+      "expand-aria-label": "Expand section: {{sectionName}}",
+      "loading-aria-label": "Loading {{sectionName}}"
     },
     "org-switcher": {
       "aria-label": "Change organization"


### PR DESCRIPTION
**What is this feature?**

The starred section of the mega menu is now populated on the client: a new `useSyncStarredItemsInNav` hook fetches the user's starred dashboard uids (legacy or App Platform stars API, depending on the `starsFromAPIServer` toggle), resolves their metadata via unified search, and syncs them into the nav tree. While the initial sync is in flight, an expanded starred section shows skeleton placeholder rows instead of flashing the empty-state message.


https://github.com/user-attachments/assets/62d5f3f1-2b2e-4fde-b2ae-590975609c03

