### PR TITLE
fix(annotations): ignore duplicate annotation_tag rows on concurrent writes

### DIFF
--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -268,12 +268,46 @@ func (r *xormRepositoryImpl) ensureTags(ctx context.Context, annotationID int64,
 			}
 		}
 		if len(tagsInsert) != 0 {
-			if _, err := sess.InsertMulti(tagsInsert); err != nil {
+			if err := r.insertTagsIgnoringConflicts(sess, tagsInsert); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+}
+
+// insertTagsIgnoringConflicts inserts annotation_tag rows, ignoring any conflicts
+// that arise from duplicate annotation_id/tag_id pairs.
+func (r *xormRepositoryImpl) insertTagsIgnoringConflicts(sess *sqlstore.DBSession, tags []annotationTag) error {
+	dialect := r.db.GetDialect()
+
+	switch dialect.DriverName() {
+	case migrator.MySQL:
+		args := make([]any, 0, len(tags)*2)
+		valuesClause := make([]string, 0, len(tags))
+		for _, t := range tags {
+			valuesClause = append(valuesClause, "(?, ?)")
+			args = append(args, t.AnnotationID, t.TagID)
+		}
+		sql := "INSERT IGNORE INTO annotation_tag (annotation_id, tag_id) VALUES " + strings.Join(valuesClause, ", ")
+		_, err := sess.Exec(append([]any{sql}, args...)...)
+		return err
+
+	default: // postgres, sqlite
+		args := make([]any, 0, len(tags)*2)
+		valuesClause := make([]string, 0, len(tags))
+		for i, t := range tags {
+			if dialect.DriverName() == migrator.Postgres {
+				valuesClause = append(valuesClause, fmt.Sprintf("($%d, $%d)", i*2+1, i*2+2))
+			} else {
+				valuesClause = append(valuesClause, "(?, ?)")
+			}
+			args = append(args, t.AnnotationID, t.TagID)
+		}
+		sql := "INSERT INTO annotation_tag (annotation_id, tag_id) VALUES " + strings.Join(valuesClause, ", ") + " ON CONFLICT (annotation_id, tag_id) DO NOTHING"
+		_, err := sess.Exec(append([]any{sql}, args...)...)
+		return err
+	}
 }
 
 func tagSet[T any](fn func(T) int64, list []T) map[int64]struct{} {

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -637,6 +637,30 @@ func TestIntegrationAnnotations(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, result.Tags, 0)
 		})
+
+		t.Run("insertTagsIgnoringConflicts tolerates duplicate annotation_tag rows", func(t *testing.T) {
+			annotation := &annotations.Item{
+				OrgID:  1,
+				UserID: 1,
+				Text:   "test duplicate tags",
+				Epoch:  10,
+				Tags:   []string{"alertname:cpu", "severity:critical"},
+			}
+			err := store.Add(t.Context(), annotation)
+			require.NoError(t, err)
+
+			var existingTags []annotationTag
+			err = sql.WithDbSession(t.Context(), func(sess *sqlstore.DBSession) error {
+				return sess.SQL("SELECT annotation_id, tag_id FROM annotation_tag WHERE annotation_id = ?", annotation.ID).Find(&existingTags)
+			})
+			require.NoError(t, err)
+			require.Len(t, existingTags, 2)
+
+			err = sql.WithDbSession(t.Context(), func(sess *sqlstore.DBSession) error {
+				return store.insertTagsIgnoringConflicts(sess, existingTags)
+			})
+			require.NoError(t, err)
+		})
 	})
 }
 


### PR DESCRIPTION
This PR fixes an issue where concurrent annotation tag writes fail with a unique constraint violation due to a non-atomic read then insert pattern in `ensureTags`. This changes the `InsertMulti` call with `INSERT` statements that ignore conflicting `annotation_id`/`tag_id` records.