### PR TITLE
Provisioning: Only export needed folders during selective export

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/all.go
+++ b/pkg/registry/apis/provisioning/jobs/export/all.go
@@ -29,12 +29,15 @@ func exportAll(ctx context.Context, repoName string, options provisioning.Export
 		return err
 	}
 
-	if err := ExportFolders(ctx, repoName, options, folderClient, repositoryResources, progress); err != nil {
-		return err
+	// A selective export must not pull in the entire instance folder tree: only
+	// the folders needed to place the requested resources are written, and each
+	// resource's missing parent folder is generated on demand from its ancestry.
+	if len(options.Resources) > 0 {
+		return ExportSpecificResources(ctx, options, folderClient, clients, repositoryResources, progress, generateNewUIDs)
 	}
 
-	if len(options.Resources) > 0 {
-		return ExportSpecificResources(ctx, options, clients, repositoryResources, progress, generateNewUIDs)
+	if err := ExportFolders(ctx, repoName, options, folderClient, repositoryResources, progress); err != nil {
+		return err
 	}
 
 	return ExportResources(ctx, options, clients, repositoryResources, progress, generateNewUIDs)

--- a/pkg/registry/apis/provisioning/jobs/export/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders.go
@@ -97,11 +97,18 @@ func exportFolderAncestry(ctx context.Context, options provisioning.ExportJobOpt
 	return writeFolderTree(ctx, options, repositoryResources, tree, progress)
 }
 
-// collectFolderAncestry adds the folder identified by folderUID and all of its
+// collectFolderAncestry adds the folder identified by folderUID and its
 // ancestors to tree by walking the parent chain through the folder API. The
-// full chain must be present so the tree can derive each folder's path from the
+// chain must be present so the tree can derive each folder's path from the
 // titles of its ancestors. Folders already in seen (and therefore already in
 // the tree with their own ancestry) are skipped.
+//
+// The walk stops at the first folder already owned by a manager (repository,
+// file provisioning, etc.): such a folder must not be re-written into this
+// repository, since it may be owned elsewhere. This mirrors the full
+// ExportFolders pass, which skips folders with a manager identity. Ancestors
+// above a managed boundary are intentionally not collected — the path then
+// roots at the highest unmanaged folder, exactly as the full export resolves it.
 func collectFolderAncestry(ctx context.Context, folderUID string, folderClient dynamic.ResourceInterface, tree resources.FolderTree, seen map[string]struct{}) error {
 	current := folderUID
 	for current != "" {
@@ -116,14 +123,19 @@ func collectFolderAncestry(ctx context.Context, folderUID string, folderClient d
 		if err != nil {
 			return fmt.Errorf("get folder %q: %w", current, err)
 		}
-		if err := tree.AddUnstructured(obj); err != nil {
-			return fmt.Errorf("add folder %q to tree: %w", current, err)
-		}
-		seen[current] = struct{}{}
 
 		meta, err := utils.MetaAccessor(obj)
 		if err != nil {
 			return fmt.Errorf("extract meta accessor for folder %q: %w", current, err)
+		}
+		seen[current] = struct{}{}
+
+		if manager, _ := meta.GetManagerProperties(); manager.Identity != "" {
+			return nil
+		}
+
+		if err := tree.AddUnstructured(obj); err != nil {
+			return fmt.Errorf("add folder %q to tree: %w", current, err)
 		}
 		current = meta.GetFolder()
 	}

--- a/pkg/registry/apis/provisioning/jobs/export/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 
@@ -43,7 +44,19 @@ func ExportFolders(ctx context.Context, repoName string, options provisioning.Ex
 	}
 
 	progress.SetMessage(ctx, "write folders to repository")
-	err := repositoryResources.EnsureFolderTreeExists(ctx, options.Branch, options.Path, tree, func(folder resources.Folder, created bool, err error) error {
+	if err := writeFolderTree(ctx, options, repositoryResources, tree, progress); err != nil {
+		return fmt.Errorf("write folders to repository: %w", err)
+	}
+
+	return nil
+}
+
+// writeFolderTree replicates every folder in tree to the repository, recording
+// each folder as a job result. It is shared by the full-tree export and by the
+// selective export, which only assembles the folders that the requested
+// resources actually need.
+func writeFolderTree(ctx context.Context, options provisioning.ExportJobOptions, repositoryResources resources.RepositoryResources, tree resources.FolderTree, progress jobs.JobProgressRecorder) error {
+	return repositoryResources.EnsureFolderTreeExists(ctx, options.Branch, options.Path, tree, func(folder resources.Folder, created bool, err error) error {
 		resultBuilder := jobs.NewFolderResult(folder.Path).WithName(folder.ID).WithAction(repository.FileActionCreated)
 
 		if err != nil {
@@ -54,14 +67,65 @@ func ExportFolders(ctx context.Context, repoName string, options provisioning.Ex
 			resultBuilder.WithAction(repository.FileActionIgnored)
 		}
 		progress.Record(ctx, resultBuilder.Build())
-		if err := progress.TooManyErrors(); err != nil {
+
+		return progress.TooManyErrors()
+	})
+}
+
+// exportFolderAncestry writes only the folders needed to place the selectively
+// exported resources, instead of dragging in the entire instance folder tree.
+// For every folder UID in folderUIDs it walks up to the root via the folder
+// API, collecting each ancestor so the full nested path can be reconstructed,
+// then writes that limited tree. A folder that was not explicitly requested is
+// generated here purely so its child resources resolve to a valid path.
+func exportFolderAncestry(ctx context.Context, options provisioning.ExportJobOptions, folderClient dynamic.ResourceInterface, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, folderUIDs []string) error {
+	if len(folderUIDs) == 0 {
+		return nil
+	}
+
+	progress.SetMessage(ctx, "export folders for selected resources")
+
+	tree := resources.NewEmptyFolderTree()
+	// seen guards against re-fetching ancestors shared by multiple resources.
+	seen := make(map[string]struct{})
+	for _, uid := range folderUIDs {
+		if err := collectFolderAncestry(ctx, uid, folderClient, tree, seen); err != nil {
 			return err
 		}
+	}
 
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("write folders to repository: %w", err)
+	return writeFolderTree(ctx, options, repositoryResources, tree, progress)
+}
+
+// collectFolderAncestry adds the folder identified by folderUID and all of its
+// ancestors to tree by walking the parent chain through the folder API. The
+// full chain must be present so the tree can derive each folder's path from the
+// titles of its ancestors. Folders already in seen (and therefore already in
+// the tree with their own ancestry) are skipped.
+func collectFolderAncestry(ctx context.Context, folderUID string, folderClient dynamic.ResourceInterface, tree resources.FolderTree, seen map[string]struct{}) error {
+	current := folderUID
+	for current != "" {
+		if _, ok := seen[current]; ok {
+			return nil
+		}
+		if tree.Count() >= resources.MaxNumberOfFolders {
+			return errors.New("too many folders")
+		}
+
+		obj, err := folderClient.Get(ctx, current, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("get folder %q: %w", current, err)
+		}
+		if err := tree.AddUnstructured(obj); err != nil {
+			return fmt.Errorf("add folder %q to tree: %w", current, err)
+		}
+		seen[current] = struct{}{}
+
+		meta, err := utils.MetaAccessor(obj)
+		if err != nil {
+			return fmt.Errorf("extract meta accessor for folder %q: %w", current, err)
+		}
+		current = meta.GetFolder()
 	}
 
 	return nil

--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -63,12 +63,16 @@ func ExportResources(ctx context.Context, options provisioning.ExportJobOptions,
 // Each reference is resolved against its own kind/group via discovery, so any
 // kind the admission validator accepts can be selectively exported. The
 // dashboard conversion shim is applied only to dashboards; other kinds are
-// written as returned. Folders are exported as a tree by ExportFolders, so a
-// folder reference is skipped here to avoid writing a conflicting standalone
-// file. A reference whose kind cannot be resolved is recorded as a failed item
-// so a misconfigured caller surfaces in the job summary rather than silently
-// failing.
-func ExportSpecificResources(ctx context.Context, options provisioning.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, generateNewUIDs bool) error {
+// written as returned. A reference whose kind cannot be resolved is recorded as
+// a failed item so a misconfigured caller surfaces in the job summary rather
+// than silently failing.
+//
+// Unlike the full export, this does not write the entire instance folder tree.
+// Only the folders the requested resources need are exported: an explicitly
+// named folder, and the parent-folder ancestry of every requested resource.
+// A resource whose folder was not named still lands at its nested path because
+// that folder (and its ancestors) is generated on demand from the folder API.
+func ExportSpecificResources(ctx context.Context, options provisioning.ExportJobOptions, folderClient dynamic.ResourceInterface, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, generateNewUIDs bool) error {
 	progress.SetMessage(ctx, "start selective resource export")
 
 	// resolvedKind caches the per-kind client and (for dashboards only) the
@@ -80,6 +84,20 @@ func ExportSpecificResources(ctx context.Context, options provisioning.ExportJob
 		shim   conversionShim
 	}
 	resolved := make(map[schema.GroupVersionKind]resolvedKind)
+
+	// pendingResource pairs a fetched, non-folder resource with the shim needed
+	// to write it. Resources are written only after their folder ancestry has
+	// been exported so each one resolves to its correct nested path.
+	type pendingResource struct {
+		item *unstructured.Unstructured
+		shim conversionShim
+	}
+	var pending []pendingResource
+
+	// folderUIDs accumulates every folder whose ancestry must be written:
+	// explicitly named folders plus the parent folder of each requested
+	// resource. Duplicates are harmless; collectFolderAncestry de-duplicates.
+	var folderUIDs []string
 
 	for _, ref := range options.Resources {
 		// ForKind resolves the preferred version when Version is empty.
@@ -110,11 +128,10 @@ func ExportSpecificResources(ctx context.Context, options provisioning.ExportJob
 			resolved[gvk] = rk
 		}
 
-		// Folders are exported as a tree by ExportFolders; skip them here so we
-		// don't write a conflicting standalone folder file.
+		// An explicitly named folder is exported as part of the folder tree
+		// (with its ancestry) rather than as a standalone resource file.
 		if rk.gvr.GroupResource() == resources.FolderResource.GroupResource() {
-			result.WithAction(repository.FileActionIgnored)
-			progress.Record(ctx, result.Build())
+			folderUIDs = append(folderUIDs, ref.Name)
 			continue
 		}
 
@@ -132,7 +149,23 @@ func ExportSpecificResources(ctx context.Context, options provisioning.ExportJob
 			continue
 		}
 
-		if err := exportItem(ctx, item, options, rk.shim, repositoryResources, progress, generateNewUIDs, true); err != nil {
+		// Record the parent folder so its ancestry is exported before the
+		// resource is written. Meta extraction failures are surfaced by
+		// exportItem when the resource is written below.
+		if meta, err := utils.MetaAccessor(item); err == nil {
+			if folder := meta.GetFolder(); folder != "" {
+				folderUIDs = append(folderUIDs, folder)
+			}
+		}
+		pending = append(pending, pendingResource{item: item, shim: rk.shim})
+	}
+
+	if err := exportFolderAncestry(ctx, options, folderClient, repositoryResources, progress, folderUIDs); err != nil {
+		return err
+	}
+
+	for _, p := range pending {
+		if err := exportItem(ctx, p.item, options, p.shim, repositoryResources, progress, generateNewUIDs, true); err != nil {
 			return err
 		}
 	}

--- a/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
@@ -366,6 +366,53 @@ func TestExportSpecificResources_GeneratesFolderForDashboard(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestExportSpecificResources_ManagedFolderAncestryIsSkipped verifies that a
+// requested dashboard's parent folder is NOT written into this repository when
+// it is already owned by another manager: writing it would let the target repo
+// try to manage a folder it does not own. The dashboard is still written; the
+// folder tree assembled for the export excludes the managed folder.
+func TestExportSpecificResources_ManagedFolderAncestryIsSkipped(t *testing.T) {
+	dashClient := &mockGetByName{items: map[string]*unstructured.Unstructured{
+		"dash-1": dashboardInFolder("dash-1", "managed-folder"),
+	}}
+
+	resourceClients := resources.NewMockResourceClients(t)
+	resourceClients.On("ForKind", mock.Anything, dashboardGVK()).
+		Return(dashClient, resources.DashboardResource, nil)
+
+	// The parent folder is owned by another repository.
+	managedFolder := folderObject("managed-folder", "")
+	managedFolder.Object["metadata"].(map[string]any)["annotations"] = map[string]any{
+		"grafana.app/managedBy": "repo",
+		"grafana.app/managerId": "other-repo",
+	}
+	folderClient := &mockGetByName{items: map[string]*unstructured.Unstructured{
+		"managed-folder": managedFolder,
+	}}
+
+	repoResources := resources.NewMockRepositoryResources(t)
+	// The managed folder must not appear in the exported tree.
+	repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "", mock.MatchedBy(func(tree resources.FolderTree) bool {
+		return tree.Count() == 0
+	}), mock.Anything).Return(nil)
+	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
+		return obj.GetName() == "dash-1"
+	}), mock.Anything).Return("dash-1.json", nil)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, mock.Anything).Return()
+	progress.On("Record", mock.Anything, mock.Anything).Return()
+	progress.On("TooManyErrors").Return(nil)
+
+	options := provisioningV0.ExportJobOptions{
+		Branch:    "feature/branch",
+		Resources: []provisioningV0.ResourceRef{{Name: "dash-1", Kind: "Dashboard", Group: resources.DashboardResource.Group}},
+	}
+
+	err := ExportSpecificResources(context.Background(), options, folderClient, resourceClients, repoResources, progress, false)
+	require.NoError(t, err)
+}
+
 func TestExportSpecificResources_NonDashboardKindIsExported(t *testing.T) {
 	// A supported non-dashboard, non-folder kind (here a Playlist) is resolved
 	// against its own kind/group and exported through the shared write path,

--- a/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
@@ -43,6 +43,13 @@ func (m *mockGetByName) Get(_ context.Context, name string, _ metav1.GetOptions,
 	}, name)
 }
 
+// emptyFolderClient returns a folder client with no folders. It is used by the
+// tests whose resources live at the root, where ExportSpecificResources never
+// needs to resolve a folder ancestry.
+func emptyFolderClient() *mockGetByName {
+	return &mockGetByName{items: map[string]*unstructured.Unstructured{}}
+}
+
 func managedDashboardObject(name, managerID string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]any{
@@ -65,11 +72,42 @@ func dashboardObject(name string) *unstructured.Unstructured {
 	return &obj
 }
 
+// dashboardInFolder returns a dashboard whose parent folder annotation points at
+// folderUID, exercising the folder-ancestry export path.
+func dashboardInFolder(name, folderUID string) *unstructured.Unstructured {
+	obj := dashboardObject(name)
+	meta := obj.Object["metadata"].(map[string]any)
+	meta["annotations"] = map[string]any{"grafana.app/folder": folderUID}
+	return obj
+}
+
+// folderObject returns a folder with the given parent (pass "" for a root
+// folder). The spec title doubles as the path segment when the tree derives the
+// folder path from its ancestors.
+func folderObject(name, parentUID string) *unstructured.Unstructured {
+	metadata := map[string]any{"name": name}
+	if parentUID != "" {
+		metadata["annotations"] = map[string]any{"grafana.app/folder": parentUID}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.FolderResource.GroupVersion().String(),
+			"kind":       "Folder",
+			"metadata":   metadata,
+			"spec":       map[string]any{"title": name},
+		},
+	}
+}
+
 func dashboardGVK() schema.GroupVersionKind {
 	return schema.GroupVersionKind{
 		Group: resources.DashboardResource.Group,
 		Kind:  "Dashboard",
 	}
+}
+
+func folderGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: resources.FolderResource.Group, Kind: resources.FolderKind.Kind}
 }
 
 func TestExportSpecificResources_Success(t *testing.T) {
@@ -110,7 +148,7 @@ func TestExportSpecificResources_Success(t *testing.T) {
 		},
 	}
 
-	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, false)
+	err := ExportSpecificResources(context.Background(), options, emptyFolderClient(), resourceClients, repoResources, progress, false)
 	require.NoError(t, err)
 }
 
@@ -143,7 +181,7 @@ func TestExportSpecificResources_ManagedDashboardError(t *testing.T) {
 		Resources: []provisioningV0.ResourceRef{{Name: "managed-dash", Kind: "Dashboard", Group: resources.DashboardResource.Group}},
 	}
 
-	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, false)
+	err := ExportSpecificResources(context.Background(), options, emptyFolderClient(), resourceClients, repoResources, progress, false)
 	require.NoError(t, err)
 	repoResources.AssertNotCalled(t, "WriteResourceFileFromObject", mock.Anything, mock.Anything, mock.Anything)
 }
@@ -173,7 +211,7 @@ func TestExportSpecificResources_NotFoundRecordsError(t *testing.T) {
 		Resources: []provisioningV0.ResourceRef{{Name: "missing", Kind: "Dashboard", Group: resources.DashboardResource.Group}},
 	}
 
-	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, false)
+	err := ExportSpecificResources(context.Background(), options, emptyFolderClient(), resourceClients, repoResources, progress, false)
 	require.NoError(t, err)
 	repoResources.AssertNotCalled(t, "WriteResourceFileFromObject", mock.Anything, mock.Anything, mock.Anything)
 }
