### PR TITLE
CI: Add unified storage compatibility check and AGENTS.md guidance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1302,6 +1302,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/pr-checks.yml @tolzhabayev
 /.github/workflows/pr-endpoint-feature-toggle.yml @grafana/alerting-frontend
 /.github/workflows/pr-mt-service-compatibility.yml @evictorero
+/.github/workflows/pr-unified-storage-compatibility.yml @grafana/grafana-search-and-storage
 /.github/workflows/pr-commands.yml @tolzhabayev
 /.github/workflows/pr-external-labelling.yml @Proximyst
 /.github/workflows/pr-patch-check.yml @grafana/grafana-backend-services-squad

--- a/.github/workflows/pr-unified-storage-compatibility.yml
+++ b/.github/workflows/pr-unified-storage-compatibility.yml
@@ -26,6 +26,9 @@ jobs:
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
         with:
           files_yaml: |
+            # pkg/server/** is intentionally not in api_layer: it hosts the
+            # standalone storage/search server targets, and wire_gen.go churns
+            # on most storage provider changes, which would fail server-only PRs.
             api_layer:
               - 'pkg/registry/apis/**'
               - 'pkg/services/apiserver/**'
@@ -34,15 +37,18 @@ jobs:
               - 'pkg/services/search/**'
               - 'pkg/services/stats/**'
               - 'pkg/services/team/search/**'
+              # consumes pkg/storage/unified/resource/{kv,lease}
               - 'pkg/infra/leaderelection/kvlease/**'
               - 'pkg/storage/legacysql/**'
               # client-side unified storage code, runs inside the Grafana process
+              # (keep in sync with the negations in unified_storage below)
               - 'pkg/storage/unified/apistore/**'
               - 'pkg/storage/unified/federated/**'
               - 'pkg/storage/unified/*.go'
             unified_storage:
               - 'pkg/storage/unified/**'
-              # client-side code deployed with Grafana, not with the storage/search server
+              # client-side code deployed with Grafana, not with the storage/search
+              # server (keep in sync with the client-side block in api_layer above)
               - '!pkg/storage/unified/apistore/**'
               - '!pkg/storage/unified/federated/**'
               - '!pkg/storage/unified/*.go'

--- a/.github/workflows/pr-unified-storage-compatibility.yml
+++ b/.github/workflows/pr-unified-storage-compatibility.yml
@@ -32,6 +32,10 @@ jobs:
               - 'pkg/services/dashboards/**'
               - 'pkg/services/folder/**'
               - 'pkg/services/search/**'
+              - 'pkg/services/stats/**'
+              - 'pkg/services/team/search/**'
+              - 'pkg/infra/leaderelection/kvlease/**'
+              - 'pkg/storage/legacysql/**'
               # client-side unified storage code, runs inside the Grafana process
               - 'pkg/storage/unified/apistore/**'
               - 'pkg/storage/unified/federated/**'

