### PR TITLE
PanelEditorNext: Rudderstack events

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/BulkActionsBar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/BulkActionsBar.test.tsx
@@ -1,11 +1,19 @@
 import { screen, within } from '@testing-library/react';
 
 import { type DataSourceInstanceSettings } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 
 import { renderWithQueryEditorProvider } from '../testUtils';
 import { type Transformation } from '../types';
 
 import { BulkActionsBar } from './BulkActionsBar';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+const mockReportInteraction = jest.mocked(reportInteraction);
 
 // Replace DataSourceModal with a minimal test double to avoid loading its full dep tree.
 jest.mock('app/features/datasources/components/picker/DataSourceModal', () => ({
@@ -48,6 +56,10 @@ function renderBar(overrides: Parameters<typeof renderWithQueryEditorProvider>[1
 }
 
 describe('BulkActionsBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('visibility', () => {
     it('renders nothing when multi-select mode is off', () => {
       // Bulk arrays may linger; the bar is gated on the explicit multi-select mode.
@@ -98,6 +110,22 @@ describe('BulkActionsBar', () => {
       await user.click(screen.getByRole('button', { name: /clear selection/i }));
 
       expect(setMultiSelectMode).toHaveBeenCalledWith(false);
+    });
+
+    it('tracks an interaction when the clear button is clicked', async () => {
+      const { user } = renderBar({
+        uiStateOverrides: {
+          multiSelectMode: true,
+          selectedQueryRefIds: ['A', 'B'],
+        },
+      });
+
+      await user.click(screen.getByRole('button', { name: /clear selection/i }));
+
+      expect(mockReportInteraction).toHaveBeenCalledWith('grafana_panel_edit_next_interaction', {
+        action: 'toggle_multi_select',
+        direction: 'exit',
+      });
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/BulkActionsBar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/BulkActionsBar.tsx
@@ -8,6 +8,7 @@ import { isExpressionReference } from '@grafana/runtime';
 import { Button, ConfirmModal, type IconName, Stack, useStyles2 } from '@grafana/ui';
 import { DataSourceModal } from 'app/features/datasources/components/picker/DataSourceModal';
 
+import { trackMultiSelectToggle } from '../../tracking';
 import {
   useActionsContext,
   usePanelContext,
@@ -254,6 +255,7 @@ export function BulkActionsBar({ className }: BulkActionsBarProps = {}) {
   }
 
   const handleClear = () => {
+    trackMultiSelectToggle('exit');
     setMultiSelectMode(false);
   };
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.test.tsx
@@ -112,7 +112,8 @@ describe('SidebarFooter', () => {
 
       expect(setMultiSelectMode).toHaveBeenCalledWith(true);
       expect(mockReportInteraction).toHaveBeenCalledWith('grafana_panel_edit_next_interaction', {
-        action: 'click_multi_select',
+        action: 'toggle_multi_select',
+        direction: 'enter',
       });
     });
   });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
@@ -5,7 +5,7 @@ import { t } from '@grafana/i18n';
 import { Button, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
 
 import { FOOTER_HEIGHT, QueryEditorType } from '../../../constants';
-import { trackSelectButtonClick } from '../../../tracking';
+import { trackMultiSelectToggle } from '../../../tracking';
 import {
   useAlertingContext,
   usePanelContext,
@@ -53,7 +53,7 @@ export function SidebarFooter() {
 
   const handleSelectClick = () => {
     setMultiSelectMode(true);
-    trackSelectButtonClick();
+    trackMultiSelectToggle('enter');
   };
 
   return (

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.test.tsx
@@ -1,5 +1,7 @@
 import { screen } from '@testing-library/react';
 
+import { reportInteraction } from '@grafana/runtime';
+
 import { SidebarSize } from '../../constants';
 import { type QueryEditorUIState } from '../QueryEditorContext';
 import { ds1SettingsMock, makeStackedMode, renderWithQueryEditorProvider } from '../testUtils';
@@ -11,7 +13,10 @@ jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: () => ({
     getInstanceSettings: () => ds1SettingsMock,
   }),
+  reportInteraction: jest.fn(),
 }));
+
+const mockReportInteraction = jest.mocked(reportInteraction);
 
 describe('QueryEditorSidebar', () => {
   beforeEach(() => {
@@ -84,6 +89,24 @@ describe('QueryEditorSidebar', () => {
       expect(enter).toHaveBeenCalled();
     });
 
+    it('tracks an interaction when entering stacked mode', async () => {
+      const { user } = renderWithQueryEditorProvider(
+        <Sidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />,
+        {
+          uiStateOverrides: {
+            stackedMode: makeStackedMode({ enabled: false }),
+          } satisfies Partial<QueryEditorUIState>,
+        }
+      );
+
+      await user.click(screen.getByRole('button', { name: /enter stacked view/i }));
+
+      expect(mockReportInteraction).toHaveBeenCalledWith('grafana_panel_edit_next_interaction', {
+        action: 'toggle_stacked_view',
+        direction: 'enter',
+      });
+    });
+
     it('clicking exits stacked mode when currently enabled', async () => {
       const exit = jest.fn();
       const { user } = renderWithQueryEditorProvider(
@@ -98,6 +121,24 @@ describe('QueryEditorSidebar', () => {
       await user.click(screen.getByRole('button', { name: /exit stacked view/i }));
 
       expect(exit).toHaveBeenCalled();
+    });
+
+    it('tracks an interaction when exiting stacked mode', async () => {
+      const { user } = renderWithQueryEditorProvider(
+        <Sidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />,
+        {
+          uiStateOverrides: {
+            stackedMode: makeStackedMode({ enabled: true }),
+          } satisfies Partial<QueryEditorUIState>,
+        }
+      );
+
+      await user.click(screen.getByRole('button', { name: /exit stacked view/i }));
+
+      expect(mockReportInteraction).toHaveBeenCalledWith('grafana_panel_edit_next_interaction', {
+        action: 'toggle_stacked_view',
+        direction: 'exit',
+      });
     });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
@@ -7,7 +7,7 @@ import { IconButton, ScrollContainer, useStyles2 } from '@grafana/ui';
 
 import { SegmentedToggle, type SegmentedToggleProps } from '../../SegmentedToggle';
 import { QueryEditorType, type SidebarSize } from '../../constants';
-import { trackSidebarViewChange } from '../../tracking';
+import { trackSidebarViewChange, trackStackedViewToggle } from '../../tracking';
 import { useAlertingContext, useQueryEditorUIContext } from '../QueryEditorContext';
 import { getSelectedStackedItem } from '../StackedEditor/utils';
 import { EMPTY_ALERT } from '../types';
@@ -44,6 +44,16 @@ export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: Si
   const handleViewChange = (view: QueryEditorType) => {
     trackSidebarViewChange(view);
     setSelectedAlert(view === QueryEditorType.Alert ? (alertRules[0] ?? EMPTY_ALERT) : null);
+  };
+
+  const handleStackedModeToggle = () => {
+    if (stackedMode.enabled) {
+      trackStackedViewToggle('exit');
+      stackedMode.exit();
+    } else {
+      trackStackedViewToggle('enter');
+      stackedMode.enter();
+    }
   };
 
   const toggleValue = cardType === QueryEditorType.Alert ? QueryEditorType.Alert : QueryEditorType.Query;
@@ -83,7 +93,7 @@ export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: Si
               size="sm"
               variant="secondary"
               className={cx({ [styles.stackedModeActionButtonActive]: stackedMode.enabled })}
-              onClick={stackedMode.enabled ? stackedMode.exit : stackedMode.enter}
+              onClick={handleStackedModeToggle}
               aria-label={stackedModeLabel}
               aria-pressed={stackedMode.enabled}
               tooltip={stackedModeLabel}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -130,6 +130,13 @@ export function trackSidebarViewChange(view: QueryEditorType) {
   });
 }
 
+export function trackStackedViewToggle(direction: 'enter' | 'exit') {
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+    action: 'toggle_stacked_view',
+    direction,
+  });
+}
+
 export function trackQueryOptionsToggle(open: boolean) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
     action: 'toggle_query_options',
@@ -137,9 +144,10 @@ export function trackQueryOptionsToggle(open: boolean) {
   });
 }
 
-export function trackSelectButtonClick() {
+export function trackMultiSelectToggle(direction: 'enter' | 'exit') {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {
-    action: 'click_multi_select',
+    action: 'toggle_multi_select',
+    direction,
   });
 }
 


### PR DESCRIPTION
## Description
Adds RudderStack analytics for the query editor v2 (PanelEditNext) "Stacked view" toggle, and brings multi-select tracking to parity with it.

## Changes
* Add `trackStackedViewToggle('enter' | 'exit')` and emit it from the sidebar "Stacked view" button.
* Replace the one-off `trackSelectButtonClick` (`click_multi_select`) with a `direction`-discriminated `trackMultiSelectToggle('enter' | 'exit')`, fired on multi-select enter (footer button) and exit (bulk actions "Clear selection").
* Both reuse the shared `grafana_panel_edit_next_interaction` event, matching the existing `action` + `direction` toggle convention.
* Add/update unit tests for the new events.

## Risks
* Low — analytics-only, no behavioral changes to the editor.
* **Breaking for dashboards:** the `click_multi_select` event is renamed to `toggle_multi_select` (with `direction`); any RudderStack queries keyed on the old name must be updated.
* Implicit multi-select exits (bulk-delete, view switch, entering stacked mode) are intentionally not tracked — only explicit user toggles.

## Demo
<!-- Attach a screen recording of toggling stacked view + multi-select with the RudderStack/network events visible -->

## Testing Instructions
* Open a panel in the v2 query editor (PanelEditNext).
* Toggle the "Stacked view" button on/off → verify `grafana_panel_edit_next_interaction` fires with `action: 'toggle_stacked_view'` and `direction: 'enter' | 'exit'`.
* Click "Select" in the sidebar footer → verify `action: 'toggle_multi_select'`, `direction: 'enter'`.
* Click "Clear selection" in the bulk actions bar → verify `action: 'toggle_multi_select'`, `direction: 'exit'`.

## Reviewer Checklist
- [x] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable