### PR TITLE
Runtime: Add legacy DataSourceSrv fallback and logging to async datasource APIs

### DIFF
--- a/packages/grafana-flamegraph/src/FlameGraph/rendering.ts
+++ b/packages/grafana-flamegraph/src/FlameGraph/rendering.ts
@@ -386,8 +386,10 @@ function useColorFunction(
  * triggers:
  *   - Moving the browser window between a HiDPI and a standard display (matchMedia)
  *   - Browser zoom changes (visualViewport resize)
+ *
+ * Exported for testing — do not use directly outside this module.
  */
-function useDevicePixelRatio() {
+export function useDevicePixelRatio() {
   const [devicePixelRatio, setDevicePixelRatio] = useState(window.devicePixelRatio);
 
   useEffect(() => {

--- a/packages/grafana-flamegraph/src/FlameGraph/rendering.ts
+++ b/packages/grafana-flamegraph/src/FlameGraph/rendering.ts
@@ -386,10 +386,8 @@ function useColorFunction(
  * triggers:
  *   - Moving the browser window between a HiDPI and a standard display (matchMedia)
  *   - Browser zoom changes (visualViewport resize)
- *
- * Exported for testing — do not use directly outside this module.
  */
-export function useDevicePixelRatio() {
+function useDevicePixelRatio() {
   const [devicePixelRatio, setDevicePixelRatio] = useState(window.devicePixelRatio);
 
   useEffect(() => {

--- a/packages/grafana-runtime/src/services/dataSource/constants.ts
+++ b/packages/grafana-runtime/src/services/dataSource/constants.ts
@@ -1,0 +1,3 @@
+export const FALLBACK_TO_LEGACY_SETTINGS_WARNING = `DataSource: getDataSourceInstanceSettings found nothing in the new cache but the legacy DataSourceSrv did — falling back`;
+export const FALLBACK_TO_LEGACY_LIST_WARNING = `DataSource: getDataSourceInstanceSettingsList was empty but the legacy DataSourceSrv returned results — falling back`;
+export const FALLBACK_TO_LEGACY_INSTANCE_WARNING = `DataSource: getDataSourceInstance failed via the new path but the legacy DataSourceSrv resolved it — falling back`;

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -1,9 +1,11 @@
 import { DataSourceApi, type DataSourceInstanceSettings, type DataSourcePluginMeta } from '@grafana/data';
 
 import { RuntimeDataSource } from '../RuntimeDataSource';
+import { type DataSourceSrv, setDataSourceSrv } from '../dataSourceSrv';
 import { setLogger } from '../logging/registry';
 import { setTemplateSrv, type TemplateSrv } from '../templateSrv';
 
+import { FALLBACK_TO_LEGACY_INSTANCE_WARNING } from './constants';
 import {
   _resetForTests as resetPlugin,
   getDataSourceInstance,
@@ -56,19 +58,23 @@ function ds(overrides: Partial<DataSourceInstanceSettings> = {}): DataSourceInst
 }
 
 const logError = jest.fn();
+const logWarning = jest.fn();
 
 beforeEach(() => {
   resetInstanceSettings();
   resetPlugin();
   resetPluginCache();
   logError.mockClear();
+  logWarning.mockClear();
   setLogger('grafana/runtime.plugins.datasource', {
     logDebug: jest.fn(),
     logError,
     logInfo: jest.fn(),
     logMeasurement: jest.fn(),
-    logWarning: jest.fn(),
+    logWarning,
   });
+  // No legacy srv by default — the fallback should be inert.
+  setDataSourceSrv(undefined as unknown as DataSourceSrv);
 });
 
 describe('plugin', () => {
@@ -428,6 +434,88 @@ describe('plugin', () => {
     it('throws if the singleton has not been registered', async () => {
       initDataSourceInstanceSettings({}, '');
       await expect(getDataSourceInstance('__expr__')).rejects.toThrow('Expression datasource has not been initialised');
+    });
+  });
+
+  describe('legacy DataSourceSrv fallback', () => {
+    it('falls back to the legacy srv and logs a warning when the new path cannot resolve the instance', async () => {
+      // Empty cache so the new path throws "not found".
+      initDataSourceInstanceSettings({}, '');
+      setDataSourcePluginImporter(jest.fn());
+
+      const legacyInstance = Object.create(DataSourceApi.prototype) as DataSourceApi;
+      const get = jest.fn().mockResolvedValue(legacyInstance);
+      // getInstanceSettings also misses, so the settings-level fallback stays silent and the
+      // instance-level fallback is what resolves the instance.
+      const getInstanceSettings = jest.fn().mockReturnValue(undefined);
+      setDataSourceSrv({ get, getInstanceSettings } as unknown as DataSourceSrv);
+
+      const result = await getDataSourceInstance('unknown-uid');
+
+      expect(result).toBe(legacyInstance);
+      expect(get).toHaveBeenCalledWith('unknown-uid', undefined);
+      expect(logWarning).toHaveBeenCalledTimes(1);
+      expect(logWarning).toHaveBeenCalledWith(FALLBACK_TO_LEGACY_INSTANCE_WARNING, { ref: 'unknown-uid' });
+    });
+
+    it('rethrows the original error and does not log when the legacy srv also cannot resolve it', async () => {
+      initDataSourceInstanceSettings({}, '');
+      setDataSourcePluginImporter(jest.fn());
+
+      const get = jest.fn().mockRejectedValue(new Error('legacy not found'));
+      const getInstanceSettings = jest.fn().mockReturnValue(undefined);
+      setDataSourceSrv({ get, getInstanceSettings } as unknown as DataSourceSrv);
+
+      await expect(getDataSourceInstance('unknown-uid')).rejects.toThrow(/was not found/);
+      expect(logWarning).not.toHaveBeenCalled();
+    });
+
+    it('does not consult the legacy srv when the new path succeeds', async () => {
+      const settings = ds();
+      initDataSourceInstanceSettings({ [settings.name]: settings }, settings.name);
+
+      const instance = Object.create(DataSourceApi.prototype) as DataSourceApi;
+      setDataSourcePluginImporter(
+        jest.fn().mockResolvedValue({ DataSourceClass: jest.fn().mockReturnValue(instance), components: {} })
+      );
+      const get = jest.fn();
+      setDataSourceSrv({ get } as unknown as DataSourceSrv);
+
+      const result = await getDataSourceInstance(settings.uid);
+
+      expect(result).toBe(instance);
+      expect(get).not.toHaveBeenCalled();
+      expect(logWarning).not.toHaveBeenCalled();
+    });
+
+    it('routes a concurrent in-flight caller through the fallback when the load rejects', async () => {
+      const settings = ds();
+      initDataSourceInstanceSettings({ [settings.name]: settings }, settings.name);
+
+      // A deferred import so the first caller's load stays in-flight while the second arrives.
+      let rejectImport: (err: Error) => void = () => {};
+      const importPromise = new Promise((_, reject) => {
+        rejectImport = reject;
+      });
+      setDataSourcePluginImporter(jest.fn().mockReturnValue(importPromise));
+
+      const legacyInstance = Object.create(DataSourceApi.prototype) as DataSourceApi;
+      const get = jest.fn().mockResolvedValue(legacyInstance);
+      setDataSourceSrv({ get } as unknown as DataSourceSrv);
+
+      // First caller starts the load; the second reuses the in-flight promise.
+      const first = getDataSourceInstance(settings.uid);
+      const second = getDataSourceInstance(settings.uid);
+
+      // Let both reach their await points (first awaiting the load, second awaiting in-flight).
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      rejectImport(new Error('module not found'));
+
+      // Both callers — including the in-flight one — fall back to the legacy instance.
+      await expect(first).resolves.toBe(legacyInstance);
+      await expect(second).resolves.toBe(legacyInstance);
+      expect(get).toHaveBeenCalledTimes(2);
+      expect(logWarning).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -159,12 +159,13 @@ async function getDataSourceInstanceFallback(
   scopedVars: ScopedVars | undefined,
   originalError: unknown
 ): Promise<DataSourceApi> {
-  const legacy = await getDataSourceSrv()
-    ?.get(ref, scopedVars)
-    .catch(() => undefined);
-  if (legacy) {
-    logDataSourceWarning(FALLBACK_TO_LEGACY_INSTANCE_WARNING, { ref: describeRef(ref) });
-    return legacy;
+  const srv = getDataSourceSrv();
+  if (srv) {
+    const legacy = await srv.get(ref, scopedVars).catch(() => undefined);
+    if (legacy) {
+      logDataSourceWarning(FALLBACK_TO_LEGACY_INSTANCE_WARNING, { ref: describeRef(ref) });
+      return legacy;
+    }
   }
   throw originalError;
 }

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -2,10 +2,11 @@ import { DataSourceApi, type DataSourceInstanceSettings, type DataSourceRef, typ
 
 import { isExpressionReference } from '../../utils/DataSourceWithBackend';
 import { UserStorage } from '../../utils/userStorage';
-import { type RuntimeDataSourceRegistration } from '../dataSourceSrv';
+import { getDataSourceSrv, type RuntimeDataSourceRegistration } from '../dataSourceSrv';
 
+import { FALLBACK_TO_LEGACY_INSTANCE_WARNING } from './constants';
 import { getExpressionDataSourceInstance } from './expressionDs';
-import { logDataSourceInstanceError } from './logging';
+import { logDataSourceInstanceError, logDataSourceWarning } from './logging';
 import { getCachedPlugin, setCachedPlugin, setRuntimePlugin } from './pluginCache';
 import { getDataSourceInstanceSettings, upsertRuntimeDataSourceInstanceSettings } from './settings';
 import { type ImportDataSourcePluginFn } from './types';
@@ -36,43 +37,50 @@ export async function getDataSourceInstance(
   ref?: DataSourceRef | string | null,
   scopedVars?: ScopedVars
 ): Promise<DataSourceApi> {
-  if (isExpressionReference(ref)) {
-    const expressionDs = getExpressionDataSourceInstance();
-    if (!expressionDs) {
-      throw new Error(
-        'Expression datasource has not been initialised. Call setExpressionDataSourceInstance during application boot.'
-      );
-    }
-    return expressionDs;
-  }
-
-  const settings = await getDataSourceInstanceSettings(ref, scopedVars);
-  if (!settings) {
-    throw new Error(`Datasource ${describeRef(ref)} was not found`);
-  }
-
-  // When ref is a template variable, settings.uid is the raw variable string
-  // (e.g. "${datasource}"). Use the resolved uid as the cache key so repeated
-  // calls for the same variable don't create duplicate instances.
-  const cacheUid = settings.rawRef?.uid ?? settings.uid;
-
-  const cached = getCachedPlugin(cacheUid);
-  if (cached) {
-    return cached;
-  }
-
-  const inflight = inflightLoads.get(cacheUid);
-  if (inflight) {
-    return inflight;
-  }
-
-  const promise = loadDataSourceInstance(cacheUid, settings);
-  inflightLoads.set(cacheUid, promise);
-
   try {
-    return await promise;
-  } finally {
-    inflightLoads.delete(cacheUid);
+    if (isExpressionReference(ref)) {
+      const expressionDs = getExpressionDataSourceInstance();
+      if (!expressionDs) {
+        throw new Error(
+          'Expression datasource has not been initialised. Call setExpressionDataSourceInstance during application boot.'
+        );
+      }
+      return expressionDs;
+    }
+
+    const settings = await getDataSourceInstanceSettings(ref, scopedVars);
+    if (!settings) {
+      throw new Error(`Datasource ${describeRef(ref)} was not found`);
+    }
+
+    // When ref is a template variable, settings.uid is the raw variable string
+    // (e.g. "${datasource}"). Use the resolved uid as the cache key so repeated
+    // calls for the same variable don't create duplicate instances.
+    const cacheUid = settings.rawRef?.uid ?? settings.uid;
+
+    const cached = getCachedPlugin(cacheUid);
+    if (cached) {
+      return cached;
+    }
+
+    const inflight = inflightLoads.get(cacheUid);
+    if (inflight) {
+      // `await` (not a bare `return`) so a rejection routes through the catch below to the
+      // fallback. A bare `return` adopts the promise without awaiting, so concurrent callers
+      // would skip the fallback that the first caller (which awaits) gets.
+      return await inflight;
+    }
+
+    const promise = loadDataSourceInstance(cacheUid, settings);
+    inflightLoads.set(cacheUid, promise);
+
+    try {
+      return await promise;
+    } finally {
+      inflightLoads.delete(cacheUid);
+    }
+  } catch (err) {
+    return getDataSourceInstanceFallback(ref, scopedVars, err);
   }
 }
 
@@ -138,6 +146,27 @@ export function registerRuntimeDataSourceInstance(entry: RuntimeDataSourceRegist
 
   upsertRuntimeDataSourceInstanceSettings(dataSource.instanceSettings);
   setRuntimePlugin(dataSource.uid, dataSource);
+}
+
+/**
+ * Last resort while the legacy `DataSourceSrv` still exists: the new path failed to resolve
+ * the data source. If the legacy service can resolve it, that's a divergence worth tracking;
+ * otherwise rethrow the original error so a genuine "not found" stays an error and is not
+ * logged. Delete this (and its call site) once `DataSourceSrv` is gone.
+ */
+async function getDataSourceInstanceFallback(
+  ref: DataSourceRef | string | null | undefined,
+  scopedVars: ScopedVars | undefined,
+  originalError: unknown
+): Promise<DataSourceApi> {
+  const legacy = await getDataSourceSrv()
+    ?.get(ref, scopedVars)
+    .catch(() => undefined);
+  if (legacy) {
+    logDataSourceWarning(FALLBACK_TO_LEGACY_INSTANCE_WARNING, { ref: describeRef(ref) });
+    return legacy;
+  }
+  throw originalError;
 }
 
 function describeRef(ref: DataSourceRef | string | null | undefined): string {

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -6,7 +6,7 @@ import { getDataSourceSrv, type RuntimeDataSourceRegistration } from '../dataSou
 
 import { FALLBACK_TO_LEGACY_INSTANCE_WARNING } from './constants';
 import { getExpressionDataSourceInstance } from './expressionDs';
-import { logDataSourceInstanceError, logDataSourceWarning } from './logging';
+import { describeRef, logDataSourceInstanceError, logDataSourceWarning } from './logging';
 import { getCachedPlugin, setCachedPlugin, setRuntimePlugin } from './pluginCache';
 import { getDataSourceInstanceSettings, upsertRuntimeDataSourceInstanceSettings } from './settings';
 import { type ImportDataSourcePluginFn } from './types';
@@ -168,16 +168,6 @@ async function getDataSourceInstanceFallback(
     }
   }
   throw originalError;
-}
-
-function describeRef(ref: DataSourceRef | string | null | undefined): string {
-  if (ref == null) {
-    return 'default';
-  }
-  if (typeof ref === 'string') {
-    return ref;
-  }
-  return ref.uid ?? ref.type ?? 'unknown';
 }
 
 /**

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -37,17 +37,17 @@ export async function getDataSourceInstance(
   ref?: DataSourceRef | string | null,
   scopedVars?: ScopedVars
 ): Promise<DataSourceApi> {
-  try {
-    if (isExpressionReference(ref)) {
-      const expressionDs = getExpressionDataSourceInstance();
-      if (!expressionDs) {
-        throw new Error(
-          'Expression datasource has not been initialised. Call setExpressionDataSourceInstance during application boot.'
-        );
-      }
-      return expressionDs;
+  if (isExpressionReference(ref)) {
+    const expressionDs = getExpressionDataSourceInstance();
+    if (!expressionDs) {
+      throw new Error(
+        'Expression datasource has not been initialised. Call setExpressionDataSourceInstance during application boot.'
+      );
     }
+    return expressionDs;
+  }
 
+  try {
     const settings = await getDataSourceInstanceSettings(ref, scopedVars);
     if (!settings) {
       throw new Error(`Datasource ${describeRef(ref)} was not found`);

--- a/packages/grafana-runtime/src/services/dataSource/logging.ts
+++ b/packages/grafana-runtime/src/services/dataSource/logging.ts
@@ -5,3 +5,7 @@ import { getLogger } from '../logging/registry';
 export function logDataSourceInstanceError(message: string, error: unknown, context?: LogContext): void {
   getLogger('grafana/runtime.plugins.datasource').logError(new Error(message, { cause: error }), context);
 }
+
+export function logDataSourceWarning(message: string, context?: LogContext): void {
+  getLogger('grafana/runtime.plugins.datasource').logWarning(message, context);
+}

--- a/packages/grafana-runtime/src/services/dataSource/logging.ts
+++ b/packages/grafana-runtime/src/services/dataSource/logging.ts
@@ -1,3 +1,4 @@
+import { type DataSourceRef } from '@grafana/data';
 import { type LogContext } from '@grafana/faro-web-sdk';
 
 import { getLogger } from '../logging/registry';
@@ -8,4 +9,14 @@ export function logDataSourceInstanceError(message: string, error: unknown, cont
 
 export function logDataSourceWarning(message: string, context?: LogContext): void {
   getLogger('grafana/runtime.plugins.datasource').logWarning(message, context);
+}
+
+export function describeRef(ref: DataSourceRef | string | null | undefined): string {
+  if (ref == null) {
+    return 'default';
+  }
+  if (typeof ref === 'string') {
+    return ref;
+  }
+  return ref.uid ?? ref.type ?? 'unknown';
 }

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -2,8 +2,10 @@ import { type DataSourceApi, type DataSourceInstanceSettings } from '@grafana/da
 
 import { setBackendSrv } from '../backendSrv';
 import { type DataSourceSrv, setDataSourceSrv } from '../dataSourceSrv';
+import { setLogger } from '../logging/registry';
 import { setTemplateSrv, type TemplateSrv } from '../templateSrv';
 
+import { FALLBACK_TO_LEGACY_LIST_WARNING, FALLBACK_TO_LEGACY_SETTINGS_WARNING } from './constants';
 import { setExpressionDataSourceInstance } from './expressionDs';
 import {
   _resetForTests,
@@ -114,6 +116,7 @@ const templateSrv: TemplateSrv = {
 } as unknown as TemplateSrv;
 
 const backendGet = jest.fn();
+const logWarning = jest.fn();
 
 beforeAll(() => {
   setTemplateSrv(templateSrv);
@@ -126,6 +129,14 @@ beforeAll(() => {
 beforeEach(() => {
   _resetForTests();
   backendGet.mockReset();
+  logWarning.mockClear();
+  setLogger('grafana/runtime.plugins.datasource', {
+    logDebug: jest.fn(),
+    logError: jest.fn(),
+    logInfo: jest.fn(),
+    logMeasurement: jest.fn(),
+    logWarning,
+  });
   // No legacy srv by default — reloadDataSourceInstanceSettings() should use the fetch path.
   setDataSourceSrv(undefined as unknown as DataSourceSrv);
 });
@@ -768,6 +779,88 @@ describe('instanceSettings', () => {
 
       const result = await getDataSourceInstanceSettings('runtime-ds');
       expect(result?.name).toBe('Runtime');
+    });
+  });
+
+  describe('legacy DataSourceSrv fallback', () => {
+    describe('getDataSourceInstanceSettings', () => {
+      it('falls back to the legacy srv and logs a warning when the new cache misses but legacy resolves', async () => {
+        initDataSourceInstanceSettings({}, '');
+        const getInstanceSettings = jest.fn().mockReturnValue(fixtures.Alpha);
+        setDataSourceSrv({ getInstanceSettings } as unknown as DataSourceSrv);
+
+        const result = await getDataSourceInstanceSettings('uid-alpha');
+
+        expect(result).toBe(fixtures.Alpha);
+        expect(getInstanceSettings).toHaveBeenCalledWith('uid-alpha', undefined);
+        expect(logWarning).toHaveBeenCalledTimes(1);
+        expect(logWarning).toHaveBeenCalledWith(FALLBACK_TO_LEGACY_SETTINGS_WARNING, { ref: 'uid-alpha' });
+      });
+
+      it('returns undefined and does not log when both the new cache and the legacy srv miss', async () => {
+        initDataSourceInstanceSettings({}, '');
+        const getInstanceSettings = jest.fn().mockReturnValue(undefined);
+        setDataSourceSrv({ getInstanceSettings } as unknown as DataSourceSrv);
+
+        const result = await getDataSourceInstanceSettings('uid-alpha');
+
+        expect(result).toBeUndefined();
+        expect(getInstanceSettings).toHaveBeenCalledTimes(1);
+        expect(logWarning).not.toHaveBeenCalled();
+      });
+
+      it('never consults the legacy srv when the new cache hits', async () => {
+        initDataSourceInstanceSettings(fixtures, 'Bravo');
+        const getInstanceSettings = jest.fn();
+        setDataSourceSrv({ getInstanceSettings } as unknown as DataSourceSrv);
+
+        const result = await getDataSourceInstanceSettings('uid-alpha');
+
+        expect(result?.name).toBe('Alpha');
+        expect(getInstanceSettings).not.toHaveBeenCalled();
+        expect(logWarning).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getDataSourceInstanceSettingsList', () => {
+      it('falls back to the legacy srv and logs a warning when the new list is empty but legacy is not', async () => {
+        initDataSourceInstanceSettings({}, '');
+        const getList = jest.fn().mockReturnValue([fixtures.Alpha]);
+        setDataSourceSrv({ getList } as unknown as DataSourceSrv);
+
+        const items = await getDataSourceInstanceSettingsList({ metrics: true });
+
+        expect(items).toEqual([fixtures.Alpha]);
+        expect(getList).toHaveBeenCalledWith({ metrics: true });
+        expect(logWarning).toHaveBeenCalledTimes(1);
+        expect(logWarning).toHaveBeenCalledWith(FALLBACK_TO_LEGACY_LIST_WARNING, {
+          filters: JSON.stringify({ metrics: true }),
+        });
+      });
+
+      it('returns the empty list and does not log when both the new list and the legacy srv are empty', async () => {
+        initDataSourceInstanceSettings({}, '');
+        const getList = jest.fn().mockReturnValue([]);
+        setDataSourceSrv({ getList } as unknown as DataSourceSrv);
+
+        const items = await getDataSourceInstanceSettingsList({ metrics: true });
+
+        expect(items).toEqual([]);
+        expect(getList).toHaveBeenCalledTimes(1);
+        expect(logWarning).not.toHaveBeenCalled();
+      });
+
+      it('never consults the legacy srv when the new list is non-empty', async () => {
+        initDataSourceInstanceSettings(fixtures, 'Bravo');
+        const getList = jest.fn();
+        setDataSourceSrv({ getList } as unknown as DataSourceSrv);
+
+        const items = await getDataSourceInstanceSettingsList();
+
+        expect(items.length).toBeGreaterThan(0);
+        expect(getList).not.toHaveBeenCalled();
+        expect(logWarning).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -14,7 +14,7 @@ import { getTemplateSrv } from '../templateSrv';
 
 import { FALLBACK_TO_LEGACY_LIST_WARNING, FALLBACK_TO_LEGACY_SETTINGS_WARNING } from './constants';
 import { getExpressionDataSourceSettings, _resetForTests as resetExpressionDs } from './expressionDs';
-import { logDataSourceWarning } from './logging';
+import { describeRef, logDataSourceWarning } from './logging';
 import { clearPluginCache } from './pluginCache';
 
 let byName: Record<string, DataSourceInstanceSettings> = {};
@@ -147,7 +147,7 @@ export async function getDataSourceInstanceSettingsList(
   if (results.length > 0) {
     return results;
   }
-  return getInstanceSettingsListFallback(filters) ?? results;
+  return getInstanceSettingsListFallback(filters);
 }
 
 /**
@@ -344,7 +344,7 @@ function getInstanceSettingsFallback(
 ): DataSourceInstanceSettings | undefined {
   const legacy = getDataSourceSrv()?.getInstanceSettings(ref, scopedVars);
   if (legacy) {
-    logDataSourceWarning(FALLBACK_TO_LEGACY_SETTINGS_WARNING, { ref: describeRefForLog(ref) });
+    logDataSourceWarning(FALLBACK_TO_LEGACY_SETTINGS_WARNING, { ref: describeRef(ref) });
     return legacy;
   }
   return undefined;
@@ -355,25 +355,13 @@ function getInstanceSettingsFallback(
  * an empty list, so consult the legacy service. Delete this (and its call site) once
  * `DataSourceSrv` is gone.
  */
-function getInstanceSettingsListFallback(
-  filters: GetDataSourceListFilters | undefined
-): DataSourceInstanceSettings[] | undefined {
+function getInstanceSettingsListFallback(filters: GetDataSourceListFilters | undefined): DataSourceInstanceSettings[] {
   const legacy = getDataSourceSrv()?.getList(filters) ?? [];
   if (legacy.length > 0) {
     logDataSourceWarning(FALLBACK_TO_LEGACY_LIST_WARNING, { filters: filtersForLog(filters) });
     return legacy;
   }
-  return undefined;
-}
-
-function describeRefForLog(ref: DataSourceRef | string | null | undefined): string {
-  if (ref == null) {
-    return 'default';
-  }
-  if (typeof ref === 'string') {
-    return ref;
-  }
-  return ref.uid ?? ref.type ?? 'unknown';
+  return [];
 }
 
 function filtersForLog(filters: GetDataSourceListFilters | undefined): string {

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -12,7 +12,9 @@ import { getBackendSrv } from '../backendSrv';
 import { getDataSourceSrv, type GetDataSourceListFilters } from '../dataSourceSrv';
 import { getTemplateSrv } from '../templateSrv';
 
+import { FALLBACK_TO_LEGACY_LIST_WARNING, FALLBACK_TO_LEGACY_SETTINGS_WARNING } from './constants';
 import { getExpressionDataSourceSettings, _resetForTests as resetExpressionDs } from './expressionDs';
+import { logDataSourceWarning } from './logging';
 import { clearPluginCache } from './pluginCache';
 
 let byName: Record<string, DataSourceInstanceSettings> = {};
@@ -126,7 +128,11 @@ export async function getDataSourceInstanceSettings(
   ref?: DataSourceRef | string | null,
   scopedVars?: ScopedVars
 ): Promise<DataSourceInstanceSettings | undefined> {
-  return lookupFromMaps(ref, scopedVars);
+  const result = lookupFromMaps(ref, scopedVars);
+  if (result) {
+    return result;
+  }
+  return getInstanceSettingsFallback(ref, scopedVars);
 }
 
 /**
@@ -137,7 +143,11 @@ export async function getDataSourceInstanceSettings(
 export async function getDataSourceInstanceSettingsList(
   filters?: GetDataSourceListFilters
 ): Promise<DataSourceInstanceSettings[]> {
-  return applyFilters(filters);
+  const results = applyFilters(filters);
+  if (results.length > 0) {
+    return results;
+  }
+  return getInstanceSettingsListFallback(filters) ?? results;
 }
 
 /**
@@ -321,6 +331,58 @@ function variableInterpolation<T>(value: T | T[]): T {
     return value[0];
   }
   return value;
+}
+
+/**
+ * Last resort while the legacy `DataSourceSrv` still exists: the new in-memory cache found
+ * nothing, so consult the legacy service. If it resolves what the new path missed, that's a
+ * divergence worth tracking. Delete this (and its call site) once `DataSourceSrv` is gone.
+ */
+function getInstanceSettingsFallback(
+  ref: DataSourceRef | string | null | undefined,
+  scopedVars: ScopedVars | undefined
+): DataSourceInstanceSettings | undefined {
+  const legacy = getDataSourceSrv()?.getInstanceSettings(ref, scopedVars);
+  if (legacy) {
+    logDataSourceWarning(FALLBACK_TO_LEGACY_SETTINGS_WARNING, { ref: describeRefForLog(ref) });
+    return legacy;
+  }
+  return undefined;
+}
+
+/**
+ * Last resort while the legacy `DataSourceSrv` still exists: the new in-memory cache produced
+ * an empty list, so consult the legacy service. Delete this (and its call site) once
+ * `DataSourceSrv` is gone.
+ */
+function getInstanceSettingsListFallback(
+  filters: GetDataSourceListFilters | undefined
+): DataSourceInstanceSettings[] | undefined {
+  const legacy = getDataSourceSrv()?.getList(filters) ?? [];
+  if (legacy.length > 0) {
+    logDataSourceWarning(FALLBACK_TO_LEGACY_LIST_WARNING, { filters: filtersForLog(filters) });
+    return legacy;
+  }
+  return undefined;
+}
+
+function describeRefForLog(ref: DataSourceRef | string | null | undefined): string {
+  if (ref == null) {
+    return 'default';
+  }
+  if (typeof ref === 'string') {
+    return ref;
+  }
+  return ref.uid ?? ref.type ?? 'unknown';
+}
+
+function filtersForLog(filters: GetDataSourceListFilters | undefined): string {
+  if (!filters) {
+    return 'none';
+  }
+  // The `filter` callback can't be serialized; the rest is enough to identify the query.
+  const { filter: _filter, ...rest } = filters;
+  return JSON.stringify(rest);
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

Adds a last-resort fallback to the legacy `DataSourceSrv` across the new async datasource APIs (`getDataSourceInstance`, `getDataSourceInstanceSettings`, `getDataSourceInstanceSettingsList`), emitting a warning (logger `grafana/runtime.plugins.datasource`) only when the legacy service resolves something the new in-memory cache missed.

**Why do we need this feature?**

It de-risks the migration to the new APIs: by shipping the fallback and watching production for these divergence warnings, we can confirm the new path is complete before deleting the legacy "last resort" path in a follow-up PR. A concurrent in-flight caller is also routed through the fallback (the in-flight promise is now awaited so its rejection reaches the fallback path).

**Who is this feature for?**

Grafana developers migrating datasource access off the deprecated `DataSourceSrv` singleton.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

The fallback is intentionally additive and self-disabling (it becomes inert once `DataSourceSrv` is removed); each fallback lives in its own private helper for easy removal later.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
