### PR TITLE
perf(xychart): resolve tooltip series color via field.display.color

### DIFF
--- a/public/app/plugins/panel/xychart/XYChartTooltip.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.tsx
@@ -65,7 +65,12 @@ export const XYChartTooltip = ({
 
   let label = series.name.value;
 
-  let seriesColor = colorField?.display?.(colorField.values[rowIndex]).color ?? series.color.fixed ?? '#fff';
+  // color-only: skip the formatted text we'd otherwise discard
+  let seriesColor =
+    colorField?.display?.color?.(colorField.values[rowIndex]) ??
+    colorField?.display?.(colorField.values[rowIndex]).color ??
+    series.color.fixed ??
+    '#fff';
   let fillOpacity = colorField?.config.custom?.fillOpacity;
 
   // TODO: skip this if seriesColor already has an alpha component, such as opacity-by-value or opacity gradient schemes


### PR DESCRIPTION
The tooltip only needs the color field's color; field.display(v) also formats
text we discard here. Use the color-only resolver with a full-processor fallback.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
