### PR TITLE
Provisioning: Generic managed-resource helpers

### DIFF
--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -9,6 +9,7 @@ import {
   useGetResourceRepositoryView,
 } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
+import { isItemManagedByRepository } from 'app/features/provisioning/utils/managedResource';
 import { type DashboardViewItem } from 'app/features/search/types';
 import { type FolderDTO } from 'app/types/folders';
 
@@ -58,7 +59,7 @@ function getCanSkipEarly(folder: FolderDTO | DashboardViewItem | undefined): boo
   if (hasParent) {
     return true;
   }
-  const isNotManaged = folder.managedBy !== ManagerKind.Repo;
+  const isNotManaged = !isItemManagedByRepository(folder);
   if (isNotManaged) {
     return true;
   }

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -13,13 +13,13 @@ import { Page } from 'app/core/components/Page/Page';
 import { useDispatch } from 'app/types/store';
 
 import { FolderRepo } from '../../core/components/NestedFolderPicker/FolderRepo';
-import { ManagerKind } from '../apiserver/types';
 import { TemplateDashboardModal } from '../dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal';
 import { buildNavModel, getDashboardsTabID } from '../folders/state/navModel';
 import { ProvisionedFolderPreviewBanner } from '../provisioning/components/Folders/ProvisionedFolderPreviewBanner';
 import { RenameProvisionedFolderForm } from '../provisioning/components/Folders/RenameProvisionedFolderForm';
 import { OrphanedResourceBanner } from '../provisioning/components/Shared/OrphanedResourceBanner';
 import { RepoViewStatus, useGetResourceRepositoryView } from '../provisioning/hooks/useGetResourceRepositoryView';
+import { isItemManagedByRepository } from '../provisioning/utils/managedResource';
 import { useSearchStateManager } from '../search/state/SearchStateManager';
 import { getSearchPlaceholder } from '../search/tempI18nPhrases';
 
@@ -123,7 +123,7 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
   const folder = folderDTO ?? rootFolderDTO;
 
   const { canEditFolders, canDeleteFolders, canDeleteDashboards, canEditDashboards } = getFolderPermissions(folder);
-  const isProvisionedFolder = folder?.managedBy === ManagerKind.Repo;
+  const isProvisionedFolder = isItemManagedByRepository(folder);
   const isRepoRootFolder = isProvisionedFolder && folderUID === repository?.name;
   const [showRenameDrawer, setShowRenameDrawer] = useState(false);
   const showEditTitle = canEditFolders && !!folderUID;

--- a/public/app/features/browse-dashboards/api/isProvisioned.ts
+++ b/public/app/features/browse-dashboards/api/isProvisioned.ts
@@ -1,14 +1,14 @@
 import { type Folder } from 'app/api/clients/folder/v1beta1';
