### PR TITLE
Unified: opt-in chunked writes for resource migration

### DIFF
--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -260,7 +260,7 @@ func (s *ModuleServer) Run() error {
 			if err != nil {
 				return nil, err
 			}
-			s.storageBackend, err = sql.NewStorageBackend(s.cfg, eDB, s.registerer, s.storageMetrics, disableStorageServices, kvStore)
+			s.storageBackend, err = sql.NewStorageBackend(s.cfg, eDB, s.registerer, s.storageMetrics, disableStorageServices, kvStore, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -400,7 +400,7 @@ func createBaselineServer(t *testing.T, dbType, dbConnStr string, testNamespaces
 	cfg.DisablePruner = dbType == "sqlite3"
 	eDB, err := sql.ProvideResourceDB(cfg, nil)
 	require.NoError(t, err)
-	backend, err := sql.NewStorageBackend(cfg, eDB, nil, nil, false, nil)
+	backend, err := sql.NewStorageBackend(cfg, eDB, nil, nil, false, nil, nil)
 	require.NoError(t, err)
 	backendService := backend.(services.Service)
 	require.NotNil(t, backendService)

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -596,7 +596,8 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	}
 	storageMetrics := resource.ProvideStorageMetrics(registerer)
 	bleveIndexMetrics := resource.ProvideIndexMetrics(registerer)
-	resourceClient, err := unified.ProvideUnifiedStorageClient(options, storageMetrics, bleveIndexMetrics, vectorMetrics)
+	gcGate := resource.NewGCGate()
+	resourceClient, err := unified.ProvideUnifiedStorageClient(options, storageMetrics, bleveIndexMetrics, vectorMetrics, gcGate)
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +652,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	queryCacheConfigMigrator := migrator5.ProvideQueryCacheConfigMigrator(legacyDatabaseProvider)
 	migrationRegistry := provideMigrationRegistry(foldersDashboardsMigrator, playlistMigrator, shortURLMigrator, dataSourceMigrator, starsMigrator, preferencesMigrator, queryCacheConfigMigrator)
 	unifiedMigrator := migrations2.ProvideUnifiedMigrator(resourceClient, migrationRegistry)
-	unifiedStorageMigrationService := migrations2.ProvideUnifiedStorageMigrationService(unifiedMigrator, legacyDatabaseProvider, cfg, sqlStore, kvStore, resourceClient, migrationRegistry)
+	unifiedStorageMigrationService := migrations2.ProvideUnifiedStorageMigrationService(unifiedMigrator, legacyDatabaseProvider, cfg, sqlStore, kvStore, resourceClient, migrationRegistry, gcGate)
 	migrationStatusReader, err := migrations2.ProvideMigrationStatusReader(sqlStore, cfg, migrationRegistry, registerer)
 	if err != nil {
 		return nil, err
@@ -1327,7 +1328,8 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	storageMetrics := resource.ProvideStorageMetrics(registerer)
 	bleveIndexMetrics := resource.ProvideIndexMetrics(registerer)
-	resourceClient, err := unified.ProvideUnifiedStorageClient(options, storageMetrics, bleveIndexMetrics, vectorMetrics)
+	gcGate := resource.NewGCGate()
+	resourceClient, err := unified.ProvideUnifiedStorageClient(options, storageMetrics, bleveIndexMetrics, vectorMetrics, gcGate)
 	if err != nil {
 		return nil, err
 	}
@@ -1371,7 +1373,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	queryCacheConfigMigrator := migrator5.ProvideQueryCacheConfigMigrator(legacyDatabaseProvider)
 	migrationRegistry := provideMigrationRegistry(foldersDashboardsMigrator, playlistMigrator, shortURLMigrator, dataSourceMigrator, starsMigrator, preferencesMigrator, queryCacheConfigMigrator)
 	unifiedMigrator := migrations2.ProvideUnifiedMigrator(resourceClient, migrationRegistry)
-	unifiedStorageMigrationService := migrations2.ProvideUnifiedStorageMigrationService(unifiedMigrator, legacyDatabaseProvider, cfg, sqlStore, kvStore, resourceClient, migrationRegistry)
+	unifiedStorageMigrationService := migrations2.ProvideUnifiedStorageMigrationService(unifiedMigrator, legacyDatabaseProvider, cfg, sqlStore, kvStore, resourceClient, migrationRegistry, gcGate)
 	migrationStatusReader, err := migrations2.ProvideMigrationStatusReader(sqlStore, cfg, migrationRegistry, registerer)
 	if err != nil {
 		return nil, err

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -153,6 +153,7 @@ var wireExtsBasicSet = wire.NewSet(
 	sandbox.ProvideService,
 	wire.Bind(new(sandbox.Sandbox), new(*sandbox.Service)),
 	wire.Struct(new(unified.Options), "*"),
+	resource.NewGCGate,
 	unified.ProvideUnifiedStorageClient,
 	sql.ProvideStorageBackend,
 	sql.ProvideKV,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -663,6 +663,12 @@ type Cfg struct {
 	// This separates the read phase (legacy DB) from the write phase (unified storage)
 	// Default: false.
 	MigrationParquetBuffer bool
+	// MigrationChunkedWrites writes each migration chunk in its own transaction,
+	// bounded by migration_chunk_max_bytes. Requires migration_locking=true for HA. Default: false.
+	MigrationChunkedWrites bool
+	// MigrationChunkMaxBytes is the soft maximum byte budget per migration chunk
+	// when MigrationChunkedWrites is enabled. Default: 256 MiB.
+	MigrationChunkMaxBytes int64
 	// RenameWaitDeadline is the maximum time to wait for MySQL RENAME TABLE
 	// statements to appear in the processlist. Default: 1 minute.
 	RenameWaitDeadline time.Duration

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -167,6 +167,8 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	section := cfg.Raw.Section("unified_storage")
 	cfg.MigrationCacheSizeKB = section.Key("migration_cache_size_kb").MustInt(1000000)
 	cfg.MigrationParquetBuffer = section.Key("migration_parquet_buffer").MustBool(false)
+	cfg.MigrationChunkedWrites = section.Key("migration_chunked_writes").MustBool(false)
+	cfg.MigrationChunkMaxBytes = section.Key("migration_chunk_max_bytes").MustInt64(256 * 1024 * 1024)
 	cfg.DisableLegacyTableRename = section.Key("disable_legacy_table_rename").MustBool(false)
 	cfg.RenameWaitDeadline = section.Key("rename_wait_deadline").MustDuration(time.Minute)
 	cfg.SearchInjectFailuresPercent = section.Key("search_inject_failures_percent").MustInt(0)

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -197,6 +197,31 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		assert.Equal(t, 3, cfg.IndexWorkers)
 	})
 
+	t.Run("chunked writes config defaults", func(t *testing.T) {
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+
+		cfg.setUnifiedStorageConfig()
+
+		assert.False(t, cfg.MigrationChunkedWrites)
+		assert.Equal(t, int64(256*1024*1024), cfg.MigrationChunkMaxBytes)
+	})
+
+	t.Run("chunked writes config from env vars", func(t *testing.T) {
+		t.Setenv("GF_UNIFIED_STORAGE_MIGRATION_CHUNKED_WRITES", "true")
+		t.Setenv("GF_UNIFIED_STORAGE_MIGRATION_CHUNK_MAX_BYTES", "134217728")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+
+		cfg.setUnifiedStorageConfig()
+
+		assert.True(t, cfg.MigrationChunkedWrites)
+		assert.Equal(t, int64(134217728), cfg.MigrationChunkMaxBytes)
+	})
+
 	t.Run("vector_embedder bedrock config", func(t *testing.T) {
 		setSectionKey := func(cfg *Cfg, key, value string) {
 			section := cfg.Raw.Section("vector_embedder")

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -68,6 +68,7 @@ func ProvideUnifiedStorageClient(opts *Options,
 	storageMetrics *resource.StorageMetrics,
 	indexMetrics *resource.BleveIndexMetrics,
 	vectorMetrics *resource.VectorMetrics,
+	gcGate *resource.GCGate,
 ) (resource.ResourceClient, error) {
 	apiserverCfg := opts.Cfg.SectionWithEnvOverrides("grafana-apiserver")
 	client, err := newClient(options.StorageOptions{
@@ -78,7 +79,7 @@ func ProvideUnifiedStorageClient(opts *Options,
 		BlobStoreURL:            apiserverCfg.Key("blob_url").MustString(""),
 		BlobThresholdBytes:      apiserverCfg.Key("blob_threshold_bytes").MustInt(options.BlobThresholdDefault),
 		GrpcClientKeepaliveTime: apiserverCfg.Key("grpc_client_keepalive_time").MustDuration(0),
-	}, opts.Cfg, opts.Features, opts.Tracer, opts.Reg, opts.Authzc, opts.Docs, storageMetrics, indexMetrics, vectorMetrics, opts.SecureValues, opts.VectorBackend, opts.Embedder, opts.DashboardStats, opts.KV, opts.EDB)
+	}, opts.Cfg, opts.Features, opts.Tracer, opts.Reg, opts.Authzc, opts.Docs, storageMetrics, indexMetrics, vectorMetrics, opts.SecureValues, opts.VectorBackend, opts.Embedder, opts.DashboardStats, opts.KV, opts.EDB, gcGate)
 	if err == nil {
 		// Used to get the folder stats
 		// Pass cfg directly so the federated client reads the current dual-writer mode
@@ -110,6 +111,7 @@ func newClient(opts options.StorageOptions,
 	dashboardStats builders.DashboardStats,
 	kvStore kv.KV,
 	eDB sqldb.DBProvider,
+	gcGate *resource.GCGate,
 ) (resource.ResourceClient, error) {
 	ctx := context.Background()
 
@@ -167,7 +169,7 @@ func newClient(opts options.StorageOptions,
 			return nil, err
 		}
 
-		backend, err := sql.NewStorageBackend(cfg, eDB, reg, storageMetrics, false, kvStore)
+		backend, err := sql.NewStorageBackend(cfg, eDB, reg, storageMetrics, false, kvStore, gcGate)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/unified/client_test.go
+++ b/pkg/storage/unified/client_test.go
@@ -54,6 +54,7 @@ func TestUnifiedStorageClient(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -83,6 +84,7 @@ func TestUnifiedStorageClient(t *testing.T) {
 				nil,
 				nil,
 				authlib.FixedAccessClient(true),
+				nil,
 				nil,
 				nil,
 				nil,

--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -66,6 +66,17 @@ func TestIntegrationMigrations(t *testing.T) {
 	runMigrationTestSuite(t, defaultMigrationTestCases(), migrationTestOptions{})
 }
 
+// TestIntegrationMigrationsChunked same as TestIntegrationMigrations but with the chunked bulk writes (multiple txs).
+func TestIntegrationMigrationsChunked(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	if db.IsTestDbSQLite() {
+		t.Skip("chunked migration write path is non-sqlite only; run with GRAFANA_TEST_DB=mysql or postgres")
+	}
+	runMigrationTestSuite(t, defaultMigrationTestCases(), migrationTestOptions{
+		chunkMaxBytes: 64 * 1024, // small chunks to force multiple txs
+	})
+}
+
 // TestIntegrationKVMigrations runs the same migration test suite as TestIntegrationMigrations
 // but with the KV storage backend enabled instead of the SQL backend.
 func TestIntegrationKVMigrations(t *testing.T) {
@@ -78,6 +89,8 @@ type migrationTestOptions struct {
 	// extraMigrationIDs adds migration IDs (and their default status) to the verification map.
 	// Used by enterprise tests to include enterprise-only migrations.
 	extraMigrationIDs map[string]bool
+	// chunkMaxBytes, if > 0, enables chunked migration and sets chunk size
+	chunkMaxBytes int64
 }
 
 // runMigrationTestSuite executes the migration test suite for the given test cases
@@ -301,6 +314,7 @@ func runMigrationTestSuite(t *testing.T, testCases []testcases.ResourceMigratorT
 				APIServerStorageType:   "unified",
 				UnifiedStorageConfig:   unifiedConfig,
 				MigrationParquetBuffer: true,
+				MigrationChunkMaxBytes: opts.chunkMaxBytes,
 				EnableFeatureToggles:   featureToggles,
 				EnableSQLKVBackend:     opts.enableSQLKVBackend,
 			},

--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -29,6 +29,7 @@ type UnifiedStorageMigrationServiceImpl struct {
 	kv           kvstore.KVStore
 	client       resource.ResourceClient
 	registry     *MigrationRegistry
+	gcGate       *resource.GCGate
 }
 
 var _ contract.UnifiedStorageMigrationService = (*UnifiedStorageMigrationServiceImpl)(nil)
@@ -42,6 +43,7 @@ func ProvideUnifiedStorageMigrationService(
 	kv kvstore.KVStore,
 	client resource.ResourceClient,
 	registry *MigrationRegistry,
+	gcGate *resource.GCGate,
 ) contract.UnifiedStorageMigrationService {
 	return &UnifiedStorageMigrationServiceImpl{
 		migrator:     migrator,
@@ -52,10 +54,14 @@ func ProvideUnifiedStorageMigrationService(
 		kv:           kv,
 		client:       client,
 		registry:     registry,
+		gcGate:       gcGate,
 	}
 }
 
 func (p *UnifiedStorageMigrationServiceImpl) Run(ctx context.Context) error {
+	// Start GC after migration for chunked history + backfill transactions.
+	defer p.gcGate.Release()
+
 	if !p.cfg.ShouldRunMigrations() {
 		metrics.MUnifiedStorageMigrationStatus.Set(1)
 		logger.Info("Data migrations are disabled, skipping",
@@ -117,6 +123,14 @@ func RegisterMigrations(
 
 	// Run all registered migrations (blocking)
 	sec := cfg.Raw.Section("database")
+
+	// Chunked writes need the advisory lock for HA read-isolation: without it,
+	// readers on other instances may see partially migrated data.
+	if cfg.MigrationChunkedWrites && !sec.Key("migration_locking").MustBool(true) {
+		logger.Warn("migration_chunked_writes needs migration_locking for HA read-isolation; " +
+			"readers may see partially migrated data")
+	}
+
 	db := mg.DBEngine.DB().DB
 	maxOpenConns := db.Stats().MaxOpenConnections
 	maxConcurrentRenameConns := 0

--- a/pkg/storage/unified/migrations/service_test.go
+++ b/pkg/storage/unified/migrations/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
 func TestUnifiedStorageMigrationServiceImpl_Run_SkipsMigrations(t *testing.T) {
@@ -49,15 +50,19 @@ func TestUnifiedStorageMigrationServiceImpl_Run_SkipsMigrations(t *testing.T) {
 
 			fake := &fakeUnifiedMigrator{}
 
+			gate := resource.NewGCGate()
 			svc := &UnifiedStorageMigrationServiceImpl{
 				cfg:      cfg,
 				migrator: fake,
+				gcGate:   gate,
 			}
 
 			err := svc.Run(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, float64(1), testutil.ToFloat64(metrics.MUnifiedStorageMigrationStatus))
 			require.Equal(t, 0, fake.migrateCalled)
+			require.True(t, gate.Wait(context.Background(), make(chan struct{})),
+				"expected Run to release the GC gate on the skip path")
 		})
 	}
 }

--- a/pkg/storage/unified/resource/gc_gate.go
+++ b/pkg/storage/unified/resource/gc_gate.go
@@ -1,0 +1,40 @@
+package resource
+
+import (
+	"context"
+	"sync"
+)
+
+// GCGate defers background GC until Release is called.
+type GCGate struct {
+	once sync.Once
+	ch   chan struct{}
+}
+
+// NewGCGate returns an un-released gate; Wait blocks until Release is called.
+func NewGCGate() *GCGate { return &GCGate{ch: make(chan struct{})} }
+
+// Release unblocks Wait callers.
+func (g *GCGate) Release() {
+	if g == nil || g.ch == nil {
+		return
+	}
+	g.once.Do(func() { close(g.ch) })
+}
+
+// Wait blocks until the gate is released, returning true to proceed. It returns
+// false if the caller should abort (context cancelled or done closed).
+// A nil gate returns true immediately.
+func (g *GCGate) Wait(ctx context.Context, done <-chan struct{}) bool {
+	if g == nil || g.ch == nil {
+		return true
+	}
+	select {
+	case <-g.ch:
+		return true
+	case <-done:
+		return false
+	case <-ctx.Done():
+		return false
+	}
+}

--- a/pkg/storage/unified/resource/gc_gate_test.go
+++ b/pkg/storage/unified/resource/gc_gate_test.go
@@ -1,0 +1,77 @@
+package resource
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCGate_NilProceedsImmediately(t *testing.T) {
+	t.Parallel()
+
+	var g *GCGate // nil gate
+	require.True(t, g.Wait(context.Background(), nil))
+	// Release on a nil gate must not panic.
+	require.NotPanics(t, func() { g.Release() })
+}
+
+func TestGCGate_BlocksUntilRelease(t *testing.T) {
+	t.Parallel()
+
+	g := NewGCGate()
+
+	// Before release, Wait must not return. Use a short window with a
+	// never-closing done channel to assert it blocks.
+	released := make(chan bool, 1)
+	go func() {
+		released <- g.Wait(context.Background(), make(chan struct{}))
+	}()
+
+	select {
+	case <-released:
+		t.Fatal("Wait returned before Release was called")
+	case <-time.After(50 * time.Millisecond):
+		// expected: still blocked
+	}
+
+	g.Release()
+
+	select {
+	case proceed := <-released:
+		require.True(t, proceed, "Wait should return true after Release")
+	case <-time.After(time.Second):
+		t.Fatal("Wait did not return after Release")
+	}
+}
+
+func TestGCGate_ReleaseIdempotent(t *testing.T) {
+	t.Parallel()
+
+	g := NewGCGate()
+	require.NotPanics(t, func() {
+		g.Release()
+		g.Release()
+	})
+	// Still proceeds after multiple releases.
+	require.True(t, g.Wait(context.Background(), make(chan struct{})))
+}
+
+func TestGCGate_AbortsOnDone(t *testing.T) {
+	t.Parallel()
+
+	g := NewGCGate()
+	done := make(chan struct{})
+	close(done)
+	require.False(t, g.Wait(context.Background(), done), "Wait should abort when done is closed")
+}
+
+func TestGCGate_AbortsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	g := NewGCGate()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.False(t, g.Wait(ctx, make(chan struct{})), "Wait should abort when context is cancelled")
+}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -88,6 +88,7 @@ type kvStorageBackend struct {
 	eventPruningInterval    time.Duration
 	historyPruner           Pruner
 	garbageCollection       GarbageCollectionConfig
+	gcGate                  *GCGate
 	lastImportStore         *lastImportStore
 	lastImportTimeMaxAge    time.Duration
 	//reg     prometheus.Registerer
@@ -165,6 +166,9 @@ type KVBackendOptions struct {
 	Reg                  prometheus.Registerer // TODO add metrics
 	Log                  log.Logger
 	GarbageCollection    GarbageCollectionConfig
+
+	// GCGate defers the start of the GC until released (optional).
+	GCGate *GCGate
 
 	UseChannelNotifier bool
 	WatchOptions       WatchOptions
@@ -276,6 +280,7 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 		lastImportStore:         newLastImportStore(kv),
 		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
 		garbageCollection:       garbageCollection,
+		gcGate:                  opts.GCGate,
 		searchLookback:          opts.SearchLookback,
 		disablePruner:           opts.DisablePruner,
 		dashboardVersionsToKeep: opts.DashboardVersionsToKeep,
@@ -500,6 +505,10 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 	}
 
 	go func() {
+		if !b.gcGate.Wait(ctx, ctx.Done()) {
+			return
+		}
+
 		// delay the first run by a random amount between 0 and the interval to avoid thundering herd
 		jitter := time.Duration(rand.Int64N(b.garbageCollection.Interval.Nanoseconds()))
 		select {

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -108,6 +108,7 @@ func NewStorageBackend(
 	storageMetrics *resource.StorageMetrics,
 	disableStorageServices bool,
 	kvStore kv.KV,
+	gcGate *resource.GCGate,
 ) (resource.StorageBackend, error) {
 	storageType := options.StorageType(cfg.SectionWithEnvOverrides("grafana-apiserver").Key("storage_type").
 		MustString(string(options.StorageTypeUnified)))
@@ -129,6 +130,7 @@ func NewStorageBackend(
 			IsHA:                 isHA,
 			storageMetrics:       storageMetrics,
 			LastImportTimeMaxAge: cfg.MaxFileIndexAge,
+			GCGate:               gcGate,
 			GarbageCollection: GarbageCollectionConfig{
 				Enabled:          cfg.EnableGarbageCollection,
 				Interval:         cfg.GarbageCollectionInterval,
@@ -139,6 +141,8 @@ func NewStorageBackend(
 			},
 			SimulatedNetworkLatency: cfg.SimulatedNetworkLatency,
 			MigrationParquetBuffer:  cfg.MigrationParquetBuffer,
+			MigrationChunkedWrites:  cfg.MigrationChunkedWrites,
+			MigrationChunkMaxBytes:  cfg.MigrationChunkMaxBytes,
 			TmpDir:                  tmpDir(cfg.DataPath),
 			DisableStorageServices:  disableStorageServices,
 			DisablePruner:           cfg.DisablePruner,
@@ -177,6 +181,7 @@ func NewStorageBackend(
 		LastImportTimeMaxAge: cfg.MaxFileIndexAge,
 		TenantWatcherConfig:  resource.NewTenantWatcherConfig(cfg),
 		TenantDeleterConfig:  tenantDeleterCfg,
+		GCGate:               gcGate,
 		GarbageCollection: resource.GarbageCollectionConfig{
 			Enabled:          cfg.EnableGarbageCollection,
 			DryRun:           cfg.GarbageCollectionDryRun,
@@ -252,6 +257,9 @@ type BackendOptions struct {
 	storageMetrics    *resource.StorageMetrics
 	GarbageCollection GarbageCollectionConfig
 
+	// GCGate defers the start of the GC until released (optional).
+	GCGate *resource.GCGate
+
 	DisableStorageServices bool
 	DisablePruner          bool
 
@@ -259,6 +267,14 @@ type BackendOptions struct {
 
 	// When true, bulk migrations buffer data through a temporary Parquet file
 	MigrationParquetBuffer bool
+
+	// When true, bulk migrations write data in chunks, each in its own transaction.
+	// Requires migration_locking=true for safe HA operation.
+	MigrationChunkedWrites bool
+
+	// MigrationChunkMaxBytes is the soft maximum byte budget per migration chunk
+	// when MigrationChunkedWrites is enabled.
+	MigrationChunkMaxBytes int64
 
 	// Directory for temporary Parquet files during bulk migration.
 	// Defaults to the OS temp dir when empty. Set to cfg.DataPath/tmp to
@@ -309,10 +325,13 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		analyzeBulkRowThreshold: analyzeResourceHistoryRowThreshold,
 		simulatedNetworkLatency: opts.SimulatedNetworkLatency,
 		migrationParquetBuffer:  opts.MigrationParquetBuffer,
+		migrationChunkedWrites:  opts.MigrationChunkedWrites,
+		migrationChunkMaxBytes:  opts.MigrationChunkMaxBytes,
 		tmpDir:                  opts.TmpDir,
 		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
 		batchTxnTimeout:         opts.BatchTransactionTimeout,
 		garbageCollection:       garbageCollection,
+		gcGate:                  opts.GCGate,
 	}
 	if err := backend.Init(ctx); err != nil {
 		return nil, err
@@ -365,6 +384,8 @@ type backend struct {
 
 	// testing
 	simulatedNetworkLatency time.Duration
+	// bulkCommitObserver is used by tests to check the committed bytes per chunk.
+	bulkCommitObserver func(phase string, bytes int64)
 
 	disablePruner           bool
 	dashboardVersionsToKeep int
@@ -372,9 +393,15 @@ type backend struct {
 	historyPruner           resource.Pruner
 
 	garbageCollection GarbageCollectionConfig
+	gcGate            *resource.GCGate
 
 	// When true, bulk migrations buffer data through a temporary Parquet file
 	migrationParquetBuffer bool
+
+	// When true, bulk migrations write data in chunks, each in its own transaction.
+	migrationChunkedWrites bool
+	// migrationChunkMaxBytes is the soft maximum byte budget per migration chunk.
+	migrationChunkMaxBytes int64
 
 	// tmpDir is the directory for temporary Parquet files; empty means OS default.
 	tmpDir string
@@ -519,6 +546,12 @@ func (b *backend) initGarbageCollection(ctx context.Context) error {
 	b.log.Info("starting garbage collection loop")
 
 	go func() {
+		// Wait for the migration gate so GC never prunes rows an in-process
+		// chunked migration is still committing. A nil gate proceeds immediately.
+		if !b.gcGate.Wait(ctx, b.done) {
+			return
+		}
+
 		// delay the first run by a random amount between 0 and the interval to avoid thundering herd
 		if b.garbageCollection.Interval > 0 {
 			jitter := time.Duration(rand.Int63n(b.garbageCollection.Interval.Nanoseconds()))

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
@@ -39,6 +40,9 @@ const (
 	// analyzeResourceHistoryRowThreshold is the number of rows bulk-loaded into
 	// resource_history to trigger an ANALYZE before the resource backfill.
 	analyzeResourceHistoryRowThreshold = 10000
+
+	// txChunkerMaxRows forces a chunk commit at this row count as safety cap.
+	txChunkerMaxRows = 100_000
 )
 
 // noRollbackTx wraps a db.Tx but makes Rollback() a no-op.
@@ -231,6 +235,10 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		}
 	}
 
+	if b.migrationChunkedWrites && b.dialect.DialectName() != "sqlite" {
+		return b.processBulkChunked(ctx, setting, iter)
+	}
+
 	return b.processBulk(ctx, setting, iter)
 }
 
@@ -293,7 +301,7 @@ func (b *backend) processBulkWithTx(ctx context.Context, tx db.Tx, setting resou
 		if len(batch) == 0 {
 			return rollbackWithError(fmt.Errorf("missing request batch"))
 		}
-		if err := b.insertHistoryBatch(ctx, tx, batch, rv, rsp); err != nil {
+		if _, err := b.insertHistoryBatch(ctx, tx, batch, rv, rsp, nil); err != nil {
 			return rollbackWithError(err)
 		}
 	}
@@ -311,8 +319,7 @@ func (b *backend) processBulkWithTx(ctx context.Context, tx db.Tx, setting resou
 			return rollbackWithError(fmt.Errorf("missing summary key for: %s", k))
 		}
 
-		err := bulk.syncCollection(key, summary)
-		if err != nil {
+		if err := bulk.syncCollection(key, summary); err != nil {
 			return err
 		}
 
@@ -331,7 +338,7 @@ func (b *backend) processBulkWithTx(ctx context.Context, tx db.Tx, setting resou
 			}
 		} else {
 			// Make sure the collection RV is above our last written event
-			_, err = b.rvManager.ExecWithRV(ctx, key, func(_ context.Context, _ db.Tx) (string, error) {
+			_, err := b.rvManager.ExecWithRV(ctx, key, func(_ context.Context, _ db.Tx) (string, error) {
 				return "", nil
 			})
 			if err != nil {
@@ -343,6 +350,245 @@ func (b *backend) processBulkWithTx(ctx context.Context, tx db.Tx, setting resou
 		// of the resource for a given namespace.
 		if err := b.updateLastImportTime(ctx, tx, key, time.Now()); err != nil {
 			return rollbackWithError(err)
+		}
+	}
+	return nil
+}
+
+// processBulkChunked mirrors processBulkWithTx but uses multiple txs and autocommit.
+//
+// Note: mid-stream rollback is not possible. A RollbackRequested signal or error
+// returns a hard error after best-effort re-wiping the committed chunks.
+func (b *backend) processBulkChunked(ctx context.Context, setting resource.BulkSettings, iter resource.BulkRequestIterator) *resourcepb.BulkResponse {
+	rsp := &resourcepb.BulkResponse{}
+	budget := b.migrationChunkMaxBytes
+
+	// Clear each collection using bounded autocommit batches.
+	summaries := make(map[string]*resourcepb.BulkResponse_Summary, len(setting.Collection))
+	for _, key := range setting.Collection {
+		summary, err := b.deleteCollectionChunked(ctx, key)
+		if err != nil {
+			rsp.Error = resource.AsErrorResult(err)
+			return rsp
+		}
+		summaries[resource.NSGR(key)] = summary
+		rsp.Summary = append(rsp.Summary, summary)
+	}
+
+	if err := b.writeBulkChunked(ctx, setting, iter, rsp, summaries, budget); err != nil {
+		// Best-effort re-wipe of the partially committed collections.
+		for _, key := range setting.Collection {
+			if _, derr := b.deleteCollectionChunked(ctx, key); derr != nil {
+				b.log.Warn("cleanup after failed chunked migration", "key", resource.NSGR(key), "error", derr)
+			}
+		}
+		rsp.Error = resource.AsErrorResult(err)
+		return rsp
+	}
+	return rsp
+}
+
+// txChunker owns a sequence of bounded transactions on a db.DB. Callers Exec
+// against the open tx field and report work via add(); it commits and reopens
+// once pending bytes reach the budget or rows reach maxRows. flush commits the
+// last tx. Not safe for concurrent use.
+type txChunker struct {
+	ctx      context.Context
+	db       db.DB
+	opts     *sql.TxOptions
+	budget   int64             // commit when pendingBytes >= budget
+	maxRows  int               // forced commit when pendingRows >= maxRows
+	onCommit func(bytes int64) // optional, fired after each committed chunk that had work
+
+	tx           db.Tx // open transaction; nil after a commit/begin error
+	pendingBytes int64
+	pendingRows  int
+}
+
+// newTxChunker falls back to the default budget when non-positive and begins the
+// first transaction.
+func newTxChunker(ctx context.Context, database db.DB, opts *sql.TxOptions, budget int64, maxRows int, onCommit func(int64)) (*txChunker, error) {
+	if budget <= 0 {
+		budget = defaultChunkBudget
+	}
+	tx, err := database.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &txChunker{ctx: ctx, db: database, opts: opts, budget: budget, maxRows: maxRows, onCommit: onCommit, tx: tx}, nil
+}
+
+// commit commits the open tx (firing onCommit when it held work) and resets the
+// counters. The chunker holds no open tx afterward.
+func (c *txChunker) commit() error {
+	if c.tx == nil {
+		return nil
+	}
+	hadWork := c.pendingRows > 0
+	err := c.tx.Commit()
+	c.tx = nil
+	if err != nil {
+		return err
+	}
+	if hadWork && c.onCommit != nil {
+		c.onCommit(c.pendingBytes)
+	}
+	c.pendingBytes, c.pendingRows = 0, 0
+	return nil
+}
+
+// add accumulates the last write's bytes/rows; once the byte budget or row limit
+// is reached it commits the chunk and opens a fresh transaction.
+func (c *txChunker) add(bytes int64, rows int) error {
+	c.pendingBytes += bytes
+	c.pendingRows += rows
+	if c.pendingBytes >= c.budget || (c.maxRows > 0 && c.pendingRows >= c.maxRows) {
+		if err := c.commit(); err != nil {
+			return err
+		}
+		tx, err := c.db.BeginTx(c.ctx, c.opts)
+		if err != nil {
+			return err
+		}
+		c.tx = tx
+	}
+	return nil
+}
+
+// abort rolls back the open transaction
+func (c *txChunker) abort() error {
+	if c.tx == nil {
+		return nil
+	}
+	err := c.tx.Rollback()
+	c.tx = nil
+	return err
+}
+
+// writeBulkChunked stream history in chunks, refresh stats, and
+// then backfill the resource table using name ranges.
+func (b *backend) writeBulkChunked(ctx context.Context, setting resource.BulkSettings, iter resource.BulkRequestIterator, rsp *resourcepb.BulkResponse, summaries map[string]*resourcepb.BulkResponse_Summary, budget int64) error {
+	// Write each event into history, committed per chunk.
+	rv := newBulkRV()
+	batchIter, ok := iter.(resource.BulkRequestBatchIterator)
+	if !ok {
+		batchIter = &singleRequestBatchIterator{iter: iter}
+	}
+
+	// colSizes accumulates max-RV row size per NSGR
+	// for backfill with budget without a second pass.
+	colSizes := map[string]backfillSizes{}
+
+	var onCommit func(int64)
+	if b.bulkCommitObserver != nil {
+		onCommit = func(bytes int64) {
+			b.bulkCommitObserver("history", bytes)
+		}
+	}
+	chunker, err := newTxChunker(ctx, b.db, ReadCommitted, budget, txChunkerMaxRows, onCommit)
+	if err != nil {
+		return err
+	}
+	processChunkFn := func() error {
+		if batchIter.RollbackRequested() {
+			return fmt.Errorf("bulk migration rollback requested (best-effort)")
+		}
+		batch := batchIter.Batch()
+		if len(batch) == 0 {
+			if err := chunker.abort(); err != nil {
+				b.log.Warn("rollback", "error", err)
+			}
+			return fmt.Errorf("missing request batch")
+		}
+		bytes, err := b.insertHistoryBatch(ctx, chunker.tx, batch, rv, rsp, colSizes)
+		if err != nil {
+			return err
+		}
+		return chunker.add(int64(bytes), len(batch))
+	}
+
+	for batchIter.NextBatch() {
+		if err := processChunkFn(); err != nil {
+			if abortErr := chunker.abort(); abortErr != nil {
+				b.log.Warn("rollback", "error", err, "aborting", abortErr)
+			}
+			return err
+		}
+	}
+	if err := chunker.commit(); err != nil {
+		return err
+	}
+
+	// Refresh planner stats so backfill avoids a nested-loop plan.
+	if err := b.analyzeResourceHistoryForBackfill(ctx, b.db, rsp.Processed); err != nil {
+		return err
+	}
+
+	// Backfill the resource table from history and finalize
+	worker := &bulkWroker{
+		ctx:     ctx,
+		tx:      b.db,
+		dialect: b.dialect,
+		logger:  logging.FromContext(ctx),
+	}
+	for _, key := range setting.Collection {
+		k := resource.NSGR(key)
+		summary := summaries[k]
+		if summary == nil {
+			return fmt.Errorf("missing summary key for: %s", k)
+		}
+
+		// Paginated INSERT...SELECT backfill: split the rebuild into
+		// byte-bounded name ranges so no single write-set exceeds the budget.
+		sizes := colSizes[k]
+		sizeOf := func(name string) int64 {
+			ns := sizes[name]
+			if ns == nil || ns.deleted {
+				return 0
+			}
+			return int64(ns.size)
+		}
+
+		names, err := dbutil.Query(ctx, b.db, sqlResourceHistoryDistinctNames, &sqlResourceHistoryDistinctNamesRequest{
+			SQLTemplate: sqltemplate.New(b.dialect),
+			Namespace:   key.Namespace,
+			Group:       key.Group,
+			Resource:    key.Resource,
+			Response:    new(distinctName),
+		})
+		if err != nil {
+			return err
+		}
+		nameList := make([]string, len(names))
+		for i, n := range names {
+			nameList[i] = n.Name
+		}
+
+		for _, r := range planNameRanges(nameList, sizeOf, budget) {
+			if err := worker.insertFromHistoryRange(key, r.startName, r.endName); err != nil {
+				return err
+			}
+			if b.bulkCommitObserver != nil {
+				b.bulkCommitObserver("backfill", r.plannedBytes)
+			}
+		}
+
+		if err := worker.collectStats(key, summary); err != nil {
+			return err
+		}
+
+		// Bump the collection RV above our last written event. It manages its own
+		// transaction, so a failure is warn-only as in processBulkWithTx.
+		if _, err := b.rvManager.ExecWithRV(ctx, key, func(_ context.Context, _ db.Tx) (string, error) {
+			return "", nil
+		}); err != nil {
+			b.log.Warn("error increasing RV", "error", err)
+		}
+
+		// Update the last import time LAST. This is important to trigger
+		// reindexing of the resource for a given namespace.
+		if err := b.updateLastImportTime(ctx, b.db, key, time.Now()); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -364,12 +610,39 @@ func (b *backend) analyzeResourceHistoryForBackfill(ctx context.Context, tx db.C
 	return err
 }
 
-func (b *backend) insertHistoryBatch(ctx context.Context, tx db.ContextExecer, batch []*resourcepb.BulkRequest, rv *bulkRV, rsp *resourcepb.BulkResponse) error {
+// nameMaxRow records the byte size and delete flag of the highest-RV row seen
+// for a name. The backfill copies that row, so size is the name's write-set cost.
+type nameMaxRow struct {
+	rv      int64
+	size    int
+	deleted bool
+}
+
+// backfillSizes maps a name to its max-RV row summary for a single collection.
+type backfillSizes map[string]*nameMaxRow
+
+// observe keeps the highest-RV row for name, recording its size and delete flag.
+func (s backfillSizes) observe(name string, resourceVersion int64, size int, deleted bool) {
+	cur, ok := s[name]
+	if !ok {
+		s[name] = &nameMaxRow{rv: resourceVersion, size: size, deleted: deleted}
+		return
+	}
+	if resourceVersion > cur.rv {
+		cur.rv = resourceVersion
+		cur.size = size
+		cur.deleted = deleted
+	}
+}
+
+// insertHistoryBatch inserts a batch of history rows. When colSizes is non-nil
+// (chunked path), it records per-name max-RV value size and delete flag.
+func (b *backend) insertHistoryBatch(ctx context.Context, tx db.ContextExecer, batch []*resourcepb.BulkRequest, rv *bulkRV, rsp *resourcepb.BulkResponse, colSizes map[string]backfillSizes) (int, error) {
 	rows := make([]sqlResourceRequest, 0, len(batch))
 	payloadBytes := 0
 	for _, req := range batch {
 		if req == nil {
-			return fmt.Errorf("missing request")
+			return 0, fmt.Errorf("missing request")
 		}
 		rsp.Processed++
 		payloadBytes += len(req.Value)
@@ -394,6 +667,15 @@ func (b *backend) insertHistoryBatch(ctx context.Context, tx db.ContextExecer, b
 		}
 
 		resourceVersion := rv.next(obj)
+		if colSizes != nil {
+			nsgr := resource.NSGR(req.Key)
+			sizes := colSizes[nsgr]
+			if sizes == nil {
+				sizes = backfillSizes{}
+				colSizes[nsgr] = sizes
+			}
+			sizes.observe(req.Key.Name, resourceVersion, len(req.Value), req.Action == resourcepb.BulkRequest_DELETED)
+		}
 		rows = append(rows, sqlResourceRequest{
 			WriteEvent: resource.WriteEvent{
 				Key:        req.Key,
@@ -409,7 +691,7 @@ func (b *backend) insertHistoryBatch(ctx context.Context, tx db.ContextExecer, b
 	}
 
 	if len(rows) == 0 {
-		return nil
+		return payloadBytes, nil
 	}
 
 	insertStart := time.Now()
@@ -423,7 +705,7 @@ func (b *backend) insertHistoryBatch(ctx context.Context, tx db.ContextExecer, b
 			SQLTemplate: sqltemplate.New(b.dialect),
 			Rows:        rows[start:end],
 		}); err != nil {
-			return fmt.Errorf("insert into resource history: %w", err)
+			return payloadBytes, fmt.Errorf("insert into resource history: %w", err)
 		}
 	}
 	insertDuration := time.Since(insertStart)
@@ -434,7 +716,7 @@ func (b *backend) insertHistoryBatch(ctx context.Context, tx db.ContextExecer, b
 		b.log.Debug("bulk insert timing", "processed", rsp.Processed, "batch_size", len(batch), "inserted", len(rows), "payload_bytes", payloadBytes, "insert", insertDuration)
 	}
 
-	return nil
+	return payloadBytes, nil
 }
 
 func bulkHistoryInsertRowLimit(dialectName string) int {
@@ -474,7 +756,7 @@ func (s *singleRequestBatchIterator) RollbackRequested() bool {
 	return s.iter.RollbackRequested()
 }
 
-func (b *backend) updateLastImportTime(ctx context.Context, tx db.Tx, key *resourcepb.ResourceKey, now time.Time) error {
+func (b *backend) updateLastImportTime(ctx context.Context, tx db.ContextExecer, key *resourcepb.ResourceKey, now time.Time) error {
 	if _, err := dbutil.Exec(ctx, tx, sqlResourceLastImportTimeInsert, sqlResourceLastImportTimeInsertRequest{
 		SQLTemplate:    sqltemplate.New(b.dialect),
 		Namespace:      key.Namespace,
@@ -532,17 +814,193 @@ func (w *bulkWroker) deleteCollection(key *resourcepb.ResourceKey) (*resourcepb.
 	return summary, err
 }
 
-// Copy the latest value from history into the active resource table
+const (
+	// deleteCollectionChunkBatchSize is the number of candidate rows fetched per
+	// SELECT during a chunked wipe.
+	deleteCollectionChunkBatchSize = 2000
+	// defaultChunkBudget (256 MiB) when b.migrationChunkMaxBytes is <= 0 and chunking is enabled.
+	defaultChunkBudget = 256 * 1024 * 1024
+)
+
+// deleteCollectionChunked clears the resource and resource_history tables for a
+// namespace/group/resource in multiple transactions.
+func (b *backend) deleteCollectionChunked(ctx context.Context, key *resourcepb.ResourceKey) (*resourcepb.BulkResponse_Summary, error) {
+	summary := &resourcepb.BulkResponse_Summary{
+		Namespace: key.Namespace,
+		Group:     key.Group,
+		Resource:  key.Resource,
+	}
+
+	// History first, then the active resource table, matching deleteCollection.
+	history, err := b.wipeTableChunked(ctx, key, tableResourceHistory)
+	if err != nil {
+		return nil, err
+	}
+	summary.PreviousHistory = history
+
+	count, err := b.wipeTableChunked(ctx, key, tableResource)
+	if err != nil {
+		return nil, err
+	}
+	summary.PreviousCount = count
+
+	return summary, nil
+}
+
+// wipeTableChunked deletes every row for key from the table ("resource"
+// or "resource_history") and returns the number of rows deleted.
+func (b *backend) wipeTableChunked(ctx context.Context, key *resourcepb.ResourceKey, table string) (int64, error) {
+	budget := b.migrationChunkMaxBytes
+	if budget <= 0 {
+		budget = defaultChunkBudget
+	}
+	var totalDeleted int64
+
+	for {
+		// Get delete candidates and their value sizes to bound each delete's write-set.
+		// Read them into a slice (not held open across the deletes) and delete every
+		// one before the next SELECT, or the loop won't terminate.
+		candidates, err := dbutil.Query(ctx, b.db, sqlChunkCandidates, &sqlChunkCandidatesRequest{
+			SQLTemplate: sqltemplate.New(b.dialect),
+			Table:       table,
+			Namespace:   key.Namespace,
+			Group:       key.Group,
+			Resource:    key.Resource,
+			BatchSize:   deleteCollectionChunkBatchSize,
+			Response:    new(chunkCandidate),
+		})
+		if err != nil {
+			return 0, err
+		}
+		if len(candidates) == 0 {
+			break
+		}
+
+		// Greedily group guids into sub-batches whose total value bytes stay under
+		// budget; an oversize row goes alone in its own sub-batch.
+		var (
+			guids   []string
+			subSize int64
+		)
+		flush := func() error {
+			if len(guids) == 0 {
+				return nil
+			}
+			res, err := dbutil.Exec(ctx, b.db, sqlDeleteByGUIDs, &sqlDeleteByGUIDsRequest{
+				SQLTemplate: sqltemplate.New(b.dialect),
+				Table:       table,
+				Namespace:   key.Namespace,
+				Group:       key.Group,
+				Resource:    key.Resource,
+				GUIDs:       guids,
+			})
+			if err != nil {
+				return err
+			}
+			rows, err := res.RowsAffected()
+			if err != nil {
+				return err
+			}
+			totalDeleted += rows
+			guids = guids[:0]
+			subSize = 0
+			return nil
+		}
+
+		for _, c := range candidates {
+			cost := c.Size
+			if len(guids) > 0 && subSize+cost > budget {
+				if err := flush(); err != nil {
+					return 0, err
+				}
+			}
+			guids = append(guids, c.GUID)
+			subSize += cost
+		}
+		if err := flush(); err != nil {
+			return 0, err
+		}
+	}
+
+	return totalDeleted, nil
+}
+
+// syncCollection copies the latest history value into the resource table for the
+// whole collection, then records its stats.
 func (w *bulkWroker) syncCollection(key *resourcepb.ResourceKey, summary *resourcepb.BulkResponse_Summary) error {
+	if err := w.insertFromHistoryRange(key, "", ""); err != nil {
+		return err
+	}
+	return w.collectStats(key, summary)
+}
+
+// insertFromHistoryRange copies the latest history value into the resource table
+// for names in the half-open range (startName, endName]. An empty bound leaves
+// that side unbounded.
+func (w *bulkWroker) insertFromHistoryRange(key *resourcepb.ResourceKey, startName, endName string) error {
 	w.logger.Info("synchronize collection", "key", resource.NSGR(key))
 	_, err := dbutil.Exec(w.ctx, w.tx, sqlResourceInsertFromHistory, &sqlResourceInsertFromHistoryRequest{
 		SQLTemplate: sqltemplate.New(w.dialect),
 		Key:         key,
+		StartName:   startName,
+		EndName:     endName,
 	})
-	if err != nil {
-		return err
+	return err
+}
+
+// nameRange selects the names for one backfill INSERT...SELECT: those with
+// startName < name <= endName. An empty startName/endName means no lower/upper
+// bound. plannedBytes is the summed size of those names, for budgeting.
+type nameRange struct {
+	startName    string
+	endName      string
+	plannedBytes int64
+}
+
+// planNameRanges splits names into contiguous half-open (startName, endName]
+// ranges whose summed sizeOf stays within budget, keeping each backfill
+// write-set under the byte cap.
+//
+// names MUST be kept in DB collation order (as returned by the distinct-name query).
+//
+// The result covers every name exactly once and ends with an unbounded range
+// (endName == "") as a catch-all. An empty names slice yields one unbounded
+// range, matching the original single-statement backfill.
+func planNameRanges(names []string, sizeOf func(name string) int64, budget int64) []nameRange {
+	if budget <= 0 {
+		budget = defaultChunkBudget
+	}
+	if len(names) == 0 {
+		return []nameRange{{startName: "", endName: ""}}
 	}
 
+	var ranges []nameRange
+	rangeStart := "" // exclusive lower bound of the current open range
+	prev := ""       // most recently accumulated name (acc > 0 ⇒ prev is set)
+	var acc int64
+
+	for _, name := range names {
+		sz := sizeOf(name)
+
+		// Adding this name would overflow the current non-empty range: close
+		// the range at the previous name and start a new one there.
+		if acc > 0 && acc+sz > budget {
+			ranges = append(ranges, nameRange{startName: rangeStart, endName: prev, plannedBytes: acc})
+			rangeStart = prev
+			acc = 0
+		}
+		acc += sz
+		prev = name
+	}
+
+	// Final range: unbounded above so any name past the last boundary is still
+	// copied. It carries the trailing accumulated bytes.
+	ranges = append(ranges, nameRange{startName: rangeStart, endName: "", plannedBytes: acc})
+	return ranges
+}
+
+// collectStats reads the resource stats for the collection and records them in summary.
+func (w *bulkWroker) collectStats(key *resourcepb.ResourceKey, summary *resourcepb.BulkResponse_Summary) error {
 	w.logger.Info("get stats (still in transaction)", "key", resource.NSGR(key))
 	rows, err := dbutil.QueryRows(w.ctx, w.tx, sqlResourceStats, &sqlStatsRequest{
 		SQLTemplate: sqltemplate.New(w.dialect),

--- a/pkg/storage/unified/sql/backend_bulk_chunked_test.go
+++ b/pkg/storage/unified/sql/backend_bulk_chunked_test.go
@@ -1,0 +1,423 @@
+package sql
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/dskit/services"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	sqldb "github.com/grafana/grafana/pkg/storage/unified/sql/db"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
+	unitest "github.com/grafana/grafana/pkg/storage/unified/testing"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// chunkedCommit records a single observed bulk commit, captured via the
+// backend's bulkCommitObserver hook.
+type chunkedCommit struct {
+	phase string
+	bytes int64
+}
+
+// commitRecorder is a concurrency-safe collector of observed commits.
+type commitRecorder struct {
+	mu      sync.Mutex
+	commits []chunkedCommit
+}
+
+func (r *commitRecorder) observe(phase string, bytes int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.commits = append(r.commits, chunkedCommit{phase: phase, bytes: bytes})
+}
+
+func (r *commitRecorder) snapshot() []chunkedCommit {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]chunkedCommit, len(r.commits))
+	copy(out, r.commits)
+	return out
+}
+
+func (r *commitRecorder) byPhase(phase string) []chunkedCommit {
+	var out []chunkedCommit
+	for _, c := range r.snapshot() {
+		if c.phase == phase {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// chunkedTestValue builds a padded object value for name at the given version,
+// large enough that a tiny per-chunk budget forces multiple history chunks.
+func chunkedTestValue(name string, version, padBytes int) []byte {
+	pad := strings.Repeat("x", padBytes)
+	return []byte(fmt.Sprintf(
+		`{"apiVersion":"shorturl.grafana.app/v1beta1","kind":"ShortURL","metadata":{"name":%q,"namespace":"default"},"spec":{"path":"d/%s-v%d","pad":%q}}`,
+		name, name, version, pad))
+}
+
+// buildMultiVersionBulk emits `versions` ADDED/MODIFIED events per name (plus a
+// final DELETE for names in deleteLatest), each padded to exceed a tiny budget.
+// It returns the requests and a map of name -> expected latest non-deleted value
+// (nil when the latest version is a delete, so the name must be absent after backfill).
+func buildMultiVersionBulk(names []string, versions, padBytes int, deleteLatest map[string]bool) ([]*resourcepb.BulkRequest, map[string][]byte) {
+	var reqs []*resourcepb.BulkRequest
+	expected := map[string][]byte{}
+	for _, name := range names {
+		var lastValue []byte
+		for v := 0; v < versions; v++ {
+			action := resourcepb.BulkRequest_MODIFIED
+			if v == 0 {
+				action = resourcepb.BulkRequest_ADDED
+			}
+			val := chunkedTestValue(name, v, padBytes)
+			reqs = append(reqs, newSQLBulkRequest(name, action, val))
+			lastValue = val
+		}
+		if deleteLatest[name] {
+			// The delete carries the same value but is the latest version.
+			reqs = append(reqs, newSQLBulkRequest(name, resourcepb.BulkRequest_DELETED, chunkedTestValue(name, versions, padBytes)))
+			expected[name] = nil
+		} else {
+			expected[name] = lastValue
+		}
+	}
+	return reqs, expected
+}
+
+// chunkedTestWhere builds the collection WHERE clause with the dialect's
+// argument placeholders (postgres needs $N, not ?) and quotes the reserved
+// `group` column. Args order: namespace, group, resource.
+func chunkedTestWhere(t *testing.T, b *backend) string {
+	t.Helper()
+	groupCol, err := b.dialect.Ident("group")
+	require.NoError(t, err)
+	return fmt.Sprintf("namespace = %s AND %s = %s AND resource = %s",
+		b.dialect.ArgPlaceholder(1), groupCol, b.dialect.ArgPlaceholder(2), b.dialect.ArgPlaceholder(3))
+}
+
+// readResourceTable returns name -> value for every resource-table row in the
+// collection.
+func readResourceTable(t *testing.T, ctx context.Context, b *backend, sdb sqldb.DB, key *resourcepb.ResourceKey) map[string]string {
+	t.Helper()
+	q := "SELECT name, value FROM resource WHERE " + chunkedTestWhere(t, b)
+	rows, err := sdb.QueryContext(ctx, q, key.Namespace, key.Group, key.Resource)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	out := map[string]string{}
+	for rows.Next() {
+		var name string
+		var value []byte // bytea on postgres; can't scan into string
+		require.NoError(t, rows.Scan(&name, &value))
+		out[name] = string(value)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// countTableRows returns the number of rows for the collection in the named
+// table (resource or resource_history).
+func countTableRows(t *testing.T, ctx context.Context, b *backend, sdb sqldb.DB, table string, key *resourcepb.ResourceKey) int {
+	t.Helper()
+	q := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", table, chunkedTestWhere(t, b))
+	row := sdb.QueryRowContext(ctx, q, key.Namespace, key.Group, key.Resource)
+	var n int
+	require.NoError(t, row.Scan(&n))
+	return n
+}
+
+// countLastImportRows returns the number of resource_last_import_time rows for
+// the collection.
+func countLastImportRows(t *testing.T, ctx context.Context, b *backend, sdb sqldb.DB, key *resourcepb.ResourceKey) int {
+	t.Helper()
+	q := "SELECT COUNT(*) FROM resource_last_import_time WHERE " + chunkedTestWhere(t, b)
+	row := sdb.QueryRowContext(ctx, q, key.Namespace, key.Group, key.Resource)
+	var n int
+	require.NoError(t, row.Scan(&n))
+	return n
+}
+
+// chunkedTestKey returns the collection key the chunked tests operate on. It
+// MUST match the namespace/group/resource hardcoded in newSQLBulkRequest, or the
+// table reads (filtered by this key) would silently return 0 rows.
+func chunkedTestKey() *resourcepb.ResourceKey {
+	return &resourcepb.ResourceKey{
+		Namespace: "default",
+		Group:     "shorturl.grafana.app",
+		Resource:  "shorturls",
+	}
+}
+
+// chunkedBudget is the tiny per-chunk byte budget that forces multi-version,
+// padded inputs to commit across multiple chunks.
+const chunkedBudget = 64 * 1024
+
+// chunkBudgetTolerance is the slack allowed above the budget: the chunker commits
+// once bytes REACH the budget, so the last Add can overshoot by one batch (~10 KiB
+// per object here). 32 KiB covers that while still catching a runaway chunk.
+const chunkBudgetTolerance = 32 * 1024
+
+// TestIntegrationBulkChunkedCorrectnessAndBudget runs a multi-version import via
+// the chunked path with a tiny budget and asserts: a clean response, a resource
+// table holding the latest non-deleted version per name (matching a non-chunked
+// run), and >1 commit per phase with no commit exceeding budget. Non-sqlite only
+// (run with GRAFANA_TEST_DB=mysql).
+func TestIntegrationBulkChunkedCorrectnessAndBudget(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	if db.IsTestDbSQLite() {
+		t.Skip("chunked path is non-sqlite only; run with GRAFANA_TEST_DB=mysql")
+	}
+	t.Cleanup(db.CleanupTestDB)
+
+	ctx := testutil.NewTestContext(t, time.Now().Add(2*time.Minute))
+	key := chunkedTestKey()
+
+	// 12 names x 3 versions x ~10 KiB = ~360 KiB history, far over the 64 KiB
+	// budget, so the history phase chunks. Two names end with a DELETE; the 10
+	// survivors add ~100 KiB to the backfill, also over budget, so it splits into
+	// multiple ranges. This exercises chunking in BOTH phases.
+	names := []string{
+		"item-a", "item-b", "item-c", "item-d", "item-e", "item-f",
+		"item-g", "item-h", "item-i", "item-j", "item-k", "item-l",
+	}
+	deleteLatest := map[string]bool{"item-c": true, "item-j": true}
+	reqs, expected := buildMultiVersionBulk(names, 3, 10*1024, deleteLatest)
+
+	rec := &commitRecorder{}
+	b, sdb := newChunkedTestBackend(t, chunkedBudget, rec.observe)
+
+	rsp := b.ProcessBulk(ctx, resource.BulkSettings{Collection: []*resourcepb.ResourceKey{key}}, unitest.ToBulkIterator(reqs))
+	require.Nil(t, rsp.Error)
+	require.Equal(t, int64(len(reqs)), rsp.Processed)
+	require.Len(t, rsp.Summary, 1)
+	require.Equal(t, int64(0), rsp.Summary[0].PreviousHistory, "first run wipes an empty collection")
+	require.Equal(t, int64(0), rsp.Summary[0].PreviousCount)
+
+	// Read the chunked result BEFORE creating the non-chunked sibling below:
+	// newTestBackend re-inits and truncates the shared process-global test DB,
+	// so reading afterwards would see an empty table.
+	got := readResourceTable(t, ctx, b, sdb, key)
+	expectNames := map[string]string{}
+	for name, val := range expected {
+		if val != nil {
+			expectNames[name] = string(val)
+		}
+	}
+	require.Equal(t, expectNames, got, "chunked resource table must equal latest non-deleted per name")
+
+	// Chunking must have actually happened in BOTH phases: more than one history
+	// commit and more than one backfill range.
+	history := rec.byPhase("history")
+	backfill := rec.byPhase("backfill")
+	require.Greater(t, len(history), 1, "expected >1 history commit (history chunking must have happened): %#v", rec.snapshot())
+	require.Greater(t, len(backfill), 1, "expected >1 backfill range (backfill chunking must have happened): %#v", rec.snapshot())
+
+	// No observed commit may exceed the budget beyond the documented tolerance.
+	for _, c := range rec.snapshot() {
+		require.LessOrEqualf(t, c.bytes, int64(chunkedBudget)+chunkBudgetTolerance,
+			"commit in phase %q exceeded budget+tolerance: %d bytes", c.phase, c.bytes)
+	}
+
+	t.Logf("observed %d history commits and %d backfill ranges", len(history), len(backfill))
+	for _, c := range rec.snapshot() {
+		t.Logf("commit phase=%s bytes=%d", c.phase, c.bytes)
+	}
+
+	// Idempotency: a second identical import must wipe the first run's rows
+	// (reporting their counts) and reproduce the same end state. Runs before the
+	// non-chunked sibling below, which truncates the shared test DB.
+	t.Run("idempotent re-run", func(t *testing.T) {
+		firstHistoryCount := countTableRows(t, ctx, b, sdb, "resource_history", key)
+		firstResourceCount := countTableRows(t, ctx, b, sdb, "resource", key)
+		require.Equal(t, int64(len(reqs)), int64(firstHistoryCount), "all events land in history")
+
+		rsp2 := b.ProcessBulk(ctx, resource.BulkSettings{Collection: []*resourcepb.ResourceKey{key}}, unitest.ToBulkIterator(reqs))
+		require.Nil(t, rsp2.Error)
+		require.Len(t, rsp2.Summary, 1)
+		require.Equal(t, int64(firstHistoryCount), rsp2.Summary[0].PreviousHistory, "second wipe sees first run's history rows")
+		require.Equal(t, int64(firstResourceCount), rsp2.Summary[0].PreviousCount, "second wipe sees first run's resource rows")
+		require.Equal(t, got, readResourceTable(t, ctx, b, sdb, key), "end state identical after re-run")
+	})
+
+	// Same input through a non-chunked backend must produce identical resource
+	// rows. Truncates the shared test DB, so it runs after the idempotency subtest.
+	nonChunked, nsdb := newTestBackend(t, GarbageCollectionConfig{})
+	nb := nonChunked.(*backend)
+	require.False(t, nb.migrationChunkedWrites)
+	rspNC := nb.ProcessBulk(ctx, resource.BulkSettings{Collection: []*resourcepb.ResourceKey{key}}, unitest.ToBulkIterator(reqs))
+	require.Nil(t, rspNC.Error)
+	nonChunkedGot := readResourceTable(t, ctx, nb, nsdb, key)
+	require.Equal(t, nonChunkedGot, got, "chunked and non-chunked final resource rows must match")
+}
+
+// killAfterKBatchIterator is a batch iterator that signals RollbackRequested
+// after k batches, simulating a mid-stream kill (which the chunked path treats
+// as a hard error).
+type killAfterKBatchIterator struct {
+	items []*resourcepb.BulkRequest
+	k     int
+	idx   int // number of NextBatch calls so far
+}
+
+func (it *killAfterKBatchIterator) NextBatch() bool {
+	if it.idx >= len(it.items) {
+		return false
+	}
+	it.idx++
+	return true
+}
+
+func (it *killAfterKBatchIterator) Batch() []*resourcepb.BulkRequest {
+	return []*resourcepb.BulkRequest{it.items[it.idx-1]}
+}
+
+func (it *killAfterKBatchIterator) RollbackRequested() bool {
+	return it.idx > it.k
+}
+
+// Next and Request only satisfy the non-batch BulkRequestIterator interface; the
+// chunked path uses NextBatch/Batch/RollbackRequested, so these are unreachable.
+func (it *killAfterKBatchIterator) Next() bool                       { return it.NextBatch() }
+func (it *killAfterKBatchIterator) Request() *resourcepb.BulkRequest { return it.Batch()[0] }
+
+// TestIntegrationBulkChunkedKillMidMigrationThenRestart checks cleanup and
+// restart recovery: a run killed mid-history returns a hard error, leaves the
+// resource table / last-import untouched, and its cleanup re-wipes the partial
+// history committed by earlier chunks. A clean re-run then lands the correct end
+// state. Non-sqlite only.
+func TestIntegrationBulkChunkedKillMidMigrationThenRestart(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	if db.IsTestDbSQLite() {
+		t.Skip("chunked path is non-sqlite only; run with GRAFANA_TEST_DB=mysql")
+	}
+	t.Cleanup(db.CleanupTestDB)
+
+	ctx := testutil.NewTestContext(t, time.Now().Add(2*time.Minute))
+	key := chunkedTestKey()
+
+	names := []string{"item-a", "item-b", "item-c", "item-d", "item-e", "item-f"}
+	reqs, expected := buildMultiVersionBulk(names, 3, 4*1024, nil)
+
+	// 8 KiB budget: ~4 KiB batches commit a chunk every ~2 batches, so earlier
+	// chunks commit before the kill - the partial garbage the cleanup must wipe.
+	const killBudget = 8 * 1024
+	b, sdb := newChunkedTestBackend(t, killBudget, nil)
+
+	// Kill after 8 batches: several chunks have committed by then, so partial
+	// history rows exist when the hard error is raised.
+	killed := &killAfterKBatchIterator{items: reqs, k: 8}
+	rsp := b.ProcessBulk(ctx, resource.BulkSettings{Collection: []*resourcepb.ResourceKey{key}}, killed)
+	require.NotNil(t, rsp.Error, "killed migration must return a hard error")
+	require.Contains(t, rsp.Error.Message, "rollback requested")
+
+	// The resource table and last-import time must NOT have been touched: those
+	// phases run only after a clean history phase.
+	require.Equal(t, 0, countTableRows(t, ctx, b, sdb, "resource", key), "resource table must be untouched after a killed run")
+	require.Equal(t, 0, countLastImportRows(t, ctx, b, sdb, key), "last-import must not be set after a killed run")
+	// Earlier chunks committed partial history rows, but the failed run's cleanup
+	// re-wipes the collection with the chunked deleter, so no partial garbage is
+	// left behind.
+	require.Equal(t, 0, countTableRows(t, ctx, b, sdb, "resource_history", key), "cleanup must wipe partial history committed by earlier chunks")
+
+	// Now run a full clean import: the phase-1 wipe must remove the partial
+	// garbage and the end state must be correct.
+	rsp2 := b.ProcessBulk(ctx, resource.BulkSettings{Collection: []*resourcepb.ResourceKey{key}}, unitest.ToBulkIterator(reqs))
+	require.Nil(t, rsp2.Error)
+	require.Equal(t, int64(len(reqs)), rsp2.Processed)
+
+	got := readResourceTable(t, ctx, b, sdb, key)
+	expectNames := map[string]string{}
+	for name, val := range expected {
+		if val != nil {
+			expectNames[name] = string(val)
+		}
+	}
+	require.Equal(t, expectNames, got, "clean re-run must produce the correct end state")
+	// History now holds exactly the clean run's events (partial garbage wiped).
+	require.Equal(t, len(reqs), countTableRows(t, ctx, b, sdb, "resource_history", key), "partial garbage must be wiped, only clean run remains")
+	require.Equal(t, 1, countLastImportRows(t, ctx, b, sdb, key), "last-import set after clean run")
+}
+
+// TestIntegrationBulkChunkedSQLiteRegression verifies that with
+// MigrationChunkedWrites=true on sqlite, the chunked path is NOT taken: the
+// observer never fires and the normal path still produces the correct result.
+func TestIntegrationBulkChunkedSQLiteRegression(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	if !db.IsTestDbSQLite() {
+		t.Skip("regression guard only meaningful on sqlite; run with default test DB")
+	}
+	t.Cleanup(db.CleanupTestDB)
+
+	ctx := testutil.NewTestContext(t, time.Now().Add(1*time.Minute))
+	key := chunkedTestKey()
+
+	names := []string{"item-a", "item-b", "item-c"}
+	reqs, expected := buildMultiVersionBulk(names, 3, 1024, map[string]bool{"item-b": true})
+
+	rec := &commitRecorder{}
+	b, sdb := newChunkedTestBackend(t, chunkedBudget, rec.observe)
+	require.Equal(t, "sqlite", b.dialect.DialectName())
+	require.True(t, b.migrationChunkedWrites, "chunked writes are enabled on the backend")
+
+	rsp := b.ProcessBulk(ctx, resource.BulkSettings{Collection: []*resourcepb.ResourceKey{key}}, unitest.ToBulkIterator(reqs))
+	require.Nil(t, rsp.Error)
+	require.Equal(t, int64(len(reqs)), rsp.Processed)
+
+	// The chunked path must NOT have been taken on sqlite.
+	require.Empty(t, rec.snapshot(), "chunked observer must never fire on sqlite")
+
+	// The normal path still produces the correct result.
+	got := readResourceTable(t, ctx, b, sdb, key)
+	expectNames := map[string]string{}
+	for name, val := range expected {
+		if val != nil {
+			expectNames[name] = string(val)
+		}
+	}
+	require.Equal(t, expectNames, got)
+}
+
+// newChunkedTestBackend builds a backend (like newTestBackend) with chunked writes
+// enabled, the given per-chunk byte budget, and observer installed as bulkCommitObserver
+// so tests can record every committed chunk.
+func newChunkedTestBackend(t *testing.T, chunkBytes int64, observer func(phase string, bytes int64)) (*backend, sqldb.DB) {
+	dbstore := db.InitTestDB(t)
+	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, eDB)
+
+	be, err := NewBackend(BackendOptions{
+		DBProvider:             eDB,
+		IsHA:                   false,
+		DisablePruner:          db.IsTestDbSQLite(),
+		LastImportTimeMaxAge:   24 * time.Hour,
+		MigrationChunkedWrites: true,
+		MigrationChunkMaxBytes: chunkBytes,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, be)
+
+	ctx := testutil.NewTestContext(t, time.Now().Add(1*time.Minute))
+	svc, ok := be.(services.Service)
+	require.True(t, ok)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, svc))
+
+	sqlDB, err := eDB.Init(testutil.NewTestContext(t, time.Now().Add(1*time.Minute)))
+	require.NoError(t, err)
+
+	bk := be.(*backend)
+	bk.bulkCommitObserver = observer
+	return bk, sqlDB
+}

--- a/pkg/storage/unified/sql/backend_bulk_chunked_test.go
+++ b/pkg/storage/unified/sql/backend_bulk_chunked_test.go
@@ -173,11 +173,11 @@ const chunkBudgetTolerance = 32 * 1024
 // the chunked path with a tiny budget and asserts: a clean response, a resource
 // table holding the latest non-deleted version per name (matching a non-chunked
 // run), and >1 commit per phase with no commit exceeding budget. Non-sqlite only
-// (run with GRAFANA_TEST_DB=mysql).
+// (run with GRAFANA_TEST_DB=mysql or postgres).
 func TestIntegrationBulkChunkedCorrectnessAndBudget(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 	if db.IsTestDbSQLite() {
-		t.Skip("chunked path is non-sqlite only; run with GRAFANA_TEST_DB=mysql")
+		t.Skip("chunked path is non-sqlite only; run with GRAFANA_TEST_DB=mysql or postgres")
 	}
 	t.Cleanup(db.CleanupTestDB)
 
@@ -300,7 +300,7 @@ func (it *killAfterKBatchIterator) Request() *resourcepb.BulkRequest { return it
 func TestIntegrationBulkChunkedKillMidMigrationThenRestart(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 	if db.IsTestDbSQLite() {
-		t.Skip("chunked path is non-sqlite only; run with GRAFANA_TEST_DB=mysql")
+		t.Skip("chunked path is non-sqlite only; run with GRAFANA_TEST_DB=mysql or postgres")
 	}
 	t.Cleanup(db.CleanupTestDB)
 

--- a/pkg/storage/unified/sql/backend_bulk_test.go
+++ b/pkg/storage/unified/sql/backend_bulk_test.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
@@ -58,11 +59,11 @@ func TestBackendInsertHistoryBatch(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 2))
 
 	rsp := &resourcepb.BulkResponse{}
-	err := b.insertHistoryBatch(ctx, b.db, []*resourcepb.BulkRequest{
+	_, err := b.insertHistoryBatch(ctx, b.db, []*resourcepb.BulkRequest{
 		newSQLBulkRequest("item-1", resourcepb.BulkRequest_ADDED, []byte(`{"apiVersion":"shorturl.grafana.app/v1beta1","kind":"ShortURL","metadata":{"name":"item-1","namespace":"default"},"spec":{"path":"d/test"}}`)),
 		newSQLBulkRequest("item-2", resourcepb.BulkRequest_UNKNOWN, []byte(`{"apiVersion":"shorturl.grafana.app/v1beta1","kind":"ShortURL","metadata":{"name":"item-2","namespace":"default"},"spec":{"path":"d/test"}}`)),
 		newSQLBulkRequest("item-3", resourcepb.BulkRequest_ADDED, []byte(`{"apiVersion":"shorturl.grafana.app/v1beta1","kind":"ShortURL","metadata":{"name":"item-3","namespace":"default"},"spec":{"path":"d/test"}}`)),
-	}, newBulkRV(), rsp)
+	}, newBulkRV(), rsp, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), rsp.Processed)
 	require.Len(t, rsp.Rejected, 1)
@@ -71,10 +72,376 @@ func TestBackendInsertHistoryBatch(t *testing.T) {
 	require.NoError(t, b.SQLMock.ExpectationsWereMet())
 }
 
+func TestDeleteCollectionChunked(t *testing.T) {
+	key := &resourcepb.ResourceKey{
+		Namespace: "default",
+		Group:     "shorturl.grafana.app",
+		Resource:  "shorturls",
+	}
+
+	t.Run("splits deletes into byte-budgeted sub-batches per table", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+		b.dialect = sqltemplate.MySQL
+		// Budget fits two 100-byte rows (200) but not three (300), forcing the
+		// three candidates into two sub-batches.
+		b.migrationChunkMaxBytes = 250
+
+		candidateCols := []string{"guid", "size"}
+
+		// History table: 3 candidates -> 2 delete sub-batches, then empty. The
+		// WithArgs assertions lock the exact grouping (h1+h2, then h3) so a
+		// mis-grouping such as 1+2 vs 2+1 is caught. Args are ns, group,
+		// resource, then the guids of the sub-batch in order.
+		b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource_history").
+			WillReturnRows(sqlmock.NewRows(candidateCols).
+				AddRow("h1", int64(100)).
+				AddRow("h2", int64(100)).
+				AddRow("h3", int64(100)))
+		b.SQLMock.ExpectExec("DELETE FROM resource_history").
+			WithArgs(key.Namespace, key.Group, key.Resource, "h1", "h2").
+			WillReturnResult(sqlmock.NewResult(0, 2))
+		b.SQLMock.ExpectExec("DELETE FROM resource_history").
+			WithArgs(key.Namespace, key.Group, key.Resource, "h3").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource_history").
+			WillReturnRows(sqlmock.NewRows(candidateCols))
+
+		// Resource table: 3 candidates -> 2 delete sub-batches, then empty.
+		b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource").
+			WillReturnRows(sqlmock.NewRows(candidateCols).
+				AddRow("r1", int64(100)).
+				AddRow("r2", int64(100)).
+				AddRow("r3", int64(100)))
+		b.SQLMock.ExpectExec("DELETE FROM resource").
+			WillReturnResult(sqlmock.NewResult(0, 2))
+		b.SQLMock.ExpectExec("DELETE FROM resource").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource").
+			WillReturnRows(sqlmock.NewRows(candidateCols))
+
+		summary, err := b.deleteCollectionChunked(ctx, key)
+		require.NoError(t, err)
+		require.Equal(t, int64(3), summary.PreviousHistory)
+		require.Equal(t, int64(3), summary.PreviousCount)
+		require.Equal(t, key.Namespace, summary.Namespace)
+		require.Equal(t, key.Group, summary.Group)
+		require.Equal(t, key.Resource, summary.Resource)
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+	})
+
+	t.Run("empty collection issues no deletes", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+		b.dialect = sqltemplate.MySQL
+		b.migrationChunkMaxBytes = 17000
+
+		candidateCols := []string{"guid", "size"}
+		b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource_history").
+			WillReturnRows(sqlmock.NewRows(candidateCols))
+		b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource").
+			WillReturnRows(sqlmock.NewRows(candidateCols))
+
+		summary, err := b.deleteCollectionChunked(ctx, key)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), summary.PreviousHistory)
+		require.Equal(t, int64(0), summary.PreviousCount)
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+	})
+
+	t.Run("oversize single row gets its own delete", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+		b.dialect = sqltemplate.MySQL
+		// Tiny budget: the lone candidate's size alone exceeds it, so it must
+		// still be deleted on its own rather than being dropped or hanging.
+		b.migrationChunkMaxBytes = 10
+
+		candidateCols := []string{"guid", "size"}
+
+		b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource_history").
+			WillReturnRows(sqlmock.NewRows(candidateCols).
+				AddRow("big", int64(1<<20)))
+		b.SQLMock.ExpectExec("DELETE FROM resource_history").
+			WithArgs(key.Namespace, key.Group, key.Resource, "big").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource_history").
+			WillReturnRows(sqlmock.NewRows(candidateCols))
+
+		b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource").
+			WillReturnRows(sqlmock.NewRows(candidateCols))
+
+		summary, err := b.deleteCollectionChunked(ctx, key)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), summary.PreviousHistory)
+		require.Equal(t, int64(0), summary.PreviousCount)
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+	})
+}
+
+func TestTxChunker(t *testing.T) {
+	// Commit-boundary cases: drive Adds, then assert the number of committed
+	// transactions (Begin/Commit pairs) and how many fired onCommit. onCommit
+	// fires per commit that held work; the trailing empty Flush commit does not.
+	for _, tc := range []struct {
+		name         string
+		budget       int64
+		maxRows      int
+		adds         []int64 // bytes per Add, one row each
+		wantTxns     int     // Begin/Commit pairs
+		wantOnCommit int
+	}{
+		{"no crossing", 1000, txChunkerMaxRows, []int64{100, 200}, 1, 1},
+		{"one byte crossing", 100, txChunkerMaxRows, []int64{60, 60}, 2, 1},
+		{"n byte crossings", 100, txChunkerMaxRows, []int64{100, 100, 100, 100}, 5, 4},
+		{"forced row commit", 1 << 40, 2, []int64{1, 1, 1}, 2, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, ctx := setupBackendTest(t)
+			for i := 0; i < tc.wantTxns; i++ {
+				b.SQLMock.ExpectBegin()
+				b.SQLMock.ExpectCommit()
+			}
+			var onCommit int
+			c, err := newTxChunker(ctx, b.db, ReadCommitted, tc.budget, tc.maxRows, func(int64) { onCommit++ })
+			require.NoError(t, err)
+			for _, n := range tc.adds {
+				require.NoError(t, c.add(n, 1))
+			}
+			require.NoError(t, c.commit())
+			require.Equal(t, tc.wantOnCommit, onCommit)
+			require.NoError(t, b.SQLMock.ExpectationsWereMet())
+		})
+	}
+
+	t.Run("abort after partial: one Begin, one Rollback, no Commit", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+
+		b.SQLMock.ExpectBegin()
+		b.SQLMock.ExpectRollback()
+
+		c, err := newTxChunker(ctx, b.db, ReadCommitted, 1000, txChunkerMaxRows, nil)
+		require.NoError(t, err)
+		require.NoError(t, c.add(100, 1))
+		require.NoError(t, c.abort())
+
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+	})
+
+	t.Run("commit error surfaces and does not reopen", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+
+		b.SQLMock.ExpectBegin()
+		b.SQLMock.ExpectCommit().WillReturnError(errTest)
+
+		c, err := newTxChunker(ctx, b.db, ReadCommitted, 1000, txChunkerMaxRows, nil)
+		require.NoError(t, err)
+		// Flush triggers the failing commit; the error must surface and no new
+		// tx is begun.
+		require.ErrorIs(t, c.commit(), errTest)
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+	})
+
+	t.Run("zero budget falls back to default", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+
+		b.SQLMock.ExpectBegin()
+		b.SQLMock.ExpectCommit()
+
+		c, err := newTxChunker(ctx, b.db, ReadCommitted, 0, txChunkerMaxRows, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(defaultChunkBudget), c.budget)
+		require.NoError(t, c.commit())
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+	})
+}
+
+// fakeBatchIterator is a minimal BulkRequestBatchIterator for driving
+// processBulkChunked's phase-2 loop in unit tests.
+type fakeBatchIterator struct {
+	batches  [][]*resourcepb.BulkRequest
+	rollback []bool
+	idx      int
+}
+
+func (f *fakeBatchIterator) NextBatch() bool {
+	f.idx++
+	return f.idx <= len(f.batches)
+}
+
+func (f *fakeBatchIterator) Batch() []*resourcepb.BulkRequest {
+	return f.batches[f.idx-1]
+}
+
+func (f *fakeBatchIterator) RollbackRequested() bool {
+	if f.idx-1 < len(f.rollback) {
+		return f.rollback[f.idx-1]
+	}
+	return false
+}
+
+// Next and Request satisfy BulkRequestIterator so the value can be passed to
+// processBulkChunked, which type-asserts it back to BulkRequestBatchIterator.
+func (f *fakeBatchIterator) Next() bool                       { return f.NextBatch() }
+func (f *fakeBatchIterator) Request() *resourcepb.BulkRequest { return nil }
+
+func TestProcessBulkChunkedRollbackRequested(t *testing.T) {
+	b, ctx := setupBackendTest(t)
+	b.dialect = sqltemplate.MySQL
+	b.migrationChunkedWrites = true
+	b.migrationChunkMaxBytes = 1 << 20
+
+	key := &resourcepb.ResourceKey{
+		Namespace: "default",
+		Group:     "shorturl.grafana.app",
+		Resource:  "shorturls",
+	}
+
+	// Phase 1 wipe: both tables report no candidates, so no deletes are issued.
+	candidateCols := []string{"guid", "size"}
+	b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource_history").
+		WillReturnRows(sqlmock.NewRows(candidateCols))
+	b.SQLMock.ExpectQuery("SELECT .* OCTET_LENGTH .* FROM resource").
+		WillReturnRows(sqlmock.NewRows(candidateCols))
+
+	// Phase 2: the chunker begins a tx, the first batch signals rollback, and
+	// the open chunk is rolled back before the hard error is returned.
+	b.SQLMock.ExpectBegin()
+	b.SQLMock.ExpectRollback()
+
+	iter := &fakeBatchIterator{
+		batches:  [][]*resourcepb.BulkRequest{{newSQLBulkRequest("item-1", resourcepb.BulkRequest_ADDED, nil)}},
+		rollback: []bool{true},
+	}
+
+	rsp := b.processBulkChunked(ctx, resource.BulkSettings{Collection: []*resourcepb.ResourceKey{key}}, iter)
+	require.NotNil(t, rsp.Error)
+	require.Contains(t, rsp.Error.Message, "rollback requested")
+	require.NoError(t, b.SQLMock.ExpectationsWereMet())
+}
+
 func TestBulkHistoryInsertRowLimit(t *testing.T) {
 	require.Equal(t, bulkHistoryInsertSQLiteMaxRows, bulkHistoryInsertRowLimit("sqlite"))
 	require.Equal(t, bulkHistoryInsertDefaultMaxRows, bulkHistoryInsertRowLimit("mysql"))
 	require.Equal(t, bulkHistoryInsertDefaultMaxRows, bulkHistoryInsertRowLimit("postgres"))
+}
+
+func TestPlanNameRanges(t *testing.T) {
+	// uniform size helper.
+	const sz = int64(10)
+	sizeOf := func(string) int64 { return sz }
+
+	// Half-open coverage: ranges are (startName, endName], "" meaning unbounded.
+	for _, tc := range []struct {
+		name   string
+		names  []string
+		budget int64
+		want   []nameRange
+	}{
+		{"empty yields one unbounded range", nil, 100, []nameRange{{"", "", 0}}},
+		{"single name fits", []string{"a"}, 100, []nameRange{{"", "", 10}}},
+		{"multiple names fit one range", []string{"a", "b", "c"}, 100, []nameRange{{"", "", 30}}},
+		{"sum equals budget stays in one range", []string{"a", "b", "c"}, 30, []nameRange{{"", "", 30}}},
+		{"crossing budget splits half-open", []string{"a", "b", "c", "d"}, 20, []nameRange{{"", "b", 20}, {"b", "", 20}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, planNameRanges(tc.names, sizeOf, tc.budget))
+		})
+	}
+
+	t.Run("coverage: every name maps to exactly one range, no gaps", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1))
+		// Names in sorted order (DB collation order is mimicked by sorted
+		// fixed-width strings, which matches Go byte order here).
+		const n = 500
+		names := make([]string, n)
+		sizes := make(map[string]int64, n)
+		for i := 0; i < n; i++ {
+			names[i] = fmtName(i)
+			// inject occasional objects larger than budget to exercise the tail.
+			s := int64(rng.Intn(50) + 1)
+			if rng.Intn(50) == 0 {
+				s = 10000
+			}
+			sizes[names[i]] = s
+		}
+		sizeFn := func(name string) int64 { return sizes[name] }
+
+		ranges := planNameRanges(names, sizeFn, 200)
+		require.NotEmpty(t, ranges)
+		require.Equal(t, "", ranges[len(ranges)-1].endName, "final range must be unbounded above")
+
+		for _, name := range names {
+			matched := 0
+			for _, r := range ranges {
+				inLower := r.startName == "" || name > r.startName
+				inUpper := r.endName == "" || name <= r.endName
+				if inLower && inUpper {
+					matched++
+				}
+			}
+			require.Equalf(t, 1, matched, "name %q must map to exactly one range, matched %d", name, matched)
+		}
+	})
+}
+
+// fmtName returns a fixed-width zero-padded name so byte order matches numeric
+// order, used by the coverage test.
+func fmtName(i int) string {
+	const digits = "0123456789"
+	b := []byte{'0', '0', '0', '0'}
+	for p := 3; p >= 0 && i > 0; p-- {
+		b[p] = digits[i%10]
+		i /= 10
+	}
+	return "n-" + string(b)
+}
+
+func TestBackendInsertHistoryBatchSizeTracking(t *testing.T) {
+	t.Run("records max-RV size per name", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+		b.SQLMock.ExpectExec("insert into resource_history values").
+			WillReturnResult(sqlmock.NewResult(0, 2))
+
+		colSizes := map[string]backfillSizes{}
+		rsp := &resourcepb.BulkResponse{}
+		// Two versions of the same name (valid unstructured JSON so they aren't
+		// rejected); the higher-RV row's size must win. large is padded larger.
+		small := chunkedTestValue("item-1", 0, 0)
+		large := chunkedTestValue("item-1", 1, 100)
+		_, err := b.insertHistoryBatch(ctx, b.db, []*resourcepb.BulkRequest{
+			newSQLBulkRequest("item-1", resourcepb.BulkRequest_ADDED, small),
+			newSQLBulkRequest("item-1", resourcepb.BulkRequest_MODIFIED, large),
+		}, newBulkRV(), rsp, colSizes)
+		require.NoError(t, err)
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+
+		nsgr := resource.NSGR(&resourcepb.ResourceKey{Namespace: "default", Group: "shorturl.grafana.app", Resource: "shorturls"})
+		sizes := colSizes[nsgr]
+		require.NotNil(t, sizes)
+		row := sizes["item-1"]
+		require.NotNil(t, row)
+		require.False(t, row.deleted)
+		require.Equal(t, len(large), row.size, "max-RV row size must win")
+	})
+
+	t.Run("deleted latest version marks name deleted", func(t *testing.T) {
+		b, ctx := setupBackendTest(t)
+		b.SQLMock.ExpectExec("insert into resource_history values").
+			WillReturnResult(sqlmock.NewResult(0, 2))
+
+		colSizes := map[string]backfillSizes{}
+		rsp := &resourcepb.BulkResponse{}
+		payload := chunkedTestValue("item-2", 0, 0)
+		_, err := b.insertHistoryBatch(ctx, b.db, []*resourcepb.BulkRequest{
+			newSQLBulkRequest("item-2", resourcepb.BulkRequest_ADDED, payload),
+			newSQLBulkRequest("item-2", resourcepb.BulkRequest_DELETED, payload),
+		}, newBulkRV(), rsp, colSizes)
+		require.NoError(t, err)
+		require.NoError(t, b.SQLMock.ExpectationsWereMet())
+
+		nsgr := resource.NSGR(&resourcepb.ResourceKey{Namespace: "default", Group: "shorturl.grafana.app", Resource: "shorturls"})
+		row := colSizes[nsgr]["item-2"]
+		require.NotNil(t, row)
+		require.True(t, row.deleted, "name whose latest version is a delete must be marked deleted")
+	})
 }
 
 func newSQLBulkRequest(name string, action resourcepb.BulkRequest_Action, value []byte) *resourcepb.BulkRequest {

--- a/pkg/storage/unified/sql/data/chunk_candidates.sql
+++ b/pkg/storage/unified/sql/data/chunk_candidates.sql
@@ -1,0 +1,9 @@
+{{/* Select a bounded batch of rows for a collection from .Table, with each row's value byte size, so the caller can group deletes within a byte budget. */}}
+SELECT {{ .Ident "guid" | .Into .Response.GUID }},
+       OCTET_LENGTH({{ .Ident "value" }}) AS {{ .Ident "size" | .Into .Response.Size }}
+FROM {{ .Ident .Table }}
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+  AND {{ .Ident "group" }} = {{ .Arg .Group }}
+  AND {{ .Ident "resource" }} = {{ .Arg .Resource }}
+ORDER BY {{ .Ident "guid" }}
+LIMIT {{ .Arg .BatchSize }};

--- a/pkg/storage/unified/sql/data/delete_by_guids.sql
+++ b/pkg/storage/unified/sql/data/delete_by_guids.sql
@@ -1,0 +1,11 @@
+{{/* Delete a sub-batch of rows by guid within a collection from .Table. */}}
+DELETE FROM {{ .Ident .Table }}
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+  AND {{ .Ident "group" }} = {{ .Arg .Group }}
+  AND {{ .Ident "resource" }} = {{ .Arg .Resource }}
+  AND {{ .Ident "guid" }} IN (
+    {{- range $i, $guid := .GUIDs -}}
+    {{- if $i }}, {{ end -}}
+    {{ $.Arg $guid }}
+    {{- end -}}
+  );

--- a/pkg/storage/unified/sql/data/resource_history_distinct_names.sql
+++ b/pkg/storage/unified/sql/data/resource_history_distinct_names.sql
@@ -1,0 +1,7 @@
+{{/* Select the distinct names for a collection in DB collation order, so the caller can split the resource backfill into byte-bounded name ranges. Index-only over IDX_resource_history_namespace_group_name. */}}
+SELECT DISTINCT {{ .Ident "name" | .Into .Response.Name }}
+FROM {{ .Ident "resource_history" }}
+WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+  AND {{ .Ident "group" }} = {{ .Arg .Group }}
+  AND {{ .Ident "resource" }} = {{ .Arg .Resource }}
+ORDER BY {{ .Ident "name" }};

--- a/pkg/storage/unified/sql/data/resource_insert_from_history.sql
+++ b/pkg/storage/unified/sql/data/resource_insert_from_history.sql
@@ -28,6 +28,12 @@ FROM {{ .Ident "resource_history" }} AS kv
       {{ if .Key.Name }}
       AND {{ .Ident "name" }}      = {{ .Arg .Key.Name }}
       {{ end }}
+      {{ if .StartName }}
+      AND {{ .Ident "name" }} > {{ .Arg .StartName }}
+      {{ end }}
+      {{ if .EndName }}
+      AND {{ .Ident "name" }} <= {{ .Arg .EndName }}
+      {{ end }}
     GROUP BY mkv.{{ .Ident "namespace" }}, mkv.{{ .Ident "group" }}, mkv.{{ .Ident "resource" }}, mkv.{{ .Ident "name" }} 
   ) AS maxkv
        ON maxkv.{{ .Ident "resource_version" }} = kv.{{ .Ident "resource_version" }}
@@ -47,6 +53,12 @@ FROM {{ .Ident "resource_history" }} AS kv
       {{ end }}
       {{ if .Key.Name }}
       AND kv.{{ .Ident "name" }}      = {{ .Arg .Key.Name }}
+      {{ end }}
+      {{ if .StartName }}
+      AND kv.{{ .Ident "name" }} > {{ .Arg .StartName }}
+      {{ end }}
+      {{ if .EndName }}
+      AND kv.{{ .Ident "name" }} <= {{ .Arg .EndName }}
       {{ end }}
     ORDER BY kv.{{ .Ident "resource_version" }} ASC
 ;

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -48,8 +48,11 @@ var (
 	sqlResourceHistoryPrune                = mustTemplate("resource_history_prune.sql")
 	sqlResourceHistoryGarbageGetCandidates = mustTemplate("resource_history_gc_get_candidates.sql")
 	sqlResourceHistoryGCDeleteByNames      = mustTemplate("resource_history_gc_delete_by_names.sql")
+	sqlChunkCandidates                     = mustTemplate("chunk_candidates.sql")
+	sqlDeleteByGUIDs                       = mustTemplate("delete_by_guids.sql")
 	sqlResourceTrash                       = mustTemplate("resource_trash.sql")
 	sqlResourceInsertFromHistory           = mustTemplate("resource_insert_from_history.sql")
+	sqlResourceHistoryDistinctNames        = mustTemplate("resource_history_distinct_names.sql")
 
 	// sqlResourceLabelsInsert = mustTemplate("resource_labels_insert.sql")
 	sqlResourceVersionList = mustTemplate("resource_version_list.sql")
@@ -115,6 +118,10 @@ func (r sqlBulkResourceHistoryInsertRequest) Validate() error {
 type sqlResourceInsertFromHistoryRequest struct {
 	sqltemplate.SQLTemplate
 	Key *resourcepb.ResourceKey
+	// StartName and EndName bound the name range as (StartName, EndName]:
+	// exclusive start, inclusive end. An empty value means unbounded on that side.
+	StartName string
+	EndName   string
 }
 
 func (r sqlResourceInsertFromHistoryRequest) Validate() error {
@@ -122,6 +129,39 @@ func (r sqlResourceInsertFromHistoryRequest) Validate() error {
 		return fmt.Errorf("missing key")
 	}
 	return nil
+}
+
+// distinctName is one row returned by the distinct-names query: a single name
+// from resource_history for a collection.
+type distinctName struct {
+	Name string
+}
+
+// sqlResourceHistoryDistinctNamesRequest selects a collection's distinct names
+// in DB collation order, so the backfill can be split into byte-bounded ranges.
+type sqlResourceHistoryDistinctNamesRequest struct {
+	sqltemplate.SQLTemplate
+	Namespace string
+	Group     string
+	Resource  string
+	Response  *distinctName
+}
+
+func (r *sqlResourceHistoryDistinctNamesRequest) Validate() error {
+	if r.Namespace == "" {
+		return fmt.Errorf("missing namespace")
+	}
+	if r.Group == "" {
+		return fmt.Errorf("missing group")
+	}
+	if r.Resource == "" {
+		return fmt.Errorf("missing resource")
+	}
+	return nil
+}
+
+func (r *sqlResourceHistoryDistinctNamesRequest) Results() (distinctName, error) {
+	return *r.Response, nil
 }
 
 type sqlStatsRequest struct {
@@ -409,6 +449,93 @@ func (r *sqlGarbageCollectDeleteByNamesRequest) Validate() error {
 	}
 	if len(r.Candidates) == 0 {
 		return fmt.Errorf("missing candidates")
+	}
+	return nil
+}
+
+// chunkCandidate is one row returned by the chunked-wipe candidate queries: a
+// row's guid plus the byte size of its value column.
+type chunkCandidate struct {
+	GUID string
+	Size int64
+}
+
+// sqlChunkCandidatesRequest selects a bounded batch of rows for a collection
+// with each row's value byte size. Table selects which table to read
+// ("resource" or "resource_history").
+type sqlChunkCandidatesRequest struct {
+	sqltemplate.SQLTemplate
+	Table     string
+	Namespace string
+	Group     string
+	Resource  string
+	BatchSize int
+	Response  *chunkCandidate
+}
+
+func (r *sqlChunkCandidatesRequest) Validate() error {
+	if err := validateResourceTable(r.Table); err != nil {
+		return err
+	}
+	if r.Namespace == "" {
+		return fmt.Errorf("missing namespace")
+	}
+	if r.Group == "" {
+		return fmt.Errorf("missing group")
+	}
+	if r.Resource == "" {
+		return fmt.Errorf("missing resource")
+	}
+	if r.BatchSize <= 0 {
+		return fmt.Errorf("invalid batch size")
+	}
+	return nil
+}
+
+func (r *sqlChunkCandidatesRequest) Results() (chunkCandidate, error) {
+	x := *r.Response
+	return x, nil
+}
+
+// sqlDeleteByGUIDsRequest deletes a sub-batch of rows by guid within a
+// collection. Table selects which table to delete from ("resource" or
+// "resource_history").
+type sqlDeleteByGUIDsRequest struct {
+	sqltemplate.SQLTemplate
+	Table     string
+	Namespace string
+	Group     string
+	Resource  string
+	GUIDs     []string
+}
+
+func (r *sqlDeleteByGUIDsRequest) Validate() error {
+	if err := validateResourceTable(r.Table); err != nil {
+		return err
+	}
+	if r.Namespace == "" {
+		return fmt.Errorf("missing namespace")
+	}
+	if r.Group == "" {
+		return fmt.Errorf("missing group")
+	}
+	if r.Resource == "" {
+		return fmt.Errorf("missing resource")
+	}
+	if len(r.GUIDs) == 0 {
+		return fmt.Errorf("missing guids")
+	}
+	return nil
+}
+
+const (
+	tableResource        = "resource"
+	tableResourceHistory = "resource_history"
+)
+
+func validateResourceTable(table string) error {
+	if table != tableResource && table != tableResourceHistory {
+		return fmt.Errorf("invalid table %q: must be %q or %q", table, tableResource, tableResourceHistory)
 	}
 	return nil
 }

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -187,6 +187,56 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					},
 				},
 			},
+			sqlChunkCandidates: {
+				{
+					Name: "resource",
+					Data: &sqlChunkCandidatesRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Table:       tableResource,
+						Namespace:   "ns",
+						Group:       "group",
+						Resource:    "res",
+						BatchSize:   2000,
+						Response:    new(chunkCandidate),
+					},
+				},
+				{
+					Name: "history",
+					Data: &sqlChunkCandidatesRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Table:       tableResourceHistory,
+						Namespace:   "ns",
+						Group:       "group",
+						Resource:    "res",
+						BatchSize:   2000,
+						Response:    new(chunkCandidate),
+					},
+				},
+			},
+			sqlDeleteByGUIDs: {
+				{
+					Name: "resource",
+					Data: &sqlDeleteByGUIDsRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Table:       tableResource,
+						Namespace:   "ns",
+						Group:       "group",
+						Resource:    "res",
+						GUIDs:       []string{"guid1", "guid2", "guid3"},
+					},
+				},
+				{
+					Name: "history",
+					Data: &sqlDeleteByGUIDsRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Table:       tableResourceHistory,
+						Namespace:   "ns",
+						Group:       "group",
+						Resource:    "res",
+						GUIDs:       []string{"guid1", "guid2", "guid3"},
+					},
+				},
+			},
 			sqlResourceHistoryPoll: {
 				{
 					Name: "single path",
@@ -589,6 +639,31 @@ func TestUnifiedStorageQueries(t *testing.T) {
 							Group:     "dashboard.grafana.app",
 							Resource:  "dashboards",
 						},
+					},
+				},
+				{
+					Name: "update-ranged",
+					Data: &sqlResourceInsertFromHistoryRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Key: &resourcepb.ResourceKey{
+							Namespace: "default",
+							Group:     "dashboard.grafana.app",
+							Resource:  "dashboards",
+						},
+						StartName: "aaa",
+						EndName:   "mmm",
+					},
+				},
+			},
+			sqlResourceHistoryDistinctNames: {
+				{
+					Name: "single path",
+					Data: &sqlResourceHistoryDistinctNamesRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Namespace:   "ns",
+						Group:       "group",
+						Resource:    "res",
+						Response:    new(distinctName),
 					},
 				},
 			},

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -71,7 +71,7 @@ func newTestBackend(t *testing.T, isHA bool, simulatedNetworkLatency time.Durati
 	}
 	eDB, err := sql.ProvideResourceDB(cfg, dbstore)
 	require.NoError(t, err)
-	backend, err := sql.NewStorageBackend(cfg, eDB, registerer, storageMetrics, false, nil)
+	backend, err := sql.NewStorageBackend(cfg, eDB, registerer, storageMetrics, false, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, backend)
 	backendService, ok := backend.(services.Service)
@@ -227,7 +227,7 @@ func TestClientServer(t *testing.T) {
 	storageMetrics := resource.ProvideStorageMetrics(registerer)
 	eDB, err := sql.ProvideResourceDB(cfg, dbstore)
 	require.NoError(t, err)
-	backend, err := sql.NewStorageBackend(cfg, eDB, registerer, storageMetrics, false, nil)
+	backend, err := sql.NewStorageBackend(cfg, eDB, registerer, storageMetrics, false, nil, nil)
 	require.NoError(t, err)
 
 	grpcService, err := grpcserver.ProvideDSKitService(cfg, otel.Tracer("test-grpc-server"), prometheus.NewPedanticRegistry(), "test-grpc-server")
@@ -339,7 +339,7 @@ func TestIntegrationSearchClientServer(t *testing.T) {
 	storageMetrics := resource.ProvideStorageMetrics(registerer)
 	eDB, err := sql.ProvideResourceDB(cfg, dbstore)
 	require.NoError(t, err)
-	backend, err := sql.NewStorageBackend(cfg, eDB, registerer, storageMetrics, false, nil)
+	backend, err := sql.NewStorageBackend(cfg, eDB, registerer, storageMetrics, false, nil, nil)
 	require.NoError(t, err)
 	backendService := backend.(services.Service)
 	require.NotNil(t, backendService)

--- a/pkg/storage/unified/sql/testdata/mysql--chunk_candidates-history.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--chunk_candidates-history.sql
@@ -1,0 +1,8 @@
+SELECT `guid`,
+       OCTET_LENGTH(`value`) AS `size`
+FROM `resource_history`
+WHERE `namespace` = 'ns'
+  AND `group` = 'group'
+  AND `resource` = 'res'
+ORDER BY `guid`
+LIMIT 2000;

--- a/pkg/storage/unified/sql/testdata/mysql--chunk_candidates-resource.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--chunk_candidates-resource.sql
@@ -1,0 +1,8 @@
+SELECT `guid`,
+       OCTET_LENGTH(`value`) AS `size`
+FROM `resource`
+WHERE `namespace` = 'ns'
+  AND `group` = 'group'
+  AND `resource` = 'res'
+ORDER BY `guid`
+LIMIT 2000;

--- a/pkg/storage/unified/sql/testdata/mysql--delete_by_guids-history.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--delete_by_guids-history.sql
@@ -1,0 +1,5 @@
+DELETE FROM `resource_history`
+WHERE `namespace` = 'ns'
+  AND `group` = 'group'
+  AND `resource` = 'res'
+  AND `guid` IN ('guid1', 'guid2', 'guid3');

--- a/pkg/storage/unified/sql/testdata/mysql--delete_by_guids-resource.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--delete_by_guids-resource.sql
@@ -1,0 +1,5 @@
+DELETE FROM `resource`
+WHERE `namespace` = 'ns'
+  AND `group` = 'group'
+  AND `resource` = 'res'
+  AND `guid` IN ('guid1', 'guid2', 'guid3');

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_distinct_names-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_distinct_names-single path.sql
@@ -1,0 +1,6 @@
+SELECT DISTINCT `name`
+FROM `resource_history`
+WHERE `namespace` = 'ns'
+  AND `group` = 'group'
+  AND `resource` = 'res'
+ORDER BY `name`;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_insert_from_history-update-ranged.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_insert_from_history-update-ranged.sql
@@ -1,0 +1,38 @@
+INSERT INTO `resource`
+SELECT 
+  kv.`guid`,
+  kv.`resource_version`,
+  kv.`group`, 
+  kv.`resource`, 
+  kv.`namespace`,   
+  kv.`name`,
+  kv.`value`,
+  kv.`action`,
+  kv.`label_set`,
+  kv.`previous_resource_version`,
+  kv.`folder`
+FROM `resource_history` AS kv
+  INNER JOIN  (
+    SELECT `namespace`, `group`, `resource`, `name`,  max(`resource_version`) AS `resource_version`
+    FROM `resource_history` AS mkv
+    WHERE 1 = 1
+      AND `namespace` = 'default'
+      AND `group`     = 'dashboard.grafana.app'
+      AND `resource`  = 'dashboards'
+      AND `name` > 'aaa'
+      AND `name` <= 'mmm'
+    GROUP BY mkv.`namespace`, mkv.`group`, mkv.`resource`, mkv.`name` 
+  ) AS maxkv
+       ON maxkv.`resource_version` = kv.`resource_version`
+      AND maxkv.`namespace` = kv.`namespace`
+      AND maxkv.`group`     = kv.`group`
+      AND maxkv.`resource`  = kv.`resource`
+      AND maxkv.`name`      = kv.`name`
+    WHERE kv.`action`   != 3 
+      AND kv.`namespace` = 'default'
+      AND kv.`group`     = 'dashboard.grafana.app'
+      AND kv.`resource`  = 'dashboards'
+      AND kv.`name` > 'aaa'
+      AND kv.`name` <= 'mmm'
+    ORDER BY kv.`resource_version` ASC
+;

--- a/pkg/storage/unified/sql/testdata/postgres--chunk_candidates-history.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--chunk_candidates-history.sql
@@ -1,0 +1,8 @@
+SELECT "guid",
+       OCTET_LENGTH("value") AS "size"
+FROM "resource_history"
+WHERE "namespace" = 'ns'
+  AND "group" = 'group'
+  AND "resource" = 'res'
+ORDER BY "guid"
+LIMIT 2000;

--- a/pkg/storage/unified/sql/testdata/postgres--chunk_candidates-resource.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--chunk_candidates-resource.sql
@@ -1,0 +1,8 @@
+SELECT "guid",
+       OCTET_LENGTH("value") AS "size"
+FROM "resource"
+WHERE "namespace" = 'ns'
+  AND "group" = 'group'
+  AND "resource" = 'res'
+ORDER BY "guid"
+LIMIT 2000;

--- a/pkg/storage/unified/sql/testdata/postgres--delete_by_guids-history.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--delete_by_guids-history.sql
@@ -1,0 +1,5 @@
+DELETE FROM "resource_history"
+WHERE "namespace" = 'ns'
+  AND "group" = 'group'
+  AND "resource" = 'res'
+  AND "guid" IN ('guid1', 'guid2', 'guid3');

--- a/pkg/storage/unified/sql/testdata/postgres--delete_by_guids-resource.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--delete_by_guids-resource.sql
@@ -1,0 +1,5 @@
+DELETE FROM "resource"
+WHERE "namespace" = 'ns'
+  AND "group" = 'group'
+  AND "resource" = 'res'
+  AND "guid" IN ('guid1', 'guid2', 'guid3');

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_distinct_names-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_distinct_names-single path.sql
@@ -1,0 +1,6 @@
+SELECT DISTINCT "name"
+FROM "resource_history"
+WHERE "namespace" = 'ns'
+  AND "group" = 'group'
+  AND "resource" = 'res'
+ORDER BY "name";

--- a/pkg/storage/unified/sql/testdata/postgres--resource_insert_from_history-update-ranged.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_insert_from_history-update-ranged.sql
@@ -1,0 +1,38 @@
+INSERT INTO "resource"
+SELECT 
+  kv."guid",
+  kv."resource_version",
+  kv."group", 
+  kv."resource", 
+  kv."namespace",   
+  kv."name",
+  kv."value",
+  kv."action",
+  kv."label_set",
+  kv."previous_resource_version",
+  kv."folder"
+FROM "resource_history" AS kv
+  INNER JOIN  (
+    SELECT "namespace", "group", "resource", "name",  max("resource_version") AS "resource_version"
+    FROM "resource_history" AS mkv
+    WHERE 1 = 1
+      AND "namespace" = 'default'
+      AND "group"     = 'dashboard.grafana.app'
+      AND "resource"  = 'dashboards'
+      AND "name" > 'aaa'
+      AND "name" <= 'mmm'
+    GROUP BY mkv."namespace", mkv."group", mkv."resource", mkv."name" 
+  ) AS maxkv
+       ON maxkv."resource_version" = kv."resource_version"
+      AND maxkv."namespace" = kv."namespace"
+      AND maxkv."group"     = kv."group"
+      AND maxkv."resource"  = kv."resource"
+      AND maxkv."name"      = kv."name"
+    WHERE kv."action"   != 3 
+      AND kv."namespace" = 'default'
+      AND kv."group"     = 'dashboard.grafana.app'
+      AND kv."resource"  = 'dashboards'
+      AND kv."name" > 'aaa'
+      AND kv."name" <= 'mmm'
+    ORDER BY kv."resource_version" ASC
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--chunk_candidates-history.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--chunk_candidates-history.sql
@@ -1,0 +1,8 @@
+SELECT "guid",
+       OCTET_LENGTH("value") AS "size"
+FROM "resource_history"
+WHERE "namespace" = 'ns'
+  AND "group" = 'group'
+  AND "resource" = 'res'
+ORDER BY "guid"
+LIMIT 2000;

--- a/pkg/storage/unified/sql/testdata/sqlite--chunk_candidates-resource.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--chunk_candidates-resource.sql
@@ -1,0 +1,8 @@
+SELECT "guid",
+       OCTET_LENGTH("value") AS "size"
+FROM "resource"
+WHERE "namespace" = 'ns'
+  AND "group" = 'group'
+  AND "resource" = 'res'
+ORDER BY "guid"
+LIMIT 2000;

--- a/pkg/storage/unified/sql/testdata/sqlite--delete_by_guids-history.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--delete_by_guids-history.sql
@@ -1,0 +1,5 @@
+DELETE FROM "resource_history"
+WHERE "namespace" = 'ns'
+  AND "group" = 'group'
+  AND "resource" = 'res'
+  AND "guid" IN ('guid1', 'guid2', 'guid3');

--- a/pkg/storage/unified/sql/testdata/sqlite--delete_by_guids-resource.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--delete_by_guids-resource.sql
@@ -1,0 +1,5 @@
+DELETE FROM "resource"
+WHERE "namespace" = 'ns'
+  AND "group" = 'group'
+  AND "resource" = 'res'
+  AND "guid" IN ('guid1', 'guid2', 'guid3');

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_distinct_names-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_distinct_names-single path.sql
@@ -1,0 +1,6 @@
+SELECT DISTINCT "name"
+FROM "resource_history"
+WHERE "namespace" = 'ns'
+  AND "group" = 'group'
+  AND "resource" = 'res'
+ORDER BY "name";

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_insert_from_history-update-ranged.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_insert_from_history-update-ranged.sql
@@ -1,0 +1,38 @@
+INSERT INTO "resource"
+SELECT 
+  kv."guid",
+  kv."resource_version",
+  kv."group", 
+  kv."resource", 
+  kv."namespace",   
+  kv."name",
+  kv."value",
+  kv."action",
+  kv."label_set",
+  kv."previous_resource_version",
+  kv."folder"
+FROM "resource_history" AS kv
+  INNER JOIN  (
+    SELECT "namespace", "group", "resource", "name",  max("resource_version") AS "resource_version"
+    FROM "resource_history" AS mkv
+    WHERE 1 = 1
+      AND "namespace" = 'default'
+      AND "group"     = 'dashboard.grafana.app'
+      AND "resource"  = 'dashboards'
+      AND "name" > 'aaa'
+      AND "name" <= 'mmm'
+    GROUP BY mkv."namespace", mkv."group", mkv."resource", mkv."name" 
+  ) AS maxkv
+       ON maxkv."resource_version" = kv."resource_version"
+      AND maxkv."namespace" = kv."namespace"
+      AND maxkv."group"     = kv."group"
+      AND maxkv."resource"  = kv."resource"
+      AND maxkv."name"      = kv."name"
+    WHERE kv."action"   != 3 
+      AND kv."namespace" = 'default'
+      AND kv."group"     = 'dashboard.grafana.app'
+      AND kv."resource"  = 'dashboards'
+      AND kv."name" > 'aaa'
+      AND kv."name" <= 'mmm'
+    ORDER BY kv."resource_version" ASC
+;

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -175,7 +175,7 @@ func StartGrafanaEnvWithManualCleanup(t *testing.T, grafDir, cfgPath string) (st
 		env.Cfg.DisablePruner = db.IsTestDbSQLite()
 		eDB, err := sql.ProvideResourceDB(env.Cfg, env.SQLStore)
 		require.NoError(t, err)
-		storageBackend, err := sql.NewStorageBackend(env.Cfg, eDB, registerer, storageMetrics, false, nil)
+		storageBackend, err := sql.NewStorageBackend(env.Cfg, eDB, registerer, storageMetrics, false, nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, storageBackend)
 		backendService := storageBackend.(services.Service)
@@ -786,6 +786,14 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = section.NewKey("migration_parquet_buffer", "true")
 		require.NoError(t, err)
 	}
+	if opts.MigrationChunkMaxBytes > 0 {
+		section, err := getOrCreateSection("unified_storage")
+		require.NoError(t, err)
+		_, err = section.NewKey("migration_chunked_writes", "true")
+		require.NoError(t, err)
+		_, err = section.NewKey("migration_chunk_max_bytes", fmt.Sprintf("%d", opts.MigrationChunkMaxBytes))
+		require.NoError(t, err)
+	}
 	if opts.EnableSQLKVBackend {
 		section, err := getOrCreateSection("unified_storage")
 		require.NoError(t, err)
@@ -1031,6 +1039,7 @@ type GrafanaOpts struct {
 	DisableControllers                                   bool
 	DisableDBCleanup                                     bool
 	MigrationParquetBuffer                               bool
+	MigrationChunkMaxBytes                               int64
 	EnableSQLKVBackend                                   bool
 	SecretsManagerEnableDBMigrations                     bool
 	OpenFeatureAPIEnabled                                bool


### PR DESCRIPTION
**What is this feature?**

An opt-in "chunked writes" mode for the legacy→unified-storage migration. When `migration_chunked_writes` is enabled (default off, mysql/postgres only), the migration splits the single giant import transaction into multiple bounded, per-chunk committed transactions: a byte-bounded wipe, per-chunk history inserts via a `txChunker`, and a paginated resource backfill split into byte-bounded name ranges. Background GC is gated so it cannot prune rows an in-flight migration is still committing (`GCGate` defers GC start until the node's migration completes).

**Why do we need this feature?**

On MySQL/Galera (Percona XtraDB Cluster) the original single-transaction migration's replication write-set exceeds the cluster's hard `wsrep_max_ws_size` (2 GB) cap, so PXC aborts it and the migration can never complete on large instances. Chunking keeps every committed write-set well under the cap.

**Who is this feature for?**

Operators running the unified-storage migration on large Galera/PXC-backed databases.

**Which issue(s) does this PR fix?**:

https://github.com/grafana/support-escalations/issues/22686

**Special notes for your reviewer:**

Behind `migration_chunked_writes` (default off); recovery is marker-as-done + wipe-and-restart, with best-effort re-wipe of committed chunks on failure. Verified end-to-end on MySQL: a stress reproduction shows the single-tx path aborting at a scaled `max_binlog_cache_size` cap (errno 1197) while the chunked path completes with every commit bounded; integration tests cover correctness vs a non-chunked run, idempotency, kill-mid-migration recovery, and the sqlite no-op regression.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (config flag `migration_chunked_writes`, default off)
- [x] The docs are updated.
