### PR TITLE
Alerting: Fix rule matching when expressions contain inline comments

### DIFF
--- a/public/app/features/alerting/unified/rule-list/ruleMatching.test.ts
+++ b/public/app/features/alerting/unified/rule-list/ruleMatching.test.ts
@@ -624,4 +624,44 @@ max by (service) (up{env="staging"}) * 0.8`,
     expect(result.matches.get(rulerRule2)).toBe(promRule2);
     expect(result.promOnlyRules).toHaveLength(0);
   });
+
+  it('should match rules where ruler expressions have inline comments (# after code on the same line)', () => {
+    // The ruler stores expressions with inline comments (e.g. `or # Fallback for staging`).
+    // Mimir strips all comments before returning the query in Prometheus state.
+    // Both rules share the same name and empty labels, so the matcher must fall back to query comparison.
+    const rulerRule1 = alertingFactory.ruler.recordingRule.build({
+      record: 'service_condition',
+      labels: {},
+      expr: `(max by (environment, namespace, service, area) (service_condition{area_check!="", monitored="true"}))`,
+    });
+    const rulerRule2 = alertingFactory.ruler.recordingRule.build({
+      record: 'service_condition',
+      labels: {},
+      expr: `max by (environment, namespace, service) (service_condition{environment="production"}) # production path
+or # combine with non-production fallback
+max by (environment, namespace, service) (service_condition{environment!="production"})`,
+    });
+    const rulerGroup = alertingFactory.ruler.group.build({ rules: [rulerRule1, rulerRule2] });
+
+    // Prometheus returns the same queries with all comments stripped and whitespace normalized
+    const promRule1 = mockPromRecordingRule({
+      name: 'service_condition',
+      labels: {},
+      query: `(max by (environment, namespace, service, area) (service_condition{area_check!="",monitored="true"}))`,
+    });
+    const promRule2 = mockPromRecordingRule({
+      name: 'service_condition',
+      labels: {},
+      query: `max by (environment, namespace, service) (service_condition{environment="production"}) or max by (environment, namespace, service) (service_condition{environment!="production"})`,
+    });
+    const promGroup = alertingFactory.prometheus.group.build({ rules: [promRule1, promRule2] });
+
+    const result = matchRulesGroup(rulerGroup, promGroup);
+
+    // Both rules must match — no ghost "creating" or "deleting" entries
+    expect(result.matches.size).toBe(2);
+    expect(result.matches.get(rulerRule1)).toBe(promRule1);
+    expect(result.matches.get(rulerRule2)).toBe(promRule2);
+    expect(result.promOnlyRules).toHaveLength(0);
+  });
 });

--- a/public/app/features/alerting/unified/utils/rule-id.test.tsx
+++ b/public/app/features/alerting/unified/utils/rule-id.test.tsx
@@ -21,6 +21,7 @@ import {
   hashRulerRule,
   parse,
   stringifyIdentifier,
+  stripPromQLComments,
 } from './rule-id';
 
 const alertingRule = {
@@ -372,5 +373,62 @@ describe('hashQuery', () => {
 
     expect(hash1).toBe(hash2);
     expect(hash1).toBe(hash1.split('').sort().join(''));
+  });
+
+  it('should strip inline comments (# after code on the same line)', () => {
+    const query1 = `max by (service) (up{env="production"}) # production fallback
+or # combine with staging
+max by (service) (up{env="staging"}) * 0.8`;
+    const query2 = `max by (service) (up{env="production"}) or max by (service) (up{env="staging"}) * 0.8`;
+
+    expect(hashQuery(query1)).toBe(hashQuery(query2));
+  });
+
+  it('should strip mixed full-line and inline comments', () => {
+    const query1 = `# Full-line comment
+max by (environment, namespace, service) (service_condition{environment="production"}) # inline comment
+or
+# Another full-line comment
+max by (environment, namespace, service) (service_condition{environment!="production"})`;
+    const query2 = `max by (environment, namespace, service) (service_condition{environment="production"}) or max by (environment, namespace, service) (service_condition{environment!="production"})`;
+
+    expect(hashQuery(query1)).toBe(hashQuery(query2));
+  });
+});
+
+describe('stripPromQLComments', () => {
+  it('should strip full-line comments', () => {
+    expect(stripPromQLComments('# comment\nmetric')).toBe('metric');
+  });
+
+  it('should strip inline comments', () => {
+    expect(stripPromQLComments('metric or # fallback\nother_metric')).toBe('metric or\nother_metric');
+  });
+
+  it('should strip mixed full-line and inline comments', () => {
+    const input = `# header comment
+max by (service) (up{env="production"}) # inline
+or
+# another full-line
+max by (service) (up{env="staging"})`;
+    const expected = `max by (service) (up{env="production"})
+or
+max by (service) (up{env="staging"})`;
+    expect(stripPromQLComments(input)).toBe(expected);
+  });
+
+  it('should return empty string for a comment-only query', () => {
+    expect(stripPromQLComments('# just a comment')).toBe('');
+  });
+
+  it('should return the query unchanged when there are no comments', () => {
+    expect(stripPromQLComments('rate(requests_total[5m])')).toBe('rate(requests_total[5m])');
+  });
+
+  it('should collapse lines that become empty after comment removal', () => {
+    const input = `metric1
+# this whole line is a comment
+metric2`;
+    expect(stripPromQLComments(input)).toBe('metric1\nmetric2');
   });
 });

