### PR TITLE
feat(grafana-data): add selective color and text resolvers to field.display

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.caching.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.caching.test.ts
@@ -1,0 +1,86 @@
+import { createDataFrame } from '../dataframe/processDataFrame';
+import { createTheme } from '../themes/createTheme';
+import { type DataFrame, FieldType } from '../types/dataFrame';
+import { ThresholdsMode } from '../types/thresholds';
+import { MappingType } from '../types/valueMapping';
+
+import { FieldConfigOptionsRegistry } from './FieldConfigOptionsRegistry';
+import { applyFieldOverrides } from './fieldOverrides';
+
+// applyFieldOverrides wraps field.display in cachingDisplayProcessor. This verifies
+// the selective resolvers survive that wrapping: display.color(v) is attached and
+// equals the cached, hex-normalized display(v).color.
+function withOverrides(frame: DataFrame): DataFrame {
+  return applyFieldOverrides({
+    data: [frame],
+    fieldConfig: { defaults: {}, overrides: [] },
+    replaceVariables: (v) => v,
+    theme: createTheme(),
+    fieldConfigRegistry: new FieldConfigOptionsRegistry(),
+  })[0];
+}
+
+describe('cached display selective resolvers', () => {
+  it('display.color equals the cached, hex-normalized display(v).color (value mappings)', () => {
+    const frame = withOverrides(
+      createDataFrame({
+        fields: [
+          {
+            name: 'status',
+            type: FieldType.number,
+            values: [1, 2, 3],
+            config: {
+              mappings: [
+                {
+                  type: MappingType.ValueToText,
+                  options: { '1': { color: 'green' }, '2': { color: 'yellow' }, '3': { color: 'red' } },
+                },
+              ],
+            },
+          },
+        ],
+      })
+    );
+
+    const { display } = frame.fields[0];
+    expect(display!.color).toBeDefined();
+
+    for (const v of [1, 2, 3, 4]) {
+      const cached = display!(v).color;
+      expect(display!.color!(v)).toEqual(cached);
+      // cached colors are hex-normalized (hex6/hex8)
+      expect(display!.color!(v)).toMatch(/^#[0-9a-f]{6}([0-9a-f]{2})?$/i);
+    }
+  });
+
+  it('display.color equals display(v).color (thresholds)', () => {
+    const frame = withOverrides(
+      createDataFrame({
+        fields: [
+          {
+            name: 'v',
+            type: FieldType.number,
+            values: [10, 60, 90],
+            config: {
+              thresholds: {
+                mode: ThresholdsMode.Absolute,
+                steps: [
+                  { value: -Infinity, color: 'green' },
+                  { value: 50, color: 'yellow' },
+                  { value: 80, color: 'red' },
+                ],
+              },
+            },
+          },
+        ],
+      })
+    );
+
+    const { display } = frame.fields[0];
+    const values = [10, 60, 90];
+
+    for (const v of values) {
+      expect(display!.color!(v)).toEqual(display!(v).color);
+    }
+  });
+});

--- a/packages/grafana-data/src/field/displayProcessor.selective.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.selective.test.ts
@@ -1,0 +1,158 @@
+import { createTheme } from '../themes/createTheme';
+import { type Field, type FieldConfig, FieldType } from '../types/dataFrame';
+import { FieldColorModeId } from '../types/fieldColor';
+import { ThresholdsMode } from '../types/thresholds';
+import { MappingType, SpecialValueMatch } from '../types/valueMapping';
+
+import { getDisplayProcessor } from './displayProcessor';
+
+// Proves the selective resolvers added to DisplayProcessor are equivalent to the
+// full processor: display.color(v) === display(v).color and display.text(v) ===
+// display(v).text. The full-path color baseline itself is pinned in displayProcessor.color.test.ts.
+const theme = createTheme();
+
+function field(config: FieldConfig, type: FieldType = FieldType.number, values: unknown[] = []): Field {
+  return { name: 'test', type, config, values, state: {} } as Field;
+}
+
+interface Scenario {
+  name: string;
+  field: Field;
+  values: unknown[];
+}
+
+const scenarios: Scenario[] = [
+  {
+    name: 'ValueToText mapping',
+    field: field({
+      mappings: [
+        {
+          type: MappingType.ValueToText,
+          options: { '1': { color: 'green' }, '2': { color: 'yellow' }, '3': { color: 'red' } },
+        },
+      ],
+    }),
+    values: [1, 2, 3, 4, null],
+  },
+  {
+    name: 'RangeToText mapping',
+    field: field({
+      mappings: [
+        { type: MappingType.RangeToText, options: { from: 0, to: 50, result: { color: 'blue' } } },
+        { type: MappingType.RangeToText, options: { from: 51, to: 100, result: { color: 'red' } } },
+      ],
+    }),
+    values: [10, 75, 200, null],
+  },
+  {
+    name: 'RangeToText preceding ValueToText (order-sensitive)',
+    field: field({
+      mappings: [
+        { type: MappingType.RangeToText, options: { from: 0, to: 10, result: { color: 'red' } } },
+        { type: MappingType.ValueToText, options: { '5': { color: 'green' } } },
+      ],
+    }),
+    // 5 is in 0..10 so RangeToText wins (red), NOT the ValueToText green — the case a
+    // naive value->color precompute would get wrong.
+    values: [5, 20],
+  },
+  {
+    name: 'SpecialValue mappings',
+    field: field({
+      mappings: [
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.NaN, result: { color: 'orange' } } },
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.Null, result: { color: 'purple' } } },
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.Empty, result: { color: 'blue' } } },
+      ],
+    }),
+    values: [NaN, null, '', 5],
+  },
+  {
+    name: 'RegexToText mapping',
+    field: field(
+      {
+        mappings: [
+          { type: MappingType.RegexToText, options: { pattern: '/^foo/', result: { text: 'm', color: 'orange' } } },
+        ],
+      },
+      FieldType.string
+    ),
+    values: ['foobar', 'baz'],
+  },
+  {
+    name: 'absolute thresholds',
+    field: field({
+      thresholds: {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: 'green' },
+          { value: 50, color: 'yellow' },
+          { value: 80, color: 'red' },
+        ],
+      },
+    }),
+    values: [10, 50, 79, 80, 100, null],
+  },
+  {
+    name: 'percentage thresholds',
+    field: field({
+      min: 0,
+      max: 200,
+      thresholds: {
+        mode: ThresholdsMode.Percentage,
+        steps: [
+          { value: -Infinity, color: 'green' },
+          { value: 50, color: 'yellow' },
+          { value: 90, color: 'red' },
+        ],
+      },
+    }),
+    values: [50, 100, 190],
+  },
+  {
+    name: 'continuous gradient',
+    field: field({ color: { mode: FieldColorModeId.ContinuousGrYlRd } }, FieldType.number, [0, 50, 100]),
+    values: [0, 25, 50, 75, 100],
+  },
+  {
+    name: 'boolean',
+    field: field({}, FieldType.boolean, [true, false]),
+    values: [true, false],
+  },
+  {
+    name: 'enum with configured colors',
+    field: field({ type: { enum: { text: ['A', 'B', 'C'], color: ['#aaa', '#bbb', '#ccc'] } } }, FieldType.enum),
+    values: [0, 1, 2, null],
+  },
+  {
+    name: 'enum with palette fallback',
+    field: field({ type: { enum: { text: ['A', 'B', 'C'] } } }, FieldType.enum),
+    values: [0, 1, 2, null],
+  },
+  {
+    name: 'plain number (no mappings/thresholds)',
+    field: field({}, FieldType.number, [1, 2, 3]),
+    values: [1, 2, 3, null],
+  },
+  {
+    name: 'string field',
+    field: field({}, FieldType.string),
+    values: ['a', 'b'],
+  },
+];
+
+describe.each(scenarios)('selective resolvers — $name', ({ field: f, values }) => {
+  const dp = getDisplayProcessor({ field: f, theme });
+
+  it('display.color(v) === display(v).color for every value', () => {
+    for (const v of values) {
+      expect(dp.color!(v)).toEqual(dp(v).color);
+    }
+  });
+
+  it('display.text(v) === display(v).text for every value', () => {
+    for (const v of values) {
+      expect(dp.text!(v)).toEqual(dp(v).text);
+    }
+  });
+});

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -11,6 +11,7 @@ import { type Field, FieldType } from '../types/dataFrame';
 import { type DecimalCount, type DisplayProcessor, type DisplayValue } from '../types/displayValue';
 import { type TimeZone } from '../types/time';
 import { type FormattedValue } from '../types/valueFormats';
