### PR TITLE
Dashboard Edit Actions: Apply grid position with undo

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -16,6 +16,7 @@ import { type ElementSelectionContextItem } from '@grafana/ui';
 
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { SceneGridRowEditableElement } from '../scene/layout-default/SceneGridRowEditableElement';
 import { type BulkActionElement, isBulkActionElement } from '../scene/types/BulkActionElement';
 import { type EditableDashboardElement, isEditableDashboardElement } from '../scene/types/EditableDashboardElement';
@@ -192,6 +193,12 @@ export interface MoveElementActionHelperProps {
   undo: () => void;
 }
 
+export interface ChangeGridPositionActionHelperProps {
+  /** Panel whose wrapping DashboardGridItem should be repositioned/resized. */
+  source: VizPanel;
+  position: { x?: number; y?: number; width?: number; height?: number };
+}
+
 export const dashboardEditActions = {
   /**
    * Registers and peforms an edit action
@@ -353,6 +360,35 @@ export const dashboardEditActions = {
       source,
       perform,
       undo,
+    });
+  },
+
+  changeGridPosition({ source, position }: ChangeGridPositionActionHelperProps) {
+    const gridItem = source.parent;
+    if (!(gridItem instanceof DashboardGridItem)) {
+      return;
+    }
+
+    const updates: Record<string, number> = {};
+    const previous: Record<string, number> = {};
+
+    for (const key of ['x', 'y', 'width', 'height'] as const) {
+      const value = position[key];
+      if (value !== undefined) {
+        updates[key] = value;
+        previous[key] = gridItem.state[key];
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return;
+    }
+
+    dashboardEditActions.edit({
+      description: t('dashboard.edit-actions.change-grid-position', 'Change panel position'),
+      source,
+      perform: () => gridItem.setState(updates),
+      undo: () => gridItem.setState(previous),
     });
   },
 };

--- a/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
@@ -9,8 +9,7 @@
 
 import { type z } from 'zod';
 
-import type { VizPanel } from '@grafana/scenes';
-
+import { dashboardEditActions } from '../../edit-pane/shared';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
@@ -25,34 +24,6 @@ import { enterEditModeIfNeeded, requiresNewDashboardLayouts, type MutationComman
 export const movePanelPayloadSchema = payloads.movePanel;
 
 export type MovePanelPayload = z.infer<typeof movePanelPayloadSchema>;
-
-function applyGridPosition(
-  panel: VizPanel,
-  position: { x?: number; y?: number; width?: number; height?: number }
-): void {
-  const gridItem = panel.parent;
-  if (!(gridItem instanceof DashboardGridItem)) {
-    return;
-  }
-
-  const updates: Record<string, number> = {};
-  if (position.x !== undefined) {
-    updates.x = position.x;
-  }
-  if (position.y !== undefined) {
-    updates.y = position.y;
-  }
-  if (position.width !== undefined) {
-    updates.width = position.width;
-  }
-  if (position.height !== undefined) {
-    updates.height = position.height;
-  }
-
-  if (Object.keys(updates).length > 0) {
-    gridItem.setState(updates);
-  }
-}
 
 function resolveEffectivePosition(
   payload: MovePanelPayload,
@@ -144,7 +115,7 @@ export const movePanelCommand: MutationCommand<MovePanelPayload> = {
           if (isAutoGrid) {
             warnings.push('Position ignored: current layout uses AutoGridLayout which auto-arranges panels.');
           } else {
-            applyGridPosition(vizPanel, effectivePosition);
+            dashboardEditActions.changeGridPosition({ source: vizPanel, position: effectivePosition });
           }
         }
 
@@ -202,10 +173,10 @@ export const movePanelCommand: MutationCommand<MovePanelPayload> = {
         if (isTargetAutoGrid) {
           warnings.push('Position ignored: target uses AutoGridLayout which auto-arranges panels.');
         } else {
-          applyGridPosition(panelClone, effectivePosition);
+          dashboardEditActions.changeGridPosition({ source: panelClone, position: effectivePosition });
         }
       } else if (originalPosition && !isTargetAutoGrid) {
-        applyGridPosition(panelClone, originalPosition);
+        dashboardEditActions.changeGridPosition({ source: panelClone, position: originalPosition });
       }
 
       const resultLayoutItem = serializeResultLayoutItem(panelClone);


### PR DESCRIPTION
Mutation API defines actions that are Assistant-specific. They should be turned into action wrappers to support proper undo/redo. This PRs shows an example of how applyGridPosition helper should be turned into a Dashboard Edit Action and used in the Mutation API command.