### PR TITLE
[release-11.6.16] Docker: Bump Alpine-based images to 3.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG JS_SRC=js-builder
 
 # Dependabot cannot update dependencies listed in ARGs
 # By using FROM instructions we can delegate dependency updates to dependabot
-FROM alpine:3.23.4 AS alpine-base
+FROM alpine:3.24.1 AS alpine-base
 FROM ubuntu:22.04 AS ubuntu-base
 FROM golang:1.26.4-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:22-alpine AS js-builder-base

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -59,7 +59,7 @@ docker_build () {
   esac
   if [ $UBUNTU_BASE = "0" ]; then
     libc="-musl"
-    base_image="${base_arch}alpine:3.23.4"
+    base_image="${base_arch}alpine:3.24.1"
   else
     libc=""
     base_image="${base_arch}ubuntu:22.04"

--- a/pkg/build/daggerbuild/artifacts/package_targz.go
+++ b/pkg/build/daggerbuild/artifacts/package_targz.go
@@ -219,7 +219,7 @@ func (t *Tarball) Builder(ctx context.Context, opts *pipeline.ArtifactContainerO
 	version := t.Version
 
 	container := opts.Client.Container().
-		From("alpine:3.23.4").
+		From("alpine:3.24.1").
 		WithExec([]string{"apk", "add", "--update", "tar"}).
 		WithExec([]string{"/bin/sh", "-c", fmt.Sprintf("echo %s > VERSION", version)})
 

--- a/pkg/build/daggerbuild/frontend/node.go
+++ b/pkg/build/daggerbuild/frontend/node.go
@@ -9,7 +9,7 @@ import (
 
 // NodeVersionContainer returns a container whose `stdout` will return the node version from the '.nvmrc' file in the directory 'src'.
 func NodeVersion(d *dagger.Client, src *dagger.Directory) *dagger.Container {
-	return d.Container().From("alpine:3.23.4").
+	return d.Container().From("alpine:3.24.1").
 		WithMountedDirectory("/src", src).
 		WithWorkdir("/src").
 		WithExec([]string{"cat", ".nvmrc"})


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana/pull/126529