### PR TITLE
Provisioning: Fix PR links when folder is renamed via UI

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -315,6 +315,12 @@ func (r *DualReadWriter) UpdateFolderMetadata(ctx context.Context, opts DualWrit
 		},
 	}
 
+	urls, err := getFolderURLs(ctx, opts.Path, opts.Ref, r.repo)
+	if err != nil {
+		return nil, err
+	}
+	wrap.URLs = urls
+
 	if r.shouldUpdateGrafanaDB(opts, nil) {
 		if _, err := r.folders.EnsureFolderPathExist(ctx, opts.Path, opts.Ref); err != nil {
 			return nil, fmt.Errorf("ensure folder path exists: %w", err)

--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -315,7 +315,9 @@ func (r *DualReadWriter) UpdateFolderMetadata(ctx context.Context, opts DualWrit
 		},
 	}
 
-	urls, err := getFolderURLs(ctx, opts.Path, opts.Ref, r.repo)
+	// URLs must point at the updated _folder.json file, not the directory, so the
+	// "view file" link resolves to the actual changed resource on the remote.
+	urls, err := getFolderURLs(ctx, safepath.Join(opts.Path, folderMetadataFileName), opts.Ref, r.repo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apis/provisioning/resources/dualwriter_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_test.go
@@ -1388,6 +1388,96 @@ func TestUpdateFolderMetadata(t *testing.T) {
 				assert.Nil(t, result.Resource.Upsert.Object, "Upsert should be nil when sync is disabled")
 			},
 		},
+		{
+			name: "repo with URL support: URLs field is populated",
+			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
+				config := &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "default"},
+					Spec: provisioning.RepositorySpec{
+						Type:      provisioning.GitRepositoryType,
+						Workflows: []provisioning.Workflow{provisioning.WriteWorkflow, provisioning.BranchWorkflow},
+						Git:       &provisioning.GitRepositoryConfig{Branch: "main"},
+						Sync:      provisioning.SyncOptions{Enabled: false},
+					},
+				}
+				rw := repository.NewMockReaderWriter(t)
+				rw.On("Config").Return(config)
+				existingData := makeExistingData(t)
+				rw.On("Read", mock.Anything, "myfolder/_folder.json", "feature").
+					Return(&repository.FileInfo{Data: existingData, Hash: "old-hash"}, nil).Once()
+				rw.On("Update", mock.Anything, "myfolder/_folder.json", "feature", mock.Anything, "update title").Return(nil)
+				rw.On("Read", mock.Anything, "myfolder/_folder.json", "feature").
+					Return(&repository.FileInfo{Data: []byte("{}"), Hash: "branch-hash"}, nil).Once()
+
+				urlRepo := &mockReaderWriterWithURLs{
+					MockReaderWriter: rw,
+					resourceURLsFn: func(_ context.Context, file *repository.FileInfo) (*provisioning.RepositoryURLs, error) {
+						return &provisioning.RepositoryURLs{
+							SourceURL:         "https://github.com/org/repo/blob/feature/myfolder/_folder.json",
+							NewPullRequestURL: "https://github.com/org/repo/compare/main...feature",
+						}, nil
+					},
+				}
+
+				accessMock := auth.NewMockAccessChecker(t)
+				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				dw := &DualReadWriter{
+					repo:                  urlRepo,
+					authorizer:            NewAuthorizer(config, urlRepo, accessMock, authTestClients(t), false),
+					folderMetadataEnabled: true,
+				}
+				return dw, DualWriteOptions{
+					Path:    "myfolder/",
+					Ref:     "feature",
+					Message: "update title",
+					Data:    makeSubmitBody(t, existingUID, "New Title"),
+				}
+			},
+			check: func(t *testing.T, result *provisioning.ResourceWrapper) {
+				require.NotNil(t, result.URLs, "URLs should be populated for repos with URL support")
+				assert.Equal(t, "https://github.com/org/repo/blob/feature/myfolder/_folder.json", result.URLs.SourceURL)
+				assert.Equal(t, "https://github.com/org/repo/compare/main...feature", result.URLs.NewPullRequestURL)
+			},
+		},
+		{
+			name: "repo without URL support: URLs field is nil",
+			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
+				config := &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "default"},
+					Spec: provisioning.RepositorySpec{
+						Type:      provisioning.GitRepositoryType,
+						Workflows: []provisioning.Workflow{provisioning.WriteWorkflow, provisioning.BranchWorkflow},
+						Git:       &provisioning.GitRepositoryConfig{Branch: "main"},
+						Sync:      provisioning.SyncOptions{Enabled: false},
+					},
+				}
+				rw := repository.NewMockReaderWriter(t)
+				rw.On("Config").Return(config)
+				existingData := makeExistingData(t)
+				rw.On("Read", mock.Anything, "myfolder/_folder.json", "feature").
+					Return(&repository.FileInfo{Data: existingData, Hash: "old-hash"}, nil).Once()
+				rw.On("Update", mock.Anything, "myfolder/_folder.json", "feature", mock.Anything, "update title").Return(nil)
+				rw.On("Read", mock.Anything, "myfolder/_folder.json", "feature").
+					Return(&repository.FileInfo{Data: []byte("{}"), Hash: "branch-hash"}, nil).Once()
+
+				accessMock := auth.NewMockAccessChecker(t)
+				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				dw := &DualReadWriter{
+					repo:                  rw,
+					authorizer:            NewAuthorizer(config, rw, accessMock, authTestClients(t), false),
+					folderMetadataEnabled: true,
+				}
+				return dw, DualWriteOptions{
+					Path:    "myfolder/",
+					Ref:     "feature",
+					Message: "update title",
+					Data:    makeSubmitBody(t, existingUID, "New Title"),
+				}
+			},
+			check: func(t *testing.T, result *provisioning.ResourceWrapper) {
+				assert.Nil(t, result.URLs, "URLs should be nil for repos without URL support")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/registry/apis/provisioning/resources/dualwriter_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_test.go
@@ -1412,6 +1412,8 @@ func TestUpdateFolderMetadata(t *testing.T) {
 				urlRepo := &mockReaderWriterWithURLs{
 					MockReaderWriter: rw,
 					resourceURLsFn: func(_ context.Context, file *repository.FileInfo) (*provisioning.RepositoryURLs, error) {
+						// URLs must resolve to the updated _folder.json file, not the directory.
+						assert.Equal(t, "myfolder/_folder.json", file.Path)
 						return &provisioning.RepositoryURLs{
 							SourceURL:         "https://github.com/org/repo/blob/feature/myfolder/_folder.json",
 							NewPullRequestURL: "https://github.com/org/repo/compare/main...feature",


### PR DESCRIPTION
## What is this feature?

`DualReadWriter.UpdateFolderMetadata` builds a `ResourceWrapper` response but never populates its `URLs` field. This change sets `wrap.URLs` via the existing `getFolderURLs` helper, mirroring the established `CreateFolder` pattern.

## Why do we need this feature?

When a client PUTs a folder-metadata update against a Git/GitHub repo on a branch, the response was missing the typed links (`sourceURL`, `compareURL`, `newPullRequestURL`) that the client uses to surface "view file" / "open PR" actions. `UpdateFolderMetadata` was the only `ResourceWrapper`-returning method missing this; `CreateFolder` and `moveDirectory` already populate URLs.

## Changes

- `dualwriter.go` — `UpdateFolderMetadata` now calls `getFolderURLs(ctx, opts.Path, opts.Ref, r.repo)` and assigns the result to `wrap.URLs`. No type/API changes.
- `dualwriter_test.go` — two new `TestUpdateFolderMetadata` cases: URLs populated for repos implementing `RepositoryWithURLs`, URLs nil otherwise.

URLs are populated only when the repo implements `RepositoryWithURLs` (e.g. GitHub) and `ref != ""`, consistent with `CreateFolder`.