### PR TITLE
Dashboards: Add user tracking when changing variable value on mobile

### DIFF
--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -71,9 +71,6 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
   const { isSelected, isSelectable } = useElementSelection(variable.state.key);
   const isHidden = state.hide === VariableHide.hideVariable;
   const { markUserInitiated } = useTrackDashboardVariableValueChange(variable);
-  const trackUserInteraction = {
-    onPointerDown: markUserInitiated,
-  };
 
   const onClickEditVariable = useCallback(() => {
     const dashboard = sceneGraph.getAncestor(variable, DashboardScene);
@@ -114,7 +111,7 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
             isSelectable && !isSelected && 'dashboard-selectable-element'
           )}
           data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}
-          {...trackUserInteraction}
+          onPointerDown={markUserInitiated}
         >
           <div className={styles.switchControl}>
             <variable.Component model={variable} />
@@ -139,7 +136,7 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
             isSelectable && !isSelected && 'dashboard-selectable-element'
           )}
           data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}
-          {...trackUserInteraction}
+          onPointerDown={markUserInitiated}
         >
           <VariableLabel
             variable={variable}
@@ -161,7 +158,7 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
           isSelectable && !isSelected && 'dashboard-selectable-element'
         )}
         data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}
-        {...trackUserInteraction}
+        onPointerDown={markUserInitiated}
       >
         <VariableLabel variable={variable} className={cx(isSelectable && styles.labelSelectable, styles.label)} />
         <variable.Component model={variable} />

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -24,6 +24,7 @@ import { ControlActionsPopover, ControlEditActions } from './ControlActionsPopov
 import { DashboardScene } from './DashboardScene';
 import { AddVariableButton } from './VariableControlsAddButton';
 import { VariableDescriptionTooltip } from './VariableDescriptionTooltip';
+import { useTrackDashboardVariableValueChange } from './useTrackDashboardVariableValueChange';
 
 export function VariableControls({
   dashboard,
@@ -69,6 +70,10 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
   const state = useSceneObjectState<SceneVariableState>(variable, { shouldActivateOrKeepAlive: true });
   const { isSelected, isSelectable } = useElementSelection(variable.state.key);
   const isHidden = state.hide === VariableHide.hideVariable;
+  const { markUserInitiated } = useTrackDashboardVariableValueChange(variable);
+  const trackUserInteraction = {
+    onPointerDown: markUserInitiated,
+  };
 
   const onClickEditVariable = useCallback(() => {
     const dashboard = sceneGraph.getAncestor(variable, DashboardScene);
@@ -109,6 +114,7 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
             isSelectable && !isSelected && 'dashboard-selectable-element'
           )}
           data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}
+          {...trackUserInteraction}
         >
           <div className={styles.switchControl}>
             <variable.Component model={variable} />
@@ -133,6 +139,7 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
             isSelectable && !isSelected && 'dashboard-selectable-element'
           )}
           data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}
+          {...trackUserInteraction}
         >
           <VariableLabel
             variable={variable}
@@ -154,6 +161,7 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
           isSelectable && !isSelected && 'dashboard-selectable-element'
         )}
         data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}
+        {...trackUserInteraction}
       >
         <VariableLabel variable={variable} className={cx(isSelectable && styles.labelSelectable, styles.label)} />
         <variable.Component model={variable} />

--- a/public/app/features/dashboard-scene/scene/useTrackDashboardVariableValueChange.test.ts
+++ b/public/app/features/dashboard-scene/scene/useTrackDashboardVariableValueChange.test.ts
@@ -53,7 +53,7 @@ describe('useTrackDashboardVariableValueChange', () => {
     });
 
     expect(reportInteraction).toHaveBeenCalledWith('dashboards_variable_value_changed', {
-      type: 'custom', 
+      type: 'custom',
       isDynamicDashboard: true,
     });
   });

