### PR TITLE
`IAM`: Remove resource permissions for teams and users

### DIFF
--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/authlib/types"
@@ -41,14 +40,6 @@ type ResourcePermSqlBackend struct {
 
 func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider, mappers *MappersRegistry) *ResourcePermSqlBackend {
 	store := idStore.NewLegacySQLStores(dbProvider)
-	mappers.RegisterMapper(
-		schema.GroupResource{Group: "iam.grafana.app", Resource: "teams"},
-		NewIDScopedMapper("teams", []string{"Member", "Admin"}), nil,
-	)
-	mappers.RegisterMapper(
-		schema.GroupResource{Group: "iam.grafana.app", Resource: "users"},
-		NewIDScopedMapper("users", defaultLevels), nil,
-	)
 	return &ResourcePermSqlBackend{
 		dbProvider:    dbProvider,
 		identityStore: store,


### PR DESCRIPTION
This PR removes the possibility to grant permissions **on** specific users and teams through the resource permissions APIs.

**Why**

1. It was never possible to grant permissions **on** specific users in the legacy resource permissions apis. This would be a new feature.
2. Resource Permissions on teams, were actually used to store memberships. But memberships are now going to be part of the team object and shouldn't be managed through the IAM App's Resource Permissions apis. If we ever want to grant permissions **on** teams to specific users without granting them membership, we can reconsider this removal. 