### PR TITLE
Provisioning: Check hmac header presence before reading body

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/webhook.go
+++ b/pkg/registry/apis/provisioning/webhooks/webhook.go
@@ -155,6 +155,12 @@ func (s *webhookConnector) Connect(ctx context.Context, name string, opts runtim
 			return
 		}
 
+		if hmacHeader := r.Header.Get("X-Hub-Signature-256"); hmacHeader == "" {
+			span.RecordError(err)
+			responder.Error(errors.NewBadRequest("X-Hub-Signature-256 header is missing"))
+			return
+		}
+
 		// Limit the webhook request body size
 		r.Body = http.MaxBytesReader(w, r.Body, webhookMaxBodySize)
 


### PR DESCRIPTION
**What is this feature?**
Check for hmac signature header before reading body to quickly discard any invalid requests.

**Why do we need this feature?**
Rather than reading up to `25MB` of the body, check for the presence of the required HMAC signature header. If not there, we can save unnecessarily reading.


**Who is this feature for?**


**Which issue(s) does this PR fix?**:
Partially fixes: https://github.com/grafana/git-ui-sync-project/issues/1147

- Automatically closes linked issue when the Pull Request is merged.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
