### PR TITLE
Unified storage: export BuildKVSnapshotStore

### DIFF
--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -386,7 +386,7 @@ func (s *service) registerServer(provider grpcserver.Provider) error {
 
 	var snapshotStore search.RemoteIndexStore
 	if s.cfg.IndexSnapshotEnabled && s.cfg.IndexSnapshotStorageKV {
-		snapshotStore, err = buildKVSnapshotStore(s.cfg, s.backend, s.log)
+		snapshotStore, err = BuildKVSnapshotStore(s.cfg, s.backend, s.log)
 		if err != nil {
 			return err
 		}
@@ -595,13 +595,18 @@ func (s *service) registerUnifiedResourceServer(provider grpcserver.Provider, se
 	_, _ = grpcserver.ProvideReflectionService(s.cfg, provider)
 }
 
-// buildKVSnapshotStore wires a KVRemoteIndexStore that shares the KV
+// BuildKVSnapshotStore wires a KVRemoteIndexStore that shares the KV
 // store and lease manager with the storage backend. The caller is
 // responsible for ensuring cfg.IndexSnapshotStorageKV is true. This
 // function validates the remaining preconditions and fails loudly so
 // misconfiguration is caught at process start rather than at the first
 // snapshot operation.
-func buildKVSnapshotStore(cfg *setting.Cfg, backend resource.StorageBackend, logger log.Logger) (search.RemoteIndexStore, error) {
+//
+// Exported so wiring paths outside this package (notably the
+// unified-kv-grpc client in pkg/extensions/storage/unified/kv) can
+// reuse the same construction and validation when they build their
+// own search options.
+func BuildKVSnapshotStore(cfg *setting.Cfg, backend resource.StorageBackend, logger log.Logger) (search.RemoteIndexStore, error) {
 	if cfg.IndexSnapshotBucketURL != "" {
 		return nil, fmt.Errorf("index_snapshot_storage_kv and index_snapshot_bucket_url are mutually exclusive")
 	}

--- a/pkg/storage/unified/sql/service_test.go
+++ b/pkg/storage/unified/sql/service_test.go
@@ -285,21 +285,21 @@ func TestBuildKVSnapshotStore(t *testing.T) {
 			IndexSnapshotBucketURL: "file:///tmp/snapshot",
 			EnableKVLeases:         true,
 		}
-		_, err := buildKVSnapshotStore(cfg, &stubKVBackend{}, logger)
+		_, err := BuildKVSnapshotStore(cfg, &stubKVBackend{}, logger)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "mutually exclusive")
 	})
 
 	t.Run("rejects when enable_kv_leases is off", func(t *testing.T) {
 		cfg := &setting.Cfg{}
-		_, err := buildKVSnapshotStore(cfg, &stubKVBackend{}, logger)
+		_, err := BuildKVSnapshotStore(cfg, &stubKVBackend{}, logger)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "requires enable_kv_leases")
 	})
 
 	t.Run("rejects when backend is not a KVBackend", func(t *testing.T) {
 		cfg := &setting.Cfg{EnableKVLeases: true}
-		_, err := buildKVSnapshotStore(cfg, &nonKVBackend{}, logger)
+		_, err := BuildKVSnapshotStore(cfg, &nonKVBackend{}, logger)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "requires a KV-backed storage backend")
 	})
@@ -307,7 +307,7 @@ func TestBuildKVSnapshotStore(t *testing.T) {
 	t.Run("rejects when backend has no lease manager", func(t *testing.T) {
 		cfg := &setting.Cfg{EnableKVLeases: true}
 		backend := &stubKVBackend{kv: newTestKV(t)}
-		_, err := buildKVSnapshotStore(cfg, backend, logger)
+		_, err := BuildKVSnapshotStore(cfg, backend, logger)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no lease manager")
 	})
@@ -319,7 +319,7 @@ func TestBuildKVSnapshotStore(t *testing.T) {
 		t.Cleanup(mgr.Stop)
 		backend := &stubKVBackend{kv: store, mgr: mgr}
 
-		got, err := buildKVSnapshotStore(cfg, backend, logger)
+		got, err := BuildKVSnapshotStore(cfg, backend, logger)
 		require.NoError(t, err)
 		assert.NotNil(t, got)
 	})


### PR DESCRIPTION
Rename `buildKVSnapshotStore` to `BuildKVSnapshotStore` so wiring paths outside the `sql` package can reuse the same construction and validation when they build their own search options.

The matching caller lives in grafana-enterprise: the `unified-kv-grpc` client embeds a local search server but never wired a snapshot store, so grafana pods using KV-based snapshots were rebuilding every index from scratch on each restart. Sharing this helper means the same lease and validation rules apply on both wiring paths.

No behaviour change in this repo: the only in-repo caller (`service.registerServer`) is updated to the new name and tests are renamed accordingly.