### PR TITLE
PanelEditNext: Empty state polish

### DIFF
--- a/e2e-playwright/panels-suite/panelEdit_queryEditorNext.spec.ts
+++ b/e2e-playwright/panels-suite/panelEdit_queryEditorNext.spec.ts
@@ -81,8 +81,8 @@ test.describe('Query Editor Next: Layout & Navigation', { tag: ['@panels', '@que
     await expect(page.getByRole('tab', { name: /Queries/i })).toHaveCount(0);
     await expect(page.getByRole('tab', { name: /Transformations/i })).toHaveCount(0);
 
-    await expect(page.getByText('Queries & Expressions')).toBeVisible();
-    await expect(page.getByText('Transformations')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Queries & Expressions' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Transformations' })).toBeVisible();
     await expect(page.getByRole('button', { name: /Query Options/i })).toBeVisible();
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueriesEmptyState.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueriesEmptyState.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/react';
+
+import { QueriesEmptyState } from './QueriesEmptyState';
+import { renderWithQueryEditorProvider } from './testUtils';
+
+describe('QueriesEmptyState', () => {
+  it('renders the call-to-action message', () => {
+    renderWithQueryEditorProvider(<QueriesEmptyState />);
+
+    expect(screen.getByText('Add a query, expression, or transformation to get started')).toBeInTheDocument();
+  });
+
+  it('adds and selects a new query when the button is clicked', async () => {
+    const addQuery = jest.fn().mockReturnValue('B');
+    const setSelectedQuery = jest.fn();
+
+    const { user } = renderWithQueryEditorProvider(<QueriesEmptyState />, {
+      actionsOverrides: { addQuery },
+      uiStateOverrides: { setSelectedQuery },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Add query' }));
+
+    expect(addQuery).toHaveBeenCalledTimes(1);
+    expect(setSelectedQuery).toHaveBeenCalledWith({ refId: 'B', hide: false });
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueriesEmptyState.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueriesEmptyState.tsx
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+
+import { t } from '@grafana/i18n';
+import { Button, EmptyState, Stack } from '@grafana/ui';
+
+import { trackAddQuery } from '../tracking';
+
+import { useActionsContext, useQueryEditorUIContext } from './QueryEditorContext';
+
+/**
+ * Shown when a panel has no queries and no transformations — e.g. after the user deletes every
+ * sidebar card. Offers a direct way back by adding (and selecting) a new query, mirroring the
+ * sidebar's "Add query" action.
+ */
+export function QueriesEmptyState() {
+  const { addQuery } = useActionsContext();
+  const { setSelectedQuery } = useQueryEditorUIContext();
+
+  const handleAddQuery = useCallback(() => {
+    const refId = addQuery();
+    if (refId) {
+      trackAddQuery('new_query', 'empty_state');
+      setSelectedQuery({ refId, hide: false });
+    }
+  }, [addQuery, setSelectedQuery]);
+
+  return (
+    <Stack alignItems="center" justifyContent="center" flex={1}>
+      <EmptyState
+        variant="call-to-action"
+        message={t(
+          'query-editor-next.queries-empty-state.message',
+          'Add a query, expression, or transformation to get started'
+        )}
+        button={
+          <Button icon="plus" onClick={handleAddQuery}>
+            {t('query-editor-next.queries-empty-state.add-query', 'Add query')}
+          </Button>
+        }
+      />
+    </Stack>
+  );
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContent.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContent.test.tsx
@@ -1,10 +1,13 @@
 import { screen } from '@testing-library/react';
 
+import { type DataQuery } from '@grafana/schema';
+
 import { QueryEditorType } from '../constants';
 
 import { QueryEditorContent } from './QueryEditorContent';
 import { type QueryEditorUIState } from './QueryEditorContext';
 import { makeStackedMode, renderWithQueryEditorProvider } from './testUtils';
+import { type Transformation } from './types';
 
 // QueryEditorContent's job is composition: pick between the stacked editor and the single-edit
 // body based on stacked-mode/picker/alert state. The children have their own tests, so we stub
@@ -24,9 +27,21 @@ jest.mock('./Header/ContentHeader', () => ({
 jest.mock('./Header/DatasourceHelpPanel', () => ({
   DatasourceHelpPanel: () => <div data-testid="datasource-help-panel" />,
 }));
+jest.mock('./QueriesEmptyState', () => ({
+  QueriesEmptyState: () => <div data-testid="queries-empty-state" />,
+}));
 
-function renderContent(uiStateOverrides: Partial<QueryEditorUIState> = {}) {
-  return renderWithQueryEditorProvider(<QueryEditorContent />, { uiStateOverrides });
+const query: DataQuery = { refId: 'A' };
+const transformation: Transformation = {
+  registryItem: undefined,
+  transformId: 'transform-1',
+  transformConfig: { id: 'reduce', options: {} },
+};
+
+// Existing branch tests assert the editor surface, which now only renders when the panel has at
+// least one card. Seed a query by default so empty-panel behaviour is tested explicitly below.
+function renderContent(uiStateOverrides: Partial<QueryEditorUIState> = {}, queries: DataQuery[] = [query]) {
+  return renderWithQueryEditorProvider(<QueryEditorContent />, { uiStateOverrides, queries });
 }
 
 describe('QueryEditorContent', () => {
@@ -36,6 +51,7 @@ describe('QueryEditorContent', () => {
     expect(screen.getByTestId('stacked-editor-renderer')).toBeInTheDocument();
     expect(screen.queryByTestId('query-editor-body')).not.toBeInTheDocument();
     expect(screen.queryByTestId('query-editor-footer')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('queries-empty-state')).not.toBeInTheDocument();
   });
 
   it.each([
@@ -64,10 +80,65 @@ describe('QueryEditorContent', () => {
 
     expect(screen.queryByTestId('stacked-editor-renderer')).not.toBeInTheDocument();
     expect(screen.getByTestId('query-editor-body')).toBeInTheDocument();
+    expect(screen.queryByTestId('queries-empty-state')).not.toBeInTheDocument();
     if (expectedFooter) {
       expect(screen.getByTestId('query-editor-footer')).toBeInTheDocument();
     } else {
       expect(screen.queryByTestId('query-editor-footer')).not.toBeInTheDocument();
     }
+  });
+
+  describe('when the panel has no queries or transformations', () => {
+    it('shows the empty state instead of the editor surface', () => {
+      renderWithQueryEditorProvider(<QueryEditorContent />, { queries: [], transformations: [] });
+
+      expect(screen.getByTestId('queries-empty-state')).toBeInTheDocument();
+      expect(screen.queryByTestId('content-header')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('query-editor-body')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('query-editor-footer')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('stacked-editor-renderer')).not.toBeInTheDocument();
+    });
+
+    it('shows the empty state even when stacked mode is enabled', () => {
+      renderWithQueryEditorProvider(<QueryEditorContent />, {
+        queries: [],
+        transformations: [],
+        uiStateOverrides: { stackedMode: makeStackedMode({ enabled: true }) },
+      });
+
+      expect(screen.getByTestId('queries-empty-state')).toBeInTheDocument();
+      expect(screen.queryByTestId('stacked-editor-renderer')).not.toBeInTheDocument();
+    });
+
+    it('keeps the transformation card editor when only transformations remain', () => {
+      renderWithQueryEditorProvider(<QueryEditorContent />, { queries: [], transformations: [transformation] });
+
+      expect(screen.queryByTestId('queries-empty-state')).not.toBeInTheDocument();
+      expect(screen.getByTestId('query-editor-body')).toBeInTheDocument();
+    });
+
+    it.each([
+      { name: 'a pending expression is open', overrides: { pendingExpression: { insertAfter: 'A' } } },
+      { name: 'a pending transformation is open', overrides: { pendingTransformation: { insertAfter: 'A' } } },
+      { name: 'a saved query picker is open', overrides: { pendingSavedQuery: { insertAfter: 'A' } } },
+    ])('does not show the empty state while $name', ({ overrides }) => {
+      renderWithQueryEditorProvider(<QueryEditorContent />, {
+        queries: [],
+        transformations: [],
+        uiStateOverrides: overrides,
+      });
+
+      expect(screen.queryByTestId('queries-empty-state')).not.toBeInTheDocument();
+    });
+
+    it('does not show the empty state in alert view', () => {
+      renderWithQueryEditorProvider(<QueryEditorContent />, {
+        queries: [],
+        transformations: [],
+        uiStateOverrides: { cardType: QueryEditorType.Alert },
+      });
+
+      expect(screen.queryByTestId('queries-empty-state')).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContent.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContent.tsx
@@ -9,27 +9,43 @@ import { QueryEditorBody } from './Body/QueryEditorBody';
 import { QueryEditorFooter } from './Footer/QueryEditorFooter';
 import { ContentHeaderSceneWrapper } from './Header/ContentHeader';
 import { DatasourceHelpPanel } from './Header/DatasourceHelpPanel';
-import { useAlertingContext, useQueryEditorUIContext } from './QueryEditorContext';
+import { QueriesEmptyState } from './QueriesEmptyState';
+import {
+  useAlertingContext,
+  usePanelContext,
+  useQueryEditorUIContext,
+  useQueryRunnerContext,
+} from './QueryEditorContext';
 import { StackedEditorRenderer } from './StackedEditor/StackedEditorRenderer';
 
 export function QueryEditorContent() {
   const styles = useStyles2(getStyles);
 
-  const { cardType, showingDatasourceHelp, pendingExpression, pendingTransformation, stackedMode } =
+  const { cardType, showingDatasourceHelp, pendingExpression, pendingTransformation, pendingSavedQuery, stackedMode } =
     useQueryEditorUIContext();
   const { alertRules } = useAlertingContext();
+  const { queries } = useQueryRunnerContext();
+  const { transformations } = usePanelContext();
+
   const hasPendingPicker = !!pendingExpression || !!pendingTransformation;
+  const hasPendingCard = hasPendingPicker || !!pendingSavedQuery;
   const isAlertView = cardType === QueryEditorType.Alert;
   const isAlertEmptyState = isAlertView && alertRules.length === 0;
-  const shouldShowStackedEditor = stackedMode.enabled && !hasPendingPicker && !isAlertView;
 
+  // The user can delete every card; with nothing pending and no alert view there is nothing to
+  // edit, so guide them back to adding a card instead of showing an empty editor surface.
+  const isQueriesEmptyState = !isAlertView && !hasPendingCard && queries.length === 0 && transformations.length === 0;
+
+  const shouldShowStackedEditor = stackedMode.enabled && !hasPendingPicker && !isAlertView;
   const shouldShowHeader = !isAlertEmptyState;
   const shouldShowFooter = !hasPendingPicker && !isAlertView;
   const shouldShowDatasourceHelp = !hasPendingPicker && showingDatasourceHelp;
 
   return (
     <div className={styles.container}>
-      {shouldShowStackedEditor ? (
+      {isQueriesEmptyState ? (
+        <QueriesEmptyState />
+      ) : shouldShowStackedEditor ? (
         <StackedEditorRenderer />
       ) : (
         <>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -44,7 +44,7 @@ describe('QueryEditorSidebar', () => {
     expect(screen.getByText('No transformations')).toBeInTheDocument();
   });
 
-  it('shows only the transformations empty state when queries exist but transformations do not', () => {
+  it('does not show section empty states when queries exist but transformations do not', () => {
     const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
 
     renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
@@ -54,7 +54,7 @@ describe('QueryEditorSidebar', () => {
     });
 
     expect(screen.queryByText('No queries or expressions')).not.toBeInTheDocument();
-    expect(screen.getByText('No transformations')).toBeInTheDocument();
+    expect(screen.queryByText('No transformations')).not.toBeInTheDocument();
   });
 
   it('hides the queries empty state while a pending expression ghost card is shown', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -27,7 +27,7 @@ describe('QueryEditorSidebar', () => {
       selectedQuery: queries[0],
     });
 
-    expect(screen.getByText(/transformations/i)).toBeInTheDocument();
+    expect(screen.getByText('Transformations')).toBeInTheDocument();
   });
 
   it('should render queries section even when no queries exist', () => {
@@ -35,6 +35,37 @@ describe('QueryEditorSidebar', () => {
 
     // Should still render the queries section header
     expect(screen.getByText(/queries & expressions/i)).toBeInTheDocument();
+  });
+
+  it('shows an empty state in each section when there are no cards', () => {
+    renderWithQueryEditorProvider(<QueriesAndTransformationsView />, { queries: [], transformations: [] });
+
+    expect(screen.getByText('No queries or expressions')).toBeInTheDocument();
+    expect(screen.getByText('No transformations')).toBeInTheDocument();
+  });
+
+  it('shows only the transformations empty state when queries exist but transformations do not', () => {
+    const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
+
+    renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
+      queries,
+      transformations: [],
+      selectedQuery: queries[0],
+    });
+
+    expect(screen.queryByText('No queries or expressions')).not.toBeInTheDocument();
+    expect(screen.getByText('No transformations')).toBeInTheDocument();
+  });
+
+  it('hides the queries empty state while a pending expression ghost card is shown', () => {
+    renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
+      queries: [],
+      transformations: [],
+      uiStateOverrides: { pendingExpression: { insertAfter: '' } },
+    });
+
+    expect(screen.queryByText('No queries or expressions')).not.toBeInTheDocument();
+    expect(screen.getByText('No transformations')).toBeInTheDocument();
   });
 
   it('should only render DataTransformerConfig cards and not CustomTransformerDefinition', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
@@ -32,8 +32,12 @@ export function QueriesAndTransformationsView() {
   const showSavedQueryGhost = !!pendingSavedQuery && !pendingSavedQuery.insertAfter;
   const showTransformationGhost = !!pendingTransformation && !pendingTransformation.insertAfter;
 
-  const isQueriesEmpty = queries.length === 0 && !showExpressionGhost && !showSavedQueryGhost;
-  const isTransformationsEmpty = transformations.length === 0 && !showTransformationGhost;
+  // Only surface the per-section placeholders when the whole panel is empty. Showing "No
+  // transformations yet" on every panel that simply hasn't added a transformation (the common
+  // case) would be noise.
+  const isPanelEmpty = queries.length === 0 && transformations.length === 0;
+  const showQueriesEmptyState = isPanelEmpty && !showExpressionGhost && !showSavedQueryGhost;
+  const showTransformationsEmptyState = isPanelEmpty && !showTransformationGhost;
 
   return (
     <>
@@ -54,7 +58,7 @@ export function QueriesAndTransformationsView() {
         )}
         {showExpressionGhost && <GhostSidebarCard id={PENDING_CARD_ID.expression} type={QueryEditorType.Expression} />}
         {showSavedQueryGhost && <GhostSidebarCard id={PENDING_CARD_ID.savedQuery} type={QueryEditorType.Query} />}
-        {isQueriesEmpty && (
+        {showQueriesEmptyState && (
           <SectionEmptyState message={t('query-editor-next.sidebar.queries-empty', 'No queries or expressions')} />
         )}
       </CollapsableSection>
@@ -76,7 +80,7 @@ export function QueriesAndTransformationsView() {
         {showTransformationGhost && (
           <GhostSidebarCard id={PENDING_CARD_ID.transformation} type={QueryEditorType.Transformation} />
         )}
-        {isTransformationsEmpty && (
+        {showTransformationsEmptyState && (
           <SectionEmptyState message={t('query-editor-next.sidebar.transformations-empty', 'No transformations')} />
         )}
       </CollapsableSection>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
@@ -12,6 +12,7 @@ import { TransformationCard } from './Cards/TransformationCard';
 import { CollapsableSection } from './CollapsableSection';
 import { DraggableList } from './DraggableList/DraggableList';
 import { useSidebarDragAndDrop } from './DraggableList/useSidebarDragAndDrop';
+import { SectionEmptyState } from './SectionEmptyState';
 
 export function QueriesAndTransformationsView() {
   const { queries } = useQueryRunnerContext();
@@ -25,6 +26,15 @@ export function QueriesAndTransformationsView() {
   const expandQueries = useCallback(() => setQueriesOpen(true), []);
   const expandTransformations = useCallback(() => setTransformationsOpen(true), []);
 
+  // A pending card renders a ghost placeholder in the section, so the section isn't truly empty
+  // while one is being added.
+  const showExpressionGhost = !!pendingExpression && !pendingExpression.insertAfter;
+  const showSavedQueryGhost = !!pendingSavedQuery && !pendingSavedQuery.insertAfter;
+  const showTransformationGhost = !!pendingTransformation && !pendingTransformation.insertAfter;
+
+  const isQueriesEmpty = queries.length === 0 && !showExpressionGhost && !showSavedQueryGhost;
+  const isTransformationsEmpty = transformations.length === 0 && !showTransformationGhost;
+
   return (
     <>
       <CollapsableSection
@@ -33,18 +43,19 @@ export function QueriesAndTransformationsView() {
         onToggle={setQueriesOpen}
         headerAction={<AddCardButton variant="query" alwaysVisible onAdd={expandQueries} />}
       >
-        <DraggableList
-          droppableId="query-sidebar-queries"
-          items={queries}
-          keyExtractor={(query) => query.refId}
-          renderItem={(query) => <QueryCard query={query} />}
-          onDragEnd={onQueryDragEnd}
-        />
-        {pendingExpression && !pendingExpression.insertAfter && (
-          <GhostSidebarCard id={PENDING_CARD_ID.expression} type={QueryEditorType.Expression} />
+        {queries.length > 0 && (
+          <DraggableList
+            droppableId="query-sidebar-queries"
+            items={queries}
+            keyExtractor={(query) => query.refId}
+            renderItem={(query) => <QueryCard query={query} />}
+            onDragEnd={onQueryDragEnd}
+          />
         )}
-        {pendingSavedQuery && !pendingSavedQuery.insertAfter && (
-          <GhostSidebarCard id={PENDING_CARD_ID.savedQuery} type={QueryEditorType.Query} />
+        {showExpressionGhost && <GhostSidebarCard id={PENDING_CARD_ID.expression} type={QueryEditorType.Expression} />}
+        {showSavedQueryGhost && <GhostSidebarCard id={PENDING_CARD_ID.savedQuery} type={QueryEditorType.Query} />}
+        {isQueriesEmpty && (
+          <SectionEmptyState message={t('query-editor-next.sidebar.queries-empty', 'No queries or expressions')} />
         )}
       </CollapsableSection>
       <CollapsableSection
@@ -62,8 +73,11 @@ export function QueriesAndTransformationsView() {
             onDragEnd={onTransformationDragEnd}
           />
         )}
-        {pendingTransformation && !pendingTransformation.insertAfter && (
+        {showTransformationGhost && (
           <GhostSidebarCard id={PENDING_CARD_ID.transformation} type={QueryEditorType.Transformation} />
+        )}
+        {isTransformationsEmpty && (
+          <SectionEmptyState message={t('query-editor-next.sidebar.transformations-empty', 'No transformations')} />
         )}
       </CollapsableSection>
     </>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SectionEmptyState.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/SectionEmptyState.tsx
@@ -1,0 +1,43 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Text, useStyles2 } from '@grafana/ui';
+
+import { SIDEBAR_CARD_HEIGHT, SIDEBAR_CARD_INDENT } from '../../constants';
+
+interface SectionEmptyStateProps {
+  message: string;
+}
+
+/**
+ * Lightweight placeholder shown inside a sidebar section that has no cards. Kept intentionally
+ * minimal — the section's "+" button is the action, so this only signals the section is empty
+ * rather than broken or still loading.
+ */
+export function SectionEmptyState({ message }: SectionEmptyStateProps) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.container}>
+      <Text variant="bodySmall" color="secondary" textAlignment="center">
+        {message}
+      </Text>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  // Match the sidebar card footprint (width via the same horizontal inset, height, radius) so the
+  // placeholder lines up with real cards; the dashed border distinguishes it as an empty slot.
+  container: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: theme.spacing(SIDEBAR_CARD_INDENT),
+    marginRight: theme.spacing(SIDEBAR_CARD_INDENT),
+    minHeight: SIDEBAR_CARD_HEIGHT,
+    padding: theme.spacing(0.5, 1),
+    border: `1px dashed ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+  }),
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -28,7 +28,7 @@ export function trackTransformationFilterChanged(filter: string | null) {
   });
 }
 
-type AddCardSource = 'section_header' | 'inline';
+type AddCardSource = 'section_header' | 'inline' | 'empty_state';
 
 export function trackAddQuery(querySource: 'saved_query' | 'new_query', cardSource: AddCardSource) {
   reportInteraction(EVENT_PANEL_EDIT_NEXT, {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14158,6 +14158,10 @@
       "query": "query",
       "transformation": "transformation"
     },
+    "queries-empty-state": {
+      "add-query": "Add query",
+      "message": "Add a query, expression, or transformation to get started"
+    },
     "sidebar": {
       "add-below": "Add below {{id}}",
       "add-expression": "Add expression",
@@ -14182,9 +14186,11 @@
       "footer-select": "Select...",
       "footer-select-label": "Select multiple items",
       "new-type": "New {{type}}",
+      "queries-empty": "No queries or expressions",
       "queries-expressions": "Queries & Expressions",
       "toggle-size": "Toggle sidebar size",
       "transformations": "Transformations",
+      "transformations-empty": "No transformations",
       "view-toggle": "View"
     },
     "stacked": {


### PR DESCRIPTION
## Description

In the new panel editor, deleting every sidebar card left the editor looking broken — an empty body and bare sidebar sections. This adds empty states to fill those gaps.

## Changes

* **Body**: when a panel has no queries/transformations, show a `call-to-action` `EmptyState` ("Add a query, expression, or transformation to get started") with an **Add query** button that creates and selects a query.
* **Sidebar sections**: show a placeholder ("No queries or expressions yet" / "No transformations yet") sized to match the cards (shared `SIDEBAR_CARD_*` constants, dashed border). Hidden while a pending ghost card is showing.
* **Analytics**: added an `empty_state` source to `add_query` tracking.

## Risks

Low — additive UI scoped to `PanelEditNext`; no query/transformation/alert behavior changed. The "No transformations yet" placeholder now appears on panels with queries but no transformations (common, intentional).

## Demo

<!-- TODO: screenshots -->

#### Before

<img width="1384" height="454" alt="image" src="https://github.com/user-attachments/assets/112814c3-da99-4222-b71b-9c2b95160d5a" />

#### After

<img width="1387" height="477" alt="image" src="https://github.com/user-attachments/assets/f8459cea-3bdd-4aa9-a21d-7d60fd24cf67" />

## Testing Instructions

* Open a panel in the new editor and delete all queries and transformations.
* Confirm the body empty state shows and **Add query** adds + selects a query.
* Confirm each empty section shows its placeholder, card-aligned.
* Confirm placeholders/body state are suppressed during pending adds and in alert view.
* `yarn jest --watchAll=false PanelEditNext/QueryEditor/QueriesEmptyState PanelEditNext/QueryEditor/QueryEditorContent PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView`

## Reviewer Checklist

- [x] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable