### PR TITLE
CloudWatch: Migrate datalinks to getDataSourceInstanceSettings

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -1,10 +1,21 @@
-import { type DataQueryRequest, type DataQueryResponse, dateMath, FieldType } from '@grafana/data';
-import { config, setDataSourceSrv } from '@grafana/runtime';
-import { type DatasourceSrv } from 'app/features/plugins/datasource_srv';
+import {
+  type DataQueryRequest,
+  type DataQueryResponse,
+  type DataSourceInstanceSettings,
+  dateMath,
+  FieldType,
+} from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { type CloudWatchQuery } from '../types';
 
 import { addDataLinksToLogsResponse } from './datalinks';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(),
+}));
 
 describe('addDataLinksToLogsResponse', () => {
   // @ts-ignore ignore feature toggle type error
@@ -56,13 +67,9 @@ describe('addDataLinksToLogsResponse', () => {
       range: { ...time, raw: time },
     } as DataQueryRequest<CloudWatchQuery>;
 
-    setDataSourceSrv({
-      async get() {
-        return {
-          name: 'Xray',
-        };
-      },
-    } as DatasourceSrv);
+    jest
+      .mocked(getDataSourceInstanceSettings)
+      .mockResolvedValue({ name: 'Xray' } as unknown as DataSourceInstanceSettings);
 
     await addDataLinksToLogsResponse(
       mockResponse,

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -7,7 +7,8 @@ import {
   type ScopedVars,
   type TimeRange,
 } from '@grafana/data';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { type AwsUrl, encodeUrl } from '../aws_url';
 import { type CloudWatchLogsQuery } from '../dataquery.gen';
@@ -65,9 +66,13 @@ export async function addDataLinksToLogsResponse(
 async function createInternalXrayLink(datasourceUid: string, region: string): Promise<DataLink | undefined> {
   let ds;
   try {
-    ds = await getDataSourceSrv().get(datasourceUid);
+    ds = await getDataSourceInstanceSettings(datasourceUid);
   } catch (e) {
     console.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
+    return undefined;
+  }
+
+  if (!ds) {
     return undefined;
   }
 


### PR DESCRIPTION
**What is this feature?**

Migrates one representative call site from the legacy `DataSourceSrv` singleton to the async APIs introduced in #123037. One of a set of worked migration examples, split out from #124394 into focused PRs.

**Why do we need this feature?**

The new async API surface needs adoption examples. These worked examples were extracted from the core APIs PR (#123037) to keep that PR focused on the new API surface.

**Who is this feature for?**

Grafana engineers migrating existing code away from the deprecated `DataSourceSrv` singleton.

**Which issue(s) does this PR fix?**:

Part of #121465
Partly addresses https://github.com/grafana/grafana/issues/125083

---

## Migration pattern: Async utility function → `getDataSourceInstanceSettings`

**`cloudwatch/utils/datalinks.ts`** — the original code loaded the full plugin instance via `getDataSourceSrv().get()` just to read `ds.name`. The migration swaps to `getDataSourceInstanceSettings` since only metadata is needed — no plugin import required.

**Special notes for your reviewer:**

- Depends on #123037.
- Split out from #124394.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/grafana/latest/whatsnew/), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
