### PR TITLE
Provisioning: take over unmanaged parent folders during selective migrate

### DIFF
--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -244,13 +244,25 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 	obj, err := fm.client.Get(ctx, folder.ID, metav1.GetOptions{})
 	if err == nil {
 		current, ok := obj.GetAnnotations()[utils.AnnoKeyManagerIdentity]
+		// takeover is set when the folder exists but is unmanaged and the
+		// migration allowlist permits claiming it. In that case we stamp repo
+		// ownership and force an update so the previously unmanaged folder
+		// becomes managed by this repository.
+		takeover := false
 		if !ok {
-			return NewResourceUnmanagedConflictError(folder.ID, utils.ManagerProperties{
-				Kind:     utils.ManagerKindRepo,
-				Identity: cfg.Name,
-			})
-		}
-		if current != cfg.Name {
+			// EnsureFolderExists is the ownership gate for folders, so it must
+			// honour the same takeover allowlist as CheckResourceOwnership does
+			// for other resources. Without this, a selective migrate of a
+			// resource living under a pre-existing unmanaged folder can never
+			// create its parent.
+			if !folderTakeoverAllowed(ctx, folder.ID) {
+				return NewResourceUnmanagedConflictError(folder.ID, utils.ManagerProperties{
+					Kind:     utils.ManagerKindRepo,
+					Identity: cfg.Name,
+				})
+			}
+			takeover = true
+		} else if current != cfg.Name {
 			return NewFolderManagedByOtherError(folder.ID, current)
 		}
 
@@ -268,7 +280,7 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 			ParentID:     meta.GetFolder(),
 		}
 
-		if !folder.Equal(existing) {
+		if takeover || !folder.Equal(existing) {
 			if err := unstructured.SetNestedField(obj.Object, folder.Title, "spec", "title"); err != nil {
 				return fmt.Errorf("set folder title: %w", err)
 			}
@@ -277,32 +289,18 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 				Checksum: folder.MetadataHash,
 			})
 			meta.SetFolder(folder.ParentID)
+			if takeover {
+				meta.SetManagerProperties(utils.ManagerProperties{
+					Kind:     utils.ManagerKindRepo,
+					Identity: cfg.GetName(),
+				})
+			}
 			ctx, _, err = identity.WithProvisioningIdentity(ctx, cfg.GetNamespace())
 			if err != nil {
 				return fmt.Errorf("unable to use provisioning identity %w", err)
 			}
 			if _, err := fm.client.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
-				// A managed folder being moved into a path that exceeds the
-				// folder API's max depth is the same user-side problem as a
-				// fresh create: surface it as a typed warning so the sync is
-				// not retried in a loop.
-				if IsFolderDepthExceededAPIError(err) {
-					return NewFolderDepthExceededError(folder.Path, err)
-				}
-				// A managed folder ending up with a UID longer than 40 chars
-				// (typically via _folder.json metadata) cannot be repaired by
-				// a retry; surface it as a typed warning instead.
-				if IsFolderUIDTooLongAPIError(err) {
-					return NewFolderUIDTooLongError(folder.Path, folder.ID, err)
-				}
-				// Catch-all for any other folder-API validation 4xx
-				// (illegal-uid-chars, reserved-uid, etc.). The repository
-				// owner must fix the offending input; retrying produces
-				// the same rejection.
-				if IsFolderValidationAPIError(err) {
-					return NewFolderValidationError(folder.Path, err)
-				}
-				return fmt.Errorf("update folder: %w", err)
+				return mapFolderWriteError(folder, err, "update folder")
 			}
 		}
 
