### PR TITLE
[release-13.0.3] Pyroscope: Fix debug logs bypassing GF_LOG_LEVEL

### DIFF
--- a/pkg/tsdb/grafana-pyroscope-datasource/instance.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/prometheus/prometheus/model/labels"
@@ -43,10 +44,11 @@ type PyroscopeDatasource struct {
 	httpClient *http.Client
 	client     ProfilingClient
 	settings   backend.DataSourceInstanceSettings
+	logger     log.Logger
 }
 
 // NewPyroscopeDatasource creates a new datasource instance.
-func NewPyroscopeDatasource(ctx context.Context, httpClientProvider httpclient.Provider, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+func NewPyroscopeDatasource(ctx context.Context, httpClientProvider httpclient.Provider, settings backend.DataSourceInstanceSettings, logger log.Logger) (instancemgmt.Instance, error) {
 	opt, err := settings.HTTPClientOptions(ctx)
 	if err != nil {
 		return nil, backend.DownstreamErrorf("failed to get HTTP client options: %w. function: %s", err, logEntrypoint())
@@ -60,11 +62,12 @@ func NewPyroscopeDatasource(ctx context.Context, httpClientProvider httpclient.P
 		httpClient: httpClient,
 		client:     NewPyroscopeClient(httpClient, settings.URL),
 		settings:   settings,
+		logger:     logger,
 	}, nil
 }
 
 func (d *PyroscopeDatasource) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	ctxLogger := logger.FromContext(ctx)
+	ctxLogger := d.logger.FromContext(ctx)
 	ctx, span := tracing.DefaultTracer().Start(ctx, "datasource.pyroscope.CallResource", trace.WithAttributes(attribute.String("path", req.Path), attribute.String("method", req.Method)))
 	defer span.End()
 	ctxLogger.Debug("CallResource", "Path", req.Path, "Method", req.Method, "Body", req.Body, "function", logEntrypoint())
@@ -229,7 +232,7 @@ func (d *PyroscopeDatasource) profileMetadata(ctx context.Context, _ *backend.Ca
 // The QueryDataResponse contains a map of RefID to the response for each query, and each response
 // contains Frames ([]*Frame).
 func (d *PyroscopeDatasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	ctxLogger := logger.FromContext(ctx)
+	ctxLogger := d.logger.FromContext(ctx)
 	ctxLogger.Debug("Processing queries", "queryLength", len(req.Queries), "function", logEntrypoint())
 
 	// create response struct
@@ -254,7 +257,7 @@ func (d *PyroscopeDatasource) QueryData(ctx context.Context, req *backend.QueryD
 // datasource configuration page which allows users to verify that
 // a datasource is working as expected.
 func (d *PyroscopeDatasource) CheckHealth(ctx context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	logger.FromContext(ctx).Debug("CheckHealth called", "function", logEntrypoint())
+	d.logger.FromContext(ctx).Debug("CheckHealth called", "function", logEntrypoint())
 
 	status := backend.HealthStatusOk
 	message := "Data source is working"
@@ -277,7 +280,7 @@ func (d *PyroscopeDatasource) CheckHealth(ctx context.Context, _ *backend.CheckH
 // SubscribeStream is called when a client wants to connect to a stream.
 // This callback allows sending the first message.
 func (d *PyroscopeDatasource) SubscribeStream(_ context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	logger.Debug("Subscribing stream called", "function", logEntrypoint())
+	d.logger.Debug("Subscribing stream called", "function", logEntrypoint())
 
 	status := backend.SubscribeStreamStatusPermissionDenied
 	if req.Path == "stream" {
@@ -292,7 +295,7 @@ func (d *PyroscopeDatasource) SubscribeStream(_ context.Context, req *backend.Su
 // RunStream is called once for any open channel.
 // Results are shared with everyone subscribed to the same channel.
 func (d *PyroscopeDatasource) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	ctxLogger := logger.FromContext(ctx)
+	ctxLogger := d.logger.FromContext(ctx)
 	ctxLogger.Debug("Running stream", "path", req.Path, "function", logEntrypoint())
 
 	// Create the same data frame as for query data.
@@ -330,7 +333,7 @@ func (d *PyroscopeDatasource) RunStream(ctx context.Context, req *backend.RunStr
 
 // PublishStream is called when a client sends a message to the stream.
 func (d *PyroscopeDatasource) PublishStream(ctx context.Context, _ *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	logger.FromContext(ctx).Debug("Publishing stream", "function", logEntrypoint())
+	d.logger.FromContext(ctx).Debug("Publishing stream", "function", logEntrypoint())
 
 	// Do not allow publishing at all.
 	return &backend.PublishStreamResponse{

--- a/pkg/tsdb/grafana-pyroscope-datasource/instance_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/instance_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/stretchr/testify/require"
 )
 
 // This is where the tests for the datasource backend live.
 func Test_QueryData(t *testing.T) {
-	ds := PyroscopeDatasource{}
+	ds := PyroscopeDatasource{logger: log.NewNullLogger()}
 
 	resp, err := ds.QueryData(
 		context.Background(),
@@ -32,6 +33,7 @@ func Test_QueryData(t *testing.T) {
 func Test_CallResource(t *testing.T) {
 	ds := &PyroscopeDatasource{
 		client: &FakeClient{},
+		logger: log.NewNullLogger(),
 	}
 
 	t.Run("series resource", func(t *testing.T) {

--- a/pkg/tsdb/grafana-pyroscope-datasource/query.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/live"
@@ -81,7 +82,7 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 				parsedInterval, err = gtime.ParseDuration(dsJson.MinStep)
 				if err != nil {
 					parsedInterval = time.Second * 15
-					logger.Error("Failed to parse the MinStep using default", "MinStep", dsJson.MinStep, "function", logEntrypoint())
+					d.logger.Error("Failed to parse the MinStep using default", "MinStep", dsJson.MinStep, "function", logEntrypoint())
 				}
 			}
 			exemplarType := typesv1.ExemplarType_EXEMPLAR_TYPE_NONE
@@ -102,7 +103,7 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 			if err != nil {
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
-				logger.Error("Querying SelectSeries()", "err", err, "function", logEntrypoint())
+				d.logger.Error("Querying SelectSeries()", "err", err, "function", logEntrypoint())
 				return err
 			}
 			// add the frames to the response.
@@ -113,7 +114,7 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 			if err != nil {
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
-				logger.Error("Querying SelectSeries()", "err", err, "function", logEntrypoint())
+				d.logger.Error("Querying SelectSeries()", "err", err, "function", logEntrypoint())
 				return err
 			}
 			response.Frames = append(response.Frames, frames...)
@@ -126,22 +127,22 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 		g.Go(func() error {
 			var profileResp *ProfileResponse
 			if len(qm.SpanSelector) > 0 {
-				logger.Debug("Calling GetSpanProfile", "queryModel", qm, "function", logEntrypoint())
+				d.logger.Debug("Calling GetSpanProfile", "queryModel", qm, "function", logEntrypoint())
 				prof, err := d.client.GetSpanProfile(gCtx, profileTypeId, labelSelector, qm.SpanSelector, query.TimeRange.From.UnixMilli(), query.TimeRange.To.UnixMilli(), qm.MaxNodes)
 				if err != nil {
 					span.RecordError(err)
 					span.SetStatus(codes.Error, err.Error())
-					logger.Error("Error GetSpanProfile()", "err", err, "function", logEntrypoint())
+					d.logger.Error("Error GetSpanProfile()", "err", err, "function", logEntrypoint())
 					return err
 				}
 				profileResp = prof
 			} else {
-				logger.Debug("Calling GetProfile", "queryModel", qm, "function", logEntrypoint())
+				d.logger.Debug("Calling GetProfile", "queryModel", qm, "function", logEntrypoint())
 				prof, err := d.client.GetProfile(gCtx, profileTypeId, labelSelector, query.TimeRange.From.UnixMilli(), query.TimeRange.To.UnixMilli(), qm.MaxNodes, qm.ProfileIdSelector)
 				if err != nil {
 					span.RecordError(err)
 					span.SetStatus(codes.Error, err.Error())
-					logger.Error("Error GetProfile()", "err", err, "function", logEntrypoint())
+					d.logger.Error("Error GetProfile()", "err", err, "function", logEntrypoint())
 					return err
 				}
 				profileResp = prof
@@ -162,11 +163,11 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 					parsedInterval, err = gtime.ParseDuration(dsJson.MinStep)
 					if err != nil {
 						parsedInterval = time.Second * 15
-						logger.Error("Failed to parse the MinStep using default", "MinStep", dsJson.MinStep, "function", logEntrypoint())
+						d.logger.Error("Failed to parse the MinStep using default", "MinStep", dsJson.MinStep, "function", logEntrypoint())
 					}
 				}
 				stepDuration := math.Max(query.Interval.Seconds(), parsedInterval.Seconds())
-				frame = responseToDataFrames(profileResp, stepDuration, profileTypeId)
+				frame = responseToDataFrames(profileResp, stepDuration, profileTypeId, d.logger)
 
 				// If query called with streaming on then return a channel
 				// to subscribe on a client-side and consume updates from a plugin.
@@ -203,8 +204,8 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 // responseToDataFrames turns Pyroscope response to data.Frame. We encode the data into a nested set format where we have
 // [level, value, label] columns and by ordering the items in a depth first traversal order we can recreate the whole
 // tree back.
-func responseToDataFrames(resp *ProfileResponse, stepDurationSec float64, profileTypeID string) *data.Frame {
-	tree := levelsToTree(resp.Flamebearer.Levels, resp.Flamebearer.Names)
+func responseToDataFrames(resp *ProfileResponse, stepDurationSec float64, profileTypeID string, logger log.Logger) *data.Frame {
+	tree := levelsToTree(resp.Flamebearer.Levels, resp.Flamebearer.Names, logger)
 	return treeToNestedSetDataFrame(tree, resp.Units, stepDurationSec, profileTypeID)
 }
 
@@ -234,7 +235,7 @@ type ProfileTree struct {
 
 // levelsToTree converts flamebearer format into a tree. This is needed to then convert it into nested set format
 // dataframe. This should be temporary, and ideally we should get some sort of tree struct directly from Pyroscope API.
-func levelsToTree(levels []*Level, names []string) *ProfileTree {
+func levelsToTree(levels []*Level, names []string, logger log.Logger) *ProfileTree {
 	if len(levels) == 0 {
 		return nil
 	}

--- a/pkg/tsdb/grafana-pyroscope-datasource/query_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
@@ -20,6 +21,7 @@ func Test_query(t *testing.T) {
 	client := &FakeClient{}
 	ds := &PyroscopeDatasource{
 		client: client,
+		logger: log.NewNullLogger(),
 	}
 
 	pCtx := backend.PluginContext{
@@ -134,7 +136,7 @@ func Test_profileToDataFrame(t *testing.T) {
 		},
 		Units: "short",
 	}
-	frame := responseToDataFrames(profile, 15.0, "goroutine:goroutine:count:goroutine:count")
+	frame := responseToDataFrames(profile, 15.0, "goroutine:goroutine:count:goroutine:count", log.NewNullLogger())
 	require.Equal(t, 4, len(frame.Fields))
 	require.Equal(t, data.NewField("level", nil, []int64{0, 1, 1}), frame.Fields[0])
 	require.Equal(t, data.NewField("value", nil, []int64{20, 10, 5}).SetConfig(&data.FieldConfig{Unit: "short"}), frame.Fields[1])
@@ -153,7 +155,7 @@ func Test_levelsToTree(t *testing.T) {
 			{Values: []int64{0, 15, 0, 3}},
 		}
 
-		tree := levelsToTree(levels, []string{"root", "func1", "func2", "func1:func3"})
+		tree := levelsToTree(levels, []string{"root", "func1", "func2", "func1:func3"}, log.NewNullLogger())
 		require.Equal(t, &ProfileTree{
 			Start: 0, Value: 100, Level: 0, Name: "root", Nodes: []*ProfileTree{
 				{
@@ -173,7 +175,7 @@ func Test_levelsToTree(t *testing.T) {
 			{Values: []int64{0, 20, 0, 4, 50, 10, 0, 5}},
 		}
 
-		tree := levelsToTree(levels, []string{"root", "func1", "func2", "func3", "func1:func4", "func3:func5"})
+		tree := levelsToTree(levels, []string{"root", "func1", "func2", "func3", "func1:func4", "func3:func5"}, log.NewNullLogger())
 		require.Equal(t, &ProfileTree{
 			Start: 0, Value: 100, Level: 0, Name: "root", Nodes: []*ProfileTree{
 				{

--- a/pkg/tsdb/grafana-pyroscope-datasource/service.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/service.go
@@ -34,8 +34,6 @@ type Service struct {
 	logger log.Logger
 }
 
-var logger = backend.NewLoggerWith("logger", "tsdb.pyroscope")
-
 // Return the file, line, and (full-path) function name of the caller
 func getRunContext() (string, int, string) {
 	pc := make([]uintptr, 10)
@@ -64,15 +62,18 @@ func (s *Service) getInstance(ctx context.Context, pluginCtx backend.PluginConte
 }
 
 func ProvideService(httpClientProvider *httpclient.Provider) *Service {
+	// Constructed here (not as a package-level var) so it picks up Grafana's
+	// in-process logger override installed during coreplugin init.
+	logger := backend.NewLoggerWith("logger", "tsdb.pyroscope")
 	return &Service{
-		im:     datasource.NewInstanceManager(newInstanceSettings(httpClientProvider)),
+		im:     datasource.NewInstanceManager(newInstanceSettings(httpClientProvider, logger)),
 		logger: logger,
 	}
 }
 
-func newInstanceSettings(httpClientProvider *httpclient.Provider) datasource.InstanceFactoryFunc {
+func newInstanceSettings(httpClientProvider *httpclient.Provider, logger log.Logger) datasource.InstanceFactoryFunc {
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return NewPyroscopeDatasource(ctx, *httpClientProvider, settings)
+		return NewPyroscopeDatasource(ctx, *httpClientProvider, settings, logger)
 	}
 }
 


### PR DESCRIPTION
Backport f443b2ba20f0e9e8635b565a8c8c1ba33c4031b0 from #126289

---

## Summary

- The Pyroscope datasource emitted `@level=debug` JSON lines on every query and health check regardless of `GF_LOG_LEVEL`, because `var logger = backend.NewLoggerWith(...)` at package level was evaluated before `coreplugin` could install Grafana's in-process logger override. The `var` therefore captured the SDK's default `hclog` constructor at Debug level and bypassed Grafana's log filter for the lifetime of the process.
- Fix moves logger construction into `ProvideService` and threads it through `NewPyroscopeDatasource` (and the `levelsToTree` / `responseToDataFrames` helpers), matching the pattern Loki, Tempo and the SQL datasources already use.
- A short comment in `ProvideService` records why the logger must not be a package-level var, to prevent regression.

Internal escalation: https://github.com/grafana/support-escalations/issues/22785

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./pkg/tsdb/grafana-pyroscope-datasource/...`
- [ ] Manual: run Grafana with `GF_LOG_LEVEL=info`, configure a Pyroscope datasource, run a query and a health check, confirm no `@level=debug` lines appear in the server logs.
- [ ] Manual: with `GF_LOG_LEVEL=debug`, confirm the Pyroscope debug lines reappear (and come out in Grafana's `logfmt` format, not hclog JSON).
