### PR TITLE
Unified Storage Vector: Only embed panels that have changed

### DIFF
--- a/pkg/storage/unified/resource/search_vector_test.go
+++ b/pkg/storage/unified/resource/search_vector_test.go
@@ -89,8 +89,8 @@ func (f *fakeVectorBackend) Delete(context.Context, string, string, string, stri
 func (f *fakeVectorBackend) DeleteSubresources(context.Context, string, string, string, string, []string) error {
 	return nil
 }
-func (f *fakeVectorBackend) GetSubresourceContent(context.Context, string, string, string, string) (map[string]string, error) {
-	return nil, nil
+func (f *fakeVectorBackend) GetSubresourceContent(context.Context, string, string, string, string) (map[string]string, string, error) {
+	return nil, "", nil
 }
 func (f *fakeVectorBackend) Exists(context.Context, string, string, string, string) (bool, error) {
 	return false, nil

--- a/pkg/storage/unified/resource/search_vector_test.go
+++ b/pkg/storage/unified/resource/search_vector_test.go
@@ -80,7 +80,7 @@ func (f *fakeVectorBackend) Search(_ context.Context, namespace, model, resource
 
 // stub the rest of VectorBackend; not exercised by these tests.
 func (f *fakeVectorBackend) Upsert(context.Context, []vector.Vector) error { return nil }
-func (f *fakeVectorBackend) UpsertReplaceSubresources(context.Context, []vector.Vector) error {
+func (f *fakeVectorBackend) UpsertReplaceSubresources(context.Context, string, string, string, string, []vector.Vector, []string) error {
 	return nil
 }
 func (f *fakeVectorBackend) Delete(context.Context, string, string, string, string) error {

--- a/pkg/storage/unified/resource/vector_metrics.go
+++ b/pkg/storage/unified/resource/vector_metrics.go
@@ -15,12 +15,16 @@ type VectorMetrics struct {
 	ReconcilerPendingEvents      prometheus.Gauge
 	ReconcilerRetriesTotal       *prometheus.CounterVec
 	ReconcilerEventsDroppedTotal *prometheus.CounterVec
-	BackfillItemDuration         *prometheus.HistogramVec
-	QueryCacheHitsTotal          *prometheus.CounterVec
-	QueryCacheMissesTotal        *prometheus.CounterVec
-	QueryCacheEvictionsTotal     prometheus.Counter
-	RateLimitedRequestsTotal     prometheus.Counter
-	RateLimiterErrorsTotal       prometheus.Counter
+
+	ReconcilerSubresourcesExtractedTotal *prometheus.CounterVec
+	ReconcilerSubresourcesEmbeddedTotal  *prometheus.CounterVec
+	ReconcilerSubresourcesDeletedTotal   *prometheus.CounterVec
+	BackfillItemDuration                 *prometheus.HistogramVec
+	QueryCacheHitsTotal                  *prometheus.CounterVec
+	QueryCacheMissesTotal                *prometheus.CounterVec
+	QueryCacheEvictionsTotal             prometheus.Counter
+	RateLimitedRequestsTotal             prometheus.Counter
+	RateLimiterErrorsTotal               prometheus.Counter
 }
 
 func ProvideVectorMetrics(reg prometheus.Registerer) *VectorMetrics {
@@ -61,6 +65,18 @@ func ProvideVectorMetrics(reg prometheus.Registerer) *VectorMetrics {
 			Name: "vector_storage_reconciler_events_dropped_total",
 			Help: "Total number of reconciler events dropped (gave up on), labeled by reason.",
 		}, []string{"group", "resource", "reason"}),
+		ReconcilerSubresourcesExtractedTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "vector_storage_reconciler_subresources_extracted_total",
+			Help: "Total subresources extracted from processed resources. Compare with embedded to see how many re-embeds the content diff avoids.",
+		}, []string{"group", "resource"}),
+		ReconcilerSubresourcesEmbeddedTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "vector_storage_reconciler_subresources_embedded_total",
+			Help: "Total subresources re-embedded (new or content-changed). Equal to extracted means the diff is saving nothing.",
+		}, []string{"group", "resource"}),
+		ReconcilerSubresourcesDeletedTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "vector_storage_reconciler_subresources_deleted_total",
+			Help: "Total stale subresources deleted because they no longer exist in the resource.",
+		}, []string{"group", "resource"}),
 		BackfillItemDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "vector_storage_backfill_item_duration_seconds",
 			Help:                            "Time (in seconds) to process a single backfill item, labeled by group, resource, and outcome status (including skip reasons).",

--- a/pkg/storage/unified/search/embed/backfill/fakes_test.go
+++ b/pkg/storage/unified/search/embed/backfill/fakes_test.go
@@ -248,7 +248,7 @@ func (f *fakeVector) DeleteSubresources(_ context.Context, namespace, model, res
 	f.subresourceDeletes = append(f.subresourceDeletes, deleteSubsCall{namespace, model, res, uid, subs})
 	return nil
 }
