### PR TITLE
Dashboards: support v2 dashboards via import

### DIFF
--- a/pkg/services/dashboardimport/api/api_test.go
+++ b/pkg/services/dashboardimport/api/api_test.go
@@ -101,6 +101,52 @@ func TestImportDashboardAPI(t *testing.T) {
 		})
 	})
 
+	t.Run("Signed in, marshaled request without folder fields should not select a folder", func(t *testing.T) {
+		var capturedReq *dashboardimport.ImportDashboardRequest
+		service := &serviceMock{
+			importDashboardFunc: func(ctx context.Context, req *dashboardimport.ImportDashboardRequest) (*dashboardimport.ImportDashboardResponse, error) {
+				capturedReq = req
+				return &dashboardimport.ImportDashboardResponse{UID: "direct-v2-dashboard"}, nil
+			},
+		}
+
+		importDashboardAPI := New(service, quotaServiceFunc(quotaNotReached), nil, actest.FakeAccessControl{ExpectedEvaluate: true}, featuremgmt.WithFeatures())
+		routeRegister := routing.NewRouteRegister()
+		importDashboardAPI.RegisterAPIEndpoints(routeRegister)
+		s := webtest.NewServer(t, routeRegister)
+
+		cmd := &dashboardimport.ImportDashboardRequest{
+			Dashboard: simplejson.NewFromAny(map[string]any{
+				"apiVersion": "dashboard.grafana.app/v2",
+				"kind":       "Dashboard",
+				"metadata": map[string]any{
+					"name": "direct-v2-dashboard",
+					"annotations": map[string]any{
+						"grafana.app/folder": "resource-folder",
+					},
+				},
+				"spec": map[string]any{
+					"title": "Direct V2 Dashboard",
+				},
+			}),
+			Overwrite: true,
+		}
+		jsonBytes, err := json.Marshal(cmd)
+		require.NoError(t, err)
+		require.NotContains(t, string(jsonBytes), "folderId")
+		require.NotContains(t, string(jsonBytes), "folderUid")
+
+		req := s.NewPostRequest("/api/dashboards/import", bytes.NewReader(jsonBytes))
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{UserID: 1})
+		resp, err := s.SendJSON(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		require.NotNil(t, capturedReq)
+		require.False(t, capturedReq.HasFolderSelection())
+	})
+
 	t.Run("Quota not reached, schema loader service enabled", func(t *testing.T) {
 		importDashboardServiceCalled := false
 		service := &serviceMock{

--- a/pkg/services/dashboardimport/dashboardimport.go
+++ b/pkg/services/dashboardimport/dashboardimport.go
@@ -2,6 +2,7 @@ package dashboardimport
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -23,10 +24,47 @@ type ImportDashboardRequest struct {
 	Dashboard *simplejson.Json       `json:"dashboard"`
 	Inputs    []ImportDashboardInput `json:"inputs"`
 	// Deprecated: use FolderUID instead
-	FolderId  int64  `json:"folderId"`
-	FolderUid string `json:"folderUid"`
+	FolderId  int64  `json:"folderId,omitempty"`
+	FolderUid string `json:"folderUid,omitempty"`
 
 	User identity.Requester `json:"-"`
+
+	folderIdSet  bool
+	folderUidSet bool
+}
+
+// UnmarshalJSON remembers whether folderId or folderUid were present in the request.
+// An omitted folder means "use the folder from the dashboard resource." An explicit
+// empty folderUid, or folderId: 0, means "save at root." Plain Go zero values cannot
+// tell those cases apart after decoding.
+func (r *ImportDashboardRequest) UnmarshalJSON(data []byte) error {
+	type importDashboardRequest ImportDashboardRequest
+
+	var decoded importDashboardRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*r = ImportDashboardRequest(decoded)
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	_, r.folderIdSet = fields["folderId"]
+	_, r.folderUidSet = fields["folderUid"]
+
+	return nil
+}
+
+// HasFolderSelection reports whether the caller chose a folder, including root.
+func (r *ImportDashboardRequest) HasFolderSelection() bool {
+	return r.HasFolderUIDSelection() || r.folderIdSet || r.FolderId != 0
+}
+
+// HasFolderUIDSelection reports whether folderUid chose the folder. An empty
+// folderUid still counts because it means "save at root" and overrides folderId.
+func (r *ImportDashboardRequest) HasFolderUIDSelection() bool {
+	return r.folderUidSet || r.FolderUid != ""
 }
 
 // ImportDashboardResponse response object returned when importing a dashboard.

--- a/pkg/services/dashboardimport/dashboardimport_test.go
+++ b/pkg/services/dashboardimport/dashboardimport_test.go
@@ -1,0 +1,37 @@
+package dashboardimport
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportDashboardRequestFolderSelection(t *testing.T) {
+	t.Run("marshal omits zero value folder fields", func(t *testing.T) {
+		data, err := json.Marshal(ImportDashboardRequest{PluginId: "test-plugin"})
+		require.NoError(t, err)
+
+		var fields map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(data, &fields))
+		require.NotContains(t, fields, "folderId")
+		require.NotContains(t, fields, "folderUid")
+	})
+
+	t.Run("unmarshal distinguishes omitted folder from explicit root", func(t *testing.T) {
+		var omitted ImportDashboardRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"pluginId":"test-plugin"}`), &omitted))
+		require.False(t, omitted.HasFolderSelection())
+		require.False(t, omitted.HasFolderUIDSelection())
+
+		var explicitUIDRoot ImportDashboardRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"pluginId":"test-plugin","folderUid":""}`), &explicitUIDRoot))
+		require.True(t, explicitUIDRoot.HasFolderSelection())
+		require.True(t, explicitUIDRoot.HasFolderUIDSelection())
+
+		var explicitIDRoot ImportDashboardRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"pluginId":"test-plugin","folderId":0}`), &explicitIDRoot))
+		require.True(t, explicitIDRoot.HasFolderSelection())
+		require.False(t, explicitIDRoot.HasFolderUIDSelection())
+	})
+}

--- a/pkg/services/dashboardimport/service/service.go
+++ b/pkg/services/dashboardimport/service/service.go
@@ -49,7 +49,13 @@ type ImportDashboardService struct {
 	features               featuremgmt.FeatureToggles
 }
 
-func (s *ImportDashboardService) InterpolateDashboard(ctx context.Context, req *dashboardimport.ImportDashboardRequest) (*simplejson.Json, error) {
+type interpolatedDashboard struct {
+	data       *simplejson.Json
+	apiVersion string
+	folderUID  string
+}
+
+func (s *ImportDashboardService) interpolateDashboard(ctx context.Context, req *dashboardimport.ImportDashboardRequest) (*interpolatedDashboard, error) {
 	var draftDashboard *dashboards.Dashboard
 	if req.PluginId != "" {
 		loadReq := &plugindashboards.LoadPluginDashboardRequest{
@@ -73,14 +79,28 @@ func (s *ImportDashboardService) InterpolateDashboard(ctx context.Context, req *
 		return nil, err
 	}
 
-	return generatedDash, nil
+	return &interpolatedDashboard{
+		data:       generatedDash,
+		apiVersion: draftDashboard.APIVersion,
+		folderUID:  draftDashboard.FolderUID,
+	}, nil
 }
 
-func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashboardimport.ImportDashboardRequest) (*dashboardimport.ImportDashboardResponse, error) {
-	generatedDash, err := s.InterpolateDashboard(ctx, req)
+func (s *ImportDashboardService) InterpolateDashboard(ctx context.Context, req *dashboardimport.ImportDashboardRequest) (*simplejson.Json, error) {
+	result, err := s.interpolateDashboard(ctx, req)
 	if err != nil {
 		return nil, err
 	}
+
+	return result.data, nil
+}
+
+func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashboardimport.ImportDashboardRequest) (*dashboardimport.ImportDashboardResponse, error) {
+	interpolated, err := s.interpolateDashboard(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	generatedDash := interpolated.data
 
 	// Maintain backwards compatibility by transforming array of library elements to map
 	libraryElements := generatedDash.Get("__elements")
@@ -100,6 +120,13 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 	generatedDash.Del("__requires")
 
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.DashboardImport).Inc()
+	if !req.HasFolderSelection() && interpolated.folderUID != "" {
+		req.FolderUid = interpolated.folderUID
+	}
+	if req.HasFolderUIDSelection() {
+		req.FolderId = 0
+	}
+
 	// here we need to get FolderId from FolderUID if it present in the request, if both exist, FolderUID would overwrite FolderID
 	if req.FolderUid != "" {
 		folder, err := s.folderService.Get(ctx, &folder.GetFolderQuery{
@@ -130,13 +157,14 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 	}
 
 	saveCmd := dashboards.SaveDashboardCommand{
-		Dashboard: generatedDash,
-		OrgID:     req.User.GetOrgID(),
-		UserID:    userID,
-		Overwrite: req.Overwrite,
-		PluginID:  req.PluginId,
-		FolderID:  req.FolderId, // nolint:staticcheck
-		FolderUID: req.FolderUid,
+		Dashboard:  generatedDash,
+		OrgID:      req.User.GetOrgID(),
+		UserID:     userID,
+		Overwrite:  req.Overwrite,
+		PluginID:   req.PluginId,
+		FolderID:   req.FolderId, // nolint:staticcheck
+		FolderUID:  req.FolderUid,
+		APIVersion: interpolated.apiVersion,
 	}
 
 	dto := &dashboards.SaveDashboardDTO{

--- a/pkg/services/dashboardimport/service/service.go
+++ b/pkg/services/dashboardimport/service/service.go
@@ -123,8 +123,9 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 	if !req.HasFolderSelection() && interpolated.folderUID != "" {
 		req.FolderUid = interpolated.folderUID
 	}
+	folderID := req.FolderId // nolint:staticcheck
 	if req.HasFolderUIDSelection() {
-		req.FolderId = 0
+		folderID = 0
 	}
 
 	// here we need to get FolderId from FolderUID if it present in the request, if both exist, FolderUID would overwrite FolderID
@@ -137,11 +138,10 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 		if err != nil {
 			return nil, err
 		}
-		// nolint:staticcheck
-		req.FolderId = folder.ID
+		folderID = folder.ID //nolint:staticcheck
 	} else {
 		folder, err := s.folderService.Get(ctx, &folder.GetFolderQuery{
-			ID:           &req.FolderId, // nolint:staticcheck
+			ID:           &folderID, // nolint:staticcheck
 			OrgID:        req.User.GetOrgID(),
 			SignedInUser: req.User,
 		})
@@ -162,7 +162,7 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 		UserID:     userID,
 		Overwrite:  req.Overwrite,
 		PluginID:   req.PluginId,
-		FolderID:   req.FolderId, // nolint:staticcheck
+		FolderID:   folderID, // nolint:staticcheck
 		FolderUID:  req.FolderUid,
 		APIVersion: interpolated.apiVersion,
 	}
@@ -175,7 +175,7 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 	}
 
 	// nolint:staticcheck
-	err = s.libraryPanelService.ImportLibraryPanelsForDashboard(ctx, req.User, libraryElements, generatedDash.Get("panels").MustArray(), req.FolderId, req.FolderUid)
+	err = s.libraryPanelService.ImportLibraryPanelsForDashboard(ctx, req.User, libraryElements, generatedDash.Get("panels").MustArray(), folderID, req.FolderUid)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/dashboardimport/service/service_test.go
+++ b/pkg/services/dashboardimport/service/service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -157,6 +158,154 @@ func TestImportDashboardService(t *testing.T) {
 
 		panel := importDashboardArg.Dashboard.Data.Get("panels").GetIndex(0)
 		require.Equal(t, "prom", panel.Get("datasource").MustString())
+	})
+
+	t.Run("When importing a DashboardV2 plugin dashboard should preserve API version and resource folder", func(t *testing.T) {
+		pluginDashboardService := &pluginDashboardServiceMock{
+			loadPluginDashboardFunc: func(ctx context.Context, req *plugindashboards.LoadPluginDashboardRequest) (*plugindashboards.LoadPluginDashboardResponse, error) {
+				return &plugindashboards.LoadPluginDashboardResponse{
+					Dashboard: dashboards.NewDashboardFromJson(dashboardV2Resource("team-folder")),
+				}, nil
+			},
+		}
+
+		var importDashboardArg *dashboards.SaveDashboardDTO
+		dashboardService := dashboardServiceCapturingImport(&importDashboardArg)
+		folderService := foldertest.NewFakeService()
+		folderService.AddFolder(&folder.Folder{ID: 12, UID: "team-folder", OrgID: 3})
+
+		s := &ImportDashboardService{
+			pluginDashboardService: pluginDashboardService,
+			dashboardService:       dashboardService,
+			libraryPanelService:    &libraryPanelServiceMock{},
+			folderService:          folderService,
+			features:               featuremgmt.WithFeatures(),
+		}
+
+		req := &dashboardimport.ImportDashboardRequest{
+			PluginId:  "grafana-test-plugin",
+			Path:      "dashboards/dashboard-v2.json",
+			User:      &user.SignedInUser{UserID: 2, OrgRole: org.RoleAdmin, OrgID: 3},
+			Overwrite: true,
+		}
+		resp, err := s.ImportDashboard(context.Background(), req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		require.NotNil(t, importDashboardArg)
+		require.Equal(t, "dashboard.grafana.app/v2", importDashboardArg.Dashboard.APIVersion)
+		require.Equal(t, "plugin-v2-dashboard", importDashboardArg.Dashboard.UID)
+		require.Equal(t, "team-folder", importDashboardArg.Dashboard.FolderUID)
+	})
+
+	t.Run("When importing a DashboardV2 plugin dashboard should prefer an explicit request folder", func(t *testing.T) {
+		pluginDashboardService := &pluginDashboardServiceMock{
+			loadPluginDashboardFunc: func(ctx context.Context, req *plugindashboards.LoadPluginDashboardRequest) (*plugindashboards.LoadPluginDashboardResponse, error) {
+				return &plugindashboards.LoadPluginDashboardResponse{
+					Dashboard: dashboards.NewDashboardFromJson(dashboardV2Resource("resource-folder")),
+				}, nil
+			},
+		}
+
+		var importDashboardArg *dashboards.SaveDashboardDTO
+		dashboardService := dashboardServiceCapturingImport(&importDashboardArg)
+		folderService := foldertest.NewFakeService()
+		folderService.AddFolder(&folder.Folder{ID: 12, UID: "resource-folder", OrgID: 3})
+		folderService.AddFolder(&folder.Folder{ID: 13, UID: "explicit-folder", OrgID: 3})
+
+		s := &ImportDashboardService{
+			pluginDashboardService: pluginDashboardService,
+			dashboardService:       dashboardService,
+			libraryPanelService:    &libraryPanelServiceMock{},
+			folderService:          folderService,
+			features:               featuremgmt.WithFeatures(),
+		}
+
+		req := &dashboardimport.ImportDashboardRequest{
+			PluginId:  "grafana-test-plugin",
+			Path:      "dashboards/dashboard-v2.json",
+			User:      &user.SignedInUser{UserID: 2, OrgRole: org.RoleAdmin, OrgID: 3},
+			FolderUid: "explicit-folder",
+			Overwrite: true,
+		}
+		resp, err := s.ImportDashboard(context.Background(), req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		require.NotNil(t, importDashboardArg)
+		require.Equal(t, "dashboard.grafana.app/v2", importDashboardArg.Dashboard.APIVersion)
+		require.Equal(t, "explicit-folder", importDashboardArg.Dashboard.FolderUID)
+	})
+
+	t.Run("When importing DashboardV2 JSON directly should preserve API version and resource folder", func(t *testing.T) {
+		var importDashboardArg *dashboards.SaveDashboardDTO
+		dashboardService := dashboardServiceCapturingImport(&importDashboardArg)
+		folderService := foldertest.NewFakeService()
+		folderService.AddFolder(&folder.Folder{ID: 12, UID: "team-folder", OrgID: 3})
+
+		s := &ImportDashboardService{
+			dashboardService:    dashboardService,
+			libraryPanelService: &libraryPanelServiceMock{},
+			folderService:       folderService,
+			features:            featuremgmt.WithFeatures(),
+		}
+
+		req := &dashboardimport.ImportDashboardRequest{
+			Dashboard: dashboardV2Resource("team-folder"),
+			User:      &user.SignedInUser{UserID: 2, OrgRole: org.RoleAdmin, OrgID: 3},
+			Overwrite: true,
+			FolderUid: "",
+			FolderId:  0,
+		}
+		resp, err := s.ImportDashboard(context.Background(), req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		require.NotNil(t, importDashboardArg)
+		require.Equal(t, "dashboard.grafana.app/v2", importDashboardArg.Dashboard.APIVersion)
+		require.Equal(t, "plugin-v2-dashboard", importDashboardArg.Dashboard.UID)
+		require.Equal(t, "team-folder", importDashboardArg.Dashboard.FolderUID)
+	})
+
+	t.Run("When importing DashboardV2 JSON directly should allow explicit root folder override", func(t *testing.T) {
+		var importDashboardArg *dashboards.SaveDashboardDTO
+		dashboardService := dashboardServiceCapturingImport(&importDashboardArg)
+		var folderQuery *folder.GetFolderQuery
+		folderService := &folderServiceMock{
+			getFunc: func(ctx context.Context, q *folder.GetFolderQuery) (*folder.Folder, error) {
+				folderQuery = q
+				return &folder.Folder{OrgID: 3}, nil
+			},
+		}
+
+		s := &ImportDashboardService{
+			dashboardService:    dashboardService,
+			libraryPanelService: &libraryPanelServiceMock{},
+			folderService:       folderService,
+			features:            featuremgmt.WithFeatures(),
+		}
+
+		dashboardJSON, err := dashboardV2Resource("team-folder").Encode()
+		require.NoError(t, err)
+		body := append([]byte(`{"dashboard":`), dashboardJSON...)
+		body = append(body, []byte(`,"overwrite":true,"folderUid":"","folderId":12}`)...)
+
+		var req dashboardimport.ImportDashboardRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		req.User = &user.SignedInUser{UserID: 2, OrgRole: org.RoleAdmin, OrgID: 3}
+
+		resp, err := s.ImportDashboard(context.Background(), &req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		require.NotNil(t, importDashboardArg)
+		require.Equal(t, "dashboard.grafana.app/v2", importDashboardArg.Dashboard.APIVersion)
+		require.Equal(t, "plugin-v2-dashboard", importDashboardArg.Dashboard.UID)
+		require.Empty(t, importDashboardArg.Dashboard.FolderUID)
+		require.NotNil(t, folderQuery)
+		require.NotNil(t, folderQuery.ID)
+		require.Equal(t, int64(0), *folderQuery.ID)
+		require.Nil(t, folderQuery.UID)
 	})
 }
 
@@ -331,6 +480,49 @@ func loadTestDashboard(ctx context.Context, req *plugindashboards.LoadPluginDash
 	}, nil
 }
 
+func dashboardV2Resource(folderUID string) *simplejson.Json {
+	return simplejson.NewFromAny(map[string]any{
+		"apiVersion": "dashboard.grafana.app/v2",
+		"kind":       "Dashboard",
+		"metadata": map[string]any{
+			"name": "plugin-v2-dashboard",
+			"annotations": map[string]any{
+				"grafana.app/folder": folderUID,
+			},
+		},
+		"spec": map[string]any{
+			"title":    "Plugin V2 Dashboard",
+			"elements": map[string]any{},
+			"layout": map[string]any{
+				"kind": "GridLayout",
+				"spec": map[string]any{
+					"items": []any{},
+				},
+			},
+		},
+	})
+}
+
+func dashboardServiceCapturingImport(importDashboardArg **dashboards.SaveDashboardDTO) *dashboardServiceMock {
+	return &dashboardServiceMock{
+		importDashboardFunc: func(ctx context.Context, dto *dashboards.SaveDashboardDTO) (*dashboards.Dashboard, error) {
+			*importDashboardArg = dto
+			return &dashboards.Dashboard{
+				ID:         4,
+				UID:        dto.Dashboard.UID,
+				Slug:       dto.Dashboard.Slug,
+				OrgID:      dto.OrgID,
+				Version:    dto.Dashboard.Version,
+				APIVersion: dto.Dashboard.APIVersion,
+				PluginID:   dto.Dashboard.PluginID,
+				FolderUID:  dto.Dashboard.FolderUID,
+				Title:      dto.Dashboard.Title,
+				Data:       dto.Dashboard.Data,
+			}, nil
+		},
+	}
+}
+
 type pluginDashboardServiceMock struct {
 	plugindashboards.Service
 	loadPluginDashboardFunc func(ctx context.Context, req *plugindashboards.LoadPluginDashboardRequest) (*plugindashboards.LoadPluginDashboardResponse, error)
@@ -352,6 +544,19 @@ type dashboardServiceMock struct {
 func (s *dashboardServiceMock) ImportDashboard(ctx context.Context, dto *dashboards.SaveDashboardDTO) (*dashboards.Dashboard, error) {
 	if s.importDashboardFunc != nil {
 		return s.importDashboardFunc(ctx, dto)
+	}
+
+	return nil, nil
+}
+
+type folderServiceMock struct {
+	folder.Service
+	getFunc func(ctx context.Context, q *folder.GetFolderQuery) (*folder.Folder, error)
+}
+
+func (s *folderServiceMock) Get(ctx context.Context, q *folder.GetFolderQuery) (*folder.Folder, error) {
+	if s.getFunc != nil {
+		return s.getFunc(ctx, q)
 	}
 
 	return nil, nil

--- a/pkg/services/dashboardimport/service/service_test.go
+++ b/pkg/services/dashboardimport/service/service_test.go
@@ -303,8 +303,9 @@ func TestImportDashboardService(t *testing.T) {
 		require.Equal(t, "plugin-v2-dashboard", importDashboardArg.Dashboard.UID)
 		require.Empty(t, importDashboardArg.Dashboard.FolderUID)
 		require.NotNil(t, folderQuery)
-		require.NotNil(t, folderQuery.ID)
-		require.Equal(t, int64(0), *folderQuery.ID)
+		folderQueryID := folderQuery.ID //nolint:staticcheck
+		require.NotNil(t, folderQueryID)
+		require.Equal(t, int64(0), *folderQueryID)
 		require.Nil(t, folderQuery.UID)
 	})
 }

--- a/pkg/services/dashboards/service/client/client.go
+++ b/pkg/services/dashboards/service/client/client.go
@@ -277,6 +277,34 @@ func (h *K8sClientWithFallback) Update(
 	return res, nil
 }
 
+// Create cannot use the embedded handler. That handler was built for the legacy
+// dashboard resource, so client-go will post to that resource path even when obj
+// says apiVersion: dashboard.grafana.app/v2. A new dashboard has no stored version
+// to look up, so the create path must choose the handler from the object itself.
+func (h *K8sClientWithFallback) Create(
+	ctx context.Context, obj *unstructured.Unstructured, orgID int64, options metav1.CreateOptions,
+) (*unstructured.Unstructured, error) {
+	ctx, span := tracing.Start(ctx, "K8sClientWithFallback.Create")
+	defer span.End()
+
+	version := obj.GroupVersionKind().Version
+	h.log.Debug("using client for version", "version", version)
+
+	span.SetAttributes(
+		attribute.String("version", version),
+		attribute.String("dashboard.metadata.name", obj.GetName()),
+		attribute.Int64("org.id", orgID),
+	)
+
+	res, err := h.newClientFunc(ctx, version).Create(ctx, obj, orgID, options)
+	if err != nil {
+		h.log.Debug("failed to create object", "error", err)
+		return nil, tracing.Error(span, err)
+	}
+
+	return res, nil
+}
+
 // fetchWithVersion fetches multiple resources from the K8s API.
 // It uses concurrent Get requests, one for each name.
 //

--- a/pkg/services/dashboards/service/client/client_test.go
+++ b/pkg/services/dashboards/service/client/client_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	v1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
-	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2"
+	v2 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2"
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
 	"github.com/grafana/grafana/pkg/infra/log"

--- a/pkg/services/dashboards/service/client/client_test.go
+++ b/pkg/services/dashboards/service/client/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	v1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
+	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2"
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -29,6 +30,7 @@ type testSetup struct {
 	mockClientV1       *client.MockK8sHandler
 	mockClientV2Alpha1 *client.MockK8sHandler
 	mockClientV2Beta1  *client.MockK8sHandler
+	mockClientV2       *client.MockK8sHandler
 }
 
 func setupTest(t *testing.T) *testSetup {
@@ -37,6 +39,7 @@ func setupTest(t *testing.T) *testSetup {
 		mockClientV1       = &client.MockK8sHandler{}
 		mockClientV2Alpha1 = &client.MockK8sHandler{}
 		mockClientV2Beta1  = &client.MockK8sHandler{}
+		mockClientV2       = &client.MockK8sHandler{}
 	)
 
 	mockMetrics := newK8sClientMetrics(prometheus.NewRegistry())
@@ -56,6 +59,8 @@ func setupTest(t *testing.T) *testSetup {
 				return mockClientV2Alpha1
 			case v2beta1.VERSION:
 				return mockClientV2Beta1
+			case v2.VERSION:
+				return mockClientV2
 			case v1.VERSION:
 				return mockClientV1
 			default:
@@ -76,6 +81,7 @@ func setupTest(t *testing.T) *testSetup {
 		mockClientV1:       mockClientV1,
 		mockClientV2Alpha1: mockClientV2Alpha1,
 		mockClientV2Beta1:  mockClientV2Beta1,
+		mockClientV2:       mockClientV2,
 	}
 }
 
@@ -672,6 +678,83 @@ func TestK8sHandlerWithFallback_Update(t *testing.T) {
 
 		setup.mockClientV1.AssertExpectations(t)
 		setup.mockClientV2Alpha1.AssertExpectations(t)
+	})
+}
+
+func TestK8sHandlerWithFallback_Create(t *testing.T) {
+	t.Run("Create with DashboardV2 API version", func(t *testing.T) {
+		setup := setupTest(t)
+
+		ctx := context.Background()
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "dashboard.grafana.app/" + v2.VERSION,
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"name": "test-dashboard-v2",
+				},
+				"spec": map[string]interface{}{
+					"title": "Created Dashboard V2",
+				},
+			},
+		}
+		orgID := int64(2)
+		options := metav1.CreateOptions{}
+
+		expectedResult := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "dashboard.grafana.app/" + v2.VERSION,
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"name":            "test-dashboard-v2",
+					"resourceVersion": "456",
+				},
+				"spec": map[string]interface{}{
+					"title": "Created Dashboard V2",
+				},
+			},
+		}
+
+		setup.mockClientV2.On("Create", mock.Anything, obj, orgID, options).Return(expectedResult, nil).Once()
+
+		result, err := setup.handler.Create(ctx, obj, orgID, options)
+		require.NoError(t, err)
+		require.Equal(t, expectedResult, result)
+		require.Equal(t, 1, setup.mockFactoryCalls[v2.VERSION], "Factory should be called once with v2")
+
+		setup.mockClientV1.AssertExpectations(t)
+		setup.mockClientV2.AssertExpectations(t)
+	})
+
+	t.Run("Create with error", func(t *testing.T) {
+		setup := setupTest(t)
+
+		ctx := context.Background()
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": v0alpha1.VERSION,
+				"metadata": map[string]interface{}{
+					"name": "test-dashboard-error",
+				},
+				"spec": map[string]interface{}{
+					"title": "Error Dashboard",
+				},
+			},
+		}
+		orgID := int64(3)
+		options := metav1.CreateOptions{}
+		expectedErr := errors.New("create failed")
+
+		setup.mockClientV0Alpha1.On("Create", mock.Anything, obj, orgID, options).Return(nil, expectedErr).Once()
+
+		result, err := setup.handler.Create(ctx, obj, orgID, options)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Equal(t, expectedErr, err)
+		require.Equal(t, 1, setup.mockFactoryCalls[v0alpha1.VERSION], "Factory should be called once with v0alpha1")
+
+		setup.mockClientV0Alpha1.AssertExpectations(t)
+		setup.mockClientV2Beta1.AssertExpectations(t)
 	})
 }
 

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -1865,6 +1865,21 @@ func TestLegacySaveCommandToUnstructured(t *testing.T) {
 		assert.Equal(t, result.GetAnnotations(), map[string]string{utils.AnnoKeyFolder: "folder-uid", utils.AnnoKeyMessage: "saving this dashboard"})
 	})
 
+	t.Run("preserves API version and folder metadata", func(t *testing.T) {
+		cmd := &dashboards.SaveDashboardCommand{
+			APIVersion: "dashboard.grafana.app/v2",
+			FolderUID:  "folder-uid",
+			Dashboard:  simplejson.NewFromAny(map[string]any{"title": "testing slugify", "uid": "test-uid"}),
+		}
+
+		result, err := LegacySaveCommandToUnstructured(cmd, namespace)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "dashboard.grafana.app/v2", result.GetAPIVersion())
+		assert.Equal(t, "test-uid", result.GetName())
+		assert.Equal(t, "folder-uid", result.GetAnnotations()[utils.AnnoKeyFolder])
+	})
+
 	t.Run("should increase version when called", func(t *testing.T) {
 		cmd := &dashboards.SaveDashboardCommand{
 			Dashboard: simplejson.NewFromAny(map[string]any{"test": "test", "title": "testing slugify", "uid": "test-uid", "version": int64(1)}),


### PR DESCRIPTION
# Summary

This PR keeps DashboardV2 resource metadata when a dashboard is imported from Kubernetes-shaped JSON. Import interpolation now keeps the parsed dashboard `apiVersion` and resource folder beside the generated dashboard JSON, then passes that `apiVersion` into `SaveDashboardCommand` when saving ([service.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/service/service.go#L52-L86), [service.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/service/service.go#L159-L167)).

Example input:

```json
{
  "dashboard": {
    "apiVersion": "dashboard.grafana.app/v2",
    "kind": "Dashboard",
    "metadata": {
      "name": "direct-v2-dashboard",
      "annotations": {
        "grafana.app/folder": "direct-folder"
      }
    },
    "spec": {
      "title": "Direct V2 Dashboard"
    }
  },
  "overwrite": true,
  "inputs": []
}
```

Expected saved resource:

```text
apiVersion: dashboard.grafana.app/v2
kind: Dashboard
metadata.name: direct-v2-dashboard
metadata.annotations["grafana.app/folder"]: direct-folder
spec.title: Direct V2 Dashboard
```

The same behavior applies when the DashboardV2 JSON comes from a plugin dashboard include because plugin-loaded dashboards and direct request dashboards flow through the same interpolation path ([service.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/service/service.go#L58-L86)).

# What Changed

- Import interpolation now returns the generated dashboard JSON plus the parsed resource metadata ([service.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/service/service.go#L52-L86)).
- `SaveDashboardCommand` receives the parsed `apiVersion`, so the final unstructured dashboard keeps `dashboard.grafana.app/v2` ([service.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/service/service.go#L159-L167), [dashboard_service_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboards/service/dashboard_service_test.go#L1867-L1880)).
- If the request does not choose a folder, import uses the resource folder annotation as the default folder ([service.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/service/service.go#L122-L125)).
- If the request does choose a folder, the request wins; `folderUid` also wins over deprecated `folderId`, including `folderUid: ""` for root ([service.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/service/service.go#L126-L151), [service_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/service/service_test.go#L201-L238), [service_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/service/service_test.go#L270-L309)).
- First-time creates now use the dashboard object's API version when choosing a Kubernetes client ([client.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboards/service/client/client.go#L280-L306), [client_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboards/service/client/client_test.go#L684-L727)).

# Folder Examples

| Import request | Resource annotation | Saved folder |
| --- | --- | --- |
| no `folderUid` or `folderId` | `grafana.app/folder: direct-folder` | `direct-folder` |
| `folderUid: "explicit-folder"` | `grafana.app/folder: direct-folder` | `explicit-folder` |
| `folderUid: ""` | `grafana.app/folder: direct-folder` | root |
| `folderUid: ""`, `folderId: 12` | `grafana.app/folder: direct-folder` | root |
| `folderId: 0` | `grafana.app/folder: direct-folder` | root |

`folderId` is deprecated, but the import API still accepts it. The request type tracks whether `folderUid` or `folderId` appeared in the JSON request because these cases decode to the same Go values ([dashboardimport.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/dashboardimport.go#L26-L67)):

```json
{}
```

```json
{ "folderUid": "" }
```

Both produce `FolderUid == ""`. The first means "use the folder from the dashboard resource." The second means "save at root." Unit and API tests cover that distinction at the request boundary ([dashboardimport_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/dashboardimport_test.go#L10-L37), [api_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/api/api_test.go#L104-L148)).

# Why `Create` Needs Its Own Override

`K8sClientWithFallback` embeds a handler created with `dashboardv0.VERSION` ([client.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboards/service/client/client.go#L83-L86)):

```go
K8sHandler: newClientFunc(context.Background(), dashboardv0.VERSION)
```

If `Create` is inherited from that embedded handler, client-go posts to the embedded handler's resource path. It does not switch paths because the object says `apiVersion: dashboard.grafana.app/v2`.

The first save path is:

```text
Update object using obj.apiVersion
Update returns not found
Create object
```

`Update` already chooses a handler from the object version. `Create` has to do the same thing because a new dashboard has no stored version to look up ([client.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboards/service/client/client.go#L280-L306)).

# Tests

The tests cover request encoding, HTTP binding, import behavior for plugin and direct DashboardV2 JSON, `folderUid` precedence over deprecated `folderId`, create-client dispatch, and the final unstructured dashboard conversion ([dashboardimport_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/dashboardimport_test.go#L10-L37), [api_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/api/api_test.go#L104-L148), [service_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboardimport/service/service_test.go#L163-L309), [client_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboards/service/client/client_test.go#L684-L727), [dashboard_service_test.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/pkg/services/dashboards/service/dashboard_service_test.go#L1867-L1880)).

```bash
go test ./pkg/services/dashboardimport -count=1
go test ./pkg/services/dashboardimport/api -count=1
go test ./pkg/services/dashboardimport/service -count=1
go test ./pkg/services/dashboards/service/client -count=1
go test ./pkg/services/dashboards/service -run TestLegacySaveCommandToUnstructured -count=1
```

# Manual Verification

Manual run date: 2026-06-13

- Folder API: `folder.grafana.app/v1`
- Dashboard API: `dashboard.grafana.app/v2`
- Import endpoint: `POST /api/dashboards/import`

Observed saved dashboards:

```text
dashboard.grafana.app/v2 Dashboard plugin-v2-dashboard team-folder Plugin V2 Dashboard GridLayout
dashboard.grafana.app/v2 Dashboard direct-v2-dashboard direct-folder Direct V2 Dashboard GridLayout
dashboard.grafana.app/v2 Dashboard root-override-v2-dashboard <none> Root Override V2 Dashboard GridLayout
```

The direct import payload proved that omitted folder fields stay omitted:

```text
has("folderUid") = false
has("folderId") = false
```

The root override payload proved that `folderUid: ""` wins over stale deprecated `folderId: 12`:

```text
has("folderUid") = true
folderUid = ""
has("folderId") = true
folderId = 12
saved folder annotation = <none>
```

<details>
<summary># Manual verification transcript</summary>

Setup:

- Started Grafana on `127.0.0.1:3129` with isolated temp data, plugin, log, and provisioning paths.
- Used a temporary unsigned datasource plugin with a dashboard include at `dashboards/dashboard-v2.json`.
- The normal `go run ./pkg/cmd/grafana -- server ...` path currently imports `pkg/operators`, which pulls unrelated enterprise provisioning code that does not compile in this checkout:

```text
pkg/extensions/apiserver/registry/provisioning/bitbucket/validator.go:42:75: not enough arguments in call to git.ValidateGitConfigFields
pkg/extensions/apiserver/registry/provisioning/gitlab/validator.go:42:75: not enough arguments in call to git.ValidateGitConfigFields
```

For this manual run only, I created a temporary `manual_grafana_server.go` entrypoint that calls Grafana's regular server command without importing `pkg/operators`. The file was deleted after the run.

Health check:

```text
ok	12.3.0-dev	manual
```

Command:

```bash
curl -fsS -u admin:admin \
  http://127.0.0.1:3129/api/plugins/artur-dashboardv2-test-datasource/dashboards |
  jq -r '.[0] | [.pluginId, .path, .title] | @tsv'
