### PR TITLE
FS: Move PluginsCDNBaseURL to GetBaseFrontendSettings

### DIFF
--- a/pkg/api/bootdata.go
+++ b/pkg/api/bootdata.go
@@ -126,7 +126,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 	c, span := hs.injectSpan(c, "api.getFrontendSettings")
 	defer span.End()
 
-	frontendSettings, err := frontendsettings.GetBaseFrontendSettings(c, hs.Cfg, hs.License)
+	frontendSettings, err := frontendsettings.GetBaseFrontendSettings(c, hs.Cfg, hs.License, hs.pluginsCDNService)
 
 	if err != nil {
 		return nil, err
@@ -248,15 +248,6 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 	if hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagScopeFilters) {
 		frontendSettings.ListScopesEndpoint = hs.Cfg.ScopesListScopesURL
 		frontendSettings.ListDashboardScopesEndpoint = hs.Cfg.ScopesListDashboardsURL
-	}
-
-	// [TODO] Move back to GetBaseFrontendSettings
-	if hs.pluginsCDNService != nil && hs.pluginsCDNService.IsEnabled() {
-		cdnBaseURL, err := hs.pluginsCDNService.BaseURL()
-		if err != nil {
-			return nil, fmt.Errorf("plugins cdn base url: %w", err)
-		}
-		frontendSettings.PluginsCDNBaseURL = cdnBaseURL
 	}
 
 	return frontendSettings, nil

