### PR TITLE
Dashboards: Add "Copy as resource" button to Edit as code pane

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardCodePane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardCodePane.tsx
@@ -4,12 +4,12 @@ import { useCallback, useState } from 'react';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
-import { Alert, Button, IconButton, Modal, Sidebar, Tooltip, useStyles2 } from '@grafana/ui';
+import { Alert, Button, ClipboardButton, IconButton, Modal, Sidebar, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { getDashboardSceneFor } from '../utils/utils';
 import { DashboardSchemaEditor, type SchemaEditorFormat } from '../v2schema/DashboardSchemaEditor';
 
-import { applyJsonToDashboard, getDashboardJsonText } from './codePaneUtils';
+import { applyJsonToDashboard, getDashboardJsonText, getDashboardResourceText } from './codePaneUtils';
 
 export class DashboardCodePane extends SceneObjectBase {
   public static Component = DashboardCodePaneRenderer;
@@ -43,6 +43,26 @@ export function DashboardCodePaneRenderer({ model }: SceneComponentProps<Dashboa
       setApplyError(result.error ?? 'Failed to apply changes');
     }
   }, [dashboard, jsonText]);
+
+  const getResourceText = useCallback(
+    () => getDashboardResourceText(dashboard, editorFormat),
+    [dashboard, editorFormat]
+  );
+
+  const copyAsResourceButton = (
+    <ClipboardButton
+      variant="secondary"
+      size="sm"
+      icon="copy"
+      getText={getResourceText}
+      tooltip={t(
+        'dashboard.code-pane.copy-as-resource-tooltip',
+        'Copy dashboard as resource (with apiVersion, kind and metadata) for use in provisioning files'
+      )}
+    >
+      {t('dashboard.code-pane.copy-as-resource', 'Copy as resource')}
+    </ClipboardButton>
+  );
 
   const applyTooltip =
     editorFormat === 'yaml'