--- a/public/app/features/dashboard-scene/scene/useTrackDashboardVariableValueChange.test.ts
+++ b/public/app/features/dashboard-scene/scene/useTrackDashboardVariableValueChange.test.ts
@@ -1,0 +1,101 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { reportInteraction } from '@grafana/runtime';
+import { CustomVariable, SceneVariableSet } from '@grafana/scenes';
+
+import { useTrackDashboardVariableValueChange } from './useTrackDashboardVariableValueChange';
+
+jest.mock('@grafana/runtime', () => {
+  const runtime = jest.requireActual('@grafana/runtime');
+  return {
+    ...runtime,
+    config: {
+      ...runtime.config,
+      featureToggles: {
+        ...runtime.config.featureToggles,
+        dashboardNewLayouts: true,
+      },
+    },
+    reportInteraction: jest.fn(),
+  };
+});
+
+const mockUseMediaQueryMinWidth = jest.fn();
+
+jest.mock('app/core/hooks/useMediaQueryMinWidth', () => ({
+  useMediaQueryMinWidth: () => mockUseMediaQueryMinWidth(),
+}));
+
+describe('useTrackDashboardVariableValueChange', () => {
+  beforeEach(() => {
+    jest.mocked(reportInteraction).mockClear();
+    mockUseMediaQueryMinWidth.mockReturnValue(false);
+  });
+
+  it('should report interaction on mobile when user changes a variable', () => {
+    const variable = new CustomVariable({
+      name: 'query0',
+      query: 'A,B',
+      value: 'A',
+      text: 'A',
+    });
+    const variableSet = new SceneVariableSet({ variables: [variable] });
+    variableSet.activate();
+
+    const { result } = renderHook(() => useTrackDashboardVariableValueChange(variable));
+
+    act(() => {
+      result.current.markUserInitiated();
+    });
+
+    act(() => {
+      variable.changeValueTo('B', 'B', true);
+    });
+
+    expect(reportInteraction).toHaveBeenCalledWith('dashboards_variable_value_changed', {
+      type: 'custom', 
+      isDynamicDashboard: true,
+    });
+  });
+
+  it('should not report interaction on desktop', () => {
+    mockUseMediaQueryMinWidth.mockReturnValue(true);
+
+    const variable = new CustomVariable({
+      name: 'query0',
+      query: 'A,B',
+      value: 'A',
+      text: 'A',
+    });
+    const variableSet = new SceneVariableSet({ variables: [variable] });
+    variableSet.activate();
+
+    const { result } = renderHook(() => useTrackDashboardVariableValueChange(variable));
+
+    act(() => {
+      result.current.markUserInitiated();
+      variable.changeValueTo('B', 'B', true);
+    });
+
+    expect(reportInteraction).not.toHaveBeenCalled();
+  });
+
+  it('should not report interaction without user interaction', () => {
+    const variable = new CustomVariable({
+      name: 'query0',
+      query: 'A,B',
+      value: 'A',
+      text: 'A',
+    });
+    const variableSet = new SceneVariableSet({ variables: [variable] });
+    variableSet.activate();
+
+    renderHook(() => useTrackDashboardVariableValueChange(variable));
+
+    act(() => {
+      variable.changeValueTo('B', 'B', true);
+    });
+
+    expect(reportInteraction).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/dashboard-scene/scene/useTrackDashboardVariableValueChange.ts
+++ b/public/app/features/dashboard-scene/scene/useTrackDashboardVariableValueChange.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+
+import { SceneVariableValueChangedEvent, type SceneVariable } from '@grafana/scenes';
+import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
+
+import { DashboardInteractions } from '../utils/interactions';
+
+export function useTrackDashboardVariableValueChange(variable: SceneVariable) {
+  const userInitiatedRef = useRef(false);
+  const isMobile = !useMediaQueryMinWidth('sm');
+
+  useEffect(() => {
+    const subscription = variable.subscribeToEvent(SceneVariableValueChangedEvent, (event) => {
+      if (!isMobile || event.payload !== variable || !userInitiatedRef.current) {
+        return;
+      }
+
+      userInitiatedRef.current = false;
+
+      DashboardInteractions.variableValueChanged({
+        type: variable.state.type,
+      });
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [isMobile, variable]);
+
+  return {
+    markUserInitiated: () => {
+      if (!isMobile) {
+        return;
+      }
+      userInitiatedRef.current = true;
+    },
+  };
+}

--- a/public/app/features/dashboard-scene/scene/useTrackDashboardVariableValueChange.ts
+++ b/public/app/features/dashboard-scene/scene/useTrackDashboardVariableValueChange.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { SceneVariableValueChangedEvent, type SceneVariable } from '@grafana/scenes';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
@@ -28,11 +28,11 @@ export function useTrackDashboardVariableValueChange(variable: SceneVariable) {
   }, [isMobile, variable]);
 
   return {
-    markUserInitiated: () => {
+    markUserInitiated: useCallback(() => {
       if (!isMobile) {
         return;
       }
       userInitiatedRef.current = true;
-    },
+    }, [isMobile]),
   };
 }

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -136,6 +136,12 @@ export const DashboardInteractions = {
     reportDashboardInteraction('variables_reordered', properties);
   },
 
+  // dashboards_variable_value_changed
+  // when a user changes a variable value from dashboard controls, the controls menu, or a section
+  variableValueChanged: (properties: { type: string }) => {
+    reportDashboardInteraction('variable_value_changed', properties);
+  },
+
   // dashboards_add_annotation_button_clicked
   // when a user clicks on 'Add annotation'
   addAnnotationButtonClicked: (properties: { source: 'edit_pane' }) => {


### PR DESCRIPTION
Adding some tracking for variable change on mobile to see and confirm usage. Part of investigating https://github.com/grafana/grafana/issues/123618

I decided to not do this in scenes because it will be less complicated to remove when we're done with this. Added a cleanup task [here](https://github.com/grafana/grafana/issues/126680)