### PR TITLE
[release-13.0.3] Provisioning: Write `_folder.json` when creating dashboards in new folders

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -397,7 +397,27 @@ func (r *DualReadWriter) createOrUpdate(ctx context.Context, create bool, opts D
 
 	// Create or update
 	if create {
-		err = r.repo.Create(ctx, opts.Path, opts.Ref, data, opts.Message)
+		// Write the resource file together with any missing ancestor _folder.json
+		// files in a single commit using the staging mechanism. When the repository
+		// does not support staging (e.g. local repos), writes are applied directly.
+		writeFn := func(stagedRepo repository.Repository, _ bool) error {
+			rw, ok := stagedRepo.(repository.ReaderWriter)
+			if !ok {
+				return fmt.Errorf("repository does not support read/write operations")
+			}
+			if r.folderMetadataEnabled && !safepath.IsDir(opts.Path) {
+				if err := r.writeAncestorFolderMetadata(ctx, rw, opts.Path, opts.Ref, opts.Message); err != nil {
+					return err
+				}
+			}
+			return rw.Create(ctx, opts.Path, opts.Ref, data, opts.Message)
+		}
+		stageOptions := repository.StageOptions{
+			Ref:                   opts.Ref,
+			Mode:                  repository.StageModeCommitOnlyOnce,
+			CommitOnlyOnceMessage: opts.Message,
+		}
+		err = repository.WrapWithStageAndPushIfPossible(ctx, r.repo, stageOptions, writeFn)
 	} else {
 		err = r.repo.Update(ctx, opts.Path, opts.Ref, data, opts.Message)
 	}
@@ -420,14 +440,59 @@ func (r *DualReadWriter) createOrUpdate(ctx context.Context, create bool, opts D
 			})
 		}
 
-		if _, err := r.folders.EnsureFolderPathExist(ctx, opts.Path, opts.Ref); err != nil {
+		parent, err := r.folders.EnsureFolderPathExist(ctx, opts.Path, opts.Ref)
+		if err != nil {
 			return nil, fmt.Errorf("ensure folder path exists: %w", err)
 		}
 
-		err = parsed.Run(ctx)
+		// In case the parent folder has a different ID than the one from the initially parsed resource,
+		// e.g. when the folder metadata has been generated as part of the create operation, we need to update it.
+		if parsed.Meta.GetFolder() != parent {
+			parsed.Meta.SetFolder(parent)
+		}
+
+		if err := parsed.Run(ctx); err != nil {
+			return nil, fmt.Errorf("run resource: %w", err)
+		}
 	}
 
-	return parsed, err
+	return parsed, nil
+}
+
+// writeAncestorFolderMetadata walks the ancestor directories of filePath and
+// writes a _folder.json with a stable UID for any folder that does not exist in
+// the repository yet. Folders that already exist (with or without metadata) are
+// left untouched — we never backfill metadata for pre-existing folders. Reads
+// and writes go through the provided ReaderWriter (the staged repo during a
+// staged write) so reads observe writes made earlier in the same stage.
+func (r *DualReadWriter) writeAncestorFolderMetadata(ctx context.Context, rw repository.ReaderWriter, filePath, ref, message string) error {
+	dir := safepath.Dir(filePath)
+	if dir == "" {
+		return nil
+	}
+
+	return safepath.Walk(ctx, dir, func(ctx context.Context, segPath string) error {
+		folderPath := safepath.EnsureTrailingSlash(segPath)
+
+		// Skip folders that already exist in the repository (with or without metadata).
+		_, err := rw.Read(ctx, folderPath, ref)
+		if errors.Is(err, repository.ErrRefNotFound) {
+			// Target branch not created yet; check the branch it will inherit from.
+			_, err = rw.Read(ctx, folderPath, "")
+		}
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, repository.ErrFileNotFound) && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("check if folder exists for %q: %w", folderPath, err)
+		}
+
+		manifest := NewFolderManifest(util.GenerateShortUID(), safepath.Base(folderPath), r.folders.FolderGVK())
+		if _, err := WriteFolderMetadata(ctx, rw, folderPath, manifest, ref, message); err != nil {
+			return fmt.Errorf("write folder metadata for %q: %w", folderPath, err)
+		}
+		return nil
+	})
 }
 
 // MoveResource moves a resource from one path to another in the repository