@@ -201,7 +239,7 @@ func TestExportSpecificResources_GetErrorRecordsError(t *testing.T) {
 		Resources: []provisioningV0.ResourceRef{{Name: "boom", Kind: "Dashboard", Group: resources.DashboardResource.Group}},
 	}
 
-	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, false)
+	err := ExportSpecificResources(context.Background(), options, emptyFolderClient(), resourceClients, repoResources, progress, false)
 	require.NoError(t, err)
 }
 
@@ -230,37 +268,102 @@ func TestExportSpecificResources_NewUIDsSetsRandomName(t *testing.T) {
 		Resources: []provisioningV0.ResourceRef{{Name: "original-uid", Kind: "Dashboard", Group: resources.DashboardResource.Group}},
 	}
 
-	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, true)
+	err := ExportSpecificResources(context.Background(), options, emptyFolderClient(), resourceClients, repoResources, progress, true)
 	require.NoError(t, err)
 	require.NotEmpty(t, writtenName)
 	require.NotEqual(t, "original-uid", writtenName, "generateNewUIDs=true should have rewritten the object name")
 }
 
-func TestExportSpecificResources_FolderKindIsSkipped(t *testing.T) {
-	// Folders are exported as a tree by ExportFolders; a folder named in
-	// Resources must be skipped here (recorded as ignored) so we don't write a
-	// conflicting standalone folder file.
-	folderGVK := schema.GroupVersionKind{Group: resources.FolderResource.Group, Kind: resources.FolderKind.Kind}
-
+// TestExportSpecificResources_FolderKindIsExported verifies that an explicitly
+// named folder is written via the folder tree (with its full ancestry) rather
+// than being skipped: "don't export folders unless they are passed" implies a
+// passed folder is exported.
+func TestExportSpecificResources_FolderKindIsExported(t *testing.T) {
 	resourceClients := resources.NewMockResourceClients(t)
-	resourceClients.On("ForKind", mock.Anything, folderGVK).
-		Return(&mockGetByName{items: map[string]*unstructured.Unstructured{}}, resources.FolderResource, nil)
+	resourceClients.On("ForKind", mock.Anything, folderGVK()).
+		Return(emptyFolderClient(), resources.FolderResource, nil)
+
+	// child sits under parent; both ancestors are recreated from the folder API.
+	folderClient := &mockGetByName{items: map[string]*unstructured.Unstructured{
+		"child":  folderObject("child", "parent"),
+		"parent": folderObject("parent", ""),
+	}}
 
 	repoResources := resources.NewMockRepositoryResources(t)
+	repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "", mock.MatchedBy(func(tree resources.FolderTree) bool {
+		return tree.Count() == 2
+	}), mock.MatchedBy(func(fn func(folder resources.Folder, created bool, err error) error) bool {
+		require.NoError(t, fn(resources.Folder{ID: "parent", Path: "parent"}, true, nil))
+		require.NoError(t, fn(resources.Folder{ID: "child", Path: "parent/child"}, true, nil))
+		return true
+	})).Return(nil)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
 	progress.On("SetMessage", mock.Anything, "start selective resource export").Return()
+	progress.On("SetMessage", mock.Anything, "export folders for selected resources").Return()
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-		return r.Name() == "folder-ref" && r.Action() == repository.FileActionIgnored && r.Error() == nil
+		return r.Name() == "parent" && r.Action() == repository.FileActionCreated
 	})).Return()
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Name() == "child" && r.Action() == repository.FileActionCreated
+	})).Return()
+	progress.On("TooManyErrors").Return(nil)
 
 	options := provisioningV0.ExportJobOptions{
-		Resources: []provisioningV0.ResourceRef{{Name: "folder-ref", Kind: resources.FolderKind.Kind, Group: resources.FolderResource.Group}},
+		Branch:    "feature/branch",
+		Resources: []provisioningV0.ResourceRef{{Name: "child", Kind: resources.FolderKind.Kind, Group: resources.FolderResource.Group}},
 	}
 
