### PR TITLE
IAM: Index created field for user search

### DIFF
--- a/pkg/storage/unified/search/builders/document_test.go
+++ b/pkg/storage/unified/search/builders/document_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -207,4 +208,24 @@ func TestBuildSelectableFields(t *testing.T) {
 	user := &iamv0.User{}
 	_, err = BuildSelectableFields(user, iamv0.TeamBindingKind())
 	require.Error(t, err)
+}
+
+func TestUserDocumentBuilder_Created(t *testing.T) {
+	info, err := GetUserBuilder()
+	require.NoError(t, err)
+
+	value := []byte(`{
+		"metadata": {
+			"name": "uid-1",
+			"creationTimestamp": "2024-01-02T03:04:05Z"
+		},
+		"spec": {"login": "jdoe", "email": "jdoe@example.com", "role": "Admin"}
+	}`)
+
+	doc, err := info.Builder.BuildDocument(context.Background(),
+		&resourcepb.ResourceKey{Namespace: "default", Group: "iam.grafana.app", Resource: "users", Name: "uid-1"},
+		1, value)
+	require.NoError(t, err)
+
+	assert.Equal(t, time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC).UnixMilli(), doc.Fields[USER_CREATED])
 }

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-last-seen-at-and-role-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-last-seen-at-and-role-out.json
@@ -8,6 +8,7 @@
   "name": "with-last-seen-at-and-role",
   "rv": 1234,
   "fields": {
+    "createdAt": 0,
     "disabled": false,
     "email": "user.three@test.com",
     "lastSeenAt": 1698321600,

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-login-and-email-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-login-and-email-out.json
@@ -8,6 +8,7 @@
   "name": "with-login-and-email",
   "rv": 1234,
   "fields": {
+    "createdAt": 0,
     "disabled": false,
     "email": "user.one@test.com",
     "lastSeenAt": 0,

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-login-only-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-login-only-out.json
@@ -8,6 +8,7 @@
   "name": "with-login-only",
   "rv": 1234,
   "fields": {
+    "createdAt": 0,
     "disabled": false,
     "lastSeenAt": 0,
     "login": "user.two",

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -14,6 +14,7 @@ const (
 	USER_LAST_SEEN_AT = "lastSeenAt"
 	USER_ROLE         = "role"
 	USER_DISABLED     = "disabled"
+	USER_CREATED      = "createdAt"
 )
 
 // UserSortableExtraFields are the additional fields that can be used for sorting user search results.
@@ -67,6 +68,11 @@ var UserTableColumnDefinitions = map[string]*resourcepb.ResourceTableColumnDefin
 			Filterable: true,
 		},
 	},
+	USER_CREATED: {
+		Name:        USER_CREATED,
+		Type:        resourcepb.ResourceTableColumnDefinition_INT64,
+		Description: "The creation timestamp of the user, in epoch milliseconds",
+	},
 }
 
 func GetUserBuilder() (resource.DocumentBuilderInfo, error) {
@@ -102,6 +108,7 @@ func (u *userDocumentBuilder) BuildDocument(ctx context.Context, key *resourcepb
 	doc.Fields[USER_LAST_SEEN_AT] = user.Status.LastSeenAt
 	doc.Fields[USER_ROLE] = user.Spec.Role
 	doc.Fields[USER_DISABLED] = user.Spec.Disabled
+	doc.Fields[USER_CREATED] = doc.Created
 
 	return doc, nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Related to https://github.com/grafana/grafana/pull/126328.

Adds the user's creation timestamp `createdAt` as a resource-specific field in the user search document builder, so it's stored in the index and returned by user search.

**Why do we need this feature?**

User search results need the creation time (e.g. the Users list uses it to detect users who have never logged in). It's indexed as a fields.* value rather than relying on the standard created document field because the user index uses a static document mapping that doesn't store top-level standard fields.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
