### PR TITLE
[release-12.4.5] Docker: Bump Alpine-based images to 3.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG JS_SRC=js-builder
 
 # Dependabot cannot update dependencies listed in ARGs
 # By using FROM instructions we can delegate dependency updates to dependabot
-FROM alpine:3.23.4 AS alpine-base
+FROM alpine:3.24.1 AS alpine-base
 FROM ubuntu:24.04 AS ubuntu-base
 FROM golang:1.26.4-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:24-alpine AS js-builder-base

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -59,7 +59,7 @@ docker_build () {
   esac
   if [ $UBUNTU_BASE = "0" ]; then
     libc="-musl"
-    base_image="${base_arch}alpine:3.23.3"
+    base_image="${base_arch}alpine:3.24.1"
   else
     libc=""
     base_image="${base_arch}ubuntu:22.04"


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana/pull/126529