@@ -367,10 +365,17 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 
 			current, ok := obj.GetAnnotations()[utils.AnnoKeyManagerIdentity]
 			if !ok {
-				return NewResourceUnmanagedConflictError(folder.ID, utils.ManagerProperties{
-					Kind:     utils.ManagerKindRepo,
-					Identity: cfg.Name,
-				})
+				// Another sync raced us to create the folder, but it landed
+				// unmanaged. Honour the migration allowlist here too, mirroring
+				// the primary path above, otherwise a concurrent migrate could
+				// still reject a folder we are allowed to take over.
+				if !folderTakeoverAllowed(ctx, folder.ID) {
+					return NewResourceUnmanagedConflictError(folder.ID, utils.ManagerProperties{
+						Kind:     utils.ManagerKindRepo,
+						Identity: cfg.Name,
+					})
+				}
+				return fm.claimUnmanagedFolder(ctx, obj, folder)
 			}
 			if current != cfg.Name {
 				return NewFolderManagedByOtherError(folder.ID, current)
@@ -379,33 +384,75 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 			return nil
 		}
 
-		// The folder API enforces a global maximum folder depth that
-		// provisioning cannot influence. Repositories containing paths
-		// deeper than this limit will fail forever, so surface it as a
-		// typed warning instead of a retryable error and let the sync
-		// keep going for the rest of the tree.
-		if IsFolderDepthExceededAPIError(err) {
-			return NewFolderDepthExceededError(folder.Path, err)
-		}
-		// Same reasoning as depth above: a UID longer than the folder
-		// API's 40-character limit is a permanent rejection. Path-derived
-		// UIDs are always truncated to <=40 by appendHashSuffix, so this
-		// only fires for user-supplied UIDs (typically a _folder.json
-		// stable UID, but also any future caller-provided UID source).
-		// Surface it as a typed warning so the sync moves on.
-		if IsFolderUIDTooLongAPIError(err) {
-			return NewFolderUIDTooLongError(folder.Path, folder.ID, err)
-		}
-		// Catch-all for any other folder-API validation 4xx the more
-		// specific matchers above did not claim (illegal-uid-chars,
-		// reserved-uid, future folder validations). The repository owner
-		// must fix the offending input; retrying produces the same
-		// rejection.
-		if IsFolderValidationAPIError(err) {
-			return NewFolderValidationError(folder.Path, err)
-		}
+		return mapFolderWriteError(folder, err, "failed to create folder")
+	}
+	return nil
+}
 
