### PR TITLE
search: drive bleve field mappings from SearchFieldDefinition capabilities

### DIFF
--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -78,7 +78,7 @@ func (f SearchFieldDefinition) HasCapability(c SearchCapability) bool {
 	return slices.Contains(f.Capabilities, c)
 }
 
-// searchFieldsFromTableColumns translates the legacy
+// SearchFieldsFromTableColumns translates the legacy
 // *resourcepb.ResourceTableColumnDefinition column list into the new internal
 // SearchFieldDefinition representation. Bleve mapping code uses the new type
 // while the rest of the codebase continues to declare fields with the protobuf
@@ -90,7 +90,7 @@ func (f SearchFieldDefinition) HasCapability(c SearchCapability) bool {
 //
 // Nil entries are dropped. Protobuf types that have no corresponding
 // SearchFieldType (OBJECT, BINARY, UNKNOWN_TYPE) yield SearchFieldTypeUnknown.
-func searchFieldsFromTableColumns(cols []*resourcepb.ResourceTableColumnDefinition) []SearchFieldDefinition {
+func SearchFieldsFromTableColumns(cols []*resourcepb.ResourceTableColumnDefinition) []SearchFieldDefinition {
 	out := make([]SearchFieldDefinition, 0, len(cols))
 	for _, c := range cols {
 		if c == nil {

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSearchFieldsFromTableColumns(t *testing.T) {
 	t.Run("filterable string produces filter+retrieve", func(t *testing.T) {
-		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+		got := SearchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
 			{
 				Name:        "email",
 				Type:        resourcepb.ResourceTableColumnDefinition_STRING,
@@ -34,7 +34,7 @@ func TestSearchFieldsFromTableColumns(t *testing.T) {
 	})
 
 	t.Run("non-filterable string is retrieve-only", func(t *testing.T) {
-		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+		got := SearchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
 			{
 				Name: "title",
 				Type: resourcepb.ResourceTableColumnDefinition_STRING,
@@ -47,7 +47,7 @@ func TestSearchFieldsFromTableColumns(t *testing.T) {
 	t.Run("filterable non-string is retrieve-only", func(t *testing.T) {
 		// Filterable is only honored on STRING fields in the current mapper;
 		// non-string types must not gain a keyword variant via translation.
-		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+		got := SearchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
 			{
 				Name: "lastSeenAt",
 				Type: resourcepb.ResourceTableColumnDefinition_INT64,
@@ -62,7 +62,7 @@ func TestSearchFieldsFromTableColumns(t *testing.T) {
 	})
 
 	t.Run("array flag is propagated", func(t *testing.T) {
-		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+		got := SearchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
 			{
 				Name:    "tags",
 				Type:    resourcepb.ResourceTableColumnDefinition_STRING,
@@ -81,7 +81,7 @@ func TestSearchFieldsFromTableColumns(t *testing.T) {
 	})
 
 	t.Run("date_time collapses to date", func(t *testing.T) {
-		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+		got := SearchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
 			{Name: "ts", Type: resourcepb.ResourceTableColumnDefinition_DATE_TIME},
 		})
 		require.Len(t, got, 1)
@@ -91,7 +91,7 @@ func TestSearchFieldsFromTableColumns(t *testing.T) {
 	t.Run("object and binary types map to unknown", func(t *testing.T) {
 		// OBJECT and BINARY have no corresponding SearchFieldType because the
 		// new design omits them; they map to SearchFieldTypeUnknown.
-		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+		got := SearchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
 			{Name: "obj", Type: resourcepb.ResourceTableColumnDefinition_OBJECT},
 			{Name: "bin", Type: resourcepb.ResourceTableColumnDefinition_BINARY},
 		})
@@ -101,7 +101,7 @@ func TestSearchFieldsFromTableColumns(t *testing.T) {
 	})
 
 	t.Run("nil entries are dropped", func(t *testing.T) {
-		got := searchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
+		got := SearchFieldsFromTableColumns([]*resourcepb.ResourceTableColumnDefinition{
 			nil,
 			{Name: "x", Type: resourcepb.ResourceTableColumnDefinition_STRING},
 			nil,

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -13,6 +13,92 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
+// addCapabilityFieldMappings adds bleve field mappings to parent for a single
+// declared search field. The field is placed under parent using def.Name as
+// the local name; this helper does not add any sub-document prefix (callers
+// scope by passing the right parent, e.g. the "fields" sub-document mapper).
+//
+// Mappings emitted are driven by def.Capabilities:
+//
+//   - filter / facet / sort   → keyword mapping at the keyword variant name
+//     (see keywordVariantName). sort enables DocValues.
+//   - text                    → standard-analyzer text mapping at def.Name.
+//   - partial                 → ngram mapping at def.Name + "_ngram".
+//   - retrieve                → Store: true on the canonical field
+//     (def.Name if text is declared, else the keyword variant).
+//
+// Special case: when a field has only [filter] (with or without retrieve) and
+// no text capability, the keyword variant is named def.Name directly, without
+// the "_keyword" suffix. This preserves the on-disk shape of today's
+// Filterable-STRING fields under the "fields." prefix.
+//
+// Special case: when def.Name == resource.SEARCH_FIELD_TITLE, the keyword
+// variant is named resource.SEARCH_FIELD_TITLE_PHRASE rather than
+// "<name>_keyword". In-tree gRPC clients reference "title_phrase" by name.
+func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.SearchFieldDefinition) {
+	hasFilter := def.HasCapability(resource.SearchCapabilityFilter)
+	hasText := def.HasCapability(resource.SearchCapabilityText)
+	hasPartial := def.HasCapability(resource.SearchCapabilityPartial)
+	hasSort := def.HasCapability(resource.SearchCapabilitySort)
+	hasFacet := def.HasCapability(resource.SearchCapabilityFacet)
+	hasRetrieve := def.HasCapability(resource.SearchCapabilityRetrieve)
+
+	needKeyword := hasFilter || hasFacet || hasSort
+	keywordName := keywordVariantName(def.Name, hasText)
+
+	if needKeyword {
+		m := bleve.NewKeywordFieldMapping()
+		m.IncludeTermVectors = false
+		m.SkipFreqNorm = true
+		m.DocValues = hasSort
+		// Canonical field for storage is the keyword variant only when no text
+		// mapping will also be created.
+		m.Store = hasRetrieve && !hasText
+		parent.AddFieldMappingsAt(keywordName, m)
+	}
+
+	if hasText {
+		m := bleve.NewTextFieldMapping()
+		m.Analyzer = standard.Name
+		m.IncludeTermVectors = false
+		m.DocValues = false
+		m.Store = hasRetrieve
+		parent.AddFieldMappingsAt(def.Name, m)
+	}
+
+	if hasPartial {
+		m := bleve.NewTextFieldMapping()
+		m.Analyzer = TITLE_ANALYZER
+		m.IncludeTermVectors = false
+		m.DocValues = false
+		// ngram variant is never the canonical retrieval target; the keyword
+		// or text variant already stores the value.
+		m.Store = false
+		parent.AddFieldMappingsAt(def.Name+"_ngram", m)
+	}
+
+	// retrieve without any other capability has no place to live; today's
+	// translation never produces such a shape. Silently ignored.
+}
+
+// keywordVariantName returns the name the keyword analyzer variant of a field
+// should occupy. Rules:
+//
+//   - name == "title" → "title_phrase" (legacy in-tree client compatibility).
+//   - text capability present → name + "_keyword" so the text variant can
+//     take name.
+//   - otherwise → name itself, so filter-only fields keep today's on-disk
+//     shape (no suffix).
+func keywordVariantName(name string, hasText bool) string {
+	if name == resource.SEARCH_FIELD_TITLE {
+		return resource.SEARCH_FIELD_TITLE_PHRASE
+	}
+	if hasText {
+		return name + "_keyword"
+	}
+	return name
+}
+
 func GetBleveMappings(fields resource.SearchableDocumentFields, selectableFields []string) (mapping.IndexMapping, error) {
 	mapper := bleve.NewIndexMapping()
 	mapper.DocValuesDynamic = false // only folder and title_phrase need DocValues
@@ -197,22 +283,20 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 
 	fieldMapper := bleve.NewDocumentMapping()
 	if fields != nil {
-		for _, field := range fields.Fields() {
-			def := fields.Field(field)
-
-			// Filterable should use keyword analyzer for exact matches
-			if def.Properties != nil && def.Properties.Filterable && def.Type == resourcepb.ResourceTableColumnDefinition_STRING {
-				keywordMapping := bleve.NewKeywordFieldMapping()
-				keywordMapping.Store = true
-				keywordMapping.DocValues = false
-				keywordMapping.IncludeTermVectors = false
-				keywordMapping.SkipFreqNorm = true
-
-				fieldMapper.AddFieldMappingsAt(def.Name, keywordMapping)
+		// Collect the per-kind column definitions so they can be translated
+		// in one shot. Anything the helper does not emit a mapping for (no
+		// filter/text/partial/facet/sort capability) is left to Bleve's
+		// dynamic mapping at index time, which is the previous behaviour for
+		// non-filterable fields.
+		names := fields.Fields()
+		cols := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(names))
+		for _, name := range names {
+			if def := fields.Field(name); def != nil {
+				cols = append(cols, def)
 			}
-			// For all other fields, we do nothing.
-			// Bleve will see them at index time and dynamically map them as
-			// numeric, datetime, boolean, or standard text based on their content.
+		}
+		for _, def := range resource.SearchFieldsFromTableColumns(cols) {
+			addCapabilityFieldMappings(fieldMapper, def)
 		}
 	}
 

--- a/pkg/storage/unified/search/bleve_mappings_golden_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_golden_test.go
@@ -1,0 +1,119 @@
+package search_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/storage/unified/search"
+)
+
+// Run with -update-golden to regenerate the JSON snapshots after an
+// intentional change to the bleve mapping shape:
+//
+//	go test ./pkg/storage/unified/search/ -run TestBleveMappingsGoldenJSON -update-golden
+var updateGolden = flag.Bool("update-golden", false, "regenerate bleve mapping golden JSON files")
+
+// TestBleveMappingsGoldenJSON pins the bleve index mapping shape produced by
+// GetBleveMappings to JSON snapshots committed under testdata. The snapshots
+// were generated from origin/main at commit 518fecc6df7 (the last commit
+// before the manifest-driven search-fields work started) so this test serves
+// as a regression guard: any future change that alters the on-disk index
+// mapping shape will fail this test, forcing an explicit review and
+// -update-golden regeneration.
+//
+// The standard search fields (title, title_phrase, title_ngram, description,
+// tags, folder, ownerReferences, createdBy, managedBy, manager.*, source.*,
+// labels.*, reference.*) are part of the mapping returned by
+// GetBleveMappings even with nil inputs, so the "empty" case below already
+// captures their full bleve representation. A separate snapshot of the
+// raw StandardSearchFields column definitions would not add information.
+func TestBleveMappingsGoldenJSON(t *testing.T) {
+	filterableStringFields := func(t *testing.T) resource.SearchableDocumentFields {
+		t.Helper()
+		f, err := resource.NewSearchableDocumentFields([]*resourcepb.ResourceTableColumnDefinition{
+			{
+				// A typical per-kind custom field: filterable STRING. Today's
+				// inner-loop output is a single keyword mapping at fields.<name>.
+				Name: "panel_types",
+				Type: resourcepb.ResourceTableColumnDefinition_STRING,
+				Properties: &resourcepb.ResourceTableColumnDefinition_Properties{
+					Filterable: true,
+				},
+			},
+			{
+				// A non-filterable STRING: no explicit mapping today.
+				Name: "panel_title",
+				Type: resourcepb.ResourceTableColumnDefinition_STRING,
+			},
+			{
+				// A non-string column: no explicit mapping today.
+				Name: "schema_version",
+				Type: resourcepb.ResourceTableColumnDefinition_INT32,
+			},
+		})
+		require.NoError(t, err)
+		return f
+	}
+
+	cases := []struct {
+		name             string
+		fields           func(t *testing.T) resource.SearchableDocumentFields
+		selectableFields []string
+		path             string
+	}{
+		{
+			name: "empty",
+			path: "testdata/bleve_mapping_empty.json",
+		},
+		{
+			name:   "filterable_string_field",
+			fields: filterableStringFields,
+			path:   "testdata/bleve_mapping_filterable_string.json",
+		},
+		{
+			name:             "selectable_fields",
+			selectableFields: []string{"spec.title", "spec.description"},
+			path:             "testdata/bleve_mapping_selectable_fields.json",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var fields resource.SearchableDocumentFields
+			if tc.fields != nil {
+				fields = tc.fields(t)
+			}
+
+			mappings, err := search.GetBleveMappings(fields, tc.selectableFields)
+			require.NoError(t, err)
+
+			got, err := json.MarshalIndent(mappings, "", "  ")
+			require.NoError(t, err)
+			got = append(got, '\n')
+
+			compareOrUpdateGolden(t, tc.path, got)
+		})
+	}
+}
+
+func compareOrUpdateGolden(t *testing.T, path string, got []byte) {
+	t.Helper()
+	if *updateGolden {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, os.WriteFile(path, got, 0o600))
+		return
+	}
+	want, err := os.ReadFile(path) //nolint:gosec // path comes from a hardcoded test case
+	require.NoError(t, err, "missing golden file %s; regenerate with -update-golden", path)
+	assert.Equal(t, strings.TrimSpace(string(want)), strings.TrimSpace(string(got)),
+		"golden snapshot changed; if intended, rerun with -update-golden")
+}

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -1,0 +1,200 @@
+package search
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/analysis/analyzer/keyword"
+	"github.com/blevesearch/bleve/v2/analysis/analyzer/standard"
+	"github.com/blevesearch/bleve/v2/mapping"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+// flatMappings returns the field mappings emitted by the helper for the given
+// SearchFieldDefinition, keyed by the resulting field name.
+func flatMappings(t *testing.T, def resource.SearchFieldDefinition) map[string]*mapping.FieldMapping {
+	t.Helper()
+	parent := bleve.NewDocumentMapping()
+	addCapabilityFieldMappings(parent, def)
+
+	out := map[string]*mapping.FieldMapping{}
+	for name, sub := range parent.Properties {
+		require.Lenf(t, sub.Fields, 1, "field %q should have exactly one mapping", name)
+		out[name] = sub.Fields[0]
+	}
+	return out
+}
+
+func TestAddCapabilityFieldMappings_FilterRetrieve_LegacyShape(t *testing.T) {
+	// The only capability combination exercised by today's
+	// SearchFieldsFromTableColumns translation: a Filterable STRING becomes
+	// [filter, retrieve]. The on-disk shape must match the pre-refactor
+	// keyword mapping byte-for-byte so existing indexes remain valid.
+	got := flatMappings(t, resource.SearchFieldDefinition{
+		Name: "panel_types",
+		Type: resource.SearchFieldTypeString,
+		Capabilities: []resource.SearchCapability{
+			resource.SearchCapabilityFilter,
+			resource.SearchCapabilityRetrieve,
+		},
+	})
+
+	require.Equal(t, []string{"panel_types"}, slices.Sorted(maps.Keys(got)))
+	m := got["panel_types"]
+	assert.Equal(t, keyword.Name, m.Analyzer)
+	assert.True(t, m.Store)
+	assert.False(t, m.DocValues)
+	assert.False(t, m.IncludeTermVectors)
+	assert.True(t, m.SkipFreqNorm)
+}
+
+func TestAddCapabilityFieldMappings_TextRetrieve(t *testing.T) {
+	got := flatMappings(t, resource.SearchFieldDefinition{
+		Name: "summary",
+		Type: resource.SearchFieldTypeString,
+		Capabilities: []resource.SearchCapability{
+			resource.SearchCapabilityText,
+			resource.SearchCapabilityRetrieve,
+		},
+	})
+
+	require.Equal(t, []string{"summary"}, slices.Sorted(maps.Keys(got)))
+	m := got["summary"]
+	assert.Equal(t, standard.Name, m.Analyzer)
+	assert.True(t, m.Store)
+	assert.False(t, m.DocValues)
+	assert.False(t, m.IncludeTermVectors)
+}
+
+func TestAddCapabilityFieldMappings_FilterAndText(t *testing.T) {
+	// Filter together with text: text takes the base name, keyword variant
+	// moves to "<name>_keyword".
+	got := flatMappings(t, resource.SearchFieldDefinition{
+		Name: "summary",
+		Type: resource.SearchFieldTypeString,
+		Capabilities: []resource.SearchCapability{
+			resource.SearchCapabilityFilter,
+			resource.SearchCapabilityText,
+			resource.SearchCapabilityRetrieve,
+		},
+	})
+
+	require.Equal(t, []string{"summary", "summary_keyword"}, slices.Sorted(maps.Keys(got)))
+
+	text := got["summary"]
+	assert.Equal(t, standard.Name, text.Analyzer)
+	assert.True(t, text.Store, "text variant takes the retrieve store")
+
+	kw := got["summary_keyword"]
+	assert.Equal(t, keyword.Name, kw.Analyzer)
+	assert.False(t, kw.Store, "keyword variant must not also store when text takes that role")
+	assert.False(t, kw.DocValues)
+}
+
+func TestAddCapabilityFieldMappings_FullSet(t *testing.T) {
+	// A field that declares the full capability set produces the same shape
+	// as today's hardcoded standard "title" field: three mappings.
+	got := flatMappings(t, resource.SearchFieldDefinition{
+		Name: resource.SEARCH_FIELD_TITLE,
+		Type: resource.SearchFieldTypeString,
+		Capabilities: []resource.SearchCapability{
+			resource.SearchCapabilityFilter,
+			resource.SearchCapabilityText,
+			resource.SearchCapabilityPartial,
+			resource.SearchCapabilitySort,
+			resource.SearchCapabilityRetrieve,
+		},
+	})
+
+	require.Equal(t, []string{
+		resource.SEARCH_FIELD_TITLE,
+		resource.SEARCH_FIELD_TITLE_NGRAM,
+		resource.SEARCH_FIELD_TITLE_PHRASE,
+	}, slices.Sorted(maps.Keys(got)))
+
+	// text variant: standard analyzer, stored.
+	text := got[resource.SEARCH_FIELD_TITLE]
+	assert.Equal(t, standard.Name, text.Analyzer)
+	assert.True(t, text.Store)
+	assert.False(t, text.DocValues)
+	assert.False(t, text.IncludeTermVectors)
+
+	// keyword variant uses the "title_phrase" legacy name. sort adds DocValues.
+	phrase := got[resource.SEARCH_FIELD_TITLE_PHRASE]
+	assert.Equal(t, keyword.Name, phrase.Analyzer)
+	assert.False(t, phrase.Store, "text variant already stores; phrase must not duplicate")
+	assert.True(t, phrase.DocValues, "sort capability enables DocValues on the keyword variant")
+	assert.True(t, phrase.SkipFreqNorm)
+
+	// ngram variant: never canonical for retrieval.
+	ngram := got[resource.SEARCH_FIELD_TITLE_NGRAM]
+	assert.Equal(t, TITLE_ANALYZER, ngram.Analyzer)
+	assert.False(t, ngram.Store)
+	assert.False(t, ngram.DocValues)
+}
+
+func TestAddCapabilityFieldMappings_NonTitleFullSet(t *testing.T) {
+	// Same capability combo as title but a different field name: keyword
+	// variant uses the uniform "_keyword" suffix, not "_phrase".
+	got := flatMappings(t, resource.SearchFieldDefinition{
+		Name: "subject",
+		Type: resource.SearchFieldTypeString,
+		Capabilities: []resource.SearchCapability{
+			resource.SearchCapabilityFilter,
+			resource.SearchCapabilityText,
+			resource.SearchCapabilityPartial,
+			resource.SearchCapabilitySort,
+			resource.SearchCapabilityRetrieve,
+		},
+	})
+	require.Equal(t, []string{"subject", "subject_keyword", "subject_ngram"}, slices.Sorted(maps.Keys(got)))
+}
+
+func TestAddCapabilityFieldMappings_SortWithoutFilter(t *testing.T) {
+	// sort on its own still needs a keyword variant to back DocValues.
+	got := flatMappings(t, resource.SearchFieldDefinition{
+		Name: "lastSeenAt",
+		Type: resource.SearchFieldTypeInt64,
+		Capabilities: []resource.SearchCapability{
+			resource.SearchCapabilitySort,
+			resource.SearchCapabilityRetrieve,
+		},
+	})
+	require.Equal(t, []string{"lastSeenAt"}, slices.Sorted(maps.Keys(got)))
+	m := got["lastSeenAt"]
+	assert.Equal(t, keyword.Name, m.Analyzer)
+	assert.True(t, m.DocValues)
+	assert.True(t, m.Store)
+}
+
+func TestAddCapabilityFieldMappings_FacetOnly(t *testing.T) {
+	// facet shares the keyword variant. Without retrieve, the field is
+	// indexed but not stored — same as the existing "managedBy" mapping.
+	got := flatMappings(t, resource.SearchFieldDefinition{
+		Name:         "managedBy",
+		Type:         resource.SearchFieldTypeString,
+		Capabilities: []resource.SearchCapability{resource.SearchCapabilityFacet},
+	})
+	require.Equal(t, []string{"managedBy"}, slices.Sorted(maps.Keys(got)))
+	m := got["managedBy"]
+	assert.Equal(t, keyword.Name, m.Analyzer)
+	assert.False(t, m.Store)
+}
+
+func TestAddCapabilityFieldMappings_RetrieveOnly_NoMapping(t *testing.T) {
+	// A retrieve-only field gets no explicit mapping; Bleve's dynamic
+	// mapping handles it at index time, matching pre-refactor behaviour for
+	// non-filterable, non-string fields.
+	parent := bleve.NewDocumentMapping()
+	addCapabilityFieldMappings(parent, resource.SearchFieldDefinition{
+		Name:         "linkCount",
+		Type:         resource.SearchFieldTypeInt32,
+		Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve},
+	})
+	assert.Empty(t, parent.Properties, "retrieve-only fields fall back to dynamic mapping")
+}

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -1,0 +1,274 @@
+{
+  "default_mapping": {
+    "enabled": true,
+    "dynamic": false,
+    "properties": {
+      "_all": {
+        "enabled": false,
+        "dynamic": false
+      },
+      "createdBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "createdBy",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "description": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "description",
+            "type": "text",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "fields": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "folder": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "folder",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "include_in_all": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "labels": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "managedBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "managedBy",
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "manager": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "id": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "id",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "kind": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "kind",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "name": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "ownerReferences": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "ownerReferences",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "reference": {
+        "enabled": true,
+        "dynamic": true,
+        "default_analyzer": "keyword"
+      },
+      "selectableFields": {
+        "enabled": true,
+        "dynamic": false
+      },
+      "source": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "checksum": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "checksum",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "path": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "path",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "timestampMillis": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true,
+                "include_in_all": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "tags": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "tags",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "title": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true,
+            "include_in_all": true
+          }
+        ]
+      },
+      "title_ngram": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "title_analyzer",
+            "index": true,
+            "include_in_all": true
+          }
+        ]
+      },
+      "title_phrase": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "include_in_all": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      }
+    }
+  },
+  "type_field": "_type",
+  "default_type": "_default",
+  "default_analyzer": "standard",
+  "default_datetime_parser": "dateTimeOptional",
+  "scoring_model": "bm25",
+  "default_field": "_all",
+  "store_dynamic": true,
+  "index_dynamic": true,
+  "docvalues_dynamic": false,
+  "analysis": {
+    "token_filters": {
+      "ngram_filter": {
+        "max": 10,
+        "min": 3,
+        "type": "ngram"
+      }
+    },
+    "analyzers": {
+      "title_analyzer": {
+        "token_filters": [
+          "ngram_filter",
+          "to_lower",
+          "unique"
+        ],
+        "tokenizer": "whitespace",
+        "type": "custom"
+      }
+    }
+  }
+}

--- a/pkg/storage/unified/search/testdata/bleve_mapping_filterable_string.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_filterable_string.json
@@ -1,0 +1,290 @@
+{
+  "default_mapping": {
+    "enabled": true,
+    "dynamic": false,
+    "properties": {
+      "_all": {
+        "enabled": false,
+        "dynamic": false
+      },
+      "createdBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "createdBy",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "description": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "description",
+            "type": "text",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "fields": {
+        "enabled": true,
+        "dynamic": true,
+        "properties": {
+          "panel_types": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "include_in_all": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "folder": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "folder",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "include_in_all": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "labels": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "managedBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "managedBy",
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "manager": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "id": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "id",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "kind": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "kind",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "name": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "ownerReferences": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "ownerReferences",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "reference": {
+        "enabled": true,
+        "dynamic": true,
+        "default_analyzer": "keyword"
+      },
+      "selectableFields": {
+        "enabled": true,
+        "dynamic": false
+      },
+      "source": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "checksum": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "checksum",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "path": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "path",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "timestampMillis": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true,
+                "include_in_all": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "tags": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "tags",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "title": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true,
+            "include_in_all": true
+          }
+        ]
+      },
+      "title_ngram": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "title_analyzer",
+            "index": true,
+            "include_in_all": true
+          }
+        ]
+      },
+      "title_phrase": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "include_in_all": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      }
+    }
+  },
+  "type_field": "_type",
+  "default_type": "_default",
+  "default_analyzer": "standard",
+  "default_datetime_parser": "dateTimeOptional",
+  "scoring_model": "bm25",
+  "default_field": "_all",
+  "store_dynamic": true,
+  "index_dynamic": true,
+  "docvalues_dynamic": false,
+  "analysis": {
+    "token_filters": {
+      "ngram_filter": {
+        "max": 10,
+        "min": 3,
+        "type": "ngram"
+      }
+    },
+    "analyzers": {
+      "title_analyzer": {
+        "token_filters": [
+          "ngram_filter",
+          "to_lower",
+          "unique"
+        ],
+        "tokenizer": "whitespace",
+        "type": "custom"
+      }
+    }
+  }
+}

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -1,0 +1,302 @@
+{
+  "default_mapping": {
+    "enabled": true,
+    "dynamic": false,
+    "properties": {
+      "_all": {
+        "enabled": false,
+        "dynamic": false
+      },
+      "createdBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "createdBy",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "description": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "description",
+            "type": "text",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "fields": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "folder": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "folder",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "include_in_all": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "labels": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "managedBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "managedBy",
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "manager": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "id": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "id",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "kind": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "kind",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "name": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "ownerReferences": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "ownerReferences",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "reference": {
+        "enabled": true,
+        "dynamic": true,
+        "default_analyzer": "keyword"
+      },
+      "selectableFields": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "spec.description": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "spec.description",
+                "type": "text",
+                "analyzer": "keyword",
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "spec.title": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "spec.title",
+                "type": "text",
+                "analyzer": "keyword",
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "source": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "checksum": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "checksum",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "path": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "name": "path",
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "timestampMillis": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true,
+                "include_in_all": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "tags": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "name": "tags",
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "title": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true,
+            "include_in_all": true
+          }
+        ]
+      },
+      "title_ngram": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "title_analyzer",
+            "index": true,
+            "include_in_all": true
+          }
+        ]
+      },
+      "title_phrase": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "include_in_all": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      }
+    }
+  },
+  "type_field": "_type",
+  "default_type": "_default",
+  "default_analyzer": "standard",
+  "default_datetime_parser": "dateTimeOptional",
+  "scoring_model": "bm25",
+  "default_field": "_all",
+  "store_dynamic": true,
+  "index_dynamic": true,
+  "docvalues_dynamic": false,
+  "analysis": {
+    "token_filters": {
+      "ngram_filter": {
+        "max": 10,
+        "min": 3,
+        "type": "ngram"
+      }
+    },
+    "analyzers": {
+      "title_analyzer": {
+        "token_filters": [
+          "ngram_filter",
+          "to_lower",
+          "unique"
+        ],
+        "tokenizer": "whitespace",
+        "type": "custom"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Refactors the per-kind `fields.<name>` loop in `getBleveDocMappings`. It used to special-case Filterable STRING and fall back to Bleve dynamic mapping for everything else. It now translates the per-kind `SearchableDocumentFields` into `SearchFieldDefinition` and emits bleve mappings based on declared capabilities (`filter`, `text`, `partial`, `sort`, `facet`, `retrieve`).

Today's only translation output — Filterable+STRING → `[filter, retrieve]` — produces the same single keyword mapping at `fields.<name>` as before. Other capability combinations are reachable through the helper but not exercised by any in-tree builder yet.

Standard top-level mappings (title, title_phrase, title_ngram, description, tags, folder, manager.*, source.*, labels.*, reference.*, …) are not touched by this PR.

No on-disk index format change, no wire change, no reindex required.

`TestBleveMappingsGoldenJSON` pins the `GetBleveMappings` output to JSON snapshots generated from `origin/main` at `518fecc6df7` (the last commit before this work began). Regenerate with `-update-golden` after an intentional shape change.

`SearchFieldsFromTableColumns` was exported because this is the first cross-package caller.

Stacked on #126269. Tracking: grafana/search-and-storage-team#827