-	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, false)
+	err := ExportSpecificResources(context.Background(), options, folderClient, resourceClients, repoResources, progress, false)
 	require.NoError(t, err)
 	repoResources.AssertNotCalled(t, "WriteResourceFileFromObject", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestExportSpecificResources_GeneratesFolderForDashboard verifies the core
+// fix: a dashboard whose folder was NOT named still has that folder (and its
+// ancestry) generated from the folder API so the dashboard lands at its nested
+// path, instead of dragging in the whole instance tree or failing to resolve.
+func TestExportSpecificResources_GeneratesFolderForDashboard(t *testing.T) {
+	dashClient := &mockGetByName{items: map[string]*unstructured.Unstructured{
+		"dash-1": dashboardInFolder("dash-1", "child"),
+	}}
+
+	resourceClients := resources.NewMockResourceClients(t)
+	resourceClients.On("ForKind", mock.Anything, dashboardGVK()).
+		Return(dashClient, resources.DashboardResource, nil)
+
+	folderClient := &mockGetByName{items: map[string]*unstructured.Unstructured{
+		"child":  folderObject("child", "parent"),
+		"parent": folderObject("parent", ""),
+	}}
+
+	repoResources := resources.NewMockRepositoryResources(t)
+	// Both ancestor folders are assembled into the tree before the dashboard is
+	// written.
+	repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "", mock.MatchedBy(func(tree resources.FolderTree) bool {
+		return tree.Count() == 2
+	}), mock.MatchedBy(func(fn func(folder resources.Folder, created bool, err error) error) bool {
+		require.NoError(t, fn(resources.Folder{ID: "parent", Path: "parent"}, true, nil))
+		require.NoError(t, fn(resources.Folder{ID: "child", Path: "parent/child"}, true, nil))
+		return true
+	})).Return(nil)
+	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
+		return obj.GetName() == "dash-1"
+	}), mock.Anything).Return("parent/child/dash-1.json", nil)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, "start selective resource export").Return()
+	progress.On("SetMessage", mock.Anything, "export folders for selected resources").Return()
+	progress.On("Record", mock.Anything, mock.Anything).Return()
+	progress.On("TooManyErrors").Return(nil)
+
+	options := provisioningV0.ExportJobOptions{
+		Branch:    "feature/branch",
+		Resources: []provisioningV0.ResourceRef{{Name: "dash-1", Kind: "Dashboard", Group: resources.DashboardResource.Group}},
+	}
+
+	err := ExportSpecificResources(context.Background(), options, folderClient, resourceClients, repoResources, progress, false)
+	require.NoError(t, err)
 }
 
 func TestExportSpecificResources_NonDashboardKindIsExported(t *testing.T) {
@@ -299,7 +402,7 @@ func TestExportSpecificResources_NonDashboardKindIsExported(t *testing.T) {
 		Resources: []provisioningV0.ResourceRef{{Name: "playlist-1", Kind: "Playlist", Group: "playlist.grafana.app"}},
 	}
 
-	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, false)
+	err := ExportSpecificResources(context.Background(), options, emptyFolderClient(), resourceClients, repoResources, progress, false)
 	require.NoError(t, err)
 }
 
