### PR TITLE
Dashboard Edit Actions: Batching

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/BatchAction.ts
+++ b/public/app/features/dashboard-scene/edit-pane/BatchAction.ts
@@ -1,0 +1,59 @@
+import { type SceneObject } from '@grafana/scenes';
+
+import { type DashboardEditActionEventPayload } from './events';
+
+/**
+ * Groups several edit actions into a single undo/redo unit.
+ *
+ * A batch is created by `dashboardEditActions.batch(...)` and dispatched like any
+ * other edit action (it carries a `source`). While it is the active batch
+ * (`inProgress === true` and it's the top of the undo stack) any edit actions
+ * published during the batch closure are performed and collected here instead of
+ * being pushed onto the undo stack individually. The batch itself is the single
+ * entry on the stack.
+ *
+ * - `perform` (redo) replays the collected actions in order.
+ * - `undo` reverses them in the opposite order.
+ *
+ * Selection metadata is derived from the collected actions so the edit pane can
+ * restore selection on undo/redo just like it does for a single action.
+ */
+export class BatchAction implements DashboardEditActionEventPayload {
+  /** True while the batch closure is running and actions are being collected. */
+  public inProgress = false;
+
+  private actions: DashboardEditActionEventPayload[] = [];
+
+  public constructor(
+    public readonly source: SceneObject,
+    public readonly description: string
+  ) {}
+
+  public add(action: DashboardEditActionEventPayload): void {
+    this.actions.push(action);
+  }
+
+  public isEmpty(): boolean {
+    return this.actions.length === 0;
+  }
+
+  public perform = (): void => {
+    this.actions.forEach((action) => action.perform());
+  };
+
+  public undo = (): void => {
+    [...this.actions].reverse().forEach((action) => action.undo());
+  };
+
+  public get addedObject(): SceneObject | undefined {
+    return [...this.actions].reverse().find((action) => action.addedObject)?.addedObject;
+  }
+
+  public get removedObject(): SceneObject | undefined {
+    return this.actions.find((action) => action.removedObject)?.removedObject;
+  }
+
+  public get movedObject(): SceneObject | undefined {
+    return this.actions.find((action) => action.movedObject)?.movedObject;
+  }
+}

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -13,6 +13,7 @@ import { getRepeatCloneSourceKey } from '../utils/clone';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDefaultVizPanel, getLayoutForObject, getDashboardSceneFor } from '../utils/utils';
 
+import { BatchAction } from './BatchAction';
 import { DashboardOutline } from './DashboardOutline';
 import { ElementEditPane } from './ElementEditPane';
 import {
@@ -146,6 +147,21 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
    * @param payload
    */
   private handleEditAction(action: DashboardEditActionEventPayload) {
+    const lastAction = this.state.undoStack[this.state.undoStack.length - 1];
+
+    // If a batch is open (it's the last item on the stack and still in progress), perform
+    // the action and collect it into the batch rather than pushing it as its own entry.
+    if (lastAction instanceof BatchAction && lastAction.inProgress) {
+      // A nested batch flattens into the open one — ignore its wrapper.
+      if (action instanceof BatchAction) {
+        return;
+      }
+
+      this.performAction(action);
+      lastAction.add(action);
+      return;
+    }
+
     // Clear redo stack when user performs a new action
     // Otherwise things can get into very broken states
     if (this.state.redoStack.length > 0) {

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -27,6 +27,7 @@ import { VariableEditableElement } from '../settings/variables/VariableEditableE
 import { VariableSetEditableElement } from '../settings/variables/VariableSetEditableElement';
 import { isSceneVariable } from '../settings/variables/utils';
 
+import { BatchAction } from './BatchAction';
 import { type DashboardEditPane } from './DashboardEditPane';
 import { MultiSelectedObjectsEditableElement } from './MultiSelectedObjectsEditableElement';
 import { VizPanelEditableElement } from './VizPanelEditableElement';
@@ -198,6 +199,28 @@ export const dashboardEditActions = {
    */
   edit(props: DashboardEditActionEventPayload) {
     props.source.publishEvent(new DashboardEditActionEvent(props), true);
+  },
+
+  /**
+   * Groups every edit action performed inside `fn` into a single undo/redo unit.
+   *
+   * The BatchAction is dispatched like any other action (via `source`, which can be
+   * any object in the scene tree) so it lands on the undo stack; while it's the open
+   * (top, in-progress) entry the edit pane collects the actions performed inside `fn`
+   * into it. A single undo then reverses the whole group (in reverse order) and a
+   * single redo replays it (in order). Nested batches are flattened into the outer one.
+   */
+  batch(source: SceneObject, description: string, fn: () => void) {
+    const batch = new BatchAction(source, description);
+    batch.inProgress = true;
+
+    dashboardEditActions.edit(batch);
+
+    try {
+      fn();
+    } finally {
+      batch.inProgress = false;
+    }
   },
   /**
    * Helper for makeEdit that adds elements

--- a/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
@@ -28,6 +28,9 @@ jest.mock('../../edit-pane/shared', () => {
       removeElement(props: { perform: () => void }) {
         props.perform();
       },
+      batch(_source: unknown, _description: string, fn: () => void) {
+        fn();
+      },
     },
   };
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
@@ -11,6 +11,7 @@ import { type z } from 'zod';
 
 import type { VizPanel } from '@grafana/scenes';
 
+import { dashboardEditActions } from '../../edit-pane/shared';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
@@ -194,9 +195,10 @@ export const movePanelCommand: MutationCommand<MovePanelPayload> = {
       if (!currentLayout.removePanel) {
         throw new Error('Source layout does not support panel removal');
       }
-      currentLayout.removePanel(vizPanel);
-
-      targetLayout.addPanel(panelClone);
+      dashboardEditActions.batch(scene, 'Move panel', () => {
+        currentLayout.removePanel!(vizPanel);
+        targetLayout.addPanel(panelClone);
+      });
 
       if (effectivePosition) {
         if (isTargetAutoGrid) {

--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -37,6 +37,9 @@ jest.mock('../../edit-pane/shared', () => {
       removeElement(props: { perform: () => void }) {
         props.perform();
       },
+      batch(_source: unknown, _description: string, fn: () => void) {
+        fn();
+      },
     },
   };
 });


### PR DESCRIPTION
An example showing how actions could be batched together. Implemented in movePanel.ts command in mutation API .

```typescript
dashboardEditActions.batch(scene, 'Move panel', () => {
  currentLayout.removePanel(vizPanel);
  targetLayout.addPanel(panelClone);
});
```

Note the code above is a simplified version just to prove the concept and makes calls to `layout.removePanel`/`layout.addPanel` 

eventually it will be:

```typescript
dashboardEditActions.batch(scene, 'Move panel', () => {
  dashboardEditActions.removePanel(current, vizPanel);
  dashboardEditActions.addPanel(layout, panelClone);
  dashboardEditActions.applyGridPosition(panelClone, position);
});
```

and ideally wrapped into an action:

```typescript
dashboardEditActions.movePanel = (source, target, panel, position) => {
  dashboardEditActions.batch(scene, 'Move panel', () => {
    dashboardEditActions.removePanel(current, vizPanel);
    dashboardEditActions.addPanel(layout, panelClone);
    dashboardEditActions.applyGridPosition(panelClone, position);
  });
}
```

so in the command we end up with simple:

```typescript
dashboardEditActions.movePanel(from, to, panel, position);
```