--- a/.github/workflows/pr-unified-storage-compatibility.yml
+++ b/.github/workflows/pr-unified-storage-compatibility.yml
@@ -1,0 +1,82 @@
+name: "Unified Storage Compatibility"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-separation:
+    runs-on: ubuntu-arm64-small
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Detect changes
+        id: changed-files
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        with:
+          files_yaml: |
+            api_layer:
+              - 'pkg/registry/apis/**'
+              - 'pkg/services/apiserver/**'
+              - 'pkg/services/dashboards/**'
+              - 'pkg/services/folder/**'
+              - 'pkg/services/search/**'
+              # client-side unified storage code, runs inside the Grafana process
+              - 'pkg/storage/unified/apistore/**'
+              - 'pkg/storage/unified/federated/**'
+              - 'pkg/storage/unified/*.go'
+            unified_storage:
+              - 'pkg/storage/unified/**'
+              # client-side code deployed with Grafana, not with the storage/search server
+              - '!pkg/storage/unified/apistore/**'
+              - '!pkg/storage/unified/federated/**'
+              - '!pkg/storage/unified/*.go'
+
+      - name: Check for exception label
+        if: steps.changed-files.outputs.api_layer_any_changed == 'true' && steps.changed-files.outputs.unified_storage_any_changed == 'true'
+        run: |
+          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json labels --jq '.labels[].name')
+          if echo "$LABELS" | grep -q "no-check-unified-storage-compatibility"; then
+            echo "✅ Mixed changes allowed - exception label 'no-check-unified-storage-compatibility' is present"
+            exit 0
+          else
+            echo "❌ This PR contains changes that may not be deployed together."
+            echo ""
+            echo "Why this check failed:"
+            echo "• Unified storage and search can run as separate services, deployed independently from the Grafana API layer at different cadences"
+            echo "• A PR changing both sides may break compatibility between versions during rollout"
+            echo ""
+            echo "How to fix:"
+            echo "• Split this PR into two separate PRs (recommended):"
+            echo "  - One PR for unified storage/search changes (pkg/storage/unified/)"
+            echo "  - One PR for API layer changes (pkg/registry/apis/, pkg/services/)"
+            echo "• Ensure each change is backwards compatible on its own:"
+            echo "  - New API layer must work with the old storage/search server"
+            echo "  - New storage/search server must work with the old API layer"
+            echo ""
+            echo "Exception process (if changes MUST be coupled):"
+            echo "• Add the 'no-check-unified-storage-compatibility' label to this PR"
+            echo "• Explain in the PR description why these changes cannot be separated"
+            echo ""
+            echo "For more details, see pkg/storage/unified/AGENTS.md"
+            echo ""
+            echo "API layer changed files:"
+            echo "${{ steps.changed-files.outputs.api_layer_all_changed_files }}" | tr ' ' '\n' | sed 's/^/- /'
+            echo ""
+            echo "Unified storage changed files:"
+            echo "${{ steps.changed-files.outputs.unified_storage_all_changed_files }}" | tr ' ' '\n' | sed 's/^/- /'
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.policy.yml
+++ b/.policy.yml
@@ -39,6 +39,7 @@ policy:
             - Workflow .github/workflows/pr-test-docker.yml succeeded or skipped
             - Workflow .github/workflows/pr-test-integration-pgvector.yml succeeded or skipped
             - Workflow .github/workflows/pr-test-integration.yml succeeded or skipped
+            - Workflow .github/workflows/pr-unified-storage-compatibility.yml succeeded or skipped
             - Workflow .github/workflows/reject-gh-secrets.yml succeeded or skipped
             - Workflow .github/workflows/run-schema-v2-e2e.yml succeeded or skipped
             - Workflow .github/workflows/shellcheck.yml succeeded or skipped
@@ -636,6 +637,21 @@ approval_rules:
             - success
           workflows:
             - .github/workflows/pr-test-integration.yml
+  - name: Workflow .github/workflows/pr-unified-storage-compatibility.yml succeeded or skipped
+    if:
+      file_not_deleted:
+        paths:
+          - ^\.github\/workflows\/pr-unified-storage-compatibility\.yml$
+      targets_branch:
+        pattern: (^main$)
+    requires:
+      conditions:
+        has_workflow_result:
+          conclusions:
+            - skipped
+            - success
+          workflows:
+            - .github/workflows/pr-unified-storage-compatibility.yml
   - name: Workflow .github/workflows/reject-gh-secrets.yml succeeded or skipped
     if:
       file_not_deleted:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This file provides guidance to AI agents when working with code in the Grafana r
 
 - `docs/AGENTS.md` — Documentation style guide (for work under `docs/`)
 - `public/app/features/alerting/unified/AGENTS.md` — Alerting squad patterns
+- `pkg/storage/unified/AGENTS.md` — Unified storage/search compatibility rules (for work under `pkg/storage/unified/`)
 
 ## Project Overview
 
@@ -142,6 +143,7 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 - **Config**: Defaults in `conf/defaults.ini`, overrides in `conf/custom.ini`.
 - **Database migrations**: Live in `pkg/services/sqlstore/migrations/`. Test with `make devenv sources=postgres_tests,mysql_tests` then `make test-go-integration-postgres`.
 - **CI sharding**: Backend tests use `SHARD`/`SHARDS` env vars for parallelization.
+- **Service compatibility**: Unified storage/search (`pkg/storage/unified/`) can be deployed as separate services at a different cadence than the Grafana API layer. Changes spanning API-layer callers and `pkg/storage/unified/` must be backwards compatible in both directions — see `pkg/storage/unified/AGENTS.md`.
 
 ## Cursor Cloud specific instructions
 

