### PR TITLE
Table: Fix stories freezing the browser

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.story.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.story.tsx
@@ -31,6 +31,12 @@ const meta: Meta<typeof Table> = {
     },
     docs: {
       page: mdx,
+      // Render the literal story source instead of serializing the rendered table. The data-heavy
+      // stories (e.g. SubTables) otherwise produce a huge dynamic-source string that the syntax
+      // highlighter turns into tens of thousands of spans, freezing the tab.
+      source: {
+        type: 'code',
+      },
     },
     a11y: {
       config: {


### PR DESCRIPTION
**What is this feature?**

Fixes the `Table` stories freezing the browser. The data-heavy stories (notably `SubTables`, 100 rows of nested frames) made Storybook's dynamic source serialize the whole rendered table into a giant string, which `react-syntax-highlighter` turned into tens of thousands of `<span>`s — enough to stall React's commit phase (`getHostSibling` is O(n²) there) and lock up the tab in Chrome, Firefox and Safari. Setting `docs.source.type: 'code'` makes Storybook show the literal story source instead.

**Why do we need this feature?**

So viewing the `Table` stories no longer freezes the browser.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Not a `Table` bug — the component renders fine on its own; this is purely Storybook's source rendering of the large generated `data`. Confirmed by pausing the frozen tab: React was stuck committing `code-segment-N` spans from `react-syntax-highlighter`. Applied at the meta level so `Basic` and `CustomColumn` (which also build large data) are covered too.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
