### PR TITLE
Alerting: Fix Test button not shown for provisioned contact points

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.test.tsx
@@ -1049,6 +1049,30 @@ describe('GrafanaReceiverForm', () => {
       const nameField = screen.getByRole('textbox', { name: /^name/i });
       expect(nameField).toHaveAttribute('readonly');
     });
+
+    it('should show test button for a provisioned contact point when the user has the test permission', async () => {
+      // Regression: isTestable was previously computed as !readOnly && canTest. For provisioned
+      // contact points, EditReceiverView sets readOnly=true (canWrite annotation is false), which
+      // suppressed the test button even when the user held the test permission (canTest=true).
+      // isTestable is now driven solely by useContactPointAbility(Test), which reads the
+      // grafana.com/access/canTest annotation independently of whether the form is read-only.
+      const contactPoint = alertingFactory.alertmanager.grafana.contactPoint
+        .withIntegrations((integrationFactory) => [integrationFactory.email().build()])
+        .build({
+          metadata: {
+            annotations: {
+              'grafana.com/access/canTest': 'true',
+            },
+          },
+        });
+
+      // readOnly={true} simulates what EditReceiverView passes for provisioned contact points
+      renderWithProvider(<GrafanaReceiverForm contactPoint={contactPoint} editMode readOnly />);
+
+      await waitFor(() => expect(ui.loadingIndicator.query()).not.toBeInTheDocument());
+
+      expect(ui.testButton.get()).toBeInTheDocument();
+    });
   });
 
   describe('with alertingSyncNotifiersApiMigration flag enabled', () => {

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
@@ -20,7 +20,9 @@ import {
 } from 'app/plugins/datasource/alertmanager/types';
 
 import { useIntegrationTypeSchemas } from '../../../api/integrationSchemasApi';
-import { useTestContactPoint } from '../../../hooks/useTestContactPoint';
+import { isGranted } from '../../../hooks/abilities/abilityUtils';
+import { useContactPointAbility } from '../../../hooks/abilities/alertmanager/useContactPointAbility';
+import { ContactPointAction } from '../../../hooks/abilities/types';
 import { type GrafanaChannelValues, type ReceiverFormValues } from '../../../types/receiver-form';
 import { canCreateNotifier, hasLegacyIntegrations } from '../../../utils/notifier-versions';
 import { formValuesToGrafanaReceiver, grafanaReceiverToFormValues } from '../../../utils/receiver-form';
@@ -127,17 +129,14 @@ export const GrafanaReceiverForm = ({ contactPoint, readOnly = false, editMode }
     });
   };
 
-  const { canTest } = useTestContactPoint({
-    contactPoint,
-    defaultChannelValues,
-  });
+  const testAbility = useContactPointAbility({ action: ContactPointAction.Test, context: contactPoint });
 
   // If there is no contact point it means we're creating a new one, so scoped permissions doesn't exist yet
   const hasScopedEditPermissions = contactPoint ? canEditEntity(contactPoint) : true;
   const hasScopedEditProtectedPermissions = contactPoint ? canModifyProtectedEntity(contactPoint) : true;
   const isProvisioned = isProvisionedResource(contactPoint?.provenance);
   const isEditable = !readOnly && hasScopedEditPermissions && !isProvisioned;
