### PR TITLE
unified-storage: fix flaky TestPeriodicBookmarks by ignoring context cancellation in Watch

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1691,8 +1691,20 @@ func (s *server) initWatcher() error {
 }
 
 //nolint:gocyclo
-func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStore_WatchServer) error {
+func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStore_WatchServer) (retErr error) {
 	ctx := srv.Context()
+
+	// When our context is canceled (e.g. client disconnects), downstream calls
+	// like srv.Send may surface that cancellation back to us. Treat it as a
+	// clean shutdown to match the explicit `case <-ctx.Done(): return nil`
+	// branch in the watch loop. Context errors from other contexts are still
+	// propagated.
+	defer func() {
+		if retErr != nil && ctx.Err() != nil &&
+			(errors.Is(retErr, context.Canceled) || errors.Is(retErr, context.DeadlineExceeded)) {
+			retErr = nil
+		}
+	}()
 
 	user, ok := claims.AuthInfoFrom(ctx)
 	if !ok || user == nil {

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -1508,6 +1508,86 @@ func TestPeriodicBookmarks(t *testing.T) {
 	})
 }
 
+// stubWatchServer is a ResourceStore_WatchServer mock whose Send returns a
+// caller-supplied error. It is used to exercise Watch's error handling without
+// relying on races between the watch context and concrete Send failures.
+type stubWatchServer struct {
+	grpc.ServerStream
+	ctx     context.Context
+	sendErr error
+}
+
+func (s *stubWatchServer) Send(*resourcepb.WatchEvent) error { return s.sendErr }
+func (s *stubWatchServer) Context() context.Context          { return s.ctx }
+func (s *stubWatchServer) SetHeader(metadata.MD) error       { return nil }
+func (s *stubWatchServer) SendHeader(metadata.MD) error      { return nil }
+func (s *stubWatchServer) SetTrailer(metadata.MD)            {}
+func (s *stubWatchServer) SendMsg(any) error                 { return nil }
+func (s *stubWatchServer) RecvMsg(any) error                 { return nil }
+
+// TestWatchContextCancellation pins down how Watch translates errors that
+// surface during context cancellation. The watch loop has an explicit
+// `case <-ctx.Done(): return nil` branch, but `select` is nondeterministic, so
+// when the context is canceled we may instead run a Send/Read that returns
+// the context error. Watch must treat that as a clean shutdown, while still
+// surfacing unrelated errors and context errors that did not originate from
+// our own context.
+func TestWatchContextCancellation(t *testing.T) {
+	testUser := newWatchTestUser()
+
+	watchReq := &resourcepb.WatchRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Group:    watchTestGroup,
+				Resource: watchTestResource,
+			},
+		},
+		// SendInitialEvents forces Watch to call Send during the backfill, so
+		// the configured stub error path is hit deterministically without
+		// having to race with the bookmark ticker or the broadcaster.
+		SendInitialEvents: true,
+	}
+
+	setup := func(t *testing.T) *server {
+		t.Helper()
+		srv := newWatchTestServer(t, watchTestServerOpts{})
+		require.NoError(t, createTestPlaylist(authlib.WithAuthInfo(t.Context(), testUser), srv))
+		return srv
+	}
+
+	t.Run("returns nil when own context is canceled", func(t *testing.T) {
+		srv := setup(t)
+		ctx, cancel := context.WithCancel(authlib.WithAuthInfo(t.Context(), testUser))
+		cancel()
+
+		// Whatever sendErr we configure, Watch should swallow it because the
+		// context error from our own ctx will always be the proximate cause.
+		stub := &stubWatchServer{ctx: ctx, sendErr: context.Canceled}
+		require.NoError(t, srv.Watch(watchReq, stub))
+	})
+
+	t.Run("propagates non-context Send errors", func(t *testing.T) {
+		srv := setup(t)
+		ctx := authlib.WithAuthInfo(t.Context(), testUser)
+
+		sentinel := errors.New("send failed")
+		stub := &stubWatchServer{ctx: ctx, sendErr: sentinel}
+		err := srv.Watch(watchReq, stub)
+		require.ErrorIs(t, err, sentinel)
+	})
+
+	t.Run("propagates context errors that did not come from our own context", func(t *testing.T) {
+		srv := setup(t)
+		// Own context is alive; a Send returning context.Canceled here must
+		// have come from somewhere else and is a real error to report.
+		ctx := authlib.WithAuthInfo(t.Context(), testUser)
+
+		stub := &stubWatchServer{ctx: ctx, sendErr: context.Canceled}
+		err := srv.Watch(watchReq, stub)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
 // TestWatchEventMetricsWithSinceRV makes sure that we don't emit watch delay metrics when replaying
 // cached events for clients that start watching from old RVs. The metric should only be reporting
 // data for events emitted after the Watch is setup.


### PR DESCRIPTION
`server.Watch` has a `case <-ctx.Done(): return nil` branch, but Go's `select` is nondeterministic: when the context is canceled, the loop sometimes runs a `srv.Send` instead, which returns `context.Canceled`. Watch then propagates that error, even though the cancellation was clean. This is what makes `TestPeriodicBookmarks` flaky ([example failure](https://github.com/grafana/grafana/actions/runs/27268709468/job/80532449778)).

Fix: a deferred check at the top of `Watch` converts a returned `context.Canceled` / `context.DeadlineExceeded` to nil, but only when our own context is done. Other errors are still propagated. New `TestWatchContextCancellation` covers all three branches.