### PR TITLE
CloudWatch: Remove redundant code in log groups selector modal toggle

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -70,8 +70,8 @@ export const LogGroupsSelector = ({
 
   const toggleModal = () => {
     setIsModalOpen(!isModalOpen);
-    if (isModalOpen) {
-    } else {
+
+    if (!isModalOpen) {
       setSelectedLogGroups(selectedLogGroups);
       searchFn(searchPhrase, searchAccountId);
     }


### PR DESCRIPTION
**What is this feature?**

Removes a redundant empty branch and no-op state update from the CloudWatch log groups selector modal toggle logic.

The behavior stays the same: opening the modal still fetches log groups, and closing the modal doesn't trigger a fetch.

**Which issue(s) does this PR fix?**

N/A