### PR TITLE
CloudWatch: Migrate ConfigEditor to getDataSourceInstance

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
@@ -2,7 +2,14 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { AwsAuthType } from '@grafana/aws-sdk';
-import { PluginContextProvider, type PluginMeta, type PluginMetaInfo, PluginType } from '@grafana/data';
+import {
+  type DataSourceApi,
+  PluginContextProvider,
+  type PluginMeta,
+  type PluginMetaInfo,
+  PluginType,
+} from '@grafana/data';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 
 import { CloudWatchDatasource } from '../../datasource';
 import {
@@ -19,7 +26,6 @@ import {
 } from './ConfigEditor';
 
 const datasource = new CloudWatchDatasource(CloudWatchSettings, setupMockedTemplateService());
-const loadDataSourceMock = jest.fn();
 
 jest.mock('./XrayLinkConfig', () => ({
   XrayLinkConfig: () => <></>,
@@ -37,9 +43,6 @@ jest.mock('@grafana/runtime', () => ({
     put: putMock,
     get: getMock,
   }),
-  getDataSourceSrv: () => ({
-    get: loadDataSourceMock,
-  }),
   getAppEvents: () => mockAppEvents,
   config: {
     ...jest.requireActual('@grafana/runtime').config,
@@ -48,6 +51,11 @@ jest.mock('@grafana/runtime', () => ({
       cloudWatchCrossAccountQuerying: true,
     },
   },
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
 }));
 
 const props: Props = {
@@ -119,7 +127,7 @@ describe('Render', () => {
     jest.resetAllMocks();
     putMock.mockImplementation(async () => ({ datasource: setupMockedDataSource().datasource }));
     getMock.mockImplementation(async () => ({ datasource: setupMockedDataSource().datasource }));
-    loadDataSourceMock.mockResolvedValue(datasource);
+    jest.mocked(getDataSourceInstance).mockResolvedValue(datasource as unknown as DataSourceApi);
     datasource.resources.getRegions = jest.fn().mockResolvedValue([
       {
         label: 'ap-east-1',
@@ -247,16 +255,16 @@ describe('Render', () => {
     });
   });
 
-  it('should load the data source if it was saved before', async () => {
-    const SAVED_VERSION = 2;
-    setup({ version: SAVED_VERSION });
-    await waitFor(async () => expect(loadDataSourceMock).toHaveBeenCalled());
+  it('should load the data source when version is set', async () => {
+    setup({ version: 2 });
+    await waitFor(() => expect(getDataSourceInstance).toHaveBeenCalledWith('CloudWatch'));
   });
 
-  it('should not load the data source if it wasnt saved before', async () => {
-    const SAVED_VERSION = undefined;
-    setup({ version: SAVED_VERSION });
-    await waitFor(async () => expect(loadDataSourceMock).not.toHaveBeenCalled());
+  it('should not load the data source when version is not set', async () => {
+    setup({ version: undefined });
+    // Wait for the component to finish rendering before asserting the negative.
+    await waitFor(() => expect(screen.getByText('Namespaces of Custom Metrics')).toBeInTheDocument());
+    expect(getDataSourceInstance).not.toHaveBeenCalled();
   });
 
   it('should show error message if Select log group button is clicked when data source is never saved', async () => {

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx
@@ -13,7 +13,8 @@ import {
   type GrafanaTheme2,
 } from '@grafana/data';
 import { ConfigSection, DataSourceDescription } from '@grafana/plugin-ui';
-import { getAppEvents, usePluginInteractionReporter, getDataSourceSrv, config } from '@grafana/runtime';
+import { getAppEvents, usePluginInteractionReporter, config } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { Alert, Input, type FieldProps, Field, Divider, useStyles2 } from '@grafana/ui';
 
 import { CloudWatchDatasource } from '../../datasource';
@@ -209,13 +210,11 @@ function useDatasource(props: Props) {
 
   useEffect(() => {
     if (props.options.version) {
-      getDataSourceSrv()
-        .get(props.options.name)
-        .then((datasource) => {
-          if (datasource instanceof CloudWatchDatasource) {
-            setDatasource(datasource);
-          }
-        });
+      getDataSourceInstance(props.options.name).then((ds) => {
+        if (ds instanceof CloudWatchDatasource) {
+          setDatasource(ds);
+        }
+      });
     }
   }, [props.options.version, props.options.name]);
 


### PR DESCRIPTION
**What is this feature?**

Migrates one representative call site from the legacy `DataSourceSrv` singleton to the async APIs introduced in #123037. One of a set of worked migration examples, split out from #124394 into focused PRs.

**Why do we need this feature?**

The new async API surface needs adoption examples. These worked examples were extracted from the core APIs PR (#123037) to keep that PR focused on the new API surface.

**Who is this feature for?**

Grafana engineers migrating existing code away from the deprecated `DataSourceSrv` singleton.

**Which issue(s) does this PR fix?**:

Part of #121465
Partly addresses https://github.com/grafana/grafana/issues/125083

---

## Migration pattern: `useEffect` + `useState` hook → `getDataSourceInstance`

**`cloudwatch/components/ConfigEditor/ConfigEditor.tsx`** — manual loading pattern swapped to the new function. Version guard preserved because an unsaved data source doesn't exist in the backend yet.

**Special notes for your reviewer:**

- Depends on #123037.
- Split out from #124394.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/grafana/latest/whatsnew/), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
