### PR TITLE
Search: Fix Bedrock embedding throttling under token quota

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -745,7 +745,7 @@ type Cfg struct {
 	BedrockModel       string // default "cohere.embed-v4:0"
 	BedrockDimensions  int    // default 1024
 	BedrockBatchSize   int    // texts per Bedrock invoke call; default 50
-	BedrockMaxAttempts int    // max InvokeModel attempts per call under throttling; default 10
+	BedrockMaxAttempts int    // max InvokeModel attempts per call under throttling; default 5
 
 	// Overrides/Quotas
 	OverridesFilePath             string

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -735,16 +735,17 @@ type Cfg struct {
 	VectorRateLimitWindow    time.Duration
 
 	// Embedding provider used by the VectorSearch RPC. "" = disabled.
-	EmbeddingProvider string // "vertex" | "bedrock" | ""
-	VertexProjectID   string
-	VertexLocation    string // default "us-central1"
-	VertexModel       string // default "gemini-embedding-001"
-	VertexDimensions  int    // default 768
-	VertexBatchSize   int    // texts per Vertex predict call; default 50
-	BedrockRegion     string // default "us-east-1"
-	BedrockModel      string // default "cohere.embed-v4:0"
-	BedrockDimensions int    // default 1024
-	BedrockBatchSize  int    // texts per Bedrock invoke call; default 50
+	EmbeddingProvider  string // "vertex" | "bedrock" | ""
+	VertexProjectID    string
+	VertexLocation     string // default "us-central1"
+	VertexModel        string // default "gemini-embedding-001"
+	VertexDimensions   int    // default 768
+	VertexBatchSize    int    // texts per Vertex predict call; default 50
+	BedrockRegion      string // default "us-east-1"
+	BedrockModel       string // default "cohere.embed-v4:0"
+	BedrockDimensions  int    // default 1024
+	BedrockBatchSize   int    // texts per Bedrock invoke call; default 50
+	BedrockMaxAttempts int    // max InvokeModel attempts per call under throttling; default 10
 
 	// Overrides/Quotas
 	OverridesFilePath             string

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -317,7 +317,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.BedrockModel = embedSection.Key("bedrock_model").MustString("cohere.embed-v4:0")
 	cfg.BedrockDimensions = embedSection.Key("bedrock_dimensions").MustInt(1024)
 	cfg.BedrockBatchSize = embedSection.Key("bedrock_batch_size").MustInt(50)
-	cfg.BedrockMaxAttempts = embedSection.Key("bedrock_max_attempts").MustInt(10)
+	cfg.BedrockMaxAttempts = embedSection.Key("bedrock_max_attempts").MustInt(5)
 }
 
 // applyMigrationEnforcements enforces unified storage migration configs when migrations should run,

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -317,6 +317,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.BedrockModel = embedSection.Key("bedrock_model").MustString("cohere.embed-v4:0")
 	cfg.BedrockDimensions = embedSection.Key("bedrock_dimensions").MustInt(1024)
 	cfg.BedrockBatchSize = embedSection.Key("bedrock_batch_size").MustInt(50)
+	cfg.BedrockMaxAttempts = embedSection.Key("bedrock_max_attempts").MustInt(10)
 }
 
 // applyMigrationEnforcements enforces unified storage migration configs when migrations should run,

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -210,7 +210,7 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 			assert.NoError(t, err)
 			cfg.setUnifiedStorageConfig()
 			assert.Equal(t, 50, cfg.BedrockBatchSize)
-			assert.Equal(t, 10, cfg.BedrockMaxAttempts)
+			assert.Equal(t, 5, cfg.BedrockMaxAttempts)
 		})
 
 		t.Run("reads configured values independent of vertex_batch_size", func(t *testing.T) {

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -197,6 +197,36 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		assert.Equal(t, 3, cfg.IndexWorkers)
 	})
 
+	t.Run("vector_embedder bedrock config", func(t *testing.T) {
+		setSectionKey := func(cfg *Cfg, key, value string) {
+			section := cfg.Raw.Section("vector_embedder")
+			_, err := section.NewKey(key, value)
+			assert.NoError(t, err)
+		}
+
+		t.Run("applies defaults", func(t *testing.T) {
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			cfg.setUnifiedStorageConfig()
+			assert.Equal(t, 50, cfg.BedrockBatchSize)
+			assert.Equal(t, 10, cfg.BedrockMaxAttempts)
+		})
+
+		t.Run("reads configured values independent of vertex_batch_size", func(t *testing.T) {
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			setSectionKey(cfg, "vertex_batch_size", "33")
+			setSectionKey(cfg, "bedrock_batch_size", "7")
+			setSectionKey(cfg, "bedrock_max_attempts", "15")
+			cfg.setUnifiedStorageConfig()
+			// Guards a regression where bedrock used vertex_batch_size.
+			assert.Equal(t, 7, cfg.BedrockBatchSize)
+			assert.Equal(t, 15, cfg.BedrockMaxAttempts)
+		})
+	})
+
 	t.Run("read unified_storage configs with defaults", func(t *testing.T) {
 		cfg := NewCfg()
 		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})

