### PR TITLE
docs: remove SAML Okta aliases with duplicated path segments

### DIFF
--- a/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/_index.md
@@ -1,6 +1,5 @@
 ---
 aliases:
-  - ../../../configure-security/configure-authentication/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-okta/ # /docs/grafana/next/setup-grafana/configure-security/configure-authentication/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-okta/
   - ../../../configure-security/configure-authentication/saml/configure-saml-with-okta/ # /docs/grafana/next/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-okta/
 description: Learn how to configure SAML authentication in Grafana's UI.
 labels:

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/oin-application.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/oin-application.md
@@ -1,6 +1,5 @@
 ---
 aliases:
-  - ../../../../configure-security/configure-authentication/saml/setup-grafana/configure-security/configure-authentication/saml/configure-saml-org-mapping/configure-saml-with-okta/oin-application/ # /docs/grafana/next/setup-grafana/configure-security/configure-authentication/saml/setup-grafana/configure-security/configure-authentication/saml/configure-saml-org-mapping/configure-saml-with-okta/oin-application/
   - ../../../../configure-security/configure-authentication/saml/configure-saml-with-okta/oin-application/ # /docs/grafana/next/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-okta/oin-application/
 description: Learn how to configure SAML authentication with Okta using the Okta Integration Network (OIN) application.
 labels:


### PR DESCRIPTION
While reading the SAML Okta setup docs I noticed the first alias in each of these two files repeats the setup-grafana/configure-security/configure-authentication path segments. Hugo turns those into redirects from URLs that never existed, for example /docs/grafana/next/setup-grafana/configure-security/configure-authentication/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-okta/. The correct old-path alias is already present in both files, so this just drops the broken ones.