### PR TITLE
Download logs: improved meta handling in txt and added trailing space in csv

### DIFF
--- a/public/app/features/inspector/utils/download.test.ts
+++ b/public/app/features/inspector/utils/download.test.ts
@@ -77,7 +77,7 @@ describe('inspector download', () => {
       const blob = call[0];
       const text = typeof blob === 'string' ? blob : await blob.text();
 
-      expect(text).toEqual('"time","name","value"\r\n100,Åäö中文العربية,1\r\n')
+      expect(text).toEqual('"time","name","value"\r\n100,Åäö中文العربية,1\r\n');
     });
   });
 

--- a/public/app/features/inspector/utils/download.test.ts
+++ b/public/app/features/inspector/utils/download.test.ts
@@ -69,6 +69,16 @@ describe('inspector download', () => {
       expect(filename).toEqual(`test-data-${dateTimeFormat(1400000000000)}.csv`);
       expect.assertions(4);
     });
+
+    it('end with a new line if asked', async () => {
+      downloadDataFrameAsCsv(dataFrameFromJSON(json), 'test', undefined, undefined, false, true);
+
+      const call = jest.mocked(saveAs).mock.calls[0];
+      const blob = call[0];
+      const text = typeof blob === 'string' ? blob : await blob.text();
+
+      expect(text).toEqual('"time","name","value"\r\n100,Åäö中文العربية,1\r\n')
+    });
   });
 
   describe('downloadAsJson', () => {
@@ -90,7 +100,7 @@ describe('inspector download', () => {
 
   describe('downloadLogsModelAsTxt', () => {
     it.each([
-      [{ meta: [], rows: [] }, 'test', '\n\n'],
+      [{ meta: [], rows: [] }, 'test', ''],
       [
         { meta: [{ label: 'testLabel', value: 'testValue', kind: LogsMetaKind.String }], rows: [] },
         'test',
@@ -124,7 +134,7 @@ describe('inspector download', () => {
       const call = jest.mocked(saveAs).mock.calls[0];
       const blob = call[0];
       const filename = call[1];
-      const text = typeof blob === 'string' ? blob : await blob.text();
+      const text = typeof blob === 'string' ? blob : blob.size === 0 ? '' : await blob.text();
 
       expect(text).toEqual(expected);
       expect(filename).toEqual(`${title}-logs-${dateTimeFormat(1400000000000)}.txt`);

--- a/public/app/features/inspector/utils/download.ts
+++ b/public/app/features/inspector/utils/download.ts
@@ -25,11 +25,13 @@ import { transformToZipkin } from './transformToZipkin';
 export function downloadLogsModelAsTxt(logsModel: Pick<LogsModel, 'meta' | 'rows'>, title = '', fields: string[] = []) {
   let textToDownload = '';
 
-  logsModel.meta?.forEach((metaItem) => {
-    const string = `${metaItem.label}: ${JSON.stringify(metaItem.value)}\n`;
-    textToDownload = textToDownload + string;
-  });
-  textToDownload = textToDownload + '\n\n';
+  if (logsModel.meta?.length) {
+    logsModel.meta?.forEach((metaItem) => {
+      const string = `${metaItem.label ? `${metaItem.label}: ` : ''}${JSON.stringify(metaItem.value)}\n`;
+      textToDownload = textToDownload + string;
+    });
+    textToDownload = textToDownload + '\n\n';
+  }
 
   logsModel.rows.forEach((row) => {
     const entry = !fields.length ? row.entry : fields.map((field) => row.labels[field] ?? '').join(' ');

--- a/public/app/features/inspector/utils/download.ts
+++ b/public/app/features/inspector/utils/download.ts
@@ -59,9 +59,11 @@ export function downloadDataFrameAsCsv(
   title: string,
   csvConfig?: CSVConfig,
   transformId: DataTransformerID = DataTransformerID.noop,
-  excelCompatibilityMode = false
+  excelCompatibilityMode = false,
+  trailingNewline = false
 ) {
   let blob;
+  const newline = trailingNewline ? (csvConfig?.newline ?? '\r\n') : '';
 
   if (excelCompatibilityMode) {
     /**
@@ -73,13 +75,13 @@ export function downloadDataFrameAsCsv(
      *
      * When excel opens a utf16le csv file it will no longer try to use the system list separator, and instead use \t as the separator.
      */
-    const dataFrameCsv = toCSV([dataFrame], { ...csvConfig, useExcelHeader: false, delimiter: '\t' });
+    const dataFrameCsv = toCSV([dataFrame], { ...csvConfig, useExcelHeader: false, delimiter: '\t' }) + newline;
     const utf16le = new Uint16Array(Array.from('\ufeff' + dataFrameCsv).map((char) => char.charCodeAt(0)));
     blob = new Blob([utf16le], {
       type: 'text/csv;charset=utf-16le',
     });
   } else {
-    const dataFrameCsv = toCSV([dataFrame], csvConfig);
+    const dataFrameCsv = toCSV([dataFrame], csvConfig) + newline;
     blob = new Blob([dataFrameCsv], {
       type: 'text/csv;charset=utf-8',
     });

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -574,14 +574,7 @@ export const downloadLogs = async (
           );
         }
         const transformedDataFrame = await lastValueFrom(transformDataFrame(transforms, [dataFrame]));
-        downloadDataFrameAsCsv(
-          transformedDataFrame[0],
-          `Logs-${dataFrame.refId}`,
-          undefined,
-          undefined,
-          false,
-          true
-        );
+        downloadDataFrameAsCsv(transformedDataFrame[0], `Logs-${dataFrame.refId}`, undefined, undefined, false, true);
       }
       break;
     }

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -574,7 +574,14 @@ export const downloadLogs = async (
           );
         }
         const transformedDataFrame = await lastValueFrom(transformDataFrame(transforms, [dataFrame]));
-        downloadDataFrameAsCsv(transformedDataFrame[0], `Logs-${dataFrame.refId}`);
+        downloadDataFrameAsCsv(
+          transformedDataFrame[0],
+          `Logs-${dataFrame.refId}`,
+          undefined,
+          undefined,
+          false,
+          true
+        );
       }
       break;
     }


### PR DESCRIPTION
Txt:
- Removed two extra spaces at the beginning of the file (e.g. logs downloaded from Logs Drilldown)
- Improved meta attributes display when there's no label. For example:
  Before:
  
  ```
  : "1000 lines shown — 5.95% (54sec) of 15min"
  Total bytes processed: "4.21  MB"
  Common labels: ...
  ```
  
  After:
  
  ```
  "1000 lines shown — 5.95% (54sec) of 15min"
  Total bytes processed: "4.21  MB"
  Common labels: ...
  ```

CSV:
- Added trailing new line at the end of the file