@@ -88,7 +108,10 @@ export function DashboardCodePaneRenderer({ model }: SceneComponentProps<Dashboa
           <DashboardSchemaEditor {...editorProps} containerStyles={styles.codeEditor} />
         </div>
         <div className={styles.toolbar}>
-          {applyButton}
+          <Stack gap={1} alignItems="center">
+            {applyButton}
+            {copyAsResourceButton}
+          </Stack>
           <IconButton
             name="expand-arrows"
             size="sm"
@@ -112,7 +135,10 @@ export function DashboardCodePaneRenderer({ model }: SceneComponentProps<Dashboa
             {errorAlert}
             <DashboardSchemaEditor {...editorProps} />
             <div className={styles.toolbar}>
-              {applyButton}
+              <Stack gap={1} alignItems="center">
+                {applyButton}
+                {copyAsResourceButton}
+              </Stack>
               <IconButton
                 name="compress-arrows"
                 size="sm"

--- a/public/app/features/dashboard-scene/edit-pane/codePaneUtils.test.ts
+++ b/public/app/features/dashboard-scene/edit-pane/codePaneUtils.test.ts
@@ -1,0 +1,63 @@
+import yaml from 'js-yaml';
+
+import { type DashboardScene } from '../scene/DashboardScene';
+
+import { getDashboardJsonText, getDashboardResourceText } from './codePaneUtils';
+
+jest.mock('../serialization/transformSceneToSaveModelSchemaV2', () => ({
+  transformSceneToSaveModelSchemaV2: jest.fn(() => ({ title: 'Test dashboard' })),
+}));
+
+jest.mock('../../dashboard/api/v2', () => ({
+  getK8sV2DashboardApiConfig: () => ({
+    group: 'dashboard.grafana.app',
+    version: 'v2',
+    resource: 'dashboards',
+  }),
+}));
+
+function buildDashboard(uid?: string): DashboardScene {
+  return { state: { uid } } as unknown as DashboardScene;
+}
+
+describe('getDashboardResourceText', () => {
+  it('returns valid JSON by default with apiVersion, kind, metadata.name and spec', () => {
+    const text = getDashboardResourceText(buildDashboard('abc-123'));
+    const parsed = JSON.parse(text);
+
+    expect(parsed).toEqual({
+      apiVersion: 'dashboard.grafana.app/v2',
+      kind: 'Dashboard',
+      metadata: { name: 'abc-123' },
+      spec: { title: 'Test dashboard' },
+    });
+  });
+
+  it('uses a placeholder name when the dashboard has no uid yet', () => {
+    const text = getDashboardResourceText(buildDashboard(undefined));
+    const parsed = JSON.parse(text);
+
+    expect(parsed.metadata.name).toBe('<dashboard-uid>');
+  });
+
+  it('wraps the same spec returned by getDashboardJsonText', () => {
+    const dashboard = buildDashboard('abc-123');
+    const bareSpec = JSON.parse(getDashboardJsonText(dashboard));
+    const wrapped = JSON.parse(getDashboardResourceText(dashboard));
+
+    expect(wrapped.spec).toEqual(bareSpec);
+  });
+
+  it('emits YAML with the same envelope when format is "yaml"', () => {
+    const text = getDashboardResourceText(buildDashboard('abc-123'), 'yaml');
+    const parsed = yaml.load(text);
+
+    expect(parsed).toEqual({
+      apiVersion: 'dashboard.grafana.app/v2',
+      kind: 'Dashboard',
+      metadata: { name: 'abc-123' },
+      spec: { title: 'Test dashboard' },
+    });
+    expect(text).toMatch(/^apiVersion: dashboard\.grafana\.app\/v2$/m);
+  });
+});

--- a/public/app/features/dashboard-scene/edit-pane/codePaneUtils.ts
+++ b/public/app/features/dashboard-scene/edit-pane/codePaneUtils.ts
@@ -1,3 +1,5 @@
+import yaml from 'js-yaml';
+
 import { t } from '@grafana/i18n';
 import { sceneUtils } from '@grafana/scenes';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -7,11 +9,32 @@ import { getK8sV2DashboardApiConfig } from '../../dashboard/api/v2';
 import { type DashboardScene } from '../scene/DashboardScene';
 import { transformSaveModelSchemaV2ToScene } from '../serialization/transformSaveModelSchemaV2ToScene';
 import { transformSceneToSaveModelSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
+import { type SchemaEditorFormat } from '../v2schema/DashboardSchemaEditor';
 
 import { DashboardEditActionEvent, DashboardStateChangedEvent } from './events';
 
 export function getDashboardJsonText(dashboard: DashboardScene): string {
   return JSON.stringify(transformSceneToSaveModelSchemaV2(dashboard), null, 2);
+}
+
+const NEW_DASHBOARD_NAME_PLACEHOLDER = '<dashboard-uid>';
+
+export function getDashboardResourceText(dashboard: DashboardScene, format: SchemaEditorFormat = 'json'): string {
+  const spec = transformSceneToSaveModelSchemaV2(dashboard);
+  const { group, version } = getK8sV2DashboardApiConfig();
+  const resource = {
+    apiVersion: `${group}/${version}`,
+    kind: 'Dashboard',
+    metadata: {
+      name: dashboard.state.uid ?? NEW_DASHBOARD_NAME_PLACEHOLDER,
+    },
+    spec,
+  };
+
+  if (format === 'yaml') {
+    return yaml.dump(resource, { indent: 2, lineWidth: -1, noRefs: true });
+  }
+  return JSON.stringify(resource, null, 2);
 }
 
 export function applyJsonToDashboard(

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5373,6 +5373,8 @@
     },
     "code-pane": {
       "collapse": "Collapse editor",
+      "copy-as-resource": "Copy as resource",
+      "copy-as-resource-tooltip": "Copy dashboard as resource (with apiVersion, kind and metadata) for use in provisioning files",
       "expand": "Expand editor",
       "header": "Edit as code",
       "modal-title": "Edit dashboard as code"


### PR DESCRIPTION
The v2 Edit as code pane shows only the dashboard spec, since metadata and apiVersion are not editable surface. But users still need the full envelope-wrapped form for e.g. provisioning files, and gdev json.

Adds a "Copy as resource" ClipboardButton next to Apply that emits the envelope { apiVersion, kind, metadata.name, spec } in whichever format (JSON or YAML) the editor is currently displaying.

See butto next to `Apply...`
<img width="731" height="702" alt="image" src="https://github.com/user-attachments/assets/9760f600-fed5-455b-b372-b266b4e4a63e" />