### PR TITLE
Search: wire DashboardStats into the standalone server backfiller

### DIFF
--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -34,12 +34,21 @@ import (
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
 	"github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
 	embedderprovider "github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder/provider"
 	"github.com/grafana/grafana/pkg/storage/unified/search/vector"
 	"github.com/grafana/grafana/pkg/storage/unified/sql"
 	"go.opentelemetry.io/otel"
 )
+
+// SearchSupport bundles the document builder supplier with the dashboard
+// stats instance it was built from, so both can be shared by the
+// storage-server module.
+type SearchSupport struct {
+	DocBuilders    resource.DocumentBuilderSupplier
+	DashboardStats builders.DashboardStats
+}
 
 // NewModule returns an instance of a ModuleServer, responsible for managing
 // dskit modules (services).
@@ -60,7 +69,7 @@ func NewModule(opts Options,
 	storeProvider zStore.StoreProvider,
 	reconcileCRDs []schema.GroupVersionResource,
 ) (*ModuleServer, error) {
-	s, err := newModuleServer(opts, apiOpts, features, cfg, storageMetrics, indexMetrics, vectorMetrics, reg, promGatherer, license, moduleRegisterer, storageBackend, hooksService, storeProvider, reconcileCRDs)
+	s, err := newModuleServer(opts, apiOpts, features, cfg, storageMetrics, indexMetrics, vectorMetrics, reg, promGatherer, tracer, license, moduleRegisterer, storageBackend, hooksService, storeProvider, reconcileCRDs)
 	if err != nil {
 		return nil, err
 	}
@@ -81,6 +90,7 @@ func newModuleServer(opts Options,
 	vectorMetrics *resource.VectorMetrics,
 	reg prometheus.Registerer,
 	promGatherer prometheus.Gatherer,
+	tracer tracing.Tracer,
 	license licensing.Licensing,
 	moduleRegisterer ModuleRegisterer,
 	storageBackend resource.StorageBackend,
@@ -114,6 +124,7 @@ func newModuleServer(opts Options,
 		vectorMetrics:    vectorMetrics,
 		promGatherer:     promGatherer,
 		registerer:       reg,
+		tracer:           tracer,
 		license:          license,
 		moduleRegisterer: moduleRegisterer,
 		storageBackend:   storageBackend,
@@ -159,6 +170,7 @@ type ModuleServer struct {
 
 	promGatherer prometheus.Gatherer
 	registerer   prometheus.Registerer
+	tracer       tracing.Tracer
 
 	MemberlistKVConfig         kv.Config
 	httpServerRouter           *mux.Router
@@ -294,17 +306,33 @@ func (s *ModuleServer) Run() error {
 	m.RegisterModule(modules.StorageServer, func() (services.Service, error) {
 		// Only set docBuilders and indexMetrics if enable_search is true
 		var docBuilders resource.DocumentBuilderSupplier
+		var dashboardStats builders.DashboardStats
 		var indexMetrics *resource.BleveIndexMetrics
 		if s.cfg.EnableSearch {
 			s.log.Warn("Support for 'enable_search' config with 'storage-server' target is deprecated and will be removed in a future release. Please use the 'search-server' target instead.")
-			var err error
-			docBuilders, err = InitializeDocumentBuilders(s.cfg)
+			// The document builders and the vector backfiller share one
+			// stats instance; building them from one graph also avoids
+			// registering the sprinkles metrics twice.
+			support, err := InitializeSearchSupport(s.cfg, s.features, s.tracer, s.registerer)
 			if err != nil {
 				return nil, err
 			}
+			docBuilders = support.DocBuilders
+			dashboardStats = support.DashboardStats
 			indexMetrics = s.indexMetrics
+		} else if s.cfg.VectorIndexingEnabled {
+			// The vector backfiller views filter needs dashboard stats.
+			var err error
+			dashboardStats, err = InitializeDashboardStats(s.cfg, s.features, s.tracer, s.registerer)
+			if err != nil {
+				return nil, err
+			}
 		}
-		svc, err := sql.ProvideUnifiedStorageGrpcService(s.cfg, s.features, s.log, s.registerer, docBuilders, s.storageMetrics, indexMetrics, s.vectorMetrics, s.searchServerRing, s.MemberlistKVConfig, s.httpServerRouter, s.storageBackend, s.vectorBackend, s.embedder, s.searchClient, s.grpcService, s.StorageServiceOptions...)
+		serviceOptions := s.StorageServiceOptions
+		if dashboardStats != nil {
+			serviceOptions = append(serviceOptions, sql.WithDashboardStats(dashboardStats))
+		}
+		svc, err := sql.ProvideUnifiedStorageGrpcService(s.cfg, s.features, s.log, s.registerer, docBuilders, s.storageMetrics, indexMetrics, s.vectorMetrics, s.searchServerRing, s.MemberlistKVConfig, s.httpServerRouter, s.storageBackend, s.vectorBackend, s.embedder, s.searchClient, s.grpcService, serviceOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -331,11 +359,11 @@ func (s *ModuleServer) Run() error {
 	})
 
 	m.RegisterModule(modules.SearchServer, func() (services.Service, error) {
-		docBuilders, err := InitializeDocumentBuilders(s.cfg)
+		support, err := InitializeSearchSupport(s.cfg, s.features, s.tracer, s.registerer)
 		if err != nil {
 			return nil, err
 		}
-		svc, err := sql.ProvideSearchGRPCService(s.cfg, s.features, s.log, s.registerer, docBuilders, s.indexMetrics, s.vectorMetrics, s.searchServerRing, s.MemberlistKVConfig, s.httpServerRouter, s.storageBackend, s.vectorBackend, s.embedder, s.grpcService, s.StorageServiceOptions...)
+		svc, err := sql.ProvideSearchGRPCService(s.cfg, s.features, s.log, s.registerer, support.DocBuilders, s.indexMetrics, s.vectorMetrics, s.searchServerRing, s.MemberlistKVConfig, s.httpServerRouter, s.storageBackend, s.vectorBackend, s.embedder, s.grpcService, s.StorageServiceOptions...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -249,7 +249,7 @@ func getDistributorResponse[Req any, Resp any](t *testing.T, req *Req, fn func(c
 
 func startAndWaitHealthy(t *testing.T, testServer testModuleServer) {
 	go func() {
-		// this next line is to avoid double registration, as both InitializeDocumentBuilders as well as ProvideUnifiedStorageGrpcService
+		// this next line is to avoid double registration, as both InitializeSearchSupport as well as ProvideUnifiedStorageGrpcService
 		// are hard-coded to use prometheus.DefaultRegisterer
 		// the alternative would be to get the registry from wire, in which case the tests would receive a new
 		// registry automatically, but that _may_ change metric names
@@ -393,10 +393,9 @@ func createBaselineServer(t *testing.T, dbType, dbConnStr string, testNamespaces
 	cfg.IndexFileThreshold = testIndexFileThreshold
 	cfg.EnableSearch = true
 	features := featuremgmt.WithFeatures()
-	docBuilders, err := InitializeDocumentBuilders(cfg)
+	support, err := InitializeSearchSupport(cfg, features, tracing.InitializeTracerForTest(), prometheus.NewRegistry())
 	require.NoError(t, err)
-	require.NoError(t, err)
-	searchOpts, err := search.NewSearchOptions(features, cfg, docBuilders, nil, nil, nil)
+	searchOpts, err := search.NewSearchOptions(features, cfg, support.DocBuilders, nil, nil, nil)
 	require.NoError(t, err)
 	cfg.DisablePruner = dbType == "sqlite3"
 	eDB, err := sql.ProvideResourceDB(cfg, nil)

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/google/wire"
+	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -191,7 +192,7 @@ import (
 	secretmigrator "github.com/grafana/grafana/pkg/storage/secret/migrator"
 	unifiedmigrations "github.com/grafana/grafana/pkg/storage/unified/migrations"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	unifiedsearch "github.com/grafana/grafana/pkg/storage/unified/search"
+	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor"
 	cloudmonitoring "github.com/grafana/grafana/pkg/tsdb/cloud-monitoring"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch"
@@ -592,9 +593,23 @@ func InitializeAPIServerFactory() (standalone.APIServerFactory, error) {
 	return &standalone.NoOpAPIServerFactory{}, nil // Wire will replace this with a real interface
 }
 
-func InitializeDocumentBuilders(cfg *setting.Cfg) (resource.DocumentBuilderSupplier, error) {
-	wire.Build(wireExtsSet)
-	return &unifiedsearch.StandardDocumentBuilders{}, nil
+// InitializeSearchSupport builds the document builders together with the
+// dashboard stats they use, so the storage-server target shares a single
+// stats instance (and a single metrics registration) between the search
+// document builders and the vector backfiller. It receives the dependencies
+// the module server has already constructed so they aren't recreated.
+func InitializeSearchSupport(cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer, reg promclient.Registerer) (SearchSupport, error) {
+	wire.Build(wireExtsSearchSupportSet, wire.Struct(new(SearchSupport), "*"))
+	return SearchSupport{}, nil
+}
+
+// InitializeDashboardStats builds only the dashboard stats dependency used by
+// the vector backfiller views filter, for the storage-server target running
+// without enable_search. It receives the dependencies the module server has
+// already constructed so they aren't recreated.
+func InitializeDashboardStats(cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer, reg promclient.Registerer) (builders.DashboardStats, error) {
+	wire.Build(wireExtsDashboardStatsSet)
+	return nil, nil
 }
 
 /*

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -296,6 +296,7 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/parca"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus"
 	"github.com/grafana/grafana/pkg/tsdb/tempo"
+	prometheus2 "github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -1950,33 +1951,34 @@ func InitializeAPIServerFactory() (standalone.APIServerFactory, error) {
 	return apiServerFactory, nil
 }
 
-func InitializeDocumentBuilders(cfg *setting.Cfg) (resource.DocumentBuilderSupplier, error) {
-	featureManager, err := featuremgmt.ProvideManagerService(cfg)
+// InitializeSearchSupport builds the document builders together with the
+// dashboard stats they use, so the storage-server target shares a single
+// stats instance (and a single metrics registration) between the search
+// document builders and the vector backfiller. It receives the dependencies
+// the module server has already constructed so they aren't recreated.
+func InitializeSearchSupport(cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer, reg prometheus2.Registerer) (SearchSupport, error) {
+	ossMigrations := migrations.ProvideOSSMigrations(features)
+	inProcBus := bus.ProvideBus(tracer)
+	sqlStore, err := sqlstore.ProvideService(cfg, features, ossMigrations, inProcBus, tracer)
 	if err != nil {
-		return nil, err
-	}
-	featureToggles := featuremgmt.ProvideToggles(featureManager)
-	ossMigrations := migrations.ProvideOSSMigrations(featureToggles)
-	configProvider, err := configprovider.ProvideService(cfg)
-	if err != nil {
-		return nil, err
-	}
-	tracingConfig, err := tracing.ProvideTracingConfig(configProvider)
-	if err != nil {
-		return nil, err
-	}
-	tracingService, err := tracing.ProvideService(tracingConfig)
-	if err != nil {
-		return nil, err
-	}
-	inProcBus := bus.ProvideBus(tracingService)
-	sqlStore, err := sqlstore.ProvideService(cfg, featureToggles, ossMigrations, inProcBus, tracingService)
-	if err != nil {
-		return nil, err
+		return SearchSupport{}, err
 	}
 	ossDashboardStats := builders.ProvideDashboardStats()
 	documentBuilderSupplier := search.ProvideDocumentBuilders(sqlStore, ossDashboardStats)
-	return documentBuilderSupplier, nil
+	searchSupport := SearchSupport{
+		DocBuilders:    documentBuilderSupplier,
+		DashboardStats: ossDashboardStats,
+	}
+	return searchSupport, nil
+}
+
+// InitializeDashboardStats builds only the dashboard stats dependency used by
+// the vector backfiller views filter, for the storage-server target running
+// without enable_search. It receives the dependencies the module server has
+// already constructed so they aren't recreated.
+func InitializeDashboardStats(cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer, reg prometheus2.Registerer) (builders.DashboardStats, error) {
+	ossDashboardStats := builders.ProvideDashboardStats()
+	return ossDashboardStats, nil
 }
 
 // wire.go:

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -7,7 +7,9 @@ package server
 import (
 	"github.com/google/wire"
 
+	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/configprovider"
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
@@ -60,6 +62,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/searchusers/filters"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	secretsMigrator "github.com/grafana/grafana/pkg/services/secrets/migrator"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/validations"
@@ -222,4 +225,26 @@ var wireExtsModuleServerSet = wire.NewSet(
 
 var wireExtsStandaloneAPIServerSet = wire.NewSet(
 	standalone.ProvideAPIServerFactory,
+)
+
+// wireExtsDashboardStatsSet provides the dashboard stats dependency for the
+// InitializeDashboardStats injector. Kept separate from wireExtsSet so the
+// injector can receive already-constructed dependencies as parameters
+// without duplicate bindings.
+var wireExtsDashboardStatsSet = wire.NewSet(
+	builders.ProvideDashboardStats,
+	wire.Bind(new(builders.DashboardStats), new(*builders.OssDashboardStats)),
+)
+
+// wireExtsSearchSupportSet provides the document builders together with the
+// dashboard stats they use, for the InitializeSearchSupport injector.
+var wireExtsSearchSupportSet = wire.NewSet(
+	wireExtsDashboardStatsSet,
+	migrations.ProvideOSSMigrations,
+	wire.Bind(new(registry.DatabaseMigrator), new(*migrations.OSSMigrations)),
+	bus.ProvideBus,
+	wire.Bind(new(bus.Bus), new(*bus.InProcBus)),
+	sqlstore.ProvideService,
+	wire.Bind(new(db.DB), new(*sqlstore.SQLStore)),
+	search2.ProvideDocumentBuilders,
 )

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/storage/unified/search"
+	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
 	"github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
 	"github.com/grafana/grafana/pkg/storage/unified/search/vector"
 	"github.com/grafana/grafana/pkg/util/scheduler"
@@ -70,6 +71,7 @@ type service struct {
 
 	// -- Search Services
 	docBuilders      resource.DocumentBuilderSupplier
+	dashboardStats   builders.DashboardStats
 	indexMetrics     *resource.BleveIndexMetrics
 	searchRing       *ring.Ring
 	ringLifecycler   *ring.BasicLifecycler // Ring state for sharding
@@ -90,6 +92,14 @@ type ServiceOption func(*service)
 func WithAuthenticator(authn func(ctx context.Context) (context.Context, error)) ServiceOption {
 	return func(s *service) {
 		s.authenticator = authn
+	}
+}
+
+// WithDashboardStats sets the dashboard stats used by the vector backfiller
+// views filter. Optional; nil disables the filter.
+func WithDashboardStats(stats builders.DashboardStats) ServiceOption {
+	return func(s *service) {
+		s.dashboardStats = stats
 	}
 }
 
@@ -403,6 +413,7 @@ func (s *service) registerServer(provider grpcserver.Provider) error {
 		Features:       s.features,
 		QOSQueue:       s.queue,
 		OwnsIndexFn:    s.OwnsIndex,
+		DashboardStats: s.dashboardStats,
 	}
 
 	if !s.searchStandalone && s.cfg.OverridesFilePath != "" {


### PR DESCRIPTION
## What is this feature?

Wires the `DashboardStats` dependency into the vector backfiller when running via the standalone `storage-server` target.

The `registerServer` path built `ServerOptions` without `DashboardStats`, so the backfiller's zero-views filter was silently disabled (nil stats = filter off). The unified storage client path already set it.

## Why do we need this feature?

Without it, the standalone storage server backfills embeddings for dashboards that would otherwise be skipped by the views filter.

## Changes

- `pkg/storage/unified/sql/service.go`: new `WithDashboardStats` `ServiceOption` (same pattern as `WithAuthenticator`); sets `ServerOptions.DashboardStats` in `registerServer`. No gRPC service provider signature changes.
- `pkg/server/wire.go`:
  - `InitializeSearchSupport` (replaces `InitializeDocumentBuilders`) returns the document builders together with the dashboard stats they were built from, so they share one stats instance and the sprinkles metrics register once (no duplicate-registration panic). Used by the `search-server` target and the deprecated `enable_search` storage-server path.
  - `InitializeDashboardStats` for the vector-only storage-server path.
  - Both injectors receive the module server's already-constructed dependencies (features, tracer, registerer) as parameters via dedicated wire sets (`wireExtsSearchSupportSet`, `wireExtsDashboardStatsSet`), so they aren't recreated.
- `pkg/server/module_server.go`: the modules call the injectors inside their init closures — the dependency chain is built lazily and only for the selected target.

## Enterprise

Companion PR: https://github.com/grafana/grafana-enterprise/pull/12289 — adds the enterprise wire sets (usage insights chain) and regenerates `enterprise_wire_gen.go`.

## Who is this feature for?

Vector search / semantic search backfill in unified storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)