### PR TITLE
PanelEditNext: Header delete polish for multi-select

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/HeaderActions.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/HeaderActions.test.tsx
@@ -133,6 +133,38 @@ describe('HeaderActions', () => {
     expect(deleteTransformation).toHaveBeenCalledWith('transform-42');
   });
 
+  it('exits multi-select mode when the header delete is clicked', async () => {
+    const deleteQuery = jest.fn();
+    const setMultiSelectMode = jest.fn();
+
+    const { user } = renderWithQueryEditorProvider(<HeaderActions />, {
+      selectedQuery: { refId: 'A', hide: false },
+      uiStateOverrides: { cardType: QueryEditorType.Query, multiSelectMode: true, setMultiSelectMode },
+      actionsOverrides: { deleteQuery },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Delete action' }));
+
+    expect(deleteQuery).toHaveBeenCalledWith('A');
+    expect(setMultiSelectMode).toHaveBeenCalledWith(false);
+  });
+
+  it('does not toggle multi-select mode on header delete when not in multi-select mode', async () => {
+    const deleteQuery = jest.fn();
+    const setMultiSelectMode = jest.fn();
+
+    const { user } = renderWithQueryEditorProvider(<HeaderActions />, {
+      selectedQuery: { refId: 'A', hide: false },
+      uiStateOverrides: { cardType: QueryEditorType.Query, multiSelectMode: false, setMultiSelectMode },
+      actionsOverrides: { deleteQuery },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Delete action' }));
+
+    expect(deleteQuery).toHaveBeenCalledWith('A');
+    expect(setMultiSelectMode).not.toHaveBeenCalled();
+  });
+
   it('passes the selected transformation id to Actions', () => {
     const selectedTransformation = makeTransformation({
       transformId: 'reduce-0',

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/HeaderActions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/HeaderActions.tsx
@@ -31,7 +31,8 @@ interface HeaderActionsProps {
  * own visibility by reading from QueryEditorUIContext.
  */
 export function HeaderActions({ containerRef }: HeaderActionsProps) {
-  const { selectedQuery, selectedTransformation, cardType } = useQueryEditorUIContext();
+  const { selectedQuery, selectedTransformation, cardType, multiSelectMode, setMultiSelectMode } =
+    useQueryEditorUIContext();
   const { toggleQueryHide, toggleTransformationDisabled, deleteQuery, deleteTransformation } = useActionsContext();
 
   const onToggleHide = useCallback(() => {
@@ -48,7 +49,10 @@ export function HeaderActions({ containerRef }: HeaderActionsProps) {
     } else if (selectedTransformation) {
       deleteTransformation(selectedTransformation.transformId);
     }
-  }, [selectedQuery, selectedTransformation, deleteQuery, deleteTransformation]);
+    if (multiSelectMode) {
+      setMultiSelectMode(false);
+    }
+  }, [selectedQuery, selectedTransformation, deleteQuery, deleteTransformation, multiSelectMode, setMultiSelectMode]);
 
   if (cardType === QueryEditorType.Alert) {
     return null;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedCard.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedCard.test.ts
@@ -34,12 +34,12 @@ describe('useSelectedCard', () => {
   ];
 
   describe('query selection', () => {
-    it('should select first query by default when nothing is active', () => {
+    it('should select nothing when no id is provided (useSelectionState supplies the queries[0] fallback upstream)', () => {
       const { result } = renderHook(() =>
         useSelectedCard(null, null, null, mockQueries, mockTransformations, mockAlerts)
       );
 
-      expect(result.current.selectedQuery).toEqual(mockQueries[0]);
+      expect(result.current.selectedQuery).toBeNull();
       expect(result.current.selectedTransformation).toBeNull();
       expect(result.current.selectedAlert).toBeNull();
     });
@@ -94,13 +94,14 @@ describe('useSelectedCard', () => {
       expect(result.current.selectedQuery).toBeNull();
     });
 
-    it('should fall back to first query when the active refId does not exist', () => {
+    it('should return null when the active refId does not exist', () => {
       const { result } = renderHook(() =>
         useSelectedCard('INVALID', null, null, mockQueries, mockTransformations, mockAlerts)
       );
 
-      // Active refId not found and no other type is active — defaults to first query.
-      expect(result.current.selectedQuery).toEqual(mockQueries[0]);
+      // Ids arrive already resolved from useSelectionState, so an unknown id maps to nothing
+      // rather than silently showing a different query.
+      expect(result.current.selectedQuery).toBeNull();
       expect(result.current.selectedTransformation).toBeNull();
       expect(result.current.selectedAlert).toBeNull();
     });
@@ -214,8 +215,8 @@ describe('useSelectedCard', () => {
     });
 
     it('should resolve both when activeQueryRefId and activeTransformationId are simultaneously set', () => {
-      // The wrapper enforces mutual exclusivity for the active ids, but useSelectedCard itself
-      // does not — when both are provided, both resolve.
+      // useSelectionState enforces mutual exclusivity for the active ids, but useSelectedCard
+      // itself does not — when both are provided, both resolve.
       const { result } = renderHook(() =>
         useSelectedCard('B', 'transform-1', null, mockQueries, mockTransformations, mockAlerts)
       );
@@ -292,7 +293,7 @@ describe('useSelectedCard', () => {
       expect(result.current.selectedAlert).toEqual(newAlerts[0]);
     });
 
-    it('should handle the active query being removed from the array by falling back to the first query', () => {
+    it('should return null when the active query is removed from the array (useSelectionState re-resolves upstream)', () => {
       const { result, rerender } = renderHook(
         ({ queries }) => useSelectedCard('B', null, null, queries, mockTransformations, mockAlerts),
         {
@@ -309,7 +310,7 @@ describe('useSelectedCard', () => {
 
       rerender({ queries: newQueries });
 
-      expect(result.current.selectedQuery).toEqual(newQueries[0]);
+      expect(result.current.selectedQuery).toBeNull();
     });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedCard.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedCard.ts
@@ -5,15 +5,13 @@ import { type DataQuery } from '@grafana/schema';
 import { type AlertRule, EMPTY_ALERT, type Transformation } from '../types';
 
 /**
- * Resolves `selectedQuery`, `selectedTransformation`, and `selectedAlert` from active
- * selection ids and the live Scene query/transformation lists.
+ * Maps the resolved active ids from useSelectionState to the corresponding query /
+ * transformation / alert objects. The ids arrive already resolved against the live lists
+ * (useSelectionState falls back to queries[0] when nothing is explicitly active), so this
+ * hook only applies cross-type precedence on top.
  *
- * Query selection has an auto-select fallback: when no active query is set and no other
- * type or picker is active, it defaults to queries[0] so the editor pane is never empty.
- * If the active query is deleted, its refId is no longer found and the fallback kicks in.
- *
- * @param hasPendingPicker - Suppresses the query auto-select fallback while an expression or
- *   transformation type picker is active, so the content area shows the picker instead.
+ * @param hasPendingPicker - Suppresses the query card while an expression or transformation
+ *   type picker is active, so the content area shows the picker instead.
  */
 export function useSelectedCard(
   activeQueryRefId: string | null,
@@ -25,23 +23,12 @@ export function useSelectedCard(
   hasPendingPicker = false
 ) {
   const selectedQuery = useMemo(() => {
-    if (selectedAlertId || hasPendingPicker) {
+    if (selectedAlertId || hasPendingPicker || !activeQueryRefId) {
       return null;
     }
 
-    if (activeQueryRefId) {
-      const query = queries.find(({ refId }) => refId === activeQueryRefId);
-      if (query) {
-        return query;
-      }
-    }
-
-    if (activeTransformationId) {
-      return null;
-    }
-
-    return queries.length > 0 ? queries[0] : null;
-  }, [queries, activeQueryRefId, activeTransformationId, selectedAlertId, hasPendingPicker]);
+    return queries.find(({ refId }) => refId === activeQueryRefId) ?? null;
+  }, [queries, activeQueryRefId, selectedAlertId, hasPendingPicker]);
 
   const selectedTransformation = useMemo(() => {
     if (activeTransformationId) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.test.ts
@@ -337,11 +337,13 @@ describe('useSelectionState', () => {
       expect(result.current.selectedTransformationIds).toEqual([]);
     });
 
-    it('clears active and bulk arrays when both args are null', () => {
+    it('resets the active card to the default (queries[0]) when both args are null', () => {
       const { result } = setup();
       act(() => result.current.toggleQuerySelection({ refId: 'A' }, { multi: true }));
       act(() => result.current.onCardSelectionChange(null, null));
-      expect(result.current.activeQueryRefId).toBeNull();
+      // With no explicit activation, the resolved active query falls back to queries[0] —
+      // matching the card the editor pane shows.
+      expect(result.current.activeQueryRefId).toBe('A');
       expect(result.current.activeTransformationId).toBeNull();
       expect(result.current.selectedQueryRefIds).toEqual([]);
       expect(result.current.selectedTransformationIds).toEqual([]);
@@ -400,6 +402,39 @@ describe('useSelectionState', () => {
       act(() => result.current.selectActiveInMultiSelection());
       expect(result.current.selectedQueryRefIds).toEqual([]);
       expect(result.current.selectedTransformationIds).toEqual(['tx-1']);
+    });
+
+    it('falls back to queries[0] when no card is explicitly active', () => {
+      const { result } = setup();
+      // No activate* call: the resolved active query falls back to queries[0], so entering
+      // multi-select seeds the card the editor pane is showing.
+      act(() => result.current.selectActiveInMultiSelection());
+      expect(result.current.selectedQueryRefIds).toEqual(['A']);
+      expect(result.current.selectedTransformationIds).toEqual([]);
+    });
+
+    it('falls back to queries[0] after the active transformation is deleted from the list', () => {
+      const { result, rerender } = renderHook((props: UseSelectionStateOptions) => useSelectionState(props), {
+        initialProps: defaultProps,
+      });
+      act(() => result.current.activateTransformation(mockTransformations[1]));
+      expect(result.current.activeTransformationId).toBe('tx-1');
+
+      // Deleting the active transformation resolves its active id to null, so the active
+      // card falls back to queries[0] — the seed must follow that fallback.
+      rerender({ ...defaultProps, transformations: mockTransformations.filter((t) => t.transformId !== 'tx-1') });
+      expect(result.current.activeTransformationId).toBeNull();
+
+      act(() => result.current.selectActiveInMultiSelection());
+      expect(result.current.selectedQueryRefIds).toEqual(['A']);
+      expect(result.current.selectedTransformationIds).toEqual([]);
+    });
+
+    it('seeds nothing when there are no cards at all', () => {
+      const { result } = setup({ ...defaultProps, queries: [], transformations: [] });
+      act(() => result.current.selectActiveInMultiSelection());
+      expect(result.current.selectedQueryRefIds).toEqual([]);
+      expect(result.current.selectedTransformationIds).toEqual([]);
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
@@ -35,10 +35,7 @@ export interface UseSelectionStateResult {
   removeTransformationFromSelection: (transformId: string) => void;
 }
 
-/**
- * Returns the contiguous ids between `anchorId` and `clickedId` (inclusive), in list order.
- * Returns null when either id is not present in `orderedIds`.
- */
+/** Ids between anchor and clicked (inclusive, list order), or null if either id is missing. */
 function getContiguousRange(orderedIds: string[], anchorId: string, clickedId: string): string[] | null {
   const anchorIdx = orderedIds.indexOf(anchorId);
   const clickedIdx = orderedIds.indexOf(clickedId);
@@ -52,33 +49,41 @@ function getContiguousRange(orderedIds: string[], anchorId: string, clickedId: s
   return orderedIds.slice(start, end + 1);
 }
 
-/**
- * Merges the stable "range base" (selections made before the current Shift sequence, e.g. via
- * Ctrl+Click) with the freshly computed contiguous range, preserving order and de-duplicating.
- */
+/** Merges the "range base" (selections predating the current Shift sequence) with the new range. */
 function mergeRangeWithBase(base: string[], range: string[]): string[] {
   const baseSet = new Set(base);
   return [...base, ...range.filter((id) => !baseSet.has(id))];
 }
 
 /**
- * Manages active (editor/highlight) and multi-select (bulk actions) state separately.
- *
- * - `activeQueryRefId` / `activeTransformationId`: active card for the editor pane.
- * - `selectedQueryRefIds` / `selectedTransformationIds`: bulk selection set (checkbox / modifiers).
- *
- * Query and transformation active selections are mutually exclusive, as are query vs
- * transformation multi-select sets.
+ * Manages the active card and the multi-select (bulk) sets; queries and transformations are
+ * mutually exclusive in both. The exposed active ids are resolved against the live lists each
+ * render (stale transformation → null, stale/unset query → queries[0]), so every consumer
+ * agrees on which card is active.
  */
 export function useSelectionState({
   queries,
   transformations,
   onClearSideEffects,
 }: UseSelectionStateOptions): UseSelectionStateResult {
-  const [activeQueryRefId, setActiveQueryRefId] = useState<string | null>(() => queries[0]?.refId ?? null);
-  const [activeTransformationId, setActiveTransformationId] = useState<string | null>(null);
+  // Last explicit activation. Can go stale while Scene mutations propagate, so never
+  // exposed — consumers read the resolved ids derived below.
+  const [rawActiveQueryRefId, setRawActiveQueryRefId] = useState<string | null>(null);
+  const [rawActiveTransformationId, setRawActiveTransformationId] = useState<string | null>(null);
   const [selectedQueryRefIds, setSelectedQueryRefIds] = useState<string[]>([]);
   const [selectedTransformationIds, setSelectedTransformationIds] = useState<string[]>([]);
+
+  // Resolved active ids — valid by construction: stale transformation → null, stale/unset
+  // query → queries[0].
+  const activeTransformationId =
+    rawActiveTransformationId !== null &&
+    transformations.some(({ transformId }) => transformId === rawActiveTransformationId)
+      ? rawActiveTransformationId
+      : null;
+
+  const rawQueryExists = rawActiveQueryRefId !== null && queries.some(({ refId }) => refId === rawActiveQueryRefId);
+  const activeQueryRefId =
+    activeTransformationId !== null ? null : rawQueryExists ? rawActiveQueryRefId : (queries[0]?.refId ?? null);
 
   const onClearSideEffectsRef = useRef(onClearSideEffects);
   onClearSideEffectsRef.current = onClearSideEffects;
@@ -101,11 +106,8 @@ export function useSelectionState({
   const selectedTransformationIdsRef = useRef(selectedTransformationIds);
   selectedTransformationIdsRef.current = selectedTransformationIds;
 
-  // Range-select anchors. The anchor is pinned by the last non-range action (plain or
-  // Ctrl/Cmd toggle) and stays fixed across consecutive Shift+Clicks, so each Shift+Click
-  // re-derives the range from the same origin (e.g. anchor 1: Shift+3 → 1-3, Shift+2 → 1-2).
-  // The matching "range base" holds the selections that existed when the anchor was set so
-  // independent Ctrl picks survive a later Shift-range.
+  // Shift-range anchors: pinned by the last non-range action, fixed across consecutive
+  // Shift+Clicks. The "range base" keeps prior Ctrl picks alive outside a later range.
   const queryAnchorRef = useRef<string | null>(null);
   const queryRangeBaseRef = useRef<string[]>([]);
   const transformationAnchorRef = useRef<string | null>(null);
@@ -118,26 +120,27 @@ export function useSelectionState({
     transformationRangeBaseRef.current = [];
   }, []);
 
-  // Reconcile active ids when the underlying lists change (e.g. after a delete propagates
-  // from the Scene). Without this, activeQueryRefId / activeTransformationId can reference
-  // items that no longer exist, causing downstream consumers like selectActiveInMultiSelection
-  // to seed stale ids into the bulk set.
+  // GC stale raw ids after deletes. Resolution already covers display; this only stops a
+  // recycled id (deleting "A" frees "A" for the next added query) from re-attaching.
   useEffect(() => {
-    if (activeQueryRefId !== null && !queries.some((q) => q.refId === activeQueryRefId)) {
-      setActiveQueryRefId(queries[0]?.refId ?? null);
+    if (rawActiveQueryRefId !== null && !queries.some(({ refId }) => refId === rawActiveQueryRefId)) {
+      setRawActiveQueryRefId(null);
     }
-  }, [queries, activeQueryRefId]);
+  }, [queries, rawActiveQueryRefId]);
 
   useEffect(() => {
-    if (activeTransformationId !== null && !transformations.some((t) => t.transformId === activeTransformationId)) {
-      setActiveTransformationId(null);
+    if (
+      rawActiveTransformationId !== null &&
+      !transformations.some(({ transformId }) => transformId === rawActiveTransformationId)
+    ) {
+      setRawActiveTransformationId(null);
     }
-  }, [transformations, activeTransformationId]);
+  }, [transformations, rawActiveTransformationId]);
 
   const onCardSelectionChange = useCallback(
     (queryRefId: string | null, transformationId: string | null, options?: { seedBulk?: boolean }) => {
-      setActiveQueryRefId(queryRefId);
-      setActiveTransformationId(transformationId);
+      setRawActiveQueryRefId(queryRefId);
+      setRawActiveTransformationId(transformationId);
       resetSelectionAnchors();
       if (options?.seedBulk) {
         setSelectedQueryRefIds(queryRefId ? [queryRefId] : []);
@@ -153,7 +156,7 @@ export function useSelectionState({
   );
 
   const trackQueryRename = useCallback((originalRefId: string, updatedRefId: string) => {
-    setActiveQueryRefId((current) => (current === originalRefId ? updatedRefId : current));
+    setRawActiveQueryRefId((current) => (current === originalRefId ? updatedRefId : current));
     setSelectedQueryRefIds((current) => current.map((id) => (id === originalRefId ? updatedRefId : id)));
     if (queryAnchorRef.current === originalRefId) {
       queryAnchorRef.current = updatedRefId;
@@ -162,14 +165,14 @@ export function useSelectionState({
   }, []);
 
   const activateQuery = useCallback((query: DataQuery | ExpressionQuery) => {
-    setActiveQueryRefId(query.refId);
-    setActiveTransformationId(null);
+    setRawActiveQueryRefId(query.refId);
+    setRawActiveTransformationId(null);
     onClearSideEffectsRef.current?.();
   }, []);
 
   const activateTransformation = useCallback((transformation: Transformation) => {
-    setActiveQueryRefId(null);
-    setActiveTransformationId(transformation.transformId);
+    setRawActiveQueryRefId(null);
+    setRawActiveTransformationId(transformation.transformId);
     onClearSideEffectsRef.current?.();
   }, []);
 
@@ -182,19 +185,13 @@ export function useSelectionState({
     const currentSelection = selectedQueryRefIdsRef.current;
 
     if (modifiers?.range) {
-      // When a transformation is active and there's no pinned query anchor, fall through to
-      // plain-click instead of range-selecting from queries[0] — avoids surprising ranges
-      // that cross card types.
-      const hasActiveTransformation = activeTransformationIdRef.current !== null;
-      const anchorRefId =
-        queryAnchorRef.current ??
-        activeQueryRefIdRef.current ??
-        (hasActiveTransformation ? null : (orderedIds[0] ?? null));
+      // Pinned anchor wins, else the resolved active query — null while a transformation is
+      // active, so Shift+Click plain-selects instead of ranging across card types.
+      const anchorRefId = queryAnchorRef.current ?? activeQueryRefIdRef.current;
 
       if (anchorRefId !== null) {
         const range = getContiguousRange(orderedIds, anchorRefId, query.refId);
         if (range) {
-          // Anchor and base stay fixed so consecutive Shift+Clicks grow/shrink from the origin.
           setSelectedQueryRefIds(mergeRangeWithBase(queryRangeBaseRef.current, range));
           return;
         }
@@ -209,7 +206,7 @@ export function useSelectionState({
           : currentSelection.filter((id) => id !== query.refId)
         : [...currentSelection, query.refId];
       setSelectedQueryRefIds(next);
-      // Pin the anchor to the toggled card; everything else becomes the base a later Shift extends.
+      // The toggled card becomes the anchor; the rest becomes the Shift-range base.
       queryAnchorRef.current = query.refId;
       queryRangeBaseRef.current = next.filter((id) => id !== query.refId);
       return;
@@ -269,8 +266,10 @@ export function useSelectionState({
   const selectActiveInMultiSelection = useCallback(() => {
     resetSelectionAnchors();
 
+    // Seed from the resolved ids so the selection matches the card the editor is showing —
+    // multi-select can never open with checkboxes visible but nothing checked.
     const transformationId = activeTransformationIdRef.current;
-    if (transformationId) {
+    if (transformationId !== null) {
       setSelectedQueryRefIds([]);
       setSelectedTransformationIds([transformationId]);
       transformationAnchorRef.current = transformationId;
@@ -278,7 +277,7 @@ export function useSelectionState({
     }
 
     const queryRefId = activeQueryRefIdRef.current;
-    if (queryRefId) {
+    if (queryRefId !== null) {
       setSelectedTransformationIds([]);
       setSelectedQueryRefIds([queryRefId]);
       queryAnchorRef.current = queryRefId;
@@ -286,21 +285,18 @@ export function useSelectionState({
   }, [resetSelectionAnchors]);
 
   const clearSelection = useCallback(() => {
-    const firstQueryRefId = queriesRef.current[0]?.refId ?? null;
-    setActiveQueryRefId(firstQueryRefId);
-    setActiveTransformationId(null);
+    // Null raw ids resolve to queries[0].
+    setRawActiveQueryRefId(null);
+    setRawActiveTransformationId(null);
     clearMultiSelection();
     onClearSideEffectsRef.current?.();
   }, [clearMultiSelection]);
 
   const removeQueryFromSelection = useCallback((refId: string) => {
     setSelectedQueryRefIds((current) => current.filter((id) => id !== refId));
-    setActiveQueryRefId((current) => {
-      if (current !== refId) {
-        return current;
-      }
-      return queriesRef.current[0]?.refId ?? null;
-    });
+    // Null the raw id rather than pick a successor — `queries` may still contain the
+    // deleted item this render, so any successor chosen here could be stale.
+    setRawActiveQueryRefId((current) => (current === refId ? null : current));
     if (queryAnchorRef.current === refId) {
       queryAnchorRef.current = null;
     }
@@ -309,7 +305,7 @@ export function useSelectionState({
 
   const removeTransformationFromSelection = useCallback((transformId: string) => {
     setSelectedTransformationIds((current) => current.filter((id) => id !== transformId));
-    setActiveTransformationId((current) => (current === transformId ? null : current));
+    setRawActiveTransformationId((current) => (current === transformId ? null : current));
     if (transformationAnchorRef.current === transformId) {
       transformationAnchorRef.current = null;
     }


### PR DESCRIPTION
## Description

Fixes a broken multi-select state in the Query Experience v2 query editor: deleting the focused card from the content header while in multi-select mode left the mode active with a stale selection, and after the first fix, re-entering multi-select showed checkboxes with nothing checked and no bulk-actions footer.

The root cause was that "which card is active" had multiple competing answers: the raw selection state in `useSelectionState`, and a silent `queries[0]` display fallback in `useSelectedCard`. The bulk-selection seeding read the former while the screen showed the latter. This PR makes the header delete exit multi-select mode, and consolidates active-card resolution into a single derived value in `useSelectionState` so the seeding can never disagree with the display again.

## Changes

* `HeaderActions`: deleting the focused query/transformation from the content header now exits multi-select mode, since the deletion invalidates the bulk selection.
* `useSelectionState`: the exposed `activeQueryRefId`/`activeTransformationId` are now *resolved* values, derived against the live lists every render — a stale transformation id resolves to `null`, a stale/unset query id falls back to `queries[0]`. The raw "last activated" ids are private. Multi-select seeding, range anchors, and display all read the same resolved value.
* `useSelectionState`: `removeQueryFromSelection`/`clearSelection` no longer pick a successor from a potentially stale list snapshot (Scene deletes land on a later render); they null the raw id and let resolution supply the fallback. The reconcile effects are demoted to GC of raw ids, guarding only against recycled refIds re-attaching.
* `useSelectedCard`: removed its now-dead `queries[0]` fallback; it maps already-resolved ids to objects and applies alert/pending-picker precedence only.
* Tests: new coverage for header-delete exiting multi-select and for seeding after the active card is deleted; existing assertions updated to the resolved-id semantics.

## Risks

* `activeQueryRefId` is now never `null` while queries exist (it resolves to `queries[0]`). Its only consumers are inside the context wrapper; the visible behavior change is that the query error indicator now follows the displayed query after a delete instead of going blank — intentional, but worth eyes on.
* Multi-select seeding while an expression/transformation picker is pending seeds `queries[0]` (the resolved active card) even though the pane shows the picker — same as the prior fallback behavior, but now explicit.

## Testing Instructions

* Open any dashboard panel in edit mode with the Query Experience v2 enabled, with 2+ queries.
* Click **Select…** in the sidebar footer to enter multi-select mode and check 2+ queries.
* Click the **Delete** action in the content header (not the bulk bar).
* Verify multi-select mode exits: checkboxes disappear, footer returns to item counts.
* Click **Select…** again — verify the currently displayed card is checked and the bulk-actions footer is visible.
* Repeat with a transformation as the focused card; after the header delete and re-entry, the first query should be checked (transformation was removed).
* Regression pass: Ctrl/Cmd+Click and Shift+Click selection, bulk delete/hide/datasource from the footer bar, and stacked mode entry/exit.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable