### PR TITLE
Alerting: Add StatusPreparer callback to PrepareRuleGroupStatusesV2

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1009,12 +1009,15 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/grafana/alerting v0.0.0-20260330161147-03db0b961b17/go.mod h1:06F4s5KJ6LpL7od+rcusjKnsst+vRhdFqev9GdVNz4c=
 github.com/grafana/alerting v0.0.0-20260521151554-b942723acbb2/go.mod h1:06F4s5KJ6LpL7od+rcusjKnsst+vRhdFqev9GdVNz4c=
 github.com/grafana/authlib v0.0.0-20260414201248-d766c8627a66/go.mod h1:AWryAuOp+dICuspMD555qPikxDraraypjMU8/C+yHx0=
+github.com/grafana/authlib v0.0.0-20260511070317-cdec9a89f585/go.mod h1:AWryAuOp+dICuspMD555qPikxDraraypjMU8/C+yHx0=
 github.com/grafana/authlib/types v0.0.0-20260304161757-e152786a5bb4/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/authlib/types v0.0.0-20260414201248-d766c8627a66/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
+github.com/grafana/authlib/types v0.0.0-20260511070317-cdec9a89f585/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2 h1:qhugDMdQ4Vp68H0tp/0iN17DM2ehRo1rLEdOFe/gB8I=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2/go.mod h1:w/aiO1POVIeXUQyl0VQSZjl5OAGDTL5aX+4v0RA1tcw=
 github.com/grafana/cog v0.1.7/go.mod h1:COrMoYqkPLqUOycJ7619qR0O7QPGOsoBzDtPILtaC4I=
 github.com/grafana/cog v0.1.11/go.mod h1:vXehXG9c/mp0CwqfQLWbT/0VEEIw+IEXe5LGhZspcqQ=
+github.com/grafana/cog v0.1.12/go.mod h1:vXehXG9c/mp0CwqfQLWbT/0VEEIw+IEXe5LGhZspcqQ=
 github.com/grafana/dskit v0.0.0-20230914143233-4b32fbf08128/go.mod h1:mZkAJTODiHxuvqvmwwFvp0ww9XA3mwlGA8Iv0SHP+5c=
 github.com/grafana/dskit v0.0.0-20250818234656-8ff9c6532e85/go.mod h1:kImsvJ1xnmeT9Z6StK+RdEKLzlpzBsKwJbEQfmBJdFs=
 github.com/grafana/dskit v0.0.0-20251031165806-a6f15387939b/go.mod h1:4att0nkXGqVtpAXofibCPjQlek1nYJcCnxOI94m7o1g=
@@ -1023,6 +1026,8 @@ github.com/grafana/dskit v0.0.0-20260209132809-8d1c6d34bb5a/go.mod h1:M2NzmN1SL1
 github.com/grafana/e2e v0.1.1/go.mod h1:RpNLgae5VT+BUHvPE+/zSypmOXKwEu4t+tnEMS1ATaE=
 github.com/grafana/go-gelf/v2 v2.0.1 h1:BOChP0h/jLeD+7F9mL7tq10xVkDG15he3T1zHuQaWak=
 github.com/grafana/go-gelf/v2 v2.0.1/go.mod h1:lexHie0xzYGwCgiRGcvZ723bSNyNI8ZRD4s0CLobh90=
+github.com/grafana/go-mysql-server v0.20.2-grafana-2 h1:Odgye5nVNmxma8PUN6QrLz9ygdjJLrpSOE5vPpezJzI=
+github.com/grafana/go-mysql-server v0.20.2-grafana-2/go.mod h1:phaWF0mUq6w4kkHi+ahJ+nUwZ20gkf2vAm8pGMZOJRw=
 github.com/grafana/go-mysql-server v0.20.2-grafana-3 h1:d9t/ZbwjchVL/VLJ+W51h6z9JaSzQ84xG1hTZBU5oWY=
 github.com/grafana/go-mysql-server v0.20.2-grafana-3/go.mod h1:Oy0XD/nfIkwVBMud5aY8Rvqw8Rbi+2yCxW84a9391+A=
 github.com/grafana/gomemcache v0.0.0-20250318131618-74242eea118d h1:oXRJlb9UjVsl6LhqBdbyAQ9YFhExwsj4bjh5vwMNRZY=
@@ -1031,6 +1036,7 @@ github.com/grafana/grafana-app-sdk v0.53.1/go.mod h1:wR7nY/6FbkSjLgSyzE4buEy4JF0
 github.com/grafana/grafana-app-sdk v0.55.0/go.mod h1:JV9ExtfujB3Wz832J3MOZQDdmxelAPXg+f+FmYoRDSQ=
 github.com/grafana/grafana-app-sdk/logging v0.53.2/go.mod h1:f0r/XriExa4jpUMHnI9aTRYzbbMHiDV+MXSpaSRGqIE=
 github.com/grafana/grafana-app-sdk/logging v0.54.1/go.mod h1:t0rXNkTz3R6PLpjxk4BIl2erHYkMBX+rd+UHSL0k5nw=
+github.com/grafana/grafana-cloud-migration-snapshot v1.10.0/go.mod h1:WpjMtcZmoU1KnBok8R+xt2Tb5WOnIcIcU0sd9fgyyE4=
 github.com/grafana/grafana-prometheus-datasource/pkg/promlib v0.0.10/go.mod h1:S6d7Ck6J8UDOkQj9xfTp8pM9uAmslU5PXr+/h7ixYfY=
 github.com/grafana/loki/pkg/push v0.0.0-20250630054201-94c0ba7b0952/go.mod h1:ny/0bFitf8KNZkZfweaI4hmwb5XPhaFD2d0kVcyKmjo=
 github.com/grafana/loki/v3 v3.5.11/go.mod h1:vT/ZnjX2++rBwKSdsjzNELU+66PWkop5KetzeALZH5Y=
@@ -1038,9 +1044,12 @@ github.com/grafana/nanogit v0.17.0/go.mod h1:4fLGQZphcwp2AHqdeju11Z8v5jiJ8MbAQqw
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/grafana/schemads v0.0.9/go.mod h1:5mjuxhSmbQZLjUSjzv+vTmNp+R2fYhSdiZLSPxeM3LA=
 github.com/grafana/schemads v0.0.11/go.mod h1:5mjuxhSmbQZLjUSjzv+vTmNp+R2fYhSdiZLSPxeM3LA=
+github.com/grafana/schemads v0.2.0/go.mod h1:TX0YfoMxJ8dl1ONXTa+rFk1y3sw1khGwQjB8dKKfzds=
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0 h1:bjh0PVYSVVFxzINqPFYJmAmJNrWPgnVjuSdYJGHmtFU=
 github.com/grafana/tail v0.0.0-20230510142333-77b18831edf0/go.mod h1:7t5XR+2IA8P2qggOAHTj/GCZfoLBle3OvNSYh1VkRBU=
 github.com/grafana/tempo v1.5.1-0.20250529124718-87c2dc380cec/go.mod h1:j1IY7J2rUz7TcTjFVVx6HCpyTlYOJPtXuGRZ7sI+vSo=
+github.com/grafana/vitess v0.0.0-grafana-1 h1:Q/HDraFFj94iuyfWrfEZRvNn3c76JR4sZY2NsBgw6uM=
+github.com/grafana/vitess v0.0.0-grafana-1/go.mod h1:eLLslh1CSPMf89pPcaMG4yM72PQbTN9OUYJeAy0fAis=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0/go.mod h1:XKMd7iuf/RGPSMJ/U4HP0zS2Z9Fh8Ps9a+6X26m/tmI=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -2196,6 +2205,7 @@ google.golang.org/grpc v1.79.1/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhH
 google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc v1.81.0/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6 h1:ExN12ndbJ608cboPYflpTny6mXSzPrDLh0iTaVrRrds=
 google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6/go.mod h1:6ytKWczdvnpnO+m+JiG9NjEDzR1FJfsnmJdG7B8QVZ8=
