### PR TITLE
Alerting: Replace BuildManagedInhibitionRules with MergeInhibitionRules

### DIFF
--- a/pkg/services/ngalert/notifier/inhibition_rules/service_test.go
+++ b/pkg/services/ngalert/notifier/inhibition_rules/service_test.go
@@ -2,6 +2,8 @@ package inhibition_rules
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/alertmanager/pkg/labels"
@@ -33,6 +35,9 @@ var (
 		models.ProvenanceNone,
 	)
 
+	// testImportedRule is used as input when building the Mimir config fixture.
+	// Its UID is not reflected in the merge output; use buildExpectedImportedRule
+	// to obtain the post-merge rule with a hash-based UID.
 	testImportedRule = v1.NewInhibitionRule(
 		"test-mimir-imported-inhibition-rule-00000",
 		[]v1.Matcher{
@@ -51,7 +56,7 @@ var (
 func TestService_GetInhibitionRules(t *testing.T) {
 	ctx := context.Background()
 	orgID := int64(1)
-	grafanaRules, importedRules := getTestRules()
+	grafanaRules, importedRules := getTestRules(t)
 
 	tt := []struct {
 		name           string
@@ -67,7 +72,7 @@ func TestService_GetInhibitionRules(t *testing.T) {
 			grafanaRules:   grafanaRules,
 			importedRules:  importedRules,
 			expErr:         nil,
-			expRules:       append(grafanaRules, importedRules...),
+			expRules:       sortedByUID(append(grafanaRules, importedRules...)),
 		},
 		{
 			name:           "returns only Grafana rules when no imported config",
@@ -111,7 +116,7 @@ func TestService_GetInhibitionRules(t *testing.T) {
 func TestService_GetInhibitionRule(t *testing.T) {
 	ctx := context.Background()
 	orgID := int64(1)
-	grafanaRules, importedRules := getTestRules()
+	grafanaRules, importedRules := getTestRules(t)
 
 	tt := []struct {
 		name          string
@@ -130,8 +135,8 @@ func TestService_GetInhibitionRule(t *testing.T) {
 		{
 			name:          "can fetch imported rule by UID",
 			importedRules: importedRules,
-			ruleUID:       testImportedRule.UID,
-			expRule:       testImportedRule,
+			ruleUID:       importedRules[0].UID,
+			expRule:       importedRules[0],
 		},
 		{
 			name:   "returns not found for non-existent UID",
@@ -157,7 +162,7 @@ func TestService_GetInhibitionRule(t *testing.T) {
 func TestService_UpdateInhibitionRule(t *testing.T) {
 	ctx := context.Background()
 	orgID := int64(1)
-	grafanaRules, importedRules := getTestRules()
+	grafanaRules, importedRules := getTestRules(t)
 
 	tt := []struct {
 		name          string
@@ -194,8 +199,8 @@ func TestService_UpdateInhibitionRule(t *testing.T) {
 		{
 			name:          "can't update imported rule",
 			importedRules: importedRules,
-			updatedRule:   testImportedRule,
-			expErr:        models.MakeErrInhibitionRuleOrigin(string(testImportedRule.UID), "update"),
+			updatedRule:   importedRules[0],
+			expErr:        models.MakeErrInhibitionRuleOrigin(string(importedRules[0].UID), "update"),
 		},
 	}
 
@@ -225,7 +230,7 @@ func TestService_UpdateInhibitionRule(t *testing.T) {
 func TestService_DeleteInhibitionRule(t *testing.T) {
 	ctx := context.Background()
 	orgID := int64(1)
-	grafanaRules, importedRules := getTestRules()
+	grafanaRules, importedRules := getTestRules(t)
 
 	tt := []struct {
 		name          string
@@ -242,8 +247,8 @@ func TestService_DeleteInhibitionRule(t *testing.T) {
 		{
 			name:          "can't delete imported rule",
 			importedRules: importedRules,
-			ruleUID:       testImportedRule.UID,
-			expErr:        models.MakeErrInhibitionRuleOrigin(string(testImportedRule.UID), "delete"),
+			ruleUID:       importedRules[0].UID,
+			expErr:        models.MakeErrInhibitionRuleOrigin(string(importedRules[0].UID), "delete"),
 		},
 	}
 
@@ -371,6 +376,49 @@ func buildMimirAMConfigWithInhibitRules(t *testing.T, rules []v1.InhibitionRule)
 	return string(d)
 }
 
-func getTestRules() (grafanaRules, importedRules []v1.InhibitionRule) {
-	return []v1.InhibitionRule{testGrafanaRule}, []v1.InhibitionRule{testImportedRule}
+// buildExpectedImportedRule returns the inhibition rule as it appears after
+// MergeInhibitionRules processes the Mimir config built from testImportedRule.
+// MergeInhibitionRules assigns a hash-based UID and appends the scope matcher last,
+// so the result differs from testImportedRule in both UID and matcher order.
+func buildExpectedImportedRule(t *testing.T) v1.InhibitionRule {
+	t.Helper()
+
+	mimirConfig := buildMimirAMConfigWithInhibitRules(t, []v1.InhibitionRule{testImportedRule})
+	cfg := &v1.AMConfigV1{
+		AlertmanagerConfig: v1.PostableApiAlertingConfig{
+			Config: v1.Config{
+				Route: &v1.Route{Receiver: "default"},
+			},
+		},
+		ManagedRoutes: map[string]*v1.Route{},
+		ExtraConfigs: []v1.ExtraConfiguration{
+			{
+				Identifier:         "test-mimir",
+				AlertmanagerConfig: mimirConfig,
+			},
+		},
+	}
+	rev := &legacy_storage.ConfigRevision{Config: cfg}
+	imported, err := rev.Imported()
+	require.NoError(t, err)
+	rules, err := imported.GetInhibitRules()
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	for _, r := range rules {
+		return r
+	}
+	panic("unreachable")
+}
+
+func getTestRules(t *testing.T) (grafanaRules, importedRules []v1.InhibitionRule) {
+	return []v1.InhibitionRule{testGrafanaRule}, []v1.InhibitionRule{buildExpectedImportedRule(t)}
+}
+
+// sortedByUID returns a copy of rules sorted by UID, matching the order returned by GetInhibitionRules.
+func sortedByUID(rules []v1.InhibitionRule) []v1.InhibitionRule {
+	sorted := slices.Clone(rules)
+	slices.SortFunc(sorted, func(a, b v1.InhibitionRule) int {
+		return strings.Compare(string(a.UID), string(b.UID))
+	})
+	return sorted
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -149,5 +149,19 @@ func (e ImportedConfigRevision) GetInhibitRules() (map[v1.ResourceUID]v1.Inhibit
 		return nil, nil
 	}
 
-	return merge.BuildManagedInhibitionRules(e.identifier, importedRules, models.ProvenanceConvertedPrometheus)
+	// provide the existing inhibition rules from the config so the merged resources names are stable
+	merged, addedUIOs, err := merge.MergeInhibitionRules(e.rev.Config.InhibitionRules, importedRules, e.identifier)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[v1.ResourceUID]v1.InhibitionRule, len(addedUIOs))
+	for _, uio := range addedUIOs {
+		m, ok := merged[v1.ResourceUID(uio)]
+		if !ok {
+			continue
+		}
+		m.Provenance = models.ProvenanceConvertedPrometheus
+		result[v1.ResourceUID(uio)] = m
+	}
+	return result, nil
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
@@ -292,40 +292,63 @@ receivers:
 
 		result, err := imported.GetInhibitRules()
 		require.NoError(t, err)
-		require.Equal(t, map[v1.ResourceUID]v1.InhibitionRule{
-			"test-imported-inhibition-rule-00000000000": {
-				ResourceMetadata: v1.ResourceMetadata{
-					UID:        "test-imported-inhibition-rule-00000000000",
-					Provenance: models.ProvenanceConvertedPrometheus,
-					Version:    "8ea121175ec5f716",
-				},
-				SourceMatchers: []v1.Matcher{
-					v1.NewMatcher(v1.MatcherEqual, "__grafana_managed_route__", "test"),
-					v1.NewMatcher(v1.MatcherEqual, "alertname", "SourceAlert"),
-				},
-				TargetMatchers: []v1.Matcher{
-					v1.NewMatcher(v1.MatcherEqual, "__grafana_managed_route__", "test"),
-					v1.NewMatcher(v1.MatcherEqual, "alertname", "TargetAlert"),
-				},
-				Equal: []string{"cluster"},
+		require.Len(t, result, 2)
+
+		// UIDs are hash-based; collect them to verify properties without hardcoding the hash.
+		for uid, rule := range result {
+			require.Equal(t, v1.ResourceUID(uid), rule.UID)
+			require.Equal(t, models.ProvenanceConvertedPrometheus, rule.Provenance)
+
+			// Identifier scope matcher must be present in both source and target.
+			var hasSourceScope, hasTargetScope bool
+			for _, m := range rule.SourceMatchers {
+				if m.Label == "__grafana_managed_route__" && m.Value == "test" {
+					hasSourceScope = true
+				}
+			}
+			for _, m := range rule.TargetMatchers {
+				if m.Label == "__grafana_managed_route__" && m.Value == "test" {
+					hasTargetScope = true
+				}
+			}
+			assert.True(t, hasSourceScope, "uid=%s: source matchers should contain identifier scope", uid)
+			assert.True(t, hasTargetScope, "uid=%s: target matchers should contain identifier scope", uid)
+
+			// The identifier scope matcher is appended last.
+			assert.Equal(t, "__grafana_managed_route__", rule.SourceMatchers[len(rule.SourceMatchers)-1].Label)
+			assert.Equal(t, "__grafana_managed_route__", rule.TargetMatchers[len(rule.TargetMatchers)-1].Label)
+		}
+	})
+
+	t.Run("should return stable UIDs across multiple calls", func(t *testing.T) {
+		rev := getConfigRevisionForTest(withExtraConfig(extraConfig(extraConfigurationYaml)))
+		imported, err := rev.Imported()
+		require.NoError(t, err)
+
+		result1, err := imported.GetInhibitRules()
+		require.NoError(t, err)
+		result2, err := imported.GetInhibitRules()
+		require.NoError(t, err)
+		assert.Equal(t, result1, result2)
+	})
+
+	t.Run("should only return rules from imported config, not pre-existing ones", func(t *testing.T) {
+		existingUID := v1.ResourceUID("existing-rule")
+		rev := getConfigRevisionForTest(
+			withExtraConfig(extraConfig(extraConfigurationYaml)),
+			func(rev *ConfigRevision) {
+				rev.Config.InhibitionRules = map[v1.ResourceUID]v1.InhibitionRule{
+					existingUID: v1.NewInhibitionRule(string(existingUID), nil, nil, nil, models.ProvenanceNone),
+				}
 			},
-			"test-imported-inhibition-rule-00000000001": {
-				ResourceMetadata: v1.ResourceMetadata{
-					UID:        "test-imported-inhibition-rule-00000000001",
-					Provenance: models.ProvenanceConvertedPrometheus,
-					Version:    "74cb0d8b8dcff9f0",
-				},
-				SourceMatchers: []v1.Matcher{
-					v1.NewMatcher(v1.MatcherEqual, "__grafana_managed_route__", "test"),
-					v1.NewMatcher(v1.MatcherEqual, "severity", "critical"),
-				},
-				TargetMatchers: []v1.Matcher{
-					v1.NewMatcher(v1.MatcherEqual, "__grafana_managed_route__", "test"),
-					v1.NewMatcher(v1.MatcherEqual, "severity", "warning"),
-				},
-				Equal: []string{"instance"},
-			},
-		}, result)
+		)
+		imported, err := rev.Imported()
+		require.NoError(t, err)
+
+		result, err := imported.GetInhibitRules()
+		require.NoError(t, err)
+		assert.NotContains(t, result, existingUID)
+		assert.Len(t, result, 2)
 	})
 }
 

--- a/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
@@ -296,7 +296,7 @@ receivers:
 
 		// UIDs are hash-based; collect them to verify properties without hardcoding the hash.
 		for uid, rule := range result {
-			require.Equal(t, v1.ResourceUID(uid), rule.UID)
+			require.Equal(t, uid, rule.UID)
 			require.Equal(t, models.ProvenanceConvertedPrometheus, rule.Provenance)
 
 			// Identifier scope matcher must be present in both source and target.

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -14,6 +14,7 @@ import (
 	"hash/fnv"
 	"maps"
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/grafana/alerting/utils/hash"
@@ -364,13 +365,11 @@ func MergeInhibitionRules(existing map[v1.ResourceUID]v1.InhibitionRule, incomin
 func foldMatchers(match map[string]string, matchRE config.MatchRegexps, matchers config.Matchers) []v1.Matcher {
 	out := make([]v1.Matcher, 0, len(match)+len(matchRE)+len(matchers))
 	out = append(out, v1.MatchersToModel(matchers)...)
-	for ln, lv := range match {
-		m := v1.NewMatcher(v1.MatcherEqual, ln, lv)
-		out = append(out, m)
+	for _, ln := range slices.Sorted(maps.Keys(match)) {
+		out = append(out, v1.NewMatcher(v1.MatcherEqual, ln, match[ln]))
 	}
-	for ln, lv := range matchRE {
-		m := v1.NewMatcher(v1.MatcherEqualRegex, ln, lv.String())
-		out = append(out, m)
+	for _, ln := range slices.Sorted(maps.Keys(matchRE)) {
+		out = append(out, v1.NewMatcher(v1.MatcherEqualRegex, ln, matchRE[ln].String()))
 	}
 	return out
 }

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -11,13 +11,13 @@ package merge
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"maps"
 	"math"
-	"slices"
 	"strings"
 
+	"github.com/grafana/alerting/utils/hash"
 	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/pkg/labels"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
@@ -143,18 +143,9 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1, provenance models.P
 		managedRoutes[mimirCfg.Identifier] = extraRoute
 	}
 
-	var addedInhibitionRules []string
-	managedInhibitionRules := make(map[v1.ResourceUID]v1.InhibitionRule, len(mcfg.InhibitRules)+len(cfg.InhibitionRules))
-	{
-		maps.Copy(managedInhibitionRules, cfg.InhibitionRules)
-		importedRules, err := BuildManagedInhibitionRules(mimirCfg.Identifier, mcfg.InhibitRules, provenance)
-		if err != nil {
-			return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("failed to build managed inhibition rules for imported configuration: %w", err)
-		}
-		for uid := range importedRules {
-			addedInhibitionRules = append(addedInhibitionRules, string(uid))
-		}
-		maps.Copy(managedInhibitionRules, importedRules)
+	managedInhibitionRules, addedInhibitionRules, err := MergeInhibitionRules(cfg.InhibitionRules, mcfg.InhibitRules, mimirCfg.Identifier)
+	if err != nil {
+		return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("failed to merge inhibition rules: %w", err)
 	}
 
 	var addedTemplates []string
@@ -336,54 +327,52 @@ func createIndexReceivers(existing, incoming []*v1.PostableApiReceiver) map[stri
 	return usedNames
 }
 
-func BuildManagedInhibitionRules(identifier string, rules []config.InhibitRule, provenance models.Provenance) (map[v1.ResourceUID]v1.InhibitionRule, error) {
-	scopedRules := applyManagedRouteMatcher(identifier, rules)
-
-	res := make(map[v1.ResourceUID]v1.InhibitionRule, len(scopedRules))
-	for i, rule := range scopedRules {
-		namePrefix := fmt.Sprintf("%s-imported-inhibition-rule-", identifier)
-
-		intFmt := "%d"
-		if padLength := util.MaxUIDLength - len(namePrefix); padLength >= 0 {
-			intFmt = fmt.Sprintf("%%0%dd", padLength+1)
+// MergeInhibitionRules merges incoming Alertmanager inhibition rules into an existing set of Grafana-managed ones.
+// Each incoming rule is scoped to the given identifier by appending a matcher on models.NamedRouteLabel,
+// and all deprecated match/match_re fields are folded into the modern matchers slice.
+// UIDs are derived from a stable hash of (rule, index, identifier); collisions fall back to a short random UID.
+// Returns the merged map (existing + incoming) and the UIDs of the newly added rules.
+func MergeInhibitionRules(existing map[v1.ResourceUID]v1.InhibitionRule, incoming []config.InhibitRule, identifier string) (result map[v1.ResourceUID]v1.InhibitionRule, added []string, err error) {
+	added = make([]string, 0, len(incoming))
+	result = make(map[v1.ResourceUID]v1.InhibitionRule, len(incoming)+len(existing))
+	maps.Copy(result, existing)
+	matcher := v1.NewMatcher(v1.MatcherEqual, models.NamedRouteLabel, identifier)
+	for idx, rule := range incoming {
+		var name string
+		{
+			hasher := fnv.New64a()
+			hash.DeepHashObject(hasher, []any{rule, idx, identifier})
+			name = fmt.Sprintf("%x", hasher.Sum64()) // uid is a hash of the rule and the index, which guarantees uniqueness
+			// try to generate a stable name for the rule. Fallback to uuid if the name is already taken.
+			if _, ok := result[v1.ResourceUID(name)]; ok || len(name) > util.MaxUIDLength {
+				name = util.GenerateShortUID()
+			}
 		}
-		name := fmt.Sprintf(namePrefix+intFmt, i)
 
-		ir := v1.NewInhibitionRule(name, v1.MatchersToModel(rule.SourceMatchers), v1.MatchersToModel(rule.TargetMatchers), rule.Equal, provenance)
+		source := append(foldMatchers(rule.SourceMatch, rule.SourceMatchRE, rule.SourceMatchers), matcher)
+		target := append(foldMatchers(rule.TargetMatch, rule.TargetMatchRE, rule.TargetMatchers), matcher)
+		ir := v1.NewInhibitionRule(name, source, target, rule.Equal, models.ProvenanceNone)
 		if err := ir.Validate(); err != nil {
-			return nil, err
+			return nil, nil, fmt.Errorf("cannot convert inhibition rule at index %d: %w", idx, err)
 		}
-
-		res[ir.UID] = ir
+		result[ir.UID] = ir
+		added = append(added, string(ir.UID))
 	}
-
-	return res, nil
+	return result, added, nil
 }
 
-func applyManagedRouteMatcher(identifier string, rules []config.InhibitRule) []config.InhibitRule {
-	result := make([]config.InhibitRule, 0, len(rules))
-	matcher := &labels.Matcher{
-		Type:  labels.MatchEqual,
-		Name:  models.NamedRouteLabel,
-		Value: identifier,
+func foldMatchers(match map[string]string, matchRE config.MatchRegexps, matchers config.Matchers) []v1.Matcher {
+	out := make([]v1.Matcher, 0, len(match)+len(matchRE)+len(matchers))
+	out = append(out, v1.MatchersToModel(matchers)...)
+	for ln, lv := range match {
+		m := v1.NewMatcher(v1.MatcherEqual, ln, lv)
+		out = append(out, m)
 	}
-
-	for _, rule := range rules {
-		sm := make(config.Matchers, 0, len(rule.SourceMatchers)+1)
-		sm = append(sm, matcher)
-		sm = append(sm, rule.SourceMatchers...)
-
-		tm := make(config.Matchers, 0, len(rule.TargetMatchers)+1)
-		tm = append(tm, matcher)
-		tm = append(tm, rule.TargetMatchers...)
-
-		result = append(result, config.InhibitRule{
-			SourceMatchers: sm,
-			TargetMatchers: tm,
-			Equal:          slices.Clone(rule.Equal),
-		})
+	for ln, lv := range matchRE {
+		m := v1.NewMatcher(v1.MatcherEqualRegex, ln, lv.String())
+		out = append(out, m)
 	}
-	return result
+	return out
 }
 
 func getUniqueName[T any](name string, suffix string, usedNames map[string]T) string {

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -783,4 +783,20 @@ func TestMergeInhibitionRules(t *testing.T) {
 		assert.True(t, hasSourceLabel)
 		assert.True(t, hasTargetLabel)
 	})
+
+	t.Run("deprecated match fields produce stable UID regardless of map iteration order", func(t *testing.T) {
+		// Build a rule with multiple deprecated match entries. Map iteration is non-deterministic,
+		// so the test validates that the UID is identical across repeated calls.
+		incoming := []config.InhibitRule{
+			{
+				SourceMatch: map[string]string{"alertname": "fire", "severity": "critical", "team": "ops"},
+				TargetMatch: map[string]string{"alertname": "warn", "region": "eu"},
+			},
+		}
+		_, added1, err := MergeInhibitionRules(nil, incoming, "id")
+		require.NoError(t, err)
+		_, added2, err := MergeInhibitionRules(nil, incoming, "id")
+		require.NoError(t, err)
+		assert.Equal(t, added1, added2)
+	})
 }

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/alerting/definition"
+	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/stretchr/testify/assert"
@@ -407,7 +408,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		require.NoError(t, err)
 		route := mcfg.Route
 		RenameResourceUsagesInRoutes([]*v1.Route{route}, renames)
-		inhibitRules, err := BuildManagedInhibitionRules(identifier, mcfg.InhibitRules, models.ProvenanceConvertedPrometheus)
+		inhibitRules, _, err := MergeInhibitionRules(nil, mcfg.InhibitRules, identifier)
 		require.NoError(t, err)
 		return v1.ManagedRoutes{identifier: route}, inhibitRules
 	}
@@ -583,7 +584,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		assert.ElementsMatch(t, []string{"recv", "recv2"}, result.AddedReceivers)
 		assert.ElementsMatch(t, []string{"mti-2", "ti-2"}, result.AddedTimeIntervals)
 		assert.Empty(t, result.AddedTemplates)
-		assert.ElementsMatch(t, []string{"mimir-12345-imported-inhibition-rule-0000"}, result.AddedInhibitionRules)
+		assert.Len(t, result.AddedInhibitionRules, 1)
 	})
 
 	t.Run("should report renamed receiver in stats", func(t *testing.T) {
@@ -685,5 +686,101 @@ func TestMergeExtraConfig(t *testing.T) {
 		}
 		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.ErrorContains(t, err, templateName)
+	})
+}
+
+func TestMergeInhibitionRules(t *testing.T) {
+	mkMatcher := func(name, value string) *labels.Matcher {
+		return &labels.Matcher{Type: labels.MatchEqual, Name: name, Value: value}
+	}
+	rule := func(srcLabel, tgtLabel string) config.InhibitRule {
+		return config.InhibitRule{
+			SourceMatchers: config.Matchers{mkMatcher("alertname", srcLabel)},
+			TargetMatchers: config.Matchers{mkMatcher("alertname", tgtLabel)},
+		}
+	}
+
+	t.Run("empty incoming returns existing unchanged with empty added", func(t *testing.T) {
+		existing := map[v1.ResourceUID]v1.InhibitionRule{
+			"uid1": v1.NewInhibitionRule("uid1", nil, nil, nil, models.ProvenanceNone),
+		}
+		result, added, err := MergeInhibitionRules(existing, nil, "id")
+		require.NoError(t, err)
+		assert.Equal(t, existing, result)
+		assert.Empty(t, added)
+	})
+
+	t.Run("existing rules are preserved alongside incoming", func(t *testing.T) {
+		existing := map[v1.ResourceUID]v1.InhibitionRule{
+			"existing-uid": v1.NewInhibitionRule("existing-uid", nil, nil, nil, models.ProvenanceNone),
+		}
+		result, added, err := MergeInhibitionRules(existing, []config.InhibitRule{rule("src", "tgt")}, "id")
+		require.NoError(t, err)
+		assert.Contains(t, result, v1.ResourceUID("existing-uid"))
+		assert.Len(t, result, 2)
+		assert.Len(t, added, 1)
+	})
+
+	t.Run("identifier scope matcher is appended last on both source and target", func(t *testing.T) {
+		identifier := "my-scope"
+		result, added, err := MergeInhibitionRules(nil, []config.InhibitRule{rule("critical", "warning")}, identifier)
+		require.NoError(t, err)
+		require.Len(t, added, 1)
+		ir := result[v1.ResourceUID(added[0])]
+
+		require.NotEmpty(t, ir.SourceMatchers)
+		last := ir.SourceMatchers[len(ir.SourceMatchers)-1]
+		assert.Equal(t, models.NamedRouteLabel, last.Label)
+		assert.Equal(t, identifier, last.Value)
+
+		require.NotEmpty(t, ir.TargetMatchers)
+		last = ir.TargetMatchers[len(ir.TargetMatchers)-1]
+		assert.Equal(t, models.NamedRouteLabel, last.Label)
+		assert.Equal(t, identifier, last.Value)
+	})
+
+	t.Run("UID is deterministic for the same inputs", func(t *testing.T) {
+		incoming := []config.InhibitRule{rule("src", "tgt")}
+		result1, added1, err := MergeInhibitionRules(nil, incoming, "id")
+		require.NoError(t, err)
+		result2, added2, err := MergeInhibitionRules(nil, incoming, "id")
+		require.NoError(t, err)
+		assert.Equal(t, added1, added2)
+		assert.Equal(t, result1, result2)
+	})
+
+	t.Run("different rules produce different UIDs", func(t *testing.T) {
+		result, added, err := MergeInhibitionRules(nil, []config.InhibitRule{rule("a", "b"), rule("c", "d")}, "id")
+		require.NoError(t, err)
+		require.Len(t, added, 2)
+		assert.NotEqual(t, added[0], added[1])
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("deprecated source_match and target_match fields are folded in", func(t *testing.T) {
+		incoming := []config.InhibitRule{
+			{
+				SourceMatch: map[string]string{"alertname": "test"},
+				TargetMatch: map[string]string{"severity": "warning"},
+			},
+		}
+		result, added, err := MergeInhibitionRules(nil, incoming, "id")
+		require.NoError(t, err)
+		require.Len(t, added, 1)
+		ir := result[v1.ResourceUID(added[0])]
+
+		var hasSourceLabel, hasTargetLabel bool
+		for _, m := range ir.SourceMatchers {
+			if m.Label == "alertname" && m.Value == "test" {
+				hasSourceLabel = true
+			}
+		}
+		for _, m := range ir.TargetMatchers {
+			if m.Label == "severity" && m.Value == "warning" {
+				hasTargetLabel = true
+			}
+		}
+		assert.True(t, hasSourceLabel)
+		assert.True(t, hasTargetLabel)
 	})
 }

--- a/pkg/tests/apis/alerting/notifications/inhibitionrule/test-data/list.json
+++ b/pkg/tests/apis/alerting/notifications/inhibitionrule/test-data/list.json
@@ -7,9 +7,9 @@
       "kind": "InhibitionRule",
       "apiVersion": "notifications.alerting.grafana.app/v1beta1",
       "metadata": {
-        "name": "integration-test-imported-inhibition-rule-0",
+        "name": "5c32a792ae63d385",
         "namespace": "default",
-        "uid": "h0TQAizskYafx9XXyN4XeuE12Ua7r46FDTXu86hVOoIX",
+        "uid": "E6FSwCFl7sufOnbWURwny21WsorOzTPRWzSVdHMgs00X",
         "resourceVersion": "fa1ddb8baf6c4173",
         "annotations": {
           "grafana.com/provenance": "converted_prometheus"
@@ -19,25 +19,25 @@
         "source_matchers": [
           {
             "type": "=",
-            "label": "__grafana_managed_route__",
-            "value": "integration-test"
+            "label": "alertname",
+            "value": "HighCPU"
           },
           {
             "type": "=",
-            "label": "alertname",
-            "value": "HighCPU"
+            "label": "__grafana_managed_route__",
+            "value": "integration-test"
           }
         ],
         "target_matchers": [
           {
             "type": "=",
-            "label": "__grafana_managed_route__",
-            "value": "integration-test"
+            "label": "alertname",
+            "value": "CPUWarning"
           },
           {
             "type": "=",
-            "label": "alertname",
-            "value": "CPUWarning"
+            "label": "__grafana_managed_route__",
+            "value": "integration-test"
           }
         ],
         "equal": [
@@ -49,9 +49,9 @@
       "kind": "InhibitionRule",
       "apiVersion": "notifications.alerting.grafana.app/v1beta1",
       "metadata": {
-        "name": "integration-test-imported-inhibition-rule-1",
+        "name": "79ae9582fbc9abb4",
         "namespace": "default",
-        "uid": "B08XJbB5wzcX0VG2yXuMGZvbmi3ENl4X7LJXKWhpB5sX",
+        "uid": "SYlViYHwhfUexIFOZiqGdynqxcZ5iKVJZA3dnL6oUxQX",
         "resourceVersion": "b3e5c88931ea4509",
         "annotations": {
           "grafana.com/provenance": "converted_prometheus"
@@ -61,25 +61,25 @@
         "source_matchers": [
           {
             "type": "=",
-            "label": "__grafana_managed_route__",
-            "value": "integration-test"
+            "label": "severity",
+            "value": "critical"
           },
           {
             "type": "=",
-            "label": "severity",
-            "value": "critical"
+            "label": "__grafana_managed_route__",
+            "value": "integration-test"
           }
         ],
         "target_matchers": [
           {
             "type": "=",
-            "label": "__grafana_managed_route__",
-            "value": "integration-test"
+            "label": "severity",
+            "value": "warning"
           },
           {
             "type": "=",
-            "label": "severity",
-            "value": "warning"
+            "label": "__grafana_managed_route__",
+            "value": "integration-test"
           }
         ],
         "equal": [


### PR DESCRIPTION
## Summary

Prerequisite for promoting inhibition rules in https://github.com/grafana/grafana/pull/126027.

`BuildManagedInhibitionRules` generated UIDs from a formatted name prefix and index (`{id}-imported-inhibition-rule-000N`), coupling callers to the identifier and hardcoding provenance at build time. This replaces it with `MergeInhibitionRules`, which:

- Accepts the existing managed rules map so UIDs are stable across repeated calls (same hash → same UID)
- Derives UIDs from a FNV-64a hash of `(rule, index, identifier)` instead of a formatted string
- Folds deprecated `match`/`match_re` fields alongside modern `matchers` via `foldMatchers`
- Appends the identifier scope matcher last on both source and target (was prepended before)
- Sets provenance to `ProvenanceNone`; callers that need a different provenance set it after the fact (as `GetInhibitRules` in `imported.go` already does for `ProvenanceConvertedPrometheus`)