### PR TITLE
perf(timeline): resolve cell color via field.display.color

### DIFF
--- a/public/app/core/components/TimelineChart/TimelineChart.tsx
+++ b/public/app/core/components/TimelineChart/TimelineChart.tsx
@@ -46,9 +46,11 @@ export const TimelineChart = (props: TimelineProps) => {
       const field = frames[frameIdx]?.fields[fieldIdx];
 
       if (field?.display) {
-        const disp = field.display(value); // will apply color modes
-        if (disp.color) {
-          return disp.color;
+        // color-only: skip the formatted text we'd otherwise discard. Falls back to
+        // the full processor for inline displays that don't provide .color.
+        const color = field.display.color?.(value) ?? field.display(value).color;
+        if (color) {
+          return color;
         }
       }
 


### PR DESCRIPTION
state-timeline / status-history getValueColor only needs the color; calling
field.display(value) also formats text we discard. Use the color-only resolver,
falling back to the full processor for inline displays (e.g. merged thresholds)
that don't provide .color.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
