### PR TITLE
Alerting: Add kind to template preview requests

### DIFF
--- a/public/app/features/alerting/unified/api/templateApi.ts
+++ b/public/app/features/alerting/unified/api/templateApi.ts
@@ -1,3 +1,4 @@
+import { type TemplateGroupTemplateKind } from '@grafana/api-clients/rtkq/notifications.alerting/v1beta1';
 import { alertingApi } from 'app/features/alerting/unified/api/alertingApi';
 import { type Template } from 'app/features/alerting/unified/components/receivers/form/fields/TemplateSelector';
 import { DEFAULT_TEMPLATES } from 'app/features/alerting/unified/utils/template-constants';
@@ -29,14 +30,19 @@ export interface AlertField {
   labels: KeyValueField[];
 }
 
-export type TemplatesTestPayload = { template: string; alerts: AlertField[]; name: string };
+export type TemplatesTestPayload = {
+  template: string;
+  alerts: AlertField[];
+  name: string;
+  kind?: TemplateGroupTemplateKind;
+};
 
 export const templatesApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
     previewTemplate: build.mutation<TemplatePreviewResponse, TemplatesTestPayload>({
-      query: ({ template, alerts, name }) => ({
+      query: ({ template, alerts, name, kind }) => ({
         url: previewTemplateUrl,
-        data: { template: template, alerts: alerts, name: name },
+        data: { template, alerts, name, kind },
         method: 'POST',
       }),
     }),

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -399,6 +399,7 @@ export const TemplateForm = ({ originalTemplate, prefill, alertmanager }: Props)
                       className={cx(styles.templatePreview, styles.minEditorSize)}
                       aiGeneratedTemplate={aiGeneratedTemplate}
                       setAiGeneratedTemplate={setAiGeneratedTemplate}
+                      kind={originalTemplate?.kind ?? 'grafana'}
                     />
                   </div>
                 )}

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -1,3 +1,5 @@
+import { HttpResponse, http } from 'msw';
+import { type SetupServer } from 'msw/node';
 import { type JSX, default as React } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { Provider } from 'react-redux';
@@ -8,7 +10,7 @@ import { Components } from '@grafana/e2e-selectors';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { configureStore } from 'app/store/configureStore';
 
