### PR TITLE
Plugins: Add plugins/:slug/entitlement path to gnet proxy allowed path

### DIFF
--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -19,6 +19,7 @@ import (
 var ssoTokenAllowedPaths = []*regexp.Regexp{
 	regexp.MustCompile(`^/?plugins$`),
 	regexp.MustCompile(`^/?plugins/[^/]+$`),
+	regexp.MustCompile(`^/?plugins/[^/]+/entitlement$`),
 	regexp.MustCompile(`^/?plugins/[^/]+/versions$`),
 	regexp.MustCompile(`^/?plugins/[^/]+/versions/[^/]+$`),
 	regexp.MustCompile(`^/?plugins/[^/]+/versions/[^/]+/logos/[^/]+$`),

--- a/pkg/api/grafana_com_proxy_test.go
+++ b/pkg/api/grafana_com_proxy_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestSSOTokenAllowedPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		proxyPath string
+		allowed   bool
+	}{
+		{name: "plugins list", proxyPath: "plugins", allowed: true},
+		{name: "plugin by id", proxyPath: "plugins/grafana-clock-panel", allowed: true},
+		{name: "plugin entitlement", proxyPath: "plugins/grafana-clock-panel/entitlement", allowed: true},
+		{name: "plugin entitlement leading slash", proxyPath: "/plugins/grafana-clock-panel/entitlement", allowed: true},
+		{name: "plugin versions", proxyPath: "plugins/grafana-clock-panel/versions", allowed: true},
+		{name: "dashboards list", proxyPath: "dashboards", allowed: true},
+		{name: "entitlement subpath", proxyPath: "plugins/grafana-clock-panel/entitlement/extra", allowed: false},
+		{name: "unrelated path", proxyPath: "plugins/grafana-clock-panel/install", allowed: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ssoTokenAllowedPath(tt.proxyPath); got != tt.allowed {
+				t.Errorf("ssoTokenAllowedPath(%q) = %v, want %v", tt.proxyPath, got, tt.allowed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Adds the `plugins/:slug/entitlement` path to the gnet proxy allowed paths.

**Why do we need this feature?**

So gcom can validate if org is entitled to install this plugin.

**Who is this feature for?**

Grafana users viewing marketplace plugins in the plugin catalog.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-catalog-team/issues/815
