### PR TITLE
Alerting: Convert Prometheus rules via Kubernetes API behind feature flag

### DIFF
--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/ext.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/ext.go
@@ -17,6 +17,8 @@ const (
 	// Annotation key used to store the folder UID on resources
 	FolderAnnotationKey = "grafana.app/folder"
 	FolderLabelKey      = FolderAnnotationKey
+	// Annotation key mirroring the legacy PrometheusStyleRule original definition.
+	PrometheusRuleDefinitionAnnotationKey = "alerting.grafana.app/prometheus-rule-definition"
 )
 
 // NOTE: This is a copy of the constants from the alertrule package to avoid circular imports.

--- a/pkg/registry/apps/alerting/rules/alertrule/compat.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/compat.go
@@ -160,6 +160,13 @@ func convertToK8sResource(
 		return nil, fmt.Errorf("failed to set provenance status: %w", err)
 	}
 
+	if def, err := rule.PrometheusRuleDefinition(); err == nil {
+		if k8sRule.Annotations == nil {
+			k8sRule.Annotations = make(map[string]string, 1)
+		}
+		k8sRule.Annotations[model.PrometheusRuleDefinitionAnnotationKey] = def
+	}
+
 	// FIXME: we don't have a creation timestamp in the domain model, so we can't set it here.
 	// We should consider adding it to the domain model. Migration can set it to the Updated timestamp for existing
 	// k8sRule.SetCreationTimestamp(rule.)
@@ -396,6 +403,12 @@ func convertToBaseDomainModel(orgID int64, k8sRule *model.AlertRule) (*ngmodels.
 			return nil, err
 		}
 		domainRule.NotificationSettings = &settings
+	}
+
+	if def := k8sRule.Annotations[model.PrometheusRuleDefinitionAnnotationKey]; def != "" {
+		domainRule.Metadata.PrometheusStyleRule = &ngmodels.PrometheusStyleRule{
+			OriginalRuleDefinition: def,
+		}
 	}
 
 	return domainRule, nil

--- a/pkg/registry/apps/alerting/rules/alertrule/compat_test.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/compat_test.go
@@ -82,3 +82,38 @@ func TestConvertDeletedToK8sResources(t *testing.T) {
 	assert.Equal(t, alerting.GUID, got.Name)
 	require.NotNil(t, got.DeletionTimestamp, "deleted rule should carry a deletion timestamp")
 }
+
+func TestPrometheusRuleDefinitionRoundTrip(t *testing.T) {
+	mapper := nsMapperForTest()
+	gen := ngmodels.RuleGen
+	const def = "alert: HighErrors\nexpr: errors > 0\n"
+
+	t.Run("original definition survives a k8s round-trip", func(t *testing.T) {
+		rule := gen.With(gen.WithOrgID(1)).GenerateRef()
+		rule.Record = nil
+		rule.Condition = rule.Data[0].RefID // mark the single query as the source so the round-trip is valid
+		rule.Metadata.PrometheusStyleRule = &ngmodels.PrometheusStyleRule{OriginalRuleDefinition: def}
+
+		k8sRule, err := convertToK8sResource(1, rule, ngmodels.ProvenanceConvertedPrometheus, mapper)
+		require.NoError(t, err)
+
+		domainRule, _, err := convertToDomainModel(1, k8sRule)
+		require.NoError(t, err)
+		require.NotNil(t, domainRule.Metadata.PrometheusStyleRule)
+		assert.Equal(t, def, domainRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition)
+	})
+
+	t.Run("rule without an original definition stays without one", func(t *testing.T) {
+		rule := gen.With(gen.WithOrgID(1)).GenerateRef()
+		rule.Record = nil
+		rule.Condition = rule.Data[0].RefID
+		rule.Metadata.PrometheusStyleRule = nil
+
+		k8sRule, err := convertToK8sResource(1, rule, ngmodels.ProvenanceNone, mapper)
+		require.NoError(t, err)
+
+		domainRule, _, err := convertToDomainModel(1, k8sRule)
+		require.NoError(t, err)
+		assert.Nil(t, domainRule.Metadata.PrometheusStyleRule)
+	})
+}

--- a/pkg/registry/apps/alerting/rules/recordingrule/compat.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/compat.go
@@ -93,6 +93,13 @@ func convertToK8sResource(
 		return nil, fmt.Errorf("failed to set provenance status: %w", err)
 	}
 
+	if def, err := rule.PrometheusRuleDefinition(); err == nil {
+		if k8sRule.Annotations == nil {
+			k8sRule.Annotations = make(map[string]string, 1)
+		}
+		k8sRule.Annotations[model.PrometheusRuleDefinitionAnnotationKey] = def
+	}
+
 	// FIXME: we don't have a creation timestamp in the domain model, so we can't set it here.
 	// We should consider adding it to the domain model. Migration can set it to the Updated timestamp for existing
 	// k8sRule.SetCreationTimestamp(rule.)
@@ -291,6 +298,13 @@ func convertToBaseDomainModel(orgID int64, k8sRule *model.RecordingRule) (*ngmod
 	if domainRule.Record.From == "" {
 		return nil, fmt.Errorf("no query marked as source")
 	}
+
+	if def := k8sRule.Annotations[model.PrometheusRuleDefinitionAnnotationKey]; def != "" {
+		domainRule.Metadata.PrometheusStyleRule = &ngmodels.PrometheusStyleRule{
+			OriginalRuleDefinition: def,
+		}
+	}
+
 	return domainRule, nil
 }
 

--- a/pkg/registry/apps/alerting/rules/recordingrule/compat_test.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/compat_test.go
@@ -75,3 +75,36 @@ func TestConvertDeletedToK8sResources(t *testing.T) {
 	assert.Equal(t, rule.GUID, got.Name)
 	require.NotNil(t, got.DeletionTimestamp, "deleted rule should carry a deletion timestamp")
 }
