### PR TITLE
Table: Reduce circular dependencies in utils

### DIFF
--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -9,8 +9,8 @@ import { Stack } from '../Layout/Stack/Stack';
 import { type TooltipPlacement } from '../Tooltip/types';
 
 import { TableCellInspectorMode } from './TableCellInspector';
+import { getTextAlign } from './cellUtils';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR, type TableCellProps } from './types';
-import { getTextAlign } from './utils';
 
 interface CellActionProps extends TableCellProps {
   previewMode: TableCellInspectorMode;

--- a/packages/grafana-ui/src/components/Table/Cells/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/BarGaugeCell.tsx
@@ -5,13 +5,13 @@ import { BarGaugeDisplayMode, BarGaugeValueMode, TableCellDisplayMode } from '@g
 
 import { BarGauge } from '../../BarGauge/BarGauge';
 import { DataLinksActionsTooltip, renderSingleLink } from '../DataLinksActionsTooltip';
-import { type TableCellProps } from '../types';
 import {
   type DataLinksActionsTooltipCoords,
   getAlignmentFactor,
   getCellOptions,
   getDataLinksActionsTooltipUtils,
-} from '../utils';
+} from '../cellUtils';
+import { type TableCellProps } from '../types';
 
 const defaultScale: ThresholdsConfig = {
   mode: ThresholdsMode.Absolute,

--- a/packages/grafana-ui/src/components/Table/Cells/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/DefaultCell.tsx
@@ -9,14 +9,14 @@ import { CellActions } from '../CellActions';
 import { DataLinksActionsTooltip, renderSingleLink } from '../DataLinksActionsTooltip';
 import { TableCellInspectorMode } from '../TableCellInspector';
 import { type TableStyles } from '../TableRT/styles';
-import { type TableCellProps, type CustomCellRendererProps, type TableCellOptions } from '../types';
 import {
   type DataLinksActionsTooltipCoords,
   getCellColors,
   getCellOptions,
   getDataLinksActionsTooltipUtils,
   tooltipOnClickHandler,
-} from '../utils';
+} from '../cellUtils';
+import { type TableCellProps, type CustomCellRendererProps, type TableCellOptions } from '../types';
 
 export const DefaultCell = (props: TableCellProps) => {
   const { field, cell, tableStyles, row, cellProps, frame, rowStyled, rowExpanded, textWrapped, height } = props;

--- a/packages/grafana-ui/src/components/Table/Cells/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/ImageCell.tsx
@@ -2,13 +2,13 @@ import { useState } from 'react';
 
 import { getCellLinks } from '../../../utils/table';
 import { DataLinksActionsTooltip, renderSingleLink } from '../DataLinksActionsTooltip';
-import { TableCellDisplayMode, type TableCellProps } from '../types';
 import {
   tooltipOnClickHandler,
   type DataLinksActionsTooltipCoords,
   getCellOptions,
   getDataLinksActionsTooltipUtils,
-} from '../utils';
+} from '../cellUtils';
+import { TableCellDisplayMode, type TableCellProps } from '../types';
 
 const DATALINKS_HEIGHT_OFFSET = 10;
 

--- a/packages/grafana-ui/src/components/Table/Cells/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/JSONViewCell.tsx
@@ -5,8 +5,12 @@ import { getCellLinks } from '../../../utils/table';
 import { CellActions } from '../CellActions';
 import { DataLinksActionsTooltip, renderSingleLink } from '../DataLinksActionsTooltip';
 import { TableCellInspectorMode } from '../TableCellInspector';
+import {
+  tooltipOnClickHandler,
+  type DataLinksActionsTooltipCoords,
+  getDataLinksActionsTooltipUtils,
+} from '../cellUtils';
 import { type TableCellProps } from '../types';
