### PR TITLE
Datasources: Migrate SuggestedDashboardsLoader to getDataSourceInstanceSettings

### DIFF
--- a/public/app/features/datasources/components/SuggestedDashboardsLoader.test.tsx
+++ b/public/app/features/datasources/components/SuggestedDashboardsLoader.test.tsx
@@ -40,11 +40,11 @@ jest.mock('app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsM
     ) : null,
 }));
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => ({
-    getInstanceSettings: jest.fn((uid?: string) => (uid ? { uid, type: 'test-datasource', name: 'Test DS' } : null)),
-  }),
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn((uid?: string) =>
+    Promise.resolve(uid ? { uid, type: 'test-datasource', name: 'Test DS' } : undefined)
+  ),
 }));
 
 const mockFetchProvisioned = jest.mocked(fetchProvisionedDashboards);

--- a/public/app/features/datasources/components/SuggestedDashboardsLoader.tsx
+++ b/public/app/features/datasources/components/SuggestedDashboardsLoader.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { SuggestedDashboardsModal } from 'app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsModal';
 import { TrackingProvider } from 'app/features/dashboard/dashgrid/DashboardLibrary/TrackingContext';
 import {
@@ -83,7 +83,7 @@ export const SuggestedDashboardsLoader = ({
     setFetchStatus('loading');
 
     try {
-      const ds = getDataSourceSrv().getInstanceSettings(datasourceUid);
+      const ds = await getDataSourceInstanceSettings(datasourceUid);
       if (!ds) {
         setFetchStatus('done');
         onFetchCompletedRef.current?.(false);
@@ -157,13 +157,14 @@ export const SuggestedDashboardsLoader = ({
     (count: number) => {
       setLastPageItemCount(count);
       // Persist in the module-level cache so it survives modal close/reopen
-      const ds = getDataSourceSrv().getInstanceSettings(datasourceUid);
-      if (ds) {
-        const cached = dashboardCache.get(ds.type);
-        if (cached) {
-          cached.lastPageItemCount = count;
+      getDataSourceInstanceSettings(datasourceUid).then((ds) => {
+        if (ds) {
+          const cached = dashboardCache.get(ds.type);
+          if (cached) {
+            cached.lastPageItemCount = count;
+          }
         }
-      }
+      });
     },
     [datasourceUid]
   );


### PR DESCRIPTION
**What is this feature?**

Migrates one representative call site from the legacy `DataSourceSrv` singleton to the async APIs introduced in #123037. One of a set of worked migration examples, split out from #124394 into focused PRs.

**Why do we need this feature?**

The new async API surface needs adoption examples. These worked examples were extracted from the core APIs PR (#123037) to keep that PR focused on the new API surface.

**Who is this feature for?**

Grafana engineers migrating existing code away from the deprecated `DataSourceSrv` singleton.

**Which issue(s) does this PR fix?**:

Part of #121465
Partly addresses https://github.com/grafana/grafana/issues/125083

---

## Migration pattern: Sync lookup inside an async callback → `getDataSourceInstanceSettings`

**`datasources/components/SuggestedDashboardsLoader.tsx`** — call site was already inside an async `useCallback`; only `await` and import needed changing.

**Special notes for your reviewer:**

- Depends on #123037.
- Split out from #124394.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/grafana/latest/whatsnew/), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
