### PR TITLE
Histogram: Fix tooltip footer resolving the wrong series

### DIFF
--- a/public/app/plugins/panel/histogram/HistogramTooltip.tsx
+++ b/public/app/plugins/panel/histogram/HistogramTooltip.tsx
@@ -63,7 +63,10 @@ export const HistogramTooltip = ({
   let footer: ReactNode;
 
   if (isPinned && seriesIdx != null) {
-    const field = series.fields[seriesIdx];
+    // seriesIdx/dataIdxs are indexed against xMinOnlyFrame (the xMax bucket field is
+    // removed before the uPlot data is built), so the field must be looked up there too.
+    // Using `series` (which still contains xMax) yields an off-by-one wrong series.
+    const field = xMinOnlyFrame.fields[seriesIdx];
     const dataIdx = dataIdxs[seriesIdx]!;
     const links = getDataLinks(field, dataIdx);
 


### PR DESCRIPTION
The histogram tooltip's pinned footer (data links / actions) looked up the hovered field via series.fields[seriesIdx]. But the aligned `series` frame still contains the xMax bucket field, whereas uPlot's seriesIdx/dataIdxs are indexed against the xMinOnly frame (xMax removed) used to build the plot data. This off-by-one made the footer resolve a different series than the hovered bar.

Look the field up in xMinOnlyFrame, matching how the tooltip body content is already resolved.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
