### PR TITLE
Alerting: gate rule edit form on alert.rules:read and folders:read

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.test.tsx
@@ -157,7 +157,11 @@ describe('AlertRuleForm — submit routing by group presence', () => {
   const folder = mockFolder({
     title: 'Folder A',
     uid: grafanaRulerRule.grafana_alert.namespace_uid,
-    accessControl: { [AccessControlAction.AlertingRuleUpdate]: true },
+    accessControl: {
+      [AccessControlAction.AlertingRuleRead]: true,
+      [AccessControlAction.AlertingRuleUpdate]: true,
+      [AccessControlAction.FoldersRead]: true,
+    },
   });
 
   beforeEach(() => {
@@ -341,7 +345,11 @@ describe('AlertRuleForm — alerting.rulesAPIV2 gate (flag off)', () => {
       mockFolder({
         title: 'Folder A',
         uid: grafanaRulerRule.grafana_alert.namespace_uid,
-        accessControl: { [AccessControlAction.AlertingRuleUpdate]: true },
+        accessControl: {
+          [AccessControlAction.AlertingRuleRead]: true,
+          [AccessControlAction.AlertingRuleUpdate]: true,
+          [AccessControlAction.FoldersRead]: true,
+        },
       })
     );
     mockPreviewApiResponse(server, []);

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
@@ -400,7 +400,9 @@ describe('PolicyTreeSelector - feature toggle ON', () => {
           uid: grafanaRulerNamespace.uid,
           title: grafanaRulerNamespace.name,
           accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
             [AccessControlAction.AlertingRuleUpdate]: true,
+            [AccessControlAction.FoldersRead]: true,
           },
         })
       );
@@ -463,7 +465,9 @@ describe('PolicyTreeSelector - feature toggle ON', () => {
           uid: grafanaRulerNamespace.uid,
           title: grafanaRulerNamespace.name,
           accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
             [AccessControlAction.AlertingRuleUpdate]: true,
+            [AccessControlAction.FoldersRead]: true,
           },
         })
       );
@@ -544,7 +548,9 @@ describe('PolicyTreeSelector - feature toggle ON', () => {
           uid: grafanaRulerNamespace.uid,
           title: grafanaRulerNamespace.name,
           accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
             [AccessControlAction.AlertingRuleUpdate]: true,
+            [AccessControlAction.FoldersRead]: true,
           },
         })
       );
@@ -699,7 +705,9 @@ describe('PolicyTreeSelector - alertingPolicyRoutingSettings ON', () => {
           uid: grafanaRulerNamespace.uid,
           title: grafanaRulerNamespace.name,
           accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
             [AccessControlAction.AlertingRuleUpdate]: true,
+            [AccessControlAction.FoldersRead]: true,
           },
         })
       );
@@ -747,7 +755,9 @@ describe('PolicyTreeSelector - alertingPolicyRoutingSettings ON', () => {
           uid: grafanaRulerNamespace.uid,
           title: grafanaRulerNamespace.name,
           accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
             [AccessControlAction.AlertingRuleUpdate]: true,
+            [AccessControlAction.FoldersRead]: true,
           },
         })
       );

