### PR TITLE
[release-12.4.5] Live/Plugins: Fix "namespace" to "scope" rename

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -227,7 +227,7 @@
       "count": 1
     },
     "@typescript-eslint/no-explicit-any": {
-      "count": 7
+      "count": 2
     }
   },
   "packages/grafana-data/src/types/options.ts": {

--- a/packages/grafana-data/src/types/live.test.ts
+++ b/packages/grafana-data/src/types/live.test.ts
@@ -1,17 +1,62 @@
-import { LiveChannelScope, parseLiveChannelAddress } from './live';
+import { isValidLiveChannelAddress, LiveChannelScope, parseLiveChannelAddress, toLiveChannelId } from './live';
 
-describe('parse address', () => {
-  it('simple address', () => {
+describe('channels', () => {
+  it('parse simple address', () => {
     const addr = parseLiveChannelAddress('plugin/testdata/random-flakey-stream');
     expect(addr?.scope).toBe(LiveChannelScope.Plugin);
     expect(addr?.stream).toBe('testdata');
     expect(addr?.path).toBe('random-flakey-stream');
   });
 
-  it('suppors full path', () => {
+  it('parse support full path', () => {
     const addr = parseLiveChannelAddress('plugin/testdata/a/b/c/d   ');
     expect(addr?.scope).toBe(LiveChannelScope.Plugin);
     expect(addr?.stream).toBe('testdata');
     expect(addr?.path).toBe('a/b/c/d');
+  });
+
+  it('toLiveChannelId', () => {
+    expect(
+      toLiveChannelId({
+        scope: LiveChannelScope.DataSource,
+        stream: 'xxx',
+        path: 'yyy',
+      })
+    ).toEqual('ds/xxx/yyy');
+    expect(
+      toLiveChannelId({
+        scope: LiveChannelScope.DataSource,
+        namespace: 'xxx', // convert to stream
+        path: 'yyy',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+    ).toEqual('ds/xxx/yyy');
+    expect(
+      toLiveChannelId({
+        scope: LiveChannelScope.Plugin,
+        stream: '', // convert to stream
+        path: '',
+      })
+    ).toEqual('plugin');
+  });
+
+  it('isValidLiveChannelAddress', () => {
+    expect(
+      isValidLiveChannelAddress({
+        scope: LiveChannelScope.DataSource,
+        namespace: 'xxx', // convert to stream
+        path: 'yyy',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+    ).toBeTruthy();
+
+    const addr = {
+      scope: LiveChannelScope.DataSource,
+      namespace: 'xxx', // convert to stream
+      path: 'yyy',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    expect(isValidLiveChannelAddress(addr)).toBeTruthy();
+    expect(addr.stream).toBe('xxx'); // mutates the input
   });
 });


### PR DESCRIPTION
Backport of #119108 to release-12.4.5.

Cherry-picked from a7c9417dfe03b8b6c0b9f34d8669f80aebc4a2d2 (the squash-merged commit of #119108). The automatic backport did not run since the original PR was already merged when the `backport v12.4.x` label took effect, so this was created manually.

Clean cherry-pick, no conflicts. Content is identical to the original change.