+
+func TestPrometheusRuleDefinitionRoundTrip(t *testing.T) {
+	mapper := nsMapperForTest()
+	gen := ngmodels.RuleGen
+	const def = "record: job:errors:rate5m\nexpr: rate(errors[5m])\n"
+
+	t.Run("original definition survives a k8s round-trip", func(t *testing.T) {
+		rule := gen.With(gen.WithOrgID(1), gen.WithAllRecordingRules()).GenerateRef()
+		rule.Record.From = rule.Data[0].RefID // mark the single query as the source so the round-trip is valid
+		rule.Metadata.PrometheusStyleRule = &ngmodels.PrometheusStyleRule{OriginalRuleDefinition: def}
+
+		k8sRule, err := convertToK8sResource(1, rule, ngmodels.ProvenanceConvertedPrometheus, mapper)
+		require.NoError(t, err)
+
+		domainRule, _, err := convertToDomainModel(1, k8sRule)
+		require.NoError(t, err)
+		require.NotNil(t, domainRule.Metadata.PrometheusStyleRule)
+		assert.Equal(t, def, domainRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition)
+	})
+
+	t.Run("rule without an original definition stays without one", func(t *testing.T) {
+		rule := gen.With(gen.WithOrgID(1), gen.WithAllRecordingRules()).GenerateRef()
+		rule.Record.From = rule.Data[0].RefID
+		rule.Metadata.PrometheusStyleRule = nil
+
+		k8sRule, err := convertToK8sResource(1, rule, ngmodels.ProvenanceNone, mapper)
+		require.NoError(t, err)
+
+		domainRule, _, err := convertToDomainModel(1, k8sRule)
+		require.NoError(t, err)
+		assert.Nil(t, domainRule.Metadata.PrometheusStyleRule)
+	})
+}

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2026,6 +2026,15 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:         "alertingConvertPrometheusViaKubernetesAPI",
+			Description:  "Use internal Kubernetes clients to create AlertRule, RecordingRule, and RuleSequence resources during Prometheus rule conversion instead of the legacy provisioning path",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaAlertingSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{LegacyGo: true},
+		},
+		{
 			Name:         "alertingDisableDMAinUI",
 			Description:  "Disables the DMA feature in the UI",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -235,6 +235,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-07-31,alertEnrichmentConditional,experimental,@grafana/alerting-squad,false,false,false
 2026-05-22,alertEnrichmentPreview,experimental,@grafana/alerting-squad,false,false,false
 2025-06-10,alertingImportAlertmanagerAPI,experimental,@grafana/alerting-squad,false,false,false
+2026-06-09,alertingConvertPrometheusViaKubernetesAPI,experimental,@grafana/alerting-squad,false,false,false
 2026-05-22,alertingDisableDMAinUI,experimental,@grafana/alerting-squad,false,false,false
 2025-07-15,sharingDashboardImage,GA,@grafana/sharing-squad,false,false,true
 2025-06-17,preferLibraryPanelTitle,privatePreview,@grafana/dashboards-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -638,6 +638,10 @@ const (
 	// Enables the API to import Alertmanager configuration
 	FlagAlertingImportAlertmanagerAPI = "alertingImportAlertmanagerAPI"
 
+	// FlagAlertingConvertPrometheusViaKubernetesAPI
+	// Use internal Kubernetes clients to create AlertRule, RecordingRule, and RuleSequence resources during Prometheus rule conversion instead of the legacy provisioning path
+	FlagAlertingConvertPrometheusViaKubernetesAPI = "alertingConvertPrometheusViaKubernetesAPI"
+
 	// FlagAlertingDisableDMAinUI
 	// Disables the DMA feature in the UI
 	FlagAlertingDisableDMAinUI = "alertingDisableDMAinUI"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -301,6 +301,50 @@
     },
     {
       "metadata": {
+        "name": "alertingConvertPrometheusK8S",
+        "resourceVersion": "1781019607465",
+        "creationTimestamp": "2026-06-09T15:40:07Z",
+        "deletionTimestamp": "2026-06-09T15:41:28Z"
+      },
+      "spec": {
+        "description": "Use internal k8s clients to create AlertRule, RecordingRule, and RuleSequence resources during Prometheus rule conversion instead of the legacy provisioning path",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingConvertPrometheusK8s",
+        "resourceVersion": "1781019463714",
+        "creationTimestamp": "2026-06-09T15:37:43Z",
+        "deletionTimestamp": "2026-06-09T15:40:07Z"
+      },
+      "spec": {
+        "description": "Use internal k8s clients to create AlertRule, RecordingRule, and RuleSequence resources during Prometheus rule conversion instead of the legacy provisioning path",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingConvertPrometheusViaKubernetesAPI",
+        "resourceVersion": "1781019688373",
+        "creationTimestamp": "2026-06-09T15:41:28Z"
+      },
+      "spec": {
+        "description": "Use internal Kubernetes clients to create AlertRule, RecordingRule, and RuleSequence resources during Prometheus rule conversion instead of the legacy provisioning path",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingDisableDMAinUI",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2026-05-22T09:03:04Z"

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -87,6 +88,7 @@ type API struct {
 	AppUrl                *url.URL
 	UserService           user.Service
 	SilenceLimitsProvider notifier.LimitsProvider
+	ClientGenerator       resource.ClientGenerator
 
 	// Hooks can be used to replace API handlers for specific paths.
 	Hooks *Hooks
@@ -110,6 +112,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 		api.FeatureManager,
 		api.MultiOrgAlertmanager,
 		accesscontrol.NewAlertmanagerImportsAccess(api.AccessControl),
+		api.ClientGenerator,
 	)
 
 	// Register endpoints for proxying to Alertmanager-compatible backends.

--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -10,13 +10,21 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana-app-sdk/resource"
+	"github.com/open-feature/go-sdk/openfeature"
 	prommodel "github.com/prometheus/common/model"
 	"go.yaml.in/yaml/v3"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
+	alertingv0 "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -138,6 +146,15 @@ type ConvertPrometheusSrv struct {
 	featureToggles   featuremgmt.FeatureToggles
 	am               Alertmanager
 	importsAuthz     notifier.ExtraConfigAuthz
+	clientGenerator  resource.ClientGenerator
+
+	// Lazy-initialized k8s typed clients, protected by clientsMu. Created on
+	// first use when the feature flag is enabled, following the same pattern
+	// as K8sRuleSequenceStore.
+	clientsMu       sync.Mutex
+	alertRuleClient *alertingv0.AlertRuleClient
+	recordingClient *alertingv0.RecordingRuleClient
+	ruleSeqClient   *alertingv0.RuleSequenceClient
 }
 
 type Alertmanager interface {
@@ -156,6 +173,7 @@ func NewConvertPrometheusSrv(
 	featureToggles featuremgmt.FeatureToggles,
 	am Alertmanager,
 	importsAuthz notifier.ExtraConfigAuthz,
+	clientGenerator resource.ClientGenerator,
 ) *ConvertPrometheusSrv {
 	return &ConvertPrometheusSrv{
 		cfg:              cfg,
@@ -166,6 +184,7 @@ func NewConvertPrometheusSrv(
 		featureToggles:   featureToggles,
 		am:               am,
 		importsAuthz:     importsAuthz,
+		clientGenerator:  clientGenerator,
 	}
 }
 
@@ -431,8 +450,12 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroups(c *context
 		logger.Error("Failed to parse version message header", "error", err)
 		return errorToResponse(err)
 	}
-	// 2. Convert Prometheus Rules to GMA
-	grafanaGroups := make([]*models.AlertRuleGroup, 0, len(promNamespaces))
+	// 2. Resolve folders for every namespace up front (shared by both paths).
+	type nsGroups struct {
+		folderUID string
+		groups    []apimodels.PrometheusRuleGroup
+	}
+	resolved := make([]nsGroups, 0, len(promNamespaces))
 	for ns, rgs := range promNamespaces {
 		logger.Debug("Creating a new namespace", "title", ns)
 		namespace, errResp := srv.getOrCreateNamespace(c, ns, logger, workingFolderUID)
@@ -440,22 +463,65 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroups(c *context
 			logger.Error("Failed to create a new namespace", "folder_uid", workingFolderUID)
 			return errResp
 		}
+		resolved = append(resolved, nsGroups{folderUID: namespace.UID, groups: rgs})
+	}
 
-		for _, rg := range rgs {
-			// If we're importing recording rules, we can only import them if the feature is enabled,
-			// and the feature flag that enables configuring target datasources per-rule is also enabled.
-			if promGroupHasRecordingRules(rg) {
-				if !srv.cfg.RecordingRules.Enabled {
-					logger.Error("Cannot import recording rules", "error", errRecordingRulesNotEnabled)
-					return errorToResponse(errRecordingRulesNotEnabled)
-				}
+	// Gate: check recording-rules enablement for every group before doing any work.
+	for _, ns := range resolved {
+		for _, rg := range ns.groups {
+			if promGroupHasRecordingRules(rg) && !srv.cfg.RecordingRules.Enabled {
+				logger.Error("Cannot import recording rules", "error", errRecordingRulesNotEnabled)
+				return errorToResponse(errRecordingRulesNotEnabled)
 			}
+		}
+	}
 
+	// 3. Branch: k8s path or legacy path.
+	useK8s := openfeature.NewDefaultClient().Boolean(
+		c.Req.Context(),
+		featuremgmt.FlagAlertingConvertPrometheusViaKubernetesAPI,
+		false,
+		openfeature.TransactionContext(c.Req.Context()),
+	)
+
+	if useK8s {
+		k8sGroups := make(map[string][]promGroupWithFolder, len(resolved))
+		for _, ns := range resolved {
+			for _, rg := range ns.groups {
+				pg := toPromGroup(rg)
+				k8sGroups[ns.folderUID] = append(k8sGroups[ns.folderUID], promGroupWithFolder{
+					folderUID: ns.folderUID,
+					group:     pg,
+				})
+			}
+		}
+		if notificationSettings != nil {
+			logger.Warn("Notification settings header is not supported by the Kubernetes conversion path and will be ignored")
+		}
+		if versionMessage != "" {
+			logger.Warn("Version message header is not supported by the Kubernetes conversion path and will be ignored")
+		}
+		if err := srv.createRulesViaK8sClient(
+			c.Req.Context(), c.GetOrgID(), ds, tds,
+			k8sGroups, keepOriginalRuleDefinition, provenance,
+			pauseAlertRules, pauseRecordingRules, extraLabels,
+			logger,
+		); err != nil {
+			logger.Error("Failed to create rules via k8s client", "error", err)
+			return errorToResponse(err)
+		}
+		return successfulResponse()
+	}
+
+	// Legacy path: convert to GMA domain models and persist via provisioning service.
+	grafanaGroups := make([]*models.AlertRuleGroup, 0, len(resolved))
+	for _, ns := range resolved {
+		for _, rg := range ns.groups {
 			grafanaGroup, err := srv.convertToGrafanaRuleGroup(
 				c,
 				ds,
 				tds,
-				namespace.UID,
+				ns.folderUID,
 				rg,
 				pauseRecordingRules,
 				pauseAlertRules,
@@ -468,12 +534,9 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroups(c *context
 				logger.Error("Failed to convert Prometheus rules to Grafana rules", "error", err)
 				return errorToResponse(err)
 			}
-
 			grafanaGroups = append(grafanaGroups, grafanaGroup)
 		}
 	}
-
-	// 3. Update the GMA Rules in the DB
 	err = srv.alertRuleService.ReplaceRuleGroups(c.Req.Context(), c.SignedInUser, grafanaGroups, provenance, versionMessage)
 	if err != nil {
 		logger.Error("Failed to replace rule groups", "error", err)
@@ -590,6 +653,459 @@ func (srv *ConvertPrometheusSrv) convertToGrafanaRuleGroup(
 	}
 
 	return grafanaGroup, nil
+}
+
+// toPromGroup converts an API-level PrometheusRuleGroup to the prom package type.
+func toPromGroup(rg apimodels.PrometheusRuleGroup) prom.PrometheusRuleGroup {
+	rules := make([]prom.PrometheusRule, len(rg.Rules))
+	for i, r := range rg.Rules {
+		rules[i] = prom.PrometheusRule{
+			Alert:         r.Alert,
+			Expr:          r.Expr,
+			For:           r.For,
+			KeepFiringFor: r.KeepFiringFor,
+			Labels:        r.Labels,
+			Annotations:   r.Annotations,
+			Record:        r.Record,
+		}
+	}
+	return prom.PrometheusRuleGroup{
+		Name:        rg.Name,
+		Interval:    rg.Interval,
+		Rules:       rules,
+		QueryOffset: rg.QueryOffset,
+		Limit:       rg.Limit,
+		Labels:      rg.Labels,
+	}
+}
+
+// getK8sClients lazily initializes and returns the typed k8s clients for
+// AlertRule, RecordingRule, and RuleSequence. Safe for concurrent use.
+func (srv *ConvertPrometheusSrv) getK8sClients() (*alertingv0.AlertRuleClient, *alertingv0.RecordingRuleClient, *alertingv0.RuleSequenceClient, error) {
+	srv.clientsMu.Lock()
+	defer srv.clientsMu.Unlock()
+	if srv.alertRuleClient != nil {
+		return srv.alertRuleClient, srv.recordingClient, srv.ruleSeqClient, nil
+	}
+	if srv.clientGenerator == nil {
+		return nil, nil, nil, fmt.Errorf("k8s client generator is not available")
+	}
+	ac, err := alertingv0.NewAlertRuleClientFromGenerator(srv.clientGenerator)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("building alert rule client: %w", err)
+	}
+	rc, err := alertingv0.NewRecordingRuleClientFromGenerator(srv.clientGenerator)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("building recording rule client: %w", err)
+	}
+	sc, err := alertingv0.NewRuleSequenceClientFromGenerator(srv.clientGenerator)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("building rule sequence client: %w", err)
+	}
+	srv.alertRuleClient = ac
+	srv.recordingClient = rc
+	srv.ruleSeqClient = sc
+	return ac, rc, sc, nil
+}
+
+// createRulesViaK8sClient converts each Prometheus rule group into k8s-native
+// AlertRule / RecordingRule / RuleSequence resources and upserts them through
+// the internal k8s API. Groups containing recording rules also get a
+// RuleSequence that references all rules in the group.
+func (srv *ConvertPrometheusSrv) createRulesViaK8sClient(
+	ctx context.Context,
+	orgID int64,
+	ds *datasources.DataSource,
+	tds *datasources.DataSource,
+	namespaces map[string][]promGroupWithFolder,
+	keepOriginalRuleDefinition bool,
+	provenance models.Provenance,
+	pauseAlertRules bool,
+	pauseRecordingRules bool,
+	extraLabels map[string]string,
+	logger log.Logger,
+) error {
+	arClient, rrClient, seqClient, err := srv.getK8sClients()
+	if err != nil {
+		return err
+	}
+
+	k8sNamespace := authlib.OrgNamespaceFormatter(orgID)
+
+	// FromTimeRange and NoDataState/ExecErrState are left at their zero values
+	// so withDefaults() applies the same defaults the legacy converter uses
+	// (600s, Ok/Ok). If the legacy path ever allows per-request overrides for
+	// these, they should be wired through here as well.
+	converter, err := prom.NewK8sConverter(prom.K8sConverterConfig{
+		DatasourceUID:        ds.UID,
+		DatasourceType:       ds.Type,
+		TargetDatasourceUID:  tds.UID,
+		TargetDatasourceType: tds.Type,
+		DefaultInterval:      srv.cfg.DefaultRuleEvaluationInterval,
+		EvaluationOffset:     srv.cfg.PrometheusConversion.RuleQueryOffset,
+		PauseAlertRules:      pauseAlertRules,
+		PauseRecordingRules:  pauseRecordingRules,
+		ExtraLabels:          extraLabels,
+	})
+	if err != nil {
+		return fmt.Errorf("creating k8s converter: %w", err)
+	}
+
+	var groupErr error
+	for _, groups := range namespaces {
+		for _, pg := range groups {
+			if err := pg.group.Validate(); err != nil {
+				groupErr = errors.Join(groupErr, fmt.Errorf("group %q: %w", pg.group.Name, err))
+				continue
+			}
+			if err := srv.upsertGroupViaK8s(
+				ctx, converter,
+				arClient, rrClient, seqClient,
+				k8sNamespace, pg.folderUID, pg.group,
+				keepOriginalRuleDefinition, provenance,
+				logger,
+			); err != nil {
+				groupErr = errors.Join(groupErr, fmt.Errorf("group %q: %w", pg.group.Name, err))
+			}
+		}
+	}
+	return groupErr
+}
+
+// promGroupWithFolder pairs a Prometheus rule group with its resolved folder UID.
+type promGroupWithFolder struct {
+	folderUID string
+	group     prom.PrometheusRuleGroup
+}
+
+func (srv *ConvertPrometheusSrv) upsertGroupViaK8s(
+	ctx context.Context,
+	converter *prom.K8sConverter,
+	arClient *alertingv0.AlertRuleClient,
+	rrClient *alertingv0.RecordingRuleClient,
+	seqClient *alertingv0.RuleSequenceClient,
+	k8sNamespace string,
+	folderUID string,
+	group prom.PrometheusRuleGroup,
+	keepOriginalRuleDefinition bool,
+	provenance models.Provenance,
+	logger log.Logger,
+) error {
+	// Pre-compute desired names for all rules in the group. This set drives
+	// pruning and must reflect the full input regardless of which upserts
+	// succeed, so that a transient upsert failure does not cause the prune
+	// step to delete a rule that was healthy from a prior import.
+	desiredNames := make(map[string]struct{}, len(group.Rules))
+	ruleNames := make([]string, len(group.Rules))
+	ruleNameErrs := make([]error, len(group.Rules))
+	for idx, rule := range group.Rules {
+		name, err := prom.RuleName(k8sNamespace, folderUID, group.Name, idx, rule)
+		if err != nil {
+			ruleNameErrs[idx] = fmt.Errorf("rule at position %d: %w", idx, err)
+			continue
+		}
+		ruleNames[idx] = name
+		desiredNames[name] = struct{}{}
+	}
+
+	var recordingRuleNames []string
+	var alertRuleNames []string
+	var upsertErr error
+
+	for idx, rule := range group.Rules {
+		name := ruleNames[idx]
+		if name == "" {
+			upsertErr = errors.Join(upsertErr, ruleNameErrs[idx])
+			continue
+		}
+		ruleYAML := ""
+		if keepOriginalRuleDefinition {
+			b, err := yaml.Marshal(rule)
+			if err != nil {
+				return fmt.Errorf("marshalling original rule definition: %w", err)
+			}
+			ruleYAML = string(b)
+		}
+
+		switch {
+		case rule.Record != "":
+			spec, err := converter.BuildRecordingRuleSpec(group, rule)
+			if err != nil {
+				upsertErr = errors.Join(upsertErr, fmt.Errorf("building recording rule spec for %q: %w", rule.Record, err))
+				continue
+			}
+			// Mark as converted from Prometheus, matching the legacy converter's behaviour.
+			if spec.Labels == nil {
+				spec.Labels = make(map[string]alertingv0.RecordingRuleTemplateString, 1)
+			}
+			spec.Labels[models.ConvertedPrometheusRuleLabel] = "true"
+			obj := &alertingv0.RecordingRule{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: alertingv0.GroupVersion.Identifier(),
+					Kind:       alertingv0.RecordingRuleKind().Kind(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: k8sNamespace,
+					Annotations: map[string]string{
+						alertingv0.FolderAnnotationKey: folderUID,
+					},
+					Labels: map[string]string{
+						prom.GroupNameLabelKey: group.Name,
+					},
+				},
+				Spec: spec,
+			}
+			setProvenance(obj.Annotations, provenance)
+			setOriginalDefinition(obj.Annotations, ruleYAML)
+			if err := upsertResource(ctx, rrClient, obj); err != nil {
+				upsertErr = errors.Join(upsertErr, err)
+				continue
+			}
+			recordingRuleNames = append(recordingRuleNames, name)
+
+		case rule.Alert != "":
+			spec, err := converter.BuildAlertRuleSpec(group, rule)
+			if err != nil {
+				upsertErr = errors.Join(upsertErr, fmt.Errorf("building alert rule spec for %q: %w", rule.Alert, err))
+				continue
+			}
+			if spec.Labels == nil {
+				spec.Labels = make(map[string]alertingv0.AlertRuleTemplateString, 1)
+			}
+			spec.Labels[models.ConvertedPrometheusRuleLabel] = "true"
+			obj := &alertingv0.AlertRule{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: alertingv0.GroupVersion.Identifier(),
+					Kind:       alertingv0.AlertRuleKind().Kind(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: k8sNamespace,
+					Annotations: map[string]string{
+						alertingv0.FolderAnnotationKey: folderUID,
+					},
+					Labels: map[string]string{
+						prom.GroupNameLabelKey: group.Name,
+					},
+				},
+				Spec: spec,
+			}
+			setProvenance(obj.Annotations, provenance)
+			setOriginalDefinition(obj.Annotations, ruleYAML)
+			if err := upsertResource(ctx, arClient, obj); err != nil {
+				upsertErr = errors.Join(upsertErr, err)
+				continue
+			}
+			alertRuleNames = append(alertRuleNames, name)
+
+		default:
+			logger.Warn("Skipping rule entry with neither alert nor record set", "position", idx)
+		}
+	}
+
+	// Always prune, even on partial failure, to remove stale resources from
+	// previous imports that are no longer in the desired set. This prevents a
+	// transient error from leaving dangling resources indefinitely.
+
+	// Create or prune the RuleSequence for this group. A sequence is needed
+	// when the group contains recording rules; otherwise any previous sequence
+	// for this group must be removed.
+	desiredSeqName := ""
+	if len(recordingRuleNames) > 0 {
+		seqSpec := converter.BuildRuleSequenceSpec(group, recordingRuleNames, alertRuleNames)
+		desiredSeqName = prom.SequenceName(k8sNamespace, folderUID, group.Name)
+		obj := &alertingv0.RuleSequence{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: alertingv0.GroupVersion.Identifier(),
+				Kind:       alertingv0.RuleSequenceKind().Kind(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      desiredSeqName,
+				Namespace: k8sNamespace,
+				Annotations: map[string]string{
+					alertingv0.FolderAnnotationKey: folderUID,
+				},
+				Labels: map[string]string{
+					prom.GroupNameLabelKey: group.Name,
+				},
+			},
+			Spec: seqSpec,
+		}
+		setProvenance(obj.Annotations, provenance)
+		if err := upsertResource(ctx, seqClient, obj); err != nil {
+			upsertErr = errors.Join(upsertErr, fmt.Errorf("upserting rule sequence: %w", err))
+		}
+	}
+	if err := pruneStaleRuleSequences(ctx, seqClient, k8sNamespace, folderUID, group.Name, desiredSeqName, logger); err != nil {
+		upsertErr = errors.Join(upsertErr, fmt.Errorf("pruning stale rule sequences: %w", err))
+	}
+
+	// Prune stale rules from previous imports of this group. desiredNames was
+	// pre-computed from the full input above, so a transient upsert failure
+	// does not cause a healthy rule from a prior import to be deleted.
+	if err := pruneStaleAlertRules(ctx, arClient, k8sNamespace, folderUID, group.Name, desiredNames, logger); err != nil {
+		upsertErr = errors.Join(upsertErr, fmt.Errorf("pruning stale alert rules: %w", err))
+	}
+	if err := pruneStaleRecordingRules(ctx, rrClient, k8sNamespace, folderUID, group.Name, desiredNames, logger); err != nil {
+		upsertErr = errors.Join(upsertErr, fmt.Errorf("pruning stale recording rules: %w", err))
+	}
+
+	return upsertErr
+}
+
+func setProvenance(annotations map[string]string, provenance models.Provenance) {
+	if provenance != "" {
+		annotations[alertingv0.ProvenanceStatusAnnotationKey] = string(provenance)
+	}
+}
+
+func setOriginalDefinition(annotations map[string]string, ruleYAML string) {
+	if ruleYAML != "" {
+		annotations[alertingv0.PrometheusRuleDefinitionAnnotationKey] = ruleYAML
+	}
+}
+
+// upsertMaxRetries is the maximum number of attempts for an upsert operation
+// when a conflict (stale ResourceVersion) is encountered.
+const upsertMaxRetries = 3
+
+// k8sResource is the minimal interface satisfied by the generated k8s resource
+// objects (AlertRule, RecordingRule, RuleSequence) that upsertResource needs.
+// GetObjectKind is provided by metav1.TypeMeta and supplies the Kind string
+// for error messages.
+type k8sResource interface {
+	GetName() string
+	GetNamespace() string
+	GetResourceVersion() string
+	SetResourceVersion(string)
+	GetObjectKind() schema.ObjectKind
+}
+
+// k8sClient is the minimal interface for a typed k8s client that supports
+// Get, Create, and Update. All three generated clients satisfy this.
+type k8sClient[T k8sResource] interface {
+	Get(ctx context.Context, id resource.Identifier) (T, error)
+	Create(ctx context.Context, obj T, opts resource.CreateOptions) (T, error)
+	Update(ctx context.Context, obj T, opts resource.UpdateOptions) (T, error)
+}
+
+// upsertResource performs a Get-then-Create-or-Update with retry on conflict.
+// It clears ResourceVersion before Create to avoid issues from prior retry
+// iterations that set it during an Update attempt. The Kind for error messages
+// is derived from the object's TypeMeta.
+func upsertResource[T k8sResource](ctx context.Context, c k8sClient[T], desired T) error {
+	kind := desired.GetObjectKind().GroupVersionKind().Kind
+	ident := resource.Identifier{Namespace: desired.GetNamespace(), Name: desired.GetName()}
+	for attempt := range upsertMaxRetries {
+		existing, err := c.Get(ctx, ident)
+		if apierrors.IsNotFound(err) {
+			desired.SetResourceVersion("") // Clear stale RV from prior retry iterations.
+			if _, createErr := c.Create(ctx, desired, resource.CreateOptions{}); createErr != nil {
+				// Another writer may have created it between our Get and Create.
+				if apierrors.IsAlreadyExists(createErr) && attempt < upsertMaxRetries-1 {
+					continue
+				}
+				return fmt.Errorf("creating %s %q: %w", kind, desired.GetName(), createErr)
+			}
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("fetching %s %q: %w", kind, desired.GetName(), err)
+		}
+		desired.SetResourceVersion(existing.GetResourceVersion())
+		if _, err = c.Update(ctx, desired, resource.UpdateOptions{}); err != nil {
+			if apierrors.IsConflict(err) && attempt < upsertMaxRetries-1 {
+				continue
+			}
+			return fmt.Errorf("updating %s %q: %w", kind, desired.GetName(), err)
+		}
+		return nil
+	}
+	return fmt.Errorf("%s %q: exceeded %d upsert retries", kind, desired.GetName(), upsertMaxRetries)
+}
+
+// groupLabelFilter returns the label selector string for the group-name label.
+// Note: the folder UID is stored as an annotation, which cannot be filtered
+// server-side via label selectors. The caller must filter by folder client-side.
+func groupLabelFilter(groupName string) string {
+	return prom.GroupNameLabelKey + "=" + groupName
+}
+
+func pruneStaleAlertRules(ctx context.Context, c *alertingv0.AlertRuleClient, namespace, folderUID, groupName string, desired map[string]struct{}, logger log.Logger) error {
+	list, err := c.List(ctx, namespace, resource.ListOptions{
+		LabelFilters: []string{groupLabelFilter(groupName)},
+	})
+	if err != nil {
+		return fmt.Errorf("listing alert rules for prune: %w", err)
+	}
+	for _, rule := range list.Items {
+		// Skip resources whose folder annotation is missing or belongs to a
+		// different folder. A missing annotation means the resource was not
+		// created by this code path (or the API returned a partial object);
+		// deleting it would be a false positive.
+		ruleFolder := rule.Annotations[alertingv0.FolderAnnotationKey]
+		if ruleFolder == "" || ruleFolder != folderUID {
+			continue
+		}
+		if _, keep := desired[rule.Name]; keep {
+			continue
+		}
+		logger.Info("Pruning stale alert rule", "name", rule.Name)
+		if err := c.Delete(ctx, resource.Identifier{Namespace: namespace, Name: rule.Name}, resource.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting stale alert rule %q: %w", rule.Name, err)
+		}
+	}
+	return nil
+}
+
+func pruneStaleRecordingRules(ctx context.Context, c *alertingv0.RecordingRuleClient, namespace, folderUID, groupName string, desired map[string]struct{}, logger log.Logger) error {
+	list, err := c.List(ctx, namespace, resource.ListOptions{
+		LabelFilters: []string{groupLabelFilter(groupName)},
+	})
+	if err != nil {
+		return fmt.Errorf("listing recording rules for prune: %w", err)
+	}
+	for _, rule := range list.Items {
+		ruleFolder := rule.Annotations[alertingv0.FolderAnnotationKey]
+		if ruleFolder == "" || ruleFolder != folderUID {
+			continue
+		}
+		if _, keep := desired[rule.Name]; keep {
+			continue
+		}
+		logger.Info("Pruning stale recording rule", "name", rule.Name)
+		if err := c.Delete(ctx, resource.Identifier{Namespace: namespace, Name: rule.Name}, resource.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting stale recording rule %q: %w", rule.Name, err)
+		}
+	}
+	return nil
+}
+
+// pruneStaleRuleSequences deletes RuleSequences for this group that are no
+// longer needed (e.g. the group no longer contains recording rules). If
+// desiredSeqName is empty, all sequences matching the group label are removed.
+func pruneStaleRuleSequences(ctx context.Context, c *alertingv0.RuleSequenceClient, namespace, folderUID, groupName, desiredSeqName string, logger log.Logger) error {
+	list, err := c.List(ctx, namespace, resource.ListOptions{
+		LabelFilters: []string{groupLabelFilter(groupName)},
+	})
+	if err != nil {
+		return fmt.Errorf("listing rule sequences for prune: %w", err)
+	}
+	for _, seq := range list.Items {
+		seqFolder := seq.Annotations[alertingv0.FolderAnnotationKey]
+		if seqFolder == "" || seqFolder != folderUID {
+			continue
+		}
+		if seq.Name == desiredSeqName {
+			continue
+		}
+		logger.Info("Pruning stale rule sequence", "name", seq.Name)
+		if err := c.Delete(ctx, resource.Identifier{Namespace: namespace, Name: seq.Name}, resource.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting stale rule sequence %q: %w", seq.Name, err)
+		}
+	}
+	return nil
 }
 
 func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostAlertmanagerConfig(c *contextmodel.ReqContext, amCfg apimodels.AlertmanagerUserConfig) response.Response {

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -10,10 +10,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-app-sdk/resource"
 	prommodel "github.com/prometheus/common/model"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -1817,7 +1821,7 @@ func createConvertPrometheusSrv(t *testing.T, opts ...convertPrometheusSrvOption
 		},
 	}
 
-	srv := NewConvertPrometheusSrv(cfg, log.NewNopLogger(), ruleStore, dsCache, alertRuleService, options.featureToggles, options.alertmanager, nil)
+	srv := NewConvertPrometheusSrv(cfg, log.NewNopLogger(), ruleStore, dsCache, alertRuleService, options.featureToggles, options.alertmanager, nil, nil)
 
 	return srv, dsCache, ruleStore
 }
@@ -2509,4 +2513,184 @@ func TestRouteConvertPrometheusDeleteAlertmanagerConfig(t *testing.T) {
 		require.Equal(t, http.StatusAccepted, response.Status())
 		mockAM.AssertExpectations(t)
 	})
+}
+
+// fakeK8sObject is a minimal k8sResource implementation for testing upsertResource.
+type fakeK8sObject struct {
+	name            string
+	namespace       string
+	resourceVersion string
+}
+
+func (f *fakeK8sObject) GetName() string              { return f.name }
+func (f *fakeK8sObject) GetNamespace() string         { return f.namespace }
+func (f *fakeK8sObject) GetResourceVersion() string   { return f.resourceVersion }
+func (f *fakeK8sObject) SetResourceVersion(rv string) { f.resourceVersion = rv }
+func (f *fakeK8sObject) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+}
+
+var fakeGR = schema.GroupResource{Group: "test", Resource: "fakes"}
+
+// fakeK8sClient is a test double for k8sClient[*fakeK8sObject] that stores
+// objects in memory and supports injecting errors via function fields.
+type fakeK8sClient struct {
+	store      map[string]*fakeK8sObject
+	getFunc    func(context.Context, resource.Identifier) (*fakeK8sObject, error)
+	createFunc func(context.Context, *fakeK8sObject, resource.CreateOptions) (*fakeK8sObject, error)
+	updateFunc func(context.Context, *fakeK8sObject, resource.UpdateOptions) (*fakeK8sObject, error)
+}
+
+func newFakeK8sClient() *fakeK8sClient {
+	c := &fakeK8sClient{store: make(map[string]*fakeK8sObject)}
+	// Default implementations.
+	c.getFunc = c.defaultGet
+	c.createFunc = c.defaultCreate
+	c.updateFunc = c.defaultUpdate
+	return c
+}
+
+func storeKey(ns, name string) string { return ns + "/" + name }
+
+func (f *fakeK8sClient) Get(ctx context.Context, id resource.Identifier) (*fakeK8sObject, error) {
+	return f.getFunc(ctx, id)
+}
+
+func (f *fakeK8sClient) Create(ctx context.Context, obj *fakeK8sObject, opts resource.CreateOptions) (*fakeK8sObject, error) {
+	return f.createFunc(ctx, obj, opts)
+}
+
+func (f *fakeK8sClient) Update(ctx context.Context, obj *fakeK8sObject, opts resource.UpdateOptions) (*fakeK8sObject, error) {
+	return f.updateFunc(ctx, obj, opts)
+}
+
+func (f *fakeK8sClient) defaultGet(_ context.Context, id resource.Identifier) (*fakeK8sObject, error) {
+	obj, ok := f.store[storeKey(id.Namespace, id.Name)]
+	if !ok {
+		return nil, apierrors.NewNotFound(fakeGR, id.Name)
+	}
+	cp := *obj
+	return &cp, nil
+}
+
+func (f *fakeK8sClient) defaultCreate(_ context.Context, obj *fakeK8sObject, _ resource.CreateOptions) (*fakeK8sObject, error) {
+	k := storeKey(obj.GetNamespace(), obj.GetName())
+	if _, exists := f.store[k]; exists {
+		return nil, apierrors.NewAlreadyExists(fakeGR, obj.GetName())
+	}
+	stored := *obj
+	stored.resourceVersion = "1"
+	f.store[k] = &stored
+	return &stored, nil
+}
+
+func (f *fakeK8sClient) defaultUpdate(_ context.Context, obj *fakeK8sObject, _ resource.UpdateOptions) (*fakeK8sObject, error) {
+	k := storeKey(obj.GetNamespace(), obj.GetName())
+	existing, ok := f.store[k]
+	if !ok {
+		return nil, apierrors.NewNotFound(fakeGR, obj.GetName())
+	}
+	if obj.GetResourceVersion() != existing.GetResourceVersion() {
+		return nil, apierrors.NewConflict(fakeGR, obj.GetName(), errors.New("resource version mismatch"))
+	}
+	stored := *obj
+	stored.resourceVersion = existing.resourceVersion + "u"
+	f.store[k] = &stored
+	return &stored, nil
+}
+
+func TestUpsertResource_CreatesWhenNotFound(t *testing.T) {
+	c := newFakeK8sClient()
+	obj := &fakeK8sObject{name: "rule-1", namespace: "default"}
+
+	err := upsertResource(context.Background(), c, obj)
+	require.NoError(t, err)
+
+	stored, ok := c.store["default/rule-1"]
+	require.True(t, ok)
+	require.Equal(t, "1", stored.resourceVersion)
+}
+
+func TestUpsertResource_UpdatesWhenExists(t *testing.T) {
+	c := newFakeK8sClient()
+	c.store["default/rule-1"] = &fakeK8sObject{name: "rule-1", namespace: "default", resourceVersion: "42"}
+
+	obj := &fakeK8sObject{name: "rule-1", namespace: "default"}
+	err := upsertResource(context.Background(), c, obj)
+	require.NoError(t, err)
+
+	stored := c.store["default/rule-1"]
+	require.Equal(t, "42u", stored.resourceVersion, "update should bump the version")
+}
+
+func TestUpsertResource_RetriesOnConflict(t *testing.T) {
+	c := newFakeK8sClient()
+	c.store["default/rule-1"] = &fakeK8sObject{name: "rule-1", namespace: "default", resourceVersion: "1"}
+	// First Update fails with conflict, second succeeds (default impl uses fresh RV).
+	calls := 0
+	c.updateFunc = func(ctx context.Context, obj *fakeK8sObject, opts resource.UpdateOptions) (*fakeK8sObject, error) {
+		calls++
+		if calls == 1 {
+			return nil, apierrors.NewConflict(fakeGR, obj.GetName(), errors.New("stale"))
+		}
+		return c.defaultUpdate(ctx, obj, opts)
+	}
+
+	obj := &fakeK8sObject{name: "rule-1", namespace: "default"}
+	err := upsertResource(context.Background(), c, obj)
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+}
+
+func TestUpsertResource_RetriesOnAlreadyExistsAfterNotFound(t *testing.T) {
+	c := newFakeK8sClient()
+	// Simulate race: Get returns NotFound, Create returns AlreadyExists,
+	// then retry's Get finds the object and Update succeeds.
+	createCalls := 0
+	c.createFunc = func(ctx context.Context, obj *fakeK8sObject, _ resource.CreateOptions) (*fakeK8sObject, error) {
+		createCalls++
+		if createCalls == 1 {
+			// Another writer created it between our Get and Create.
+			stored := *obj
+			stored.resourceVersion = "race-1"
+			c.store[storeKey(obj.GetNamespace(), obj.GetName())] = &stored
+			return nil, apierrors.NewAlreadyExists(fakeGR, obj.GetName())
+		}
+		return c.defaultCreate(ctx, obj, resource.CreateOptions{})
+	}
+
+	obj := &fakeK8sObject{name: "rule-1", namespace: "default"}
+	err := upsertResource(context.Background(), c, obj)
+	require.NoError(t, err)
+	require.Equal(t, 1, createCalls, "Create should only be called once before falling through to Update on retry")
+}
+
+func TestUpsertResource_ExhaustsRetriesOnPersistentConflict(t *testing.T) {
+	c := newFakeK8sClient()
+	c.store["default/rule-1"] = &fakeK8sObject{name: "rule-1", namespace: "default", resourceVersion: "1"}
+	c.updateFunc = func(_ context.Context, obj *fakeK8sObject, _ resource.UpdateOptions) (*fakeK8sObject, error) {
+		return nil, apierrors.NewConflict(fakeGR, obj.GetName(), errors.New("always stale"))
+	}
+
+	obj := &fakeK8sObject{name: "rule-1", namespace: "default"}
+	err := upsertResource(context.Background(), c, obj)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "updating")
+	require.True(t, apierrors.IsConflict(errors.Unwrap(err)), "underlying error should be a conflict")
+}
+
+func TestUpsertResource_ClearsResourceVersionBeforeCreate(t *testing.T) {
+	c := newFakeK8sClient()
+	// Object starts with a stale ResourceVersion from a hypothetical prior Update attempt.
+	obj := &fakeK8sObject{name: "rule-1", namespace: "default", resourceVersion: "stale-rv"}
+
+	var rvAtCreate string
+	c.createFunc = func(ctx context.Context, obj *fakeK8sObject, _ resource.CreateOptions) (*fakeK8sObject, error) {
+		rvAtCreate = obj.GetResourceVersion()
+		return c.defaultCreate(ctx, obj, resource.CreateOptions{})
+	}
+
+	err := upsertResource(context.Background(), c, obj)
+	require.NoError(t, err)
+	require.Equal(t, "", rvAtCreate, "ResourceVersion must be cleared before Create call")
 }

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -614,6 +614,7 @@ func (ng *AlertNG) init() error {
 		Tracer:                ng.tracer,
 		UserService:           ng.userService,
 		SilenceLimitsProvider: limitsProvider,
+		ClientGenerator:       ng.clientGenerator,
 	}
 	ng.Api.RegisterAPIEndpoints(ng.Metrics.GetAPIMetrics())
 

