### PR TITLE
test: baseline color resolution coverage for field.display refactor

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.color.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.color.test.ts
@@ -1,0 +1,180 @@
+import { createTheme } from '../themes/createTheme';
+import { type Field, type FieldConfig, FieldType } from '../types/dataFrame';
+import { FieldColorModeId } from '../types/fieldColor';
+import { ThresholdsMode } from '../types/thresholds';
+import { MappingType, SpecialValueMatch, type ValueMapping } from '../types/valueMapping';
+
+import { getDisplayProcessor } from './displayProcessor';
+import { getScaleCalculator } from './scale';
+
+// This suite pins down the `.color` of `field.display(value)` across every
+// mapping / threshold / color-mode path. It is the baseline that the upcoming
+// `field.display.color()` refactor must reproduce exactly (display(v).color
+// stays identical, and display.color(v) === display(v).color). Expected colors
+// are derived from the canonical sources display() delegates to today:
+//   - value-mapping colors  -> theme.visualization.getColorByName(name)
+//   - threshold/continuous  -> getScaleCalculator(field, theme)(value).color
+const theme = createTheme();
+
+function makeField(config: FieldConfig, type: FieldType = FieldType.number, values: unknown[] = []): Field {
+  return { name: 'test', type, config, values, state: {} } as Field;
+}
+
+function colorOf(field: Field, value: unknown): string | undefined {
+  return getDisplayProcessor({ field, theme })(value).color;
+}
+
+describe('display().color — value mappings', () => {
+  it('ValueToText resolves the mapped named color', () => {
+    const field = makeField({
+      mappings: [
+        {
+          type: MappingType.ValueToText,
+          options: {
+            '1': { text: 'low', color: 'green' },
+            '2': { text: 'mid', color: 'yellow' },
+            '3': { text: 'high', color: 'red' },
+          },
+        },
+      ],
+    });
+
+    expect(colorOf(field, 1)).toEqual(theme.visualization.getColorByName('green'));
+    expect(colorOf(field, 2)).toEqual(theme.visualization.getColorByName('yellow'));
+    expect(colorOf(field, 3)).toEqual(theme.visualization.getColorByName('red'));
+  });
+
+  it('RangeToText resolves color in-range and falls back out-of-range', () => {
+    const field = makeField({
+      mappings: [
+        { type: MappingType.RangeToText, options: { from: 0, to: 50, result: { text: 'low', color: 'blue' } } },
+        { type: MappingType.RangeToText, options: { from: 51, to: 100, result: { text: 'high', color: 'red' } } },
+      ],
+    });
+
+    expect(colorOf(field, 10)).toEqual(theme.visualization.getColorByName('blue'));
+    expect(colorOf(field, 75)).toEqual(theme.visualization.getColorByName('red'));
+    // 200 matches no range -> no mapping color, no thresholds => -Infinity base color
+    expect(colorOf(field, 200)).toEqual(getScaleCalculator(field, theme)(-Infinity).color);
+  });
+
+  it.each([
+    ['NaN', SpecialValueMatch.NaN, NaN],
+    ['Null', SpecialValueMatch.Null, null],
+    ['Empty', SpecialValueMatch.Empty, ''],
+    ['True', SpecialValueMatch.True, true],
+    ['False', SpecialValueMatch.False, false],
+  ])('SpecialValue %s resolves the mapped color', (_label, match, value) => {
+    const field = makeField({
+      mappings: [{ type: MappingType.SpecialValue, options: { match, result: { text: 'special', color: 'purple' } } }],
+    });
+
+    expect(colorOf(field, value)).toEqual(theme.visualization.getColorByName('purple'));
+  });
+
+  it('RegexToText resolves the mapped color', () => {
+    const mappings: ValueMapping[] = [
+      { type: MappingType.RegexToText, options: { pattern: '/^foo/', result: { text: 'matched', color: 'orange' } } },
+    ];
+    const field = makeField({ mappings }, FieldType.string);
+
+    expect(colorOf(field, 'foobar')).toEqual(theme.visualization.getColorByName('orange'));
+  });
+});
+
+describe('display().color — thresholds', () => {
+  it('absolute thresholds pick the active step color', () => {
+    const field = makeField({
+      thresholds: {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: 'green' },
+          { value: 50, color: 'yellow' },
+          { value: 80, color: 'red' },
+        ],
+      },
+    });
+    const scale = getScaleCalculator(field, theme);
+
+    expect(colorOf(field, 10)).toEqual(scale(10).color);
+    expect(colorOf(field, 50)).toEqual(scale(50).color); // boundary (>=)
+    expect(colorOf(field, 79)).toEqual(scale(79).color);
+    expect(colorOf(field, 80)).toEqual(scale(80).color); // boundary (>=)
+    expect(colorOf(field, 100)).toEqual(scale(100).color);
+  });
+
+  it('percentage thresholds pick the active step color', () => {
+    const field = makeField({
+      min: 0,
+      max: 200,
+      thresholds: {
+        mode: ThresholdsMode.Percentage,
+        steps: [
+          { value: -Infinity, color: 'green' },
+          { value: 50, color: 'yellow' }, // 50% => value 100
+          { value: 90, color: 'red' }, // 90% => value 180
+        ],
+      },
+    });
+    const scale = getScaleCalculator(field, theme);
+
+    expect(colorOf(field, 50)).toEqual(scale(50).color); // 25%
+    expect(colorOf(field, 100)).toEqual(scale(100).color); // 50% boundary
+    expect(colorOf(field, 190)).toEqual(scale(190).color); // 95%
+  });
+
+  it('null value gets the -Infinity base color', () => {
+    const field = makeField({
+      thresholds: {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#000' },
+          { value: 50, color: '#fff' },
+        ],
+      },
+    });
+
+    expect(colorOf(field, null)).toEqual(getScaleCalculator(field, theme)(-Infinity).color);
+  });
+});
+
+describe('display().color — color modes', () => {
+  it('continuous mode interpolates across the field range', () => {
+    const values = [0, 50, 100];
+    const field = makeField({ color: { mode: FieldColorModeId.ContinuousGrYlRd } }, FieldType.number, values);
+    const scale = getScaleCalculator(field, theme);
+
+    for (const v of values) {
+      expect(colorOf(field, v)).toEqual(scale(v).color);
+    }
+  });
+
+  it('boolean field resolves green/red', () => {
+    const field = makeField({}, FieldType.boolean, [true, false]);
+
+    expect(colorOf(field, true)).toEqual(theme.visualization.getColorByName('green'));
+    expect(colorOf(field, false)).toEqual(theme.visualization.getColorByName('red'));
+  });
+});
+
+describe('display().color — enum fields', () => {
+  it('uses configured enum colors when present', () => {
+    const field = makeField(
+      { type: { enum: { text: ['A', 'B', 'C'], color: ['#aaa', '#bbb', '#ccc'] } } },
+      FieldType.enum,
+      [0, 1, 2]
+    );
+
+    expect(colorOf(field, 0)).toEqual('#aaa');
+    expect(colorOf(field, 1)).toEqual('#bbb');
+    expect(colorOf(field, 2)).toEqual('#ccc');
+  });
+
+  it('falls back to the theme palette by index when no enum colors configured', () => {
+    const field = makeField({ type: { enum: { text: ['A', 'B', 'C'] } } }, FieldType.enum, [0, 1, 2]);
+    const { palette } = theme.visualization;
+
+    expect(colorOf(field, 0)).toEqual(theme.visualization.getColorByName(palette[0]));
+    expect(colorOf(field, 1)).toEqual(theme.visualization.getColorByName(palette[1]));
+  });
+});

