### PR TITLE
Removal: GroupAttributeSync routes

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -19,7 +19,6 @@ export const addTagTypes = [
   'health',
   'folders',
   'permissions',
-  'group_attribute_sync',
   'library_elements',
   'licensing',
   'saml',
@@ -885,34 +884,6 @@ const injectedRtkApi = api
           body: queryArg.updateDashboardAclCommand,
         }),
         invalidatesTags: ['folders', 'permissions'],
-      }),
-      getMappedGroups: build.query<GetMappedGroupsApiResponse, GetMappedGroupsApiArg>({
-        query: () => ({ url: `/groupsync/groups` }),
-        providesTags: ['group_attribute_sync', 'enterprise'],
-      }),
-      deleteGroupMappings: build.mutation<DeleteGroupMappingsApiResponse, DeleteGroupMappingsApiArg>({
-        query: (queryArg) => ({ url: `/groupsync/groups/${queryArg.groupId}`, method: 'DELETE' }),
-        invalidatesTags: ['group_attribute_sync', 'enterprise'],
-      }),
-      createGroupMappings: build.mutation<CreateGroupMappingsApiResponse, CreateGroupMappingsApiArg>({
-        query: (queryArg) => ({
-          url: `/groupsync/groups/${queryArg.groupId}`,
-          method: 'POST',
-          body: queryArg.groupAttributes,
-        }),
-        invalidatesTags: ['group_attribute_sync', 'enterprise'],
-      }),
-      updateGroupMappings: build.mutation<UpdateGroupMappingsApiResponse, UpdateGroupMappingsApiArg>({
-        query: (queryArg) => ({
-          url: `/groupsync/groups/${queryArg.groupId}`,
-          method: 'PUT',
-          body: queryArg.groupAttributes,
-        }),
-        invalidatesTags: ['group_attribute_sync', 'enterprise'],
-      }),
-      getGroupRoles: build.query<GetGroupRolesApiResponse, GetGroupRolesApiArg>({
-        query: (queryArg) => ({ url: `/groupsync/groups/${queryArg.groupId}/roles` }),
-        providesTags: ['group_attribute_sync', 'enterprise'],
       }),
       getHealth: build.query<GetHealthApiResponse, GetHealthApiArg>({
         query: () => ({ url: `/health` }),
@@ -2414,27 +2385,6 @@ export type UpdateFolderPermissionsApiResponse =
 export type UpdateFolderPermissionsApiArg = {
   folderUid: string;
   updateDashboardAclCommand: UpdateDashboardAclCommand;
-};
-export type GetMappedGroupsApiResponse = /** status 200 (empty) */ GetGroupsResponse;
-export type GetMappedGroupsApiArg = void;
-export type DeleteGroupMappingsApiResponse =
-  /** status 204 An OKResponse is returned if the request was successful. */ SuccessResponseBody;
-export type DeleteGroupMappingsApiArg = {
-  groupId: string;
-};
-export type CreateGroupMappingsApiResponse = /** status 201 (empty) */ MessageResponse;
-export type CreateGroupMappingsApiArg = {
-  groupId: string;
-  groupAttributes: GroupAttributes;
-};
-export type UpdateGroupMappingsApiResponse = /** status 201 (empty) */ MessageResponse;
-export type UpdateGroupMappingsApiArg = {
-  groupId: string;
-  groupAttributes: GroupAttributes;
-};
-export type GetGroupRolesApiResponse = /** status 200 (empty) */ RoleDto[];
-export type GetGroupRolesApiArg = {
-  groupId: string;
 };
 export type GetHealthApiResponse = /** status 200 healthResponse */ HealthResponse;
 export type GetHealthApiArg = void;
@@ -4280,20 +4230,6 @@ export type DashboardAclUpdateItem = {
 export type UpdateDashboardAclCommand = {
   items?: DashboardAclUpdateItem[];
 };
-export type Group = {
-  groupID?: string;
-  mappings?: any;
-};
-export type GetGroupsResponse = {
-  groups?: Group[];
-  total?: number;
-};
-export type MessageResponse = {
-  message?: string;
-};
-export type GroupAttributes = {
-  roles?: string[];
-};
 export type HealthResponse = {
   apiserver?: string;
   commit?: string;
@@ -5631,13 +5567,6 @@ export const {
   useEnableDataSourceCacheMutation,
   useQueryMetricsWithExpressionsMutation,
   useUpdateFolderPermissionsMutation,
-  useGetMappedGroupsQuery,
-  useLazyGetMappedGroupsQuery,
-  useDeleteGroupMappingsMutation,
-  useCreateGroupMappingsMutation,
-  useUpdateGroupMappingsMutation,
-  useGetGroupRolesQuery,
-  useLazyGetGroupRolesQuery,
   useGetHealthQuery,
   useLazyGetHealthQuery,
   useGetLibraryElementsQuery,

--- a/packages/grafana-openapi/src/api/openapi3.json
+++ b/packages/grafana-openapi/src/api/openapi3.json
@@ -93,16 +93,6 @@
         },
         "description": "(empty)"
       },
-      "apiResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/messageResponse"
-            }
-          }
-        },
-        "description": "(empty)"
-      },
       "badRequestError": {
         "content": {
           "application/json": {
@@ -807,29 +797,6 @@
                 "$ref": "#/components/schemas/FolderSearchHit"
               },
               "type": "array"
-            }
-          }
-        },
-        "description": "(empty)"
-      },
-      "getGroupRolesResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/RoleDTO"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "description": "(empty)"
-      },
-      "getGroupsResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/getGroupsResponse"
             }
           }
         },
