### PR TITLE
Docs: GS - dashboard import

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -54,7 +54,7 @@ To access the Import dashboard tool from the Git Sync UI:
 Keep in mind the following:
 
 - UIDs are globally unique per org. Two repositories with dashboards sharing a UID will conflict.
-- Two dashboards can share a title as long as they live at different file paths in the repo. If a file with the same name already exists at the target path, the import is stopped before it overwrites anything.
+- Two dashboards can share a title as long as they live at different paths in the repo. If a file with the same name already exists at the target path, the import is stopped before it overwrites anything.
 
 For more information refer to [Import dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/import-dashboards/) in the Data Visualization documentation.
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -53,7 +53,7 @@ To access the Import dashboard tool from the Git Sync UI:
 
 Keep in mind the following:
 
-- UIDs are globally unique per org. Two repos with dashboards sharing a UID will conflict.
+- UIDs are globally unique per org. Two repositories with dashboards sharing a UID will conflict.
 - Two dashboards can share a title as long as they live at different file paths in the repo. If a file with the same name already exists at the target path, the import is stopped before it overwrites anything.
 
 For more information refer to [Import dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/import-dashboards/) in the Data Visualization documentation.

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -40,7 +40,7 @@ You can add dashboards to Git Sync using any of the following options:
 
 You can import dashboards directly into your Git Sync provisioned folders using the Grafana UI or the HTTP API.
 
-![Import dashboard](/static/img/docs/ascode/gitsync-dashboard-import.png)
+![Import dashboard](/static/img/docs/ascode/gitsync-dashboards-import.png)
 
 To access the Import dashboard tool from the Git Sync UI:
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -49,7 +49,7 @@ To access the Import dashboard tool from the Git Sync UI:
 1. Select **Import dashboard** and you'll be redirected to the wizard.
 1. Upload or paste the dashboard JSON.
 1. Fill in the relevant fields, including the branch and repository folder, and press **Import**.
-1. Open the pull request, follow your regular workflow, and merge.  
+1. Open the pull request, follow your regular workflow, and merge.
 
 Keep in mind the following:
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -49,7 +49,7 @@ To access the Import dashboard tool from the Git Sync UI:
 1. Select **Import dashboard** and you'll be redirected to the wizard.
 1. Upload or paste the dashboard JSON.
 1. Fill in the relevant fields, including the branch and repository folder, and press **Import**.
-1. Open the pull request, follow your regular workflow, and merge.
+1. Open the pull request, follow your regular workflow, and merge. Note that it could take a few minutes until the imported dashboard appear.
 
 Keep in mind the following:
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -31,13 +31,20 @@ aliases:
 
 You can add dashboards to Git Sync using any of the following options:
 
+- [Add a dashboard using Import dashboards](#add-a-dashboard-using-import-dashboards)
 - [Export an existing dashboard from the Grafana UI as a copy](#copy-an-existing-dashboard-from-the-grafana-ui)
 - [Export a dashboard with Grafana CLI](#add-a-dashboard-with-the-grafana-cli)
 - [Copy a dashboard as JSON and commit to the repository](#add-a-dashboard-via-json-export)
 
+## Add a dashboard using Import dashboards
+
+You can import dashboards directly into your Git Sync provisioned folders using the Grafana UI or the HTTP API.
+
+For more information refer to [Import dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/import-dashboards/) in the Data Visualization documentation.
+
 ## Copy an existing dashboard from the Grafana UI
 
-You can save a copy of dashboard directly from the Grafana UI to your provisioned folder.
+You can also save a copy of dashboard directly from the Grafana UI to your provisioned folder.
 
 To do so, follow these steps:
 
@@ -77,8 +84,6 @@ Where:
 - _<GIT_REPO>_: The path to the repository synced with Git Sync
 - _<DASHBOARDS_PATH>_: The path where the dashboards you want to export are located. The dashboards path must be under the repository
 
-See more at [Manage resources with Grafana CLI](https://grafana.github.io/grafanactl/guides/manage-resources/).
-
 ## Add a dashboard via JSON export
 
 To add an existing dashboard to Git Sync via JSON export, you need to:
@@ -102,10 +107,10 @@ To export a dashboard as a JSON file it must follow this CRD structure:
 
 The structure includes:
 
-- `apiVersion`: Specifies the API version. Both classic and `v2` JSON models are supported. For more information, refer to [Dashboard JSON model](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/view-dashboard-json-model/)
-- `kind`: Identifies the resource type (Dashboard)
-- `metadata`: Contains the dashboard identifier `uid`. You can find the identifier in the dashboard's URL or in the exported JSON
-- `spec`: Wraps your original dashboard JSON
+- `apiVersion`: Specifies the API version. Both classic and `v2` JSON models are supported. For more information, refer to [Dashboard JSON model](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/view-dashboard-json-model/).
+- `kind`: Identifies the resource type (Dashboard).
+- `metadata`: Contains the dashboard identifier `uid`. You can find the identifier in the dashboard's URL or in the exported JSON.
+- `spec`: Wraps your original dashboard JSON.
 
 ## Work with Git-managed dashboards
 

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -40,6 +40,22 @@ You can add dashboards to Git Sync using any of the following options:
 
 You can import dashboards directly into your Git Sync provisioned folders using the Grafana UI or the HTTP API.
 
+![Import dashboard](/static/img/docs/ascode/gitsync-dashboard-import.png)
+
+To access the Import dashboard tool from the Git Sync UI:
+
+1. Go to the **Dashboards tab** of you connection.
+1. On the top right corner, click **New**.
+1. Select **Import dashboard** and you'll be redirected to the wizard.
+1. Upload or paste the dashboard JSON.
+1. Fill in the relevant fields, including the branch and repository folder, and press **Import**.
+1. Open the pull request, follow your regular workflow, and merge.  
+
+The following applies:
+
+- UIDs are globally unique per org. Two repos with dashboards sharing a UID will conflict.
+- Two dashboards can share a title as long as they live at different file paths in the repo. If a file with the same name already exists at the target path, the import is stopped before it overwrites anything.
+
 For more information refer to [Import dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/import-dashboards/) in the Data Visualization documentation.
 
 ## Copy an existing dashboard from the Grafana UI

--- a/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/export-resources.md
@@ -51,7 +51,7 @@ To access the Import dashboard tool from the Git Sync UI:
 1. Fill in the relevant fields, including the branch and repository folder, and press **Import**.
 1. Open the pull request, follow your regular workflow, and merge.  
 
-The following applies:
+Keep in mind the following:
 
 - UIDs are globally unique per org. Two repos with dashboards sharing a UID will conflict.
 - Two dashboards can share a title as long as they live at different file paths in the repo. If a file with the same name already exists at the target path, the import is stopped before it overwrites anything.


### PR DESCRIPTION
Adding Dashboard Import for Grafana 13.1.

Resources:
* https://grafana.com/docs/grafana/next/visualizations/dashboards/build-dashboards/import-dashboards/