@@ -326,7 +429,7 @@ func TestExportSpecificResources_UnresolvableKindRecordsError(t *testing.T) {
 		Resources: []provisioningV0.ResourceRef{{Name: "mystery-1", Kind: "Mystery", Group: "unknown.grafana.app"}},
 	}
 
-	err := ExportSpecificResources(context.Background(), options, resourceClients, repoResources, progress, false)
+	err := ExportSpecificResources(context.Background(), options, emptyFolderClient(), resourceClients, repoResources, progress, false)
 	require.NoError(t, err)
 	repoResources.AssertNotCalled(t, "WriteResourceFileFromObject", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
@@ -335,3 +335,78 @@ func TestIntegrationProvisioning_ExportJob_NestedFolders(t *testing.T) {
 		require.Equal(t, siblingBTitle, siblingBManifest.Spec.Title)
 	})
 }
+
+// TestIntegrationProvisioning_ExportJob_SelectiveGeneratesFolderMetadata
+// verifies that a selective export of a single dashboard generates _folder.json
+// metadata for the dashboard's parent folder ancestry — even though those
+// folders were not named in the export — while leaving an unrelated folder
+// (and its metadata) out of the repository entirely.
+func TestIntegrationProvisioning_ExportJob_SelectiveGeneratesFolderMetadata(t *testing.T) {
+	readFolderManifest := func(t *testing.T, path string) foldersV1.Folder {
+		t.Helper()
+		data, err := os.ReadFile(path) //nolint:gosec
+		require.NoError(t, err, "_folder.json should exist at %s", path)
+		var manifest foldersV1.Folder
+		require.NoError(t, json.Unmarshal(data, &manifest), "_folder.json at %s should be valid JSON", path)
+		return manifest
+	}
+
+	helper := sharedHelper(t)
+
+	const repo = "selective-export-meta-repo"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "instance",
+		Workflows:              []string{"write"},
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	const (
+		parentUID   = "selective-meta-parent-uid"
+		parentTitle = "selective-meta-parent"
+		childUID    = "selective-meta-child-uid"
+		childTitle  = "selective-meta-child"
+
+		unrelatedUID   = "selective-meta-unrelated-uid"
+		unrelatedTitle = "selective-meta-unrelated"
+	)
+	createUnmanagedFolder(t, helper, parentUID, parentTitle)
+	createUnmanagedFolderWithParent(t, helper, childUID, childTitle, parentUID)
+	createUnmanagedFolder(t, helper, unrelatedUID, unrelatedTitle)
+
+	// The dashboard lives in the child folder; only it is named in the export.
+	selectedDash := helper.CreateUnmanagedDashboard(t, t.Context(), "selective-meta-dash", childUID)
+
+	result := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPush,
+		Push: &provisioning.ExportJobOptions{
+			Resources: []provisioning.ResourceRef{
+				{Name: selectedDash, Kind: "Dashboard", Group: "dashboard.grafana.app"},
+			},
+		},
+	})
+	job := &provisioning.Job{}
+	require.NoError(t, k8sruntime.DefaultUnstructuredConverter.FromUnstructured(result.Object, job))
+	require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "selective export job should succeed")
+
+	// The parent ancestry is generated with metadata even though it was not
+	// named: the dashboard's nested path must resolve to managed folders.
+	require.DirExists(t, filepath.Join(helper.ProvisioningPath, parentTitle))
+	require.DirExists(t, filepath.Join(helper.ProvisioningPath, parentTitle, childTitle))
+
+	parentManifest := readFolderManifest(t, filepath.Join(helper.ProvisioningPath, parentTitle, "_folder.json"))
+	require.Equal(t, parentUID, parentManifest.Name, "generated parent _folder.json should preserve the folder UID")
+	require.Equal(t, parentTitle, parentManifest.Spec.Title)
+
+	childManifest := readFolderManifest(t, filepath.Join(helper.ProvisioningPath, parentTitle, childTitle, "_folder.json"))
+	require.Equal(t, childUID, childManifest.Name, "generated child _folder.json should preserve the folder UID")
+	require.Equal(t, childTitle, childManifest.Spec.Title)
+
+	// The dashboard itself lands inside the generated child folder.
+	require.FileExists(t, filepath.Join(helper.ProvisioningPath, parentTitle, childTitle, "selective-meta-dash.json"))
+
+	// The unrelated folder must not be exported at all: no directory, no metadata.
+	_, err := os.Stat(filepath.Join(helper.ProvisioningPath, unrelatedTitle))
+	require.True(t, os.IsNotExist(err), "unrelated folder must not be exported during a selective export")
+}

