### PR TITLE
Snapshots: Save dashboard data and verify panel title interpolation

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboards-repeats-snapshots.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-repeats-snapshots.spec.ts
@@ -25,6 +25,19 @@ async function expectRepeatPanelsRendered(
   await expect(repeatedPanels.first()).toBeVisible();
 }
 
+async function expectRepeatPanelTitlesInterpolated(
+  dashboardPage: DashboardPage,
+  selectors: E2ESelectorGroups,
+  expectedTitles: string[]
+) {
+  for (const title of expectedTitles) {
+    const panel = dashboardPage
+      .getByGrafanaSelector(selectors.components.Panels.Panel.headerContainer)
+      .filter({ hasText: new RegExp(`^${title}$`) });
+    await expect(panel).toBeVisible();
+  }
+}
+
 async function publishDashboardSnapshot(
   page: Page,
   dashboardPage: DashboardPage,
@@ -71,6 +84,9 @@ test.describe(
       // Sanity check: repeats exist before snapshot.
       await expectRepeatPanelsRendered(dashboardPage, selectors, repeatOptions.length);
 
+      const expectedTitlesBefore = repeatOptions.map((opt) => `${repeatTitleBase}${opt}`);
+      await expectRepeatPanelTitlesInterpolated(dashboardPage, selectors, expectedTitlesBefore);
+
       // Open share drawer -> Share snapshot.
       await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.DashNav.newShareButton.arrowMenu).click();
       await dashboardPage
@@ -83,6 +99,9 @@ test.describe(
 
       // Regression: snapshot must include repeat clones; otherwise panels are missing / fail to render.
       await expectRepeatPanelsRendered(dashboardPage, selectors, repeatOptions.length);
+
+      const expectedTitlesInSnapshot = repeatOptions.map((opt) => `${repeatTitleBase}${opt}`);
+      await expectRepeatPanelTitlesInterpolated(dashboardPage, selectors, expectedTitlesInSnapshot);
     });
 
     test('dashboard snapshot renders repeated panels (auto grid)', async ({ dashboardPage, selectors, page }) => {
@@ -102,6 +121,9 @@ test.describe(
 
       await expectRepeatPanelsRendered(dashboardPage, selectors, repeatOptions.length);
 
+      const expectedTitlesBefore = repeatOptions.map((opt) => `${repeatTitleBase}${opt}`);
+      await expectRepeatPanelTitlesInterpolated(dashboardPage, selectors, expectedTitlesBefore);
+
       await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.DashNav.newShareButton.arrowMenu).click();
       await dashboardPage
         .getByGrafanaSelector(selectors.pages.Dashboard.DashNav.newShareButton.menu.shareSnapshot)
@@ -112,6 +134,9 @@ test.describe(
       await expect(dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Controls)).toBeVisible();
 
       await expectRepeatPanelsRendered(dashboardPage, selectors, repeatOptions.length);
+
+      const expectedTitlesInSnapshot = repeatOptions.map((opt) => `${repeatTitleBase}${opt}`);
+      await expectRepeatPanelTitlesInterpolated(dashboardPage, selectors, expectedTitlesInSnapshot);
     });
   }
 );

--- a/pkg/services/dashboardsnapshots/database/database.go
+++ b/pkg/services/dashboardsnapshots/database/database.go
@@ -46,15 +46,16 @@ func (d *DashboardSnapshotStore) DeleteExpiredSnapshots(ctx context.Context, cmd
 
 func (d *DashboardSnapshotStore) CreateDashboardSnapshot(ctx context.Context, cmd *dashboardsnapshots.CreateDashboardSnapshotCommand) (*dashboardsnapshots.DashboardSnapshot, error) {
 	var result *dashboardsnapshots.DashboardSnapshot
+
+	dashboardJSON := simplejson.New()
+	if cmd.Dashboard != nil && cmd.Dashboard.Object != nil {
+		dashboardJSON = simplejson.NewFromAny(cmd.Dashboard.Object)
+	}
+
 	err := d.store.WithDbSession(ctx, func(sess *db.Session) error {
 		var expires = time.Now().Add(time.Hour * 24 * 365 * 50)
 		if cmd.Expires > 0 {
 			expires = time.Now().Add(time.Second * time.Duration(cmd.Expires))
-		}
-
-		dashboardJSON := simplejson.New()
-		if cmd.Dashboard != nil && cmd.Dashboard.Object != nil {
-			dashboardJSON = simplejson.NewFromAny(cmd.Dashboard.Object)
 		}
 
 		snapshot := &dashboardsnapshots.DashboardSnapshot{

--- a/pkg/services/dashboardsnapshots/database/database.go
+++ b/pkg/services/dashboardsnapshots/database/database.go
@@ -52,6 +52,11 @@ func (d *DashboardSnapshotStore) CreateDashboardSnapshot(ctx context.Context, cm
 			expires = time.Now().Add(time.Second * time.Duration(cmd.Expires))
 		}
 
+		dashboardJSON := simplejson.New()
+		if cmd.Dashboard != nil && cmd.Dashboard.Object != nil {
+			dashboardJSON = simplejson.NewFromAny(cmd.Dashboard.Object)
+		}
+
 		snapshot := &dashboardsnapshots.DashboardSnapshot{
 			Name:               cmd.Name,
 			Key:                cmd.Key,
@@ -61,7 +66,7 @@ func (d *DashboardSnapshotStore) CreateDashboardSnapshot(ctx context.Context, cm
 			External:           cmd.External,
 			ExternalURL:        cmd.ExternalURL,
 			ExternalDeleteURL:  cmd.ExternalDeleteURL,
-			Dashboard:          simplejson.New(),
+			Dashboard:          dashboardJSON,
 			DashboardEncrypted: cmd.DashboardEncrypted,
 			Expires:            expires,
 			Created:            time.Now(),


### PR DESCRIPTION
Snapshots: Save dashboard data and verify panel title interpolation

fixes issue #126159

Root Cause: The backend snapshot database function was ignoring cmd.Dashboard and saving an empty JSON object instead. This caused all panel data (including scopedVars needed for variable interpolation) to be lost.

Changes:
1. pkg/services/dashboardsnapshots/database/database.go:
   - Fix CreateDashboardSnapshot to actually save cmd.Dashboard instead of empty JSON
   - Convert cmd.Dashboard (Unstructured) to simplejson for storage

2. e2e-playwright/dashboard-new-layouts/dashboards-repeats-snapshots.spec.ts:
   - Add expectRepeatPanelTitlesInterpolated() helper to verify panel titles
   - Enhance existing tests to verify panel titles are correctly interpolated
   - Add regression tests to ensure titles aren't set to 'All'

Fixes the regression in Grafana 13.0.1 where snapshot panel titles were not being interpolated correctly.
