### PR TITLE
Alerting: Allow Silences page to use the default timezone

### DIFF
--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
-import { type GrafanaTheme2, dateMath } from '@grafana/data';
+import { type GrafanaTheme2, dateTimeFormat } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import {
   Alert,
@@ -347,10 +347,10 @@ function useColumns(alertManagerSourceName: string) {
         id: 'schedule',
         label: t('alerting.use-columns.columns.label.schedule', 'Schedule'),
         renderCell: function renderSchedule({ data: { startsAt, endsAt } }) {
-          const startsAtDate = dateMath.parse(startsAt);
-          const endsAtDate = dateMath.parse(endsAt);
           const dateDisplayFormat = 'YYYY-MM-DD HH:mm';
-          return `${startsAtDate?.format(dateDisplayFormat)} - ${endsAtDate?.format(dateDisplayFormat)}`;
+          const startsAtDate = dateTimeFormat(startsAt, { format: dateDisplayFormat });
+          const endsAtDate = dateTimeFormat(endsAt, { format: dateDisplayFormat });
+          return `${startsAtDate} - ${endsAtDate}`;
         },
         size: 7,
       },

--- a/public/app/features/alerting/unified/components/silences/utils.ts
+++ b/public/app/features/alerting/unified/components/silences/utils.ts
@@ -1,4 +1,4 @@
-import { DefaultTimeZone, addDurationToDate, dateTime, intervalToAbbreviatedDurationString } from '@grafana/data';
+import { addDurationToDate, dateTime, intervalToAbbreviatedDurationString } from '@grafana/data';
 import { type SilenceFormFields } from 'app/features/alerting/unified/types/silence-form';
 import { matcherToMatcherField } from 'app/features/alerting/unified/utils/alertmanager';
 import { MATCHER_ALERT_RULE_UID } from 'app/features/alerting/unified/utils/constants';
@@ -53,7 +53,7 @@ export const getFormFieldsForSilence = (silence: Silence): SilenceFormFields => 
     matchers: silence.matchers?.map(matcherToMatcherField) || [],
     matcherName: '',
     matcherValue: '',
-    timeZone: DefaultTimeZone,
+    timeZone: '',
   };
 };
 
@@ -74,7 +74,7 @@ export const getDefaultSilenceFormValues = (partial?: Partial<SilenceFormFields>
     isRegex: false,
     matcherName: '',
     matcherValue: '',
-    timeZone: DefaultTimeZone,
+    timeZone: '',
     matchers: [{ name: '', value: '', operator: MatcherOperator.equal }],
     ...partial,
   };


### PR DESCRIPTION

**What is this feature?**

This small pull request updates `SilencesTable.tsx` and default Silence form values to initially use the "Default" timezone instead of "Browser". 

**Why do we need this feature?**

This fix helps prevent confusion for organizations with set timezones (for example UTC) when viewing and editing Silences.

**Who is this feature for?**

All Users


Fixes #101129

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
