### PR TITLE
CI: skip frontend coverage jobs for forks for now

### DIFF
--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -17,6 +17,7 @@ permissions: {}
 jobs:
   setup:
     name: Setup opted-in teams
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-x64-small
     outputs:
       # NOTE: Only checks test coverage for opted-in codeowners.
@@ -35,6 +36,7 @@ jobs:
 
   detect-changes:
     name: Detect changed files
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-x64-small
     permissions:
       contents: read
@@ -160,7 +162,7 @@ jobs:
   coverage:
     name: Coverage - ${{ matrix.codeowner }}
     needs: [setup, detect-changes]
-    if: "!contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage') && github.event.pull_request.head.repo.fork == false"
     runs-on: ubuntu-x64-large
     permissions:
       contents: read
@@ -328,7 +330,10 @@ jobs:
       - name: Check if skipped
         id: check-skip
         run: |
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage') }}" == "true" ]]; then
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Coverage checks skipped for fork PR"
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage') }}" == "true" ]]; then
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             echo "✅ Coverage checks skipped due to 'no-check-frontend-test-coverage' label"
           else

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -332,7 +332,7 @@ jobs:
         run: |
           if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
             echo "skipped=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Coverage checks skipped for fork PR"
+            echo "⏭️ Coverage checks skipped for fork PR"
           elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage') }}" == "true" ]]; then
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             echo "✅ Coverage checks skipped due to 'no-check-frontend-test-coverage' label"


### PR DESCRIPTION
We would like to add this back later, but since we use GATB to make comments as the main feedback mechanism of the job at the moment, we need to skip the whole job on forks.