### PR TITLE
Plugins: add more debug logging before rollout

### DIFF
--- a/packages/grafana-runtime/src/services/pluginMeta/apps.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.ts
@@ -5,7 +5,7 @@ import { getFeatureFlagClient } from '../../internal/openFeature';
 import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 
 import { FALLBACK_TO_BOOTDATA_WARNING } from './constants';
-import { logPluginMetaWarning } from './logging';
+import { logPluginMetaDebug, logPluginMetaWarning } from './logging';
 import { getAppPluginMapper } from './mappers/mappers';
 import { initPluginMetas } from './plugins';
 import type { AppPluginMetas, PluginMetasResponse } from './types';
@@ -38,11 +38,13 @@ async function initAppPluginMetas(): Promise<void> {
   if (!getFeatureFlagClient().getBooleanValue(FlagKeys.PluginsUseMTPlugins, false)) {
     // eslint-disable-next-line @grafana/no-config-apps
     setApps(config.apps);
+    logPluginMetaDebug('PluginMeta: initializing app plugins cache with bootdata values', {});
     return;
   }
 
   const metas = await initPluginMetas();
   setMetas(metas);
+  logPluginMetaDebug('PluginMeta: initializing app plugins cache with meta values', {});
 }
 
 export async function getAppPluginMetas(): Promise<AppPluginConfig[]> {

--- a/packages/grafana-runtime/src/services/pluginMeta/datasources.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/datasources.test.ts
@@ -27,6 +27,7 @@ jest.mock('./plugins', () => ({
 jest.mock('./logging', () => ({
   logPluginMetaWarning: jest.fn(),
   logPluginMetaError: jest.fn(),
+  logPluginMetaDebug: jest.fn(),
 }));
 
 const initPluginMetasMock = jest.mocked(initPluginMetas);

--- a/packages/grafana-runtime/src/services/pluginMeta/datasources.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/datasources.ts
@@ -6,7 +6,7 @@ import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { getBackendSrv } from '../backendSrv';
 
 import { FALLBACK_TO_BOOTDATA_WARNING } from './constants';
-import { logPluginMetaWarning } from './logging';
+import { logPluginMetaDebug, logPluginMetaWarning } from './logging';
 import { getDatasourcePluginMapper } from './mappers/mappers';
 import { initPluginMetas, refetchPluginMetas } from './plugins';
 import type { DatasourcePluginMetas, FrontendSettings, PluginMetasResponse } from './types';
@@ -96,11 +96,13 @@ async function initDatasourcePluginMetas(): Promise<void> {
   if (!getFeatureFlagClient().getBooleanValue(FlagKeys.PluginsUseMTPlugins, false)) {
     // eslint-disable-next-line no-restricted-syntax
     setDatasourcesAndAliases(extractFromConfig(config.datasources));
+    logPluginMetaDebug('PluginMeta: initializing datasource plugins cache with bootdata values', {});
     return;
   }
 
   const metas = await initPluginMetas();
   setMetas(metas);
+  logPluginMetaDebug('PluginMeta: initializing datasource plugins cache with meta values', {});
 }
 
 export async function getDatasourcePluginMetas(): Promise<DataSourcePluginMeta[]> {

--- a/packages/grafana-runtime/src/services/pluginMeta/logging.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/logging.ts
@@ -9,3 +9,7 @@ export function logPluginMetaWarning(message: string, context: LogContext): void
 export function logPluginMetaError(message: string, error: unknown, context?: LogContext): void {
   getLogger('grafana/runtime.plugins.meta').logError(new Error(message, { cause: error }), context);
 }
+
+export function logPluginMetaDebug(message: string, context: LogContext): void {
+  getLogger('grafana/runtime.plugins.meta').logDebug(message, context);
+}

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.ts
@@ -6,7 +6,7 @@ import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { getBackendSrv } from '../backendSrv';
 
 import { FALLBACK_TO_BOOTDATA_WARNING } from './constants';
-import { logPluginMetaWarning } from './logging';
+import { logPluginMetaDebug, logPluginMetaWarning } from './logging';
 import { getPanelPluginMapper } from './mappers/mappers';
 import { initPluginMetas, refetchPluginMetas } from './plugins';
 import type { PanelPluginMetas, PluginMetasResponse } from './types';
@@ -63,11 +63,13 @@ async function initPanelPluginMetas(): Promise<void> {
   if (!getFeatureFlagClient().getBooleanValue(FlagKeys.PluginsUseMTPlugins, false)) {
     // eslint-disable-next-line @grafana/no-config-panels
     setPanelsAndAliases(config.panels);
+    logPluginMetaDebug('PluginMeta: initializing panel plugins cache with bootdata values', {});
     return;
   }
 
   const metas = await initPluginMetas();
   setMetas(metas);
+  logPluginMetaDebug('PluginMeta: initializing panel plugins cache with meta values', {});
 }
 
 function getListedPanels(panels: PanelPluginMeta[]): PanelPluginMeta[] {

--- a/packages/grafana-runtime/src/services/pluginMeta/plugins.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/plugins.ts
@@ -3,6 +3,7 @@ import { getFeatureFlagClient } from '../../internal/openFeature';
 import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { getCachedPromise } from '../../utils/getCachedPromise';
 
+import { logPluginMetaError } from './logging';
 import type { PluginMetasResponse } from './types';
 import { type Meta } from './types/meta/meta_object_gen';
 import { type Plugin } from './types/plugin/plugin_object_gen';
@@ -20,7 +21,12 @@ async function loadPluginMetas(): Promise<PluginMetasResponse> {
 
   const metas = await fetch(`apis/plugins.grafana.app/${getApiVersion()}/namespaces/${config.namespace}/metas`);
   if (!metas.ok) {
-    throw new Error(`Failed to load plugin metas ${metas.status}:${metas.statusText}`);
+    const error = new Error(`Failed to load plugin metas ${metas.status}:${metas.statusText}`);
+    logPluginMetaError('PluginMeta: failed to load plugin metas', error, {
+      status: String(metas.status),
+      statusText: metas.statusText,
+    });
+    throw error;
   }
 
   const result = await metas.json();
@@ -49,7 +55,13 @@ export async function installPluginMeta(pluginId: string, version: string): Prom
   });
 
   if (!result.ok) {
-    throw new Error(`Failed to install plugin ${pluginId} ${result.status}:${result.statusText}`);
+    const error = new Error(`Failed to install plugin ${pluginId} ${result.status}:${result.statusText}`);
+    logPluginMetaError('PluginMeta: failed to install plugin', error, {
+      pluginId,
+      status: String(result.status),
+      statusText: result.statusText,
+    });
+    throw error;
   }
 }
 
@@ -66,7 +78,13 @@ export async function uninstallPluginMeta(pluginId: string): Promise<void> {
   );
 
   if (!result.ok) {
-    throw new Error(`Failed to uninstall plugin ${pluginId} ${result.status}:${result.statusText}`);
+    const error = new Error(`Failed to uninstall plugin ${pluginId} ${result.status}:${result.statusText}`);
+    logPluginMetaError('PluginMeta: failed to uninstall plugin', error, {
+      pluginId,
+      status: String(result.status),
+      statusText: result.statusText,
+    });
+    throw error;
   }
 }
 

--- a/packages/grafana-runtime/src/services/pluginSettings/getPluginSettings.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/getPluginSettings.ts
@@ -6,12 +6,14 @@ import { getCachedPromiseWithArgs } from '../../utils/getCachedPromise';
 import { getBackendSrv } from '../backendSrv';
 import { getPluginMetaFromCache } from '../pluginMeta/plugins';
 
+import { logPluginSettingsDebug, logPluginSettingsError } from './logging';
 import { getSettingsMapper } from './mappers/mappers';
 import { type Settings as v0alpha1Settings } from './types';
 import { getApiVersion, getCacheKey, getLegacyCacheKey, getNamespace, isAuthError } from './utils';
 
 export function getLegacySettings(pluginId: string, showErrorAlert?: boolean): Promise<PluginMeta> {
   const options = { showErrorAlert, validatePath: true };
+  logPluginSettingsDebug('PluginSettings: getting legacy plugin settings', { pluginId });
 
   return getBackendSrv()
     .get(`/api/plugins/${pluginId}/settings`, undefined, undefined, options)
@@ -22,12 +24,14 @@ export function getLegacySettings(pluginId: string, showErrorAlert?: boolean): P
         return Promise.reject(err);
       }
 
+      logPluginSettingsError('PluginSettings: getting legacy plugin settings failed', err, { pluginId });
       return Promise.reject(new Error('Unknown Plugin', { cause: err }));
     });
 }
 
 export function getAppPluginSettings(pluginId: string, showErrorAlert?: boolean): Promise<v0alpha1Settings> {
   const options = { showErrorAlert, validatePath: true };
+  logPluginSettingsDebug('PluginSettings: getting plugin settings', { pluginId });
 
   return getBackendSrv()
     .get<v0alpha1Settings>(
@@ -43,6 +47,7 @@ export function getAppPluginSettings(pluginId: string, showErrorAlert?: boolean)
         return Promise.reject(err);
       }
 
+      logPluginSettingsError('PluginSettings: getting plugin settings failed', err, { pluginId });
       return Promise.reject(new Error('Unknown Plugin', { cause: err }));
     });
 }

