### PR TITLE
DashboardDS: Fix chained dashboard datasource panels showing stale data

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -1280,6 +1280,271 @@ describe('DashboardDatasourceBehaviour', () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('Chained dashboard datasource', () => {
+    // A "chained" dashboard datasource is a dashboard-DS panel whose source is itself
+    // a dashboard-DS panel. The intermediate forwards fresh upstream data on its
+    // already-open subscription without re-running, so its requestId stays constant
+    // across the stale -> fresh change. The consumer must still re-run (unlike a
+    // cancel, which keeps the same requestId but brings no new data).
+    it('Should re-run consumer when a source panel emits new Done data under the same requestId', async () => {
+      jest.spyOn(console, 'error').mockImplementation();
+
+      // Intermediate panel: a dashboard-DS panel pointing at a deeper query panel.
+      const sourcePanel = new VizPanel({
+        title: 'Intermediate dashboard-DS panel',
+        pluginId: 'table',
+        key: 'panel-1',
+        $data: new SceneDataTransformer({
+          transformations: [{ id: 'transformA', options: {} }],
+          $data: new SceneQueryRunner({
+            datasource: { uid: SHARED_DASHBOARD_QUERY },
+            queries: [{ refId: 'A', panelId: 44 }],
+            $behaviors: [new DashboardDatasourceBehaviour({})],
+          }),
+        }),
+      });
+
+      // Consumer panel: reads the intermediate panel via dashboard DS.
+      const dashboardDSPanel = new VizPanel({
+        title: 'Consumer panel',
+        pluginId: 'table',
+        key: 'panel-2',
+        $data: new SceneDataTransformer({
+          transformations: [],
+          $data: new SceneQueryRunner({
+            datasource: { uid: MIXED_DATASOURCE_NAME },
+            queries: [
+              {
+                datasource: { uid: SHARED_DASHBOARD_QUERY },
+                refId: 'B',
+                panelId: 1,
+              },
+            ],
+            $behaviors: [new DashboardDatasourceBehaviour({})],
+          }),
+        }),
+      });
+
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        meta: {
+          canEdit: true,
+        },
+        body: DefaultGridLayoutManager.fromVizPanels([sourcePanel, dashboardDSPanel]),
+      });
+
+      activateFullSceneTree(scene);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const spy = jest
+        .spyOn(dashboardDSPanel.state.$data!.state.$data as SceneQueryRunner, 'runQueries')
+        .mockImplementation();
+
+      const sameRequestId = 'SQR100';
+
+      // The intermediate forwards a STALE Done from its upstream.
+      (sourcePanel.state.$data as SceneDataTransformer).setState({
+        data: {
+          state: LoadingState.Done,
+          series: [{ fields: [], length: 10 }],
+          timeRange: getDefaultTimeRange(),
+          request: { requestId: sameRequestId } as DataQueryRequest,
+        },
+      });
+
+      spy.mockClear();
+
+      // The intermediate's upstream finishes; the intermediate forwards FRESH data
+      // on its still-open subscription. It did NOT re-run, so the requestId is
+      // unchanged, but the series content is different and the state is still Done.
+      (sourcePanel.state.$data as SceneDataTransformer).setState({
+        data: {
+          state: LoadingState.Done,
+          series: [{ fields: [], length: 20 }],
+          timeRange: getDefaultTimeRange(),
+          request: { requestId: sameRequestId } as DataQueryRequest,
+        },
+      });
+
+      // The consumer must re-run to pick up the fresh forwarded data.
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    // With no transformations the intermediate runs through the #118629 branch that
+    // subscribes to the source's SceneQueryRunner directly. The two tests below cover
+    // re-running on a fresh Done under the same requestId, and the #116767 cancel guard.
+    it('Should re-run consumer when a no-transformations source emits new Done data under the same requestId', async () => {
+      jest.spyOn(console, 'error').mockImplementation();
+
+      const sourcePanel = new VizPanel({
+        title: 'Intermediate dashboard-DS panel (no transformations)',
+        pluginId: 'table',
+        key: 'panel-1',
+        $data: new SceneDataTransformer({
+          transformations: [],
+          $data: new SceneQueryRunner({
+            datasource: { uid: SHARED_DASHBOARD_QUERY },
+            queries: [{ refId: 'A', panelId: 44 }],
+            $behaviors: [new DashboardDatasourceBehaviour({})],
+          }),
+        }),
+      });
+
+      const dashboardDSPanel = new VizPanel({
+        title: 'Consumer panel',
+        pluginId: 'table',
+        key: 'panel-2',
+        $data: new SceneDataTransformer({
+          transformations: [],
+          $data: new SceneQueryRunner({
+            datasource: { uid: MIXED_DATASOURCE_NAME },
+            queries: [
+              {
+                datasource: { uid: SHARED_DASHBOARD_QUERY },
+                refId: 'B',
+                panelId: 1,
+              },
+            ],
+            $behaviors: [new DashboardDatasourceBehaviour({})],
+          }),
+        }),
+      });
+
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        meta: {
+          canEdit: true,
+        },
+        body: DefaultGridLayoutManager.fromVizPanels([sourcePanel, dashboardDSPanel]),
+      });
+
+      activateFullSceneTree(scene);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const spy = jest
+        .spyOn(dashboardDSPanel.state.$data!.state.$data as SceneQueryRunner, 'runQueries')
+        .mockImplementation();
+
+      const sameRequestId = 'SQR100';
+
+      // The no-transformations branch subscribes to the source's inner query
+      // runner, so drive state there.
+      const sourceRunner = sourcePanel.state.$data!.state.$data as SceneQueryRunner;
+
+      // Stale Done forwarded by the intermediate.
+      sourceRunner.setState({
+        data: {
+          state: LoadingState.Done,
+          series: [{ fields: [], length: 10 }],
+          timeRange: getDefaultTimeRange(),
+          request: { requestId: sameRequestId } as DataQueryRequest,
+        },
+      });
+
+      spy.mockClear();
+
+      // Fresh Done forwarded on the still-open subscription: same requestId, new content.
+      sourceRunner.setState({
+        data: {
+          state: LoadingState.Done,
+          series: [{ fields: [], length: 20 }],
+          timeRange: getDefaultTimeRange(),
+          request: { requestId: sameRequestId } as DataQueryRequest,
+        },
+      });
+
+      // The consumer must re-run to pick up the fresh forwarded data.
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should NOT re-run consumer on cancel when the source panel has no transformations', async () => {
+      jest.spyOn(console, 'error').mockImplementation();
+
+      const sourcePanel = new VizPanel({
+        title: 'Source panel (no transformations)',
+        pluginId: 'table',
+        key: 'panel-1',
+        $data: new SceneDataTransformer({
+          transformations: [],
+          $data: new SceneQueryRunner({
+            datasource: { uid: SHARED_DASHBOARD_QUERY },
+            queries: [{ refId: 'A', panelId: 44 }],
+            $behaviors: [new DashboardDatasourceBehaviour({})],
+          }),
+        }),
+      });
+
+      const dashboardDSPanel = new VizPanel({
+        title: 'Consumer panel',
+        pluginId: 'table',
+        key: 'panel-2',
+        $data: new SceneDataTransformer({
+          transformations: [],
+          $data: new SceneQueryRunner({
+            datasource: { uid: MIXED_DATASOURCE_NAME },
+            queries: [
+              {
+                datasource: { uid: SHARED_DASHBOARD_QUERY },
+                refId: 'B',
+                panelId: 1,
+              },
+            ],
+            $behaviors: [new DashboardDatasourceBehaviour({})],
+          }),
+        }),
+      });
+
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        meta: {
+          canEdit: true,
+        },
+        body: DefaultGridLayoutManager.fromVizPanels([sourcePanel, dashboardDSPanel]),
+      });
+
+      activateFullSceneTree(scene);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const spy = jest
+        .spyOn(dashboardDSPanel.state.$data!.state.$data as SceneQueryRunner, 'runQueries')
+        .mockImplementation();
+
+      const sameRequestId = 'SQR100';
+      const sourceRunner = sourcePanel.state.$data!.state.$data as SceneQueryRunner;
+
+      // Query in flight.
+      sourceRunner.setState({
+        data: {
+          state: LoadingState.Loading,
+          series: [],
+          timeRange: getDefaultTimeRange(),
+          request: { requestId: sameRequestId } as DataQueryRequest,
+        },
+      });
+
+      spy.mockClear();
+
+      // Cancel: state flips to Done with the same requestId and no new data.
+      sourceRunner.setState({
+        data: {
+          state: LoadingState.Done,
+          series: [],
+          timeRange: getDefaultTimeRange(),
+          request: { requestId: sameRequestId } as DataQueryRequest,
+        },
+      });
+
+      // Must NOT re-run on cancel (regression guard for #116767 on the #118629 branch).
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
 });
 
 async function buildTestScene() {

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
@@ -121,11 +121,13 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
       }
 
       // Only re-run if there's actually new data to process.
