### PR TITLE
perf(grafana-ui): resolve uPlot cursor color via field.display.color

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -227,7 +227,9 @@ export class UPlotConfigBuilder {
         // interpolate for gradients/thresholds
         if (typeof s !== 'string') {
           let field = this.frames![0].fields[seriesIdx];
-          s = field.display!(field.values[u.cursor.idxs![seriesIdx]!]).color!;
+          let v = field.values[u.cursor.idxs![seriesIdx]!];
+          // color-only: skip the formatted text we'd otherwise discard
+          s = field.display!.color?.(v) ?? field.display!(v).color!;
         }
 
         return s + alphaHex;


### PR DESCRIPTION
The cursor stroke interpolation only needs the color; field.display(v).color
also formats text we discard. Use the color-only resolver, falling back to the
full processor when a field's display has no .color (e.g. inline processors).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