-  const isTestable = !readOnly && canTest;
+  const isTestable = isGranted(testAbility);
   const canEditProtectedFields = editMode ? hasScopedEditProtectedPermissions : true;
 
   if (isLoadingNotifiers || isLoadingOnCallIntegration) {

--- a/public/app/features/alerting/unified/hooks/abilities/alertmanager/useContactPointAbility.ts
+++ b/public/app/features/alerting/unified/hooks/abilities/alertmanager/useContactPointAbility.ts
@@ -5,7 +5,13 @@ import { AccessControlAction } from 'app/types/accessControl';
 
 import { useAlertmanager } from '../../../state/AlertmanagerContext';
 import { notificationsPermissions } from '../../../utils/access-control';
-import { type EntityToCheck, canDeleteEntity, canEditEntity, shouldUseK8sApi } from '../../../utils/k8s/utils';
+import {
+  type EntityToCheck,
+  canDeleteEntity,
+  canEditEntity,
+  canTestEntity,
+  shouldUseK8sApi,
+} from '../../../utils/k8s/utils';
 import { makeAbility, makeScopedAbility } from '../abilityUtils';
 import { type Ability, ContactPointAction, Granted, InUse, InsufficientPermissions } from '../types';
 
@@ -15,7 +21,8 @@ export type ContactPointAbilityParam =
   | { action: ContactPointAction.BulkExport }
   | { action: ContactPointAction.Update; context?: EntityToCheck }
   | { action: ContactPointAction.Delete; context: EntityToCheck }
-  | { action: ContactPointAction.Export; context: EntityToCheck };
+  | { action: ContactPointAction.Export; context: EntityToCheck }
+  | { action: ContactPointAction.Test; context?: EntityToCheck };
 
 /** Permissions for the Grafana-managed alertmanager (internal k8s API). */
 const PERMISSIONS: Record<ContactPointAction, AccessControlAction[]> = {
@@ -25,6 +32,11 @@ const PERMISSIONS: Record<ContactPointAction, AccessControlAction[]> = {
   [ContactPointAction.Delete]: [notificationsPermissions.delete.grafana, AccessControlAction.AlertingReceiversDelete],
   [ContactPointAction.Export]: [notificationsPermissions.read.grafana, AccessControlAction.AlertingReceiversRead],
   [ContactPointAction.BulkExport]: [notificationsPermissions.read.grafana, AccessControlAction.AlertingReceiversRead],
+  [ContactPointAction.Test]: [
+    notificationsPermissions.update.grafana, // alert.notifications:write — legacy broad permission
+    AccessControlAction.AlertingReceiversTest, // deprecated specific action, kept for backward compat
+    AccessControlAction.AlertingReceiversTestCreate, // current scoped test action
+  ],
 };
 
 /** Permissions for external alertmanagers (Mimir, Cortex, Vanilla Alertmanager, etc.). */
@@ -35,6 +47,7 @@ const EXTERNAL_AM_PERMISSIONS: Record<ContactPointAction, AccessControlAction[]>
   [ContactPointAction.Delete]: [notificationsPermissions.delete.external],
   [ContactPointAction.Export]: [notificationsPermissions.read.external],
   [ContactPointAction.BulkExport]: [], // Not applicable — gated by isGrafanaAlertmanager
+  [ContactPointAction.Test]: [], // Not applicable — the k8s test endpoint is Grafana AM only
 };
 
 export const PERMISSIONS_CONTACT_POINTS: AccessControlAction[] = Object.values(PERMISSIONS).flatMap(
@@ -111,6 +124,23 @@ export function useContactPointAbility(payload: ContactPointAbilityParam): Abili
           return makeAbility(hasConfigurationAPI, permissions[ContactPointAction.Export]);
         }
         return makeScopedAbility(hasConfigurationAPI, permissions[ContactPointAction.Export], payload.context);
+
+      case ContactPointAction.Test:
+        // The k8s integration-test endpoint exists only on the Grafana AM.
+        if (!isGrafanaAlertmanager || !hasConfigurationAPI) {
+          return makeAbility(false, PERMISSIONS[ContactPointAction.Test]);
+        }
+        // When we have a context (existing contact point), defer to the server-set canTest
+        // annotation. Deliberately bypass makeScopedAbility: provisioned contact points CAN
+        // still be tested when the user holds the test:create RBAC action, so we must not
+        // apply the provisioning guard that makeScopedAbility adds for Update/Delete.
+        if (usingK8sApi && payload.context !== undefined) {
+          return canTestEntity(payload.context)
+            ? Granted
+            : InsufficientPermissions(PERMISSIONS[ContactPointAction.Test]);
+        }
+        // New contact point (no context yet) — fall back to pure RBAC.
+        return makeAbility(true, PERMISSIONS[ContactPointAction.Test]);
     }
   }, [payload, hasConfigurationAPI, isGrafanaAlertmanager, selectedAlertmanager]);
 }

