### PR TITLE
perf(grafana-ui): resolve PillCell mapping color via field.display.color

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/PillCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/PillCell.tsx
@@ -90,7 +90,8 @@ function getPillColor(value: unknown, field: Field, theme: GrafanaTheme2): strin
   const cfg = field.config;
 
   if (cfg.mappings?.length ?? 0 > 0) {
-    return field.display!(value).color ?? FALLBACK_COLOR;
+    // color-only: skip the mapped text we'd otherwise discard
+    return field.display!.color?.(value) ?? field.display!(value).color ?? FALLBACK_COLOR;
   }
 
   if (cfg.color?.mode === FieldColorModeId.Fixed) {


### PR DESCRIPTION
The mapping-based pill background only needs the color; field.display(v) also
formats text we discard. Use the color-only resolver with a full-processor
fallback.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
