### PR TITLE
chore: upgrade nanogit to v0.18.1

### DIFF
--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grafana/grafana/apps/dashboard v0.0.0-20260424050122-76eba5631b44
 	github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
-	github.com/grafana/nanogit v0.18.0
+	github.com/grafana/nanogit v0.18.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/migueleliasweb/go-github-mock v1.5.0
 	github.com/prometheus/client_golang v1.23.2

--- a/apps/provisioning/go.sum
+++ b/apps/provisioning/go.sum
@@ -113,8 +113,8 @@ github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6 h1:TJd
 github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6/go.mod h1:6ZLwJmNc+7dWXQ+NRBV09HZbg/XZ6yN7kWFf7w301Lo=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6/go.mod h1:BpUYFztGINSLZmkzcS9dSHdNwBZAb8w1KD5unG1oNeg=
-github.com/grafana/nanogit v0.18.0 h1:aSIwr5OGnaxh03TWozbC43T+D3bl32d6SGziwSmld4Q=
-github.com/grafana/nanogit v0.18.0/go.mod h1:QhFA4nFZcKIG7Q22CXfAPe6eQwXWF+sef6zuGKKJLGE=
+github.com/grafana/nanogit v0.18.1 h1:4bOWHj0138m/x8ojz1UpThBMixkci1GwZvyjVn4XTtg=
+github.com/grafana/nanogit v0.18.1/go.mod h1:QhFA4nFZcKIG7Q22CXfAPe6eQwXWF+sef6zuGKKJLGE=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/go.mod
+++ b/go.mod
@@ -486,7 +486,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/grafana/jsonparser v0.0.0-20241004153430-023329977675 // indirect
-	github.com/grafana/nanogit v0.18.0 // indirect
+	github.com/grafana/nanogit v0.18.1 // indirect
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect
 	github.com/grafana/sqlds/v5 v5.1.1 // indirect
 	github.com/hashicorp/consul/api v1.33.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1644,8 +1644,8 @@ github.com/grafana/loki/v3 v3.7.2 h1:YqrDecBkmlYOhdWiCY34GKzZcW8anhTABhZY2qL98AQ
 github.com/grafana/loki/v3 v3.7.2/go.mod h1:dM38zSrv141vSEh3+8CXZNrvVj6qB0IEXpy4uwGcjHY=
 github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86 h1:aTwfQuroOmOr//QEn9J1MtC4R4CPR9/IbUd8hZrbWKo=
 github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86/go.mod h1:h60o12SZn/ua/j0B6iKAZezA4eDaGsIuPO70eOaJ6WE=
-github.com/grafana/nanogit v0.18.0 h1:aSIwr5OGnaxh03TWozbC43T+D3bl32d6SGziwSmld4Q=
-github.com/grafana/nanogit v0.18.0/go.mod h1:QhFA4nFZcKIG7Q22CXfAPe6eQwXWF+sef6zuGKKJLGE=
+github.com/grafana/nanogit v0.18.1 h1:4bOWHj0138m/x8ojz1UpThBMixkci1GwZvyjVn4XTtg=
+github.com/grafana/nanogit v0.18.1/go.mod h1:QhFA4nFZcKIG7Q22CXfAPe6eQwXWF+sef6zuGKKJLGE=
 github.com/grafana/nanogit/gittest v0.10.2 h1:2+e/zvmBCjpTN/8AeHS7OIjEI6FnzqyNs5RmiJYcJdY=
 github.com/grafana/nanogit/gittest v0.10.2/go.mod h1:qewV4AZOErVbxBMYLj9yAv5ITs/VOc+t/Ko/2w3pSfo=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=


### PR DESCRIPTION
Upgrade nanogit to release https://github.com/grafana/nanogit/releases/tag/v0.18.1
