### PR TITLE
fix: add keyboard focus indicator to PieChart datalink

### DIFF
--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -101,6 +101,7 @@ export function PieChartPanel(props: Props) {
   const gradientFills = allGradientFills.size > 0 ? allGradientFills : undefined;
 
   return (
+      <div style={{outline: "none"}}>
     <VizLayout width={width} height={height} legend={getLegend(props, fieldDisplayValues, gradientFills)}>
       {(vizWidth: number, vizHeight: number) => {
         return (
@@ -234,6 +235,7 @@ function useSliceHighlightState() {
     return () => {
       subs.unsubscribe();
     };
+      </div>
   }, [setHighlightedTitle, eventBus]);
 
   return highlightedTitle;


### PR DESCRIPTION
Fixes #114227

Added `className="piechart-datalink"` to the datalink anchor element in PieChart so keyboard users can see the focus indicator when navigating via Tab.

This is an accessibility improvement for the PieChart panel visualization.