### PR TITLE
CloudWatch: Reset log group selection on cancel

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -417,4 +417,19 @@ describe('LogGroupsSelector', () => {
       })
     );
   });
+
+  it('resets unapplied log group selections after canceling', async () => {
+    render(<LogGroupsSelector {...defaultProps} />);
+
+    await userEvent.click(screen.getByText('Select log groups'));
+    expect(screen.getByLabelText('logGroup2')).not.toBeChecked();
+
+    await userEvent.click(screen.getByLabelText('logGroup2'));
+    expect(screen.getByLabelText('logGroup2')).toBeChecked();
+
+    await userEvent.click(screen.getByText('Cancel'));
+
+    await userEvent.click(screen.getByText('Select log groups'));
+    expect(screen.getByLabelText('logGroup2')).not.toBeChecked();
+  });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -155,7 +155,7 @@ export const LogGroupsSelector = ({
   };
 
   const handleCancel = () => {
-    setSelectedLogGroups(selectedLogGroups);
+    setSelectedLogGroups(props.selectedLogGroups ?? []);
     toggleModal();
   };
 


### PR DESCRIPTION
**What is this fix?**

Resets unapplied log group selections when the CloudWatch log groups modal is canceled.

Before this change, a user could select a log group, click **Cancel**, and then reopen the modal with that unapplied selection still checked in the modal state. This change resets the local draft selection back to the applied `selectedLogGroups` prop when the user cancels.

**Why do we need this fix?**

Canceling the modal shouldn't preserve uncommitted selections. The modal should reflect the applied query state when it's reopened.

**Who is this fix for?**

Users who configure CloudWatch Logs queries with the log groups selector.

**Which issue(s) does this PR fix?**

N/A

**Tests**

I have added a regression test that selects a log group, cancels the modal, reopens it, and verifies the log group hasn't remained checked.

```sh
yarn jest public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx --runInBand
```