--- a/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx
@@ -271,12 +271,24 @@ describe('AlertRuleMenu', () => {
           switch (action) {
             case AlertRuleAction.Pause:
             case AlertRuleAction.Update:
-              permissions.push(AccessControlAction.AlertingRuleUpdate);
+              permissions.push(
+                AccessControlAction.AlertingRuleRead,
+                AccessControlAction.AlertingRuleUpdate,
+                AccessControlAction.FoldersRead
+              );
+              folderAccessControl[AccessControlAction.AlertingRuleRead] = true;
               folderAccessControl[AccessControlAction.AlertingRuleUpdate] = true;
+              folderAccessControl[AccessControlAction.FoldersRead] = true;
               break;
             case AlertRuleAction.Delete:
-              permissions.push(AccessControlAction.AlertingRuleDelete);
+              permissions.push(
+                AccessControlAction.AlertingRuleRead,
+                AccessControlAction.AlertingRuleDelete,
+                AccessControlAction.FoldersRead
+              );
+              folderAccessControl[AccessControlAction.AlertingRuleRead] = true;
               folderAccessControl[AccessControlAction.AlertingRuleDelete] = true;
+              folderAccessControl[AccessControlAction.FoldersRead] = true;
               break;
             case AlertRuleAction.Duplicate:
               permissions.push(AccessControlAction.AlertingRuleCreate);
@@ -444,12 +456,15 @@ describe('AlertRuleMenu', () => {
         AccessControlAction.AlertingRuleUpdate,
         AccessControlAction.AlertingRuleDelete,
         AccessControlAction.AlertingRuleCreate,
+        AccessControlAction.FoldersRead,
         AccessControlAction.AlertingInstanceCreate,
         AccessControlAction.AlertingSilenceCreate,
       ]);
       setFolderAccessControl({
+        [AccessControlAction.AlertingRuleRead]: true,
         [AccessControlAction.AlertingRuleUpdate]: true,
         [AccessControlAction.AlertingRuleDelete]: true,
+        [AccessControlAction.FoldersRead]: true,
       });
       mockFolderApi(server).folder(
         'namespace-uid',
@@ -457,8 +472,10 @@ describe('AlertRuleMenu', () => {
           uid: 'namespace-uid',
           title: 'Test Folder',
           accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
             [AccessControlAction.AlertingRuleUpdate]: true,
             [AccessControlAction.AlertingRuleDelete]: true,
+            [AccessControlAction.FoldersRead]: true,
           },
         })
       );
@@ -786,14 +803,26 @@ describe('AlertRuleMenu', () => {
 
     describe('handleDelete', () => {
       it('calls handleDelete with correct identifier and groupIdentifier when Delete menu item is clicked', async () => {
-        grantUserPermissions([AccessControlAction.AlertingRuleDelete]);
-        setFolderAccessControl({ [AccessControlAction.AlertingRuleDelete]: true });
+        grantUserPermissions([
+          AccessControlAction.AlertingRuleRead,
+          AccessControlAction.AlertingRuleDelete,
+          AccessControlAction.FoldersRead,
+        ]);
+        setFolderAccessControl({
+          [AccessControlAction.AlertingRuleRead]: true,
+          [AccessControlAction.AlertingRuleDelete]: true,
+          [AccessControlAction.FoldersRead]: true,
+        });
         mockFolderApi(server).folder(
           'namespace-uid',
           mockFolder({
             uid: 'namespace-uid',
             title: 'Test Folder',
-            accessControl: { [AccessControlAction.AlertingRuleDelete]: true },
+            accessControl: {
+              [AccessControlAction.AlertingRuleRead]: true,
+              [AccessControlAction.AlertingRuleDelete]: true,
+              [AccessControlAction.FoldersRead]: true,
+            },
           })
         );
 
@@ -886,14 +915,26 @@ describe('AlertRuleMenu', () => {
     describe('onPauseChange', () => {
       it('calls onPauseChange after pause state change when Pause menu item is clicked', async () => {
         const onPauseChange = jest.fn();
-        grantUserPermissions([AccessControlAction.AlertingRuleUpdate]);
-        setFolderAccessControl({ [AccessControlAction.AlertingRuleUpdate]: true });
+        grantUserPermissions([
+          AccessControlAction.AlertingRuleRead,
+          AccessControlAction.AlertingRuleUpdate,
+          AccessControlAction.FoldersRead,
+        ]);
+        setFolderAccessControl({
+          [AccessControlAction.AlertingRuleRead]: true,
+          [AccessControlAction.AlertingRuleUpdate]: true,
+          [AccessControlAction.FoldersRead]: true,
+        });
         mockFolderApi(server).folder(
           'namespace-uid',
           mockFolder({
             uid: 'namespace-uid',
             title: 'Test Folder',
-            accessControl: { [AccessControlAction.AlertingRuleUpdate]: true },
+            accessControl: {
+              [AccessControlAction.AlertingRuleRead]: true,
+              [AccessControlAction.AlertingRuleUpdate]: true,
+              [AccessControlAction.FoldersRead]: true,
+            },
           })
         );
 
@@ -927,14 +968,26 @@ describe('AlertRuleMenu', () => {
 
       it('calls onPauseChange after resume state change when Resume menu item is clicked', async () => {
         const onPauseChange = jest.fn();
-        grantUserPermissions([AccessControlAction.AlertingRuleUpdate]);
-        setFolderAccessControl({ [AccessControlAction.AlertingRuleUpdate]: true });
+        grantUserPermissions([
+          AccessControlAction.AlertingRuleRead,
+          AccessControlAction.AlertingRuleUpdate,
+          AccessControlAction.FoldersRead,
+        ]);
+        setFolderAccessControl({
+          [AccessControlAction.AlertingRuleRead]: true,
+          [AccessControlAction.AlertingRuleUpdate]: true,
+          [AccessControlAction.FoldersRead]: true,
+        });
         mockFolderApi(server).folder(
           'namespace-uid',
           mockFolder({
             uid: 'namespace-uid',
             title: 'Test Folder',
-            accessControl: { [AccessControlAction.AlertingRuleUpdate]: true },
+            accessControl: {
+              [AccessControlAction.AlertingRuleRead]: true,
+              [AccessControlAction.AlertingRuleUpdate]: true,
+              [AccessControlAction.FoldersRead]: true,
+            },
           })
         );
 
@@ -1407,14 +1460,26 @@ describe('AlertRuleMenu', () => {
       });
 
       it('pause still works when onPauseChange is not provided', async () => {
-        grantUserPermissions([AccessControlAction.AlertingRuleUpdate]);
-        setFolderAccessControl({ [AccessControlAction.AlertingRuleUpdate]: true });
+        grantUserPermissions([
+          AccessControlAction.AlertingRuleRead,
+          AccessControlAction.AlertingRuleUpdate,
+          AccessControlAction.FoldersRead,
+        ]);
+        setFolderAccessControl({
+          [AccessControlAction.AlertingRuleRead]: true,
+          [AccessControlAction.AlertingRuleUpdate]: true,
+          [AccessControlAction.FoldersRead]: true,
+        });
         mockFolderApi(server).folder(
           'namespace-uid',
           mockFolder({
             uid: 'namespace-uid',
             title: 'Test Folder',
-            accessControl: { [AccessControlAction.AlertingRuleUpdate]: true },
+            accessControl: {
+              [AccessControlAction.AlertingRuleRead]: true,
+              [AccessControlAction.AlertingRuleUpdate]: true,
+              [AccessControlAction.FoldersRead]: true,
+            },
           })
         );
 

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -176,6 +176,7 @@ describe('RuleViewer', () => {
         AccessControlAction.AlertingRuleRead,
         AccessControlAction.AlertingRuleUpdate,
         AccessControlAction.AlertingRuleDelete,
+        AccessControlAction.FoldersRead,
         AccessControlAction.AlertingInstanceRead,
         AccessControlAction.AlertingInstanceCreate,
         AccessControlAction.AlertingInstanceRead,

--- a/public/app/features/alerting/unified/group-details/GroupDetailsPage.test.tsx
+++ b/public/app/features/alerting/unified/group-details/GroupDetailsPage.test.tsx
@@ -72,6 +72,7 @@ describe('GroupDetailsPage', () => {
       AccessControlAction.AlertingRuleUpdate,
       AccessControlAction.AlertingRuleExternalRead,
       AccessControlAction.AlertingRuleExternalWrite,
+      AccessControlAction.FoldersRead,
     ]);
   });
 

--- a/public/app/features/alerting/unified/hooks/abilities/rules/ruleAbilities.test.tsx
+++ b/public/app/features/alerting/unified/hooks/abilities/rules/ruleAbilities.test.tsx
@@ -54,8 +54,10 @@ describe('useRuleAdministrationAbility', () => {
 
   it('grants update and delete when user has permissions and ruler is available', async () => {
     setFolderAccessControl({
+      'alert.rules:read': true,
       'alert.rules:write': true,
       'alert.rules:delete': true,
+      'folders:read': true,
     });
 
     const rule = getGrafanaRule();
@@ -71,8 +73,10 @@ describe('useRuleAdministrationAbility', () => {
 
   it('matches snapshot for a Grafana rule with all permissions granted', async () => {
     setFolderAccessControl({
+      'alert.rules:read': true,
       'alert.rules:write': true,
       'alert.rules:delete': true,
+      'folders:read': true,
     });
     grantUserPermissions([AccessControlAction.AlertingRuleCreate]);
 
@@ -146,7 +150,7 @@ describe('useRuleAdministrationAbility', () => {
   });
 
   it('is editable (not IS_PLUGIN_MANAGED) when plugin origin label references a non-existent plugin', async () => {
-    setFolderAccessControl({ 'alert.rules:write': true });
+    setFolderAccessControl({ 'alert.rules:read': true, 'alert.rules:write': true, 'folders:read': true });
 
     const rule = getGrafanaRule({
       labels: { __grafana_origin: 'plugin/non-existent-plugin' },
@@ -193,7 +197,7 @@ describe('useRuleAdministrationAbility', () => {
   });
 
   it('grants restore and pause for Grafana-managed rules with edit permission', async () => {
-    setFolderAccessControl({ 'alert.rules:write': true });
+    setFolderAccessControl({ 'alert.rules:read': true, 'alert.rules:write': true, 'folders:read': true });
 
     const rule = getGrafanaRule();
     const groupId = groupIdentifier.fromCombinedRule(rule);
@@ -238,7 +242,12 @@ describe('useRuleAdministrationAbility', () => {
 
   it('returns INSUFFICIENT_PERMISSIONS for deletePermanently when user has delete permission but is not admin', async () => {
     jest.spyOn(misc, 'isAdmin').mockReturnValue(false);
-    setFolderAccessControl({ 'alert.rules:write': true, 'alert.rules:delete': true });
+    setFolderAccessControl({
+      'alert.rules:read': true,
+      'alert.rules:write': true,
+      'alert.rules:delete': true,
+      'folders:read': true,
+    });
 
     const rule = getGrafanaRule();
     const groupId = groupIdentifier.fromCombinedRule(rule);
@@ -257,7 +266,12 @@ describe('useRuleAdministrationAbility', () => {
 
   it('grants deletePermanently when user has delete permission and is admin', async () => {
     jest.spyOn(misc, 'isAdmin').mockReturnValue(true);
-    setFolderAccessControl({ 'alert.rules:write': true, 'alert.rules:delete': true });
+    setFolderAccessControl({
+      'alert.rules:read': true,
+      'alert.rules:write': true,
+      'alert.rules:delete': true,
+      'folders:read': true,
+    });
 
     const rule = getGrafanaRule();
     const groupId = groupIdentifier.fromCombinedRule(rule);

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.test.tsx
@@ -34,10 +34,12 @@ describe('useIsRuleEditable', () => {
   describe('RBAC enabled', () => {
     describe('Grafana rules', () => {
       // When RBAC is enabled we require appropriate alerting permissions in the folder scope
-      it('Should allow editing when the user has the alert rule update permission in the folder', async () => {
+      it('Should allow editing when the user has alert rule update, read, and folder read permissions', async () => {
         mockUseFolder({
           accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
             [AccessControlAction.AlertingRuleUpdate]: true,
+            [AccessControlAction.FoldersRead]: true,
           },
         });
 
@@ -49,10 +51,12 @@ describe('useIsRuleEditable', () => {
         expect(result.current.isEditable).toBe(true);
       });
 
-      it('Should allow deleting when the user has the alert rule delete permission', async () => {
+      it('Should allow deleting when the user has alert rule delete, read, and folder read permissions', async () => {
         mockUseFolder({
           accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
             [AccessControlAction.AlertingRuleDelete]: true,
+            [AccessControlAction.FoldersRead]: true,
           },
         });
 
@@ -64,6 +68,74 @@ describe('useIsRuleEditable', () => {
 
         await waitFor(() => expect(result.current.loading).toBe(false));
         expect(result.current.isRemovable).toBe(true);
+      });
+
+      it('Should forbid editing when the user has write permission but is missing alert.rules:read', async () => {
+        mockUseFolder({
+          accessControl: {
+            [AccessControlAction.AlertingRuleUpdate]: true,
+            [AccessControlAction.FoldersRead]: true,
+            // alert.rules:read deliberately absent — this is the reported bug scenario
+          },
+        });
+
+        const wrapper = getProviderWrapper();
+
+        const { result } = renderHook(() => useIsRuleEditable('grafana', mockRulerGrafanaRule()), { wrapper });
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.isEditable).toBe(false);
+      });
+
+      it('Should forbid editing when the user has write and rule read permissions but is missing folders:read', async () => {
+        mockUseFolder({
+          accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
+            [AccessControlAction.AlertingRuleUpdate]: true,
+            // folders:read deliberately absent
+          },
+        });
+
+        const wrapper = getProviderWrapper();
+
+        const { result } = renderHook(() => useIsRuleEditable('grafana', mockRulerGrafanaRule()), { wrapper });
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.isEditable).toBe(false);
+      });
+
+      it('Should forbid deleting when the user has delete permission but is missing alert.rules:read', async () => {
+        mockUseFolder({
+          accessControl: {
+            [AccessControlAction.AlertingRuleDelete]: true,
+            [AccessControlAction.FoldersRead]: true,
+            // alert.rules:read deliberately absent
+          },
+        });
+
+        const wrapper = getProviderWrapper();
+
+        const { result } = renderHook(() => useIsRuleEditable('grafana', mockRulerGrafanaRule()), { wrapper });
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.isRemovable).toBe(false);
+      });
+
+      it('Should forbid deleting when the user has delete and rule read permissions but is missing folders:read', async () => {
+        mockUseFolder({
+          accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
+            [AccessControlAction.AlertingRuleDelete]: true,
+            // folders:read deliberately absent
+          },
+        });
+
+        const wrapper = getProviderWrapper();
+
+        const { result } = renderHook(() => useIsRuleEditable('grafana', mockRulerGrafanaRule()), { wrapper });
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.isRemovable).toBe(false);
       });
 
       it('Should forbid editing when the user has no alert rule update permission', async () => {
@@ -92,8 +164,10 @@ describe('useIsRuleEditable', () => {
         mockUseFolder({
           canSave: false,
           accessControl: {
+            [AccessControlAction.AlertingRuleRead]: true,
             [AccessControlAction.AlertingRuleUpdate]: true,
             [AccessControlAction.AlertingRuleDelete]: true,
+            [AccessControlAction.FoldersRead]: true,
           },
         });
 

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
@@ -1,4 +1,5 @@
 import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
 import { type RulerRuleDTO } from 'app/types/unified-alerting-dto';
 
 import { featureDiscoveryApi } from '../api/featureDiscoveryApi';
@@ -64,8 +65,15 @@ export function useIsRuleEditable(rulesSourceName: string, rule?: RulerRuleDTO):
       };
     }
 
-    const canEditGrafanaRules = contextSrv.hasPermissionInMetadata(rulePermission.update, folder);
-    const canRemoveGrafanaRules = contextSrv.hasPermissionInMetadata(rulePermission.delete, folder);
+    // The backend requires alert.rules:read and folders:read as prerequisites for any
+    // write operation (POST /api/ruler/grafana/api/v1/rules/{Namespace}).
+    // Mirror that compound requirement here so the edit form is blocked before Save.
+    const canReadGrafanaRules = contextSrv.hasPermissionInMetadata(rulePermission.read, folder);
+    const canReadFolder = contextSrv.hasPermissionInMetadata(AccessControlAction.FoldersRead, folder);
+    const canEditGrafanaRules =
+      canReadGrafanaRules && canReadFolder && contextSrv.hasPermissionInMetadata(rulePermission.update, folder);
+    const canRemoveGrafanaRules =
+      canReadGrafanaRules && canReadFolder && contextSrv.hasPermissionInMetadata(rulePermission.delete, folder);
 
     return {
       isRulerAvailable: true,

--- a/public/app/features/alerting/unified/rule-editor/CloneRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/rule-editor/CloneRuleEditor.test.tsx
@@ -62,7 +62,9 @@ describe('CloneRuleEditor', function () {
     id: 1,
     type: DashboardSearchItemType.DashDB,
     accessControl: {
+      [AccessControlAction.AlertingRuleRead]: true,
       [AccessControlAction.AlertingRuleUpdate]: true,
+      [AccessControlAction.FoldersRead]: true,
     },
   };
 

--- a/public/app/features/alerting/unified/rule-editor/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/rule-editor/RuleEditorExisting.test.tsx
@@ -43,7 +43,9 @@ describe('RuleEditor grafana managed rules', () => {
     id: 1,
     type: DashboardSearchItemType.DashDB,
     accessControl: {
+      [AccessControlAction.AlertingRuleRead]: true,
       [AccessControlAction.AlertingRuleUpdate]: true,
+      [AccessControlAction.FoldersRead]: true,
     },
   };
 
@@ -52,7 +54,9 @@ describe('RuleEditor grafana managed rules', () => {
     uid: 'abcde',
     id: 2,
     accessControl: {
+      [AccessControlAction.AlertingRuleRead]: true,
       [AccessControlAction.AlertingRuleUpdate]: true,
+      [AccessControlAction.FoldersRead]: true,
     },
   };
   beforeEach(() => {

--- a/public/app/features/alerting/unified/rule-editor/RuleEditorGroupedToUngrouped.test.tsx
+++ b/public/app/features/alerting/unified/rule-editor/RuleEditorGroupedToUngrouped.test.tsx
@@ -38,7 +38,9 @@ describe('RuleEditor - editing a grouped Grafana rule to ungrouped', () => {
     id: 1,
     type: DashboardSearchItemType.DashDB,
     accessControl: {
+      [AccessControlAction.AlertingRuleRead]: true,
       [AccessControlAction.AlertingRuleUpdate]: true,
+      [AccessControlAction.FoldersRead]: true,
     },
   };
 

--- a/public/app/features/alerting/unified/utils/access-control.ts
+++ b/public/app/features/alerting/unified/utils/access-control.ts
@@ -18,6 +18,7 @@ import { getConfig } from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { isGranted } from '../hooks/abilities/abilityUtils';
 import { getExternalGlobalRuleAbility, getGlobalRuleAbility } from '../hooks/abilities/rules/ruleAbilities';
 import { ExternalRuleAction, RuleAction } from '../hooks/abilities/types';
 
@@ -183,14 +184,20 @@ export function evaluateAccess(actions: AccessControlAction[]) {
 export function getRulesAccess() {
   return {
     canCreateGrafanaRules:
-      contextSrv.hasPermission(AccessControlAction.FoldersRead) && getGlobalRuleAbility(RuleAction.Create).granted,
+      contextSrv.hasPermission(AccessControlAction.FoldersRead) && isGranted(getGlobalRuleAbility(RuleAction.Create)),
     canCreateCloudRules:
       contextSrv.hasPermission(AccessControlAction.DataSourcesRead) &&
-      getExternalGlobalRuleAbility(ExternalRuleAction.CreateAlertRule).granted,
+      isGranted(getExternalGlobalRuleAbility(ExternalRuleAction.CreateAlertRule)),
     canEditRules: (rulesSourceName: string) => {
+      // The backend requires alert.rules:read alongside alert.rules:write for all rule mutations.
+      // Check both here so RuleEditor shows "no access" immediately rather than after Save.
+      const canViewGrafanaRules = isGranted(getGlobalRuleAbility(RuleAction.View));
+      const canUpdateGrafanaRules = isGranted(getGlobalRuleAbility(RuleAction.Update));
+      const canUpdateCloudRules = isGranted(getExternalGlobalRuleAbility(ExternalRuleAction.UpdateAlertRule));
+
       return rulesSourceName === GRAFANA_SOURCE_NAME
-        ? getGlobalRuleAbility(RuleAction.Update).granted
-        : getExternalGlobalRuleAbility(ExternalRuleAction.UpdateAlertRule).granted;
+        ? contextSrv.hasPermission(AccessControlAction.FoldersRead) && canViewGrafanaRules && canUpdateGrafanaRules
+        : canUpdateCloudRules;
     },
   };
 }
@@ -201,8 +208,8 @@ export function getRulesAccess() {
  */
 export function getCreateAlertInMenuAvailability() {
   const { unifiedAlertingEnabled } = getConfig();
-  const canRead = getGlobalRuleAbility(RuleAction.View).granted;
-  const canUpdate = getGlobalRuleAbility(RuleAction.Update).granted;
+  const canRead = isGranted(getGlobalRuleAbility(RuleAction.View));
+  const canUpdate = isGranted(getGlobalRuleAbility(RuleAction.Update));
 
   return unifiedAlertingEnabled && canRead && canUpdate;
 }


### PR DESCRIPTION
**What is this feature?**

This is a bug fix. The alert rule edit form was accessible to users who had `alert.rules:write` but lacked `alert.rules:read` or `folders:read`. Those users could fill in the entire form and were only denied access when clicking Save, at which point the backend returned the error shown below.

```
You'll need additional permissions to perform this action.
Permissions needed: all of alert.rules:read, folders:read, any of alert.rules:write, alert.rules:create, alert.rules:delete
```

**Why do we need this feature?**

The backend requires `alert.rules:read` **and** `folders:read` as mandatory prerequisites alongside any write permission — enforced in `authorization.go` for `POST /api/ruler/grafana/api/v1/rules/{Namespace}`. The frontend only checked `alert.rules:write`, so users with a custom role that removes read access could reach the edit form. This is a regression introduced by #78289 (March 2024), which tightened the backend requirement without a corresponding frontend update.

**Who is this feature for?**

Grafana operators using custom RBAC roles that grant alerting write permissions without read permissions.

**Changes**

- `useIsRuleEditable.ts` — folder-scoped check now requires `alert.rules:read` **and** `folders:read` alongside `alert.rules:write`, mirroring `getReadFolderAccessEvaluator` in `pkg/services/ngalert/accesscontrol/rules.go`. Applied consistently to the delete (`isRemovable`) check too.
- `access-control.ts` — `canEditRules()` global fast-fail in `RuleEditor` now also requires `alert.rules:read`, so users without any read permission see the "cannot edit" screen before the folder even loads.
- `useIsRuleEditable.test.tsx` — existing tests updated to supply the now-required permissions; two new regression tests added for the reported scenario (write without read = denied, write + rule-read without folders:read = denied).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.