### PR TITLE
Dashboard: keep section constant values independent after row duplicate

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -24,7 +24,7 @@ import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeRow } from '../../serialization/layoutSerializers/RowsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
 import { SectionFiltersSet } from '../../settings/variables/SectionFiltersSet';
-import { removeRepeatLocalVariableFromSet } from '../../utils/clone';
+import { cloneSectionVariableSet, removeRepeatLocalVariableFromSet } from '../../utils/clone';
 import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { trackDropItemCrossLayout } from '../../utils/tracking';
 import { getDashboardSceneFor, getSlugForRowOrTab, interpolateSectionTitle } from '../../utils/utils';
@@ -203,7 +203,11 @@ export class RowItem
   // panelIdGenerator is a shared sequential counter created by the parent layout
   // we forward id to ensure sibling tabs never produce duplicate panel IDs
   public duplicate(panelIdGenerator?: PanelIdGenerator): RowItem {
-    return this.clone({ key: undefined, layout: this.getLayout().duplicate(panelIdGenerator) });
+    return this.clone({
+      key: undefined,
+      layout: this.getLayout().duplicate(panelIdGenerator),
+      $variables: cloneSectionVariableSet(this.state.$variables),
+    });
   }
 
   public serialize(): RowsLayoutRowKind {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
@@ -1,4 +1,5 @@
-import { SceneGridLayout, VizPanel } from '@grafana/scenes';
+import { VariableHide } from '@grafana/data';
+import { ConstantVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
 
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { DashboardScene } from '../DashboardScene';
@@ -281,6 +282,38 @@ describe('RowsLayoutManager', () => {
       expect(duplicated.state.rows[0]).not.toBe(rows[0]);
       expect(duplicated.state.rows[1]).not.toBe(rows[1]);
       expect(duplicated.state.rows[2]).not.toBe(rows[2]);
+    });
+
+    it('should clone section constant variables as independent instances with the same name', () => {
+      const constantVar = new ConstantVariable({
+        name: 'env',
+        type: 'constant',
+        value: 'prod',
+        hide: VariableHide.hideVariable,
+      });
+      const originalRow = new RowItem({
+        title: 'Row 1',
+        layout: AutoGridLayoutManager.createEmpty(),
+        $variables: new SceneVariableSet({ variables: [constantVar] }),
+      });
+      buildRowsLayoutManager([originalRow]);
+
+      const duplicatedRow = originalRow.duplicate();
+
+      const originalConstant = originalRow.state.$variables!.state.variables[0] as ConstantVariable;
+      const duplicatedConstant = duplicatedRow.state.$variables!.state.variables[0] as ConstantVariable;
+
+      expect(duplicatedConstant).not.toBe(originalConstant);
+      expect(duplicatedConstant.state.key).not.toBe(originalConstant.state.key);
+      expect(originalConstant.state.name).toBe('env');
+      expect(duplicatedConstant.state.name).toBe('env');
+      expect(originalConstant.state.value).toBe('prod');
+      expect(duplicatedConstant.state.value).toBe('prod');
+
+      duplicatedConstant.setState({ value: 'staging' });
+
+      expect(originalConstant.state.value).toBe('prod');
+      expect(duplicatedConstant.state.value).toBe('staging');
     });
 
     describe('when rows contain panels', () => {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -24,7 +24,7 @@ import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeTab } from '../../serialization/layoutSerializers/TabsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
 import { SectionFiltersSet } from '../../settings/variables/SectionFiltersSet';
-import { removeRepeatLocalVariableFromSet } from '../../utils/clone';
+import { cloneSectionVariableSet, removeRepeatLocalVariableFromSet } from '../../utils/clone';
 import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { trackDropItemCrossLayout } from '../../utils/tracking';
 import { getDashboardSceneFor, getSlugForRowOrTab, interpolateSectionTitle } from '../../utils/utils';
@@ -215,7 +215,11 @@ export class TabItem
   // panelIdGenerator is a shared sequential counter created by the parent layout
   // we forward id to ensure sibling tabs never produce duplicate panel IDs
   public duplicate(panelIdGenerator?: PanelIdGenerator): TabItem {
-    return this.clone({ key: undefined, layout: this.getLayout().duplicate(panelIdGenerator) });
+    return this.clone({
+      key: undefined,
+      layout: this.getLayout().duplicate(panelIdGenerator),
+      $variables: cloneSectionVariableSet(this.state.$variables),
+    });
   }
 
   public onChangeTitle(title: string) {

--- a/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ConstantVariable } from '@grafana/scenes';
+import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 
 import { ConstantVariableEditor, getConstantVariableOptions } from './ConstantVariableEditor';
 
@@ -40,6 +41,45 @@ describe('ConstantVariableEditor', () => {
   it('should get variable options', () => {
     const options = getConstantVariableOptions(constantVar);
     expect(options).toHaveLength(1);
+  });
+
+  it('shows the correct value when switching between constants with the same name', async () => {
+    const constant1 = new ConstantVariable({
+      name: 'env',
+      type: 'constant',
+      value: 'prod',
+      key: 'constant-key-1',
+    });
+    const constant2 = new ConstantVariable({
+      name: 'env',
+      type: 'constant',
+      value: 'staging',
+      key: 'constant-key-2',
+    });
+
+    const renderOptionsInput = (variable: ConstantVariable) => {
+      const descriptor = getConstantVariableOptions(variable)[0];
+      descriptor.parent = new OptionsPaneCategoryDescriptor({
+        id: 'mock-parent-id',
+        title: 'Mock Parent',
+      });
+      return render(descriptor.renderElement());
+    };
+
+    const { unmount } = renderOptionsInput(constant1);
+    expect(screen.getByRole('textbox')).toHaveValue('prod');
+
+    unmount();
+    renderOptionsInput(constant2);
+    expect(screen.getByRole('textbox')).toHaveValue('staging');
+
+    const input = screen.getByRole('textbox');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'dev');
+    await userEvent.tab();
+
+    expect(constant2.state.value).toBe('dev');
+    expect(constant1.state.value).toBe('prod');
   });
 });
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
@@ -28,27 +28,34 @@ export function getConstantVariableOptions(variable: SceneVariable): OptionsPane
     return [];
   }
 
+  const valueInputId = `variable-${variable.state.key}-value`;
+
   return [
     new OptionsPaneItemDescriptor({
       title: t('dashboard-scene.constant-variable-form.label-value', 'Value'),
-      id: 'constant-variable-value',
-      render: (descriptor) => <ConstantValueInput id={descriptor.props.id} variable={variable} />,
+      id: valueInputId,
+      render: () => <ConstantValueInput id={valueInputId} variable={variable} />,
     }),
   ];
 }
 
