### PR TITLE
Annotation list panel (client): fix creator filtering

### DIFF
--- a/packages/grafana-data/src/types/annotations.ts
+++ b/packages/grafana-data/src/types/annotations.ts
@@ -30,6 +30,7 @@ export interface AnnotationEvent {
   dashboardUID?: string | null;
   panelId?: number;
   userId?: number;
+  userUID?: string;
   login?: string;
   email?: string;
   avatarUrl?: string;

--- a/public/app/plugins/panel/annolist/AnnoListPanel.test.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.test.tsx
@@ -86,6 +86,7 @@ const defaultOptions: Options = {
 const defaultResult = {
   text: 'Result text',
   userId: 1,
+  userUID: 'u-1',
   login: 'Result login',
   email: 'Result email',
   avatarUrl: 'Result avatarUrl',
@@ -333,7 +334,7 @@ describe('AnnoListPanel', () => {
     });
 
     describe('and the user clicks on the user avatar', () => {
-      it('then it should filter annotations by login and the filter should show', async () => {
+      it('then it should filter annotations by the creator uid and the filter should show', async () => {
         const { getMock } = await setupTestContext();
 
         getMock.mockClear();
@@ -348,7 +349,7 @@ describe('AnnoListPanel', () => {
             limit: 10,
             tags: ['tag A', 'tag B'],
             type: 'annotation',
-            userId: 1,
+            userUID: 'u-1',
           },
           expect.stringMatching(/^anno-list-panel-\d\.\d+/) // string is appended with Math.random()
         );

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -306,9 +306,8 @@ export class AnnoListPanel extends PureComponent<Props, State> {
   };
 
   onUserClick = (anno: AnnotationEvent) => {
-    // Both paths filter by the creator's uid. The k8s client exposes it via the identity
-    // ref ("user:<uid>") on createdBy; the legacy /api/annotations response carries it as
-    // userUID. Stash whichever is present so the next query can filter by it.
+    // Normalize the creator's uid: the k8s client wraps it as "user:<uid>" in createdBy,
+    // the legacy response exposes it directly as userUID. Either way, doSearch filters by uid.
     const createdBy = 'createdBy' in anno && typeof anno.createdBy === 'string' ? anno.createdBy : undefined;
     const uid = createdBy?.startsWith('user:') ? createdBy.slice('user:'.length) : anno.userUID;
     this.setState({

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -38,8 +38,9 @@ interface UserInfo {
   id?: number;
   login?: string;
   email?: string;
-  // The k8s identity ref ("user:<uid>") used to filter through the new /search endpoint.
-  // Absent when the legacy path (k8s annotations client disabled) populated this entry.
+  // The creator's uid, used to filter by user on both the k8s /search and legacy
+  // /api/annotations endpoints. Sourced from the k8s identity ref ("user:<uid>") or
+  // the legacy response's userUID.
   uid?: string;
 }
 
@@ -177,7 +178,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
         dashboardUID,
         from,
         to,
-        userId: queryUser?.id,
+        userUID: queryUser?.uid,
       };
       annotations = await getBackendSrv().get('/api/annotations', params, requestId);
     }
@@ -305,10 +306,11 @@ export class AnnoListPanel extends PureComponent<Props, State> {
   };
 
   onUserClick = (anno: AnnotationEvent) => {
-    // Hydrated events expose the k8s identity ref ("user:<uid>") via createdBy when
-    // the k8s annotations client is enabled. Stash the uid so the next /search can filter by it.
+    // Both paths filter by the creator's uid. The k8s client exposes it via the identity
+    // ref ("user:<uid>") on createdBy; the legacy /api/annotations response carries it as
+    // userUID. Stash whichever is present so the next query can filter by it.
     const createdBy = 'createdBy' in anno && typeof anno.createdBy === 'string' ? anno.createdBy : undefined;
-    const uid = createdBy?.startsWith('user:') ? createdBy.slice('user:'.length) : undefined;
+    const uid = createdBy?.startsWith('user:') ? createdBy.slice('user:'.length) : anno.userUID;
     this.setState({
       queryUser: {
         id: anno.userId,


### PR DESCRIPTION
What is this feature?

Fixes regressions by https://github.com/grafana/grafana/pull/118982

**Filtering by creator (the user avatar) doesn't filter the list**. Clicking a user avatar adds a "Filter" chip, but the displayed annotations are unchanged. (Tag filtering worked correctly.)

This is a client side update
related backend update - https://github.com/grafana/grafana/pull/126418