### PR TITLE
DataSources: Register built-in datasources within the new async API

### DIFF
--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -74,7 +74,7 @@ export { invalidatePluginSettingsCache } from '../services/pluginSettings/invali
 
 export {
   initDataSourceInstanceSettings,
-  registerBuiltInDataSourceInstanceSettings,
+  setExpressionDataSourceInstanceSettings,
   getDataSourceInstanceSettingsList,
 } from '../services/dataSource/settings';
 export { setDataSourcePluginImporter } from '../services/dataSource/dataSource';

--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -72,7 +72,11 @@ export { logPluginMetaError, logPluginMetaWarning } from '../services/pluginMeta
 export { refetchPluginSettings } from '../services/pluginSettings/refetchPluginSettings';
 export { invalidatePluginSettingsCache } from '../services/pluginSettings/invalidatePluginSettingsCache';
 
-export { initDataSourceInstanceSettings, getDataSourceInstanceSettingsList } from '../services/dataSource/settings';
+export {
+  initDataSourceInstanceSettings,
+  registerBuiltInDataSourceInstanceSettings,
+  getDataSourceInstanceSettingsList,
+} from '../services/dataSource/settings';
 export { setDataSourcePluginImporter } from '../services/dataSource/dataSource';
 export {
   useDataSourceInstanceSettingsList,

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -8,7 +8,7 @@ import {
   getDataSourceInstanceSettingsList,
   getDataSourceInstanceSettings,
   initDataSourceInstanceSettings,
-  registerBuiltInDataSourceInstanceSettings,
+  setExpressionDataSourceInstanceSettings,
   reloadDataSourceInstanceSettings,
   upsertRuntimeDataSourceInstanceSettings,
 } from './settings';
@@ -439,40 +439,40 @@ describe('instanceSettings', () => {
     });
   });
 
