### PR TITLE
Unified Storage: fix flaky TestIntegrationSQLKVConcurrentCreateClientRetry

### DIFF
--- a/pkg/storage/unified/testing/storage_backend_test.go
+++ b/pkg/storage/unified/testing/storage_backend_test.go
@@ -11,9 +11,11 @@ import (
 
 	badger "github.com/dgraph-io/badger/v4"
 	"github.com/google/uuid"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"google.golang.org/grpc"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -269,10 +271,23 @@ func runConcurrentCreateRetry(t *testing.T, client resource.ResourceClient, ns s
 		success       bool
 	}
 	results := make([]result, concurrency)
+
+	// The local client (pkg/storage/unified/resource/client.go) and the remote
+	// gRPC connection (pkg/storage/unified/client.go) both wire a retry
+	// interceptor with WithMax(3) and a 1s exponential backoff. With
+	// concurrency=10 that budget is too small: lease.Acquire returns
+	// ErrLeaseAlreadyHeld without waiting, so callers contend in waves and only
+	// ~1 caller can drain per wave. Override the retry budget per call so all 9
+	// losers can observe AlreadyExists. This does not change production behavior.
+	retryOpts := []grpc.CallOption{
+		grpc_retry.WithMax(uint(concurrency * 2)),
+		grpc_retry.WithBackoff(grpc_retry.BackoffLinearWithJitter(500*time.Millisecond, 0.5)),
+	}
+
 	var wg sync.WaitGroup
 	for i := range concurrency {
 		wg.Go(func() {
-			rsp, err := client.Create(clientCtx, &resourcepb.CreateRequest{Key: key, Value: value})
+			rsp, err := client.Create(clientCtx, &resourcepb.CreateRequest{Key: key, Value: value}, retryOpts...)
 			if err != nil {
 				results[i] = result{err: err}
 				return


### PR DESCRIPTION
Raise the gRPC retry budget for `Create` calls inside `runConcurrentCreateRetry`, so the test does not run out of retries.

The test starts 10 goroutines that all try to create the same resource. It expects 1 to succeed and the other 9 to get `AlreadyExists`.

When the lease backend is used, only one caller at a time can hold the lease. The other 9 get a conflict and need to retry. The gRPC client is configured to retry only 3 times, with a 1 second base delay. With 10 concurrent callers, 3 retries is not enough, so some calls give up and return `code = Aborted` to the test.

The retry settings can be overridden per call by passing `grpc.CallOption`s. The test now passes a larger max retries (`concurrency * 2`) and a 500 ms linear backoff, so all 9 losing callers have time to retry until they see `AlreadyExists`. Production code is not changed.

Seen on:
- https://github.com/grafana/grafana/actions/runs/27288863730/job/80605575955 (`Without_RvManager/Local`)
- https://github.com/grafana/grafana-enterprise/actions/runs/27333996649/job/80753301316 (`Without_RvManager/Remote`)