### PR TITLE
Modal: don't dismiss when pressing portal-container content

### DIFF
--- a/packages/grafana-ui/src/components/Modal/Modal.test.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.test.tsx
@@ -1,5 +1,8 @@
+import { UNSAFE_PortalProvider } from '@react-aria/overlays';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+import { getPortalContainer, PortalContainer } from '../Portal/Portal';
 
 import { Modal } from './Modal';
 
@@ -129,5 +132,57 @@ describe('Modal', () => {
     await userEvent.keyboard('{Escape}');
 
     expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  // Mirrors the app arrangement (see AppWrapper): UNSAFE_PortalProvider routes react-aria
+  // overlays — including the modal and its backdrop — into <PortalContainer />.
+  describe('with the app portal container', () => {
+    function setup(onDismiss: jest.Mock) {
+      const ui = (isOpen: boolean) => (
+        <UNSAFE_PortalProvider getContainer={getPortalContainer}>
+          <PortalContainer />
+          <div data-testid="page-content">Page content</div>
+          <Modal title="Some Title" isOpen={isOpen} onDismiss={onDismiss}>
+            <div data-testid="modal-content">Content</div>
+          </Modal>
+        </UNSAFE_PortalProvider>
+      );
+      const { rerender } = render(ui(false));
+      return { openModal: () => rerender(ui(true)) };
+    }
+
+    it('pressing an overlay inside the portal container does not dismiss', async () => {
+      const onDismiss = jest.fn();
+      const { openModal } = setup(onDismiss);
+
+      const overlay = document.createElement('button');
+      getPortalContainer().appendChild(overlay);
+      openModal();
+      await userEvent.click(overlay);
+
+      expect(onDismiss).not.toHaveBeenCalled();
+    });
+
+    it('clicking the backdrop still dismisses', async () => {
+      const onDismiss = jest.fn();
+      const { openModal } = setup(onDismiss);
+      openModal();
+
+      const backdrop = screen.getByRole('presentation');
+      expect(getPortalContainer().contains(backdrop)).toBe(true);
+      await userEvent.click(backdrop);
+
+      expect(onDismiss).toHaveBeenCalled();
+    });
+
+    it('pressing page content outside the portal container still dismisses', async () => {
+      const onDismiss = jest.fn();
+      const { openModal } = setup(onDismiss);
+      openModal();
+
+      await userEvent.click(screen.getByTestId('page-content'));
+
+      expect(onDismiss).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Modal/ModalBase.tsx
+++ b/packages/grafana-ui/src/components/Modal/ModalBase.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import { FloatingFocusManager, useDismiss, useFloating, useInteractions, useRole } from '@floating-ui/react';
 import { OverlayContainer } from '@react-aria/overlays';
-import { type PropsWithChildren } from 'react';
+import { type PropsWithChildren, useRef } from 'react';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { getPortalContainer } from '../Portal/Portal';
@@ -43,9 +43,23 @@ export function ModalBase({
     },
   });
 
+  const backdropRef = useRef<HTMLDivElement>(null);
+
   const dismiss = useDismiss(context, {
     escapeKey: closeOnEscape,
-    outsidePress: () => {
+    outsidePress: (event) => {
+      // The portal container is "inside" the modal (see getInsideElements below), so presses
+      // there must not dismiss it — except on the backdrop, which also renders there.
+      const target = event.target instanceof Node ? event.target : null;
+      const portalContainer = getPortalContainer();
+      if (
+        target &&
+        portalContainer !== document.body &&
+        portalContainer.contains(target) &&
+        !backdropRef.current?.contains(target)
+      ) {
+        return false;
+      }
       if (onClickBackdrop) {
         onClickBackdrop();
         return false;
@@ -66,7 +80,7 @@ export function ModalBase({
 
   return (
     <OverlayContainer>
-      <div role="presentation" className={styles.modalBackdrop} />
+      <div role="presentation" ref={backdropRef} className={styles.modalBackdrop} />
       <FloatingFocusManager context={context} modal={trapFocus} getInsideElements={() => [getPortalContainer()]}>
         <div
           className={cx(styles.modal, className)}

--- a/packages/grafana-ui/src/components/Portal/Portal.tsx
+++ b/packages/grafana-ui/src/components/Portal/Portal.tsx
@@ -41,7 +41,11 @@ export function Portal(props: PropsWithChildren<Props>) {
   );
 }
 
-/** @internal */
+/**
+ * Returns the container element Grafana renders overlays into (tooltips, menus, modals).
+ * Content rendered into this container coexists with an open Modal: it is treated as
+ * inside the modal for focus management and pressing it does not dismiss the modal.
+ */
 export function getPortalContainer() {
   return window.document.getElementById('grafana-portal-container') ?? document.body;
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

**Why this exists:** Grafana Pathfinder is building a "companion mode" (grafana/grafana-pathfinder-app#1012) where its guide panel pops out as a floating panel and stays interactive while the user follows the steps of a guide — including steps that open native modals. Today that cannot work: `Modal` defaults to `closeOnBackdropClick`, and `useDismiss` treats *any* press outside the modal's own floating element as an outside press — so the first click on the guide panel dismisses the very modal the guide just asked the user to open.


https://github.com/user-attachments/assets/4dffb803-1eff-470d-b601-bf9b4c0fc919



The same inconsistency affects plain Grafana with no plugins involved: `ModalBase` already declares the portal container "inside" the modal for focus/aria via `getInsideElements={() => [getPortalContainer()]}`, but `outsidePress` doesn't honor that same set. So overlays that render into the portal container *over* an open modal — a `Select`/`Combobox` menu, a `Tooltip`, a `Popover` — can dismiss the modal on press.

^^ Update statement not really fair since: protected by Reacts event propagation which protects overlays opened from inside the modal's own tree.

**The fix:** make `outsidePress` consistent with `getInsideElements` — presses inside the portal container no longer dismiss the modal. The backdrop also renders in the portal container, so it is explicitly excluded to keep `closeOnBackdropClick` working. Backdrop and plain-page presses behave exactly as before.



https://github.com/user-attachments/assets/f76d718b-6ff9-4b1f-a35d-0495a2b0e016



**Also:** `getPortalContainer` loses its `@internal` marker and gains docs. "Render your overlay into the portal container" is the supported contract for overlays that need to coexist with modals — Pathfinder already imports it from `@grafana/ui` in grafana/grafana-pathfinder-app#1012. (JSDoc-only change; the function was already exported.)

**Which issue(s) this PR fixes:**

Required by grafana/grafana-pathfinder-app#1012 (companion mode is version-gated on this fix landing in a release). Discovered in grafana/grafana-pathfinder-app#1007. Also fixes the general case of in-modal dropdowns/tooltips dismissing the modal.

**Special notes for your reviewer:**

- Includes unit tests covering the press distinction (portal-container overlay → no dismiss; backdrop and page content → dismiss). The tests replicate the app arrangement — `UNSAFE_PortalProvider` routing react-aria overlays into `<PortalContainer />`, as in `AppWrapper` — because floating-ui's outside-press handling is sensitive to where the portal container sits relative to the content it marks `aria-hidden`: with the container as a bare `document.body` child, floating-ui's "third-party element injected after render" heuristic swallows backdrop presses before `outsidePress` matters. Verified the overlay test fails against the previous `ModalBase` (modal was dismissed) and passes with this fix.
- Verified live (Grafana 13.1 nightly): a portal-container element stays interactive over an open modal without dismissing it; a `document.body`-level element and the backdrop still dismiss.
