### PR TITLE
SQLStore: exponential backoff with jitter for SQLITE_BUSY transaction retries

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -214,8 +214,8 @@ locking_attempt_timeout_sec = 0
 # For "sqlite" only. How many times to retry query in case of database is locked failures. Default is 0 (disabled).
 query_retries = 0
 
-# For "sqlite" only. How many times to retry transaction in case of database is locked failures. Default is 5.
-transaction_retries = 5
+# For "sqlite" only. How many times to retry transaction in case of database is locked failures. Default is 10.
+transaction_retries = 10
 
 # Set to true to add metrics and tracing for database queries.
 instrument_queries = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -200,8 +200,8 @@
 # For "sqlite" only. How many times to retry query in case of database is locked failures. Default is 0 (disabled).
 ;query_retries = 0
 
-# For "sqlite" only. How many times to retry transaction in case of database is locked failures. Default is 5.
-;transaction_retries = 5
+# For "sqlite" only. How many times to retry transaction in case of database is locked failures. Default is 10.
+;transaction_retries = 10
 
 # Set to true to add metrics and tracing for database queries.
 ;instrument_queries = false

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -124,7 +124,7 @@ func (dbCfg *DatabaseConfig) readConfig(cfg *setting.Cfg) error {
 	dbCfg.MigrationLockAttemptTimeout = sec.Key("locking_attempt_timeout_sec").MustInt()
 
 	dbCfg.QueryRetries = sec.Key("query_retries").MustInt()
-	dbCfg.TransactionRetries = sec.Key("transaction_retries").MustInt(5)
+	dbCfg.TransactionRetries = sec.Key("transaction_retries").MustInt(10)
 
 	dbCfg.LogQueries = sec.Key("log_queries").MustBool(false)
 	dbCfg.DeleteAutoGenIDs = sec.Key("delete_auto_gen_ids").MustBool(false)

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -3,6 +3,7 @@ package sqlstore
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"time"
 
 	"github.com/grafana/grafana/pkg/util/xorm"
@@ -12,6 +13,26 @@ import (
 )
 
 var tsclogger = log.New("sqlstore.transactions")
+
+// SQLITE_BUSY backoff parameters for retrying transactions. We use exponential
+// backoff with full jitter so concurrent writers don't all wake up and collide
+// again on the same tick.
+const (
+	txnRetryBaseDelay = 100 * time.Millisecond
+	txnRetryMaxDelay  = 2 * time.Second
+)
+
+// txnRetryBackoff returns the sleep duration for the given retry attempt
+// (0-indexed): a uniformly random value in [0, capped exponential delay).
+//
+// The exponential delay doubles each retry (100ms, 200ms, 400ms, ...) and is
+// clamped to txnRetryMaxDelay. The retry count is clamped before shifting so
+// that large TransactionRetries values can't overflow the shift.
+func txnRetryBackoff(retry int) time.Duration {
+	retry = min(retry, 10)
+	delay := min(txnRetryBaseDelay<<retry, txnRetryMaxDelay)
+	return rand.N(delay)
+}
 
 // WithTransactionalDbSession calls the callback with a session within a transaction.
 func (ss *SQLStore) WithTransactionalDbSession(ctx context.Context, callback DBTransactionFunc) error {
@@ -61,15 +82,17 @@ func (ss *SQLStore) inTransactionWithRetryCtx(ctx context.Context, engine *xorm.
 		return err
 	}
 
-	// special handling of database locked errors for sqlite, then we can retry 5 times
+	// Special handling of database-locked errors for SQLite: retry with exponential
+	// backoff and jitter, up to TransactionRetries times.
 	if r, ok := engine.Dialect().(xorm.DialectWithRetryableErrors); ok {
 		if retry < ss.dbCfg.TransactionRetries && r.RetryOnError(err) {
 			if rollErr := sess.Rollback(); rollErr != nil {
 				return fmt.Errorf("rolling back transaction due to error failed: %s: %w", rollErr, err)
 			}
 
-			time.Sleep(time.Millisecond * time.Duration(10))
-			ctxLogger.Info("Database locked, sleeping then retrying", "error", err, "retry", retry)
+			sleep := txnRetryBackoff(retry)
+			ctxLogger.Info("Database locked, sleeping then retrying", "error", err, "retry", retry, "sleep", sleep)
+			time.Sleep(sleep)
 			return ss.inTransactionWithRetryCtx(ctx, engine, bus, callback, retry+1)
 		}
 	}

--- a/pkg/services/sqlstore/transactions_test.go
+++ b/pkg/services/sqlstore/transactions_test.go
@@ -4,11 +4,24 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestTxnRetryBackoff(t *testing.T) {
+	// The cap on the exponential ramp; once we hit it the delay should stay at
+	// the max regardless of how high retry climbs.
+	for _, retry := range []int{0, 1, 2, 4, 5, 10, 62, 63, 100, 1000} {
+		for range 100 {
+			d := txnRetryBackoff(retry)
+			require.GreaterOrEqual(t, d, time.Duration(0))
+			require.Less(t, d, txnRetryMaxDelay)
+		}
+	}
+}
 
 func TestIntegrationReuseSessionWithTransaction(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)


### PR DESCRIPTION
When a SQLite write hits SQLITE_BUSY, WithTransactionalDbSession retries the transaction. Today the retry uses a constant 10 ms sleep with 5 retries (worst case 50 ms total), which is too short for the contention we actually see. The symptom in CI is e.g. plugin signature key writes failing during server startup, which then cascades into plugin signature verification errors and flaky e2e tests (e.g. advisor.spec.ts).

Changes:
- Replace the constant 10 ms sleep with exponential backoff capped at 2 s, with full jitter so concurrent writers don't wake up on the same tick and immediately collide again.
- Bump the default `transaction_retries` from 5 to 10.

Not included in this PR (worth a follow-up): the non-transactional retry path (`WithDbSession` -> `retryOnLocks` -> `pkg/util/retryer`) has its own retry logic with exponential backoff but no jitter, and its `query_retries` config defaults to 0 (no retries). Adding jitter to `pkg/util/retryer` would benefit all callers; deferred so we can audit those callers separately.