--- a/pkg/api/frontendsettings/frontendsettings.go
+++ b/pkg/api/frontendsettings/frontendsettings.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -19,7 +20,7 @@ import (
 
 // GetBaseFrontendSettings returns the JSON object with all the settings needed for
 // front end initialisation.
-func GetBaseFrontendSettings(reqCtx *contextmodel.ReqContext, cfg *setting.Cfg, license licensing.Licensing) (*dtos.FrontendSettingsDTO, error) {
+func GetBaseFrontendSettings(reqCtx *contextmodel.ReqContext, cfg *setting.Cfg, license licensing.Licensing, pluginsCDN *pluginscdn.Service) (*dtos.FrontendSettingsDTO, error) {
 	defaultDS := "-- Grafana --"
 
 	trustedTypesDefaultPolicyEnabled := (cfg.CSPEnabled && strings.Contains(cfg.CSPTemplate, "require-trusted-types-for")) || (cfg.CSPReportOnlyEnabled && strings.Contains(cfg.CSPReportOnlyTemplate, "require-trusted-types-for"))
@@ -220,6 +221,14 @@ func GetBaseFrontendSettings(reqCtx *contextmodel.ReqContext, cfg *setting.Cfg, 
 
 	if !cfg.GeomapEnableCustomBaseLayers {
 		frontendSettings.GeomapDisableCustomBaseLayer = true
+	}
+
+	if pluginsCDN != nil && pluginsCDN.IsEnabled() {
+		cdnBaseURL, err := pluginsCDN.BaseURL()
+		if err != nil {
+			return nil, fmt.Errorf("plugins cdn base url: %w", err)
+		}
+		frontendSettings.PluginsCDNBaseURL = cdnBaseURL
 	}
 
 	// Set the kubernetes namespace

--- a/pkg/api/frontendsettings/frontendsettings_test.go
+++ b/pkg/api/frontendsettings/frontendsettings_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/plugins/config"
+	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -23,7 +25,7 @@ func TestGetBaseFrontendSettings(t *testing.T) {
 		cfg := setting.NewCfg()
 		license := &licensing.OSSLicensingService{Cfg: cfg}
 
-		settings, err := GetBaseFrontendSettings(newTestReqContext(), cfg, license)
+		settings, err := GetBaseFrontendSettings(newTestReqContext(), cfg, license, nil)
 		require.NoError(t, err)
 		require.NotNil(t, settings)
 
@@ -49,7 +51,7 @@ func TestGetBaseFrontendSettings(t *testing.T) {
 
 		license := &licensing.OSSLicensingService{Cfg: cfg}
 
-		settings, err := GetBaseFrontendSettings(newTestReqContext(), cfg, license)
+		settings, err := GetBaseFrontendSettings(newTestReqContext(), cfg, license, nil)
 		require.NoError(t, err)
 		require.NotNil(t, settings)
 
@@ -65,7 +67,7 @@ func TestGetBaseFrontendSettings(t *testing.T) {
 
 		license := &licensing.OSSLicensingService{Cfg: cfg}
 
-		settings, err := GetBaseFrontendSettings(newTestReqContext(), cfg, license)
+		settings, err := GetBaseFrontendSettings(newTestReqContext(), cfg, license, nil)
 		require.NoError(t, err)
 		assert.True(t, settings.TrustedTypesDefaultPolicyEnabled)
 	})
@@ -77,10 +79,34 @@ func TestGetBaseFrontendSettings(t *testing.T) {
 
 		license := &licensing.OSSLicensingService{Cfg: cfg}
 
-		settings, err := GetBaseFrontendSettings(newTestReqContext(), cfg, license)
+		settings, err := GetBaseFrontendSettings(newTestReqContext(), cfg, license, nil)
 		require.NoError(t, err)
 		require.NotNil(t, settings.UnifiedAlerting.StateHistory)
 		assert.Equal(t, "loki", settings.UnifiedAlerting.StateHistory.Backend)
 		assert.Equal(t, "loki", settings.UnifiedAlerting.AlertStateHistoryBackend)
+	})
+
+	t.Run("populates plugins CDN base URL when the CDN is enabled", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		license := &licensing.OSSLicensingService{Cfg: cfg}
+
+		pluginsCDN := pluginscdn.ProvideService(&config.PluginManagementCfg{
+			PluginsCDNURLTemplate: "https://cdn.example.com",
+		})
+
+		settings, err := GetBaseFrontendSettings(newTestReqContext(), cfg, license, pluginsCDN)
+		require.NoError(t, err)
+		assert.Equal(t, "https://cdn.example.com", settings.PluginsCDNBaseURL)
+	})
+
+	t.Run("leaves plugins CDN base URL empty when the CDN is disabled", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		license := &licensing.OSSLicensingService{Cfg: cfg}
+
+		pluginsCDN := pluginscdn.ProvideService(&config.PluginManagementCfg{})
+
+		settings, err := GetBaseFrontendSettings(newTestReqContext(), cfg, license, pluginsCDN)
+		require.NoError(t, err)
+		assert.Empty(t, settings.PluginsCDNBaseURL)
 	})
 }

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/middleware/loggermw"
 	"github.com/grafana/grafana/pkg/middleware/requestmeta"
+	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/licensing"
@@ -58,6 +59,7 @@ type frontendService struct {
 
 	index           *IndexProvider
 	settingsService settingservice.Service // nil if not configured
+	pluginsCDN      *pluginscdn.Service
 }
 
 func ProvideFrontendService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, promGatherer prometheus.Gatherer, promRegister prometheus.Registerer, license licensing.Licensing, hooksService *hooks.HooksService) (*frontendService, error) {
@@ -77,6 +79,11 @@ func ProvideFrontendService(cfg *setting.Cfg, features featuremgmt.FeatureToggle
 		settingsService = settingsSvc
 	}
 
+	pluginsCDN, err := setupPluginsCDNService(cfg, features)
+	if err != nil {
+		return nil, err
+	}
+
 	s := &frontendService{
 		cfg:             cfg,
 		features:        features,
@@ -87,6 +94,7 @@ func ProvideFrontendService(cfg *setting.Cfg, features featuremgmt.FeatureToggle
 		license:         license,
 		index:           index,
 		settingsService: settingsService,
+		pluginsCDN:      pluginsCDN,
 	}
 	s.BasicService = services.NewBasicService(s.start, s.running, s.stop)
 	return s, nil
@@ -156,7 +164,7 @@ func (s *frontendService) addMiddlewares(m *web.Mux) {
 	m.UseMiddleware(loggermiddleware.Middleware())
 
 	// Must run before CSP middleware since CSP reads config from context
-	m.UseMiddleware(RequestConfigMiddleware(s.cfg, s.license, s.settingsService))
+	m.UseMiddleware(RequestConfigMiddleware(s.cfg, s.license, s.settingsService, s.pluginsCDN))
 
 	m.UseMiddleware(CSPMiddleware())
 

--- a/pkg/services/frontend/request_config.go
+++ b/pkg/services/frontend/request_config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/frontendsettings"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/setting"
@@ -37,7 +38,7 @@ type FSRequestConfig struct {
 
 // NewFSRequestConfig creates a new FSRequestConfig from the global configuration.
 // This is used to create the base configuration at service startup.
-func NewFSRequestConfig(ctx context.Context, cfg *setting.Cfg, license licensing.Licensing, fullFrontendSettingsEnabled bool) (FSRequestConfig, error) {
+func NewFSRequestConfig(ctx context.Context, cfg *setting.Cfg, license licensing.Licensing, pluginsCDN *pluginscdn.Service, fullFrontendSettingsEnabled bool) (FSRequestConfig, error) {
 	frontendSettings := FSFrontendSettings{
 		AnalyticsConsoleReporting:            cfg.FrontendAnalyticsConsoleReporting,
 		AnonymousEnabled:                     cfg.Anonymous.Enabled,
@@ -88,7 +89,7 @@ func NewFSRequestConfig(ctx context.Context, cfg *setting.Cfg, license licensing
 
 	if fullFrontendSettingsEnabled {
 		reqCtx := contexthandler.FromContext(ctx)
-		fullFrontendSettings, err := frontendsettings.GetBaseFrontendSettings(reqCtx, cfg, license, nil)
+		fullFrontendSettings, err := frontendsettings.GetBaseFrontendSettings(reqCtx, cfg, license, pluginsCDN)
 
 		if err != nil {
 			return FSRequestConfig{}, err

--- a/pkg/services/frontend/request_config.go
+++ b/pkg/services/frontend/request_config.go
@@ -88,7 +88,7 @@ func NewFSRequestConfig(ctx context.Context, cfg *setting.Cfg, license licensing
 
 	if fullFrontendSettingsEnabled {
 		reqCtx := contexthandler.FromContext(ctx)
-		fullFrontendSettings, err := frontendsettings.GetBaseFrontendSettings(reqCtx, cfg, license)
+		fullFrontendSettings, err := frontendsettings.GetBaseFrontendSettings(reqCtx, cfg, license, nil)
 
 		if err != nil {
 			return FSRequestConfig{}, err

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
@@ -24,7 +25,7 @@ import (
 // - Stores final configuration in context
 //
 // Otherwise, uses base configuration for all requests.
-func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, settingsService settingservice.Service) web.Middleware {
+func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, settingsService settingservice.Service, pluginsCDN *pluginscdn.Service) web.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx, span := tracing.Start(r.Context(), "frontend.RequestConfigMiddleware")
@@ -38,7 +39,7 @@ func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, sett
 
 			// Create base request config from global settings
 			// This is the default configuration that will be used for all requests
-			requestConfig, err := NewFSRequestConfig(ctx, cfg, license, fullFrontendSettingsEnabled)
+			requestConfig, err := NewFSRequestConfig(ctx, cfg, license, pluginsCDN, fullFrontendSettingsEnabled)
 
 			if err != nil {
 				logger.Error("failed to create request config", "err", err)

--- a/pkg/services/frontend/request_config_middleware_test.go
+++ b/pkg/services/frontend/request_config_middleware_test.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/plugins/config"
+	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -460,7 +462,11 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		cfg := setting.NewCfg()
 		cfg.AppURL = "https://grafana.example.com"
 
-		middleware := RequestConfigMiddleware(cfg, license, nil)
+		pluginsCDN := pluginscdn.ProvideService(&config.PluginManagementCfg{
+			PluginsCDNURLTemplate: "https://cdn.example.com",
+		})
+
+		middleware := RequestConfigMiddleware(cfg, license, nil, pluginsCDN)
 
 		var capturedConfig FSRequestConfig
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -483,6 +489,8 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		assert.Equal(t, "https://grafana.example.com", capturedConfig.FullFrontendSettings.AppUrl)
 		// Namespace is taken from the request baggage when the flag is enabled.
 		assert.Equal(t, "stacks-123", capturedConfig.FullFrontendSettings.Namespace)
+		// The plugins CDN base URL is sourced from the plugins CDN service.
+		assert.Equal(t, "https://cdn.example.com", capturedConfig.FullFrontendSettings.PluginsCDNBaseURL)
 	})
 }
 

--- a/pkg/services/frontend/request_config_middleware_test.go
+++ b/pkg/services/frontend/request_config_middleware_test.go
@@ -148,7 +148,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			AppURL:      "https://grafana.example.com",
 		}
 
-		middleware := RequestConfigMiddleware(cfg, license, nil)
+		middleware := RequestConfigMiddleware(cfg, license, nil, nil)
 
 		var capturedConfig FSRequestConfig
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -182,7 +182,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			AppURL:      "https://grafana.example.com",
 		}
 
-		middleware := RequestConfigMiddleware(cfg, license, nil)
+		middleware := RequestConfigMiddleware(cfg, license, nil, nil)
 
 		nextCalled := false
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -221,7 +221,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			AppURL:      "https://grafana.example.com",
 		}
 
-		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService)
+		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService, nil)
 
 		var capturedConfig FSRequestConfig
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -273,7 +273,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			AppURL:      "https://base.example.com",
 		}
 
-		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService)
+		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService, nil)
 
 		var capturedConfig FSRequestConfig
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -319,7 +319,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			AppURL:   "https://base.example.com",
 		}
 
-		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService)
+		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService, nil)
 
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -351,7 +351,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			AppURL:      "https://grafana.example.com",
 		}
 
