### PR TITLE
Annotation list panel (backend): fix creator filtering

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -365,6 +365,7 @@ const injectedRtkApi = api
             from: queryArg['from'],
             to: queryArg.to,
             userId: queryArg.userId,
+            userUID: queryArg.userUid,
             alertId: queryArg.alertId,
             alertUID: queryArg.alertUid,
             dashboardId: queryArg.dashboardId,
@@ -1975,6 +1976,8 @@ export type GetAnnotationsApiArg = {
   to?: number;
   /** Limit response to annotations created by specific user. */
   userId?: number;
+  /** Limit response to annotations created by a specific user, identified by UID. */
+  userUid?: string;
   /** Find annotations for a specified alert rule by its ID.
     deprecated: AlertID is deprecated and will be removed in future versions. Please use AlertUID instead. */
   alertId?: number;

--- a/packages/grafana-data/src/types/annotations.ts
+++ b/packages/grafana-data/src/types/annotations.ts
@@ -30,6 +30,7 @@ export interface AnnotationEvent {
   dashboardUID?: string | null;
   panelId?: number;
   userId?: number;
+  userUID?: string;
   login?: string;
   email?: string;
   avatarUrl?: string;

--- a/packages/grafana-data/src/types/annotations.ts
+++ b/packages/grafana-data/src/types/annotations.ts
@@ -30,7 +30,6 @@ export interface AnnotationEvent {
   dashboardUID?: string | null;
   panelId?: number;
   userId?: number;
-  userUID?: string;
   login?: string;
   email?: string;
   avatarUrl?: string;

--- a/packages/grafana-openapi/src/api/openapi3.json
+++ b/packages/grafana-openapi/src/api/openapi3.json
@@ -15263,6 +15263,14 @@
             }
           },
           {
+            "description": "Limit response to annotations created by a specific user, identified by UID.",
+            "in": "query",
+            "name": "userUID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "description": "Find annotations for a specified alert rule by its ID.\ndeprecated: AlertID is deprecated and will be removed in future versions. Please use AlertUID instead.",
             "in": "query",
             "name": "alertId",

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -38,6 +38,7 @@ func (hs *HTTPServer) GetAnnotations(c *contextmodel.ReqContext) response.Respon
 		To:           c.QueryInt64("to"),
 		OrgID:        c.GetOrgID(),
 		UserID:       c.QueryInt64("userId"),
+		UserUID:      c.Query("userUID"),
 		AlertID:      c.QueryInt64("alertId"),
 		AlertUID:     c.Query("alertUID"),
 		DashboardID:  c.QueryInt64("dashboardId"),
@@ -640,6 +641,10 @@ type GetAnnotationsParams struct {
 	// in:query
 	// required:false
 	UserID int64 `json:"userId"`
+	// Limit response to annotations created by a specific user, identified by UID.
+	// in:query
+	// required:false
+	UserUID string `json:"userUID"`
 	// Find annotations for a specified alert rule by its ID.
 	// deprecated: AlertID is deprecated and will be removed in future versions. Please use AlertUID instead.
 	// in:query

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -1844,6 +1844,12 @@
             "in": "query"
           },
           {
+            "type": "string",
+            "description": "Limit response to annotations created by a specific user, identified by UID.",
+            "name": "userUID",
+            "in": "query"
+          },
+          {
             "type": "integer",
             "format": "int64",
             "description": "Find annotations for a specified alert rule by its ID.\ndeprecated: AlertID is deprecated and will be removed in future versions. Please use AlertUID instead.",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -15733,6 +15733,14 @@
             }
           },
           {
+            "description": "Limit response to annotations created by a specific user, identified by UID.",
+            "in": "query",
+            "name": "userUID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "description": "Find annotations for a specified alert rule by its ID.\ndeprecated: AlertID is deprecated and will be removed in future versions. Please use AlertUID instead.",
             "in": "query",
             "name": "alertId",


### PR DESCRIPTION
**What is this feature?**

Fixes regressions by #118982

**Filtering by creator (the user avatar) doesn't filter the list.** Clicking a user avatar adds a "Filter" chip, but the displayed annotations are unchanged. (Tag filtering worked correctly.) regressed 

This is a backend update
related client side update - https://github.com/grafana/grafana/pull/126426
