### PR TITLE
Alerting: Use safe parser for legacy queryString URL migration

### DIFF
--- a/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
@@ -14,7 +14,9 @@ import {
   mockRulerGrafanaRule,
 } from '../mocks';
 import { RuleHealth } from '../search/rulesSearchParser';
+import { matcherToMatcherField } from '../utils/alertmanager';
 import { Annotation } from '../utils/constants';
+import { parsePromQLStyleMatcherLooseSafe } from '../utils/matchers';
 import { getFilter } from '../utils/search';
 
 import { filterRules } from './useFilteredRules';
@@ -324,5 +326,31 @@ describe('filterRules', function () {
 
     expect(filtered[0]?.groups[0]?.rules).toHaveLength(1);
     expect(filtered[0]?.groups[0]?.rules[0]?.name).toBe(longRuleName);
+  });
+});
+
+// Legacy URLs may put free-text or search-syntax tokens in queryString instead of PromQL matchers.
+describe('legacy queryString URL param parsing', () => {
+  const parseLegacyQueryString = (queryString: string) =>
+    parsePromQLStyleMatcherLooseSafe(queryString).map(matcherToMatcherField);
+
+  it.each([
+    'state:firing',
+    'state:nodata',
+    'High CPU Usage',
+    'Payment Gateway Errors',
+    'auth.service.SessionTimeout',
+    'prod/api-gateway',
+    'eu-west/em-processor',
+    'k8s-cluster-alerts',
+    'PaymentService-Prod',
+  ])('should return empty label filter for non-matcher legacy queryString "%s"', (queryString) => {
+    expect(parseLegacyQueryString(queryString)).toEqual([]);
+  });
+
+  it('should parse valid legacy matcher syntax into label filters', () => {
+    expect(parseLegacyQueryString('severity="critical"')).toEqual([
+      { name: 'severity', operator: '=', value: 'critical' },
+    ]);
   });
 });

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -19,7 +19,7 @@ import { labelsMatchMatchers, matcherToMatcherField } from '../utils/alertmanage
 import { Annotation } from '../utils/constants';
 import { isCloudRulesSource } from '../utils/datasource';
 import { fuzzyFilter } from '../utils/fuzzySearch';
-import { parseMatcher, parsePromQLStyleMatcherLoose } from '../utils/matchers';
+import { parseMatcher, parsePromQLStyleMatcherLooseSafe } from '../utils/matchers';
 import {
   getRuleHealth,
   isPluginProvidedRule,
@@ -66,7 +66,7 @@ export function useRulesFilter() {
       dataSource: queryParams.get('dataSource') ?? undefined,
       alertState: queryParams.get('alertState') ?? undefined,
       ruleType: queryParams.get('ruleType') ?? undefined,
-      labels: parsePromQLStyleMatcherLoose(queryParams.get('queryString') ?? '').map(matcherToMatcherField),
+      labels: parsePromQLStyleMatcherLooseSafe(queryParams.get('queryString') ?? '').map(matcherToMatcherField),
     };
 
     const hasLegacyFilters = Object.values(legacyFilters).some((legacyFilter) => !isEmpty(legacyFilter));

--- a/public/app/features/alerting/unified/utils/matchers.test.ts
+++ b/public/app/features/alerting/unified/utils/matchers.test.ts
@@ -275,6 +275,20 @@ describe('parsePromQLStyleMatcherLooseSafe', () => {
       { name: 'baz-bar.foo', value: 'bazz', isEqual: true, isRegex: false },
     ]);
   });
+
+  it.each([
+    'state:firing',
+    'state:nodata',
+    'High CPU Usage',
+    'Payment Gateway Errors',
+    'auth.service.SessionTimeout',
+    'prod/api-gateway',
+    'eu-west/em-processor',
+    'k8s-cluster-alerts',
+    'PaymentService-Prod',
+  ])('should return empty array for non-matcher legacy queryString input "%s"', (input) => {
+    expect(parsePromQLStyleMatcherLooseSafe(input)).toEqual([]);
+  });
 });
 
 describe('parsePromQLStyleMatcherLoose', () => {


### PR DESCRIPTION
This pull request improves the handling and testing of legacy `queryString` URL parameters in the alerting rules filtering logic. The main focus is to ensure that only valid PromQL-style matchers are parsed into label filters, while legacy free-text or search-syntax tokens are safely ignored. This helps prevent incorrect filtering and improves robustness when dealing with legacy URLs.

**Improvements to legacy queryString parsing:**

* Updated `useFilteredRules.ts` to use `parsePromQLStyleMatcherLooseSafe` instead of the less strict `parsePromQLStyleMatcherLoose`, ensuring only valid PromQL matchers are converted into label filters, and non-matcher legacy query strings are ignored. [[1]](diffhunk://#diff-b02f5418c844ae8ebb6d84787a8965919ef214993bab179569c024f2caa688e4L22-R22) [[2]](diffhunk://#diff-b02f5418c844ae8ebb6d84787a8965919ef214993bab179569c024f2caa688e4L69-R69)
* Added comprehensive tests in `useFilteredRules.test.ts` and `matchers.test.ts` to verify that various legacy query strings (free-text and search-syntax) yield empty label filters, while valid matcher syntax is correctly parsed. [[1]](diffhunk://#diff-6ff454d07cfe126d7d999a0d7868a3091ac607011d123d65b84ab876a942b2faR331-R356) [[2]](diffhunk://#diff-f08f5c49ca51e73c9e45c12ecd698c0c96d956aa97d2e75d59d3877ecd72e48dR278-R291)

**Test and import updates:**

* Updated imports in `useFilteredRules.test.ts` to include `matcherToMatcherField` and `parsePromQLStyleMatcherLooseSafe` for use in new tests.