### PR TITLE
unified-storage/search: keep cached bleve index on disk regardless of ownership

### DIFF
--- a/pkg/storage/unified/search/disk_cleanup.go
+++ b/pkg/storage/unified/search/disk_cleanup.go
@@ -271,7 +271,15 @@ func splitResourceGroup(name string) (string, string, bool) {
 // sweepResource dispatches each timestamp directory inside one resource
 // folder into one of three buckets:
 //
-//   - active index (owned + currently cached): always kept, no gate.
+//   - active index (currently cached): always kept, no gate. Ownership is
+//     deliberately not consulted here: the cache can hold an index this pod
+//     no longer owns (the ring reshuffled but runEvictExpiredOrUnownedIndexes
+//     has not yet evicted it, e.g. because traffic keeps refreshing
+//     lastFetchedFromCache). Deleting that directory while bleve still has
+//     it open causes the live scorch persister to fail on its next segment
+//     write with "persist err: ... no such file or directory". Unowned
+//     cached indexes are closed by runEvictExpiredOrUnownedIndexes once
+//     they go idle past IndexCacheTTL.
 //   - newest sibling we own but haven't opened: gated with the longer
 //     unopened-grace so a later BuildIndex can reuse it on cold start.
 //   - everything else (older siblings, anything under an unowned resource):
@@ -318,7 +326,10 @@ func (b *bleveBackend) sweepResource(ctx context.Context, root *os.Root, resourc
 
 		// Active index: the directory we currently have open. Keep
 		// unconditionally — deleting it would close-and-lose the live index.
-		if owned && cachedName != "" && name == cachedName {
+		// Intentionally not gated on `owned`: see the comment block on
+		// sweepResource for why an unowned index can still be cached and in
+		// use.
+		if cachedName != "" && name == cachedName {
 			stats.keptActive++
 			continue
 		}

--- a/pkg/storage/unified/search/disk_cleanup_test.go
+++ b/pkg/storage/unified/search/disk_cleanup_test.go
@@ -155,6 +155,50 @@ func TestRunDiskCleanup_OwnedResource_KeepsCachedActive(t *testing.T) {
 	require.NoDirExists(t, older)
 }
 
+func TestRunDiskCleanup_UnownedResource_KeepsCachedActive(t *testing.T) {
+	// Regression: after a ring reshuffle this pod can lose ownership of a
+	// resource while its file-based index is still cached and in use. The
+	// cleanup sweep must keep the on-disk directory until the eviction loop
+	// closes the index; otherwise the live scorch persister fails on its
+	// next segment write with "persist err: ... no such file or directory".
+	owns := func(_ resource.NamespacedResource) (bool, error) { return false, nil }
+	b, metrics := setupDiskCleanupBackend(t, time.Minute, owns)
+
+	ns := resource.NamespacedResource{Namespace: "ns1", Group: "dashboard.grafana.app", Resource: "dashboards"}
+	resourceDir := b.getResourceDir(ns)
+	require.NoError(t, os.MkdirAll(resourceDir, 0o750))
+
+	mapper, err := GetBleveMappings(nil, nil)
+	require.NoError(t, err)
+	activeDir := filepath.Join(resourceDir, "20240301-120000")
+	activeIdx, err := newBleveIndex(activeDir, mapper, time.Now(), buildVersion, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = activeIdx.Close() })
+	older := mkdirOld(t, resourceDir, "20240101-000000")
+	writeFileOld(t, older, "root.bolt")
+
+	b.cacheMx.Lock()
+	b.cache[ns] = &bleveIndex{key: ns, index: activeIdx, indexStorage: indexStorageFile}
+	b.cacheMx.Unlock()
+	t.Cleanup(func() {
+		b.cacheMx.Lock()
+		delete(b.cache, ns)
+		b.cacheMx.Unlock()
+	})
+
+	// Force the active dir to look stale on disk so the only thing that can
+	// save it is the active-cache check (not the mtime gate). This mirrors
+	// production, where a read-heavy unowned index ages out of fresh-mtime
+	// well before the eviction loop closes it.
+	chtimesRecursive(t, activeDir, time.Now().Add(-24*time.Hour))
+
+	b.runDiskCleanup(t.Context())
+
+	require.DirExists(t, activeDir, "cached active index directory must survive even when this pod no longer owns it")
+	require.NoDirExists(t, older, "unowned, uncached, stale sibling is still deleted")
+	require.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexDiskCleanupDirsDeleted.WithLabelValues("index", "success")))
+}
+
 func TestRunDiskCleanup_OwnedResource_KeepsNewestSiblingWhenNotCached(t *testing.T) {
 	// Normal grace is short so the older sibling falls through to delete.
 	// Unopened grace is generous so the newest — stale by 24h on disk —


### PR DESCRIPTION
Fix a race in the bleve disk cleanup sweep that deletes the on-disk directory of an index still loaded in memory. The pod then keeps serving the broken index and every scorch flush fails with `persist err: ... no such file or directory` until restart.

`sweepResource` gates the "keep the currently-cached active index" branch on ownership:

```go
if owned && cachedName != "" && name == cachedName { ... }
```

After a ring reshuffle (e.g. KEDA scale up/down), this pod can lose ownership while the file-based index is still cached. File-based indexes have no TTL and are only closed by `runEvictExpiredOrUnownedIndexes` once idle past `IndexCacheTTL` — read traffic keeps that timer reset. In that window the cleanup sees `owned == false` and `RemoveAll`s the directory under the live index.

Drop the `owned &&` guard. The cache is the source of truth for "is this index open"; closing unowned cached indexes is the eviction loop's job. Other branches of `sweepResource` are unchanged.
