### PR TITLE
Alerting: Skip retries for deterministic Mimir resource-limit errors

### DIFF
--- a/pkg/expr/errors.go
+++ b/pkg/expr/errors.go
@@ -3,11 +3,61 @@ package expr
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 )
 
 var ErrSeriesMustBeWide = errors.New("input data must be a wide series")
+
+// ErrQueryLimit marks a datasource query rejected by a Mimir query-time resource
+// limit. These fail identically on every in-cycle retry, so callers can treat
+// them as non-retryable via errors.Is(err, ErrQueryLimit).
+var ErrQueryLimit = errors.New("query exceeded a resource limit")
+
+// queryLimitErrorIDs are the Mimir global error IDs that ErrQueryLimit covers.
+// They survive only as substrings of the datasource error, so they are matched
+// here — the single place query errors are built — and surfaced as the sentinel.
+var queryLimitErrorIDs = []string{
+	"err-mimir-max-chunks-per-query",
+	"err-mimir-max-series-per-query",
+	"err-mimir-max-chunks-bytes-per-query",
+	"err-mimir-max-estimated-chunks-per-query",
+	"err-mimir-max-estimated-memory-consumption-per-query",
+}
+
+func isQueryLimitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, id := range queryLimitErrorIDs {
+		if strings.Contains(msg, id) {
+			return true
+		}
+	}
+	return false
+}
+
+// queryLimitError wraps a built query error so that errors.Is(err, ErrQueryLimit)
+// reports true, without altering the error message or breaking the underlying
+// errutil.Error chain (errors.As and Unwrap keep working).
+type queryLimitError struct{ error }
+
+func (queryLimitError) Is(target error) bool { return target == ErrQueryLimit }
+func (e queryLimitError) Unwrap() error      { return e.error }
+
+// WrapQueryLimitError tags err with ErrQueryLimit when its message contains a known
+// Mimir query-limit error ID, preserving the original message and chain. Use it at
+// boundaries where a query error is reconstructed from its string and the original
+// error chain is lost — e.g. an error deserialized from a remote query service — so
+// errors.Is(err, ErrQueryLimit) classification keeps working there too.
+func WrapQueryLimitError(err error) error {
+	if err == nil || !isQueryLimitError(err) {
+		return err
+	}
+	return queryLimitError{err}
+}
 
 var ConversionError = errutil.BadRequest("sse.readDataError").MustTemplate(
 	"[{{ .Public.refId }}] got error: {{ .Error }}",
@@ -53,7 +103,7 @@ func MakeQueryError(refID, datasourceUID string, err error) error {
 		Error: err,
 	}
 
-	return QueryError.Build(data)
+	return WrapQueryLimitError(QueryError.Build(data))
 }
 
 var depErrStr = "did not execute expression [{{ .Public.refId }}] due to a failure of the dependent expression or query [{{.Public.depRefId}}]"

--- a/pkg/expr/errors_test.go
+++ b/pkg/expr/errors_test.go
@@ -19,3 +19,48 @@ func TestQueryErrorType(t *testing.T) {
 	require.True(t, errors.Is(qe, qet))
 	require.True(t, errors.As(qe, &utilError))
 }