+import { type ValueMappingResult } from '../types/valueMapping';
 import { anyToNumber } from '../utils/anyToNumber';
 import { getValueMappingResult } from '../utils/valueMappings';
 import { isBooleanUnit } from '../valueFormats/baseFormatters';
@@ -86,8 +87,46 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
 
   const formatFunc = getValueFormat(unit || 'none');
   const scaleFunc = getScaleCalculator(field, options.theme);
+  const isStringUnitOuter = unit === 'string';
+  const hasMappings = (config.mappings?.length ?? 0) > 0;
 
-  return (value: unknown, adjacentDecimals?: DecimalCount) => {
+  // Single source of truth for a value's color + percent, shared by the full
+  // processor and the color-only resolver below. The full processor passes the
+  // value mapping it already resolved (for text/icon) so we don't look it up twice;
+  // the color-only path resolves its own mapping and discards the percent.
+  const resolveColorAndPercent = (
+    value: unknown,
+    numeric: number,
+    mappingResult: ValueMappingResult | null
+  ): { color: string | undefined; percent: number | undefined } => {
+    let color: string | undefined;
+    let percent: number | undefined;
+
+    if (mappingResult?.color != null) {
+      color = options.theme.visualization.getColorByName(mappingResult.color);
+    } else if (!hasMappings && field.type === FieldType.enum && value != null && config.type?.enum) {
+      const enumIndex = +value;
+      const { color: enumColor } = config.type.enum;
+      color = enumColor ? enumColor[enumIndex] : undefined;
+
+      // If no color specified in enum field config we will fallback to iterating through the theme palette
+      if (color == null) {
+        color = options.theme.visualization.getColorByName(palette[enumIndex % palette.length]);
+      }
+    }
+
+    if (!Number.isNaN(numeric) && color == null) {
+      ({ color, percent } = scaleFunc(numeric));
+    }
+
+    if (!color) {
+      ({ color, percent } = scaleFunc(-Infinity));
+    }
+
+    return { color, percent };
+  };
+
+  const proc: DisplayProcessor = (value: unknown, adjacentDecimals?: DecimalCount): DisplayValue => {
     const { mappings } = config;
     const isStringUnit = unit === 'string';
 
@@ -102,17 +141,14 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
     let color: string | undefined;
     let icon: string | undefined;
     let percent: number | undefined;
+    let mappingResult: ValueMappingResult | null = null;
 
     if (mappings && mappings.length > 0) {
-      const mappingResult = getValueMappingResult(mappings, value);
+      mappingResult = getValueMappingResult(mappings, value);
 
       if (mappingResult) {
         if (mappingResult.text != null) {
           text = mappingResult.text;
-        }
-
-        if (mappingResult.color != null) {
-          color = options.theme.visualization.getColorByName(mappingResult.color);
         }
 
         if (mappingResult.icon != null) {
@@ -130,16 +166,9 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
 
       const enumIndex = +value;
       if (config && config.type && config.type.enum) {
-        const { text: enumText, color: enumColor } = config.type.enum;
+        const { text: enumText } = config.type.enum;
 
         text = enumText ? enumText[enumIndex] : `${value}`;
-        // If no color specified in enum field config we will fallback to iterating through the theme palette
-        color = enumColor ? enumColor[enumIndex] : undefined;
-
-        if (color == null) {
-          const namedColor = palette[enumIndex % palette.length];
-          color = options.theme.visualization.getColorByName(namedColor);
-        }
       }
     }
 
@@ -167,13 +196,6 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
         suffix = v.suffix;
         prefix = v.prefix;
       }
-
-      // Return the value along with scale info
-      if (color == null) {
-        const scaleResult = scaleFunc(numeric);
-        color = scaleResult.color;
-        percent = scaleResult.percent;
-      }
     }
 
     if (text == null && isArray(value)) {
@@ -191,11 +213,7 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
       }
     }
 
-    if (!color) {
-      const scaleResult = scaleFunc(-Infinity);
-      color = scaleResult.color;
-      percent = scaleResult.percent;
-    }
+    ({ color, percent } = resolveColorAndPercent(value, numeric, mappingResult));
 
     const display: DisplayValue = {
       text,
@@ -215,6 +233,38 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
 
     return display;
   };
+
+  // Lean color-only resolver: resolves the value mapping itself (we must, because
+  // mapping resolution is order-sensitive — a RangeToText/SpecialValue mapping can
+  // match before a later ValueToText one — so a precomputed value->color map would
+  // diverge) then delegates to the shared color logic, skipping all text/number
+  // formatting that callers wanting only a color would otherwise pay for.
+  const resolveColor = (value: unknown): string | undefined => {
+    if (hasDateUnit && typeof value === 'string') {
+      value = toUtc(value).valueOf();
+    }
+
+    const numeric = isStringUnitOuter ? NaN : anyToNumber(value);
+
+    let mappingResult: ValueMappingResult | null = null;
+    if (hasMappings) {
+      mappingResult = getValueMappingResult(config.mappings!, value);
+    } else if (field.type === FieldType.enum && value == null) {
+      // matches the full processor's enum-null short-circuit (no color)
+      return undefined;
+    }
+
+    return resolveColorAndPercent(value, numeric, mappingResult).color;
+  };
+
+  proc.color = resolveColor;
+
+  // Text-only is currently a thin wrapper over the full processor. A lean text
+  // path (skipping scale/color resolution) can follow once needed; today the
+  // color path is the one callers pay for unnecessarily.
+  proc.text = (value, decimals) => proc(value, decimals).text;
+
+  return proc;
 }
 
 function toStringProcessor(value: unknown): DisplayValue {

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -342,7 +342,9 @@ type DecimalsCache = Map<unknown, DisplayValue>;
 // 3. sufficently optimize text formatting and threshold color determinitation
 function cachingDisplayProcessor(disp: DisplayProcessor, maxCacheSize = 2500): DisplayProcessor {
   let caches: Map<number, DecimalsCache>;
-  return (value: unknown, decimals?: DecimalCount) => {
+  let colorCache: Map<unknown, string | undefined>;
+
+  const wrapped: DisplayProcessor = (value: unknown, decimals?: DecimalCount) => {
     // pre-allocating these maps is quite expensive, so we do it just-in-time.
     // -1, 0, 1..15 = 17 entries
     caches ??= new Map(Array.from({ length: 17 }, (_, i) => [i - 1, new Map()]));
@@ -370,6 +372,33 @@ function cachingDisplayProcessor(disp: DisplayProcessor, maxCacheSize = 2500): D
 
     return v;
   };
+
+  // Color-only cache: a single value->hex map (decimals don't affect color). A miss
+  // here computes only the color via disp.color (no text/number formatting), and we
+  // deliberately do NOT read the full DisplayValue cache, since a miss there would
+  // compute text too. Colors are hex-normalized to match the full cached path.
+  if (disp.color) {
+    wrapped.color = (value: unknown) => {
+      colorCache ??= new Map();
+
+      if (!colorCache.has(value)) {
+        if (colorCache.size === maxCacheSize) {
+          colorCache.clear();
+        }
+
+        const c = disp.color!(value);
+        colorCache.set(value, c != null ? asHexString(c) : c);
+      }
+
+      return colorCache.get(value);
+    };
+  }
+
+  if (disp.text) {
+    wrapped.text = (value: unknown, decimals?: DecimalCount) => disp.text!(value, decimals);
+  }
+
+  return wrapped;
 }
 
 export interface FieldOverrideEnv extends FieldOverrideContext {

--- a/packages/grafana-data/src/types/displayValue.ts
+++ b/packages/grafana-data/src/types/displayValue.ts
@@ -1,6 +1,23 @@
 import { type FormattedValue } from './valueFormats';
 
-export type DisplayProcessor = (value: unknown, decimals?: DecimalCount) => DisplayValue;
+export interface DisplayProcessor {
+  (value: unknown, decimals?: DecimalCount): DisplayValue;
+  /**
+   * Resolve only the color of a value, skipping the (expensive) text/number
+   * formatting. Equivalent to `display(value).color`. Optional because not every
+   * DisplayProcessor (e.g. plain inline ones) provides it — fall back to
+   * `display(value).color` when absent.
+   *
+   * @alpha
+   */
+  color?(value: unknown): string | undefined;
+  /**
+   * Resolve only the formatted text of a value. Equivalent to `display(value).text`.
+   *
+   * @alpha
+   */
+  text?(value: unknown, decimals?: DecimalCount): string;
+}
 
 export interface DisplayValue extends FormattedValue {
   /**


### PR DESCRIPTION
This adds `displayProcessor.color()` and `displayProcessor.text()`. These methods may be called to bypass other aspects of the DisplayProcessor logic and only process the relevant logical piece. `displayProcessor()` has been refactored to use the new colors code but is behaviorally unchanged.

This will help DataViz (and presumably plugin authors) with performance bottlenecks introduced by the all-or-nothing behavior today.