### PR TITLE
feat(datasources): allow plugins to return custom follow-up message on health check success

### DIFF
--- a/public/app/features/datasources/components/DataSourceTestingStatus.test.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.test.tsx
@@ -593,5 +593,25 @@ describe('<DataSourceTestingStatus />', () => {
       expect(screen.getByLabelText('Create a dashboard')).toBeInTheDocument();
       expect(screen.getByLabelText('Explore data')).toBeInTheDocument();
     });
+
+    it('should render custom followUpMessage instead of default links when provided', () => {
+      render(
+        <MemoryRouter>
+          <DataSourceTestingStatus
+            {...successWithDetails({
+              testingStatus: {
+                status: 'success',
+                message: 'Data source is working',
+                details: { message: 'All good', followUpMessage: 'Check our docs for next steps.' },
+              },
+            })}
+          />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText('Check our docs for next steps.')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Create a dashboard')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Explore data')).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -43,6 +43,8 @@ interface AlertMessageProps extends HTMLAttributes<HTMLDivElement> {
   onSuggestedDashboardsClick?: () => void;
   onDashboardLinkClicked: () => void;
   extensionLinks?: PluginExtensionLink[];
+  /** Optional custom follow-up message returned by the plugin's health check. When set, replaces the default "Next, you can start to visualize data..." text. */
+  followUpMessage?: string;
 }
 
 const getStyles = (theme: GrafanaTheme2, hasTitle: boolean) => {
@@ -72,12 +74,17 @@ const AlertSuccessMessage = ({
   hasDashboards,
   onSuggestedDashboardsClick,
   onDashboardLinkClicked,
+  followUpMessage,
 }: AlertMessageProps) => {
   const theme = useTheme2();
 
   const hasTitle = Boolean(title);
   const styles = getStyles(theme, hasTitle);
   const canExploreDataSources = contextSrv.hasAccessToExplore();
+
+  if (followUpMessage) {
+    return <div className={styles.content}>{followUpMessage}</div>;
+  }
 
   return (
     <div className={styles.content}>
@@ -209,6 +216,10 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
   const detailsMessage = testingStatus?.details?.message;
   const detailsVerboseMessage = testingStatus?.details?.verboseMessage;
   const errorDetailsLink = testingStatus?.details?.errorDetailsLink;
+  const followUpMessage =
+    typeof testingStatus?.details?.followUpMessage === 'string'
+      ? testingStatus.details.followUpMessage
+      : undefined;
   const onDashboardLinkClicked = () => {
     trackCreateDashboardClicked({
       grafana_version: config.buildInfo.version,
@@ -295,6 +306,7 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
                           hasDashboards={hasDashboards}
                           onSuggestedDashboardsClick={onSuggestedDashboardsClick}
                           onDashboardLinkClicked={onDashboardLinkClicked}
+                          followUpMessage={followUpMessage}
                         />
                       );
                     }}
@@ -305,6 +317,7 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
                     exploreUrl={exploreUrl}
                     dataSourceId={dataSource.uid}
                     onDashboardLinkClicked={onDashboardLinkClicked}
+                    followUpMessage={followUpMessage}
                   />
                 )
               ) : null}


### PR DESCRIPTION
Closes #118379

## What's changed

When a plugin's health check returns `followUpMessage` in the result details, the success alert now shows that text instead of the default "Next, you can start to visualize data by building a dashboard..." message.

No changes for plugins that don't use this — the fallback behaviour is identical to before.

## How it works

`testingStatus.details` is already typed as `Record<string, unknown>`, so `followUpMessage` is picked up without any schema changes. The component checks if `details.followUpMessage` is a string, and if so passes it down to `AlertSuccessMessage` which returns early with a plain `<div>` containing the custom text.

## Testing

Added a test that verifies:
- custom text renders when `followUpMessage` is set
- the default dashboard/explore links are not shown alongside it