### PR TITLE
PanelEditNext (stacked view): Improved hidden/disabled state in stacked view

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
@@ -15,7 +15,7 @@ import {
   SIDEBAR_CARD_SPACING,
 } from '../../../constants';
 import { type SelectionModifiers, useQueryEditorTypeConfig, useQueryEditorUIContext } from '../../QueryEditorContext';
-import { getEditorBorderColor } from '../../utils';
+import { getEditorBorderColor, getHiddenMaskStyles } from '../../utils';
 import { AddCardButton } from '../AddCardButton';
 import { getGhostCardVisuals } from '../SidebarCardGhostStyles';
 
@@ -333,8 +333,7 @@ function getStyles(
       },
 
       ...(item.isHidden && {
-        opacity: theme.isDark ? 0.6 : 0.7,
-        filter: 'grayscale(0.8)',
+        ...getHiddenMaskStyles(theme),
         boxShadow: 'none',
       }),
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedItem.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedItem.tsx
@@ -50,7 +50,12 @@ function StackedItemHeader({ icon, label, identifier, headingId, isHidden = fals
       )}
       <span className={styles.headerRefId}>{identifier}</span>
       {isHidden && (
-        <Icon name="eye-slash" size="sm" aria-label={t('query-editor-next.stacked.hidden-aria-label', 'Hidden')} />
+        <Icon
+          name="eye-slash"
+          size="sm"
+          className={styles.headerHiddenIcon}
+          aria-label={t('query-editor-next.stacked.hidden-aria-label', 'Hidden')}
+        />
       )}
     </div>
   );
@@ -176,6 +181,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   headerRefId: css({
     ...theme.typography.code,
+  }),
+  headerHiddenIcon: css({
+    marginLeft: 'auto',
   }),
   itemBody: css({
     padding: theme.spacing(2),

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedSection.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedSection.tsx
@@ -5,9 +5,10 @@ import { useStyles2 } from '@grafana/ui';
 
 import { getQueryEditorTypeConfig, QueryEditorType } from '../../constants';
 import { type StackedEditorItem } from '../QueryEditorContext';
+import { getHiddenMaskStyles } from '../utils';
 
 import { StackedQueryItem, StackedTransformationItem } from './StackedItem';
-import { type StackedItem } from './utils';
+import { isStackedItemHidden, type StackedItem } from './utils';
 
 interface StackedSectionProps {
   item: StackedItem;
@@ -18,10 +19,11 @@ interface StackedSectionProps {
 export function StackedSection({ item, isCurrent, headingId }: StackedSectionProps) {
   const styles = useStyles2(getStyles);
   const activeStyle = isCurrent ? styles.activeItemStyleByType[item.type] : undefined;
+  const isHidden = isStackedItemHidden(item);
 
   return (
     <section
-      className={cx(styles.item, activeStyle)}
+      className={cx(styles.item, activeStyle, { [styles.hiddenAccentBar]: isHidden })}
       aria-current={isCurrent ? 'true' : undefined}
       aria-labelledby={headingId}
       data-stacked-editor-item-id={item.id}
@@ -68,5 +70,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       },
     }),
     activeItemStyleByType,
+    hiddenAccentBar: css({
+      '&::before': getHiddenMaskStyles(theme),
+    }),
   };
 };

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/utils.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/utils.test.ts
@@ -9,6 +9,7 @@ import {
   getStackedItemsKey,
   getStackedQueryEditorType,
   isCurrentStackedItem,
+  isStackedItemHidden,
   parseStackedItemType,
   type StackedItem,
 } from './utils';
@@ -91,6 +92,31 @@ describe('isCurrentStackedItem', () => {
   it('returns false when no selection is provided', () => {
     expect(isCurrentStackedItem({ item: queryItem })).toBe(false);
     expect(isCurrentStackedItem({ item: transformationItem })).toBe(false);
+  });
+});
+
+describe('isStackedItemHidden', () => {
+  it('treats a query as hidden only when its hide flag is set', () => {
+    expect(isStackedItemHidden({ type: QueryEditorType.Query, id: 'A', query: queryA })).toBe(false);
+    expect(isStackedItemHidden({ type: QueryEditorType.Query, id: 'A', query: { ...queryA, hide: true } })).toBe(true);
+  });
+
+  it('treats an expression as hidden only when its hide flag is set', () => {
+    expect(isStackedItemHidden({ type: QueryEditorType.Expression, id: 'C', query: expressionQuery })).toBe(false);
+    expect(
+      isStackedItemHidden({ type: QueryEditorType.Expression, id: 'C', query: { ...expressionQuery, hide: true } })
+    ).toBe(true);
+  });
+
+  it('treats a transformation as hidden only when its config is disabled', () => {
+    expect(isStackedItemHidden({ type: QueryEditorType.Transformation, id: 'organize-0', transformation })).toBe(false);
+    expect(
+      isStackedItemHidden({
+        type: QueryEditorType.Transformation,
+        id: 'organize-0',
+        transformation: { ...transformation, transformConfig: { ...transformation.transformConfig, disabled: true } },
+      })
+    ).toBe(true);
   });
 });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/utils.ts
@@ -36,6 +36,12 @@ export function getStackedQueryEditorType(query: DataQuery): QueryEditorType.Que
   return getEditorType(query) === QueryEditorType.Expression ? QueryEditorType.Expression : QueryEditorType.Query;
 }
 
