### PR TITLE
[release-13.0.3] Live: Resolve channel id from legacy `namespace` field in plugin addresses (#123233)

### DIFF
--- a/public/app/features/live/centrifuge/service.test.ts
+++ b/public/app/features/live/centrifuge/service.test.ts
@@ -126,4 +126,29 @@ describe('CentrifugeService', () => {
     expect(mockCentrifuge.newSubscription).toHaveBeenCalled();
     expect(mockSubscription.subscribe).toHaveBeenCalled();
   });
+
+  it('resolves channel id when the address uses the legacy `namespace` field', async () => {
+    mockCentrifugeState = State.Connected;
+
+    const service = new CentrifugeService(makeDeps());
+
+    // Older plugin builds (e.g. @grafana/llm <=1.0.2) still construct
+    // addresses with `namespace` instead of `stream`. The subscription id
+    // must resolve without an `undefined` segment so the backend can route
+    // the subscription.
+    const legacyAddr = {
+      scope: LiveChannelScope.Plugin,
+      namespace: 'grafana-llm-app',
+      path: 'stream/chat-completions',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    service.getStream(legacyAddr).subscribe();
+
+    expect(mockCentrifuge.newSubscription).toHaveBeenCalledTimes(1);
+    expect(mockCentrifuge.newSubscription).toHaveBeenCalledWith(
+      'default/plugin/grafana-llm-app/stream/chat-completions',
+      expect.anything()
+    );
+  });
 });

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -155,7 +155,11 @@ export class CentrifugeService implements CentrifugeSrv {
    * channel will be returned with an error state indicated in its status
    */
   private getChannel<TMessage>(addr: LiveChannelAddress): CentrifugeLiveChannel<TMessage> {
-    const id = `${this.deps.namespace}/${addr.scope}/${addr.stream}/${addr.path}`;
+    // Use toLiveChannelId so addresses from plugins still using the legacy
+    // `namespace` field (pre-rename) resolve to the same channel id as ones
+    // using `stream`. Without this, subscriptions get an id with `undefined`
+    // in place of the stream segment and silently never receive data.
+    const id = `${this.deps.namespace}/${toLiveChannelId(addr)}`;
     let channel = this.open.get(id);
     if (channel != null) {
       return channel;


### PR DESCRIPTION
Backports #123233.

Clean cherry-pick (service.ts fix + the accompanying unit test).