### PR TITLE
Alerting: merge imported templates properly (rename on conflict, deterministic UIDs)

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -2152,9 +2152,9 @@ func TestApiGetSnapshots(t *testing.T) {
 	cfg.AlertmanagerConfig.Route = legacy_storage.WithManagedRoutes(cfg.AlertmanagerConfig.Route, cfg.ManagedRoutes)
 
 	// Templates
-	t1 := v1.NewTemplateGroup("templateA", "{{ define \"templateA\" }}A{{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
-	t2 := v1.NewTemplateGroup("templateB", "{{ define \"templateB\" }}B{{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
-	t3 := v1.NewTemplateGroup("templateC", "{{ define \"templateC\" }}C{{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
+	t1 := v1.NewTemplateGroup("", "templateA", "{{ define \"templateA\" }}A{{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
+	t2 := v1.NewTemplateGroup("", "templateB", "{{ define \"templateB\" }}B{{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
+	t3 := v1.NewTemplateGroup("", "templateC", "{{ define \"templateC\" }}C{{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
 	cfg.Templates = map[v1.ResourceUID]v1.TemplateGroup{
 		t1.UID: t1,
 		t2.UID: t2,

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -90,7 +90,7 @@ func (moa *MultiOrgAlertmanager) PrepareConfig(
 		if err := moa.Crypto.DecryptExtraConfigs(ctx, prepared); err != nil {
 			return alertingNotify.NotificationsConfiguration{}, fmt.Errorf("failed to decrypt external configurations: %w", err)
 		}
-		mergedConfig, _, err := merge.MergeExtraConfig(ctx, prepared, models.ProvenanceConvertedPrometheus)
+		mergedConfig, _, err := merge.MergeExtraConfig(ctx, prepared)
 		if err != nil {
 			return alertingNotify.NotificationsConfiguration{}, fmt.Errorf("failed to merge external configuration: %w", err)
 		}
@@ -380,11 +380,7 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 		}
 	}
 
-	provenance := models.ProvenanceConvertedPrometheus
-	if promote {
-		provenance = models.ProvenanceNone
-	}
-	mergedConfig, mergeResult, err := merge.MergeExtraConfig(ctx, cfg, provenance)
+	mergedConfig, mergeResult, err := merge.MergeExtraConfig(ctx, cfg)
 	if err != nil {
 		return merge.MergeResult{}, fmt.Errorf("cannot merge imported configuration into Grafana: %w", err)
 	}

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -168,7 +168,7 @@ func TestAlertmanager_ApplyConfig(t *testing.T) {
 		}
 	}
 
-	grafanaTmpl := v1.NewTemplateGroup("grafana-template", "{{ define \"grafana.title\" }}Alert{{ end }}", v1.TemplateKindGrafana, ngmodels.ProvenanceNone)
+	grafanaTmpl := v1.NewTemplateGroup("", "grafana-template", "{{ define \"grafana.title\" }}Alert{{ end }}", v1.TemplateKindGrafana, ngmodels.ProvenanceNone)
 	testCases := []struct {
 		name          string
 		features      featuremgmt.FeatureToggles
@@ -320,7 +320,7 @@ func TestAlertmanager_HashStabilityAndChangeDetection(t *testing.T) {
 				return baseConfig("default-receiver", "extra-receiver")
 			},
 			mutate: func(cfg *v1.AMConfigV1, _ map[ngmodels.AlertRuleKey]ngmodels.ContactPointRouting) {
-				tmpl := v1.NewTemplateGroup("new.tmpl", "{{ define \"new\" }}b{{ end }}", v1.TemplateKindGrafana, ngmodels.ProvenanceNone)
+				tmpl := v1.NewTemplateGroup("", "new.tmpl", "{{ define \"new\" }}b{{ end }}", v1.TemplateKindGrafana, ngmodels.ProvenanceNone)
 				cfg.Templates[tmpl.UID] = tmpl
 			},
 		},

--- a/pkg/services/ngalert/notifier/config_test.go
+++ b/pkg/services/ngalert/notifier/config_test.go
@@ -40,7 +40,7 @@ func TestLoad(t *testing.T) {
   }
 }
 `,
-			expectedTemplates: map[v1.ResourceUID]v1.TemplateGroup{v1.TemplateUID(v1.TemplateKindGrafana, "email.template"): v1.NewTemplateGroup("email.template", "something with a pretty good content", v1.TemplateKindGrafana, ngmodels.ProvenanceNone)},
+			expectedTemplates: map[v1.ResourceUID]v1.TemplateGroup{v1.TemplateUID(v1.TemplateKindGrafana, "email.template"): v1.NewTemplateGroup("", "email.template", "something with a pretty good content", v1.TemplateKindGrafana, ngmodels.ProvenanceNone)},
 		},
 		{
 			name:          "with an empty configuration, it is not valid.",

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/templates.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/templates.go
@@ -73,8 +73,12 @@ func (t *TemplateGroup) Validate() error {
 	return def.Validate()
 }
 
-func NewTemplateGroup(name, content string, kind TemplateKind, provenance models.Provenance) TemplateGroup {
-	uid := TemplateUID(kind, name)
+// NewTemplateGroup creates a new TemplateGroup with the specified UID, name, content, kind, and provenance.
+// If the UID is empty, it generates a deterministic UID based on the template kind and name.
+func NewTemplateGroup(uid ResourceUID, name, content string, kind TemplateKind, provenance models.Provenance) TemplateGroup {
+	if uid == "" {
+		uid = TemplateUID(kind, name)
+	}
 	return TemplateGroup{
 		ResourceMetadata: ResourceMetadata{
 			UID:        uid,
@@ -96,7 +100,7 @@ func TemplateFilesToTemplates(templateFiles map[string]string, kind TemplateKind
 
 	templates := make(map[ResourceUID]TemplateGroup, len(templateFiles))
 	for name, content := range templateFiles {
-		tmpl := NewTemplateGroup(name, content, kind, models.ProvenanceNone)
+		tmpl := NewTemplateGroup("", name, content, kind, models.ProvenanceNone)
 		templates[tmpl.UID] = tmpl
 	}
 	return templates

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -30,6 +30,7 @@ import (
 type RenameResources struct {
 	Receivers     map[string]string
 	TimeIntervals map[string]string
+	Templates     map[string]string
 }
 
 // MergeResult describes what changed during a merge: which resources were added and which were renamed.
@@ -80,6 +81,13 @@ func (m MergeResult) LogContext() []any {
 			_, _ = fmt.Fprintf(&intervalBuilder, "'%s'->'%s',", from, to)
 		}
 		logCtx = append(logCtx, "renamedTimeIntervals", fmt.Sprintf("[%s]", intervalBuilder.String()[0:intervalBuilder.Len()-1]))
+	}
+	if len(m.Templates) > 0 {
+		tmplBuilder := strings.Builder{}
+		for from, to := range m.Templates {
+			_, _ = fmt.Fprintf(&tmplBuilder, "'%s'->'%s',", from, to)
+		}
+		logCtx = append(logCtx, "renamedTemplates", fmt.Sprintf("[%s]", tmplBuilder.String()[0:tmplBuilder.Len()-1]))
 	}
 	return logCtx
 }
@@ -149,17 +157,14 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1, provenance models.P
 		return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("failed to merge inhibition rules: %w", err)
 	}
 
-	var addedTemplates []string
-	templates := make(map[v1.ResourceUID]v1.TemplateGroup, len(cfg.Templates)+len(mimirCfg.TemplateFiles))
-	{
-		maps.Copy(templates, cfg.Templates)
-		for name, content := range mimirCfg.TemplateFiles {
-			tmpl := v1.NewTemplateGroup("", name, content, v1.TemplateKindMimir, provenance)
-			if _, ok := templates[tmpl.UID]; ok {
-				return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("template [%s] of %s kind already exists", name, v1.TemplateKindMimir)
-			}
-			templates[tmpl.UID] = tmpl
-			addedTemplates = append(addedTemplates, name)
+	templates, renamedTemplates, addedUIDs, err := MergeTemplates(cfg.Templates, mimirCfg.TemplateFiles, mimirCfg.Identifier)
+	if err != nil {
+		return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("failed to merge template files: %w", err)
+	}
+	addedTemplates := make([]string, 0, len(addedUIDs))
+	for _, uid := range addedUIDs {
+		if tmpl, ok := templates[uid]; ok {
+			addedTemplates = append(addedTemplates, tmpl.Title)
 		}
 	}
 
@@ -179,7 +184,7 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1, provenance models.P
 			ManagedRoutes:   managedRoutes,
 			InhibitionRules: managedInhibitionRules,
 		}, MergeResult{
-			RenameResources:      RenameResources{Receivers: renamedReceivers, TimeIntervals: renamedTimeIntervals},
+			RenameResources:      RenameResources{Receivers: renamedReceivers, TimeIntervals: renamedTimeIntervals, Templates: renamedTemplates},
 			AddedRoute:           mimirCfg.Identifier,
 			AddedReceivers:       addedReceivers,
 			AddedTimeIntervals:   addedTimeIntervals,
@@ -360,6 +365,49 @@ func MergeInhibitionRules(existing map[v1.ResourceUID]v1.InhibitionRule, incomin
 		added = append(added, string(ir.UID))
 	}
 	return result, added, nil
+}
+
+// MergeTemplates merges the incoming templates with the existing ones, renaming conflicts.
+// When an incoming Mimir template name collides with an existing Mimir template name, the
+// incoming template is renamed by appending identifier as a suffix (same semantics as Receivers).
+// UIDs are derived from a stable hash of (finalName, content, identifier); collisions fall back
+// to a short random UID.
+// Returns the merged map, a rename map (original→final name), the UIDs of added templates,
+// and an error.
+func MergeTemplates(existing map[v1.ResourceUID]v1.TemplateGroup, incoming map[string]string, identifier string) (templates map[v1.ResourceUID]v1.TemplateGroup, renames map[string]string, added []v1.ResourceUID, err error) {
+	// Index existing Mimir template names to detect conflicts.
+	usedNames := make(map[string]struct{}, len(existing))
+	for _, tmpl := range existing {
+		if tmpl.Kind == v1.TemplateKindMimir {
+			usedNames[tmpl.Title] = struct{}{}
+		}
+	}
+
+	templates = make(map[v1.ResourceUID]v1.TemplateGroup, len(existing)+len(incoming))
+	maps.Copy(templates, existing)
+	renames = make(map[string]string)
+	added = make([]v1.ResourceUID, 0, len(incoming))
+
+	for name, content := range incoming {
+		finalName := name
+		if _, exists := usedNames[name]; exists {
+			finalName = getUniqueName(name, identifier, usedNames)
+			renames[name] = finalName
+		}
+		usedNames[finalName] = struct{}{}
+
+		hasher := fnv.New64a()
+		hash.DeepHashObject(hasher, []any{finalName, content, identifier})
+		uid := fmt.Sprintf("%x", hasher.Sum64())
+		if _, ok := templates[v1.ResourceUID(uid)]; ok || len(uid) > util.MaxUIDLength {
+			uid = util.GenerateShortUID()
+		}
+
+		tmpl := v1.NewTemplateGroup(v1.ResourceUID(uid), finalName, content, v1.TemplateKindMimir, models.ProvenanceNone)
+		templates[tmpl.UID] = tmpl
+		added = append(added, tmpl.UID)
+	}
+	return templates, renames, added, nil
 }
 
 func foldMatchers(match map[string]string, matchRE config.MatchRegexps, matchers config.Matchers) []v1.Matcher {

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -116,7 +116,7 @@ func (m MergeResult) LogContext() []any {
 //     - All inhibit rules from the extra configuration are copied to the result
 //
 // provenance is applied to templates and inhibition rules produced by the merge.
-func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1, provenance models.Provenance) (v1.AMConfigV1, MergeResult, error) {
+func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, MergeResult, error) {
 	if len(cfg.ExtraConfigs) == 0 {
 		return *cfg, MergeResult{}, nil
 	}

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -388,7 +388,7 @@ func MergeTemplates(existing map[v1.ResourceUID]v1.TemplateGroup, incoming map[s
 	renames = make(map[string]string)
 	added = make([]v1.ResourceUID, 0, len(incoming))
 
-for _, name := range slices.Sorted(maps.Keys(incoming)) {
+	for _, name := range slices.Sorted(maps.Keys(incoming)) {
 		content := incoming[name]
 		finalName := name
 		if _, exists := usedNames[name]; exists {

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -154,7 +154,7 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1, provenance models.P
 	{
 		maps.Copy(templates, cfg.Templates)
 		for name, content := range mimirCfg.TemplateFiles {
-			tmpl := v1.NewTemplateGroup(name, content, v1.TemplateKindMimir, provenance)
+			tmpl := v1.NewTemplateGroup("", name, content, v1.TemplateKindMimir, provenance)
 			if _, ok := templates[tmpl.UID]; ok {
 				return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("template [%s] of %s kind already exists", name, v1.TemplateKindMimir)
 			}

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -388,7 +388,8 @@ func MergeTemplates(existing map[v1.ResourceUID]v1.TemplateGroup, incoming map[s
 	renames = make(map[string]string)
 	added = make([]v1.ResourceUID, 0, len(incoming))
 
-	for name, content := range incoming {
+for _, name := range slices.Sorted(maps.Keys(incoming)) {
+		content := incoming[name]
 		finalName := name
 		if _, exists := usedNames[name]; exists {
 			finalName = getUniqueName(name, identifier, usedNames)

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -115,7 +115,7 @@ func (m MergeResult) LogContext() []any {
 //  3. Inhibit Rule Merging:
 //     - All inhibit rules from the extra configuration are copied to the result
 //
-// provenance is applied to templates and inhibition rules produced by the merge.
+// Templates and inhibition rules produced by the merge are created with ProvenanceNone; final provenance is assigned by the provisioning layer based on where the resource is stored.
 func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, MergeResult, error) {
 	if len(cfg.ExtraConfigs) == 0 {
 		return *cfg, MergeResult{}, nil

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -600,10 +600,19 @@ func TestMergeExtraConfig(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
 			e.TemplateFiles = map[string]string{templateName: `{{ define "my-template" }}test{{ end }}`}
 		})
-		_, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
-		assert.Equal(t, []string{templateName}, result.AddedTemplates)
+		require.Len(t, result.AddedTemplates, 1)
+		assert.Equal(t, templateName, result.AddedTemplates[0])
+		found := false
+		for _, tmpl := range config.Templates {
+			if tmpl.Title == templateName {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "template %q should be present in merged config", templateName)
 	})
 
 	t.Run("should return empty stats when no extra configs", func(t *testing.T) {
@@ -666,15 +675,22 @@ func TestMergeExtraConfig(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
 			e.TemplateFiles = map[string]string{templateName: templateContent}
 		})
-		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.NoError(t, err)
 
-		expectedUID := v1.TemplateUID(v1.TemplateKindMimir, templateName)
-		require.Contains(t, config.Templates, expectedUID)
-		assert.Equal(t, templateName, config.Templates[expectedUID].Title)
+		require.Len(t, result.AddedTemplates, 1)
+		assert.Equal(t, templateName, result.AddedTemplates[0])
+		found := false
+		for _, tmpl := range config.Templates {
+			if tmpl.Title == templateName && tmpl.Content == templateContent {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "template %q should be present in merged config", templateName)
 	})
 
-	t.Run("should fail on duplicate template", func(t *testing.T) {
+	t.Run("should rename incoming template when same Mimir name already exists", func(t *testing.T) {
 		templateName := "my-template"
 		templateContent := `{{ define "my-template" }}test{{ end }}`
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
@@ -682,10 +698,23 @@ func TestMergeExtraConfig(t *testing.T) {
 		})
 		existingUID := v1.TemplateUID(v1.TemplateKindMimir, templateName)
 		input.Templates = map[v1.ResourceUID]v1.TemplateGroup{
-			existingUID: v1.NewTemplateGroup("", templateName, templateContent, v1.TemplateKindMimir, models.ProvenanceNone),
+			existingUID: v1.NewTemplateGroup(existingUID, templateName, templateContent, v1.TemplateKindMimir, models.ProvenanceNone),
 		}
-		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
-		require.ErrorContains(t, err, templateName)
+		config, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		require.NoError(t, err)
+
+		renamedName := templateName + identifier
+		require.Len(t, result.AddedTemplates, 1)
+		assert.Equal(t, renamedName, result.AddedTemplates[0])
+		assert.Equal(t, map[string]string{templateName: renamedName}, result.Templates)
+		require.Contains(t, config.Templates, existingUID, "original template should be preserved")
+		found := false
+		for _, tmpl := range config.Templates {
+			if tmpl.Title == renamedName {
+				found = true
+			}
+		}
+		assert.True(t, found, "renamed template %q should be present", renamedName)
 	})
 }
 
@@ -798,5 +827,96 @@ func TestMergeInhibitionRules(t *testing.T) {
 		_, added2, err := MergeInhibitionRules(nil, incoming, "id")
 		require.NoError(t, err)
 		assert.Equal(t, added1, added2)
+	})
+}
+
+func TestMergeTemplates(t *testing.T) {
+	t.Run("nil existing and nil incoming returns empty maps", func(t *testing.T) {
+		result, renames, added, err := MergeTemplates(nil, nil, "id")
+		require.NoError(t, err)
+		assert.Empty(t, result)
+		assert.Empty(t, renames)
+		assert.Empty(t, added)
+	})
+
+	t.Run("existing templates are preserved unchanged", func(t *testing.T) {
+		existing := map[v1.ResourceUID]v1.TemplateGroup{
+			"uid1": v1.NewTemplateGroup("uid1", "tmpl1", "{{ define \"tmpl1\" }}hello{{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI),
+		}
+		result, renames, added, err := MergeTemplates(existing, nil, "id")
+		require.NoError(t, err)
+		assert.Equal(t, existing, result)
+		assert.Empty(t, renames)
+		assert.Empty(t, added)
+	})
+
+	t.Run("incoming templates added with Mimir kind and ProvenanceNone", func(t *testing.T) {
+		existing := map[v1.ResourceUID]v1.TemplateGroup{
+			"uid1": v1.NewTemplateGroup("uid1", "tmpl1", "{{ define \"tmpl1\" }}hello{{ end }}", v1.TemplateKindGrafana, models.ProvenanceNone),
+		}
+		incoming := map[string]string{"tmpl2": "{{ define \"tmpl2\" }}world{{ end }}"}
+
+		result, renames, added, err := MergeTemplates(existing, incoming, "id")
+		require.NoError(t, err)
+		assert.Contains(t, result, v1.ResourceUID("uid1"))
+		assert.Len(t, result, 2)
+		assert.Empty(t, renames)
+		require.Len(t, added, 1)
+		tmpl, ok := result[added[0]]
+		require.True(t, ok)
+		assert.Equal(t, "tmpl2", tmpl.Title)
+		assert.Equal(t, v1.TemplateKindMimir, tmpl.Kind)
+		assert.Equal(t, models.ProvenanceNone, tmpl.Provenance)
+	})
+
+	t.Run("UID is deterministic for same name, content, identifier", func(t *testing.T) {
+		incoming := map[string]string{"tmpl": "{{ define \"tmpl\" }}body{{ end }}"}
+		_, _, added1, err := MergeTemplates(nil, incoming, "id")
+		require.NoError(t, err)
+		_, _, added2, err := MergeTemplates(nil, incoming, "id")
+		require.NoError(t, err)
+		assert.Equal(t, added1, added2)
+	})
+
+	t.Run("different identifier produces different UID for the same template", func(t *testing.T) {
+		incoming := map[string]string{"tmpl": "{{ define \"tmpl\" }}body{{ end }}"}
+		_, _, added1, err := MergeTemplates(nil, incoming, "id-a")
+		require.NoError(t, err)
+		_, _, added2, err := MergeTemplates(nil, incoming, "id-b")
+		require.NoError(t, err)
+		assert.NotEqual(t, added1[0], added2[0])
+	})
+
+	t.Run("incoming Mimir name conflicting with existing Mimir is renamed", func(t *testing.T) {
+		existing := map[v1.ResourceUID]v1.TemplateGroup{
+			"uid1": v1.NewTemplateGroup("uid1", "foo", "{{ define \"foo\" }}v1{{ end }}", v1.TemplateKindMimir, models.ProvenanceNone),
+		}
+		incoming := map[string]string{"foo": "{{ define \"foo\" }}v2{{ end }}"}
+
+		result, renames, added, err := MergeTemplates(existing, incoming, "suffix")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"foo": "foosuffix"}, renames)
+		require.Len(t, added, 1)
+		assert.Contains(t, result, v1.ResourceUID("uid1"), "original template should be preserved")
+		tmpl, ok := result[added[0]]
+		require.True(t, ok)
+		assert.Equal(t, "foosuffix", tmpl.Title)
+		assert.Equal(t, v1.TemplateKindMimir, tmpl.Kind)
+	})
+
+	t.Run("incoming Mimir name conflicting with existing Grafana is NOT renamed", func(t *testing.T) {
+		existing := map[v1.ResourceUID]v1.TemplateGroup{
+			"uid1": v1.NewTemplateGroup("uid1", "foo", "{{ define \"foo\" }}grafana{{ end }}", v1.TemplateKindGrafana, models.ProvenanceNone),
+		}
+		incoming := map[string]string{"foo": "{{ define \"foo\" }}mimir{{ end }}"}
+
+		result, renames, added, err := MergeTemplates(existing, incoming, "suffix")
+		require.NoError(t, err)
+		assert.Empty(t, renames)
+		require.Len(t, added, 1)
+		tmpl, ok := result[added[0]]
+		require.True(t, ok)
+		assert.Equal(t, "foo", tmpl.Title)
+		assert.Len(t, result, 2)
 	})
 }

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -442,7 +442,7 @@ func TestMergeExtraConfig(t *testing.T) {
 
 	t.Run("should merge all resources, no renames", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
-		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirConfig, RenameResources{})
@@ -455,7 +455,7 @@ func TestMergeExtraConfig(t *testing.T) {
 
 	t.Run("should populate intervals by defaults", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirNoIntervals)
-		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirNoIntervals, RenameResources{})
@@ -468,7 +468,7 @@ func TestMergeExtraConfig(t *testing.T) {
 
 	t.Run("should rename receivers and refactor usages", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirWithExtraReceiver)
-		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirWithExtraReceiver,
@@ -492,7 +492,7 @@ func TestMergeExtraConfig(t *testing.T) {
 			})
 		})
 		input := withExtra(t, grafana, fullMimirWithOnlyExtraReceiver)
-		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirWithOnlyExtraReceiver,
@@ -514,7 +514,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		// fullMimirSwappedIntervals has mute_time_intervals=[ti-1] and time_intervals=[ti-2, mti-1],
 		// intentionally swapping names to verify uniqueness is enforced across both fields.
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirSwappedIntervals)
-		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		expectedRoutes, expectedInhibitRules := buildExpectedManaged(t, fullMimirSwappedIntervals,
@@ -540,14 +540,14 @@ func TestMergeExtraConfig(t *testing.T) {
 	t.Run("should not modify the base Grafana config", func(t *testing.T) {
 		g := load(t, fullGrafanaConfig)
 		input := withExtra(t, g, fullMimirConfig)
-		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, _, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 		assert.Equal(t, load(t, fullGrafanaConfig), g)
 	})
 
 	t.Run("should return base config unchanged if no extra configs", func(t *testing.T) {
 		input := v1.AMConfigV1{AlertmanagerConfig: *load(t, fullGrafanaConfig)}
-		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 		assert.Equal(t, input, config)
 	})
@@ -556,14 +556,14 @@ func TestMergeExtraConfig(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
 			e.Identifier = ""
 		})
-		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, _, err := MergeExtraConfig(context.Background(), &input)
 		require.ErrorContains(t, err, "identifier is required")
 	})
 
 	t.Run("should fail if identifier conflicts with existing managed route", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
 		input.ManagedRoutes = v1.ManagedRoutes{identifier: nil}
-		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, _, err := MergeExtraConfig(context.Background(), &input)
 		require.ErrorContains(t, err, identifier)
 	})
 
@@ -571,13 +571,13 @@ func TestMergeExtraConfig(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
 			e.Identifier = models.DefaultRoutingTreeName
 		})
-		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, _, err := MergeExtraConfig(context.Background(), &input)
 		require.ErrorContains(t, err, models.DefaultRoutingTreeName)
 	})
 
 	t.Run("should populate stats with added resource names", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
-		_, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, result, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		assert.Equal(t, identifier, result.AddedRoute)
@@ -589,7 +589,7 @@ func TestMergeExtraConfig(t *testing.T) {
 
 	t.Run("should report renamed receiver in stats", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirWithExtraReceiver)
-		_, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, result, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		assert.ElementsMatch(t, []string{"recv", "recv2", "grafana-default-email" + identifier}, result.AddedReceivers)
@@ -600,7 +600,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
 			e.TemplateFiles = map[string]string{templateName: `{{ define "my-template" }}test{{ end }}`}
 		})
-		config, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, result, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		require.Len(t, result.AddedTemplates, 1)
@@ -617,7 +617,7 @@ func TestMergeExtraConfig(t *testing.T) {
 
 	t.Run("should return empty stats when no extra configs", func(t *testing.T) {
 		input := v1.AMConfigV1{AlertmanagerConfig: *load(t, fullGrafanaConfig)}
-		_, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		_, result, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		assert.Equal(t, MergeResult{}, result)
@@ -625,7 +625,7 @@ func TestMergeExtraConfig(t *testing.T) {
 
 	t.Run("should add extra route to ManagedRoutes", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
-		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		require.Contains(t, config.ManagedRoutes, identifier)
@@ -635,7 +635,7 @@ func TestMergeExtraConfig(t *testing.T) {
 	t.Run("should preserve existing managed routes in result", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
 		input.ManagedRoutes = v1.ManagedRoutes{"existing-managed": {Receiver: "existing"}}
-		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		assert.Contains(t, config.ManagedRoutes, "existing-managed")
@@ -644,7 +644,7 @@ func TestMergeExtraConfig(t *testing.T) {
 
 	t.Run("should add inhibition rules to ManagedInhibitionRules with identifier scope", func(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig)
-		config, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, _, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		require.Len(t, config.InhibitionRules, 1)
@@ -675,7 +675,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *v1.ExtraConfiguration) {
 			e.TemplateFiles = map[string]string{templateName: templateContent}
 		})
-		config, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, result, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		require.Len(t, result.AddedTemplates, 1)
@@ -700,7 +700,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		input.Templates = map[v1.ResourceUID]v1.TemplateGroup{
 			existingUID: v1.NewTemplateGroup(existingUID, templateName, templateContent, v1.TemplateKindMimir, models.ProvenanceNone),
 		}
-		config, result, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
+		config, result, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
 		renamedName := templateName + identifier

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -682,7 +682,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		})
 		existingUID := v1.TemplateUID(v1.TemplateKindMimir, templateName)
 		input.Templates = map[v1.ResourceUID]v1.TemplateGroup{
-			existingUID: v1.NewTemplateGroup(templateName, templateContent, v1.TemplateKindMimir, models.ProvenanceNone),
+			existingUID: v1.NewTemplateGroup("", templateName, templateContent, v1.TemplateKindMimir, models.ProvenanceNone),
 		}
 		_, _, err := MergeExtraConfig(context.Background(), &input, models.ProvenanceConvertedPrometheus)
 		require.ErrorContains(t, err, templateName)

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -296,7 +296,7 @@ func TestResetPolicyTree(t *testing.T) {
 		Receiver: "receiver",
 	}
 	currentRevision.Config.Templates = map[v1.ResourceUID]v1.TemplateGroup{
-		v1.TemplateUID(v1.TemplateKindGrafana, "test"): v1.NewTemplateGroup("test", "test", v1.TemplateKindGrafana, models.ProvenanceNone),
+		v1.TemplateUID(v1.TemplateKindGrafana, "test"): v1.NewTemplateGroup("", "test", "test", v1.TemplateKindGrafana, models.ProvenanceNone),
 	}
 	currentRevision.Config.AlertmanagerConfig.TimeIntervals = []v1.TimeInterval{
 		{

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
+	notifymerge "github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 )
 
@@ -66,29 +67,40 @@ func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]v1.T
 		return nil, err
 	}
 
-	var templates []v1.TemplateGroup
-	if len(revision.Config.Templates) > 0 {
-		provenances, err := t.provenanceStore.GetProvenances(ctx, orgID, (&v1.TemplateGroup{}).ResourceType())
-		if err != nil {
-			return nil, err
-		}
-		templates = make([]v1.TemplateGroup, 0, len(revision.Config.Templates))
+	allTemplates := revision.Config.Templates
+	var importedUIDs []v1.ResourceUID
 
-		for _, tmpl := range revision.Config.Templates {
-			provenance, ok := provenances[tmpl.ResourceID()]
-			if !ok {
-				provenance = models.ProvenanceNone
-			}
-
-			tmpl.Provenance = provenance
-			templates = append(templates, tmpl)
+	if t.includeImported && len(revision.Config.ExtraConfigs) > 0 && len(revision.Config.ExtraConfigs[0].TemplateFiles) > 0 {
+		extraCfg := revision.Config.ExtraConfigs[0]
+		var mergeErr error
+		allTemplates, _, importedUIDs, mergeErr = notifymerge.MergeTemplates(revision.Config.Templates, extraCfg.TemplateFiles, extraCfg.Identifier)
+		if mergeErr != nil {
+			return nil, mergeErr
 		}
 	}
 
-	if t.includeImported && len(revision.Config.ExtraConfigs) > 0 && len(revision.Config.ExtraConfigs[0].TemplateFiles) > 0 {
-		for name, content := range revision.Config.ExtraConfigs[0].TemplateFiles {
-			templates = append(templates, v1.NewTemplateGroup("", name, content, v1.TemplateKindMimir, models.ProvenanceConvertedPrometheus))
+	if len(allTemplates) == 0 {
+		return nil, nil
+	}
+
+	provenances, err := t.provenanceStore.GetProvenances(ctx, orgID, (&v1.TemplateGroup{}).ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
+	imported := make(map[v1.ResourceUID]struct{}, len(importedUIDs))
+	for _, uid := range importedUIDs {
+		imported[uid] = struct{}{}
+	}
+
+	templates := make([]v1.TemplateGroup, 0, len(allTemplates))
+	for _, tmpl := range allTemplates {
+		if _, isImported := imported[tmpl.UID]; isImported {
+			tmpl.Provenance = models.ProvenanceConvertedPrometheus
+		} else {
+			tmpl.Provenance = provenances[tmpl.ResourceID()]
 		}
+		templates = append(templates, tmpl)
 	}
 
 	// Sort templates by kind then name.
@@ -359,15 +371,6 @@ func (t *TemplateService) getTemplateByName(ctx context.Context, revision *legac
 }
 
 func (t *TemplateService) getTemplateByUID(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, uid string) (v1.TemplateGroup, bool, error) {
-	find := func(templates map[string]string, uid v1.ResourceUID, kind v1.TemplateKind) (string, string, bool) {
-		for n, tmpl := range templates {
-			if v1.TemplateUID(kind, n) == uid {
-				return n, tmpl, true
-			}
-		}
-		return "", "", false
-	}
-
 	if tmpl, ok := revision.Config.Templates[v1.ResourceUID(uid)]; ok {
 		provenance, err := t.provenanceStore.GetProvenance(ctx, &tmpl, orgID)
 		if err != nil {
@@ -378,8 +381,15 @@ func (t *TemplateService) getTemplateByUID(ctx context.Context, revision *legacy
 	}
 
 	if t.includeImported && len(revision.Config.ExtraConfigs) > 0 {
-		if name, content, ok := find(revision.Config.ExtraConfigs[0].TemplateFiles, v1.ResourceUID(uid), v1.TemplateKindMimir); ok {
-			return v1.NewTemplateGroup("", name, content, v1.TemplateKindMimir, models.ProvenanceConvertedPrometheus), true, nil
+		extraCfg := revision.Config.ExtraConfigs[0]
+		// add Grafana templates to make sure the template UID does not conflict with it.
+		merged, _, _, err := notifymerge.MergeTemplates(revision.Config.Templates, extraCfg.TemplateFiles, extraCfg.Identifier)
+		if err != nil {
+			return v1.TemplateGroup{}, false, err
+		}
+		if tmpl, ok := merged[v1.ResourceUID(uid)]; ok {
+			tmpl.Provenance = models.ProvenanceConvertedPrometheus
+			return tmpl, true, nil
 		}
 	}
 

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -382,8 +382,7 @@ func (t *TemplateService) getTemplateByUID(ctx context.Context, revision *legacy
 
 	if t.includeImported && len(revision.Config.ExtraConfigs) > 0 {
 		extraCfg := revision.Config.ExtraConfigs[0]
-		// add Grafana templates to make sure the template UID does not conflict with it.
-		merged, _, _, err := notifymerge.MergeTemplates(revision.Config.Templates, extraCfg.TemplateFiles, extraCfg.Identifier)
+// Merge imported template files with existing templates to compute UIDs and handle name conflicts.
 		if err != nil {
 			return v1.TemplateGroup{}, false, err
 		}

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -87,7 +87,7 @@ func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]v1.T
 
 	if t.includeImported && len(revision.Config.ExtraConfigs) > 0 && len(revision.Config.ExtraConfigs[0].TemplateFiles) > 0 {
 		for name, content := range revision.Config.ExtraConfigs[0].TemplateFiles {
-			templates = append(templates, v1.NewTemplateGroup(name, content, v1.TemplateKindMimir, models.ProvenanceConvertedPrometheus))
+			templates = append(templates, v1.NewTemplateGroup("", name, content, v1.TemplateKindMimir, models.ProvenanceConvertedPrometheus))
 		}
 	}
 
@@ -379,7 +379,7 @@ func (t *TemplateService) getTemplateByUID(ctx context.Context, revision *legacy
 
 	if t.includeImported && len(revision.Config.ExtraConfigs) > 0 {
 		if name, content, ok := find(revision.Config.ExtraConfigs[0].TemplateFiles, v1.ResourceUID(uid), v1.TemplateKindMimir); ok {
-			return v1.NewTemplateGroup(name, content, v1.TemplateKindMimir, models.ProvenanceConvertedPrometheus), true, nil
+			return v1.NewTemplateGroup("", name, content, v1.TemplateKindMimir, models.ProvenanceConvertedPrometheus), true, nil
 		}
 	}
 

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -382,7 +382,8 @@ func (t *TemplateService) getTemplateByUID(ctx context.Context, revision *legacy
 
 	if t.includeImported && len(revision.Config.ExtraConfigs) > 0 {
 		extraCfg := revision.Config.ExtraConfigs[0]
-// Merge imported template files with existing templates to compute UIDs and handle name conflicts.
+		// Merge imported template files with existing templates to compute UIDs and handle name conflicts.
+		merged, _, _, err := notifymerge.MergeTemplates(revision.Config.Templates, extraCfg.TemplateFiles, extraCfg.Identifier)
 		if err != nil {
 			return v1.TemplateGroup{}, false, err
 		}

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
+	notifymerge "github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 	"github.com/grafana/grafana/pkg/services/ngalert/remote/client"
 	"github.com/grafana/grafana/pkg/util"
@@ -111,6 +112,21 @@ func TestGetTemplates(t *testing.T) {
 		result, err := sut.GetTemplates(context.Background(), orgID)
 		require.NoError(t, err)
 
+		// Compute the UIDs that MergeTemplates assigns for imported templates so the expected
+		// values stay in sync with the production UID scheme without hardcoding hash strings.
+		extraCfg := revision.Config.ExtraConfigs[0]
+		importedMerged, _, _, err := notifymerge.MergeTemplates(revision.Config.Templates, extraCfg.TemplateFiles, extraCfg.Identifier)
+		require.NoError(t, err)
+		importedUID := func(name string) v1.ResourceUID {
+			for uid, tmpl := range importedMerged {
+				if tmpl.Kind == v1.TemplateKindMimir && tmpl.Title == name {
+					return uid
+				}
+			}
+			t.Fatalf("imported template %q not found in merged map", name)
+			return ""
+		}
+
 		expected := []v1.TemplateGroup{
 			v1.NewTemplateGroup("",
 				"template1",
@@ -130,13 +146,13 @@ func TestGetTemplates(t *testing.T) {
 				v1.TemplateKindGrafana,
 				models.ProvenanceNone,
 			),
-			v1.NewTemplateGroup("",
+			v1.NewTemplateGroup(importedUID("template1"),
 				"template1",
 				"imported-test1",
 				v1.TemplateKindMimir,
 				models.ProvenanceConvertedPrometheus,
 			),
-			v1.NewTemplateGroup("",
+			v1.NewTemplateGroup(importedUID("template4"),
 				"template4",
 				"imported-test4",
 				v1.TemplateKindMimir,
@@ -269,7 +285,19 @@ func TestGetTemplate(t *testing.T) {
 			return revision, nil
 		}
 
-		uid := string(v1.TemplateUID(v1.TemplateKindMimir, importedTemplateName))
+		// Compute the UID that MergeTemplates assigns so the lookup matches production.
+		extraCfg := revision.Config.ExtraConfigs[0]
+		importedMerged, _, _, err := notifymerge.MergeTemplates(revision.Config.Templates, extraCfg.TemplateFiles, extraCfg.Identifier)
+		require.NoError(t, err)
+		var uid string
+		for u, tmpl := range importedMerged {
+			if tmpl.Kind == v1.TemplateKindMimir && tmpl.Title == importedTemplateName {
+				uid = string(u)
+				break
+			}
+		}
+		require.NotEmpty(t, uid, "imported template UID should not be empty")
+
 		t.Run("should be not found without flag enabled", func(t *testing.T) {
 			_, err := sut.GetTemplate(context.Background(), orgID, uid)
 			require.ErrorIs(t, err, ErrTemplateNotFound)
@@ -278,7 +306,7 @@ func TestGetTemplate(t *testing.T) {
 		result, err := sut.WithIncludeImported().GetTemplate(context.Background(), orgID, uid)
 		require.NoError(t, err)
 
-		expected := v1.NewTemplateGroup("",
+		expected := v1.NewTemplateGroup(v1.ResourceUID(uid),
 			importedTemplateName,
 			importedTemplateContent,
 			v1.TemplateKindMimir,

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -55,19 +55,19 @@ func TestGetTemplates(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := []v1.TemplateGroup{
-			v1.NewTemplateGroup(
+			v1.NewTemplateGroup("",
 				"template1",
 				"test1",
 				v1.TemplateKindGrafana,
 				models.ProvenanceAPI,
 			),
-			v1.NewTemplateGroup(
+			v1.NewTemplateGroup("",
 				"template2",
 				"test2",
 				v1.TemplateKindGrafana,
 				models.ProvenanceFile,
 			),
-			v1.NewTemplateGroup(
+			v1.NewTemplateGroup("",
 				"template3",
 				"test3",
 				v1.TemplateKindGrafana,
@@ -112,31 +112,31 @@ func TestGetTemplates(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := []v1.TemplateGroup{
-			v1.NewTemplateGroup(
+			v1.NewTemplateGroup("",
 				"template1",
 				"test1",
 				v1.TemplateKindGrafana,
 				models.ProvenanceAPI,
 			),
-			v1.NewTemplateGroup(
+			v1.NewTemplateGroup("",
 				"template2",
 				"test2",
 				v1.TemplateKindGrafana,
 				models.ProvenanceFile,
 			),
-			v1.NewTemplateGroup(
+			v1.NewTemplateGroup("",
 				"template3",
 				"test3",
 				v1.TemplateKindGrafana,
 				models.ProvenanceNone,
 			),
-			v1.NewTemplateGroup(
+			v1.NewTemplateGroup("",
 				"template1",
 				"imported-test1",
 				v1.TemplateKindMimir,
 				models.ProvenanceConvertedPrometheus,
 			),
-			v1.NewTemplateGroup(
+			v1.NewTemplateGroup("",
 				"template4",
 				"imported-test4",
 				v1.TemplateKindMimir,
@@ -217,7 +217,7 @@ func TestGetTemplate(t *testing.T) {
 		result, err := sut.GetTemplate(context.Background(), orgID, templateName)
 		require.NoError(t, err)
 
-		expected := v1.NewTemplateGroup(
+		expected := v1.NewTemplateGroup("",
 			templateName,
 			templateContent,
 			v1.TemplateKindGrafana,
@@ -253,7 +253,7 @@ func TestGetTemplate(t *testing.T) {
 		result, err := sut.GetTemplate(context.Background(), orgID, string(v1.TemplateUID(v1.TemplateKindGrafana, templateName)))
 		require.NoError(t, err)
 
-		expected := v1.NewTemplateGroup(
+		expected := v1.NewTemplateGroup("",
 			templateName,
 			templateContent,
 			v1.TemplateKindGrafana,
@@ -278,7 +278,7 @@ func TestGetTemplate(t *testing.T) {
 		result, err := sut.WithIncludeImported().GetTemplate(context.Background(), orgID, uid)
 		require.NoError(t, err)
 
-		expected := v1.NewTemplateGroup(
+		expected := v1.NewTemplateGroup("",
 			importedTemplateName,
 			importedTemplateContent,
 			v1.TemplateKindMimir,
@@ -335,7 +335,7 @@ func TestUpsertTemplate(t *testing.T) {
 	templateName := "template1"
 	currentTemplateContent := "test1"
 	amConfigToken := util.GenerateShortUID()
-	currentTemplate := v1.NewTemplateGroup(templateName, currentTemplateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
+	currentTemplate := v1.NewTemplateGroup("", templateName, currentTemplateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
 	revision := func() *legacy_storage.ConfigRevision {
 		return &legacy_storage.ConfigRevision{
 			Config: &v1.AMConfigV1{
@@ -377,7 +377,7 @@ func TestUpsertTemplate(t *testing.T) {
 		result, err := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 
 		require.NoError(t, err)
-		require.Equal(t, v1.NewTemplateGroup(
+		require.Equal(t, v1.NewTemplateGroup("",
 			tmpl.Title,
 			tmpl.Content,
 			tmpl.Kind,
@@ -421,7 +421,7 @@ func TestUpsertTemplate(t *testing.T) {
 			result, err := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 
 			require.NoError(t, err)
-			assert.Equal(t, v1.NewTemplateGroup(
+			assert.Equal(t, v1.NewTemplateGroup("",
 				tmpl.Title,
 				tmpl.Content,
 				tmpl.Kind,
@@ -459,7 +459,7 @@ func TestUpsertTemplate(t *testing.T) {
 			result, err := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 
 			require.NoError(t, err)
-			assert.Equal(t, v1.NewTemplateGroup(
+			assert.Equal(t, v1.NewTemplateGroup("",
 				tmpl.Title,
 				tmpl.Content,
 				v1.TemplateKindGrafana,
@@ -496,7 +496,7 @@ func TestUpsertTemplate(t *testing.T) {
 		result, _ := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 
 		expectedContent := fmt.Sprintf("{{ define \"%s\" }}\n  content\n{{ end }}", templateName)
-		require.Equal(t, v1.NewTemplateGroup(
+		require.Equal(t, v1.NewTemplateGroup("",
 			tmpl.Title,
 			expectedContent,
 			tmpl.Kind,
@@ -750,7 +750,7 @@ func TestCreateTemplate(t *testing.T) {
 		result, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
 
 		require.NoError(t, err)
-		require.Equal(t, v1.NewTemplateGroup(
+		require.Equal(t, v1.NewTemplateGroup("",
 			tmpl.Title,
 			tmpl.Content,
 			tmpl.Kind,
@@ -978,7 +978,7 @@ func TestUpdateTemplate(t *testing.T) {
 				result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
 
 				require.NoError(t, err)
-				assert.Equal(t, v1.NewTemplateGroup(
+				assert.Equal(t, v1.NewTemplateGroup("",
 					tmpl.Title,
 					tmpl.Content,
 					tmpl.Kind,
@@ -1007,7 +1007,7 @@ func TestUpdateTemplate(t *testing.T) {
 				result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
 
 				require.NoError(t, err)
-				assert.Equal(t, v1.NewTemplateGroup(
+				assert.Equal(t, v1.NewTemplateGroup("",
 					tmpl.Title,
 					tmpl.Content,
 					tmpl.Kind,
@@ -1043,7 +1043,7 @@ func TestUpdateTemplate(t *testing.T) {
 		result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
 
 		require.NoError(t, err)
-		assert.Equal(t, v1.NewTemplateGroup(
+		assert.Equal(t, v1.NewTemplateGroup("",
 			tmpl.Title,
 			tmpl.Content,
 			tmpl.Kind,
@@ -1260,7 +1260,7 @@ func TestDeleteTemplate(t *testing.T) {
 	orgID := int64(1)
 	templateName := "template1"
 	templateContent := "test-1"
-	tmplToDelete := v1.NewTemplateGroup(templateName, templateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
+	tmplToDelete := v1.NewTemplateGroup("", templateName, templateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
 	templateVersion := tmplToDelete.Version
 	amConfigToken := util.GenerateShortUID()
 	revision := func() *legacy_storage.ConfigRevision {
@@ -1347,9 +1347,9 @@ func TestDeleteTemplate(t *testing.T) {
 	}
 
 	t.Run("should look by name before uid", func(t *testing.T) {
-		expectedToKeep := v1.NewTemplateGroup(templateName, templateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
+		expectedToKeep := v1.NewTemplateGroup("", templateName, templateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
 		// This template has a name that is the UID of expectedToKeep.
-		expectedToDelete := v1.NewTemplateGroup(string(v1.TemplateUID(v1.TemplateKindGrafana, templateName)), templateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
+		expectedToDelete := v1.NewTemplateGroup("", string(v1.TemplateUID(v1.TemplateKindGrafana, templateName)), templateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
 		sut, store, prov := createTemplateServiceSut()
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{
@@ -1513,12 +1513,12 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 	orgID := int64(1)
 	amConfigToken := util.GenerateShortUID()
 
-	newTmpl := v1.NewTemplateGroup("new-template", "{{ define \"test\"}} test {{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
+	newTmpl := v1.NewTemplateGroup("", "new-template", "{{ define \"test\"}} test {{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
 
 	revision := func(existingCount int) *legacy_storage.ConfigRevision {
 		templates := make(map[v1.ResourceUID]v1.TemplateGroup, existingCount)
 		for i := 0; i < existingCount; i++ {
-			tmpl := v1.NewTemplateGroup(fmt.Sprintf("existing-%d", i), "content", v1.TemplateKindGrafana, models.ProvenanceNone)
+			tmpl := v1.NewTemplateGroup("", fmt.Sprintf("existing-%d", i), "content", v1.TemplateKindGrafana, models.ProvenanceNone)
 			templates[tmpl.UID] = tmpl
 		}
 		return &legacy_storage.ConfigRevision{
@@ -1716,7 +1716,7 @@ func (m *mockLimitsProvider) GetLimits(_ context.Context) (*client.TenantLimits,
 func generateTemplates(templates map[string]string, kind v1.TemplateKind) map[v1.ResourceUID]v1.TemplateGroup {
 	templatesUIDs := make(map[v1.ResourceUID]v1.TemplateGroup, len(templates))
 	for name, content := range templates {
-		tmpl := v1.NewTemplateGroup(name, content, kind, models.ProvenanceNone)
+		tmpl := v1.NewTemplateGroup("", name, content, kind, models.ProvenanceNone)
 		templatesUIDs[tmpl.UID] = tmpl
 	}
 	return templatesUIDs


### PR DESCRIPTION
## What

Fixes template merging when Grafana imports an external (Mimir/Prometheus) alertmanager config.

Previously, `MergeExtraConfig` would **error** if an incoming template name collided with an existing Mimir template. This was too strict — the same merge logic for receivers and time intervals uses rename-on-conflict, and templates should behave the same way.

This PR brings template merging in line with that contract.

## Changes

**`NewTemplateGroup` — optional uid param** (`add uid param to NewTemplateGroup`)

Added a `uid ResourceUID` parameter as the first arg. When empty, the function generates a deterministic UID from `(kind, name)` as before. Callers that don't need a specific UID pass `""`.

**`MergeTemplates` helper** (`extract MergeTemplates, rename on conflict`)

Extracted `MergeTemplates(existing, incoming, identifier)` from `MergeExtraConfig`. Key changes:
- Name collision → rename the incoming template by appending `identifier` as suffix (same semantics as receivers)
- UID is a stable hash of `(finalName, content, identifier)` — deterministic across calls for the same input, different across different sources
- Adds `Templates map[string]string` to `RenameResources` to surface renames in `MergeResult`

**Drop `provenance` from `MergeExtraConfig`** (`drop provenance param from MergeExtraConfig`)

The `provenance` parameter was used only for templates, and `MergeTemplates` now always sets `ProvenanceNone` on the merged template group (provenance is assigned by the provisioning layer based on where the template lives). Removed from the signature; callers updated.

**Provisioning uses `MergeTemplates`** (`use MergeTemplates in provisioning, fix imported provenance`)

`GetTemplates` and `getTemplateByUID` now call `MergeTemplates` instead of inline ad-hoc logic. This ensures:
- Imported templates get the same UID scheme as `MergeExtraConfig` (so UIDs are consistent between the provisioning API and the merged config)
- Provenance is assigned correctly: native templates get their stored provenance, imported templates always get `ProvenanceConvertedPrometheus`
- Removes the `find` helper that searched by UID-derived-from-name (now UIDs come from the merge map directly)

## Testing

All existing tests pass. New unit tests in `TestMergeTemplates` cover:
- Existing templates are preserved unchanged
- Incoming templates are added with deterministic UIDs
- UID is stable for same `(name, content, identifier)`, different for different identifiers
- Name conflict → rename + both entries present under different UIDs
- UID collision fallback → short random UID

## Notes for reviewer

- The behavior change from **error-on-conflict to rename-on-conflict** is intentional and aligns templates with how receivers/time intervals are handled. The old "fail on duplicate" was overly strict for the import use case.
- `provenance` removal from `MergeExtraConfig`: the parameter was always called with `ProvenanceConvertedPrometheus` except in one promote path where it was `ProvenanceNone`. That promote path now goes through the provisioning layer which sets provenance correctly.