### PR TITLE
Datasources: Simplify expression datasource registration in async APIs

### DIFF
--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -77,7 +77,8 @@ export {
   syncDataSourceInstanceSettings,
   getDataSourceInstanceSettingsList,
 } from '../services/dataSource/settings';
-export { setDataSourcePluginImporter, setExpressionDataSourceInstance } from '../services/dataSource/dataSource';
+export { setDataSourcePluginImporter } from '../services/dataSource/dataSource';
+export { setExpressionDataSourceInstance } from '../services/dataSource/expressionDs';
 export {
   useDataSourceInstanceSettingsList,
   type UseDataSourceInstanceSettingsListResult,

--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -74,11 +74,10 @@ export { invalidatePluginSettingsCache } from '../services/pluginSettings/invali
 
 export {
   initDataSourceInstanceSettings,
-  setExpressionDataSourceInstanceSettings,
   syncDataSourceInstanceSettings,
   getDataSourceInstanceSettingsList,
 } from '../services/dataSource/settings';
-export { setDataSourcePluginImporter } from '../services/dataSource/dataSource';
+export { setDataSourcePluginImporter, setExpressionDataSourceInstance } from '../services/dataSource/dataSource';
 export {
   useDataSourceInstanceSettingsList,
   type UseDataSourceInstanceSettingsListResult,

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -8,6 +8,7 @@ import {
   getDataSourceInstance,
   registerRuntimeDataSourceInstance,
   setDataSourcePluginImporter,
+  setExpressionDataSourceInstance,
 } from './dataSource';
 import { _resetForTests as resetPluginCache } from './pluginCache';
 import {
@@ -256,6 +257,63 @@ describe('plugin', () => {
 
       const result = await getDataSourceInstance('runtime-uid');
       expect(result).toBe(runtime);
+    });
+  });
+
+  describe('expression short-circuit', () => {
+    function registerExpression(): DataSourceApi {
+      const instance = Object.create(DataSourceApi.prototype) as DataSourceApi;
+      // The expression singleton retains its full instance settings as a public field.
+      (instance as unknown as { instanceSettings: DataSourceInstanceSettings }).instanceSettings = ds({
+        id: 0,
+        uid: '__expr__',
+        name: 'Expression',
+        type: '__expr__',
+      });
+      setExpressionDataSourceInstance(instance);
+      return instance;
+    }
+
+    it('returns the registered singleton without importing a plugin', async () => {
+      initDataSourceInstanceSettings({}, '');
+      const expr = registerExpression();
+      const mockImport = jest.fn();
+      setDataSourcePluginImporter(mockImport);
+
+      const result = await getDataSourceInstance('__expr__');
+
+      expect(result).toBe(expr);
+      expect(mockImport).not.toHaveBeenCalled();
+    });
+
+    it('resolves legacy id -100 and name Expression to the same singleton', async () => {
+      initDataSourceInstanceSettings({}, '');
+      const expr = registerExpression();
+      setDataSourcePluginImporter(jest.fn());
+
+      expect(await getDataSourceInstance('-100')).toBe(expr);
+      expect(await getDataSourceInstance('Expression')).toBe(expr);
+    });
+
+    it('resolves a DataSourceRef with the expression type', async () => {
+      initDataSourceInstanceSettings({}, '');
+      const expr = registerExpression();
+      setDataSourcePluginImporter(jest.fn());
+
+      const result = await getDataSourceInstance({ type: '__expr__', uid: '__expr__' });
+      expect(result).toBe(expr);
+    });
+
+    it('survives a reload (stored as a runtime cache entry)', async () => {
+      initDataSourceInstanceSettings({}, '');
+      const expr = registerExpression();
+
+      jest.spyOn(require('../../services/backendSrv'), 'getBackendSrv').mockReturnValue({
+        get: jest.fn().mockResolvedValue({ datasources: {}, defaultDatasource: '' }),
+      });
+      await reloadDataSourceInstanceSettings();
+
+      expect(await getDataSourceInstance('__expr__')).toBe(expr);
     });
   });
 });

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -9,7 +9,7 @@ import {
   registerRuntimeDataSourceInstance,
   setDataSourcePluginImporter,
 } from './dataSource';