@@ -2246,6 +2256,7 @@ k8s.io/gengo/v2 v2.0.0-20251215205346-5ee0d033ba5b/go.mod h1:yvyl3l9E+UxlqOMUULd
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/kms v0.35.1/go.mod h1:VT+4ekZAdrZDMgShK37vvlyHUVhwI9t/9tvh0AyCWmQ=
 k8s.io/kube-aggregator v0.35.0/go.mod h1:vKBRpQUfDryb7udwUwF3eCSvv3AJNgHtL4PGl6PqAg8=
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -8,11 +8,13 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -3705,4 +3707,112 @@ func withExpressionsMultiQuery() ngmodels.AlertRuleMutator {
 		}
 		r.Data = queries
 	}
+}
+
+func noopRuleMutator(_ context.Context, _ *ngmodels.AlertRule, _ *apimodels.AlertingRule, _ map[eval.State]struct{}, _ labels.Matchers, _ []ngmodels.LabelOption, _ int64) (map[string]int64, map[string]int64) {
+	return nil, nil
+}
+
+func TestPrepareRuleGroupStatusesV2_StatusPreparer(t *testing.T) {
+	const orgID int64 = 1
+	const nsUID = "folder-status-preparer"
+
+	// newStore builds a fake store containing the given rules and a matching AllowedNamespaces map.
+	newStore := func(t *testing.T, rules ...*ngmodels.AlertRule) (*fakes.RuleStore, map[string]string) {
+		t.Helper()
+		store := fakes.NewRuleStore(t)
+		allowed := map[string]string{}
+		for _, r := range rules {
+			store.PutRule(context.Background(), r)
+			allowed[r.NamespaceUID] = "folder"
+		}
+		return store, allowed
+	}
+
+	t.Run("is invoked with the page's rule UIDs", func(t *testing.T) {
+		gen := ngmodels.RuleGen
+		// Two rules in the same group so a single store fetch returns both.
+		groupKey := ngmodels.AlertRuleGroupKey{RuleGroup: "group-a", NamespaceUID: nsUID, OrgID: orgID}
+		rule1 := gen.With(gen.WithGroupKey(groupKey), gen.WithUID("uid-1"), gen.WithTitle("rule-1")).GenerateRef()
+		rule2 := gen.With(gen.WithGroupKey(groupKey), gen.WithUID("uid-2"), gen.WithTitle("rule-2")).GenerateRef()
+
+		store, allowed := newStore(t, rule1, rule2)
+
+		var capturedUIDs []string
+		opts := RuleGroupStatusesOptions{
+			Ctx:               context.Background(),
+			OrgID:             orgID,
+			Query:             url.Values{},
+			AllowedNamespaces: allowed,
+			StatusPreparer: func(ruleUIDs []string) {
+				capturedUIDs = append(capturedUIDs, ruleUIDs...)
+			},
+		}
+
+		resp := PrepareRuleGroupStatusesV2(log.NewNopLogger(), store, opts, noopRuleMutator, fakes.NewFakeProvisioningStore())
+
+		require.Equal(t, "success", resp.Status)
+		sort.Strings(capturedUIDs)
+		assert.Equal(t, []string{"uid-1", "uid-2"}, capturedUIDs, "StatusPreparer should receive the UIDs of the rules on the page")
+	})
+
+	t.Run("is invoked once per fetched store page", func(t *testing.T) {
+		gen := ngmodels.RuleGen
+		// Three rules, each in its own group, so group_limit=1 forces one store fetch per group.
+		rule1 := gen.With(gen.WithGroupKey(ngmodels.AlertRuleGroupKey{RuleGroup: "group-1", NamespaceUID: nsUID, OrgID: orgID}), gen.WithUID("uid-1")).GenerateRef()
+		rule2 := gen.With(gen.WithGroupKey(ngmodels.AlertRuleGroupKey{RuleGroup: "group-2", NamespaceUID: nsUID, OrgID: orgID}), gen.WithUID("uid-2")).GenerateRef()
+		rule3 := gen.With(gen.WithGroupKey(ngmodels.AlertRuleGroupKey{RuleGroup: "group-3", NamespaceUID: nsUID, OrgID: orgID}), gen.WithUID("uid-3")).GenerateRef()
+
+		store, allowed := newStore(t, rule1, rule2, rule3)
+
+		query := url.Values{}
+		query.Set("group_limit", "1")
+
+		var calls int
+		var pages [][]string
+		opts := RuleGroupStatusesOptions{
+			Ctx:               context.Background(),
+			OrgID:             orgID,
+			Query:             query,
+			AllowedNamespaces: allowed,
+			StatusPreparer: func(ruleUIDs []string) {
+				calls++
+				pages = append(pages, append([]string(nil), ruleUIDs...))
+			},
+		}
+
+		resp := PrepareRuleGroupStatusesV2(log.NewNopLogger(), store, opts, noopRuleMutator, fakes.NewFakeProvisioningStore())
+
+		require.Equal(t, "success", resp.Status)
+		// group_limit=1 returns a single group per page, but the response only contains
+		// the first page's group. The preparer should still have been invoked at least once.
+		assert.GreaterOrEqual(t, calls, 1, "StatusPreparer should be invoked for the fetched page")
+		require.NotEmpty(t, pages)
+		// The first page must carry exactly the first group's single rule UID.
+		assert.Len(t, pages[0], 1, "each page with group_limit=1 should contain a single rule's UID")
+	})
+
+	t.Run("nil StatusPreparer is a no-op", func(t *testing.T) {
+		gen := ngmodels.RuleGen
+		groupKey := ngmodels.AlertRuleGroupKey{RuleGroup: "group-nil", NamespaceUID: nsUID, OrgID: orgID}
+		rule := gen.With(gen.WithGroupKey(groupKey), gen.WithUID("uid-nil"), gen.WithTitle("rule-nil")).GenerateRef()
+
+		store, allowed := newStore(t, rule)
+
+		opts := RuleGroupStatusesOptions{
+			Ctx:               context.Background(),
+			OrgID:             orgID,
+			Query:             url.Values{},
+			AllowedNamespaces: allowed,
+			StatusPreparer:    nil,
+		}
+
+		require.NotPanics(t, func() {
+			resp := PrepareRuleGroupStatusesV2(log.NewNopLogger(), store, opts, noopRuleMutator, fakes.NewFakeProvisioningStore())
+			require.Equal(t, "success", resp.Status)
+			require.Len(t, resp.Data.RuleGroups, 1)
+			require.Len(t, resp.Data.RuleGroups[0].Rules, 1)
+			assert.Equal(t, "uid-nil", resp.Data.RuleGroups[0].Rules[0].UID)
+		})
+	})
 }

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -270,12 +270,15 @@ func GetHealthFromQuery(v url.Values) (map[string]struct{}, error) {
 	return health, nil
 }
 