--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -82,8 +82,13 @@ type RulesConfig struct {
 	IsPaused bool
 }
 
+// DefaultFromTimeRange is the default relative-time-range `from` distance
+// applied to the query node when the converter config does not specify one.
+// Shared between the legacy and k8s converters to keep them in sync.
+const DefaultFromTimeRange = 600 * time.Second
+
 var (
-	defaultTimeRange        = 600 * time.Second
+	defaultTimeRange        = DefaultFromTimeRange
 	defaultEvaluationOffset = 0 * time.Minute
 
 	defaultConfig = Config{

--- a/pkg/services/ngalert/prom/convert_k8s.go
+++ b/pkg/services/ngalert/prom/convert_k8s.go
@@ -1,0 +1,457 @@
+package prom
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	prom_model "github.com/prometheus/common/model"
+
+	alertingv0 "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+// K8sConverter translates Prometheus rule groups/rules into Kubernetes-native
+// AlertRuleSpec, RecordingRuleSpec, and RuleSequenceSpec resources. It is the
+// counterpart of the legacy Converter (convert.go) which produces models.AlertRule
+// objects for the database-backed provisioning path.
+//
+// The two converters produce semantically identical query graphs so that switching
+// between the legacy and k8s code paths (gated by the
+// alertingConvertPrometheusViaKubernetesAPI feature flag) does not change rule behaviour.
+
+const (
+	// Annotation / label keys used by the k8s conversion path.
+
+	// GroupNameLabelKey labels each created resource with the Prometheus group name it
+	// was imported from. Combined with the folder annotation this uniquely identifies the
+	// import group, allowing the handler to prune stale rules on re-import.
+	GroupNameLabelKey = "alerting.grafana.app/group-name"
+
+	// JSON model defaults injected by AlertQuery.InitDefaults in the legacy storage layer.
+	k8sDefaultMaxDataPoints float64 = 43200
+	k8sDefaultIntervalMS    float64 = 1000
+)
+
+// K8sConverterConfig holds the configuration needed to translate Prometheus rule
+// entries into k8s AlertRule / RecordingRule specs.
+type K8sConverterConfig struct {
+	DatasourceUID       string
+	DatasourceType      string
+	TargetDatasourceUID string
+	// TargetDatasourceType is validated for recording rules (must be
+	// Prometheus-compatible). Defaults to DatasourceType if empty.
+	TargetDatasourceType string
+	DefaultInterval      time.Duration
+	FromTimeRange        time.Duration
+	EvaluationOffset     time.Duration
+	NoDataState          alertingv0.AlertRuleNoDataState
+	ExecErrState         alertingv0.AlertRuleExecErrState
+	// PauseAlertRules, if true, sets Paused=true on every alerting rule spec.
+	PauseAlertRules bool
+	// PauseRecordingRules, if true, sets Paused=true on every recording rule spec.
+	PauseRecordingRules bool
+	// ExtraLabels are merged into every alerting rule's spec labels with the
+	// lowest precedence (group labels and rule labels override).
+	ExtraLabels map[string]string
+}
+
+func (c K8sConverterConfig) withDefaults() K8sConverterConfig {
+	if c.DatasourceType == "" {
+		c.DatasourceType = datasources.DS_PROMETHEUS
+	}
+	if c.TargetDatasourceUID == "" {
+		c.TargetDatasourceUID = c.DatasourceUID
+	}
+	if c.TargetDatasourceType == "" {
+		c.TargetDatasourceType = c.DatasourceType
+	}
+	if c.DefaultInterval == 0 {
+		c.DefaultInterval = time.Minute
+	}
+	if c.FromTimeRange == 0 {
+		c.FromTimeRange = DefaultFromTimeRange
+	}
+	if c.NoDataState == "" {
+		c.NoDataState = alertingv0.AlertRuleNoDataStateOk
+	}
+	if c.ExecErrState == "" {
+		c.ExecErrState = alertingv0.AlertRuleExecErrStateOk
+	}
+	return c
+}
+
+func (c K8sConverterConfig) validate() error {
+	if c.DatasourceUID == "" {
+		return fmt.Errorf("datasource UID is required")
+	}
+	if c.DatasourceType == "" {
+		return fmt.Errorf("datasource type is required")
+	}
+	if !isConvertibleDatasourceType(c.DatasourceType) {
+		return ErrInvalidDatasourceType.Errorf("invalid datasource type: %s, must be prometheus-compatible or loki", c.DatasourceType)
+	}
+	if c.DefaultInterval == 0 {
+		return fmt.Errorf("default evaluation interval is required")
+	}
+	return nil
+}
+
+// K8sConverter builds k8s-native alert/recording rule specs from Prometheus rule
+// definitions. It is stateless: all inputs are supplied per call.
+type K8sConverter struct {
+	cfg K8sConverterConfig
+}
+
+func NewK8sConverter(cfg K8sConverterConfig) (*K8sConverter, error) {
+	cfg = cfg.withDefaults()
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return &K8sConverter{cfg: cfg}, nil
+}
+
+// BuildAlertRuleSpec produces the AlertRuleSpec for an alerting rule entry.
+// The caller is responsible for ObjectMeta (name, namespace, folder annotation, etc.).
+func (c *K8sConverter) BuildAlertRuleSpec(group PrometheusRuleGroup, rule PrometheusRule) (alertingv0.AlertRuleSpec, error) {
+	if rule.Alert == "" {
+		return alertingv0.AlertRuleSpec{}, fmt.Errorf("not an alerting rule")
+	}
+	interval := c.groupInterval(group.Interval)
+
+	expressions, err := c.buildAlertingExpressions(rule.Expr, group)
+	if err != nil {
+		return alertingv0.AlertRuleSpec{}, err
+	}
+	// Trigger.Interval is formatted via prom_model.Duration.String() (e.g. "1m"), not
+	// Go's time.Duration.String() (e.g. "1m0s"), to match the compat layer.
+	// Extra labels have lowest precedence, then group, then rule.
+	merged := mergeLabels(c.cfg.ExtraLabels, mergeLabels(group.Labels, rule.Labels))
+
+	spec := alertingv0.AlertRuleSpec{
+		Title:        rule.Alert,
+		Trigger:      alertingv0.AlertRuleIntervalTrigger{Interval: alertingv0.AlertRulePromDuration(prom_model.Duration(interval).String())},
+		NoDataState:  c.cfg.NoDataState,
+		ExecErrState: c.cfg.ExecErrState,
+		Expressions:  expressions,
+		Labels:       toAlertTemplateLabels(merged),
+		Annotations:  toAlertTemplateLabels(rule.Annotations),
+	}
+	// MissingSeriesEvalsToResolve=1 mirrors Prometheus' "alert resolves as soon as
+	// series disappears" semantics.
+	one := int64(1)
+	spec.MissingSeriesEvalsToResolve = &one
+
+	if c.cfg.PauseAlertRules {
+		paused := true
+		spec.Paused = &paused
+	}
+	if rule.For != nil {
+		canonical := k8sCanonicalDuration(*rule.For)
+		spec.For = &canonical
+	}
+	if rule.KeepFiringFor != nil {
+		canonical := k8sCanonicalDuration(*rule.KeepFiringFor)
+		spec.KeepFiringFor = &canonical
+	}
+	return spec, nil
+}
+
+// BuildRecordingRuleSpec produces the RecordingRuleSpec for a recording rule entry.
+func (c *K8sConverter) BuildRecordingRuleSpec(group PrometheusRuleGroup, rule PrometheusRule) (alertingv0.RecordingRuleSpec, error) {
+	if rule.Record == "" {
+		return alertingv0.RecordingRuleSpec{}, fmt.Errorf("not a recording rule")
+	}
+	if !isPrometheusCompatibleDatasourceType(c.cfg.TargetDatasourceType) {
+		return alertingv0.RecordingRuleSpec{}, ErrInvalidTargetDatasourceType.Errorf(
+			"invalid target datasource type: %s, must be prometheus-compatible", c.cfg.TargetDatasourceType)
+	}
+	interval := c.groupInterval(group.Interval)
+
+	expressions, err := c.buildRecordingExpressions(rule.Expr, group)
+	if err != nil {
+		return alertingv0.RecordingRuleSpec{}, err
+	}
+	spec := alertingv0.RecordingRuleSpec{
+		Title:               rule.Record,
+		Metric:              alertingv0.RecordingRuleMetricName(rule.Record),
+		Trigger:             alertingv0.RecordingRuleIntervalTrigger{Interval: alertingv0.RecordingRulePromDuration(prom_model.Duration(interval).String())},
+		TargetDatasourceUID: alertingv0.RecordingRuleDatasourceUID(c.cfg.TargetDatasourceUID),
+		Expressions:         expressions,
+		Labels:              toRecordingTemplateLabels(mergeLabels(group.Labels, rule.Labels)),
+	}
+	if c.cfg.PauseRecordingRules {
+		paused := true
+		spec.Paused = &paused
+	}
+	return spec, nil
+}
+
+// BuildRuleSequenceSpec produces a RuleSequenceSpec for a group that contains
+// recording rules. The caller supplies the k8s resource names (metadata.name) of
+// the rules that were already created.
+func (c *K8sConverter) BuildRuleSequenceSpec(
+	group PrometheusRuleGroup,
+	recordingRuleNames []string,
+	alertRuleNames []string,
+) alertingv0.RuleSequenceSpec {
+	interval := c.groupInterval(group.Interval)
+
+	recRefs := make([]alertingv0.RuleSequenceRuleRef, 0, len(recordingRuleNames))
+	for _, name := range recordingRuleNames {
+		recRefs = append(recRefs, alertingv0.RuleSequenceRuleRef{
+			Name: alertingv0.RuleSequenceRuleUID(name),
+		})
+	}
+
+	alertRefs := make([]alertingv0.RuleSequenceRuleRef, 0, len(alertRuleNames))
+	for _, name := range alertRuleNames {
+		alertRefs = append(alertRefs, alertingv0.RuleSequenceRuleRef{
+			Name: alertingv0.RuleSequenceRuleUID(name),
+		})
+	}
+
+	return alertingv0.RuleSequenceSpec{
+		Trigger: alertingv0.RuleSequenceIntervalTrigger{
+			Interval: alertingv0.RuleSequencePromDuration(prom_model.Duration(interval).String()),
+		},
+		RecordingRules: recRefs,
+		AlertingRules:  alertRefs,
+	}
+}
+
+// buildAlertingExpressions produces the three-node query graph used for alerting rules:
+//  1. "query": executes the PromQL/LogQL query
+//  2. "prometheus_math": math expression that treats any returned value as alerting
+//  3. "threshold": greater-than-zero check, marked as the rule's source
+func (c *K8sConverter) buildAlertingExpressions(expr string, group PrometheusRuleGroup) (alertingv0.AlertRuleExpressionMap, error) {
+	queryNode, err := c.buildAlertQueryNode(expr, group)
+	if err != nil {
+		return nil, err
+	}
+	return alertingv0.AlertRuleExpressionMap{
+		queryRefID:          queryNode,
+		prometheusMathRefID: c.buildAlertMathNode(),
+		thresholdRefID:      c.buildAlertThresholdNode(),
+	}, nil
+}
+
+// buildRecordingExpressions produces a single query node marked as the source.
+func (c *K8sConverter) buildRecordingExpressions(expr string, group PrometheusRuleGroup) (alertingv0.RecordingRuleExpressionMap, error) {
+	from, to := c.queryRelativeTimeRange(group)
+	dsUID := alertingv0.RecordingRuleDatasourceUID(c.cfg.DatasourceUID)
+	source := true
+	queryType := c.queryNodeQueryType()
+
+	return alertingv0.RecordingRuleExpressionMap{
+		queryRefID: {
+			DatasourceUID: &dsUID,
+			QueryType:     &queryType,
+			RelativeTimeRange: &alertingv0.RecordingRuleRelativeTimeRange{
+				From: alertingv0.RecordingRulePromDurationWMillis(from),
+				To:   alertingv0.RecordingRulePromDurationWMillis(to),
+			},
+			Model:  c.queryNodeModel(expr),
+			Source: &source,
+		},
+	}, nil
+}
+
+// buildAlertQueryNode returns the query node for an alerting rule. It returns
+// an error for forward compatibility (e.g. if query-time-range parsing is
+// reintroduced); today it cannot fail.
+func (c *K8sConverter) buildAlertQueryNode(expr string, group PrometheusRuleGroup) (alertingv0.AlertRuleExpression, error) {
+	from, to := c.queryRelativeTimeRange(group)
+	dsUID := alertingv0.AlertRuleDatasourceUID(c.cfg.DatasourceUID)
+	queryType := c.queryNodeQueryType()
+	return alertingv0.AlertRuleExpression{
+		DatasourceUID: &dsUID,
+		QueryType:     &queryType,
+		RelativeTimeRange: &alertingv0.AlertRuleRelativeTimeRange{
+			From: alertingv0.AlertRulePromDurationWMillis(from),
+			To:   alertingv0.AlertRulePromDurationWMillis(to),
+		},
+		Model: c.queryNodeModel(expr),
+	}, nil
+}
+
+func (c *K8sConverter) buildAlertMathNode() alertingv0.AlertRuleExpression {
+	queryType := "math"
+	return alertingv0.AlertRuleExpression{
+		QueryType: &queryType,
+		Model:     c.exprNodeModel(prometheusMathRefID, "math", c.mathExpressionModel()),
+	}
+}
+
+func (c *K8sConverter) buildAlertThresholdNode() alertingv0.AlertRuleExpression {
+	queryType := "threshold"
+	source := true
+	return alertingv0.AlertRuleExpression{
+		QueryType: &queryType,
+		Source:    &source,
+		Model:     c.exprNodeModel(thresholdRefID, "threshold", c.thresholdExpressionModel()),
+	}
+}
+
+func (c *K8sConverter) queryNodeModel(expr string) map[string]any {
+	m := map[string]any{
+		"datasource": map[string]any{
+			"type": c.cfg.DatasourceType,
+			"uid":  c.cfg.DatasourceUID,
+		},
+		"expr":          expr,
+		"instant":       true,
+		"range":         false,
+		"refId":         queryRefID,
+		"maxDataPoints": k8sDefaultMaxDataPoints,
+		"intervalMs":    k8sDefaultIntervalMS,
+	}
+	if c.cfg.DatasourceType == datasources.DS_LOKI {
+		m["queryType"] = "instant"
+	}
+	return m
+}
+
+func (c *K8sConverter) exprNodeModel(refID, nodeType string, extra map[string]any) map[string]any {
+	m := map[string]any{
+		"datasource": map[string]any{
+			"type": "__expr__",
+			"uid":  "__expr__",
+		},
+		"refId":         refID,
+		"type":          nodeType,
+		"maxDataPoints": k8sDefaultMaxDataPoints,
+		"intervalMs":    k8sDefaultIntervalMS,
+	}
+	for k, v := range extra {
+		m[k] = v
+	}
+	return m
+}
+
+func (c *K8sConverter) mathExpressionModel() map[string]any {
+	return map[string]any{
+		"expression": fmt.Sprintf("is_number($%[1]s) || is_nan($%[1]s) || is_inf($%[1]s)", queryRefID),
+	}
+}
+
+func (c *K8sConverter) thresholdExpressionModel() map[string]any {
+	return map[string]any{
+		"expression": prometheusMathRefID,
+		"conditions": []any{
+			map[string]any{
+				"evaluator": map[string]any{
+					"type":   "gt",
+					"params": []any{float64(0)},
+				},
+			},
+		},
+	}
+}
+
+func (c *K8sConverter) queryNodeQueryType() string {
+	if c.cfg.DatasourceType == datasources.DS_LOKI {
+		return datasources.DS_LOKI
+	}
+	return datasources.DS_PROMETHEUS
+}
+
+// queryRelativeTimeRange resolves the (from, to) duration strings used on the
+// query node. Per-group queryOffset overrides the global EvaluationOffset. The
+// returned strings use Go's time.Duration.String() format.
+func (c *K8sConverter) queryRelativeTimeRange(group PrometheusRuleGroup) (from, to string) {
+	evaluationOffset := c.cfg.EvaluationOffset
+	if group.QueryOffset != nil {
+		evaluationOffset = time.Duration(*group.QueryOffset)
+	}
+	return (c.cfg.FromTimeRange + evaluationOffset).String(), evaluationOffset.String()
+}
+
+// groupInterval resolves the group's evaluation interval, falling back to the
+// converter's DefaultInterval when the group doesn't specify one.
+func (c *K8sConverter) groupInterval(d prom_model.Duration) time.Duration {
+	if d == 0 {
+		return c.cfg.DefaultInterval
+	}
+	return time.Duration(d)
+}
+
+// k8sCanonicalDuration normalises a prommodel.Duration to Go's time.Duration.String()
+// format (e.g. prommodel 5m -> "5m0s") to match the compat layer.
+func k8sCanonicalDuration(d prom_model.Duration) string {
+	return time.Duration(d).String()
+}
+
+func toAlertTemplateLabels(in map[string]string) map[string]alertingv0.AlertRuleTemplateString {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]alertingv0.AlertRuleTemplateString, len(in))
+	for k, v := range in {
+		out[k] = alertingv0.AlertRuleTemplateString(v)
+	}
+	return out
+}
+
+func toRecordingTemplateLabels(in map[string]string) map[string]alertingv0.RecordingRuleTemplateString {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]alertingv0.RecordingRuleTemplateString, len(in))
+	for k, v := range in {
+		out[k] = alertingv0.RecordingRuleTemplateString(v)
+	}
+	return out
+}
+
+// mergeLabels merges two label sets, with override winning on conflict. Used
+// to layer rule labels over group labels (and group+rule over extra labels),
+// matching Prometheus' inner-scope-wins semantics.
+func mergeLabels(base, override map[string]string) map[string]string {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(base)+len(override))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range override {
+		out[k] = v
+	}
+	return out
+}
+
+// RuleName produces a deterministic, DNS-1123 compliant metadata.name for a
+// rule created by the k8s conversion path. If the rule carries the special
+// __grafana_alert_rule_uid__ label, that value is validated and used as-is
+// (matching the legacy converter's getUID behaviour). Otherwise a stable UUID
+// is derived from the k8s namespace, folder UID, group name, and position
+// index. Including folderUID prevents collisions when the same group name
+// appears in different folders.
+//
+// The hash inputs deliberately differ from the legacy getUID
+// (orgID|namespaceUID|group|position) because this path operates in k8s
+// namespace terms, not org-ID terms. The two paths produce different UUIDs
+// for the same logical rule. This is intentional: legacy rules live in the
+// database while k8s rules live in unified storage, so name overlap would be
+// meaningless. Do not "unify" the hash inputs without migrating all existing
+// k8s-path resources.
+func RuleName(k8sNamespace, folderUID, groupName string, position int, rule PrometheusRule) (string, error) {
+	if uid, ok := rule.Labels[ruleUIDLabel]; ok && uid != "" {
+		if err := util.ValidateUID(uid); err != nil {
+			return "", fmt.Errorf("invalid %s label value %q: %w", ruleUIDLabel, uid, err)
+		}
+		return uid, nil
+	}
+	data := fmt.Sprintf("%s|%s|%s|%d", k8sNamespace, folderUID, groupName, position)
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(data)).String(), nil
+}
+
+// SequenceName produces a deterministic, DNS-1123 compliant metadata.name for
+// a RuleSequence created by the k8s conversion path. Includes folderUID to
+// avoid collisions across folders.
+func SequenceName(k8sNamespace, folderUID, groupName string) string {
+	data := fmt.Sprintf("seq|%s|%s|%s", k8sNamespace, folderUID, groupName)
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(data)).String()
+}

