### PR TITLE
Homepage: Add analytics tracking for tab changes and dashboard interactions

### DIFF
--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -11,6 +11,8 @@ import { getRecentlyViewedDashboards } from 'app/features/browse-dashboards/api/
 import { useDashboardLocationInfo } from 'app/features/search/hooks/useDashboardLocationInfo';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 
+import { tabChanged } from '../analytics/main';
+
 import { RecentDashboardsTab } from './RecentDashboardsTab';
 import { StarredDashboardsTab } from './StarredDashboardsTab';
 import { type HomepageTabExtensionProps, type HomepageTab, validateHomepageTab } from './types';
@@ -144,7 +146,10 @@ export function DashboardTabs() {
               label={isActive ? (tab.activeLabel ?? tab.label) : tab.label}
               active={isActive}
               counter={tab.counter}
-              onChangeTab={() => setActiveTab(tab.id)}
+              onChangeTab={() => {
+                setActiveTab(tab.id);
+                tabChanged({ tab: tab.id });
+              }}
             />
           );
         })}

--- a/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
@@ -10,6 +10,8 @@ import { type DashboardQueryResult, type LocationInfo } from 'app/features/searc
 import { DashListItem } from 'app/plugins/panel/dashlist/DashListItem';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { clearHistoryClicked, emptyCtaClicked } from '../analytics/main';
+
 interface Props {
   dashboards: DashboardQueryResult[];
   loading: boolean;
@@ -56,11 +58,20 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
           message={t('home.recent-dashboards-tab.empty', "Dashboards you've recently viewed will appear here.")}
           button={
             canCreate ? (
-              <LinkButton icon="plus" href="/dashboard/new">
+              <LinkButton
+                icon="plus"
+                href="/dashboard/new"
+                onClick={() => emptyCtaClicked({ cta_type: 'create_dashboard' })}
+              >
                 <Trans i18nKey="home.recent-dashboards-tab.create">Create your first dashboard</Trans>
               </LinkButton>
             ) : (
-              <LinkButton icon="apps" href="/dashboards" variant="secondary">
+              <LinkButton
+                icon="apps"
+                href="/dashboards"
+                variant="secondary"
+                onClick={() => emptyCtaClicked({ cta_type: 'browse_dashboards' })}
+              >
                 <Trans i18nKey="home.recent-dashboards-tab.browse">Browse dashboards</Trans>
               </LinkButton>
             )
@@ -76,6 +87,7 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
   }
 
   const handleClearHistory = () => {
+    clearHistoryClicked({ dashboard_count: dashboards.length });
     impressionSrv.clearImpressions();
     retry();
   };

--- a/public/app/features/home/analytics/main.ts
+++ b/public/app/features/home/analytics/main.ts
@@ -1,0 +1,14 @@
+import { defineFeatureEvents } from '@grafana/runtime/unstable';
+
+import { type ClearHistoryClicked, type EmptyCtaClicked, type TabChanged } from './types';
+
+const createHomepageEvent = defineFeatureEvents('grafana', 'homepage');
+
+/** Fired when the user clicks a tab on the homepage. */
+export const tabChanged = createHomepageEvent<TabChanged>('tab_changed');
+
+/** Fired when the user clears their recently-viewed dashboard history. */
+export const clearHistoryClicked = createHomepageEvent<ClearHistoryClicked>('clear_history_clicked');
+
+/** Fired when the user clicks the empty-state call-to-action on the Recent tab. */
+export const emptyCtaClicked = createHomepageEvent<EmptyCtaClicked>('empty_cta_clicked');

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -1,0 +1,16 @@
+import { type EventProperty } from '@grafana/runtime/unstable';
+
+export interface TabChanged extends EventProperty {
+  /** Tab the user switched to. */
+  tab: string;
+}
+
+export interface ClearHistoryClicked extends EventProperty {
+  /** Number of dashboards in history before clearing. */
+  dashboard_count: number;
+}
+
+export interface EmptyCtaClicked extends EventProperty {
+  /** Which empty-state button was clicked. */
+  cta_type: 'create_dashboard' | 'browse_dashboards';
+}


### PR DESCRIPTION
**What is this feature?**

Adds product analytics tracking to the unified homepage using the typed `defineFeatureEvents` framework from `@grafana/runtime/unstable`. Three events are tracked: tab switches (`grafana_homepage_tab_changed`), clearing recent dashboard history (`grafana_homepage_clear_history_clicked`), and empty-state CTA clicks (`grafana_homepage_empty_cta_clicked`).


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/125728

**Special notes for your reviewer:**

Dashboard item clicks and star/unstar are already tracked by `DashListItem` and `StarToolbarButton` (with `source: "homepage_recentTab"/"homepage_starredTab"`), so those are intentionally excluded. Auto-tab-switching (internal UX behavior) is also excluded — only user-initiated tab clicks fire `grafana_homepage_tab_changed`.