```

Output:

```text
artur-dashboardv2-test-datasource	dashboards/dashboard-v2.json	Plugin V2 Dashboard
```

Command:

```bash
curl -fsS -u admin:admin \
  -H 'Content-Type: application/json' \
  -X POST \
  http://127.0.0.1:3129/apis/folder.grafana.app/v1/namespaces/default/folders \
  -d '{"apiVersion":"folder.grafana.app/v1","kind":"Folder","metadata":{"name":"team-folder"},"spec":{"title":"Team Folder"}}' |
  jq -r '[.apiVersion, .kind, .metadata.name, .spec.title] | @tsv'
```

Output:

```text
folder.grafana.app/v1	Folder	team-folder	Team Folder
```

Command:

```bash
curl -fsS -u admin:admin \
  -H 'Content-Type: application/json' \
  -X POST \
  http://127.0.0.1:3129/api/dashboards/import \
  -d '{"pluginId":"artur-dashboardv2-test-datasource","path":"dashboards/dashboard-v2.json","overwrite":true,"inputs":[]}' |
  jq -r '[.uid, .folderUid, .imported, .title] | @tsv'
```

Output:

```text
plugin-v2-dashboard	team-folder	true	Plugin V2 Dashboard
```

Command:

```bash
curl -fsS -u admin:admin \
  http://127.0.0.1:3129/apis/dashboard.grafana.app/v2/namespaces/default/dashboards/plugin-v2-dashboard |
  jq -r '[.apiVersion, .kind, .metadata.name, .metadata.annotations["grafana.app/folder"], .spec.title, (.spec.layout.kind // "")] | @tsv'
