### PR TITLE
Canvas: Make imported `@grafana/data` code dependencies public

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -212,7 +212,13 @@ export {
 } from './field/overrides/processors';
 
 // Utils
-export { PanelOptionsEditorBuilder, FieldConfigEditorBuilder } from './utils/OptionsUIBuilders';
+export {
+  PanelOptionsEditorBuilder,
+  FieldConfigEditorBuilder,
+  type NestedValueAccess,
+  type NestedPanelOptions,
+  isNestedPanelOptions,
+} from './utils/OptionsUIBuilders';
 export { getFlotPairs, getFlotPairsConstant } from './utils/flotPairs';
 export { locationUtil } from './utils/location';
 export { urlUtil, type UrlQueryMap, type UrlQueryValue, serializeStateToUrlParam, toURLRange } from './utils/url';
@@ -440,6 +446,7 @@ export {
 export { LayoutModes, type LayoutMode } from './types/layout';
 export {
   PanelPlugin,
+  type PanelOptionsSupplier,
   type SetFieldConfigOptionsArgs,
   type StandardOptionConfig,
   type PanelScreenshotContext,

--- a/packages/grafana-data/src/internal/index.ts
+++ b/packages/grafana-data/src/internal/index.ts
@@ -119,12 +119,8 @@ export { getStreamingFrameOptions } from '../dataframe/StreamingDataFrame';
 export { fieldIndexComparer } from '../field/fieldComparers';
 export { decoupleHideFromState } from '../field/decoupleHideFromState';
 export { findNumericFieldMinMax } from '../field/fieldOverrides';
-export {
-  type PanelOptionsSupplier,
-  type PluginViewOptionsQuickToggles,
-  type PanelPluginViewOptions,
-} from '../panel/PanelPlugin';
+export { type PluginViewOptionsQuickToggles, type PanelPluginViewOptions } from '../panel/PanelPlugin';
 export { sanitize, sanitizeUrl } from '../text/sanitize';
-export { type NestedValueAccess, type NestedPanelOptions, isNestedPanelOptions } from '../utils/OptionsUIBuilders';
+
 export { NewThemeOptionsSchema } from '../themes/createTheme';
 export { createFieldsOrdererAuto } from '../transformations/transformers/order';

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -124,6 +124,12 @@ export interface SetFieldConfigOptionsArgs<TFieldConfigOptions = any> {
   useCustomConfig?: (builder: FieldConfigEditorBuilder<TFieldConfigOptions>) => void;
 }
 
+/**
+ * Callback used to declare a panel's option editors via {@link PanelPlugin.setPanelOptions}.
+ * Receives a builder and an editor context, and should call builder methods to register editors.
+ *
+ * @typeParam TOptions - The panel options type.
+ */
 export type PanelOptionsSupplier<TOptions> = (
   builder: PanelOptionsEditorBuilder<TOptions>,
   context: StandardEditorContext<TOptions>

--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -165,16 +165,33 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
   }
 }
 
+/**
+ * Provides read and write access to a specific path within a parent options object.
+ * Used as the value accessor when building nested panel option editors via
+ * {@link PanelOptionsEditorBuilder.addNestedOptions}.
+ */
 export interface NestedValueAccess {
   getValue: (path: string) => any;
   onChange: (path: string, value: any) => void;
   getContext?: (parent: StandardEditorContext<any>) => StandardEditorContext<any>;
 }
+
+/**
+ * Configuration for a nested sub-section of panel options, used with
+ * {@link PanelOptionsEditorBuilder.addNestedOptions}.
+ *
+ * @typeParam TSub - The type of the nested options object.
+ */
 export interface NestedPanelOptions<TSub = any> {
+  /** The dot-separated path within the parent options object where the sub-options live. */
   path: string;
+  /** Optional category label(s) for grouping in the options pane. */
   category?: string[];
+  /** Default value for the sub-options object. */
   defaultValue?: TSub;
+  /** Builder function that declares the editors for the sub-options. */
   build: PanelOptionsSupplier<TSub>;
+  /** Optional override for how values are read/written relative to the parent accessor. */
   values?: (parent: NestedValueAccess) => NestedValueAccess;
 }
 
@@ -226,6 +243,10 @@ class NestedPanelOptionsBuilder<TSub = any> implements OptionsEditorItem<TSub, a
   };
 }
 
+/**
+ * Type guard that returns true if `item` is a {@link NestedPanelOptions} builder instance.
+ * Useful when iterating over registered panel option items to identify and handle nested sub-options.
+ */
 export function isNestedPanelOptions(item: unknown): item is NestedPanelOptionsBuilder {
   return isObject(item) && 'id' in item && item.id === 'nested-panel-options';
 }

--- a/public/app/features/canvas/element.ts
+++ b/public/app/features/canvas/element.ts
@@ -1,7 +1,6 @@
 import { type ComponentType } from 'react';
 
