### PR TITLE
Dashboard Edit Actions / Mutation API: Create a command builder

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/changePanelTitle.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/changePanelTitle.ts
@@ -1,0 +1,30 @@
+/**
+ * CHANGE_PANEL_TITLE command
+ *
+ * Thin wrapper around the existing `editPanelTitleAction`, built with
+ * `createActionCommand`: the schema maps 1-1 to the params, `map` resolves the
+ * element name to the scene VizPanel, and the action does the undoable change.
+ */
+
+import { z } from 'zod';
+
+import { editPanelTitleAction } from '../../panel-edit/getPanelFrameOptions';
+
+import { createActionCommand } from './createActionCommand';
+import { resolvePanelByElementName } from './resolvePanel';
+import { elementReferenceSchema } from './schemas';
+
+export const changePanelTitleCommand = createActionCommand({
+  name: 'CHANGE_PANEL_TITLE',
+  description: 'Change the title of an existing panel',
+  schema: z.object({
+    panel: elementReferenceSchema.describe('Panel to update, identified by element name'),
+    title: z.string().describe('New panel title'),
+  }),
+  map: (payload, { scene }) => ({
+    panel: resolvePanelByElementName(scene, payload.panel.name),
+    title: payload.title,
+  }),
+  // Call lazily (not as a bare reference at module load) to avoid an init cycle.
+  action: ({ panel, title }) => editPanelTitleAction(panel, title),
+});

