### PR TITLE
Search: drop IAM custom document builders in favour of declared fields

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -308,6 +308,19 @@ func (s *standardDocumentBuilder) extractDeclaredFields(_ context.Context, tmp *
 		return
 	}
 	for _, def := range defs {
+		if def.CopyFromStandard != StandardFieldUnknown {
+			if v, ok := standardFieldValue(doc, def.CopyFromStandard); ok {
+				if doc.Fields == nil {
+					doc.Fields = make(map[string]any)
+				}
+				doc.Fields[def.Name] = v
+			} else {
+				s.log.Warn("unknown CopyFromStandard target",
+					"group", gvr.Group, "version", gvr.Version, "resource", gvr.Resource,
+					"field", def.Name, "target", def.CopyFromStandard)
+			}
+			continue
+		}
 		if def.Path == "" {
 			continue
 		}
@@ -319,6 +332,13 @@ func (s *standardDocumentBuilder) extractDeclaredFields(_ context.Context, tmp *
 			continue
 		}
 		if raw == nil {
+			if !def.EmitZeroIfAbsent {
+				continue
+			}
+			if doc.Fields == nil {
+				doc.Fields = make(map[string]any)
+			}
+			doc.Fields[def.Name] = zeroValueForFieldDefinition(def)
 			continue
 		}
 		coerced, ok := coerceToFieldShape(raw, def.Type, def.Array)
@@ -334,6 +354,48 @@ func (s *standardDocumentBuilder) extractDeclaredFields(_ context.Context, tmp *
 		}
 		doc.Fields[def.Name] = coerced
 	}
+}
+
+// standardFieldValue returns the value of a top-level IndexableDocument field
+// referenced by CopyFromStandard. The set of supported targets is closed and
+// matches the StandardField* constants in search_field.go.
+func standardFieldValue(doc *IndexableDocument, target StandardField) (any, bool) {
+	switch target {
+	case StandardFieldCreated:
+		return doc.Created, true
+	case StandardFieldUpdated:
+		return doc.Updated, true
+	case StandardFieldCreatedBy:
+		return doc.CreatedBy, true
+	case StandardFieldUpdatedBy:
+		return doc.UpdatedBy, true
+	case StandardFieldUnknown:
+		return nil, false
+	}
+	return nil, false
+}
+
+// zeroValueForFieldDefinition returns the type-appropriate zero value for a
+// declared field. Used when Path resolves to nil and EmitZeroIfAbsent is set,
+// so the indexed document still carries the field. Returns nil for unknown
+// types so the caller drops the field instead of indexing a typeless value.
+func zeroValueForFieldDefinition(def SearchFieldDefinition) any {
+	if def.Array {
+		return []any{}
+	}
+	switch def.Type {
+	case SearchFieldTypeBoolean:
+		return false
+	case SearchFieldTypeInt64:
+		return int64(0)
+	case SearchFieldTypeDouble:
+		return float64(0)
+	case SearchFieldTypeString, SearchFieldTypeDate:
+		return ""
+	case SearchFieldTypeUnknown:
+		return nil
+	}
+	return nil
 }
 
 // gvrForLookup resolves the GroupVersionResource the provider should be

--- a/pkg/storage/unified/resource/document_test.go
+++ b/pkg/storage/unified/resource/document_test.go
@@ -186,6 +186,41 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 		assert.Equal(t, "alice@example.com", doc.Fields["email"])
 	})
 
