### PR TITLE
Plugins: Default marketplace plugins to Contact us until entitled

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
@@ -259,9 +259,10 @@ describe('InstallControlsButton', () => {
       expect(link).toHaveTextContent(/contact us/i);
       expect(link).toHaveAttribute('href', expect.stringContaining('/plugins/test-plugin?tab=installation'));
       expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('aria-disabled', 'false');
     });
 
-    it('should render a disabled install button with a spinner when entitlement is loading', () => {
+    it('should render a disabled contact us link with a spinner when entitlement is loading', () => {
       render(
         <TestProvider>
           <InstallControlsButton
@@ -271,11 +272,11 @@ describe('InstallControlsButton', () => {
           />
         </TestProvider>
       );
-      const button = screen.getByRole('button');
-      expect(button).toHaveTextContent(/install/i);
-      expect(button).toBeDisabled();
-      expect(button.querySelector('svg')).toBeInTheDocument();
-      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+      const link = screen.getByRole('link');
+      expect(link).toHaveTextContent(/contact us/i);
+      expect(link).toHaveAttribute('aria-disabled', 'true');
+      expect(link.querySelector('svg')).toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
 
     it('should render the normal install button when the org is entitled', () => {

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -208,21 +208,14 @@ export function InstallControlsButton({
   }
 
   if (isMarketplacePlugin(plugin)) {
-    if (entitlement?.isLoading) {
-      return (
-        <Button disabled icon="spinner">
-          <Trans i18nKey="plugins.install-controls.install">Install</Trans>
-        </Button>
-      );
-    }
-
     if (!entitlement?.entitled) {
       return (
         <LinkButton
           href={`${getExternalManageLink(plugin.id)}?tab=installation`}
           target="_blank"
           rel="noopener noreferrer"
-          icon="external-link-alt"
+          icon={entitlement?.isLoading ? 'spinner' : 'external-link-alt'}
+          disabled={entitlement?.isLoading}
         >
           <Trans i18nKey="plugins.install-controls.contact-us">Contact us</Trans>
         </LinkButton>


### PR DESCRIPTION
**What is this feature?**

Marketplace plugins now default to "Contact us"; the Install button appears only when the org is confirmed entitled. While entitlement is loading, the "Contact us" button is shown disabled with a spinner instead of a disabled Install button.

**Why do we need this feature?**

We should never imply a marketplace plugin is installable before entitlement is confirmed. Defaulting to "Contact us" keeps the install affordance behind a verified entitlement.

**Who is this feature for?**

Grafana users viewing marketplace plugins in the plugin catalog.

**Which issue(s) does this PR fix?**:

Fixes #