-		return fmt.Errorf("failed to create folder: %w", err)
+// mapFolderWriteError converts a folder create/update API error into a typed
+// provisioning warning when it represents a permanent, user-side rejection that
+// a retry cannot fix (path depth exceeded, UID too long, or any other folder-API
+// validation such as illegal-uid-chars or reserved-uid). Surfacing these as
+// warnings keeps the sync from retrying in a loop. Any other error is wrapped
+// with the supplied context message.
+func mapFolderWriteError(folder Folder, err error, wrap string) error {
+	switch {
+	case IsFolderDepthExceededAPIError(err):
+		return NewFolderDepthExceededError(folder.Path, err)
+	case IsFolderUIDTooLongAPIError(err):
+		return NewFolderUIDTooLongError(folder.Path, folder.ID, err)
+	case IsFolderValidationAPIError(err):
+		return NewFolderValidationError(folder.Path, err)
+	default:
+		return fmt.Errorf("%s: %w", wrap, err)
+	}
+}
+
+// folderTakeoverAllowed reports whether the migration takeover allowlist stored
+// in ctx permits claiming the given unmanaged folder. It mirrors the allowlist
+// gate in CheckResourceOwnership so folders and other resources share the same
+// takeover semantics during migration.
+func folderTakeoverAllowed(ctx context.Context, folderID string) bool {
+	allowlist := TakeoverAllowlistFromContext(ctx)
+	if allowlist == nil {
+		return false
+	}
+	return allowlist.Contains(ResourceIdentifier{
+		Name:  folderID,
+		Group: FolderResource.Group,
+		Kind:  FolderKind.Kind,
+	})
+}
+
+// claimUnmanagedFolder stamps repo ownership and the metadata-backed properties
+// onto an existing unmanaged folder and writes the update. It is only called
+// once folderTakeoverAllowed has confirmed the takeover is permitted.
+func (fm *FolderManager) claimUnmanagedFolder(ctx context.Context, obj *unstructured.Unstructured, folder Folder) error {
+	cfg := fm.repo.Config()
+	meta, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return fmt.Errorf("create meta accessor: %w", err)
+	}
+
+	if err := unstructured.SetNestedField(obj.Object, folder.Title, "spec", "title"); err != nil {
+		return fmt.Errorf("set folder title: %w", err)
+	}
+	meta.SetSourceProperties(utils.SourceProperties{
+		Path:     folder.Path,
+		Checksum: folder.MetadataHash,
+	})
+	meta.SetFolder(folder.ParentID)
+	meta.SetManagerProperties(utils.ManagerProperties{
+		Kind:     utils.ManagerKindRepo,
+		Identity: cfg.GetName(),
+	})
+
+	ctx, _, err = identity.WithProvisioningIdentity(ctx, cfg.GetNamespace())
+	if err != nil {
+		return fmt.Errorf("unable to use provisioning identity %w", err)
+	}
+	if _, err := fm.client.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
+		return mapFolderWriteError(folder, err, fmt.Sprintf("claim unmanaged folder %s", folder.ID))
 	}
 	return nil
 }

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -8,6 +8,7 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -663,6 +664,218 @@ func TestEnsureFolderExists_TitleUpdate(t *testing.T) {
 		require.True(t, errors.As(err, &validationErr), "Update path should also return FolderValidationError")
 		require.Equal(t, "bad-folder/", validationErr.Path)
 		require.NotEmpty(t, client.updateCalls)
+	})
+}
+
+// TestEnsureFolderExists_TakeoverAllowlist covers the migration takeover path:
+// EnsureFolderExists is the ownership gate for folders, so it must honour the
+// same allowlist as CheckResourceOwnership does for other resources. Without
+// this, a selective migrate of a resource living under a pre-existing unmanaged
+// folder can never create its parent.
+func TestEnsureFolderExists_TakeoverAllowlist(t *testing.T) {
+	const repoName = "repo-a"
+	const folderID = "folder-id"
+
+	newRepo := func(t *testing.T) *repository.MockReaderWriter {
+		cfg := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      repoName,
+				Namespace: "default",
+			},
+			Spec: provisioning.RepositorySpec{
+				Sync: provisioning.SyncOptions{Target: provisioning.SyncTargetTypeFolder},
+			},
+		}
+		repo := repository.NewMockReaderWriter(t)
+		repo.On("Config").Return(cfg)
+		return repo
+	}
+
+	unmanagedFolder := func(name, title string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "folder.grafana.app/v1beta1",
+				"kind":       "Folder",
+				"metadata": map[string]interface{}{
+					"name":        name,
+					"namespace":   "default",
+					"annotations": map[string]interface{}{},
+				},
+				"spec": map[string]interface{}{
+					"title": title,
+				},
+			},
+		}
+	}
+
+	allowlistCtx := func(ids ...ResourceIdentifier) context.Context {
+		set := make(map[ResourceIdentifier]struct{}, len(ids))
+		for _, id := range ids {
+			set[id] = struct{}{}
+		}
+		return WithTakeoverAllowlist(context.Background(), NewTakeoverAllowlist(set))
+	}
+
+	folderIdentifier := func(name string) ResourceIdentifier {
+		return ResourceIdentifier{Name: name, Group: FolderResource.Group, Kind: FolderKind.Kind}
+	}
+
+	t.Run("claims unmanaged folder when it is in the allowlist", func(t *testing.T) {
+		repo := newRepo(t)
+
+		var updatedObj *unstructured.Unstructured
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return unmanagedFolder(name, "Existing Title"), nil
+			},
+			updateFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				updatedObj = obj.DeepCopy()
+				return obj, nil
+			},
+		}
+
+		fm := NewFolderManager(repo, client, NewEmptyFolderTree(), FolderKind)
+		err := fm.EnsureFolderExists(allowlistCtx(folderIdentifier(folderID)), Folder{
+			ID:    folderID,
+			Title: "New Title",
+			Path:  "Testing/",
+		}, "")
+
+		require.NoError(t, err)
+		require.Equal(t, []string{folderID}, client.updateCalls, "the unmanaged folder should be claimed via update")
+
+		require.NotNil(t, updatedObj)
+		manager := updatedObj.GetAnnotations()[utils.AnnoKeyManagerIdentity]
+		require.Equal(t, repoName, manager, "the claimed folder should be managed by this repository")
+		title, _, _ := unstructured.NestedString(updatedObj.Object, "spec", "title")
+		require.Equal(t, "New Title", title)
+	})
+
+	t.Run("rejects unmanaged folder when there is no allowlist", func(t *testing.T) {
+		repo := newRepo(t)
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return unmanagedFolder(name, "Existing Title"), nil
+			},
+		}
+
+		fm := NewFolderManager(repo, client, NewEmptyFolderTree(), FolderKind)
+		err := fm.EnsureFolderExists(context.Background(), Folder{ID: folderID, Title: "New Title"}, "")
+
+		var unmanagedErr *ResourceUnmanagedConflictError
+		require.True(t, errors.As(err, &unmanagedErr), "should return ResourceUnmanagedConflictError")
+		require.Empty(t, client.updateCalls)
+	})
+
+	t.Run("rejects unmanaged folder when a different folder is allowlisted", func(t *testing.T) {
+		repo := newRepo(t)
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return unmanagedFolder(name, "Existing Title"), nil
+			},
+		}
+
+		fm := NewFolderManager(repo, client, NewEmptyFolderTree(), FolderKind)
+		err := fm.EnsureFolderExists(allowlistCtx(folderIdentifier("some-other-folder")), Folder{ID: folderID, Title: "New Title"}, "")
+
+		var unmanagedErr *ResourceUnmanagedConflictError
+		require.True(t, errors.As(err, &unmanagedErr), "should return ResourceUnmanagedConflictError")
+		require.Empty(t, client.updateCalls)
+	})
+
+	t.Run("claims unmanaged folder on the create-then-already-exists race path", func(t *testing.T) {
+		repo := newRepo(t)
+
+		var getCount int
+		var updatedObj *unstructured.Unstructured
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				getCount++
+				if getCount == 1 {
+					return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+				}
+				return unmanagedFolder(name, "Existing Title"), nil
+			},
+			createFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, folderID)
+			},
+			updateFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				updatedObj = obj.DeepCopy()
+				return obj, nil
+			},
+		}
+
+		fm := NewFolderManager(repo, client, NewEmptyFolderTree(), FolderKind)
+		err := fm.EnsureFolderExists(allowlistCtx(folderIdentifier(folderID)), Folder{
+			ID:    folderID,
+			Title: "New Title",
+			Path:  "Testing/",
+		}, "")
+
+		require.NoError(t, err)
+		require.Equal(t, []string{folderID}, client.updateCalls, "the raced unmanaged folder should be claimed via update")
+		require.NotNil(t, updatedObj)
+		require.Equal(t, repoName, updatedObj.GetAnnotations()[utils.AnnoKeyManagerIdentity])
+	})
+
+	t.Run("rejects unmanaged folder on the race path when not allowlisted", func(t *testing.T) {
+		repo := newRepo(t)
+
+		var getCount int
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				getCount++
+				if getCount == 1 {
+					return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+				}
+				return unmanagedFolder(name, "Existing Title"), nil
+			},
+			createFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, folderID)
+			},
+		}
+
+		fm := NewFolderManager(repo, client, NewEmptyFolderTree(), FolderKind)
+		err := fm.EnsureFolderExists(context.Background(), Folder{ID: folderID, Title: "New Title"}, "")
+
+		var unmanagedErr *ResourceUnmanagedConflictError
+		require.True(t, errors.As(err, &unmanagedErr), "should return ResourceUnmanagedConflictError")
+		require.Empty(t, client.updateCalls)
+	})
+
+	t.Run("classifies a permanent folder-API error from the race-path claim as a typed warning", func(t *testing.T) {
+		// A permanent 4xx during the takeover-claim Update on the race path must
+		// be surfaced as a typed warning (so the sync does not retry forever),
+		// not wrapped as a generic error.
+		repo := newRepo(t)
+
+		var getCount int
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				getCount++
+				if getCount == 1 {
+					return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+				}
+				return unmanagedFolder(name, "Existing Title"), nil
+			},
+			createFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, folderID)
+			},
+			updateFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewBadRequest("folder max depth exceeded, max depth is 4")
+			},
+		}
+
+		fm := NewFolderManager(repo, client, NewEmptyFolderTree(), FolderKind)
+		err := fm.EnsureFolderExists(allowlistCtx(folderIdentifier(folderID)), Folder{
+			ID:    folderID,
+			Title: "New Title",
+			Path:  "a/b/c/d/e/",
+		}, "")
+
+		var depthErr *FolderDepthExceededError
+		require.True(t, errors.As(err, &depthErr), "claim path should classify the depth error as FolderDepthExceededError")
+		require.NotEmpty(t, client.updateCalls, "the claim should have attempted an update")
 	})
 }
 

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -2614,6 +2614,80 @@ func NewManagedDashboard(apiVersion, name, repoName, sourcePath, message string)
 	}
 }
 