+	t.Run("EmitZeroIfAbsent emits the type's zero value when path is missing", func(t *testing.T) {
+		// Body has none of the declared fields populated. Each one is set
+		// to its zero value so sort and range queries treat every document
+		// as having the field present.
+		bodyEmpty := []byte(`{
+			"apiVersion": "example.grafana.app/v1",
+			"kind": "Thing",
+			"metadata": {"name": "thing-1", "namespace": "default"},
+			"spec": {}
+		}`)
+		provider := NewMapProvider(
+			map[schema.GroupVersionResource][]SearchFieldDefinition{
+				gvr: {
+					{Name: "flag", Path: "spec.flag", Type: SearchFieldTypeBoolean, EmitZeroIfAbsent: true},
+					{Name: "count", Path: "spec.count", Type: SearchFieldTypeInt64, EmitZeroIfAbsent: true},
+					{Name: "ratio", Path: "spec.ratio", Type: SearchFieldTypeDouble, EmitZeroIfAbsent: true},
+					{Name: "label", Path: "spec.label", Type: SearchFieldTypeString, EmitZeroIfAbsent: true},
+					{Name: "tags", Path: "spec.tags", Type: SearchFieldTypeString, Array: true, EmitZeroIfAbsent: true},
+					// Without the flag, an absent field stays absent.
+					{Name: "silent", Path: "spec.silent", Type: SearchFieldTypeString},
+				},
+			}, nil,
+		)
+		builder := StandardDocumentBuilderWithFields(nil, provider)
+		doc, err := builder.BuildDocument(ctx, key, 1, bodyEmpty)
+		require.NoError(t, err)
+		assert.Equal(t, false, doc.Fields["flag"])
+		assert.Equal(t, int64(0), doc.Fields["count"])
+		assert.Equal(t, float64(0), doc.Fields["ratio"])
+		assert.Equal(t, "", doc.Fields["label"])
+		assert.Equal(t, []any{}, doc.Fields["tags"])
+		_, hasSilent := doc.Fields["silent"]
+		assert.False(t, hasSilent, "field without EmitZeroIfAbsent must stay absent")
+	})
+
 	t.Run("missing apiVersion and no PreferredVersion: no extraction", func(t *testing.T) {
 		bodyNoVersion := []byte(`{
 			"kind": "Thing",

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -90,7 +90,44 @@ type SearchFieldDefinition struct {
 
 	// Description is informational; not used for indexing decisions.
 	Description string
+
+	// EmitZeroIfAbsent makes the path extractor emit the type's zero value
+	// (false, 0, 0.0, "", or an empty array) when Path resolves to nil.
+	// Without it, missing paths are skipped and the field is absent from the
+	// indexed document. Set this when sort or range queries depend on every
+	// document having the field present.
+	EmitZeroIfAbsent bool
+
+	// CopyFromStandard copies a value from one of the IndexableDocument's
+	// standard top-level fields into doc.Fields[Name]. Used to expose a
+	// standard field (e.g. Created) under a resource-specific name in the
+	// per-kind fields.* sub-document, because some top-level fields lack a
+	// bleve FieldMapping and are otherwise unindexed / unretrievable.
+	//
+	// Mutually exclusive with Path: when CopyFromStandard is set, the
+	// extractor reads from the already-built IndexableDocument instead of
+	// from the raw JSON.
+	//
+	// This is a workaround for the current top-level mapping asymmetry.
+	// A planned follow-up promotes Created, Updated and similar fields to
+	// StandardSearchFieldDefinitions with their own top-level
+	// FieldMappings; once that lands, kinds can read those fields directly
+	// and the CopyFromStandard mirror becomes redundant.
+	CopyFromStandard StandardField
 }
+
+// StandardField identifies a top-level field of IndexableDocument that
+// CopyFromStandard can mirror into doc.Fields. The set is intentionally
+// closed; adding a new value requires extending the switch in document.go.
+type StandardField string
+
+const (
+	StandardFieldUnknown   StandardField = ""
+	StandardFieldCreated   StandardField = "Created"
+	StandardFieldUpdated   StandardField = "Updated"
+	StandardFieldCreatedBy StandardField = "CreatedBy"
+	StandardFieldUpdatedBy StandardField = "UpdatedBy"
+)
 
 // HasCapability reports whether the field declares the given capability.
 func (f SearchFieldDefinition) HasCapability(c SearchCapability) bool {

--- a/pkg/storage/unified/search/builders/document_test.go
+++ b/pkg/storage/unified/search/builders/document_test.go
@@ -79,7 +79,7 @@ func TestTeamSearchBuilder(t *testing.T) {
 	doSnapshotTests(t, info.Builder, "team", &resourcepb.ResourceKey{
 		Namespace: "default",
 		Group:     "iam.grafana.app",
-		Resource:  "searchTeams",
+		Resource:  "teams",
 	}, []string{
 		"with-email-and-external-uid",
 	})
@@ -215,6 +215,8 @@ func TestUserDocumentBuilder_Created(t *testing.T) {
 	require.NoError(t, err)
 
 	value := []byte(`{
+		"apiVersion": "iam.grafana.app/v0alpha1",
+		"kind": "User",
 		"metadata": {
 			"name": "uid-1",
 			"creationTimestamp": "2024-01-02T03:04:05Z"

--- a/pkg/storage/unified/search/builders/external_group_mapping.go
+++ b/pkg/storage/unified/search/builders/external_group_mapping.go
@@ -1,7 +1,7 @@
 package builders
 
 import (
-	"context"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -32,38 +32,37 @@ var ExternalGroupMappingTableColumnDefinitions = map[string]*resourcepb.Resource
 	},
 }
 
+// ExternalGroupMappingSearchFields declares paths and types for each external
+// group mapping search field. The standard document builder uses these to
+// extract spec values from the raw JSON, avoiding a custom builder.
+var ExternalGroupMappingSearchFields = []resource.SearchFieldDefinition{
+	{Name: EXTERNAL_GROUP_MAPPING_TEAM, Path: "spec.teamRef.name", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+	{Name: EXTERNAL_GROUP_MAPPING_EXTERNAL_GROUP, Path: "spec.externalGroupId", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+}
+
 func GetExternalGroupMappingBuilder() (resource.DocumentBuilderInfo, error) {
 	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(ExternalGroupMappingTableColumnDefinitions))
 	for _, v := range ExternalGroupMappingTableColumnDefinitions {
 		values = append(values, v)
 	}
-
 	fields, err := resource.NewSearchableDocumentFields(values)
+	if err != nil {
+		return resource.DocumentBuilderInfo{}, err
+	}
+
+	gvr := iamv0.ExternalGroupMappingResourceInfo.GroupVersionResource()
+	provider := resource.NewMapProvider(
+		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+			gvr: ExternalGroupMappingSearchFields,
+		},
+		map[schema.GroupResource]string{
+			gvr.GroupResource(): gvr.Version,
+		},
+	)
+
 	return resource.DocumentBuilderInfo{
 		GroupResource: iamv0.ExternalGroupMappingResourceInfo.GroupResource(),
 		Fields:        fields,
-		Builder:       new(extGroupMappingDocumentBuilder),
-	}, err
-}
-
-var _ resource.DocumentBuilder = new(extGroupMappingDocumentBuilder)
-
-type extGroupMappingDocumentBuilder struct{}
-
-// BuildDocument implements resource.DocumentBuilder.
-func (u *extGroupMappingDocumentBuilder) BuildDocument(ctx context.Context, key *resourcepb.ResourceKey, rv int64, value []byte) (*resource.IndexableDocument, error) {
-	extGroupMapping := &iamv0.ExternalGroupMapping{}
-	doc, err := NewIndexableDocumentFromValue(key, rv, value, extGroupMapping, iamv0.ExternalGroupMappingKind())
-	if err != nil {
-		return nil, err
-	}
-
-	if extGroupMapping.Spec.TeamRef.Name != "" {
-		doc.Fields[EXTERNAL_GROUP_MAPPING_TEAM] = extGroupMapping.Spec.TeamRef.Name
-	}
-	if extGroupMapping.Spec.ExternalGroupId != "" {
-		doc.Fields[EXTERNAL_GROUP_MAPPING_EXTERNAL_GROUP] = extGroupMapping.Spec.ExternalGroupId
-	}
-
-	return doc, nil
+		Builder:       resource.StandardDocumentBuilderWithFields(iamManifests, provider),
+	}, nil
 }

--- a/pkg/storage/unified/search/builders/team.go
+++ b/pkg/storage/unified/search/builders/team.go
@@ -1,8 +1,6 @@
 package builders
 
 import (
-	"context"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
@@ -60,12 +58,37 @@ var TeamSearchTableColumnDefinitions = map[string]*resourcepb.ResourceTableColum
 	},
 }
 
+// TeamSearchFields declares paths and types for each team search field. The
+// standard document builder uses these to extract spec values from the raw
+// JSON, avoiding a custom builder. Members is a projection over
+// spec.members[*].name so the indexed array contains member UIDs only.
+var TeamSearchFields = []resource.SearchFieldDefinition{
+	{Name: TEAM_SEARCH_EMAIL, Path: "spec.email", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}},
+	{Name: TEAM_SEARCH_PROVISIONED, Path: "spec.provisioned", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}},
+	{Name: TEAM_SEARCH_EXTERNAL_UID, Path: "spec.externalUID", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}},
+	{Name: TEAM_SEARCH_MEMBERS, Path: "spec.members[*].name", Type: resource.SearchFieldTypeString, Array: true, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+	{Name: TEAM_SEARCH_EXTERNAL_GROUPS, Path: "spec.externalGroups", Type: resource.SearchFieldTypeString, Array: true, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+}
+
 func GetTeamSearchBuilder() (resource.DocumentBuilderInfo, error) {
 	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(TeamSearchTableColumnDefinitions))
 	for _, v := range TeamSearchTableColumnDefinitions {
 		values = append(values, v)
 	}
 	fields, err := resource.NewSearchableDocumentFields(values)
+	if err != nil {
+		return resource.DocumentBuilderInfo{}, err
+	}
+
+	gvr := v0alpha1.TeamResourceInfo.GroupVersionResource()
+	provider := resource.NewMapProvider(
+		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+			gvr: TeamSearchFields,
+		},
+		map[schema.GroupResource]string{
+			gvr.GroupResource(): gvr.Version,
+		},
+	)
 
 	return resource.DocumentBuilderInfo{
 		GroupResource: schema.GroupResource{
@@ -73,40 +96,6 @@ func GetTeamSearchBuilder() (resource.DocumentBuilderInfo, error) {
 			Resource: v0alpha1.TeamResourceInfo.GroupResource().Resource,
 		},
 		Fields:  fields,
-		Builder: new(teamSearchBuilder),
-	}, err
-}
-
-var _ resource.DocumentBuilder = new(teamSearchBuilder)
-
-type teamSearchBuilder struct{}
-
-func (t *teamSearchBuilder) BuildDocument(ctx context.Context, key *resourcepb.ResourceKey, rv int64, value []byte) (*resource.IndexableDocument, error) {
-	team := &v0alpha1.Team{}
-	doc, err := NewIndexableDocumentFromValue(key, rv, value, team, v0alpha1.TeamKind())
-	if err != nil {
-		return nil, err
-	}
-
-	if team.Spec.Email != "" {
-		doc.Fields[TEAM_SEARCH_EMAIL] = team.Spec.Email
-	}
-	if team.Spec.Provisioned {
-		doc.Fields[TEAM_SEARCH_PROVISIONED] = team.Spec.Provisioned
-	}
-	if team.Spec.ExternalUID != "" {
-		doc.Fields[TEAM_SEARCH_EXTERNAL_UID] = team.Spec.ExternalUID
-	}
-	if len(team.Spec.Members) > 0 {
-		uids := make([]string, 0, len(team.Spec.Members))
-		for _, m := range team.Spec.Members {
-			uids = append(uids, m.Name)
-		}
-		doc.Fields[TEAM_SEARCH_MEMBERS] = uids
-	}
-	if len(team.Spec.ExternalGroups) > 0 {
-		doc.Fields[TEAM_SEARCH_EXTERNAL_GROUPS] = team.Spec.ExternalGroups
-	}
-
-	return doc, nil
+		Builder: resource.StandardDocumentBuilderWithFields(iamManifests, provider),
+	}, nil
 }

