### PR TITLE
Dashboard Edit Actions: Define perform/undo at actions layer

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -17,6 +17,7 @@ import { DashboardOutline } from './DashboardOutline';
 import { ElementEditPane } from './ElementEditPane';
 import {
   ConditionalRenderingChangedEvent,
+  dashboardEditActions,
   DashboardEditActionEvent,
   type DashboardEditActionEventPayload,
   DashboardStateChangedEvent,
@@ -427,12 +428,8 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     const panel = getDefaultVizPanel();
     const dashboard = getDashboardSceneFor(this);
 
-    if (target) {
-      const layout = getLayoutForObject(target) ?? dashboard;
-      layout.addPanel(panel);
-    } else {
-      dashboard.addPanel(panel);
-    }
+    const layout = (target ? getLayoutForObject(target) : null) ?? dashboard.state.body;
+    dashboardEditActions.addPanel(layout, panel);
 
     DashboardInteractions.trackAddPanelClick('sidebar', getLayoutType(target));
   }

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -3,6 +3,7 @@ import { useSessionStorage } from 'react-use';
 
 import { BusEventWithPayload } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import {
   dataLayers,
   LocalValueVariable,
@@ -18,6 +19,7 @@ import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
 import { SceneGridRowEditableElement } from '../scene/layout-default/SceneGridRowEditableElement';
 import { type BulkActionElement, isBulkActionElement } from '../scene/types/BulkActionElement';
+import { type DashboardLayoutManager } from '../scene/types/DashboardLayoutManager';
 import { type EditableDashboardElement, isEditableDashboardElement } from '../scene/types/EditableDashboardElement';
 import { AnnotationEditableElement } from '../settings/annotations/AnnotationEditableElement';
 import { AnnotationSetEditableElement } from '../settings/annotations/AnnotationSetEditableElement';
@@ -26,6 +28,7 @@ import { LocalVariableEditableElement } from '../settings/variables/LocalVariabl
 import { VariableEditableElement } from '../settings/variables/VariableEditableElement';
 import { VariableSetEditableElement } from '../settings/variables/VariableSetEditableElement';
 import { isSceneVariable } from '../settings/variables/utils';
+import { getLayoutManagerFor } from '../utils/utils';
 
 import { type DashboardEditPane } from './DashboardEditPane';
 import { MultiSelectedObjectsEditableElement } from './MultiSelectedObjectsEditableElement';
@@ -237,6 +240,65 @@ export const dashboardEditActions = {
       source,
       perform,
       undo,
+    });
+  },
+
+  /**
+   * Adds a panel to a layout and records it on the undo stack. The layout's
+   * own `addPanel`/`removePanel` are pure state mutations; the inverse for undo
+   * is to remove the panel from wherever it ended up.
+   */
+  addPanel(layout: DashboardLayoutManager, panel: VizPanel) {
+    if (!config.featureToggles.dashboardNewLayouts) {
+      // No undo/redo support in legacy edit mode
+      layout.addPanel(panel);
+      return;
+    }
+
+    const element = getEditableElementFor(panel);
+    if (!element) {
+      throw new Error('Added panel is not an editable element');
+    }
+
+    const typeName = element.getEditableElementInfo().typeName;
+
+    dashboardEditActions.edit({
+      description: t('dashboard.edit-actions.add', 'Add {{typeName}}', { typeName }),
+      addedObject: panel,
+      source: layout,
+      perform: () => layout.addPanel(panel),
+      undo: () => getLayoutManagerFor(panel).removePanel?.(panel),
+    });
+  },
+
+  /**
+   * Removes a panel from a layout and records it on the undo stack. Undo
+   * re-adds the panel to the same layout at its original position.
+   */
+  removePanel(layout: DashboardLayoutManager, panel: VizPanel) {
+    if (!config.featureToggles.dashboardNewLayouts) {
+      // No undo/redo support in legacy edit mode
+      layout.removePanel?.(panel);
+      return;
+    }
+
+    const element = getEditableElementFor(panel);
+    if (!element) {
+      throw new Error('Removed panel is not an editable element');
+    }
+
+    const typeName = element.getEditableElementInfo().typeName;
+
+    let restoreIndex: number | undefined;
+
+    dashboardEditActions.edit({
+      description: t('dashboard.edit-actions.remove', 'Remove {{typeName}}', { typeName }),
+      removedObject: panel,
+      source: layout,
+      perform: () => {
+        restoreIndex = layout.removePanel?.(panel);
+      },
+      undo: () => layout.addPanel(panel, restoreIndex),
     });
   },
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/addPanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addPanel.ts
@@ -9,6 +9,7 @@
 import { type z } from 'zod';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
