### PR TITLE
chore: reduce circular deps in @grafana/ui

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
@@ -4,15 +4,15 @@ import { type FieldSparkline, FieldType } from '@grafana/data';
 
 import { useTheme2 } from '../../themes/ThemeContext';
 
+import { BigValue } from './BigValue';
+import mdx from './BigValue.mdx';
 import {
-  BigValue,
   BigValueColorMode,
   BigValueGraphMode,
   BigValueJustifyMode,
   BigValueTextMode,
   type Props,
-} from './BigValue';
-import mdx from './BigValue.mdx';
+} from './BigValueTypes';
 
 const meta: Meta = {
   title: 'Plugins/BigValue',

--- a/packages/grafana-ui/src/components/BigValue/BigValue.test.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.test.tsx
@@ -2,7 +2,8 @@ import { render, screen } from '@testing-library/react';
 
 import { createTheme } from '@grafana/data';
 
-import { BigValue, BigValueColorMode, BigValueGraphMode, type Props } from './BigValue';
+import { BigValue } from './BigValue';
+import { BigValueColorMode, BigValueGraphMode, type Props } from './BigValueTypes';
 
 const valueObject = {
   text: '25',

--- a/packages/grafana-ui/src/components/BigValue/BigValue.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.tsx
@@ -1,86 +1,12 @@
 import { cx } from '@emotion/css';
-import { memo, type MouseEventHandler } from 'react';
+import { memo } from 'react';
 
-import { type DisplayValue, type DisplayValueAlignmentFactors, type FieldSparkline } from '@grafana/data';
-import { type PercentChangeColorMode, type VizTextDisplayOptions } from '@grafana/schema';
-
-import { type Themeable2 } from '../../types/theme';
 import { clearButtonStyles } from '../Button/Button';
 import { FormattedValueDisplay } from '../FormattedValueDisplay/FormattedValueDisplay';
 
 import { buildLayout } from './BigValueLayout';
+import { BigValueJustifyMode, type Props } from './BigValueTypes';
 import { PercentChange } from './PercentChange';
-
-export enum BigValueColorMode {
-  Background = 'background',
-  BackgroundSolid = 'background_solid',
-  None = 'none',
-  Value = 'value',
-}
-
-export enum BigValueGraphMode {
-  None = 'none',
-  Line = 'line',
-  Area = 'area',
-}
-
-export enum BigValueJustifyMode {
-  Auto = 'auto',
-  Center = 'center',
-}
-
-/**
- * Options for how the value & title are to be displayed
- */
-export enum BigValueTextMode {
-  Auto = 'auto',
-  Value = 'value',
-  ValueAndName = 'value_and_name',
-  Name = 'name',
-  None = 'none',
-}
-
-export interface Props extends Themeable2 {
-  /** Height of the component */
-  height: number;
-  /** Width of the component */
-  width: number;
-  /** Value displayed as Big Value */
-  value: DisplayValue;
-  /** Sparkline values for showing a graph under/behind the value  */
-  sparkline?: FieldSparkline;
-  /** onClick handler for the value */
-  onClick?: MouseEventHandler<HTMLElement>;
-  /** Custom styling */
-  className?: string;
-  /** Color mode for coloring the value or the background */
-  colorMode: BigValueColorMode;
-  /** Show a graph behind/under the value */
-  graphMode: BigValueGraphMode;
-  /** Auto justify value and text or center it */
-  justifyMode?: BigValueJustifyMode;
-  /** Factors that should influence the positioning of the text  */
-  alignmentFactors?: DisplayValueAlignmentFactors;
-  /** Explicit font size control */
-  text?: VizTextDisplayOptions;
-  /** Specify which text should be visible in the BigValue */
-  textMode?: BigValueTextMode;
-  /** If true disables the tooltip */
-  hasLinks?: boolean;
-  /** Percent change color mode */
-  percentChangeColorMode?: PercentChangeColorMode;
-
-  /**
-   * If part of a series of stat panes, this is the total number.
-   * Used by BigValueTextMode.Auto text mode.
-   */
-  count?: number;
-
-  /**
-   * Disable the wide layout for the BigValue
-   */
-  disableWideLayout?: boolean;
-}
 
 /**
  * Component for showing a value based on a [DisplayValue](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/displayValue.ts#L5).

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.test.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.test.tsx
@@ -3,7 +3,6 @@ import { type CSSProperties } from 'react';
 import { createTheme, FieldType } from '@grafana/data';
 import { PercentChangeColorMode } from '@grafana/schema';
 
-import { type Props, BigValueColorMode, BigValueGraphMode, BigValueTextMode } from './BigValue';
 import {
   buildLayout,
   getPercentChangeColor,
@@ -11,6 +10,7 @@ import {
   StackedWithNoChartLayout,
   WideWithChartLayout,
 } from './BigValueLayout';
+import { type Props, BigValueColorMode, BigValueGraphMode, BigValueTextMode } from './BigValueTypes';
 
 function getProps(propOverrides?: Partial<Props>): Props {
   const props: Props = {

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -15,7 +15,7 @@ import { getTextColorForAlphaBackground } from '../../utils/colors';
 import { calculateFontSize } from '../../utils/measureText';
 import { Sparkline } from '../Sparkline/Sparkline';
 
-import { BigValueColorMode, type Props, BigValueJustifyMode, BigValueTextMode } from './BigValue';
+import { BigValueColorMode, type Props, BigValueJustifyMode, BigValueTextMode } from './BigValueTypes';
 import { percentChangeString } from './PercentChange';
 
 const LINE_HEIGHT = 1.2;

--- a/packages/grafana-ui/src/components/BigValue/BigValueTypes.ts
+++ b/packages/grafana-ui/src/components/BigValue/BigValueTypes.ts
@@ -1,0 +1,77 @@
+import { type MouseEventHandler } from 'react';
+
+import { type DisplayValue, type DisplayValueAlignmentFactors, type FieldSparkline } from '@grafana/data';
+import { type PercentChangeColorMode, type VizTextDisplayOptions } from '@grafana/schema';
+
+import { type Themeable2 } from '../../types/theme';
+
+export enum BigValueColorMode {
+  Background = 'background',
+  BackgroundSolid = 'background_solid',
+  None = 'none',
+  Value = 'value',
+}
+
+export enum BigValueGraphMode {
+  None = 'none',
+  Line = 'line',
+  Area = 'area',
+}
+
+export enum BigValueJustifyMode {
+  Auto = 'auto',
+  Center = 'center',
+}
+
+/**
+ * Options for how the value & title are to be displayed
+ */
+export enum BigValueTextMode {
+  Auto = 'auto',
+  Value = 'value',
+  ValueAndName = 'value_and_name',
+  Name = 'name',
+  None = 'none',
+}
+
+export interface Props extends Themeable2 {
+  /** Height of the component */
+  height: number;
+  /** Width of the component */
+  width: number;
+  /** Value displayed as Big Value */
+  value: DisplayValue;
+  /** Sparkline values for showing a graph under/behind the value  */
+  sparkline?: FieldSparkline;
+  /** onClick handler for the value */
+  onClick?: MouseEventHandler<HTMLElement>;
+  /** Custom styling */
+  className?: string;
+  /** Color mode for coloring the value or the background */
+  colorMode: BigValueColorMode;
+  /** Show a graph behind/under the value */
+  graphMode: BigValueGraphMode;
+  /** Auto justify value and text or center it */
+  justifyMode?: BigValueJustifyMode;
+  /** Factors that should influence the positioning of the text  */
+  alignmentFactors?: DisplayValueAlignmentFactors;
+  /** Explicit font size control */
+  text?: VizTextDisplayOptions;
+  /** Specify which text should be visible in the BigValue */
+  textMode?: BigValueTextMode;
+  /** If true disables the tooltip */
+  hasLinks?: boolean;
+  /** Percent change color mode */
+  percentChangeColorMode?: PercentChangeColorMode;
+
+  /**
+   * If part of a series of stat panes, this is the total number.
+   * Used by BigValueTextMode.Auto text mode.
+   */
+  count?: number;
+
+  /**
+   * Disable the wide layout for the BigValue
+   */
+  disableWideLayout?: boolean;
+}

--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -129,13 +129,13 @@ export { Counter } from './components/Tabs/Counter';
 export { RenderUserContentAsHTML } from './components/RenderUserContentAsHTML/RenderUserContentAsHTML';
 
 // Visualizations
+export { BigValue } from './components/BigValue/BigValue';
 export {
-  BigValue,
   BigValueColorMode,
   BigValueGraphMode,
   BigValueJustifyMode,
   BigValueTextMode,
-} from './components/BigValue/BigValue';
+} from './components/BigValue/BigValueTypes';
 export { Sparkline } from './components/Sparkline/Sparkline';
 
 export { BarGauge } from './components/BarGauge/BarGauge';


### PR DESCRIPTION
**What is this feature?**

Breaks the circular dependency between `BigValue` and `BigValueLayout` by moving the shared enums (`BigValueColorMode`, `BigValueGraphMode`, `BigValueJustifyMode`, `BigValueTextMode`) and the `Props` interface into a new `BigValueTypes.ts`. Both files now import from there instead of from each other.

**Why do we need this feature?**

So `@grafana/ui` has one fewer circular dependency.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #117123

**Special notes for your reviewer:**

The enums are still re-exported from `@grafana/ui` via `index.ts`, so the public API is unchanged. `madge` confirms the cycle is gone, and the existing `BigValue` tests still pass.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
