### PR TITLE
Navigation: Migrate QuickAdd and CreateNewButton to useDataSourceInstanceList

### DIFF
--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
@@ -1,9 +1,14 @@
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
-import { type NavModelItem } from '@grafana/data';
+import { type DataSourceInstanceListItem, type NavModelItem } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
+import { useDataSourceInstanceList } from '@grafana/runtime/unstable';
+import { NewDashboardLibraryInteractions } from 'app/features/dashboard/dashgrid/DashboardLibrary/analytics/main';
+import { CONTENT_KINDS, SOURCE_ENTRY_POINTS } from 'app/features/dashboard/dashgrid/DashboardLibrary/constants';
+import { DashboardLibraryInteractions } from 'app/features/dashboard/dashgrid/DashboardLibrary/interactions';
 import { configureStore } from 'app/store/configureStore';
 
 import { QuickAdd } from './QuickAdd';
@@ -12,34 +17,62 @@ jest.mock('@grafana/runtime', () => {
   return {
     ...jest.requireActual('@grafana/runtime'),
     reportInteraction: jest.fn(),
-    getDataSourceSrv: () => ({
-      getList: jest
-        .fn()
-        .mockReturnValue([
-          { name: 'Test Data Source', uid: 'test-data-source-uid', type: 'grafana-testdata-datasource' },
-        ]),
-    }),
   };
 });
 
