### PR TITLE
AuthZ: Surface external groups to forward Check via client decorator (alt to #126197)

### DIFF
--- a/pkg/services/authz/external_groups_client.go
+++ b/pkg/services/authz/external_groups_client.go
@@ -1,0 +1,67 @@
+package authz
+
+import (
+	"context"
+
+	authlib "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// newExternalGroupsAccessClient decorates an AccessClient so that, when
+// id_use_external_groups_for_groups_claim is set, the contextual team-membership
+// tuples the forward authz path derives from AuthInfo.GetGroups() come from the
+// IdP/proxy-supplied external groups (external group names match team UIDs) instead
+// of Grafana-stored team memberships.
+//
+// This is the authz-boundary alternative to setting Identity.Groups during authn:
+// it confines the flag handling to the forward Check/Compile/BatchCheck path without
+// changing the identity seen by the rest of the system. When the flag is off it is a
+// no-op and returns the inner client unchanged (preserving any wider interface it
+// implements, e.g. zanzana.Client).
+func newExternalGroupsAccessClient(cfg *setting.Cfg, inner authlib.AccessClient) authlib.AccessClient {
+	if cfg == nil || !cfg.IDUseExternalGroupsForGroupsClaim {
+		return inner
+	}
+	return &externalGroupsAccessClient{inner: inner}
+}
+
+type externalGroupsAccessClient struct {
+	inner authlib.AccessClient
+}
+
+// swap returns an AuthInfo whose GetGroups() yields the identity's external groups,
+// leaving every other AuthInfo method delegated to the original.
+func (c *externalGroupsAccessClient) swap(info authlib.AuthInfo) authlib.AuthInfo {
+	r, ok := info.(identity.Requester)
+	if !ok {
+		return info
+	}
+	ext := r.GetExternalGroups()
+	if len(ext) == 0 {
+		return info
+	}
+	return externalGroupsAuthInfo{AuthInfo: info, groups: ext}
+}
+
+func (c *externalGroupsAccessClient) Check(ctx context.Context, info authlib.AuthInfo, req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+	return c.inner.Check(ctx, c.swap(info), req, folder)
+}
+
+func (c *externalGroupsAccessClient) Compile(ctx context.Context, info authlib.AuthInfo, req authlib.ListRequest) (authlib.ItemChecker, authlib.Zookie, error) {
+	return c.inner.Compile(ctx, c.swap(info), req)
+}
+
+func (c *externalGroupsAccessClient) BatchCheck(ctx context.Context, info authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+	return c.inner.BatchCheck(ctx, c.swap(info), req)
+}
+
+// externalGroupsAuthInfo overrides GetGroups() to return external groups while
+// delegating all other AuthInfo methods to the embedded value.
+type externalGroupsAuthInfo struct {
+	authlib.AuthInfo
+	groups []string
+}
+
+func (e externalGroupsAuthInfo) GetGroups() []string { return e.groups }

--- a/pkg/services/authz/external_groups_client.go
+++ b/pkg/services/authz/external_groups_client.go
@@ -9,17 +9,10 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-// newExternalGroupsAccessClient decorates an AccessClient so that, when
-// id_use_external_groups_for_groups_claim is set, the contextual team-membership
-// tuples the forward authz path derives from AuthInfo.GetGroups() come from the
-// IdP/proxy-supplied external groups (external group names match team UIDs) instead
-// of Grafana-stored team memberships.
-//
-// This is the authz-boundary alternative to setting Identity.Groups during authn:
-// it confines the flag handling to the forward Check/Compile/BatchCheck path without
-// changing the identity seen by the rest of the system. When the flag is off it is a
-// no-op and returns the inner client unchanged (preserving any wider interface it
-// implements, e.g. zanzana.Client).
+// newExternalGroupsAccessClient decorates an AccessClient so that, under
+// id_use_external_groups_for_groups_claim, the forward authz path sources its contextual
+// team membership from the identity's external groups instead of stored team memberships.
+// No-op (returns inner unchanged) when the flag is off.
 func newExternalGroupsAccessClient(cfg *setting.Cfg, inner authlib.AccessClient) authlib.AccessClient {
 	if cfg == nil || !cfg.IDUseExternalGroupsForGroupsClaim {
 		return inner
@@ -31,8 +24,7 @@ type externalGroupsAccessClient struct {
 	inner authlib.AccessClient
 }
 
-// swap returns an AuthInfo whose GetGroups() yields the identity's external groups,
-// leaving every other AuthInfo method delegated to the original.
+// swap returns an AuthInfo whose GetGroups() yields the external groups.
 func (c *externalGroupsAccessClient) swap(info authlib.AuthInfo) authlib.AuthInfo {
 	r, ok := info.(identity.Requester)
 	if !ok {
@@ -57,8 +49,7 @@ func (c *externalGroupsAccessClient) BatchCheck(ctx context.Context, info authli
 	return c.inner.BatchCheck(ctx, c.swap(info), req)
 }
 
-// externalGroupsAuthInfo overrides GetGroups() to return external groups while
-// delegating all other AuthInfo methods to the embedded value.
+// externalGroupsAuthInfo overrides GetGroups() and delegates the rest.
 type externalGroupsAuthInfo struct {
 	authlib.AuthInfo
 	groups []string

--- a/pkg/services/authz/external_groups_client_test.go
+++ b/pkg/services/authz/external_groups_client_test.go
@@ -1,0 +1,51 @@
+package authz
+
+import (
+	"testing"
+
+	claims "github.com/grafana/authlib/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestExternalGroupsAccessClient_swap(t *testing.T) {
+	c := &externalGroupsAccessClient{}
+
+	t.Run("user with external groups: GetGroups returns external groups", func(t *testing.T) {
+		base := &identity.StaticRequester{
+			Type:           claims.TypeUser,
+			Groups:         []string{"stored-team"},
+			ExternalGroups: []string{"admins-editors", "editors-viewers"},
+		}
+		got := c.swap(base)
+		assert.Equal(t, []string{"admins-editors", "editors-viewers"}, got.GetGroups())
+		// other AuthInfo methods still delegate
+		assert.Equal(t, base.GetUID(), got.GetUID())
+	})
+
+	t.Run("no external groups: original is returned untouched", func(t *testing.T) {
+		base := &identity.StaticRequester{
+			Type:           claims.TypeUser,
+			Groups:         []string{"stored-team"},
+			ExternalGroups: nil,
+		}
+		got := c.swap(base)
+		assert.Equal(t, []string{"stored-team"}, got.GetGroups())
+	})
+}
+
+func TestNewExternalGroupsAccessClient_flagGating(t *testing.T) {
+	inner := &externalGroupsAccessClient{} // any AccessClient; only identity matters
+
+	t.Run("flag off: returns inner unchanged", func(t *testing.T) {
+		got := newExternalGroupsAccessClient(&setting.Cfg{IDUseExternalGroupsForGroupsClaim: false}, inner)
+		assert.Same(t, inner, got)
+	})
+
+	t.Run("flag on: returns decorator", func(t *testing.T) {
+		got := newExternalGroupsAccessClient(&setting.Cfg{IDUseExternalGroupsForGroupsClaim: true}, inner)
+		assert.NotSame(t, inner, got)
+	})
+}

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -54,7 +54,16 @@ func ProvideAuthZClient(
 	acService accesscontrol.Service,
 	zanzanaClient zanzana.Client,
 	restConfig apiserver.RestConfigProvider,
-) (authlib.AccessClient, error) {
+) (client authlib.AccessClient, err error) {
+	// Option 2 (authz-boundary): decorate the returned client so the forward Check
+	// derives contextual team membership from external groups under the flag. No-op
+	// when the flag is off. Wrapping here covers every return path below.
+	defer func() {
+		if err == nil && client != nil {
+			client = newExternalGroupsAccessClient(cfg, client)
+		}
+	}()
+
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	zanzanaEnabled := features.IsEnabledGlobally(featuremgmt.FlagZanzana)
 

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -55,9 +55,8 @@ func ProvideAuthZClient(
 	zanzanaClient zanzana.Client,
 	restConfig apiserver.RestConfigProvider,
 ) (client authlib.AccessClient, err error) {
-	// Option 2 (authz-boundary): decorate the returned client so the forward Check
-	// derives contextual team membership from external groups under the flag. No-op
-	// when the flag is off. Wrapping here covers every return path below.
+	// Decorate so the forward Check sources team membership from external groups under
+	// id_use_external_groups_for_groups_claim. No-op when off; covers every return path.
 	defer func() {
 		if err == nil && client != nil {
 			client = newExternalGroupsAccessClient(cfg, client)


### PR DESCRIPTION
## What

Same fix as #126197 — making team membership delivered via external groups (IdP/proxy, `team_sync` disabled) reach the **forward** authz Check so a user with folder edit *via a team* can create dashboards in that folder — but implemented at the **authz boundary** instead of at identity construction.

> Alternative to #126197. These two PRs are mutually exclusive — pick one. This thread is for comparing approaches.

## Why a second approach

Team membership becomes the Zanzana contextual tuple `team:<name>#member`, built from `request.Teams`, which the authz client fills from `authInfo.GetGroups()`. `GetGroups()` returns *stored* team memberships (`SignedInUser.TeamUIDs`); with `team_sync` disabled those are empty, so the forward Check sends no teams and denies. The ID token and the Zanzana merge resolver already prefer external groups under the flag; the forward Check did not.

## Change

A thin `AccessClient` decorator (`newExternalGroupsAccessClient`) wraps the app-wide client returned by `ProvideAuthZClient`. Under `id_use_external_groups_for_groups_claim`, it swaps the `AuthInfo` passed to `Check`/`Compile`/`BatchCheck` for one whose `GetGroups()` returns `GetExternalGroups()`, delegating all other methods. No-op when the flag is off (returns the inner client unchanged).

## Trade-offs vs #126197 (the identity hook)

| | #126197 (identity hook) | This PR (boundary decorator) |
|---|---|---|
| Scope | Sets `Identity.Groups` once; **all** `GetGroups()` consumers consistent (forward Check, merge resolver, ID token) | Confined to the forward authz path only |
| Blast radius | Larger — changes the identity seen everywhere | Smaller — identity untouched |
| Flag locations | Consolidates toward one source of truth (could then retire `teamsForCurrentUser`'s switch) | Adds a third place that consults the flag |
| Failure mode | Relies on the authn post-auth hook running | Relies on consumers going through `ProvideAuthZClient`'s client |

## Notes

- The decorator implements only the `AccessClient` interface, so for *that DI binding* the wider `zanzana.Client` methods are not exposed. Consumers needing those receive `zanzana.Client` via its own binding, so this is fine in practice; flagged for review.
- Name equality is load-bearing either way: external group string == team UID == `metadata.name`; `getContextuals` does no translation.

## Testing

- Unit tests in `external_groups_client_test.go` (swap behavior, flag gating).
- Verified end-to-end in a local multi-instance auth-proxy env: an editor with team-only folder edit can now create dashboards via `/apis` — same result as #126197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
