### PR TITLE
Dashboard Edit Actions: Simple example - remove a variable

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -6,9 +6,12 @@
 
 import { type z } from 'zod';
 
+import { SceneVariableSet } from '@grafana/scenes';
+
+import { dashboardEditActions } from '../../edit-pane/shared';
+
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
-import { replaceVariableSet } from './variableUtils';
 
 export const removeVariablePayloadSchema = payloads.removeVariable;
 
@@ -29,7 +32,7 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
 
     try {
       const variables = scene.state.$variables;
-      if (!variables) {
+      if (!(variables instanceof SceneVariableSet)) {
         throw new Error('Dashboard has no variable set');
       }
 
@@ -40,8 +43,7 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
 
       const previousState = variable.state;
 
-      const updatedVariables = variables.state.variables.filter((v) => v.state.name !== name);
-      replaceVariableSet(scene, updatedVariables);
+      dashboardEditActions.removeVariable({ source: variables, removedObject: variable });
 
       return {
         success: true,

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -1,8 +1,21 @@
-import { SceneVariableSet } from '@grafana/scenes';
+import { type SceneVariable, SceneVariableSet } from '@grafana/scenes';
 
 import type { DashboardScene } from '../../scene/DashboardScene';
 import { DashboardMutationClient } from '../DashboardMutationClient';
 import type { MutationResult } from '../types';
+
+jest.mock('../../edit-pane/shared', () => {
+  const actual = jest.requireActual('../../edit-pane/shared');
+  return {
+    ...actual,
+    dashboardEditActions: {
+      ...actual.dashboardEditActions,
+      removeVariable({ source, removedObject }: { source: SceneVariableSet; removedObject: SceneVariable }) {
+        source.setState({ variables: source.state.variables.filter((v) => v !== removedObject) });
+      },
+    },
+  };
+});
 
 function buildMockScene(options: { editable?: boolean; isEditing?: boolean } = {}): DashboardScene {
   const { editable = true, isEditing = false } = options;
@@ -104,6 +117,9 @@ describe('Variable mutation commands', () => {
 
     expect(result.success).toBe(true);
     expect(result.changes.length).toBeGreaterThan(0);
+    // The variable is actually removed from the set (delegated to dashboardEditActions).
+    const variables = scene.state.$variables;
+    expect(variables instanceof SceneVariableSet && variables.getByName('env')).toBeUndefined();
   });
 
   it('ADD_VARIABLE with position inserts at the specified index', async () => {


### PR DESCRIPTION
Mutation API should delegate state changes to Dashboard Edit Actions. Here's the most simple example - removing a variable.