### PR TITLE
Docs: update contributing guide links to HTTPS

### DIFF
--- a/contribute/backend/style-guide.md
+++ b/contribute/backend/style-guide.md
@@ -6,7 +6,7 @@ Unless stated otherwise, use the guidelines listed in the following articles:
 
 - [Effective Go](https://golang.org/doc/effective_go.html)
 - [Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
-- [Go: Best Practices for Production Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style)
+- [Go: Best Practices for Production Environments](https://peter.bourgon.org/go-in-production/#formatting-and-style)
 
 ## Linting and formatting
 

--- a/contribute/backend/upgrade-dependencies.md
+++ b/contribute/backend/upgrade-dependencies.md
@@ -4,7 +4,7 @@ We recommend the practices in this documentation when upgrading the various back
 
 ## Protocol buffers (protobufs)
 
-Use the most recent stable version of the [protobuf library](http://github.com/golang/protobuf) in Grafana and the plugin SDK.
+Use the most recent stable version of the [protobuf library](https://github.com/golang/protobuf) in Grafana and the plugin SDK.
 
 Additionally, you typically want to upgrade your protobuf compiler toolchain and re-compile the protobuf files.
 


### PR DESCRIPTION
Update insecure HTTP links in the backend contributing documentation:

- `contribute/backend/style-guide.md`: peter.bourgon.org link updated to HTTPS
- `contribute/backend/upgrade-dependencies.md`: github.com/golang/protobuf link updated to HTTPS

Both sites support HTTPS and the HTTP versions redirect.