### PR TITLE
Replace GetMergedTemplateDefinitions with TemplatesMapToPostableAPITemplates

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -717,15 +717,6 @@ type PostableUserConfig struct {
 	ManagedInhibitionRules ManagedInhibitionRules    `yaml:"managed_inhibition_rules,omitempty" json:"managed_inhibition_rules,omitempty"` // TODO: Move to ConfigRevision?
 }
 
-// GetMergedTemplateDefinitions converts the given PostableUserConfig's TemplateFiles to a slice of Templates.
-func (c *PostableUserConfig) GetMergedTemplateDefinitions() []definition.PostableApiTemplate {
-	out := definition.TemplatesMapToPostableAPITemplates(c.TemplateFiles, definition.GrafanaTemplateKind)
-	if len(c.ExtraConfigs) == 0 || len(c.ExtraConfigs[0].TemplateFiles) == 0 {
-		return out
-	}
-	return append(out, definition.TemplatesMapToPostableAPITemplates(c.ExtraConfigs[0].TemplateFiles, definition.MimirTemplateKind)...)
-}
-
 func (c *PostableUserConfig) UnmarshalJSON(b []byte) error {
 	type plain PostableUserConfig
 	if err := json.Unmarshal(b, (*plain)(c)); err != nil {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/grafana/alerting/definition"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,90 +94,6 @@ func Test_RawMessageMarshaling(t *testing.T) {
 		require.NoError(t, yaml.Unmarshal(data, &n))
 		assert.Equal(t, RawMessage(`{"data":"test"}`), n.Field)
 	})
-}
-
-func TestPostableUserConfig_GetMergedTemplateDefinitions(t *testing.T) {
-	testCases := []struct {
-		name              string
-		config            PostableUserConfig
-		expectedTemplates int
-	}{
-		{
-			name: "no templates",
-			config: PostableUserConfig{
-				TemplateFiles: map[string]string{},
-				ExtraConfigs:  []ExtraConfiguration{},
-			},
-			expectedTemplates: 0,
-		},
-		{
-			name: "grafana templates only",
-			config: PostableUserConfig{
-				TemplateFiles: map[string]string{
-					"grafana-template1": "{{ define \"test\" }}Hello{{ end }}",
-					"grafana-template2": "{{ define \"test2\" }}World{{ end }}",
-				},
-				ExtraConfigs: []ExtraConfiguration{},
-			},
-			expectedTemplates: 2,
-		},
-		{
-			name: "mimir templates only",
-			config: PostableUserConfig{
-				TemplateFiles: map[string]string{},
-				ExtraConfigs: []ExtraConfiguration{
-					{
-						TemplateFiles: map[string]string{
-							"mimir-template": "{{ define \"mimir\" }}Mimir{{ end }}",
-						},
-					},
-				},
-			},
-			expectedTemplates: 1,
-		},
-		{
-			name: "mixed templates",
-			config: PostableUserConfig{
-				TemplateFiles: map[string]string{
-					"grafana-template": "{{ define \"grafana\" }}Grafana{{ end }}",
-				},
-				ExtraConfigs: []ExtraConfiguration{
-					{
-						TemplateFiles: map[string]string{
-							"mimir-template": "{{ define \"mimir\" }}Mimir{{ end }}",
-						},
-					},
-				},
-			},
-			expectedTemplates: 2,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := tc.config.GetMergedTemplateDefinitions()
-			require.Len(t, result, tc.expectedTemplates)
-
-			templateMap := make(map[string]string)
-			kindMap := make(map[string]definition.TemplateKind)
-			for _, tmpl := range result {
-				templateMap[tmpl.Name] = tmpl.Content
-				kindMap[tmpl.Name] = tmpl.Kind
-			}
-
-			for name, content := range tc.config.TemplateFiles {
-				require.Equal(t, content, templateMap[name])
-				require.Equal(t, definition.GrafanaTemplateKind, kindMap[name])
-			}
-
-			if len(tc.config.ExtraConfigs) > 0 {
-				for name, content := range tc.config.ExtraConfigs[0].TemplateFiles {
-					require.Equal(t, content, templateMap[name])
-					require.Equal(t, definition.MimirTemplateKind, kindMap[name])
-				}
-			}
-		})
-	}
 }
 
 func TestExtraConfiguration_Validate(t *testing.T) {

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -308,7 +308,7 @@ func TestIntegrationApplyConfig(t *testing.T) {
 		require.NoError(t, err)
 		return client.GrafanaAlertmanagerConfig{
 			AlertmanagerConfig: postable.AlertmanagerConfig,
-			Templates:          postable.GetMergedTemplateDefinitions(),
+			Templates:          definition.TemplatesMapToPostableAPITemplates(postable.TemplateFiles, definition.GrafanaTemplateKind),
 		}
 	}
 
@@ -1259,7 +1259,7 @@ func TestIntegrationRemoteAlertmanagerConfiguration(t *testing.T) {
 		require.NoError(t, err)
 		return client.GrafanaAlertmanagerConfig{
 			AlertmanagerConfig: postable.AlertmanagerConfig,
-			Templates:          postable.GetMergedTemplateDefinitions(),
+			Templates:          definition.TemplatesMapToPostableAPITemplates(postable.TemplateFiles, definition.GrafanaTemplateKind),
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Replaces the existing `GetMergedTemplateDefinitions` method with `TemplatesMapToPostableAPITemplates` to improve template handling and align with new API conventions.

**Why do we need this feature?**

This update simplifies and optimizes the conversion of template definitions to API-compatible formats.

**Who is this feature for?**

Developers working with template APIs and users who rely on accurate and efficient template management.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