+// NewUnmanagedFolder builds an unstructured Folder with no manager annotations,
+// for tests that need a pre-existing folder the provisioning code has not
+// claimed. A generated name is used so multiple folders can coexist; pass a
+// non-empty parentUID to nest the folder beneath another.
+func NewUnmanagedFolder(title, parentUID string) *unstructured.Unstructured {
+	metadata := map[string]interface{}{
+		"generateName": "unmanaged-folder-",
+		"namespace":    "default",
+	}
+	if parentUID != "" {
+		metadata["annotations"] = map[string]interface{}{
+			utils.AnnoKeyFolder: parentUID,
+		}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "folder.grafana.app/v1",
+			"kind":       "Folder",
+			"metadata":   metadata,
+			"spec": map[string]interface{}{
+				"title": title,
+			},
+		},
+	}
+}
+
+// NewUnmanagedDashboard builds an unstructured Dashboard with no manager
+// annotations. A generated name is used; pass a non-empty folderUID to place it
+// inside a folder.
+func NewUnmanagedDashboard(apiVersion, title, folderUID string) *unstructured.Unstructured {
+	metadata := map[string]interface{}{
+		"generateName": "unmanaged-dash-",
+		"namespace":    "default",
+	}
+	if folderUID != "" {
+		metadata["annotations"] = map[string]interface{}{
+			utils.AnnoKeyFolder: folderUID,
+		}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       "Dashboard",
+			"metadata":   metadata,
+			"spec": map[string]interface{}{
+				"title":         title,
+				"schemaVersion": 41,
+			},
+		},
+	}
+}
+
+// CreateUnmanagedFolder creates a folder with no manager annotations under the
+// given parent (pass "" for a root folder) and returns its generated UID. It
+// asserts the folder starts unmanaged so callers can rely on that precondition.
+func (h *ProvisioningTestHelper) CreateUnmanagedFolder(t *testing.T, ctx context.Context, title, parentUID string) string {
+	t.Helper()
+	created, err := h.Folders.Resource.Create(ctx, NewUnmanagedFolder(title, parentUID), metav1.CreateOptions{})
+	require.NoError(t, err, "should create unmanaged folder %q", title)
+	require.Empty(t, created.GetAnnotations()[utils.AnnoKeyManagerIdentity], "folder %q should start unmanaged", title)
+	return created.GetName()
+}
+
+// CreateUnmanagedDashboard creates a v1 dashboard with no manager annotations in
+// the given folder (pass "" for a root dashboard) and returns its generated
+// name. It asserts the dashboard starts unmanaged.
+func (h *ProvisioningTestHelper) CreateUnmanagedDashboard(t *testing.T, ctx context.Context, title, folderUID string) string {
+	t.Helper()
+	created, err := h.DashboardsV1.Resource.Create(ctx, NewUnmanagedDashboard("dashboard.grafana.app/v1", title, folderUID), metav1.CreateOptions{})
+	require.NoError(t, err, "should create unmanaged dashboard %q", title)
+	require.Empty(t, created.GetAnnotations()[utils.AnnoKeyManagerIdentity], "dashboard %q should start unmanaged", title)
+	return created.GetName()
+}
+
 type exportRepoInfo struct {
 	user   *gittest.User
 	remote *gittest.RemoteRepository

--- a/pkg/tests/apis/provisioning/jobs/exportjob_specific_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_specific_test.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
@@ -118,6 +120,84 @@ func TestIntegrationProvisioning_ExportSpecificResources(t *testing.T) {
 	excluded := filepath.Join(helper.ProvisioningPath, "test-dashboard-created-at-v2alpha1.json")
 	_, err = os.Stat(excluded)
 	require.True(t, os.IsNotExist(err), "non-selected dashboard file should not be written: %s", excluded)
+}
+
+// TestIntegrationProvisioning_SelectiveMigrateDashboardInNestedFolders verifies the
+// end-to-end selective migrate of a single dashboard that lives several levels
+// deep in a pre-existing unmanaged folder hierarchy: the migrate job completes
+// successfully and the dashboard ends up managed by the repository, parented
+// under a fully-managed folder chain.
+//
+// Note: this package runs with the provisioningFolderMetadata flag disabled, so
+// the export does not write a _folder.json preserving the original folder UIDs;
+// the sync therefore creates fresh managed folders instead of taking over the
+// original unmanaged ones. The unmanaged-parent-folder takeover path (the
+// selective-migrate folder-conflict regression) requires that flag and is
+// covered by the unit tests in
+// pkg/registry/apis/provisioning/resources/folders_test.go
+// (TestEnsureFolderExists_TakeoverAllowlist).
+func TestIntegrationProvisioning_SelectiveMigrateDashboardInNestedFolders(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	// Pre-existing unmanaged folder hierarchy: grandparent > parent > child, with
+	// an unmanaged dashboard in the deepest (child) folder.
+	grandparentUID := helper.CreateUnmanagedFolder(t, ctx, "Selective Migrate Grandparent", "")
+	parentUID := helper.CreateUnmanagedFolder(t, ctx, "Selective Migrate Parent", grandparentUID)
+	childUID := helper.CreateUnmanagedFolder(t, ctx, "Selective Migrate Child", parentUID)
+	dashName := helper.CreateUnmanagedDashboard(t, ctx, "Dashboard in nested unmanaged folder", childUID)
+
+	const repo = "selective-migrate-nested-repo"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:               repo,
+		SyncTarget:         "instance",
+		Workflows:          []string{"write"},
+		Copies:             map[string]string{},
+		ExpectedDashboards: 1,
+		ExpectedFolders:    3,
+	})
+
+	// Selective migrate naming only the dashboard. The folders are not named, but
+	// the export emits the folder tree so the dashboard's nested path resolves.
+	migrateJob := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionMigrate,
+		Migrate: &provisioning.MigrateJobOptions{
+			Message: "Selectively migrate one nested dashboard",
+			Resources: []provisioning.ResourceRef{
+				{Name: dashName, Kind: "Dashboard", Group: "dashboard.grafana.app"},
+			},
+		},
+	})
+	common.HasNoErrors()(t, migrateJob)
+	common.HasState(provisioning.JobStateSuccess)(t, migrateJob)
+
+	// The dashboard is now managed by the repo, and every folder in its ancestry
+	// (child > parent > grandparent) is managed by the repo too.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		d, err := helper.DashboardsV1.Resource.Get(ctx, dashName, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "dashboard should still exist") {
+			return
+		}
+		assert.Equal(collect, repo, d.GetAnnotations()[utils.AnnoKeyManagerIdentity],
+			"dashboard should be managed by the repo after migration")
+
+		// Walk the parent chain from the dashboard up to the root, asserting each
+		// folder is managed by the repo. Three folders deep proves the nested path
+		// was fully created and claimed.
+		depth := 0
+		folderUID := d.GetAnnotations()[utils.AnnoKeyFolder]
+		for folderUID != "" {
+			f, err := helper.Folders.Resource.Get(ctx, folderUID, metav1.GetOptions{})
+			if !assert.NoError(collect, err, "ancestor folder %q should exist", folderUID) {
+				return
+			}
+			assert.Equal(collect, repo, f.GetAnnotations()[utils.AnnoKeyManagerIdentity],
+				"ancestor folder %q should be managed by the repo", folderUID)
+			depth++
+			folderUID = f.GetAnnotations()[utils.AnnoKeyFolder]
+		}
+		assert.Equal(collect, 3, depth, "dashboard should sit under a 3-level managed folder chain")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard should become managed under a managed nested folder chain")
 }
 
 // TestIntegrationProvisioning_ExportSpecificResources_NotFound verifies that


