### PR TITLE
Provisioning: Record Grafana user in bulk, move and fix-metadata commits

### DIFF
--- a/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
@@ -37,17 +37,17 @@ export function useCreateSyncJob({ repoName, setStepStatusInfo }: UseCreateSyncJ
         const jobSpec = requiresMigration
           ? {
               action: 'migrate' as const,
-              migrate: {
-                message: withSavedByTrailer(
-                  t('provisioning.sync-job.migrate-default-message', 'Migrate Grafana resources into repository')
-                ),
-              },
+              // The Grafana-saved-by trailer rides through the top-level
+              // JobSpec.Message to the resulting git commit.
+              message: withSavedByTrailer(
+                t('provisioning.sync-job.migrate-default-message', 'Migrate Grafana resources into repository')
+              ),
+              migrate: {},
             }
           : {
               action: 'pull' as const,
-              // TODO(grafana/git-ui-sync-project#1162): SyncJobOptions has no
-              // `message` field on the backend yet — when it gains one, append
-              // the Grafana-saved-by trailer here too.
+              // A pull replicates the remote branch locally and produces no
+              // git commit, so there's no commit message to tag.
               pull: {
                 incremental: false,
               },

--- a/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.test.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.test.tsx
@@ -152,6 +152,7 @@ describe('BulkDeleteProvisionedResource', () => {
       defaultRepository,
       expect.objectContaining({
         action: 'delete',
+        message: expect.stringContaining('Delete resources'),
         delete: expect.objectContaining({
           resources: expect.arrayContaining([
             expect.objectContaining({ name: 'folder-1', kind: 'Folder' }),

--- a/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
@@ -17,6 +17,7 @@ import { ProvisioningAlert } from '../../Shared/ProvisioningAlert';
 import { type StepStatusInfo } from '../../Wizard/types';
 import { useSelectionRepoValidation } from '../../hooks/useSelectionRepoValidation';
 import { type StatusInfo } from '../../types';
+import { withSavedByTrailer } from '../../utils/currentUser';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
 import { getCanPushToConfiguredBranch, getDefaultWorkflow } from '../defaults';
@@ -58,13 +59,14 @@ function FormContent({ initialValues, selectedItems, repository, canPushToConfig
       dashboardCount,
     });
 
-    // Create the delete job spec.
-    // TODO(grafana/git-ui-sync-project#1162): DeleteJobOptions has no
-    // `message` field on the backend yet — once it gains one, pass
-    // `withSavedByTrailer(<default or data.comment>)` so the
-    // Grafana-saved-by trailer rides through to the resulting git commit.
+    // Create the delete job spec. The Grafana-saved-by trailer rides through
+    // JobSpec.Message to the resulting git commit.
     const jobSpec: DeleteJobSpec = {
       action: 'delete',
+      message: withSavedByTrailer(
+        data.comment?.trim() ||
+          t('browse-dashboards.bulk-delete-resources-form.default-commit-message', 'Delete resources')
+      ),
       delete: {
         ref: data.workflow === 'write' ? undefined : data.ref,
         resources,

--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.test.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.test.tsx
@@ -193,6 +193,7 @@ describe('BulkMoveProvisionedResource', () => {
       defaultRepository,
       expect.objectContaining({
         action: 'move',
+        message: expect.stringContaining('Move resources'),
         move: expect.objectContaining({
           targetPath: expect.any(String),
           resources: expect.arrayContaining([

--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -25,6 +25,7 @@ import { ProvisioningAlert } from '../../Shared/ProvisioningAlert';
 import { type StepStatusInfo } from '../../Wizard/types';
 import { useSelectionRepoValidation } from '../../hooks/useSelectionRepoValidation';
 import { type StatusInfo } from '../../types';
+import { withSavedByTrailer } from '../../utils/currentUser';
 import { MoveActionAvailableTargetWarning } from '../Shared/MoveActionAvailableTargetWarning';
 import { ProvisioningAwareFolderPicker } from '../Shared/ProvisioningAwareFolderPicker';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
@@ -120,13 +121,13 @@ function FormContent({
       resourceCount: resources.length,
     });
 
-    // Create the move job spec.
-    // TODO(grafana/git-ui-sync-project#1162): MoveJobOptions has no `message`
-    // field on the backend yet — once it gains one, pass
-    // `withSavedByTrailer(<default or data.comment>)` so the
-    // Grafana-saved-by trailer rides through to the resulting git commit.
+    // Create the move job spec. The Grafana-saved-by trailer rides through
+    // JobSpec.Message to the resulting git commit.
     const jobSpec: MoveJobSpec = {
       action: 'move',
+      message: withSavedByTrailer(
+        data.comment?.trim() || t('browse-dashboards.bulk-move-resources-form.default-commit-message', 'Move resources')
+      ),
       move: {
         ref: data.workflow === 'write' ? undefined : data.ref,
         targetPath: targetFolderPathInRepo,

--- a/public/app/features/provisioning/components/BulkActions/useBulkActionJob.ts
+++ b/public/app/features/provisioning/components/BulkActions/useBulkActionJob.ts
@@ -10,6 +10,8 @@ export interface ResourceRef {
 
 export interface DeleteJobSpec {
   action: 'delete';
+  // Commit message for the resulting git commit. Carries the Grafana-saved-by trailer.
+  message?: string;
   delete: {
     ref?: string;
     resources: ResourceRef[];
@@ -18,6 +20,8 @@ export interface DeleteJobSpec {
 
 export interface MoveJobSpec {
   action: 'move';
+  // Commit message for the resulting git commit. Carries the Grafana-saved-by trailer.
+  message?: string;
   move: {
     ref?: string;
     targetPath: string; // Must end with '/' slash

--- a/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.test.tsx
+++ b/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.test.tsx
@@ -88,6 +88,7 @@ describe('FixFolderMetadataDrawer', () => {
       expect(capturedBody).toEqual(
         expect.objectContaining({
           action: 'fixFolderMetadata',
+          message: expect.stringContaining('Fix folder metadata'),
           fixFolderMetadata: expect.objectContaining({
             ref: 'main',
           }),

--- a/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
+++ b/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
@@ -12,6 +12,7 @@ import { useGetResourceRepositoryView } from '../../hooks/useGetResourceReposito
 import { type StatusInfo } from '../../types';
 import { type BaseProvisionedFormData } from '../../types/form';
 import { useGetActiveJob } from '../../useGetActiveJob';
+import { withSavedByTrailer } from '../../utils/currentUser';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
 import { getCanPushToConfiguredBranch, getDefaultRef, getDefaultWorkflow } from '../defaults';
@@ -136,14 +137,15 @@ function FixFolderMetadataForm({
   const handleSubmitForm = async ({ ref }: BaseProvisionedFormData) => {
     onSubmitError(undefined);
     try {
-      // TODO(grafana/git-ui-sync-project#1162): FixFolderMetadataJobOptions
-      // has no `message` field on the backend yet — once it gains one, pass
-      // `withSavedByTrailer('Fix folder metadata')` so the Grafana-saved-by
-      // trailer rides through to the resulting git commit.
+      // The Grafana-saved-by trailer rides through JobSpec.Message to the
+      // resulting git commit.
       const result = await createJob({
         name: repositoryName,
         jobSpec: {
           action: 'fixFolderMetadata',
+          message: withSavedByTrailer(
+            t('provisioning.fix-folder-metadata-drawer.default-commit-message', 'Fix folder metadata')
+          ),
           fixFolderMetadata: { ref },
         },
       }).unwrap();

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4269,6 +4269,7 @@
       "button-cancel": "Cancel",
       "button-delete": "Delete",
       "button-deleting": "Deleting...",
+      "default-commit-message": "Delete resources",
       "delete-warning": "This will delete selected folders and their descendants.",
       "error-deleting-resources": "Error deleting resources",
       "folder-empty_one": "Selected folder is empty",
@@ -4280,6 +4281,7 @@
       "button-cancel": "Cancel",
       "button-move": "Move",
       "button-moving": "Moving...",
+      "default-commit-message": "Move resources",
       "error": {
         "read-only-message": "If you have direct access to the target, please make modifications directly in the target repository.",
         "read-only-saving-message": "Repository is read-only and provisioned in git. {{readOnlyMessage}}",
@@ -13249,6 +13251,7 @@
     },
     "fix-folder-metadata-drawer": {
       "cancel": "Cancel",
+      "default-commit-message": "Fix folder metadata",
       "error-message": "Failed to start folder metadata fix job. Please try again.",
       "error-title": "Error fixing folder metadata",
       "loading": "Loading repository...",


### PR DESCRIPTION
## What

Extends the `Grafana-saved-by:` git trailer (introduced in #125571) to the remaining commit-producing provisioning jobs that previously left the acting Grafana user unrecorded:

- **Bulk delete** and **bulk move** — use the user's comment when provided, otherwise a sensible default, tagged with the trailer.
- **Fix folder metadata** — tags its default message with the trailer.
- **Migrate** — moved off the deprecated `MigrateJobOptions.message` onto the non-deprecated top-level `JobSpec.message`.

`pull`/sync is intentionally left untagged: it replicates the remote branch into Grafana and produces no commit.

This is the **last piece** that finishes the loop on #124191 — every commit-producing provisioning flow now records the Grafana user who triggered the write, not just the shared bot account from the access token. The single-resource and migrate paths landed in #125571; this PR covers the bulk, move, and fix-metadata jobs that were blocked at the time on the backend lacking a message field.

## Why

When #125571 landed, the backend job options for bulk/move/fix-metadata had no `message` field, so those flows shipped commits attributed only to the shared bot account. The backend now exposes a top-level `JobSpec.Message` that applies to every commit-producing action (`delete`, `move`, `migrate`, `push`, `fixFolderMetadata`) via `jobs.CommitMessage()`, so this is now purely a frontend wiring change — no backend changes required.

This also means the user's typed commit comment on bulk delete/move (previously collected but silently dropped) now actually reaches the commit.

## Changes

- `useBulkActionJob.ts` — add optional `message` to `DeleteJobSpec` / `MoveJobSpec`.
- `BulkDeleteProvisionedResource.tsx`, `BulkMoveProvisionedResource.tsx`, `FixFolderMetadataDrawer.tsx` — pass `withSavedByTrailer(...)` via the top-level `message`.
- `useCreateSyncJob.ts` — migrate job uses top-level `message` instead of the deprecated nested field.
- New i18n default messages; updated tests.

## Testing

- `yarn jest` for the touched suites — 57 passing.
- `yarn typecheck`, `yarn eslint`, `yarn prettier`, `make i18n-extract` all clean.

Closes #124191

🤖 Generated with [Claude Code](https://claude.com/claude-code)