-import { type DataLink, type RegistryItem, type Action } from '@grafana/data';
-import { type PanelOptionsSupplier } from '@grafana/data/internal';
+import { type DataLink, type PanelOptionsSupplier, type RegistryItem, type Action } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { type ColorDimensionConfig, type ScaleDimensionConfig, type DirectionDimensionConfig } from '@grafana/schema';
 import {

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
@@ -3,14 +3,16 @@ import { get as lodashGet } from 'lodash';
 import {
   type EventBus,
   type InterpolateFunction,
+  isNestedPanelOptions,
+  type NestedValueAccess,
   type PanelData,
   type PanelPlugin,
+  type PanelOptionsSupplier,
   type StandardEditorContext,
   type VariableSuggestionsScope,
   type FieldConfigSource,
   PanelOptionsEditorBuilder,
 } from '@grafana/data';
-import { type NestedValueAccess, isNestedPanelOptions, type PanelOptionsSupplier } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { type VizPanel } from '@grafana/scenes';

--- a/public/app/features/transformers/spatial/optionsHelper.tsx
+++ b/public/app/features/transformers/spatial/optionsHelper.tsx
@@ -1,7 +1,12 @@
 import { set, get as lodashGet } from 'lodash';
 
-import { type StandardEditorContext, type TransformerUIProps, PanelOptionsEditorBuilder } from '@grafana/data';
-import { type NestedValueAccess, type PanelOptionsSupplier } from '@grafana/data/internal';
+import {
+  type NestedValueAccess,
+  type PanelOptionsSupplier,
+  type StandardEditorContext,
+  type TransformerUIProps,
+  PanelOptionsEditorBuilder,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { fillOptionsPaneItems } from 'app/features/dashboard/components/PanelEditor/getVisualizationOptions';

--- a/public/app/plugins/panel/canvas/editor/connectionEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/connectionEditor.tsx
@@ -1,6 +1,6 @@
 import { get as lodashGet } from 'lodash';
 
-import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data/internal';
+import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data';
 import { type Scene } from 'app/features/canvas/runtime/scene';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
 

--- a/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
@@ -1,6 +1,6 @@
 import { get as lodashGet } from 'lodash';
 
-import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data/internal';
+import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type CanvasElementOptions } from 'app/features/canvas/element';
 import {

--- a/public/app/plugins/panel/canvas/editor/inline/InlineEditBody.tsx
+++ b/public/app/plugins/panel/canvas/editor/inline/InlineEditBody.tsx
@@ -6,10 +6,11 @@ import { useObservable } from 'react-use';
 import {
   type DataFrame,
   type GrafanaTheme2,
+  type NestedValueAccess,
   type PanelOptionsEditorBuilder,
+  type PanelOptionsSupplier,
   type StandardEditorContext,
 } from '@grafana/data';
-import { type NestedValueAccess, type PanelOptionsSupplier } from '@grafana/data/internal';
 import { Trans, t } from '@grafana/i18n';
 import { useStyles2 } from '@grafana/ui';
 import { AddLayerButton } from 'app/core/components/Layers/AddLayerButton';

--- a/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
@@ -1,6 +1,6 @@
 import { get as lodashGet } from 'lodash';
 
-import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data/internal';
+import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { FrameState } from 'app/features/canvas/runtime/frame';

--- a/public/app/plugins/panel/canvas/editor/options.ts
+++ b/public/app/plugins/panel/canvas/editor/options.ts
@@ -1,5 +1,4 @@
-import { FieldType } from '@grafana/data';
-import { type PanelOptionsSupplier } from '@grafana/data/internal';
+import { FieldType, type PanelOptionsSupplier } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { ConnectionDirection, DirectionDimensionMode } from '@grafana/schema';
 import { SVGElements } from 'app/features/canvas/runtime/element';

--- a/public/app/plugins/panel/geomap/editor/layerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/layerEditor.tsx
@@ -1,7 +1,12 @@
 import { get as lodashGet, isEqual } from 'lodash';
 
-import { FrameGeometrySourceMode, getFrameMatchers, type MapLayerOptions } from '@grafana/data';
-import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data/internal';
+import {
+  FrameGeometrySourceMode,
+  getFrameMatchers,
+  type MapLayerOptions,
+  type NestedPanelOptions,
+  type NestedValueAccess,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
 import { addLocationFields } from 'app/features/geo/editor/locationEditor';


### PR DESCRIPTION
**What is this feature?**

Promotes `Canvas` related code from `@grafana/data/internal` to the public `@grafana/data` interface for `13.1.x`, unblocking the `Canvas` which depends on it, so it can be externalized in Grafana `v13.2.x`.

**Why do we need this feature?**

So we can externalize the `Canvas` panel as a standalone plugin.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

🎟️ Fixes https://github.com/grafana/grafana/issues/126294

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
