### PR TITLE
Alerting: Skip quota check on rule group delete

### DIFF
--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -908,10 +908,9 @@ func (service *AlertRuleService) persistDelta(ctx context.Context, user identity
 					return err
 				}
 			}
-		}
-
-		if err := service.checkLimitsTransactionCtx(ctx, user); err != nil {
-			return err
+			if err := service.checkLimitsTransactionCtx(ctx, user); err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -3230,6 +3230,24 @@ func TestDeleteRuleGroups(t *testing.T) {
 		deletes := getDeletedRules(t, ruleStore)
 		require.Empty(t, deletes)
 	})
+
+	t.Run("succeeds even when quota is exceeded", func(t *testing.T) {
+		filterOpts := &FilterOptions{
+			NamespaceUIDs: []string{"namespace1"},
+			RuleGroups:    []string{"group1"},
+		}
+
+		service, _, _, ac := initServiceWithData(t)
+		ac.CanWriteAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+			return true, nil
+		}
+		checker := &MockQuotaChecker{}
+		checker.EXPECT().LimitExceeded()
+		service.quotas = checker
+
+		err := service.DeleteRuleGroups(context.Background(), u, models.ProvenanceAPI, filterOpts)
+		require.NoError(t, err)
+	})
 }
 
 func getDeleteQueries(ruleStore *fakes.RuleStore) []fakes.GenericRecordedQuery {


### PR DESCRIPTION
## Summary

- `persistDelta` was calling `checkLimitsTransactionCtx` unconditionally after every operation, including pure deletes
- When an org was at quota, `DELETE /api/convert/prometheus/config/v1/rules/{namespace}/{group}` returned 403 `quota has been exceeded`
- Quota only matters when inserting new rules — moved the check inside the `if len(delta.New) > 0` block

## Test plan

- [ ] `TestDeleteRuleGroups/succeeds_even_when_quota_is_exceeded` verifies delete succeeds when org is at quota
- [ ] Existing quota tests (`quota met causes create to be rejected`, `quota met causes group write to be rejected`) still pass — quota is still enforced for inserts

Fixes https://github.com/grafana/alerting-squad/issues/1783