--- a/pkg/storage/unified/AGENTS.md
+++ b/pkg/storage/unified/AGENTS.md
@@ -30,7 +30,7 @@ When run as separate services, the storage/search servers are deployed independe
 
 Because of independent deployment, **any mix of versions must work during rollout**: a new API layer with an old storage/search server, and an old API layer with a new storage/search server.
 
-- **Client side** (runs in Grafana): `apistore/`, `federated/`, the root client files (`client.go`, `client_retry.go`), and API-layer callers in `pkg/registry/apis/`, `pkg/services/apiserver/`, `pkg/services/dashboards/`, `pkg/services/folder/`, `pkg/services/search/`.
+- **Client side** (runs in Grafana): `apistore/`, `federated/`, the root client files (`client.go`, `client_retry.go`), and callers such as `pkg/registry/apis/`, `pkg/services/apiserver/`, `pkg/services/dashboards/`, `pkg/services/folder/`, `pkg/services/search/`, `pkg/services/stats/`, `pkg/services/team/search/`, `pkg/infra/leaderelection/kvlease/`, `pkg/storage/legacysql/`.
 - **Server side** (may be deployed separately): `resource/`, `sql/`, `search/`.
 
 Rules:
@@ -40,3 +40,5 @@ Rules:
 3. **Behavior changes need a fallback.** If the client starts relying on new server behavior (e.g. new query semantics), keep handling the old behavior until the server change is fully rolled out.
 
 The CI check `pr-unified-storage-compatibility.yml` fails PRs that change both the API layer and `pkg/storage/unified/`. If changes truly cannot be separated, add the `no-check-unified-storage-compatibility` label and justify it in the PR description.
+
+The check covers the common client-side callers, not every importer — it is a heuristic, not a proof. The compatibility rules above apply regardless of whether the check fires.

--- a/pkg/storage/unified/AGENTS.md
+++ b/pkg/storage/unified/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md — Unified Storage
+
+Guidance for AI agents working under `pkg/storage/unified/`.
+
+## What lives here
+
+| Directory     | Purpose                                                                       |
+| ------------- | ----------------------------------------------------------------------------- |
+| `resource/`   | Core resource server (gRPC endpoints, storage backend interface, watch/events) |
+| `sql/`        | SQL storage backend and resource version management                            |
+| `search/`     | Bleve-based search indexing and search server                                  |
+| `apistore/`   | Kubernetes-style storage adapter — runs inside the Grafana API server process  |
+| `proto/`      | Protocol buffer definitions (gRPC contract)                                    |
+| `resourcepb/` | Generated protobuf Go code                                                     |
+| `federated/`  | Federation client for reading across legacy and unified storage                |
+| `migrations/` | Data migration from legacy SQL to unified storage                              |
+| `parquet/`    | Parquet support for bulk import/export                                         |
+
+## Deployment modes
+
+Unified storage runs in several modes:
+
+- **In-process** (default): storage and search run inside the main Grafana process.
+- **Separate storage server** (`unified-grpc`): Grafana connects to a standalone storage server over gRPC.
+- **Distributed search**: standalone search servers behind a distributor, sharded by namespace.
+
+When run as separate services, the storage/search servers are deployed independently from the Grafana API layer, potentially at different cadences. The same commit can therefore be live on one side and not the other.
+
+## Compatibility rules
+
+Because of independent deployment, **any mix of versions must work during rollout**: a new API layer with an old storage/search server, and an old API layer with a new storage/search server.
+
+- **Client side** (runs in Grafana): `apistore/`, `federated/`, the root client files (`client.go`, `client_retry.go`), and API-layer callers in `pkg/registry/apis/`, `pkg/services/apiserver/`, `pkg/services/dashboards/`, `pkg/services/folder/`, `pkg/services/search/`.
+- **Server side** (may be deployed separately): `resource/`, `sql/`, `search/`.
+
+Rules:
+
+1. **Don't move responsibility between client and server in a single PR.** Ship server-side support first; switch client behavior in a follow-up after the server change is released. Each PR must work on its own against the other side's old version.
+2. **Proto/contract changes must be additive.** Never remove or repurpose fields or RPCs in `proto/`/`resourcepb/` that a deployed version still uses.
+3. **Behavior changes need a fallback.** If the client starts relying on new server behavior (e.g. new query semantics), keep handling the old behavior until the server change is fully rolled out.
+
+The CI check `pr-unified-storage-compatibility.yml` fails PRs that change both the API layer and `pkg/storage/unified/`. If changes truly cannot be separated, add the `no-check-unified-storage-compatibility` label and justify it in the PR description.

