### PR TITLE
Provisioning: Return 404 instead of 500 for missing ref in files listing

### DIFF
--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -225,13 +225,13 @@ func (c *filesConnector) parseRequestOptions(r *http.Request, name string, repo 
 // handleDirectoryListing handles GET requests for directory listing.
 func (c *filesConnector) handleDirectoryListing(ctx context.Context, name string, opts resources.DualWriteOptions, readWriter repository.ReaderWriter, responder rest.Responder) {
 	if err := c.authorizeListFiles(ctx, name); err != nil {
-		responder.Error(err)
+		respondWithError(responder, err)
 		return
 	}
 
 	files, err := c.listFolderFiles(ctx, opts.Path, opts.Ref, readWriter)
 	if err != nil {
-		responder.Error(err)
+		respondWithError(responder, err)
 		return
 	}
 

--- a/pkg/registry/apis/provisioning/files_test.go
+++ b/pkg/registry/apis/provisioning/files_test.go
@@ -182,9 +182,11 @@ func TestHandleDirectoryListing_RefNotFoundMapsTo404(t *testing.T) {
 
 	require.Error(t, responder.err)
 	// The responder must receive a concrete *StatusError (an APIStatus), not a wrapped
-	// error — otherwise the generic apiserver maps it to 500 + UnhandledError. errors.As /
-	// IsNotFound would unwrap and pass either way, so assert the concrete type the
-	// responder actually gets.
+	// error — the apiserver's ErrorToAPIStatus maps via a non-unwrapping type assertion,
+	// so a wrapped error becomes 500 + UnhandledError. A deliberate type assertion (not
+	// errors.As) is what mirrors that behavior here; errors.As would unwrap and pass even
+	// for the wrapped error that causes the 500.
+	//nolint:errorlint // intentional: assert the concrete type the responder receives, matching the apiserver's non-unwrapping mapping
 	statusErr, ok := responder.err.(*apierrors.StatusError)
 	require.True(t, ok, "responder must receive a *StatusError, got %T", responder.err)
 	require.True(t, apierrors.IsNotFound(statusErr), "expected a 404 NotFound, got %#v", statusErr)

--- a/pkg/registry/apis/provisioning/files_test.go
+++ b/pkg/registry/apis/provisioning/files_test.go
@@ -3,6 +3,7 @@ package provisioning
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -155,6 +156,38 @@ func TestCheckQuota(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A missing ref surfaces from the git layer as ErrRefNotFound wrapped by fmt.Errorf
+// (a *fmt.wrapError, not an APIStatus). The directory-listing handler must unwrap it so
+// the client gets a 404 instead of a 500 + UnhandledError log.
+func TestHandleDirectoryListing_RefNotFoundMapsTo404(t *testing.T) {
+	mockAccess := auth.NewMockAccessChecker(t)
+	mockAccess.EXPECT().Check(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	wrappedErr := fmt.Errorf("ref not found: %s: %w", "refs/heads/test-panel", repository.ErrRefNotFound)
+	mockReadWriter := repository.NewMockReaderWriter(t)
+	mockReadWriter.EXPECT().ReadTree(mock.Anything, "test-panel").Return([]repository.FileTreeEntry(nil), wrappedErr)
+
+	connector := &filesConnector{access: mockAccess}
+	responder := &fakeResponder{}
+
+	connector.handleDirectoryListing(
+		context.Background(),
+		"test-repo",
+		resources.DualWriteOptions{Path: "", Ref: "test-panel"},
+		mockReadWriter,
+		responder,
+	)
+
+	require.Error(t, responder.err)
+	// The responder must receive a concrete *StatusError (an APIStatus), not a wrapped
+	// error — otherwise the generic apiserver maps it to 500 + UnhandledError. errors.As /
+	// IsNotFound would unwrap and pass either way, so assert the concrete type the
+	// responder actually gets.
+	statusErr, ok := responder.err.(*apierrors.StatusError)
+	require.True(t, ok, "responder must receive a *StatusError, got %T", responder.err)
+	require.True(t, apierrors.IsNotFound(statusErr), "expected a 404 NotFound, got %#v", statusErr)
 }
 
 func TestHandleMethodRequest_FolderMetadataGuard(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

When listing a provisioned repository's files for a ref that does not exist (`GET /apis/provisioning.grafana.app/v0alpha1/namespaces/{ns}/repositories/{repo}/files/?ref=<branch>`), the directory-listing endpoint now returns a clean `404 Not Found` instead of `500` with an `UnhandledError` log line. The fix routes the two `handleDirectoryListing` error paths through the existing `respondWithError` unwrap helper, matching the read-file path in the same connector.

**Why do we need this feature?**

The git layer surfaces a missing ref as `repository.ErrRefNotFound` (a `*apierrors.StatusError`, 404) wrapped by `fmt.Errorf(... %w ...)`, producing a `*fmt.wrapError`. The directory-listing path passed that raw to `responder.Error`, so the generic apiserver never recognized it as an `APIStatus` and mapped it to a 500 plus `logger=UnhandledError` noise. Requesting a not-yet-existing ref is legitimate (the new-branch workflow targets a branch that is not created until the first commit), so the backend must return a proper status the client can handle.