-const setup = () => {
-  const navBarTree: NavModelItem[] = [
-    {
-      text: 'Dashboards',
-      id: 'dashboards/browse',
-      url: '/dashboards',
-      children: [
-        { text: 'New dashboard', id: 'dashboards/new', url: '/dashboard/new', isCreateAction: true },
-        { text: 'Import dashboard', id: 'dashboards/import', url: '/dashboard/import', isCreateAction: true },
-        { text: 'Browse', id: 'dashboards-browse', url: '/dashboards' },
-      ],
-    },
-    {
-      text: 'Alerting',
-      id: 'alerting',
-      url: '/alerting',
-      children: [{ text: 'New alert rule', id: 'alert', url: '/alerting/new', isCreateAction: true }],
-    },
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  useDataSourceInstanceList: jest.fn(),
+}));
+
+jest.mock('@openfeature/react-sdk', () => ({
+  ...jest.requireActual('@openfeature/react-sdk'),
+  useBooleanFlagValue: jest.fn(),
+}));
+
+jest.mock('app/features/dashboard/dashgrid/DashboardLibrary/analytics/main', () => ({
+  NewDashboardLibraryInteractions: { entryPointClicked: jest.fn() },
+}));
+
+jest.mock('app/features/dashboard/dashgrid/DashboardLibrary/interactions', () => ({
+  DashboardLibraryInteractions: { entryPointClicked: jest.fn() },
+}));
+
+const useBooleanFlagValueMock = jest.mocked(useBooleanFlagValue);
+const useDataSourceInstanceListMock = jest.mocked(useDataSourceInstanceList);
+
+const testDataSource = {
+  name: 'Test Data Source',
+  uid: 'test-data-source-uid',
+  type: 'grafana-testdata-datasource',
+} as DataSourceInstanceListItem;
+
+const dashboardsNavItem: NavModelItem = {
+  text: 'Dashboards',
+  id: 'dashboards/browse',
+  url: '/dashboards',
+  children: [
+    { text: 'New dashboard', id: 'dashboards/new', url: '/dashboard/new', isCreateAction: true },
+    { text: 'Import dashboard', id: 'dashboards/import', url: '/dashboard/import', isCreateAction: true },
+    { text: 'Browse', id: 'dashboards-browse', url: '/dashboards' },
+  ],
+};
+
+const alertingNavItem: NavModelItem = {
+  text: 'Alerting',
+  id: 'alerting',
+  url: '/alerting',
+  children: [{ text: 'New alert rule', id: 'alert', url: '/alerting/new', isCreateAction: true }],
+};
+
+const setTestDataSources = (items: DataSourceInstanceListItem[]) => {
+  useDataSourceInstanceListMock.mockReturnValue({ items, isLoading: false });
+};
+
+const setup = (navBarTree?: NavModelItem[]) => {
+  const tree: NavModelItem[] = navBarTree ?? [
+    dashboardsNavItem,
+    alertingNavItem,
     // Synthetic top-level create action — not in production navtree today, but exercises the ungrouped code path
     {
       text: 'New import',
@@ -48,11 +81,13 @@ const setup = () => {
       isCreateAction: true,
     },
   ];
-  const store = configureStore({ navBarTree });
+  const store = configureStore({ navBarTree: tree });
   return render(<QuickAdd />, { store });
 };
 
 describe('QuickAdd', () => {
+  const originalDashboardTemplates = config.featureToggles.dashboardTemplates;
+
   beforeAll(() => {
     jest.spyOn(window, 'matchMedia').mockImplementation(
       () =>
@@ -62,6 +97,18 @@ describe('QuickAdd', () => {
           matches: true,
         }) as unknown as MediaQueryList
     );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // analyticsFramework defaults to enabled in production
+    useBooleanFlagValueMock.mockReturnValue(true);
+    config.featureToggles.dashboardTemplates = false;
+    setTestDataSources([]);
+  });
+
+  afterEach(() => {
+    config.featureToggles.dashboardTemplates = originalDashboardTemplates;
   });
 
   it('renders a `New` button', () => {
@@ -121,16 +168,30 @@ describe('QuickAdd', () => {
   describe('Use template button', () => {
     beforeEach(() => {
       config.featureToggles.dashboardTemplates = true;
+      setTestDataSources([testDataSource]);
     });
 
-    it('shows a `Use template` button when the feature flag is enabled', async () => {
+    it('shows a `Use template` button when the feature flag is enabled and a test data source exists', async () => {
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
       expect(screen.getByRole('menuitem', { name: 'Use template' })).toBeInTheDocument();
     });
 
+    it('does not show a `Use template` button when there is no dashboard group', async () => {
+      setup([alertingNavItem]);
+      await userEvent.click(screen.getByRole('button', { name: 'New' }));
+      expect(screen.queryByRole('menuitem', { name: 'Use template' })).not.toBeInTheDocument();
+    });
+
     it('does not show a `Use template` button when the feature flag is disabled', async () => {
       config.featureToggles.dashboardTemplates = false;
+      setup();
+      await userEvent.click(screen.getByRole('button', { name: 'New' }));
+      expect(screen.queryByRole('menuitem', { name: 'Use template' })).not.toBeInTheDocument();
+    });
+
+    it('does not show a `Use template` button when there are no test data sources', async () => {
+      setTestDataSources([]);
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
       expect(screen.queryByRole('menuitem', { name: 'Use template' })).not.toBeInTheDocument();
@@ -142,6 +203,40 @@ describe('QuickAdd', () => {
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
       const link = screen.getByRole('menuitem', { name: 'Use template' });
       expect(link).toHaveAttribute('href', '/dashboards?templateDashboards=true&source=quickAdd');
+    });
+
+    it('reports the new analytics framework interaction when clicked and the framework is enabled', async () => {
+      // Clicking the menu item navigates via its href, which jsdom logs as unimplemented
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+      useBooleanFlagValueMock.mockReturnValue(true);
+      setup();
+
+      await userEvent.click(screen.getByRole('button', { name: 'New' }));
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Use template' }));
+
+      expect(NewDashboardLibraryInteractions.entryPointClicked).toHaveBeenCalledWith({
+        entryPoint: SOURCE_ENTRY_POINTS.QUICK_ADD_BUTTON,
+        contentKind: CONTENT_KINDS.TEMPLATE_DASHBOARD,
+      });
+      expect(DashboardLibraryInteractions.entryPointClicked).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
+    it('reports the legacy interaction when clicked and the analytics framework is disabled', async () => {
+      // Clicking the menu item navigates via its href, which jsdom logs as unimplemented
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+      useBooleanFlagValueMock.mockReturnValue(false);
+      setup();
+
+      await userEvent.click(screen.getByRole('button', { name: 'New' }));
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Use template' }));
+
+      expect(DashboardLibraryInteractions.entryPointClicked).toHaveBeenCalledWith({
+        entryPoint: SOURCE_ENTRY_POINTS.QUICK_ADD_BUTTON,
+        contentKind: CONTENT_KINDS.TEMPLATE_DASHBOARD,
+      });
+      expect(NewDashboardLibraryInteractions.entryPointClicked).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 });

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -3,7 +3,8 @@ import { Fragment, useMemo, useState } from 'react';
 
 import { type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv, reportInteraction, config } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
+import { useDataSourceInstanceList } from '@grafana/runtime/unstable';
 import { Menu, Dropdown, ToolbarButton, useTheme2 } from '@grafana/ui';
 import { NewDashboardLibraryInteractions } from 'app/features/dashboard/dashgrid/DashboardLibrary/analytics/main';
 import { CONTENT_KINDS, SOURCE_ENTRY_POINTS } from 'app/features/dashboard/dashgrid/DashboardLibrary/constants';
@@ -20,6 +21,8 @@ import {
   findCreateActionGroups,
 } from './utils';
 
+const testDsFilters = { type: 'grafana-testdata-datasource' };
+
 export interface Props {}
 
 export const QuickAdd = ({}: Props) => {
@@ -27,40 +30,41 @@ export const QuickAdd = ({}: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const isAnalyticsFrameworkEnabled = useBooleanFlagValue('analyticsFramework', true);
   const theme = useTheme2();
+  const { items: testDataSources } = useDataSourceInstanceList(
+    config.featureToggles.dashboardTemplates ? testDsFilters : undefined
+  );
+  const hasTestDataSource = config.featureToggles.dashboardTemplates && testDataSources.length > 0;
 
   const actionGroups = useMemo(() => {
     const groups = findCreateActionGroups(navBarTree);
 
-    if (config.featureToggles.dashboardTemplates) {
-      const testDataSources = getDataSourceSrv().getList({ type: 'grafana-testdata-datasource' });
-      if (testDataSources.length > 0) {
-        const templateItem: NavModelItem = {
-          id: 'browse-template-dashboard',
-          text: t('navigation.quick-add.new-template-dashboard-button', 'Use template'),
-          url: '/dashboards?templateDashboards=true&source=quickAdd',
-          onClick: () => {
-            isAnalyticsFrameworkEnabled
-              ? NewDashboardLibraryInteractions.entryPointClicked({
-                  entryPoint: SOURCE_ENTRY_POINTS.QUICK_ADD_BUTTON,
-                  contentKind: CONTENT_KINDS.TEMPLATE_DASHBOARD,
-                })
-              : DashboardLibraryInteractions.entryPointClicked({
-                  entryPoint: SOURCE_ENTRY_POINTS.QUICK_ADD_BUTTON,
-                  contentKind: CONTENT_KINDS.TEMPLATE_DASHBOARD,
-                });
-          },
-        };
+    if (hasTestDataSource) {
+      const templateItem: NavModelItem = {
+        id: 'browse-template-dashboard',
+        text: t('navigation.quick-add.new-template-dashboard-button', 'Use template'),
+        url: '/dashboards?templateDashboards=true&source=quickAdd',
+        onClick: () => {
+          isAnalyticsFrameworkEnabled
+            ? NewDashboardLibraryInteractions.entryPointClicked({
+                entryPoint: SOURCE_ENTRY_POINTS.QUICK_ADD_BUTTON,
+                contentKind: CONTENT_KINDS.TEMPLATE_DASHBOARD,
+              })
+            : DashboardLibraryInteractions.entryPointClicked({
+                entryPoint: SOURCE_ENTRY_POINTS.QUICK_ADD_BUTTON,
+                contentKind: CONTENT_KINDS.TEMPLATE_DASHBOARD,
+              });
+        },
+      };
 
-        // Matches NavIDDashboards ("dashboards/browse") from pkg/services/navtree/models.go
-        const dashboardGroup = groups.find((g) => g.parentId === 'dashboards/browse');
-        if (dashboardGroup) {
-          dashboardGroup.items.push(templateItem);
-        }
+      // Matches NavIDDashboards ("dashboards/browse") from pkg/services/navtree/models.go
+      const dashboardGroup = groups.find((g) => g.parentId === 'dashboards/browse');
+      if (dashboardGroup) {
+        dashboardGroup.items.push(templateItem);
       }
     }
 
     return groups;
-  }, [isAnalyticsFrameworkEnabled, navBarTree]);
+  }, [isAnalyticsFrameworkEnabled, navBarTree, hasTestDataSource]);
 
   const showQuickAdd = actionGroups.some((g) => g.items.length > 0);
 

--- a/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
@@ -14,18 +14,13 @@ jest.mock('app/features/provisioning/hooks/useIsProvisionedInstance', () => ({
   useIsProvisionedInstance: jest.fn(),
 }));
 
-jest.mock('@grafana/runtime', () => {
-  return {
-    ...jest.requireActual('@grafana/runtime'),
-    getDataSourceSrv: () => ({
-      getList: jest
-        .fn()
-        .mockReturnValue([
-          { name: 'Test Data Source', uid: 'test-data-source-uid', type: 'grafana-testdata-datasource' },
-        ]),
-    }),
-  };
-});
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  useDataSourceInstanceList: jest.fn().mockReturnValue({
+    items: [{ name: 'Test Data Source', uid: 'test-data-source-uid', type: 'grafana-testdata-datasource' }],
+    isLoading: false,
+  }),
+}));
 
 const mockUseIsProvisionedInstance = useIsProvisionedInstance as jest.MockedFunction<typeof useIsProvisionedInstance>;
 

--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -4,7 +4,8 @@ import { useLocation } from 'react-router-dom-v5-compat';
 
 import { locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getDataSourceSrv, locationService, reportInteraction } from '@grafana/runtime';
+import { config, locationService, reportInteraction } from '@grafana/runtime';
+import { useDataSourceInstanceList } from '@grafana/runtime/unstable';
 import { Button, Drawer, Dropdown, Icon, Menu, useTheme2 } from '@grafana/ui';
 import { type OwnerReference } from 'app/api/clients/folder/v1beta1';
 import { useCreateFolder } from 'app/api/clients/folder/v1beta1/hooks';
@@ -29,6 +30,8 @@ import { type FolderDTO } from 'app/types/folders';
 
 import { NewFolderForm } from './NewFolderForm';
 
+const testDsFilters = { type: 'grafana-testdata-datasource' };
+
 interface Props {
   parentFolder?: FolderDTO;
   canCreateFolder: boolean;
@@ -52,6 +55,10 @@ export default function CreateNewButton({
   const isProvisionedInstance = useIsProvisionedInstance();
   const isAnalyticsFrameworkEnabled = useBooleanFlagValue('analyticsFramework', true);
   const theme = useTheme2();
+  const { items: testDataSources } = useDataSourceInstanceList(
+    config.featureToggles.dashboardTemplates ? testDsFilters : undefined
+  );
+  const renderPreBuiltDashboardAction = config.featureToggles.dashboardTemplates && testDataSources.length > 0;
 
   const handleVisibleChange = () => {
     if (!isOpen) {
@@ -61,12 +68,6 @@ export default function CreateNewButton({
     }
     setIsOpen(!isOpen);
   };
-
-  let renderPreBuiltDashboardAction = false;
-  if (config.featureToggles.dashboardTemplates) {
-    const testDataSources = getDataSourceSrv().getList({ type: 'grafana-testdata-datasource' });
-    renderPreBuiltDashboardAction = testDataSources.length > 0;
-  }
 
   const onCreateFolder = async (folderName: string, teamOwnerRefs?: OwnerReference[]) => {
     try {


### PR DESCRIPTION
**What is this feature?**

Migrates representative call sites from the legacy `DataSourceSrv` singleton to the async hooks introduced in #123037. One of a set of worked migration examples, split out from #124394 into focused PRs.

**Why do we need this feature?**

The new async API surface needs adoption examples. These worked examples were extracted from the core APIs PR (#123037) to keep that PR focused on the new API surface.

**Who is this feature for?**

Grafana engineers migrating existing code away from the deprecated `DataSourceSrv` singleton.

**Which issue(s) does this PR fix?**:

Part of #121465
Partly addresses https://github.com/grafana/grafana/issues/125083

---

## Migration pattern: Sync list in render → `useDataSourceInstanceList`

**`AppChrome/QuickAdd/QuickAdd.tsx`** + **`browse-dashboards/CreateNewButton.tsx`** — the synchronous `getDataSourceSrv().getList()` call is replaced by the `useDataSourceInstanceList` hook (from `@grafana/runtime/unstable`), called directly at the top of each component. Passing `undefined` as the filter when the toggle is off returns an empty list without fetching, and `items` defaults to `[]` while loading, so no explicit loading-state handling is needed. The hook returns slim `DataSourceInstanceListItem`s; these call sites only need `items.length`, so the trimmed list type is sufficient.

**Special notes for your reviewer:**

- Builds on #127126, which renamed `useDataSourceInstanceSettingsList` → `useDataSourceInstanceList` and moved it from `@grafana/runtime/internal` to `@grafana/runtime/unstable` (returning the slim `DataSourceInstanceListItem` type).
- Depends on #123037.
- Split out from #124394.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/grafana/latest/whatsnew/), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
