### PR TITLE
Search: declare standard search fields as SearchFieldDefinitions

### DIFF
--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -16,12 +16,25 @@ import (
 type SearchCapability string
 
 const (
-	SearchCapabilityFilter   SearchCapability = "filter"   // exact-match filtering (Bleve keyword analyzer)
-	SearchCapabilityText     SearchCapability = "text"     // full-token search (Bleve standard analyzer)
-	SearchCapabilityPartial  SearchCapability = "partial"  // substring matching (Bleve ngram analyzer); requires text
-	SearchCapabilitySort     SearchCapability = "sort"     // sortable on the keyword variant
+	SearchCapabilityFilter SearchCapability = "filter" // exact-match filtering (Bleve keyword analyzer)
+	SearchCapabilityText   SearchCapability = "text"   // full-token search (Bleve standard analyzer)
+	// SearchCapabilityPartial enables substring matching (Bleve ngram
+	// analyzer). Requires SearchCapabilityText.
+	SearchCapabilityPartial SearchCapability = "partial"
+	// SearchCapabilitySort makes the field sortable. It also enables DocValues
+	// on the keyword variant, which the authz searcher reads column-wise to
+	// check folder permissions on every matching document.
+	SearchCapabilitySort     SearchCapability = "sort"
 	SearchCapabilityFacet    SearchCapability = "facet"    // facetable on the keyword variant
 	SearchCapabilityRetrieve SearchCapability = "retrieve" // value is stored and returned in search results
+	// SearchCapabilityUnranked applies only to text fields. It drops per-term
+	// frequency stats and field-length norms from the index, saving space at
+	// the cost of BM25 ranking quality. Use it for text fields that are
+	// indexed (for example so the value can be retrieved or matched) but are
+	// never queried in a scored context. Redundant on filter / facet / sort
+	// fields: keyword variants are always exact-match and never carry BM25
+	// stats.
+	SearchCapabilityUnranked SearchCapability = "unranked"
 )
 
 // SearchFieldType is the value type of a search field.

--- a/pkg/storage/unified/resource/standard_search_fields.go
+++ b/pkg/storage/unified/resource/standard_search_fields.go
@@ -1,0 +1,86 @@
+package resource
+
+// StandardSearchFieldDefinitions returns the standard searchable fields that
+// every kind shares, in their internal SearchFieldDefinition form. The bleve
+// mapping builder iterates this list to emit top-level field mappings.
+//
+// Not every standard field appears here. Fields excluded:
+//
+//   - Pseudo / wire-only columns (_id, _legacy_id, _score, _explain,
+//     _all_columns, rv, kind, namespace, group/resource, created): they exist
+//     solely to populate ResourceTable column metadata in the gRPC response
+//     and are not indexed.
+//   - Sub-document fields under "manager." and "source.": nested documents
+//     whose bleve mappings are emitted hardcoded.
+//   - Fields under "labels." and "reference.": open key sets, served by
+//     dynamic bleve mappings rather than static field declarations.
+func StandardSearchFieldDefinitions() []SearchFieldDefinition {
+	return []SearchFieldDefinition{
+		{
+			Name:         SEARCH_FIELD_NAME,
+			Type:         SearchFieldTypeString,
+			Capabilities: []SearchCapability{SearchCapabilityFilter},
+			Description:  "Kubernetes name. Unique identifier within a namespace+group+resource.",
+		},
+		{
+			Name: SEARCH_FIELD_TITLE,
+			Type: SearchFieldTypeString,
+			// Title gets every capability today: keyword variant (title_phrase)
+			// for filtering, exact match, sorting, and DocValues-backed reads;
+			// text variant for full-token search; ngram for partial matching.
+			Capabilities: []SearchCapability{
+				SearchCapabilityFilter,
+				SearchCapabilityText,
+				SearchCapabilityPartial,
+				SearchCapabilitySort,
+				SearchCapabilityRetrieve,
+			},
+			Description: "Display name for the resource.",
+		},
+		{
+			Name: SEARCH_FIELD_DESCRIPTION,
+			Type: SearchFieldTypeString,
+			// unranked: description is indexed as text (the proto column declares
+			// FreeText:true), but no caller scores against it today; skipping
+			// BM25 frequency and length stats keeps the index small.
+			Capabilities: []SearchCapability{SearchCapabilityText, SearchCapabilityRetrieve, SearchCapabilityUnranked},
+			Description:  "Free-text description of the resource.",
+		},
+		{
+			Name:         SEARCH_FIELD_TAGS,
+			Type:         SearchFieldTypeString,
+			Array:        true,
+			Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve},
+			Description:  "Unique tags.",
+		},
+		{
+			Name: SEARCH_FIELD_FOLDER,
+			Type: SearchFieldTypeString,
+			// sort here unlocks DocValues on the keyword variant. The authz
+			// searcher reads folder column-wise via DocValues for every
+			// matching document; sort capability is the same implementation
+			// requirement.
+			Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilitySort, SearchCapabilityRetrieve},
+			Description:  "Kubernetes name of the folder containing the resource.",
+		},
+		{
+			Name:         SEARCH_FIELD_CREATED_BY,
+			Type:         SearchFieldTypeString,
+			Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve},
+			Description:  "Who created the resource (format: user:<uid>).",
+		},
+		{
+			Name:         SEARCH_FIELD_OWNER_REFERENCES,
+			Type:         SearchFieldTypeString,
+			Array:        true,
+			Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve},
+			Description:  "Owner references in format {Group}/{Kind}/{Name}.",
+		},
+		{
+			Name:         SEARCH_FIELD_MANAGED_BY,
+			Type:         SearchFieldTypeString,
+			Capabilities: []SearchCapability{SearchCapabilityFacet},
+			Description:  "Manager identity in format {kind}:{id}; used for faceting.",
+		},
+	}
+}

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -35,6 +35,11 @@ import (
 // Special case: when def.Name == resource.SEARCH_FIELD_TITLE, the keyword
 // variant is named resource.SEARCH_FIELD_TITLE_PHRASE rather than
 // "<name>_keyword". In-tree gRPC clients reference "title_phrase" by name.
+//
+// All emitted mappings have IncludeInAll explicitly set to false. The
+// composite "_all" sub-document is disabled at the index level (see
+// getBleveDocMappings), so IncludeInAll has no runtime effect; setting it
+// false keeps the emitted JSON consistent.
 func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.SearchFieldDefinition) {
 	hasFilter := def.HasCapability(resource.SearchCapabilityFilter)
 	hasText := def.HasCapability(resource.SearchCapabilityText)
@@ -42,6 +47,7 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 	hasSort := def.HasCapability(resource.SearchCapabilitySort)
 	hasFacet := def.HasCapability(resource.SearchCapabilityFacet)
 	hasRetrieve := def.HasCapability(resource.SearchCapabilityRetrieve)
+	hasUnranked := def.HasCapability(resource.SearchCapabilityUnranked)
 
 	needKeyword := hasFilter || hasFacet || hasSort
 	keywordName := keywordVariantName(def.Name, hasText)
@@ -54,6 +60,7 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 		// Canonical field for storage is the keyword variant only when no text
 		// mapping will also be created.
 		m.Store = hasRetrieve && !hasText
+		m.IncludeInAll = false
 		parent.AddFieldMappingsAt(keywordName, m)
 	}
 
