### PR TITLE
Annotation list panel: fix title click navigation

### DIFF
--- a/public/app/plugins/panel/annolist/AnnoListPanel.test.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.test.tsx
@@ -307,6 +307,35 @@ describe('AnnoListPanel', () => {
       });
     });
 
+    describe('and the user clicks directly on the annotation title text', () => {
+      it('then it should navigate, even when the click lands on the heading text', async () => {
+        const { pushSpy } = await setupTestContext();
+
+        // Click the heading element itself (not the row padding) to guard against the
+        // heading swallowing clicks and blocking row navigation.
+        await userEvent.click(await screen.findByText(/result text/i));
+        await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(1));
+
+        expect(pushSpy).toHaveBeenCalledWith('/d/asdkjhajksd/some-dash?from=1609458600000&to=1609459800000');
+      });
+    });
+
+    describe('and the user clicks a link rendered inside the annotation title', () => {
+      silenceConsoleOutput();
+
+      it('then the link handles its own navigation and the row does not open the annotation', async () => {
+        const { pushSpy, partialSpy } = await setupTestContext({
+          results: [{ ...defaultResult, text: '<a href="/path">embedded link</a>' }],
+        });
+
+        await userEvent.click(await screen.findByRole('link', { name: /embedded link/i }));
+
+        expect(searchMock).not.toHaveBeenCalled();
+        expect(pushSpy).not.toHaveBeenCalled();
+        expect(partialSpy).not.toHaveBeenCalled();
+      });
+    });
+
     describe('and the user clicks on a tag', () => {
       it('then it should navigate to the dashboard connected to the annotation', async () => {
         const { getMock } = await setupTestContext();

--- a/public/app/plugins/panel/annolist/AnnotationListItem.tsx
+++ b/public/app/plugins/panel/annolist/AnnotationListItem.tsx
@@ -38,19 +38,16 @@ export const AnnotationListItem = ({ options, annotation, formatDate, onClick, o
       tabIndex={0}
       className={styles.row}
       onClick={(e) => {
-        // A link inside the annotation text handles its own navigation; clicking
-        // anywhere else on the row opens the annotation.
         if (e.target instanceof Element && e.target.closest('a')) {
           return;
         }
         onItemClick();
       }}
       onKeyDown={(e) => {
-        // A focused link inside the annotation text handles its own activation;
-        // bail so we don't cancel it and navigate the row instead.
         if (e.target instanceof Element && e.target.closest('a')) {
           return;
         }
+
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           onItemClick();

--- a/public/app/plugins/panel/annolist/AnnotationListItem.tsx
+++ b/public/app/plugins/panel/annolist/AnnotationListItem.tsx
@@ -46,6 +46,11 @@ export const AnnotationListItem = ({ options, annotation, formatDate, onClick, o
         onItemClick();
       }}
       onKeyDown={(e) => {
+        // A focused link inside the annotation text handles its own activation;
+        // bail so we don't cancel it and navigate the row instead.
+        if (e.target instanceof Element && e.target.closest('a')) {
+          return;
+        }
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           onItemClick();

--- a/public/app/plugins/panel/annolist/AnnotationListItem.tsx
+++ b/public/app/plugins/panel/annolist/AnnotationListItem.tsx
@@ -37,7 +37,14 @@ export const AnnotationListItem = ({ options, annotation, formatDate, onClick, o
       role="button"
       tabIndex={0}
       className={styles.row}
-      onClick={onItemClick}
+      onClick={(e) => {
+        // A link inside the annotation text handles its own navigation; clicking
+        // anywhere else on the row opens the annotation.
+        if (e.target instanceof Element && e.target.closest('a')) {
+          return;
+        }
+        onItemClick();
+      }}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
@@ -45,13 +52,7 @@ export const AnnotationListItem = ({ options, annotation, formatDate, onClick, o
         }
       }}
     >
-      <RenderUserContentAsHTML
-        className={styles.heading}
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
-        content={text}
-      />
+      <RenderUserContentAsHTML className={styles.heading} content={text} />
       {showTimeStamp && (
         <div className={styles.timestamp}>
           <TimeStamp formatDate={formatDate} time={time!} />


### PR DESCRIPTION
**What is this feature?**

Fixes regression by #124398

**Clicking an annotation title does nothing.** -  Clicking next to or below the title navigated to the dashboard, but a click landing directly on the title text was swallowed 

before:

https://github.com/user-attachments/assets/b6eaa18a-4dfb-481c-a130-2d326850bfb0


after:

https://github.com/user-attachments/assets/94cca80b-dac6-433b-b6be-27941dc2e638


