### PR TITLE
Logs: Log line menu is now sticky

### DIFF
--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -548,6 +548,10 @@ export const getStyles = (
   };
 
   const hoverColor = tinycolor(theme.colors.background.canvas).darken(11).toRgbString();
+  const pinnedColor = tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString();
+  const detailsColor = tinycolor(theme.colors.background.canvas)
+    .darken(theme.isDark ? 2 : 5)
+    .toRgbString();
 
   return {
     logLine: css({
@@ -559,6 +563,10 @@ export const getStyles = (
       wordBreak: 'break-all',
       '&:hover': {
         background: hoverColor,
+        // Keep the sticky menu background in sync with the hovered log line.
+        '& .log-line-menu': {
+          background: hoverColor,
+        },
       },
       '&.infinite-scroll': {
         '&::before': {
@@ -625,19 +633,36 @@ export const getStyles = (
       lineHeight: theme.typography.body.lineHeight,
     }),
     detailsDisplayed: css({
-      background: tinycolor(theme.colors.background.canvas)
-        .darken(theme.isDark ? 2 : 5)
-        .toRgbString(),
+      background: detailsColor,
+      '& .log-line-menu': {
+        background: detailsColor,
+      },
     }),
     currentLog: css({
       background: hoverColor,
       fontWeight: theme.typography.fontWeightBold,
+      '& .log-line-menu': {
+        background: hoverColor,
+      },
     }),
     pinnedLogLine: css({
-      backgroundColor: tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString(),
+      backgroundColor: pinnedColor,
+      // The pinned highlight is translucent, so layer it over the panel background to keep the sticky menu opaque.
+      '& .log-line-menu': {
+        background: `linear-gradient(${pinnedColor}, ${pinnedColor}), ${theme.colors.background.primary}`,
+      },
     }),
     permalinkedLogLine: css({
-      backgroundColor: tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString(),
+      backgroundColor: pinnedColor,
+      '& .log-line-menu': {
+        background: `linear-gradient(${pinnedColor}, ${pinnedColor}), ${theme.colors.background.primary}`,
+      },
+    }),
+    menuWrapper: css({
+      background: theme.colors.background.primary,
+      left: 0,
+      position: 'sticky',
+      zIndex: 1,
     }),
     menuIcon: css({
       height: virtualization?.getLineHeight() ?? DEFAULT_LINE_HEIGHT,

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -168,15 +168,17 @@ export const LogLineMenu = ({ active, log, styles }: Props) => {
   );
 
   return (
-    <Dropdown overlay={menu} placement="bottom-start">
-      <IconButton
-        className={styles.menuIcon}
-        name={active ? 'angle-right' : 'ellipsis-v'}
-        aria-label={t('logs.log-line-menu.icon-label', 'Log menu')}
-        role="button"
-        variant={active ? 'primary' : undefined}
-      />
-    </Dropdown>
+    <div className={`${styles.menuWrapper} log-line-menu`}>
+      <Dropdown overlay={menu} placement="bottom-start">
+        <IconButton
+          className={styles.menuIcon}
+          name={active ? 'angle-right' : 'ellipsis-v'}
+          aria-label={t('logs.log-line-menu.icon-label', 'Log menu')}
+          role="button"
+          variant={active ? 'primary' : undefined}
+        />
+      </Dropdown>
+    </div>
   );
 };
 


### PR DESCRIPTION
This PR updates the Logs panel to make the log line menu sticky, so it's visible when the user horizontally scrolls.

https://github.com/user-attachments/assets/1eccc173-8229-46b0-93d7-29ba46fefc81