@@ -63,6 +70,8 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 		m.IncludeTermVectors = false
 		m.DocValues = false
 		m.Store = hasRetrieve
+		m.IncludeInAll = false
+		m.SkipFreqNorm = hasUnranked
 		parent.AddFieldMappingsAt(def.Name, m)
 	}
 
@@ -74,6 +83,7 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 		// ngram variant is never the canonical retrieval target; the keyword
 		// or text variant already stores the value.
 		m.Store = false
+		m.IncludeInAll = false
 		parent.AddFieldMappingsAt(def.Name+"_ngram", m)
 	}
 
@@ -116,159 +126,14 @@ func GetBleveMappings(fields resource.SearchableDocumentFields, selectableFields
 func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFields []string) *mapping.DocumentMapping {
 	mapper := bleve.NewDocumentStaticMapping()
 
-	nameMapping := &mapping.FieldMapping{
-		Analyzer:     keyword.Name,
-		Type:         "text",
-		Index:        true,
-		SkipFreqNorm: true,
+	// Standard top-level search fields are declared as SearchFieldDefinitions
+	// and emitted through the capability helper.
+	for _, def := range resource.StandardSearchFieldDefinitions() {
+		addCapabilityFieldMappings(mapper, def)
 	}
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_NAME, nameMapping)
 
-	// for exact title matching and sorting. Keyword mapping means Bleve indexes the whole value as one token.
-	titlePhraseMapping := bleve.NewKeywordFieldMapping()
-	titlePhraseMapping.Store = false // already stored in title
-	titlePhraseMapping.IncludeTermVectors = false
-	titlePhraseMapping.SkipFreqNorm = true
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE_PHRASE, titlePhraseMapping)
-
-	// for partial/prefix searching by title - uses ngram token filter
-	titleNgramMapping := bleve.NewTextFieldMapping()
-	titleNgramMapping.Analyzer = TITLE_ANALYZER
-	titleNgramMapping.Store = false // already stored in title
-	titleNgramMapping.DocValues = false
-	titleNgramMapping.IncludeTermVectors = false
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE_NGRAM, titleNgramMapping)
-
-	// for full-token title search; partial matches use title_ngram
-	titleMapping := bleve.NewTextFieldMapping()
-	titleMapping.Analyzer = standard.Name
-	titleMapping.Store = true
-	titleMapping.DocValues = false
-	titleMapping.IncludeTermVectors = false
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE, titleMapping)
-
-	descriptionMapping := &mapping.FieldMapping{
-		Name:               resource.SEARCH_FIELD_DESCRIPTION,
-		Type:               "text",
-		Store:              true,
-		Index:              true,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-		DocValues:          false,
-		SkipFreqNorm:       true,
-	}
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_DESCRIPTION, descriptionMapping)
-
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TAGS, &mapping.FieldMapping{
-		Name:               resource.SEARCH_FIELD_TAGS,
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Store:              true,
-		Index:              true,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-		DocValues:          false,
-		SkipFreqNorm:       true,
-	})
-
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_OWNER_REFERENCES, &mapping.FieldMapping{
-		Name:               resource.SEARCH_FIELD_OWNER_REFERENCES,
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Store:              true,
-		Index:              true,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-		DocValues:          false,
-		SkipFreqNorm:       true,
-	})
-
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_CREATED_BY, &mapping.FieldMapping{
-		Name:               resource.SEARCH_FIELD_CREATED_BY,
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Store:              true,
-		Index:              true,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-		DocValues:          false,
-		SkipFreqNorm:       true,
-	})
-
-	folderMapping := &mapping.FieldMapping{
-		Name:               resource.SEARCH_FIELD_FOLDER,
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Store:              true,
-		Index:              true,
-		IncludeTermVectors: false,
-		IncludeInAll:       true,
-		DocValues:          true, // will be needed for authz client
-		SkipFreqNorm:       true,
-	}
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_FOLDER, folderMapping)
-
-	// Repositories
-	manager := bleve.NewDocumentStaticMapping()
-	manager.AddFieldMappingsAt("kind", &mapping.FieldMapping{
-		Name:               "kind",
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Store:              true,
-		Index:              true,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-		SkipFreqNorm:       true,
-	})
-	manager.AddFieldMappingsAt("id", &mapping.FieldMapping{
-		Name:               "id",
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Store:              true,
-		Index:              true,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-		SkipFreqNorm:       true,
-	})
-
-	source := bleve.NewDocumentStaticMapping()
-	source.AddFieldMappingsAt("path", &mapping.FieldMapping{
-		Name:               "path",
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Store:              true,
-		Index:              true,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-		SkipFreqNorm:       true,
-	})
-	source.AddFieldMappingsAt("checksum", &mapping.FieldMapping{
-		Name:               "checksum",
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Store:              true,
-		Index:              true,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-		SkipFreqNorm:       true,
-	})
-	timestampMillisMapping := mapping.NewNumericFieldMapping()
-	timestampMillisMapping.DocValues = false
-	timestampMillisMapping.SkipFreqNorm = true
-	source.AddFieldMappingsAt("timestampMillis", timestampMillisMapping)
-
-	mapper.AddSubDocumentMapping("source", source)
-	mapper.AddSubDocumentMapping("manager", manager)
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_MANAGED_BY, &mapping.FieldMapping{
-		Name:               "managedBy",
-		Type:               "text",
-		Analyzer:           keyword.Name,
-		Index:              true, // only used for faceting
-		Store:              false,
-		IncludeTermVectors: false,
-		IncludeInAll:       false,
-		SkipFreqNorm:       true,
-	})
+	mapper.AddSubDocumentMapping("manager", managerSubDocumentMapping())
+	mapper.AddSubDocumentMapping("source", sourceSubDocumentMapping())
 
 	// NOTE: reference and labels use dynamic mappings because their keys aren't
 	// known at mapping time. Bleve auto-creates fields using NewTextFieldMapping()
