### PR TITLE
Dashboard Edit Actions: Split actions into multiple files

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1536,7 +1536,7 @@
   },
   "public/app/features/dashboard-scene/edit-pane/shared.ts": {
     "no-barrel-files/no-barrel-files": {
-      "count": 3
+      "count": 1
     }
   },
   "public/app/features/dashboard-scene/inspect/HelpWizard/HelpWizard.tsx": {

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/addElement.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/addElement.ts
@@ -1,0 +1,29 @@
+import { t } from '@grafana/i18n';
+
+import { getEditableElementFor } from '../shared';
+
+import { edit } from './edit';
+import { type AddElementActionHelperProps } from './types';
+
+/**
+ * Adds an element to the dashboard, deriving the undo-stack description from the
+ * added object's editable element type.
+ */
+export function addElement(props: AddElementActionHelperProps) {
+  const { addedObject, source, perform, undo } = props;
+
+  const element = getEditableElementFor(addedObject);
+  if (!element) {
+    throw new Error('Added object is not an editable element');
+  }
+
+  const typeName = element.getEditableElementInfo().typeName;
+
+  edit({
+    description: t('dashboard.edit-actions.add', 'Add {{typeName}}', { typeName }),
+    addedObject,
+    source,
+    perform,
+    undo,
+  });
+}

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/addVariable.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/addVariable.ts
@@ -1,0 +1,17 @@
+import { addElement } from './addElement';
+import { type AddVariableActionHelperProps } from './types';
+
+export function addVariable({ source, addedObject }: AddVariableActionHelperProps) {
+  const varsBeforeAddition = [...(source.state.variables ?? [])];
+
+  addElement({
+    source,
+    addedObject,
+    perform() {
+      source.setState({ variables: [...varsBeforeAddition, addedObject] });
+    },
+    undo() {
+      source.setState({ variables: [...varsBeforeAddition] });
+    },
+  });
+}

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeDescription.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeDescription.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @grafana/i18n/no-translation-top-level */
+import { t } from '@grafana/i18n';
+
+import { type DashboardScene } from '../../scene/DashboardScene';
+
+import { makeEditAction } from './makeEditAction';
+
+export const changeDescription = makeEditAction<DashboardScene, 'description'>({
+  description: t('dashboard.description.action', 'Change dashboard description'),
+  prop: 'description',
+});

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeTitle.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeTitle.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @grafana/i18n/no-translation-top-level */
+import { t } from '@grafana/i18n';
+
+import { type DashboardScene } from '../../scene/DashboardScene';
+
+import { makeEditAction } from './makeEditAction';
+
+export const changeTitle = makeEditAction<DashboardScene, 'title'>({
+  description: t('dashboard.title.action', 'Change dashboard title'),
+  prop: 'title',
+});

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeVariableDescription.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeVariableDescription.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @grafana/i18n/no-translation-top-level */
+import { t } from '@grafana/i18n';
+import { type SceneVariable } from '@grafana/scenes';
+
+import { makeEditAction } from './makeEditAction';
+
+export const changeVariableDescription = makeEditAction<SceneVariable, 'description'>({
+  description: t('dashboard.variable.description.action', 'Change variable description'),
+  prop: 'description',
+});

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeVariableHideValue.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeVariableHideValue.ts
@@ -1,0 +1,29 @@
+import { t } from '@grafana/i18n';
+import { type SceneVariable, SceneVariableSet } from '@grafana/scenes';
+
+import { edit } from './edit';
+import { type EditActionProps } from './types';
+
+export function changeVariableHideValue({ source, oldValue, newValue }: EditActionProps<SceneVariable, 'hide'>) {
+  const variableSet = source.parent;
+  const variablesBeforeChange =
+    variableSet instanceof SceneVariableSet ? [...(variableSet.state.variables ?? [])] : undefined;
+
+  edit({
+    description: t('dashboard.variable.hide.action', 'Change variable hide option'),
+    source,
+    perform: () => {
+      source.setState({ hide: newValue });
+      // Updating the variables set since components that show/hide variables subscribe to the variable set, not the individual variables.
+      if (variableSet instanceof SceneVariableSet) {
+        variableSet.setState({ variables: [...(variableSet.state.variables ?? [])] });
+      }
+    },
+    undo: () => {
+      source.setState({ hide: oldValue });
+      if (variableSet instanceof SceneVariableSet && variablesBeforeChange) {
+        variableSet.setState({ variables: variablesBeforeChange });
+      }
+    },
+  });
+}

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeVariableLabel.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeVariableLabel.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @grafana/i18n/no-translation-top-level */
+import { t } from '@grafana/i18n';
+import { type SceneVariable } from '@grafana/scenes';
+
+import { makeEditAction } from './makeEditAction';
+
+export const changeVariableLabel = makeEditAction<SceneVariable, 'label'>({
+  description: t('dashboard.variable.label.action', 'Change variable label'),
+  prop: 'label',
+});

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeVariableName.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeVariableName.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @grafana/i18n/no-translation-top-level */
+import { t } from '@grafana/i18n';
+import { type SceneVariable } from '@grafana/scenes';
+
+import { makeEditAction } from './makeEditAction';
+
+export const changeVariableName = makeEditAction<SceneVariable, 'name'>({
+  description: t('dashboard.variable.name.action', 'Change variable name'),
+  prop: 'name',
+});

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeVariableType.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/changeVariableType.ts
@@ -1,0 +1,29 @@
+import { t } from '@grafana/i18n';
+
+import { edit } from './edit';
+import { type ChangeVariableTypeActionHelperProps } from './types';
+
+export function changeVariableType({ source, oldVariable, newVariable }: ChangeVariableTypeActionHelperProps) {
+  const varsBeforeChange = [...source.state.variables];
+  const variableIndex = varsBeforeChange.indexOf(oldVariable);
+
+  if (variableIndex === -1) {
+    throw new Error('Variable not found in source set');
+  }
+
+  const varsAfterChange = [...varsBeforeChange];
+  varsAfterChange[variableIndex] = newVariable;
+
+  edit({
+    description: t('dashboard.variable.type.action', 'Change variable type'),
+    source,
+    addedObject: newVariable,
+    removedObject: oldVariable,
+    perform() {
+      source.setState({ variables: varsAfterChange });
+    },
+    undo() {
+      source.setState({ variables: varsBeforeChange });
+    },
+  });
+}

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/edit.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/edit.ts
@@ -1,0 +1,12 @@
+import { DashboardEditActionEvent, type DashboardEditActionEventPayload } from '../events';
+
+/**
+ * Registers and performs an edit action.
+ *
+ * This is the low-level primitive every other action is built on: it publishes a
+ * DashboardEditActionEvent which DashboardEditPane picks up to perform the change
+ * and push it onto the undo stack.
+ */
+export function edit(props: DashboardEditActionEventPayload) {
+  props.source.publishEvent(new DashboardEditActionEvent(props), true);
+}

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/makeEditAction.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/makeEditAction.ts
@@ -1,0 +1,26 @@
+import { type SceneObject } from '@grafana/scenes';
+
+import { edit } from './edit';
+import { type EditActionProps, type MakeEditActionProps } from './types';
+
+/**
+ * Builds a simple edit action that sets a single state property, with undo
+ * restoring the previous value. Used for the various "change X" property edits.
+ */
+export function makeEditAction<Source extends SceneObject, T extends keyof Source['state']>({
+  description,
+  prop,
+}: MakeEditActionProps<Source, T>) {
+  return ({ source, oldValue, newValue }: EditActionProps<Source, T>) => {
+    edit({
+      description,
+      source,
+      perform: () => {
+        source.setState({ [prop]: newValue });
+      },
+      undo: () => {
+        source.setState({ [prop]: oldValue });
+      },
+    });
+  };
+}

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/moveElement.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/moveElement.ts
@@ -1,0 +1,29 @@
+import { t } from '@grafana/i18n';
+
+import { getEditableElementFor } from '../shared';
+
+import { edit } from './edit';
+import { type MoveElementActionHelperProps } from './types';
+
+/**
+ * Moves an element within the dashboard, deriving the undo-stack description from
+ * the moved object's editable element type.
+ */
+export function moveElement(props: MoveElementActionHelperProps) {
+  const { movedObject, source, perform, undo } = props;
+
+  const element = getEditableElementFor(movedObject);
+  if (!element) {
+    throw new Error('Moved object is not an editable element');
+  }
+
+  const typeName = element.getEditableElementInfo().typeName;
+
+  edit({
+    description: t('dashboard.edit-actions.move', 'Move {{typeName}}', { typeName }),
+    movedObject,
+    source,
+    perform,
+    undo,
+  });
+}

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/removeElement.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/removeElement.ts
@@ -1,0 +1,29 @@
+import { t } from '@grafana/i18n';
+
+import { getEditableElementFor } from '../shared';
+
+import { edit } from './edit';
+import { type RemoveElementActionHelperProps } from './types';
+
+/**
+ * Removes an element from the dashboard, deriving the undo-stack description from
+ * the removed object's editable element type.
+ */
+export function removeElement(props: RemoveElementActionHelperProps) {
+  const { removedObject, source, perform, undo } = props;
+
+  const element = getEditableElementFor(removedObject);
+  if (!element) {
+    throw new Error('Removed object is not an editable element');
+  }
+
+  const typeName = element.getEditableElementInfo().typeName;
+
+  edit({
+    description: t('dashboard.edit-actions.remove', 'Remove {{typeName}}', { typeName }),
+    removedObject,
+    source,
+    perform,
+    undo,
+  });
+}

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/removeVariable.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/removeVariable.ts
@@ -1,0 +1,17 @@
+import { removeElement } from './removeElement';
+import { type RemoveVariableActionHelperProps } from './types';
+
+export function removeVariable({ source, removedObject }: RemoveVariableActionHelperProps) {
+  const varsBeforeRemoval = [...source.state.variables];
+
+  removeElement({
+    source,
+    removedObject,
+    perform() {
+      source.setState({ variables: varsBeforeRemoval.filter((v) => v !== removedObject) });
+    },
+    undo() {
+      source.setState({ variables: varsBeforeRemoval });
+    },
+  });
+}

--- a/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/types.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboardEditActions/types.ts
@@ -1,0 +1,63 @@
+import { type SceneObject, type SceneVariable, type SceneVariableSet } from '@grafana/scenes';
+
+import { type DashboardScene } from '../../scene/DashboardScene';
+
+export interface AddElementActionHelperProps {
+  addedObject: SceneObject;
+  source: SceneObject;
+  perform: () => void;
+  undo: () => void;
+}
+
+export interface RemoveElementActionHelperProps {
+  removedObject: SceneObject;
+  source: SceneObject;
+  perform: () => void;
+  undo: () => void;
+}
+
+export interface AddVariableActionHelperProps {
+  addedObject: SceneVariable;
+  source: SceneVariableSet;
+}
+
+export interface RemoveVariableActionHelperProps {
+  removedObject: SceneVariable;
+  source: SceneVariableSet;
+}
+
+export interface ChangeVariableTypeActionHelperProps {
+  oldVariable: SceneVariable;
+  newVariable: SceneVariable;
+  source: SceneVariableSet;
+}
+
+export interface ChangeTitleActionHelperProps {
+  oldTitle: string;
+  newTitle: string;
+  source: DashboardScene;
+}
+
+export interface ChangeDescriptionActionHelperProps {
+  oldDescription: string;
+  newDescription: string;
+  source: DashboardScene;
+}
+
+export interface MoveElementActionHelperProps {
+  movedObject: SceneObject;
+  source: SceneObject;
+  perform: () => void;
+  undo: () => void;
+}
+
+export interface MakeEditActionProps<Source extends SceneObject, T extends keyof Source['state']> {
+  description: string;
+  prop: T;
+}
+
+export interface EditActionProps<Source extends SceneObject, T extends keyof Source['state']> {
+  source: Source;
+  oldValue: Source['state'][T];
+  newValue: Source['state'][T];
+}

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -1,14 +1,11 @@
-/* eslint-disable @grafana/i18n/no-translation-top-level */
 import { useSessionStorage } from 'react-use';
 
 import { BusEventWithPayload } from '@grafana/data';
-import { t } from '@grafana/i18n';
 import {
   dataLayers,
   LocalValueVariable,
   SceneGridRow,
   type SceneObject,
-  type SceneVariable,
   SceneVariableSet,
   VizPanel,
 } from '@grafana/scenes';
@@ -31,7 +28,19 @@ import { type DashboardEditPane } from './DashboardEditPane';
 import { MultiSelectedObjectsEditableElement } from './MultiSelectedObjectsEditableElement';
 import { VizPanelEditableElement } from './VizPanelEditableElement';
 import { DashboardEditableElement } from './dashboard/DashboardEditableElement';
-import { DashboardEditActionEvent, type DashboardEditActionEventPayload } from './events';
+import { addElement } from './dashboardEditActions/addElement';
+import { addVariable } from './dashboardEditActions/addVariable';
+import { changeDescription } from './dashboardEditActions/changeDescription';
+import { changeTitle } from './dashboardEditActions/changeTitle';
+import { changeVariableDescription } from './dashboardEditActions/changeVariableDescription';
+import { changeVariableHideValue } from './dashboardEditActions/changeVariableHideValue';
+import { changeVariableLabel } from './dashboardEditActions/changeVariableLabel';
+import { changeVariableName } from './dashboardEditActions/changeVariableName';
+import { changeVariableType } from './dashboardEditActions/changeVariableType';
+import { edit } from './dashboardEditActions/edit';
+import { moveElement } from './dashboardEditActions/moveElement';
+import { removeElement } from './dashboardEditActions/removeElement';
+import { removeVariable } from './dashboardEditActions/removeVariable';
 
 export const EDIT_PANE_COLLAPSED_KEY = 'grafana.dashboards.edit-pane.isCollapsed';
 
@@ -143,245 +152,27 @@ export class RepeatsUpdatedEvent extends BusEventWithPayload<SceneObject> {
 
 export { DashboardEditActionEvent, DashboardStateChangedEvent, type DashboardEditActionEventPayload } from './events';
 
-export interface AddElementActionHelperProps {
-  addedObject: SceneObject;
-  source: SceneObject;
-  perform: () => void;
-  undo: () => void;
-}
-
-export interface RemoveElementActionHelperProps {
-  removedObject: SceneObject;
-  source: SceneObject;
-  perform: () => void;
-  undo: () => void;
-}
-
-export interface AddVariableActionHelperProps {
-  addedObject: SceneVariable;
-  source: SceneVariableSet;
-}
-
-export interface RemoveVariableActionHelperProps {
-  removedObject: SceneVariable;
-  source: SceneVariableSet;
-}
-
-export interface ChangeVariableTypeActionHelperProps {
-  oldVariable: SceneVariable;
-  newVariable: SceneVariable;
-  source: SceneVariableSet;
-}
-
-export interface ChangeTitleActionHelperProps {
-  oldTitle: string;
-  newTitle: string;
-  source: DashboardScene;
-}
-
-export interface ChangeDescriptionActionHelperProps {
-  oldDescription: string;
-  newDescription: string;
-  source: DashboardScene;
-}
-
-export interface MoveElementActionHelperProps {
-  movedObject: SceneObject;
-  source: SceneObject;
-  perform: () => void;
-  undo: () => void;
-}
-
+/**
+ * Dashboard edit actions.
+ *
+ * `edit` is the low-level primitive; the rest are thin, named wrappers around it.
+ * Each one lives in its own file under ./dashboardEditActions — add new actions
+ * there and wire them into this object. Aggregated here (rather than in a dedicated
+ * index that shared.ts re-exports) so existing `dashboardEditActions` imports from
+ * this module keep working unchanged.
+ */
 export const dashboardEditActions = {
-  /**
-   * Registers and peforms an edit action
-   */
-  edit(props: DashboardEditActionEventPayload) {
-    props.source.publishEvent(new DashboardEditActionEvent(props), true);
-  },
-  /**
-   * Helper for makeEdit that adds elements
-   */
-  addElement(props: AddElementActionHelperProps) {
-    const { addedObject, source, perform, undo } = props;
-
-    const element = getEditableElementFor(addedObject);
-    if (!element) {
-      throw new Error('Added object is not an editable element');
-    }
-
-    const typeName = element.getEditableElementInfo().typeName;
-
-    dashboardEditActions.edit({
-      description: t('dashboard.edit-actions.add', 'Add {{typeName}}', { typeName }),
-      addedObject,
-      source,
-      perform,
-      undo,
-    });
-  },
-
-  removeElement(props: RemoveElementActionHelperProps) {
-    const { removedObject, source, perform, undo } = props;
-
-    const element = getEditableElementFor(removedObject);
-    if (!element) {
-      throw new Error('Removed object is not an editable element');
-    }
-
-    const typeName = element.getEditableElementInfo().typeName;
-
-    dashboardEditActions.edit({
-      description: t('dashboard.edit-actions.remove', 'Remove {{typeName}}', { typeName }),
-      removedObject,
-      source,
-      perform,
-      undo,
-    });
-  },
-
-  changeTitle: makeEditAction<DashboardScene, 'title'>({
-    description: t('dashboard.title.action', 'Change dashboard title'),
-    prop: 'title',
-  }),
-  changeDescription: makeEditAction<DashboardScene, 'description'>({
-    description: t('dashboard.description.action', 'Change dashboard description'),
-    prop: 'description',
-  }),
-
-  addVariable({ source, addedObject }: AddVariableActionHelperProps) {
-    const varsBeforeAddition = [...(source.state.variables ?? [])];
-
-    dashboardEditActions.addElement({
-      source,
-      addedObject,
-      perform() {
-        source.setState({ variables: [...varsBeforeAddition, addedObject] });
-      },
-      undo() {
-        source.setState({ variables: [...varsBeforeAddition] });
-      },
-    });
-  },
-  removeVariable({ source, removedObject }: RemoveVariableActionHelperProps) {
-    const varsBeforeRemoval = [...source.state.variables];
-
-    dashboardEditActions.removeElement({
-      source,
-      removedObject,
-      perform() {
-        source.setState({ variables: varsBeforeRemoval.filter((v) => v !== removedObject) });
-      },
-      undo() {
-        source.setState({ variables: varsBeforeRemoval });
-      },
-    });
-  },
-  changeVariableType({ source, oldVariable, newVariable }: ChangeVariableTypeActionHelperProps) {
-    const varsBeforeChange = [...source.state.variables];
-    const variableIndex = varsBeforeChange.indexOf(oldVariable);
-
-    if (variableIndex === -1) {
-      throw new Error('Variable not found in source set');
-    }
-
-    const varsAfterChange = [...varsBeforeChange];
-    varsAfterChange[variableIndex] = newVariable;
-
-    dashboardEditActions.edit({
-      description: t('dashboard.variable.type.action', 'Change variable type'),
-      source,
-      addedObject: newVariable,
-      removedObject: oldVariable,
-      perform() {
-        source.setState({ variables: varsAfterChange });
-      },
-      undo() {
-        source.setState({ variables: varsBeforeChange });
-      },
-    });
-  },
-  changeVariableName: makeEditAction<SceneVariable, 'name'>({
-    description: t('dashboard.variable.name.action', 'Change variable name'),
-    prop: 'name',
-  }),
-  changeVariableLabel: makeEditAction<SceneVariable, 'label'>({
-    description: t('dashboard.variable.label.action', 'Change variable label'),
-    prop: 'label',
-  }),
-  changeVariableDescription: makeEditAction<SceneVariable, 'description'>({
-    description: t('dashboard.variable.description.action', 'Change variable description'),
-    prop: 'description',
-  }),
-  changeVariableHideValue({ source, oldValue, newValue }: EditActionProps<SceneVariable, 'hide'>) {
-    const variableSet = source.parent;
-    const variablesBeforeChange =
-      variableSet instanceof SceneVariableSet ? [...(variableSet.state.variables ?? [])] : undefined;
-
-    dashboardEditActions.edit({
-      description: t('dashboard.variable.hide.action', 'Change variable hide option'),
-      source,
-      perform: () => {
-        source.setState({ hide: newValue });
-        // Updating the variables set since components that show/hide variables subscribe to the variable set, not the individual variables.
-        if (variableSet instanceof SceneVariableSet) {
-          variableSet.setState({ variables: [...(variableSet.state.variables ?? [])] });
-        }
-      },
-      undo: () => {
-        source.setState({ hide: oldValue });
-        if (variableSet instanceof SceneVariableSet && variablesBeforeChange) {
-          variableSet.setState({ variables: variablesBeforeChange });
-        }
-      },
-    });
-  },
-
-  moveElement(props: MoveElementActionHelperProps) {
-    const { movedObject, source, perform, undo } = props;
-
-    const element = getEditableElementFor(movedObject);
-    if (!element) {
-      throw new Error('Moved object is not an editable element');
-    }
-
-    const typeName = element.getEditableElementInfo().typeName;
-
-    dashboardEditActions.edit({
-      description: t('dashboard.edit-actions.move', 'Move {{typeName}}', { typeName }),
-      movedObject,
-      source,
-      perform,
-      undo,
-    });
-  },
+  edit,
+  addElement,
+  removeElement,
+  changeTitle,
+  changeDescription,
+  addVariable,
+  removeVariable,
+  changeVariableType,
+  changeVariableName,
+  changeVariableLabel,
+  changeVariableDescription,
+  changeVariableHideValue,
+  moveElement,
 };
-
-interface MakeEditActionProps<Source extends SceneObject, T extends keyof Source['state']> {
-  description: string;
-  prop: T;
-}
-
-interface EditActionProps<Source extends SceneObject, T extends keyof Source['state']> {
-  source: Source;
-  oldValue: Source['state'][T];
-  newValue: Source['state'][T];
-}
-
-export function makeEditAction<Source extends SceneObject, T extends keyof Source['state']>({
-  description,
-  prop,
-}: MakeEditActionProps<Source, T>) {
-  return ({ source, oldValue, newValue }: EditActionProps<Source, T>) => {
-    dashboardEditActions.edit({
-      description,
-      source,
-      perform: () => {
-        source.setState({ [prop]: newValue });
-      },
-      undo: () => {
-        source.setState({ [prop]: oldValue });
-      },
-    });
-  };
-}


### PR DESCRIPTION
All actions are in shared.ts. For better discoverability, adding tests, and readability they could be split into separate files.