### PR TITLE
Provisioning: drop Grafana-saved-by trailer note from CommitOptions spec

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -326,8 +326,7 @@ type CommitOptions struct {
 	SingleResourceMessageTemplate string `json:"singleResourceMessageTemplate,omitempty"`
 
 	// When true, the Comment field in Save drawers is pre-filled from
-	// SingleResourceMessageTemplate and rendered read-only. The
-	// Grafana-saved-by trailer is always appended regardless of this setting.
+	// SingleResourceMessageTemplate and rendered read-only.
 	EnforceTemplate bool `json:"enforceTemplate,omitempty"`
 	// Name used as the commit signer. Required for the signing key's identity
 	// to match the commit, which providers need to mark commits as Verified. When

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -226,7 +226,7 @@ func schema_pkg_apis_provisioning_v0alpha1_CommitOptions(ref common.ReferenceCal
 					},
 					"enforceTemplate": {
 						SchemaProps: spec.SchemaProps{
-							Description: "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only. The Grafana-saved-by trailer is always appended regardless of this setting.",
+							Description: "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/commitoptions.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/commitoptions.go
@@ -19,8 +19,7 @@ type CommitOptionsApplyConfiguration struct {
 	// When empty, a built-in default is used (e.g. "Save dashboard: <title>").
 	SingleResourceMessageTemplate *string `json:"singleResourceMessageTemplate,omitempty"`
 	// When true, the Comment field in Save drawers is pre-filled from
-	// SingleResourceMessageTemplate and rendered read-only. The
-	// Grafana-saved-by trailer is always appended regardless of this setting.
+	// SingleResourceMessageTemplate and rendered read-only.
 	EnforceTemplate *bool `json:"enforceTemplate,omitempty"`
 	// Name used as the commit signer. Required for the signing key's identity
 	// to match the commit, which providers need to mark commits as Verified. When

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1817,7 +1817,7 @@ export type BranchOptions = {
   nameTemplate?: string;
 };
 export type CommitOptions = {
-  /** When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only. The Grafana-saved-by trailer is always appended regardless of this setting. */
+  /** When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only. */
   enforceTemplate?: boolean;
   /** Email used as the commit signer. Must match the signing key's identity and a verified email on the account where the matching public key is registered. When empty, defaults to "noreply@grafana.com". */
   signerEmail?: string;

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -3752,7 +3752,7 @@
         "type": "object",
         "properties": {
           "enforceTemplate": {
-            "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only. The Grafana-saved-by trailer is always appended regardless of this setting.",
+            "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only.",
             "type": "boolean"
           },
           "signerEmail": {

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -3752,7 +3752,7 @@
         "type": "object",
         "properties": {
           "enforceTemplate": {
-            "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only. The Grafana-saved-by trailer is always appended regardless of this setting.",
+            "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only.",
             "type": "boolean"
           },
           "signerEmail": {

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4081,7 +4081,7 @@
         "type": "object",
         "properties": {
           "enforceTemplate": {
-            "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only. The Grafana-saved-by trailer is always appended regardless of this setting.",
+            "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only.",
             "type": "boolean"
           },
           "signerEmail": {

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -4081,7 +4081,7 @@
         "type": "object",
         "properties": {
           "enforceTemplate": {
-            "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only. The Grafana-saved-by trailer is always appended regardless of this setting.",
+            "description": "When true, the Comment field in Save drawers is pre-filled from SingleResourceMessageTemplate and rendered read-only.",
             "type": "boolean"
           },
           "signerEmail": {


### PR DESCRIPTION
## Summary

Removes the "Grafana-saved-by trailer is always appended regardless of this setting" sentence from the `CommitOptions.EnforceTemplate` doc in the provisioning backend spec.

The doc asserted that the trailer is always appended, but that behavior isn't settled yet and may not be implemented in that shape. Dropping the premature claim from the spec.

## Changes

- Drop the trailer sentence from the `EnforceTemplate` comment in `apps/provisioning/.../v0alpha1/types.go`
- Propagate the same drop to the generated openapi/clients/snapshot artifacts (openapi.go, commitoptions.go, grafana-openapi v0alpha1/v1beta1 JSON, api-clients endpoints.gen.ts, openapi snapshots)

## Testing

- `go build ./pkg/apis/... ./pkg/generated/...` passes
- Doc-only change; no behavioral tests affected

## Checklist

- [ ] Tests added/updated (N/A — doc-only)
- [x] Documentation updated
- [x] No breaking changes

🤖 Generated with Claude Code