### PR TITLE
Alerting: Map Prometheus rule definition to k8s rule annotations

### DIFF
--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/ext.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/ext.go
@@ -17,6 +17,8 @@ const (
 	// Annotation key used to store the folder UID on resources
 	FolderAnnotationKey = "grafana.app/folder"
 	FolderLabelKey      = FolderAnnotationKey
+	// Annotation key mirroring the legacy PrometheusStyleRule original definition.
+	PrometheusRuleDefinitionAnnotationKey = "alerting.grafana.app/prometheus-rule-definition"
 )
 
 // NOTE: This is a copy of the constants from the alertrule package to avoid circular imports.

--- a/pkg/registry/apps/alerting/rules/alertrule/compat.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/compat.go
@@ -107,47 +107,8 @@ func convertToK8sResource(
 		k8sRule.Spec.Expressions[query.RefID] = convertToK8sExpression(query, rule)
 	}
 
-	if setting := rule.ContactPointRouting(); setting != nil {
-		simplifiedRouting := model.AlertRuleSimplifiedRouting{
-			Type:     model.AlertRuleNotificationSettingsTypeSimplifiedRouting,
-			Receiver: setting.Receiver,
-			GroupBy:  setting.GroupBy,
-		}
-		if setting.GroupWait != nil {
-			simplifiedRouting.GroupWait = new(model.AlertRulePromDuration(setting.GroupWait.String()))
-		}
-		if setting.GroupInterval != nil {
-			simplifiedRouting.GroupInterval = new(model.AlertRulePromDuration(setting.GroupInterval.String()))
-		}
-		if setting.RepeatInterval != nil {
-			simplifiedRouting.RepeatInterval = new(model.AlertRulePromDuration(setting.RepeatInterval.String()))
-		}
-		if setting.MuteTimeIntervals != nil {
-			simplifiedRouting.MuteTimeIntervals = make([]model.AlertRuleTimeIntervalRef, 0, len(setting.MuteTimeIntervals))
-			for _, m := range setting.MuteTimeIntervals {
-				simplifiedRouting.MuteTimeIntervals = append(simplifiedRouting.MuteTimeIntervals, model.AlertRuleTimeIntervalRef(m))
-			}
-		}
-		if setting.ActiveTimeIntervals != nil {
-			simplifiedRouting.ActiveTimeIntervals = make([]model.AlertRuleTimeIntervalRef, 0, len(setting.ActiveTimeIntervals))
-			for _, a := range setting.ActiveTimeIntervals {
-				simplifiedRouting.ActiveTimeIntervals = append(simplifiedRouting.ActiveTimeIntervals, model.AlertRuleTimeIntervalRef(a))
-			}
-		}
-		k8sRule.Spec.NotificationSettings = &model.AlertRuleNotificationSettings{
-			SimplifiedRouting: &simplifiedRouting,
-		}
-	}
-
-	if setting := rule.PolicyRouting(); setting != nil {
-		namedRoutingTree := model.AlertRuleNamedRoutingTree{
-			Type:        model.AlertRuleNotificationSettingsTypeNamedRoutingTree,
-			RoutingTree: setting.Policy,
-		}
-
-		k8sRule.Spec.NotificationSettings = &model.AlertRuleNotificationSettings{
-			NamedRoutingTree: &namedRoutingTree,
-		}
+	if ns := convertToK8sNotificationSettings(rule); ns != nil {
+		k8sRule.Spec.NotificationSettings = ns
 	}
 
 	meta, err := utils.MetaAccessor(k8sRule)
@@ -181,6 +142,53 @@ func convertToK8sResource(
 	// We should consider adding it to the domain model. Migration can set it to the Updated timestamp for existing
 	// k8sRule.SetCreationTimestamp(rule.)
 	return k8sRule, nil
+}
+
+// convertToK8sNotificationSettings maps the domain rule's routing configuration into k8s
+// notification settings. It returns nil when the rule has no routing configured.
+func convertToK8sNotificationSettings(rule *ngmodels.AlertRule) *model.AlertRuleNotificationSettings {
+	if setting := rule.ContactPointRouting(); setting != nil {
+		simplifiedRouting := model.AlertRuleSimplifiedRouting{
+			Type:     model.AlertRuleNotificationSettingsTypeSimplifiedRouting,
+			Receiver: setting.Receiver,
+			GroupBy:  setting.GroupBy,
+		}
+		if setting.GroupWait != nil {
+			simplifiedRouting.GroupWait = new(model.AlertRulePromDuration(setting.GroupWait.String()))
+		}
+		if setting.GroupInterval != nil {
+			simplifiedRouting.GroupInterval = new(model.AlertRulePromDuration(setting.GroupInterval.String()))
+		}
+		if setting.RepeatInterval != nil {
+			simplifiedRouting.RepeatInterval = new(model.AlertRulePromDuration(setting.RepeatInterval.String()))
+		}
+		if setting.MuteTimeIntervals != nil {
+			simplifiedRouting.MuteTimeIntervals = make([]model.AlertRuleTimeIntervalRef, 0, len(setting.MuteTimeIntervals))
+			for _, m := range setting.MuteTimeIntervals {
+				simplifiedRouting.MuteTimeIntervals = append(simplifiedRouting.MuteTimeIntervals, model.AlertRuleTimeIntervalRef(m))
+			}
+		}
+		if setting.ActiveTimeIntervals != nil {
+			simplifiedRouting.ActiveTimeIntervals = make([]model.AlertRuleTimeIntervalRef, 0, len(setting.ActiveTimeIntervals))
+			for _, a := range setting.ActiveTimeIntervals {
+				simplifiedRouting.ActiveTimeIntervals = append(simplifiedRouting.ActiveTimeIntervals, model.AlertRuleTimeIntervalRef(a))
+			}
+		}
+		return &model.AlertRuleNotificationSettings{
+			SimplifiedRouting: &simplifiedRouting,
+		}
+	}
+
+	if setting := rule.PolicyRouting(); setting != nil {
+		return &model.AlertRuleNotificationSettings{
+			NamedRoutingTree: &model.AlertRuleNamedRoutingTree{
+				Type:        model.AlertRuleNotificationSettingsTypeNamedRoutingTree,
+				RoutingTree: setting.Policy,
+			},
+		}
+	}
+
+	return nil
 }
 
 func ConvertToK8sNoDataState(state ngmodels.NoDataState) (model.AlertRuleNoDataState, error) {

--- a/pkg/registry/apps/alerting/rules/alertrule/compat.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/compat.go
@@ -170,6 +170,13 @@ func convertToK8sResource(
 		return nil, fmt.Errorf("failed to set provenance status: %w", err)
 	}
 
+	if def, err := rule.PrometheusRuleDefinition(); err == nil {
+		if k8sRule.Annotations == nil {
+			k8sRule.Annotations = make(map[string]string, 1)
+		}
+		k8sRule.Annotations[model.PrometheusRuleDefinitionAnnotationKey] = def
+	}
+
 	// FIXME: we don't have a creation timestamp in the domain model, so we can't set it here.
 	// We should consider adding it to the domain model. Migration can set it to the Updated timestamp for existing
 	// k8sRule.SetCreationTimestamp(rule.)
@@ -446,6 +453,12 @@ func convertToBaseDomainModel(orgID int64, k8sRule *model.AlertRule) (*ngmodels.
 			return nil, err
 		}
 		domainRule.NotificationSettings = &settings
+	}
+
+	if def := k8sRule.Annotations[model.PrometheusRuleDefinitionAnnotationKey]; def != "" {
+		domainRule.Metadata.PrometheusStyleRule = &ngmodels.PrometheusStyleRule{
+			OriginalRuleDefinition: def,
+		}
 	}
 
 	return domainRule, nil

--- a/pkg/registry/apps/alerting/rules/alertrule/compat_test.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/compat_test.go
@@ -82,3 +82,38 @@ func TestConvertDeletedToK8sResources(t *testing.T) {
 	assert.Equal(t, alerting.GUID, got.Name)
 	require.NotNil(t, got.DeletionTimestamp, "deleted rule should carry a deletion timestamp")
 }
+
+func TestPrometheusRuleDefinitionRoundTrip(t *testing.T) {
+	mapper := nsMapperForTest()
+	gen := ngmodels.RuleGen
+	const def = "alert: HighErrors\nexpr: errors > 0\n"
+
+	t.Run("original definition survives a k8s round-trip", func(t *testing.T) {
+		rule := gen.With(gen.WithOrgID(1)).GenerateRef()
+		rule.Record = nil
+		rule.Condition = rule.Data[0].RefID // mark the single query as the source so the round-trip is valid
+		rule.Metadata.PrometheusStyleRule = &ngmodels.PrometheusStyleRule{OriginalRuleDefinition: def}
+
+		k8sRule, err := convertToK8sResource(1, rule, ngmodels.ProvenanceConvertedPrometheus, mapper)
+		require.NoError(t, err)
+
+		domainRule, _, err := convertToDomainModel(1, k8sRule)
+		require.NoError(t, err)
+		require.NotNil(t, domainRule.Metadata.PrometheusStyleRule)
+		assert.Equal(t, def, domainRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition)
+	})
+
+	t.Run("rule without an original definition stays without one", func(t *testing.T) {
+		rule := gen.With(gen.WithOrgID(1)).GenerateRef()
+		rule.Record = nil
+		rule.Condition = rule.Data[0].RefID
+		rule.Metadata.PrometheusStyleRule = nil
+
+		k8sRule, err := convertToK8sResource(1, rule, ngmodels.ProvenanceNone, mapper)
+		require.NoError(t, err)
+
+		domainRule, _, err := convertToDomainModel(1, k8sRule)
+		require.NoError(t, err)
+		assert.Nil(t, domainRule.Metadata.PrometheusStyleRule)
+	})
+}

--- a/pkg/registry/apps/alerting/rules/recordingrule/compat.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/compat.go
@@ -93,6 +93,13 @@ func convertToK8sResource(
 		return nil, fmt.Errorf("failed to set provenance status: %w", err)
 	}
 
+	if def, err := rule.PrometheusRuleDefinition(); err == nil {
+		if k8sRule.Annotations == nil {
+			k8sRule.Annotations = make(map[string]string, 1)
+		}
+		k8sRule.Annotations[model.PrometheusRuleDefinitionAnnotationKey] = def
+	}
+
 	// FIXME: we don't have a creation timestamp in the domain model, so we can't set it here.
 	// We should consider adding it to the domain model. Migration can set it to the Updated timestamp for existing
 	// k8sRule.SetCreationTimestamp(rule.)
@@ -291,6 +298,13 @@ func convertToBaseDomainModel(orgID int64, k8sRule *model.RecordingRule) (*ngmod
 	if domainRule.Record.From == "" {
 		return nil, fmt.Errorf("no query marked as source")
 	}
+
+	if def := k8sRule.Annotations[model.PrometheusRuleDefinitionAnnotationKey]; def != "" {
+		domainRule.Metadata.PrometheusStyleRule = &ngmodels.PrometheusStyleRule{
+			OriginalRuleDefinition: def,
+		}
+	}
+
 	return domainRule, nil
 }
 

--- a/pkg/registry/apps/alerting/rules/recordingrule/compat_test.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/compat_test.go
@@ -75,3 +75,36 @@ func TestConvertDeletedToK8sResources(t *testing.T) {
 	assert.Equal(t, rule.GUID, got.Name)
 	require.NotNil(t, got.DeletionTimestamp, "deleted rule should carry a deletion timestamp")
 }
+
+func TestPrometheusRuleDefinitionRoundTrip(t *testing.T) {
+	mapper := nsMapperForTest()
+	gen := ngmodels.RuleGen
+	const def = "record: job:errors:rate5m\nexpr: rate(errors[5m])\n"
+
+	t.Run("original definition survives a k8s round-trip", func(t *testing.T) {
+		rule := gen.With(gen.WithOrgID(1), gen.WithAllRecordingRules()).GenerateRef()
+		rule.Record.From = rule.Data[0].RefID // mark the single query as the source so the round-trip is valid
+		rule.Metadata.PrometheusStyleRule = &ngmodels.PrometheusStyleRule{OriginalRuleDefinition: def}
+
+		k8sRule, err := convertToK8sResource(1, rule, ngmodels.ProvenanceConvertedPrometheus, mapper)
+		require.NoError(t, err)
+
+		domainRule, _, err := convertToDomainModel(1, k8sRule)
+		require.NoError(t, err)
+		require.NotNil(t, domainRule.Metadata.PrometheusStyleRule)
+		assert.Equal(t, def, domainRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition)
+	})
+
+	t.Run("rule without an original definition stays without one", func(t *testing.T) {
+		rule := gen.With(gen.WithOrgID(1), gen.WithAllRecordingRules()).GenerateRef()
+		rule.Record.From = rule.Data[0].RefID
+		rule.Metadata.PrometheusStyleRule = nil
+
+		k8sRule, err := convertToK8sResource(1, rule, ngmodels.ProvenanceNone, mapper)
+		require.NoError(t, err)
+
+		domainRule, _, err := convertToDomainModel(1, k8sRule)
+		require.NoError(t, err)
+		assert.Nil(t, domainRule.Metadata.PrometheusStyleRule)
+	})
+}


### PR DESCRIPTION
**What is this feature?**

Adds a compatibility mapping for the original Prometheus rule definition in the k8s AlertRule/RecordingRule APIs. The legacy domain model stores the original rule YAML in `AlertRuleMetadata.PrometheusStyleRule.OriginalRuleDefinition` for rules imported from Prometheus-compatible sources. This PR mirrors that value to and from a new annotation, `alerting.grafana.app/prometheus-rule-definition`, in both conversion directions:

- Domain → k8s (`convertToK8sResource`): stamps the annotation when the rule has an original definition.
- k8s → domain (`convertToBaseDomainModel`): reads the annotation back into the metadata field.

Applies to both `AlertRule` and `RecordingRule`.

**Why do we need this feature?**

Rules imported via the Prometheus conversion API (e.g. mimirtool) store their original definition in the domain model (`AlertRuleMetadata.PrometheusStyleRule`) so the convert API can return them in Prometheus format. That field was never surfaced by the k8s rules API, so clients reading an `AlertRule`/`RecordingRule` through the k8s API had no way to see the original Prometheus definition. This PR exposes it as an annotation and maps it back on write so the annotation and the domain field stay in sync.

**Who is this feature for?**

Users importing Prometheus/Mimir rules into Grafana and anyone reading or writing alerting rules through the k8s / app-platform API.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Backend-only, behavior-preserving compat mapping; no feature toggle since it only surfaces data that already exists on the domain model. Round-trip tests are included for both rule kinds.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
