### PR TITLE
Provisioning: Add shared WebhookRepository interface

### DIFF
--- a/apps/provisioning/pkg/repository/github/webhook.go
+++ b/apps/provisioning/pkg/repository/github/webhook.go
@@ -21,16 +21,14 @@ import (
 
 var subscribedEvents = []string{"pull_request", "push"} // same order as slices.Sort()
 
-type WebhookRepository interface {
-	Webhook(ctx context.Context, req *http.Request) (*provisioning.WebhookResponse, error)
-}
-
 type GithubWebhookRepository interface {
 	GithubRepository
 	repository.Hooks
 
-	WebhookRepository
+	repository.WebhookRepository
 }
+
+var _ repository.WebhookRepository = (*githubWebhookRepository)(nil)
 
 type githubWebhookRepository struct {
 	GithubRepository

--- a/apps/provisioning/pkg/repository/repository.go
+++ b/apps/provisioning/pkg/repository/repository.go
@@ -165,6 +165,14 @@ type RepositoryWithURLs interface {
 	RefURLs(ctx context.Context, ref string) (*provisioning.RepositoryURLs, error)
 }
 
+// WebhookRepository is implemented by repositories that can receive and handle
+// incoming webhook requests from their git provider.
+type WebhookRepository interface {
+	Repository
+
+	Webhook(ctx context.Context, req *http.Request) (*provisioning.WebhookResponse, error)
+}
+
 // Hooks called after the repository has been created, updated or deleted
 type Hooks interface {
 	Repository

--- a/pkg/registry/apis/provisioning/webhooks/webhook.go
+++ b/pkg/registry/apis/provisioning/webhooks/webhook.go
@@ -24,10 +24,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type WebhookRepository interface {
-	Webhook(ctx context.Context, req *http.Request) (*provisioning.WebhookResponse, error)
-}
-
 // Webhook endpoint max size (25MB)
 // See https://docs.github.com/en/webhooks/webhook-events-and-payloads
 const webhookMaxBodySize = 25 * 1024 * 1024
@@ -149,7 +145,7 @@ func (s *webhookConnector) Connect(ctx context.Context, name string, opts runtim
 			return
 		}
 
-		hooks, ok := repo.(WebhookRepository)
+		hooks, ok := repo.(repository.WebhookRepository)
 		if !ok {
 			cfg := repo.Config()
 			if cfg.Spec.GitHub != nil && cfg.Spec.GitHub.WebhookDisabled {


### PR DESCRIPTION
Consolidates the duplicated `WebhookRepository` interface into the shared
`repository` package, so the webhook connector and every provider reference a
single definition instead of per-package copies.

No behavior change.

Paired with grafana/grafana-enterprise#12337.
Epic: grafana/git-ui-sync-project#17.

---
PR description generated with Claude Code.