### PR TITLE
TraceView: Add meticulous-ignore class to Start time value

### DIFF
--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -328,6 +328,7 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
               <span
                 className={cx(
                   styles.metadataValue,
+                  'meticulous-ignore',
                   css({
                     gap: theme.spacing(0.5),
                   })

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -326,9 +326,9 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
             <div className={styles.metadataItem}>
               <span className={styles.metadataLabel}>{t('explore.trace-page-header.start-time', 'Start time')}</span>
               <span
+                data-meticulous-ignore
                 className={cx(
                   styles.metadataValue,
-                  'meticulous-ignore',
                   css({
                     gap: theme.spacing(0.5),
                   })


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The trace Start time is derived locally (earliest span start time) and formatted with the current timezone and a relative "time ago" string, so its rendered text changes between Meticulous test runs. Mark the value span with the meticulous-ignore class so Meticulous excludes this non-deterministic content from visual snapshot comparisons.

Adding this class will resolve issues like these ([meticulous link](https://app.meticulous.ai/projects/grafana/grafana/test-runs/khQGgkKDngCgdh7WBNdtLH7zKC?diff=diff-f2442cd0d4f8cb62f-before&modal-tab=replay-after#diff-f2442cd0d4f8cb62f-before-html)):

<img width="2552" height="1274" alt="meticulous ai_grafana_grafana_UaenxHyY" src="https://github.com/user-attachments/assets/e51fff1a-a7b6-4e57-83ea-066a5bb07341" />


**Who is this feature for?**

This is part of setting up the [Meticulous](https://meticulous.ai) pilot with Grafana. The main internal grafana PoC here is @fastfrwrd .


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
