### PR TITLE
[release-12.4.5] fix(plugins): forward Azure managed identity env vars to plugin proce…

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1355,6 +1355,8 @@ clouds_config = `[
 
 Specifies whether Grafana is running in Azure with Managed Identity configured (for example, running in a Azure Virtual Machines instance). Disabled by default, needs to be explicitly enabled.
 
+When enabled, Grafana automatically forwards the Azure platform's managed-identity discovery environment variables (`IDENTITY_ENDPOINT`, `IDENTITY_HEADER`, `IDENTITY_SERVER_THUMBPRINT`, `IMDS_ENDPOINT`, `MSI_ENDPOINT`, `MSI_SECRET`) to the Grafana-owned Azure plugins listed in [`forward_settings_to_plugins`](#forward_settings_to_plugins). This is required for the Azure SDK inside the plugin process to obtain tokens on Azure App Service, Azure Container Apps, Azure Arc, and Service Fabric, where managed-identity endpoints are not reachable via IMDS.
+
 #### `managed_identity_client_id`
 
 The client ID to use for user-assigned managed identity.
@@ -1368,6 +1370,8 @@ Specifies whether Entra ID Workload Identity authentication should be enabled in
 For more documentation on Entra ID Workload Identity, review [Entra ID Workload Identity](https://azure.github.io/azure-workload-identity/docs/) documentation.
 
 Disabled by default, needs to be explicitly enabled.
+
+When enabled, Grafana automatically forwards the workload-identity environment variables injected by the AKS `azure-workload-identity` webhook (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_FEDERATED_TOKEN_FILE`, `AZURE_AUTHORITY_HOST`) to the Grafana-owned Azure plugins listed in [`forward_settings_to_plugins`](#forward_settings_to_plugins). This is required for the Azure SDK inside the plugin process to perform federated token exchange.
 
 #### `workload_identity_tenant_id`
 

--- a/pkg/services/pluginsintegration/pluginconfig/envvars.go
+++ b/pkg/services/pluginsintegration/pluginconfig/envvars.go
@@ -67,7 +67,9 @@ func (p *EnvVarsProvider) PluginEnvVars(ctx context.Context, plugin *plugins.Plu
 	hostEnv = append(hostEnv, p.featureToggleEnableVars(ctx)...)
 	hostEnv = append(hostEnv, p.awsEnvVars(plugin.PluginID())...)
 	hostEnv = append(hostEnv, p.secureSocksProxyEnvVars()...)
-	hostEnv = append(hostEnv, azsettings.WriteToEnvStr(p.getAzureSettings())...)
+	azureSettings := p.getAzureSettings()
+	hostEnv = append(hostEnv, azsettings.WriteToEnvStr(azureSettings)...)
+	hostEnv = append(hostEnv, p.azureHostEnvVars(azureSettings, plugin.PluginID())...)
 	hostEnv = append(hostEnv, p.tracingEnvVars(plugin)...)
 	hostEnv = append(hostEnv, p.pluginSettingsEnvVars(plugin.PluginID())...)
 
@@ -151,6 +153,56 @@ var awsHostEnvVarNames = []string{
 	// Region
 	"AWS_REGION",
 	"AWS_DEFAULT_REGION",
+}
+
+// azureManagedIdentityHostEnvVarNames are host vars injected by Azure
+// platforms (App Service, Container Apps, Service Fabric, Arc, Cloud Shell)
+// that the azidentity SDK reads to locate the local managed identity
+// token endpoint. Without them the SDK falls back to IMDS, which is not
+// reachable on platforms like Azure Container Apps.
+var azureManagedIdentityHostEnvVarNames = []string{
+	"IDENTITY_ENDPOINT",
+	"IDENTITY_HEADER",
+	"IDENTITY_SERVER_THUMBPRINT",
+	"IMDS_ENDPOINT",
+	"MSI_ENDPOINT",
+	"MSI_SECRET",
+}
+
+// azureWorkloadIdentityHostEnvVarNames are host vars injected by the AKS
+// azure-workload-identity mutating webhook into pods that use Azure AD
+// Workload Identity federation.
+var azureWorkloadIdentityHostEnvVarNames = []string{
+	"AZURE_TENANT_ID",
+	"AZURE_CLIENT_ID",
+	"AZURE_FEDERATED_TOKEN_FILE",
+	"AZURE_AUTHORITY_HOST",
+}
+
+func (p *EnvVarsProvider) azureHostEnvVars(azureSettings *azsettings.AzureSettings, pluginID string) []string {
+	if azureSettings == nil {
+		return nil
+	}
+	if !slices.Contains(azureSettings.ForwardSettingsPlugins, pluginID) {
+		return nil
+	}
+
+	var variables []string
+	if azureSettings.ManagedIdentityEnabled {
+		for _, envVarName := range azureManagedIdentityHostEnvVarNames {
+			if v, ok := os.LookupEnv(envVarName); ok {
+				variables = append(variables, p.envVar(envVarName, v))
+			}
+		}
+	}
+	if azureSettings.WorkloadIdentityEnabled {
+		for _, envVarName := range azureWorkloadIdentityHostEnvVarNames {
+			if v, ok := os.LookupEnv(envVarName); ok {
+				variables = append(variables, p.envVar(envVarName, v))
+			}
+		}
+	}
+	return variables
 }
 
 func (p *EnvVarsProvider) secureSocksProxyEnvVars() []string {

--- a/pkg/services/pluginsintegration/pluginconfig/envvars_test.go
+++ b/pkg/services/pluginsintegration/pluginconfig/envvars_test.go
@@ -785,3 +785,160 @@ func TestPluginEnvVarsProvider_azureEnvVars(t *testing.T) {
 		}, envVars)
 	})
 }