+
+func TestMakeQueryError_QueryLimit(t *testing.T) {
+	t.Run("tags deterministic query-limit rejections as ErrQueryLimit", func(t *testing.T) {
+		dsErr := fmt.Errorf("execution: the query exceeded the maximum number of chunks (limit: 2000000 chunks) (err-mimir-max-chunks-per-query). Consider reducing the time range")
+		qe := expr.MakeQueryError("A", "uid", dsErr)
+
+		require.True(t, errors.Is(qe, expr.ErrQueryLimit), "should be classifiable as a query-limit error")
+		// It must remain a normal query error and a usable errutil.Error.
+		require.True(t, errors.Is(qe, expr.QueryError))
+		utilError := errutil.Error{}
+		require.True(t, errors.As(qe, &utilError))
+		// The message must be preserved: the underlying Mimir ID is still present and
+		// the sentinel's own text is not injected into the rendered error.
+		require.Contains(t, qe.Error(), "err-mimir-max-chunks-per-query")
+		require.NotContains(t, qe.Error(), expr.ErrQueryLimit.Error())
+	})
+
+	t.Run("leaves other query errors retryable", func(t *testing.T) {
+		qe := expr.MakeQueryError("A", "uid", fmt.Errorf("connection refused"))
+		require.False(t, errors.Is(qe, expr.ErrQueryLimit))
+	})
+}
+
+func TestWrapQueryLimitError(t *testing.T) {
+	t.Run("tags a plain (e.g. deserialized) error that carries a query-limit ID", func(t *testing.T) {
+		// Mimics an error reconstructed from a remote query service response: a plain
+		// error whose message contains the Mimir ID but no original error chain.
+		deserialized := errors.New("failed to execute query [A]: execution: the query exceeded the maximum number of chunks (err-mimir-max-chunks-per-query)")
+		wrapped := expr.WrapQueryLimitError(deserialized)
+
+		require.True(t, errors.Is(wrapped, expr.ErrQueryLimit))
+		require.Equal(t, deserialized.Error(), wrapped.Error(), "message must be preserved")
+		require.ErrorIs(t, wrapped, deserialized, "chain to the original error must be preserved")
+	})
+
+	t.Run("leaves non-matching errors untouched", func(t *testing.T) {
+		err := errors.New("connection refused")
+		require.Equal(t, err, expr.WrapQueryLimitError(err))
+		require.False(t, errors.Is(expr.WrapQueryLimitError(err), expr.ErrQueryLimit))
+	})
+
+	t.Run("nil stays nil", func(t *testing.T) {
+		require.NoError(t, expr.WrapQueryLimitError(nil))
+	})
+}

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/writer"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -193,14 +194,20 @@ func (evalResults Results) HasNonRetryableErrors() bool {
 	return false
 }
 