```

Output:

```text
dashboard.grafana.app/v2	Dashboard	plugin-v2-dashboard	team-folder	Plugin V2 Dashboard	GridLayout
```

Command:

```bash
curl -fsS -u admin:admin \
  -H 'Content-Type: application/json' \
  -X POST \
  http://127.0.0.1:3129/apis/folder.grafana.app/v1/namespaces/default/folders \
  -d '{"apiVersion":"folder.grafana.app/v1","kind":"Folder","metadata":{"name":"direct-folder"},"spec":{"title":"Direct Folder"}}' |
  jq -r '[.apiVersion, .kind, .metadata.name, .spec.title] | @tsv'
```

Output:

```text
folder.grafana.app/v1	Folder	direct-folder	Direct Folder
```

Command:

```bash
DIRECT_PAYLOAD=$(cat <<'JSON' | jq -c .
{
  "dashboard": {
    "apiVersion": "dashboard.grafana.app/v2",
    "kind": "Dashboard",
    "metadata": {
      "name": "direct-v2-dashboard",
      "annotations": {
        "grafana.app/folder": "direct-folder"
      }
    },
    "spec": {
      "title": "Direct V2 Dashboard",
      "elements": {},
      "layout": {
        "kind": "GridLayout",
        "spec": {
          "items": []
        }
      }
    }
  },
  "overwrite": true,
  "inputs": []
}
JSON
)
printf '%s' "$DIRECT_PAYLOAD" | jq -r '[has("folderUid"), has("folderId")] | @tsv'
```

Output:

```text
false	false
```

Command:

```bash
curl -fsS -u admin:admin \
  -H 'Content-Type: application/json' \
  -X POST \
  http://127.0.0.1:3129/api/dashboards/import \
  -d "$DIRECT_PAYLOAD" |
  jq -r '[.uid, .folderUid, .imported, .title] | @tsv'
