### PR TITLE
PanelEditNext (multi-select): Checkbox polish

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
@@ -441,6 +441,10 @@ function getStyles(
       paddingInline: theme.spacing(CHECKBOX_HIT_PADDING),
       cursor: 'pointer',
 
+      '& input': {
+        cursor: 'pointer',
+      },
+
       '&:hover input:not(:checked) + span': {
         borderColor: theme.components.input.borderHover,
       },
@@ -457,6 +461,7 @@ function getStyles(
         },
       },
     }),
+
     ghostCard: css({
       border: `1px solid ${ghostBorderColor}`,
       background: ghostBackgroundColor,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx, keyframes } from '@emotion/css';
 import { useCallback, useRef, useState } from 'react';
 
 import { colorManipulator, type GrafanaTheme2 } from '@grafana/data';
@@ -18,6 +18,25 @@ import { type SelectionModifiers, useQueryEditorTypeConfig, useQueryEditorUICont
 import { getEditorBorderColor } from '../../utils';
 import { AddCardButton } from '../AddCardButton';
 import { getGhostCardVisuals } from '../SidebarCardGhostStyles';
+
+const checkboxPop = keyframes({
+  '0%': { transform: 'scale(1)' },
+  '45%': { transform: 'scale(0.9)' },
+  '100%': { transform: 'scale(1)' },
+});
+
+const checkboxTickIn = keyframes({
+  '0%': { transform: 'rotate(45deg) scale(0.6)', opacity: 0 },
+  '100%': { transform: 'rotate(45deg) scale(1)', opacity: 1 },
+});
+
+// The visible checkbox box is 16px (theme.spacing(2)), matching the @grafana/ui
+// Checkbox. We extend the click target by CHECKBOX_HIT_PADDING on every side; the
+// open slot must therefore be the box plus that padding on both horizontal sides,
+// and the slot's negative margins absorb the same padding so nothing visually moves.
+const CHECKBOX_BOX_SIZE = 2;
+const CHECKBOX_HIT_PADDING = 0.75;
+const CHECKBOX_SLOT_OPEN_WIDTH = CHECKBOX_BOX_SIZE + CHECKBOX_HIT_PADDING * 2;
 
 interface SidebarCardProps {
   children: React.ReactNode;
@@ -137,8 +156,9 @@ export const SidebarCard = ({
           {...(!multiSelectMode && { inert: '' })}
         >
           {onToggleMultiSelect && (
-            <div onMouseDownCapture={handleBulkCheckboxMouseDownCapture}>
+            <div className={styles.checkboxClickArea} onMouseDownCapture={handleBulkCheckboxMouseDownCapture}>
               <Checkbox
+                className={styles.checkboxHitArea}
                 value={isMultiSelected}
                 onChange={handleCheckboxChange}
                 aria-label={t('query-editor-next.sidebar.card-multi-select', 'Include card {{id}} in bulk selection', {
@@ -384,26 +404,58 @@ function getStyles(
       gap: theme.spacing(1.25),
     }),
 
-    // Slot for the always-rendered checkbox: width animates open/closed to slide
-    // the card and reveal/clip it. Negative margin cancels `cardRow`'s gap when closed.
+    // Animated slot: width opens/closes to slide the card aside. overflow:hidden
+    // clips the box when closed; alignSelf:stretch lets the hit area fill card height.
     checkboxWrapper: css({
       display: 'flex',
-      alignItems: 'center',
+      alignItems: 'stretch',
+      alignSelf: 'stretch',
       overflow: 'hidden',
       width: 0,
       flexShrink: 0,
       lineHeight: 0,
       marginRight: `-${theme.spacing(1.25)}`,
       [theme.transitions.handleMotion('no-preference')]: {
-        transition: theme.transitions.create(['width', 'margin-right'], {
+        transition: theme.transitions.create(['width', 'margin-left', 'margin-right'], {
           duration: theme.transitions.duration.short,
           easing: theme.transitions.easing.easeOut,
         }),
       },
     }),
     checkboxWrapperOpen: css({
-      width: theme.spacing(2),
-      marginRight: 0,
+      width: theme.spacing(CHECKBOX_SLOT_OPEN_WIDTH),
+      marginLeft: `-${theme.spacing(CHECKBOX_HIT_PADDING)}`,
+      marginRight: `-${theme.spacing(CHECKBOX_HIT_PADDING)}`,
+    }),
+
+    checkboxClickArea: css({
+      display: 'flex',
+      alignItems: 'stretch',
+    }),
+
+    // Enlarges the click target (the Checkbox <label>) to the full card height and a
+    // few px beyond the box on each side, with hover + press/check feedback.
+    checkboxHitArea: css({
+      height: '100%',
+      alignContent: 'center',
+      paddingInline: theme.spacing(CHECKBOX_HIT_PADDING),
+      cursor: 'pointer',
+
+      '&:hover input:not(:checked) + span': {
+        borderColor: theme.components.input.borderHover,
+      },
+
+      [theme.transitions.handleMotion('no-preference')]: {
+        '&:active input + span': {
+          transform: 'scale(0.94)',
+        },
+        '& input:checked + span': {
+          animation: `${checkboxPop} 180ms ${theme.transitions.easing.easeOut}`,
+        },
+        '& input:checked + span::after': {
+          animation: `${checkboxTickIn} 180ms ${theme.transitions.easing.easeOut}`,
+        },
+      },
     }),
     ghostCard: css({
       border: `1px solid ${ghostBorderColor}`,


### PR DESCRIPTION
## Description
Improves the multi-select checkbox in the PanelEditNext query editor sidebar to feel more responsive: a larger click target and subtle press/check micro-interactions.

## Changes
* Enlarge the checkbox click target to the full card height plus a few px beyond the box on every side (the visible 16px box is unchanged) — scoped locally to the sidebar card, not the shared `@grafana/ui` Checkbox.
* Widen the open slide-in slot and absorb the extra width with negative margins so the box and the card don't visually move; derived from single-source constants (`CHECKBOX_HIT_PADDING`) to avoid magic-number coupling.
* Add hover border affordance across the enlarged target, a press dip (`scale(0.94)`), and a soft check "settle" + tick fade-in — all gated behind `prefers-reduced-motion`.

## Risks
* Low / CSS-only, scoped to `SidebarCard`. Most likely area to break is the slot slide-in animation alignment or the card horizontal position in multi-select mode. No change to the shared Checkbox, so no blast radius outside this sidebar.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

https://github.com/user-attachments/assets/d16fe162-309a-48b1-bd5c-7d7d96e985bd

## Testing Instructions
* Open a panel in edit mode (PanelEditNext query editor), click "Select…" in the sidebar footer to enter multi-select.
* Confirm clicking anywhere in the enlarged area (above/below/beside the box, not just the box) toggles selection; hover shows the border highlight; checking shows the subtle pop/tick.
* Enable OS "reduce motion" and confirm animations are suppressed while the larger hit area still works.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable