### PR TITLE
e2e: MT plugin panel & datasource loading and icons

### DIFF
--- a/e2e-playwright/test-plugins/grafana-test-datasource/tests/datasourceIcons.spec.ts
+++ b/e2e-playwright/test-plugins/grafana-test-datasource/tests/datasourceIcons.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+import { expectAllIconsLoaded } from './utils';
+
+test.describe('grafana-test-datasource', { tag: ['@plugins'] }, () => {
+  test('all datasource type icons load in the add-new-datasource list', async ({ page }) => {
+    await page.goto('/connections/datasources/new');
+
+    // Each datasource type renders as a DataSourceTypeCard (literal class `card-parent`) with
+    // its logo <img> inside.
+    const cards = page.locator('.card-parent').filter({ has: page.locator('img') });
+    await expect(cards.first()).toBeVisible();
+    await expectAllIconsLoaded(cards, 1);
+  });
+});

--- a/e2e-playwright/test-plugins/grafana-test-datasource/tests/useMTPlugins/datasourceIcons.spec.ts
+++ b/e2e-playwright/test-plugins/grafana-test-datasource/tests/useMTPlugins/datasourceIcons.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+import { expectAllIconsLoaded } from '../utils';
+
+// /connections/datasources/new (NewDataSource) loads from /api/plugins, which does NOT branch
+// on plugins.useMTPlugins (there is no getDatasourcePluginMetas() call in app.ts yet). So this
+// currently guards icon rendering on the classic path and becomes a true MT test once the
+// page is wired to the meta API.
+test.use({ openFeature: { flags: { 'plugins.useMTPlugins': true } } });
+
+test.describe('grafana-test-datasource', { tag: ['@plugins', '@plugins.useMTPlugins'] }, () => {
+  test('all datasource type icons load in the add-new-datasource list', async ({ page }) => {
+    await page.goto('/connections/datasources/new');
+
+    // Each datasource type renders as a DataSourceTypeCard (literal class `card-parent`) with
+    // its logo <img> inside.
+    const cards = page.locator('.card-parent').filter({ has: page.locator('img') });
+    await expect(cards.first()).toBeVisible();
+    await expectAllIconsLoaded(cards, 1);
+  });
+});

--- a/e2e-playwright/test-plugins/grafana-test-datasource/tests/utils.ts
+++ b/e2e-playwright/test-plugins/grafana-test-datasource/tests/utils.ts
@@ -1,0 +1,48 @@
+import { Locator } from '@playwright/test';
+
+import { expect } from '@grafana/plugin-e2e';
+
+type IconStatus = 'ok' | 'decode-failed' | 'zero-size';
+
+// Resolves once the <img> has settled. decode() rejects on a failed/404 load; the naturalWidth
+// check covers the rare "decoded but no pixels" case. Needed because the plugin logos are SVGs
+// with a viewBox but no intrinsic width/height. Awaiting decode() is the wait — no polling.
+async function iconStatus(img: Locator): Promise<IconStatus> {
+  return img.evaluate(async (el: HTMLImageElement): Promise<IconStatus> => {
+    try {
+      await el.decode();
+    } catch {
+      return 'decode-failed';
+    }
+    return el.naturalWidth > 0 ? 'ok' : 'zero-size';
+  });
+}
+
+// First line of the card's text — the plugin/datasource name — falling back to its index.
+async function cardLabel(card: Locator, index: number): Promise<string> {
+  const text = await card.innerText().catch(() => '');
+  return text.split('\n')[0].trim() || `card #${index}`;
+}
+
+// Asserts every card's <img> loaded. Checks all icons in a single pass and fails once with a
+// list of every broken icon (plugin name + reason + src) — no expect.poll retry spam, and you
+// see all failures rather than only the first. The non-empty guard stops a silently empty list
+// from passing as a no-op.
+export async function expectAllIconsLoaded(cards: Locator, min = 1): Promise<void> {
+  const count = await cards.count();
+  expect(count, `expected at least ${min} card(s) with an icon, found ${count}`).toBeGreaterThanOrEqual(min);
+
+  const failures: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const card = cards.nth(i);
+    const img = card.locator('img');
+    const label = await cardLabel(card, i);
+    const src = await img.getAttribute('src');
+    const status = await iconStatus(img);
+    if (status !== 'ok') {
+      failures.push(`- "${label}": ${status} (src="${src}")`);
+    }
+  }
+
+  expect(failures, `${failures.length} icon(s) failed to load:\n${failures.join('\n')}`).toEqual([]);
+}