### PR DESCRIPTION
## Summary

Selective migrate (the "Migrate to GitOps" flow with an explicit resource list) of a dashboard living inside a **pre-existing unmanaged folder** failed. The job ended in the `warning` state and the dashboard was skipped:

```
ensuring folder exists at path Testing/: failed to create path Testing: ensure folder exists:
resource 'cfow7n6tbs9vkd' already exists and is not managed; repo 'repository-18c5c45'
cannot take over without an explicit migration (file: Testing/, action: created)
resource was not processed because the parent folder could not be created
(file: Testing/new-dashboard.json, action: ignored)
```

### Root cause

The migrate worker exports the resource, records the exported identifiers in a **takeover allowlist**, and passes it to the sync phase via context. `CheckResourceOwnership` honours that allowlist for regular resources — but folders are created through `FolderManager.EnsureFolderExists`, which checked the manager annotation directly and rejected any unmanaged folder **without ever consulting the allowlist**. The export phase *does* add the folder to the allowlist (the whole unmanaged folder tree is exported and recorded as created), so the only missing piece was the folder gate honouring it.

> The conflict surfaces when the `provisioningFolderMetadata` flag is on (GA / default): the export writes a `_folder.json` preserving the folder's original UID, so the sync phase resolves the same unmanaged folder that already exists.

