### PR TITLE
Dashboards: Add copy buttons to "Edit as code" pane

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardCodePane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardCodePane.tsx
@@ -1,15 +1,27 @@
-import { css } from '@emotion/css';
-import { useCallback, useState } from 'react';
+import { css, cx } from '@emotion/css';
+import { useCallback, useRef, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
-import { Alert, Button, IconButton, Modal, Sidebar, Tooltip, useStyles2 } from '@grafana/ui';
+import {
+  Alert,
+  Button,
+  ClipboardButton,
+  Icon,
+  IconButton,
+  InlineToast,
+  Modal,
+  Sidebar,
+  Stack,
+  Tooltip,
+  useStyles2,
+} from '@grafana/ui';
 
 import { getDashboardSceneFor } from '../utils/utils';
 import { DashboardSchemaEditor, type SchemaEditorFormat } from '../v2schema/DashboardSchemaEditor';
 
-import { applyJsonToDashboard, getDashboardJsonText } from './codePaneUtils';
+import { applyJsonToDashboard, formatForEditor, getDashboardJsonText, getSharingExportText } from './codePaneUtils';
 
 export class DashboardCodePane extends SceneObjectBase {
   public static Component = DashboardCodePaneRenderer;
@@ -29,6 +41,8 @@ export function DashboardCodePaneRenderer({ model }: SceneComponentProps<Dashboa
   const [jsonText, setJsonText] = useState(() => getDashboardJsonText(dashboard));
   const [isExpanded, setIsExpanded] = useState(false);
   const [editorFormat, setEditorFormat] = useState<SchemaEditorFormat>('json');
+  const [sharingCopied, setSharingCopied] = useState(false);
+  const sharingButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleChange = useCallback((value: string) => {
     setJsonText(value);
@@ -44,6 +58,23 @@ export function DashboardCodePaneRenderer({ model }: SceneComponentProps<Dashboa
     }
   }, [dashboard, jsonText]);
 
+  const handleCopyForSharing = useCallback(async () => {
+    setApplyError(null);
+
+    try {
+      const text = await getSharingExportText(dashboard, jsonText, editorFormat);
+      await navigator.clipboard.writeText(text);
+      setSharingCopied(true);
+      setTimeout(() => setSharingCopied(false), 2000);
+    } catch (error) {
+      setApplyError(
+        error instanceof Error
+          ? error.message
+          : t('dashboard.code-pane.copy-for-sharing-error', 'Failed to copy dashboard for sharing')
+      );
+    }
+  }, [dashboard, jsonText, editorFormat]);
+
   const applyTooltip =
     editorFormat === 'yaml'
       ? t(
@@ -58,6 +89,42 @@ export function DashboardCodePaneRenderer({ model }: SceneComponentProps<Dashboa
         {t('dashboard.schema-editor.apply-button', 'Apply changes')}
       </Button>
     </Tooltip>
+  );
+
+  const actionButtons = (
+    <Stack direction="row" gap={1} alignItems="center">
+      {applyButton}
+      <ClipboardButton
+        icon="copy"
+        variant="secondary"
+        size="sm"
+        disabled={hasValidationErrors}
+        getText={() => formatForEditor(jsonText, editorFormat)}
+      >
+        {t('dashboard.code-pane.copy-to-clipboard', 'Copy to clipboard')}
+      </ClipboardButton>
+      {sharingCopied && (
+        <InlineToast placement="top" referenceElement={sharingButtonRef.current}>
+          {t('dashboard.code-pane.copy-for-sharing-copied', 'Copied')}
+        </InlineToast>
+      )}
+      <Button
+        ref={sharingButtonRef}
+        icon="copy"
+        variant={sharingCopied ? 'success' : 'secondary'}
+        size="sm"
+        disabled={hasValidationErrors}
+        onClick={handleCopyForSharing}
+        className={cx(styles.copyButton, sharingCopied && styles.copyButtonSuccess)}
+      >
+        {t('dashboard.code-pane.copy-for-sharing', 'Copy for sharing')}
+        {sharingCopied && (
+          <div className={styles.copySuccessOverlay}>
+            <Icon name="check" />
+          </div>
+        )}
+      </Button>
+    </Stack>
   );
 
   const errorAlert = applyError ? (
@@ -88,7 +155,7 @@ export function DashboardCodePaneRenderer({ model }: SceneComponentProps<Dashboa
           <DashboardSchemaEditor {...editorProps} containerStyles={styles.codeEditor} />
         </div>
         <div className={styles.toolbar}>
-          {applyButton}
+          {actionButtons}
           <IconButton
             name="expand-arrows"
             size="sm"
@@ -112,7 +179,7 @@ export function DashboardCodePaneRenderer({ model }: SceneComponentProps<Dashboa
             {errorAlert}
             <DashboardSchemaEditor {...editorProps} />
             <div className={styles.toolbar}>
-              {applyButton}
+              {actionButtons}
               <IconButton
                 name="compress-arrows"
                 size="sm"
@@ -154,6 +221,25 @@ const getStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
     justifyContent: 'space-between',
     flex: '0 0 auto',
+  }),
+  copyButton: css({
+    position: 'relative',
+  }),
+  copyButtonSuccess: css({
+    '> *': {
+      visibility: 'hidden',
+    },
+  }),
+  copySuccessOverlay: css({
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    right: 0,
+    left: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    visibility: 'visible',
   }),
   modal: css({
     width: '90vw',

--- a/public/app/features/dashboard-scene/edit-pane/codePaneUtils.test.ts
+++ b/public/app/features/dashboard-scene/edit-pane/codePaneUtils.test.ts
@@ -1,0 +1,89 @@
+import yaml from 'js-yaml';
+
+import { type DashboardScene } from '../scene/DashboardScene';
+
+import { buildSharingExport, formatForEditor, getSharingExportText } from './codePaneUtils';
+
+const mockMakeExportableV2 = jest.fn();
+
+jest.mock('../scene/export/exporters', () => ({
+  ...jest.requireActual('../scene/export/exporters'),
+  makeExportableV2: (...args: unknown[]) => mockMakeExportableV2(...args),
+}));
+
+jest.mock('../../dashboard/api/v2', () => ({
+  getK8sV2DashboardApiConfig: () => ({ version: 'v2' }),
+}));
+
+const makeExportableV2Mock = mockMakeExportableV2;
+
+function createDashboard(): DashboardScene {
+  return {
+    state: { uid: 'abc-123' },
+    serializer: {
+      metadata: {
+        name: 'abc-123',
+        resourceVersion: '42',
+        creationTimestamp: '2024-01-01T00:00:00Z',
+        uid: 'should-be-stripped',
+        labels: { 'grafana.app/internal': 'x', team: 'frontend' },
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('formatForEditor', () => {
+  const jsonText = JSON.stringify({ title: 'My dashboard', tags: ['a', 'b'] }, null, 2);
+
+  it('returns the JSON text unchanged for the json format', () => {
+    expect(formatForEditor(jsonText, 'json')).toBe(jsonText);
+  });
+
+  it('converts the JSON text to YAML for the yaml format', () => {
+    const result = formatForEditor(jsonText, 'yaml');
+    expect(result).toBe(yaml.dump({ title: 'My dashboard', tags: ['a', 'b'] }));
+    expect(result).toContain('title: My dashboard');
+  });
+});
+
+describe('buildSharingExport', () => {
+  it('wraps the exported spec in the sharing envelope and strips internal metadata', async () => {
+    const exportedSpec = { title: 'My dashboard', exported: true };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    makeExportableV2Mock.mockResolvedValue(exportedSpec as any);
+
+    const jsonText = JSON.stringify({ title: 'My dashboard' });
+    const envelope = await buildSharingExport(createDashboard(), jsonText);
+
+    expect(envelope.spec).toEqual(exportedSpec);
+    expect(makeExportableV2Mock).toHaveBeenCalledWith({ title: 'My dashboard' }, true);
+    expect(envelope.apiVersion).toBe('v2');
+    expect(envelope.kind).toBe('Dashboard');
+
+    // External-sharing metadata stripping removes uid and grafana.app/* labels.
+    expect(envelope.metadata).not.toHaveProperty('uid');
+    expect(envelope.metadata.labels).toEqual({ team: 'frontend' });
+    expect(envelope.metadata.name).toBe('abc-123');
+  });
+});
+
+describe('getSharingExportText', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    makeExportableV2Mock.mockResolvedValue({ title: 'My dashboard' } as any);
+  });
+
+  it('produces pretty-printed JSON for the json format', async () => {
+    const text = await getSharingExportText(createDashboard(), '{"title":"My dashboard"}', 'json');
+    const parsed = JSON.parse(text);
+    expect(parsed.kind).toBe('Dashboard');
+    expect(text).toContain('\n  '); // pretty-printed with indentation
+  });
+
+  it('produces YAML for the yaml format', async () => {
+    const text = await getSharingExportText(createDashboard(), '{"title":"My dashboard"}', 'yaml');
+    expect(text).toContain('kind: Dashboard');
+    expect(text).toContain('apiVersion: v2');
+  });
+});

--- a/public/app/features/dashboard-scene/edit-pane/codePaneUtils.ts
+++ b/public/app/features/dashboard-scene/edit-pane/codePaneUtils.ts
@@ -1,3 +1,5 @@
+import yaml from 'js-yaml';
+
 import { t } from '@grafana/i18n';
 import { sceneUtils } from '@grafana/scenes';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -5,13 +7,56 @@ import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.gra
 import { type DashboardWithAccessInfo } from '../../dashboard/api/types';
 import { getK8sV2DashboardApiConfig } from '../../dashboard/api/v2';
 import { type DashboardScene } from '../scene/DashboardScene';
+import { makeExportableV2, stripMetadataForExport } from '../scene/export/exporters';
 import { transformSaveModelSchemaV2ToScene } from '../serialization/transformSaveModelSchemaV2ToScene';
 import { transformSceneToSaveModelSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
+import { type ExportableResource } from '../sharing/ShareExportTab';
+import { type SchemaEditorFormat } from '../v2schema/DashboardSchemaEditor';
 
 import { DashboardEditActionEvent, DashboardStateChangedEvent } from './events';
 
 export function getDashboardJsonText(dashboard: DashboardScene): string {
   return JSON.stringify(transformSceneToSaveModelSchemaV2(dashboard), null, 2);
+}
+
+// Converts the canonical JSON editor content into the currently selected editor format.
+export function formatForEditor(jsonText: string, format: SchemaEditorFormat): string {
+  if (format === 'yaml') {
+    return yaml.dump(JSON.parse(jsonText));
+  }
+  return jsonText;
+}
+
+// Builds the external-sharing envelope, matching the format produced by
+// "Share dashboard with another instance" in the export drawer.
+export async function buildSharingExport(dashboard: DashboardScene, jsonText: string): Promise<ExportableResource> {
+  const spec: DashboardV2Spec = JSON.parse(jsonText);
+  const exportedSpec = await makeExportableV2(spec, true);
+
+  return {
+    apiVersion: getK8sV2DashboardApiConfig().version,
+    kind: 'Dashboard',
+    metadata: stripMetadataForExport(
+      {
+        name: dashboard.state.uid ?? '',
+        resourceVersion: '',
+        creationTimestamp: '',
+        ...dashboard.serializer.metadata,
+      },
+      true
+    ),
+    spec: exportedSpec,
+  };
+}
+
+// Serializes the external-sharing envelope into the currently selected editor format.
+export async function getSharingExportText(
+  dashboard: DashboardScene,
+  jsonText: string,
+  format: SchemaEditorFormat
+): Promise<string> {
+  const envelope = await buildSharingExport(dashboard, jsonText);
+  return format === 'yaml' ? yaml.dump(envelope) : JSON.stringify(envelope, null, 2);
 }
 
 export function applyJsonToDashboard(

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -1,4 +1,4 @@
-import { defaults, each, sortBy } from 'lodash';
+import { cloneDeep, defaults, each, sortBy } from 'lodash';
 
 import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
@@ -16,6 +16,7 @@ import {
 import config from 'app/core/config';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
+import { type ObjectMeta } from 'app/features/apiserver/types';
 import { buildPanelKind } from 'app/features/dashboard/api/ResponseTransformers';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { type PanelModel, type GridPos } from 'app/features/dashboard/state/PanelModel';
@@ -567,4 +568,31 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
       error: err,
     };
   }
+}
+
+export function stripMetadataForExport(metadata: ObjectMeta, isSharingExternally: boolean): Partial<ObjectMeta> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result: Record<string, any> = cloneDeep(metadata);
+
+  delete result['managedFields'];
+
+  if (isSharingExternally) {
+    delete result['uid'];
+    delete result['resourceVersion'];
+    delete result['namespace'];
+
+    for (const key in result['labels']) {
+      if (key.startsWith('grafana.app/')) {
+        delete result['labels'][key];
+      }
+    }
+
+    for (const key in result['annotations']) {
+      if (key.startsWith('grafana.app/')) {
+        delete result['annotations'][key];
+      }
+    }
+  }
+
+  return result;
 }

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -1,6 +1,5 @@
 import saveAs from 'file-saver';
 import yaml from 'js-yaml';
-import { cloneDeep } from 'lodash';
 import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
@@ -18,7 +17,7 @@ import { shareDashboardType } from 'app/features/dashboard/components/ShareModal
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
 
-import { makeExportableV1, makeExportableV2 } from '../scene/export/exporters';
+import { makeExportableV1, makeExportableV2, stripMetadataForExport } from '../scene/export/exporters';
 import { getVariablesCompatibility } from '../utils/getVariablesCompatibility';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor, hasLibraryPanelsInV1Dashboard } from '../utils/utils';
@@ -258,33 +257,6 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
       action: 'copy',
     });
   };
-}
-
-function stripMetadataForExport(metadata: ObjectMeta, isSharingExternally: boolean): Partial<ObjectMeta> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const result: Record<string, any> = cloneDeep(metadata);
-
-  delete result['managedFields'];
-
-  if (isSharingExternally) {
-    delete result['uid'];
-    delete result['resourceVersion'];
-    delete result['namespace'];
-
-    for (const key in result['labels']) {
-      if (key.startsWith('grafana.app/')) {
-        delete result['labels'][key];
-      }
-    }
-
-    for (const key in result['annotations']) {
-      if (key.startsWith('grafana.app/')) {
-        delete result['annotations'][key];
-      }
-    }
-  }
-
-  return result;
 }
 
 function ShareExportTabRenderer({ model }: SceneComponentProps<ShareExportTab>) {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5373,6 +5373,10 @@
     },
     "code-pane": {
       "collapse": "Collapse editor",
+      "copy-for-sharing": "Copy for sharing",
+      "copy-for-sharing-copied": "Copied",
+      "copy-for-sharing-error": "Failed to copy dashboard for sharing",
+      "copy-to-clipboard": "Copy to clipboard",
       "expand": "Expand editor",
       "header": "Edit as code",
       "modal-title": "Edit dashboard as code"


### PR DESCRIPTION
## What this PR does

Adds two buttons to the **"Edit as code"** pane in the v2 dashboard editor:

- **Copy to clipboard** — copies the current editor content as shown (JSON, or YAML if the editor's format toggle is set to YAML).
- **Copy for sharing** — copies the dashboard in the same external-share envelope format produced by **"Share dashboard with another instance"** in the export drawer (`makeExportableV2(spec, true)` wrapped in `{ apiVersion, kind: 'Dashboard', metadata, spec }`, with internal metadata stripped).

Both buttons are **disabled while the schema fails validation**, matching the existing "Apply changes" gating. They appear in both the inline toolbar and the expanded-editor modal.

## Implementation notes

- Extracted `stripMetadataForExport` out of `ShareExportTab.tsx` into `exporters.ts` (next to `makeExportableV2`) so it can be shared between the share drawer and the code pane. No behavior change to the share drawer.
- Added `formatForEditor`, `buildSharingExport`, and `getSharingExportText` helpers in `codePaneUtils.ts`.
- "Copy for sharing" replicates `ClipboardButton`'s success visual (green button, centered check overlay, "Copied" `InlineToast`) since the sharing export is async and `ClipboardButton.getText()` is synchronous.

## Testing

- New unit tests in `codePaneUtils.test.ts` covering format conversion, the sharing envelope shape, and metadata stripping.
- Existing `ShareExportTab` and `exporters` suites still pass (49 tests) after the refactor.
- `yarn typecheck` and `yarn lint` pass.

Before:

<img width="693" height="679" alt="Screenshot 2026-06-11 at 13 00 21" src="https://github.com/user-attachments/assets/c71c534b-26a5-40db-adc7-24a0ce53652b" />

After:
<img width="697" height="698" alt="Screenshot 2026-06-11 at 13 01 15" src="https://github.com/user-attachments/assets/cf5f6312-9d39-46b6-933b-c7fcbe5b1241" />