--- a/e2e-playwright/test-plugins/grafana-test-panel/tests/panelIcons.spec.ts
+++ b/e2e-playwright/test-plugins/grafana-test-panel/tests/panelIcons.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+import { expectAllIconsLoaded } from './utils';
+
+// Literal of VisualizationSelectPaneTab[VisualizationSelectPaneTab.Visualizations]
+// (public/app/features/dashboard/components/PanelEditor/types.ts). Kept a literal to avoid
+// importing core across the isolated test-plugin tsconfig boundary.
+const ALL_VISUALIZATIONS_TAB = 'Visualizations';
+
+test.describe('grafana-test-panel', { tag: ['@plugins'] }, () => {
+  test('all panel type icons load in the visualization picker', async ({ gotoPanelEditPage, selectors }) => {
+    const panelEditPage = await gotoPanelEditPage({ dashboard: { uid: 'aBXrJ0R7z' }, id: '9' });
+
+    await panelEditPage.getByGrafanaSelector(selectors.components.PanelEditor.toggleVizPicker).click();
+    await panelEditPage.getByGrafanaSelector(selectors.components.Tab.title(ALL_VISUALIZATIONS_TAB)).click();
+
+    // Readiness signal: a core panel always present, so the async metas load has resolved.
+    await expect(
+      panelEditPage.getByGrafanaSelector(selectors.components.PluginVisualization.item('Text'))
+    ).toBeVisible();
+
+    // One card per panel type, with the <img> inside.
+    const cards = panelEditPage.getByGrafanaSelector(selectors.components.PluginVisualization.item(''), {
+      startsWith: true,
+    });
+    await expectAllIconsLoaded(cards, 5);
+  });
+});

--- a/e2e-playwright/test-plugins/grafana-test-panel/tests/panelLoading.spec.ts
+++ b/e2e-playwright/test-plugins/grafana-test-panel/tests/panelLoading.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+import { expectAllPanelsLoaded } from './utils';
+
+test.describe('grafana-test-panel', { tag: ['@plugins'] }, () => {
+  test('all panels load on the dashboard without errors', async ({ gotoDashboardPage, selectors }) => {
+    const dashboardPage = await gotoDashboardPage({ uid: 'n1jR8vnnz' });
+
+    // Every panel renders a "panel content" element — holding the viz, or an "Error loading:"
+    // alert if its plugin failed to load.
+    const panels = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content);
+    await expect(panels.first()).toBeVisible();
+    // This dashboard has a fixed set of 18 panels.
+    await expectAllPanelsLoaded(panels, 18);
+  });
+});

--- a/e2e-playwright/test-plugins/grafana-test-panel/tests/useMTPlugins/panelIcons.spec.ts
+++ b/e2e-playwright/test-plugins/grafana-test-panel/tests/useMTPlugins/panelIcons.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+import { expectAllIconsLoaded } from '../utils';
+
+// Literal of VisualizationSelectPaneTab[VisualizationSelectPaneTab.Visualizations]
+// (public/app/features/dashboard/components/PanelEditor/types.ts). Kept a literal to avoid
+// importing core across the isolated test-plugin tsconfig boundary.
+const ALL_VISUALIZATIONS_TAB = 'Visualizations';
+
+test.use({ openFeature: { flags: { 'plugins.useMTPlugins': true } } });
+
+test.describe('grafana-test-panel', { tag: ['@plugins', '@plugins.useMTPlugins'] }, () => {
+  test('all panel type icons load in the visualization picker', async ({ gotoPanelEditPage, selectors }) => {
+    const panelEditPage = await gotoPanelEditPage({ dashboard: { uid: 'aBXrJ0R7z' }, id: '9' });
+
+    await panelEditPage.getByGrafanaSelector(selectors.components.PanelEditor.toggleVizPicker).click();
+    await panelEditPage.getByGrafanaSelector(selectors.components.Tab.title(ALL_VISUALIZATIONS_TAB)).click();
+
+    // Readiness signal: a core panel always present, so the async metas load has resolved.
+    await expect(
+      panelEditPage.getByGrafanaSelector(selectors.components.PluginVisualization.item('Text'))
+    ).toBeVisible();
+
+    // One card per panel type, with the <img> inside.
+    const cards = panelEditPage.getByGrafanaSelector(selectors.components.PluginVisualization.item(''), {
+      startsWith: true,
+    });
+    await expectAllIconsLoaded(cards, 5);
+  });
+});

--- a/e2e-playwright/test-plugins/grafana-test-panel/tests/useMTPlugins/panelLoading.spec.ts
+++ b/e2e-playwright/test-plugins/grafana-test-panel/tests/useMTPlugins/panelLoading.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+import { expectAllPanelsLoaded } from '../utils';
+
+test.use({ openFeature: { flags: { 'plugins.useMTPlugins': true } } });
+
+test.describe('grafana-test-panel', { tag: ['@plugins', '@plugins.useMTPlugins'] }, () => {
+  test('all panels load on the dashboard without errors', async ({ gotoDashboardPage, selectors }) => {
+    const dashboardPage = await gotoDashboardPage({ uid: 'n1jR8vnnz' });
+
+    // Every panel renders a "panel content" element — holding the viz, or an "Error loading:"
+    // alert if its plugin failed to load.
+    const panels = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content);
+    await expect(panels.first()).toBeVisible();
+    // This dashboard has a fixed set of 18 panels.
+    await expectAllPanelsLoaded(panels, 18);
+  });
+});

