### PR TITLE
OAuth: Allow configurable timeout for OAuth token exchange

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -892,6 +892,7 @@ tls_skip_verify_insecure = false
 tls_client_cert =
 tls_client_key =
 tls_client_ca =
+token_exchange_timeout = 15s
 use_pkce = true
 skip_org_role_sync = false
 use_refresh_token = true

--- a/pkg/login/social/connectors/common.go
+++ b/pkg/login/social/connectors/common.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/oauth2"
@@ -203,6 +204,15 @@ func createOAuthInfoFromKeyValues(settingsKV map[string]any, parsingWarns *[]err
 			}
 			return splitStr, nil
 		}
+
+		if from.Kind() == reflect.String && to == reflect.TypeOf(time.Duration(0)) {
+			strData, ok := data.(string)
+			if !ok || strData == "" {
+				return time.Duration(0), nil
+			}
+			return time.ParseDuration(strData)
+		}
+
 		return data, nil
 	}
 

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/grafana/grafana/pkg/services/org"
 	"golang.org/x/oauth2"
@@ -97,6 +98,7 @@ type OAuthInfo struct {
 	TlsClientKey                string            `mapstructure:"tls_client_key" toml:"tls_client_key"`
 	TlsSkipVerify               bool              `mapstructure:"tls_skip_verify_insecure" toml:"tls_skip_verify_insecure"`
 	TokenUrl                    string            `mapstructure:"token_url" toml:"token_url"`
+	TokenExchangeTimeout        time.Duration     `mapstructure:"token_exchange_timeout" toml:"token_exchange_timeout"`
 	UsePKCE                     bool              `mapstructure:"use_pkce" toml:"use_pkce"`
 	UseRefreshToken             bool              `mapstructure:"use_refresh_token" toml:"use_refresh_token"`
 	LoginPrompt                 string            `mapstructure:"login_prompt" toml:"login_prompt"`
@@ -107,10 +109,11 @@ type OAuthInfo struct {
 
 func NewOAuthInfo() *OAuthInfo {
 	return &OAuthInfo{
-		Scopes:         []string{},
-		AllowedDomains: []string{},
-		AllowedGroups:  []string{},
-		Extra:          map[string]string{},
+		Scopes:               []string{},
+		AllowedDomains:       []string{},
+		AllowedGroups:        []string{},
+		Extra:                map[string]string{},
+		TokenExchangeTimeout: 15 * time.Second,
 	}
 }
 

--- a/pkg/login/social/socialimpl/service.go
+++ b/pkg/login/social/socialimpl/service.go
@@ -119,9 +119,14 @@ func (ss *SocialService) GetOAuthHttpClient(name string) (*http.Client, error) {
 		IdleConnTimeout:       90 * time.Second,
 	}
 
+	timeout := info.TokenExchangeTimeout
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+
 	oauthClient := &http.Client{
 		Transport: tr,
-		Timeout:   time.Second * 15,
+		Timeout:   timeout,
 	}
 
 	if info.TlsClientCert != "" || info.TlsClientKey != "" {


### PR DESCRIPTION
Allow users to configure the timeout duration for OAuth token exchange requests via the `token_exchange_timeout` setting.

**Why:**
When using OAuth providers like Microsoft Entra ID (Azure AD), token exchange can intermittently fail due to network latency or slow provider responses. The current hardcoded 15-second timeout cannot be adjusted.

**What:**
- Added `TokenExchangeTimeout` field to `OAuthInfo` struct (parsed via `mapstructure` with a new string-to-Duration decode hook)
- `GetOAuthHttpClient()` now uses the per-provider timeout from `OAuthInfo` instead of hardcoded 15s, falling back to 15s if unset or zero
- Added `token_exchange_timeout` default (`15s`) to `[auth.azuread]` in `defaults.ini`
- Any OAuth provider can use this setting; the INI key is e.g. `token_exchange_timeout = 30s`

**Usage example:**
```ini
[auth.azuread]
token_exchange_timeout = 30s
```

Fixes #120907