### PR TITLE
Annotations: Add missing composite index for dashboard_uid time-range queries

### DIFF
--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -202,6 +202,10 @@ func addAnnotationMig(mg *Migrator) {
 	}))
 
 	mg.AddMigration("Add missing dashboard_uid to annotation table", &SetDashboardUIDMigration{})
+
+	mg.AddMigration("Add index for org_id_dashboard_uid_epoch_end_epoch on annotation table", NewAddIndexMigration(table, &Index{
+		Cols: []string{"org_id", "dashboard_uid", "epoch_end", "epoch"}, Type: IndexType,
+	}))
 }
 
 type AddMakeRegionSingleRowMigration struct {


### PR DESCRIPTION
**What is this feature?**

Adds a composite database index `(org_id, dashboard_uid, epoch_end, epoch)` on
the `annotation` table via a new migration, matching the query shape used by the
annotation read path when filtering by dashboard UID.

**Why do we need this feature?**

After upgrading to v13, `GET /annotations` changed behavior: when only
`dashboardId` is provided, the API layer resolves it to `dashboardUID` and the
repository then filters exclusively by `a.dashboard_uid = ?`. The existing
composite index covers `(org_id, dashboard_id, epoch_end, epoch)` but there is
no equivalent index for `dashboard_uid`. On large annotation tables this causes
the database to fall back to the less-selective `(org_id, epoch_end, epoch)`
index, resulting in high DB load, slow annotation responses, and connection pool
exhaustion - a performance regression compared to v12.

**Who is this feature for?**

Grafana operators and users running v13+ with large annotation tables (especially
on MySQL/Aurora) who are experiencing degraded performance or high DB load on
annotation queries scoped to a dashboard.

**Which issue(s) does this PR fix?**

Fixes #126504