@@ -6390,26 +6357,6 @@
           },
           "wechat_api_url": {
             "$ref": "#/components/schemas/URL"
-          }
-        },
-        "type": "object"
-      },
-      "Group": {
-        "properties": {
-          "groupID": {
-            "type": "string"
-          },
-          "mappings": {}
-        },
-        "type": "object"
-      },
-      "GroupAttributes": {
-        "properties": {
-          "roles": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           }
         },
         "type": "object"
@@ -12928,21 +12875,6 @@
         },
         "type": "object"
       },
-      "getGroupsResponse": {
-        "properties": {
-          "groups": {
-            "items": {
-              "$ref": "#/components/schemas/Group"
-            },
-            "type": "array"
-          },
-          "total": {
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
       "gettableAlert": {
         "description": "GettableAlert gettable alert",
         "properties": {
@@ -13159,14 +13091,6 @@
           "$ref": "#/components/schemas/matcher"
         },
         "type": "array"
-      },
-      "messageResponse": {
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        },
-        "type": "object"
       },
       "peerStatus": {
         "description": "PeerStatus peer status",
@@ -19106,187 +19030,6 @@
         },
         "summary": "Updates permissions for a folder. This operation will remove existing permissions if they’re not included in the request.",
         "tags": ["folders", "permissions"]
-      }
-    },
-    "/groupsync/groups": {
-      "get": {
-        "operationId": "getMappedGroups",
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/getGroupsResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "List groups that have mappings set. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "tags": ["group_attribute_sync", "enterprise"]
-      }
-    },
-    "/groupsync/groups/{group_id}": {
-      "delete": {
-        "operationId": "deleteGroupMappings",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "group_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "$ref": "#/components/responses/okResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "Delete mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "tags": ["group_attribute_sync", "enterprise"]
-      },
-      "post": {
-        "operationId": "createGroupMappings",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "group_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GroupAttributes"
-              }
-            }
-          },
-          "required": true,
-          "x-originalParamName": "body"
-        },
-        "responses": {
-          "201": {
-            "$ref": "#/components/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "Create mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "tags": ["group_attribute_sync", "enterprise"]
-      },
-      "put": {
-        "operationId": "updateGroupMappings",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "group_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GroupAttributes"
-              }
-            }
-          },
-          "required": true,
-          "x-originalParamName": "body"
-        },
-        "responses": {
-          "201": {
-            "$ref": "#/components/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "Update mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "tags": ["group_attribute_sync", "enterprise"]
-      }
-    },
-    "/groupsync/groups/{group_id}/roles": {
-      "get": {
-        "operationId": "getGroupRoles",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "group_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/getGroupRolesResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "404": {
-            "$ref": "#/components/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "Get roles mapped to a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "tags": ["group_attribute_sync", "enterprise"]
       }
     },
     "/health": {

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -1028,188 +1028,6 @@
         }
       }
     },
-    "/groupsync/groups": {
-      "get": {
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ],
-        "summary": "List groups that have mappings set. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "operationId": "getMappedGroups",
-        "responses": {
-          "200": {
-            "$ref": "#/responses/getGroupsResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
-    },
-    "/groupsync/groups/{group_id}": {
-      "put": {
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ],
-        "summary": "Update mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "operationId": "updateGroupMappings",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GroupAttributes"
-            }
-          },
-          {
-            "type": "string",
-            "name": "group_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "201": {
-            "$ref": "#/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ],
-        "summary": "Create mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "operationId": "createGroupMappings",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GroupAttributes"
-            }
-          },
-          {
-            "type": "string",
-            "name": "group_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "201": {
-            "$ref": "#/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ],
-        "summary": "Delete mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "operationId": "deleteGroupMappings",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "group_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "$ref": "#/responses/okResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
-    },
-    "/groupsync/groups/{group_id}/roles": {
-      "get": {
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ],
-        "summary": "Get roles mapped to a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "operationId": "getGroupRoles",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "group_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/getGroupRolesResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
-    },
     "/licensing/check": {
       "get": {
         "tags": [
@@ -5195,26 +5013,6 @@
         }
       }
     },