-      // This prevents re-running when the source panel is cancelled, which only changes
-      // the loading state but keeps the same requestId.
       // We trigger when:
       // 1. requestId changed (new query completed)
       // 2. isStreaming (continuous data updates)
+      // 3. a terminal -> terminal (Done/Error) transition: a chained dashboard-DS
+      //    source forwarded fresh data under an unchanged requestId. A cancel
+      //    (Loading -> Done) is excluded since oldState is not terminal.
+      const isTerminal = (state?: LoadingState) => state === LoadingState.Done || state === LoadingState.Error;
       const onSourceDataChange = (
         newState: { data?: typeof sourcePanelQueryRunner.state.data },
         oldState: { data?: typeof sourcePanelQueryRunner.state.data }
@@ -134,7 +136,8 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
         const oldRequestId = oldState.data?.request?.requestId;
         const hasNewRequest = newRequestId !== oldRequestId;
         const isStreaming = newState.data?.state === LoadingState.Streaming;
-        if (newState.data !== oldState.data && (hasNewRequest || isStreaming)) {
+        const forwardedNewData = isTerminal(oldState.data?.state) && isTerminal(newState.data?.state);
+        if (newState.data !== oldState.data && (hasNewRequest || isStreaming || forwardedNewData)) {
           queryRunner.runQueries();
         }
       };

--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -196,6 +196,40 @@ describe('DashboardDatasource', () => {
     expect(emissions[0].data[0].fields[0].values).toEqual([42]);
   });
 
+  it('Once a stale Done is latched, a later fresh frame on the same stream is dropped', async () => {
+    // A chained dashboard-DS panel re-stamps a stale frame with the current range,
+    // so it passes the Mixed stale-Done filter and is latched by first(Done). A
+    // later fresh frame on the same (completed) stream is then dropped, so recovery
+    // must come from DashboardDatasourceBehaviour re-running the consumer.
+    const range = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
+
+    const { observable, upstreamStream } = setupWithControllableUpstream(
+      { refId: 'A', panelId: 1 },
+      `${MIXED_REQUEST_PREFIX}1`,
+      range
+    );
+
+    // Stale content stamped with the current range: kept by the filter, latched by first(Done).
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([1]), range));
+
+    const emissions: DataQueryResponse[] = [];
+    observable.subscribe({ next: (data) => emissions.push(data) });
+
+    await waitForDebounce();
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].state).toBe(LoadingState.Done);
+    expect(emissions[0].data[0].fields[0].values).toEqual([1]);
+
+    // A later fresh frame on the same (completed) substream is dropped: the consumer stays stale.
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([2, 3]), range));
+
+    await waitForDebounce();
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].data[0].fields[0].values).toEqual([1]);
+  });
+
   it('Should still emit Done on the Mixed path when the source range differs from the chain (PanelTimeRange override, #22618)', async () => {
     // Regression for #22618: a Mixed chain panel where the source (or the chain)
     // carries a `PanelTimeRange` override observes an upstream range that


### PR DESCRIPTION
## What this PR does

Fixes a Dashboard datasource (`-- Dashboard --`) bug where a panel that reads **another** Dashboard-datasource panel (a "chained" reference) from inside a **Mixed** datasource panel keeps showing stale/empty data for that chained series after a time-range change, until a manual refresh.

## The shape that triggers it

```
Consumer panel  (Mixed datasource)
  ├─ "-- Dashboard --"  →  Intermediate panel  (itself a "-- Dashboard --" panel)
  │                           └─ "-- Dashboard --" → Leaf panel (the real, slow query)
  └─ "-- Dashboard --"  →  A leaf panel read directly        ← this series stays fine
```

The series routed through the **extra hop** goes stale; a sibling series read **directly** from a leaf updates normally.

## Root cause

1. On a time-range change the consumer runs immediately. Its Mixed substream for the chained query reads the intermediate, which is still waiting on its slow leaf, so `emitFirstLoadedDataIfMixedDS`'s `first(Done | Error)` completes the substream on the intermediate's current (stale/empty) `Done`.
2. When the leaf finishes, the intermediate forwards the fresh data on its already-open subscription **without re-running**. A `SceneQueryRunner` stamps one `request.requestId` per run and reuses it for every emission, so the requestId is unchanged across the stale → fresh content change.
3. `DashboardDatasourceBehaviour` gates the consumer's re-run on the requestId changing (the guard added in #116767 to avoid re-running on cancel, carried into the no-transformations branch in #118629). Since the requestId never changes here, the consumer never re-runs, and the already-completed Mixed substream means it latches the stale frame.

The stale-`Done` range filter (#124665 / #125954) does not cover this: the replayed frame is for the **same** range, so it is not filtered. The gap is the missing re-run, not a stale-range emission.

## Not a flaky race, deterministic given a slow upstream

It only looked intermittent because it depends on the consumer running before the leaf completes. Whenever the chained leaf query is slow enough for that ordering to hold, it reproduces every time. Two confirmations:
- Pointing the consumer's chained query **directly at the leaf panel** (removing the intermediate hop) makes it update correctly every time.
- A dashboard with no chained Dashboard-DS reference never exhibits it.

## The fix

Also re-run the consumer when the source delivers fresh data while it was already finished, a terminal → terminal (`Done`/`Error`) transition with a changed data object. Cancel stays excluded: it is a `Loading → Done` transition (old state not terminal) carrying no new data, so it does not trigger a re-run.

## Tests

- Behaviour: re-run on a fresh `Done` under an unchanged requestId, on both the with- and no-transformations subscription branches; plus a regression guard that cancel (`Loading → Done`, same requestId) still does **not** re-run.
- Datasource: a characterization test documenting why the Mixed range filter can't catch a re-stamped stale frame and why a single `query()` pass can't self-heal (recovery must come from the behaviour re-running).

## Scope

Contained to `DashboardDatasourceBehaviour`'s re-run gate; it only adds a re-run on genuinely new terminal data, and preserves the #116767 cancel behavior.