-		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService)
+		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService, nil)
 
 		var capturedConfig FSRequestConfig
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -393,7 +393,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			AppURL:   "https://grafana.example.com",
 		}
 
-		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService)
+		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService, nil)
 
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -432,7 +432,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			AppURL:   "https://grafana.example.com",
 		}
 
-		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService)
+		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService, nil)
 
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/pkg/services/frontend/request_config_test.go
+++ b/pkg/services/frontend/request_config_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/plugins/config"
+	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/licensing"
@@ -204,11 +206,17 @@ func TestNewFSRequestConfig(t *testing.T) {
 		return cfg
 	}
 
+	newPluginsCDN := func() *pluginscdn.Service {
+		return pluginscdn.ProvideService(&config.PluginManagementCfg{
+			PluginsCDNURLTemplate: "https://cdn.example.com",
+		})
+	}
+
 	t.Run("does not build full frontend settings when flag disabled", func(t *testing.T) {
 		cfg := newCfg()
 		license := &licensing.OSSLicensingService{Cfg: cfg}
 
-		config, err := NewFSRequestConfig(context.Background(), cfg, license, false)
+		config, err := NewFSRequestConfig(context.Background(), cfg, license, newPluginsCDN(), false)
 		require.NoError(t, err)
 
 		assert.Nil(t, config.FullFrontendSettings)
@@ -227,10 +235,12 @@ func TestNewFSRequestConfig(t *testing.T) {
 		}
 		ctx := ctxkey.Set(context.Background(), reqCtx)
 
-		config, err := NewFSRequestConfig(ctx, cfg, license, true)
+		config, err := NewFSRequestConfig(ctx, cfg, license, newPluginsCDN(), true)
 		require.NoError(t, err)
 
 		require.NotNil(t, config.FullFrontendSettings)
 		assert.Equal(t, "https://grafana.example.com", config.FullFrontendSettings.AppUrl)
+		// The plugins CDN base URL is sourced from the plugins CDN service.
+		assert.Equal(t, "https://cdn.example.com", config.FullFrontendSettings.PluginsCDNBaseURL)
 	})
 }