--- a/pkg/storage/unified/AGENTS.md
+++ b/pkg/storage/unified/AGENTS.md
@@ -30,8 +30,9 @@ When run as separate services, the storage/search servers are deployed independe
 
 Because of independent deployment, **any mix of versions must work during rollout**: a new API layer with an old storage/search server, and an old API layer with a new storage/search server.
 
-- **Client side** (runs in Grafana): `apistore/`, `federated/`, the root client files (`client.go`, `client_retry.go`), and callers such as `pkg/registry/apis/`, `pkg/services/apiserver/`, `pkg/services/dashboards/`, `pkg/services/folder/`, `pkg/services/search/`, `pkg/services/stats/`, `pkg/services/team/search/`, `pkg/infra/leaderelection/kvlease/`, `pkg/storage/legacysql/`.
-- **Server side** (may be deployed separately): `resource/`, `sql/`, `search/`.
+- **Client side** (runs in Grafana): `apistore/`, `federated/`, the root client files (`client.go`, `client_retry.go`), and callers such as `pkg/registry/apis/`, `pkg/services/{apiserver,dashboards,folder,search,stats}/`, `pkg/services/team/search/`, `pkg/infra/leaderelection/kvlease/`, `pkg/storage/legacysql/`.
+- **Server side** (may be deployed separately): `resource/`, `sql/`, `search/`, `migrations/`, `parquet/`.
+- **Contract** (used by both sides): `proto/`, `resourcepb/` — governed by rule 2 below.
 
 Rules:
 
@@ -39,6 +40,4 @@ Rules:
 2. **Proto/contract changes must be additive.** Never remove or repurpose fields or RPCs in `proto/`/`resourcepb/` that a deployed version still uses.
 3. **Behavior changes need a fallback.** If the client starts relying on new server behavior (e.g. new query semantics), keep handling the old behavior until the server change is fully rolled out.
 
-The CI check `pr-unified-storage-compatibility.yml` fails PRs that change both the API layer and `pkg/storage/unified/`. If changes truly cannot be separated, add the `no-check-unified-storage-compatibility` label and justify it in the PR description.
-
-The check covers the common client-side callers, not every importer — it is a heuristic, not a proof. The compatibility rules above apply regardless of whether the check fires.
+The CI check `pr-unified-storage-compatibility.yml` fails PRs that change both sides. If changes truly cannot be separated, add the `no-check-unified-storage-compatibility` label and justify it in the PR description. The check covers common client-side callers, not every importer, and contract-only PRs (`proto/`, `resourcepb/`) don't fire it — rule 2 is the only safeguard there. The rules above apply regardless of whether the check fires.

--- a/pkg/storage/unified/AGENTS.md
+++ b/pkg/storage/unified/AGENTS.md
@@ -1,43 +1,19 @@
 # AGENTS.md — Unified Storage
 
-Guidance for AI agents working under `pkg/storage/unified/`.
+Unified storage/search runs in-process (default), as a standalone storage server (`unified-grpc`), or as distributed search servers. When run separately, those servers deploy independently from the Grafana API layer at different cadences — the same commit can be live on one side and not the other.
 
-## What lives here
+## Client/server split
 
