### PR TITLE
Folders: Grant creator admin permission on nested folders

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -281,10 +281,9 @@ var defaultPermissions = []map[string]any{
 	},
 }
 
-// buildDefaultFolderPermissions returns the default folder permissions with the creator granted
-// admin (in addition to the default basic-role permissions). Non-user/service-account identities
-// (anonymous, render service, etc.) get only the default permission set.
-func buildDefaultFolderPermissions(id authlib.AuthInfo) []map[string]any {
+// buildDefaultFolderPermissions grants the creator admin on the folder. Non-user identities get no
+// grant. Root folders also seed the default Editor/Viewer roles; nested folders inherit those.
+func buildDefaultFolderPermissions(id authlib.AuthInfo, isNested bool) []map[string]any {
 	var creatorKind string
 	switch id.GetIdentityType() {
 	case authlib.TypeUser:
@@ -296,16 +295,19 @@ func buildDefaultFolderPermissions(id authlib.AuthInfo) []map[string]any {
 		// default permission set; no creator admin grant.
 	}
 
-	if creatorKind == "" {
-		return defaultPermissions
+	permissions := make([]map[string]any, 0, len(defaultPermissions)+1)
+	if creatorKind != "" {
+		permissions = append(permissions, map[string]any{
+			"kind": creatorKind,
+			"name": id.GetIdentifier(),
+			"verb": "admin",
+		})
 	}
 
-	permissions := make([]map[string]any, 0, len(defaultPermissions)+1)
-	permissions = append(permissions, map[string]any{
-		"kind": creatorKind,
-		"name": id.GetIdentifier(),
-		"verb": "admin",
-	})
+	if isNested {
+		return permissions
+	}
+
 	return append(permissions, defaultPermissions...)
 }
 
@@ -348,13 +350,16 @@ func (b *FolderAPIBuilder) setDefaultFolderPermissions(ctx context.Context, key 
 		return nil
 	}
 
-	// only set default permissions for root folders
-	if !folder.IsRootFolderUID(obj.GetFolder()) {
+	isNested := !folder.IsRootFolderUID(obj.GetFolder())
+
+	// Nothing to write for a nested folder created by a non-user identity; keep inheriting from ancestors.
+	permissions := buildDefaultFolderPermissions(id, isNested)
+	if len(permissions) == 0 {
 		return nil
 	}
 
 	log := logging.FromContext(ctx)
-	log.Debug("setting default folder permissions", "uid", obj.GetName(), "namespace", obj.GetNamespace())
+	log.Debug("setting default folder permissions", "uid", obj.GetName(), "namespace", obj.GetNamespace(), "nested", isNested)
 
 	// Setting the default permissions is a system operation triggered by the creation of the
 	// folder, not an action the requester performs directly. The creator does not yet have
@@ -365,10 +370,6 @@ func (b *FolderAPIBuilder) setDefaultFolderPermissions(ctx context.Context, key 
 		return fmt.Errorf("parse namespace: %w", err)
 	}
 	ctx = identity.WithServiceIdentityContext(ctx, nsInfo.OrgID)
-
-	// The creator gets admin on their folder, in addition to the default basic-role permissions.
-	// Anonymous and other non-user identities don't get an explicit grant.
-	permissions := buildDefaultFolderPermissions(id)
 
 	client := (*resourcePermissionsSvc).Namespace(obj.GetNamespace())
 	name := fmt.Sprintf("%s-%s-%s", foldersv1.FolderResourceInfo.GroupVersionResource().Group, foldersv1.FolderResourceInfo.GroupVersionResource().Resource, obj.GetName())

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -61,15 +61,14 @@ func (ss *FolderUnifiedStoreImpl) Create(ctx context.Context, cmd folder.CreateF
 		return nil, err
 	}
 
-	// Request default permissions for new root folders via the App Platform path; the folder API
-	// server's permission setter acts on this annotation. Root-only (nested inherit from the parent).
-	if folder.IsRootFolderUID(cmd.ParentUID) {
-		meta, err := utils.MetaAccessor(obj)
-		if err != nil {
-			return nil, err
-		}
-		meta.SetAnnotation(utils.AnnoKeyGrantPermissions, utils.AnnoGrantPermissionsDefault)
+	// Request default permissions via the App Platform path; the folder API server's permission setter
+	// acts on this annotation. Set for nested folders too so the creator is granted admin; the setter
+	// only seeds the Editor/Viewer defaults on root folders (nested inherit those from the parent).
+	meta, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return nil, err
 	}
+	meta.SetAnnotation(utils.AnnoKeyGrantPermissions, utils.AnnoGrantPermissionsDefault)
 
 	out, err := ss.k8sclient.Create(ctx, obj, cmd.OrgID, v1.CreateOptions{
 		FieldValidation: v1.FieldValidationIgnore})


### PR DESCRIPTION
## What this PR does

When the App Platform folder permission path is used (`kubernetesAuthzResourcePermissionApis`), the creator of a folder was only granted **admin** on **root** folders. Nested folders relied entirely on inheritance from their parent, so a user who could create a subfolder — e.g. an **editor** with edit access to the parent via a **team** — did **not** become admin of the folder they just created.

This restores the legacy `SetDefaultPermissions` behaviour, where the creator always became admin of the folder they created, regardless of nesting.

## Why

The legacy SQL path (`DashboardServiceImpl.SetDefaultPermissions`) granted the creator admin unconditionally; only the Editor/Viewer basic-role defaults were root-only. The App Platform path diverged by skipping the creator grant entirely for nested folders, which is a behaviour regression for anyone creating subfolders without org-admin.

## Changes

- **`folderimpl/unifiedstore.go`**: request default permissions (the `grafana.app/grant-permissions` annotation) for nested folders too, not just root. The annotation is consumed and stripped by the apistore prepare step before the object is persisted, so nothing leaks into stored objects.
- **`folders/register.go`**: `buildDefaultFolderPermissions` now grants the creator admin on nested folders as well. The Editor/Viewer basic-role defaults remain root-only, since nested folders inherit those from their ancestors (avoids overriding inheritance semantics).

## Behaviour after the change

| Folder | Creator grant | Editor/Viewer defaults |
|--------|---------------|------------------------|
| Root   | Admin         | Yes (seeded)           |
| Nested | Admin         | No (inherited)         |

Non-user identities (anonymous, render service) still get no explicit grant; for nested folders created by such identities nothing is written, so they keep inheriting from ancestors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)