### PR TITLE
Resource permissions: redirects hard fail

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -75,6 +75,12 @@ func (a *api) getFallbackStatus(ctx context.Context) string {
 	return "success"
 }
 
+// unifiedStorageIsAuthoritative returns true when unified storage is the authoritative
+// backend (Mode4 or Mode5). In that case K8s redirect failures must not fall back to legacy.
+func (a *api) unifiedStorageIsAuthoritative(groupResource string) bool {
+	return a.cfg.UnifiedStorageConfig(groupResource).DualWriterMode > grafanarest.Mode3
+}
+
 func (a *api) registerEndpoints() {
 	auth := accesscontrol.Middleware(a.ac)
 	licenseMW := a.service.options.LicenseMW
@@ -225,6 +231,10 @@ func (a *api) getPermissions(c *contextmodel.ReqContext) response.Response {
 		teamPermissions, err := a.getTeamPermissionsFromMembers(c, c.Namespace, resourceID)
 		if err != nil {
 			span.RecordError(err)
+			if a.unifiedStorageIsAuthoritative(iamv0.TeamResourceInfo.GroupResource().String()) {
+				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "get", a.service.options.Resource, "error").Inc()
+				return response.ErrOrFallback(http.StatusInternalServerError, "Failed to get team permissions from k8s API", err)
+			}
 			if errors.Is(err, ErrRestConfigNotAvailable) {
 				a.logger.Debug("k8s API not available for team permissions via team members, falling back to legacy", "error", err, "resourceID", resourceID)
 			} else {
@@ -238,15 +248,20 @@ func (a *api) getPermissions(c *contextmodel.ReqContext) response.Response {
 
 	if a.service.options.Resource != "teams" && a.shouldUseK8sAPIs(ctx) {
 		k8sPermissions, err := a.getResourcePermissionsFromK8s(c, c.Namespace, resourceID)
-		if err == nil {
+		if err != nil {
+			span.RecordError(err)
+			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
+				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "get", a.service.options.Resource, "error").Inc()
+				return response.ErrOrFallback(http.StatusInternalServerError, "Failed to get resource permissions from k8s API", err)
+			}
+			if errors.Is(err, ErrRestConfigNotAvailable) {
+				a.logger.Debug("k8s API not available for resource permissions, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			} else {
+				a.logger.Warn("Failed to get resource permissions from k8s API, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			}
+		} else {
 			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "get", a.service.options.Resource, "success").Inc()
 			return response.JSON(http.StatusOK, k8sPermissions)
-		}
-		span.RecordError(err)
-		if errors.Is(err, ErrRestConfigNotAvailable) {
-			a.logger.Debug("k8s API not available for resource permissions, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
-		} else {
-			a.logger.Warn("Failed to get resource permissions from k8s API, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
 		}
 	}
 
@@ -384,8 +399,9 @@ func (a *api) setUserPermission(c *contextmodel.ReqContext) response.Response {
 		// In Mode4/5 unified storage is authoritative: return the K8s result and do not fall
 		// back to legacy (which would fail for identities that exist only in unified storage).
 		// In Mode0-3 we dual-write, so continue to the legacy path below.
-		if a.cfg.UnifiedStorageConfig(iamv0.TeamResourceInfo.GroupResource().String()).DualWriterMode > grafanarest.Mode3 {
+		if a.unifiedStorageIsAuthoritative(iamv0.TeamResourceInfo.GroupResource().String()) {
 			if err != nil {
+				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", a.service.options.Resource, "error").Inc()
 				return response.Err(err)
 			}
 			return permissionSetResponse(cmd)
@@ -394,15 +410,22 @@ func (a *api) setUserPermission(c *contextmodel.ReqContext) response.Response {
 
 	if a.service.options.Resource != "teams" && a.shouldUseK8sAPIs(ctx) {
 		err := a.setUserPermissionToK8s(c, c.Namespace, resourceID, userID, cmd.Permission)
-		if err == nil {
-			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", a.service.options.Resource, "success").Inc()
-			return permissionSetResponse(cmd)
-		}
-		span.RecordError(err)
-		if errors.Is(err, ErrRestConfigNotAvailable) {
-			a.logger.Debug("k8s API not available for resource permissions, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+		if err != nil {
+			span.RecordError(err)
+			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
+				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", a.service.options.Resource, "error").Inc()
+				return response.ErrOrFallback(http.StatusInternalServerError, "Failed to set user permission in k8s API", err)
+			}
+			if errors.Is(err, ErrRestConfigNotAvailable) {
+				a.logger.Debug("k8s API not available for resource permissions, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			} else {
+				a.logger.Warn("Failed to set user permission in k8s API, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			}
 		} else {
-			a.logger.Warn("Failed to set user permission in k8s API, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", a.service.options.Resource, "success").Inc()
+			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
+				return permissionSetResponse(cmd)
+			}
 		}
 	}
 
@@ -476,15 +499,22 @@ func (a *api) setTeamPermission(c *contextmodel.ReqContext) response.Response {
 
 	if a.shouldUseK8sAPIs(ctx) {
 		err := a.setTeamPermissionToK8s(c, c.Namespace, resourceID, teamID, cmd.Permission)
-		if err == nil {
-			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_team", a.service.options.Resource, "success").Inc()
-			return permissionSetResponse(cmd)
-		}
-		span.RecordError(err)
-		if errors.Is(err, ErrRestConfigNotAvailable) {
-			a.logger.Debug("k8s API not available for resource permissions, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+		if err != nil {
+			span.RecordError(err)
+			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
+				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_team", a.service.options.Resource, "error").Inc()
+				return response.ErrOrFallback(http.StatusInternalServerError, "Failed to set team permission in k8s API", err)
+			}
+			if errors.Is(err, ErrRestConfigNotAvailable) {
+				a.logger.Debug("k8s API not available for resource permissions, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			} else {
+				a.logger.Warn("Failed to set team permission in k8s API, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			}
 		} else {
-			a.logger.Warn("Failed to set team permission in k8s API, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_team", a.service.options.Resource, "success").Inc()
+			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
+				return permissionSetResponse(cmd)
+			}
 		}
 	}
 
@@ -555,13 +585,22 @@ func (a *api) setBuiltinRolePermission(c *contextmodel.ReqContext) response.Resp
 
 	if a.shouldUseK8sAPIs(ctx) {
 		err := a.setBuiltInRolePermissionToK8s(c, c.Namespace, resourceID, builtInRole, cmd.Permission)
-		if err == nil {
+		if err != nil {
+			span.RecordError(err)
+			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
+				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_builtin_role", a.service.options.Resource, "error").Inc()
+				return response.ErrOrFallback(http.StatusInternalServerError, "Failed to set built-in role permission in k8s API", err)
+			}
+			if errors.Is(err, ErrRestConfigNotAvailable) {
+				a.logger.Debug("k8s API not available for resource permissions, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			} else {
+				a.logger.Warn("Failed to set built-in role permission in k8s API, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			}
+		} else {
 			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_builtin_role", a.service.options.Resource, "success").Inc()
-			return permissionSetResponse(cmd)
-		}
-		span.RecordError(err)
-		if errors.Is(err, ErrRestConfigNotAvailable) {
-			a.logger.Debug("k8s API not available for resource permissions, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
+				return permissionSetResponse(cmd)
+			}
 		}
 	}
 
@@ -627,13 +666,22 @@ func (a *api) setPermissions(c *contextmodel.ReqContext) response.Response {
 
 	if a.shouldUseK8sAPIs(ctx) {
 		err := a.setResourcePermissionsToK8s(c, c.Namespace, resourceID, cmd.Permissions)
-		if err == nil {
+		if err != nil {
+			span.RecordError(err)
+			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
+				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_bulk", a.service.options.Resource, "error").Inc()
+				return response.ErrOrFallback(http.StatusInternalServerError, "Failed to set resource permissions in k8s API", err)
+			}
+			if errors.Is(err, ErrRestConfigNotAvailable) {
+				a.logger.Debug("k8s API not available for resource permissions, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			} else {
+				a.logger.Warn("Failed to set resource permissions in k8s API, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			}
+		} else {
 			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_bulk", a.service.options.Resource, "success").Inc()
-			return response.Success("Permissions updated")
-		}
-		span.RecordError(err)
-		if errors.Is(err, ErrRestConfigNotAvailable) {
-			a.logger.Debug("k8s API not available for resource permissions, falling back to legacy", "error", err, "resourceID", resourceID, "resource", a.service.options.Resource)
+			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
+				return response.Success("Permissions updated")
+			}
 		}
 	}
 

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -423,9 +423,7 @@ func (a *api) setUserPermission(c *contextmodel.ReqContext) response.Response {
 			}
 		} else {
 			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", a.service.options.Resource, "success").Inc()
-			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
-				return permissionSetResponse(cmd)
-			}
+			return permissionSetResponse(cmd)
 		}
 	}
 
@@ -512,9 +510,7 @@ func (a *api) setTeamPermission(c *contextmodel.ReqContext) response.Response {
 			}
 		} else {
 			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_team", a.service.options.Resource, "success").Inc()
-			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
-				return permissionSetResponse(cmd)
-			}
+			return permissionSetResponse(cmd)
 		}
 	}
 
@@ -598,9 +594,7 @@ func (a *api) setBuiltinRolePermission(c *contextmodel.ReqContext) response.Resp
 			}
 		} else {
 			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_builtin_role", a.service.options.Resource, "success").Inc()
-			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
-				return permissionSetResponse(cmd)
-			}
+			return permissionSetResponse(cmd)
 		}
 	}
 
@@ -679,9 +673,7 @@ func (a *api) setPermissions(c *contextmodel.ReqContext) response.Response {
 			}
 		} else {
 			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_bulk", a.service.options.Resource, "success").Inc()
-			if a.unifiedStorageIsAuthoritative(iamv0.ResourcePermissionInfo.GroupResource().String()) {
-				return response.Success("Permissions updated")
-			}
+			return response.Success("Permissions updated")
 		}
 	}
 

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -609,6 +609,109 @@ func TestIntegrationApi_setUserPermissionForTeams(t *testing.T) {
 	}
 }
 
+// Verifies the ResourcePermission redirect falls back to legacy only in Mode0-3. With no rest
+// config the K8s write fails, so Mode0-3 falls back (200) and Mode4/5 returns the error (500).
+func TestIntegrationApi_setUserPermission_dualWriterModeFallback(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	tests := []struct {
+		name           string
+		mode           grafanarest.DualWriterMode
+		expectedStatus int
+	}{
+		{name: "Mode3 falls back to legacy", mode: grafanarest.Mode3, expectedStatus: http.StatusOK},
+		{name: "Mode5 does not fall back", mode: grafanarest.Mode5, expectedStatus: http.StatusInternalServerError},
+	}
+
+	perms := []accesscontrol.Permission{
+		{Action: "dashboards.permissions:read", Scope: "dashboards:id:1"},
+		{Action: "dashboards.permissions:write", Scope: "dashboards:id:1"},
+		{Action: accesscontrol.ActionOrgUsersRead, Scope: accesscontrol.ScopeUsersAll},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setOpenFeatureFlags(t, map[string]bool{
+				featuremgmt.FlagKubernetesAuthZResourcePermissionsRedirect: true,
+				featuremgmt.FlagKubernetesAuthzResourcePermissionApis:      true,
+			})
+
+			service, usrSvc, _, cfg := setupTestEnvironmentWithCfg(t, testOptions, featuremgmt.WithFeatures())
+			cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+				iamv0.ResourcePermissionInfo.GroupResource().String(): {DualWriterMode: tt.mode},
+			}
+
+			server := setupTestServer(t, &user.SignedInUser{
+				OrgID:       1,
+				Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByActionContext(context.Background(), perms)},
+			}, service)
+
+			createdUser, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test", OrgID: 1})
+			require.NoError(t, err)
+
+			recorder := setPermission(t, server, testOptions.Resource, "1", "Edit", "users", strconv.Itoa(int(createdUser.ID)))
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+
+			if tt.expectedStatus == http.StatusOK {
+				permissions, _ := getPermission(t, server, testOptions.Resource, "1")
+				require.Len(t, permissions, 1)
+				assert.Equal(t, "Edit", permissions[0].Permission)
+				assert.Equal(t, createdUser.ID, permissions[0].UserID)
+			}
+		})
+	}
+}
+
+// Verifies the ResourcePermission redirect read falls back to legacy only in Mode0-3. With no rest
+// config the K8s read fails, so Mode0-3 falls back to seeded legacy permissions (200) and Mode4/5
+// returns the error (500).
+func TestIntegrationApi_getPermissions_dualWriterModeFallback(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	tests := []struct {
+		name           string
+		mode           grafanarest.DualWriterMode
+		expectedStatus int
+	}{
+		{name: "Mode3 falls back to legacy", mode: grafanarest.Mode3, expectedStatus: http.StatusOK},
+		{name: "Mode5 does not fall back", mode: grafanarest.Mode5, expectedStatus: http.StatusInternalServerError},
+	}
+
+	perms := []accesscontrol.Permission{
+		{Action: "dashboards.permissions:read", Scope: "dashboards:id:1"},
+		{Action: accesscontrol.ActionTeamsRead, Scope: accesscontrol.ScopeTeamsAll},
+		{Action: accesscontrol.ActionOrgUsersRead, Scope: accesscontrol.ScopeUsersAll},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setOpenFeatureFlags(t, map[string]bool{
+				featuremgmt.FlagKubernetesAuthZResourcePermissionsRedirect: true,
+				featuremgmt.FlagKubernetesAuthzResourcePermissionApis:      true,
+			})
+
+			service, usrSvc, teamSvc, cfg := setupTestEnvironmentWithCfg(t, testOptions, featuremgmt.WithFeatures())
+			cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+				iamv0.ResourcePermissionInfo.GroupResource().String(): {DualWriterMode: tt.mode},
+			}
+
+			server := setupTestServer(t, &user.SignedInUser{
+				OrgID:       1,
+				Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByActionContext(context.Background(), perms)},
+			}, service)
+
+			seedPermissions(t, "1", usrSvc, teamSvc, service)
+
+			permissions, recorder := getPermission(t, server, testOptions.Resource, "1")
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+
+			if tt.expectedStatus == http.StatusOK {
+				checkSeededPermissions(t, permissions)
+			}
+		})
+	}
+}
+
 // Verifies the team-members write falls back to legacy only in Mode0-3. With no rest config
 // the K8s write fails, so Mode0-3 falls back (200) and Mode4/5 returns the error (500).
 func TestIntegrationApi_setUserPermissionForTeams_dualWriterModeFallback(t *testing.T) {
@@ -660,11 +763,20 @@ var openFeatureTestMu sync.Mutex
 // setOpenFeatureFlag sets the global OpenFeature provider so flag resolves to value for the test.
 func setOpenFeatureFlag(t *testing.T, flag string, value bool) {
 	t.Helper()
+	setOpenFeatureFlags(t, map[string]bool{flag: value})
+}
+
+// setOpenFeatureFlags sets multiple flags on the global OpenFeature provider for the test.
+func setOpenFeatureFlags(t *testing.T, flags map[string]bool) {
+	t.Helper()
 	openFeatureTestMu.Lock()
 
-	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
-		flag: {Key: flag, Variants: map[string]any{"": value}},
-	})
+	flagMap := make(map[string]memprovider.InMemoryFlag, len(flags))
+	for flag, value := range flags {
+		flagMap[flag] = memprovider.InMemoryFlag{Key: flag, Variants: map[string]any{"": value}}
+	}
+
+	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(flagMap)
 	require.NoError(t, err)
 	require.NoError(t, openfeature.SetProviderAndWait(provider))
 


### PR DESCRIPTION
Context: mode 5 enablement / enforce hard fails https://github.com/grafana/identity-access-team/issues/2097
Tested on local tilt setup.