### PR TITLE
Revert "`RBAC`: Use user context to fetch resource permissions"

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -24,6 +24,7 @@ import (
 	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -121,6 +122,11 @@ func (a *api) convertK8sResourcePermissionToDTO(ctx context.Context, resourcePer
 	}
 	orgID := namespaceInfo.OrgID
 
+	// Resolve subject names with a service identity: the caller is already authorized
+	// to read this resource's permissions but may lack users:read (e.g. an editor),
+	// which would otherwise leave the subject unnamed. Mirrors the legacy SQL join.
+	lookupCtx, _ := identity.WithServiceIdentity(ctx, orgID)
+
 	permissions := resourcePerm.Spec.Permissions
 	dto := make(getResourcePermissionsResponse, 0, len(permissions))
 
@@ -154,7 +160,7 @@ func (a *api) convertK8sResourcePermissionToDTO(ctx context.Context, resourcePer
 
 		switch kind {
 		case iamv0.ResourcePermissionSpecPermissionKindUser, iamv0.ResourcePermissionSpecPermissionKindServiceAccount:
-			userDetails, err := a.service.userService.GetByUID(ctx, &user.GetUserByUIDQuery{UID: name})
+			userDetails, err := a.service.userService.GetByUID(lookupCtx, &user.GetUserByUIDQuery{UID: name})
 			if err == nil {
 				permDTO.UserID = userDetails.ID
 				permDTO.UserUID = userDetails.UID
@@ -165,7 +171,7 @@ func (a *api) convertK8sResourcePermissionToDTO(ctx context.Context, resourcePer
 				permDTO.ID = a.getRoleIDFromK8sObject(permDTO.RoleName, orgID)
 			}
 		case iamv0.ResourcePermissionSpecPermissionKindTeam:
-			teamDetails, err := a.service.teamService.GetTeamByID(ctx, &team.GetTeamByIDQuery{
+			teamDetails, err := a.service.teamService.GetTeamByID(lookupCtx, &team.GetTeamByIDQuery{
 				UID:   name,
 				OrgID: orgID,
 			})


### PR DESCRIPTION
Reintroduce behavior from https://github.com/grafana/grafana/pull/125945

**Why:**

An admin of a folder / dashboard is allowed to view who has access to their resource.

It's also necessary to display the full info as the  iam app's resource permissions does not allow partial updates.