-    "Group": {
-      "type": "object",
-      "properties": {
-        "groupID": {
-          "type": "string"
-        },
-        "mappings": {}
-      }
-    },
-    "GroupAttributes": {
-      "type": "object",
-      "properties": {
-        "roles": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "Hit": {
       "type": "object",
       "properties": {
@@ -8996,21 +8794,6 @@
         }
       }
     },
-    "getGroupsResponse": {
-      "type": "object",
-      "properties": {
-        "groups": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Group"
-          }
-        },
-        "total": {
-          "type": "integer",
-          "format": "int64"
-        }
-      }
-    },
     "healthResponse": {
       "type": "object",
       "properties": {
@@ -9027,14 +8810,6 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
-        }
-      }
-    },
-    "messageResponse": {
-      "type": "object",
-      "properties": {
-        "message": {
           "type": "string"
         }
       }
@@ -9181,12 +8956,6 @@
         "items": {
           "$ref": "#/definitions/UserToken"
         }
-      }
-    },
-    "apiResponse": {
-      "description": "",
-      "schema": {
-        "$ref": "#/definitions/messageResponse"
       }
     },
     "badRequestError": {
@@ -9705,21 +9474,6 @@
         "items": {
           "$ref": "#/definitions/FolderSearchHit"
         }
-      }
-    },
-    "getGroupRolesResponse": {
-      "description": "",
-      "schema": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/RoleDTO"
-        }
-      }
-    },
-    "getGroupsResponse": {
-      "description": "",
-      "schema": {
-        "$ref": "#/definitions/getGroupsResponse"
       }
     },
     "getHomeDashboardResponse": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -5425,188 +5425,6 @@
         }
       }
     },
-    "/groupsync/groups": {
-      "get": {
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ],
-        "summary": "List groups that have mappings set. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "operationId": "getMappedGroups",
-        "responses": {
-          "200": {
-            "$ref": "#/responses/getGroupsResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
-    },
-    "/groupsync/groups/{group_id}": {
-      "put": {
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ],
-        "summary": "Update mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "operationId": "updateGroupMappings",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GroupAttributes"
-            }
-          },
-          {
-            "type": "string",
-            "name": "group_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "201": {
-            "$ref": "#/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ],
-        "summary": "Create mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "operationId": "createGroupMappings",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GroupAttributes"
-            }
-          },
-          {
-            "type": "string",
-            "name": "group_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "201": {
-            "$ref": "#/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ],
-        "summary": "Delete mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "operationId": "deleteGroupMappings",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "group_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "$ref": "#/responses/okResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
-    },
-    "/groupsync/groups/{group_id}/roles": {
-      "get": {
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ],
-        "summary": "Get roles mapped to a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "operationId": "getGroupRoles",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "group_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/getGroupRolesResponse"
-          },
-          "400": {
-            "$ref": "#/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "404": {
-            "$ref": "#/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
-    },
     "/health": {
       "get": {
         "description": "apiHealthHandler will return ok if Grafana's web server is running and it\ncan access the database. If the database cannot be accessed it will return\nhttp status code 503.",
@@ -16740,26 +16558,6 @@
         }
       }
     },
-    "Group": {
-      "type": "object",
-      "properties": {
-        "groupID": {
-          "type": "string"
-        },
-        "mappings": {}
-      }
-    },
-    "GroupAttributes": {
-      "type": "object",
-      "properties": {
-        "roles": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "HTTPClientConfig": {
       "type": "object",
       "title": "HTTPClientConfig configures an HTTP client.",
@@ -23417,21 +23215,6 @@
         }
       }
     },
-    "getGroupsResponse": {
-      "type": "object",
-      "properties": {
-        "groups": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Group"
-          }
-        },
-        "total": {
-          "type": "integer",
-          "format": "int64"
-        }
-      }
-    },
     "gettableAlert": {
       "description": "GettableAlert gettable alert",
       "type": "object",
@@ -23680,14 +23463,6 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/matcher"
-      }
-    },
-    "messageResponse": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string"
-        }
       }
     },
     "peerStatus": {
@@ -24059,12 +23834,6 @@
         "items": {
           "$ref": "#/definitions/UserToken"
         }
-      }
-    },
-    "apiResponse": {
-      "description": "(empty)",
-      "schema": {
-        "$ref": "#/definitions/messageResponse"
       }
     },
     "badRequestError": {
@@ -24583,21 +24352,6 @@
         "items": {
           "$ref": "#/definitions/FolderSearchHit"
         }
-      }
-    },
-    "getGroupRolesResponse": {
-      "description": "(empty)",
-      "schema": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/RoleDTO"
-        }
-      }
-    },
-    "getGroupsResponse": {
-      "description": "(empty)",
-      "schema": {
-        "$ref": "#/definitions/getGroupsResponse"
       }
     },
     "getHomeDashboardResponse": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -93,16 +93,6 @@
         },
         "description": "(empty)"
       },
