### PR TITLE
Geomap: Fix issues with exports for tests

### DIFF
--- a/public/app/plugins/panel/geomap/style/markers.ts
+++ b/public/app/plugins/panel/geomap/style/markers.ts
@@ -32,7 +32,7 @@ const MarkerShapePath = {
   x: 'img/icons/marker/x-mark.svg',
 };
 
-function getFillColor(cfg: StyleConfigValues) {
+export function getFillColor(cfg: StyleConfigValues) {
   const opacity = cfg.opacity == null ? 0.8 : cfg.opacity;
   if (opacity === 1) {
     return new Fill({ color: cfg.color });
@@ -44,7 +44,7 @@ function getFillColor(cfg: StyleConfigValues) {
   return undefined;
 }
 
-function getStrokeStyle(cfg: StyleConfigValues) {
+export function getStrokeStyle(cfg: StyleConfigValues) {
   const opacity = cfg.opacity == null ? 0.8 : cfg.opacity;
   if (opacity === 1) {
     return new Stroke({ color: cfg.color, width: cfg.lineWidth ?? 1 });


### PR DESCRIPTION
Main typechecks and lints are broken due to these functions not being exported - not sure how this passed any of the CI in the first place...?

Ah, it's because https://github.com/grafana/grafana/pull/126143 helpfully got rid of the unused exports, but then we started using them for a test.