### PR TITLE
[main] chore(deps): Upgrade hono to 4.12.25

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18912,9 +18912,9 @@ __metadata:
   linkType: hard
 
 "hono@npm:^4.11.4":
-  version: 4.12.18
-  resolution: "hono@npm:4.12.18"
-  checksum: 10/0adda91eeb68c921e073bcbedd8758f026cc47dbbe7824147cf0ee8ef03004b1891f4d4edc80f6ab4c6ab33ec1f2fac52c4f7098752f8acf6833bcb76efb39e4
+  version: 4.12.25
+  resolution: "hono@npm:4.12.25"
+  checksum: 10/0cbdcdfdfb45b43cc915beaa44604170bb73b45e647927917714ec222347e7f44c944708471a45b4733cfd20b03c53820593db5b3b19663b935afca9cf984817
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Upgrades the transitive `hono` dependency from `4.12.18` to `4.12.25`. This fixes four CVEs: `CVE-2026-47673` (JWT scheme bypass), `CVE-2026-47674` (IP restriction bypass), `CVE-2026-47675` (cookie injection), and `CVE-2026-47676` (URL routing mismatch), all fixed in `4.12.21`.

**Why do we need this feature?**

So we don't ship `hono` with known security vulnerabilities.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Only `yarn.lock` changed. `hono` is pulled in transitively via `@grafana/llm@1.0.8` → `@modelcontextprotocol/sdk@1.29.0`, and the existing `^4.11.4` range already allowed the fix, so `yarn up -R hono` resolved it with no code or `package.json` change.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