--- a/e2e-playwright/test-plugins/grafana-test-panel/tests/utils.ts
+++ b/e2e-playwright/test-plugins/grafana-test-panel/tests/utils.ts
@@ -1,0 +1,91 @@
+import { Locator, Page } from '@playwright/test';
+
+import { expect } from '@grafana/plugin-e2e';
+
+type IconStatus = 'ok' | 'decode-failed' | 'zero-size';
+
+// Resolves once the <img> has settled. decode() rejects on a failed/404 load; the naturalWidth
+// check covers the rare "decoded but no pixels" case. Needed because the plugin logos are SVGs
+// with a viewBox but no intrinsic width/height.
+async function iconStatus(img: Locator): Promise<IconStatus> {
+  return img.evaluate(async (el: HTMLImageElement): Promise<IconStatus> => {
+    try {
+      await el.decode();
+    } catch {
+      return 'decode-failed';
+    }
+    return el.naturalWidth > 0 ? 'ok' : 'zero-size';
+  });
+}
+
+// First line of the card's text — the plugin/datasource name — falling back to its index.
+async function cardLabel(card: Locator, index: number): Promise<string> {
+  const text = await card.innerText().catch(() => '');
+  return text.split('\n')[0].trim() || `card #${index}`;
+}
+
+// Asserts every card's <img> loaded. Checks all icons in a single pass and fails once with a
+// list of every broken icon (plugin name + reason + src). The non-empty guard stops a silently empty list
+// from passing as a no-op.
+export async function expectAllIconsLoaded(cards: Locator, min = 1): Promise<void> {
+  const count = await cards.count();
+  expect(count, `expected at least ${min} card(s) with an icon, found ${count}`).toBeGreaterThanOrEqual(min);
+
+  const failures: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const card = cards.nth(i);
+    const img = card.locator('img');
+    const label = await cardLabel(card, i);
+    const src = await img.getAttribute('src');
+    const status = await iconStatus(img);
+    if (status !== 'ok') {
+      failures.push(`- "${label}": ${status} (src="${src}")`);
+    }
+  }
+
+  expect(failures, `${failures.length} icon(s) failed to load:\n${failures.join('\n')}`).toEqual([]);
+}
+
+// https://github.com/microsoft/playwright/issues/4302
+async function scrollToBottom(page: Page) {
+  await page.evaluate(async () => {
+    await new Promise((resolve) => {
+      let totalHeight = 0;
+      const distance = 100;
+
+      const scroll = () => {
+        const scrollHeight = document.body.scrollHeight;
+        window.scrollBy(0, distance);
+        totalHeight += distance;
+
+        if (totalHeight >= scrollHeight) {
+          clearInterval(timer);
+          observer.disconnect();
+          resolve('');
+        }
+      };
+
+      const timer = setInterval(scroll, 100);
+
+      const observer = new MutationObserver(() => {
+        totalHeight = 0;
+        scroll();
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+    });
+  });
+}
+
+// Asserts no panel rendered the "Error loading: <plugin>" alert (data-testid "Alert error"),
+// which is what shows when a panel plugin fails to load.
+export async function expectAllPanelsLoaded(panels: Locator, expected: number): Promise<void> {
+  const page = panels.page();
+
+  await scrollToBottom(page);
+
+  const errors = panels.getByTestId('data-testid Alert error');
+  const reasons = (await errors.allInnerTexts()).map((text) => `- ${text.split('\n')[0].trim() || 'Error loading'}`);
+
+  expect(reasons, `${reasons.length} panel(s) failed to load:\n${reasons.join('\n')}`).toEqual([]);
+}


### PR DESCRIPTION
**What is this feature?**

Adds e2e tests that verify plugin assets load correctly with and without the `plugins.useMTPlugins` flag: panel and datasource type icons (the visualization picker and the add-new-datasource list), and that every panel on a dashboard renders without an `Error loading` alert.

**Why do we need this feature?**

So we catch broken plugin icons or panels when plugin metadata is served through the MT plugins meta API.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #126659

**Special notes for your reviewer:**

1. command to run panel tests 
```bash 
yarn e2e:pw --project=grafana-e2etest-panel
```
2. command to run datasource tests
```bash 
yarn e2e:pw --project=grafana-e2etest-datasource
```
Each check has a flag-off baseline in `tests/` and a flag-on copy in `tests/useMTPlugins/`, mirroring `grafana-extensionstest-app`. Heads up: `/connections/datasources/new` isn't wired to the MT meta API yet, so the datasource spec guards the classic path for now and becomes a true MT test once it is.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