--- a/pkg/services/ngalert/prom/convert_k8s_test.go
+++ b/pkg/services/ngalert/prom/convert_k8s_test.go
@@ -1,0 +1,328 @@
+package prom
+
+import (
+	"testing"
+	"time"
+
+	prommodel "github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	alertingv0 "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/datasources"
+)
+
+func newTestConverter(t *testing.T, cfg K8sConverterConfig) *K8sConverter {
+	t.Helper()
+	c, err := NewK8sConverter(cfg)
+	require.NoError(t, err)
+	return c
+}
+
+func TestK8sConverterConfig_Defaults(t *testing.T) {
+	cfg := K8sConverterConfig{DatasourceUID: "ds-123"}.withDefaults()
+	assert.Equal(t, datasources.DS_PROMETHEUS, cfg.DatasourceType)
+	assert.Equal(t, "ds-123", cfg.TargetDatasourceUID, "TargetDatasourceUID should default to DatasourceUID")
+	assert.Equal(t, time.Minute, cfg.DefaultInterval)
+	assert.Equal(t, DefaultFromTimeRange, cfg.FromTimeRange)
+	assert.Equal(t, alertingv0.AlertRuleNoDataStateOk, cfg.NoDataState)
+	assert.Equal(t, alertingv0.AlertRuleExecErrStateOk, cfg.ExecErrState)
+}
+
+func TestNewK8sConverter_RejectsInvalidDatasourceType(t *testing.T) {
+	_, err := NewK8sConverter(K8sConverterConfig{
+		DatasourceUID:  "ds-prom",
+		DatasourceType: "mysql",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidDatasourceType)
+}
+
+func TestNewK8sConverter_AcceptsLoki(t *testing.T) {
+	_, err := NewK8sConverter(K8sConverterConfig{
+		DatasourceUID:  "ds-loki",
+		DatasourceType: datasources.DS_LOKI,
+	})
+	require.NoError(t, err)
+}
+
+func TestK8sBuildAlertRuleSpec_ThreeNodeQueryGraph(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{DatasourceUID: "ds-prom", DatasourceType: datasources.DS_PROMETHEUS})
+	forD := prommodel.Duration(5 * time.Minute)
+	group := PrometheusRuleGroup{Name: "group-1"}
+	rule := PrometheusRule{
+		Alert:       "HighRequestRate",
+		Expr:        `sum(rate(http_requests_total[5m])) > 100`,
+		For:         &forD,
+		Labels:      map[string]string{"severity": "page"},
+		Annotations: map[string]string{"summary": "request rate too high"},
+	}
+
+	spec, err := c.BuildAlertRuleSpec(group, rule)
+	require.NoError(t, err)
+
+	assert.Equal(t, "HighRequestRate", spec.Title)
+	assert.Equal(t, alertingv0.AlertRulePromDuration("1m"), spec.Trigger.Interval, "default group interval rendered prom-style")
+	require.NotNil(t, spec.For)
+	assert.Equal(t, "5m0s", *spec.For, "For uses Go time.Duration.String() to match compat-layer output")
+
+	// Three nodes: query / prometheus_math / threshold.
+	require.Len(t, spec.Expressions, 3)
+	queryNode := spec.Expressions[queryRefID]
+	require.NotNil(t, queryNode.DatasourceUID)
+	assert.Equal(t, "ds-prom", string(*queryNode.DatasourceUID))
+	require.NotNil(t, queryNode.QueryType)
+	assert.Equal(t, datasources.DS_PROMETHEUS, *queryNode.QueryType)
+	require.NotNil(t, queryNode.RelativeTimeRange)
+	assert.Equal(t, alertingv0.AlertRulePromDurationWMillis("10m0s"), queryNode.RelativeTimeRange.From, "default FromTimeRange=600s + offset=0")
+	assert.Equal(t, alertingv0.AlertRulePromDurationWMillis("0s"), queryNode.RelativeTimeRange.To)
+	assert.Nil(t, queryNode.Source)
+
+	mathNode := spec.Expressions[prometheusMathRefID]
+	assert.Nil(t, mathNode.DatasourceUID, "math node runs on the expr engine; DatasourceUID must be nil")
+	require.NotNil(t, mathNode.QueryType)
+	assert.Equal(t, "math", *mathNode.QueryType)
+	assert.Nil(t, mathNode.Source)
+	mathModel, ok := mathNode.Model.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "is_number($query) || is_nan($query) || is_inf($query)", mathModel["expression"])
+
+	thresholdNode := spec.Expressions[thresholdRefID]
+	assert.Nil(t, thresholdNode.DatasourceUID)
+	require.NotNil(t, thresholdNode.QueryType)
+	assert.Equal(t, "threshold", *thresholdNode.QueryType)
+	require.NotNil(t, thresholdNode.Source)
+	assert.True(t, *thresholdNode.Source, "threshold must be the rule's source")
+}
+
+func TestK8sBuildAlertRuleSpec_GroupQueryOffsetOverridesGlobal(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{
+		DatasourceUID:    "ds-prom",
+		EvaluationOffset: 30 * time.Second,
+	})
+	off := prommodel.Duration(2 * time.Minute)
+	group := PrometheusRuleGroup{Name: "g", QueryOffset: &off}
+	rule := PrometheusRule{Alert: "X", Expr: "up"}
+
+	spec, err := c.BuildAlertRuleSpec(group, rule)
+	require.NoError(t, err)
+	queryNode := spec.Expressions[queryRefID]
+	require.NotNil(t, queryNode.RelativeTimeRange)
+	assert.Equal(t, alertingv0.AlertRulePromDurationWMillis("12m0s"), queryNode.RelativeTimeRange.From, "from = FromTimeRange + group queryOffset (10m + 2m)")
+	assert.Equal(t, alertingv0.AlertRulePromDurationWMillis("2m0s"), queryNode.RelativeTimeRange.To, "to = group queryOffset, overriding the global EvaluationOffset")
+}
+
+func TestK8sBuildRecordingRuleSpec_SingleQueryNodeIsSource(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{DatasourceUID: "ds-prom", TargetDatasourceUID: "ds-target"})
+	group := PrometheusRuleGroup{Name: "g"}
+	rule := PrometheusRule{
+		Record: "http_request_rate:sum",
+		Expr:   `sum(rate(http_requests_total[1m]))`,
+		Labels: map[string]string{"team": "core"},
+	}
+
+	spec, err := c.BuildRecordingRuleSpec(group, rule)
+	require.NoError(t, err)
+
+	assert.Equal(t, "http_request_rate:sum", spec.Title)
+	assert.Equal(t, alertingv0.RecordingRuleMetricName("http_request_rate:sum"), spec.Metric)
+	assert.Equal(t, alertingv0.RecordingRuleDatasourceUID("ds-target"), spec.TargetDatasourceUID)
+
+	require.Len(t, spec.Expressions, 1, "recording rules have a single query node")
+	node := spec.Expressions[queryRefID]
+	require.NotNil(t, node.Source)
+	assert.True(t, *node.Source)
+	require.NotNil(t, node.DatasourceUID)
+	assert.Equal(t, "ds-prom", string(*node.DatasourceUID))
+}
+
+func TestK8sBuildAlertRuleSpec_GroupLabelsMergeWithRuleLabels(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{DatasourceUID: "ds-prom"})
+	group := PrometheusRuleGroup{
+		Name:   "g",
+		Labels: map[string]string{"severity": "warning", "team": "core"},
+	}
+	rule := PrometheusRule{
+		Alert:  "X",
+		Expr:   "up == 0",
+		Labels: map[string]string{"severity": "critical"},
+	}
+
+	spec, err := c.BuildAlertRuleSpec(group, rule)
+	require.NoError(t, err)
+	assert.Equal(t, alertingv0.AlertRuleTemplateString("critical"), spec.Labels["severity"])
+	assert.Equal(t, alertingv0.AlertRuleTemplateString("core"), spec.Labels["team"])
+}
+
+func TestK8sBuildAlertRuleSpec_ExtraLabelsLowestPrecedence(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{
+		DatasourceUID: "ds-prom",
+		ExtraLabels:   map[string]string{"env": "prod", "severity": "info"},
+	})
+	group := PrometheusRuleGroup{
+		Name:   "g",
+		Labels: map[string]string{"severity": "warning"},
+	}
+	rule := PrometheusRule{
+		Alert: "X",
+		Expr:  "up == 0",
+	}
+
+	spec, err := c.BuildAlertRuleSpec(group, rule)
+	require.NoError(t, err)
+	// Extra labels provide "env", group label overrides "severity".
+	assert.Equal(t, alertingv0.AlertRuleTemplateString("prod"), spec.Labels["env"])
+	assert.Equal(t, alertingv0.AlertRuleTemplateString("warning"), spec.Labels["severity"])
+}
+
+func TestK8sBuildAlertRuleSpec_PausedWhenConfigured(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{DatasourceUID: "ds-prom", PauseAlertRules: true})
+	spec, err := c.BuildAlertRuleSpec(
+		PrometheusRuleGroup{Name: "g"},
+		PrometheusRule{Alert: "X", Expr: "up"},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, spec.Paused)
+	assert.True(t, *spec.Paused)
+}
+
+func TestK8sBuildRecordingRuleSpec_PausedWhenConfigured(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{DatasourceUID: "ds-prom", PauseRecordingRules: true})
+	spec, err := c.BuildRecordingRuleSpec(
+		PrometheusRuleGroup{Name: "g"},
+		PrometheusRule{Record: "x:sum", Expr: "sum(x)"},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, spec.Paused)
+	assert.True(t, *spec.Paused)
+}
+
+func TestK8sBuildAlertRuleSpec_RejectsRecordingEntry(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{DatasourceUID: "ds-prom"})
+	_, err := c.BuildAlertRuleSpec(
+		PrometheusRuleGroup{Name: "g"},
+		PrometheusRule{Record: "x", Expr: "x"},
+	)
+	assert.Error(t, err)
+}
+
+func TestK8sBuildRecordingRuleSpec_RejectsAlertingEntry(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{DatasourceUID: "ds-prom"})
+	_, err := c.BuildRecordingRuleSpec(
+		PrometheusRuleGroup{Name: "g"},
+		PrometheusRule{Alert: "x", Expr: "x"},
+	)
+	assert.Error(t, err)
+}
+
+func TestK8sBuildAlertRuleSpec_LokiDatasourceQueryTypeInModel(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{DatasourceUID: "ds-loki", DatasourceType: datasources.DS_LOKI})
+	spec, err := c.BuildAlertRuleSpec(
+		PrometheusRuleGroup{Name: "g"},
+		PrometheusRule{Alert: "X", Expr: `{job="x"} |= "err"`},
+	)
+	require.NoError(t, err)
+
+	queryNode := spec.Expressions[queryRefID]
+	require.NotNil(t, queryNode.QueryType)
+	assert.Equal(t, datasources.DS_LOKI, *queryNode.QueryType)
+	m, ok := queryNode.Model.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "instant", m["queryType"], "Loki query nodes carry an `instant` queryType inside the model JSON")
+}
+
+func TestK8sBuildRuleSequenceSpec(t *testing.T) {
+	interval := prommodel.Duration(30 * time.Second)
+	c := newTestConverter(t, K8sConverterConfig{DatasourceUID: "ds-prom"})
+	group := PrometheusRuleGroup{Name: "g", Interval: interval}
+
+	spec := c.BuildRuleSequenceSpec(group, []string{"rec-rule-1", "rec-rule-2"}, []string{"alert-rule-1"})
+
+	assert.Equal(t, alertingv0.RuleSequencePromDuration("30s"), spec.Trigger.Interval)
+	require.Len(t, spec.RecordingRules, 2)
+	assert.Equal(t, alertingv0.RuleSequenceRuleUID("rec-rule-1"), spec.RecordingRules[0].Name)
+	assert.Equal(t, alertingv0.RuleSequenceRuleUID("rec-rule-2"), spec.RecordingRules[1].Name)
+	require.Len(t, spec.AlertingRules, 1)
+	assert.Equal(t, alertingv0.RuleSequenceRuleUID("alert-rule-1"), spec.AlertingRules[0].Name)
+}
+
+func TestK8sBuildRuleSequenceSpec_NoAlertingRules(t *testing.T) {
+	c := newTestConverter(t, K8sConverterConfig{DatasourceUID: "ds-prom"})
+	group := PrometheusRuleGroup{Name: "g"}
+
+	spec := c.BuildRuleSequenceSpec(group, []string{"rec-rule-1"}, nil)
+
+	require.Len(t, spec.RecordingRules, 1)
+	assert.Empty(t, spec.AlertingRules)
+}
+
+func TestRuleName_StableAcrossInvocations(t *testing.T) {
+	rule := PrometheusRule{Alert: "X", Expr: "up"}
+	name1, err1 := RuleName("default", "folder-1", "mygroup", 0, rule)
+	require.NoError(t, err1)
+	name2, err2 := RuleName("default", "folder-1", "mygroup", 0, rule)
+	require.NoError(t, err2)
+	assert.Equal(t, name1, name2, "same inputs must produce the same name")
+}
+
+func TestRuleName_DifferentPositionsProduceDifferentNames(t *testing.T) {
+	rule := PrometheusRule{Alert: "X", Expr: "up"}
+	name0, _ := RuleName("default", "folder-1", "mygroup", 0, rule)
+	name1, _ := RuleName("default", "folder-1", "mygroup", 1, rule)
+	assert.NotEqual(t, name0, name1)
+}
+
+func TestRuleName_DifferentGroupsProduceDifferentNames(t *testing.T) {
+	rule := PrometheusRule{Alert: "X", Expr: "up"}
+	nameA, _ := RuleName("default", "folder-1", "group-a", 0, rule)
+	nameB, _ := RuleName("default", "folder-1", "group-b", 0, rule)
+	assert.NotEqual(t, nameA, nameB)
+}
+
+func TestRuleName_DifferentFoldersProduceDifferentNames(t *testing.T) {
+	rule := PrometheusRule{Alert: "X", Expr: "up"}
+	nameA, _ := RuleName("default", "folder-a", "mygroup", 0, rule)
+	nameB, _ := RuleName("default", "folder-b", "mygroup", 0, rule)
+	assert.NotEqual(t, nameA, nameB, "same group name in different folders must produce different names")
+}
+
+func TestRuleName_HonorsUIDLabel(t *testing.T) {
+	rule := PrometheusRule{
+		Alert:  "X",
+		Expr:   "up",
+		Labels: map[string]string{"__grafana_alert_rule_uid__": "custom-uid-123"},
+	}
+	name, err := RuleName("default", "folder-1", "mygroup", 0, rule)
+	require.NoError(t, err)
+	assert.Equal(t, "custom-uid-123", name)
+}
+
+func TestRuleName_RejectsInvalidUIDLabel(t *testing.T) {
+	rule := PrometheusRule{
+		Alert:  "X",
+		Expr:   "up",
+		Labels: map[string]string{"__grafana_alert_rule_uid__": ""},
+	}
+	// Empty UID label is ignored (falls through to generated UUID).
+	name, err := RuleName("default", "folder-1", "mygroup", 0, rule)
+	require.NoError(t, err)
+	assert.NotEmpty(t, name)
+
+	// Too-long UID label should be rejected.
+	rule.Labels["__grafana_alert_rule_uid__"] = "aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmm"
+	_, err = RuleName("default", "folder-1", "mygroup", 0, rule)
+	assert.Error(t, err)
+}
+
+func TestSequenceName_StableAcrossInvocations(t *testing.T) {
+	name1 := SequenceName("default", "folder-1", "mygroup")
+	name2 := SequenceName("default", "folder-1", "mygroup")
+	assert.Equal(t, name1, name2)
+}
+
+func TestSequenceName_DiffersFromRuleName(t *testing.T) {
+	rule := PrometheusRule{Alert: "X", Expr: "up"}
+	ruleName, _ := RuleName("default", "folder-1", "mygroup", 0, rule)
+	seqName := SequenceName("default", "folder-1", "mygroup")
+	assert.NotEqual(t, ruleName, seqName)
+}


