### PR TITLE
Map legacy data_source.version to k8s ResourceVersion

### DIFF
--- a/public/app/features/datasources/api.test.ts
+++ b/public/app/features/datasources/api.test.ts
@@ -66,13 +66,14 @@ describe('Datasources / API', () => {
         },
         readOnly: true,
         withCredentials: false,
+        version: 2,
       };
 
       let k8sMetadata: K8sMetadata = {
         name: 'fortytwo',
         namespace: 'default',
         uid: 'fortytwo',
-        resourceVersion: '',
+        resourceVersion: '2',
         generation: 42,
         creationTimestamp: '1234',
         labels: { 'grafana.app/deprecatedInternalID': '42' },
@@ -118,6 +119,7 @@ describe('Datasources / API', () => {
     it('should convert legacy datasource to k8s datasource', () => {
       let dsLegacySettings: DataSourceSettings = {
         id: 42,
+        version: 2,
         uid: 'fortytwo',
         orgId: 1,
         name: 'slartybartfast',
@@ -139,7 +141,7 @@ describe('Datasources / API', () => {
       let k8sMetadata: K8sMetadata = {
         name: 'fortytwo',
         namespace: 'default',
-        resourceVersion: '',
+        resourceVersion: '2',
         labels: { 'grafana.app/deprecatedInternalID': '42' },
         annotations: {},
       };

--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -97,7 +97,7 @@ export const convertLegacyDatasourceSettingsToK8sDatasourceSettings = (
   let k8sMetadata: K8sMetadata = {
     name: dsSettings.uid,
     namespace: namespace,
-    resourceVersion: '',
+    resourceVersion: dsSettings.version ? dsSettings.version.toString() : '',
     labels: { 'grafana.app/deprecatedInternalID': dsSettings.id.toString() },
     annotations: {},
   };
@@ -138,6 +138,10 @@ export const convertK8sDatasourceSettingsToLegacyDatasourceSettings = (
   // TODO: remove this once we figure out what code is using the deprecated
   // id field.
   let id = parseInt(dsK8sSettings.metadata.labels?.[DeprecatedInternalId] || '', 10);
+  let version = 0;
+  if (dsK8sSettings.metadata.resourceVersion) {
+    version = parseInt(dsK8sSettings.metadata.resourceVersion, 10);
+  }
   let dsSettings: DataSourceSettings = {
     id: id,
     uid: dsK8sSettings.metadata.name!,
@@ -145,6 +149,7 @@ export const convertK8sDatasourceSettingsToLegacyDatasourceSettings = (
     name: dsK8sSettings.spec.title,
     typeLogoUrl: '',
     type: dsK8sSettings.apiVersion.replace(/\.datasource\.grafana\.app\/[a-z0-9]+$/, ''),
+    version: version,
     typeName: '',
     access: dsK8sSettings.spec.access,
     url: dsK8sSettings.spec.url,


### PR DESCRIPTION
This is the UI part of fixing the mapping of legacy `data_source.version` to kubernetes ResourceVersion.

Accompanying PR for the backend: #126021 