### PR TITLE
Dockerfile: fix entrypoint for distroless target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -389,7 +389,12 @@ EXPOSE 3000
 
 USER $GF_UID
 
-ENTRYPOINT ["/usr/share/grafana/bin/grafana", "server", "--homepath=/usr/share/grafana", "--config=/etc/grafana/grafana.ini", "--packaging=docker", "cfg:default.log.mode=console"]
+# ENTRYPOINT holds the invariant invocation; CMD holds the overridable default
+# args. Splitting them follows the conventional Docker pattern so runtime args
+# (docker run <img> <args> / Kubernetes args:) replace the defaults instead of
+# being permanently pinned after a fully-baked ENTRYPOINT.
+ENTRYPOINT ["/usr/share/grafana/bin/grafana", "server", "--homepath=/usr/share/grafana", "--config=/etc/grafana/grafana.ini", "--packaging=docker"]
+CMD ["cfg:default.log.mode=console"]
 
 # Default stage — alpine. Builds without --target produce an alpine image.
 # Use --target=final-ubuntu to build the ubuntu variant instead.


### PR DESCRIPTION
By putting everything in ENTRYPOINT and not specifying a CMD we weren't allowing the caller to pass additional args to the binary without overriding the ENTRYPOINT

You can test this by running `make build-docker-distroless`.

```
make build-docker-distroless OS=linux ARCH=arm64
docker load -i ./dist/grafana_13.1.0-local_local_linux_arm64.distroless.docker.tar.gz
docker run --rm -it grafana:13.1.0-local --version
Version 13.1.0-local (commit: 6f7f66f1f62, branch: main)
```

Before, this would start up the grafana server and ignore the `--version` arg.