### PR TITLE
[main] chore(deps): Upgrade @opentelemetry/core to 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -440,7 +440,8 @@
     "@types/slate/immutable": "^4.0.0",
     "@types/slate-react/immutable": "^4.0.0",
     "ws": "^8.20.1",
-    "js-cookie": "^3.0.7"
+    "js-cookie": "^3.0.7",
+    "@opentelemetry/core": "2.8.0"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5758,26 +5758,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@opentelemetry/core@npm:0.25.0"
-  dependencies:
-    "@opentelemetry/semantic-conventions": "npm:0.25.0"
-    semver: "npm:^7.3.5"
-  peerDependencies:
-    "@opentelemetry/api": ^1.0.2
-  checksum: 10/43a685aa57b7c05ec0c4b1b6d6212f89e0097b1844c855eeb5659b46f1a25cb2b950af2aa1b3b353a8f13c91b5415c3e7bc54c6600816ba5d6de2e95d0d49227
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/core@npm:2.7.1, @opentelemetry/core@npm:^2.0.0":
-  version: 2.7.1
-  resolution: "@opentelemetry/core@npm:2.7.1"
+"@opentelemetry/core@npm:2.8.0":
+  version: 2.8.0
+  resolution: "@opentelemetry/core@npm:2.8.0"
   dependencies:
     "@opentelemetry/semantic-conventions": "npm:^1.29.0"
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10/aaec929e1f22b3704e3cb195f8a27b2d9bd0292a565741c00b1e8cde0f3043de41713632fe15e4bfd588d83807a5b10a861deffad173e28787802ede9123ced7
+  checksum: 10/47f1a492d02c1f468390ce9ee45d55bbc940e96ec26d5356abd9903f6c332adddd23ed1a6a6c8871b54efc1536f235b7d5304c83e5dfeb459ae5ab980dc67c70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Upgrades the transitive `@opentelemetry/core` dependency from `2.7.1` to `2.8.0`. This fixes `CVE-2026-54285`, an unbounded memory allocation issue in `W3CBaggagePropagator.extract()` when parsing oversized `baggage` HTTP headers.

**Why do we need this feature?**

So we don't ship `@opentelemetry/core` with a known DoS vulnerability.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

`@opentelemetry/core` is pulled in via the Faro frontend tracing stack (`@grafana/faro-web-tracing@2.7.0`). The direct dependency declares `^2.0.0` so `yarn up -R @opentelemetry/core` can move it, but the `0.218.0`-series instrumentation siblings (`exporter-trace-otlp-http`, `instrumentation-fetch`, etc.) exact-pin `2.7.1`, which a plain `yarn up` can't touch. This PR combines the `yarn up -R` with a `resolutions` entry in `package.json` to force all copies to `2.8.0`. The old `0.25.0` copy (legacy tempo plugin) is also unified to `2.8.0` by the resolution.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