--- a/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
@@ -56,6 +56,7 @@ describe('Command consistency', () => {
       'ADD_ROW',
       'ADD_TAB',
       'ADD_VARIABLE',
+      'CHANGE_PANEL_TITLE',
       'ENTER_EDIT_MODE',
       'GET_DASHBOARD_INFO',
       'GET_LAYOUT',

--- a/public/app/features/dashboard-scene/mutation-api/commands/createActionCommand.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/createActionCommand.ts
@@ -1,0 +1,79 @@
+/**
+ * Builder for mutation commands that are thin wrappers around a single
+ * `dashboardEditActions.*` action.
+ *
+ * Most write commands follow the same shape: validate a payload, resolve the
+ * referenced scene objects (e.g. an element name -> the actual VizPanel), then
+ * call one undoable action. `createActionCommand` captures that boilerplate so a
+ * new command is just: a schema (1-1 with params), a `map` from params to the
+ * action's args, and the action itself.
+ *
+ * Commands created this way self-register, so they only need to be imported in
+ * `registry.ts` to be picked up by `ALL_COMMANDS` — no manual array entry and no
+ * separate `payloads` entry (the schema travels with the command).
+ */
+
+import { type z } from 'zod';
+
+import type { MutationResult } from '../types';
+
+import {
+  enterEditModeIfNeeded,
+  requiresEdit,
+  type MutationCommand,
+  type MutationContext,
+  type PermissionCheck,
+} from './types';
+
+interface ActionCommandConfig<Payload, ActionParams> {
+  /** Command name -- must be UPPER_CASE. */
+  name: string;
+  description: string;
+  /** Zod schema for the command params (1-1 with the public API). */
+  schema: z.ZodType<Payload>;
+  /** Permission check. Defaults to `requiresEdit`. */
+  permission?: PermissionCheck;
+  /** Maps validated params to the action's args (resolves ids -> scene objects). */
+  map: (payload: Payload, context: MutationContext) => ActionParams;
+  /** The `dashboardEditActions.*` action to run with the mapped args. */
+  action: (params: ActionParams) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- heterogeneous registry, each command typed internally
+const actionCommands: Array<MutationCommand<any>> = [];
+
+/** All commands created via `createActionCommand` (populated as their modules load). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
+export function getActionCommands(): Array<MutationCommand<any>> {
+  return actionCommands;
+}
+
+export function createActionCommand<Payload, ActionParams>(
+  config: ActionCommandConfig<Payload, ActionParams>
+): MutationCommand<Payload> {
+  const command: MutationCommand<Payload> = {
+    name: config.name,
+    description: config.description,
+    payloadSchema: config.schema,
+    permission: config.permission ?? requiresEdit,
+    readOnly: false,
+    handler: async (payload, context): Promise<MutationResult> => {
+      enterEditModeIfNeeded(context.scene);
+
+      try {
+        config.action(config.map(payload, context));
+        return { success: true, data: payload, changes: [] };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+          changes: [],
+        };
+      }
+    },
+  };
+
+  actionCommands.push(command);
+
+  return command;
+}

--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -1011,4 +1011,48 @@ describe('Panel mutation commands', () => {
       expect(result.warnings![0]).toContain('DEPRECATED');
     });
   });
+
+  describe('CHANGE_PANEL_TITLE', () => {
+    it('changes the title of an existing panel', async () => {
+      const scene = buildPanelScene();
+      const client = new DashboardMutationClient(scene);
+      const elementName = await addPanel(client, 'Old Title');
+
+      const result = await client.execute({
+        type: 'CHANGE_PANEL_TITLE',
+        payload: { panel: { name: elementName }, title: 'New Title' },
+      });
+
+      expect(result.success).toBe(true);
+      const body = scene.state.body as unknown as DefaultGridLayoutManager;
+      expect(body.getVizPanels()[0].state.title).toBe('New Title');
+    });
+
+    it('returns an error for a non-existent panel', async () => {
+      const scene = buildPanelScene();
+      const client = new DashboardMutationClient(scene);
+
+      const result = await client.execute({
+        type: 'CHANGE_PANEL_TITLE',
+        payload: { panel: { name: 'nonexistent' }, title: 'Whatever' },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+
+    it('rejects payloads missing the title', async () => {
+      const scene = buildPanelScene();
+      const client = new DashboardMutationClient(scene);
+      const elementName = await addPanel(client, 'Has Title');
+
+      const result = await client.execute({
+        type: 'CHANGE_PANEL_TITLE',
+        payload: { panel: { name: elementName } },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Validation failed');
+    });
+  });
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
@@ -7,9 +7,14 @@
 
 import { addAnnotationCommand } from './addAnnotation';
 import { addPanelCommand } from './addPanel';
+// Builder-based commands self-register via createActionCommand. Importing each
+// module (for its side effect) runs that registration; getActionCommands() then
+// returns them, so they're added to ALL_COMMANDS without a manual array entry.
+import './changePanelTitle';
 import { addRowCommand } from './addRow';
 import { addTabCommand } from './addTab';
 import { addVariableCommand } from './addVariable';
+import { getActionCommands } from './createActionCommand';
 import { enterEditModeCommand } from './enterEditMode';
 import { getDashboardInfoCommand } from './getDashboardInfo';
 import { getLayoutCommand } from './getLayout';
@@ -61,6 +66,8 @@ export const ALL_COMMANDS: Array<MutationCommand<any>> = [
   listPanelsCommand,
   getDashboardInfoCommand,
   updateDashboardSettingsCommand,
+  // Commands defined via createActionCommand (self-registered on import above).
+  ...getActionCommands(),
 ];
 
 /** All valid command names. */

--- a/public/app/features/dashboard-scene/mutation-api/commands/resolvePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/resolvePanel.ts
@@ -1,0 +1,23 @@
+import { type VizPanel } from '@grafana/scenes';
+
+import { type DashboardScene } from '../../scene/DashboardScene';
+import { getVizPanelKeyForPanelId } from '../../utils/utils';
+
+/**
+ * Resolves an element name (as used in the mutation-api payloads) to the actual
+ * VizPanel in the scene. Throws if the element or panel cannot be found.
+ */
+export function resolvePanelByElementName(scene: DashboardScene, elementName: string): VizPanel {
+  const panelId = scene.serializer.getPanelIdForElement(elementName);
+  if (panelId === undefined) {
+    throw new Error(`Element "${elementName}" not found in the dashboard`);
+  }
+
+  const expectedKey = getVizPanelKeyForPanelId(panelId);
+  const panel = scene.state.body.getVizPanels().find((p) => p.state.key === expectedKey);
+  if (!panel) {
+    throw new Error(`Panel for element "${elementName}" not found in the layout`);
+  }
+
+  return panel;
+}


### PR DESCRIPTION
A builder to simplify exposing Dashboard Edit Actions to mutation API.