--- a/pkg/tests/apis/provisioning/jobs/exportjob_specific_kinds_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_specific_kinds_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -31,7 +30,7 @@ func TestIntegrationProvisioning_ExportSpecificResources_FolderExported(t *testi
 
 	// A real folder, named explicitly in the export. Unlike the old behavior, a
 	// passed folder is now exported rather than silently skipped.
-	helper.CreateUnmanagedFolder(t, ctx, "exportedfolderref", "")
+	folderUID := helper.CreateUnmanagedFolder(t, ctx, "exportedfolderref", "")
 
 	const repo = "selective-export-folderref-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -41,8 +40,6 @@ func TestIntegrationProvisioning_ExportSpecificResources_FolderExported(t *testi
 		Copies:                 map[string]string{},
 		SkipResourceAssertions: true,
 	})
-
-	folderUID := folderUIDByTitle(t, ctx, helper, "exportedfolderref")
 
 	spec := provisioning.JobSpec{
 		Action: provisioning.JobActionPush,
@@ -63,18 +60,4 @@ func TestIntegrationProvisioning_ExportSpecificResources_FolderExported(t *testi
 	// The explicitly named folder is exported as a directory in the repository.
 	require.DirExists(t, filepath.Join(helper.ProvisioningPath, "exportedfolderref"),
 		"explicitly requested folder should be exported")
-}
-
-// folderUIDByTitle returns the UID of the folder with the given title.
-func folderUIDByTitle(t *testing.T, ctx context.Context, helper *common.ProvisioningTestHelper, title string) string {
-	t.Helper()
-	folders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
-	require.NoError(t, err, "should be able to list folders")
-	for _, f := range folders.Items {
-		if got, _, _ := unstructured.NestedString(f.Object, "spec", "title"); got == title {
-			return f.GetName()
-		}
-	}
-	require.Failf(t, "folder not found", "no folder with title %q", title)
-	return ""
 }

--- a/pkg/tests/apis/provisioning/jobs/exportjob_specific_kinds_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_specific_kinds_test.go
@@ -8,19 +8,20 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
-// TestIntegrationProvisioning_ExportSpecificResources_FolderSkipped verifies the
+// TestIntegrationProvisioning_ExportSpecificResources_FolderExported verifies the
 // generalized selective-export controller against a non-dashboard kind end to
 // end: a Folder reference in Push.Resources passes admission (the default
-// supported set is {Folder, Dashboard}) and is then skipped by the worker
-// (folders are exported as a tree by ExportFolders, not as standalone files)
-// rather than failing the job with the old dashboard-only "is not a Dashboard"
-// rejection. The job still succeeds and the requested dashboard is exported.
-func TestIntegrationProvisioning_ExportSpecificResources_FolderSkipped(t *testing.T) {
+// supported set is {Folder, Dashboard}) and is exported as part of the folder
+// tree (with its ancestry) rather than failing the job with the old
+// dashboard-only "is not a Dashboard" rejection. The job succeeds and both the
+// requested dashboard and the requested folder are written.
+func TestIntegrationProvisioning_ExportSpecificResources_FolderExported(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()
 
@@ -28,7 +29,11 @@ func TestIntegrationProvisioning_ExportSpecificResources_FolderSkipped(t *testin
 	_, err := helper.DashboardsV1.Resource.Create(ctx, dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v1 dashboard")
 
-	const repo = "selective-export-folderskip-repo"
+	// A real folder, named explicitly in the export. Unlike the old behavior, a
+	// passed folder is now exported rather than silently skipped.
+	helper.CreateUnmanagedFolder(t, ctx, "exportedfolderref", "")
+
+	const repo = "selective-export-folderref-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
 		Name:                   repo,
 		SyncTarget:             "instance",
@@ -37,21 +42,39 @@ func TestIntegrationProvisioning_ExportSpecificResources_FolderSkipped(t *testin
 		SkipResourceAssertions: true,
 	})
 
-	// The folder reference need not resolve to an existing object: the
-	// controller skips folders right after resolving the kind, before any Get.
+	folderUID := folderUIDByTitle(t, ctx, helper, "exportedfolderref")
+
 	spec := provisioning.JobSpec{
 		Action: provisioning.JobActionPush,
 		Push: &provisioning.ExportJobOptions{
 			Resources: []provisioning.ResourceRef{
 				{Name: "test-v1", Kind: "Dashboard", Group: "dashboard.grafana.app"},
-				{Name: "any-folder", Kind: "Folder", Group: "folder.grafana.app"},
+				{Name: folderUID, Kind: "Folder", Group: "folder.grafana.app"},
 			},
 		},
 	}
 	helper.TriggerJobAndWaitForSuccess(t, repo, spec)
 
-	// The dashboard sibling is still exported despite the folder ref being skipped.
+	// The dashboard sibling is exported alongside the folder ref.
 	present := filepath.Join(helper.ProvisioningPath, "test-dashboard-created-at-v1.json")
 	_, err = os.Stat(present)
-	require.NoError(t, err, "requested dashboard should be exported alongside the skipped folder ref")
+	require.NoError(t, err, "requested dashboard should be exported alongside the folder ref")
+
+	// The explicitly named folder is exported as a directory in the repository.
+	require.DirExists(t, filepath.Join(helper.ProvisioningPath, "exportedfolderref"),
+		"explicitly requested folder should be exported")
+}
+
+// folderUIDByTitle returns the UID of the folder with the given title.
+func folderUIDByTitle(t *testing.T, ctx context.Context, helper *common.ProvisioningTestHelper, title string) string {
+	t.Helper()
+	folders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
+	require.NoError(t, err, "should be able to list folders")
+	for _, f := range folders.Items {
+		if got, _, _ := unstructured.NestedString(f.Object, "spec", "title"); got == title {
+			return f.GetName()
+		}
+	}
+	require.Failf(t, "folder not found", "no folder with title %q", title)
+	return ""
 }

--- a/pkg/tests/apis/provisioning/jobs/exportjob_specific_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_specific_test.go
@@ -259,3 +259,62 @@ func TestIntegrationProvisioning_ExportSpecificResources_NotFound(t *testing.T) 
 	_, err = os.Stat(present)
 	require.NoError(t, err, "present dashboard should still be exported despite sibling being missing")
 }
+
+// TestIntegrationProvisioning_ExportSpecificResources_GeneratesFolderAncestry
+// verifies the selective-export folder behavior: only the folders required to
+// place the named dashboard are written (its full parent ancestry, generated on
+// demand even though those folders were not named), while folders belonging to
+// unrelated, non-exported dashboards stay out of the repository entirely.
+func TestIntegrationProvisioning_ExportSpecificResources_GeneratesFolderAncestry(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	// Two independent folder hierarchies, each holding one dashboard. Only the
+	// dashboard in the "exported" hierarchy is named in the export; the
+	// "unrelated" hierarchy must not be touched.
+	exportedParent := helper.CreateUnmanagedFolder(t, ctx, "exportedparent", "")
+	exportedChild := helper.CreateUnmanagedFolder(t, ctx, "exportedchild", exportedParent)
+	selectedDash := helper.CreateUnmanagedDashboard(t, ctx, "selecteddash", exportedChild)
+
+	unrelatedFolder := helper.CreateUnmanagedFolder(t, ctx, "unrelatedfolder", "")
+	_ = helper.CreateUnmanagedDashboard(t, ctx, "unrelateddash", unrelatedFolder)
+
+	const repo = "selective-export-folders-repo"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:               repo,
+		SyncTarget:         "instance",
+		Workflows:          []string{"write"},
+		Copies:             map[string]string{},
+		ExpectedDashboards: 2,
+		ExpectedFolders:    3,
+	})
+
+	helper.DebugState(t, repo, "BEFORE SELECTIVE EXPORT")
+
+	spec := provisioning.JobSpec{
+		Action: provisioning.JobActionPush,
+		Push: &provisioning.ExportJobOptions{
+			Resources: []provisioning.ResourceRef{
+				{Name: selectedDash, Kind: "Dashboard", Group: "dashboard.grafana.app"},
+			},
+		},
+	}
+	helper.TriggerJobAndWaitForSuccess(t, repo, spec)
+
+	helper.DebugState(t, repo, "AFTER SELECTIVE EXPORT")
+	common.PrintFileTree(t, helper.ProvisioningPath)
+
+	// The named dashboard lands at its full nested path even though neither of
+	// its parent folders was named in the export.
+	selectedPath := filepath.Join(helper.ProvisioningPath, "exportedparent", "exportedchild", "selecteddash.json")
+	_, err := os.Stat(selectedPath)
+	require.NoError(t, err, "named dashboard should be exported at its generated nested path %s", selectedPath)
+
+	// The unrelated hierarchy must not have been exported: neither its folder
+	// directory nor its dashboard file may appear in the repository.
+	files := helper.ListRepositoryFiles(t, ctx, repo)
+	for _, f := range files {
+		require.NotContains(t, f.Path, "unrelated",
+			"unrelated folder/dashboard must not be exported during selective export; got file %q", f.Path)
+	}
+}


