### PR TITLE
fix(variables): containsVariable no longer matches format specifiers and field paths

### DIFF
--- a/public/app/features/variables/utils.test.ts
+++ b/public/app/features/variables/utils.test.ts
@@ -191,6 +191,20 @@ describe('containsVariable', () => {
   `('when called with value:$value then result should be:$expected', ({ value, expected }) => {
     expect(containsVariable(value, 'var')).toEqual(expected);
   });
+
+  it.each`
+    value               | variableName | expected
+    ${'${other:csv}'}   | ${'csv'}     | ${false}
+    ${'${other:json}'}  | ${'json'}    | ${false}
+    ${'${data.host}'}   | ${'host'}    | ${false}
+    ${'[[var:fmt]]'}    | ${'fmt'}     | ${false}
+    ${'$csv'}           | ${'csv'}     | ${true}
+  `(
+    'when called with value:$value and variableName:$variableName then result should be:$expected (no false positives from format specifiers or field paths)',
+    ({ value, variableName, expected }) => {
+      expect(containsVariable(value, variableName)).toEqual(expected);
+    }
+  );
 });
 
 describe('getVariablesFromUrl', () => {

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -48,7 +48,7 @@ export function containsVariable(...args: any[]) {
     matches !== null
       ? matches.find((match) => {
           const varMatch = variableRegexExec(match);
-          return varMatch !== null && varMatch.indexOf(variableName) > -1;
+          return varMatch !== null && (varMatch[1] === variableName || varMatch[2] === variableName || varMatch[4] === variableName);
         })
       : false;
 


### PR DESCRIPTION
Closes #125036

## Problem

`containsVariable('${other:csv}', 'csv')` incorrectly returns `true` because `varMatch.indexOf(variableName)` searches the entire regex match array — including format specifiers (groups 3, 6) and field path (group 5).

A variable named `csv`, `json`, `host`, etc. would be falsely detected as being referenced in expressions that just happen to use those as format specifiers or field paths.

## Fix

Changed the check to only compare against the variable name capture groups (1, 2, 4), ignoring format specifier and field path groups (3, 5, 6).

## Test cases added

Added tests for the false positive cases from the issue:
- `${other:csv}` should not match variable `csv`
- `${other:json}` should not match variable `json`
- `${data.host}` should not match variable `host`
- `[[var:fmt]]` should not match variable `fmt`