@@ -324,4 +189,37 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 	mapper.AddSubDocumentMapping(strings.TrimSuffix(resource.SEARCH_SELECTABLE_FIELDS_PREFIX, "."), selectableFieldsMapper)
 
 	return mapper
+}
+
+// keywordSubField returns a keyword (exact-match) field mapping for use inside
+// a sub-document. Sub-document fields are not modellable as
+// SearchFieldDefinitions today; this helper centralizes their shared shape.
+func keywordSubField() *mapping.FieldMapping {
+	return &mapping.FieldMapping{
+		Type:               "text",
+		Analyzer:           keyword.Name,
+		Store:              true,
+		Index:              true,
+		IncludeTermVectors: false,
+		IncludeInAll:       false,
+		SkipFreqNorm:       true,
+	}
+}
+
+func managerSubDocumentMapping() *mapping.DocumentMapping {
+	m := bleve.NewDocumentStaticMapping()
+	m.AddFieldMappingsAt("kind", keywordSubField())
+	m.AddFieldMappingsAt("id", keywordSubField())
+	return m
+}
+
+func sourceSubDocumentMapping() *mapping.DocumentMapping {
+	m := bleve.NewDocumentStaticMapping()
+	m.AddFieldMappingsAt("path", keywordSubField())
+	m.AddFieldMappingsAt("checksum", keywordSubField())
+	timestamp := mapping.NewNumericFieldMapping()
+	timestamp.DocValues = false
+	timestamp.SkipFreqNorm = true
+	m.AddFieldMappingsAt("timestampMillis", timestamp)
+	return m
 }

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -71,6 +71,26 @@ func TestAddCapabilityFieldMappings_TextRetrieve(t *testing.T) {
 	assert.False(t, m.IncludeTermVectors)
 }
 
