### PR TITLE
Provisioning: Drop unused exports in Migrate stats

### DIFF
--- a/public/app/features/provisioning/Migrate/stats.ts
+++ b/public/app/features/provisioning/Migrate/stats.ts
@@ -4,8 +4,8 @@ import { type ManagerStats, type ResourceStats } from 'app/api/clients/provision
 import { ManagerKind } from 'app/features/apiserver/types';
 
 // `folders` is the legacy storage group; the app-platform group is FOLDER_BUCKET.
-export const FOLDER_GROUPS: string[] = [FOLDER_BUCKET, 'folders'];
-export const DASHBOARD_GROUPS: string[] = [DASHBOARD_BUCKET];
+const FOLDER_GROUPS: string[] = [FOLDER_BUCKET, 'folders'];
+const DASHBOARD_GROUPS: string[] = [DASHBOARD_BUCKET];
 
 /**
  * Classify a stats entry into the dashboard or folder bucket, keyed by BOTH


### PR DESCRIPTION
## What

`FOLDER_GROUPS` and `DASHBOARD_GROUPS` in `public/app/features/provisioning/Migrate/stats.ts` are only referenced within that file, but were exported — tripping knip's **unused exports** check. This makes them module-private.

These exports were introduced by #125811 (Migrate to GitOps overview stat cards).

## Why

Resolves the 2 knip "Unused exports" findings flagged after #125811:

```
FOLDER_GROUPS     public/app/features/provisioning/Migrate/stats.ts:7:14
DASHBOARD_GROUPS  public/app/features/provisioning/Migrate/stats.ts:8:14
```

The remaining "Configuration hints" in knip output are pre-existing `knip.config.ts` suggestions unrelated to #125811 and are intentionally left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)