### PR TITLE
Improve streaming indicator in panel chrome

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -161,6 +161,16 @@ it('renders streaming indicator in the panel header if loadingState is streaming
   setup({ loadingState: LoadingState.Streaming });
 
   expect(screen.getByTestId('panel-streaming')).toBeInTheDocument();
+  expect(screen.getByRole('status', { name: 'Streaming data' })).toBeInTheDocument();
+});
+
+it('renders streaming indicator as stop button if cancel callback is provided', async () => {
+  const onCancelQuery = jest.fn();
+  const { user } = setup({ loadingState: LoadingState.Streaming, onCancelQuery });
+
+  await user.click(screen.getByRole('button', { name: 'Stop streaming' }));
+
+  expect(onCancelQuery).toHaveBeenCalledTimes(1);
 });
 
 it('collapses the controlled panel when user clicks on the chevron or the title', async () => {

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -165,6 +165,9 @@ export function PanelChrome({
   const { isSelected, onSelect, isSelectable } = useElementSelection(selectionId);
   const pointerDistance = usePointerDistance();
   const [subHeaderRef, { height: measuredSubHeaderHeight }] = useMeasure<HTMLDivElement>();
+  const streamingLabel = onCancelQuery
+    ? t('grafana-ui.panel-chrome.aria-label-stop-streaming', 'Stop streaming')
+    : t('grafana-ui.panel-chrome.aria-label-streaming', 'Streaming data');
 
   const hasHeader = !hoverHeader;
 
@@ -320,26 +323,17 @@ export function PanelChrome({
       )}
 
       {loadingState === LoadingState.Streaming && (
-        <Tooltip
-          content={
-            onCancelQuery
-              ? t('grafana-ui.panel-chrome.tooltip-stop-streaming', 'Stop streaming')
-              : t('grafana-ui.panel-chrome.tooltip-streaming', 'Streaming')
-          }
-        >
+        <Tooltip content={streamingLabel}>
           <TitleItem
             className={cx(dragClassCancel, onCancelQuery && styles.pointer)}
             data-testid="panel-streaming"
             onClick={onCancelQuery}
+            aria-label={onCancelQuery ? streamingLabel : undefined}
           >
             <span
               className={styles.streamingIndicator}
               role={onCancelQuery ? undefined : 'status'}
-              aria-label={
-                onCancelQuery
-                  ? t('grafana-ui.panel-chrome.aria-label-stop-streaming', 'Stop streaming')
-                  : t('grafana-ui.panel-chrome.aria-label-streaming', 'Streaming data')
-              }
+              aria-label={onCancelQuery ? undefined : streamingLabel}
             >
               <Icon name="circle-mono" size="md" className={styles.streaming} aria-hidden />
             </span>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx, keyframes } from '@emotion/css';
 import { type CSSProperties, type ReactElement, type ReactNode, useId, useState } from 'react';
 import * as React from 'react';
 import { useMeasure, useToggle } from 'react-use';
@@ -327,8 +327,22 @@ export function PanelChrome({
               : t('grafana-ui.panel-chrome.tooltip-streaming', 'Streaming')
           }
         >
-          <TitleItem className={dragClassCancel} data-testid="panel-streaming" onClick={onCancelQuery}>
-            <Icon name="circle-mono" size="md" className={styles.streaming} />
+          <TitleItem
+            className={cx(dragClassCancel, onCancelQuery && styles.pointer)}
+            data-testid="panel-streaming"
+            onClick={onCancelQuery}
+          >
+            <span
+              className={styles.streamingIndicator}
+              role={onCancelQuery ? undefined : 'status'}
+              aria-label={
+                onCancelQuery
+                  ? t('grafana-ui.panel-chrome.aria-label-stop-streaming', 'Stop streaming')
+                  : t('grafana-ui.panel-chrome.aria-label-streaming', 'Streaming data')
+              }
+            >
+              <Icon name="circle-mono" size="md" className={styles.streaming} aria-hidden />
+            </span>
           </TitleItem>
         </Tooltip>
       )}
@@ -517,6 +531,20 @@ const getContentStyle = (
 
 const getStyles = (theme: GrafanaTheme2) => {
   const { background, borderColor } = theme.components.panel;
+  const pulseStreaming = keyframes({
+    '0%': {
+      boxShadow: `0 0 0 0 ${theme.colors.success.transparent}`,
+      transform: 'scale(1)',
+    },
+    '70%': {
+      boxShadow: `0 0 0 ${theme.spacing(0.75)} transparent`,
+      transform: 'scale(1.08)',
+    },
+    '100%': {
+      boxShadow: '0 0 0 0 transparent',
+      transform: 'scale(1)',
+    },
+  });
 
   return {
     container: css({
@@ -617,6 +645,20 @@ const getStyles = (theme: GrafanaTheme2) => {
 
       '&:hover': {
         color: theme.colors.success.text,
+      },
+    }),
+    streamingIndicator: css({
+      label: 'panel-streaming-indicator',
+      width: theme.spacing(2),
+      height: theme.spacing(2),
+      borderRadius: theme.shape.radius.circle,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      animation: `${pulseStreaming} 1.6s ease-out infinite`,
+
+      '@media (prefers-reduced-motion: reduce)': {
+        animation: 'none',
       },
     }),
     title: css({

--- a/packages/grafana-ui/src/components/PanelChrome/TitleItem.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/TitleItem.tsx
@@ -8,7 +8,7 @@ import { useStyles2 } from '../../themes/ThemeContext';
 import { getFocusStyles, getMouseFocusStyles } from '../../themes/mixins';
 import { Button } from '../Button/Button';
 
-type TitleItemProps = {
+type TitleItemProps = React.HTMLAttributes<HTMLElement> & {
   className?: string;
   children: React.ReactNode;
   onClick?: LinkModel['onClick'];
@@ -45,6 +45,7 @@ export const TitleItem = forwardRef<TitleItemElement, TitleItemProps>(
           variant="secondary"
           fill="text"
           onClick={onClick}
+          {...rest}
         >
           {children}
         </Button>


### PR DESCRIPTION
## What
Replace the static streaming dot in `PanelChrome` with a subtle pulsing indicator and add accessible semantics. When cancellation is available, the indicator remains clickable and is labeled as a stop action.

## Why
Streaming panels currently show a static green dot. This makes the state easy to miss during active queries. The new indicator is more noticeable without being noisy, and it respects reduced-motion preferences.

## Verification
- `yarn jest --no-watch packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx`
- `yarn workspace @grafana/ui typecheck`

## Issue
Closes #89415