### PR TITLE
RBAC: Feat: include provisioning.grafana.app:* to the serviceIdentityTokenP…

### DIFF
--- a/pkg/apimachinery/identity/context.go
+++ b/pkg/apimachinery/identity/context.go
@@ -192,10 +192,7 @@ var serviceIdentityTokenPermissions = []string{
 	"query.grafana.app:*",
 	"datasource.grafana.app:*",
 	"iam.grafana.app:*",
-	"provisioning.grafana.app/repositories:read",
-	"provisioning.grafana.app/repositories:watch",
-	"provisioning.grafana.app/settings:read",
-	"provisioning.grafana.app/settings:watch",
+	"provisioning.grafana.app:*",
 	"preferences.grafana.app:*", // user, team, and org preferences
 	"collections.grafana.app:*", // user stars
 	"plugins.grafana.app:*",

--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -382,11 +382,16 @@ func (c *jobsConnector) authorizeResourceRefs(ctx context.Context, authorizer re
 
 // authorizeAdminJob checks that the requesting user has admin privileges.
 // Used for job types that are restricted to administrators.
+//
+// We check repositories:write (an admin-only RBAC action) rather than
+// jobs:create, because jobs:create is granted to Editor and would let editors
+// trigger admin-restricted jobs (pull, releaseResources, deleteResources).
+// The fallback role still allows admins whose RBAC isn't explicitly set up.
 func (c *jobsConnector) authorizeAdminJob(ctx context.Context, cfg *provisioning.Repository) error {
 	return c.access.WithFallbackRole(identity.RoleAdmin).Check(ctx, authlib.CheckRequest{
-		Verb:      "create",
+		Verb:      utils.VerbUpdate,
 		Group:     provisioning.GROUP,
-		Resource:  provisioning.JobResourceInfo.GetName(),
+		Resource:  provisioning.RepositoryResourceInfo.GetName(),
 		Namespace: cfg.Namespace,
 	}, "")
 }

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -978,9 +978,9 @@ func TestAuthorizeAdminJob(t *testing.T) {
 	t.Run("admin is authorized", func(t *testing.T) {
 		adminChecker := auth.NewMockAccessChecker(t)
 		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
-			return req.Verb == "create" &&
+			return req.Verb == utils.VerbUpdate &&
 				req.Group == provisioning.GROUP &&
-				req.Resource == provisioning.JobResourceInfo.GetName() &&
+				req.Resource == provisioning.RepositoryResourceInfo.GetName() &&
 				req.Namespace == cfg.Namespace
 		}), "").Return(nil)
 
@@ -995,9 +995,9 @@ func TestAuthorizeAdminJob(t *testing.T) {
 	t.Run("non-admin is forbidden", func(t *testing.T) {
 		adminChecker := auth.NewMockAccessChecker(t)
 		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
-			return req.Verb == "create" &&
+			return req.Verb == utils.VerbUpdate &&
 				req.Group == provisioning.GROUP &&
-				req.Resource == provisioning.JobResourceInfo.GetName()
+				req.Resource == provisioning.RepositoryResourceInfo.GetName()
 		}), "").Return(apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("admin role is required")))
 
 		accessMock := auth.NewMockAccessChecker(t)

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -543,20 +543,28 @@ func (b *APIBuilder) authorizeRepositorySubresource(ctx context.Context, a autho
 	case "files":
 		return authorizer.DecisionAllow, "", nil
 
-	// refs subresource - editors need to see branches to push changes
+	// refs subresource - editors need to see branches to push changes.
+	// We check repositories:write (an admin-only RBAC action) rather than
+	// repositories:read, because repositories:read is granted to Viewer and
+	// would let viewers read branches too. Editors pass through the Editor
+	// fallback role; admins satisfy either check.
 	case "refs":
 		return toAuthorizerDecision(b.accessWithEditor.Check(ctx, authlib.CheckRequest{
-			Verb:      apiutils.VerbGet,
+			Verb:      apiutils.VerbUpdate,
 			Group:     provisioning.GROUP,
 			Resource:  provisioning.RepositoryResourceInfo.GetName(),
 			Name:      a.GetName(),
 			Namespace: a.GetNamespace(),
 		}, ""))
 
-	// Read-only subresources: resources, history, status (admin only)
+	// Read-only subresources: resources, history, status (admin only).
+	// We check repositories:write (an admin-only RBAC action) rather than
+	// repositories:read, because repositories:read is granted to Viewer and
+	// would let viewers/editors read these admin-only views. The fallback role
+	// still allows admins whose RBAC isn't explicitly set up.
 	case "resources", "history", "status":
 		return toAuthorizerDecision(b.accessWithAdmin.Check(ctx, authlib.CheckRequest{
-			Verb:      apiutils.VerbGet,
+			Verb:      apiutils.VerbUpdate,
 			Group:     provisioning.GROUP,
 			Resource:  provisioning.RepositoryResourceInfo.GetName(),
 			Name:      a.GetName(),

--- a/pkg/services/authz/rbac/service_identity_permissions_test.go
+++ b/pkg/services/authz/rbac/service_identity_permissions_test.go
@@ -1,0 +1,99 @@
+package rbac
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	authnlib "github.com/grafana/authlib/authn"
+	authzlib "github.com/grafana/authlib/authz"
+	"github.com/grafana/authlib/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+)
+
+// TestServiceIdentityTokenPermissionsCoverMapper ensures that every (group, resource, verb)
+// combination defined in the rbac mapper is also covered by the service identity's
+// delegated permissions in pkg/apimachinery/identity/context.go.
+//
+// Why this matters: authlib.CheckServicePermissions runs *before* the user permission
+// check on every authz call. For any caller that isn't a TypeAccessPolicy (i.e. real
+// users and service accounts going through Grafana's normal auth flow), it evaluates the
+// caller's DelegatedPermissions — which AccessClaimsHook hard-codes to
+// identity.ServiceIdentityClaims.Rest.DelegatedPermissions whenever there's no upstream
+// access token. If the service identity token doesn't cover an action the validator (or
+// any other authzlib client) asks for, the request is denied before the user's RBAC
+// permissions are even consulted.
+func TestServiceIdentityTokenPermissionsCoverMapper(t *testing.T) {
+	// Simulate the post-AccessClaimsHook state for a normal user/SA: identity is not
+	// TypeAccessPolicy, so CheckServicePermissions reads DelegatedPermissions.
+	caller := &identity.StaticRequester{
+		Type: types.TypeUser,
+		AccessTokenClaims: &authnlib.Claims[authnlib.AccessTokenClaims]{
+			Rest: authnlib.AccessTokenClaims{
+				DelegatedPermissions: identity.ServiceIdentityClaims.Rest.DelegatedPermissions,
+			},
+		},
+	}
+
+	// Sanity-check the test setup: a non-TypeAccessPolicy caller should be evaluated
+	// against DelegatedPermissions, and the token must be non-empty.
+	probe := authzlib.CheckServicePermissions(caller, "dashboard.grafana.app", "dashboards", utils.VerbGet)
+	assert.False(t, probe.ServiceCall, "test caller must not be a service call so DelegatedPermissions are evaluated")
+	assert.NotEmpty(t, probe.Permissions, "service identity delegated permissions must be populated")
+
+	registry, ok := NewMapperRegistry().(mapper)
+	if !ok {
+		t.Fatal("NewMapperRegistry did not return the expected mapper type")
+	}
+
+	// Dedupe (group, apiResource, verb) triples: aliased mappings (e.g. iam.grafana.app
+	// has both "globalroles" and "roles" pointing at apiResource="roles") would
+	// otherwise produce duplicate subtests with the same assertion.
+	type triple struct{ group, resource, verb string }
+	checks := map[triple]struct{}{}
+
+	for group, resources := range registry {
+		// Wildcard groups (e.g. "*.datasource.grafana.app") are matched against
+		// concrete groups at request time. The RolePermissionValidator explicitly
+		// falls back to the legacy permission path for datasources, so the service
+		// identity token is never consulted for these. They're covered separately
+		// in the mapper's own wildcard tests.
+		if strings.HasPrefix(group, "*.") {
+			continue
+		}
+
+		for _, tr := range resources {
+			// Use the API resource name (what the validator passes to authzlib),
+			// not the internal RBAC resource name — e.g. provisioning.grafana.app
+			// uses "jobs", not "provisioning.jobs".
+			apiResource, ok := registry.GetAPIResourceName(group, tr.Resource())
+			if !ok {
+				continue
+			}
+			for verb := range tr.verbMapping {
+				checks[triple{group, apiResource, verb}] = struct{}{}
+			}
+		}
+	}
+
+	// Sanity: the mapper should contribute a non-trivial number of triples; if it
+	// drops to zero the iteration above is broken and the rest of the test would
+	// silently pass.
+	assert.GreaterOrEqual(t, len(checks), 50, "expected the mapper to yield many (group,resource,verb) triples")
+
+	for c := range checks {
+		t.Run(fmt.Sprintf("%s/%s:%s", c.group, c.resource, c.verb), func(t *testing.T) {
+			res := authzlib.CheckServicePermissions(caller, c.group, c.resource, c.verb)
+			assert.True(t, res.Allowed,
+				"service identity must allow group=%q resource=%q verb=%q; "+
+					"add %q (or a covering wildcard) to serviceIdentityTokenPermissions in "+
+					"pkg/apimachinery/identity/context.go",
+				c.group, c.resource, c.verb,
+				fmt.Sprintf("%s/%s:*", c.group, c.resource),
+			)
+		})
+	}
+}


### PR DESCRIPTION
inspired by https://github.com/grafana/grafana/pull/124578

In the [slack](https://raintank-corp.slack.com/archives/C05JDQ100NS/p1778068540153889) thread the issues has been brought up. This PR solves the issue 2:
authlib's matcher ([hasPermissionInToken](https://github.com/grafana/authlib/blob/1492b99410603ca15730a1805a9220ce48232bc3/authz/client.go#L138)):
this new entry provisioning.grafana.app:* splits into group provisioning.grafana.app + verb *.
pVerb == "*" matches any verb, including deletecollection.
A group-only permission (no /resource) matches all resources, including jobs.


**Why do we need this feature?**

authlib.CheckServicePermissions runs before the user/RBAC check on every authz call. For normal users and service accounts (non-TypeAccessPolicy callers), it evaluates the service identity's delegated permissions, which are hard-coded to serviceIdentityTokenPermissions. The provisioning subsystem performs internal service-to-service operations (creating/updating jobs, managing connections, recording historic jobs, reading stats, etc.) under this identity. Because the previous allow-list only covered repositories and settings reads, those operations were denied before the user's actual permissions were ever consulted, breaking provisioning flows that rely on delegated/service-identity authorization. The new test prevents this class of bug from recurring whenever the mapper gains a new resource/verb.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