--- a/pkg/storage/unified/search/builders/teambinding.go
+++ b/pkg/storage/unified/search/builders/teambinding.go
@@ -1,7 +1,7 @@
 package builders
 
 import (
-	"context"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -34,35 +34,39 @@ var TeamBindingTableColumnDefinitions = map[string]*resourcepb.ResourceTableColu
 	},
 }
 
+// TeamBindingSearchFields declares paths and types for each team binding
+// search field. The standard document builder uses these to extract values
+// from the raw JSON, avoiding a custom builder.
+var TeamBindingSearchFields = []resource.SearchFieldDefinition{
+	{Name: TEAM_BINDING_SUBJECT, Path: "spec.subject.name", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+	{Name: TEAM_BINDING_TEAM, Path: "spec.teamRef.name", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+	{Name: TEAM_BINDING_PERMISSION, Path: "spec.permission", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}},
+	{Name: TEAM_BINDING_EXTERNAL, Path: "spec.external", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}},
+}
+
 func GetTeamBindingBuilder() (resource.DocumentBuilderInfo, error) {
 	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(TeamBindingTableColumnDefinitions))
 	for _, v := range TeamBindingTableColumnDefinitions {
 		values = append(values, v)
 	}
-
 	fields, err := resource.NewSearchableDocumentFields(values)
