### PR TITLE
Feature Toggles: Enable faroSessionReplay by default for public preview

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -91,6 +91,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `panelTitleSearch`                | Search for dashboards using panel title                                                                |
 | `refactorVariablesTimeRange`      | Refactor time range variables flow to reduce number of API calls made when query variables are chained |
 | `faroDatasourceSelector`          | Enable the data source selector within the Frontend Apps section of the Frontend Observability         |
+| `faroSessionReplay`               | Enable Faro session replay for Grafana                                                                 |
 | `provisioning.readmes`            | Render the README.md of a Git Sync provisioned folder inline below its dashboards list                 |
 | `externalServiceAccounts`         | Automatic service account and token setup for plugins                                                  |
 | `dashboardFiltersOverview`        | Enables the dashboard filters overview pane                                                            |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -115,7 +115,7 @@ export interface FeatureToggles {
   faroDatasourceSelector?: boolean;
   /**
   * Enable Faro session replay for Grafana
-  * @default false
+  * @default true
   */
   faroSessionReplay?: boolean;
   /**

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -216,10 +216,10 @@ export const useFlagExperimentRecentlyViewedDashboards = (options?: ReactFlagEva
  *
  * **Details:**
  * - flag key: `faroSessionReplay`
- * - default value: `false`
+ * - default value: `true`
  */
 export const useFlagFaroSessionReplay = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("faroSessionReplay", false, options).value;
+  return useFlag("faroSessionReplay", true, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -195,10 +195,10 @@ var (
 		{
 			Name:        "faroSessionReplay",
 			Description: "Enable Faro session replay for Grafana",
-			Stage:       FeatureStageExperimental,
+			Stage:       FeatureStagePublicPreview,
 			Generate:    Generate{LegacyFrontend: true, React: true},
 			Owner:       grafanaSessionReplaySquad,
-			Expression:  "false",
+			Expression:  "true",
 		},
 		{
 			Name:        "queryHistory.localOnly",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -20,7 +20,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-04-03,renderAuthJWT,GA,@grafana/grafana-operator-experience-squad,false,false,false
 2023-06-06,refactorVariablesTimeRange,preview,@grafana/dashboards-squad,false,false,false
 2023-05-05,faroDatasourceSelector,preview,@grafana/app-o11y,false,false,true
-2026-05-22,faroSessionReplay,experimental,@grafana/session-replay,false,false,true
+2026-05-22,faroSessionReplay,preview,@grafana/session-replay,false,false,true
 2026-05-21,queryHistory.localOnly,experimental,@grafana/datapro,false,false,true
 2026-05-21,queryHistory.recentQueriesUI,experimental,@grafana/datapro,false,false,true
 2023-07-06,awsDatasourcesTempCredentials,GA,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2105,15 +2105,18 @@
     {
       "metadata": {
         "name": "faroSessionReplay",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1781186485738",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-06-11 14:01:25.738987 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable Faro session replay for Grafana",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/session-replay",
         "frontend": true,
-        "expression": "false"
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Changes the `faroSessionReplay` feature toggle default from `false` to `true`, enabling Session Replay for all stacks without requiring explicit opt-in.
- Promotes the toggle stage from `experimental` to `publicPreview`.
- Regenerated all feature toggle files (`toggles_gen.json`, `toggles_gen.csv`, `featureToggles.gen.ts`, `openfeature.gen.ts`, docs).

Closes https://github.com/grafana/session-replay/issues/41

## Context

This is a product decision for Public Preview — Session Replay should be enabled by default so stacks don't need to explicitly opt in. Please review with the session replay team (@grafana/session-replay).

## Test plan

- [ ] Verify `faroSessionReplay` defaults to `true` in a local Grafana instance
- [ ] Confirm Session Replay functionality works as expected with the toggle enabled
- [ ] Validate no regressions in Frontend Observability when the toggle is on by default