### PR TITLE
IAM: Fix: integration tests

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	dashboardv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -814,6 +815,7 @@ func contextProvider(tc *testContext) web.Handler {
 
 var testOptions = Options{
 	Resource:          "dashboards",
+	APIGroup:          dashboardv1.APIGroup,
 	ResourceAttribute: "id",
 	Assignments: Assignments{
 		Users:        true,


### PR DESCRIPTION

**What is this feature?**

2 PRs were merged close to each other and the second one didn't use the changes of the first one.
https://github.com/grafana/grafana/pull/126333
https://github.com/grafana/grafana/pull/126317


**Why do we need this feature?**

Fixing [CI](https://github.com/grafana/grafana/actions/runs/27437051769/job/81106768327?pr=126418):
```
--- FAIL: TestIntegrationApi_setUserPermission_dualWriterModeFallback (1.01s)
    --- FAIL: TestIntegrationApi_setUserPermission_dualWriterModeFallback/Mode3_falls_back_to_legacy (0.51s)
        api_test.go:639: 
            	Error Trace:	/opt/actions-runner/_work/grafana/grafana/pkg/services/accesscontrol/resourcepermissions/service_test.go:862
            	            				/opt/actions-runner/_work/grafana/grafana/pkg/services/accesscontrol/resourcepermissions/api_test.go:639
            	Error:      	Received unexpected error:
            	            	APIGroup is required for resource "dashboards" when Kubernetes-native permissions are enabled (K8sActionFormat or the resource-permission redirect)
            	Test:       	TestIntegrationApi_setUserPermission_dualWriterModeFallback/Mode3_falls_back_to_legacy
    --- FAIL: TestIntegrationApi_setUserPermission_dualWriterModeFallback/Mode5_does_not_fall_back (0.50s)
        api_test.go:639: 
            	Error Trace:	/opt/actions-runner/_work/grafana/grafana/pkg/services/accesscontrol/resourcepermissions/service_test.go:862
            	            				/opt/actions-runner/_work/grafana/grafana/pkg/services/accesscontrol/resourcepermissions/api_test.go:639
            	Error:      	Received unexpected error:
            	            	APIGroup is required for resource "dashboards" when Kubernetes-native permissions are enabled (K8sActionFormat or the resource-permission redirect)
            	Test:       	TestIntegrationApi_setUserPermission_dualWriterModeFallback/Mode5_does_not_fall_back
--- FAIL: TestIntegrationApi_getPermissions_dualWriterModeFallback (1.01s)
    --- FAIL: TestIntegrationApi_getPermissions_dualWriterModeFallback/Mode3_falls_back_to_legacy (0.51s)
        api_test.go:693: 
            	Error Trace:	/opt/actions-runner/_work/grafana/grafana/pkg/services/accesscontrol/resourcepermissions/service_test.go:862
            	            				/opt/actions-runner/_work/grafana/grafana/pkg/services/accesscontrol/resourcepermissions/api_test.go:693
            	Error:      	Received unexpected error:
            	            	APIGroup is required for resource "dashboards" when Kubernetes-native permissions are enabled (K8sActionFormat or the resource-permission redirect)
            	Test:       	TestIntegrationApi_getPermissions_dualWriterModeFallback/Mode3_falls_back_to_legacy
    --- FAIL: TestIntegrationApi_getPermissions_dualWriterModeFallback/Mode5_does_not_fall_back (0.51s)
        api_test.go:693: 
            	Error Trace:	/opt/actions-runner/_work/grafana/grafana/pkg/services/accesscontrol/resourcepermissions/service_test.go:862
            	            				/opt/actions-runner/_work/grafana/grafana/pkg/services/accesscontrol/resourcepermissions/api_test.go:693
            	Error:      	Received unexpected error:
            	            	APIGroup is required for resource "dashboards" when Kubernetes-native permissions are enabled (K8sActionFormat or the resource-permission redirect)
            	Test:       	TestIntegrationApi_getPermissions_dualWriterModeFallback/Mode5_does_not_fall_back
FAIL
```

thread: https://raintank-corp.slack.com/archives/C05JDQ100NS/p1781293765260719

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