--- a/public/app/plugins/panel/status-history/colors.test.ts
+++ b/public/app/plugins/panel/status-history/colors.test.ts
@@ -1,0 +1,110 @@
+import {
+  createDataFrame,
+  createTheme,
+  FALLBACK_COLOR,
+  type Field,
+  FieldType,
+  getDisplayProcessor,
+  MappingType,
+  ThresholdsMode,
+} from '@grafana/data';
+import { FieldColorModeId } from '@grafana/schema';
+
+// Baseline for the status-history / state-timeline cell color contract. The
+// TimelineChart panel colors each cell via `field.display(value).color ?? FALLBACK_COLOR`
+// (TimelineChart.tsx getValueColor). There is currently no status-history color
+// coverage; this pins the resolved status->color mapping so the upcoming
+// `field.display.color(value)` migration of getValueColor is provably equivalent
+// (the resolved colors must not change).
+const theme = createTheme();
+
+function statusField(config: Record<string, unknown>, values: unknown[], type = FieldType.number): Field {
+  const field = createDataFrame({ fields: [{ name: 'status', type, values, config }] }).fields[0];
+  field.display = getDisplayProcessor({ field, theme });
+  return field;
+}
+
+// mirrors TimelineChart.tsx getValueColor exactly (pre-migration)
+function getValueColor(field: Field, value: unknown): string {
+  const disp = field.display!(value);
+  return disp.color ?? FALLBACK_COLOR;
+}
+
+describe('status-history cell color contract', () => {
+  it('resolves ValueToText status codes to their mapped colors', () => {
+    const field = statusField(
+      {
+        mappings: [
+          {
+            type: MappingType.ValueToText,
+            options: {
+              '1': { text: 'OK', color: 'green' },
+              '2': { text: 'Warning', color: 'yellow' },
+              '3': { text: 'Critical', color: 'red' },
+            },
+          },
+        ],
+      },
+      [1, 2, 3]
+    );
+
+    expect(getValueColor(field, 1)).toEqual(theme.visualization.getColorByName('green'));
+    expect(getValueColor(field, 2)).toEqual(theme.visualization.getColorByName('yellow'));
+    expect(getValueColor(field, 3)).toEqual(theme.visualization.getColorByName('red'));
+  });
+
+  it('resolves string status values mapped to colors', () => {
+    const field = statusField(
+      {
+        mappings: [
+          {
+            type: MappingType.ValueToText,
+            options: {
+              up: { color: 'green' },
+              down: { color: 'red' },
+            },
+          },
+        ],
+      },
+      ['up', 'down'],
+      FieldType.string
+    );
+
+    expect(getValueColor(field, 'up')).toEqual(theme.visualization.getColorByName('green'));
+    expect(getValueColor(field, 'down')).toEqual(theme.visualization.getColorByName('red'));
+  });
+
+  it('resolves threshold-based status colors', () => {
+    const field = statusField(
+      {
+        color: { mode: FieldColorModeId.Thresholds },
+        thresholds: {
+          mode: ThresholdsMode.Absolute,
+          steps: [
+            { value: -Infinity, color: 'green' },
+            { value: 1, color: 'yellow' },
+            { value: 2, color: 'red' },
+          ],
+        },
+      },
+      [0, 1, 2]
+    );
+
+    // resolved colors come from the active threshold step
+    expect(getValueColor(field, 0)).toEqual(field.display!(0).color);
+    expect(getValueColor(field, 1)).toEqual(field.display!(1).color);
+    expect(getValueColor(field, 2)).toEqual(field.display!(2).color);
+    // distinct steps => distinct colors
+    expect(new Set([getValueColor(field, 0), getValueColor(field, 1), getValueColor(field, 2)]).size).toBe(3);
+  });
+
+  it('falls back to FALLBACK_COLOR only when display yields no color', () => {
+    // a string field with no mappings/thresholds still gets a base color from the
+    // scale fallback, so getValueColor should never be the raw FALLBACK here
+    const mapped = statusField(
+      { mappings: [{ type: MappingType.ValueToText, options: { '1': { text: 'OK', color: 'green' } } }] },
+      [1]
+    );
+    expect(getValueColor(mapped, 1)).not.toEqual(FALLBACK_COLOR);
+  });
+});

