### PR TITLE
Provisioning: Git sync quota limit from hard-block to a non-blocking warning

### DIFF
--- a/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
@@ -41,7 +41,7 @@ type WizardFormDefaults = Omit<Partial<WizardFormData>, 'repository'> & {
   repository?: Partial<WizardFormData['repository']>;
 };
 
-// Component to display step status errors for testing
+// Component to display step status errors/warnings for testing
 function StepStatusDisplay() {
   const { stepStatusInfo } = useStepStatus();
   if (stepStatusInfo.status === 'error' && 'error' in stepStatusInfo) {
@@ -53,6 +53,20 @@ function StepStatusDisplay() {
         <div>{title}</div>
         <div>{typeof message === 'string' ? message : message}</div>
         {stepStatusInfo.action && (
+          <button onClick={stepStatusInfo.action.onClick}>{stepStatusInfo.action.label}</button>
+        )}
+      </div>
+    );
+  }
+  if (stepStatusInfo.status === 'warning' && 'warning' in stepStatusInfo) {
+    const warning = stepStatusInfo.warning;
+    const title = typeof warning === 'string' ? warning : warning.title;
+    const message = typeof warning === 'string' ? warning : warning.message;
+    return (
+      <div>
+        <div>{title}</div>
+        <div>{typeof message === 'string' ? message : message}</div>
+        {'action' in stepStatusInfo && stepStatusInfo.action && (
           <button onClick={stepStatusInfo.action.onClick}>{stepStatusInfo.action.label}</button>
         )}
       </div>
@@ -443,8 +457,8 @@ describe('BootstrapStep', () => {
     });
   });
 
-  describe('quota exceeded', () => {
-    it('should use file count (not resource count) for quota check when file count exceeds limit', () => {
+  describe('quota warning', () => {
+    it('should use file count (not resource count) for quota check when file count exceeds limit', async () => {
       mockUseRepositoryStatus.mockReturnValue({
         isReady: true,
         isLoading: false,
@@ -475,8 +489,11 @@ describe('BootstrapStep', () => {
 
       setup();
 
-      expect(screen.queryByText('Sync external storage to a new Grafana folder')).not.toBeInTheDocument();
-      expect(screen.queryByRole('textbox', { name: /display name/i })).not.toBeInTheDocument();
+      // Content stays visible: warning does not hard-block the wizard
+      expect(await screen.findByText('Sync external storage to a new Grafana folder')).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /display name/i })).toBeInTheDocument();
+      // A non-blocking warning is surfaced based on file count (25 > 20)
+      expect(screen.getByText('Resource limit may be exceeded')).toBeInTheDocument();
     });
 
     it('should not block when resource count exceeds quota but file count is within limit', async () => {
@@ -513,7 +530,7 @@ describe('BootstrapStep', () => {
       expect(await screen.findByText('Sync external storage to a new Grafana folder')).toBeInTheDocument();
     });
 
-    it('should not render content when resource count exceeds quota limit', () => {
+    it('should render content with a warning when file count exceeds quota limit', async () => {
       mockUseRepositoryStatus.mockReturnValue({
         isReady: true,
         isLoading: false,
@@ -544,8 +561,12 @@ describe('BootstrapStep', () => {
 
       setup();
 
-      expect(screen.queryByText('Sync external storage to a new Grafana folder')).not.toBeInTheDocument();
-      expect(screen.queryByRole('textbox', { name: /display name/i })).not.toBeInTheDocument();
+      // Content stays visible and there is no blocking error
+      expect(await screen.findByText('Sync external storage to a new Grafana folder')).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /display name/i })).toBeInTheDocument();
+      expect(screen.queryByText('Resource quota exceeded')).not.toBeInTheDocument();
+      // A non-blocking warning is surfaced instead
+      expect(screen.getByText('Resource limit may be exceeded')).toBeInTheDocument();
     });
 
     it('should render content when no quota is configured even with high resource count', async () => {

--- a/public/app/features/provisioning/Wizard/BootstrapStep.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.tsx
@@ -63,7 +63,7 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
   const styles = useStyles2(getStyles);
 
   const isLoading = isRepositoryStatusLoading || isResourceStatsLoading || !isRepositoryReady;
-  const isQuotaExceeded = !isLoading && maxResourcesPerRepository > 0 && fileCount > maxResourcesPerRepository;
+  const isQuotaWarning = !isLoading && maxResourcesPerRepository > 0 && fileCount > maxResourcesPerRepository;
 
   useEffect(() => {
     // Pick a nice name based on type+settings, but only if user hasn't modified it
@@ -95,21 +95,21 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
           onClick: retryRepositoryStatus,
         },
       });
-    } else if (isQuotaExceeded) {
+    } else if (isQuotaWarning) {
       const onPrem = isOnPrem();
       setStepStatusInfo({
-        status: 'error',
-        error: {
-          title: t('provisioning.bootstrap-step.error-quota-exceeded-title', 'Resource quota exceeded'),
+        status: 'warning',
+        warning: {
+          title: t('provisioning.bootstrap-step.warning-quota-may-exceed-title', 'Resource limit may be exceeded'),
           message: onPrem
             ? t(
-                'provisioning.bootstrap-step.error-quota-exceeded-message-onprem',
-                'This repository folder contains {{fileCount}} resources, which exceeds your instance limit of {{limit}}. To sync this repository, update your Grafana configuration or reduce the number of resources to sync.',
+                'provisioning.bootstrap-step.warning-quota-may-exceed-message-onprem',
+                'This repository folder contains approximately {{fileCount}} resources, which may exceed your instance limit of {{limit}}. If the limit is reached during sync, some resources will be skipped. You can continue and adjust later, or update your Grafana configuration.',
                 { fileCount, limit: maxResourcesPerRepository }
               )
             : t(
-                'provisioning.bootstrap-step.error-quota-exceeded-message',
-                'This repository folder contains {{fileCount}} resources, which exceeds your account limit of {{limit}}. To sync this repository, upgrade your account or reduce the number of resources to sync.',
+                'provisioning.bootstrap-step.warning-quota-may-exceed-message',
+                'This repository folder contains approximately {{fileCount}} resources, which may exceed your account limit of {{limit}}. If the limit is reached during sync, some resources will be skipped. You can continue and adjust later, or upgrade your account.',
                 { fileCount, limit: maxResourcesPerRepository }
               ),
         },
@@ -134,7 +134,7 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
     repositoryStatusError,
     retryRepositoryStatus,
     maxResourcesPerRepository,
-    isQuotaExceeded,
+    isQuotaWarning,
     fileCount,
     isUnhealthy,
   ]);
@@ -153,8 +153,8 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
     );
   }
 
-  // Only show error state if: query error, OR unhealthy (already reconciled), OR quota exceeded
-  if (repositoryStatusError || isUnhealthy || isQuotaExceeded) {
+  // Only show error state if: query error, OR unhealthy (already reconciled)
+  if (repositoryStatusError || isUnhealthy) {
     // error message and retry will be set in above step status
     return null;
   }

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -221,7 +221,10 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
               <ProvisioningAlert error={stepStatusInfo.error} action={stepStatusInfo.action} />
             )}
             {'warning' in stepStatusInfo && stepStatusInfo.warning && (
-              <ProvisioningAlert warning={stepStatusInfo.warning} />
+              <ProvisioningAlert
+                warning={stepStatusInfo.warning}
+                action={'action' in stepStatusInfo ? stepStatusInfo.action : undefined}
+              />
             )}
             {isStepSuccess && 'success' in stepStatusInfo && <ProvisioningAlert success={stepStatusInfo.success} />}
 

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -221,10 +221,7 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
               <ProvisioningAlert error={stepStatusInfo.error} action={stepStatusInfo.action} />
             )}
             {'warning' in stepStatusInfo && stepStatusInfo.warning && (
-              <ProvisioningAlert
-                warning={stepStatusInfo.warning}
-                action={'action' in stepStatusInfo ? stepStatusInfo.action : undefined}
-              />
+              <ProvisioningAlert warning={stepStatusInfo.warning} action={stepStatusInfo.action} />
             )}
             {isStepSuccess && 'success' in stepStatusInfo && <ProvisioningAlert success={stepStatusInfo.success} />}
 

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -221,7 +221,12 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
               <ProvisioningAlert error={stepStatusInfo.error} action={stepStatusInfo.action} />
             )}
             {'warning' in stepStatusInfo && stepStatusInfo.warning && (
-              <ProvisioningAlert warning={stepStatusInfo.warning} action={stepStatusInfo.action} />
+              <ProvisioningAlert
+                warning={stepStatusInfo.warning}
+                // Only attach the action to standalone warnings; an 'error' status may also
+                // carry a warning + a retry action meant for the error alert, not this one.
+                action={stepStatusInfo.status === 'warning' ? stepStatusInfo.action : undefined}
+              />
             )}
             {isStepSuccess && 'success' in stepStatusInfo && <ProvisioningAlert success={stepStatusInfo.success} />}
 

--- a/public/app/features/provisioning/Wizard/types.ts
+++ b/public/app/features/provisioning/Wizard/types.ts
@@ -52,7 +52,7 @@ export type StepStatusInfo =
   | { status: 'idle' | 'running' }
   | { status: 'success'; success?: string | StatusInfo }
   | { status: 'error'; error: string | StatusInfo; warning?: string | StatusInfo; action?: AlertAction }
-  | { status: 'warning'; warning: string | StatusInfo };
+  | { status: 'warning'; warning: string | StatusInfo; action?: AlertAction };
 
 export type ConnectionCreationResult = { success: true; connectionName: string } | { success: false; error: string };
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13032,9 +13032,6 @@
       "description-clear-repository-connection": "This name will be used for the repository connection and the folder displayed in the UI",
       "empty": "Empty",
       "error-field-required": "This field is required.",
-      "error-quota-exceeded-message": "This repository folder contains {{fileCount}} resources, which exceeds your account limit of {{limit}}. To sync this repository, upgrade your account or reduce the number of resources to sync.",
-      "error-quota-exceeded-message-onprem": "This repository folder contains {{fileCount}} resources, which exceeds your instance limit of {{limit}}. To sync this repository, update your Grafana configuration or reduce the number of resources to sync.",
-      "error-quota-exceeded-title": "Resource quota exceeded",
       "error-repository-status-unhealthy-message": "There was an issue connecting to the repository. Please check the repository settings and try again.",
       "error-repository-status-unhealthy-title": "Repository status unhealthy",
       "external-storage-label": "External storage",
@@ -13048,7 +13045,10 @@
       "text-loading-resource-information": "Loading resource information...",
       "unmanaged-resources-label": "Unmanaged resources",
       "update-configuration-action": "View configuration docs",
-      "upgrade-action": "Upgrade account"
+      "upgrade-action": "Upgrade account",
+      "warning-quota-may-exceed-message": "This repository folder contains approximately {{fileCount}} resources, which may exceed your account limit of {{limit}}. If the limit is reached during sync, some resources will be skipped. You can continue and adjust later, or upgrade your account.",
+      "warning-quota-may-exceed-message-onprem": "This repository folder contains approximately {{fileCount}} resources, which may exceed your instance limit of {{limit}}. If the limit is reached during sync, some resources will be skipped. You can continue and adjust later, or update your Grafana configuration.",
+      "warning-quota-may-exceed-title": "Resource limit may be exceeded"
     },
     "branch-options": {
       "description-enforce-template": "Make the branch name read-only in save dialogs so users cannot override the generated name.",


### PR DESCRIPTION
**What is this feature?**

- In `BootstrapStep.tsx`, rename `isQuotaExceeded` to `isQuotaWarning` and set `status: 'warning'` (instead of `'error'`) with reworded, non-fatal cloud/on-prem messages while keeping the upgrade / configuration-docs action.
- Remove the quota condition from the early `return null` guard so the sync-target cards and display-name field stay visible when over quota.
- Update `BootstrapStep.test.tsx`: surface warning state in the test helper, rename the describe block to "quota warning", and assert content stays visible with a warning shown and no blocking error.

<img width="1264" height="844" alt="image" src="https://github.com/user-attachments/assets/cabeb7c4-ae81-457d-8817-65ced8d3e7c6" />



**Why do we need this feature?**

- The previous behavior hard-blocked onboarding (disabled "Next" and hid the sync target selection) when the estimated resource count exceeded the repository quota, even though sync already handles over-quota cases by skipping excess resources. This was overly restrictive and prevented users from continuing and adjusting later.


**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1047

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