+func TestAddCapabilityFieldMappings_TextRetrieveUnranked(t *testing.T) {
+	// unranked on a text field drops BM25 frequency / length stats from the
+	// index. Used by standard "description" today.
+	got := flatMappings(t, resource.SearchFieldDefinition{
+		Name: "summary",
+		Type: resource.SearchFieldTypeString,
+		Capabilities: []resource.SearchCapability{
+			resource.SearchCapabilityText,
+			resource.SearchCapabilityRetrieve,
+			resource.SearchCapabilityUnranked,
+		},
+	})
+
+	require.Equal(t, []string{"summary"}, slices.Sorted(maps.Keys(got)))
+	m := got["summary"]
+	assert.Equal(t, standard.Name, m.Analyzer)
+	assert.True(t, m.Store)
+	assert.True(t, m.SkipFreqNorm, "unranked must set SkipFreqNorm on the text mapping")
+}
+
 func TestAddCapabilityFieldMappings_FilterAndText(t *testing.T) {
 	// Filter together with text: text takes the base name, keyword variant
 	// moves to "<name>_keyword".

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -83,6 +83,8 @@ func TestTermVectorsAndFreqNorm(t *testing.T) {
 	require.NoError(t, err)
 
 	// Keyword/exact-match fields must skip freq/norm (no BM25 scoring needed).
+	// description is in this bucket because the field is not scored today; the
+	// SkipFreqNorm:true on its text mapping is an index-size optimization.
 	mustSkipFreqNorm := map[string]bool{
 		resource.SEARCH_FIELD_NAME:             true,
 		resource.SEARCH_FIELD_TITLE_PHRASE:     true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -12,7 +12,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "createdBy",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
@@ -26,8 +25,8 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "description",
             "type": "text",
+            "analyzer": "standard",
             "store": true,
             "index": true,
             "skip_freq_norm": true
@@ -43,12 +42,10 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "folder",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
             "index": true,
-            "include_in_all": true,
             "docvalues": true,
             "skip_freq_norm": true
           }
@@ -63,7 +60,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "managedBy",
             "type": "text",
             "analyzer": "keyword",
             "index": true,
@@ -80,7 +76,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "id",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -94,7 +89,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "kind",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -122,7 +116,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "ownerReferences",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
@@ -149,7 +142,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "checksum",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -163,7 +155,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "path",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -192,7 +183,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "tags",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
@@ -209,8 +199,7 @@
             "type": "text",
             "analyzer": "standard",
             "store": true,
-            "index": true,
-            "include_in_all": true
+            "index": true
           }
         ]
       },
@@ -221,8 +210,7 @@
           {
             "type": "text",
             "analyzer": "title_analyzer",
-            "index": true,
-            "include_in_all": true
+            "index": true
           }
         ]
       },
