### PR TITLE
PanelEditNext: Exit multi-select when deleting a card from its header

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.test.ts
@@ -466,22 +466,23 @@ describe('QueryEditorContextWrapper - delete actions', () => {
     });
   });
 
-  it('deleteQuery removes the deleted refId from selectedQueryRefIds', () => {
+  it('exits multi-select mode and clears the bulk selection when a query is deleted from its header', () => {
     const dataPane = makeMockDataPane();
     const { result } = renderWithBothContexts(dataPane);
 
-    // Populate the bulk array via multi-select; the active path no longer mirrors bulk.
     act(() => result.current.ui.setMultiSelectMode(true));
     act(() => result.current.ui.toggleQuerySelection({ refId: 'A' } as DataQuery, { multi: true }));
     act(() => result.current.ui.toggleQuerySelection({ refId: 'B' } as DataQuery, { multi: true }));
+    expect(result.current.ui.multiSelectMode).toBe(true);
     expect(result.current.ui.selectedQueryRefIds).toEqual(['A', 'B']);
 
     act(() => result.current.actions.deleteQuery('A'));
 
-    expect(result.current.ui.selectedQueryRefIds).toEqual(['B']);
+    expect(result.current.ui.multiSelectMode).toBe(false);
+    expect(result.current.ui.selectedQueryRefIds).toEqual([]);
   });
 
-  it('deleteTransformation removes the deleted id from selectedTransformationIds', () => {
+  it('exits multi-select mode and clears the bulk selection when a transformation is deleted from its header', () => {
     const { useTransformations } = require('./hooks/useTransformations');
     const mockTransformation: Transformation = {
       registryItem: undefined,
@@ -501,11 +502,13 @@ describe('QueryEditorContextWrapper - delete actions', () => {
     act(() => result.current.ui.setMultiSelectMode(true));
     act(() => result.current.ui.toggleTransformationSelection(mockTransformation, { multi: true }));
     act(() => result.current.ui.toggleTransformationSelection(otherTransformation, { multi: true }));
+    expect(result.current.ui.multiSelectMode).toBe(true);
     expect(result.current.ui.selectedTransformationIds).toEqual(['reduce-0', 'organize-1']);
 
     act(() => result.current.actions.deleteTransformation('reduce-0'));
 
-    expect(result.current.ui.selectedTransformationIds).toEqual(['organize-1']);
+    expect(result.current.ui.multiSelectMode).toBe(false);
+    expect(result.current.ui.selectedTransformationIds).toEqual([]);
   });
 });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.test.ts
@@ -124,6 +124,22 @@ function renderWithWrapper(dataPane: PanelDataPaneNext) {
   });
 }
 
+// Multi-select can only be entered when there are cards to seed, so tests that exercise it
+// must expose queries through the (otherwise null) query runner.
+function mockQueryRunnerQueries(queries: DataQuery[]) {
+  const { getQueryRunnerFor } = require('../../../utils/utils');
+  getQueryRunnerFor.mockReturnValue({ useState: () => ({ queries }) });
+}
+
+// Restore the defaults (no query runner, no transformations) after every test so cards set by
+// one test can't leak into the next and silently satisfy the "has cards" multi-select guard.
+afterEach(() => {
+  const { getQueryRunnerFor } = require('../../../utils/utils');
+  getQueryRunnerFor.mockReturnValue(null);
+  const { useTransformations } = require('./hooks/useTransformations');
+  useTransformations.mockReturnValue([]);
+});
+
 // ---- Tests ----
 
 describe('QueryEditorContextWrapper - side effect clearing', () => {
@@ -176,6 +192,7 @@ describe('QueryEditorContextWrapper - alert selection', () => {
   });
 
   it('keeps bulk selection when selecting a query card in multi-select mode', () => {
+    mockQueryRunnerQueries([{ refId: 'A' }, { refId: 'B' }] as DataQuery[]);
     const { result } = renderWithWrapper(makeMockDataPane());
 
     act(() => result.current.setMultiSelectMode(true));
@@ -189,6 +206,7 @@ describe('QueryEditorContextWrapper - alert selection', () => {
   });
 
   it('exits multi-select mode when an alert is selected', () => {
+    mockQueryRunnerQueries([{ refId: 'A' }] as DataQuery[]);
     const { result } = renderWithWrapper(makeMockDataPane());
 
     act(() => result.current.setMultiSelectMode(true));
@@ -202,6 +220,7 @@ describe('QueryEditorContextWrapper - alert selection', () => {
   });
 
   it('clears bulk query and transformation selection when an alert is selected', () => {
+    mockQueryRunnerQueries([{ refId: 'A' }, { refId: 'B' }] as DataQuery[]);
     const { result } = renderWithWrapper(makeMockDataPane());
 
     // Populate bulk arrays via multi-select mode so the assertion is meaningful.
@@ -239,6 +258,7 @@ describe('QueryEditorContextWrapper - clearSelection', () => {
   });
 
   it('exits multi-select mode and empties bulk selection', () => {
+    mockQueryRunnerQueries([{ refId: 'A' }, { refId: 'B' }] as DataQuery[]);
     const { result } = renderWithWrapper(makeMockDataPane());
 
     act(() => result.current.setMultiSelectMode(true));
@@ -347,6 +367,7 @@ describe('QueryEditorContextWrapper - selection toggles', () => {
   });
 
   it('clears the bulk selection when multi-select mode is turned off via setMultiSelectMode', () => {
+    mockQueryRunnerQueries([{ refId: 'A' }] as DataQuery[]);
     const { result } = renderWithWrapper(makeMockDataPane());
 
     act(() => result.current.setMultiSelectMode(true));
@@ -357,6 +378,18 @@ describe('QueryEditorContextWrapper - selection toggles', () => {
 
     expect(result.current.multiSelectMode).toBe(false);
     expect(result.current.selectedQueryRefIds).toEqual([]);
+  });
+
+  it('does not enter multi-select mode when there are no queries or transformations', () => {
+    // No query runner queries and no transformations: there is nothing to seed, so a later
+    // added card would arrive unchecked. Entering multi-select must be refused.
+    const { result } = renderWithWrapper(makeMockDataPane());
+
+    act(() => result.current.setMultiSelectMode(true));
+
+    expect(result.current.multiSelectMode).toBe(false);
+    expect(result.current.selectedQueryRefIds).toEqual([]);
+    expect(result.current.selectedTransformationIds).toEqual([]);
   });
 });
 
@@ -467,6 +500,7 @@ describe('QueryEditorContextWrapper - delete actions', () => {
   });
 
   it('exits multi-select mode and clears the bulk selection when a query is deleted from its header', () => {
+    mockQueryRunnerQueries([{ refId: 'A' }, { refId: 'B' }] as DataQuery[]);
     const dataPane = makeMockDataPane();
     const { result } = renderWithBothContexts(dataPane);
 
@@ -510,6 +544,38 @@ describe('QueryEditorContextWrapper - delete actions', () => {
     expect(result.current.ui.multiSelectMode).toBe(false);
     expect(result.current.ui.selectedTransformationIds).toEqual([]);
   });
+
+  it('seeds the promoted transformation when re-entering multi-select after a header delete', () => {
+    const { useTransformations } = require('./hooks/useTransformations');
+    const reduce: Transformation = {
+      registryItem: undefined,
+      transformId: 'reduce-0',
+      transformConfig: { id: 'reduce', options: {} },
+    };
+    const organize: Transformation = {
+      registryItem: undefined,
+      transformId: 'organize-1',
+      transformConfig: { id: 'organize', options: {} },
+    };
+    useTransformations.mockReturnValue([reduce, organize]);
+
+    const { result } = renderWithBothContexts(makeMockDataPane());
+
+    // Activate a transformation and enter multi-select so it is seeded/checked.
+    act(() => result.current.ui.setSelectedTransformation(reduce));
+    act(() => result.current.ui.setMultiSelectMode(true));
+    expect(result.current.ui.selectedTransformationIds).toEqual(['reduce-0']);
+
+    // Deleting it from the header exits multi-select and promotes the remaining transformation.
+    act(() => result.current.actions.deleteTransformation('reduce-0'));
+    expect(result.current.ui.multiSelectMode).toBe(false);
+
+    // Re-entering multi-select seeds the promoted (active) card, so it is checked rather than
+    // highlighted-but-unchecked.
+    act(() => result.current.ui.setMultiSelectMode(true));
+    expect(result.current.ui.multiSelectMode).toBe(true);
+    expect(result.current.ui.selectedTransformationIds).toEqual(['organize-1']);
+  });
 });
 
 // Regression: opening a pending picker (+Expression / +Transformation) while in multi-select
@@ -533,6 +599,7 @@ describe('QueryEditorContextWrapper - pending picker cancel preserves multi-sele
   });
 
   it('preserves bulk query selection and multi-select mode when cancelling a pending expression', () => {
+    mockQueryRunnerQueries([{ refId: 'A' }, { refId: 'B' }] as DataQuery[]);
     const { result } = renderWithWrapper(makeMockDataPane());
 
     act(() => result.current.setMultiSelectMode(true));

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -444,6 +444,9 @@ export function QueryEditorContextWrapper({
       deleteQuery: (refId: string) => {
         dataPane.deleteQuery(refId);
         removeQueryFromSelection(refId);
+        // Deleting a card from its header exits multi-select mode so the checkboxes and bulk-actions
+        // footer revert together instead of leaving a desynced multi-select state behind.
+        setMultiSelectModeState(false);
       },
       duplicateQuery: dataPane.duplicateQuery,
       toggleQueryHide: dataPane.toggleQueryHide,
@@ -459,6 +462,9 @@ export function QueryEditorContextWrapper({
           dataPane.deleteTransformation(index);
         }
         removeTransformationFromSelection(transformId);
+        // Deleting a card from its header exits multi-select mode so the checkboxes and bulk-actions
+        // footer revert together instead of leaving a desynced multi-select state behind.
+        setMultiSelectModeState(false);
       },
       toggleTransformationDisabled: (transformId: string) => {
         const index = findTransformationIndex(transformId);
@@ -489,6 +495,7 @@ export function QueryEditorContextWrapper({
       onSwitchToClassic,
       removeQueryFromSelection,
       removeTransformationFromSelection,
+      setMultiSelectModeState,
       trackQueryRename,
     ]
   );

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -179,6 +179,12 @@ export function QueryEditorContextWrapper({
   const setMultiSelectModeState = useCallback(
     (enabled: boolean) => {
       if (enabled) {
+        // Nothing to select means multi-select would have an empty set, and a card added later
+        // would arrive unchecked — so refuse to enter the mode until there's a card to seed.
+        const hasCards = (queryRunnerState?.queries?.length ?? 0) + transformations.length > 0;
+        if (!hasCards) {
+          return;
+        }
         // Multi-select and stacked mode are mutually exclusive, so leaving stacked mode here
         // keeps the two views from being active at once before seeding the bulk selection.
         exitStackedMode();
@@ -188,7 +194,13 @@ export function QueryEditorContextWrapper({
       }
       setMultiSelectMode(enabled);
     },
-    [exitStackedMode, clearMultiSelectionRaw, selectActiveInMultiSelectionRaw]
+    [
+      queryRunnerState?.queries,
+      transformations,
+      exitStackedMode,
+      clearMultiSelectionRaw,
+      selectActiveInMultiSelectionRaw,
+    ]
   );
 
   // Wraps onCardSelectionChange with a UI reset for use in finalizePendingExpression /

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.test.tsx
@@ -104,7 +104,9 @@ describe('SidebarFooter', () => {
 
     it('should enable multi-select mode and track when select is clicked', async () => {
       const setMultiSelectMode = jest.fn();
+      const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
       const { user } = renderWithQueryEditorProvider(<SidebarFooter />, {
+        queries,
         uiStateOverrides: { setMultiSelectMode },
       });
 
@@ -114,6 +116,19 @@ describe('SidebarFooter', () => {
       expect(mockReportInteraction).toHaveBeenCalledWith('grafana_panel_edit_next_interaction', {
         action: 'click_multi_select',
       });
+    });
+
+    it('should disable the select button when there are no items', () => {
+      renderWithQueryEditorProvider(<SidebarFooter />);
+
+      expect(screen.getByRole('button', { name: /select multiple items/i })).toBeDisabled();
+    });
+
+    it('should enable the select button when there is at least one item', () => {
+      const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
+      renderWithQueryEditorProvider(<SidebarFooter />, { queries });
+
+      expect(screen.getByRole('button', { name: /select multiple items/i })).toBeEnabled();
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
@@ -72,6 +72,7 @@ export function SidebarFooter() {
                 size="sm"
                 variant="secondary"
                 icon="checkbox-multiple"
+                disabled={total === 0}
                 onClick={handleSelectClick}
                 aria-label={t('query-editor-next.sidebar.footer-select-label', 'Select multiple items')}
               >

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.test.ts
@@ -497,12 +497,42 @@ describe('useSelectionState', () => {
       expect(result.current.selectedTransformationIds).toEqual(['tx-2']);
     });
 
-    it('clears the active transformation when the active one is removed', () => {
+    it('promotes the first remaining transformation when the active one is removed', () => {
       const { result } = setup();
       act(() => result.current.activateTransformation(mockTransformations[1]));
       expect(result.current.activeTransformationId).toBe('tx-1');
       act(() => result.current.removeTransformationFromSelection('tx-1'));
+      // A real card stays active so multi-select can seed it on re-entry instead of falling
+      // back to the display-only card (which would be highlighted but unchecked).
+      expect(result.current.activeTransformationId).toBe('tx-0');
+      expect(result.current.activeQueryRefId).toBeNull();
+    });
+
+    it('promotes the first query when the last remaining transformation is removed', () => {
+      const { result } = setup({ ...defaultProps, transformations: [mockTransformations[0]] });
+      act(() => result.current.activateTransformation(mockTransformations[0]));
+      expect(result.current.activeTransformationId).toBe('tx-0');
+      act(() => result.current.removeTransformationFromSelection('tx-0'));
       expect(result.current.activeTransformationId).toBeNull();
+      expect(result.current.activeQueryRefId).toBe('A');
+    });
+
+    it('leaves the active transformation untouched when a different one is removed', () => {
+      const { result } = setup();
+      act(() => result.current.activateTransformation(mockTransformations[1]));
+      act(() => result.current.removeTransformationFromSelection('tx-0'));
+      expect(result.current.activeTransformationId).toBe('tx-1');
+    });
+
+    it('seeds the promoted card into multi-select after the active transformation is removed', () => {
+      const { result } = setup({ ...defaultProps, transformations: [mockTransformations[0]] });
+      act(() => result.current.activateTransformation(mockTransformations[0]));
+      act(() => result.current.removeTransformationFromSelection('tx-0'));
+      act(() => result.current.selectActiveInMultiSelection());
+      // The promoted query is checked, matching the highlighted card — no "selected but
+      // unchecked" state on multi-select re-entry.
+      expect(result.current.selectedTransformationIds).toEqual([]);
+      expect(result.current.selectedQueryRefIds).toEqual(['A']);
     });
 
     it('clears the anchor so a later Shift+Click no longer ranges from the removed transformation', () => {
@@ -516,14 +546,43 @@ describe('useSelectionState', () => {
   });
 
   describe('reconciling the active transformation with the list', () => {
-    it('clears the active transformation when it is removed from the transformations list', () => {
+    it('promotes the first remaining transformation when the active one is removed from the list', () => {
       const { result, rerender } = renderHook((props: UseSelectionStateOptions) => useSelectionState(props), {
         initialProps: defaultProps,
       });
       act(() => result.current.activateTransformation(mockTransformations[1]));
       expect(result.current.activeTransformationId).toBe('tx-1');
       rerender({ ...defaultProps, transformations: mockTransformations.filter((t) => t.transformId !== 'tx-1') });
-      expect(result.current.activeTransformationId).toBeNull();
+      expect(result.current.activeTransformationId).toBe('tx-0');
+    });
+
+    it('promotes a surviving transformation after a delete reindexes the ids', () => {
+      // Transformation ids are `${configId}-${index}`, so deleting the first one reindexes the
+      // rest (organize-1 -> organize-0). The active id must follow the survivor, otherwise
+      // re-entering multi-select would seed nothing (highlighted-but-unchecked card).
+      const initial: Transformation[] = [
+        { transformId: 'reduce-0', registryItem: undefined, transformConfig: { id: 'reduce', options: {} } },
+        { transformId: 'organize-1', registryItem: undefined, transformConfig: { id: 'organize', options: {} } },
+      ];
+      const { result, rerender } = renderHook((props: UseSelectionStateOptions) => useSelectionState(props), {
+        initialProps: { queries: [], transformations: initial },
+      });
+      act(() => result.current.activateTransformation(initial[0]));
+      expect(result.current.activeTransformationId).toBe('reduce-0');
+
+      // Delete reduce-0 and let the scene reindex the survivor to organize-0.
+      act(() => result.current.removeTransformationFromSelection('reduce-0'));
+      rerender({
+        queries: [],
+        transformations: [
+          { transformId: 'organize-0', registryItem: undefined, transformConfig: { id: 'organize', options: {} } },
+        ],
+      });
+
+      expect(result.current.activeTransformationId).toBe('organize-0');
+
+      act(() => result.current.selectActiveInMultiSelection());
+      expect(result.current.selectedTransformationIds).toEqual(['organize-0']);
     });
 
     it('falls back to the first query when all transformations are removed', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.test.ts
@@ -525,6 +525,83 @@ describe('useSelectionState', () => {
       rerender({ ...defaultProps, transformations: mockTransformations.filter((t) => t.transformId !== 'tx-1') });
       expect(result.current.activeTransformationId).toBeNull();
     });
+
+    it('falls back to the first query when all transformations are removed', () => {
+      const { result, rerender } = renderHook((props: UseSelectionStateOptions) => useSelectionState(props), {
+        initialProps: defaultProps,
+      });
+      act(() => result.current.activateTransformation(mockTransformations[1]));
+      expect(result.current.activeTransformationId).toBe('tx-1');
+      expect(result.current.activeQueryRefId).toBeNull();
+      rerender({ ...defaultProps, transformations: [] });
+      expect(result.current.activeTransformationId).toBeNull();
+      expect(result.current.activeQueryRefId).toBe('A');
+    });
+
+    it('clears the active card when all transformations are removed and no queries exist', () => {
+      const { result, rerender } = renderHook((props: UseSelectionStateOptions) => useSelectionState(props), {
+        initialProps: { ...defaultProps, queries: [] },
+      });
+      act(() => result.current.activateTransformation(mockTransformations[1]));
+      expect(result.current.activeTransformationId).toBe('tx-1');
+      rerender({ ...defaultProps, queries: [], transformations: [] });
+      expect(result.current.activeTransformationId).toBeNull();
+      expect(result.current.activeQueryRefId).toBeNull();
+    });
+
+    it('seeds the first query into multi-select after all transformations are removed', () => {
+      const { result, rerender } = renderHook((props: UseSelectionStateOptions) => useSelectionState(props), {
+        initialProps: defaultProps,
+      });
+      act(() => result.current.activateTransformation(mockTransformations[1]));
+      rerender({ ...defaultProps, transformations: [] });
+      act(() => result.current.selectActiveInMultiSelection());
+      expect(result.current.selectedTransformationIds).toEqual([]);
+      expect(result.current.selectedQueryRefIds).toEqual(['A']);
+    });
+  });
+
+  describe('reconciling the active query with the list', () => {
+    it('falls back to the first remaining query when the active query is removed', () => {
+      const { result, rerender } = renderHook((props: UseSelectionStateOptions) => useSelectionState(props), {
+        initialProps: defaultProps,
+      });
+      act(() => result.current.activateQuery({ refId: 'B' }));
+      expect(result.current.activeQueryRefId).toBe('B');
+      rerender({ ...defaultProps, queries: mockQueries.filter((q) => q.refId !== 'B') });
+      expect(result.current.activeQueryRefId).toBe('A');
+      expect(result.current.activeTransformationId).toBeNull();
+    });
+
+    it('falls back to the first transformation when all queries are removed', () => {
+      const { result, rerender } = renderHook((props: UseSelectionStateOptions) => useSelectionState(props), {
+        initialProps: defaultProps,
+      });
+      expect(result.current.activeQueryRefId).toBe('A');
+      rerender({ ...defaultProps, queries: [] });
+      expect(result.current.activeQueryRefId).toBeNull();
+      expect(result.current.activeTransformationId).toBe('tx-0');
+    });
+
+    it('clears the active card when all queries are removed and no transformations exist', () => {
+      const { result, rerender } = renderHook((props: UseSelectionStateOptions) => useSelectionState(props), {
+        initialProps: { ...defaultProps, transformations: [] },
+      });
+      expect(result.current.activeQueryRefId).toBe('A');
+      rerender({ ...defaultProps, queries: [], transformations: [] });
+      expect(result.current.activeQueryRefId).toBeNull();
+      expect(result.current.activeTransformationId).toBeNull();
+    });
+
+    it('seeds the first transformation into multi-select after all queries are removed', () => {
+      const { result, rerender } = renderHook((props: UseSelectionStateOptions) => useSelectionState(props), {
+        initialProps: defaultProps,
+      });
+      rerender({ ...defaultProps, queries: [] });
+      act(() => result.current.selectActiveInMultiSelection());
+      expect(result.current.selectedQueryRefIds).toEqual([]);
+      expect(result.current.selectedTransformationIds).toEqual(['tx-0']);
+    });
   });
 
   describe('range selection with an unknown card', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
@@ -136,10 +136,11 @@ export function useSelectionState({
 
   useEffect(() => {
     if (activeTransformationId !== null && !transformations.some((t) => t.transformId === activeTransformationId)) {
-      setActiveTransformationId(null);
-      // No transformations left: promote the first query to active so a card stays
+      const nextTransformationId = transformations[0]?.transformId ?? null;
+      setActiveTransformationId(nextTransformationId);
+      // No transformations left: fall back to the first query so a card stays
       // active (and gets seeded into multi-select on re-entry).
-      if (transformations.length === 0) {
+      if (nextTransformationId === null) {
         setActiveQueryRefId(queries[0]?.refId ?? null);
       }
     }
@@ -320,7 +321,18 @@ export function useSelectionState({
 
   const removeTransformationFromSelection = useCallback((transformId: string) => {
     setSelectedTransformationIds((current) => current.filter((id) => id !== transformId));
-    setActiveTransformationId((current) => (current === transformId ? null : current));
+    if (activeTransformationIdRef.current === transformId) {
+      const remaining = transformationsRef.current.filter((t) => t.transformId !== transformId);
+      if (remaining.length > 0) {
+        // Stay within transformations: promote the next one so a real card stays active.
+        setActiveTransformationId(remaining[0].transformId);
+      } else {
+        // No transformations left — promote the first query so re-entering multi-select seeds a
+        // real, checkable card instead of useSelectedCard's display-only fallback.
+        setActiveTransformationId(null);
+        setActiveQueryRefId(queriesRef.current[0]?.refId ?? null);
+      }
+    }
     if (transformationAnchorRef.current === transformId) {
       transformationAnchorRef.current = null;
     }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
@@ -124,15 +124,26 @@ export function useSelectionState({
   // to seed stale ids into the bulk set.
   useEffect(() => {
     if (activeQueryRefId !== null && !queries.some((q) => q.refId === activeQueryRefId)) {
-      setActiveQueryRefId(queries[0]?.refId ?? null);
+      const nextQueryRefId = queries[0]?.refId ?? null;
+      setActiveQueryRefId(nextQueryRefId);
+      // No queries left: fall back to the first transformation so a card stays
+      // active (and gets seeded into multi-select on re-entry).
+      if (nextQueryRefId === null) {
+        setActiveTransformationId(transformations[0]?.transformId ?? null);
+      }
     }
-  }, [queries, activeQueryRefId]);
+  }, [queries, activeQueryRefId, transformations]);
 
   useEffect(() => {
     if (activeTransformationId !== null && !transformations.some((t) => t.transformId === activeTransformationId)) {
       setActiveTransformationId(null);
+      // No transformations left: promote the first query to active so a card stays
+      // active (and gets seeded into multi-select on re-entry).
+      if (transformations.length === 0) {
+        setActiveQueryRefId(queries[0]?.refId ?? null);
+      }
     }
-  }, [transformations, activeTransformationId]);
+  }, [transformations, activeTransformationId, queries]);
 
   const onCardSelectionChange = useCallback(
     (queryRefId: string | null, transformationId: string | null, options?: { seedBulk?: boolean }) => {


### PR DESCRIPTION
## What

Fix multi-select state desync in the next-gen panel query editor when deleting queries/transformations from the content-header delete button, and prevent entering multi-select when there's nothing to select.

## Why

Multi-select mode could end up out of sync with the cards rendered in the sidebar, leaving the user in a confusing "a card looks selected but its checkbox is empty" state — or in multi-select with no checkable cards at all. This was especially visible with transformations, whose ids are index-based (`${configId}-${index}`) and get reindexed on delete.

## Scenarios fixed

- **Delete the active card from its header while in multi-select** → multi-select mode now exits so the checkboxes and the bulk-actions footer revert together, instead of leaving a desynced multi-select state behind.
- **Enter multi-select with no queries and no transformations** → the "Select…" footer button is disabled and `setMultiSelectMode(true)` is a no-op, so you can't enter a mode with an empty selection where a later-added card would arrive unchecked.
- **Delete the last query while transformations remain (or vice-versa)** → the active card now falls back across lists (first transformation when queries are emptied, first query when transformations are emptied) so a real card stays active and gets seeded into multi-select on re-entry, rather than relying on the display-only fallback in `useSelectedCard`.
- **Highlight a transformation, delete it from the header, then re-enter multi-select** → because transformation ids are index-based and reindex on delete, the previously-active id would dangle and the active card would reset to nothing, producing empty checkboxes. The reconciliation effect now promotes the first remaining transformation (and `removeTransformationFromSelection` keeps a real card active), so the promoted card is seeded/checked on re-entry — matching how queries already behaved.

## Changes

- `QueryEditorContextWrapper.tsx`: guard `setMultiSelectModeState` against entering with no cards; exit multi-select after `deleteQuery` / `deleteTransformation` from the header.
- `useSelectionState.ts`: make the active-id reconciliation effects symmetric so each type falls back to the other when its list empties; promote a surviving transformation in `removeTransformationFromSelection`.
- `SidebarFooter.tsx`: disable the "Select…" button when there are no items.

## Testing

- `yarn jest public/app/features/dashboard-scene/panel-edit/PanelEditNext` — all suites pass.
- Added/updated unit tests in `useSelectionState.test.ts` (incl. an id-reindex regression case), `QueryEditorContextWrapper.test.ts`, and `SidebarFooter.test.tsx`.