### PR TITLE
Search: extract declared fields from resources via SearchFieldDefinition Path

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -299,7 +299,7 @@ func (s *standardDocumentBuilder) BuildDocument(ctx context.Context, key *resour
 // declarations when the schema diverges, so the builder leaves that
 // decision to manifest authors.
 func (s *standardDocumentBuilder) extractDeclaredFields(_ context.Context, tmp *unstructured.Unstructured, key *resourcepb.ResourceKey, doc *IndexableDocument) {
-	gvr := gvrForLookup(tmp, key)
+	gvr := gvrForLookup(tmp, key, s.provider)
 	if gvr.Resource == "" {
 		return
 	}
@@ -337,16 +337,24 @@ func (s *standardDocumentBuilder) extractDeclaredFields(_ context.Context, tmp *
 }
 
 // gvrForLookup resolves the GroupVersionResource the provider should be
-// queried with. The lookup is strict: only the document's declared
-// apiVersion is used. If the manifest does not register fields for that
-// exact version, no extraction happens. Manifest authors are responsible
-// for declaring all served versions of a kind.
-func gvrForLookup(tmp *unstructured.Unstructured, key *resourcepb.ResourceKey) schema.GroupVersionResource {
-	version := apiVersionOf(tmp)
-	if version == "" {
+// queried with. The lookup is strict on a declared apiVersion: if the
+// document carries one and the manifest does not cover that exact version,
+// no extraction happens. (Falling back across versions could silently
+// extract via a diverged schema, so manifest authors are expected to
+// declare every served version.) Only when the document has no apiVersion
+// at all do we fall back to the provider's PreferredVersion as the only
+// sane guess.
+func gvrForLookup(tmp *unstructured.Unstructured, key *resourcepb.ResourceKey, provider SearchFieldsProvider) schema.GroupVersionResource {
+	group := key.GetGroup()
+	resource := key.GetResource()
+	if version := apiVersionOf(tmp); version != "" {
+		return schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+	}
+	pref := provider.PreferredVersion(group, resource)
+	if pref == "" {
 		return schema.GroupVersionResource{}
 	}
-	return schema.GroupVersionResource{Group: key.GetGroup(), Version: version, Resource: key.GetResource()}
+	return schema.GroupVersionResource{Group: group, Version: pref, Resource: resource}
 }
 
 func apiVersionOf(tmp *unstructured.Unstructured) string {

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
@@ -241,12 +242,29 @@ func NewIndexableDocument(key *resourcepb.ResourceKey, rv int64, obj utils.Grafa
 }
 
 func StandardDocumentBuilder(manifests []app.Manifest) DocumentBuilder {
-	return &standardDocumentBuilder{selectableFields: SelectableFieldsForManifests(manifests)}
+	return StandardDocumentBuilderWithFields(manifests, nil)
+}
+
+// StandardDocumentBuilderWithFields returns the standard document builder
+// wired with a SearchFieldsProvider. When the provider is non-nil, the
+// builder reads SearchFieldDefinitions for the document's group/version/
+// resource and populates IndexableDocument.Fields from their declared Path
+// values. Path-less definitions are ignored (they require a custom builder).
+// Type mismatches are logged and the field is dropped.
+func StandardDocumentBuilderWithFields(manifests []app.Manifest, provider SearchFieldsProvider) DocumentBuilder {
+	return &standardDocumentBuilder{
+		selectableFields: SelectableFieldsForManifests(manifests),
+		provider:         provider,
+		log:              log.New("resource.document-builder"),
+	}
 }
 
 type standardDocumentBuilder struct {
 	// Maps "group/resource" (in lowercase) to list of selectable fields.
 	selectableFields map[string][]string
+	// provider supplies declarative search fields; may be nil.
+	provider SearchFieldsProvider
+	log      log.Logger
 }
 
 func (s *standardDocumentBuilder) BuildDocument(ctx context.Context, key *resourcepb.ResourceKey, rv int64, value []byte) (*IndexableDocument, error) {
@@ -266,7 +284,83 @@ func (s *standardDocumentBuilder) BuildDocument(ctx context.Context, key *resour
 	sfKey := strings.ToLower(key.GetGroup() + "/" + key.GetResource())
 	doc.SelectableFields = getSelectableFieldsFromObject(tmp, s.selectableFields[sfKey])
 
+	if s.provider != nil {
+		s.extractDeclaredFields(ctx, tmp, key, doc)
+	}
+
 	return doc, nil
+}
+
+// extractDeclaredFields populates doc.Fields from SearchFieldDefinitions
+// declared via the provider. The lookup is strict on apiVersion: a manifest
+// must declare every served version of a kind if it expects all stored
+// resources to be indexed against the same field set. Cross-version
+// fallback can silently extract an old document with a newer version's path
+// declarations when the schema diverges, so the builder leaves that
+// decision to manifest authors.
+func (s *standardDocumentBuilder) extractDeclaredFields(_ context.Context, tmp *unstructured.Unstructured, key *resourcepb.ResourceKey, doc *IndexableDocument) {
+	gvr := gvrForLookup(tmp, key)
+	if gvr.Resource == "" {
+		return
+	}
+	defs := s.provider.Fields(gvr)
+	if len(defs) == 0 {
+		return
+	}
+	for _, def := range defs {
+		if def.Path == "" {
+			continue
+		}
+		raw, err := extractPath(tmp.Object, def.Path)
+		if err != nil {
+			s.log.Warn("declared search field path failed to evaluate",
+				"group", gvr.Group, "version", gvr.Version, "resource", gvr.Resource,
+				"field", def.Name, "path", def.Path, "err", err)
+			continue
+		}
+		if raw == nil {
+			continue
+		}
+		coerced, ok := coerceToFieldShape(raw, def.Type, def.Array)
+		if !ok {
+			s.log.Warn("declared search field value does not match declared type",
+				"group", gvr.Group, "version", gvr.Version, "resource", gvr.Resource,
+				"field", def.Name, "type", def.Type, "array", def.Array,
+				"value_type", fmt.Sprintf("%T", raw))
+			continue
+		}
+		if doc.Fields == nil {
+			doc.Fields = make(map[string]any)
+		}
+		doc.Fields[def.Name] = coerced
+	}
+}
+
+// gvrForLookup resolves the GroupVersionResource the provider should be
+// queried with. The lookup is strict: only the document's declared
+// apiVersion is used. If the manifest does not register fields for that
+// exact version, no extraction happens. Manifest authors are responsible
+// for declaring all served versions of a kind.
+func gvrForLookup(tmp *unstructured.Unstructured, key *resourcepb.ResourceKey) schema.GroupVersionResource {
+	version := apiVersionOf(tmp)
+	if version == "" {
+		return schema.GroupVersionResource{}
+	}
+	return schema.GroupVersionResource{Group: key.GetGroup(), Version: version, Resource: key.GetResource()}
+}
+
+func apiVersionOf(tmp *unstructured.Unstructured) string {
+	av := tmp.GetAPIVersion()
+	if av == "" {
+		return ""
+	}
+	// apiVersion is "<group>/<version>" for non-core resources and just
+	// "<version>" for core. The Group is authoritative from the key; we
+	// only need the version segment.
+	if i := strings.IndexByte(av, '/'); i >= 0 {
+		return av[i+1:]
+	}
+	return av
 }
 
 func getSelectableFieldsFromObject(tmp *unstructured.Unstructured, fields []string) map[string]string {

--- a/pkg/storage/unified/resource/document_test.go
+++ b/pkg/storage/unified/resource/document_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -57,4 +59,111 @@ func TestStandardDocumentBuilder(t *testing.T) {
 			"checksum": "xyz"
 		}
 	}`, string(jj))
+}
+
+func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
+	ctx := t.Context()
+	gvr := schema.GroupVersionResource{Group: "example.grafana.app", Version: "v1", Resource: "things"}
+	key := &resourcepb.ResourceKey{
+		Namespace: "default",
+		Group:     gvr.Group,
+		Resource:  gvr.Resource,
+		Name:      "thing-1",
+	}
+	body := []byte(`{
+		"apiVersion": "example.grafana.app/v1",
+		"kind": "Thing",
+		"metadata": {"name": "thing-1", "namespace": "default"},
+		"spec": {
+			"email": "alice@example.com",
+			"size": 42,
+			"members": [
+				{"name": "alice"},
+				{"name": "bob"}
+			]
+		}
+	}`)
+
+	t.Run("extracts declared paths", func(t *testing.T) {
+		provider := NewMapProvider(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			gvr: {
+				{Name: "email", Path: "spec.email", Type: SearchFieldTypeString},
+				{Name: "size", Path: "spec.size", Type: SearchFieldTypeInt64},
+				{Name: "member_names", Path: "spec.members[*].name", Type: SearchFieldTypeString, Array: true},
+			},
+		}, nil)
+		builder := StandardDocumentBuilderWithFields(nil, provider)
+		doc, err := builder.BuildDocument(ctx, key, 1, body)
+		require.NoError(t, err)
+		require.Equal(t, "alice@example.com", doc.Fields["email"])
+		require.Equal(t, int64(42), doc.Fields["size"])
+		require.Equal(t, []any{"alice", "bob"}, doc.Fields["member_names"])
+	})
+
+	t.Run("path-less definitions are ignored", func(t *testing.T) {
+		provider := NewMapProvider(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			gvr: {
+				{Name: "computed", Type: SearchFieldTypeString},
+			},
+		}, nil)
+		builder := StandardDocumentBuilderWithFields(nil, provider)
+		doc, err := builder.BuildDocument(ctx, key, 1, body)
+		require.NoError(t, err)
+		_, present := doc.Fields["computed"]
+		assert.False(t, present)
+	})
+
+	t.Run("type mismatch drops the field without error", func(t *testing.T) {
+		provider := NewMapProvider(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			gvr: {
+				{Name: "email", Path: "spec.email", Type: SearchFieldTypeInt64},
+			},
+		}, nil)
+		builder := StandardDocumentBuilderWithFields(nil, provider)
+		doc, err := builder.BuildDocument(ctx, key, 1, body)
+		require.NoError(t, err)
+		_, present := doc.Fields["email"]
+		assert.False(t, present, "type mismatch should drop the field rather than fail the build")
+	})
+
+	t.Run("missing path is silently skipped", func(t *testing.T) {
+		provider := NewMapProvider(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			gvr: {
+				{Name: "absent", Path: "spec.not_there", Type: SearchFieldTypeString},
+			},
+		}, nil)
+		builder := StandardDocumentBuilderWithFields(nil, provider)
+		doc, err := builder.BuildDocument(ctx, key, 1, body)
+		require.NoError(t, err)
+		assert.Empty(t, doc.Fields)
+	})
+
+	t.Run("strict version match: no extraction when manifest does not cover the doc's apiVersion", func(t *testing.T) {
+		// Provider has fields under v2 only; doc carries apiVersion v1.
+		// Manifest authors are responsible for declaring every served
+		// version, so the builder does not silently fall back across
+		// versions.
+		v2 := schema.GroupVersionResource{Group: gvr.Group, Version: "v2", Resource: gvr.Resource}
+		provider := NewMapProvider(
+			map[schema.GroupVersionResource][]SearchFieldDefinition{
+				v2: {{Name: "email", Path: "spec.email", Type: SearchFieldTypeString}},
+			},
+			map[schema.GroupResource]string{
+				{Group: gvr.Group, Resource: gvr.Resource}: "v2",
+			},
+		)
+		builder := StandardDocumentBuilderWithFields(nil, provider)
+		doc, err := builder.BuildDocument(ctx, key, 1, body)
+		require.NoError(t, err)
+		assert.Empty(t, doc.Fields)
+	})
+
+	t.Run("nil provider preserves legacy behaviour", func(t *testing.T) {
+		// Constructor without a provider must produce the same shape as
+		// StandardDocumentBuilder(manifests).
+		builder := StandardDocumentBuilderWithFields(nil, nil)
+		doc, err := builder.BuildDocument(ctx, key, 1, body)
+		require.NoError(t, err)
+		assert.Empty(t, doc.Fields)
+	})
 }

--- a/pkg/storage/unified/resource/document_test.go
+++ b/pkg/storage/unified/resource/document_test.go
@@ -158,6 +158,43 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 		assert.Empty(t, doc.Fields)
 	})
 
+	t.Run("missing apiVersion falls back to PreferredVersion", func(t *testing.T) {
+		// Body intentionally has no apiVersion; the only sane guess at the
+		// version is the manifest's preferred served version.
+		bodyNoVersion := []byte(`{
+			"kind": "Thing",
+			"metadata": {"name": "thing-1", "namespace": "default"},
+			"spec": {"email": "alice@example.com"}
+		}`)
+		provider := NewMapProvider(
+			map[schema.GroupVersionResource][]SearchFieldDefinition{
+				gvr: {{Name: "email", Path: "spec.email", Type: SearchFieldTypeString}},
+			},
+			map[schema.GroupResource]string{
+				{Group: gvr.Group, Resource: gvr.Resource}: gvr.Version,
+			},
+		)
+		builder := StandardDocumentBuilderWithFields(nil, provider)
+		doc, err := builder.BuildDocument(ctx, key, 1, bodyNoVersion)
+		require.NoError(t, err)
+		assert.Equal(t, "alice@example.com", doc.Fields["email"])
+	})
+
+	t.Run("missing apiVersion and no PreferredVersion: no extraction", func(t *testing.T) {
+		bodyNoVersion := []byte(`{
+			"kind": "Thing",
+			"metadata": {"name": "thing-1", "namespace": "default"},
+			"spec": {"email": "alice@example.com"}
+		}`)
+		provider := NewMapProvider(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			gvr: {{Name: "email", Path: "spec.email", Type: SearchFieldTypeString}},
+		}, nil)
+		builder := StandardDocumentBuilderWithFields(nil, provider)
+		doc, err := builder.BuildDocument(ctx, key, 1, bodyNoVersion)
+		require.NoError(t, err)
+		assert.Empty(t, doc.Fields)
+	})
+
 	t.Run("nil provider preserves legacy behaviour", func(t *testing.T) {
 		// Constructor without a provider must produce the same shape as
 		// StandardDocumentBuilder(manifests).

--- a/pkg/storage/unified/resource/document_test.go
+++ b/pkg/storage/unified/resource/document_test.go
@@ -70,6 +70,9 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 		Resource:  gvr.Resource,
 		Name:      "thing-1",
 	}
+	// One members entry deliberately omits the "name" sub-field. The
+	// extractor must skip that entry rather than dropping the whole
+	// member_names field for the document.
 	body := []byte(`{
 		"apiVersion": "example.grafana.app/v1",
 		"kind": "Thing",
@@ -79,6 +82,7 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 			"size": 42,
 			"members": [
 				{"name": "alice"},
+				{"role": "viewer"},
 				{"name": "bob"}
 			]
 		}
@@ -97,6 +101,8 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "alice@example.com", doc.Fields["email"])
 		require.Equal(t, int64(42), doc.Fields["size"])
+		// The middle member has no "name" sub-field, so it is skipped
+		// without losing the names that did resolve.
 		require.Equal(t, []any{"alice", "bob"}, doc.Fields["member_names"])
 	})
 

--- a/pkg/storage/unified/resource/path_extract.go
+++ b/pkg/storage/unified/resource/path_extract.go
@@ -109,6 +109,13 @@ func coerceToFieldShape(val any, t SearchFieldType, isArray bool) (any, bool) {
 	}
 	out := make([]any, 0, len(slice))
 	for _, elem := range slice {
+		// Nil entries come from array-projection elements whose sub-path was
+		// missing (see extractPath). Skip them so the array stays indexed
+		// with the elements that did resolve, rather than dropping the
+		// whole field on a single missing sub-path.
+		if elem == nil {
+			continue
+		}
 		coerced, ok := coerceScalar(elem, t)
 		if !ok {
 			return nil, false

--- a/pkg/storage/unified/resource/path_extract.go
+++ b/pkg/storage/unified/resource/path_extract.go
@@ -18,14 +18,19 @@ const arrayProjection = "[*]"
 // shapes are supported:
 //
 //   - Plain dot path ("spec.email"): traverses the object via
-//     unstructured.NestedFieldNoCopy. The returned value may be a scalar, a
-//     slice, or a map; the caller decides what to do with it.
+//     unstructured.NestedFieldNoCopy. The returned value reflects whatever
+//     sits at the path — a scalar, a slice, or a map. coerceToFieldShape
+//     accepts scalars and slices of scalars only; a map will fail
+//     coercion and the field will be dropped with a warning. There is no
+//     SearchFieldType for maps today.
 //   - Scalar-array passthrough ("spec.tags"): identical to the plain dot
 //     path; the result happens to be a slice of scalars.
 //   - Array projection ("spec.members[*].name"): traverses to the slice
 //     before "[*]", then evaluates the remainder against each element. The
 //     returned value is []any with one entry per source element. Elements
-//     that fail their own traversal contribute nil.
+//     that fail their own traversal contribute nil; coerceToFieldShape
+//     skips those positions so a single missing sub-field does not drop
+//     the whole array.
 //
 // Returns (nil, nil) when the path resolves to a missing field at any step
 // (or to a JSON null). The caller drops such fields. An error is returned

--- a/pkg/storage/unified/resource/path_extract.go
+++ b/pkg/storage/unified/resource/path_extract.go
@@ -125,6 +125,8 @@ const maxInt64AsFloat float64 = 1 << 63
 
 func coerceScalar(val any, t SearchFieldType) (any, bool) {
 	switch t {
+	case SearchFieldTypeUnknown:
+		return nil, false
 	case SearchFieldTypeString, SearchFieldTypeDate:
 		s, ok := val.(string)
 		return s, ok

--- a/pkg/storage/unified/resource/path_extract.go
+++ b/pkg/storage/unified/resource/path_extract.go
@@ -1,0 +1,163 @@
+package resource
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// arrayProjection is the substring that marks an array projection step in a
+// declared search field path. The current evaluator supports a single
+// projection per path: everything before it is dot-traversed to a slice;
+// everything after it is dot-traversed against each element of that slice.
+const arrayProjection = "[*]"
+
+// extractPath evaluates path against the given unstructured object. Three
+// shapes are supported:
+//
+//   - Plain dot path ("spec.email"): traverses the object via
+//     unstructured.NestedFieldNoCopy. The returned value may be a scalar, a
+//     slice, or a map; the caller decides what to do with it.
+//   - Scalar-array passthrough ("spec.tags"): identical to the plain dot
+//     path; the result happens to be a slice of scalars.
+//   - Array projection ("spec.members[*].name"): traverses to the slice
+//     before "[*]", then evaluates the remainder against each element. The
+//     returned value is []any with one entry per source element. Elements
+//     that fail their own traversal contribute nil.
+//
+// Returns (nil, nil) when the path resolves to a missing field at any step
+// (or to a JSON null). The caller drops such fields. An error is returned
+// only for malformed paths or type mismatches during projection (a non-slice
+// found at the [*] step).
+func extractPath(obj map[string]any, path string) (any, error) {
+	if path == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+
+	idx := strings.Index(path, arrayProjection)
+	if idx < 0 {
+		return extractDotPath(obj, path)
+	}
+
+	pre := strings.TrimSuffix(path[:idx], ".")
+	post := strings.TrimPrefix(path[idx+len(arrayProjection):], ".")
+
+	if strings.Contains(post, arrayProjection) {
+		return nil, fmt.Errorf("path %q: only one %s projection is supported", path, arrayProjection)
+	}
+
+	val, err := extractDotPath(obj, pre)
+	if err != nil || val == nil {
+		return nil, err
+	}
+
+	slice, ok := val.([]any)
+	if !ok {
+		return nil, fmt.Errorf("path %q: expected slice at %q, got %T", path, pre, val)
+	}
+
+	out := make([]any, 0, len(slice))
+	for _, elem := range slice {
+		if post == "" {
+			out = append(out, elem)
+			continue
+		}
+		elemMap, ok := elem.(map[string]any)
+		if !ok {
+			// Non-object element under a projection that wants a sub-field.
+			// Contribute nil rather than fail the whole extraction.
+			out = append(out, nil)
+			continue
+		}
+		sub, err := extractDotPath(elemMap, post)
+		if err != nil {
+			return nil, fmt.Errorf("path %q: %w", path, err)
+		}
+		out = append(out, sub)
+	}
+	return out, nil
+}
+
+func extractDotPath(obj map[string]any, path string) (any, error) {
+	val, _, err := unstructured.NestedFieldNoCopy(obj, strings.Split(path, ".")...)
+	return val, err
+}
+
+// coerceToFieldShape converts the raw value produced by extractPath into the
+// shape declared by the SearchFieldDefinition. Returns (nil, false) on type
+// mismatch or on a nil input; the caller is expected to drop the field and
+// log a warning.
+//
+// Number handling is shaped by unstructured.Unstructured.UnmarshalJSON, which
+// preserves integer JSON values as int64 and fractional values as float64.
+// Int64 accepts an int64 directly or a float64 that rounds (half away from
+// zero) into the int64 range; fractional input is rounded rather than
+// rejected. Double accepts a float64 directly or an int64 (numbers without a
+// decimal point still represent a valid double).
+func coerceToFieldShape(val any, t SearchFieldType, isArray bool) (any, bool) {
+	if val == nil {
+		return nil, false
+	}
+	if !isArray {
+		return coerceScalar(val, t)
+	}
+	slice, ok := val.([]any)
+	if !ok {
+		return nil, false
+	}
+	out := make([]any, 0, len(slice))
+	for _, elem := range slice {
+		coerced, ok := coerceScalar(elem, t)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, coerced)
+	}
+	return out, true
+}
+
+// maxInt64AsFloat is the smallest float64 strictly greater than math.MaxInt64.
+// math.MaxInt64 (2^63 - 1) has no exact float64 representation, so the safe
+// upper bound for a rounded-to-int64 conversion is 2^63 (strict-less).
+const maxInt64AsFloat float64 = 1 << 63
+
+func coerceScalar(val any, t SearchFieldType) (any, bool) {
+	switch t {
+	case SearchFieldTypeString, SearchFieldTypeDate:
+		s, ok := val.(string)
+		return s, ok
+	case SearchFieldTypeBoolean:
+		b, ok := val.(bool)
+		return b, ok
+	case SearchFieldTypeInt64:
+		switch v := val.(type) {
+		case int64:
+			return v, true
+		case float64:
+			// Round to nearest, half away from zero (3.7 → 4, 3.4 → 3,
+			// -3.7 → -4). Range-check explicitly: Go's float-to-int64
+			// conversion is implementation-defined for out-of-range
+			// values, and rejecting is safer than corrupting.
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				return nil, false
+			}
+			rounded := math.Round(v)
+			if rounded < float64(math.MinInt64) || rounded >= maxInt64AsFloat {
+				return nil, false
+			}
+			return int64(rounded), true
+		}
+		return nil, false
+	case SearchFieldTypeDouble:
+		switch v := val.(type) {
+		case float64:
+			return v, true
+		case int64:
+			return float64(v), true
+		}
+		return nil, false
+	}
+	return nil, false
+}

--- a/pkg/storage/unified/resource/path_extract_test.go
+++ b/pkg/storage/unified/resource/path_extract_test.go
@@ -184,6 +184,18 @@ func TestCoerceToFieldShape_Array(t *testing.T) {
 	// Non-slice when Array is true is rejected.
 	_, ok = coerceToFieldShape("a", SearchFieldTypeString, true)
 	assert.False(t, ok)
+
+	// Nil elements (produced by extractPath for array-projection entries
+	// whose sub-path was missing) are skipped, not treated as a coercion
+	// failure for the whole array.
+	v, ok = coerceToFieldShape([]any{"alice", nil, "bob"}, SearchFieldTypeString, true)
+	require.True(t, ok)
+	assert.Equal(t, []any{"alice", "bob"}, v)
+
+	// An all-nil array indexes as an empty slice, not a dropped field.
+	v, ok = coerceToFieldShape([]any{nil, nil}, SearchFieldTypeString, true)
+	require.True(t, ok)
+	assert.Equal(t, []any{}, v)
 }
 
 func TestCoerceToFieldShape_Nil(t *testing.T) {

--- a/pkg/storage/unified/resource/path_extract_test.go
+++ b/pkg/storage/unified/resource/path_extract_test.go
@@ -1,0 +1,192 @@
+package resource
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractPath_DotTraversal(t *testing.T) {
+	obj := map[string]any{
+		"spec": map[string]any{
+			"email": "alice@example.com",
+			"profile": map[string]any{
+				"city": "Brno",
+			},
+		},
+	}
+
+	t.Run("scalar", func(t *testing.T) {
+		v, err := extractPath(obj, "spec.email")
+		require.NoError(t, err)
+		assert.Equal(t, "alice@example.com", v)
+	})
+
+	t.Run("nested scalar", func(t *testing.T) {
+		v, err := extractPath(obj, "spec.profile.city")
+		require.NoError(t, err)
+		assert.Equal(t, "Brno", v)
+	})
+
+	t.Run("missing segment returns nil", func(t *testing.T) {
+		v, err := extractPath(obj, "spec.does.not.exist")
+		require.NoError(t, err)
+		assert.Nil(t, v)
+	})
+
+	t.Run("empty path is an error", func(t *testing.T) {
+		_, err := extractPath(obj, "")
+		require.Error(t, err)
+	})
+}
+
+func TestExtractPath_ScalarArrayPassthrough(t *testing.T) {
+	obj := map[string]any{
+		"spec": map[string]any{
+			"tags": []any{"alpha", "beta", "gamma"},
+		},
+	}
+
+	v, err := extractPath(obj, "spec.tags")
+	require.NoError(t, err)
+	assert.Equal(t, []any{"alpha", "beta", "gamma"}, v)
+}
+
+func TestExtractPath_ArrayProjection(t *testing.T) {
+	obj := map[string]any{
+		"spec": map[string]any{
+			"members": []any{
+				map[string]any{"name": "alice", "role": "admin"},
+				map[string]any{"name": "bob"},
+				map[string]any{"role": "viewer"}, // no name
+			},
+		},
+	}
+
+	t.Run("projects field from each element", func(t *testing.T) {
+		v, err := extractPath(obj, "spec.members[*].name")
+		require.NoError(t, err)
+		// Last element has no name and contributes nil.
+		assert.Equal(t, []any{"alice", "bob", nil}, v)
+	})
+
+	t.Run("identity projection returns the slice", func(t *testing.T) {
+		v, err := extractPath(obj, "spec.members[*]")
+		require.NoError(t, err)
+		got, isSlice := v.([]any)
+		require.True(t, isSlice)
+		require.Len(t, got, 3)
+	})
+
+	t.Run("missing slice", func(t *testing.T) {
+		v, err := extractPath(map[string]any{}, "spec.members[*].name")
+		require.NoError(t, err)
+		assert.Nil(t, v)
+	})
+
+	t.Run("non-slice under projection is an error", func(t *testing.T) {
+		_, err := extractPath(map[string]any{
+			"spec": map[string]any{"members": "not a slice"},
+		}, "spec.members[*].name")
+		require.Error(t, err)
+	})
+
+	t.Run("more than one projection is rejected", func(t *testing.T) {
+		_, err := extractPath(obj, "spec.members[*].nested[*].deep")
+		require.Error(t, err)
+	})
+}
+
+func TestCoerceToFieldShape_String(t *testing.T) {
+	v, ok := coerceToFieldShape("hello", SearchFieldTypeString, false)
+	require.True(t, ok)
+	assert.Equal(t, "hello", v)
+
+	// Non-string is rejected.
+	_, ok = coerceToFieldShape(42, SearchFieldTypeString, false)
+	assert.False(t, ok)
+}
+
+func TestCoerceToFieldShape_Boolean(t *testing.T) {
+	v, ok := coerceToFieldShape(true, SearchFieldTypeBoolean, false)
+	require.True(t, ok)
+	assert.Equal(t, true, v)
+
+	_, ok = coerceToFieldShape("true", SearchFieldTypeBoolean, false)
+	assert.False(t, ok)
+}
+
+func TestCoerceToFieldShape_Int64(t *testing.T) {
+	// unstructured.UnmarshalJSON preserves integers as int64.
+	v, ok := coerceToFieldShape(int64(42), SearchFieldTypeInt64, false)
+	require.True(t, ok)
+	assert.Equal(t, int64(42), v)
+
+	// Float64 with no fractional part: pass through cleanly.
+	v, ok = coerceToFieldShape(float64(7), SearchFieldTypeInt64, false)
+	require.True(t, ok)
+	assert.Equal(t, int64(7), v)
+
+	// Fractional float: rounded half away from zero rather than rejected.
+	cases := []struct {
+		in   float64
+		want int64
+	}{
+		{3.4, 3},
+		{3.5, 4},
+		{3.7, 4},
+		{-3.4, -3},
+		{-3.5, -4},
+	}
+	for _, tc := range cases {
+		got, ok := coerceToFieldShape(tc.in, SearchFieldTypeInt64, false)
+		require.True(t, ok, "%v", tc.in)
+		assert.Equal(t, tc.want, got, "%v", tc.in)
+	}
+
+	// Out of int64 range: rejected (Go's implementation-defined conversion
+	// would otherwise saturate or wrap).
+	_, ok = coerceToFieldShape(1e20, SearchFieldTypeInt64, false)
+	assert.False(t, ok, "value above MaxInt64 must be rejected")
+	_, ok = coerceToFieldShape(-1e20, SearchFieldTypeInt64, false)
+	assert.False(t, ok, "value below MinInt64 must be rejected")
+
+	// NaN and infinities are rejected.
+	_, ok = coerceToFieldShape(math.NaN(), SearchFieldTypeInt64, false)
+	assert.False(t, ok)
+	_, ok = coerceToFieldShape(math.Inf(1), SearchFieldTypeInt64, false)
+	assert.False(t, ok)
+}
+
+func TestCoerceToFieldShape_Double(t *testing.T) {
+	v, ok := coerceToFieldShape(3.14, SearchFieldTypeDouble, false)
+	require.True(t, ok)
+	assert.Equal(t, 3.14, v)
+
+	// An integer JSON value (preserved as int64 by unstructured) is accepted
+	// for a Double field — it is still a valid double.
+	v, ok = coerceToFieldShape(int64(7), SearchFieldTypeDouble, false)
+	require.True(t, ok)
+	assert.Equal(t, float64(7), v)
+}
+
+func TestCoerceToFieldShape_Array(t *testing.T) {
+	v, ok := coerceToFieldShape([]any{"a", "b"}, SearchFieldTypeString, true)
+	require.True(t, ok)
+	assert.Equal(t, []any{"a", "b"}, v)
+
+	// Mixed types in array fail the whole array.
+	_, ok = coerceToFieldShape([]any{"a", 42}, SearchFieldTypeString, true)
+	assert.False(t, ok)
+
+	// Non-slice when Array is true is rejected.
+	_, ok = coerceToFieldShape("a", SearchFieldTypeString, true)
+	assert.False(t, ok)
+}
+
+func TestCoerceToFieldShape_Nil(t *testing.T) {
+	_, ok := coerceToFieldShape(nil, SearchFieldTypeString, false)
+	assert.False(t, ok)
+}

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -47,9 +47,15 @@ const (
 	// the protobuf enum). Downstream switches can reference it by name.
 	SearchFieldTypeUnknown SearchFieldType = ""
 	SearchFieldTypeString  SearchFieldType = "string"
-	SearchFieldTypeInt32   SearchFieldType = "int32"
-	SearchFieldTypeInt64   SearchFieldType = "int64"
-	SearchFieldTypeFloat   SearchFieldType = "float"
+	// SearchFieldTypeInt64 covers integer-shaped fields. The protobuf column
+	// enum distinguishes INT32 and INT64; this SFD type set collapses them
+	// into a single int64. Standard fields never use INT32 today, and
+	// numeric search behaviour is identical (bleve indexes through float64
+	// internally).
+	SearchFieldTypeInt64 SearchFieldType = "int64"
+	// SearchFieldTypeDouble covers floating-point fields. The protobuf-level
+	// distinction between FLOAT and DOUBLE is similarly collapsed; SFDs use
+	// float64 for both.
 	SearchFieldTypeDouble  SearchFieldType = "double"
 	SearchFieldTypeBoolean SearchFieldType = "boolean"
 	SearchFieldTypeDate    SearchFieldType = "date"
@@ -126,8 +132,10 @@ func SearchFieldsFromTableColumns(cols []*resourcepb.ResourceTableColumnDefiniti
 }
 
 // searchFieldTypeFromProto maps the protobuf column type to the new
-// SearchFieldType. DATE_TIME collapses to date because the new design omits
-// a separate dateTime type. OBJECT, BINARY, and UNKNOWN_TYPE return
+// SearchFieldType. INT32 collapses into Int64 and FLOAT into Double:
+// bleve stores both as float64 and the SFD type set does not preserve the
+// distinction. DATE_TIME collapses to date because the new design omits a
+// separate dateTime type. OBJECT, BINARY, and UNKNOWN_TYPE return
 // SearchFieldTypeUnknown because they are not part of the new type set.
 func searchFieldTypeFromProto(t resourcepb.ResourceTableColumnDefinition_ColumnType) SearchFieldType {
 	switch t {
@@ -135,13 +143,11 @@ func searchFieldTypeFromProto(t resourcepb.ResourceTableColumnDefinition_ColumnT
 		return SearchFieldTypeString
 	case resourcepb.ResourceTableColumnDefinition_BOOLEAN:
 		return SearchFieldTypeBoolean
-	case resourcepb.ResourceTableColumnDefinition_INT32:
-		return SearchFieldTypeInt32
-	case resourcepb.ResourceTableColumnDefinition_INT64:
+	case resourcepb.ResourceTableColumnDefinition_INT32,
+		resourcepb.ResourceTableColumnDefinition_INT64:
 		return SearchFieldTypeInt64
-	case resourcepb.ResourceTableColumnDefinition_FLOAT:
-		return SearchFieldTypeFloat
-	case resourcepb.ResourceTableColumnDefinition_DOUBLE:
+	case resourcepb.ResourceTableColumnDefinition_FLOAT,
+		resourcepb.ResourceTableColumnDefinition_DOUBLE:
 		return SearchFieldTypeDouble
 	case resourcepb.ResourceTableColumnDefinition_DATE,
 		resourcepb.ResourceTableColumnDefinition_DATE_TIME:

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -213,7 +213,7 @@ func TestAddCapabilityFieldMappings_RetrieveOnly_NoMapping(t *testing.T) {
 	parent := bleve.NewDocumentMapping()
 	addCapabilityFieldMappings(parent, resource.SearchFieldDefinition{
 		Name:         "linkCount",
-		Type:         resource.SearchFieldTypeInt32,
+		Type:         resource.SearchFieldTypeInt64,
 		Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve},
 	})
 	assert.Empty(t, parent.Properties, "retrieve-only fields fall back to dynamic mapping")


### PR DESCRIPTION
Adds a path-based extractor to the standard document builder so any kind declaring `SearchFieldDefinition`s with a `Path` gets indexed without a custom builder. New entry point `StandardDocumentBuilderWithFields(manifests, provider)` wires a `SearchFieldsProvider`; the existing `StandardDocumentBuilder(manifests)` shims with a nil provider, so current callers are unaffected.

Path syntax: plain dot path, scalar-array passthrough, one `[*]` array projection per path. Coercion against the declared type: string/date, boolean, Int64 (accepts int64 or float64 rounded half away from zero, with explicit range and NaN/Inf rejection), Double (float64 or int64 promoted). Both int64 and float64 are handled because `unstructured.Unstructured.UnmarshalJSON` preserves integer JSON values as int64.

Version lookup is strict: a manifest must declare every served version of a kind. Cross-version fallback was rejected as risky (a diverged schema would silently extract from the wrong path).

Type set tidied: `SearchFieldTypeInt32` and `SearchFieldTypeFloat` removed in favour of `Int64` and `Double`. Bleve indexes all numerics through float64 internally so search behaviour is unaffected; no in-tree callers used the removed types.

No kind declares a `Path` yet — pure infrastructure addition.

Tracking issue: grafana/search-and-storage-team#827.