-function ConstantValueInput({ variable, id }: { variable: ConstantVariable; id?: string }) {
+function ConstantValueInput({ variable, id }: { variable: ConstantVariable; id: string }) {
   const { value } = variable.useState();
 
-  const onBlur = async (event: FormEvent<HTMLInputElement>) => {
+  const onChange = (event: FormEvent<HTMLInputElement>) => {
     variable.setState({ value: event.currentTarget.value });
+  };
+
+  const onBlur = async () => {
     await lastValueFrom(variable.validateAndUpdate!());
   };
 
   return (
     <Input
+      key={variable.state.key}
       id={id}
-      defaultValue={value.toString()}
+      value={value.toString()}
+      onChange={onChange}
       onBlur={onBlur}
       placeholder={t('dashboard-scene.constant-variable-form.placeholder-your-metric-prefix', 'Your metric prefix')}
     />

--- a/public/app/features/dashboard-scene/utils/clone.test.ts
+++ b/public/app/features/dashboard-scene/utils/clone.test.ts
@@ -1,10 +1,27 @@
-import { getCloneKey } from './clone';
+import { ConstantVariable, SceneVariableSet } from '@grafana/scenes';
+
+import { cloneSectionVariableSet, getCloneKey } from './clone';
 
 describe('clone', () => {
   describe('getCloneKey', () => {
     it('should return the clone key', () => {
       expect(getCloneKey('panel-1', 1)).toBe('panel-1-clone-1');
       expect(getCloneKey('panel-22', 1)).toBe('panel-22-clone-1');
+    });
+  });
+
+  describe('cloneSectionVariableSet', () => {
+    it('assigns new keys to the set and each variable', () => {
+      const constant = new ConstantVariable({ name: 'env', value: 'prod' });
+      const variableSet = new SceneVariableSet({ variables: [constant] });
+
+      const cloned = cloneSectionVariableSet(variableSet);
+
+      expect(cloned).not.toBe(variableSet);
+      expect(cloned!.state.key).not.toBe(variableSet.state.key);
+      expect(cloned!.state.variables[0]).not.toBe(constant);
+      expect(cloned!.state.variables[0].state.key).not.toBe(constant.state.key);
+      expect(cloned!.state.variables[0].state.name).toBe('env');
     });
   });
 });

--- a/public/app/features/dashboard-scene/utils/clone.ts
+++ b/public/app/features/dashboard-scene/utils/clone.ts
@@ -88,6 +88,21 @@ export function getRepeatVariableValueSet(
   });
 }
 
+/**
+ * Deep-clone a section-scoped variable set so duplicated rows/tabs get unique scene keys.
+ * Without new keys, edit-pane selection resolves to the first variable with a matching key.
+ */
+export function cloneSectionVariableSet(variableSet: SceneVariables | undefined): SceneVariableSet | undefined {
+  if (!(variableSet instanceof SceneVariableSet)) {
+    return undefined;
+  }
+
+  return variableSet.clone({
+    key: undefined,
+    variables: variableSet.state.variables.map((variable) => variable.clone({ key: undefined })),
+  });
+}
+
 export function removeRepeatLocalVariableFromSet(
   variableSet: SceneVariables | undefined,
   repeatVariableName: string | undefined


### PR DESCRIPTION
Fixes a bug where duplicating a dashboard row with a hidden Constant section variable made edits in the duplicate appear to update the original row’s value (until rename).

Root cause: Two issues stacked together:

1. The options-pane constant editor (`ConstantValueInput`) was uncontrolled (`defaultValue` + static `id`), so switching between same-named constants in the edit pane could show a stale value and write to the wrong instance on blur.
2. Row/tab duplicate deep-cloned `$variables` but reused scene keys. Edit-pane selection resolves objects by key (`findObject` returns the first match), so selecting the duplicate’s constant still bound to the original variable.

Fixes https://github.com/grafana/support-escalations/issues/22827

**How to test**:
Create a row with constant variable, duplicate row in edit mode, edit each row’s constant from outline — values stay independent without saving.