### PR DESCRIPTION
## Summary

Selective export (a Push or Migrate job that names specific resources in `Push.Resources` / `Migrate.Resources`) previously **always** ran the full `ExportFolders` pass first, writing **every unmanaged folder in the instance** to the repository — even when the caller asked for only a handful of dashboards. Dashboards then resolved their paths against that full tree, and a folder missing from it failed with `folder %s NOT found in tree`.

This PR makes a selective export write only the folders it actually needs.

## What changed

- **`exportAll`** now branches up front: when `len(options.Resources) > 0` it goes straight to `ExportSpecificResources` and skips the full-tree `ExportFolders`. The full-tree path is unchanged for non-selective exports. This applies to **both** the standalone export (Push) and Migrate.
- **`ExportSpecificResources`** is now two-phase and takes a `folderClient`:
  1. Resolve each ref, collecting the parent-folder UID of every requested resource plus any explicitly-named folder UID.
  2. Export just that folder ancestry.
  3. Write the resources at their resolved nested paths.
- New `folders.go` helpers:
  - `writeFolderTree` — shared by the full and selective paths.
  - `collectFolderAncestry` — walks a folder UID up to the root via the folder API so the full nested path can be reconstructed.
  - `exportFolderAncestry` — assembles only the needed folders and writes them, generating `_folder.json` metadata on demand for folders that weren't named.
- A passed **folder ref is now exported** (with its ancestry) rather than silently skipped.

## Behavior

- Only folders in the ancestry of exported resources (plus explicitly-passed folders) are written; unrelated folders stay out of the repo.
- A dashboard whose folder wasn't named still lands at its correct nested path, with fresh folder metadata generated for the ancestry.

## Testing

- **Unit** (`resources_specific_test.go`): updated call sites; replaced the folder-skip test with `..._FolderKindIsExported`; added `..._GeneratesFolderForDashboard`.
- **Integration** (`pkg/tests/apis/provisioning/jobs`, Docker-free, passing locally): added `..._GeneratesFolderAncestry` (asserts unrelated hierarchies stay out and the dashboard lands nested); replaced `..._FolderSkipped` → `..._FolderExported`. The existing `SelectiveMigrateDashboardInNestedFolders` regression test still passes.
- **Integration** (`pkg/tests/apis/provisioning/foldermetadata`): added `..._SelectiveGeneratesFolderMetadata` asserting `_folder.json` is generated for the non-passed ancestry. This package needs a Gitea Docker container for its shared env (unavailable in my sandbox), so it compiles (`go vet` clean) but I could not execute it locally — please confirm in CI.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes (selective-export behavior change is the intent)
- [x] `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)