## Changes

- `EnsureFolderExists` now consults the takeover allowlist in **both** rejection sites (the existing-folder path and the create-then-already-exists race path) via a new `folderTakeoverAllowed` helper that mirrors `CheckResourceOwnership`'s allowlist gate.
- When an unmanaged folder is allowlisted, it is **claimed**: repo manager + source properties are stamped and the update is forced, converting the previously unmanaged folder into one managed by the repository (new `claimUnmanagedFolder` helper for the race path).
- Behaviour is unchanged when no allowlist is present or the folder is not allowlisted — it still returns `ResourceUnmanagedConflictError`.

## Testing

- **Unit** (`resources/folders_test.go`, `TestEnsureFolderExists_TakeoverAllowlist`) — the primary regression guard for the fix: claim-when-allowlisted, reject-when-no-allowlist, reject-when-a-different-folder-is-allowlisted, plus both race-path variants. Asserts manager-identity stamping and update calls. Verified it fails without the fix and passes with it.
- **Integration** (`tests/apis/provisioning/jobs/exportjob_specific_test.go`, `TestIntegrationProvisioning_SelectiveMigrateDashboardInFolder`) — end-to-end selective migrate of a dashboard inside an unmanaged folder; asserts the job succeeds and the dashboard ends up managed under a managed folder, using the `common` job matchers (`HasState` / `HasNoErrors`). This package runs with folder metadata disabled, so it exercises the broader selective-migrate flow but not the UID-preserving takeover path itself — that is covered by the unit tests above (noted in a comment on the test).
- `gofmt` / `go vet` clean; the integration test passes locally.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes
- [ ] Backend-only change (frontend PR not needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)