### PR TITLE
FS: Send full frontend settings to frontend

### DIFF
--- a/devenv/frontend-service/goff-flags.yaml
+++ b/devenv/frontend-service/goff-flags.yaml
@@ -42,8 +42,15 @@ grafana.meticulousAIRecorderHighVolume:
 
 grafana.meticulousAIMode:
   variations:
-    off: "off"
-    on-prod-env: "on-prod-env"
-    on-dev-env: "on-dev-env"
+    off: 'off'
+    on-prod-env: 'on-prod-env'
+    on-dev-env: 'on-dev-env'
   defaultRule:
     variation: off
+
+frontendService.reducedBootDataAPI:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled

--- a/pkg/api/frontendsettings/frontendsettings.go
+++ b/pkg/api/frontendsettings/frontendsettings.go
@@ -17,7 +17,7 @@ import (
 
 // GetBaseFrontendSettings returns the JSON object with all the settings needed for
 // front end initialisation.
-func GetBaseFrontendSettings(c *contextmodel.ReqContext, cfg *setting.Cfg) (*dtos.FrontendSettingsDTO, error) {
+func GetBaseFrontendSettings(reqCtx *contextmodel.ReqContext, cfg *setting.Cfg) (*dtos.FrontendSettingsDTO, error) {
 	defaultDS := "-- Grafana --"
 
 	trustedTypesDefaultPolicyEnabled := (cfg.CSPEnabled && strings.Contains(cfg.CSPTemplate, "require-trusted-types-for")) || (cfg.CSPReportOnlyEnabled && strings.Contains(cfg.CSPReportOnlyTemplate, "require-trusted-types-for"))
@@ -31,7 +31,7 @@ func GetBaseFrontendSettings(c *contextmodel.ReqContext, cfg *setting.Cfg) (*dto
 		Apps:                                 make(map[string]*plugins.AppDTO, 0),
 		AppUrl:                               cfg.AppURL,
 		AppSubUrl:                            cfg.AppSubURL,
-		AllowOrgCreate:                       (cfg.AllowUserOrgCreate && c.IsSignedIn) || c.IsGrafanaAdmin,
+		AllowOrgCreate:                       (cfg.AllowUserOrgCreate && reqCtx.IsSignedIn) || reqCtx.IsGrafanaAdmin,
 		AuthProxyEnabled:                     cfg.AuthProxy.Enabled,
 		LdapEnabled:                          cfg.LDAPAuthEnabled,
 		JwtHeaderName:                        cfg.JWTAuth.HeaderName,
@@ -89,7 +89,7 @@ func GetBaseFrontendSettings(c *contextmodel.ReqContext, cfg *setting.Cfg) (*dto
 		EnableFrontendSandboxForPlugins:  cfg.EnableFrontendSandboxForPlugins,
 		PluginRestrictedAPIsAllowList:    cfg.PluginRestrictedAPIsAllowList,
 		PluginRestrictedAPIsBlockList:    cfg.PluginRestrictedAPIsBlockList,
-		PublicDashboardAccessToken:       c.PublicDashboardAccessToken,
+		PublicDashboardAccessToken:       reqCtx.PublicDashboardAccessToken,
 		PublicDashboardsEnabled:          cfg.PublicDashboardsEnabled,
 		CloudMigrationEnabled:            cfg.CloudMigration.Enabled,
 		CloudMigrationIsTarget:           isCloudMigrationTarget,

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -39,7 +39,8 @@ type IndexViewData struct {
 	AppTitle  string // TODO: remove and get from request config?
 	AppSubUrl string // TODO: remove and get from request config?
 
-	Settings FSFrontendSettings
+	Settings     FSFrontendSettings
+	FullSettings *dtos.FrontendSettingsDTO // used behind feature flag instead of Settings
 
 	Assets      dtos.EntryPointAssets // Includes CDN info
 	DefaultUser dtos.CurrentUser
@@ -136,7 +137,8 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 	meticulousAIMode, _ := ofClient.StringValue(ctx, featuremgmt.FlagGrafanaMeticulousAIMode, "off", openfeature.TransactionContext(ctx))
 	meticulousAIEnabled := meticulousAIMode == "on-prod-env" || meticulousAIMode == "on-dev-env"
 	meticulousAIProductionEnvironmentFlag := meticulousAIMode == "on-prod-env"
-	reduceBootdataAPI, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagFrontendServiceReducedBootDataAPI, false, openfeature.TransactionContext(ctx))
+
+	reduceBootdataAPI := requestConfig.FullFrontendSettings != nil
 
 	data := IndexViewData{
 		AppTitle:                              "Grafana",
@@ -147,6 +149,7 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 		Nonce:                                 reqCtx.RequestNonce,
 		PublicDashboardAccessToken:            reqCtx.PublicDashboardAccessToken,
 		Settings:                              fsSettings,
+		FullSettings:                          requestConfig.FullFrontendSettings, // only populated when FlagFrontendServiceReducedBootDataAPI enabled
 		RenderBindingSupported:                renderBindingSupported,
 		AssetSriChecksEnabled:                 grafanaAssetSriChecks,
 		MeticulousAIEnabled:                   meticulousAIEnabled,

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -184,14 +184,27 @@
       [[end]]
 
       window.__grafanaPublicDashboardAccessToken = [[.PublicDashboardAccessToken]];
-      // global config
-      window.grafanaBootData = {
-        _femt: true, // isFrontendService() needs this
-        assets: [[.Assets]],
-        navTree: [],
-        settings: [[.Settings]],
-        user: [[.DefaultUser]],
-      }
+
+      [[if .FullSettings]]
+        // global config
+        window.grafanaBootData = {
+          _femt: true, // isFrontendService() needs this
+          assets: [[.Assets]],
+          navTree: [],
+          settings: [[.FullSettings]],
+          user: [[.DefaultUser]],
+        }
+      [[else]]
+        // global config
+        window.grafanaBootData = {
+          _femt: true, // isFrontendService() needs this
+          assets: [[.Assets]],
+          navTree: [],
+          settings: [[.Settings]],
+          user: [[.DefaultUser]],
+        }
+      [[end]]
+
     </script>
 
     <script nonce="[[.Nonce]]">

--- a/pkg/services/frontend/request_config.go
+++ b/pkg/services/frontend/request_config.go
@@ -8,7 +8,9 @@ import (
 	"gopkg.in/ini.v1"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/api/frontendsettings"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -16,6 +18,9 @@ import (
 // FSRequestConfig contains all configuration that can be overridden on a per-request basis.
 type FSRequestConfig struct {
 	FSFrontendSettings
+
+	// full settings object behind feature flag
+	FullFrontendSettings *dtos.FrontendSettingsDTO
 
 	CSPEnabled            bool
 	CSPTemplate           string
@@ -32,7 +37,7 @@ type FSRequestConfig struct {
 
 // NewFSRequestConfig creates a new FSRequestConfig from the global configuration.
 // This is used to create the base configuration at service startup.
-func NewFSRequestConfig(cfg *setting.Cfg, license licensing.Licensing) FSRequestConfig {
+func NewFSRequestConfig(ctx context.Context, cfg *setting.Cfg, license licensing.Licensing, fullFrontendSettingsEnabled bool) (FSRequestConfig, error) {
 	frontendSettings := FSFrontendSettings{
 		AnalyticsConsoleReporting:            cfg.FrontendAnalyticsConsoleReporting,
 		AnonymousEnabled:                     cfg.Anonymous.Enabled,
@@ -70,7 +75,7 @@ func NewFSRequestConfig(cfg *setting.Cfg, license licensing.Licensing) FSRequest
 	allowEmbeddingHosts := securitySection.Key("allow_embedding_hosts").Strings(" ")
 	formActionHosts := securitySection.Key("form_action_additional_hosts").Strings(" ")
 
-	return FSRequestConfig{
+	requestConfig := FSRequestConfig{
 		FSFrontendSettings:        frontendSettings,
 		CSPEnabled:                cfg.CSPEnabled,
 		CSPTemplate:               cfg.CSPTemplate,
@@ -80,6 +85,19 @@ func NewFSRequestConfig(cfg *setting.Cfg, license licensing.Licensing) FSRequest
 		AllowEmbeddingHosts:       allowEmbeddingHosts,
 		FormActionAdditionalHosts: formActionHosts,
 	}
+
+	if fullFrontendSettingsEnabled {
+		reqCtx := contexthandler.FromContext(ctx)
+		fullFrontendSettings, err := frontendsettings.GetBaseFrontendSettings(reqCtx, cfg)
+
+		if err != nil {
+			return FSRequestConfig{}, err
+		}
+
+		requestConfig.FullFrontendSettings = fullFrontendSettings
+	}
+
+	return requestConfig, nil
 }
 
 type requestConfigKey struct{}
@@ -126,7 +144,7 @@ func getShortCommitHash(commitHash string, maxLength int) string {
 
 // ApplyOverrides merges tenant-specific settings from ini.File with this configuration.
 // It mutates the existing config, so ensure this object is not reused across multiple requests.
-func (c *FSRequestConfig) ApplyOverrides(settings *ini.File, logger log.Logger) {
+func (c *FSRequestConfig) ApplyOverrides(settings *ini.File, logger log.Logger, fullFrontendSettingsEnabled bool) {
 	// Apply overrides from the settings service ini to the config. Theoretically we could use setting.NewCfgFromINIFile, but
 	// because we only want overrides, and not default values, we need to manually get them out of the ini structure.
 
@@ -134,12 +152,22 @@ func (c *FSRequestConfig) ApplyOverrides(settings *ini.File, logger log.Logger) 
 	applyStringSlice(settings, "security", "allow_embedding_hosts", &c.AllowEmbeddingHosts, logger)
 	applyStringSlice(settings, "security", "form_action_additional_hosts", &c.FormActionAdditionalHosts, logger)
 
-	applyString(settings, "analytics", "rudderstack_write_key", &c.RudderstackWriteKey, logger)
-	applyString(settings, "analytics", "rudderstack_data_plane_url", &c.RudderstackDataPlaneUrl, logger)
-	applyString(settings, "analytics", "rudderstack_sdk_url", &c.RudderstackSdkUrl, logger)
-	applyString(settings, "analytics", "rudderstack_v3_sdk_url", &c.RudderstackV3SdkUrl, logger)
-	applyString(settings, "analytics", "rudderstack_config_url", &c.RudderstackConfigUrl, logger)
-	applyString(settings, "analytics", "rudderstack_integrations_url", &c.RudderstackIntegrationsUrl, logger)
+	if fullFrontendSettingsEnabled {
+		// when flag enabled, settings are in a different place
+		applyString(settings, "analytics", "rudderstack_write_key", &c.FullFrontendSettings.RudderstackWriteKey, logger)
+		applyString(settings, "analytics", "rudderstack_data_plane_url", &c.FullFrontendSettings.RudderstackDataPlaneUrl, logger)
+		applyString(settings, "analytics", "rudderstack_sdk_url", &c.FullFrontendSettings.RudderstackSdkUrl, logger)
+		applyString(settings, "analytics", "rudderstack_v3_sdk_url", &c.FullFrontendSettings.RudderstackV3SdkUrl, logger)
+		applyString(settings, "analytics", "rudderstack_config_url", &c.FullFrontendSettings.RudderstackConfigUrl, logger)
+		applyString(settings, "analytics", "rudderstack_integrations_url", &c.FullFrontendSettings.RudderstackIntegrationsUrl, logger)
+	} else {
+		applyString(settings, "analytics", "rudderstack_write_key", &c.RudderstackWriteKey, logger)
+		applyString(settings, "analytics", "rudderstack_data_plane_url", &c.RudderstackDataPlaneUrl, logger)
+		applyString(settings, "analytics", "rudderstack_sdk_url", &c.RudderstackSdkUrl, logger)
+		applyString(settings, "analytics", "rudderstack_v3_sdk_url", &c.RudderstackV3SdkUrl, logger)
+		applyString(settings, "analytics", "rudderstack_config_url", &c.RudderstackConfigUrl, logger)
+		applyString(settings, "analytics", "rudderstack_integrations_url", &c.RudderstackIntegrationsUrl, logger)
+	}
 }
 
 func getValue(settings *ini.File, section, key string) *ini.Key {

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -33,12 +33,21 @@ func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, sett
 			reqCtx := contexthandler.FromContext(ctx)
 			logger := reqCtx.Logger
 
+			ofClient := openfeature.NewDefaultClient()
+			fullFrontendSettingsEnabled, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagFrontendServiceReducedBootDataAPI, false, openfeature.TransactionContext(ctx))
+
 			// Create base request config from global settings
 			// This is the default configuration that will be used for all requests
-			requestConfig := NewFSRequestConfig(cfg, license)
+			requestConfig, err := NewFSRequestConfig(ctx, cfg, license, fullFrontendSettingsEnabled)
+
+			if err != nil {
+				logger.Error("failed to create request config", "err", err)
+				span.RecordError(err)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
 
 			// Fetch tenant-specific configuration if the feature toggle is enabled and namespace is present
-			ofClient := openfeature.NewDefaultClient()
 			settingsEnabled, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagFrontendServiceUseSettingsService, false, openfeature.TransactionContext(ctx))
 
 			if settingsService != nil && settingsEnabled {
@@ -80,7 +89,7 @@ func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, sett
 					} else {
 						settingsFetchMetric.WithLabelValues("success").Inc()
 						// Merge tenant overrides with base config
-						requestConfig.ApplyOverrides(settings, logger)
+						requestConfig.ApplyOverrides(settings, logger, fullFrontendSettingsEnabled)
 					}
 				}
 			}


### PR DESCRIPTION
Builds upon https://github.com/grafana/grafana/pull/126559 to call the new `GetBaseFrontendSettings` method to send a full settings object to the frontend, instead of the limited object that was used before.

The intention for this is to replace all the settings being loaded from the `/bootdata` api on startup, ultimately letting us remove it.