### PR TITLE
Alerting: Fix inhibition status flickering during load of alert rule detail

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -1,11 +1,14 @@
 import { within } from '@testing-library/react';
+import { HttpResponse, delay, http } from 'msw';
 import { render, screen, userEvent, waitFor } from 'test/test-utils';
 import { byLabelText, byRole, byText } from 'testing-library-selector';
 
 import { setPluginLinksHook } from '@grafana/runtime';
 import server from '@grafana/test-utils/server';
+import { alertmanagerApi } from 'app/features/alerting/unified/api/alertmanagerApi';
 import { mockAlertRuleApi, setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { type AlertManagerDataSourceJsonData, AlertState } from 'app/plugins/datasource/alertmanager/types';
+import { configureStore } from 'app/store/configureStore';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type CombinedRule, type RuleIdentifier } from 'app/types/unified-alerting';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
@@ -439,6 +442,37 @@ describe('RuleViewer', () => {
       await screen.findByText('Test alert');
       expect(screen.queryByText('Inhibited')).not.toBeInTheDocument();
     });
+
+    it('should not show a stale "Inhibited" badge while re-fetching after the rule is no longer inhibited', async () => {
+      // Seed the cache: the rule currently has an inhibited instance, so the badge shows.
+      setAlertmanagerAlertsHandler([
+        mockAlertmanagerAlert({
+          labels: { __alert_rule_uid__: grafanaRulerRule.grafana_alert.uid, alertname: 'Test alert' },
+          status: { state: AlertState.Suppressed, silencedBy: [], inhibitedBy: ['source-fingerprint'] },
+        }),
+      ]);
+
+      // Share a single store so the cached "inhibited" result survives the refetch we trigger below.
+      const store = configureStore();
+      await renderRuleViewer(mockRule, mockRuleIdentifier, ActiveTab.Query, store);
+      expect(await screen.findByText('Inhibited')).toBeInTheDocument();
+
+      // The rule is no longer inhibited, but the refetch hangs so we can observe the in-flight state.
+      server.use(
+        http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', async () => {
+          await delay('infinite');
+          return HttpResponse.json([]);
+        })
+      );
+
+      // Something invalidates the shared alerts cache (e.g. a mutation or poll), starting a background refetch.
+      store.dispatch(alertmanagerApi.util.invalidateTags(['AlertmanagerAlerts']));
+
+      // While the refetch is in flight we must not keep rendering the stale "inhibited" state.
+      await waitFor(() => {
+        expect(screen.queryByText('Inhibited')).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('Data source managed alert rule', () => {
@@ -654,13 +688,18 @@ describe('RuleViewer', () => {
   });
 });
 
-const renderRuleViewer = async (rule: CombinedRule, identifier: RuleIdentifier, tab: ActiveTab = ActiveTab.Query) => {
+const renderRuleViewer = async (
+  rule: CombinedRule,
+  identifier: RuleIdentifier,
+  tab: ActiveTab = ActiveTab.Query,
+  store?: ReturnType<typeof configureStore>
+) => {
   const path = `/alerting/${identifier.ruleSourceName}/${stringifyIdentifier(identifier)}/view?tab=${tab}`;
   const view = render(
     <AlertRuleProvider identifier={identifier} rule={rule}>
       <RuleViewer />
     </AlertRuleProvider>,
-    { historyOptions: { initialEntries: [path] } }
+    { historyOptions: { initialEntries: [path] }, store }
   );
 
   await waitFor(() => expect(ELEMENTS.loading.query()).not.toBeInTheDocument());

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -113,7 +113,7 @@ const RuleViewer = () => {
   const grafanaAlertingRuleUid = rulerRuleType.grafana.alertingRule(rulerRule)
     ? rulerRule.grafana_alert.uid
     : undefined;
-  const { hasInhibitedInstances } = useHasInhibitedInstances(grafanaAlertingRuleUid);
+  const { hasInhibitedInstances, isFetching: isInhibitionFetching } = useHasInhibitedInstances(grafanaAlertingRuleUid);
 
   const showError = hasError && !isPaused;
   const ruleOrigin = rulerRule ? getRulePluginOrigin(rulerRule) : getRulePluginOrigin(promRule);
@@ -132,7 +132,7 @@ const RuleViewer = () => {
           isProvisioned={isProvisioned}
           provenance={rulerRuleType.grafana.rule(rulerRule) ? rulerRule.grafana_alert.provenance : undefined}
           state={prometheusRuleType.alertingRule(promRule) ? promRule.state : undefined}
-          isInhibited={hasInhibitedInstances}
+          isInhibited={hasInhibitedInstances && !isInhibitionFetching}
           health={promRule?.health}
           ruleType={promRule?.type}
           ruleOrigin={ruleOrigin}

--- a/public/app/features/alerting/unified/hooks/useHasInhibitedInstances.ts
+++ b/public/app/features/alerting/unified/hooks/useHasInhibitedInstances.ts
@@ -11,11 +11,12 @@ import { useInhibitedAlerts } from './useInhibitedAlerts';
 export function useHasInhibitedInstances(ruleUid: string | undefined): {
   hasInhibitedInstances: boolean;
   isLoading: boolean;
+  isFetching: boolean;
 } {
-  const { inhibitedAlerts, isLoading } = useInhibitedAlerts();
+  const { inhibitedAlerts, isLoading, isFetching } = useInhibitedAlerts();
 
   const hasInhibitedInstances =
     ruleUid !== undefined && inhibitedAlerts.some((alert) => alert.labels.__alert_rule_uid__ === ruleUid);
 
-  return { hasInhibitedInstances, isLoading };
+  return { hasInhibitedInstances, isLoading, isFetching };
 }

--- a/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
+++ b/public/app/features/alerting/unified/hooks/useInhibitedAlerts.ts
@@ -14,8 +14,9 @@ import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 export function useInhibitedAlerts(): {
   inhibitedAlerts: AlertmanagerAlert[];
   isLoading: boolean;
+  isFetching: boolean;
 } {
-  const { data, isLoading } = alertmanagerApi.useGetAlertmanagerAlertsQuery(
+  const { data, isLoading, isFetching } = alertmanagerApi.useGetAlertmanagerAlertsQuery(
     {
       amSourceName: GRAFANA_RULES_SOURCE_NAME,
       filter: { inhibited: true, active: false, silenced: false },
@@ -27,5 +28,6 @@ export function useInhibitedAlerts(): {
   return {
     inhibitedAlerts: data ?? [],
     isLoading,
+    isFetching,
   };
 }


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where the "Inhibited" badge on the alert rule detail page would briefly flicker while the page loaded or after a background cache invalidation.

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1789

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