--- a/public/app/features/alerting/unified/utils/rule-id.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.ts
@@ -311,14 +311,27 @@ export function getPromRuleFingerprint(rule: Rule, includeQuery: boolean) {
   throw new Error('Only recording and alerting rules can be hashed');
 }
 
-// there can be slight differences in how prom & ruler render a query, this will hash them accounting for the differences
-export function hashQuery(query: string) {
-  // remove comments
-  query = query
+/**
+ * Strips PromQL comments from a query string.
+ * Handles both full-line comments (lines starting with #) and inline comments
+ * (# appearing after code on the same line, e.g. `or # fallback condition`).
+ * Mimir normalizes expressions by stripping comments before storing them in
+ * Prometheus state, so the ruler expression and the Prometheus query must be
+ * processed identically before comparison.
+ */
+export function stripPromQLComments(query: string): string {
+  return query
+    .replace(/#[^\n]*/g, '') // strip from # to end of line (inline and full-line comments)
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'))
+    .filter((line) => line)
     .join('\n');
+}
+
+// there can be slight differences in how prom & ruler render a query, this will hash them accounting for the differences
+export function hashQuery(query: string) {
+  // remove comments (full-line and inline)
+  query = stripPromQLComments(query);
 
   // one of them might be wrapped in parens
   if (query.length > 1 && query[0] === '(' && query[query.length - 1] === ')') {

--- a/public/app/features/alerting/unified/utils/rule-id.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.ts
@@ -324,7 +324,7 @@ export function stripPromQLComments(query: string): string {
     .replace(/#[^\n]*/g, '') // strip from # to end of line (inline and full-line comments)
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => line)
+    .filter((line) => Boolean(line))
     .join('\n');
 }
 


### PR DESCRIPTION
## What's Fixed

When a rule group contains multiple rules with the **same name**, the UI falls back to comparing query fingerprints via `hashQuery` to distinguish them. Mimir normalises expressions by stripping all PromQL comments before storing them in Prometheus state, but the Ruler returns the original expression verbatim.

The previous fix only stripped **full-line** comments (lines where `#` is the first non-whitespace character). **Inline comments** — where `#` appears after code on the same line, e.g. `or # fallback condition` — were not stripped, producing a different fingerprint than the Mimir-normalised query. This caused both rules to appear as ghost **"creating"** + **"deleting"** entries indefinitely.

- Extracted a new `stripPromQLComments` utility (exported from `rule-id.ts`) that strips all PromQL comments using `/#[^\n]*/g` — handles both full-line and inline comments
- `hashQuery` now delegates comment removal to `stripPromQLComments`
- The fix applies to both the new rule list (`ruleMatching.ts` path) and the legacy `useCombinedRuleNamespaces` path, since both call `hashQuery`

## Tests Added

- Unit tests for `stripPromQLComments`: full-line, inline, mixed, comment-only, no-comment, collapsed-empty-line cases
- New `hashQuery` tests for inline and mixed inline+full-line comment scenarios
- Integration test in `matchRulesGroup`: two same-named recording rules where one Ruler expression uses inline comments; asserts both match their Prometheus counterparts with zero ghost entries

**Which issue(s) does this PR fix?**

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.