--- a/public/app/plugins/panel/xychart/__snapshots__/fieldValueColors.test.ts.snap
+++ b/public/app/plugins/panel/xychart/__snapshots__/fieldValueColors.test.ts.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fieldValueColors (golden baseline) RangeToText mapping 1`] = `
+{
+  "colors": [
+    "#5794f2ff",
+    "#f2495cff",
+    null,
+  ],
+  "palette": [
+    "#5794f2ff",
+    "#f2495cff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) RegexToText is currently a no-op (documents pre-migration behavior) 1`] = `
+{
+  "colors": [
+    null,
+    null,
+  ],
+  "palette": [],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) SpecialValue mapping (NaN / Null) 1`] = `
+{
+  "colors": [
+    "#ff9830ff",
+    "#b877d9ff",
+    null,
+  ],
+  "palette": [
+    "#ff9830ff",
+    "#b877d9ff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) ValueToText mapping 1`] = `
+{
+  "colors": [
+    "#73bf69ff",
+    "#fade2aff",
+    "#f2495cff",
+    null,
+  ],
+  "palette": [
+    "#73bf69ff",
+    "#fade2aff",
+    "#f2495cff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) absolute thresholds 1`] = `
+{
+  "colors": [
+    "#73bf69ff",
+    "#fade2aff",
+    "#fade2aff",
+    "#f2495cff",
+    "#f2495cff",
+  ],
+  "palette": [
+    "#73bf69ff",
+    "#fade2aff",
+    "#f2495cff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) continuous gradient (needs min/max) 1`] = `
+{
+  "colors": [
+    "#73bf69ff",
+    "#e4be3dff",
+    "#f2495cff",
+  ],
+  "palette": [
+    "#73bf69ff",
+    "#7cc165ff",
+    "#84c361ff",
+    "#8dc55dff",
+    "#95c659ff",
+    "#9ec855ff",
+    "#a6c952ff",
+    "#aeca4eff",
+    "#b5cb4bff",
+    "#bdcb48ff",
+    "#c4cb45ff",
+    "#caca43ff",
+    "#d0c941ff",
+    "#d6c73fff",
+    "#dbc53eff",
+    "#e0c23dff",
+    "#e4be3dff",
+    "#e8b93dff",
+    "#ebb43dff",
+    "#edae3eff",
+    "#efa83fff",
+    "#f1a141ff",
+    "#f29a43ff",
+    "#f39245ff",
+    "#f38a47ff",
+    "#f4814aff",
+    "#f4784dff",
+    "#f46f4fff",
+    "#f36652ff",
+    "#f35c56ff",
+    "#f35359ff",
+    "#f2495cff",
+  ],
+}
+`;

--- a/public/app/plugins/panel/xychart/fieldValueColors.test.ts
+++ b/public/app/plugins/panel/xychart/fieldValueColors.test.ts
@@ -1,0 +1,113 @@
+import { createDataFrame, createTheme, FieldType, MappingType, SpecialValueMatch, ThresholdsMode } from '@grafana/data';
+import { FieldColorModeId } from '@grafana/schema';
+
+import { fieldValueColors } from './scatter';
+
+// Golden baseline for the value->color compiler that scatter currently builds via
+// `new Function`. The upcoming field.display.colors() migration must reproduce the
+// same resolved colors. We snapshot the deduped palette plus the resolved color per
+// representative value via getAll (the path the renderer uses), and assert getOne
+// agrees with getAll for the discrete compilers.
+const theme = createTheme();
+
+function makeColorField(config: Record<string, unknown>, values: unknown[], type: FieldType = FieldType.number) {
+  return createDataFrame({
+    fields: [{ name: 'clr', type, values, config }],
+  }).fields[0];
+}
+
+/**
+ * Resolved color per value via getAll (the path the renderer actually uses in
+ * prepData), plus the palette, in a snapshot-friendly shape. For discrete
+ * compilers (mappings/thresholds) getOne is also compiled, so we assert it
+ * agrees with getAll. Continuous gradients only compile getAll — getOne stays
+ * the -1 default there — so callers pass discrete=false to skip that check.
+ */
+function resolve(
+  config: Record<string, unknown>,
+  values: unknown[],
+  opts: { type?: FieldType; min?: number; max?: number; discrete?: boolean } = {}
+) {
+  const { type, min, max, discrete = true } = opts;
+  const field = makeColorField(config, values, type);
+  const { index, getOne, getAll } = fieldValueColors(field, theme);
+
+  const byAll = getAll(values, min, max).map((i) => index[i] ?? null);
+
+  if (discrete) {
+    const byOne = values.map((v) => index[getOne(v, min, max)] ?? null);
+    expect(byOne).toEqual(byAll);
+  }
+
+  return { palette: index, colors: byAll };
+}
+
+describe('fieldValueColors (golden baseline)', () => {
+  it('ValueToText mapping', () => {
+    const config = {
+      mappings: [
+        {
+          type: MappingType.ValueToText,
+          options: {
+            '1': { text: 'low', color: 'green' },
+            '2': { text: 'mid', color: 'yellow' },
+            '3': { text: 'high', color: 'red' },
+          },
+        },
+      ],
+    };
+    expect(resolve(config, [1, 2, 3, 4])).toMatchSnapshot();
+  });
+
+  it('RangeToText mapping', () => {
+    const config = {
+      mappings: [
+        { type: MappingType.RangeToText, options: { from: 0, to: 50, result: { text: 'low', color: 'blue' } } },
+        { type: MappingType.RangeToText, options: { from: 51, to: 100, result: { text: 'high', color: 'red' } } },
+      ],
+    };
+    expect(resolve(config, [10, 75, 200])).toMatchSnapshot();
+  });
+
+  it('SpecialValue mapping (NaN / Null)', () => {
+    const config = {
+      mappings: [
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.NaN, result: { color: 'orange' } } },
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.Null, result: { color: 'purple' } } },
+      ],
+    };
+    expect(resolve(config, [NaN, null, 5])).toMatchSnapshot();
+  });
+
+  it('absolute thresholds', () => {
+    const config = {
+      color: { mode: FieldColorModeId.Thresholds },
+      thresholds: {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: 'green' },
+          { value: 50, color: 'yellow' },
+          { value: 80, color: 'red' },
+        ],
+      },
+    };
+    expect(resolve(config, [10, 50, 79, 80, 100])).toMatchSnapshot();
+  });
+
+  it('continuous gradient (needs min/max)', () => {
+    const config = { color: { mode: FieldColorModeId.ContinuousGrYlRd } };
+    expect(
+      resolve(config, [0, 50, 100], { type: FieldType.number, min: 0, max: 100, discrete: false })
+    ).toMatchSnapshot();
+  });
+
+  it('RegexToText is currently a no-op (documents pre-migration behavior)', () => {
+    const config = {
+      mappings: [
+        { type: MappingType.RegexToText, options: { pattern: '/^foo/', result: { text: 'm', color: 'orange' } } },
+      ],
+    };
+    // empty palette, all values fall through to the -1 fallback (null here)
+    expect(resolve(config, ['foobar', 'baz'], { type: FieldType.string })).toMatchSnapshot();
+  });
+});

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -555,7 +555,7 @@ function getHex8Color(color: string, theme: GrafanaTheme2) {
   return tinycolor(theme.visualization.getColorByName(color)).toHex8String();
 }
 
-interface FieldColorValues {
+export interface FieldColorValues {
   index: unknown[];
   getOne: GetOneValue;
   getAll: GetAllValues;
@@ -568,7 +568,9 @@ type GetAllValues = (values: unknown[], min?: number, max?: number) => number[];
 type GetOneValue = (value: unknown, min?: number, max?: number) => number;
 
 /** compiler for values to palette color idxs (from thresholds, mappings, by-value gradients) */
-function fieldValueColors(f: Field, theme: GrafanaTheme2): FieldColorValues {
+// exported for golden tests that freeze its palette+index output ahead of the
+// field.display.colors() migration
+export function fieldValueColors(f: Field, theme: GrafanaTheme2): FieldColorValues {
   let index: unknown[] = [];
   let getAll: GetAllValues = () => [];
   let getOne: GetOneValue = () => -1;


### PR DESCRIPTION
We are looking at making it possible to calculate color independently of other DisplayProcessor values because there are several places in the app where the added cost of calculating all DisplayProcessor information has a negative effect on rendering. (https://github.com/grafana/grafana/pull/126600)

In order to make that change safely, we first want to shore up a bit more coverage in the relevant parts of the code which will get changed.