### PR TITLE
Alerting: Preserve evaluation interval in panel drawer Continue flow

### DIFF
--- a/public/app/features/alerting/unified/rule-editor/formDefaults.test.ts
+++ b/public/app/features/alerting/unified/rule-editor/formDefaults.test.ts
@@ -50,6 +50,22 @@ describe('formValuesFromQueryParams', () => {
     expect(result).toEqual(defaultFormValues);
   });
 
+  it('should preserve evaluateEvery when provided', () => {
+    // "Continue in Alerting" from the panel drawer passes the rule's interval through this param;
+    // it must not be overwritten with the default.
+    const ruleDefinition = JSON.stringify({ evaluateEvery: '5m' });
+
+    const result = formValuesFromQueryParams(ruleDefinition, RuleFormType.grafana);
+
+    expect(result.evaluateEvery).toBe('5m');
+  });
+
+  it('should fall back to the default evaluateEvery when not provided', () => {
+    const result = formValuesFromQueryParams(JSON.stringify({}), RuleFormType.grafana);
+
+    expect(result.evaluateEvery).toBe(defaultFormValues.evaluateEvery);
+  });
+
   it('should normalize annotations', () => {
     const ruleDefinition = JSON.stringify({
       annotations: [

--- a/public/app/features/alerting/unified/rule-editor/formDefaults.ts
+++ b/public/app/features/alerting/unified/rule-editor/formDefaults.ts
@@ -155,7 +155,7 @@ export function formValuesFromQueryParams(ruleDefinition: string, type: RuleForm
         annotations: normalizeDefaultAnnotations(ruleFromQueryParams.annotations ?? []),
         queries: ruleFromQueryParams.queries ?? getDefaultQueries(),
         type: ruleFromQueryParams.type ?? type ?? RuleFormType.grafana,
-        evaluateEvery: DEFAULT_GROUP_EVALUATION_INTERVAL,
+        evaluateEvery: ruleFromQueryParams.evaluateEvery ?? DEFAULT_GROUP_EVALUATION_INTERVAL,
       })
     )
   );


### PR DESCRIPTION
## Summary

- "Continue in Alerting" from the panel drawer carried over all form values except the evaluation interval.
- `formValuesFromQueryParams` unconditionally overwrote `evaluateEvery` with the default; it now respects the value passed from the drawer and only falls back to the default when absent.

Part of grafana/alerting-squad#1809