--- a/packages/grafana-runtime/src/services/pluginSettings/logging.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/logging.ts
@@ -9,3 +9,7 @@ export function logPluginSettingsWarning(message: string, context: LogContext): 
 export function logPluginSettingsError(message: string, error: unknown, context?: LogContext): void {
   getLogger('grafana/runtime.plugins.settings').logError(new Error(message, { cause: error }), context);
 }
+
+export function logPluginSettingsDebug(message: string, context: LogContext): void {
+  getLogger('grafana/runtime.plugins.settings').logDebug(message, context);
+}

--- a/packages/grafana-runtime/src/services/pluginSettings/updateAppPluginSettings.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/updateAppPluginSettings.ts
@@ -8,14 +8,16 @@ import { replaceCachedPromise } from '../../utils/getCachedPromise';
 import { getBackendSrv } from '../backendSrv';
 import { refetchPluginMeta } from '../pluginMeta/plugins';
 
+import { logPluginSettingsDebug } from './logging';
 import { getSettingsMapper } from './mappers/mappers';
 import { inlineSecureValuesMapper, settingsSpecMapper } from './mappers/v0alpha1SettingsMapper';
 import { refetchCachedAppSettings, refetchCachedLegacySettings } from './refetchPluginSettings';
 import { type Settings as v0alpha1Settings } from './types';
 import { getApiVersion, getCacheKey, getNamespace } from './utils';
 