+	if err != nil {
+		return resource.DocumentBuilderInfo{}, err
+	}
+
+	gvr := iamv0.TeamBindingResourceInfo.GroupVersionResource()
+	provider := resource.NewMapProvider(
+		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+			gvr: TeamBindingSearchFields,
+		},
+		map[schema.GroupResource]string{
+			gvr.GroupResource(): gvr.Version,
+		},
+	)
+
 	return resource.DocumentBuilderInfo{
 		GroupResource: iamv0.TeamBindingResourceInfo.GroupResource(),
 		Fields:        fields,
-		Builder:       new(teamBindingDocumentBuilder),
-	}, err
-}
-
-type teamBindingDocumentBuilder struct{}
-
-func (b *teamBindingDocumentBuilder) BuildDocument(ctx context.Context, key *resourcepb.ResourceKey, rv int64, value []byte) (*resource.IndexableDocument, error) {
-	tb := &iamv0.TeamBinding{}
-	doc, err := NewIndexableDocumentFromValue(key, rv, value, tb, iamv0.TeamBindingKind())
-	if err != nil {
-		return nil, err
-	}
-
-	doc.Fields = map[string]any{
-		TEAM_BINDING_SUBJECT:    tb.Spec.Subject.Name,
-		TEAM_BINDING_TEAM:       tb.Spec.TeamRef.Name,
-		TEAM_BINDING_PERMISSION: string(tb.Spec.Permission),
-		TEAM_BINDING_EXTERNAL:   tb.Spec.External,
-	}
-
-	return doc, nil
+		Builder:       resource.StandardDocumentBuilderWithFields(iamManifests, provider),
+	}, nil
 }

