### PR TITLE
perf(barchart): resolve per-bar color via field.display.color

### DIFF
--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -231,7 +231,11 @@ export const prepConfig = ({ series, totalSeries, color, orientation, options, t
     const disp = color.display!;
     fillOpacity = (color.config.custom.fillOpacity ?? 100) / 100;
     // gradientMode? ignore?
-    getColor = (seriesIdx: number, valueIdx: number) => disp(color!.values[valueIdx]).color!;
+    // color-only: skip the formatted text we'd otherwise discard
+    getColor = (seriesIdx: number, valueIdx: number) => {
+      let v = color!.values[valueIdx];
+      return disp.color?.(v) ?? disp(v).color!;
+    };
   } else {
     const hasPerBarColor = frame.fields.some((f) => {
       const fromThresholds = f.config.color?.mode === FieldColorModeId.Thresholds;
@@ -257,7 +261,9 @@ export const prepConfig = ({ series, totalSeries, color, orientation, options, t
 
       getColor = (seriesIdx: number, valueIdx: number) => {
         let field = frame.fields[seriesIdx];
-        return field.display!(field.values[valueIdx]).color!;
+        let v = field.values[valueIdx];
+        // color-only: skip the formatted text we'd otherwise discard
+        return field.display!.color?.(v) ?? field.display!(v).color!;
       };
     }
   }


### PR DESCRIPTION
Both color-by-value paths (dedicated color field, and per-bar threshold/mapping
colors) only need the color; field.display(v) also formats text we discard.
Use the color-only resolver with a full-processor fallback.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