--- a/pkg/services/frontend/settings_service.go
+++ b/pkg/services/frontend/settings_service.go
@@ -8,6 +8,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/rest"
 
+	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginconfig"
 	settingservice "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -85,4 +88,16 @@ func setupSettingsService(cfg *setting.Cfg, promRegister prometheus.Registerer) 
 	}
 
 	return settingsService, nil
+}
+
+// setupPluginsCDNService initializes the plugins CDN service from the global
+// configuration. The frontend service uses it to expose the plugins CDN base
+// URL in the frontend settings.
+func setupPluginsCDNService(cfg *setting.Cfg, features featuremgmt.FeatureToggles) (*pluginscdn.Service, error) {
+	pluginManagementCfg, err := pluginconfig.ProvidePluginManagementConfig(cfg, setting.ProvideProvider(cfg), features)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create plugin management config: %w", err)
+	}
+
+	return pluginscdn.ProvideService(pluginManagementCfg), nil
 }


### PR DESCRIPTION
This PR is one in a series make the frontend less dependent on the `/bootdata` API by sending the full frontendsettings object through frontend service. Part of https://github.com/grafana/grafana-frontend-platform/issues/166

---

Moves creating `frontendsettings.PluginsCDNBaseURL` into the `GetBaseFrontendSettings` so it can be called from both ST Grafana and MT frontend service.

This is a bit bigger as a separate `pluginscdn.Service` needs to be instantiated in the frontend service code and then plumbed through to where `GetBaseFrontendSettings` is called.