--- a/public/app/features/alerting/unified/hooks/abilities/types.ts
+++ b/public/app/features/alerting/unified/hooks/abilities/types.ts
@@ -42,6 +42,7 @@ export enum ContactPointAction {
   Delete = 'delete-contact-point',
   Export = 'export-contact-point',
   BulkExport = 'bulk-export-contact-points',
+  Test = 'test-contact-point',
 }
 
 export enum NotificationTemplateAction {

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -147,6 +147,9 @@ export enum AccessControlAction {
   AlertingReceiversWrite = 'alert.notifications.receivers:write',
   AlertingReceiversRead = 'alert.notifications.receivers:read',
   AlertingReceiversDelete = 'alert.notifications.receivers:delete',
+  /** @deprecated Use AlertingReceiversTestCreate instead */
+  AlertingReceiversTest = 'alert.notifications.receivers:test',
+  AlertingReceiversTestCreate = 'alert.notifications.receivers.test:create',
   AlertingReceiversUpdateProtected = 'alert.notifications.receivers.protected:write',
 
   // Legacy Alerting routes actions


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where the **Test** button was missing on provisioned contact points, even when the user had the required `alert.notifications.receivers.test:create` RBAC permission.

**Why do we need this feature?**

This is a regression caused by the interaction of two changes:

- [#116847](https://github.com/grafana/grafana/pull/116847) introduced the `canTest` annotation check and gated the Test button on `!readOnly && canTest`. At the time, `readOnly` was a pure RBAC check — for an admin it was always `false`, so the effective gate was just `canTest`.
- [#124978](https://github.com/grafana/grafana/pull/124978) changed `readOnly` to be derived from `useContactPointAbility({ action: Update, context: contactPoint })`, which checks the server-set `grafana.com/access/canWrite` annotation. The backend correctly sets this to `false` for provisioned resources (they can't be edited). However, the Test button inherited that gate, so `readOnly = true` suppressed the Test button for all provisioned contact points — regardless of whether the user had the test permission.

Neither change was wrong in isolation. The interaction wasn't visible from either diff.

**Fix**

This PR gives `ContactPointAction.Test` its own first-class ability check in `useContactPointAbility`, fully independent of the Update/edit gate:

- Adds `AlertingReceiversTest` (deprecated) and `AlertingReceiversTestCreate` to the `AccessControlAction` enum — mirroring the backend actions in `models.go`.
- Adds `ContactPointAction.Test` to the enum (parallel to the existing `NotificationTemplateAction.Test`).
- Handles the `Test` case in `useContactPointAbility`: reads the `grafana.com/access/canTest` annotation directly, deliberately **bypassing** `makeScopedAbility` so the provisioning guard is not applied.
- Replaces the `canTest` field from `useTestContactPoint` in `GrafanaReceiverForm` with `isGranted(useContactPointAbility({ action: Test }))`.
- The `PERMISSIONS` map for `Test` matches the backend's `testReceiversEvalOne` evaluator: `alert.notifications:write` (legacy broad), `alert.notifications.receivers:test` (deprecated), and `alert.notifications.receivers.test:create` (current).

**Who is this feature for?**

Users with provisioned contact points who have the test permission but not the write permission, or any user where the contact point is provisioned (managed via Terraform, Ansible, or the provisioning API).

**Which issue(s) does this PR fix?**

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

To verify the regression: temporarily revert `isTestable = isGranted(testAbility)` to `isTestable = !readOnly && isGranted(testAbility)` and the new test `should show test button for a provisioned contact point when the user has the test permission` will fail.