### PR TITLE
feat(ci): mint auto-triage token via GitHub App Token Broker

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -66,17 +66,13 @@ jobs:
           repo_secrets: |
             AUTOTRIAGER_OPENAI_API_KEY=plugins_platform_issue_triager:AUTOTRIAGER_OPENAI_API_KEY
             AUTOTRIAGER_SLACK_WEBHOOK_URL=plugins_platform_issue_triager:AUTOTRIAGER_SLACK_WEBHOOK_URL
-            GITHUB_APP_ID=plugins_platform_issue_triager_github_bot:app_id
-            GITHUB_APP_PRIVATE_KEY=plugins_platform_issue_triager_github_bot:app_pem
 
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          permission-members: read
-          permission-issues: write
+          github_app: grafana-pr-automation
+          permission_set: auto-triage
       - name: Check if member of grafana org
         id: check-if-grafana-org-member
         continue-on-error: true

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -122,21 +122,12 @@ jobs:
       issues: write
       id-token: write
     steps:
-        - name: "Get vault secrets"
-          id: vault-secrets
-          uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.3.0 # zizmor: ignore[unpinned-uses]
-          with:
-            # Secrets placed in the ci/repo/grafana/grafana/plugins_platform_issue_triager path in Vault
-            repo_secrets: |
-              GITHUB_APP_ID=plugins_platform_issue_triager_github_bot:app_id
-              GITHUB_APP_PRIVATE_KEY=plugins_platform_issue_triager_github_bot:app_pem
         - name: Generate token
           id: generate_token
-          uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+          uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
           with:
-            app-id: ${{ env.GITHUB_APP_ID }}
-            private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-            permission-members: read
+            github_app: grafana-pr-automation
+            permission_set: auto-label-internal
         - name: Check if member of grafana org
           id: check-if-grafana-org-member
           continue-on-error: true

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -22,12 +22,17 @@ jobs:
     steps:
 
       - name: Checkout Actions
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: "grafana/grafana-github-actions"
           path: ./actions
           ref: main
           persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: '24'
 
       - name: Install Actions
         run: npm install --production --prefix ./actions
@@ -39,7 +44,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: grafana-pr-automation
 
@@ -60,7 +65,7 @@ jobs:
 
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.3.0 # zizmor: ignore[unpinned-uses]
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v2.0.0 # zizmor: ignore[unpinned-uses]
         with:
           # Secrets placed in the ci/repo/grafana/grafana/plugins_platform_issue_triager path in Vault
           repo_secrets: |
@@ -82,7 +87,7 @@ jobs:
             ACTOR: ${{ github.actor }}
       - name: Checkout
         if: steps.check-if-grafana-org-member.outputs.is_grafana_org_member != 'true' && github.event.issue.author_association != 'MEMBER' && github.event.issue.author_association != 'OWNER'
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -94,7 +99,7 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
           issue_number: ${{ github.event.issue.number }}
-          openai_api_key: ${{ env.AUTOTRIAGER_OPENAI_API_KEY }}
+          openai_api_key: ${{ fromJSON(steps.vault-secrets.outputs.secrets).AUTOTRIAGER_OPENAI_API_KEY }}
           add_labels: true
           labels_file: ${{ github.workspace }}/.github/workflows/auto-triager/labels.txt
           types_file: ${{ github.workspace }}/.github/workflows/auto-triager/types.txt
@@ -113,7 +118,7 @@ jobs:
               "channel": "#triage-automation-ci"
             }
         env:
-          SLACK_WEBHOOK_URL:  ${{ env.AUTOTRIAGER_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL:  ${{ fromJSON(steps.vault-secrets.outputs.secrets).AUTOTRIAGER_SLACK_WEBHOOK_URL }}
   auto-label-internal-issues:
     needs: [main]
     if: github.repository == 'grafana/grafana'

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Generate token
         id: generate_token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: grafana-pr-automation
           permission_set: auto-triage


### PR DESCRIPTION
The `main` job in this workflow already mints its GitHub token through the GitHub App Token Broker. The other two jobs still pull the App's id and PEM from Vault (`plugins_platform_issue_triager_github_bot`) and generate a token with the upstream `actions/create-github-app-token`. This moves both to the broker, so the App private key no longer leaves Vault:

- `auto-triage` — needs `members: read` (org-membership check) + `issues: write` (apply triage labels). The Vault step stays here only for the OpenAI key and Slack webhook.
- `auto-label-internal-issues` — its token is used only for the org-membership check, so it needs just `members: read`; the labelling runs on the default `GITHUB_TOKEN`. The Vault step is dropped entirely.

Both reuse `grafana-pr-automation`, which is already on the broker and installed here, rather than onboarding the dedicated triager App.

Requires the broker permission-sets first: grafana/deployment_tools#617017 (adds the `auto-triage` and `auto-label-internal` sets to grafana's `config.yaml`). Merge that before this.