### PR TITLE
search: introduce SearchFieldDefinition and SearchFieldsProvider

### DIFF
--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -1,0 +1,196 @@
+package resource
+
+import (
+	"slices"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// SearchCapability identifies what a search field can be used for at query
+// time. The set is intentionally small and orthogonal; combinations produce
+// internal index fields (see pkg/storage/unified/search/bleve_mappings.go).
+//
+// Analyzer references below are Bleve-specific.
+type SearchCapability string
+
+const (
+	SearchCapabilityFilter   SearchCapability = "filter"   // exact-match filtering (Bleve keyword analyzer)
+	SearchCapabilityText     SearchCapability = "text"     // full-token search (Bleve standard analyzer)
+	SearchCapabilityPartial  SearchCapability = "partial"  // substring matching (Bleve ngram analyzer); requires text
+	SearchCapabilitySort     SearchCapability = "sort"     // sortable on the keyword variant
+	SearchCapabilityFacet    SearchCapability = "facet"    // facetable on the keyword variant
+	SearchCapabilityRetrieve SearchCapability = "retrieve" // value is stored and returned in search results
+)
+
+// SearchFieldType is the value type of a search field.
+// The design intentionally omits a separate dateTime type; use date or int64.
+type SearchFieldType string
+
+const (
+	SearchFieldTypeString  SearchFieldType = "string"
+	SearchFieldTypeInt32   SearchFieldType = "int32"
+	SearchFieldTypeInt64   SearchFieldType = "int64"
+	SearchFieldTypeFloat   SearchFieldType = "float"
+	SearchFieldTypeDouble  SearchFieldType = "double"
+	SearchFieldTypeBoolean SearchFieldType = "boolean"
+	SearchFieldTypeDate    SearchFieldType = "date"
+)
+
+// SearchFieldDefinition is the internal representation of a single searchable
+// field declared by a kind's manifest. It replaces the use of
+// *resourcepb.ResourceTableColumnDefinition for search-mapping decisions.
+// The protobuf type stays as the wire format for legacy table responses.
+type SearchFieldDefinition struct {
+	// Name is the logical field name as declared in the manifest.
+	// It must be unique within a (group, resource, version) and must not
+	// collide with any of the standard field names (the SEARCH_FIELD_*
+	// constants in document.go).
+	Name string
+
+	// Path is the JSON path inside the resource that supplies this field's
+	// value (e.g. "spec.email", "spec.members[*].name"). An empty Path marks
+	// the field as computed: the standard extractor does not populate it and
+	// a custom builder is expected to fill it in.
+	Path string
+
+	// Type is the value type produced by Path or by a custom builder.
+	Type SearchFieldType
+
+	// Array indicates that the field carries a list of values of Type.
+	Array bool
+
+	// Capabilities lists what the field can be used for at query time.
+	// Order is not significant.
+	Capabilities []SearchCapability
+
+	// Description is informational; not used for indexing decisions.
+	Description string
+}
+
+// HasCapability reports whether the field declares the given capability.
+func (f SearchFieldDefinition) HasCapability(c SearchCapability) bool {
+	return slices.Contains(f.Capabilities, c)
+}
+
+// searchFieldsFromTableColumns translates the legacy
+// *resourcepb.ResourceTableColumnDefinition column list into the new internal
+// SearchFieldDefinition representation. Bleve mapping code uses the new type
+// while the rest of the codebase continues to declare fields with the protobuf
+// type.
+//
+// Translation rules preserve current behavior:
+//   - Filterable + STRING  -> [filter, retrieve]
+//   - everything else      -> [retrieve]
+//
+// Nil entries are dropped. Protobuf types that have no corresponding
+// SearchFieldType (OBJECT, BINARY, UNKNOWN_TYPE) yield an empty Type.
+func searchFieldsFromTableColumns(cols []*resourcepb.ResourceTableColumnDefinition) []SearchFieldDefinition {
+	out := make([]SearchFieldDefinition, 0, len(cols))
+	for _, c := range cols {
+		if c == nil {
+			continue
+		}
+		sf := SearchFieldDefinition{
+			Name:        c.Name,
+			Type:        searchFieldTypeFromProto(c.Type),
+			Array:       c.IsArray,
+			Description: c.Description,
+		}
+		if c.Properties != nil && c.Properties.Filterable && c.Type == resourcepb.ResourceTableColumnDefinition_STRING {
+			sf.Capabilities = []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}
+		} else {
+			sf.Capabilities = []SearchCapability{SearchCapabilityRetrieve}
+		}
+		out = append(out, sf)
+	}
+	return out
+}
+
+// searchFieldTypeFromProto maps the protobuf column type to the new
+// SearchFieldType. DATE_TIME collapses to date because the new design omits
+// a separate dateTime type. OBJECT, BINARY, and UNKNOWN_TYPE yield an empty
+// SearchFieldType because they are not part of the new type set.
+func searchFieldTypeFromProto(t resourcepb.ResourceTableColumnDefinition_ColumnType) SearchFieldType {
+	switch t {
+	case resourcepb.ResourceTableColumnDefinition_STRING:
+		return SearchFieldTypeString
+	case resourcepb.ResourceTableColumnDefinition_BOOLEAN:
+		return SearchFieldTypeBoolean
+	case resourcepb.ResourceTableColumnDefinition_INT32:
+		return SearchFieldTypeInt32
+	case resourcepb.ResourceTableColumnDefinition_INT64:
+		return SearchFieldTypeInt64
+	case resourcepb.ResourceTableColumnDefinition_FLOAT:
+		return SearchFieldTypeFloat
+	case resourcepb.ResourceTableColumnDefinition_DOUBLE:
+		return SearchFieldTypeDouble
+	case resourcepb.ResourceTableColumnDefinition_DATE,
+		resourcepb.ResourceTableColumnDefinition_DATE_TIME:
+		return SearchFieldTypeDate
+	default:
+		return ""
+	}
+}
+
+// GroupResourceVersion identifies a specific version of a kind. It is the key
+// used to look up search field declarations.
+type GroupResourceVersion struct {
+	Group    string
+	Resource string
+	Version  string
+}
+
+// SearchFieldsProvider is the read-only interface that consumers of the new
+// manifest-driven search metadata use to ask "what searchable fields does this
+// (group, resource, version) declare?"
+//
+// The provider is keyed by {group, resource, version}. For requests that carry
+// an apiVersion the server does not know about, callers may fall back to
+// PreferredVersion. That fallback is the consumer's responsibility; the Fields
+// method itself does not perform it.
+type SearchFieldsProvider interface {
+	// Fields returns the declared search fields for the exact
+	// {group, resource, version}. Returns nil if nothing is registered for
+	// that key; the caller decides how to handle missing versions (usually
+	// by retrying with PreferredVersion).
+	Fields(grv GroupResourceVersion) []SearchFieldDefinition
+
+	// PreferredVersion returns the served version that callers should use
+	// when the requested apiVersion is unknown. Returns the empty string
+	// when no preferred version has been registered.
+	PreferredVersion(group, resource string) string
+}
+
+// mapProvider is an in-memory SearchFieldsProvider populated from Go-level
+// registrations. It is the default implementation until the provider can read
+// declarations directly from CUE-generated manifest data.
+type mapProvider struct {
+	fields           map[GroupResourceVersion][]SearchFieldDefinition
+	preferredVersion map[schema.GroupResource]string
+}
+
+// NewMapProvider returns a SearchFieldsProvider backed by the given in-memory
+// maps. Both arguments may be nil. The provider takes ownership of the maps;
+// callers must not mutate them after the call.
+func NewMapProvider(fields map[GroupResourceVersion][]SearchFieldDefinition, preferredVersions map[schema.GroupResource]string) SearchFieldsProvider {
+	if fields == nil {
+		fields = map[GroupResourceVersion][]SearchFieldDefinition{}
+	}
+	if preferredVersions == nil {
+		preferredVersions = map[schema.GroupResource]string{}
+	}
+	return &mapProvider{
+		fields:           fields,
+		preferredVersion: preferredVersions,
+	}
+}
+
+func (p *mapProvider) Fields(grv GroupResourceVersion) []SearchFieldDefinition {
+	return p.fields[grv]
+}
+
+func (p *mapProvider) PreferredVersion(group, resource string) string {
+	return p.preferredVersion[schema.GroupResource{Group: group, Resource: resource}]
+}

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -29,6 +29,10 @@ const (
 type SearchFieldType string
 
 const (
+	// SearchFieldTypeUnknown is the zero value, used for column shapes that
+	// have no corresponding SearchFieldType (OBJECT, BINARY, UNKNOWN_TYPE from
+	// the protobuf enum). Downstream switches can reference it by name.
+	SearchFieldTypeUnknown SearchFieldType = ""
 	SearchFieldTypeString  SearchFieldType = "string"
 	SearchFieldTypeInt32   SearchFieldType = "int32"
 	SearchFieldTypeInt64   SearchFieldType = "int64"
@@ -85,7 +89,7 @@ func (f SearchFieldDefinition) HasCapability(c SearchCapability) bool {
 //   - everything else      -> [retrieve]
 //
 // Nil entries are dropped. Protobuf types that have no corresponding
-// SearchFieldType (OBJECT, BINARY, UNKNOWN_TYPE) yield an empty Type.
+// SearchFieldType (OBJECT, BINARY, UNKNOWN_TYPE) yield SearchFieldTypeUnknown.
 func searchFieldsFromTableColumns(cols []*resourcepb.ResourceTableColumnDefinition) []SearchFieldDefinition {
 	out := make([]SearchFieldDefinition, 0, len(cols))
 	for _, c := range cols {
@@ -110,8 +114,8 @@ func searchFieldsFromTableColumns(cols []*resourcepb.ResourceTableColumnDefiniti
 
 // searchFieldTypeFromProto maps the protobuf column type to the new
 // SearchFieldType. DATE_TIME collapses to date because the new design omits
-// a separate dateTime type. OBJECT, BINARY, and UNKNOWN_TYPE yield an empty
-// SearchFieldType because they are not part of the new type set.
+// a separate dateTime type. OBJECT, BINARY, and UNKNOWN_TYPE return
+// SearchFieldTypeUnknown because they are not part of the new type set.
 func searchFieldTypeFromProto(t resourcepb.ResourceTableColumnDefinition_ColumnType) SearchFieldType {
 	switch t {
 	case resourcepb.ResourceTableColumnDefinition_STRING:
@@ -130,32 +134,27 @@ func searchFieldTypeFromProto(t resourcepb.ResourceTableColumnDefinition_ColumnT
 		resourcepb.ResourceTableColumnDefinition_DATE_TIME:
 		return SearchFieldTypeDate
 	default:
-		return ""
+		return SearchFieldTypeUnknown
 	}
-}
-
-// GroupResourceVersion identifies a specific version of a kind. It is the key
-// used to look up search field declarations.
-type GroupResourceVersion struct {
-	Group    string
-	Resource string
-	Version  string
 }
 
 // SearchFieldsProvider is the read-only interface that consumers of the new
 // manifest-driven search metadata use to ask "what searchable fields does this
-// (group, resource, version) declare?"
+// (group, version, resource) declare?"
 //
-// The provider is keyed by {group, resource, version}. For requests that carry
-// an apiVersion the server does not know about, callers may fall back to
-// PreferredVersion. That fallback is the consumer's responsibility; the Fields
-// method itself does not perform it.
+// The provider is keyed by schema.GroupVersionResource. For requests that
+// carry an apiVersion the server does not know about, callers may fall back
+// to PreferredVersion. That fallback is the consumer's responsibility; the
+// Fields method itself does not perform it.
 type SearchFieldsProvider interface {
 	// Fields returns the declared search fields for the exact
-	// {group, resource, version}. Returns nil if nothing is registered for
-	// that key; the caller decides how to handle missing versions (usually
-	// by retrying with PreferredVersion).
-	Fields(grv GroupResourceVersion) []SearchFieldDefinition
+	// GroupVersionResource. Returns nil if nothing is registered for that
+	// key; the caller decides how to handle missing versions (usually by
+	// retrying with PreferredVersion).
+	//
+	// The returned slice is owned by the provider; callers must not mutate
+	// it.
+	Fields(gvr schema.GroupVersionResource) []SearchFieldDefinition
 
 	// PreferredVersion returns the served version that callers should use
 	// when the requested apiVersion is unknown. Returns the empty string
@@ -167,16 +166,16 @@ type SearchFieldsProvider interface {
 // registrations. It is the default implementation until the provider can read
 // declarations directly from CUE-generated manifest data.
 type mapProvider struct {
-	fields           map[GroupResourceVersion][]SearchFieldDefinition
+	fields           map[schema.GroupVersionResource][]SearchFieldDefinition
 	preferredVersion map[schema.GroupResource]string
 }
 
 // NewMapProvider returns a SearchFieldsProvider backed by the given in-memory
 // maps. Both arguments may be nil. The provider takes ownership of the maps;
 // callers must not mutate them after the call.
-func NewMapProvider(fields map[GroupResourceVersion][]SearchFieldDefinition, preferredVersions map[schema.GroupResource]string) SearchFieldsProvider {
+func NewMapProvider(fields map[schema.GroupVersionResource][]SearchFieldDefinition, preferredVersions map[schema.GroupResource]string) SearchFieldsProvider {
 	if fields == nil {
-		fields = map[GroupResourceVersion][]SearchFieldDefinition{}
+		fields = map[schema.GroupVersionResource][]SearchFieldDefinition{}
 	}
 	if preferredVersions == nil {
 		preferredVersions = map[schema.GroupResource]string{}
@@ -187,8 +186,8 @@ func NewMapProvider(fields map[GroupResourceVersion][]SearchFieldDefinition, pre
 	}
 }
 
-func (p *mapProvider) Fields(grv GroupResourceVersion) []SearchFieldDefinition {
-	return p.fields[grv]
+func (p *mapProvider) Fields(gvr schema.GroupVersionResource) []SearchFieldDefinition {
+	return p.fields[gvr]
 }
 
 func (p *mapProvider) PreferredVersion(group, resource string) string {

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -88,16 +88,16 @@ func TestSearchFieldsFromTableColumns(t *testing.T) {
 		assert.Equal(t, SearchFieldTypeDate, got[0].Type)
 	})
 
-	t.Run("object and binary types are not represented", func(t *testing.T) {
+	t.Run("object and binary types map to unknown", func(t *testing.T) {
 		// OBJECT and BINARY have no corresponding SearchFieldType because the
-		// new design omits them; they map to the empty type.
+		// new design omits them; they map to SearchFieldTypeUnknown.
 		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
 			{Name: "obj", Type: resourcepb.ResourceTableColumnDefinition_OBJECT},
 			{Name: "bin", Type: resourcepb.ResourceTableColumnDefinition_BINARY},
 		})
 		require.Len(t, got, 2)
-		assert.Equal(t, SearchFieldType(""), got[0].Type)
-		assert.Equal(t, SearchFieldType(""), got[1].Type)
+		assert.Equal(t, SearchFieldTypeUnknown, got[0].Type)
+		assert.Equal(t, SearchFieldTypeUnknown, got[1].Type)
 	})
 
 	t.Run("nil entries are dropped", func(t *testing.T) {
@@ -121,29 +121,29 @@ func TestSearchFieldDefinition_HasCapability(t *testing.T) {
 }
 
 func TestMapProvider_FieldsLookup(t *testing.T) {
-	grv := GroupResourceVersion{Group: "iam.grafana.app", Resource: "users", Version: "v0alpha1"}
+	gvr := schema.GroupVersionResource{Group: "iam.grafana.app", Version: "v0alpha1", Resource: "users"}
 	fields := []SearchFieldDefinition{
 		{Name: "email", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}},
 	}
 	p := NewMapProvider(
-		map[GroupResourceVersion][]SearchFieldDefinition{grv: fields},
+		map[schema.GroupVersionResource][]SearchFieldDefinition{gvr: fields},
 		nil,
 	)
 
-	assert.Equal(t, fields, p.Fields(grv))
+	assert.Equal(t, fields, p.Fields(gvr))
 
 	// Unknown version returns nil; caller is expected to fall back via PreferredVersion.
-	assert.Nil(t, p.Fields(GroupResourceVersion{Group: "iam.grafana.app", Resource: "users", Version: "v99"}))
+	assert.Nil(t, p.Fields(schema.GroupVersionResource{Group: "iam.grafana.app", Version: "v99", Resource: "users"}))
 	// Unknown group/resource returns nil.
-	assert.Nil(t, p.Fields(GroupResourceVersion{Group: "nope", Resource: "nope", Version: "v0alpha1"}))
+	assert.Nil(t, p.Fields(schema.GroupVersionResource{Group: "nope", Version: "v0alpha1", Resource: "nope"}))
 }
 
 func TestMapProvider_PreferredVersionFallback(t *testing.T) {
 	gr := schema.GroupResource{Group: "iam.grafana.app", Resource: "users"}
-	v1 := GroupResourceVersion{Group: gr.Group, Resource: gr.Resource, Version: "v0alpha1"}
+	v1 := schema.GroupVersionResource{Group: gr.Group, Version: "v0alpha1", Resource: gr.Resource}
 
 	p := NewMapProvider(
-		map[GroupResourceVersion][]SearchFieldDefinition{
+		map[schema.GroupVersionResource][]SearchFieldDefinition{
 			v1: {{Name: "email", Type: SearchFieldTypeString}},
 		},
 		map[schema.GroupResource]string{gr: "v0alpha1"},
@@ -155,11 +155,11 @@ func TestMapProvider_PreferredVersionFallback(t *testing.T) {
 
 	// Caller-side fallback pattern: when the requested version is unknown,
 	// re-look-up using PreferredVersion.
-	requested := GroupResourceVersion{Group: gr.Group, Resource: gr.Resource, Version: "vUnknown"}
+	requested := schema.GroupVersionResource{Group: gr.Group, Version: "vUnknown", Resource: gr.Resource}
 	if fs := p.Fields(requested); fs == nil {
 		preferred := p.PreferredVersion(requested.Group, requested.Resource)
 		require.NotEmpty(t, preferred)
-		fs = p.Fields(GroupResourceVersion{Group: requested.Group, Resource: requested.Resource, Version: preferred})
+		fs = p.Fields(schema.GroupVersionResource{Group: requested.Group, Version: preferred, Resource: requested.Resource})
 		assert.Len(t, fs, 1)
 	}
 

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -1,0 +1,168 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+func TestSearchFieldsFromTableColumns(t *testing.T) {
+	t.Run("filterable string produces filter+retrieve", func(t *testing.T) {
+		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+			{
+				Name:        "email",
+				Type:        resourcepb.ResourceTableColumnDefinition_STRING,
+				Description: "user email",
+				Properties: &resourcepb.ResourceTableColumnDefinition_Properties{
+					Filterable: true,
+				},
+			},
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, "email", got[0].Name)
+		assert.Equal(t, SearchFieldTypeString, got[0].Type)
+		assert.False(t, got[0].Array)
+		assert.Equal(t, "user email", got[0].Description)
+		assert.ElementsMatch(t,
+			[]SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve},
+			got[0].Capabilities,
+		)
+	})
+
+	t.Run("non-filterable string is retrieve-only", func(t *testing.T) {
+		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+			{
+				Name: "title",
+				Type: resourcepb.ResourceTableColumnDefinition_STRING,
+			},
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, []SearchCapability{SearchCapabilityRetrieve}, got[0].Capabilities)
+	})
+
+	t.Run("filterable non-string is retrieve-only", func(t *testing.T) {
+		// Filterable is only honored on STRING fields in the current mapper;
+		// non-string types must not gain a keyword variant via translation.
+		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+			{
+				Name: "lastSeenAt",
+				Type: resourcepb.ResourceTableColumnDefinition_INT64,
+				Properties: &resourcepb.ResourceTableColumnDefinition_Properties{
+					Filterable: true,
+				},
+			},
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, SearchFieldTypeInt64, got[0].Type)
+		assert.Equal(t, []SearchCapability{SearchCapabilityRetrieve}, got[0].Capabilities)
+	})
+
+	t.Run("array flag is propagated", func(t *testing.T) {
+		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+			{
+				Name:    "tags",
+				Type:    resourcepb.ResourceTableColumnDefinition_STRING,
+				IsArray: true,
+				Properties: &resourcepb.ResourceTableColumnDefinition_Properties{
+					Filterable: true,
+				},
+			},
+		})
+		require.Len(t, got, 1)
+		assert.True(t, got[0].Array)
+		assert.ElementsMatch(t,
+			[]SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve},
+			got[0].Capabilities,
+		)
+	})
+
+	t.Run("date_time collapses to date", func(t *testing.T) {
+		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+			{Name: "ts", Type: resourcepb.ResourceTableColumnDefinition_DATE_TIME},
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, SearchFieldTypeDate, got[0].Type)
+	})
+
+	t.Run("object and binary types are not represented", func(t *testing.T) {
+		// OBJECT and BINARY have no corresponding SearchFieldType because the
+		// new design omits them; they map to the empty type.
+		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+			{Name: "obj", Type: resourcepb.ResourceTableColumnDefinition_OBJECT},
+			{Name: "bin", Type: resourcepb.ResourceTableColumnDefinition_BINARY},
+		})
+		require.Len(t, got, 2)
+		assert.Equal(t, SearchFieldType(""), got[0].Type)
+		assert.Equal(t, SearchFieldType(""), got[1].Type)
+	})
+
+	t.Run("nil entries are dropped", func(t *testing.T) {
+		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+			nil,
+			{Name: "x", Type: resourcepb.ResourceTableColumnDefinition_STRING},
+			nil,
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, "x", got[0].Name)
+	})
+}
+
+func TestSearchFieldDefinition_HasCapability(t *testing.T) {
+	f := SearchFieldDefinition{
+		Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve},
+	}
+	assert.True(t, f.HasCapability(SearchCapabilityFilter))
+	assert.True(t, f.HasCapability(SearchCapabilityRetrieve))
+	assert.False(t, f.HasCapability(SearchCapabilityText))
+}
+
+func TestMapProvider_FieldsLookup(t *testing.T) {
+	grv := GroupResourceVersion{Group: "iam.grafana.app", Resource: "users", Version: "v0alpha1"}
+	fields := []SearchFieldDefinition{
+		{Name: "email", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}},
+	}
+	p := NewMapProvider(
+		map[GroupResourceVersion][]SearchFieldDefinition{grv: fields},
+		nil,
+	)
+
+	assert.Equal(t, fields, p.Fields(grv))
+
+	// Unknown version returns nil; caller is expected to fall back via PreferredVersion.
+	assert.Nil(t, p.Fields(GroupResourceVersion{Group: "iam.grafana.app", Resource: "users", Version: "v99"}))
+	// Unknown group/resource returns nil.
+	assert.Nil(t, p.Fields(GroupResourceVersion{Group: "nope", Resource: "nope", Version: "v0alpha1"}))
+}
+
+func TestMapProvider_PreferredVersionFallback(t *testing.T) {
+	gr := schema.GroupResource{Group: "iam.grafana.app", Resource: "users"}
+	v1 := GroupResourceVersion{Group: gr.Group, Resource: gr.Resource, Version: "v0alpha1"}
+
+	p := NewMapProvider(
+		map[GroupResourceVersion][]SearchFieldDefinition{
+			v1: {{Name: "email", Type: SearchFieldTypeString}},
+		},
+		map[schema.GroupResource]string{gr: "v0alpha1"},
+	)
+
+	// Direct lookup with the preferred version works.
+	assert.Equal(t, "v0alpha1", p.PreferredVersion(gr.Group, gr.Resource))
+	assert.Len(t, p.Fields(v1), 1)
+
+	// Caller-side fallback pattern: when the requested version is unknown,
+	// re-look-up using PreferredVersion.
+	requested := GroupResourceVersion{Group: gr.Group, Resource: gr.Resource, Version: "vUnknown"}
+	if fs := p.Fields(requested); fs == nil {
+		preferred := p.PreferredVersion(requested.Group, requested.Resource)
+		require.NotEmpty(t, preferred)
+		fs = p.Fields(GroupResourceVersion{Group: requested.Group, Resource: requested.Resource, Version: preferred})
+		assert.Len(t, fs, 1)
+	}
+
+	// Resources without a registered preferred version return "".
+	assert.Equal(t, "", p.PreferredVersion("other.grafana.app", "things"))
+}


### PR DESCRIPTION
Phase 1 of manifest-driven search metadata. Adds the new internal model behind a translation shim, with no consumer changes — nothing in the codebase reads from the new types yet.

## What

- `SearchFieldDefinition` — internal representation for search-mapping decisions, replacing the use of `*resourcepb.ResourceTableColumnDefinition` for that purpose. The protobuf type stays as the wire format for legacy table responses.
- `SearchFieldsProvider` — read-only interface keyed by `{group, resource, version}`, with `PreferredVersion` for the "unknown apiVersion" fallback rule. Default `mapProvider` is in-memory and populated from Go-level registrations; later work will swap it for one that reads CUE-generated manifest data.
- Capability constants: `filter`, `text`, `partial`, `sort`, `facet`, `retrieve`.
- Type constants: `string`, `int32`, `int64`, `float`, `double`, `boolean`, `date`. No `dateTime`, no `object`, no `binary`.
- `searchFieldsFromTableColumns` translation helper: `Filterable+STRING → [filter, retrieve]`, everything else → `[retrieve]`. Preserves current bleve-mapping behavior exactly.

## What this is not

- No consumer reads the new types yet (that lands in subsequent PRs).
- No validation logic yet — provider returns whatever is registered.
- No bleve-mapping or query-construction changes.
- No index rebuild required.

## Risk

Very low — purely additive. No client/server compatibility impact.

Tracking: grafana/search-and-storage-team#827