-  describe('registerBuiltInDataSourceInstanceSettings', () => {
-    it('makes the settings available by uid after init', async () => {
-      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+  describe('setExpressionDataSourceInstanceSettings', () => {
+    it('makes the expression datasource available by uid after init', async () => {
+      setExpressionDataSourceInstanceSettings(fixtures.Expression);
       initDataSourceInstanceSettings({}, '');
       const result = await getDataSourceInstanceSettings('__expr__');
       expect(result?.uid).toBe('__expr__');
     });
 
     it('resolves by name via isExpressionReference path', async () => {
-      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstanceSettings(fixtures.Expression);
       initDataSourceInstanceSettings({}, '');
       const result = await getDataSourceInstanceSettings('Expression');
       expect(result?.uid).toBe('__expr__');
     });
 
     it('resolves by legacy id -100 via isExpressionReference path', async () => {
-      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstanceSettings(fixtures.Expression);
       initDataSourceInstanceSettings({}, '');
       const result = await getDataSourceInstanceSettings('-100');
       expect(result?.uid).toBe('__expr__');
     });
 
     it('is not returned by getDataSourceInstanceSettingsList (byUid-only, matching legacy)', async () => {
-      // Register as built-in, but do NOT include it in the init map — it must
-      // only live in byUid so list results are unaffected.
+      // Set via the expression setter, but do NOT include it in the init map — it
+      // must only live in byUid so list results are unaffected.
       const { Expression: _expr, ...withoutExpression } = fixtures;
-      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstanceSettings(fixtures.Expression);
       initDataSourceInstanceSettings(withoutExpression, 'Bravo');
       const items = await getDataSourceInstanceSettingsList({ all: true });
       expect(items.some((x) => x.uid === '__expr__')).toBe(false);
     });
 
     it('survives a cache repopulate via no-arg reload', async () => {
-      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstanceSettings(fixtures.Expression);
       initDataSourceInstanceSettings(fixtures, 'Bravo');
 
       // Reload with a payload that does not include the expression datasource.
@@ -485,7 +485,7 @@ describe('instanceSettings', () => {
     });
 
     it('coexists with a runtime datasource and both survive a repopulate', async () => {
-      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstanceSettings(fixtures.Expression);
       initDataSourceInstanceSettings(fixtures, 'Bravo');
       const runtime = ds({ uid: 'runtime-ds', name: 'Runtime', type: 'runtime' });
       upsertRuntimeDataSourceInstanceSettings(runtime);
@@ -495,24 +495,6 @@ describe('instanceSettings', () => {
 
       expect((await getDataSourceInstanceSettings('__expr__'))?.uid).toBe('__expr__');
       expect((await getDataSourceInstanceSettings('runtime-ds'))?.name).toBe('Runtime');
-    });
-
-    it('is idempotent — re-registering the same uid overwrites without throwing', () => {
-      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
-      expect(() => registerBuiltInDataSourceInstanceSettings(fixtures.Expression)).not.toThrow();
-    });
-
-    it('throws when the uid collides with a datasource registered via a different path', () => {
-      initDataSourceInstanceSettings(fixtures, 'Bravo');
-      expect(() => registerBuiltInDataSourceInstanceSettings(fixtures.Alpha)).toThrow(/already been registered/);
-    });
-
-    it('normalizes a missing uid to the name, matching populateMaps behaviour', async () => {
-      const noUid = ds({ uid: '', name: 'no-uid-ds', type: 'test-db' });
-      registerBuiltInDataSourceInstanceSettings(noUid);
-      initDataSourceInstanceSettings({}, '');
-      const result = await getDataSourceInstanceSettings('no-uid-ds');
-      expect(result?.name).toBe('no-uid-ds');
     });
   });
 

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -8,6 +8,7 @@ import {
   getDataSourceInstanceSettingsList,
   getDataSourceInstanceSettings,
   initDataSourceInstanceSettings,
+  registerBuiltInDataSourceInstanceSettings,
   reloadDataSourceInstanceSettings,
   upsertRuntimeDataSourceInstanceSettings,
 } from './settings';
@@ -435,6 +436,70 @@ describe('instanceSettings', () => {
       expect(backendGet).toHaveBeenCalledWith('/api/frontend/settings');
       const result = await getDataSourceInstanceSettings(null);
       expect(result?.name).toBe('Alpha');
+    });
+  });
+
+  describe('registerBuiltInDataSourceInstanceSettings', () => {
+    it('makes the settings available by uid after init', async () => {
+      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      initDataSourceInstanceSettings({}, '');
+      const result = await getDataSourceInstanceSettings('__expr__');
+      expect(result?.uid).toBe('__expr__');
+    });
+
+    it('resolves by name via isExpressionReference path', async () => {
+      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      initDataSourceInstanceSettings({}, '');
+      const result = await getDataSourceInstanceSettings('Expression');
+      expect(result?.uid).toBe('__expr__');
+    });
+
+    it('resolves by legacy id -100 via isExpressionReference path', async () => {
+      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      initDataSourceInstanceSettings({}, '');
+      const result = await getDataSourceInstanceSettings('-100');
+      expect(result?.uid).toBe('__expr__');
+    });
+
+    it('is not returned by getDataSourceInstanceSettingsList (byUid-only, matching legacy)', async () => {
+      // Register as built-in, but do NOT include it in the init map — it must
+      // only live in byUid so list results are unaffected.
+      const { Expression: _expr, ...withoutExpression } = fixtures;
+      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      initDataSourceInstanceSettings(withoutExpression, 'Bravo');
+      const items = await getDataSourceInstanceSettingsList({ all: true });
+      expect(items.some((x) => x.uid === '__expr__')).toBe(false);
+    });
+
+    it('survives a cache repopulate via no-arg reload', async () => {
+      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      initDataSourceInstanceSettings(fixtures, 'Bravo');
+
+      // Reload with a payload that does not include the expression datasource.
+      backendGet.mockResolvedValue({ datasources: { Alpha: fixtures.Alpha }, defaultDatasource: 'Alpha' });
+      await reloadDataSourceInstanceSettings();
+
+      const result = await getDataSourceInstanceSettings('__expr__');
+      expect(result?.uid).toBe('__expr__');
+      expect(backendGet).toHaveBeenCalledWith('/api/frontend/settings');
+    });
+
+    it('coexists with a runtime datasource and both survive a repopulate', async () => {
+      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      initDataSourceInstanceSettings(fixtures, 'Bravo');
+      const runtime = ds({ uid: 'runtime-ds', name: 'Runtime', type: 'runtime' });
+      upsertRuntimeDataSourceInstanceSettings(runtime);
+
+      backendGet.mockResolvedValue({ datasources: { Alpha: fixtures.Alpha }, defaultDatasource: 'Alpha' });
+      await reloadDataSourceInstanceSettings();
+
+      expect((await getDataSourceInstanceSettings('__expr__'))?.uid).toBe('__expr__');
+      expect((await getDataSourceInstanceSettings('runtime-ds'))?.name).toBe('Runtime');
+    });
+
+    it('is idempotent — re-registering the same uid overwrites without throwing', () => {
+      registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
+      expect(() => registerBuiltInDataSourceInstanceSettings(fixtures.Expression)).not.toThrow();
     });
   });
 

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -484,6 +484,24 @@ describe('instanceSettings', () => {
       expect(backendGet).toHaveBeenCalledWith('/api/frontend/settings');
     });
 
+    it('throws when called a second time outside of tests', () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      try {
+        setExpressionDataSourceInstanceSettings(fixtures.Expression);
+        expect(() => setExpressionDataSourceInstanceSettings(fixtures.Expression)).toThrow(
+          'setExpressionDataSourceInstanceSettings() function should only be called once'
+        );
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    });
+
+    it('allows being called multiple times in tests', () => {
+      setExpressionDataSourceInstanceSettings(fixtures.Expression);
+      expect(() => setExpressionDataSourceInstanceSettings(fixtures.Expression)).not.toThrow();
+    });
+
     it('coexists with a runtime datasource and both survive a repopulate', async () => {
       setExpressionDataSourceInstanceSettings(fixtures.Expression);
       initDataSourceInstanceSettings(fixtures, 'Bravo');

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -501,6 +501,19 @@ describe('instanceSettings', () => {
       registerBuiltInDataSourceInstanceSettings(fixtures.Expression);
       expect(() => registerBuiltInDataSourceInstanceSettings(fixtures.Expression)).not.toThrow();
     });
+
+    it('throws when the uid collides with a datasource registered via a different path', () => {
+      initDataSourceInstanceSettings(fixtures, 'Bravo');
+      expect(() => registerBuiltInDataSourceInstanceSettings(fixtures.Alpha)).toThrow(/already been registered/);
+    });
+
+    it('normalizes a missing uid to the name, matching populateMaps behaviour', async () => {
+      const noUid = ds({ uid: '', name: 'no-uid-ds', type: 'test-db' });
+      registerBuiltInDataSourceInstanceSettings(noUid);
+      initDataSourceInstanceSettings({}, '');
+      const result = await getDataSourceInstanceSettings('no-uid-ds');
+      expect(result?.name).toBe('no-uid-ds');
+    });
   });
 
   describe('upsertRuntimeDataSourceInstanceSettings', () => {

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -119,6 +119,14 @@ export async function getDataSourceInstanceSettingsList(
  * @internal
  */
 export function registerBuiltInDataSourceInstanceSettings(settings: DataSourceInstanceSettings): void {
+  if (!settings.uid) {
+    settings = { ...settings, uid: settings.name };
+  }
+  // Allow re-registering the same built-in uid (idempotent), but refuse to
+  // clobber a uid that was registered via a different path (init or runtime).
+  if (byUid[settings.uid] && !builtInByUid[settings.uid]) {
+    throw new Error(`A data source with uid ${settings.uid} has already been registered`);
+  }
   builtInByUid[settings.uid] = settings;
   byUid[settings.uid] = settings;
 }

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -122,6 +122,10 @@ export async function getDataSourceInstanceSettingsList(
  * @internal
  */
 export function setExpressionDataSourceInstanceSettings(settings: DataSourceInstanceSettings): void {
+  // We allow overriding in tests
+  if (expressionDsSettings && process.env.NODE_ENV !== 'test') {
+    throw new Error('setExpressionDataSourceInstanceSettings() function should only be called once, when Grafana is starting.');
+  }
   expressionDsSettings = settings;
   byUid[settings.uid] = settings;
 }

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -18,7 +18,7 @@ let byName: Record<string, DataSourceInstanceSettings> = {};
 let byUid: Record<string, DataSourceInstanceSettings> = {};
 let byId: Record<string, DataSourceInstanceSettings> = {};
 let runtimeByUid: Record<string, DataSourceInstanceSettings> = {};
-let builtInByUid: Record<string, DataSourceInstanceSettings> = {};
+let expressionDsSettings: DataSourceInstanceSettings | undefined;
 let defaultName = '';
 
 function populateMaps(settings: Record<string, DataSourceInstanceSettings>) {
@@ -42,9 +42,9 @@ function populateMaps(settings: Record<string, DataSourceInstanceSettings>) {
     byUid[ds.uid] = ds;
   }
 
-  // Re-apply built-in, client-injected data sources (e.g. the expression datasource).
-  for (const ds of Object.values(builtInByUid)) {
-    byUid[ds.uid] = ds;
+  // Re-apply the expression datasource so it survives a cache repopulate.
+  if (expressionDsSettings) {
+    byUid[expressionDsSettings.uid] = expressionDsSettings;
   }
 }
 
@@ -112,22 +112,17 @@ export async function getDataSourceInstanceSettingsList(
 }
 
 /**
- * Register a built-in, client-injected data source (e.g. the expression
- * datasource) that is not part of /api/frontend/settings. Re-applied on every
- * populate so it survives a cache repopulate. Idempotent.
+ * Set the instance settings for the expression pseudo-datasource, which is not
+ * part of /api/frontend/settings and must be injected client-side. Re-applied
+ * on every populate so it survives a cache repopulate.
+ *
+ * This is a temporary bridge until ExpressionDatasource moves from core to
+ * @grafana/runtime, at which point it can be imported directly.
  *
  * @internal
  */
-export function registerBuiltInDataSourceInstanceSettings(settings: DataSourceInstanceSettings): void {
-  if (!settings.uid) {
-    settings = { ...settings, uid: settings.name };
-  }
-  // Allow re-registering the same built-in uid (idempotent), but refuse to
-  // clobber a uid that was registered via a different path (init or runtime).
-  if (byUid[settings.uid] && !builtInByUid[settings.uid]) {
-    throw new Error(`A data source with uid ${settings.uid} has already been registered`);
-  }
-  builtInByUid[settings.uid] = settings;
+export function setExpressionDataSourceInstanceSettings(settings: DataSourceInstanceSettings): void {
+  expressionDsSettings = settings;
   byUid[settings.uid] = settings;
 }
 
@@ -327,6 +322,6 @@ export function _resetForTests(): void {
   byUid = {};
   byId = {};
   runtimeByUid = {};
-  builtInByUid = {};
+  expressionDsSettings = undefined;
   defaultName = '';
 }

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -18,6 +18,7 @@ let byName: Record<string, DataSourceInstanceSettings> = {};
 let byUid: Record<string, DataSourceInstanceSettings> = {};
 let byId: Record<string, DataSourceInstanceSettings> = {};
 let runtimeByUid: Record<string, DataSourceInstanceSettings> = {};
+let builtInByUid: Record<string, DataSourceInstanceSettings> = {};
 let defaultName = '';
 
 function populateMaps(settings: Record<string, DataSourceInstanceSettings>) {
@@ -38,6 +39,11 @@ function populateMaps(settings: Record<string, DataSourceInstanceSettings>) {
 
   // Re-apply any previously registered runtime data sources so they survive a refetch.
   for (const ds of Object.values(runtimeByUid)) {
+    byUid[ds.uid] = ds;
+  }
+
+  // Re-apply built-in, client-injected data sources (e.g. the expression datasource).
+  for (const ds of Object.values(builtInByUid)) {
     byUid[ds.uid] = ds;
   }
 }
@@ -103,6 +109,18 @@ export async function getDataSourceInstanceSettingsList(
   filters?: GetDataSourceListFilters
 ): Promise<DataSourceInstanceSettings[]> {
   return applyFilters(filters);
+}
+
+/**
+ * Register a built-in, client-injected data source (e.g. the expression
+ * datasource) that is not part of /api/frontend/settings. Re-applied on every
+ * populate so it survives a cache repopulate. Idempotent.
+ *
+ * @internal
+ */
+export function registerBuiltInDataSourceInstanceSettings(settings: DataSourceInstanceSettings): void {
+  builtInByUid[settings.uid] = settings;
+  byUid[settings.uid] = settings;
 }
 
 /**
@@ -301,5 +319,6 @@ export function _resetForTests(): void {
   byUid = {};
   byId = {};
   runtimeByUid = {};
+  builtInByUid = {};
   defaultName = '';
 }

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -124,7 +124,9 @@ export async function getDataSourceInstanceSettingsList(
 export function setExpressionDataSourceInstanceSettings(settings: DataSourceInstanceSettings): void {
   // We allow overriding in tests
   if (expressionDsSettings && process.env.NODE_ENV !== 'test') {
-    throw new Error('setExpressionDataSourceInstanceSettings() function should only be called once, when Grafana is starting.');
+    throw new Error(
+      'setExpressionDataSourceInstanceSettings() function should only be called once, when Grafana is starting.'
+    );
   }
   expressionDsSettings = settings;
   byUid[settings.uid] = settings;

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -47,7 +47,7 @@ import {
   getPanelPluginMetas,
   initDataSourceInstanceSettings,
   initOpenFeature,
-  registerBuiltInDataSourceInstanceSettings,
+  setExpressionDataSourceInstanceSettings,
   setDataSourcePluginImporter,
   setGetObservablePluginComponents,
   setGetObservablePluginLinks,
@@ -255,7 +255,7 @@ export class GrafanaApp {
       // Init async data source services (populates cache from boot data so
       // new `getInstanceSettings` / `getInstanceSettingsList` callers don't
       // need to wait on a network round trip).
-      registerBuiltInDataSourceInstanceSettings(expressionInstanceSettings);
+      setExpressionDataSourceInstanceSettings(expressionInstanceSettings);
       initDataSourceInstanceSettings(config.datasources, config.defaultDatasource);
       setDataSourcePluginImporter(pluginImporter.importDataSource.bind(pluginImporter));
 

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -47,6 +47,7 @@ import {
   getPanelPluginMetas,
   initDataSourceInstanceSettings,
   initOpenFeature,
+  registerBuiltInDataSourceInstanceSettings,
   setDataSourcePluginImporter,
   setGetObservablePluginComponents,
   setGetObservablePluginLinks,
@@ -254,10 +255,8 @@ export class GrafanaApp {
       // Init async data source services (populates cache from boot data so
       // new `getInstanceSettings` / `getInstanceSettingsList` callers don't
       // need to wait on a network round trip).
-      initDataSourceInstanceSettings(
-        { ...config.datasources, [expressionInstanceSettings.name]: expressionInstanceSettings },
-        config.defaultDatasource
-      );
+      registerBuiltInDataSourceInstanceSettings(expressionInstanceSettings);
+      initDataSourceInstanceSettings(config.datasources, config.defaultDatasource);
       setDataSourcePluginImporter(pluginImporter.importDataSource.bind(pluginImporter));
 
       // Init DataSourceSrv (legacy sync API; retained for backwards compatibility)


### PR DESCRIPTION
**What is this feature?**

Adds `setExpressionDataSourceInstanceSettings()` to `@grafana/runtime` so the expression pseudo-datasource (`__expr__`) is injected into the new async settings cache via an explicit setter rather than by the caller manually merging it into the init payload. The expression datasource is stored in a dedicated module-level variable and re-applied on every `populateMaps` call, so it survives cache repopulates automatically.

**Why do we need this feature?**

The expression datasource is not returned by `/api/frontend/settings` and must be injected client-side. Previously `app.ts` spread it into the datasources map on every `initDataSourceInstanceSettings` call — a fragile pattern that any future populate site would have to repeat and that wasn't covered by package tests. The new setter makes the injection automatic, tested, and self-documenting: the function name makes clear it is a temporary bridge until `ExpressionDatasource` moves from core to `@grafana/runtime`, at which point it can be imported directly and the setter removed.

**Who is this feature for?**

Grafana core engineers working on the datasource settings migration (`getDataSourceInstanceSettings` / `getDataSourceInstanceSettingsList`).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.