-import { tooltipOnClickHandler, type DataLinksActionsTooltipCoords, getDataLinksActionsTooltipUtils } from '../utils';
 
 export function JSONViewCell(props: TableCellProps): JSX.Element {
   const { cell, tableStyles, cellProps, field, row } = props;

--- a/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx
@@ -25,8 +25,8 @@ import { useTheme2 } from '../../../themes/ThemeContext';
 import { measureText } from '../../../utils/measureText';
 import { FormattedValueDisplay } from '../../FormattedValueDisplay/FormattedValueDisplay';
 import { Sparkline } from '../../Sparkline/Sparkline';
+import { getAlignmentFactor, getCellOptions } from '../cellUtils';
 import { type TableCellProps } from '../types';
-import { getAlignmentFactor, getCellOptions } from '../utils';
 
 export const defaultSparklineCellConfig: TableSparklineCellOptions = {
   type: TableCellDisplayMode.Sparkline,

--- a/packages/grafana-ui/src/components/Table/DataLinksActionsTooltip.tsx
+++ b/packages/grafana-ui/src/components/Table/DataLinksActionsTooltip.tsx
@@ -11,7 +11,7 @@ import { Portal } from '../Portal/Portal';
 import { VizTooltipFooter } from '../VizTooltip/VizTooltipFooter';
 import { VizTooltipWrapper } from '../VizTooltip/VizTooltipWrapper';
 
-import { type DataLinksActionsTooltipCoords } from './utils';
+import { type DataLinksActionsTooltipCoords } from './cellUtils';
 
 interface Props {
   links: LinkModel[];

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -46,9 +46,9 @@ import { Pagination } from '../../Pagination/Pagination';
 import { type PanelContext, usePanelContext } from '../../PanelChrome';
 import { DataLinksActionsTooltip } from '../DataLinksActionsTooltip';
 import { TableCellInspector, TableCellInspectorMode } from '../TableCellInspector';
+import { type DataLinksActionsTooltipState } from '../cellUtils';
 import { hasGeoCell, LazyOpenLayersProvider } from '../geo';
 import { TableCellDisplayMode } from '../types';
-import { type DataLinksActionsTooltipState } from '../utils';
 
 import { getCellRenderer, getCellSpecificStyles } from './Cells/renderers';
 import { EmptyTablePlaceholder } from './components/EmptyTablePlaceholder';

--- a/packages/grafana-ui/src/components/Table/TableRT/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/RowsList.tsx
@@ -21,6 +21,7 @@ import { useTheme2 } from '../../../themes/ThemeContext';
 import { CustomScrollbar } from '../../CustomScrollbar/CustomScrollbar';
 import { usePanelContext } from '../../PanelChrome';
 import { TableCell } from '../Cells/TableCell';
+import { getCellColors } from '../cellUtils';
 import {
   type CellColors,
   type GetActionsFunction,
@@ -28,12 +29,7 @@ import {
   type TableFilterActionCallback,
   type TableInspectCellCallback,
 } from '../types';
-import {
-  calculateAroundPointThreshold,
-  getCellColors,
-  isPointTimeValAroundTableTimeVal,
-  guessTextBoundingBox,
-} from '../utils';
+import { calculateAroundPointThreshold, isPointTimeValAroundTableTimeVal, guessTextBoundingBox } from '../utils';
 
 import { ExpandedRow, getExpandedRowHeight } from './ExpandedRow';
 import { type TableStyles } from './styles';

--- a/packages/grafana-ui/src/components/Table/cellUtils.ts
+++ b/packages/grafana-ui/src/components/Table/cellUtils.ts
@@ -1,0 +1,236 @@
+import { type Property } from 'csstype';
+import tinycolor from 'tinycolor2';
+
+import {
+  type ActionModel,
+  type DisplayValue,
+  type DisplayValueAlignmentFactors,
+  type Field,
+  FieldType,
+  formattedValueToString,
+  type GrafanaTheme2,
+  type LinkModel,
+} from '@grafana/data';
+import {
+  BarGaugeDisplayMode,
+  type TableAutoCellOptions,
+  TableCellBackgroundDisplayMode,
+  TableCellDisplayMode,
+} from '@grafana/schema';
+
+import { getTextColorForAlphaBackground } from '../../utils/colors';
+
+import { type CellColors, type TableCellOptions, type TableFieldOptions } from './types';
+
+export function getTextAlign(field?: Field): Property.JustifyContent {
+  if (!field) {
+    return 'flex-start';
+  }
+
+  if (field.config.custom) {
+    const custom: TableFieldOptions = field.config.custom;
+
+    switch (custom.align) {
+      case 'right':
+        return 'flex-end';
+      case 'left':
+        return 'flex-start';
+      case 'center':
+        return 'center';
+    }
+  }
+
+  if (field.type === FieldType.number) {
+    return 'flex-end';
+  }
+
+  return 'flex-start';
+}
+
+const defaultCellOptions: TableAutoCellOptions = { type: TableCellDisplayMode.Auto };
+
+export function getCellOptions(field: Field): TableCellOptions {
+  if (field.config.custom?.displayMode) {
+    return migrateTableDisplayModeToCellOptions(field.config.custom?.displayMode);
+  }
+
+  if (!field.config.custom?.cellOptions) {
+    return defaultCellOptions;
+  }
+
+  return field.config.custom.cellOptions;
+}
+
+/**
+ * Migrates table cell display mode to new object format.
+ *
+ * @param displayMode The display mode of the cell
+ * @returns TableCellOptions object in the correct format
+ * relative to the old display mode.
+ */
+export function migrateTableDisplayModeToCellOptions(displayMode: TableCellDisplayMode): TableCellOptions {
+  switch (displayMode) {
+    // In the case of the gauge we move to a different option
+    case 'basic':
+    case 'gradient-gauge':
+    case 'lcd-gauge':
+      let gaugeMode = BarGaugeDisplayMode.Basic;
+
+      if (displayMode === 'gradient-gauge') {
+        gaugeMode = BarGaugeDisplayMode.Gradient;
+      } else if (displayMode === 'lcd-gauge') {
+        gaugeMode = BarGaugeDisplayMode.Lcd;
+      }
+
+      return {
+        type: TableCellDisplayMode.Gauge,
+        mode: gaugeMode,
+      };
+    // Also true in the case of the color background
+    case 'color-background':
+    case 'color-background-solid':
+      let mode = TableCellBackgroundDisplayMode.Basic;
+
+      // Set the new mode field, somewhat confusingly the
+      // color-background mode is for gradient display
+      if (displayMode === 'color-background') {
+        mode = TableCellBackgroundDisplayMode.Gradient;
+      }
+
+      return {
+        type: TableCellDisplayMode.ColorBackground,
+        mode: mode,
+      };
+    default:
+      // @ts-ignore TSGO / TS7
+      return {
+        // @ts-ignore TS5 / TS6
+        type: displayMode,
+      };
+  }
+}
+
+/**
+ * Getting gauge or sparkline values to align is very tricky without looking at all values and passing them through display processor.
+ * For very large tables that could pretty expensive. So this is kind of a compromise. We look at the first 1000 rows and cache the longest value.
+ * If we have a cached value we just check if the current value is longer and update the alignmentFactor. This can obviously still lead to
+ * unaligned gauges but it should a lot less common.
+ **/
+export function getAlignmentFactor(
+  field: Field,
+  displayValue: DisplayValue,
+  rowIndex: number
+): DisplayValueAlignmentFactors {
+  let alignmentFactor = field.state?.alignmentFactors;
+
+  if (alignmentFactor) {
+    // check if current alignmentFactor is still the longest
+    if (formattedValueToString(alignmentFactor).length < formattedValueToString(displayValue).length) {
+      alignmentFactor = { ...displayValue };
+      field.state!.alignmentFactors = alignmentFactor;
+    }
+    return alignmentFactor;
+  } else {
+    // look at the next 1000 rows
+    alignmentFactor = { ...displayValue };
+    const maxIndex = Math.min(field.values.length, rowIndex + 1000);
+
+    for (let i = rowIndex + 1; i < maxIndex; i++) {
+      const nextDisplayValue = field.display!(field.values[i]);
+      if (formattedValueToString(alignmentFactor).length > formattedValueToString(nextDisplayValue).length) {
+        alignmentFactor.text = displayValue.text;
+      }
+    }
+
+    if (field.state) {
+      field.state.alignmentFactors = alignmentFactor;
+    } else {
+      field.state = { alignmentFactors: alignmentFactor };
+    }
+
+    return alignmentFactor;
+  }
+}
+
+/**
+ * Retrieve colors for a table cell (or table row).
+ *
+ * @param tableStyles
+ *  Styles for the table
+ * @param cellOptions
+ *  Table cell configuration options
+ * @param displayValue
+ *  The value that will be displayed
+ * @returns CellColors
+ */
+export function getCellColors(
+  theme: GrafanaTheme2,
+  cellOptions: TableCellOptions,
+  displayValue: DisplayValue
+): CellColors {
+  // How much to darken elements depends upon if we're in dark mode
+  const darkeningFactor = theme.isDark ? 1 : -0.7;
+
+  // Setup color variables
+  let textColor: string | undefined = undefined;
+  let bgColor: string | undefined = undefined;
+  let bgHoverColor: string | undefined = undefined;
+
+  if (cellOptions.type === TableCellDisplayMode.ColorText) {
+    textColor = displayValue.color;
+  } else if (cellOptions.type === TableCellDisplayMode.ColorBackground) {
+    const mode = cellOptions.mode ?? TableCellBackgroundDisplayMode.Gradient;
+
+    if (mode === TableCellBackgroundDisplayMode.Basic) {
+      textColor = getTextColorForAlphaBackground(displayValue.color!, theme.isDark);
+      bgColor = tinycolor(displayValue.color).toRgbString();
+      bgHoverColor = tinycolor(displayValue.color).setAlpha(1).toRgbString();
+    } else if (mode === TableCellBackgroundDisplayMode.Gradient) {
+      const hoverColor = tinycolor(displayValue.color).setAlpha(1).toRgbString();
+      const bgColor2 = tinycolor(displayValue.color)
+        .darken(10 * darkeningFactor)
+        .spin(5);
+      textColor = getTextColorForAlphaBackground(displayValue.color!, theme.isDark);
+      bgColor = `linear-gradient(120deg, ${bgColor2.toRgbString()}, ${displayValue.color})`;
+      bgHoverColor = `linear-gradient(120deg, ${bgColor2.setAlpha(1).toRgbString()}, ${hoverColor})`;
+    }
+  }
+
+  return { textColor, bgColor, bgHoverColor };
+}
+
+export interface DataLinksActionsTooltipState {
+  coords: DataLinksActionsTooltipCoords;
+  links?: LinkModel[];
+  actions?: ActionModel[];
+}
+
+export interface DataLinksActionsTooltipCoords {
+  clientX: number;
+  clientY: number;
+}
+
+export const getDataLinksActionsTooltipUtils = (links: LinkModel[], actions?: ActionModel[]) => {
+  const hasMultipleLinksOrActions = links.length > 1 || Boolean(actions?.length);
+  const shouldShowLink = links.length === 1 && !Boolean(actions?.length);
+
+  return { shouldShowLink, hasMultipleLinksOrActions };
+};
+
+const shouldTriggerTooltip = (event: React.MouseEvent<HTMLElement>): boolean => {
+  return event.target === event.currentTarget;
+};
+
+/**
+ * Creates an onClick handler for table cells that only triggers tooltip when clicking directly on the cell
+ * @param setTooltipCoords - function to set tooltip coordinates
+ * @returns onClick handler
+ */
+export const tooltipOnClickHandler = (setTooltipCoords: (coords: DataLinksActionsTooltipCoords) => void) => {
+  return (event: React.MouseEvent<HTMLElement>) => {
+    if (shouldTriggerTooltip(event)) {
+      const { clientX, clientY } = event;
+      setTooltipCoords({ clientX, clientY });
+    }
+  };
+};

--- a/packages/grafana-ui/src/components/Table/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/utils.test.ts
@@ -3,12 +3,12 @@ import { type Row } from 'react-table';
 
 import { type Field, type FieldConfigSource, FieldType, MutableDataFrame, type SelectableValue } from '@grafana/data';
 
+import { getTextAlign } from './cellUtils';
 import {
   calculateUniqueFieldValues,
   filterByValue,
   getColumns,
   getFilteredOptions,
-  getTextAlign,
   rowToFieldValue,
   sortNumber,
   sortOptions,

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -1,14 +1,9 @@
-import { type Property } from 'csstype';
 import { clone, sampleSize } from 'lodash';
 import memoize from 'micro-memoize';
 import { type HeaderGroup, type Row } from 'react-table';
-import tinycolor from 'tinycolor2';
 
 import {
-  type ActionModel,
   type DataFrame,
-  type DisplayValue,
-  type DisplayValueAlignmentFactors,
   type Field,
   type FieldConfigSource,
   fieldReducers,
@@ -20,18 +15,10 @@ import {
   isDataFrame,
   isDataFrameWithValue,
   isTimeSeriesFrame,
-  type LinkModel,
   reduceField,
   type SelectableValue,
 } from '@grafana/data';
-import {
-  BarGaugeDisplayMode,
-  type TableAutoCellOptions,
-  TableCellBackgroundDisplayMode,
-  TableCellDisplayMode,
-} from '@grafana/schema';
-
-import { getTextColorForAlphaBackground } from '../../utils/colors';
+import { TableCellDisplayMode } from '@grafana/schema';
 
 import { ActionsCell } from './ActionsCell';
 import { BarGaugeCell } from './Cells/BarGaugeCell';
@@ -43,42 +30,16 @@ import { JSONViewCell } from './Cells/JSONViewCell';
 import { SparklineCell } from './Cells/SparklineCell';
 import { getFooterValue } from './TableRT/FooterRow';
 import { RowExpander } from './TableRT/RowExpander';
+import { getTextAlign } from './cellUtils';
 import {
-  type CellColors,
   type CellComponent,
   type FooterItem,
   type GrafanaTableColumn,
-  type TableCellOptions,
   type TableFieldOptions,
   type TableFooterCalc,
 } from './types';
 
 export const EXPANDER_WIDTH = 50;
-
-export function getTextAlign(field?: Field): Property.JustifyContent {
-  if (!field) {
-    return 'flex-start';
-  }
-
-  if (field.config.custom) {
-    const custom: TableFieldOptions = field.config.custom;
-
-    switch (custom.align) {
-      case 'right':
-        return 'flex-end';
-      case 'left':
-        return 'flex-start';
-      case 'center':
-        return 'center';
-    }
-  }
-
-  if (field.type === FieldType.number) {
-    return 'flex-end';
-  }
-
-  return 'flex-start';
-}
 
 export function getColumns(
   data: DataFrame,
@@ -439,69 +400,6 @@ export function createFooterCalculationValues(rows: Row[]): any[number] {
   return values;
 }
 
-const defaultCellOptions: TableAutoCellOptions = { type: TableCellDisplayMode.Auto };
-
-export function getCellOptions(field: Field): TableCellOptions {
-  if (field.config.custom?.displayMode) {
-    return migrateTableDisplayModeToCellOptions(field.config.custom?.displayMode);
-  }
-
-  if (!field.config.custom?.cellOptions) {
-    return defaultCellOptions;
-  }
-
-  return field.config.custom.cellOptions;
-}
-
-/**
- * Migrates table cell display mode to new object format.
- *
- * @param displayMode The display mode of the cell
- * @returns TableCellOptions object in the correct format
- * relative to the old display mode.
- */
-export function migrateTableDisplayModeToCellOptions(displayMode: TableCellDisplayMode): TableCellOptions {
-  switch (displayMode) {
-    // In the case of the gauge we move to a different option
-    case 'basic':
-    case 'gradient-gauge':
-    case 'lcd-gauge':
-      let gaugeMode = BarGaugeDisplayMode.Basic;
-
-      if (displayMode === 'gradient-gauge') {
-        gaugeMode = BarGaugeDisplayMode.Gradient;
-      } else if (displayMode === 'lcd-gauge') {
-        gaugeMode = BarGaugeDisplayMode.Lcd;
-      }
-
-      return {
-        type: TableCellDisplayMode.Gauge,
-        mode: gaugeMode,
-      };
-    // Also true in the case of the color background
-    case 'color-background':
-    case 'color-background-solid':
-      let mode = TableCellBackgroundDisplayMode.Basic;
-
-      // Set the new mode field, somewhat confusingly the
-      // color-background mode is for gradient display
-      if (displayMode === 'color-background') {
-        mode = TableCellBackgroundDisplayMode.Gradient;
-      }
-
-      return {
-        type: TableCellDisplayMode.ColorBackground,
-        mode: mode,
-      };
-    default:
-      // @ts-ignore TSGO / TS7
-      return {
-        // @ts-ignore TS5 / TS6
-        type: displayMode,
-      };
-  }
-}
-
 /**
  * This recurses through an array of `filterFields` (Array<{ id: string; field?: Field } | undefined>)
  * and adds back the missing indecies that are removed due to hiding a column through an panel override.
@@ -527,48 +425,6 @@ function addMissingColumnIndex(columns: Array<{ id: string; field?: Field } | un
 
   // Recurse
   addMissingColumnIndex(columns);
-}
-
-/**
- * Getting gauge or sparkline values to align is very tricky without looking at all values and passing them through display processor.
- * For very large tables that could pretty expensive. So this is kind of a compromise. We look at the first 1000 rows and cache the longest value.
- * If we have a cached value we just check if the current value is longer and update the alignmentFactor. This can obviously still lead to
- * unaligned gauges but it should a lot less common.
- **/
-export function getAlignmentFactor(
-  field: Field,
-  displayValue: DisplayValue,
-  rowIndex: number
-): DisplayValueAlignmentFactors {
-  let alignmentFactor = field.state?.alignmentFactors;
-
-  if (alignmentFactor) {
-    // check if current alignmentFactor is still the longest
-    if (formattedValueToString(alignmentFactor).length < formattedValueToString(displayValue).length) {
-      alignmentFactor = { ...displayValue };
-      field.state!.alignmentFactors = alignmentFactor;
-    }
-    return alignmentFactor;
-  } else {
-    // look at the next 1000 rows
-    alignmentFactor = { ...displayValue };
-    const maxIndex = Math.min(field.values.length, rowIndex + 1000);
-
-    for (let i = rowIndex + 1; i < maxIndex; i++) {
-      const nextDisplayValue = field.display!(field.values[i]);
-      if (formattedValueToString(alignmentFactor).length > formattedValueToString(nextDisplayValue).length) {
-        alignmentFactor.text = displayValue.text;
-      }
-    }
-
-    if (field.state) {
-      field.state.alignmentFactors = alignmentFactor;
-    } else {
-      field.state = { alignmentFactors: alignmentFactor };
-    }
-
-    return alignmentFactor;
-  }
 }
 
 // since the conversion from timeseries panel crosshair to time is pixel based, we need
@@ -599,53 +455,6 @@ export function calculateAroundPointThreshold(timeField: Field): number {
   }
 
   return (max - min) / timeField.values.length;
-}
-
-/**
- * Retrieve colors for a table cell (or table row).
- *
- * @param tableStyles
- *  Styles for the table
- * @param cellOptions
- *  Table cell configuration options
- * @param displayValue
- *  The value that will be displayed
- * @returns CellColors
- */
-export function getCellColors(
-  theme: GrafanaTheme2,
-  cellOptions: TableCellOptions,
-  displayValue: DisplayValue
-): CellColors {
-  // How much to darken elements depends upon if we're in dark mode
-  const darkeningFactor = theme.isDark ? 1 : -0.7;
-
-  // Setup color variables
-  let textColor: string | undefined = undefined;
-  let bgColor: string | undefined = undefined;
-  let bgHoverColor: string | undefined = undefined;
-
-  if (cellOptions.type === TableCellDisplayMode.ColorText) {
-    textColor = displayValue.color;
-  } else if (cellOptions.type === TableCellDisplayMode.ColorBackground) {
-    const mode = cellOptions.mode ?? TableCellBackgroundDisplayMode.Gradient;
-
-    if (mode === TableCellBackgroundDisplayMode.Basic) {
-      textColor = getTextColorForAlphaBackground(displayValue.color!, theme.isDark);
-      bgColor = tinycolor(displayValue.color).toRgbString();
-      bgHoverColor = tinycolor(displayValue.color).setAlpha(1).toRgbString();
-    } else if (mode === TableCellBackgroundDisplayMode.Gradient) {
-      const hoverColor = tinycolor(displayValue.color).setAlpha(1).toRgbString();
-      const bgColor2 = tinycolor(displayValue.color)
-        .darken(10 * darkeningFactor)
-        .spin(5);
-      textColor = getTextColorForAlphaBackground(displayValue.color!, theme.isDark);
-      bgColor = `linear-gradient(120deg, ${bgColor2.toRgbString()}, ${displayValue.color})`;
-      bgHoverColor = `linear-gradient(120deg, ${bgColor2.setAlpha(1).toRgbString()}, ${hoverColor})`;
-    }
-  }
-
-  return { textColor, bgColor, bgHoverColor };
 }
 
 /**
@@ -771,39 +580,3 @@ export function guessLongestField(fieldConfig: FieldConfigSource, data: DataFram
 
   return longestField;
 }
-
-export interface DataLinksActionsTooltipState {
-  coords: DataLinksActionsTooltipCoords;
-  links?: LinkModel[];
-  actions?: ActionModel[];
-}
-
-export interface DataLinksActionsTooltipCoords {
-  clientX: number;
-  clientY: number;
-}
-
-export const getDataLinksActionsTooltipUtils = (links: LinkModel[], actions?: ActionModel[]) => {
-  const hasMultipleLinksOrActions = links.length > 1 || Boolean(actions?.length);
-  const shouldShowLink = links.length === 1 && !Boolean(actions?.length);
-
-  return { shouldShowLink, hasMultipleLinksOrActions };
-};
-
-const shouldTriggerTooltip = (event: React.MouseEvent<HTMLElement>): boolean => {
-  return event.target === event.currentTarget;
-};
-
-/**
- * Creates an onClick handler for table cells that only triggers tooltip when clicking directly on the cell
- * @param setTooltipCoords - function to set tooltip coordinates
- * @returns onClick handler
- */
-export const tooltipOnClickHandler = (setTooltipCoords: (coords: DataLinksActionsTooltipCoords) => void) => {
-  return (event: React.MouseEvent<HTMLElement>) => {
-    if (shouldTriggerTooltip(event)) {
-      const { clientX, clientY } = event;
-      setTooltipCoords({ clientX, clientY });
-    }
-  };
-};

--- a/packages/grafana-ui/src/internal/index.ts
+++ b/packages/grafana-ui/src/internal/index.ts
@@ -68,7 +68,7 @@ export {
 export { defaultSparklineCellConfig } from '../components/Table/Cells/SparklineCell';
 export { TableCell } from '../components/Table/Cells/TableCell';
 export { useTableStyles } from '../components/Table/TableRT/styles';
-export { migrateTableDisplayModeToCellOptions } from '../components/Table/utils';
+export { migrateTableDisplayModeToCellOptions } from '../components/Table/cellUtils';
 export { type DataLinksContextMenuApi } from '../components/DataLinks/DataLinksContextMenu';
 export { MenuDivider } from '../components/Menu/MenuDivider';
 export { AbstractList } from '../components/List/AbstractList';


### PR DESCRIPTION
**What is this feature?**

Extracts the cell-facing helpers (`getCellOptions`, `getCellColors`, `getTextAlign`, `getAlignmentFactor`, the tooltip helpers/types, and `migrateTableDisplayModeToCellOptions`) out of `Table/utils.ts` into a new `Table/cellUtils.ts`. `utils.ts` was both the cell-component factory (it imports every cell) and the helper module those cells imported back, which created 7 circular dependencies. The cells now import from the cell-free `cellUtils.ts`, so all 7 are gone.

**Why do we need this feature?**

So `@grafana/ui` has 7 fewer circular dependencies.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Pure move, no behavior change. `migrateTableDisplayModeToCellOptions` is still re-exported from `@grafana/ui/internal`, so the API surface is unchanged (`DashboardMigrator` is untouched). `madge` shows the Table circular deps drop from 18 to 11 (the 7 that routed through `utils.ts`); the remaining 11 are pre-existing TableNG/TableRT cycles, out of scope here.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
