### PR TITLE
Logging: Preserve original error stack in @grafana/runtime helpers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -697,6 +697,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/rbac.ts @grafana/identity-access-team
 /packages/grafana-runtime/src/utils/returnToPrevious.ts @grafana/grafana-frontend-navigation
 /packages/grafana-runtime/src/utils/toDataQueryError.ts @grafana/grafana-datasources-core-services
+/packages/grafana-runtime/src/utils/TracedError* @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/userStorage* @grafana/grafana-catalog @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/useFavoriteDatasources* @grafana/grafana-catalog
 /packages/grafana-runtime/src/utils/getCachedPromise* @grafana/grafana-frontend-platform

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -25,6 +25,7 @@ export {
   logMeasurement,
   type MonitoringLogger,
 } from './utils/logging';
+export { TracedError } from './utils/TracedError';
 export {
   DataSourceWithBackend,
   HealthCheckError,

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -1,5 +1,6 @@
 import { DataSourceApi, type DataSourceInstanceSettings, type DataSourcePluginMeta } from '@grafana/data';
 
+import { TracedError } from '../../utils/TracedError';
 import { RuntimeDataSource } from '../RuntimeDataSource';
 import { setLogger } from '../logging/registry';
 import { setTemplateSrv, type TemplateSrv } from '../templateSrv';
@@ -148,7 +149,7 @@ describe('plugin', () => {
       await expect(getDataSourceInstance(settings.uid)).rejects.toThrow(/module not found/);
     });
 
-    it('logs the failure with the raw error as cause and does not sanitize the rethrow', async () => {
+    it('logs a TracedError that preserves the original stack and does not sanitize the rethrow', async () => {
       const settings = ds();
       initDataSourceInstanceSettings({ [settings.name]: settings }, settings.name);
       const importError = new Error('module not found');
@@ -158,8 +159,10 @@ describe('plugin', () => {
 
       expect(logError).toHaveBeenCalledTimes(1);
       const [loggedError] = logError.mock.calls[0];
-      expect(loggedError).toBeInstanceOf(Error);
+      expect(loggedError).toBeInstanceOf(TracedError);
+      expect(loggedError.message).toContain('Failed to import datasource plugin');
       expect(loggedError.cause).toBe(importError);
+      expect(loggedError.stack).toBe(importError.stack);
     });
 
     it('returns the same instance for name-based and uid-based lookups', async () => {

--- a/packages/grafana-runtime/src/services/dataSource/logging.ts
+++ b/packages/grafana-runtime/src/services/dataSource/logging.ts
@@ -1,7 +1,8 @@
 import { type LogContext } from '@grafana/faro-web-sdk';
 
+import { TracedError } from '../../utils/TracedError';
 import { getLogger } from '../logging/registry';
 
 export function logDataSourceInstanceError(message: string, error: unknown, context?: LogContext): void {
-  getLogger('grafana/runtime.plugins.datasource').logError(new Error(message, { cause: error }), context);
+  getLogger('grafana/runtime.plugins.datasource').logError(new TracedError(message, error), context);
 }

--- a/packages/grafana-runtime/src/services/pluginMeta/logging.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/logging.ts
@@ -1,5 +1,6 @@
 import { type LogContext } from '@grafana/faro-web-sdk';
 
+import { TracedError } from '../../utils/TracedError';
 import { getLogger } from '../logging/registry';
 
 export function logPluginMetaWarning(message: string, context: LogContext): void {
@@ -7,7 +8,7 @@ export function logPluginMetaWarning(message: string, context: LogContext): void
 }
 
 export function logPluginMetaError(message: string, error: unknown, context?: LogContext): void {
-  getLogger('grafana/runtime.plugins.meta').logError(new Error(message, { cause: error }), context);
+  getLogger('grafana/runtime.plugins.meta').logError(new TracedError(message, error), context);
 }
 
 export function logPluginMetaDebug(message: string, context: LogContext): void {

--- a/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
@@ -1,6 +1,7 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
+import { TracedError } from '../../utils/TracedError';
 import { invalidateCachedPromisesCache } from '../../utils/getCachedPromise';
 import { getLogger, setLogger } from '../logging/registry';
 
@@ -112,16 +113,13 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
 
       expect(global.fetch).toHaveBeenCalledTimes(2); // first + second (because first throws), third is cached
       expect(global.fetch).toHaveBeenCalledWith('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
-      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledTimes(1);
-      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledWith(
-        new Error(`getCachedPromise: Something failed while resolving a cached promise`),
-
-        {
-          message: 'Failed to load plugin metas 500:Internal Server Error',
-          stack: expect.any(String),
-          key: expect.stringMatching(/^loadPluginMetas:-?\d+$/),
-        }
-      );
+      const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
+      expect(logErrorMock).toHaveBeenCalledTimes(1);
+      const [loggedError, context] = logErrorMock.mock.calls[0];
+      expect(loggedError).toBeInstanceOf(TracedError);
+      expect(loggedError.message).toBe('getCachedPromise: Something failed while resolving a cached promise');
+      expect(loggedError.cause).toStrictEqual(new Error('Failed to load plugin metas 500:Internal Server Error'));
+      expect(context).toEqual({ key: expect.stringMatching(/^loadPluginMetas:-?\d+$/) });
     });
 
     it('initPluginMetas should log when fetch rejects', async () => {
@@ -140,16 +138,13 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
 
       expect(global.fetch).toHaveBeenCalledTimes(2); // first + second (because first throws), third is cached
       expect(global.fetch).toHaveBeenCalledWith('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
-      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledTimes(1);
-      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledWith(
-        new Error(`getCachedPromise: Something failed while resolving a cached promise`),
-
-        {
-          message: 'Network Error',
-          stack: expect.any(String),
-          key: expect.stringMatching(/^loadPluginMetas:-?\d+$/),
-        }
-      );
+      const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
+      expect(logErrorMock).toHaveBeenCalledTimes(1);
+      const [loggedError, context] = logErrorMock.mock.calls[0];
+      expect(loggedError).toBeInstanceOf(TracedError);
+      expect(loggedError.message).toBe('getCachedPromise: Something failed while resolving a cached promise');
+      expect(loggedError.cause).toStrictEqual(new Error('Network Error'));
+      expect(context).toEqual({ key: expect.stringMatching(/^loadPluginMetas:-?\d+$/) });
     });
   });
 

--- a/packages/grafana-runtime/src/services/pluginSettings/logging.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/logging.ts
@@ -1,5 +1,6 @@
 import { type LogContext } from '@grafana/faro-web-sdk';
 
+import { TracedError } from '../../utils/TracedError';
 import { getLogger } from '../logging/registry';
 
 export function logPluginSettingsWarning(message: string, context: LogContext): void {
@@ -7,7 +8,7 @@ export function logPluginSettingsWarning(message: string, context: LogContext): 
 }
 
 export function logPluginSettingsError(message: string, error: unknown, context?: LogContext): void {
-  getLogger('grafana/runtime.plugins.settings').logError(new Error(message, { cause: error }), context);
+  getLogger('grafana/runtime.plugins.settings').logError(new TracedError(message, error), context);
 }
 
 export function logPluginSettingsDebug(message: string, context: LogContext): void {

--- a/packages/grafana-runtime/src/services/pluginSettings/settings.test.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/settings.test.ts
@@ -1,6 +1,7 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
+import { TracedError } from '../../utils/TracedError';
 import { invalidateCachedPromisesCache } from '../../utils/getCachedPromise';
 import { type MonitoringLogger } from '../../utils/logging';
 import { type BackendSrv, setBackendSrv } from '../backendSrv';
@@ -149,10 +150,13 @@ describe('settings', () => {
         const enabled = await isAppPluginEnabled(myOrgTestAppMeta.spec.pluginJson.id);
 
         expect(enabled).toEqual(false);
-        expect(logger.logError).toHaveBeenCalledWith(
-          new Error('isAppPluginEnabled: failed because of unknown reason'),
-          { pluginId: 'myorg-test-app' }
-        );
+        const calls = (logger.logError as jest.Mock).mock.calls;
+        const call = calls.find(([err]) => err.message === 'isAppPluginEnabled: failed because of unknown reason');
+        const [loggedError, context] = call ?? [];
+        expect(loggedError).toBeInstanceOf(TracedError);
+        expect(loggedError.cause).toBeInstanceOf(Error);
+        expect(loggedError.cause.message).toBe('Unknown Plugin');
+        expect(context).toEqual({ pluginId: 'myorg-test-app' });
         expect(logger.logWarning).not.toHaveBeenCalled();
       });
     });

--- a/packages/grafana-runtime/src/utils/TracedError.test.ts
+++ b/packages/grafana-runtime/src/utils/TracedError.test.ts
@@ -1,0 +1,33 @@
+import { TracedError } from './TracedError';
+
+describe('TracedError', () => {
+  it('uses the passed message as its own message', () => {
+    const error = new TracedError('something descriptive failed', new Error('boom'));
+
+    expect(error.message).toBe('something descriptive failed');
+    expect(error.name).toBe('TracedError');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('stores the original error on cause', () => {
+    const cause = new Error('boom');
+    const error = new TracedError('something descriptive failed', cause);
+
+    expect(error.cause).toBe(cause);
+  });
+
+  it("preserves the original error's stack so the real failure location is reported", () => {
+    const cause = new Error('boom');
+    const error = new TracedError('something descriptive failed', cause);
+
+    expect(error.stack).toBe(cause.stack);
+  });
+
+  it('handles a non-Error cause without copying a stack', () => {
+    const error = new TracedError('something descriptive failed', 'string failure');
+
+    expect(error.cause).toBe('string failure');
+    // No cause stack to copy, so it keeps its own.
+    expect(error.stack).toContain('something descriptive failed');
+  });
+});

--- a/packages/grafana-runtime/src/utils/TracedError.ts
+++ b/packages/grafana-runtime/src/utils/TracedError.ts
@@ -1,0 +1,20 @@
+/**
+ * An Error that presents a custom, human-readable `message` while preserving the stack
+ * trace of the original error (`cause`).
+ *
+ * Faro parses an exception's stack frames from the top-level error's `.stack`, and
+ * serializes `.cause` only as a string (its message, not its stack). Wrapping with a plain
+ * `new Error(message, { cause })` therefore reports the wrapper's shallow stack and drops the
+ * original frames. Copying the cause's stack onto this error is what gets the real failure
+ * location into telemetry under a descriptive title.
+ */
+export class TracedError extends Error {
+  constructor(message: string, cause: unknown) {
+    super(message, { cause });
+    this.name = 'TracedError';
+
+    if (cause instanceof Error && cause.stack) {
+      this.stack = cause.stack;
+    }
+  }
+}

--- a/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
@@ -1,5 +1,6 @@
 import { getLogger, setLogger } from '../services/logging/registry';
 
+import { TracedError } from './TracedError';
 import {
   getCacheKeyFromPromise,
   getCachedPromise,
@@ -221,15 +222,11 @@ describe('cached promises', () => {
 
         const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
         expect(logErrorMock).toHaveBeenCalledTimes(1);
-        expect(logErrorMock).toHaveBeenCalledWith(
-          new Error(`getCachedPromise: Something failed while resolving a cached promise`),
-          {
-            stack: expect.any(String),
-            message: 'Network Error',
-            key: expect.stringMatching(/^mockConstructor:-?\d+$/),
-          }
-        );
-        expect(logErrorMock.mock.calls[0][0].cause).toStrictEqual(new Error('Network Error'));
+        const [loggedError, context] = logErrorMock.mock.calls[0];
+        expect(loggedError).toBeInstanceOf(TracedError);
+        expect(loggedError.message).toBe('getCachedPromise: Something failed while resolving a cached promise');
+        expect(loggedError.cause).toStrictEqual(new Error('Network Error'));
+        expect(context).toEqual({ key: expect.stringMatching(/^mockConstructor:-?\d+$/) });
       });
 
       test('should log non-Error thrown values', async () => {
@@ -239,11 +236,11 @@ describe('cached promises', () => {
 
         const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
         expect(logErrorMock).toHaveBeenCalledTimes(1);
-        expect(logErrorMock).toHaveBeenCalledWith(
-          expect.any(Error),
-          expect.objectContaining({ message: 'string error', key: expect.stringMatching(/^mockConstructor:-?\d+$/) })
-        );
-        expect(logErrorMock.mock.calls[0][0].cause).toBe('string error');
+        const [loggedError, context] = logErrorMock.mock.calls[0];
+        expect(loggedError).toBeInstanceOf(TracedError);
+        expect(loggedError.message).toBe('getCachedPromise: Something failed while resolving a cached promise');
+        expect(loggedError.cause).toBe('string error');
+        expect(context).toEqual({ key: expect.stringMatching(/^mockConstructor:-?\d+$/) });
       });
     });
 
@@ -289,15 +286,11 @@ describe('cached promises', () => {
         expect(promise).toHaveBeenCalledTimes(1);
         const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
         expect(logErrorMock).toHaveBeenCalledTimes(1);
-        expect(logErrorMock).toHaveBeenCalledWith(
-          new Error(`getCachedPromise: Something failed while resolving a cached promise`),
-          {
-            stack: expect.any(String),
-            message: 'Network Error',
-            key: expect.stringMatching(/^mockConstructor:-?\d+$/),
-          }
-        );
-        expect(logErrorMock.mock.calls[0][0].cause).toStrictEqual(new Error('Network Error'));
+        const [loggedError, context] = logErrorMock.mock.calls[0];
+        expect(loggedError).toBeInstanceOf(TracedError);
+        expect(loggedError.message).toBe('getCachedPromise: Something failed while resolving a cached promise');
+        expect(loggedError.cause).toStrictEqual(new Error('Network Error'));
+        expect(context).toEqual({ key: expect.stringMatching(/^mockConstructor:-?\d+$/) });
       });
 
       test('should invalidate cache when something errors', async () => {
@@ -388,15 +381,11 @@ describe('cached promises', () => {
 
         const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
         expect(logErrorMock).toHaveBeenCalledTimes(1);
-        expect(logErrorMock).toHaveBeenCalledWith(
-          new Error(`getCachedPromise: Something failed while resolving a cached promise`),
-          {
-            stack: expect.any(String),
-            message: 'Network Error',
-            key: expect.stringMatching(/^mockConstructor:-?\d+$/),
-          }
-        );
-        expect(logErrorMock.mock.calls[0][0].cause).toStrictEqual(new Error('Network Error'));
+        const [loggedError, context] = logErrorMock.mock.calls[0];
+        expect(loggedError).toBeInstanceOf(TracedError);
+        expect(loggedError.message).toBe('getCachedPromise: Something failed while resolving a cached promise');
+        expect(loggedError.cause).toStrictEqual(new Error('Network Error'));
+        expect(context).toEqual({ key: expect.stringMatching(/^mockConstructor:-?\d+$/) });
       });
 
       test('should propagate error when onError callback throws', async () => {
@@ -820,11 +809,13 @@ describe('cached promises', () => {
       expect(keyA).toMatch(/^uncacheable:/);
       expect(keyB).toMatch(/^uncacheable:/);
       expect(keyA).not.toBe(keyB);
-      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledTimes(2);
-      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'getCachedPromiseWithArgs: serializeArg failed' }),
-        expect.objectContaining({ baseKey: 'test' })
-      );
+      const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
+      expect(logErrorMock).toHaveBeenCalledTimes(2);
+      const [loggedError, context] = logErrorMock.mock.calls[0];
+      expect(loggedError).toBeInstanceOf(TracedError);
+      expect(loggedError.message).toBe('getCachedPromiseWithArgs: serializeArg failed');
+      expect(loggedError.cause).toBeInstanceOf(Error);
+      expect(context).toEqual({ baseKey: 'test', key: expect.stringMatching(/^uncacheable:/) });
     });
   });
 

--- a/packages/grafana-runtime/src/utils/getCachedPromise.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.ts
@@ -2,9 +2,10 @@ import { hash } from 'immutable';
 import { LRUCache } from 'lru-cache';
 
 import { generateUUID } from '@grafana/data';
-import { type LogContext } from '@grafana/faro-web-sdk';
 
 import { getLogger } from '../services/logging/registry';
+
+import { TracedError } from './TracedError';
 
 // 500 is our best guestimate right now. If a session
 // goes past 500 entries, the LRU evicts the oldest one, at worst a refetch,
@@ -70,16 +71,9 @@ function invalidateCacheIfNotReplaced<T>(key: string, cached: Promise<T>): void 
 
 function logError({ error, key }: LogErrorArgs): void {
   try {
-    const err = error instanceof Error ? error : new Error(String(error));
-
-    const context: LogContext = { message: err.message, key };
-    if (err.stack) {
-      context.stack = err.stack;
-    }
-
     getLogger('grafana/runtime.utils.getCachedPromise').logError(
-      new Error(`getCachedPromise: Something failed while resolving a cached promise`, { cause: error }),
-      context
+      new TracedError('getCachedPromise: Something failed while resolving a cached promise', error),
+      { key }
     );
   } catch (error) {
     console.error(error);
@@ -223,7 +217,7 @@ export function serializeArg(value: unknown, baseKey: string): string {
   } catch (error) {
     const key = `uncacheable:${generateUUID()}`;
     getLogger('grafana/runtime.utils.getCachedPromise').logError(
-      new Error(`getCachedPromiseWithArgs: serializeArg failed`, { cause: error }),
+      new TracedError('getCachedPromiseWithArgs: serializeArg failed', error),
       { baseKey, key }
     );
     return key;

--- a/public/app/features/plugins/extensions/registry/setup.test.ts
+++ b/public/app/features/plugins/extensions/registry/setup.test.ts
@@ -1,4 +1,4 @@
-import { type MonitoringLogger } from '@grafana/runtime';
+import { TracedError, type MonitoringLogger } from '@grafana/runtime';
 import { getAppPluginMetas, invalidateCachedPromisesCache } from '@grafana/runtime/internal';
 import { mockLogger } from '@grafana/test-utils/unstable';
 
@@ -57,13 +57,10 @@ describe('getPluginExtensionRegistries', () => {
     expect(first).not.toBe(third);
     expect(second).toBe(third);
     expect(logger.logError).toHaveBeenCalledTimes(1);
-    expect(logger.logError).toHaveBeenCalledWith(
-      new Error('getCachedPromise: Something failed while resolving a cached promise'),
-      {
-        message: 'Some error',
-        stack: expect.any(String),
-        key: expect.stringMatching(/^initPluginExtensionRegistries:-?\d+$/),
-      }
-    );
+    const [loggedError, context] = (logger.logError as jest.Mock).mock.calls[0];
+    expect(loggedError).toBeInstanceOf(TracedError);
+    expect(loggedError.message).toBe('getCachedPromise: Something failed while resolving a cached promise');
+    expect(loggedError.cause).toStrictEqual(new Error('Some error'));
+    expect(context).toEqual({ key: expect.stringMatching(/^initPluginExtensionRegistries:-?\d+$/) });
   });
 });


### PR DESCRIPTION
## What this PR does

Several logging helpers in `@grafana/runtime` wrapped the original error before logging it:

```ts
getLogger(source).logError(new Error(message, { cause: error }), context);
```

`logError` forwards to `faro.api.pushError(err, …)`. Reading Faro's implementation:

- The exception **value** (title) comes from the top-level `error.message`.
- The **stack frames** are parsed **only** from the top-level `error.stack`.
- `.cause` is serialized via `cause.toString()` — i.e. only `"<name>: <message>"`, **never the stack**.

Because the synthetic `new Error(message, …)` is constructed in a `catch` after an `await`, its stack is shallow and rooted at the helper itself. So telemetry reported that shallow stack, and the real failure location (deep in the dynamic `import()` / module loader / fetch) was dropped — it only survived on `.cause`, which Faro doesn't read for the stack. (The dev console prints `.cause`, which is why this was invisible locally.)

## The fix: a `TracedError` class

```ts
export class TracedError extends Error {
  constructor(message: string, cause: unknown) {
    super(message, { cause });
    this.name = 'TracedError';
    if (cause instanceof Error && cause.stack) {
      this.stack = cause.stack; // ← surface the real failure location
    }
  }
}
```

It presents a descriptive, human-readable `message` while copying the **original error's stack** onto itself and keeping the original on `.cause`. The result in Faro:

| Field | Value |
|---|---|
| value (title) | the descriptive message |
| stacktrace.frames | the **original** error's frames — the real failure location |
| type | `TracedError` |
| context.cause | the original error's `Name: message` |

Lives at `packages/grafana-runtime/src/utils/TracedError.ts`, exported publicly from `src/index.ts` (same convention as `HealthCheckError`).

Applied consistently across all five sites that used the pattern:
- Exported helpers: `logDataSourceInstanceError`, `logPluginMetaError`, `logPluginSettingsError`
- Internal uses in `utils/getCachedPromise.ts`: the `logError` helper and `serializeArg`

Each call site collapses to a one-liner, and the repeated `error instanceof Error ? … : new Error(String(error))` normalization is gone — `TracedError` owns it.

## ⚠️ Consequence worth flagging

Faro groups exceptions by message/stack. The **title** is now the descriptive message (previously the underlying error's message) and the **frames** now point at the real failure location. This is the intended improvement, but anyone relying on the current error grouping in dashboards/telemetry should be aware the grouping will change.
