### PR TITLE
[release-13.0.3] Provisioning: Write `_folder.json` when moving dashboards into new folders

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -400,24 +400,12 @@ func (r *DualReadWriter) createOrUpdate(ctx context.Context, create bool, opts D
 		// Write the resource file together with any missing ancestor _folder.json
 		// files in a single commit using the staging mechanism. When the repository
 		// does not support staging (e.g. local repos), writes are applied directly.
-		writeFn := func(stagedRepo repository.Repository, _ bool) error {
-			rw, ok := stagedRepo.(repository.ReaderWriter)
-			if !ok {
-				return fmt.Errorf("repository does not support read/write operations")
-			}
-			if r.folderMetadataEnabled && !safepath.IsDir(opts.Path) {
-				if err := r.writeAncestorFolderMetadata(ctx, rw, opts.Path, opts.Ref, opts.Message); err != nil {
-					return err
-				}
-			}
-			return rw.Create(ctx, opts.Path, opts.Ref, data, opts.Message)
-		}
 		stageOptions := repository.StageOptions{
 			Ref:                   opts.Ref,
 			Mode:                  repository.StageModeCommitOnlyOnce,
 			CommitOnlyOnceMessage: opts.Message,
 		}
-		err = repository.WrapWithStageAndPushIfPossible(ctx, r.repo, stageOptions, writeFn)
+		err = repository.WrapWithStageAndPushIfPossible(ctx, r.repo, stageOptions, r.createResourceAndNewFolderMetadata(ctx, opts, data))
 	} else {
 		err = r.repo.Update(ctx, opts.Path, opts.Ref, data, opts.Message)
 	}
@@ -459,13 +447,54 @@ func (r *DualReadWriter) createOrUpdate(ctx context.Context, create bool, opts D
 	return parsed, nil
 }
 
