### PR TITLE
fix: don't ping teams in coverage

### DIFF
--- a/scripts/compare-coverage-by-codeowner.js
+++ b/scripts/compare-coverage-by-codeowner.js
@@ -213,7 +213,7 @@ function generateMarkdown(mainCoverage, prCoverage) {
     failureDetails = generateFailureDetailsSection(decreasedFiles, artifactUrl, prSha, repo);
   }
 
-  return `## Test Coverage Checks ${overallStatus} for ${teamName}
+  return `## Test Coverage Checks ${overallStatus} for \`${teamName}\`
 
 | Metric | Main | PR | Change | Status |
 |--------|------|----|----|--------|


### PR DESCRIPTION
We get pings from these. Let's just print the team name in inline code blocks to avoid it :)