-// IsNonRetryableError indicates whether an error is considered persistent and not worth performing evaluation retries.
-// Currently it is true if err is `&invalidEvalResultFormatError` or `ErrSeriesMustBeWide`
+// IsNonRetryableError reports whether an error is persistent and not worth retrying within an
+// evaluation cycle: malformed results, or deterministic Mimir query-limit / write rejections.
 func IsNonRetryableError(err error) bool {
 	var nonRetryableError *invalidEvalResultFormatError
 	if errors.As(err, &nonRetryableError) {
 		return true
 	}
 	if errors.Is(err, expr.ErrSeriesMustBeWide) {
+		return true
+	}
+	if errors.Is(err, expr.ErrQueryLimit) {
+		return true
+	}
+	if errors.Is(err, writer.ErrNonRetryableWrite) {
 		return true
 	}
 	return false

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dsquerierclient"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/writer"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -1484,6 +1485,53 @@ func TestResults_HasNonRetryableErrors(t *testing.T) {
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.expected, tt.eval.HasNonRetryableErrors())
+		})
+	}
+}
+
+func TestIsNonRetryableError(t *testing.T) {
+	tc := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "nil error", err: nil, expected: false},
+		{name: "generic error is retryable", err: errors.New("some weird error"), expected: false},
+		{
+			name:     "invalid eval result format is non-retryable",
+			err:      &invalidEvalResultFormatError{refID: "A", reason: "unable to get frame row length", err: errors.New("weird error")},
+			expected: true,
+		},
+		{
+			name:     "series must be wide is non-retryable",
+			err:      fmt.Errorf("%w but got type long", expr.ErrSeriesMustBeWide),
+			expected: true,
+		},
+		{
+			name:     "query-limit rejection is non-retryable (through pipeline wrap)",
+			err:      fmt.Errorf("server side expressions pipeline returned an error: %w", expr.MakeQueryError("A", "uid", errors.New("the query exceeded the maximum number of chunks (err-mimir-max-chunks-per-query)"))),
+			expected: true,
+		},
+		{
+			name:     "other query error stays retryable",
+			err:      expr.MakeQueryError("A", "uid", errors.New("connection refused")),
+			expected: false,
+		},
+		{
+			name:     "non-retryable write rejection is non-retryable (through remote-write wrap)",
+			err:      fmt.Errorf("remote write failed: %w", fmt.Errorf("%w: payload too large", writer.ErrNonRetryableWrite)),
+			expected: true,
+		},
+		{
+			name:     "plain rejected write stays retryable",
+			err:      fmt.Errorf("remote write failed: %w", fmt.Errorf("%w: invalid series", writer.ErrRejectedWrite)),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, IsNonRetryableError(tt.err))
 		})
 	}
 }

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -434,24 +434,24 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 
 		// Only retry (return errors) if this isn't the last attempt, otherwise skip these return operations.
 		if retry {
-			// The only thing that can return non-nil `err` from ruleEval.Evaluate is the server side expression pipeline.
-			// This includes transport errors such as transient network errors.
-			if err != nil {
+			// `err` is set only when the SSE pipeline itself failed; retry it unless it is
+			// deterministically non-retryable. The `err == nil` guard below is load-bearing:
+			// with a non-nil `err`, `results` is nil and HasNonRetryableErrors() would say retryable.
+			if err != nil && !eval.IsNonRetryableError(err) {
 				span.SetStatus(codes.Error, "rule evaluation failed")
 				span.RecordError(err)
 				return fmt.Errorf("server side expressions pipeline returned an error: %w", err)
-			}
-
-			// If the pipeline executed successfully but have other types of errors that can be retryable, we should do so.
-			if !results.HasNonRetryableErrors() {
+			} else if err == nil && !results.HasNonRetryableErrors() {
+				// If the pipeline executed successfully but have other types of errors that can be retryable, we should do so.
 				span.SetStatus(codes.Error, "rule evaluation failed")
-				span.RecordError(err)
+				span.RecordError(results.Error())
 				return fmt.Errorf("the result-set has errors that can be retried: %w", results.Error())
 			}
-		} else {
-			// Only count the final attempt as a failure.
-			evalTotalFailures.Inc()
 		}
+
+		// Final failure (last attempt or non-retryable): count it once. Previously this ran
+		// only on the last attempt, so non-retryable early-stops were undercounted.
+		evalTotalFailures.Inc()
 
 		// If results is nil, we assume that the error must be from the SSE pipeline (ruleEval.Evaluate) which is the only code that can actually return an `err`.
 		if results == nil {

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -24,11 +24,13 @@ import (
 
 	alertingModels "github.com/grafana/alerting/models"
 
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval/eval_mocks"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/util"
@@ -1476,4 +1478,86 @@ func stateForRule(rule *models.AlertRule, ts time.Time, evalState eval.State) *s
 	s.CacheID = id
 
 	return s
+}
+
+func TestAlertRuleNoRetryOnNonRetryableError(t *testing.T) {
+	gen := models.RuleGen.With(models.RuleGen.WithOrgID(123), withQueryForState(t, eval.Error))
+	rule := gen.GenerateRef()
+	rule.ExecErrState = models.ErrorErrState
+
+	// The evaluator returns a deterministic, non-retryable error as the top-level
+	// pipeline error, mirroring a Mimir query-limit rejection on an alert rule.
+	nonRetryable := fmt.Errorf("server side expressions pipeline returned an error: %w",
+		expr.MakeQueryError("A", "uid", errors.New("the query exceeded the maximum number of chunks (err-mimir-max-chunks-per-query)")))
+
+	condMock := &eval_mocks.ConditionEvaluatorMock{}
+	condMock.EXPECT().Evaluate(mock.Anything, mock.Anything).Return(nil, nonRetryable)
+
+	evalAppliedChan := make(chan time.Time)
+	sender := NewSyncAlertsSenderMock()
+	sender.EXPECT().Send(mock.Anything, rule.GetKey(), mock.Anything).Return()
+
+	ruleStore := newFakeRulesStore()
+	reg := prometheus.NewPedanticRegistry()
+	clk := clock.NewMock()
+	sch := setupScheduler(t, ruleStore, &state.FakeInstanceStore{}, reg, sender, eval_mocks.NewEvaluatorFactory(condMock), nil, withSchedulerClock(clk))
+	// MaxAttempts: 3 means that, without fail-fast classification, this rule would
+	// be attempted 3 times. We assert it is attempted exactly once.
+	sch.retryConfig = RetryConfig{
+		MaxAttempts:         3,
+		InitialRetryDelay:   1 * time.Second,
+		MaxRetryDelay:       1 * time.Second,
+		RandomizationFactor: 0,
+	}
+	sch.evalAppliedFunc = func(key models.AlertRuleKey, t time.Time) {
+		evalAppliedChan <- t
+	}
+	ruleStore.PutRule(context.Background(), rule)
+
+	factory := newRuleFactory(
+		sch.appURL,
+		sch.disableGrafanaFolder,
+		sch.retryConfig,
+		sch.alertsSender,
+		sch.stateManager,
+		sch.evaluatorFactory,
+		sch.clock,
+		sch.rrCfg,
+		sch.metrics,
+		sch.log,
+		sch.tracer,
+		sch.featureToggles,
+		sch.recordingWriter,
+		sch.evalAppliedFunc,
+		sch.stopAppliedFunc,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: ""})
+
+	go func() {
+		_ = ruleInfo.Run()
+	}()
+
+	ruleInfo.Eval(&Evaluation{
+		scheduledAt: sch.clock.Now(),
+		rule:        rule,
+	})
+
+	waitForTimeChannel(t, evalAppliedChan)
+
+	orgID := fmt.Sprint(rule.OrgID)
+	require.Equal(t, float64(1), testutil.ToFloat64(sch.metrics.EvalAttemptTotal.WithLabelValues(orgID)),
+		"a non-retryable error must be attempted exactly once, not retried")
+	require.Equal(t, float64(1), testutil.ToFloat64(sch.metrics.EvalAttemptFailures.WithLabelValues(orgID)))
+	require.Equal(t, float64(1), testutil.ToFloat64(sch.metrics.EvalFailures.WithLabelValues(orgID)),
+		"the rule-level failure must be counted once even though retries stopped early")
+
+	condMock.AssertNumberOfCalls(t, "Evaluate", 1)
+
+	status := ruleInfo.Status()
+	require.Equal(t, "error", status.Health)
+	require.NotNil(t, status.LastError)
+	require.Contains(t, status.LastError.Error(), "err-mimir-max-chunks-per-query")
 }

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -944,4 +945,61 @@ func getLabel(req *prompb.WriteRequest, labelName string) (string, bool) {
 	}
 
 	return "", false
+}
+
+func TestRecordingRuleNoRetryOnNonRetryableWrite(t *testing.T) {
+	gen := models.RuleGen.With(models.RuleGen.WithAllRecordingRules(), models.RuleGen.WithOrgID(123), withQueryForHealth("ok"))
+	rule := gen.GenerateRef()
+	// FakeWriter only invokes WriteFunc when the target datasource UID is empty
+	// (it writes to the default remote-write target otherwise).
+	rule.Record.TargetDatasourceUID = ""
+
+	ruleStore := newFakeRulesStore()
+	reg := prometheus.NewPedanticRegistry()
+	sch := setupScheduler(t, ruleStore, nil, reg, nil, nil, nil)
+	// MaxAttempts: 3 means that, for a retryable write error, this rule would be
+	// attempted 3 times. We assert it is attempted exactly once.
+	sch.retryConfig = RetryConfig{
+		MaxAttempts:         3,
+		InitialRetryDelay:   1 * time.Second,
+		MaxRetryDelay:       1 * time.Second,
+		RandomizationFactor: 0,
+	}
+	// The write is rejected with a deterministic, non-retryable error, mirroring
+	// err-mimir-distributor-max-write-message-size on twiliouse1 recording rules.
+	sch.recordingWriter = writer.FakeWriter{
+		WriteFunc: func(_ context.Context, _ string, _ time.Time, _ data.Frames, _ int64, _ map[string]string) error {
+			return fmt.Errorf("%w: payload too large", writer.ErrNonRetryableWrite)
+		},
+	}
+	ruleStore.PutRule(context.Background(), rule)
+
+	process := ruleFactoryFromScheduler(sch).new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
+	rr := process.(*recordingRule)
+	evalDoneChan := make(chan time.Time, 1)
+	rr.evalAppliedHook = func(_ models.AlertRuleKey, t time.Time) {
+		evalDoneChan <- t
+	}
+
+	go func() {
+		_ = process.Run()
+	}()
+
+	process.Eval(&Evaluation{scheduledAt: time.Now(), rule: rule})
+
+	select {
+	case <-evalDoneChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("evaluation did not complete")
+	}
+
+	orgID := fmt.Sprint(rule.OrgID)
+	require.Equal(t, float64(1), testutil.ToFloat64(sch.metrics.EvalAttemptFailures.WithLabelValues(orgID)),
+		"a non-retryable write rejection must be attempted exactly once, not retried")
+	require.Equal(t, float64(1), testutil.ToFloat64(sch.metrics.EvalFailures.WithLabelValues(orgID)))
+
+	require.Equal(t, "error", rr.health.Load())
+	lastErr := rr.lastError.Load()
+	require.Error(t, lastErr)
+	require.ErrorIs(t, lastErr, writer.ErrNonRetryableWrite)
 }

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -5688,3 +5688,36 @@ func (f *fakePersister) Sync(_ context.Context, _ trace.Span, _ ngmodels.AlertRu
 }
 
 var _ StatePersister = (*fakePersister)(nil)