+import { dashboardEditActions } from '../../edit-pane/shared';
 import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
@@ -57,7 +58,7 @@ export const addPanelCommand: MutationCommand<AddPanelPayload> = {
       const resolved = resolveLayoutPath(scene.state.body, parentPath ?? '/');
       const targetLayout = resolved.layoutManager;
 
-      targetLayout.addPanel(vizPanel);
+      dashboardEditActions.addPanel(targetLayout, vizPanel);
 
       const isAutoGrid = targetLayout instanceof AutoGridLayoutManager;
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
@@ -28,6 +28,12 @@ jest.mock('../../edit-pane/shared', () => {
       removeElement(props: { perform: () => void }) {
         props.perform();
       },
+      addPanel(layout: { addPanel: (panel: unknown) => void }, panel: unknown) {
+        layout.addPanel(panel);
+      },
+      removePanel(layout: { removePanel?: (panel: unknown) => void }, panel: unknown) {
+        layout.removePanel?.(panel);
+      },
     },
   };
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
@@ -11,6 +11,7 @@ import { type z } from 'zod';
 
 import type { VizPanel } from '@grafana/scenes';
 
+import { dashboardEditActions } from '../../edit-pane/shared';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
@@ -194,9 +195,9 @@ export const movePanelCommand: MutationCommand<MovePanelPayload> = {
       if (!currentLayout.removePanel) {
         throw new Error('Source layout does not support panel removal');
       }
-      currentLayout.removePanel(vizPanel);
+      dashboardEditActions.removePanel(currentLayout, vizPanel);
 
-      targetLayout.addPanel(panelClone);
+      dashboardEditActions.addPanel(targetLayout, panelClone);
 
       if (effectivePosition) {
         if (isTargetAutoGrid) {

--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -37,6 +37,12 @@ jest.mock('../../edit-pane/shared', () => {
       removeElement(props: { perform: () => void }) {
         props.perform();
       },
+      addPanel(layout: { addPanel: (panel: unknown) => void }, panel: unknown) {
+        layout.addPanel(panel);
+      },
+      removePanel(layout: { removePanel?: (panel: unknown) => void }, panel: unknown) {
+        layout.removePanel?.(panel);
+      },
     },
   };
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/removePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removePanel.ts
@@ -6,6 +6,7 @@
 
 import { type z } from 'zod';
 
+import { dashboardEditActions } from '../../edit-pane/shared';
 import { getElements } from '../../serialization/layoutSerializers/utils';
 import { getLayoutManagerFor, getVizPanelKeyForPanelId } from '../../utils/utils';
 
@@ -66,7 +67,7 @@ export const removePanelCommand: MutationCommand<RemovePanelPayload> = {
             continue;
           }
 
-          layoutManager.removePanel(vizPanel);
+          dashboardEditActions.removePanel(layoutManager, vizPanel);
           removed.push(elementName);
         } catch (err) {
           errors.push(`${elementName}: ${err instanceof Error ? err.message : String(err)}`);

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -550,7 +550,9 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
 
   private _addNewPanelToLayout = (dropTarget: DashboardDropTarget | null) => {
     const panel = getDefaultVizPanel();
-    this._getLayoutForDropTarget(dropTarget).addPanel(panel);
+    const target = this._getLayoutForDropTarget(dropTarget);
+    const layout = target instanceof DashboardScene ? target.state.body : target;
+    dashboardEditActions.addPanel(layout, panel);
     DashboardInteractions.trackAddPanelClick('sidebar', dropTarget ? getLayoutType(dropTarget) : 'dashboard', 'drop');
   };
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -687,7 +687,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     }
 
     // Add panel to layout
-    this.state.body.addPanel(vizPanel);
+    dashboardEditActions.addPanel(this.state.body, vizPanel);
   }
 
   public createLibraryPanel(panelToReplace: VizPanel, libPanel: LibraryPanel) {
@@ -925,7 +925,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   }
 
   public removePanel(panel: VizPanel) {
-    getLayoutManagerFor(panel).removePanel?.(panel);
+    dashboardEditActions.removePanel(getLayoutManagerFor(panel), panel);
   }
 
   public updatePanelTitle(panel: VizPanel, title: string) {

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.test.ts
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.test.ts
@@ -10,7 +10,6 @@ import {
 
 import { ConditionalRenderingVariable } from '../../conditional-rendering/conditions/ConditionalRenderingVariable';
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
-import { DashboardEditActionEvent } from '../../edit-pane/shared';
 import { getQueryRunnerFor } from '../../utils/utils';
 import { DashboardScene, type DashboardSceneState } from '../DashboardScene';
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
@@ -25,13 +24,15 @@ describe('AutoGridLayoutManager', () => {
     it('can remove panel', () => {
       const { manager, panel1 } = setup();
 
-      manager.subscribeToEvent(DashboardEditActionEvent, (event) => {
-        event.payload.perform();
-      });
-
       manager.removePanel(panel1);
 
       expect(manager.state.layout.state.children.length).toBe(1);
+    });
+
+    it('returns the removed grid item index', () => {
+      const { manager, gridItems } = setup();
+
+      expect(manager.removePanel(gridItems[1].state.body)).toBe(1);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -120,25 +120,24 @@ export class AutoGridLayoutManager
     return [AutoGridLayoutManager.descriptor.id];
   }
 
-  public addPanel(vizPanel: VizPanel) {
-    const panelId = dashboardSceneGraph.getNextPanelId(this);
+  public addPanel(vizPanel: VizPanel, index?: number) {
+    let gridItem: AutoGridItem;
 
-    vizPanel.setState({ key: getVizPanelKeyForPanelId(panelId) });
-    vizPanel.clearParent();
+    // Re-adding a previously removed panel (undo/redo): reuse the existing grid
+    // item so the panel id and item identity are preserved.
+    if (vizPanel.parent instanceof AutoGridItem && vizPanel.parent.parent === this.state.layout) {
+      gridItem = vizPanel.parent;
+    } else {
+      const panelId = dashboardSceneGraph.getNextPanelId(this);
+      vizPanel.setState({ key: getVizPanelKeyForPanelId(panelId) });
+      vizPanel.clearParent();
+      gridItem = new AutoGridItem({ body: vizPanel });
+    }
 
-    const newGridItem = new AutoGridItem({ body: vizPanel });
-
-    dashboardEditActions.addElement({
-      addedObject: vizPanel,
-      source: this,
-      perform: () => {
-        this.state.layout.setState({ children: [...this.state.layout.state.children, newGridItem] });
-      },
-      undo: () => {
-        this.state.layout.setState({
-          children: this.state.layout.state.children.filter((child) => child !== newGridItem),
-        });
-      },
+    const children = this.state.layout.state.children.filter((child) => child !== gridItem);
+    const insertAt = index ?? children.length;
+    this.state.layout.setState({
+      children: [...children.slice(0, insertAt), gridItem, ...children.slice(insertAt)],
     });
   }
 
@@ -177,32 +176,20 @@ export class AutoGridLayoutManager
     clearClipboard();
   }
 
-  public removePanel(panel: VizPanel) {
+  public removePanel(panel: VizPanel): number | undefined {
     const gridItem = panel.parent;
     if (!(gridItem instanceof AutoGridItem)) {
-      return;
+      return undefined;
     }
 
-    const gridItemIndex = this.state.layout.state.children.indexOf(gridItem);
+    const children = this.state.layout.state.children;
+    const index = children.indexOf(gridItem);
 
-    dashboardEditActions.removeElement({
-      removedObject: panel,
-      source: this,
-      perform: () => {
-        this.state.layout.setState({
-          children: this.state.layout.state.children.filter((child) => child !== gridItem),
-        });
-      },
-      undo: () => {
-        this.state.layout.setState({
-          children: [
-            ...this.state.layout.state.children.slice(0, gridItemIndex),
-            gridItem,
-            ...this.state.layout.state.children.slice(gridItemIndex),
-          ],
-        });
-      },
-    });
+    // Note: the grid item keeps its parent reference so addPanel can re-attach
+    // the same instance (and panel id) on undo.
+    this.state.layout.setState({ children: children.filter((child) => child !== gridItem) });
+
+    return index;
   }
 
   // panelIdGenerator is a shared counter to ensure unique panel IDs across siblings.

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -148,7 +148,19 @@ export class DefaultGridLayoutManager
     );
   }
 
-  public addPanel(vizPanel: VizPanel) {
+  public addPanel(vizPanel: VizPanel, index?: number) {
+    // Re-adding a previously removed panel (undo/redo): reuse the existing grid
+    // item so the panel id, item identity and grid position are preserved.
+    if (vizPanel.parent instanceof DashboardGridItem && vizPanel.parent.parent === this.state.grid) {
+      const gridItem = vizPanel.parent;
+      const children = this.state.grid.state.children.filter((child) => child !== gridItem);
+      const insertAt = index ?? children.length;
+      this.state.grid.setState({
+        children: [...children.slice(0, insertAt), gridItem, ...children.slice(insertAt)],
+      });
+      return;
+    }
+
     const panelId = dashboardSceneGraph.getNextPanelId(this);
 
     vizPanel.setState({ key: getVizPanelKeyForPanelId(panelId) });
@@ -163,18 +175,7 @@ export class DefaultGridLayoutManager
         key: getGridItemKeyForPanelId(panelId),
       });
 
-      dashboardEditActions.addElement({
-        addedObject: vizPanel,
-        source: this,
-        perform: () => {
-          this.state.grid.setState({ children: [...this.state.grid.state.children, newGridItem] });
-        },
-        undo: () => {
-          this.state.grid.setState({
-            children: this.state.grid.state.children.filter((child) => child !== newGridItem),
-          });
-        },
-      });
+      this.state.grid.setState({ children: [...this.state.grid.state.children, newGridItem] });
     } else {
       const newGridItem = new DashboardGridItem({
         height: NEW_PANEL_HEIGHT,
@@ -224,7 +225,7 @@ export class DefaultGridLayoutManager
     clearClipboard();
   }
 
-  public removePanel(panel: VizPanel) {
+  public removePanel(panel: VizPanel): number | undefined {
     const gridItem = panel.parent!;
 
     if (!(gridItem instanceof DashboardGridItem)) {
@@ -242,23 +243,17 @@ export class DefaultGridLayoutManager
     }
 
     if (row) {
+      const index = row.state.children.indexOf(gridItem);
       row.setState({ children: row.state.children.filter((child) => child !== gridItem) });
       layout.forceRender();
-      return;
+      return index;
     }
 
-    if (!config.featureToggles.dashboardNewLayouts) {
-      // No undo/redo support in legacy edit mode
-      layout.setState({ children: layout.state.children.filter((child) => child !== gridItem) });
-      return;
-    }
-
-    dashboardEditActions.removeElement({
-      removedObject: gridItem.state.body,
-      source: this,
-      perform: () => layout.setState({ children: layout.state.children.filter((child) => child !== gridItem) }),
-      undo: () => layout.setState({ children: [...layout.state.children, gridItem] }),
-    });
+    // Note: the grid item keeps its parent reference so addPanel can re-attach
+    // the same instance (and panel id) on undo.
+    const index = layout.state.children.indexOf(gridItem);
+    layout.setState({ children: layout.state.children.filter((child) => child !== gridItem) });
+    return index;
   }
 
   public duplicatePanel(vizPanel: VizPanel) {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -66,8 +66,8 @@ export class RowsLayoutManager
 
   public readonly descriptor = RowsLayoutManager.descriptor;
 
-  public addPanel(vizPanel: VizPanel) {
-    this.state.rows[0]?.getLayout().addPanel(vizPanel);
+  public addPanel(vizPanel: VizPanel, index?: number) {
+    this.state.rows[0]?.getLayout().addPanel(vizPanel, index);
   }
 
   public setIsDropTarget(isDropTarget: boolean): void {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -161,11 +161,11 @@ export class TabsLayoutManager
     });
   }
 
-  public addPanel(vizPanel: VizPanel) {
+  public addPanel(vizPanel: VizPanel, index?: number) {
     const tab = this.getCurrentTab() ?? this.state.tabs[0];
 
     if (tab) {
-      tab.getLayout().addPanel(vizPanel);
+      tab.getLayout().addPanel(vizPanel, index);
     }
   }
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
@@ -7,6 +7,7 @@ import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
 
+import { dashboardEditActions } from '../../edit-pane/shared';
 import { DashboardInteractions } from '../../utils/interactions';
 import { getDefaultVizPanel } from '../../utils/utils';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
@@ -44,7 +45,7 @@ export function CanvasGridAddActions({ layoutManager }: Props) {
         size="sm"
         data-testid={selectors.components.CanvasGridAddActions.addPanel}
         onClick={() => {
-          layoutManager.addPanel(getDefaultVizPanel());
+          dashboardEditActions.addPanel(layoutManager, getDefaultVizPanel());
           DashboardInteractions.trackAddPanelClick();
         }}
       >

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -25,15 +25,23 @@ export interface DashboardLayoutManager<S = {}> extends SceneObject {
   serialize(isSnapshot?: boolean): DashboardV2Spec['layout'];
 
   /**
-   * Adds a new panel to the layout
+   * Adds a panel to the layout. Pure state mutation — undo/redo is handled by
+   * `dashboardEditActions.addPanel`, not here.
+   *
+   * @param panel
+   * @param index Optional position to insert the panel's grid item at. Used when
+   *   re-adding a previously removed panel (undo) to restore its original order.
    */
-  addPanel(panel: VizPanel): void;
+  addPanel(panel: VizPanel, index?: number): void;
 
   /**
-   * Remove an element / panel
+   * Removes a panel from the layout. Pure state mutation — undo/redo is handled
+   * by `dashboardEditActions.removePanel`, not here.
+   *
    * @param panel
+   * @returns The index the panel's grid item was at, so it can be restored on undo.
    */
-  removePanel?(panel: VizPanel): void;
+  removePanel?(panel: VizPanel): number | undefined;
 
   /**
    * Creates a copy of an existing element and adds it to the layout


### PR DESCRIPTION
In some cases the logic for perform/undo is defined not inside Dashboards Edit Actions but inside Scene Objects themselves. For example AutoGridLayoutManager.addPanel() calls Dashboard Edit Actions. This leads to 2 problems:
- Confusion when to use dashboardEditActions.action() vs sceneObject.action() to ensure undo/redo is handled
- It makes it harder to unit test scene objects as executing the action relies on undo/redo mechanism.

This example shows how undo/redo can be moved away from Layout Managers.