-function updateLegacySettings(id: string, data: Partial<PluginMeta>): Promise<void> {
-  return getBackendSrv().post<void>(`/api/plugins/${id}/settings`, data, { validatePath: true });
+function updateLegacySettings(pluginId: string, data: Partial<PluginMeta>): Promise<void> {
+  logPluginSettingsDebug('PluginSettings: updating legacy plugin settings', { pluginId });
+  return getBackendSrv().post<void>(`/api/plugins/${pluginId}/settings`, data, { validatePath: true });
 }
 
 async function internalUpdateAppPluginSettings(pluginId: string, data: Partial<PluginMeta>): Promise<v0alpha1Settings> {
@@ -31,6 +33,7 @@ async function internalUpdateAppPluginSettings(pluginId: string, data: Partial<P
   const { metadata, ...stored } = await refetchCachedAppSettings(pluginId, false);
   const test: Operation = { op: 'test', path: '/metadata/resourceVersion', value: metadata.resourceVersion };
   const patch = [test, ...compare(stored, update)];
+  logPluginSettingsDebug('PluginSettings: updating plugin settings', { pluginId });
 
   const updated = await getBackendSrv().patch<v0alpha1Settings>(
     `/apis/${pluginId}/${getApiVersion()}/namespaces/${getNamespace()}/app/instance`,


### PR DESCRIPTION
**What is this feature?**

Adds `logPluginMetaDebug` and `logPluginSettingsDebug` helpers and wires them up across the plugin meta and settings init/fetch/update paths. Also logs errors to Faro in `plugins.ts` before re-throwing on failed load/install/uninstall calls.

**Why do we need this feature?**

So we can observe which code path (bootdata vs meta API) each plugin type takes during the `plugins.useMTPlugins` and `plugins.useMTPluginSettings` rollout.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
