### PR TITLE
FS: Don't use settings from bootdata api

### DIFF
--- a/devenv/frontend-service/configs/nginx.conf
+++ b/devenv/frontend-service/configs/nginx.conf
@@ -105,7 +105,7 @@ server {
     proxy_set_header X-Real-IP         $remote_addr;
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header baggage "namespace=stacks-11";
+    proxy_set_header baggage "namespace=default";
   }
 }
 

--- a/public/boot/index.ts
+++ b/public/boot/index.ts
@@ -216,17 +216,19 @@ async function initGrafana() {
     return Promise.reject({ redirect: bootData.redirect });
   }
 
-  window.grafanaBootData.settings = {
-    ...bootData.settings,
-    ...window.grafanaBootData.settings,
-  };
-  window.grafanaBootData.navTree = bootData.navTree;
   window.grafanaBootData.user = bootData.user;
-  if (bootData.settings?.buildInfo?.edition) {
-    window.grafanaBootData.settings.buildInfo.edition = bootData.settings.buildInfo.edition;
-  }
 
   if (!window.__grafanaReduceBootdataAPI) {
+    window.grafanaBootData.settings = {
+      ...bootData.settings,
+      ...window.grafanaBootData.settings,
+    };
+    window.grafanaBootData.navTree = bootData.navTree;
+
+    if (bootData.settings?.buildInfo?.edition) {
+      window.grafanaBootData.settings.buildInfo.edition = bootData.settings.buildInfo.edition;
+    }
+
     // The per-theme CSS still contains some global styles needed
     // to render the page correctly.
     const cssLink = document.createElement('link');

--- a/public/boot/index.ts
+++ b/public/boot/index.ts
@@ -216,6 +216,12 @@ async function initGrafana() {
     return Promise.reject({ redirect: bootData.redirect });
   }
 
+  // TODO: move grabbing user info behind the !window.__grafanaReduceBootdataAPI check once we have
+  // a MT-friendly substitute for it.
+  //
+  // When the __grafanaReduceBootdataAPI flag is enabled, we want to use as little of the boot data response
+  // as possible, and eventually not even call it. However there's no substitute for the user's auth state yet
+  // but we still want to test this codepath, so we keep the user info grabbing here for now.
   window.grafanaBootData.user = bootData.user;
 
   if (!window.__grafanaReduceBootdataAPI) {


### PR DESCRIPTION
This PR is one in a series make the frontend less dependent on the `/bootdata` API by sending the full frontendsettings object through frontend service. Part of https://github.com/grafana/grafana-frontend-platform/issues/166

---


Currently the index.ts file calls `/bootdata`, and from it populates `grafanaBootData.settings`, `grafanaBootData.navTree`, and `grafanaBootData.user`. This PR changes this to _not_ use the `settings` or `navTree` properties from the `/bootdata` endpoint, requiring them to be loaded from MT-friendly sources.

`grafanaBootData.user` remains, as this is required for authentication to work. I considered this to be the bare-minimum of working grafana. Because other things are not populated, such as navtree, the experience otherwise is still pretty broken when this is enabled

<img width="1440" height="1037" alt="Screenshot 2026-06-17 at 12 00 42 am" src="https://github.com/user-attachments/assets/236c3854-b296-4e89-9872-6925419e3e32" />