+type StatusPreparer func(ruleUIDs []string)
+
 type RuleGroupStatusesOptions struct {
 	Ctx               context.Context
 	OrgID             int64
 	Query             url.Values
 	AllowedNamespaces map[string]string
 	SortByFullpath    bool
+	StatusPreparer    StatusPreparer
 }
 
 type ListAlertRulesStore interface {
@@ -605,6 +608,15 @@ func (ctx *paginationContext) fetchAndFilterPage(log log.Logger, store ListAlert
 		}
 	}
 	span.AddEvent("Provenances retrieved from store")
+
+	if ctx.opts.StatusPreparer != nil {
+		ruleUIDs := make([]string, 0, len(ruleList))
+		for _, rule := range ruleList {
+			ruleUIDs = append(ruleUIDs, rule.UID)
+		}
+
+		ctx.opts.StatusPreparer(ruleUIDs)
+	}
 
 	groupedRules := getGroupedRules(log, ruleList, ctx.ruleNamesSet, ctx.opts.AllowedNamespaces)
 


### PR DESCRIPTION
**What is this feature?**

This adds a callback to PrepareRuleGroupStatusesV2 that lets us prefetch the rule uids we'll later call the rule mutator with.

**Why do we need this feature?**

This allows us to be more accurate about which rule uids we'll load to use with the rule mutator that sets statuses on the rules we fetch from the db.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
