### PR TITLE
fix http error handling for tempo datasource backend

### DIFF
--- a/pkg/tsdb/tempo/http_error.go
+++ b/pkg/tsdb/tempo/http_error.go
@@ -1,0 +1,35 @@
+package tempo
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func dataResponseFromHTTPError(resp *http.Response, body []byte, fallbackMessage string) *backend.DataResponse {
+	message := string(body)
+	if strings.TrimSpace(message) == "" {
+		message = fallbackMessage
+	}
+	if message == "" && resp != nil {
+		message = resp.Status
+	}
+	if message == "" {
+		message = http.StatusText(http.StatusInternalServerError)
+	}
+
+	status := backend.StatusUnknown
+	source := backend.DefaultErrorSource
+	if resp != nil {
+		status = backend.Status(resp.StatusCode)
+		source = backend.ErrorSourceFromHTTPStatus(resp.StatusCode)
+	}
+
+	return &backend.DataResponse{
+		Error:       errors.New(message),
+		ErrorSource: source,
+		Status:      status,
+	}
+}

--- a/pkg/tsdb/tempo/search.go
+++ b/pkg/tsdb/tempo/search.go
@@ -83,12 +83,7 @@ func (s *Service) Search(ctx context.Context, pCtx backend.PluginContext, query 
 
 	if resp.StatusCode != http.StatusOK {
 		ctxLogger.Error("Failed to execute search query", "error", err, "function", logEntrypoint())
-		err := fmt.Errorf("failed to execute search query status: %s", resp.Status)
-		if backend.ErrorSourceFromHTTPStatus(resp.StatusCode) == backend.ErrorSourceDownstream {
-			return nil, backend.DownstreamError(err)
-		}
-
-		return nil, err
+		return dataResponseFromHTTPError(resp, body, fmt.Sprintf("failed to execute search query status: %s", resp.Status)), nil
 	}
 
 	var response tempopb.SearchResponse

--- a/pkg/tsdb/tempo/tempo_test.go
+++ b/pkg/tsdb/tempo/tempo_test.go
@@ -5,11 +5,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana/pkg/tsdb/tempo/kinds/dataquery"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckHealth(t *testing.T) {
@@ -62,6 +65,77 @@ func TestCheckHealth(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedStatus, result.Status)
 			assert.Contains(t, result.Message, tt.expectedMessage)
+		})
+	}
+}
+
+func TestQueryDataPropagatesPlaintextHTTPErrorInDataResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		queryType dataquery.TempoQueryType
+		queryJSON string
+	}{
+		{
+			name:      "trace",
+			queryType: dataquery.TempoQueryTypeTraceId,
+			queryJSON: `{"query":"abc123"}`,
+		},
+		{
+			name:      "traceql search",
+			queryType: dataquery.TempoQueryTypeTraceql,
+			queryJSON: `{"query":"{ .service.name = \"api\" }"}`,
+		},
+		{
+			name:      "traceql metrics",
+			queryType: dataquery.TempoQueryTypeTraceql,
+			queryJSON: `{"query":"{} | rate()"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const apiError = "tempo API plaintext error"
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, apiError, http.StatusInternalServerError)
+			}))
+			defer server.Close()
+
+			im := datasource.NewInstanceManager(func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+				return &DatasourceInfo{
+					URL:        server.URL,
+					HTTPClient: server.Client(),
+				}, nil
+			})
+
+			service := &Service{
+				im:     im,
+				logger: backend.NewLoggerWith("logger", "tempo-test"),
+			}
+
+			response, err := service.QueryData(context.Background(), &backend.QueryDataRequest{
+				PluginContext: backend.PluginContext{
+					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{URL: server.URL},
+				},
+				Queries: []backend.DataQuery{
+					{
+						RefID:     "A",
+						QueryType: string(tt.queryType),
+						JSON:      []byte(tt.queryJSON),
+						TimeRange: backend.TimeRange{
+							From: time.Unix(1, 0),
+							To:   time.Unix(2, 0),
+						},
+					},
+				},
+			})
+
+			require.NoError(t, err)
+			require.Contains(t, response.Responses, "A")
+			dataResponse := response.Responses["A"]
+			require.Error(t, dataResponse.Error)
+			assert.Equal(t, apiError+"\n", dataResponse.Error.Error())
+			assert.Equal(t, backend.Status(http.StatusInternalServerError), dataResponse.Status)
+			assert.Equal(t, backend.ErrorSourceDownstream, dataResponse.ErrorSource)
 		})
 	}
 }

--- a/pkg/tsdb/tempo/trace.go
+++ b/pkg/tsdb/tempo/trace.go
@@ -69,16 +69,10 @@ func (s *Service) getTrace(ctx context.Context, pCtx backend.PluginContext, quer
 
 	if resp.StatusCode != http.StatusOK {
 		ctxLogger.Error("Failed to get trace", "error", err, "function", logEntrypoint())
-		err := fmt.Errorf("failed to get trace with id: %s Status: %s Body: %s", *model.Query, resp.Status, string(traceBody))
-
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-
-		if backend.ErrorSourceFromHTTPStatus(resp.StatusCode) == backend.ErrorSourceDownstream {
-			return nil, backend.DownstreamError(err)
-		}
-
-		return nil, err
+		result = dataResponseFromHTTPError(resp, traceBody, fmt.Sprintf("failed to get trace with id: %s Status: %s", *model.Query, resp.Status))
+		span.RecordError(result.Error)
+		span.SetStatus(codes.Error, result.Error.Error())
+		return result, nil
 	}
 
 	var frame *data.Frame

--- a/pkg/tsdb/tempo/traceql_query.go
+++ b/pkg/tsdb/tempo/traceql_query.go
@@ -87,16 +87,10 @@ func (s *Service) runTraceQlQueryMetrics(ctx context.Context, pCtx backend.Plugi
 
 	if resp.StatusCode != http.StatusOK {
 		ctxLogger.Error("Failed to execute TraceQL query", "error", err, "function", logEntrypoint())
-		err := fmt.Errorf("failed to execute TraceQL query: %s Status: %s Body: %s", *tempoQuery.Query, resp.Status, string(responseBody))
-
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-
-		if backend.ErrorSourceFromHTTPStatus(resp.StatusCode) == backend.ErrorSourceDownstream {
-			err = backend.DownstreamError(err)
-		}
-
-		return nil, err
+		result = dataResponseFromHTTPError(resp, responseBody, fmt.Sprintf("failed to execute TraceQL query: %s Status: %s", *tempoQuery.Query, resp.Status))
+		span.RecordError(result.Error)
+		span.SetStatus(codes.Error, result.Error.Error())
+		return result, nil
 	}
 
 	if isInstantQuery(tempoQuery.MetricsQueryType) {


### PR DESCRIPTION
The API errors used to be handled in frontend part of the plugin, but since expanding backend datasource plugin, the behavior had changed.
Handle errors from tempo api and send them as `backend.DataResponse`.
It's different from how streaming responses are displayed, but this is in line with how TraceQL metrics queries or loki errors are handled in grafana.

Fixes grafana/grafana-tempo-datasource#173

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
