### PR TITLE
Home: Switch pre extension to Assistant app

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -239,7 +239,7 @@ export enum PluginExtensionPoints {
   AdvisorRetryCheck = 'grafana/advisor/retry-check/v1',
   NavRightButton = 'grafana/singletopbar/nav-right-button/v1',
   HomepageTabs = 'grafana/homepage/tabs/v1',
-  HomepagePre = 'grafana/homepage/pre/v1',
+  HomepageAssistant = 'grafana/homepage/assistant/v1',
   HomepageExtra = 'grafana/homepage/extra/v1',
 }
 

--- a/public/app/core/constants.ts
+++ b/public/app/core/constants.ts
@@ -23,3 +23,8 @@ export const MEGA_MENU_TOGGLE_ID = 'mega-menu-toggle';
  * grafana-setupguide-app plugin ID, used in extension points to provide Cloud-only UI functionality.
  */
 export const SETUPGUIDE_PLUGIN_ID = 'grafana-setupguide-app';
+
+/**
+ * grafana-assistant-app plugin ID, used in extension points to provide Assistant-only UI functionality.
+ */
+export const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';

--- a/public/app/features/home/HomePage.test.tsx
+++ b/public/app/features/home/HomePage.test.tsx
@@ -88,21 +88,21 @@ describe('HomePage', () => {
     expect(await screen.findByText('Welcome to Grafana Cloud.')).toBeInTheDocument();
   });
 
-  it('renders homepage pre extension components', async () => {
+  it('renders homepage assistant extension components', async () => {
     setPluginComponentsHook(({ extensionPointId }) => ({
       isLoading: false,
       components:
-        extensionPointId === PluginExtensionPoints.HomepagePre
+        extensionPointId === PluginExtensionPoints.HomepageAssistant
           ? [
               createHomepageExtensionComponent(
-                'grafana-setupguide-app',
-                'Homepage pre extension',
-                PluginExtensionPoints.HomepagePre
+                'grafana-assistant-app',
+                'Homepage assistant extension',
+                PluginExtensionPoints.HomepageAssistant
               ),
               createHomepageExtensionComponent(
                 'grafana-untrusted-app',
-                'Untrusted homepage pre extension',
-                PluginExtensionPoints.HomepagePre
+                'Untrusted homepage assistant extension',
+                PluginExtensionPoints.HomepageAssistant
               ),
             ]
           : [],
@@ -110,8 +110,8 @@ describe('HomePage', () => {
 
     render(<HomePage />);
 
-    expect(await screen.findByText('Homepage pre extension')).toBeInTheDocument();
-    expect(screen.queryByText('Untrusted homepage pre extension')).not.toBeInTheDocument();
+    expect(await screen.findByText('Homepage assistant extension')).toBeInTheDocument();
+    expect(screen.queryByText('Untrusted homepage assistant extension')).not.toBeInTheDocument();
   });
 
   it('renders homepage extra extension components', async () => {

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -6,7 +6,7 @@ import { t } from '@grafana/i18n';
 import { config, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import { Grid, Stack, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
-import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
+import { ASSISTANT_PLUGIN_ID, SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
 import { FiringAlertsCard } from './AlertsIncidents/FiringAlertsCard';
@@ -31,8 +31,8 @@ export default function HomePage() {
   const styles = useStyles2(getStyles);
   const greeting = useHomeGreeting();
 
-  const { components: preComponents } = usePluginComponents({
-    extensionPointId: PluginExtensionPoints.HomepagePre,
+  const { components: assistantComponents } = usePluginComponents({
+    extensionPointId: PluginExtensionPoints.HomepageAssistant,
   });
 
   const { components: extraComponents } = usePluginComponents({
@@ -52,18 +52,22 @@ export default function HomePage() {
       <Page.Contents>
         <Stack direction="column" gap={2}>
           <HomeSection direction="column" display="flex" gap={2}>
+            {/* Assistant injects an Assistant-based prompt input when available */}
             {renderLimitedComponents({
               props: {},
-              components: preComponents,
-              pluginId: SETUPGUIDE_PLUGIN_ID,
+              limit: 1,
+              components: assistantComponents,
+              pluginId: ASSISTANT_PLUGIN_ID,
             })}
             <DashboardTabs />
           </HomeSection>
+
           <Grid gap={2} columns={{ xs: 1, md: 2 }}>
             <FiringAlertsCard />
             <IncidentsCard />
           </Grid>
 
+          {/* SetupGuide injects assorted sections for Cloud users */}
           {renderLimitedComponents({
             props: {},
             components: extraComponents,


### PR DESCRIPTION
**What is this feature?**

With https://github.com/grafana/grafana-assistant-app/pull/6962 (🔐) landed + released, Assistant is now pushing a near-identical version of the search component that is currently pushed by SetupGuide for Cloud only. This switches the homepage over to rendering the version from Assistant instead of SetupGuide.

**Why do we need this feature?**

Allows OSS users to also benefit from the Assistant search component when Assistant is installed, rather than this being Cloud-only.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana/issues/124136

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