### PR DESCRIPTION
> [!WARNING]
> **Draft — tabled for now.** Opening this to preserve the work and the context behind the decision, not for immediate review or merge. See "Why this is tabled" below.

**What is this feature?**

An experimental, feature-flagged (`alertingConvertPrometheusViaKubernetesAPI`, default off) path for the Prometheus rule conversion API that creates `AlertRule`, `RecordingRule`, and `RuleSequence` resources through the internal Kubernetes clients instead of the legacy provisioning store (`alertRuleService.ReplaceRuleGroups`). When the flag is off, the existing path is completely unchanged.

Highlights:
- `K8sConverter` builds the k8s specs (`AlertRuleSpec` / `RecordingRuleSpec` / `RuleSequenceSpec`) from Prometheus rule groups, mirroring the legacy converter's query graph.
- Groups that contain recording rules also get a `RuleSequence`.
- Idempotent upsert with retry-on-conflict; stale rules/sequences from a previous import are pruned via a `group-name` label.
- The original Prometheus definition is mapped to/from the `alerting.grafana.app/prometheus-rule-definition` annotation in the rules compat layer (also split out on its own in #126201).

**Why do we need this feature?**

Move Prometheus/Mimir rule import onto the k8s / app-platform APIs and represent imported groups as `RuleSequence`s.

**Why this is tabled**

Two guards this path depends on make more sense to implement in the backend storage migrations than in the conversion API:

1. **Preventing a sequenced rule from being moved to another folder.** A rule that belongs to a `RuleSequence` must stay in the sequence's folder.
2. **Adding a rule to a sequence when it's added to a converted group.** A converted group's sequence membership must be maintained as rules come and go.

The reason these belong in storage, not here: both only matter once a user has disabled provenance on a converted group, which would otherwise restrict access to the conversion-API only. At that point the risky writes (moving a rule out of the folder, adding a rule to the group) arrive through the **UI or the legacy API** — paths the conversion handler never sees and therefore cannot guard. Enforcing the invariants where the rules are actually persisted is the only place that covers every write path.

So we're tabling this branch until those guards land as part of the storage migrations. The branch and the (default-off) feature toggle are kept so the work isn't lost and can be picked back up.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Draft / tabled — see "Why this is tabled" above. Everything is behind the `alertingConvertPrometheusViaKubernetesAPI` toggle (default off); the legacy conversion path is unchanged when the flag is off.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