--- a/pkg/storage/unified/search/embed/embedder/bedrock/embed_dense.go
+++ b/pkg/storage/unified/search/embed/embedder/bedrock/embed_dense.go
@@ -8,7 +8,11 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
 )
 
-const callTimeout = 30 * time.Second
+// callTimeout bounds the whole per-batch InvokeModel attempt sequence (the
+// AWS SDK respects the context deadline across retries). Sized to give the
+// adaptive retryer room to back off and retry under throttling rather than
+// being cut short mid-sequence.
+const callTimeout = 60 * time.Second
 
 // DenseEmbedder embeds text via Bedrock InvokeModel and returns dense
 // float32 vectors.

--- a/pkg/storage/unified/search/embed/embedder/provider/provider.go
+++ b/pkg/storage/unified/search/embed/embedder/provider/provider.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/prometheus/client_golang/prometheus"
@@ -68,8 +69,15 @@ func newVertexEmbedder(cfg *setting.Cfg, duration *prometheus.HistogramVec) (*em
 }
 
 func newBedrockEmbedder(cfg *setting.Cfg, duration *prometheus.HistogramVec) (*embedder.Embedder, error) {
+	// Adaptive retry adds a client-side rate limiter that backs off request
+	// issuance when Bedrock returns ThrottlingException (429), which the
+	// default standard retryer does not; combined with a higher attempt
+	// ceiling it lets transient token-quota throttling recover instead of
+	// failing the embed at the default 3 attempts.
 	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(),
 		awsconfig.WithRegion(cfg.BedrockRegion),
+		awsconfig.WithRetryMode(aws.RetryModeAdaptive),
+		awsconfig.WithRetryMaxAttempts(cfg.BedrockMaxAttempts),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("aws config: %w", err)
@@ -77,7 +85,7 @@ func newBedrockEmbedder(cfg *setting.Cfg, duration *prometheus.HistogramVec) (*e
 	rt := bedrockruntime.NewFromConfig(awsCfg)
 	client := bedrock.NewClient(rt)
 	model := "bedrock/" + cfg.BedrockModel
-	dense := bedrock.NewDenseEmbedder(client, cfg.BedrockModel, cfg.BedrockDimensions, cfg.VertexBatchSize)
+	dense := bedrock.NewDenseEmbedder(client, cfg.BedrockModel, cfg.BedrockDimensions, cfg.BedrockBatchSize)
 	return &embedder.Embedder{
 		TextEmbedder: embedder.Instrument(dense, model, duration),
 		Model:        model,


### PR DESCRIPTION
**What is this feature?**

Makes the unified-storage Bedrock embedder resilient to AWS Bedrock `ThrottlingException` (429). Enables adaptive retry mode (client-side rate limiting that backs off request issuance on throttle) and raises the attempt ceiling via a new `bedrock_max_attempts` config (default 5). Also fixes a config bug where the Bedrock embedder used `VertexBatchSize` instead of `BedrockBatchSize` — silently ignoring `bedrock_batch_size` — and raises the per-batch call timeout from 30s to 60s so retries are not cut short mid-sequence.

**Why do we need this feature?**

Vector-backfill embed jobs were stuck failing for hours: the Bedrock client used the AWS SDK default retryer (3 attempts, no client-side rate limiting), so transient token-quota throttling failed `InvokeModel` outright with `exceeded maximum number of attempts, 3 ... ThrottlingException: Too many tokens`. Without the batch-size fix, operators also couldn't lower batch size to relieve throttling.

**Who is this feature for?**

Operators running Grafana vector search backfills against AWS Bedrock (Cohere embed-v4).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Adaptive retry + max-attempts are the AWS-recommended response to 429 token-quota throttling. New unit test in `setting_unified_storage_test.go` guards the `bedrock_batch_size`/`bedrock_max_attempts` wiring and the VertexBatchSize regression. Backend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)