### PR TITLE
docs: explicitly define SCIM Service Account roles

### DIFF
--- a/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-okta/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-okta/_index.md
@@ -55,8 +55,8 @@ To enable SCIM provisioning in Grafana, create a service account and generate an
 1. Click **Add service account**
 1. Create the service account with a name (for example, "SCIM provisioning").
 1. In the **Roles** dropdown, select the following roles for the service account:
-   - **User administration** — required for user sync (create, read, update, and remove users in the organization)
-   - **Teams** — required for group sync (create, read, update, and delete teams, and manage team memberships)
+   - **User administration** — required for user sync (`User administration:Reader (organizational)`, `User administration:Writer (organizational)`)
+   - **Teams** — required for group sync (`Teams:Creator`, `Teams:Writer`, `Teams:Reader`, `Teams:Permission reader`, `Teams:Permission writer`)
 1. Create a new token for the service account and save it securely. This token will be used in the Okta configuration.
 
 ## Configure SCIM in Okta

--- a/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-okta/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-okta/_index.md
@@ -51,6 +51,8 @@ To enable SCIM provisioning in Grafana, create a service account and generate an
 
 ### Create a service account
 
+If using the Grafana User Interface:
+
 1. Navigate to **Administration > Users and access > Service accounts**
 1. Click **Add service account**
 1. Create the service account with a name (for example, "SCIM provisioning").
@@ -58,6 +60,22 @@ To enable SCIM provisioning in Grafana, create a service account and generate an
    - **User administration** — required for user sync (`User administration:Reader (organizational)`, `User administration:Writer (organizational)`)
    - **Teams** — required for group sync (`Teams:Creator`, `Teams:Writer`, `Teams:Reader`, `Teams:Permission reader`, `Teams:Permission writer`)
 1. Create a new token for the service account and save it securely. This token will be used in the Okta configuration.
+
+If using the Grafana Terraform Provider:
+
+1. Configure the [grafana_role_assignment](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role_assignment) as follows
+
+```yaml
+scim_sa_roles = [
+    "fixed:org.users:reader",         # ┐ "User administration" (user sync)
+    "fixed:org.users:writer",         # ┘
+    "fixed:teams:creator",            # ┐
+    "fixed:teams:read",               # │
+    "fixed:teams:writer",             # ├ "Teams" (group sync)
+    "fixed:teams.permissions:reader", # │
+    "fixed:teams.permissions:writer", # ┘
+  ]
+```
 
 ## Configure SCIM in Okta
 

--- a/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-okta/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-okta/_index.md
@@ -63,7 +63,7 @@ If using the Grafana User Interface:
 
 If using the Grafana Terraform Provider:
 
-1. Configure the [grafana_role_assignment](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role_assignment) as follows
+1. Configure the [`grafana_role_assignment`](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role_assignment) as follows
 
 ```yaml
 scim_sa_roles = [


### PR DESCRIPTION
**What is this feature?**

A minor change which explicitly lists the Service Account Roles required to setup Okta SCIM provisioning access.  

**Why do we need this feature?**

 A Customer provided some feedback that "the [docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-scim-provisioning/configure-scim-with-okta/#create-a-service-account) are very unclear about the permissions needed by the service account especially since we're provisioning it via terraform not the UI". 

**Who is this feature for?**

Typically Grafana Cloud stack admins who are tasked with configuring access via Okta SCIM.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