-import { AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
+import { isManagedByRepository } from 'app/features/provisioning/utils/managedResource';
 import { type DashboardDTO } from 'app/types/dashboard';
 
 import { type DashboardWithAccessInfo } from '../../dashboard/api/types';
 
 export function isProvisionedDashboard(dashboard: DashboardDTO | DashboardWithAccessInfo<unknown>) {
   const annotations = 'meta' in dashboard ? dashboard.meta.k8s?.annotations : dashboard.metadata.annotations;
-  return annotations?.[AnnoKeyManagerKind] === ManagerKind.Repo;
+  return isManagedByRepository({ metadata: { annotations } });
 }
 
 export function isProvisionedFolder(folder: Folder) {
-  return folder.metadata.annotations?.[AnnoKeyManagerKind] === ManagerKind.Repo;
+  return isManagedByRepository(folder);
 }

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -4,10 +4,10 @@ import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
 import { Button, Drawer, Stack, Text } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
-import { ManagerKind } from 'app/features/apiserver/types';
 import { BulkDeleteProvisionedResource } from 'app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource';
 import { BulkMoveProvisionedResource } from 'app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource';
 import { useSelectionProvisioningStatus } from 'app/features/provisioning/hooks/useSelectionProvisioningStatus';
+import { isItemManagedByRepository } from 'app/features/provisioning/utils/managedResource';
 import { useSearchStateManager } from 'app/features/search/state/SearchStateManager';
 import { ShowModalReactEvent } from 'app/types/events';
 import { type FolderDTO } from 'app/types/folders';
@@ -45,7 +45,7 @@ export function BrowseActions({ folderDTO }: Props) {
 
   const { hasProvisioned, hasNonProvisioned } = useSelectionProvisioningStatus(
     selectedItems,
-    folderDTO?.managedBy === ManagerKind.Repo
+    isItemManagedByRepository(folderDTO)
   );
 
   const isSearching = stateManager.hasSearchFilters();

--- a/public/app/features/browse-dashboards/components/CheckboxCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxCell.tsx
@@ -4,9 +4,9 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Checkbox, Tooltip, useStyles2 } from '@grafana/ui';
-import { ManagerKind } from 'app/features/apiserver/types';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
 import { useSelectionRepoValidation } from 'app/features/provisioning/hooks/useSelectionRepoValidation';
+import { isItemManagedByRepository } from 'app/features/provisioning/utils/managedResource';
 import { getReadOnlyTooltipText } from 'app/features/provisioning/utils/tooltip';
 import { useSelector } from 'app/types/store';
 
@@ -46,7 +46,7 @@ export default function CheckboxCell({
   }
 
   // Disable the checkbox for the root provisioned folder (if the entire instance is not provisioned)
-  if (!isProvisionedInstance && item.managedBy === ManagerKind.Repo && !item.parentUID) {
+  if (!isProvisionedInstance && isItemManagedByRepository(item) && !item.parentUID) {
     return <CheckboxSpacer />;
   }
 

--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -16,6 +16,7 @@ import { DashboardLibraryInteractions } from 'app/features/dashboard/dashgrid/Da
 import { type RepoType } from 'app/features/provisioning/Wizard/types';
 import { NewProvisionedFolderForm } from 'app/features/provisioning/components/Folders/NewProvisionedFolderForm';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
+import { isItemManagedByRepository } from 'app/features/provisioning/utils/managedResource';
 import { getReadOnlyTooltipText } from 'app/features/provisioning/utils/tooltip';
 import {
   getImportPhrase,
@@ -25,8 +26,6 @@ import {
   getNewTemplateDashboardPhrase,
 } from 'app/features/search/tempI18nPhrases';
 import { type FolderDTO } from 'app/types/folders';
-
-import { ManagerKind } from '../../apiserver/types';
 
 import { NewFolderForm } from './NewFolderForm';
 
@@ -181,7 +180,7 @@ export default function CreateNewButton({
           onClose={() => setShowNewFolderDrawer(false)}
           size="sm"
         >
-          {parentFolder?.managedBy === ManagerKind.Repo || isProvisionedInstance ? (
+          {isItemManagedByRepository(parentFolder) || isProvisionedInstance ? (
             <NewProvisionedFolderForm onDismiss={() => setShowNewFolderDrawer(false)} parentFolder={parentFolder} />
           ) : (
             <NewFolderForm

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -13,13 +13,13 @@ import { BulkMoveProvisionedResource } from 'app/features/provisioning/component
 import { DeleteProvisionedFolderForm } from 'app/features/provisioning/components/Folders/DeleteProvisionedFolderForm';
 import { FolderPermissions } from 'app/features/provisioning/components/Folders/MissingFolderMetadataBanner';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
+import { isItemManagedByRepository } from 'app/features/provisioning/utils/managedResource';
 import { AccessControlAction } from 'app/types/accessControl';
 import { ShowModalReactEvent } from 'app/types/events';
 import { type FolderDTO } from 'app/types/folders';
 
 import { useDeleteFolderMutationFacade, useMoveFolderMutationFacade } from '../../../api/clients/folder/v1beta1/hooks';
 import { extractErrorMessage } from '../../../api/utils';
-import { ManagerKind } from '../../apiserver/types';
 import { getFolderPermissions } from '../permissions';
 
 import { DeleteModal } from './BrowseActions/DeleteModal';
@@ -50,7 +50,7 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
     canSetPermissions,
   } = getFolderPermissions(folder);
 
-  const isProvisionedFolder = folder.managedBy === ManagerKind.Repo;
+  const isProvisionedFolder = isItemManagedByRepository(folder);
   const isProvisionedRootFolder = isProvisionedFolder && !isProvisionedInstance && folder.parentUid === undefined;
   // Can only move folders when the folder is not provisioned
   const canMoveFolder = canEditFolders && !isProvisionedRootFolder && !isReadOnlyRepo;

--- a/public/app/features/folders/state/navModel.ts
+++ b/public/app/features/folders/state/navModel.ts
@@ -3,7 +3,7 @@ import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getNavSubTitle } from 'app/core/utils/navBarItem-translations';
-import { ManagerKind } from 'app/features/apiserver/types';
+import { isItemManagedByRepository } from 'app/features/provisioning/utils/managedResource';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type FolderDTO, type FolderParent } from 'app/types/folders';
 
@@ -15,7 +15,7 @@ export const getAlertingTabID = (folderUID: string) => `folder-alerting-${folder
 
 export function buildNavModel(folder: FolderDTO | FolderParent, parentsArg?: FolderParent[]): NavModelItem {
   const parents = parentsArg ?? ('parents' in folder ? folder.parents : undefined);
-  const isProvisioned = 'managedBy' in folder ? folder.managedBy === ManagerKind.Repo : false;
+  const isProvisioned = 'managedBy' in folder && isItemManagedByRepository(folder);
 
   const model: NavModelItem = {
     icon: 'folder',

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
@@ -3,9 +3,9 @@ import { skipToken } from '@reduxjs/toolkit/query/react';
 import { config, isFetchError } from '@grafana/runtime';
 import { type Folder, useGetFolderQuery } from 'app/api/clients/folder/v1beta1';
 import { type RepositoryView, useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
-import { AnnoKeyManagerIdentity, AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
 
 import { type RepoType } from '../Wizard/types';
+import { getManagerIdentity, isManagedByRepository } from '../utils/managedResource';
 import { getIsReadOnlyRepo } from '../utils/repository';
 
 interface GetResourceRepositoryArgs {
@@ -87,13 +87,12 @@ export const useGetResourceRepositoryView = ({
     // failing closed and blocking unrelated flows like dashboard import.
     // Repo-annotated folders and name-based lookups stay fail-closed: git-sync flows
     // cannot proceed without the settings data anyway.
-    const annotatedManagerKind = folder?.metadata?.annotations?.[AnnoKeyManagerKind];
     if (
       isFetchError(settingsError) &&
       settingsError.status === 403 &&
       !name &&
       !folderError &&
-      annotatedManagerKind !== ManagerKind.Repo
+      !(folder && isManagedByRepository(folder))
     ) {
       return { folder, isInstanceManaged: false, isReadOnlyRepo: false, status: RepoViewStatus.Ready };
     }
@@ -156,9 +155,8 @@ export const useGetResourceRepositoryView = ({
     // For nested folders we need to see what the folder thinks.
     // Only treat as repo-managed if the manager kind is explicitly 'repo' —
     // folders managed by plugins, terraform, kubectl, etc. should not be matched against provisioning repos.
-    const annotatedManagerKind = folder?.metadata?.annotations?.[AnnoKeyManagerKind];
-    const annotatedFolderName = folder?.metadata?.annotations?.[AnnoKeyManagerIdentity];
-    if (annotatedFolderName && annotatedManagerKind === ManagerKind.Repo) {
+    const annotatedFolderName = folder ? getManagerIdentity(folder) : undefined;
+    if (annotatedFolderName && folder && isManagedByRepository(folder)) {
       repository = items.find((repo) => repo.name === annotatedFolderName);
       if (repository) {
         return {

--- a/public/app/features/provisioning/hooks/useSelectionProvisioningStatus.ts
+++ b/public/app/features/provisioning/hooks/useSelectionProvisioningStatus.ts
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { config } from '@grafana/runtime';
 import { ScopedResourceClient } from 'app/features/apiserver/client';
-import { AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
 import { isProvisionedDashboard as isProvisionedDashboardFromMeta } from 'app/features/browse-dashboards/api/isProvisioned';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
+import { isItemManagedByRepository, isManagedByRepository } from 'app/features/provisioning/utils/managedResource';
 import { useSearchStateManager } from 'app/features/search/state/SearchStateManager';
 import { useSelector } from 'app/types/store';
 
@@ -54,8 +54,7 @@ export function useSelectionProvisioningStatus(
       }
       try {
         const folder = await folderClient.get(uid);
-        const managedBy = folder.metadata?.annotations?.[AnnoKeyManagerKind];
-        const result = managedBy === ManagerKind.Repo;
+        const result = isManagedByRepository(folder);
         setFolderCache((prev) => ({ ...prev, [uid]: result }));
         return result;
       } catch {
@@ -91,16 +90,16 @@ export function useSelectionProvisioningStatus(
 
       const item = findItemInState(uid);
       if (isFolder) {
-        return item?.managedBy === ManagerKind.Repo;
+        return isItemManagedByRepository(item);
       }
 
       // Check parent folder first for dashboards
       const parent = item?.parentUID ? findItemInState(item.parentUID) : undefined;
-      if (parent?.managedBy === ManagerKind.Repo) {
+      if (isItemManagedByRepository(parent)) {
         return true;
       }
 
-      return item?.managedBy === ManagerKind.Repo;
+      return isItemManagedByRepository(item);
     },
     [isSearching, getFolderMeta, getDashboardMeta, findItemInState]
   );

--- a/public/app/features/provisioning/utils/managedResource.test.ts
+++ b/public/app/features/provisioning/utils/managedResource.test.ts
@@ -1,0 +1,132 @@
+import {
+  AnnoKeyManagerAllowsEdits,
+  AnnoKeyManagerIdentity,
+  AnnoKeyManagerKind,
+  AnnoKeySourcePath,
+  ManagerKind,
+} from 'app/features/apiserver/types';
+
+import {
+  getManagerIdentity,
+  getManagerKind,
+  getSourcePath,
+  isItemManagedByRepository,
+  isManaged,
+  isManagedByRepository,
+  isManagedResourceReadOnly,
+  type ManagedResource,
+} from './managedResource';
+
+const resource = (annotations?: Record<string, string>): ManagedResource => ({
+  metadata: { annotations },
+});
+
+describe('managedResource helpers', () => {
+  describe('getManagerKind', () => {
+    it.each([ManagerKind.Repo, ManagerKind.Terraform, ManagerKind.Kubectl, ManagerKind.Plugin, ManagerKind.ClassicFP])(
+      'returns the manager kind when set (%s)',
+      (kind) => {
+        expect(getManagerKind(resource({ [AnnoKeyManagerKind]: kind }))).toBe(kind);
+      }
+    );
+
+    it('returns undefined for an unknown manager kind', () => {
+      expect(getManagerKind(resource({ [AnnoKeyManagerKind]: 'some-future-manager' }))).toBeUndefined();
+    });
+
+    it('returns undefined when not managed', () => {
+      expect(getManagerKind(resource())).toBeUndefined();
+      expect(getManagerKind({})).toBeUndefined();
+    });
+  });
+
+  describe('getManagerIdentity', () => {
+    it('returns the manager identity when set', () => {
+      expect(getManagerIdentity(resource({ [AnnoKeyManagerIdentity]: 'my-repo' }))).toBe('my-repo');
+    });
+  });
+
+  describe('getSourcePath', () => {
+    it('returns the source path when set', () => {
+      expect(getSourcePath(resource({ [AnnoKeySourcePath]: 'playlists/foo.json' }))).toBe('playlists/foo.json');
+    });
+
+    it('returns undefined when not set', () => {
+      expect(getSourcePath(resource())).toBeUndefined();
+    });
+  });
+
+  describe('isManaged', () => {
+    it.each([ManagerKind.Repo, ManagerKind.Terraform, ManagerKind.Kubectl, ManagerKind.Plugin])(
+      'returns true for any manager kind (%s)',
+      (kind) => {
+        expect(isManaged(resource({ [AnnoKeyManagerKind]: kind }))).toBe(true);
+      }
+    );
+
+    it('returns true for managers not represented by ManagerKind (unknown future kind)', () => {
+      expect(isManaged(resource({ [AnnoKeyManagerKind]: 'some-future-manager' }))).toBe(true);
+    });
+
+    it('returns false when not managed', () => {
+      expect(isManaged(resource())).toBe(false);
+    });
+  });
+
+  describe('isManagedByRepository', () => {
+    it('returns true only for repository-managed resources', () => {
+      expect(isManagedByRepository(resource({ [AnnoKeyManagerKind]: ManagerKind.Repo }))).toBe(true);
+    });
+
+    it.each([ManagerKind.Terraform, ManagerKind.Kubectl, ManagerKind.Plugin])(
+      'returns false for non-repository managers (%s)',
+      (kind) => {
+        expect(isManagedByRepository(resource({ [AnnoKeyManagerKind]: kind }))).toBe(false);
+      }
+    );
+
+    it('returns false when not managed', () => {
+      expect(isManagedByRepository(resource())).toBe(false);
+    });
+  });
+
+  describe('isManagedResourceReadOnly', () => {
+    it('returns false for repository-managed resources (they have their own edit workflow)', () => {
+      expect(isManagedResourceReadOnly(resource({ [AnnoKeyManagerKind]: ManagerKind.Repo }))).toBe(false);
+    });
+
+    it('returns true for other managers that do not allow edits', () => {
+      expect(isManagedResourceReadOnly(resource({ [AnnoKeyManagerKind]: ManagerKind.Terraform }))).toBe(true);
+    });
+
+    it('returns false when the manager allows edits', () => {
+      expect(
+        isManagedResourceReadOnly(
+          resource({ [AnnoKeyManagerKind]: ManagerKind.Terraform, [AnnoKeyManagerAllowsEdits]: 'true' })
+        )
+      ).toBe(false);
+    });
+
+    it('returns false when not managed', () => {
+      expect(isManagedResourceReadOnly(resource())).toBe(false);
+    });
+  });
+
+  describe('isItemManagedByRepository', () => {
+    it('returns true only for repository-managed items', () => {
+      expect(isItemManagedByRepository({ managedBy: ManagerKind.Repo })).toBe(true);
+    });
+
+    it.each([ManagerKind.Terraform, ManagerKind.Kubectl, ManagerKind.Plugin])(
+      'returns false for non-repository managers (%s)',
+      (managedBy) => {
+        expect(isItemManagedByRepository({ managedBy })).toBe(false);
+      }
+    );
+
+    it('returns false when not managed or undefined', () => {
+      expect(isItemManagedByRepository({})).toBe(false);
+      expect(isItemManagedByRepository(undefined)).toBe(false);
+    });
+  });
+});

--- a/public/app/features/provisioning/utils/managedResource.ts
+++ b/public/app/features/provisioning/utils/managedResource.ts
@@ -1,0 +1,93 @@
+import {
+  AnnoKeyManagerAllowsEdits,
+  AnnoKeyManagerIdentity,
+  AnnoKeyManagerKind,
+  AnnoKeySourcePath,
+  ManagerKind,
+} from 'app/features/apiserver/types';
+
+/**
+ * Minimal structural shape shared by every Grafana k8s-style resource (dashboards, folders,
+ * playlists, ...). Only the manager annotations are needed, so any resource that exposes
+ * `metadata.annotations` — regardless of which generated client it comes from — can be passed in.
+ */
+export interface ManagedResource {
+  metadata?: {
+    annotations?: {
+      [AnnoKeyManagerKind]?: string;
+      [AnnoKeyManagerIdentity]?: string;
+      [AnnoKeyManagerAllowsEdits]?: string;
+      [AnnoKeySourcePath]?: string;
+    };
+  };
+}
+
+// Derived from the enum so any manager kind (repo, terraform, kubectl, plugin, grafana,
+// classic-file-provisioning, ...) is recognised without maintaining a parallel list here.
+const MANAGER_KINDS = new Set<string>(Object.values(ManagerKind));
+
+function isManagerKind(value: string | undefined): value is ManagerKind {
+  return value !== undefined && MANAGER_KINDS.has(value);
+}
+
+/** Returns which system manages the resource, or undefined when it is not managed. */
+export function getManagerKind(resource: ManagedResource): ManagerKind | undefined {
+  const kind = resource.metadata?.annotations?.[AnnoKeyManagerKind];
+  return isManagerKind(kind) ? kind : undefined;
+}
+
+/** Returns the path of the resource's source file within its managing repository, if any. */
+export function getSourcePath(resource: ManagedResource): string | undefined {
+  return resource.metadata?.annotations?.[AnnoKeySourcePath];
+}
+
+/** Returns the identity of the managing system (e.g. the repository name), if any. */
+export function getManagerIdentity(resource: ManagedResource): string | undefined {
+  return resource.metadata?.annotations?.[AnnoKeyManagerIdentity];
+}
+
+/**
+ * True when the resource is owned by any external manager. This is a presence check on the
+ * `grafana.app/managedBy` annotation, so it also covers managers not represented by
+ * {@link ManagerKind} (e.g. classic file provisioning).
+ */
+export function isManaged(resource: ManagedResource): boolean {
+  return resource.metadata?.annotations?.[AnnoKeyManagerKind] !== undefined;
+}
+
+/**
+ * True when the resource is managed through the repository (git) provisioning feature, i.e.
+ * `grafana.app/managedBy === repo`. This is the condition for the "Provisioned" badge. Resources
+ * managed by terraform/kubectl/plugin are managed but not repository-managed — use
+ * {@link isManaged} or {@link getManagerKind} to handle those.
+ */
+export function isManagedByRepository(resource: ManagedResource): boolean {
+  return getManagerKind(resource) === ManagerKind.Repo;
+}
+
+/**
+ * True when a managed resource is read-only in the UI: it is managed by something other than the
+ * repository provisioning flow (which has its own edit workflow) and that manager does not allow
+ * edits via the `grafana.app/managerAllowsEdits` annotation.
+ */
+export function isManagedResourceReadOnly(resource: ManagedResource): boolean {
+  return (
+    isManaged(resource) &&
+    !isManagedByRepository(resource) &&
+    resource.metadata?.annotations?.[AnnoKeyManagerAllowsEdits] !== 'true'
+  );
+}
+
+/**
+ * Some surfaces (search results, folder DTOs) carry the manager kind as a flattened `managedBy`
+ * field on the item itself rather than in `metadata.annotations`. This is the counterpart to
+ * {@link isManagedByRepository} for that shape — use it for list items that expose `managedBy`.
+ */
+export interface ManagedResourceItem {
+  managedBy?: ManagerKind;
+}
+
+/** True when a list item (folder DTO / search hit) is managed through the repository (git) flow. */
+export function isItemManagedByRepository(item?: ManagedResourceItem): boolean {
+  return item?.managedBy === ManagerKind.Repo;
+}

--- a/public/app/features/provisioning/utils/repository.ts
+++ b/public/app/features/provisioning/utils/repository.ts
@@ -1,10 +1,11 @@
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
-import { ManagerKind } from 'app/features/apiserver/types';
 import { findItem } from 'app/features/browse-dashboards/state/utils';
 import { type BrowseDashboardsState } from 'app/features/browse-dashboards/types';
 import { type DashboardViewItem } from 'app/features/search/types';
 
 import { type RepoWorkflows } from '../types';
+
+import { isItemManagedByRepository } from './managedResource';
 
 export function getIsReadOnlyWorkflows(workflows?: RepoWorkflows): boolean {
   // Repository is considered read-only if it has no workflows defined (workflows are required for write operations)
@@ -29,7 +30,7 @@ export function getItemRepositoryUid(
   childrenByParentUID: BrowseDashboardsState['childrenByParentUID']
 ): string {
   // For root provisioned folders, the UID is the repository name
-  if (item.managedBy === ManagerKind.Repo && !item.parentUID && item.kind === 'folder') {
+  if (isItemManagedByRepository(item) && !item.parentUID && item.kind === 'folder') {
     return item.uid;
   }
 
@@ -41,7 +42,7 @@ export function getItemRepositoryUid(
       break;
     }
 
-    if (parent.managedBy === ManagerKind.Repo && !parent.parentUID) {
+    if (isItemManagedByRepository(parent) && !parent.parentUID) {
       return currentItem.parentUID;
     }
 

--- a/public/app/features/provisioning/utils/sourceLink.ts
+++ b/public/app/features/provisioning/utils/sourceLink.ts
@@ -2,19 +2,14 @@ import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type DashboardLink } from '@grafana/schema';
 import { provisioningAPIv0alpha1, type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
-import {
-  AnnoKeyManagerIdentity,
-  AnnoKeyManagerKind,
-  AnnoKeySourcePath,
-  ManagerKind,
-  type ObjectMeta,
-} from 'app/features/apiserver/types';
+import { AnnoKeyManagerIdentity, AnnoKeySourcePath, type ObjectMeta } from 'app/features/apiserver/types';
 import { dispatch } from 'app/store/store';
 
 import { RepoTypeDisplay } from '../Wizard/types';
 import { isValidRepoType } from '../guards';
 
 import { getHasTokenInstructions, getRepoFileUrl } from './git';
+import { isManagedByRepository } from './managedResource';
 
 /**
  * Find and remove existing source links from the links array.
@@ -35,7 +30,7 @@ export function removeExistingSourceLinks(links: DashboardLink[] | undefined): D
  * Returns undefined if the dashboard is not repo-managed or if the repository is not a git provider.
  */
 export async function buildSourceLink(annotations: ObjectMeta['annotations']): Promise<DashboardLink | undefined> {
-  if (!annotations || !config.featureToggles.provisioning || annotations[AnnoKeyManagerKind] !== ManagerKind.Repo) {
+  if (!annotations || !config.featureToggles.provisioning || !isManagedByRepository({ metadata: { annotations } })) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Extracts the resource-agnostic **managed/provisioned helpers** from #125902 into a single module and routes the existing inline checks through them. This is the next focused slice of that PR after the shared `ManagedBadge` (#125981); it contains **no behaviour change** — purely a consolidation onto shared helpers.

Fixes https://github.com/grafana/git-ui-sync-project/issues/1189

## Changes

**New helpers — `public/app/features/provisioning/utils/managedResource.ts`:**

- *Annotation shape* (`ManagedResource = { metadata.annotations }`, works for any k8s-style resource): `getManagerKind`, `getManagerIdentity`, `getSourcePath`, `isManaged`, `isManagedByRepository`, `isManagedResourceReadOnly`.
- *Flattened list-item shape* (`ManagedResourceItem = { managedBy?: ManagerKind }` — search hits, `FolderDTO`, `DashboardViewItem`): `isItemManagedByRepository`.
- Full unit-test coverage for both.

**Consolidated callsites** (replacing inline `annotations[AnnoKeyManagerKind]` / `managedBy === ManagerKind.Repo`):

- *Annotation shape:* `provisioning/utils/sourceLink.ts`, `provisioning/hooks/useGetResourceRepositoryView.ts`, `provisioning/hooks/useSelectionProvisioningStatus.ts` (folder `client.get` branch), `browse-dashboards/api/isProvisioned.ts`.
- *Flattened shape:* `browse-dashboards` `FolderActionsButton`, `CreateNewButton`, `BrowseDashboardsPage`, `BrowseActions`, `CheckboxCell`; `core/.../NestedFolderPicker/FolderRepo`; `folders/state/navModel`; `provisioning/utils/repository`; the in-state search-hit branches of `useSelectionProvisioningStatus`.

## Notes

- Frontend-only, no behaviour change. The unrelated 403 fail-open block in `useGetResourceRepositoryView` was intentionally **kept** (only its check was swapped to the helper), unlike #125902 which removes it.
- Out of scope (different shape/semantics): `useResourceStats` (`manager.kind` stats bucket), mapping/setter layers, `DashboardScene`'s own parallel methods, alerting/`useCorrelationsK8s`, and `dashboard/api/v1.ts` (outside provisioning — possible follow-up).
- `ReadOnlyBadge`, `SourceLink`, and the playlist/folder UI from #125902 are **not** included — separate slices.

## Testing

- `yarn typecheck` (14 projects), `yarn eslint`, `yarn prettier --check` — all clean on changed files.
- Unit tests green across the affected suites: `managedResource` (incl. `isItemManagedByRepository`), `FolderActionsButton`, `CreateNewButton`, `CheckboxCell`, `BrowseActions`, `BrowseView`, `FolderRepo`, `useGetResourceRepositoryView`, `navModel`.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)