+
+func TestPluginEnvVarsProvider_azureHostEnvVars(t *testing.T) {
+	tcs := []struct {
+		name                    string
+		pluginID                string
+		forwardSettingsPlugins  []string
+		managedIdentityEnabled  bool
+		workloadIdentityEnabled bool
+		hostEnvVars             map[string]string
+		expectedKeys            []string
+		unexpectedKeys          []string
+	}{
+		{
+			name:                   "forwards managed identity host vars when MSI enabled and plugin allowlisted",
+			pluginID:               "grafana-azure-data-explorer-datasource",
+			forwardSettingsPlugins: []string{"grafana-azure-data-explorer-datasource"},
+			managedIdentityEnabled: true,
+			hostEnvVars: map[string]string{
+				"IDENTITY_ENDPOINT": "http://localhost:42356/msi/token",
+				"IDENTITY_HEADER":   "header-value",
+			},
+			expectedKeys: []string{
+				"IDENTITY_ENDPOINT=http://localhost:42356/msi/token",
+				"IDENTITY_HEADER=header-value",
+			},
+		},
+		{
+			name:                    "forwards workload identity host vars when WI enabled and plugin allowlisted",
+			pluginID:                "grafana-azure-data-explorer-datasource",
+			forwardSettingsPlugins:  []string{"grafana-azure-data-explorer-datasource"},
+			workloadIdentityEnabled: true,
+			hostEnvVars: map[string]string{
+				"AZURE_TENANT_ID":            "tenant",
+				"AZURE_CLIENT_ID":            "client",
+				"AZURE_FEDERATED_TOKEN_FILE": "/var/run/secrets/azure/tokens/azure-identity-token",
+				"AZURE_AUTHORITY_HOST":       "https://login.microsoftonline.com/",
+			},
+			expectedKeys: []string{
+				"AZURE_TENANT_ID=tenant",
+				"AZURE_CLIENT_ID=client",
+				"AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/azure/tokens/azure-identity-token",
+				"AZURE_AUTHORITY_HOST=https://login.microsoftonline.com/",
+			},
+		},
+		{
+			name:                    "forwards both sets when both auth modes enabled",
+			pluginID:                "grafana-azure-monitor-datasource",
+			forwardSettingsPlugins:  []string{"grafana-azure-monitor-datasource"},
+			managedIdentityEnabled:  true,
+			workloadIdentityEnabled: true,
+			hostEnvVars: map[string]string{
+				"IDENTITY_ENDPOINT":          "http://localhost/msi",
+				"AZURE_FEDERATED_TOKEN_FILE": "/var/run/token",
+			},
+			expectedKeys: []string{
+				"IDENTITY_ENDPOINT=http://localhost/msi",
+				"AZURE_FEDERATED_TOKEN_FILE=/var/run/token",
+			},
+		},
+		{
+			name:                   "does not forward MSI host vars when MSI disabled even if plugin allowlisted",
+			pluginID:               "grafana-azure-data-explorer-datasource",
+			forwardSettingsPlugins: []string{"grafana-azure-data-explorer-datasource"},
+			managedIdentityEnabled: false,
+			hostEnvVars: map[string]string{
+				"IDENTITY_ENDPOINT": "http://localhost/msi",
+				"IDENTITY_HEADER":   "header",
+			},
+			unexpectedKeys: []string{"IDENTITY_ENDPOINT", "IDENTITY_HEADER"},
+		},
+		{
+			name:                    "does not forward workload identity host vars when WI disabled",
+			pluginID:                "grafana-azure-data-explorer-datasource",
+			forwardSettingsPlugins:  []string{"grafana-azure-data-explorer-datasource"},
+			workloadIdentityEnabled: false,
+			hostEnvVars: map[string]string{
+				"AZURE_FEDERATED_TOKEN_FILE": "/var/run/token",
+				"AZURE_CLIENT_ID":            "client",
+			},
+			unexpectedKeys: []string{"AZURE_FEDERATED_TOKEN_FILE", "AZURE_CLIENT_ID"},
+		},
+		{
+			name:                    "does not forward to plugins not in azure forward_settings_to_plugins",
+			pluginID:                "some-other-plugin",
+			forwardSettingsPlugins:  []string{"grafana-azure-data-explorer-datasource"},
+			managedIdentityEnabled:  true,
+			workloadIdentityEnabled: true,
+			hostEnvVars: map[string]string{
+				"IDENTITY_ENDPOINT":          "http://localhost/msi",
+				"AZURE_FEDERATED_TOKEN_FILE": "/var/run/token",
+			},
+			unexpectedKeys: []string{"IDENTITY_ENDPOINT", "AZURE_FEDERATED_TOKEN_FILE"},
+		},
+		{
+			name:                    "only forwards host vars that are actually set",
+			pluginID:                "grafana-azure-data-explorer-datasource",
+			forwardSettingsPlugins:  []string{"grafana-azure-data-explorer-datasource"},
+			managedIdentityEnabled:  true,
+			workloadIdentityEnabled: true,
+			hostEnvVars: map[string]string{
+				"IDENTITY_ENDPOINT": "http://localhost/msi",
+				"AZURE_CLIENT_ID":   "client",
+			},
+			expectedKeys: []string{
+				"IDENTITY_ENDPOINT=http://localhost/msi",
+				"AZURE_CLIENT_ID=client",
+			},
+			unexpectedKeys: []string{
+				"IDENTITY_HEADER", "MSI_ENDPOINT", "MSI_SECRET", "IMDS_ENDPOINT",
+				"AZURE_TENANT_ID", "AZURE_FEDERATED_TOKEN_FILE", "AZURE_AUTHORITY_HOST",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear any pre-existing Azure host env vars (e.g., from CI) that aren't
+			// explicitly set by this test case, so they don't leak into results.
+			for _, envVarName := range append(append([]string{}, azureManagedIdentityHostEnvVarNames...), azureWorkloadIdentityHostEnvVarNames...) {
+				if _, ok := tc.hostEnvVars[envVarName]; !ok {
+					require.NoError(t, os.Unsetenv(envVarName))
+				}
+			}
+			for k, v := range tc.hostEnvVars {
+				t.Setenv(k, v)
+			}
+
+			p := &plugins.Plugin{
+				JSONData: plugins.JSONData{
+					ID: tc.pluginID,
+				},
+			}
+			cfg := &setting.Cfg{
+				Raw: ini.Empty(),
+				Azure: &azsettings.AzureSettings{
+					ManagedIdentityEnabled:  tc.managedIdentityEnabled,
+					WorkloadIdentityEnabled: tc.workloadIdentityEnabled,
+					ForwardSettingsPlugins:  tc.forwardSettingsPlugins,
+				},
+			}
+
+			pCfg, err := ProvidePluginInstanceConfig(cfg, setting.ProvideProvider(cfg), featuremgmt.WithFeatures())
+			require.NoError(t, err)
+
+			provider := NewEnvVarsProvider(pCfg, nil, &fakeSSOSettingsProvider{})
+			envVars := provider.PluginEnvVars(context.Background(), p)
+
+			for _, expected := range tc.expectedKeys {
+				assert.Contains(t, envVars, expected, "expected env var %s to be forwarded", expected)
+			}
+			for _, key := range tc.unexpectedKeys {
+				_, ok := getEnvVarWithExists(envVars, key)
+				assert.False(t, ok, "env var %s should not be forwarded", key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backporting to v12.4.5 for https://github.com/grafana/grafana/pull/125170

Manually creating this PR since https://github.com/grafana/grafana/pull/125170 did not create automatic backporting PR to v12.4.5