-import { type TemplatePreviewResponse } from '../../api/templateApi';
+import { type TemplatePreviewResponse, type TemplatesTestPayload, previewTemplateUrl } from '../../api/templateApi';
 import {
   REJECTED_PREVIEW_RESPONSE,
   mockPreviewTemplateResponse,
@@ -50,6 +52,18 @@ const ui = {
   errorAlert: byRole('alert', { name: /error/i }),
   resultItems: byRole('listitem'),
 };
+
+// Captures the bodies of preview requests so tests can assert what the UI sends to the backend.
+function capturePreviewRequests(srv: SetupServer): TemplatesTestPayload[] {
+  const requests: TemplatesTestPayload[] = [];
+  srv.use(
+    http.post(previewTemplateUrl, async ({ request }) => {
+      requests.push((await request.json()) as TemplatesTestPayload);
+      return HttpResponse.json<TemplatePreviewResponse>({ results: [] });
+    })
+  );
+  return requests;
+}
 
 describe('TemplatePreview component', () => {
   it('Should render error if payload has wrong format', async () => {
@@ -150,6 +164,48 @@ describe('TemplatePreview component', () => {
     expect(within(previewItems[0]).getByTestId('mockeditor')).toHaveValue('This is the template result bla bla bla');
     expect(within(previewItems[1]).getByRole('banner')).toHaveTextContent('template2');
     expect(within(previewItems[1]).getByTestId('mockeditor')).toHaveValue('This is the template2 result bla bla bla');
+  });
+
+  it('Should send the template kind in the preview request', async () => {
+    const requests = capturePreviewRequests(server);
+    render(
+      <TemplatePreview
+        payload={'[{"a":"b"}]'}
+        templateName="potato"
+        templateContent={`{{ define "potato" }}{{ . }}{{ end }}`}
+        payloadFormatError={null}
+        setPayloadFormatError={jest.fn()}
+        kind="mimir"
+      />,
+      { wrapper: getProviderWraper() }
+    );
+
+    await waitFor(() => {
+      expect(requests.length).toBeGreaterThan(0);
+    });
+    expect(requests.at(-1)).toMatchObject({ name: 'potato', kind: 'mimir' });
+  });
+
+  // When a new frontend runs against a backend that predates kind support, the request must not carry
+  // anything the older backend would reject — omitting kind keeps the request backwards compatible.
+  it('Should omit kind from the preview request when none is provided', async () => {
+    const requests = capturePreviewRequests(server);
+    render(
+      <TemplatePreview
+        payload={'[{"a":"b"}]'}
+        templateName="potato"
+        templateContent={`{{ define "potato" }}{{ . }}{{ end }}`}
+        payloadFormatError={null}
+        setPayloadFormatError={jest.fn()}
+      />,
+      { wrapper: getProviderWraper() }
+    );
+
+    await waitFor(() => {
+      expect(requests.length).toBeGreaterThan(0);
+    });
+    expect(requests.at(-1)).toMatchObject({ name: 'potato' });
+    expect(requests.at(-1)?.kind).toBeUndefined();
   });
 
   it('Should render preview response with some errors,  if payload has correct format ', async () => {

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.tsx
@@ -1,9 +1,10 @@
 import { css, cx } from '@emotion/css';
 import { compact, uniqueId } from 'lodash';
-import * as React from 'react';
 import type { JSX } from 'react';
+import * as React from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
+import { type TemplateGroupTemplateKind } from '@grafana/api-clients/rtkq/notifications.alerting/v1beta1';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Alert, Box, Button, CodeEditor, useStyles2 } from '@grafana/ui';
@@ -28,6 +29,7 @@ export function TemplatePreview({
   className,
   aiGeneratedTemplate,
   setAiGeneratedTemplate,
+  kind,
 }: {
   payload: string;
   templateName: string;
@@ -37,6 +39,7 @@ export function TemplatePreview({
   className?: string;
   aiGeneratedTemplate?: boolean;
   setAiGeneratedTemplate?: (aiGeneratedTemplate: boolean) => void;
+  kind?: TemplateGroupTemplateKind;
 }) {
   const styles = useStyles2(getStyles);
 
@@ -45,7 +48,7 @@ export function TemplatePreview({
     isLoading,
     onPreview,
     error: previewError,
-  } = usePreviewTemplate(templateContent, templateName, payload, setPayloadFormatError);
+  } = usePreviewTemplate(templateContent, templateName, payload, setPayloadFormatError, kind);
 
   const previewToRender = getPreviewResults(previewError, payloadFormatError, data);
 

--- a/public/app/features/alerting/unified/components/receivers/usePreviewTemplate.ts
+++ b/public/app/features/alerting/unified/components/receivers/usePreviewTemplate.ts
@@ -1,12 +1,15 @@
 import { useCallback, useEffect } from 'react';
 
+import { type TemplateGroupTemplateKind } from '@grafana/api-clients/rtkq/notifications.alerting/v1beta1';
+
 import { type AlertField, usePreviewTemplateMutation } from '../../api/templateApi';
 
 export function usePreviewTemplate(
   templateContent: string,
   templateName: string,
   payload: string,
-  setPayloadFormatError: (value: React.SetStateAction<string | null>) => void
+  setPayloadFormatError: (value: React.SetStateAction<string | null>) => void,
+  kind?: TemplateGroupTemplateKind
 ) {
   const [trigger, { data, error, isLoading }] = usePreviewTemplateMutation();
 
@@ -14,12 +17,12 @@ export function usePreviewTemplate(
     try {
       const alertList: AlertField[] = JSON.parse(payload);
       JSON.stringify([...alertList]); // check if it's iterable, in order to be able to add more data
-      trigger({ template: templateContent, alerts: alertList, name: templateName });
+      trigger({ template: templateContent, alerts: alertList, name: templateName, kind });
       setPayloadFormatError(null);
     } catch (e) {
       setPayloadFormatError(e instanceof Error ? e.message : 'Invalid JSON.');
     }
-  }, [templateContent, templateName, payload, setPayloadFormatError, trigger]);
+  }, [templateContent, templateName, payload, setPayloadFormatError, trigger, kind]);
 
   useEffect(() => onPreview(), [onPreview]);
 


### PR DESCRIPTION
This is a follow up for https://github.com/grafana/grafana/pull/126450 that updates UI to include kind of the template to template preview requests.  