-| Directory     | Purpose                                                                       |
-| ------------- | ----------------------------------------------------------------------------- |
-| `resource/`   | Core resource server (gRPC endpoints, storage backend interface, watch/events) |
-| `sql/`        | SQL storage backend and resource version management                            |
-| `search/`     | Bleve-based search indexing and search server                                  |
-| `apistore/`   | Kubernetes-style storage adapter — runs inside the Grafana API server process  |
-| `proto/`      | Protocol buffer definitions (gRPC contract)                                    |
-| `resourcepb/` | Generated protobuf Go code                                                     |
-| `federated/`  | Federation client for reading across legacy and unified storage                |
-| `migrations/` | Data migration from legacy SQL to unified storage                              |
-| `parquet/`    | Parquet support for bulk import/export                                         |
-
-## Deployment modes
-
-Unified storage runs in several modes:
-
-- **In-process** (default): storage and search run inside the main Grafana process.
-- **Separate storage server** (`unified-grpc`): Grafana connects to a standalone storage server over gRPC.
-- **Distributed search**: standalone search servers behind a distributor, sharded by namespace.
-
-When run as separate services, the storage/search servers are deployed independently from the Grafana API layer, potentially at different cadences. The same commit can therefore be live on one side and not the other.
+- **Client side** (runs in Grafana): `apistore/`, `federated/`, `client.go`/`client_retry.go`, and callers such as `pkg/registry/apis/`, `pkg/services/{apiserver,dashboards,folder,search,stats}/`, `pkg/services/team/search/`, `pkg/infra/leaderelection/kvlease/`, `pkg/storage/legacysql/`.
+- **Server side** (may deploy separately): `resource/`, `sql/`, `search/`, `migrations/`, `parquet/`.
+- **Contract** (used by both sides): `proto/`, `resourcepb/`.
 
 ## Compatibility rules
 
-Because of independent deployment, **any mix of versions must work during rollout**: a new API layer with an old storage/search server, and an old API layer with a new storage/search server.
+Any mix of versions must work during rollout: new client ↔ old server and old client ↔ new server.
 
-- **Client side** (runs in Grafana): `apistore/`, `federated/`, the root client files (`client.go`, `client_retry.go`), and callers such as `pkg/registry/apis/`, `pkg/services/{apiserver,dashboards,folder,search,stats}/`, `pkg/services/team/search/`, `pkg/infra/leaderelection/kvlease/`, `pkg/storage/legacysql/`.
-- **Server side** (may be deployed separately): `resource/`, `sql/`, `search/`, `migrations/`, `parquet/`.
-- **Contract** (used by both sides): `proto/`, `resourcepb/` — governed by rule 2 below.
+1. **Don't move responsibility between client and server in one PR.** Ship server-side support first; switch client behavior in a follow-up after the server change is released.
+2. **Contract changes must be additive.** Never remove or repurpose fields or RPCs in `proto/`/`resourcepb/` that a deployed version still uses.
+3. **New client expectations need a fallback.** Keep handling old server behavior until the server change is fully rolled out.
 
-Rules:
-
-1. **Don't move responsibility between client and server in a single PR.** Ship server-side support first; switch client behavior in a follow-up after the server change is released. Each PR must work on its own against the other side's old version.
-2. **Proto/contract changes must be additive.** Never remove or repurpose fields or RPCs in `proto/`/`resourcepb/` that a deployed version still uses.
-3. **Behavior changes need a fallback.** If the client starts relying on new server behavior (e.g. new query semantics), keep handling the old behavior until the server change is fully rolled out.
-
-The CI check `pr-unified-storage-compatibility.yml` fails PRs that change both sides. If changes truly cannot be separated, add the `no-check-unified-storage-compatibility` label and justify it in the PR description. The check covers common client-side callers, not every importer, and contract-only PRs (`proto/`, `resourcepb/`) don't fire it — rule 2 is the only safeguard there. The rules above apply regardless of whether the check fires.
+The CI check `pr-unified-storage-compatibility.yml` fails PRs changing both sides; if truly inseparable, add the `no-check-unified-storage-compatibility` label and justify it in the PR description. The check covers common callers, not every importer, and contract-only PRs don't fire it (rule 2 is the safeguard there) — the rules apply regardless.


### PR DESCRIPTION
**What is this feature?**

Required CI check that fails PRs changing both Grafana API-layer code and unified storage/search server code, with a `no-check-unified-storage-compatibility` exception label. Also adds `pkg/storage/unified/AGENTS.md` with the compatibility rules.

**Why do we need this feature?**

Unified storage/search can be deployed separately from the API layer at different cadences; a PR changing both sides can break version compatibility during rollout.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/search-and-storage-team/issues/825
Fixes https://github.com/grafana/search-and-storage-team/issues/826

**Special notes for your reviewer:**

Modeled on `pr-mt-service-compatibility.yml`. `.policy.yml` regenerated via `make .policy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)