```

Output:

```text
direct-v2-dashboard	direct-folder	true	Direct V2 Dashboard
```

Command:

```bash
curl -fsS -u admin:admin \
  http://127.0.0.1:3129/apis/dashboard.grafana.app/v2/namespaces/default/dashboards/direct-v2-dashboard |
  jq -r '[.apiVersion, .kind, .metadata.name, .metadata.annotations["grafana.app/folder"], .spec.title, (.spec.layout.kind // "")] | @tsv'
```

Output:

```text
dashboard.grafana.app/v2	Dashboard	direct-v2-dashboard	direct-folder	Direct V2 Dashboard	GridLayout
```

Command:

```bash
ROOT_PAYLOAD=$(cat <<'JSON' | jq -c .
{
  "dashboard": {
    "apiVersion": "dashboard.grafana.app/v2",
    "kind": "Dashboard",
    "metadata": {
      "name": "root-override-v2-dashboard",
      "annotations": {
        "grafana.app/folder": "stale-source-folder"
      }
    },
    "spec": {
      "title": "Root Override V2 Dashboard",
      "elements": {},
      "layout": {
        "kind": "GridLayout",
        "spec": {
          "items": []
        }
      }
    }
  },
  "overwrite": true,
  "inputs": [],
  "folderUid": "",
  "folderId": 12
}
JSON
)
printf '%s' "$ROOT_PAYLOAD" | jq -r '[has("folderUid"), .folderUid, has("folderId"), .folderId] | @tsv'
```

Output:

```text
true		true	12
```

Command:

```bash
curl -fsS -u admin:admin \
  -H 'Content-Type: application/json' \
  -X POST \
  http://127.0.0.1:3129/api/dashboards/import \
  -d "$ROOT_PAYLOAD" |
  jq -r '[.uid, .folderUid, .imported, .title] | @tsv'
