### PR TITLE
[release-12.4.5] Live: Resolve channel id from legacy `namespace` field in plugin addresses (#123233)

### DIFF
--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -154,7 +154,11 @@ export class CentrifugeService implements CentrifugeSrv {
    * channel will be returned with an error state indicated in its status
    */
   private getChannel<TMessage>(addr: LiveChannelAddress): CentrifugeLiveChannel<TMessage> {
-    const id = `${this.deps.namespace}/${addr.scope}/${addr.stream}/${addr.path}`;
+    // Use toLiveChannelId so addresses from plugins still using the legacy
+    // `namespace` field (pre-rename) resolve to the same channel id as ones
+    // using `stream`. Without this, subscriptions get an id with `undefined`
+    // in place of the stream segment and silently never receive data.
+    const id = `${this.deps.namespace}/${toLiveChannelId(addr)}`;
     let channel = this.open.get(id);
     if (channel != null) {
       return channel;


### PR DESCRIPTION
Backports #123233.

Only the `service.ts` fix is included. The upstream PR also added a test case to `public/app/features/live/centrifuge/service.test.ts`, but that test file does not exist on the 12.4.x line, so the test is omitted from this backport.