-      "apiResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/messageResponse"
-            }
-          }
-        },
-        "description": "(empty)"
-      },
       "badRequestError": {
         "content": {
           "application/json": {
@@ -828,29 +818,6 @@
                 "$ref": "#/components/schemas/FolderSearchHit"
               },
               "type": "array"
-            }
-          }
-        },
-        "description": "(empty)"
-      },
-      "getGroupRolesResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/RoleDTO"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "description": "(empty)"
-      },
-      "getGroupsResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/getGroupsResponse"
             }
           }
         },
@@ -6540,26 +6507,6 @@
           },
           "wechat_api_url": {
             "$ref": "#/components/schemas/URL"
-          }
-        },
-        "type": "object"
-      },
-      "Group": {
-        "properties": {
-          "groupID": {
-            "type": "string"
-          },
-          "mappings": {}
-        },
-        "type": "object"
-      },
-      "GroupAttributes": {
-        "properties": {
-          "roles": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           }
         },
         "type": "object"
@@ -13219,21 +13166,6 @@
         },
         "type": "object"
       },
-      "getGroupsResponse": {
-        "properties": {
-          "groups": {
-            "items": {
-              "$ref": "#/components/schemas/Group"
-            },
-            "type": "array"
-          },
-          "total": {
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
       "gettableAlert": {
         "description": "GettableAlert gettable alert",
         "properties": {
@@ -13481,14 +13413,6 @@
           "$ref": "#/components/schemas/matcher"
         },
         "type": "array"
-      },
-      "messageResponse": {
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        },
-        "type": "object"
       },
       "peerStatus": {
         "description": "PeerStatus peer status",
@@ -19785,202 +19709,6 @@
         "tags": [
           "folders",
           "permissions"
-        ]
-      }
-    },
-    "/groupsync/groups": {
-      "get": {
-        "operationId": "getMappedGroups",
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/getGroupsResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "List groups that have mappings set. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ]
-      }
-    },
-    "/groupsync/groups/{group_id}": {
-      "delete": {
-        "operationId": "deleteGroupMappings",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "group_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "$ref": "#/components/responses/okResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "Delete mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ]
-      },
-      "post": {
-        "operationId": "createGroupMappings",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "group_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GroupAttributes"
-              }
-            }
-          },
-          "required": true,
-          "x-originalParamName": "body"
-        },
-        "responses": {
-          "201": {
-            "$ref": "#/components/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "Create mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ]
-      },
-      "put": {
-        "operationId": "updateGroupMappings",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "group_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GroupAttributes"
-              }
-            }
-          },
-          "required": true,
-          "x-originalParamName": "body"
-        },
-        "responses": {
-          "201": {
-            "$ref": "#/components/responses/apiResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "Update mappings for a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
-        ]
-      }
-    },
-    "/groupsync/groups/{group_id}/roles": {
-      "get": {
-        "operationId": "getGroupRoles",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "group_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/getGroupRolesResponse"
-          },
-          "400": {
-            "$ref": "#/components/responses/badRequestError"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "404": {
-            "$ref": "#/components/responses/notFoundError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "summary": "Get roles mapped to a group. This endpoint is behind the feature flag `groupAttributeSync` and is considered experimental.",
-        "tags": [
-          "group_attribute_sync",
-          "enterprise"
         ]
       }
     },


### PR DESCRIPTION
**What this PR does**

Removes the Group Attribute Sync API routes.

Group Attribute Sync was introduced as a private preview in December 2024. It allowed mapping IdP groups to Grafana roles, updating permissions on user login. However, this approach overlaps with existing Team Sync and SCIM provisioning features, which can lead to conflicting sync rules and unexpected permission changes.

**Why we're removing it**

To avoid clobbering between multiple sync systems, we're removing the Group Attribute Sync routes in this version. We recommend migrating to:

- **Team Sync** – map IdP groups to Grafana teams and assign roles via team membership. [Documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-team-sync/)
- **SCIM provisioning** – centralized user and team management with automatic role assignment. [Documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-scim-provisioning/)

These alternatives provide more robust, scalable user management for large organizations.