-func (f *fakeVector) GetSubresourceContent(_ context.Context, _, _, _, uid string) (map[string]string, error) {
+func (f *fakeVector) GetSubresourceContent(_ context.Context, _, _, _, uid string) (map[string]string, string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if existing, ok := f.existing[uid]; ok {
@@ -256,9 +256,9 @@ func (f *fakeVector) GetSubresourceContent(_ context.Context, _, _, _, uid strin
 		for k, v := range existing {
 			out[k] = v
 		}
-		return out, nil
+		return out, "", nil
 	}
-	return nil, nil
+	return nil, "", nil
 }
 func (f *fakeVector) Exists(_ context.Context, ns, model, res, uid string) (bool, error) {
 	f.mu.Lock()

--- a/pkg/storage/unified/search/embed/backfill/fakes_test.go
+++ b/pkg/storage/unified/search/embed/backfill/fakes_test.go
@@ -224,8 +224,8 @@ func (f *fakeVector) markExists(ns, model, res, uid string) {
 func (f *fakeVector) Search(context.Context, string, string, string, []float32, int, ...vector.SearchFilter) ([]vector.VectorSearchResult, error) {
 	return nil, nil
 }
-func (f *fakeVector) UpsertReplaceSubresources(ctx context.Context, vs []vector.Vector) error {
-	return f.Upsert(ctx, vs)
+func (f *fakeVector) UpsertReplaceSubresources(ctx context.Context, _, _, _, _ string, changed []vector.Vector, _ []string) error {
+	return f.Upsert(ctx, changed)
 }
 func (f *fakeVector) Upsert(_ context.Context, vs []vector.Vector) error {
 	f.mu.Lock()

--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -210,38 +210,34 @@ func (f *fakeVector) Upsert(_ context.Context, vs []vector.Vector) error {
 	return f.upsertLocked(vs)
 }
 
-func (f *fakeVector) UpsertReplaceSubresources(_ context.Context, vs []vector.Vector) error {
+func (f *fakeVector) UpsertReplaceSubresources(_ context.Context, ns, model, res, uid string, changed []vector.Vector, desired []string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	// Atomic stale-removal + upsert: stage the delete-stale step, then
-	// the upsert. Failure on either rolls back via the lock-protected
-	// snapshot.
-	type uidKey struct{ ns, model, res, uid string }
-	groups := map[uidKey]map[string]struct{}{}
-	for _, v := range vs {
-		k := uidKey{v.Namespace, v.Model, v.Resource, v.UID}
-		if groups[k] == nil {
-			groups[k] = map[string]struct{}{}
-		}
-		groups[k][v.Subresource] = struct{}{}
+	// Atomic stale-removal + upsert: delete any stored subresource not in
+	// `desired`, then upsert `changed`. Failure on either rolls back via
+	// the lock-protected snapshot.
+	keep := make(map[string]struct{}, len(desired))
+	for _, s := range desired {
+		keep[s] = struct{}{}
 	}
-	for k, keep := range groups {
-		key := subsKey(k.ns, k.model, k.res, k.uid)
-		stored := f.storedSubs[key]
-		var stale []string
-		for sub := range stored {
-			if _, ok := keep[sub]; !ok {
-				stale = append(stale, sub)
-			}
-		}
-		if len(stale) > 0 {
-			f.delsubs = append(f.delsubs, deleteSubsCall{k.ns, k.model, k.res, k.uid, stale})
-			for _, s := range stale {
-				delete(stored, s)
-			}
+	key := subsKey(ns, model, res, uid)
+	stored := f.storedSubs[key]
+	var stale []string
+	for sub := range stored {
+		if _, ok := keep[sub]; !ok {
+			stale = append(stale, sub)
 		}
 	}
-	return f.upsertLocked(vs)
+	if len(stale) > 0 {
+		f.delsubs = append(f.delsubs, deleteSubsCall{ns, model, res, uid, stale})
+		for _, s := range stale {
+			delete(stored, s)
+		}
+	}
+	if len(changed) == 0 {
+		return nil
+	}
+	return f.upsertLocked(changed)
 }
 
 func (f *fakeVector) upsertLocked(vs []vector.Vector) error {

--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -159,15 +159,15 @@ func (f *fakeStorage) ListModifiedSince(_ context.Context, key resource.Namespac
 type fakeVector struct {
 	mu sync.Mutex
 
-	latestRV    int64
-	upserts     [][]vector.Vector
-	deletes     []deleteCall
-	delsubs     []deleteSubsCall
+	latestRV     int64
+	upserts      [][]vector.Vector
+	deletes      []deleteCall
+	delsubs      []deleteSubsCall
 	storedSubs   map[string]map[string]string // ns|model|res|uid -> sub -> content
 	storedFolder map[string]string            // ns|model|res|uid -> folder
-	upsertErr   error
-	upsertErrFn func(vs []vector.Vector) error // dynamic error decision
-	deleteErr   error
+	upsertErr    error
+	upsertErrFn  func(vs []vector.Vector) error // dynamic error decision
+	deleteErr    error
 
 	lockUnavailable bool
 	lockAttempts    int
@@ -217,9 +217,7 @@ func (f *fakeVector) Upsert(_ context.Context, vs []vector.Vector) error {
 func (f *fakeVector) UpsertReplaceSubresources(_ context.Context, ns, model, res, uid string, changed []vector.Vector, desired []string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	// Atomic stale-removal + upsert: delete any stored subresource not in
-	// `desired`, then upsert `changed`. Failure on either rolls back via
-	// the lock-protected snapshot.
+	// Mirror the real backend: delete subresources not in `desired`, then upsert `changed`.
 	keep := make(map[string]struct{}, len(desired))
 	for _, s := range desired {
 		keep[s] = struct{}{}

--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -163,7 +163,8 @@ type fakeVector struct {
 	upserts     [][]vector.Vector
 	deletes     []deleteCall
 	delsubs     []deleteSubsCall
-	storedSubs  map[string]map[string]string // ns|model|res|uid -> sub -> content
+	storedSubs   map[string]map[string]string // ns|model|res|uid -> sub -> content
+	storedFolder map[string]string            // ns|model|res|uid -> folder
 	upsertErr   error
 	upsertErrFn func(vs []vector.Vector) error // dynamic error decision
 	deleteErr   error
@@ -196,7 +197,10 @@ type deleteSubsCall struct {
 }
 
 func newFakeVector() *fakeVector {
-	return &fakeVector{storedSubs: map[string]map[string]string{}}
+	return &fakeVector{
+		storedSubs:   map[string]map[string]string{},
+		storedFolder: map[string]string{},
+	}
 }
 
 func subsKey(ns, model, res, uid string) string { return ns + "|" + model + "|" + res + "|" + uid }
@@ -256,6 +260,7 @@ func (f *fakeVector) upsertLocked(vs []vector.Vector) error {
 			f.storedSubs[k] = map[string]string{}
 		}
 		f.storedSubs[k][v.Subresource] = v.Content
+		f.storedFolder[k] = v.Folder
 	}
 	return nil
 }
@@ -280,17 +285,18 @@ func (f *fakeVector) DeleteSubresources(_ context.Context, ns, model, res, uid s
 	}
 	return nil
 }
-func (f *fakeVector) GetSubresourceContent(_ context.Context, ns, model, res, uid string) (map[string]string, error) {
+func (f *fakeVector) GetSubresourceContent(_ context.Context, ns, model, res, uid string) (map[string]string, string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	key := subsKey(ns, model, res, uid)
 	out := map[string]string{}
-	for k, v := range f.storedSubs[subsKey(ns, model, res, uid)] {
+	for k, v := range f.storedSubs[key] {
 		out[k] = v
 	}
 	if len(out) == 0 {
-		return nil, nil
+		return nil, "", nil
 	}
-	return out, nil
+	return out, f.storedFolder[key], nil
 }
 func (f *fakeVector) Exists(context.Context, string, string, string, string) (bool, error) {
 	return false, nil

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -710,31 +710,24 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 	}
 
 	// A folder move refreshes the stored folder (search authz) without
-	// changing content, so force a re-embed when it differs. The len
-	// guard skips this for a brand-new resource.
+	// changing content, so force a re-embed when it differs.
 	folderMoved := len(stored) > 0 && storedFolder != items[0].Folder
 
-	// desired = every current subresource (survivor set); toEmbed = the
-	// new or content-changed panels that need an embed call.
 	desired := make([]string, 0, len(items))
-	desiredSet := make(map[string]struct{}, len(items))
 	toEmbed := make([]embed.Item, 0, len(items))
+	matched := 0
 	for _, it := range items {
 		desired = append(desired, it.Subresource)
-		desiredSet[it.Subresource] = struct{}{}
-		if prev, ok := stored[it.Subresource]; folderMoved || !ok || prev != it.Content {
+		prev, ok := stored[it.Subresource]
+		if ok {
+			matched++
+		}
+		if folderMoved || !ok || prev != it.Content {
 			toEmbed = append(toEmbed, it)
 		}
 	}
 
-	// Skip the write entirely when nothing changed and nothing vanished.
-	staleExists := false
-	for sub := range stored {
-		if _, ok := desiredSet[sub]; !ok {
-			staleExists = true
-			break
-		}
-	}
+	staleExists := matched < len(stored)
 	if len(toEmbed) == 0 && !staleExists {
 		return nil
 	}

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -626,9 +626,10 @@ func (s *Reconciler) processEvents(ctx context.Context, sinceRv int64, batch []*
 // pipeline. The status label tracked through the function powers the
 // reconciler_process_duration histogram observed in the deferred closure.
 //
-// TODO: only re-embed subresources whose content actually changed
-// since the last write. Today every dashboard write re-embeds every
-// panel, which is wasteful when only one panel changed.
+// On a write, only subresources whose extracted content differs from
+// what's already stored are re-embedded; unchanged panels are left in
+// place. Panels that disappeared are deleted. See the embed/diff block
+// below.
 func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev *pendingEvent) (retErr error) {
 	ctx, span := tracer.Start(ctx, "unified.reconciler.processEvent")
 	defer span.End()
@@ -684,37 +685,74 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 		statusLabel = "extract_error"
 		return fmt.Errorf("extract: %w", err)
 	}
+	// Cap before the diff so the survivor set, the diff, and the embed
+	// all operate on the same truncated slice; otherwise `desired` would
+	// protect keys that were never stored and stale cleanup would leak.
 	if maxItems := builder.MaxItemsPerResource(); maxItems > 0 && len(items) > maxItems {
 		items = items[:maxItems]
 	}
 
+	model := s.batchEmbedder.Model()
+
 	// An empty extract means the dashboard has no embeddable content;
 	// drop everything stored under this UID rather than leaving orphans.
 	if len(items) == 0 {
-		if err := s.vectorBackend.Delete(ctx, ev.namespace, s.batchEmbedder.Model(), builder.Resource(), ev.name); err != nil {
+		if err := s.vectorBackend.Delete(ctx, ev.namespace, model, builder.Resource(), ev.name); err != nil {
 			statusLabel = "delete_error"
 			return err
 		}
 		return nil
 	}
 
-	vectors, err := s.batchEmbedder.Embed(ctx, ev.namespace, builder.Resource(), ev.rv, items)
+	// All items from one Extract share the dashboard UID; it's the key
+	// the vectors are stored under.
+	uid := items[0].UID
+
+	stored, err := s.vectorBackend.GetSubresourceContent(ctx, ev.namespace, model, builder.Resource(), uid)
 	if err != nil {
-		statusLabel = "embed_error"
-		return fmt.Errorf("embed: %w", err)
+		statusLabel = "get_content_error"
+		return fmt.Errorf("get stored content: %w", err)
 	}
-	if len(vectors) == 0 {
-		if err := s.vectorBackend.Delete(ctx, ev.namespace, s.batchEmbedder.Model(), builder.Resource(), ev.name); err != nil {
-			statusLabel = "delete_error"
-			return err
+
+	// Diff extracted content against what's stored. `desired` is every
+	// current subresource (the survivor set); `toEmbed` is just the new
+	// or content-changed panels — the only ones worth the embed call.
+	desired := make([]string, 0, len(items))
+	desiredSet := make(map[string]struct{}, len(items))
+	toEmbed := make([]embed.Item, 0, len(items))
+	for _, it := range items {
+		desired = append(desired, it.Subresource)
+		desiredSet[it.Subresource] = struct{}{}
+		if prev, ok := stored[it.Subresource]; !ok || prev != it.Content {
+			toEmbed = append(toEmbed, it)
 		}
+	}
+
+	// Skip the write entirely when nothing changed and nothing vanished.
+	staleExists := false
+	for sub := range stored {
+		if _, ok := desiredSet[sub]; !ok {
+			staleExists = true
+			break
+		}
+	}
+	if len(toEmbed) == 0 && !staleExists {
 		return nil
+	}
+
+	var changed []vector.Vector
+	if len(toEmbed) > 0 {
+		changed, err = s.batchEmbedder.Embed(ctx, ev.namespace, builder.Resource(), ev.rv, toEmbed)
+		if err != nil {
+			statusLabel = "embed_error"
+			return fmt.Errorf("embed: %w", err)
+		}
 	}
 
 	// UpsertReplaceSubresources commits the stale-delete and the new
 	// inserts atomically — a failure mid-way leaves the dashboard in
 	// its previous self-consistent state.
-	if err := s.vectorBackend.UpsertReplaceSubresources(ctx, vectors); err != nil {
+	if err := s.vectorBackend.UpsertReplaceSubresources(ctx, ev.namespace, model, builder.Resource(), uid, changed, desired); err != nil {
 		statusLabel = "upsert_error"
 		return fmt.Errorf("upsert: %w", err)
 	}

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -715,20 +715,20 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 
 	desired := make([]string, 0, len(items))
 	toEmbed := make([]embed.Item, 0, len(items))
-	matched := 0
+	matchedExisting := 0
 	for _, it := range items {
 		desired = append(desired, it.Subresource)
 		prev, ok := stored[it.Subresource]
 		if ok {
-			matched++
+			matchedExisting++
 		}
 		if folderMoved || !ok || prev != it.Content {
 			toEmbed = append(toEmbed, it)
 		}
 	}
 
-	staleExists := matched < len(stored)
-	if len(toEmbed) == 0 && !staleExists {
+	hasStale := matchedExisting < len(stored)
+	if len(toEmbed) == 0 && !hasStale {
 		return nil
 	}
 

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -627,7 +627,7 @@ func (s *Reconciler) processEvents(ctx context.Context, sinceRv int64, batch []*
 // reconciler_process_duration histogram observed in the deferred closure.
 //
 // On a write, only panels whose content changed are re-embedded;
-// unchanged panels stay and vanished ones are deleted.
+// unchanged panels stay and stale ones are deleted.
 func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev *pendingEvent) (retErr error) {
 	ctx, span := tracer.Start(ctx, "unified.reconciler.processEvent")
 	defer span.End()
@@ -683,7 +683,6 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 		statusLabel = "extract_error"
 		return fmt.Errorf("extract: %w", err)
 	}
-	// Cap before the diff so desired and the embed set use the same items.
 	if maxItems := builder.MaxItemsPerResource(); maxItems > 0 && len(items) > maxItems {
 		items = items[:maxItems]
 	}
@@ -700,7 +699,6 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 		return nil
 	}
 
-	// All items from one Extract share the dashboard UID.
 	uid := items[0].UID
 
 	stored, storedFolder, err := s.vectorBackend.GetSubresourceContent(ctx, ev.namespace, model, builder.Resource(), uid)

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -715,19 +715,19 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 
 	desired := make([]string, 0, len(items))
 	toEmbed := make([]embed.Item, 0, len(items))
-	matchedExisting := 0
+	present := make(map[string]struct{}, len(items))
 	for _, it := range items {
 		desired = append(desired, it.Subresource)
 		prev, ok := stored[it.Subresource]
 		if ok {
-			matchedExisting++
+			present[it.Subresource] = struct{}{}
 		}
 		if folderMoved || !ok || prev != it.Content {
 			toEmbed = append(toEmbed, it)
 		}
 	}
 
-	hasStale := matchedExisting < len(stored)
+	hasStale := len(present) < len(stored)
 	if len(toEmbed) == 0 && !hasStale {
 		return nil
 	}

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -727,8 +727,23 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 		}
 	}
 
-	hasStale := len(present) < len(stored)
-	if len(toEmbed) == 0 && !hasStale {
+	extracted, embedded, deleted := len(desired), len(toEmbed), len(stored)-len(present)
+	span.SetAttributes(
+		attribute.Int("subresources.extracted", extracted),
+		attribute.Int("subresources.embedded", embedded),
+		attribute.Int("subresources.deleted", deleted),
+	)
+	recordCounts := func() {
+		if s.metrics == nil {
+			return
+		}
+		s.metrics.ReconcilerSubresourcesExtractedTotal.WithLabelValues(ev.group, ev.resource).Add(float64(extracted))
+		s.metrics.ReconcilerSubresourcesEmbeddedTotal.WithLabelValues(ev.group, ev.resource).Add(float64(embedded))
+		s.metrics.ReconcilerSubresourcesDeletedTotal.WithLabelValues(ev.group, ev.resource).Add(float64(deleted))
+	}
+
+	if embedded == 0 && deleted == 0 {
+		recordCounts()
 		return nil
 	}
 
@@ -748,6 +763,7 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 		statusLabel = "upsert_error"
 		return fmt.Errorf("upsert: %w", err)
 	}
+	recordCounts()
 	return nil
 }
 

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -626,10 +626,8 @@ func (s *Reconciler) processEvents(ctx context.Context, sinceRv int64, batch []*
 // pipeline. The status label tracked through the function powers the
 // reconciler_process_duration histogram observed in the deferred closure.
 //
-// On a write, only subresources whose extracted content differs from
-// what's already stored are re-embedded; unchanged panels are left in
-// place. Panels that disappeared are deleted. See the embed/diff block
-// below.
+// On a write, only panels whose content changed are re-embedded;
+// unchanged panels stay and vanished ones are deleted.
 func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev *pendingEvent) (retErr error) {
 	ctx, span := tracer.Start(ctx, "unified.reconciler.processEvent")
 	defer span.End()
@@ -685,9 +683,7 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 		statusLabel = "extract_error"
 		return fmt.Errorf("extract: %w", err)
 	}
-	// Cap before the diff so the survivor set, the diff, and the embed
-	// all operate on the same truncated slice; otherwise `desired` would
-	// protect keys that were never stored and stale cleanup would leak.
+	// Cap before the diff so desired and the embed set use the same items.
 	if maxItems := builder.MaxItemsPerResource(); maxItems > 0 && len(items) > maxItems {
 		items = items[:maxItems]
 	}
@@ -704,8 +700,7 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 		return nil
 	}
 
-	// All items from one Extract share the dashboard UID; it's the key
-	// the vectors are stored under.
+	// All items from one Extract share the dashboard UID.
 	uid := items[0].UID
 
 	stored, storedFolder, err := s.vectorBackend.GetSubresourceContent(ctx, ev.namespace, model, builder.Resource(), uid)
@@ -714,16 +709,13 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 		return fmt.Errorf("get stored content: %w", err)
 	}
 
-	// A folder move changes the stored `folder` (used for search authz)
-	// but not the embedded content, so it wouldn't trip the content diff.
-	// Detect it here and force a full re-embed. Folder is dashboard-wide,
-	// so items[0] is representative; the len(stored) guard distinguishes
-	// "no rows yet" from "rows stored under a different folder".
+	// A folder move refreshes the stored folder (search authz) without
+	// changing content, so force a re-embed when it differs. The len
+	// guard skips this for a brand-new resource.
 	folderMoved := len(stored) > 0 && storedFolder != items[0].Folder
 
-	// Diff extracted content against what's stored. `desired` is every
-	// current subresource (the survivor set); `toEmbed` is just the new
-	// or content-changed panels — the only ones worth the embed call.
+	// desired = every current subresource (survivor set); toEmbed = the
+	// new or content-changed panels that need an embed call.
 	desired := make([]string, 0, len(items))
 	desiredSet := make(map[string]struct{}, len(items))
 	toEmbed := make([]embed.Item, 0, len(items))

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -708,11 +708,18 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 	// the vectors are stored under.
 	uid := items[0].UID
 
-	stored, err := s.vectorBackend.GetSubresourceContent(ctx, ev.namespace, model, builder.Resource(), uid)
+	stored, storedFolder, err := s.vectorBackend.GetSubresourceContent(ctx, ev.namespace, model, builder.Resource(), uid)
 	if err != nil {
 		statusLabel = "get_content_error"
 		return fmt.Errorf("get stored content: %w", err)
 	}
+
+	// A folder move changes the stored `folder` (used for search authz)
+	// but not the embedded content, so it wouldn't trip the content diff.
+	// Detect it here and force a full re-embed. Folder is dashboard-wide,
+	// so items[0] is representative; the len(stored) guard distinguishes
+	// "no rows yet" from "rows stored under a different folder".
+	folderMoved := len(stored) > 0 && storedFolder != items[0].Folder
 
 	// Diff extracted content against what's stored. `desired` is every
 	// current subresource (the survivor set); `toEmbed` is just the new
@@ -723,7 +730,7 @@ func (s *Reconciler) processEvent(ctx context.Context, builder embed.Builder, ev
 	for _, it := range items {
 		desired = append(desired, it.Subresource)
 		desiredSet[it.Subresource] = struct{}{}
-		if prev, ok := stored[it.Subresource]; !ok || prev != it.Content {
+		if prev, ok := stored[it.Subresource]; folderMoved || !ok || prev != it.Content {
 			toEmbed = append(toEmbed, it)
 		}
 	}

--- a/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
@@ -250,9 +250,7 @@ func TestReconciler_StaleSubresources_AreDeletedBeforeUpsert(t *testing.T) {
 	require.Len(t, vec.upserts, 1)
 }
 
-// threePanelDashboard builds a dashboard whose three panels have distinct
-// content, so changing one panel's title changes only that panel's
-// extracted content.
+// threePanelDashboard builds a 3-panel dashboard with distinct per-panel content.
 func threePanelDashboard(panel2Title string) []byte {
 	body, _ := json.Marshal(map[string]any{
 		"uid": "dash-1", "title": "Dash",
@@ -265,9 +263,7 @@ func threePanelDashboard(panel2Title string) []byte {
 	return body
 }
 
-// TestReconciler_PartialReembed_OnlyChangedPanel verifies the content
-// diff: re-processing a dashboard with a single panel changed re-embeds
-// only that panel and leaves the rest in place.
+// Re-processing with one panel changed re-embeds only that panel.
 func TestReconciler_PartialReembed_OnlyChangedPanel(t *testing.T) {
 	vec := newFakeVector()
 	s, text := newReconciler(t, &fakeStorage{}, vec)
@@ -291,9 +287,7 @@ func TestReconciler_PartialReembed_OnlyChangedPanel(t *testing.T) {
 	assert.Equal(t, int64(200), vec.latestRV)
 }
 
-// TestReconciler_PartialReembed_NoChangeSkipsWrite verifies that
-// re-processing identical content embeds nothing and writes nothing,
-// while still advancing the checkpoint.
+// Re-processing identical content writes nothing but still advances the checkpoint.
 func TestReconciler_PartialReembed_NoChangeSkipsWrite(t *testing.T) {
 	vec := newFakeVector()
 	s, text := newReconciler(t, &fakeStorage{}, vec)
@@ -313,8 +307,7 @@ func TestReconciler_PartialReembed_NoChangeSkipsWrite(t *testing.T) {
 	assert.Equal(t, int64(200), vec.latestRV, "cursor still advances on a no-op write")
 }
 
-// dashboardInFolder builds a single-panel dashboard whose folder UID comes
-// from the grafana.app/folder annotation. Used to drive folder-move events.
+// dashboardInFolder sets the folder UID via the grafana.app/folder annotation.
 func dashboardInFolder(uid, title, folderUID string) []byte {
 	body, _ := json.Marshal(map[string]any{
 		"uid": uid, "title": title,
@@ -328,10 +321,8 @@ func dashboardInFolder(uid, title, folderUID string) []byte {
 	return body
 }
 
-// TestReconciler_PartialReembed_FolderMoveReembeds guards the search-authz
-// correctness case: a folder move changes the stored folder but not the
-// embedded content, so the content diff alone would skip the write and
-// leave a stale folder. The folder check must force a re-embed.
+// A folder move doesn't change content but must refresh the authz
+// folder, so it forces a re-embed.
 func TestReconciler_PartialReembed_FolderMoveReembeds(t *testing.T) {
 	vec := newFakeVector()
 	s, text := newReconciler(t, &fakeStorage{}, vec)
@@ -342,8 +333,7 @@ func TestReconciler_PartialReembed_FolderMoveReembeds(t *testing.T) {
 	require.Equal(t, "folder-a", vec.upserts[0][0].Folder)
 	require.Equal(t, 1, text.calls)
 
-	// Move to folder-b: panel content is byte-identical, only the folder
-	// annotation changed.
+	// Move to folder-b; panel content is identical.
 	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "dash-1", 200, dashboardInFolder("dash-1", "Dash", "folder-b")))
 	s.processPending(context.Background())
 

--- a/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
@@ -250,6 +250,69 @@ func TestReconciler_StaleSubresources_AreDeletedBeforeUpsert(t *testing.T) {
 	require.Len(t, vec.upserts, 1)
 }
 
+// threePanelDashboard builds a dashboard whose three panels have distinct
+// content, so changing one panel's title changes only that panel's
+// extracted content.
+func threePanelDashboard(panel2Title string) []byte {
+	body, _ := json.Marshal(map[string]any{
+		"uid": "dash-1", "title": "Dash",
+		"panels": []any{
+			map[string]any{"id": 1, "title": "CPU", "description": "cpu"},
+			map[string]any{"id": 2, "title": panel2Title, "description": "mem"},
+			map[string]any{"id": 3, "title": "Disk", "description": "disk"},
+		},
+	})
+	return body
+}
+
+// TestReconciler_PartialReembed_OnlyChangedPanel verifies the content
+// diff: re-processing a dashboard with a single panel changed re-embeds
+// only that panel and leaves the rest in place.
+func TestReconciler_PartialReembed_OnlyChangedPanel(t *testing.T) {
+	vec := newFakeVector()
+	s, text := newReconciler(t, &fakeStorage{}, vec)
+
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", 100, threePanelDashboard("Mem")))
+	s.processPending(context.Background())
+	require.Len(t, vec.upserts, 1)
+	require.Len(t, vec.upserts[0], 3, "first write embeds all three panels")
+	require.Equal(t, 1, text.calls)
+
+	// Only panel/2's title changes.
+	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "dash-1", 200, threePanelDashboard("Memory")))
+	s.processPending(context.Background())
+
+	require.Len(t, vec.upserts, 2, "second write happened")
+	require.Len(t, vec.upserts[1], 1, "only the changed panel is re-embedded")
+	assert.Equal(t, "panel/2", vec.upserts[1][0].Subresource)
+	assert.Equal(t, 2, text.calls)
+	assert.Equal(t, []int{1}, text.textSets[1], "embedder called with exactly one text")
+	assert.Empty(t, vec.delsubs, "nothing deleted; every panel is still desired")
+	assert.Equal(t, int64(200), vec.latestRV)
+}
+
+// TestReconciler_PartialReembed_NoChangeSkipsWrite verifies that
+// re-processing identical content embeds nothing and writes nothing,
+// while still advancing the checkpoint.
+func TestReconciler_PartialReembed_NoChangeSkipsWrite(t *testing.T) {
+	vec := newFakeVector()
+	s, text := newReconciler(t, &fakeStorage{}, vec)
+
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", 100, minimalDashboard("dash-1", "Dash 1")))
+	s.processPending(context.Background())
+	require.Len(t, vec.upserts, 1)
+	require.Equal(t, 1, text.calls)
+
+	// Re-process byte-identical content at a higher RV.
+	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "dash-1", 200, minimalDashboard("dash-1", "Dash 1")))
+	s.processPending(context.Background())
+
+	require.Len(t, vec.upserts, 1, "no re-embed when content is unchanged")
+	assert.Equal(t, 1, text.calls, "embedder not called again")
+	assert.Empty(t, vec.delsubs, "nothing deleted")
+	assert.Equal(t, int64(200), vec.latestRV, "cursor still advances on a no-op write")
+}
+
 func TestReconciler_MonotonicCheckpoint(t *testing.T) {
 	vec := newFakeVector()
 	s, text := newReconciler(t, &fakeStorage{}, vec)

--- a/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
@@ -313,6 +313,45 @@ func TestReconciler_PartialReembed_NoChangeSkipsWrite(t *testing.T) {
 	assert.Equal(t, int64(200), vec.latestRV, "cursor still advances on a no-op write")
 }
 
+// dashboardInFolder builds a single-panel dashboard whose folder UID comes
+// from the grafana.app/folder annotation. Used to drive folder-move events.
+func dashboardInFolder(uid, title, folderUID string) []byte {
+	body, _ := json.Marshal(map[string]any{
+		"uid": uid, "title": title,
+		"metadata": map[string]any{
+			"annotations": map[string]any{"grafana.app/folder": folderUID},
+		},
+		"panels": []any{
+			map[string]any{"id": 1, "title": "CPU", "description": "CPU usage"},
+		},
+	})
+	return body
+}
+
+// TestReconciler_PartialReembed_FolderMoveReembeds guards the search-authz
+// correctness case: a folder move changes the stored folder but not the
+// embedded content, so the content diff alone would skip the write and
+// leave a stale folder. The folder check must force a re-embed.
+func TestReconciler_PartialReembed_FolderMoveReembeds(t *testing.T) {
+	vec := newFakeVector()
+	s, text := newReconciler(t, &fakeStorage{}, vec)
+
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", 100, dashboardInFolder("dash-1", "Dash", "folder-a")))
+	s.processPending(context.Background())
+	require.Len(t, vec.upserts, 1)
+	require.Equal(t, "folder-a", vec.upserts[0][0].Folder)
+	require.Equal(t, 1, text.calls)
+
+	// Move to folder-b: panel content is byte-identical, only the folder
+	// annotation changed.
+	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "dash-1", 200, dashboardInFolder("dash-1", "Dash", "folder-b")))
+	s.processPending(context.Background())
+
+	require.Len(t, vec.upserts, 2, "folder move re-embeds despite unchanged content")
+	assert.Equal(t, "folder-b", vec.upserts[1][0].Folder, "stored folder refreshed to the new folder")
+	assert.Equal(t, 2, text.calls)
+}
+
 func TestReconciler_MonotonicCheckpoint(t *testing.T) {
 	vec := newFakeVector()
 	s, text := newReconciler(t, &fakeStorage{}, vec)

--- a/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
@@ -342,6 +342,64 @@ func TestReconciler_PartialReembed_FolderMoveReembeds(t *testing.T) {
 	assert.Equal(t, 2, text.calls)
 }
 
+// A panel removed with no other change must delete the stale row without
+// embedding anything (empty changed, non-empty desired).
+func TestReconciler_PartialReembed_DeleteOnly(t *testing.T) {
+	vec := newFakeVector()
+	s, text := newReconciler(t, &fakeStorage{}, vec)
+
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", 100, threePanelDashboard("Mem")))
+	s.processPending(context.Background())
+	require.Len(t, vec.upserts[0], 3)
+	require.Equal(t, 1, text.calls)
+
+	// Drop panel/3 (Disk); panels 1 and 2 are byte-identical.
+	twoPanel, _ := json.Marshal(map[string]any{
+		"uid": "dash-1", "title": "Dash",
+		"panels": []any{
+			map[string]any{"id": 1, "title": "CPU", "description": "cpu"},
+			map[string]any{"id": 2, "title": "Mem", "description": "mem"},
+		},
+	})
+	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "dash-1", 200, twoPanel))
+	s.processPending(context.Background())
+
+	assert.Equal(t, 1, text.calls, "no embed; surviving panels unchanged")
+	require.Len(t, vec.delsubs, 1, "the removed panel is deleted")
+	assert.ElementsMatch(t, []string{"panel/3"}, vec.delsubs[0].Subresources)
+	assert.Equal(t, int64(200), vec.latestRV)
+}
+
+// Two panels can map to the same subresource (explicit id N and an
+// id-less panel at positional index N both yield panel/N). A stale row
+// must still be detected and deleted — a per-item match count would
+// double-count the collision and wrongly skip the cleanup.
+func TestReconciler_PartialReembed_SubresourceCollision_DeletesStale(t *testing.T) {
+	vec := newFakeVector()
+	s, text := newReconciler(t, &fakeStorage{}, vec)
+
+	collide, _ := json.Marshal(map[string]any{
+		"uid": "dash-1", "title": "Dash",
+		"panels": []any{
+			map[string]any{"id": 1, "title": "X", "description": "d"}, // panel/1
+			map[string]any{"title": "X", "description": "d"},          // no id, idx 1 → panel/1
+		},
+	})
+
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", 100, collide))
+	s.processPending(context.Background())
+	require.Equal(t, 1, text.calls)
+
+	// A stale subresource that no longer exists in the dashboard.
+	vec.storedSubs[subsKey("ns", testModel, dashRes, "dash-1")]["panel/9"] = "stale"
+
+	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "dash-1", 200, collide))
+	s.processPending(context.Background())
+
+	require.Len(t, vec.delsubs, 1, "stale row deleted despite the subresource collision")
+	assert.ElementsMatch(t, []string{"panel/9"}, vec.delsubs[0].Subresources)
+}
+
 func TestReconciler_MonotonicCheckpoint(t *testing.T) {
 	vec := newFakeVector()
 	s, text := newReconciler(t, &fakeStorage{}, vec)

--- a/pkg/storage/unified/search/vector/data/vector_collection_get_content.sql
+++ b/pkg/storage/unified/search/vector/data/vector_collection_get_content.sql
@@ -1,6 +1,7 @@
 SELECT
     {{ .Ident "subresource" | .Into .Response.Subresource }},
-    {{ .Ident "content" | .Into .Response.Content }}
+    {{ .Ident "content" | .Into .Response.Content }},
+    {{ .Ident "folder" | .Into .Response.Folder }}
     FROM embeddings
     WHERE {{ .Ident "resource" }}  = {{ .Arg .Resource }}
     AND {{ .Ident "namespace" }} = {{ .Arg .Namespace }}

--- a/pkg/storage/unified/search/vector/integration_test.go
+++ b/pkg/storage/unified/search/vector/integration_test.go
@@ -243,11 +243,8 @@ func TestIntegrationVectorUpsertReplaceSubresources(t *testing.T) {
 	require.NoError(t, backend.Delete(ctx, "integration-test", testModel, testResource, "dash-b"))
 }
 
-// TestIntegrationVectorUpsertReplaceSubresources_PartialUpdate exercises
-// the changed ⊊ desired case the reconciler relies on: only panels whose
-// content changed are rewritten, unchanged panels listed in `desired` are
-// left in place (not re-upserted), and a new panel is inserted. Nothing is
-// deleted because every stored panel is still desired.
+// changed ⊊ desired: only `changed` rows are rewritten, panels in
+// `desired` but not `changed` are kept, and nothing is deleted.
 func TestIntegrationVectorUpsertReplaceSubresources_PartialUpdate(t *testing.T) {
 	backend, _, ctx := setupIntegrationTest(t)
 
@@ -285,9 +282,7 @@ func TestIntegrationVectorUpsertReplaceSubresources_PartialUpdate(t *testing.T) 
 	require.NoError(t, backend.Delete(ctx, "integration-test", testModel, testResource, "dash"))
 }
 
-// TestIntegrationVectorUpsertReplaceSubresources_DeleteOnlyNoChange covers
-// the empty-changed path: a panel was removed but no surviving panel's
-// content changed, so there's nothing to embed — only a stale delete.
+// Empty `changed`: a panel is dropped from `desired` and deleted, with nothing to upsert.
 func TestIntegrationVectorUpsertReplaceSubresources_DeleteOnlyNoChange(t *testing.T) {
 	backend, _, ctx := setupIntegrationTest(t)
 

--- a/pkg/storage/unified/search/vector/integration_test.go
+++ b/pkg/storage/unified/search/vector/integration_test.go
@@ -163,7 +163,7 @@ func TestIntegrationVectorDeleteSubresources(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	stored, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
+	stored, _, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
 	require.NoError(t, err)
 	require.Len(t, stored, 3)
 
@@ -199,7 +199,7 @@ func TestIntegrationVectorUpsertReplaceSubresources(t *testing.T) {
 	mk := func(uid, sub, content string) Vector {
 		return Vector{
 			Namespace: "integration-test", Resource: testResource, UID: uid, Title: uid,
-			Subresource: sub, ResourceVersion: 10, Content: content,
+			Subresource: sub, ResourceVersion: 10, Content: content, Folder: "folder-a",
 			Metadata: json.RawMessage(`{}`), Embedding: makeEmbedding(0.5, 0.5), Model: testModel,
 		}
 	}
@@ -223,15 +223,16 @@ func TestIntegrationVectorUpsertReplaceSubresources(t *testing.T) {
 	}, []string{"panel/1", "panel/4"})
 	require.NoError(t, err)
 
-	stored, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash-a")
+	stored, folder, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash-a")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"panel/1": "a-1 updated",
 		"panel/4": "a-4 new",
 	}, stored, "stale subresources removed; new set is the exact replacement")
+	assert.Equal(t, "folder-a", folder, "stored folder is returned alongside content")
 
 	// dash-b must be untouched.
-	storedB, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash-b")
+	storedB, _, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash-b")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"panel/1": "b-1",
@@ -272,7 +273,7 @@ func TestIntegrationVectorUpsertReplaceSubresources_PartialUpdate(t *testing.T) 
 		[]string{"panel/1", "panel/2", "panel/3", "panel/9"},
 	))
 
-	stored, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
+	stored, _, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"panel/1": "p1",    // untouched (kept via desired, not in changed)
@@ -307,7 +308,7 @@ func TestIntegrationVectorUpsertReplaceSubresources_DeleteOnlyNoChange(t *testin
 	require.NoError(t, backend.UpsertReplaceSubresources(ctx, "integration-test", testModel, testResource, "dash",
 		nil, []string{"panel/1"}))
 
-	stored, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
+	stored, _, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"panel/1": "p1"}, stored)
 
@@ -327,7 +328,7 @@ func TestIntegrationVectorUpsertReplaceSubresources_EmptyInput(t *testing.T) {
 
 	require.NoError(t, backend.UpsertReplaceSubresources(ctx, "integration-test", testModel, testResource, "dash", nil, nil))
 
-	stored, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
+	stored, _, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"panel/1": "untouched"}, stored)
 
@@ -365,7 +366,7 @@ func TestIntegrationVectorUpsertReplaceSubresources_AtomicOnValidationError(t *t
 	require.Error(t, err)
 
 	// State is unchanged: panel/1 still has v1 content, panel/2 still present.
-	stored, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
+	stored, _, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"panel/1": "v1", "panel/2": "v1"}, stored,
 		"failed batch leaves no half-applied state")

--- a/pkg/storage/unified/search/vector/integration_test.go
+++ b/pkg/storage/unified/search/vector/integration_test.go
@@ -216,10 +216,11 @@ func TestIntegrationVectorUpsertReplaceSubresources(t *testing.T) {
 
 	// Replace dash-a with just panel/1 (rewritten) and panel/4 (new).
 	// panel/2 and panel/3 must be deleted in the same transaction.
-	err := backend.UpsertReplaceSubresources(ctx, []Vector{
+	// desired = the full surviving set; changed = the rows to write.
+	err := backend.UpsertReplaceSubresources(ctx, "integration-test", testModel, testResource, "dash-a", []Vector{
 		mk("dash-a", "panel/1", "a-1 updated"),
 		mk("dash-a", "panel/4", "a-4 new"),
-	})
+	}, []string{"panel/1", "panel/4"})
 	require.NoError(t, err)
 
 	stored, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash-a")
@@ -241,10 +242,12 @@ func TestIntegrationVectorUpsertReplaceSubresources(t *testing.T) {
 	require.NoError(t, backend.Delete(ctx, "integration-test", testModel, testResource, "dash-b"))
 }
 
-// TestIntegrationVectorUpsertReplaceSubresources_MultiUID verifies
-// that a single call covering multiple UIDs replaces each UID's set
-// independently in one transaction.
-func TestIntegrationVectorUpsertReplaceSubresources_MultiUID(t *testing.T) {
+// TestIntegrationVectorUpsertReplaceSubresources_PartialUpdate exercises
+// the changed ⊊ desired case the reconciler relies on: only panels whose
+// content changed are rewritten, unchanged panels listed in `desired` are
+// left in place (not re-upserted), and a new panel is inserted. Nothing is
+// deleted because every stored panel is still desired.
+func TestIntegrationVectorUpsertReplaceSubresources_PartialUpdate(t *testing.T) {
 	backend, _, ctx := setupIntegrationTest(t)
 
 	mk := func(uid, sub, content string) Vector {
@@ -256,27 +259,59 @@ func TestIntegrationVectorUpsertReplaceSubresources_MultiUID(t *testing.T) {
 	}
 
 	require.NoError(t, backend.Upsert(ctx, []Vector{
-		mk("dash-a", "panel/1", "a-1"),
-		mk("dash-a", "panel/2", "a-2"),
-		mk("dash-b", "panel/1", "b-1"),
-		mk("dash-b", "panel/2", "b-2"),
+		mk("dash", "panel/1", "p1"),
+		mk("dash", "panel/2", "p2"),
+		mk("dash", "panel/3", "p3"),
 	}))
 
-	require.NoError(t, backend.UpsertReplaceSubresources(ctx, []Vector{
-		mk("dash-a", "panel/1", "a-1 v2"),
-		mk("dash-b", "panel/3", "b-3"),
+	require.NoError(t, backend.UpsertReplaceSubresources(ctx, "integration-test", testModel, testResource, "dash",
+		[]Vector{
+			mk("dash", "panel/2", "p2 v2"), // changed
+			mk("dash", "panel/9", "p9"),    // new
+		},
+		[]string{"panel/1", "panel/2", "panel/3", "panel/9"},
+	))
+
+	stored, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"panel/1": "p1",    // untouched (kept via desired, not in changed)
+		"panel/2": "p2 v2", // rewritten
+		"panel/3": "p3",    // untouched
+		"panel/9": "p9",    // new
+	}, stored)
+
+	require.NoError(t, backend.Delete(ctx, "integration-test", testModel, testResource, "dash"))
+}
+
+// TestIntegrationVectorUpsertReplaceSubresources_DeleteOnlyNoChange covers
+// the empty-changed path: a panel was removed but no surviving panel's
+// content changed, so there's nothing to embed — only a stale delete.
+func TestIntegrationVectorUpsertReplaceSubresources_DeleteOnlyNoChange(t *testing.T) {
+	backend, _, ctx := setupIntegrationTest(t)
+
+	mk := func(uid, sub, content string) Vector {
+		return Vector{
+			Namespace: "integration-test", Resource: testResource, UID: uid, Title: uid,
+			Subresource: sub, ResourceVersion: 1, Content: content,
+			Metadata: json.RawMessage(`{}`), Embedding: makeEmbedding(0.5, 0.5), Model: testModel,
+		}
+	}
+
+	require.NoError(t, backend.Upsert(ctx, []Vector{
+		mk("dash", "panel/1", "p1"),
+		mk("dash", "panel/2", "p2"),
 	}))
 
-	storedA, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash-a")
-	require.NoError(t, err)
-	assert.Equal(t, map[string]string{"panel/1": "a-1 v2"}, storedA)
+	// No changed vectors; desired drops panel/2.
+	require.NoError(t, backend.UpsertReplaceSubresources(ctx, "integration-test", testModel, testResource, "dash",
+		nil, []string{"panel/1"}))
 
-	storedB, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash-b")
+	stored, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{"panel/3": "b-3"}, storedB)
+	assert.Equal(t, map[string]string{"panel/1": "p1"}, stored)
 
-	require.NoError(t, backend.Delete(ctx, "integration-test", testModel, testResource, "dash-a"))
-	require.NoError(t, backend.Delete(ctx, "integration-test", testModel, testResource, "dash-b"))
+	require.NoError(t, backend.Delete(ctx, "integration-test", testModel, testResource, "dash"))
 }
 
 // TestIntegrationVectorUpsertReplaceSubresources_EmptyInput is the
@@ -290,7 +325,7 @@ func TestIntegrationVectorUpsertReplaceSubresources_EmptyInput(t *testing.T) {
 		Metadata: json.RawMessage(`{}`), Embedding: makeEmbedding(0.5, 0.5), Model: testModel,
 	}}))
 
-	require.NoError(t, backend.UpsertReplaceSubresources(ctx, nil))
+	require.NoError(t, backend.UpsertReplaceSubresources(ctx, "integration-test", testModel, testResource, "dash", nil, nil))
 
 	stored, err := backend.GetSubresourceContent(ctx, "integration-test", testModel, testResource, "dash")
 	require.NoError(t, err)
@@ -323,10 +358,10 @@ func TestIntegrationVectorUpsertReplaceSubresources_AtomicOnValidationError(t *t
 	// Second vector has empty Title — Validate() rejects it.
 	bad := mk("dash", "panel/2", "v2-bad")
 	bad.Title = ""
-	err := backend.UpsertReplaceSubresources(ctx, []Vector{
+	err := backend.UpsertReplaceSubresources(ctx, "integration-test", testModel, testResource, "dash", []Vector{
 		mk("dash", "panel/1", "v2"),
 		bad,
-	})
+	}, []string{"panel/1", "panel/2"})
 	require.Error(t, err)
 
 	// State is unchanged: panel/1 still has v1 content, panel/2 still present.

--- a/pkg/storage/unified/search/vector/pgvector.go
+++ b/pkg/storage/unified/search/vector/pgvector.go
@@ -282,9 +282,9 @@ func (b *pgvectorBackend) DeleteSubresources(ctx context.Context, namespace, mod
 	return err
 }
 
-func (b *pgvectorBackend) GetSubresourceContent(ctx context.Context, namespace, model, resource, uid string) (map[string]string, error) {
+func (b *pgvectorBackend) GetSubresourceContent(ctx context.Context, namespace, model, resource, uid string) (map[string]string, string, error) {
 	if err := validateResource(resource); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	req := &sqlVectorCollectionGetContentRequest{
 		SQLTemplate: sqltemplate.New(b.dialect),
@@ -296,16 +296,18 @@ func (b *pgvectorBackend) GetSubresourceContent(ctx context.Context, namespace, 
 	}
 	rows, err := dbutil.Query(ctx, b.db, sqlVectorCollectionGetContent, req)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if len(rows) == 0 {
-		return nil, nil
+		return nil, "", nil
 	}
 	out := make(map[string]string, len(rows))
 	for _, r := range rows {
 		out[r.Subresource] = r.Content
 	}
-	return out, nil
+	// Folder is written identically on every subresource of a resource,
+	// so any row is representative.
+	return out, rows[0].Folder, nil
 }
 
 func (b *pgvectorBackend) Exists(ctx context.Context, namespace, model, resource, uid string) (bool, error) {

--- a/pkg/storage/unified/search/vector/pgvector.go
+++ b/pkg/storage/unified/search/vector/pgvector.go
@@ -121,9 +121,18 @@ func (b *pgvectorBackend) Upsert(ctx context.Context, vectors []Vector) (retErr 
 	})
 }
 
-func (b *pgvectorBackend) UpsertReplaceSubresources(ctx context.Context, vectors []Vector) (retErr error) {
-	if len(vectors) == 0 {
+func (b *pgvectorBackend) UpsertReplaceSubresources(ctx context.Context, namespace, model, resource, uid string, changed []Vector, desired []string) (retErr error) {
+	// Both empty is a no-op: nothing to write and no survivor set means
+	// "leave the resource alone" rather than "delete everything" (the
+	// reconciler uses Delete for an intentional full wipe).
+	if len(changed) == 0 && len(desired) == 0 {
 		return nil
+	}
+	if model == "" {
+		return fmt.Errorf("model must not be empty")
+	}
+	if err := validateResource(resource); err != nil {
+		return err
 	}
 
 	ctx, span := tracer.Start(ctx, "unified.vector.pgvector.UpsertReplaceSubresources")
@@ -135,58 +144,55 @@ func (b *pgvectorBackend) UpsertReplaceSubresources(ctx context.Context, vectors
 		span.End()
 	}()
 	span.SetAttributes(
-		attribute.Int("vector_count", len(vectors)),
-		attribute.String("resource", vectors[0].Resource),
-		attribute.String("namespace", vectors[0].Namespace),
+		attribute.Int("changed_count", len(changed)),
+		attribute.Int("desired_count", len(desired)),
+		attribute.String("resource", resource),
+		attribute.String("namespace", namespace),
 	)
 
-	for i := range vectors {
-		if err := vectors[i].Validate(); err != nil {
+	for i := range changed {
+		if err := changed[i].Validate(); err != nil {
 			return fmt.Errorf("vector[%d]: %w", i, err)
+		}
+		if changed[i].Namespace != namespace || changed[i].Model != model ||
+			changed[i].Resource != resource || changed[i].UID != uid {
+			return fmt.Errorf("vector[%d] does not belong to %s/%s/%s/%s", i, namespace, model, resource, uid)
 		}
 	}
 
-	type uidKey struct{ resource, namespace, model, uid string }
-	groups := map[uidKey][]string{}
-	for _, v := range vectors {
-		k := uidKey{v.Resource, v.Namespace, v.Model, v.UID}
-		groups[k] = append(groups[k], v.Subresource)
+	keep := make(map[string]struct{}, len(desired))
+	for _, s := range desired {
+		keep[s] = struct{}{}
 	}
 
 	return b.db.WithTx(ctx, nil, func(ctx context.Context, tx db.Tx) error {
-		for k, kept := range groups {
-			if err := validateResource(k.resource); err != nil {
-				return err
-			}
-			stored, err := b.subresourceKeysTx(ctx, tx, k.namespace, k.model, k.resource, k.uid)
-			if err != nil {
-				return fmt.Errorf("read subresources %s/%s: %w", k.namespace, k.uid, err)
-			}
-			keep := make(map[string]struct{}, len(kept))
-			for _, s := range kept {
-				keep[s] = struct{}{}
-			}
-			var stale []string
-			for _, s := range stored {
-				if _, ok := keep[s]; !ok {
-					stale = append(stale, s)
-				}
-			}
-			if len(stale) > 0 {
-				req := &sqlVectorCollectionDeleteSubresourcesRequest{
-					SQLTemplate:  sqltemplate.New(b.dialect),
-					Resource:     k.resource,
-					Namespace:    k.namespace,
-					Model:        k.model,
-					UID:          k.uid,
-					Subresources: stale,
-				}
-				if _, err := dbutil.Exec(ctx, tx, sqlVectorCollectionDeleteSubresource, req); err != nil {
-					return fmt.Errorf("delete stale subresources %s/%s: %w", k.namespace, k.uid, err)
-				}
+		stored, err := b.subresourceKeysTx(ctx, tx, namespace, model, resource, uid)
+		if err != nil {
+			return fmt.Errorf("read subresources %s/%s: %w", namespace, uid, err)
+		}
+		var stale []string
+		for _, s := range stored {
+			if _, ok := keep[s]; !ok {
+				stale = append(stale, s)
 			}
 		}
-		return b.upsertAll(ctx, tx, vectors)
+		if len(stale) > 0 {
+			req := &sqlVectorCollectionDeleteSubresourcesRequest{
+				SQLTemplate:  sqltemplate.New(b.dialect),
+				Resource:     resource,
+				Namespace:    namespace,
+				Model:        model,
+				UID:          uid,
+				Subresources: stale,
+			}
+			if _, err := dbutil.Exec(ctx, tx, sqlVectorCollectionDeleteSubresource, req); err != nil {
+				return fmt.Errorf("delete stale subresources %s/%s: %w", namespace, uid, err)
+			}
+		}
+		if len(changed) == 0 {
+			return nil
+		}
+		return b.upsertAll(ctx, tx, changed)
 	})
 }
 

--- a/pkg/storage/unified/search/vector/pgvector.go
+++ b/pkg/storage/unified/search/vector/pgvector.go
@@ -122,9 +122,8 @@ func (b *pgvectorBackend) Upsert(ctx context.Context, vectors []Vector) (retErr 
 }
 
 func (b *pgvectorBackend) UpsertReplaceSubresources(ctx context.Context, namespace, model, resource, uid string, changed []Vector, desired []string) (retErr error) {
-	// Both empty is a no-op: nothing to write and no survivor set means
-	// "leave the resource alone" rather than "delete everything" (the
-	// reconciler uses Delete for an intentional full wipe).
+	// Both empty = no-op; an empty desired must not be read as "delete
+	// all" (the reconciler uses Delete for a full wipe).
 	if len(changed) == 0 && len(desired) == 0 {
 		return nil
 	}
@@ -305,8 +304,7 @@ func (b *pgvectorBackend) GetSubresourceContent(ctx context.Context, namespace, 
 	for _, r := range rows {
 		out[r.Subresource] = r.Content
 	}
-	// Folder is written identically on every subresource of a resource,
-	// so any row is representative.
+	// Folder is uniform across a resource's rows, so any row works.
 	return out, rows[0].Folder, nil
 }
 

--- a/pkg/storage/unified/search/vector/pgvector_test.go
+++ b/pkg/storage/unified/search/vector/pgvector_test.go
@@ -104,8 +104,8 @@ func TestPgvectorBackend_UpsertReplaceSubresources_EmptySlice(t *testing.T) {
 	backend := NewPgvectorBackend(context.Background(), rdb.DB, 1000, 0, false, nil)
 	ctx := testutil.NewDefaultTestContext(t)
 
-	require.NoError(t, backend.UpsertReplaceSubresources(ctx, nil))
-	require.NoError(t, backend.UpsertReplaceSubresources(ctx, []Vector{}))
+	require.NoError(t, backend.UpsertReplaceSubresources(ctx, "ns", "m", "dashboards", "dash", nil, nil))
+	require.NoError(t, backend.UpsertReplaceSubresources(ctx, "ns", "m", "dashboards", "dash", []Vector{}, []string{}))
 	require.NoError(t, rdb.SQLMock.ExpectationsWereMet())
 }
 
@@ -115,26 +115,23 @@ func TestPgvectorBackend_UpsertReplaceSubresources_InvalidVector_Rejected(t *tes
 	backend := NewPgvectorBackend(context.Background(), rdb.DB, 1000, 0, false, nil)
 	ctx := testutil.NewDefaultTestContext(t)
 
-	err := backend.UpsertReplaceSubresources(ctx, []Vector{
+	err := backend.UpsertReplaceSubresources(ctx, "ns", "m", "dashboards", "dash", []Vector{
 		{Namespace: "ns", Model: "m", Resource: "dashboards", UID: "", Title: "t", Content: "x", Embedding: []float32{0.1}},
-	})
+	}, []string{"panel/1"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "uid must not be empty")
 	require.NoError(t, rdb.SQLMock.ExpectationsWereMet())
 }
 
 func TestPgvectorBackend_UpsertReplaceSubresources_UnknownResource_Rejected(t *testing.T) {
-	// Unknown resource fires inside the transaction; tx is rolled back.
+	// Unknown resource is rejected before any DB work; no tx is opened.
 	rdb := test.NewDBProviderNopSQL(t)
 	backend := NewPgvectorBackend(context.Background(), rdb.DB, 1000, 0, false, nil)
 	ctx := testutil.NewDefaultTestContext(t)
 
-	rdb.SQLMock.ExpectBegin()
-	rdb.SQLMock.ExpectRollback()
-
-	err := backend.UpsertReplaceSubresources(ctx, []Vector{
+	err := backend.UpsertReplaceSubresources(ctx, "ns", "m", "folders", "x", []Vector{
 		{Namespace: "ns", Model: "m", Resource: "folders", UID: "x", Title: "t", Embedding: []float32{0.1}},
-	})
+	}, []string{"panel/1"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported resource")
 	require.NoError(t, rdb.SQLMock.ExpectationsWereMet())

--- a/pkg/storage/unified/search/vector/queries.go
+++ b/pkg/storage/unified/search/vector/queries.go
@@ -221,6 +221,7 @@ func (r *sqlVectorBackfillJobsCompleteRequest) Validate() error {
 type sqlVectorCollectionGetContentResponse struct {
 	Subresource string
 	Content     string
+	Folder      string
 }
 
 type sqlVectorCollectionGetContentRequest struct {

--- a/pkg/storage/unified/search/vector/store.go
+++ b/pkg/storage/unified/search/vector/store.go
@@ -30,8 +30,7 @@ type VectorBackend interface {
 	// upserts `changed` and deletes any stored subresource not listed in
 	// `desired`. `changed` is the subset whose content changed since the
 	// last write (so only those were re-embedded); `desired` is the full
-	// set of subresource keys that should exist afterwards. Pass
-	// `desired = keys(changed)` to replace the entire set.
+	// set of subresource keys that should exist afterwards.
 	//
 	// Every vector in `changed` must belong to the given (namespace,
 	// model, resource, uid). The stale-delete and the upsert commit
@@ -46,10 +45,14 @@ type VectorBackend interface {
 	// slice is a no-op. model must be non-empty.
 	DeleteSubresources(ctx context.Context, namespace, model, resource, uid string, subresources []string) error
 
-	// GetSubresourceContent returns subresource → stored content. Callers
-	// diff against candidate content to skip re-embedding unchanged rows.
-	// Used for deleting stale subresource embeddings.
-	GetSubresourceContent(ctx context.Context, namespace, model, resource, uid string) (map[string]string, error)
+	// GetSubresourceContent returns subresource → stored content plus the
+	// stored folder for the resource (folder is uniform across a
+	// resource's subresources, so a single value is returned; "" when no
+	// rows exist). Callers diff candidate content against the returned
+	// content to skip re-embedding unchanged rows, and compare the folder
+	// so a folder move — which doesn't change content — still refreshes
+	// the stored folder used for search authz.
+	GetSubresourceContent(ctx context.Context, namespace, model, resource, uid string) (content map[string]string, folder string, err error)
 
 	// Exists returns true if any row exists for the (namespace, model,
 	// resource, uid). Cheap indexed lookup; backfill uses it to skip

--- a/pkg/storage/unified/search/vector/store.go
+++ b/pkg/storage/unified/search/vector/store.go
@@ -25,17 +25,12 @@ type VectorBackend interface {
 
 	Upsert(ctx context.Context, vectors []Vector) error
 
-	// UpsertReplaceSubresources reconciles the stored subresource set for
-	// one (namespace, model, resource, uid) in a single transaction: it
-	// upserts `changed` and deletes any stored subresource not listed in
-	// `desired`. `changed` is the subset whose content changed since the
-	// last write (so only those were re-embedded); `desired` is the full
-	// set of subresource keys that should exist afterwards.
-	//
-	// Every vector in `changed` must belong to the given (namespace,
-	// model, resource, uid). The stale-delete and the upsert commit
-	// atomically, so a mid-way failure leaves the resource in its
-	// previous self-consistent state.
+	// UpsertReplaceSubresources upserts `changed` and deletes any stored
+	// subresource of (namespace, model, resource, uid) not listed in
+	// `desired`, in one transaction. `changed` (a subset of `desired`)
+	// holds only the rows that need rewriting; `desired` is the full set
+	// that should remain. Every vector in `changed` must belong to the
+	// given tuple.
 	UpsertReplaceSubresources(ctx context.Context, namespace, model, resource, uid string, changed []Vector, desired []string) error
 
 	// Delete removes every resource and subresource under `uid`. model must be non-empty.
@@ -45,13 +40,11 @@ type VectorBackend interface {
 	// slice is a no-op. model must be non-empty.
 	DeleteSubresources(ctx context.Context, namespace, model, resource, uid string, subresources []string) error
 
-	// GetSubresourceContent returns subresource → stored content plus the
-	// stored folder for the resource (folder is uniform across a
-	// resource's subresources, so a single value is returned; "" when no
-	// rows exist). Callers diff candidate content against the returned
-	// content to skip re-embedding unchanged rows, and compare the folder
-	// so a folder move — which doesn't change content — still refreshes
-	// the stored folder used for search authz.
+	// GetSubresourceContent returns subresource → stored content and the
+	// resource's stored folder ("" when no rows exist; folder is uniform
+	// across a resource's rows). Callers diff content to skip re-embedding
+	// unchanged rows and compare folder to catch a move, which changes the
+	// authz folder but not content.
 	GetSubresourceContent(ctx context.Context, namespace, model, resource, uid string) (content map[string]string, folder string, err error)
 
 	// Exists returns true if any row exists for the (namespace, model,

--- a/pkg/storage/unified/search/vector/store.go
+++ b/pkg/storage/unified/search/vector/store.go
@@ -25,18 +25,19 @@ type VectorBackend interface {
 
 	Upsert(ctx context.Context, vectors []Vector) error
 
-	// UpsertReplaceSubresources replaces, in a single transaction, the
-	// stored subresource set for each (model, namespace, resource, uid)
-	// present in `vectors`: any stored subresource for those tuples that
-	// isn't being upserted is deleted, then the input vectors are
-	// upserted. Used by the reconciler so stale-row cleanup and
-	// the new write commit atomically.
+	// UpsertReplaceSubresources reconciles the stored subresource set for
+	// one (namespace, model, resource, uid) in a single transaction: it
+	// upserts `changed` and deletes any stored subresource not listed in
+	// `desired`. `changed` is the subset whose content changed since the
+	// last write (so only those were re-embedded); `desired` is the full
+	// set of subresource keys that should exist afterwards. Pass
+	// `desired = keys(changed)` to replace the entire set.
 	//
-	// TODO: only re-embed and upsert subresources whose content actually
-	// changed since the last write. Today the reconciler re-embeds every
-	// panel on any dashboard write, which is wasteful when only one
-	// panel changed.
-	UpsertReplaceSubresources(ctx context.Context, vectors []Vector) error
+	// Every vector in `changed` must belong to the given (namespace,
+	// model, resource, uid). The stale-delete and the upsert commit
+	// atomically, so a mid-way failure leaves the resource in its
+	// previous self-consistent state.
+	UpsertReplaceSubresources(ctx context.Context, namespace, model, resource, uid string, changed []Vector, desired []string) error
 
 	// Delete removes every resource and subresource under `uid`. model must be non-empty.
 	Delete(ctx context.Context, namespace, model, resource, uid string) error

--- a/pkg/storage/unified/search/vector/testdata/postgres--vector_collection_get_content-simple.sql
+++ b/pkg/storage/unified/search/vector/testdata/postgres--vector_collection_get_content-simple.sql
@@ -1,6 +1,7 @@
 SELECT
     "subresource",
-    "content"
+    "content",
+    "folder"
     FROM embeddings
     WHERE "resource"  = 'dashboards'
     AND "namespace" = 'stacks-123'


### PR DESCRIPTION
We can save a lot of embeddings by only embedding panels (or more generically, subresources) that have changed. Right now if you have a dashboard of 100 panels and change 1 of them, we reembed them all, which sucks 😢 .

**Changes**
- Only embed subresources that have changed (new or updated)
- Updates and embeddings and removes stale ones in one transaction.
- Rembed when folder has changed

**Notes**
This wont improve backfilling or creates, as all the embedding content is new. But it should reduce embedding calls that come through updates significantly (for dashboards).

Added a few metrics also:
```
# HELP grafana_vector_storage_reconciler_subresources_deleted_total Total stale subresources deleted because they no longer exist in the resource.
# TYPE grafana_vector_storage_reconciler_subresources_deleted_total counter
grafana_vector_storage_reconciler_subresources_deleted_total{group="dashboard.grafana.app",resource="dashboards"} 0
# HELP grafana_vector_storage_reconciler_subresources_embedded_total Total subresources re-embedded (new or content-changed). Equal to extracted means the diff is saving nothing.
# TYPE grafana_vector_storage_reconciler_subresources_embedded_total counter
grafana_vector_storage_reconciler_subresources_embedded_total{group="dashboard.grafana.app",resource="dashboards"} 3
# HELP grafana_vector_storage_reconciler_subresources_extracted_total Total subresources extracted from processed resources. Compare with embedded to see how many re-embeds the content diff avoids.
# TYPE grafana_vector_storage_reconciler_subresources_extracted_total counter
grafana_vector_storage_reconciler_subresources_extracted_total{group="dashboard.grafana.app",resource="dashboards"} 11
```