### PR TITLE
RBAC: allow notifications app permissions for service accounts

### DIFF
--- a/pkg/apimachinery/identity/context.go
+++ b/pkg/apimachinery/identity/context.go
@@ -181,7 +181,7 @@ var serviceIdentityPermissions = getWildcardPermissions(
 	"serviceaccounts:read", // serviceaccounts.ActionRead,
 )
 
-// Note: Any wildcard permissions here must be whitelisted in authlib: https://github.com/grafana/authlib/blob/main/authz/service_permissions.go
+// Note: Any wildcard-prefixed permissions here must be whitelisted in authlib: https://github.com/grafana/authlib/blob/main/authz/service_permissions.go
 var serviceIdentityTokenPermissions = []string{
 	"folder.grafana.app:*",
 	"dashboard.grafana.app:*",
@@ -197,6 +197,7 @@ var serviceIdentityTokenPermissions = []string{
 	"collections.grafana.app:*", // user stars
 	"plugins.grafana.app:*",
 	"historian.alerting.grafana.app:*",
+	"notifications.alerting.grafana.app:*",
 	"advisor.grafana.app:*",
 	"annotation.grafana.app:*",
 


### PR DESCRIPTION
**What is this feature?**

Adds `notifications.alerting.grafana.app:*` to the service identity's token permission allowlist (`serviceIdentityTokenPermissions` in `pkg/apimachinery/identity/context.go`), so on-behalf-of authorization checks for that API group are allowed to proceed to actual permission evaluation.

**Why do we need this feature?**

Admins (incl. service accounts with the Admin role) got a `403 cannot delegate app permission` when adding the `notifications.alerting.grafana.app/alertmanagerimports:create` permission to a custom role via the IAM roles API — even though Admin holds that permission.

The denial comes from authlib's client-side `CheckServicePermissions` gate (`authz/service_permissions.go`), which runs *before* the request reaches RBAC. It requires the requested `group[/resource]:verb` to be present (exact match) in the service identity's token permissions. The allowlist included other app groups (`iam.grafana.app:*`, `historian.alerting.grafana.app:*`, …) but was missing `notifications.alerting.grafana.app`, so every delegation check for that group was rejected at the gate and never evaluated by RBAC. This blocked the recently added alertmanager-imports fixed role (and any other `notifications.alerting.grafana.app` resource) from being delegated.

This is a gate, not an actual grant — real authorization still flows through RBAC/user-permission checks; the entry only permits the on-behalf-of check to be performed.

**Special notes for your reviewer:**

- One-line change, consistent with how every other app group is allowlisted (group-level `:*`). No wildcard-group whitelisting needed in authlib since it's an exact group match, not a `*.`-prefixed group.
- Scope: the gate covers the whole `notifications.alerting.grafana.app` group, so this also unblocks delegation checks for the group's other resources (receivers, routes, templates, time-intervals, inhibition-rules) that share the same path.
- Not related to Zanzana (shadow-only in affected envs) or the RBAC wildcard/privilege-escalation changes — those were ruled out during investigation; the check never reached either engine.
- Frontend/no user-facing UI change; backend only.

Want me to add a regression test asserting `notifications.alerting.grafana.app` is in `serviceIdentityTokenPermissions` so this can't silently regress again?