--- a/pkg/storage/unified/search/builders/teambinding.go
+++ b/pkg/storage/unified/search/builders/teambinding.go
@@ -37,11 +37,17 @@ var TeamBindingTableColumnDefinitions = map[string]*resourcepb.ResourceTableColu
 // TeamBindingSearchFields declares paths and types for each team binding
 // search field. The standard document builder uses these to extract values
 // from the raw JSON, avoiding a custom builder.
+//
+// external sets EmitZeroIfAbsent so the field is always indexed, matching
+// the old custom builder which set doc.Fields[external] unconditionally.
+// The generated TeamBindingSpec uses json:"external" without omitempty,
+// so today the JSON always carries the value; the flag preserves intent
+// against a future schema change that adds omitempty.
 var TeamBindingSearchFields = []resource.SearchFieldDefinition{
 	{Name: TEAM_BINDING_SUBJECT, Path: "spec.subject.name", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
 	{Name: TEAM_BINDING_TEAM, Path: "spec.teamRef.name", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
 	{Name: TEAM_BINDING_PERMISSION, Path: "spec.permission", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}},
-	{Name: TEAM_BINDING_EXTERNAL, Path: "spec.external", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}},
+	{Name: TEAM_BINDING_EXTERNAL, Path: "spec.external", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}, EmitZeroIfAbsent: true},
 }
 
 func GetTeamBindingBuilder() (resource.DocumentBuilderInfo, error) {

--- a/pkg/storage/unified/search/builders/testdata/doc/team-with-email-and-external-uid-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/team-with-email-and-external-uid-out.json
@@ -2,7 +2,7 @@
   "key": {
     "namespace": "default",
     "group": "iam.grafana.app",
-    "resource": "searchTeams",
+    "resource": "teams",
     "name": "with-email-and-external-uid"
   },
   "name": "with-email-and-external-uid",

--- a/pkg/storage/unified/search/builders/testdata/doc/team_binding-with-team-and-user.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/team_binding-with-team-and-user.json
@@ -1,4 +1,6 @@
 {
+    "apiVersion": "iam.grafana.app/v0alpha1",
+    "kind": "TeamBinding",
     "metadata": {
         "name": "with-team-and-user",
         "namespace": "default"

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-last-seen-at-and-role-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-last-seen-at-and-role-out.json
@@ -7,6 +7,9 @@
   },
   "name": "with-last-seen-at-and-role",
   "rv": 1234,
+  "title": "with-last-seen-at-and-role",
+  "title_ngram": "with-last-seen-at-and-role",
+  "title_phrase": "with-last-seen-at-and-role",
   "fields": {
     "createdAt": 0,
     "disabled": false,

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-last-seen-at-and-role.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-last-seen-at-and-role.json
@@ -1,4 +1,6 @@
 {
+    "apiVersion": "iam.grafana.app/v0alpha1",
+    "kind": "User",
     "metadata": {
         "name": "with-last-seen-at-and-role",
         "namespace": "default"

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-login-and-email-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-login-and-email-out.json
@@ -7,6 +7,9 @@
   },
   "name": "with-login-and-email",
   "rv": 1234,
+  "title": "with-login-and-email",
+  "title_ngram": "with-login-and-email",
+  "title_phrase": "with-login-and-email",
   "fields": {
     "createdAt": 0,
     "disabled": false,

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-login-and-email.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-login-and-email.json
@@ -1,4 +1,6 @@
 {
+    "apiVersion": "iam.grafana.app/v0alpha1",
+    "kind": "User",
     "metadata": {
         "name": "with-login-and-email",
         "namespace": "default"

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-login-only-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-login-only-out.json
@@ -7,6 +7,9 @@
   },
   "name": "with-login-only",
   "rv": 1234,
+  "title": "with-login-only",
+  "title_ngram": "with-login-only",
+  "title_phrase": "with-login-only",
   "fields": {
     "createdAt": 0,
     "disabled": false,

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-login-only.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-login-only.json
@@ -1,4 +1,6 @@
 {
+    "apiVersion": "iam.grafana.app/v0alpha1",
+    "kind": "User",
     "metadata": {
         "name": "with-login-only",
         "namespace": "default"

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -1,12 +1,19 @@
 package builders
 
 import (
-	"context"
+	"github.com/grafana/grafana-app-sdk/app"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	iam "github.com/grafana/grafana/apps/iam/pkg/apis"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
+
+// iamManifests is the slice the IAM builders pass to the standard document
+// builder. It carries the selectable-field declarations the builder uses to
+// populate IndexableDocument.SelectableFields for IAM kinds.
+var iamManifests = []app.Manifest{iam.LocalManifest()}
 
 const (
 	USER_EMAIL        = "email"
@@ -75,40 +82,52 @@ var UserTableColumnDefinitions = map[string]*resourcepb.ResourceTableColumnDefin
 	},
 }
 
+// UserSearchFields declares paths and types for each user search field. The
+// standard document builder uses these to extract spec/status values from the
+// raw JSON, avoiding a custom builder.
+//
+// lastSeenAt and disabled set EmitZeroIfAbsent so every indexed user document
+// carries those fields. The user-search API sorts on lastSeenAt and missing
+// values would otherwise sort last, putting never-seen users in a different
+// position than the historical "sort by epoch 0" behaviour.
+//
+// createdAt mirrors the standard IndexableDocument.Created field into the
+// per-kind fields.* sub-document because the top-level created field has no
+// bleve mapping today. See PR #126405 for context.
+var UserSearchFields = []resource.SearchFieldDefinition{
+	{Name: USER_EMAIL, Path: "spec.email", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+	{Name: USER_LOGIN, Path: "spec.login", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+	{Name: USER_LAST_SEEN_AT, Path: "status.lastSeenAt", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, EmitZeroIfAbsent: true},
+	{Name: USER_ROLE, Path: "spec.role", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+	{Name: USER_DISABLED, Path: "spec.disabled", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, EmitZeroIfAbsent: true},
+	{Name: USER_CREATED, CopyFromStandard: resource.StandardFieldCreated, Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}},
+}
+
 func GetUserBuilder() (resource.DocumentBuilderInfo, error) {
 	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(UserTableColumnDefinitions))
 	for _, v := range UserTableColumnDefinitions {
 		values = append(values, v)
 	}
 	fields, err := resource.NewSearchableDocumentFields(values)
+	if err != nil {
+		return resource.DocumentBuilderInfo{}, err
+	}
+
+	gvr := iamv0.UserResourceInfo.GroupVersionResource()
+	provider := resource.NewMapProvider(
+		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+			gvr: UserSearchFields,
+		},
+		// Documents stored without an explicit apiVersion fall back to the
+		// served version so extraction still happens for legacy payloads.
+		map[schema.GroupResource]string{
+			gvr.GroupResource(): gvr.Version,
+		},
+	)
+
 	return resource.DocumentBuilderInfo{
 		GroupResource: iamv0.UserResourceInfo.GroupResource(),
 		Fields:        fields,
-		Builder:       new(userDocumentBuilder),
-	}, err
-}
-
-var _ resource.DocumentBuilder = new(userDocumentBuilder)
-
-type userDocumentBuilder struct{}
-
-func (u *userDocumentBuilder) BuildDocument(ctx context.Context, key *resourcepb.ResourceKey, rv int64, value []byte) (*resource.IndexableDocument, error) {
-	user := &iamv0.User{}
-	doc, err := NewIndexableDocumentFromValue(key, rv, value, user, iamv0.UserKind())
-	if err != nil {
-		return nil, err
-	}
-
-	if user.Spec.Email != "" {
-		doc.Fields[USER_EMAIL] = user.Spec.Email
-	}
-	if user.Spec.Login != "" {
-		doc.Fields[USER_LOGIN] = user.Spec.Login
-	}
-	doc.Fields[USER_LAST_SEEN_AT] = user.Status.LastSeenAt
-	doc.Fields[USER_ROLE] = user.Spec.Role
-	doc.Fields[USER_DISABLED] = user.Spec.Disabled
-	doc.Fields[USER_CREATED] = doc.Created
-
-	return doc, nil
+		Builder:       resource.StandardDocumentBuilderWithFields(iamManifests, provider),
+	}, nil
 }


### PR DESCRIPTION
The User, Team, TeamBinding, and ExternalGroupMapping resources each carried a custom `DocumentBuilder` that decoded stored JSON into a typed struct and copied spec or status values into `doc.Fields`. With the standard builder gaining path-based extraction in #126385, the same work can be done declaratively.

Each kind file now exports an `XxxSearchFields` slice of `SearchFieldDefinition`s. `GetXxxBuilder()` returns a `DocumentBuilderInfo` whose `Builder` is `StandardDocumentBuilderWithFields(iamManifests, perKindProvider)`. The custom builder structs and `BuildDocument` methods are gone.

`SearchFieldDefinition` gains an `EmitZeroIfAbsent` field. When the path resolves to nil, the extractor emits the type's zero value (`false`, `0`, `0.0`, `""`, or empty array) instead of skipping. Flipped on for `USER_DISABLED` and `USER_LAST_SEEN_AT` — the user-search API exposes `lastSeenAt` sorting, and missing values would otherwise sort last instead of at epoch 0.

`SearchFieldDefinition` also gains a `CopyFromStandard` field that mirrors a top-level `IndexableDocument` field (e.g. `Created`) into the per-kind `fields.*` sub-document. Used for `USER_CREATED` to preserve the behaviour added in #126405 — the user-search response reads `fields.createdAt` after #126328 because the top-level `created` field has no bleve mapping today. Marked in the doc comment as a workaround until a planned follow-up promotes `Created`, `Updated` and similar fields to `StandardSearchFieldDefinitions` with their own top-level mappings.

Test input JSONs gain `apiVersion` and `kind` because `unstructured.Unstructured.UnmarshalJSON` requires both; stored K8s docs always have them. Output goldens regenerate with `title` / `title_ngram` / `title_phrase` populated (standard builder's metadata-accessor title fallback works through unstructured decoding). The team test resource changes from `searchTeams` to `teams` to match what the indexer actually passes (`searchTeams` is only an HTTP route, not a document key).

Public surface preserved: `XxxTableColumnDefinitions`, `XxxSortableExtraFields`, field-name constants still exported. Bleve mappings still flow from `DocumentBuilderInfo.Fields`, so on-disk index shape is unchanged.

Stacked on #126385. Tracking issue: grafana/search-and-storage-team#827.
