### PR TITLE
Alerting: Remove includeImported parameter from SortedTemplates

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -252,12 +252,8 @@ receivers:
 				return
 			}
 			require.NoError(t, err)
-			templateDefs := tc.config.SortedTemplates(true)
-			expectedTemplateCount := len(tc.config.Templates)
-			if len(tc.config.ExtraConfigs) > 0 {
-				expectedTemplateCount += len(tc.config.ExtraConfigs[0].TemplateFiles)
-			}
-			require.Len(t, templateDefs, expectedTemplateCount)
+			templateDefs := tc.config.SortedTemplates()
+			require.Len(t, templateDefs, len(tc.config.Templates))
 		})
 	}
 }

--- a/pkg/services/ngalert/notifier/compat.go
+++ b/pkg/services/ngalert/notifier/compat.go
@@ -76,7 +76,7 @@ func PostableAPIConfigToNotificationsConfiguration(
 		RoutingTree:   RouteToAPI(cfg.AlertmanagerConfig.Route),
 		InhibitRules:  append(inhibitionRules, cfg.AlertmanagerConfig.InhibitRules...),
 		TimeIntervals: ModelToTimeIntervals(cfg.AlertmanagerConfig.TimeIntervals, cfg.AlertmanagerConfig.MuteTimeIntervals),
-		Templates:     ModelToTemplateDefinitions(cfg.SortedTemplates(false)), // templates are already merged.
+		Templates:     ModelToTemplateDefinitions(cfg.SortedTemplates()), // templates are already merged.
 		Receivers:     receivers,
 		Limits:        limits,
 	}, nil

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
@@ -32,16 +32,10 @@ type AMConfigV1 struct {
 }
 
 // SortedTemplates returns templates ordered by kind and title.
-func (c *AMConfigV1) SortedTemplates(includeImported bool) []TemplateGroup {
+func (c *AMConfigV1) SortedTemplates() []TemplateGroup {
 	res := make([]TemplateGroup, 0, len(c.Templates))
 	for _, t := range c.Templates {
 		res = append(res, t)
-	}
-
-	if includeImported && len(c.ExtraConfigs) > 0 {
-		for name, content := range c.ExtraConfigs[0].TemplateFiles {
-			res = append(res, NewTemplateGroup(name, content, TemplateKindMimir, models.ProvenanceConvertedPrometheus)) // Provenance shouldn't be used regardless.
-		}
 	}
 
 	return slices.SortedFunc(slices.Values(res), func(a TemplateGroup, b TemplateGroup) int {


### PR DESCRIPTION
## Summary

- Removes the `includeImported bool` parameter from `AMConfigV1.SortedTemplates`
- Drops the branch that merged `ExtraConfigs[0].TemplateFiles` into the result — the production caller always passed `false`, so this code was never exercised
- Updates the single test that called it with `true` to match the new (simpler) signature

## Test plan

- [ ] `go test ./pkg/services/ngalert/notifier/... -run TestAlertmanager_ApplyConfig` passes