### PR TITLE
Alerting: Add warning when editing grouped alert rule to ungrouped

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.test.tsx
@@ -1,5 +1,5 @@
 import { FormProvider, useForm } from 'react-hook-form';
-import { render, screen } from 'test/test-utils';
+import { render, screen, testWithFeatureToggles } from 'test/test-utils';
 
 import { type RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
@@ -154,6 +154,67 @@ function GroupCreationModalWrapper() {
     </FormProvider>
   );
 }
+
+function EvaluationBehaviorWrapper({
+  existing,
+  group,
+  isUngroupedRuleGroup,
+}: {
+  existing: boolean;
+  group: string;
+  isUngroupedRuleGroup: boolean;
+}) {
+  const formApi = useForm<RuleFormValues>({
+    defaultValues: { ...getDefaultFormValues(), group, isUngroupedRuleGroup },
+    mode: 'onChange',
+  });
+  return (
+    <FormProvider {...formApi}>
+      <GrafanaEvaluationBehaviorStep existing={existing} enableProvisionedGroups={false} />
+    </FormProvider>
+  );
+}
+
+const ungroupWarning = /Removing this rule from its group is irreversible/i;
+
+describe('GrafanaEvaluationBehaviorStep — ungroup warning (rulesAPIV2)', () => {
+  testWithFeatureToggles({ enable: ['alerting.rulesAPIV2'] });
+
+  it('warns when an existing grouped rule is switched to ungrouped', async () => {
+    const { user } = render(<EvaluationBehaviorWrapper existing group="my-group" isUngroupedRuleGroup={false} />);
+
+    expect(screen.queryByText(ungroupWarning)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: 'Set interval' }));
+
+    expect(await screen.findByText(ungroupWarning)).toBeInTheDocument();
+  });
+
+  it('hides the warning again when switching back to using groups', async () => {
+    const { user } = render(<EvaluationBehaviorWrapper existing group="my-group" isUngroupedRuleGroup={false} />);
+
+    await user.click(screen.getByRole('radio', { name: 'Set interval' }));
+    expect(await screen.findByText(ungroupWarning)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: 'Use groups (Legacy)' }));
+    expect(screen.queryByText(ungroupWarning)).not.toBeInTheDocument();
+  });
+
+  it('does not show the picker or warning for a rule that was already ungrouped', () => {
+    render(<EvaluationBehaviorWrapper existing group={`no_group_for_rule_${'a'.repeat(36)}`} isUngroupedRuleGroup />);
+
+    expect(screen.queryByRole('radio', { name: 'Set interval' })).not.toBeInTheDocument();
+    expect(screen.queryByText(ungroupWarning)).not.toBeInTheDocument();
+  });
+
+  it('does not warn when a new (non-existing) rule is set to ungrouped', async () => {
+    const { user } = render(<EvaluationBehaviorWrapper existing={false} group="" isUngroupedRuleGroup={false} />);
+
+    await user.click(screen.getByRole('radio', { name: 'Set interval' }));
+
+    expect(screen.queryByText(ungroupWarning)).not.toBeInTheDocument();
+  });
+});
 
 describe('GrafanaEvaluationBehaviorStep — evaluateEvery validation (rule-based mode)', () => {
   it('shows an error for "none" value', async () => {

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.test.tsx
@@ -175,7 +175,7 @@ function EvaluationBehaviorWrapper({
   );
 }
 
-const ungroupWarning = /Removing this rule from its group is irreversible/i;
+const ungroupWarning = /This will remove the alert rule from its group/i;
 
 describe('GrafanaEvaluationBehaviorStep — ungroup warning (rulesAPIV2)', () => {
   testWithFeatureToggles({ enable: ['alerting.rulesAPIV2'] });

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -44,6 +44,7 @@ import {
 } from '../../utils/rules';
 import { parsePrometheusDuration, safeParsePrometheusDuration } from '../../utils/time';
 import { CollapseToggle } from '../CollapseToggle';
+import { MetaText } from '../MetaText';
 import { ProvisioningBadge } from '../Provisioning';
 
 import { DurationQuickPick } from './DurationQuickPick';
@@ -209,6 +210,7 @@ export function GrafanaEvaluationBehaviorStep({
   const v2Enabled = shouldUseRulesAPIV2();
   const isEditingUngroupedRule = Boolean(existing && group && isUngroupedRuleGroup(group));
   const [lastSelectedGroup, setLastSelectedGroup] = useState(group);
+  const [wasGroupedRule] = useState(() => existing && Boolean(group) && !isUngroupedRuleGroup(group));
   const evaluationMode: EvaluationMode = isUngroupedRule ? 'rule-based' : 'group-based';
   const showGroupSelection = evaluationMode === 'group-based';
 
@@ -286,6 +288,14 @@ export function GrafanaEvaluationBehaviorStep({
               className={styles.modeField}
             />
           </Field>
+        )}
+        {v2Enabled && wasGroupedRule && evaluationMode === 'rule-based' && (
+          <MetaText icon="exclamation-triangle" color="warning">
+            <Trans i18nKey="alerting.rule-form.evaluation.ungroup-warning">
+              Removing this rule from its group is irreversible. After you save, you will not be able to add it back to
+              a group.
+            </Trans>
+          </MetaText>
         )}
         {showGroupSelection ? (
           <Stack alignItems="end" gap={1}>

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -7,6 +7,7 @@ import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import {
+  Alert,
   Box,
   Button,
   Divider,
@@ -44,7 +45,6 @@ import {
 } from '../../utils/rules';
 import { parsePrometheusDuration, safeParsePrometheusDuration } from '../../utils/time';
 import { CollapseToggle } from '../CollapseToggle';
-import { MetaText } from '../MetaText';
 import { ProvisioningBadge } from '../Provisioning';
 
 import { DurationQuickPick } from './DurationQuickPick';
@@ -290,12 +290,17 @@ export function GrafanaEvaluationBehaviorStep({
           </Field>
         )}
         {v2Enabled && wasGroupedRule && evaluationMode === 'rule-based' && (
-          <MetaText icon="exclamation-triangle" color="warning">
+          <Alert
+            severity="warning"
+            title={t(
+              'alerting.rule-form.evaluation.ungroup-warning-title',
+              'This will remove the alert rule from its group'
+            )}
+          >
             <Trans i18nKey="alerting.rule-form.evaluation.ungroup-warning">
-              Removing this rule from its group is irreversible. After you save, you will not be able to add it back to
-              a group.
+              This action is irreversible. After you save, you will not be able to add it back to a group.
             </Trans>
-          </MetaText>
+          </Alert>
         )}
         {showGroupSelection ? (
           <Stack alignItems="end" gap={1}>

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -158,7 +158,7 @@ export function GrafanaEvaluationBehaviorStep({
     setValue,
     getValues,
     clearErrors,
-    formState: { errors },
+    formState: { errors, defaultValues },
     control,
     register,
   } = useFormContext<RuleFormValues>();
@@ -210,7 +210,7 @@ export function GrafanaEvaluationBehaviorStep({
   const v2Enabled = shouldUseRulesAPIV2();
   const isEditingUngroupedRule = Boolean(existing && group && isUngroupedRuleGroup(group));
   const [lastSelectedGroup, setLastSelectedGroup] = useState(group);
-  const [wasGroupedRule] = useState(() => existing && Boolean(group) && !isUngroupedRuleGroup(group));
+  const wasGroupedRule = Boolean(existing && defaultValues?.group && !isUngroupedRuleGroup(defaultValues.group));
   const evaluationMode: EvaluationMode = isUngroupedRule ? 'rule-based' : 'group-based';
   const showGroupSelection = evaluationMode === 'group-based';
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2812,7 +2812,8 @@
           "alerting": "Turn on to pause evaluation for this alert rule.",
           "recording": "Turn on to pause evaluation for this recording rule."
         },
-        "select-folder-before": "Select a folder before setting evaluation group and interval"
+        "select-folder-before": "Select a folder before setting evaluation group and interval",
+        "ungroup-warning": "Removing this rule from its group is irreversible. After you save, you will not be able to add it back to a group."
       },
       "evaluation-behaviour": {
         "description": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2813,7 +2813,8 @@
           "recording": "Turn on to pause evaluation for this recording rule."
         },
         "select-folder-before": "Select a folder before setting evaluation group and interval",
-        "ungroup-warning": "Removing this rule from its group is irreversible. After you save, you will not be able to add it back to a group."
+        "ungroup-warning": "This action is irreversible. After you save, you will not be able to add it back to a group.",
+        "ungroup-warning-title": "This will remove the alert rule from its group"
       },
       "evaluation-behaviour": {
         "description": {


### PR DESCRIPTION
**What is this feature?**

Added a small warning in the edit page of an alert rule so that the user is aware that editing an alert from grouped to ungrouped is an irreversible action


https://github.com/user-attachments/assets/23502c70-50ef-41b9-8ad4-329506d6da59



**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1803

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