```

Output:

```text
root-override-v2-dashboard		true	Root Override V2 Dashboard
```

Command:

```bash
curl -fsS -u admin:admin \
  http://127.0.0.1:3129/apis/dashboard.grafana.app/v2/namespaces/default/dashboards/root-override-v2-dashboard |
  jq -r '[.apiVersion, .kind, .metadata.name, (.metadata.annotations["grafana.app/folder"] // "<none>"), .spec.title, (.spec.layout.kind // "")] | @tsv'
```

Output:

```text
dashboard.grafana.app/v2	Dashboard	root-override-v2-dashboard	<none>	Root Override V2 Dashboard	GridLayout
```

</details>

# Server Log Note

Grafana logged a non-fatal managed-fields warning after the DashboardV2 create. The dashboard payload is valid: DashboardV2 layout is written as `{"kind":"GridLayout","spec":...}` ([dashboard_spec.cue](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/apps/dashboard/kinds/v2/dashboard_spec.cue#L623-L626)). After the save, Kubernetes-style bookkeeping tries to record which fields changed. That bookkeeping step uses an OpenAPI schema that still describes the generated Go wrapper fields for the layout union, such as `GridLayoutKind`, instead of the external JSON fields `kind` and `spec` ([dashboard_spec_gen.go](https://github.com/grafana/grafana/blob/plugin-dash-import-v2/apps/dashboard/pkg/apis/dashboard/v2/dashboard_spec_gen.go#L3183-L3214)). Because of that schema mismatch, bookkeeping says `.spec.layout.kind` is unknown. The save itself still works, and the dashboard is read back through `dashboard.grafana.app/v2`.

```text
logger=grafana-apiserver level=error msg="[SHOULD NOT HAPPEN] failed to update managedFields" err="failed to convert new object (default/plugin-v2-dashboard; dashboard.grafana.app/v2, Kind=Dashboard) to smd typed: .spec.layout.kind: field not declared in schema"
```

The requests succeeded and all dashboards were retrieved through `dashboard.grafana.app/v2`.