@@ -234,7 +222,6 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
-            "include_in_all": true,
             "docvalues": true,
             "skip_freq_norm": true
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_filterable_string.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_filterable_string.json
@@ -12,7 +12,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "createdBy",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
@@ -26,8 +25,8 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "description",
             "type": "text",
+            "analyzer": "standard",
             "store": true,
             "index": true,
             "skip_freq_norm": true
@@ -47,7 +46,6 @@
                 "analyzer": "keyword",
                 "store": true,
                 "index": true,
-                "include_in_all": true,
                 "skip_freq_norm": true
               }
             ]
@@ -59,12 +57,10 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "folder",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
             "index": true,
-            "include_in_all": true,
             "docvalues": true,
             "skip_freq_norm": true
           }
@@ -79,7 +75,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "managedBy",
             "type": "text",
             "analyzer": "keyword",
             "index": true,
@@ -96,7 +91,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "id",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -110,7 +104,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "kind",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -138,7 +131,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "ownerReferences",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
@@ -165,7 +157,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "checksum",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -179,7 +170,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "path",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -208,7 +198,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "tags",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
@@ -225,8 +214,7 @@
             "type": "text",
             "analyzer": "standard",
             "store": true,
-            "index": true,
-            "include_in_all": true
+            "index": true
           }
         ]
       },
@@ -237,8 +225,7 @@
           {
             "type": "text",
             "analyzer": "title_analyzer",
-            "index": true,
-            "include_in_all": true
+            "index": true
           }
         ]
       },
@@ -250,7 +237,6 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
-            "include_in_all": true,
             "docvalues": true,
             "skip_freq_norm": true
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -12,7 +12,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "createdBy",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
@@ -26,8 +25,8 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "description",
             "type": "text",
+            "analyzer": "standard",
             "store": true,
             "index": true,
             "skip_freq_norm": true
@@ -43,12 +42,10 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "folder",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
             "index": true,
-            "include_in_all": true,
             "docvalues": true,
             "skip_freq_norm": true
           }
@@ -63,7 +60,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "managedBy",
             "type": "text",
             "analyzer": "keyword",
             "index": true,
@@ -80,7 +76,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "id",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -94,7 +89,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "kind",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -122,7 +116,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "ownerReferences",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
@@ -177,7 +170,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "checksum",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -191,7 +183,6 @@
             "dynamic": true,
             "fields": [
               {
-                "name": "path",
                 "type": "text",
                 "analyzer": "keyword",
                 "store": true,
@@ -220,7 +211,6 @@
         "dynamic": true,
         "fields": [
           {
-            "name": "tags",
             "type": "text",
             "analyzer": "keyword",
             "store": true,
@@ -237,8 +227,7 @@
             "type": "text",
             "analyzer": "standard",
             "store": true,
-            "index": true,
-            "include_in_all": true
+            "index": true
           }
         ]
       },
@@ -249,8 +238,7 @@
           {
             "type": "text",
             "analyzer": "title_analyzer",
-            "index": true,
-            "include_in_all": true
+            "index": true
           }
         ]
       },
@@ -262,7 +250,6 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
-            "include_in_all": true,
             "docvalues": true,
             "skip_freq_norm": true
           }


### PR DESCRIPTION
Migrates the standard top-level search fields (`name`, `title`, `description`, `tags`, `folder`, `createdBy`, `ownerReferences`, `managedBy`) from hardcoded `bleve.FieldMapping` literals to declarative `SearchFieldDefinition` entries in a new `StandardSearchFieldDefinitions()`. The bleve mapping builder iterates that list and emits the mappings through the capability helper from #126280. `getBleveDocMappings` shrinks from ~190 to 67 lines. Manager / source sub-documents are extracted into small helpers.

Adds `SearchCapabilityUnranked` to express `description`'s text-without-BM25-stats shape (`SkipFreqNorm: true`) — an index-size optimization the capability set could not previously model.

Golden snapshots lose two redundant JSON entries everywhere: `include_in_all` (no-op since `_all` is disabled at the index level) and `name` on inner `FieldMapping`s. The `name` attribute is not used by bleve for indexing or querying — those are keyed off the property path passed to `AddFieldMappingsAt(...)`, which is already labelled by the enclosing `"properties"` key, so the inner `name` was just duplicating the enclosing key. `description` gains an explicit `"analyzer": "standard"` instead of relying on the index default. All non-functional — no reindex needed, runtime behaviour unchanged.

Tracking issue: grafana/search-and-storage-team#827.