+
+func TestDatasourceErrorInfo(t *testing.T) {
+	rule := &ngmodels.AlertRule{
+		Data: []ngmodels.AlertQuery{
+			{RefID: "A", DatasourceUID: "ds-uid-1"},
+		},
+	}
+
+	t.Run("extracts refID and datasource UID from a query error", func(t *testing.T) {
+		err := expr.MakeQueryError("A", "ds-uid-1", errors.New("boom"))
+		refID, dsUID := datasourceErrorInfo(err, rule)
+		require.Equal(t, "A", refID)
+		require.Equal(t, "ds-uid-1", dsUID)
+	})
+
+	t.Run("still extracts them when the query error is wrapped as a query-limit error", func(t *testing.T) {
+		// MakeQueryError tags this with the queryLimitError wrapper because the message
+		// carries a Mimir query-limit ID. datasourceErrorInfo must still unwrap through
+		// that wrapper to reach the errutil error and read refId from its public payload.
+		err := expr.MakeQueryError("A", "ds-uid-1", errors.New("the query exceeded the maximum number of chunks (err-mimir-max-chunks-per-query)"))
+		require.True(t, errors.Is(err, expr.ErrQueryLimit), "precondition: error is wrapped by the query-limit helper")
+
+		refID, dsUID := datasourceErrorInfo(err, rule)
+		require.Equal(t, "A", refID, "refID must be extractable through the queryLimitError wrapper")
+		require.Equal(t, "ds-uid-1", dsUID)
+	})
+
+	t.Run("returns empty for a non-query error", func(t *testing.T) {
+		refID, dsUID := datasourceErrorInfo(errors.New("generic"), rule)
+		require.Empty(t, refID)
+		require.Empty(t, dsUID)
+	})
+}

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -124,6 +124,13 @@ var (
 		PrometheusDuplicateTimestampError,
 	}
 