-import { _resetForTests as resetExpressionDs, setExpressionDataSourceInstance } from './expressionDs';
+import { setExpressionDataSourceInstance } from './expressionDs';
 import { _resetForTests as resetPluginCache } from './pluginCache';
 import {
   _resetForTests as resetInstanceSettings,
@@ -58,7 +58,6 @@ beforeEach(() => {
   resetInstanceSettings();
   resetPlugin();
   resetPluginCache();
-  resetExpressionDs();
 });
 
 describe('plugin', () => {
@@ -305,7 +304,7 @@ describe('plugin', () => {
       expect(result).toBe(expr);
     });
 
-    it('survives a reload (stored as a runtime cache entry)', async () => {
+    it('survives a reload (state is in expressionDs module, independent of the plugin cache)', async () => {
       initDataSourceInstanceSettings({}, '');
       const expr = registerExpression();
 

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -319,9 +319,7 @@ describe('plugin', () => {
 
     it('throws if the singleton has not been registered', async () => {
       initDataSourceInstanceSettings({}, '');
-      await expect(getDataSourceInstance('__expr__')).rejects.toThrow(
-        'Expression datasource has not been initialised'
-      );
+      await expect(getDataSourceInstance('__expr__')).rejects.toThrow('Expression datasource has not been initialised');
     });
   });
 });

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -8,8 +8,8 @@ import {
   getDataSourceInstance,
   registerRuntimeDataSourceInstance,
   setDataSourcePluginImporter,
-  setExpressionDataSourceInstance,
 } from './dataSource';
+import { _resetForTests as resetExpressionDs, setExpressionDataSourceInstance } from './expressionDs';
 import { _resetForTests as resetPluginCache } from './pluginCache';
 import {
   _resetForTests as resetInstanceSettings,
@@ -58,6 +58,7 @@ beforeEach(() => {
   resetInstanceSettings();
   resetPlugin();
   resetPluginCache();
+  resetExpressionDs();
 });
 
 describe('plugin', () => {
@@ -314,6 +315,13 @@ describe('plugin', () => {
       await reloadDataSourceInstanceSettings();
 
       expect(await getDataSourceInstance('__expr__')).toBe(expr);
+    });
+
+    it('throws if the singleton has not been registered', async () => {
+      initDataSourceInstanceSettings({}, '');
+      await expect(getDataSourceInstance('__expr__')).rejects.toThrow(
+        'Expression datasource has not been initialised'
+      );
     });
   });
 });

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -1,5 +1,12 @@
-import { DataSourceApi, type DataSourceInstanceSettings, type DataSourceRef, type ScopedVars } from '@grafana/data';
+import {
+  DataSourceApi,
+  type DataQuery,
+  type DataSourceInstanceSettings,
+  type DataSourceRef,
+  type ScopedVars,
+} from '@grafana/data';
 
+import { ExpressionDatasourceRef, isExpressionReference } from '../../utils/DataSourceWithBackend';
 import { UserStorage } from '../../utils/userStorage';
 import { type RuntimeDataSourceRegistration } from '../dataSourceSrv';
 
@@ -33,6 +40,16 @@ export async function getDataSourceInstance(
   ref?: DataSourceRef | string | null,
   scopedVars?: ScopedVars
 ): Promise<DataSourceApi> {
+  // Expression references resolve to the preloaded singleton — its meta.module
+  // is empty, so it must never go through the plugin importer. Mirrors the
+  // legacy DatasourceSrv.get() short-circuit.
+  if (isExpressionReference(ref)) {
+    const cached = getCachedPlugin(ExpressionDatasourceRef.uid);
+    if (cached) {
+      return cached;
+    }
+  }
+
   const settings = await getDataSourceInstanceSettings(ref, scopedVars);
   if (!settings) {
     throw new Error(`Datasource ${describeRef(ref)} was not found`);
@@ -115,6 +132,26 @@ export function registerRuntimeDataSourceInstance(entry: RuntimeDataSourceRegist
 
   upsertRuntimeDataSourceInstanceSettings(dataSource.instanceSettings);
   setRuntimePlugin(dataSource.uid, dataSource);
+}
+
+/**
+ * Inject the expression pseudo-datasource singleton into the runtime plugin
+ * cache so {@link getDataSourceInstance} returns it without importing a plugin
+ * module (its meta.module is empty), and {@link getDataSourceInstanceSettings}
+ * can read its settings off the instance. Stored as a runtime entry so it
+ * survives {@link reloadDataSourceInstanceSettings}. Called once at boot.
+ *
+ * This is a temporary bridge until ExpressionDatasource moves from core to
+ * @grafana/runtime, at which point it can be imported directly.
+ *
+ * @internal
+ */
+export function setExpressionDataSourceInstance<TQuery extends DataQuery>(instance: DataSourceApi<TQuery>): void {
+  // The expression singleton is a DataSourceApi<ExpressionQuery>, which is not
+  // assignable to the base DataSourceApi because the query type is invariant.
+  // The legacy DatasourceSrv casts the same singleton when caching it.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  setRuntimePlugin(ExpressionDatasourceRef.uid, instance as DataSourceApi);
 }
 
 function describeRef(ref: DataSourceRef | string | null | undefined): string {

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -4,7 +4,7 @@ import { isExpressionReference } from '../../utils/DataSourceWithBackend';
 import { UserStorage } from '../../utils/userStorage';
 import { type RuntimeDataSourceRegistration } from '../dataSourceSrv';
 
-import { getExpressionDatasourceInstance } from './expressionDs';
+import { getExpressionDataSourceInstance } from './expressionDs';
 import { getCachedPlugin, setCachedPlugin, setRuntimePlugin } from './pluginCache';
 import { getDataSourceInstanceSettings, upsertRuntimeDataSourceInstanceSettings } from './settings';
 import { type ImportDataSourcePluginFn } from './types';
@@ -38,7 +38,7 @@ export async function getDataSourceInstance(
   // Expression references resolve to the preloaded singleton — its meta.module
   // is empty, so it must never go through the plugin importer.
   if (isExpressionReference(ref)) {
-    const expressionDs = getExpressionDatasourceInstance();
+    const expressionDs = getExpressionDataSourceInstance();
     if (!expressionDs) {
       throw new Error(
         'Expression datasource has not been initialised. Call setExpressionDataSourceInstance during application boot.'

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -35,8 +35,6 @@ export async function getDataSourceInstance(
   ref?: DataSourceRef | string | null,
   scopedVars?: ScopedVars
 ): Promise<DataSourceApi> {
-  // Expression references resolve to the preloaded singleton — its meta.module
-  // is empty, so it must never go through the plugin importer.
   if (isExpressionReference(ref)) {
     const expressionDs = getExpressionDataSourceInstance();
     if (!expressionDs) {

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -40,7 +40,9 @@ export async function getDataSourceInstance(
   if (isExpressionReference(ref)) {
     const expressionDs = getExpressionDatasourceInstance();
     if (!expressionDs) {
-      throw new Error('Expression datasource has not been initialised. Call setExpressionDataSourceInstance during application boot.');
+      throw new Error(
+        'Expression datasource has not been initialised. Call setExpressionDataSourceInstance during application boot.'
+      );
     }
     return expressionDs;
   }

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -1,15 +1,10 @@
-import {
-  DataSourceApi,
-  type DataQuery,
-  type DataSourceInstanceSettings,
-  type DataSourceRef,
-  type ScopedVars,
-} from '@grafana/data';
+import { DataSourceApi, type DataSourceInstanceSettings, type DataSourceRef, type ScopedVars } from '@grafana/data';
 
-import { ExpressionDatasourceRef, isExpressionReference } from '../../utils/DataSourceWithBackend';
+import { isExpressionReference } from '../../utils/DataSourceWithBackend';
 import { UserStorage } from '../../utils/userStorage';
 import { type RuntimeDataSourceRegistration } from '../dataSourceSrv';
 
+import { getExpressionDatasourceInstance } from './expressionDs';
 import { getCachedPlugin, setCachedPlugin, setRuntimePlugin } from './pluginCache';
 import { getDataSourceInstanceSettings, upsertRuntimeDataSourceInstanceSettings } from './settings';
 import { type ImportDataSourcePluginFn } from './types';
@@ -41,13 +36,13 @@ export async function getDataSourceInstance(
   scopedVars?: ScopedVars
 ): Promise<DataSourceApi> {
   // Expression references resolve to the preloaded singleton — its meta.module
-  // is empty, so it must never go through the plugin importer. Mirrors the
-  // legacy DatasourceSrv.get() short-circuit.
+  // is empty, so it must never go through the plugin importer.
   if (isExpressionReference(ref)) {
-    const cached = getCachedPlugin(ExpressionDatasourceRef.uid);
-    if (cached) {
-      return cached;
+    const expressionDs = getExpressionDatasourceInstance();
+    if (!expressionDs) {
+      throw new Error('Expression datasource has not been initialised. Call setExpressionDataSourceInstance during application boot.');
     }
+    return expressionDs;
   }
 
   const settings = await getDataSourceInstanceSettings(ref, scopedVars);
@@ -132,26 +127,6 @@ export function registerRuntimeDataSourceInstance(entry: RuntimeDataSourceRegist
 
   upsertRuntimeDataSourceInstanceSettings(dataSource.instanceSettings);
   setRuntimePlugin(dataSource.uid, dataSource);
-}
-
-/**
- * Inject the expression pseudo-datasource singleton into the runtime plugin
- * cache so {@link getDataSourceInstance} returns it without importing a plugin
- * module (its meta.module is empty), and {@link getDataSourceInstanceSettings}
- * can read its settings off the instance. Stored as a runtime entry so it
- * survives {@link reloadDataSourceInstanceSettings}. Called once at boot.
- *
- * This is a temporary bridge until ExpressionDatasource moves from core to
- * @grafana/runtime, at which point it can be imported directly.
- *
- * @internal
- */
-export function setExpressionDataSourceInstance<TQuery extends DataQuery>(instance: DataSourceApi<TQuery>): void {
-  // The expression singleton is a DataSourceApi<ExpressionQuery>, which is not
-  // assignable to the base DataSourceApi because the query type is invariant.
-  // The legacy DatasourceSrv casts the same singleton when caching it.
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  setRuntimePlugin(ExpressionDatasourceRef.uid, instance as DataSourceApi);
 }
 
 function describeRef(ref: DataSourceRef | string | null | undefined): string {

--- a/packages/grafana-runtime/src/services/dataSource/expressionDs.ts
+++ b/packages/grafana-runtime/src/services/dataSource/expressionDs.ts
@@ -1,0 +1,28 @@
+import { type DataQuery, type DataSourceApi, type DataSourceInstanceSettings } from '@grafana/data';
+
+let instance: DataSourceApi | undefined;
+let instanceSettings: DataSourceInstanceSettings | undefined;
+
+export function setExpressionDataSourceInstance<TQuery extends DataQuery>(ds: DataSourceApi<TQuery>): void {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  instance = ds as DataSourceApi;
+  // Extract settings once at registration so lookups need no cast.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  instanceSettings = (ds as unknown as { instanceSettings?: DataSourceInstanceSettings }).instanceSettings;
+}
+
+export function getExpressionDatasourceInstance(): DataSourceApi | undefined {
+  return instance;
+}
+
+export function getExpressionDatasourceSettings(): DataSourceInstanceSettings | undefined {
+  return instanceSettings;
+}
+
+export function _resetForTests(): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('_resetForTests must only be called from tests');
+  }
+  instance = undefined;
+  instanceSettings = undefined;
+}

--- a/packages/grafana-runtime/src/services/dataSource/expressionDs.ts
+++ b/packages/grafana-runtime/src/services/dataSource/expressionDs.ts
@@ -11,11 +11,11 @@ export function setExpressionDataSourceInstance<TQuery extends DataQuery>(ds: Da
   instanceSettings = (ds as unknown as { instanceSettings?: DataSourceInstanceSettings }).instanceSettings;
 }
 
-export function getExpressionDatasourceInstance(): DataSourceApi | undefined {
+export function getExpressionDataSourceInstance(): DataSourceApi | undefined {
   return instance;
 }
 
-export function getExpressionDatasourceSettings(): DataSourceInstanceSettings | undefined {
+export function getExpressionDataSourceSettings(): DataSourceInstanceSettings | undefined {
   return instanceSettings;
 }
 

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -4,7 +4,7 @@ import { setBackendSrv } from '../backendSrv';
 import { type DataSourceSrv, setDataSourceSrv } from '../dataSourceSrv';
 import { setTemplateSrv, type TemplateSrv } from '../templateSrv';
 
-import { _resetForTests as resetExpressionDs, setExpressionDataSourceInstance } from './expressionDs';
+import { setExpressionDataSourceInstance } from './expressionDs';
 import {
   _resetForTests,
   getDataSourceInstanceSettingsList,
@@ -125,7 +125,6 @@ beforeAll(() => {
 
 beforeEach(() => {
   _resetForTests();
-  resetExpressionDs();
   backendGet.mockReset();
   // No legacy srv by default — reloadDataSourceInstanceSettings() should use the fetch path.
   setDataSourceSrv(undefined as unknown as DataSourceSrv);

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -1,19 +1,26 @@
-import { type DataSourceInstanceSettings } from '@grafana/data';
+import { type DataSourceApi, type DataSourceInstanceSettings } from '@grafana/data';
 
 import { setBackendSrv } from '../backendSrv';
 import { type DataSourceSrv, setDataSourceSrv } from '../dataSourceSrv';
 import { setTemplateSrv, type TemplateSrv } from '../templateSrv';
 
+import { setExpressionDataSourceInstance } from './dataSource';
+import { _resetForTests as resetPluginCache } from './pluginCache';
 import {
   _resetForTests,
   getDataSourceInstanceSettingsList,
   getDataSourceInstanceSettings,
   initDataSourceInstanceSettings,
-  setExpressionDataSourceInstanceSettings,
   reloadDataSourceInstanceSettings,
   syncDataSourceInstanceSettings,
   upsertRuntimeDataSourceInstanceSettings,
 } from './settings';
+
+// The expression singleton retains its full instance settings as a public
+// field; the runtime APIs read settings off the registered instance.
+function expressionInstance(settings: DataSourceInstanceSettings): DataSourceApi {
+  return { instanceSettings: settings } as unknown as DataSourceApi;
+}
 
 function ds(overrides: Partial<DataSourceInstanceSettings>): DataSourceInstanceSettings {
   return {
@@ -119,6 +126,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   _resetForTests();
+  resetPluginCache();
   backendGet.mockReset();
   // No legacy srv by default — reloadDataSourceInstanceSettings() should use the fetch path.
   setDataSourceSrv(undefined as unknown as DataSourceSrv);
@@ -160,6 +168,7 @@ describe('instanceSettings', () => {
 
     it('resolves expression references by uid, name, and legacy id', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
+      setExpressionDataSourceInstance(expressionInstance(fixtures.Expression));
       const byUid = await getDataSourceInstanceSettings('__expr__');
       const byName = await getDataSourceInstanceSettings('Expression');
       const byLegacyId = await getDataSourceInstanceSettings('-100');
@@ -507,40 +516,46 @@ describe('instanceSettings', () => {
     });
   });
 
-  describe('setExpressionDataSourceInstanceSettings', () => {
+  describe('setExpressionDataSourceInstance', () => {
     it('makes the expression datasource available by uid after init', async () => {
-      setExpressionDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstance(expressionInstance(fixtures.Expression));
       initDataSourceInstanceSettings({}, '');
       const result = await getDataSourceInstanceSettings('__expr__');
       expect(result?.uid).toBe('__expr__');
     });
 
     it('resolves by name via isExpressionReference path', async () => {
-      setExpressionDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstance(expressionInstance(fixtures.Expression));
       initDataSourceInstanceSettings({}, '');
       const result = await getDataSourceInstanceSettings('Expression');
       expect(result?.uid).toBe('__expr__');
     });
 
     it('resolves by legacy id -100 via isExpressionReference path', async () => {
-      setExpressionDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstance(expressionInstance(fixtures.Expression));
       initDataSourceInstanceSettings({}, '');
       const result = await getDataSourceInstanceSettings('-100');
       expect(result?.uid).toBe('__expr__');
     });
 
-    it('is not returned by getDataSourceInstanceSettingsList (byUid-only, matching legacy)', async () => {
-      // Set via the expression setter, but do NOT include it in the init map — it
-      // must only live in byUid so list results are unaffected.
+    it('returns undefined for an expression ref when no instance is registered', async () => {
+      initDataSourceInstanceSettings({}, '');
+      const result = await getDataSourceInstanceSettings('__expr__');
+      expect(result).toBeUndefined();
+    });
+
+    it('is not returned by getDataSourceInstanceSettingsList (matching legacy)', async () => {
+      // The expression datasource lives only on the registered instance, never
+      // in the name/uid maps the list is built from.
       const { Expression: _expr, ...withoutExpression } = fixtures;
-      setExpressionDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstance(expressionInstance(fixtures.Expression));
       initDataSourceInstanceSettings(withoutExpression, 'Bravo');
       const items = await getDataSourceInstanceSettingsList({ all: true });
       expect(items.some((x) => x.uid === '__expr__')).toBe(false);
     });
 
     it('survives a cache repopulate via no-arg reload', async () => {
-      setExpressionDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstance(expressionInstance(fixtures.Expression));
       initDataSourceInstanceSettings(fixtures, 'Bravo');
 
       // Reload with a payload that does not include the expression datasource.
@@ -552,26 +567,8 @@ describe('instanceSettings', () => {
       expect(backendGet).toHaveBeenCalledWith('/api/frontend/settings');
     });
 
-    it('throws when called a second time outside of tests', () => {
-      const originalNodeEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'production';
-      try {
-        setExpressionDataSourceInstanceSettings(fixtures.Expression);
-        expect(() => setExpressionDataSourceInstanceSettings(fixtures.Expression)).toThrow(
-          'setExpressionDataSourceInstanceSettings() function should only be called once'
-        );
-      } finally {
-        process.env.NODE_ENV = originalNodeEnv;
-      }
-    });
-
-    it('allows being called multiple times in tests', () => {
-      setExpressionDataSourceInstanceSettings(fixtures.Expression);
-      expect(() => setExpressionDataSourceInstanceSettings(fixtures.Expression)).not.toThrow();
-    });
-
     it('coexists with a runtime datasource and both survive a repopulate', async () => {
-      setExpressionDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstance(expressionInstance(fixtures.Expression));
       initDataSourceInstanceSettings(fixtures, 'Bravo');
       const runtime = ds({ uid: 'runtime-ds', name: 'Runtime', type: 'runtime' });
       upsertRuntimeDataSourceInstanceSettings(runtime);

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -4,8 +4,7 @@ import { setBackendSrv } from '../backendSrv';
 import { type DataSourceSrv, setDataSourceSrv } from '../dataSourceSrv';
 import { setTemplateSrv, type TemplateSrv } from '../templateSrv';
 
-import { setExpressionDataSourceInstance } from './dataSource';
-import { _resetForTests as resetPluginCache } from './pluginCache';
+import { _resetForTests as resetExpressionDs, setExpressionDataSourceInstance } from './expressionDs';
 import {
   _resetForTests,
   getDataSourceInstanceSettingsList,
@@ -126,7 +125,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   _resetForTests();
-  resetPluginCache();
+  resetExpressionDs();
   backendGet.mockReset();
   // No legacy srv by default — reloadDataSourceInstanceSettings() should use the fetch path.
   setDataSourceSrv(undefined as unknown as DataSourceSrv);
@@ -495,7 +494,7 @@ describe('instanceSettings', () => {
     });
 
     it('preserves a built-in datasource and keeps it out of the list', async () => {
-      setExpressionDataSourceInstanceSettings(fixtures.Expression);
+      setExpressionDataSourceInstance(expressionInstance(fixtures.Expression));
       initDataSourceInstanceSettings(fixtures, 'Bravo');
 
       // Sync a payload that does not include the expression datasource.

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -6,13 +6,14 @@ import {
   matchPluginId,
 } from '@grafana/data';
 
-import { ExpressionDatasourceRef, isExpressionReference } from '../../utils/DataSourceWithBackend';
+import { isExpressionReference } from '../../utils/DataSourceWithBackend';
 import { getCachedPromise, invalidateCachedPromise } from '../../utils/getCachedPromise';
 import { getBackendSrv } from '../backendSrv';
 import { getDataSourceSrv, type GetDataSourceListFilters } from '../dataSourceSrv';
 import { getTemplateSrv } from '../templateSrv';
 
-import { clearPluginCache, getCachedPlugin } from './pluginCache';
+import { getExpressionDatasourceSettings } from './expressionDs';
+import { clearPluginCache } from './pluginCache';
 
 let byName: Record<string, DataSourceInstanceSettings> = {};
 let byUid: Record<string, DataSourceInstanceSettings> = {};
@@ -158,11 +159,7 @@ function lookupFromMaps(
   scopedVars: ScopedVars | undefined
 ): DataSourceInstanceSettings | undefined {
   if (isExpressionReference(ref)) {
-    const inst = getCachedPlugin(ExpressionDatasourceRef.uid);
-    // The expression singleton retains its full instance settings as a public
-    // field, which the base DataSourceApi type does not expose.
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return inst ? (inst as { instanceSettings?: DataSourceInstanceSettings }).instanceSettings : undefined;
+    return getExpressionDatasourceSettings();
   }
 
   const nameOrUid = getNameOrUid(ref);

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -12,13 +12,12 @@ import { getBackendSrv } from '../backendSrv';
 import { getDataSourceSrv, type GetDataSourceListFilters } from '../dataSourceSrv';
 import { getTemplateSrv } from '../templateSrv';
 
-import { clearPluginCache } from './pluginCache';
+import { clearPluginCache, getCachedPlugin } from './pluginCache';
 
 let byName: Record<string, DataSourceInstanceSettings> = {};
 let byUid: Record<string, DataSourceInstanceSettings> = {};
 let byId: Record<string, DataSourceInstanceSettings> = {};
 let runtimeByUid: Record<string, DataSourceInstanceSettings> = {};
-let expressionDsSettings: DataSourceInstanceSettings | undefined;
 let defaultName = '';
 
 function populateMaps(settings: Record<string, DataSourceInstanceSettings>) {
@@ -40,11 +39,6 @@ function populateMaps(settings: Record<string, DataSourceInstanceSettings>) {
   // Re-apply any previously registered runtime data sources so they survive a refetch.
   for (const ds of Object.values(runtimeByUid)) {
     byUid[ds.uid] = ds;
-  }
-
-  // Re-apply the expression datasource so it survives a cache repopulate.
-  if (expressionDsSettings) {
-    byUid[expressionDsSettings.uid] = expressionDsSettings;
   }
 }
 
@@ -146,27 +140,6 @@ export async function getDataSourceInstanceSettingsList(
 }
 
 /**
- * Set the instance settings for the expression pseudo-datasource, which is not
- * part of /api/frontend/settings and must be injected client-side. Re-applied
- * on every populate so it survives a cache repopulate.
- *
- * This is a temporary bridge until ExpressionDatasource moves from core to
- * @grafana/runtime, at which point it can be imported directly.
- *
- * @internal
- */
-export function setExpressionDataSourceInstanceSettings(settings: DataSourceInstanceSettings): void {
-  // We allow overriding in tests
-  if (expressionDsSettings && process.env.NODE_ENV !== 'test') {
-    throw new Error(
-      'setExpressionDataSourceInstanceSettings() function should only be called once, when Grafana is starting.'
-    );
-  }
-  expressionDsSettings = settings;
-  byUid[settings.uid] = settings;
-}
-
-/**
  * Register the instance settings for a runtime data source so it is returned
  * by future lookups. Throws if the uid is already in use.
  *
@@ -185,7 +158,11 @@ function lookupFromMaps(
   scopedVars: ScopedVars | undefined
 ): DataSourceInstanceSettings | undefined {
   if (isExpressionReference(ref)) {
-    return byUid[ExpressionDatasourceRef.uid];
+    const inst = getCachedPlugin(ExpressionDatasourceRef.uid);
+    // The expression singleton retains its full instance settings as a public
+    // field, which the base DataSourceApi type does not expose.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return inst ? (inst as { instanceSettings?: DataSourceInstanceSettings }).instanceSettings : undefined;
   }
 
   const nameOrUid = getNameOrUid(ref);
@@ -362,6 +339,5 @@ export function _resetForTests(): void {
   byUid = {};
   byId = {};
   runtimeByUid = {};
-  expressionDsSettings = undefined;
   defaultName = '';
 }

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -12,7 +12,7 @@ import { getBackendSrv } from '../backendSrv';
 import { getDataSourceSrv, type GetDataSourceListFilters } from '../dataSourceSrv';
 import { getTemplateSrv } from '../templateSrv';
 
-import { getExpressionDatasourceSettings } from './expressionDs';
+import { getExpressionDataSourceSettings, _resetForTests as resetExpressionDs } from './expressionDs';
 import { clearPluginCache } from './pluginCache';
 
 let byName: Record<string, DataSourceInstanceSettings> = {};
@@ -159,7 +159,7 @@ function lookupFromMaps(
   scopedVars: ScopedVars | undefined
 ): DataSourceInstanceSettings | undefined {
   if (isExpressionReference(ref)) {
-    return getExpressionDatasourceSettings();
+    return getExpressionDataSourceSettings();
   }
 
   const nameOrUid = getNameOrUid(ref);
@@ -337,4 +337,5 @@ export function _resetForTests(): void {
   byId = {};
   runtimeByUid = {};
   defaultName = '';
+  resetExpressionDs();
 }

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -47,7 +47,7 @@ import {
   getPanelPluginMetas,
   initDataSourceInstanceSettings,
   initOpenFeature,
-  setExpressionDataSourceInstanceSettings,
+  setExpressionDataSourceInstance,
   setDataSourcePluginImporter,
   setGetObservablePluginComponents,
   setGetObservablePluginLinks,
@@ -93,7 +93,7 @@ import { initAlerting } from './features/alerting/unified/initAlerting';
 import { getTimeSrv } from './features/dashboard/services/TimeSrv';
 import { EmbeddedDashboardLazy } from './features/dashboard-scene/embedding/EmbeddedDashboardLazy';
 import { DashboardLevelTimeMacro } from './features/dashboard-scene/scene/DashboardLevelTimeMacro';
-import { instanceSettings as expressionInstanceSettings } from './features/expressions/ExpressionDatasource';
+import { dataSource as expressionDatasource } from './features/expressions/ExpressionDatasource';
 import { initGrafanaLive } from './features/live';
 import { PanelDataErrorView } from './features/panel/components/PanelDataErrorView';
 import { PanelRenderer } from './features/panel/components/PanelRenderer';
@@ -255,7 +255,7 @@ export class GrafanaApp {
       // Init async data source services (populates cache from boot data so
       // new `getInstanceSettings` / `getInstanceSettingsList` callers don't
       // need to wait on a network round trip).
-      setExpressionDataSourceInstanceSettings(expressionInstanceSettings);
+      setExpressionDataSourceInstance(expressionDatasource);
       initDataSourceInstanceSettings(config.datasources, config.defaultDatasource);
       setDataSourcePluginImporter(pluginImporter.importDataSource.bind(pluginImporter));
 

--- a/public/app/features/plugins/datasource_srv.test.ts
+++ b/public/app/features/plugins/datasource_srv.test.ts
@@ -13,10 +13,10 @@ import { RuntimeDataSource, type TemplateSrv } from '@grafana/runtime';
 import {
   ExpressionDatasourceRef,
   getDataSourceInstanceSettingsList,
-  setExpressionDataSourceInstanceSettings,
+  setExpressionDataSourceInstance,
 } from '@grafana/runtime/internal';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
-import { instanceSettings as expressionInstanceSettings } from 'app/features/expressions/ExpressionDatasource';
+import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { DatasourceSrv, getNameOrUid } from 'app/features/plugins/datasource_srv';
 
 // Datasource variable $datasource with current value 'BBB'
@@ -648,7 +648,7 @@ describe('datasource_srv', () => {
 
       it('should sync the new async instance-settings cache from the same fetched payload', async () => {
         // Mirror startup: the expression datasource is injected into the new cache.
-        setExpressionDataSourceInstanceSettings(expressionInstanceSettings);
+        setExpressionDataSourceInstance(expressionDatasource);
 
         getBackendSrvGetMock.mockReset();
         getBackendSrvGetMock.mockReturnValueOnce({


### PR DESCRIPTION
**What is this feature?**

Simplifies how the expression pseudo-datasource singleton is managed in `@grafana/runtime`. Replaces the old `setExpressionDataSourceInstanceSettings` function (which stored settings separately and had to re-apply them after every cache repopulate) with a new dedicated `expressionDs.ts` module that holds the full `DataSourceApi` instance in a local variable.

**Why do we need this feature?**

The previous approach scattered expression datasource state across `settings.ts` (a separate `expressionDsSettings` variable re-applied on every `populateMaps` call) and `dataSource.ts` (storing it in the runtime plugin cache). The new module owns all expression DS state in one place: a setter (`setExpressionDataSourceInstance`) extracts and caches both the instance and its settings at registration time, two argless getters return them, and call-sites do the `isExpressionReference` guard themselves. `getDataSourceInstance` now also throws explicitly if the singleton hasn't been registered at boot.

**Who is this feature for?**

Internal / platform — no user-facing change. This is a refactor of `@grafana/runtime` internals.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/pull/126390

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.