### PR TITLE
Community Notifications: Onboard sharing squad

### DIFF
--- a/.github/team-notifications-config.json
+++ b/.github/team-notifications-config.json
@@ -8,7 +8,9 @@
       "codeowners_teams": [
         "@grafana/dataviz-squad"
       ],
-      "area_labels": ["area/dataviz"],
+      "area_labels": [
+        "area/dataviz"
+      ],
       "enabled": {
         "pr_notify": true,
         "pr_weekly": true,
@@ -23,7 +25,9 @@
       "codeowners_teams": [
         "@grafana/dashboards-squad"
       ],
-      "area_labels": ["area/dashboard"],
+      "area_labels": [
+        "area/dashboard"
+      ],
       "enabled": {
         "pr_notify": false,
         "pr_weekly": true,
@@ -38,7 +42,10 @@
       "codeowners_teams": [
         "@grafana/grafana-frontend-platform"
       ],
-      "area_labels": ["area/internationalization", "area/panel/text"],
+      "area_labels": [
+        "area/internationalization",
+        "area/panel/text"
+      ],
       "enabled": {
         "pr_notify": true,
         "pr_weekly": true,
@@ -53,7 +60,12 @@
       "codeowners_teams": [
         "@grafana/grafana-frontend-navigation"
       ],
-      "area_labels": ["area/navigation", "area/search", "area/frontend/login", "area/panel/dashboard-list"],
+      "area_labels": [
+        "area/navigation",
+        "area/search",
+        "area/frontend/login",
+        "area/panel/dashboard-list"
+      ],
       "enabled": {
         "pr_notify": true,
         "pr_weekly": true,
@@ -68,7 +80,36 @@
       "codeowners_teams": [
         "@grafana/datapro"
       ],
-      "area_labels": ["area/explore", "area/transformations", "area/correlations", "area/expressions"],
+      "area_labels": [
+        "area/explore",
+        "area/transformations",
+        "area/correlations",
+        "area/expressions"
+      ],
+      "enabled": {
+        "pr_notify": true,
+        "pr_weekly": true,
+        "fr_notify": true,
+        "fr_weekly": true
+      }
+    },
+    {
+      "name": "sharing",
+      "kickoff_date": "2026-06-17",
+      "adoption_date": "2025-06-17",
+      "codeowners_teams": [
+        "@grafana/sharing-squad"
+      ],
+      "area_labels": [
+        "area/dashboard/snapshot",
+        "area/dashboard/templating",
+        "area/frontend/library-panels",
+        "area/library-panel",
+        "area/playlist",
+        "area/saved-queries",
+        "area/suggestions",
+        "team/grafana-sharing"
+      ],
       "enabled": {
         "pr_notify": true,
         "pr_weekly": true,

--- a/.github/team-notifications-config.json
+++ b/.github/team-notifications-config.json
@@ -102,12 +102,10 @@
       ],
       "area_labels": [
         "area/dashboard/snapshot",
-        "area/dashboard/templating",
         "area/frontend/library-panels",
         "area/library-panel",
         "area/playlist",
         "area/saved-queries",
-        "area/suggestions",
         "team/grafana-sharing"
       ],
       "enabled": {


### PR DESCRIPTION
Summary
Onboards the Sharing team (@grafana/sharing-squad) to the community notifications system. All four notification types are enabled (PR real-time + weekly digest, FR real-time + weekly digest).

Follow-up
After merge, a vault admin needs to add the sharing team entry to the slack-channels / map secret so notifications can be routed to the team channel. The channel ID will be shared in #proj-community-contributions.