+	// NonRetryableWriteErrors is the deterministic subset of ExpectedErrors: retrying the
+	// same payload in-cycle fails identically. The rest stay retryable (may clear over time).
+	NonRetryableWriteErrors = []string{
+		MimirDistributorMaxWriteMessageSizeError,
+		MimirDistributorMaxWriteRequestDataItemSizeError,
+	}
+
 	// ExpectedErrors are user-level write errors like trying to write an invalid series.
 	ExpectedErrors = []string{
 		MimirDistributorMaxWriteMessageSizeError,
@@ -355,6 +362,17 @@ func promremoteLabelsFromPoint(point Point) []promremote.Label {
 	return labels
 }
 
+// ErrNonRetryableWrite is an internal marker (matched via errors.Is, never rendered) for a
+// deterministic write rejection that fails identically on every in-cycle retry.
+var ErrNonRetryableWrite = errors.New("write rejected (non-retryable)")
+
+// nonRetryableWrite tags a rejected write as non-retryable without changing its message;
+// errors.Is matches both ErrNonRetryableWrite and the wrapped ErrRejectedWrite.
+type nonRetryableWrite struct{ error }
+
+func (nonRetryableWrite) Is(target error) bool { return target == ErrNonRetryableWrite }
+func (e nonRetryableWrite) Unwrap() error      { return e.error }
+
 func checkWriteError(writeErr promremote.WriteError) (err error, ignored bool) {
 	if writeErr == nil {
 		return nil, false
@@ -386,6 +404,15 @@ func checkWriteError(writeErr promremote.WriteError) (err error, ignored bool) {
 		for _, e := range IgnoredErrors {
 			if strings.Contains(msg, e) {
 				return nil, true
+			}
+		}
+
+		// Check for deterministic, non-retryable rejections first (a subset of
+		// ExpectedErrors). These fail identically on every in-cycle retry.
+		for _, e := range NonRetryableWriteErrors {
+			if strings.Contains(msg, e) {
+				actual := extractActualError(writeErr)
+				return nonRetryableWrite{fmt.Errorf("%w: %s", ErrRejectedWrite, actual)}, false
 			}
 		}
 

--- a/pkg/services/ngalert/writer/prom_test.go
+++ b/pkg/services/ngalert/writer/prom_test.go
@@ -231,6 +231,44 @@ func TestPrometheusWriter_Write(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrRejectedWrite)
 	})
+
+	t.Run("max write message size is a non-retryable rejection", func(t *testing.T) {
+		msg := "the incoming push request has been rejected because its message size of 157568313 bytes (uncompressed) is larger than the allowed limit of 104857600 bytes (err-mimir-distributor-max-write-message-size). To adjust the related limit, configure -distributor.max-recv-msg-size, or contact your service administrator."
+		clientErr := testClientWriteError{
+			statusCode: http.StatusBadRequest,
+			msg:        &msg,
+		}
+		client.writeSeriesFunc = func(ctx context.Context, ts promremote.TSList, opts promremote.WriteOptions) (promremote.WriteResult, promremote.WriteError) {
+			return promremote.WriteResult{}, clientErr
+		}
+
+		err := writer.Write(ctx, "test", now, frames, 1, map[string]string{"extra": "label"})
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNonRetryableWrite)
+		// It must still report as ErrRejectedWrite so existing handling keeps working,
+		// keep its verbatim message, and not leak the internal classification.
+		require.ErrorIs(t, err, ErrRejectedWrite)
+		require.Contains(t, err.Error(), "series was rejected")
+		require.NotContains(t, err.Error(), "non-retryable")
+	})
+
+	t.Run("a retryable expected rejection is not classified non-retryable", func(t *testing.T) {
+		msg := "send data to ingesters: failed pushing to ingester ingester-1: user=1: per-user series limit of 10 exceeded (err-mimir-max-series-per-user)."
+		clientErr := testClientWriteError{
+			statusCode: http.StatusBadRequest,
+			msg:        &msg,
+		}
+		client.writeSeriesFunc = func(ctx context.Context, ts promremote.TSList, opts promremote.WriteOptions) (promremote.WriteResult, promremote.WriteError) {
+			return promremote.WriteResult{}, clientErr
+		}
+
+		err := writer.Write(ctx, "test", now, frames, 1, map[string]string{"extra": "label"})
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrRejectedWrite)
+		require.NotErrorIs(t, err, ErrNonRetryableWrite)
+	})
 }
 
 func TestExtractActualError(t *testing.T) {


### PR DESCRIPTION
Deterministic Mimir resource-limit rejections (query-limit and write-message-size) fail identically on every retry, so retrying them within an evaluation cycle wastes query/write cost for no benefit. Classify them as non-retryable so the rule reaches error state on the first attempt instead of exhausting retries. Recovery is unchanged — the rule is still evaluated every cycle.

Also fixes a pre-existing miscount where `rule_evaluation_failures_total` was not incremented when retries stopped early.