-// writeAncestorFolderMetadata walks the ancestor directories of filePath and
-// writes a _folder.json with a stable UID for any folder that does not exist in
-// the repository yet. Folders that already exist (with or without metadata) are
-// left untouched — we never backfill metadata for pre-existing folders. Reads
-// and writes go through the provided ReaderWriter (the staged repo during a
-// staged write) so reads observe writes made earlier in the same stage.
-func (r *DualReadWriter) writeAncestorFolderMetadata(ctx context.Context, rw repository.ReaderWriter, filePath, ref, message string) error {
+func (r *DualReadWriter) createResourceAndNewFolderMetadata(ctx context.Context, opts DualWriteOptions, data []byte) func(stagedRepo repository.Repository, _ bool) error {
+	return func(stagedRepo repository.Repository, _ bool) error {
+		rw, ok := stagedRepo.(repository.ReaderWriter)
+		if !ok {
+			return fmt.Errorf("repository does not support read/write operations")
+		}
+		if r.folderMetadataEnabled && !safepath.IsDir(opts.Path) {
+			if err := r.writeNewFoldersMetadata(ctx, rw, opts.Path, opts.Ref, opts.Message); err != nil {
+				return err
+			}
+		}
+		return rw.Create(ctx, opts.Path, opts.Ref, data, opts.Message)
+	}
+}
+
+// moveResourceAndCreateNewFolderMetadata returns a staged write that moves a file to
+// opts.Path together with any missing ancestor _folder.json files, so a move
+// into a newly-created folder lands in a single commit. When new content is
+// provided the original is deleted and recreated at the destination; otherwise
+// a plain rename is performed.
+func (r *DualReadWriter) moveResourceAndCreateNewFolderMetadata(ctx context.Context, opts DualWriteOptions, data []byte) func(stagedRepo repository.Repository, _ bool) error {
+	return func(stagedRepo repository.Repository, _ bool) error {
+		rw, ok := stagedRepo.(repository.ReaderWriter)
+		if !ok {
+			return fmt.Errorf("repository does not support read/write operations")
+		}
+		if r.folderMetadataEnabled && !safepath.IsDir(opts.Path) {
+			if err := r.writeNewFoldersMetadata(ctx, rw, opts.Path, opts.Ref, opts.Message); err != nil {
+				return err
+			}
+		}
+		if len(opts.Data) > 0 {
+			if err := rw.Delete(ctx, opts.OriginalPath, opts.Ref, opts.Message); err != nil {
+				return fmt.Errorf("delete original file in repository: %w", err)
+			}
+			return rw.Create(ctx, opts.Path, opts.Ref, data, opts.Message)
+		}
+		return rw.Move(ctx, opts.OriginalPath, opts.Path, opts.Ref, opts.Message)
+	}
+}
+
+// writeNewFoldersMetadata walks the directories of filePath and writes a _folder.json
+// with a stable UID for any folder that does not exist in the repository yet.
+// Folders that already exist (with or without metadata) are left untouched —
+// we never backfill metadata for pre-existing folders. Reads and writes go
+// through the provided ReaderWriter (the staged repo during a staged write) so
+// reads observe writes made earlier in the same stage.
+func (r *DualReadWriter) writeNewFoldersMetadata(ctx context.Context, rw repository.ReaderWriter, filePath, ref, message string) error {
 	dir := safepath.Dir(filePath)
 	if dir == "" {
 		return nil
@@ -656,28 +685,29 @@ func (r *DualReadWriter) moveFile(ctx context.Context, opts DualWriteOptions) (*
 		return nil, fmt.Errorf("unable to use provisioning identity: %w", err)
 	}
 
-	// Perform the move operation in the repository
-	// If we have new content, we need to update the file content as part of the move
-	if len(opts.Data) > 0 {
-		// FIXME: I think we should MOVE + UPDATE instead of Delete / Create
-		// For moves with content updates, we need to delete the old file and create the new one
-		if err = r.repo.Delete(ctx, opts.OriginalPath, opts.Ref, opts.Message); err != nil {
-			return nil, fmt.Errorf("delete original file in repository: %w", err)
-		}
-		if err = r.repo.Create(ctx, opts.Path, opts.Ref, data, opts.Message); err != nil {
-			return nil, fmt.Errorf("create moved file with new content in repository: %w", err)
-		}
-	} else {
-		// For simple moves without content changes, use the move operation
-		if err = r.repo.Move(ctx, opts.OriginalPath, opts.Path, opts.Ref, opts.Message); err != nil {
-			return nil, fmt.Errorf("move file in repository: %w", err)
-		}
+	// Perform the move together with any missing ancestor _folder.json files in a
+	// single commit using the staging mechanism. When the repository does not
+	// support staging (e.g. local repos), writes are applied directly.
+	stageOptions := repository.StageOptions{
+		Ref:                   opts.Ref,
+		Mode:                  repository.StageModeCommitOnlyOnce,
+		CommitOnlyOnceMessage: opts.Message,
+	}
+	if err = repository.WrapWithStageAndPushIfPossible(ctx, r.repo, stageOptions, r.moveResourceAndCreateNewFolderMetadata(ctx, opts, data)); err != nil {
+		return nil, err
 	}
 
 	// Update the grafana database if this is the main branch
 	if r.shouldUpdateGrafanaDB(opts, newParsed) {
-		if _, err := r.folders.EnsureFolderPathExist(ctx, opts.Path, opts.Ref); err != nil {
+		parent, err := r.folders.EnsureFolderPathExist(ctx, opts.Path, opts.Ref)
+		if err != nil {
 			return nil, fmt.Errorf("ensure folder path exists: %w", err)
+		}
+
+		// In case the parent folder has a different ID than the one from the initially parsed resource,
+		// e.g. when the folder metadata has been generated as part of the move operation, we need to update it.
+		if newParsed.Meta.GetFolder() != parent {
+			newParsed.Meta.SetFolder(parent)
 		}
 
 		// Delete the old resource from grafana if name changed

--- a/pkg/registry/apis/provisioning/resources/dualwriter_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_test.go
@@ -1413,7 +1413,7 @@ func TestUpdateFolderMetadata(t *testing.T) {
 	}
 }
 
-func TestWriteAncestorFolderMetadata(t *testing.T) {
+func TestWriteNewFoldersMetadata(t *testing.T) {
 	t.Run("writes _folder.json with stable UID for new folder", func(t *testing.T) {
 		rw := repository.NewMockReaderWriter(t)
 		rw.On("Read", mock.Anything, "new-folder/", "test-ref").
@@ -1426,7 +1426,7 @@ func TestWriteAncestorFolderMetadata(t *testing.T) {
 
 		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
 		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
-		err := dw.writeAncestorFolderMetadata(context.Background(), rw, "new-folder/dashboard.json", "test-ref", "msg")
+		err := dw.writeNewFoldersMetadata(context.Background(), rw, "new-folder/dashboard.json", "test-ref", "msg")
 
 		require.NoError(t, err)
 		rw.AssertCalled(t, "Create", mock.Anything, "new-folder/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg")
@@ -1447,7 +1447,7 @@ func TestWriteAncestorFolderMetadata(t *testing.T) {
 
 		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
 		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
-		err := dw.writeAncestorFolderMetadata(context.Background(), rw, "existing-folder/dashboard.json", "test-ref", "msg")
+		err := dw.writeNewFoldersMetadata(context.Background(), rw, "existing-folder/dashboard.json", "test-ref", "msg")
 
 		require.NoError(t, err)
 		rw.AssertNotCalled(t, "Create", mock.Anything, "existing-folder/_folder.json", mock.Anything, mock.Anything, mock.Anything)
@@ -1466,7 +1466,7 @@ func TestWriteAncestorFolderMetadata(t *testing.T) {
 
 		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
 		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
-		err := dw.writeAncestorFolderMetadata(context.Background(), rw, "a/b/dashboard.json", "test-ref", "msg")
+		err := dw.writeNewFoldersMetadata(context.Background(), rw, "a/b/dashboard.json", "test-ref", "msg")
 
 		require.NoError(t, err)
 		rw.AssertCalled(t, "Create", mock.Anything, "a/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg")
@@ -1478,9 +1478,104 @@ func TestWriteAncestorFolderMetadata(t *testing.T) {
 
 		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
 		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
-		err := dw.writeAncestorFolderMetadata(context.Background(), rw, "dashboard.json", "test-ref", "msg")
+		err := dw.writeNewFoldersMetadata(context.Background(), rw, "dashboard.json", "test-ref", "msg")
 
 		require.NoError(t, err)
 		rw.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestMoveResourceAndCreateNewFolderMetadata(t *testing.T) {
+	data := []byte("saved-resource")
+
+	t.Run("content move into new folder writes _folder.json then deletes and recreates", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Read", mock.Anything, "new-folder/", "test-ref").
+			Return(nil, repository.ErrFileNotFound)
+		rw.On("Create", mock.Anything, "new-folder/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg").
+			Return(nil)
+		rw.On("Delete", mock.Anything, "old-folder/dashboard.json", "test-ref", "msg").Return(nil)
+		rw.On("Create", mock.Anything, "new-folder/dashboard.json", "test-ref", data, "msg").Return(nil)
+
+		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
+		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
+		opts := DualWriteOptions{
+			OriginalPath: "old-folder/dashboard.json",
+			Path:         "new-folder/dashboard.json",
+			Ref:          "test-ref",
+			Message:      "msg",
+			Data:         []byte("new content"),
+		}
+		err := dw.moveResourceAndCreateNewFolderMetadata(context.Background(), opts, data)(rw, false)
+
+		require.NoError(t, err)
+		rw.AssertCalled(t, "Create", mock.Anything, "new-folder/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg")
+		rw.AssertCalled(t, "Delete", mock.Anything, "old-folder/dashboard.json", "test-ref", "msg")
+		rw.AssertCalled(t, "Create", mock.Anything, "new-folder/dashboard.json", "test-ref", data, "msg")
+		rw.AssertNotCalled(t, "Move", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("rename move into new folder writes _folder.json then moves", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Read", mock.Anything, "new-folder/", "test-ref").
+			Return(nil, repository.ErrFileNotFound)
+		rw.On("Create", mock.Anything, "new-folder/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg").
+			Return(nil)
+		rw.On("Move", mock.Anything, "old-folder/dashboard.json", "new-folder/dashboard.json", "test-ref", "msg").Return(nil)
+
+		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
+		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
+		opts := DualWriteOptions{
+			OriginalPath: "old-folder/dashboard.json",
+			Path:         "new-folder/dashboard.json",
+			Ref:          "test-ref",
+			Message:      "msg",
+		}
+		err := dw.moveResourceAndCreateNewFolderMetadata(context.Background(), opts, data)(rw, false)
+
+		require.NoError(t, err)
+		rw.AssertCalled(t, "Create", mock.Anything, "new-folder/_folder.json", "test-ref", mock.AnythingOfType("[]uint8"), "msg")
+		rw.AssertCalled(t, "Move", mock.Anything, "old-folder/dashboard.json", "new-folder/dashboard.json", "test-ref", "msg")
+	})
+
+	t.Run("move into existing folder does not write _folder.json", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Read", mock.Anything, "existing-folder/", "test-ref").
+			Return(&repository.FileInfo{Path: "existing-folder/"}, nil)
+		rw.On("Move", mock.Anything, "old-folder/dashboard.json", "existing-folder/dashboard.json", "test-ref", "msg").Return(nil)
+
+		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind, WithFolderMetadataEnabled(true))
+		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: true}
+		opts := DualWriteOptions{
+			OriginalPath: "old-folder/dashboard.json",
+			Path:         "existing-folder/dashboard.json",
+			Ref:          "test-ref",
+			Message:      "msg",
+		}
+		err := dw.moveResourceAndCreateNewFolderMetadata(context.Background(), opts, data)(rw, false)
+
+		require.NoError(t, err)
+		rw.AssertNotCalled(t, "Create", mock.Anything, "existing-folder/_folder.json", mock.Anything, mock.Anything, mock.Anything)
+		rw.AssertCalled(t, "Move", mock.Anything, "old-folder/dashboard.json", "existing-folder/dashboard.json", "test-ref", "msg")
+	})
+
+	t.Run("flag disabled moves without writing _folder.json", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Move", mock.Anything, "old-folder/dashboard.json", "new-folder/dashboard.json", "test-ref", "msg").Return(nil)
+
+		fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind)
+		dw := &DualReadWriter{repo: rw, folders: fm, folderMetadataEnabled: false}
+		opts := DualWriteOptions{
+			OriginalPath: "old-folder/dashboard.json",
+			Path:         "new-folder/dashboard.json",
+			Ref:          "test-ref",
+			Message:      "msg",
+		}
+		err := dw.moveResourceAndCreateNewFolderMetadata(context.Background(), opts, data)(rw, false)
+
+		require.NoError(t, err)
+		rw.AssertNotCalled(t, "Read", mock.Anything, mock.Anything, mock.Anything)
+		rw.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		rw.AssertCalled(t, "Move", mock.Anything, "old-folder/dashboard.json", "new-folder/dashboard.json", "test-ref", "msg")
 	})
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/move_creation_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/move_creation_test.go
@@ -28,8 +28,8 @@ func TestIntegrationProvisioning_MoveFile_FolderMetadataFlag(t *testing.T) {
 	ctx := context.Background()
 
 	const repo = "folder-metadata-move-test-repo"
-	helper.CreateLocalRepo(t, common.TestRepo{
-		Name: repo, SyncTarget: "instance", Workflows: []string{"write"}, SkipResourceAssertions: true,
+	helper.CreateRepo(t, common.TestRepo{
+		Name: repo, Target: "instance", SkipResourceAssertions: true,
 	})
 
 	files := helper.NewFilesClient(repo)

--- a/pkg/tests/apis/provisioning/foldermetadata/move_creation_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/move_creation_test.go
@@ -1,0 +1,103 @@
+package foldermetadata
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// move posts a file move (POST with originalPath) to the files endpoint and asserts a 200.
+func move(t *testing.T, helper *common.ProvisioningTestHelper, repo, originalPath, targetPath string, body []byte) {
+	t.Helper()
+	resp := helper.PostFilesRequest(t, repo, common.FilesPostOptions{
+		TargetPath:   targetPath,
+		OriginalPath: originalPath,
+		Body:         string(body),
+	})
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "moving %q to %q should succeed", originalPath, targetPath)
+}
+
+func TestIntegrationProvisioning_MoveFile_FolderMetadataFlag(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	const repo = "folder-metadata-move-test-repo"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name: repo, SyncTarget: "instance", Workflows: []string{"write"}, SkipResourceAssertions: true,
+	})
+
+	files := helper.NewFilesClient(repo)
+
+	t.Run("content move into new folder writes _folder.json with matching UID", func(t *testing.T) {
+		resp := files.Post(t, "move-src-1.json", common.DashboardJSON("move-dash-1", "Move Dash 1", 1))
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating source dashboard should succeed")
+
+		move(t, helper, repo, "move-src-1.json", "move-dest-1/dashboard.json",
+			common.DashboardJSON("move-dash-1", "Move Dash 1 Updated", 2))
+
+		uid, title := files.RequireValidFolderMetadata(t, ctx, "move-dest-1/_folder.json")
+		require.Equal(t, "move-dest-1", title)
+
+		_, err := helper.Folders.Resource.Get(ctx, uid, metav1.GetOptions{})
+		require.NoError(t, err, "Grafana folder should exist with the UID from _folder.json")
+
+		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "move-src-1.json")
+		require.Error(t, err, "original file should no longer exist after the move")
+	})
+
+	t.Run("nested-dest move writes _folder.json for every ancestor with distinct UIDs", func(t *testing.T) {
+		resp := files.Post(t, "move-src-2.json", common.DashboardJSON("move-dash-2", "Move Dash 2", 1))
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating source dashboard should succeed")
+
+		move(t, helper, repo, "move-src-2.json", "anc-x/anc-y/dashboard.json",
+			common.DashboardJSON("move-dash-2", "Move Dash 2 Updated", 2))
+
+		parentUID, _ := files.RequireValidFolderMetadata(t, ctx, "anc-x/_folder.json")
+		childUID, childTitle := files.RequireValidFolderMetadata(t, ctx, "anc-x/anc-y/_folder.json")
+		require.Equal(t, "anc-y", childTitle)
+		require.NotEqual(t, parentUID, childUID, "each ancestor folder gets a distinct UID")
+
+		_, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		require.NoError(t, err, "parent Grafana folder should exist")
+		_, err = helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		require.NoError(t, err, "child Grafana folder should exist")
+	})
+
+	t.Run("move into existing managed folder does not change its _folder.json UID", func(t *testing.T) {
+		resp := files.Post(t, "existing-move-folder/", nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating destination folder should succeed")
+		existingUID := files.ReadFolderUID(t, ctx, "existing-move-folder/_folder.json")
+		require.NotEmpty(t, existingUID)
+
+		resp = files.Post(t, "move-src-3.json", common.DashboardJSON("move-dash-3", "Move Dash 3", 1))
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating source dashboard should succeed")
+
+		move(t, helper, repo, "move-src-3.json", "existing-move-folder/dashboard.json",
+			common.DashboardJSON("move-dash-3", "Move Dash 3 Updated", 2))
+
+		uidAfter := files.ReadFolderUID(t, ctx, "existing-move-folder/_folder.json")
+		require.Equal(t, existingUID, uidAfter, "moving into an existing folder must not change its UID")
+	})
+
+	t.Run("rename move (no body) into new folder writes _folder.json", func(t *testing.T) {
+		resp := files.Post(t, "move-src-4.json", common.DashboardJSON("move-dash-4", "Move Dash 4", 1))
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating source dashboard should succeed")
+
+		move(t, helper, repo, "move-src-4.json", "rename-dest/move-src-4.json", nil)
+
+		uid, title := files.RequireValidFolderMetadata(t, ctx, "rename-dest/_folder.json")
+		require.Equal(t, "rename-dest", title)
+
+		_, err := helper.Folders.Resource.Get(ctx, uid, metav1.GetOptions{})
+		require.NoError(t, err, "Grafana folder should exist with the UID from _folder.json")
+
+		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "move-src-4.json")
+		require.Error(t, err, "original file should no longer exist after the rename move")
+	})
+}


### PR DESCRIPTION
Backport a92403f4c3157b20cbf4609c3214428ddd56ceb8 from #126552

---

## Summary

When `provisioningFolderMetadata` is enabled, moving a dashboard into a folder that does not exist
yet (`POST /files/<new-folder>/dashboard.json?originalPath=<old>`) now writes `_folder.json` for
every new ancestor folder created along the destination path. Previously only creation
(`POST /files/new-folder/dashboard.json`, #126042) and the sync/export paths wrote folder metadata,
so a move into a new folder produced the same permanent UID mismatch #126042 fixed for creation.

### Problem

1. User moves a dashboard into `new-folder/` via the files API (POST with `originalPath`).
2. `moveFile` writes the dashboard at the new path and calls `EnsureFolderPathExist`, which creates
   the Grafana folder with a hash-derived UID (e.g. `abc123`) — no `_folder.json` written to git.
3. User later POSTs `new-folder/` (explicit folder creation).
4. `CreateFolder` finds no `_folder.json` → writes a new one with a fresh stable UID (`def456`) →
   creates a **second** Grafana folder.
5. The moved dashboard is orphaned in folder `abc123`; `_folder.json` says `def456` — permanent
   mismatch until a full re-sync.

### Solution

`moveFile` now writes a `_folder.json` (with a stable UID via `util.GenerateShortUID()`) for any
destination ancestor folder that does not exist yet, in the **same commit** as the move, reusing the
`writeNewFoldersMetadata` helper introduced for the creation path. It then reconciles the moved
dashboard's folder reference to the stable UID returned by `EnsureFolderPathExist`.

**Key design decisions:**
- **Atomic** — the move and all `_folder.json` files are written through
  `WrapWithStageAndPushIfPossible` so they land together (falls back to direct writes when the
  repository does not support staging).
- **Covers both move forms** — content move (`Delete` + `Create`) and plain rename (`Move`).
- **Only new folders** — `writeNewFoldersMetadata` skips folders that already exist (with or without
  metadata); pre-existing folders are never backfilled.
- **Stable UIDs** — `util.GenerateShortUID()`, same as `CreateFolder`, the creation path, and
  `fixfoldermetadata`.
- **UID reconciliation** — the destination is parsed before `_folder.json` exists, so it carries a
  hash UID; after the metadata is written `EnsureFolderPathExist` returns the stable UID and the
  resource's folder reference is updated to match (mirrors `createOrUpdate`).
- **`moveFile` only** — directory moves (`moveDirectory`) are unaffected; they carry their own
  `_folder.json` in the moved tree.
- **No interface changes.**

**Files changed:**
- `pkg/registry/apis/provisioning/resources/dualwriter.go` — `moveResourceAndCreateNewFolderMetadata`;
  `moveFile` writes ancestor metadata atomically and reconciles the folder UID.
- `pkg/registry/apis/provisioning/resources/dualwriter_test.go` — `TestMoveResourceAndNewFolderMetadata`.
- `pkg/tests/apis/provisioning/foldermetadata/move_creation_test.go` — integration tests.

## Test plan

- [x] **Unit** (`dualwriter_test.go`, `TestMoveResourceAndNewFolderMetadata`): content move into new
  folder writes `_folder.json` then `Delete`+`Create`; rename move writes `_folder.json` then `Move`;
  move into existing folder writes nothing; flag disabled writes nothing.
- [x] **Integration** (`move_creation_test.go`): content-move into a new folder writes `_folder.json`
  with matching UID; nested destination writes metadata for every ancestor; move into an existing
  managed folder leaves its UID unchanged; rename move into a new folder writes `_folder.json`.
- [x] `make gofmt` — clean
- [x] `make lint-go-diff` — 0 issues
- [x] Unit tests pass