+export function isStackedItemHidden(item: StackedItem): boolean {
+  return item.type === QueryEditorType.Transformation
+    ? Boolean(item.transformation.transformConfig.disabled)
+    : Boolean(item.query.hide);
+}
+
 /**
  * The primary selected card as an identity-only {@link StackedEditorItem}. Transformations take
  * precedence over queries: they sit downstream in the pipeline, so when both are selected the user

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.test.ts
@@ -1,0 +1,17 @@
+import { createTheme } from '@grafana/data';
+
+import { getHiddenMaskStyles } from './utils';
+
+describe('getHiddenMaskStyles', () => {
+  it('desaturates and applies a stronger dim in dark mode', () => {
+    const styles = getHiddenMaskStyles(createTheme({ colors: { mode: 'dark' } }));
+
+    expect(styles).toEqual({ opacity: 0.6, filter: 'grayscale(0.8)' });
+  });
+
+  it('desaturates and applies a lighter dim in light mode', () => {
+    const styles = getHiddenMaskStyles(createTheme({ colors: { mode: 'light' } }));
+
+    expect(styles).toEqual({ opacity: 0.7, filter: 'grayscale(0.8)' });
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -1,3 +1,5 @@
+import { type CSSObject } from '@emotion/serialize';
+
 import { type AlertState, type DataTransformerConfig, type GrafanaTheme2, TransformerCategory } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type CustomTransformerDefinition } from '@grafana/scenes';
@@ -94,6 +96,13 @@ export function getEditorBorderColor({
 
   const typeConfig = getQueryEditorTypeConfig(theme);
   return typeConfig[editorType].color;
+}
+
+export function getHiddenMaskStyles(theme: GrafanaTheme2): CSSObject {
+  return {
+    opacity: theme.isDark ? 0.6 : 0.7,
+    filter: 'grayscale(0.8)',
+  };
 }
 
 export interface TransformerCategoryOption {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -1,5 +1,3 @@
-import { type CSSObject } from '@emotion/serialize';
-
 import { type AlertState, type DataTransformerConfig, type GrafanaTheme2, TransformerCategory } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type CustomTransformerDefinition } from '@grafana/scenes';
@@ -98,7 +96,7 @@ export function getEditorBorderColor({
   return typeConfig[editorType].color;
 }
 
-export function getHiddenMaskStyles(theme: GrafanaTheme2): CSSObject {
+export function getHiddenMaskStyles(theme: GrafanaTheme2) {
   return {
     opacity: theme.isDark ? 0.6 : 0.7,
     filter: 'grayscale(0.8)',


### PR DESCRIPTION
## Description
Aligns the hidden/disabled visual treatment between the query-editor sidebar and the new stacked view, and tidies the stacked item header.

## Changes
* Extracted the sidebar card's hidden/disabled "grey mask" (`opacity` + `grayscale`) into a shared `getHiddenMaskStyles` helper so it's defined once.
* Applied that same mask to the left accent bar of stacked content editors when a query is hidden or a transformation is disabled.
* Floated the `eye-slash` marker to the far right of the stacked item header (`margin-left: auto`).

## Risks
* Low — purely cosmetic CSS. Only the query-editor sidebar card and the new stacked editor are affected; hidden state is still also conveyed via the `eye-slash` icon and aria labels, so no reliance on color alone.

## Demo
<!-- TODO: attach before/after screenshots of a hidden query + disabled transformation in stacked view -->

<img width="1385" height="608" alt="image" src="https://github.com/user-attachments/assets/a63ea95e-4335-49b9-9e34-aa035e09b98b" />

## Testing Instructions
* Open a panel in the new Panel Edit query editor with multiple queries and transformations.
* Hide a query and disable a transformation.
* Enter stacked view and confirm both items show a greyed-out left accent bar matching the dimmed sidebar cards, with the `eye-slash` icon pinned to the far right of each header.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable