### PR TITLE
DataSources: Log async datasource plugin import failures

### DIFF
--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -1,6 +1,7 @@
 import { DataSourceApi, type DataSourceInstanceSettings, type DataSourcePluginMeta } from '@grafana/data';
 
 import { RuntimeDataSource } from '../RuntimeDataSource';
+import { setLogger } from '../logging/registry';
 import { setTemplateSrv, type TemplateSrv } from '../templateSrv';
 
 import {
@@ -54,10 +55,20 @@ function ds(overrides: Partial<DataSourceInstanceSettings> = {}): DataSourceInst
   } as DataSourceInstanceSettings;
 }
 
+const logError = jest.fn();
+
 beforeEach(() => {
   resetInstanceSettings();
   resetPlugin();
   resetPluginCache();
+  logError.mockClear();
+  setLogger('grafana/runtime.plugins.datasource', {
+    logDebug: jest.fn(),
+    logError,
+    logInfo: jest.fn(),
+    logMeasurement: jest.fn(),
+    logWarning: jest.fn(),
+  });
 });
 
 describe('plugin', () => {
@@ -135,6 +146,20 @@ describe('plugin', () => {
       setDataSourcePluginImporter(jest.fn().mockRejectedValue(new Error('module not found')));
 
       await expect(getDataSourceInstance(settings.uid)).rejects.toThrow(/module not found/);
+    });
+
+    it('logs the failure with the raw error as cause and does not sanitize the rethrow', async () => {
+      const settings = ds();
+      initDataSourceInstanceSettings({ [settings.name]: settings }, settings.name);
+      const importError = new Error('module not found');
+      setDataSourcePluginImporter(jest.fn().mockRejectedValue(importError));
+
+      await expect(getDataSourceInstance(settings.uid)).rejects.toBe(importError);
+
+      expect(logError).toHaveBeenCalledTimes(1);
+      const [loggedError] = logError.mock.calls[0];
+      expect(loggedError).toBeInstanceOf(Error);
+      expect(loggedError.cause).toBe(importError);
     });
 
     it('returns the same instance for name-based and uid-based lookups', async () => {

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -5,6 +5,7 @@ import { UserStorage } from '../../utils/userStorage';
 import { type RuntimeDataSourceRegistration } from '../dataSourceSrv';
 
 import { getExpressionDataSourceInstance } from './expressionDs';
+import { logDataSourceInstanceError } from './logging';
 import { getCachedPlugin, setCachedPlugin, setRuntimePlugin } from './pluginCache';
 import { getDataSourceInstanceSettings, upsertRuntimeDataSourceInstanceSettings } from './settings';
 import { type ImportDataSourcePluginFn } from './types';
@@ -80,7 +81,16 @@ async function loadDataSourceInstance(cacheUid: string, settings: DataSourceInst
     throw new Error('Data source importer has not been set. Call setDataSourcePluginImporter during application boot.');
   }
 
-  const dsPlugin = await importDataSourcePlugin(settings.meta);
+  let dsPlugin;
+  try {
+    dsPlugin = await importDataSourcePlugin(settings.meta);
+  } catch (error) {
+    logDataSourceInstanceError(`Failed to import datasource plugin ${settings.name} (${settings.uid})`, error, {
+      pluginId: settings.meta.id,
+      uid: settings.uid,
+    });
+    throw error;
+  }
 
   const racedCache = getCachedPlugin(cacheUid);
   if (racedCache) {

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -88,6 +88,7 @@ async function loadDataSourceInstance(cacheUid: string, settings: DataSourceInst
     logDataSourceInstanceError(`Failed to import datasource plugin ${settings.name} (${settings.uid})`, error, {
       pluginId: settings.meta.id,
       uid: settings.uid,
+      name: settings.name,
     });
     throw error;
   }

--- a/packages/grafana-runtime/src/services/dataSource/logging.ts
+++ b/packages/grafana-runtime/src/services/dataSource/logging.ts
@@ -1,0 +1,7 @@
+import { type LogContext } from '@grafana/faro-web-sdk';
+
+import { getLogger } from '../logging/registry';
+
+export function logDataSourceInstanceError(message: string, error: unknown, context?: LogContext): void {
+  getLogger('grafana/runtime.plugins.datasource').logError(new Error(message, { cause: error }), context);
+}

--- a/packages/grafana-runtime/src/services/logging/loggers.ts
+++ b/packages/grafana-runtime/src/services/logging/loggers.ts
@@ -6,6 +6,7 @@ export const Loggers = {
   /* new loggers should follow package/area.feature naming convention */
   'grafana/runtime.plugins.meta': { logToConsole: true },
   'grafana/runtime.plugins.settings': { logToConsole: true },
+  'grafana/runtime.plugins.datasource': { logToConsole: true },
   'grafana/runtime.utils.getCachedPromise': {},
 
   /* existing loggers that keep their existing source name */


### PR DESCRIPTION
**What is this feature?**

When a datasource plugin module fails to import, the async `getDataSourceInstance` now logs the failure via the runtime logger registry (new `grafana/runtime.plugins.datasource` source) and rethrows the raw error, instead of silently rethrowing with no diagnostics.

**Why do we need this feature?**

This closes behavioural divergence #2 between the new async datasource API and the legacy `DatasourceSrv`: legacy `loadDatasource` emitted an `AppEvents.alertError` toast and a sanitized error on plugin-load failure. Rather than replicate that toast (which has no precedent in `grafana-runtime` and risks double-toasts), this follows the convention already established by the new plugin-meta APIs — structured logging in the primitive, raw errors preserved, and user-facing presentation owned by hooks (`useDataSourceInstance` already exposes `error`).

**Who is this feature for?**

Grafana developers/maintainers migrating callers onto the async datasource API.

**Which issue(s) does this PR fix?**:

Fixes #126379

**Special notes for your reviewer:**

This is stacked on #126390 (base branch `mckn/simplify-expression-ds-settings`) and should be re-targeted to `main` once that merges. Frontend-only, no production consumer of `getDataSourceInstance` exists yet so there is no user-visible change today.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.