--- a/pkg/registry/apis/provisioning/resources/dualwriter_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_test.go
@@ -1412,3 +1412,75 @@ func TestUpdateFolderMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteAncestorFolderMetadata(t *testing.T) {
+	t.Run("writes _folder.json with stable UID for new folder", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Read", mock.Anything, "new-folder/", "test-ref").
+			Return(nil, repository.ErrFileNotFound)
+
+		var writtenData []byte
+		rw.On("Create", mock.Anything, "new-folder/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg").
+			Run(func(args mock.Arguments) { writtenData = args.Get(3).([]byte) }).
+			Return(nil)
+
+		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
+		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
+		err := dw.writeAncestorFolderMetadata(context.Background(), rw, "new-folder/dashboard.json", "test-ref", "msg")
+
+		require.NoError(t, err)
+		rw.AssertCalled(t, "Create", mock.Anything, "new-folder/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg")
+
+		// UID must be a stable short UID, not the hash-derived folder ID.
+		var manifest folders.Folder
+		require.NoError(t, json.Unmarshal(writtenData, &manifest))
+		hashID := ParseFolder("new-folder/", "test-repo").ID
+		require.NotEmpty(t, manifest.Name)
+		require.NotEqual(t, hashID, manifest.Name)
+	})
+
+	t.Run("does not write when folder already exists", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		// Folder directory already exists in the repo (with or without metadata).
+		rw.On("Read", mock.Anything, "existing-folder/", "test-ref").
+			Return(&repository.FileInfo{Path: "existing-folder/"}, nil)
+
+		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
+		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
+		err := dw.writeAncestorFolderMetadata(context.Background(), rw, "existing-folder/dashboard.json", "test-ref", "msg")
+
+		require.NoError(t, err)
+		rw.AssertNotCalled(t, "Create", mock.Anything, "existing-folder/_folder.json", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("writes _folder.json for each missing ancestor in nested path", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Read", mock.Anything, "a/", "test-ref").
+			Return(nil, repository.ErrFileNotFound)
+		rw.On("Read", mock.Anything, "a/b/", "test-ref").
+			Return(nil, repository.ErrFileNotFound)
+		rw.On("Create", mock.Anything, "a/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg").
+			Return(nil)
+		rw.On("Create", mock.Anything, "a/b/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg").
+			Return(nil)
+
+		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
+		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
+		err := dw.writeAncestorFolderMetadata(context.Background(), rw, "a/b/dashboard.json", "test-ref", "msg")
+
+		require.NoError(t, err)
+		rw.AssertCalled(t, "Create", mock.Anything, "a/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg")
+		rw.AssertCalled(t, "Create", mock.Anything, "a/b/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg")
+	})
+
+	t.Run("no-op for root-level file", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+
+		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
+		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
+		err := dw.writeAncestorFolderMetadata(context.Background(), rw, "dashboard.json", "test-ref", "msg")
+
+		require.NoError(t, err)
+		rw.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1393,9 +1393,9 @@ func (c *FilesClient) Do(t *testing.T, method, filePath string, body []byte) *Fi
 }
 
 // Post sends a POST request to the given path with no body.
-func (c *FilesClient) Post(t *testing.T, filePath string) *FilesResponse {
+func (c *FilesClient) Post(t *testing.T, filePath string, body []byte) *FilesResponse {
 	t.Helper()
-	return c.Do(t, http.MethodPost, filePath, nil)
+	return c.Do(t, http.MethodPost, filePath, body)
 }
 
 // Put sends a PUT request to the given path with a JSON body.

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_authorization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_authorization_test.go
@@ -131,7 +131,7 @@ func TestIntegrationProvisioning_FolderAuthorizationWithMetadata(t *testing.T) {
 	// 2. Folder deletion on the configured branch is intentionally disabled (returns 405)
 	// 3. Testing deletion on feature branches requires git repositories with BranchWorkflow
 	t.Run("Admin and Editor can create folders", func(t *testing.T) {
-		resp := adminFiles.Post(t, folderPathPrefix+"/")
+		resp := adminFiles.Post(t, folderPathPrefix+"/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Admin should be able to create parent folder")
 
 		parentUID := adminFiles.ReadFolderUID(t, ctx, folderPathPrefix+"/_folder.json")
@@ -139,7 +139,7 @@ func TestIntegrationProvisioning_FolderAuthorizationWithMetadata(t *testing.T) {
 
 		// Editor should be able to create a child folder.
 		// Validates authorization uses stable UID from parent's _folder.json.
-		childResp := editorFiles.Post(t, folderPathPrefix+"/child/")
+		childResp := editorFiles.Post(t, folderPathPrefix+"/child/", nil)
 		require.Equal(t, http.StatusOK, childResp.StatusCode, "Editor should be able to create child folder")
 
 		childUID := adminFiles.ReadFolderUID(t, ctx, folderPathPrefix+"/child/_folder.json")

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_creation_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_creation_test.go
@@ -16,12 +16,17 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 	ctx := context.Background()
 
 	const repo = "folder-metadata-test-repo"
-	helper.CreateRepo(t, common.TestRepo{Name: repo, Target: "instance", SkipResourceAssertions: true})
+	helper.CreateRepo(t, common.TestRepo{
+		Name: repo, Target: "instance", SkipResourceAssertions: true,
+		Copies: map[string]string{
+			"../testdata/.keep": "no-meta-existing-folder/.keep",
+		},
+	})
 
 	files := helper.NewFilesClient(repo)
 
 	t.Run("simple folder creation writes _folder.json with stable UID", func(t *testing.T) {
-		resp := files.Post(t, "meta-test-folder/")
+		resp := files.Post(t, "meta-test-folder/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating folder should succeed")
 
 		uid, title := files.RequireValidFolderMetadata(t, ctx, "meta-test-folder/_folder.json")
@@ -35,7 +40,7 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 	})
 
 	t.Run("nested creation writes _folder.json for every folder in the path", func(t *testing.T) {
-		resp := files.Post(t, "parent-folder/child-folder/")
+		resp := files.Post(t, "parent-folder/child-folder/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating nested folder should succeed")
 
 		parentUID, _ := files.RequireValidFolderMetadata(t, ctx, "parent-folder/_folder.json")
@@ -49,21 +54,77 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 	})
 
 	t.Run("duplicate folder creation returns 409 Conflict", func(t *testing.T) {
-		resp := files.Post(t, "duplicate-folder/")
+		resp := files.Post(t, "duplicate-folder/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "first creation should succeed")
 
-		resp2 := files.Post(t, "duplicate-folder/")
+		resp2 := files.Post(t, "duplicate-folder/", nil)
 		require.Equal(t, http.StatusConflict, resp2.StatusCode, "second creation should return 409 Conflict")
 	})
 
+	t.Run("dashboard creation in new folder writes _folder.json", func(t *testing.T) {
+		body := common.DashboardJSON("implicit-dash-001", "Implicit Dashboard", 1)
+		resp := files.Post(t, "implicit-folder/dashboard.json", body)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating dashboard in new folder should succeed")
+
+		uid, title := files.RequireValidFolderMetadata(t, ctx, "implicit-folder/_folder.json")
+		require.Equal(t, "implicit-folder", title)
+
+		_, err := helper.Folders.Resource.Get(ctx, uid, metav1.GetOptions{})
+		require.NoError(t, err, "Grafana folder should exist with the UID from _folder.json")
+	})
+
+	t.Run("explicit folder creation after dashboard reuses existing _folder.json UID", func(t *testing.T) {
+		body := common.DashboardJSON("reuse-dash-001", "Reuse Dashboard", 1)
+		resp := files.Post(t, "reuse-folder/dashboard.json", body)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating dashboard should succeed")
+
+		uid := files.ReadFolderUID(t, ctx, "reuse-folder/_folder.json")
+		require.NotEmpty(t, uid, "implicit _folder.json should have a UID")
+
+		resp2 := files.Post(t, "reuse-folder/", nil)
+		require.Equal(t, http.StatusConflict, resp2.StatusCode, "explicit folder creation should return 409 because folder already exists")
+
+		uid2 := files.ReadFolderUID(t, ctx, "reuse-folder/_folder.json")
+		require.Equal(t, uid, uid2, "UID must not change after explicit folder creation attempt")
+	})
+
+	t.Run("nested dashboard creation writes _folder.json for all ancestor folders", func(t *testing.T) {
+		body := common.DashboardJSON("nested-dash-001", "Nested Dashboard", 1)
+		resp := files.Post(t, "ancestor-a/ancestor-b/dashboard.json", body)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating nested dashboard should succeed: %s", string(resp.Body))
+
+		parentUID, _ := files.RequireValidFolderMetadata(t, ctx, "ancestor-a/_folder.json")
+		childUID, _ := files.RequireValidFolderMetadata(t, ctx, "ancestor-a/ancestor-b/_folder.json")
+
+		require.NotEqual(t, parentUID, childUID, "each folder gets a distinct UID")
+
+		_, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		require.NoError(t, err, "parent Grafana folder should exist")
+		_, err = helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		require.NoError(t, err, "child Grafana folder should exist")
+	})
+
+	t.Run("dashboard created on existing folder with no meta doesn't write _folder.json", func(t *testing.T) {
+		body := common.DashboardJSON("nested-dash-002", "Nested Dashboard", 1)
+		resp := files.Post(t, "no-meta-existing-folder/should-have-meta/dashboard.json", body)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating nested dashboard should succeed: %s", string(resp.Body))
+
+		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "no-meta-existing-folder/_folder.json")
+		require.Error(t, err, "_folder.json should not exist when flag is enabled")
+
+		childUID, _ := files.RequireValidFolderMetadata(t, ctx, "no-meta-existing-folder/should-have-meta/_folder.json")
+		_, err = helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		require.NoError(t, err, "child Grafana folder should exist")
+	})
+
 	t.Run("child created inside existing managed folder gets its own _folder.json", func(t *testing.T) {
-		resp := files.Post(t, "managed-parent/")
+		resp := files.Post(t, "managed-parent/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating parent folder should succeed")
 
 		parentUID := files.ReadFolderUID(t, ctx, "managed-parent/_folder.json")
 		require.NotEmpty(t, parentUID, "parent should have a non-empty stable UID")
 
-		resp2 := files.Post(t, "managed-parent/child-folder/")
+		resp2 := files.Post(t, "managed-parent/child-folder/", nil)
 		require.Equal(t, http.StatusOK, resp2.StatusCode, "creating child folder should succeed")
 
 		childUID := files.ReadFolderUID(t, ctx, "managed-parent/child-folder/_folder.json")

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_file_protection_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_file_protection_test.go
@@ -20,7 +20,7 @@ func TestIntegrationProvisioning_FolderMetadataFileProtection(t *testing.T) {
 	files := helper.NewFilesClient(repo)
 
 	// Create a managed folder so its _folder.json exists for PUT/DELETE tests.
-	resp := files.Post(t, "protected-folder/")
+	resp := files.Post(t, "protected-folder/", nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "setup: creating protected-folder should succeed")
 
 	t.Run("POST to _folder.json is blocked", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_test.go
@@ -23,7 +23,7 @@ func TestIntegrationProvisioning_UpdateFolderMetadata(t *testing.T) {
 	files := helper.NewFilesClient(repo)
 
 	// Create a folder to work with
-	resp := files.Post(t, "update-test/")
+	resp := files.Post(t, "update-test/", nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "setup: creating folder should succeed")
 
 	originalUID := files.ReadFolderUID(t, ctx, "update-test/_folder.json")
@@ -101,7 +101,7 @@ func TestIntegrationProvisioning_UpdateFolderMetadata(t *testing.T) {
 	})
 
 	t.Run("nested folder title update works", func(t *testing.T) {
-		resp := files.Post(t, "nested-parent/nested-child/")
+		resp := files.Post(t, "nested-parent/nested-child/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "setup: creating nested folder should succeed")
 
 		childUID := files.ReadFolderUID(t, ctx, "nested-parent/nested-child/_folder.json")


### PR DESCRIPTION
Backport 00de130517732ec99c6e659099be138271ebe2c7 from #126042

---

## Summary

When `provisioningFolderMetadata` is enabled, creating a dashboard via `POST /files/new-folder/dashboard.json` writes `_folder.json` for any new folders created along the path. Previously only explicit folder creation (`POST /files/folder/`) and sync/export paths wrote folder metadata, causing a permanent UID mismatch when the same folder was later created explicitly.

### Problem

1. User POSTs `new-folder/dashboard.json` via the files API
2. `EnsureFolderPathExist` creates the Grafana folder with a hash-derived UID (e.g. `abc123`) — no `_folder.json` written to git
3. User later POSTs `new-folder/` (explicit folder creation)
4. `CreateFolder` finds no `_folder.json` → writes a new one with a fresh stable UID (`def456`) → creates a **second** Grafana folder
5. Dashboard is orphaned in folder `abc123`; `_folder.json` says `def456` — permanent mismatch until full re-sync

### Solution

Adds `CreateBatch` to the `repository.Writer` interface so the dashboard file and all ancestor `_folder.json` files are written in a **single atomic commit**. A new `folderMetadataCreations` method on `DualReadWriter` walks ancestor paths and builds a `map[string][]byte` of missing `_folder.json` entries (using `util.GenerateShortUID()` for stable UIDs). This map is merged with the dashboard data and passed to `CreateBatch`.

**Key design decisions:**
- **Atomic commit** — dashboard and all `_folder.json` files land in one git commit via `CreateBatch`, avoiding partial state
- **Only on create** — `folderMetadataCreations` only runs for `create=true`, not updates (ancestors already exist for existing files)
- **Only for files** — directory creation (`safepath.IsDir`) is skipped (handled by `CreateFolder`)
- **Stable UIDs** — uses `util.GenerateShortUID()` (same as `fixfoldermetadata` and `CreateFolder`), not hash-derived UIDs
- **Works for both branches** — metadata is written regardless of `shouldUpdateGrafanaDB` (main or non-main branch)
- **No interface changes to `FolderManager`** — `EnsureFolderPathExist`, `EnsureFolderExists`, and `RepositoryResources` unchanged

**Files changed:**
- `apps/provisioning/pkg/repository/repository.go` — new `CreateBatch` method on `Writer` interface
- `apps/provisioning/pkg/repository/git/repository.go` — `CreateBatch` implementation (single staged commit)
- `apps/provisioning/pkg/repository/git/staged.go` — `CreateBatch` for staged git repos
- `apps/provisioning/pkg/repository/local/local.go` — `CreateBatch` for local repos
- `pkg/registry/apis/provisioning/resources/dualwriter.go` — `folderMetadataCreations` method; `createOrUpdate` uses `CreateBatch` for creates
- Mock files updated: `reader_writer_mock.go`, `git_repository_mock.go`, `repository_mock.go`, `staged_repository_mock.go`, `github_repository_mock.go`

## Test plan

- [x] **Unit tests** (`dualwriter_test.go`) — `TestFolderMetadataCreations`:
  - New folder → returns `_folder.json` entry with stable UID
  - Existing `_folder.json` → returns empty map (no overwrite)
  - Nested path → returns entries for each ancestor
  - Root-level file → returns nil (no ancestors)
- [x] **Integration tests** (`folder_creation_test.go`) — 3 new cases:
  - Dashboard creation in new folder writes `_folder.json` with matching UID
  - Subsequent explicit folder creation reuses existing `_folder.json` UID (returns 409)
  - Nested dashboard creation writes `_folder.json` for all ancestor folders
- [x] `make gofmt` — clean
- [x] `make lint-go-diff` — 0 issues
- [x] All existing unit tests pass (no regressions)
- [x] All affected packages vet clean

Closes https://github.com/grafana/git-ui-sync-project/issues/1206
