### PR TITLE
IAM: Implement ListByIdOrUID in the Kubernetes user service

### DIFF
--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -123,6 +123,21 @@ func (s *Service) GetByUID(ctx context.Context, cmd *user.GetUserByUIDQuery) (*u
 }
 
 func (s *Service) ListByIdOrUID(ctx context.Context, uids []string, ids []int64) ([]*user.User, error) {
+	ctx, span := s.tracer.Start(ctx, "user.wrapper.ListByIdOrUID")
+	defer span.End()
+
+	ctxLogger := s.logger.FromContext(ctx)
+
+	if s.isKubernetesUserServiceEnabled(ctx) && !s.shouldFallbackToLegacy(ctx) {
+		result, err := s.k8sService.ListByIdOrUID(s.k8sCtxWithIdentity(ctx), uids, ids)
+		if err == nil {
+			span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
+			return result, nil
+		}
+		ctxLogger.Warn("k8s ListByIdOrUID failed, falling back to legacy", "err", err)
+	}
+
+	span.SetAttributes(attribute.Bool("fallback_to_legacy", true))
 	return s.legacyService.ListByIdOrUID(ctx, uids, ids)
 }
 

--- a/pkg/services/user/userk8s/user.go
+++ b/pkg/services/user/userk8s/user.go
@@ -287,8 +287,76 @@ func (s *UserK8sService) GetByUID(ctx context.Context, cmd *user.GetUserByUIDQue
 	return toUser(found, orgID), nil
 }
 
-func (s *UserK8sService) ListByIdOrUID(ctx context.Context, ids []string, intIDs []int64) ([]*user.User, error) {
-	return nil, errors.New("not implemented")
+// ListByIdOrUID resolves users by their k8s UID (resource name) and/or legacy
+// internal ID, deduplicating users matched by both. Users that don't resolve are
+// omitted, matching the legacy "WHERE uid IN (...) OR id IN (...)" semantics.
+func (s *UserK8sService) ListByIdOrUID(ctx context.Context, uids []string, intIDs []int64) ([]*user.User, error) {
+	ctx, span := s.tracer.Start(ctx, "user.listByIdOrUID")
+	defer span.End()
+
+	ctxLogger := s.logger.FromContext(ctx)
+
+	orgID, err := s.getOrgID(ctx, ctxLogger)
+	if err != nil {
+		ctxLogger.Error("failed to get orgID from context in ListByIdOrUID", "err", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	namespace := s.namespaceMapper(orgID)
+	span.SetAttributes(attribute.Int64("orgID", orgID))
+
+	client, err := s.getUserClient(ctx)
+	if err != nil {
+		ctxLogger.Error("failed to get k8s client", "namespace", namespace, "err", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	users := make([]*user.User, 0, len(uids)+len(intIDs))
+	seen := make(map[string]struct{}, len(uids)+len(intIDs))
+
+	for _, uid := range uids {
+		if uid == "" {
+			continue
+		}
+		found, err := client.Get(ctx, resource.Identifier{Namespace: namespace, Name: uid})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			ctxLogger.Error("k8s user get by UID failed", "namespace", namespace, "userUID", uid, "err", err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, err
+		}
+		if _, ok := seen[found.Name]; ok {
+			continue
+		}
+		seen[found.Name] = struct{}{}
+		users = append(users, toUser(found, orgID))
+	}
+
+	for _, id := range intIDs {
+		found, err := s.getByInternalID(ctx, ctxLogger, client, id, namespace)
+		if err != nil {
+			if errors.Is(err, user.ErrUserNotFound) {
+				continue
+			}
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, err
+		}
+		if _, ok := seen[found.Name]; ok {
+			continue
+		}
+		seen[found.Name] = struct{}{}
+		users = append(users, toUser(found, orgID))
+	}
+
+	return users, nil
 }
 
 func (s *UserK8sService) GetByLoginWithPassword(_ context.Context, _ *user.GetUserByLoginQuery) (*user.User, error) {

--- a/pkg/services/user/userk8s/user_test.go
+++ b/pkg/services/user/userk8s/user_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strconv"
 	"testing"
 	"time"
@@ -600,6 +601,193 @@ func TestUserK8sService_GetByUID(t *testing.T) {
 			assert.Equal(t, tt.expectUser.Name, result.Name)
 			assert.Equal(t, tt.expectUser.IsAdmin, result.IsAdmin)
 			assert.Equal(t, tt.expectUser.EmailVerified, result.EmailVerified)
+		})
+	}
+}
+
+func TestUserK8sService_ListByIdOrUID(t *testing.T) {
+	mkUser := func(uid string) v0alpha1.User {
+		return v0alpha1.User{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v0alpha1.GroupVersion.Identifier(),
+				Kind:       "User",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      uid,
+				Namespace: "org-1",
+				Labels:    map[string]string{"grafana.app/deprecatedInternalID": "42"},
+			},
+			Spec: v0alpha1.UserSpec{Login: uid, Email: uid + "@example.com"},
+		}
+	}
+
+	// makeHandler dispatches list-by-internal-ID (labelSelector query) and
+	// get-by-UID (resource name in path) requests against the fake apiserver.
+	makeHandler := func(byUID map[string]v0alpha1.User, byInternalID []v0alpha1.User) func(http.ResponseWriter, *http.Request) {
+		return func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Query().Get("labelSelector") != "" {
+				items := make([]any, 0, len(byInternalID))
+				for _, u := range byInternalID {
+					items = append(items, u)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"apiVersion": "v1", "kind": "List", "items": items})
+				return
+			}
+			if u, ok := byUID[path.Base(r.URL.Path)]; ok {
+				_ = json.NewEncoder(w).Encode(u)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(metav1.Status{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Status"},
+				Status:   metav1.StatusFailure,
+				Reason:   metav1.StatusReasonNotFound,
+				Code:     http.StatusNotFound,
+			})
+		}
+	}
+
+	serverErr := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(metav1.Status{
+			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Status"},
+			Status:   metav1.StatusFailure,
+			Code:     http.StatusInternalServerError,
+		})
+	}
+
+	tests := []struct {
+		name           string
+		uids           []string
+		ids            []int64
+		requesterOrgID int64
+		serverResponse func(http.ResponseWriter, *http.Request)
+		nilProvider    bool
+		noReqContext   bool
+		noRequester    bool
+		expectErr      bool
+		expectUIDs     []string
+	}{
+		{
+			name:           "resolves users by UID",
+			requesterOrgID: 1,
+			uids:           []string{"uid-a", "uid-b"},
+			serverResponse: makeHandler(map[string]v0alpha1.User{
+				"uid-a": mkUser("uid-a"),
+				"uid-b": mkUser("uid-b"),
+			}, nil),
+			expectUIDs: []string{"uid-a", "uid-b"},
+		},
+		{
+			name:           "resolves users by internal ID",
+			requesterOrgID: 1,
+			ids:            []int64{7},
+			serverResponse: makeHandler(nil, []v0alpha1.User{mkUser("uid-c")}),
+			expectUIDs:     []string{"uid-c"},
+		},
+		{
+			name:           "deduplicates users matched by both UID and internal ID",
+			requesterOrgID: 1,
+			uids:           []string{"uid-a"},
+			ids:            []int64{7},
+			serverResponse: makeHandler(
+				map[string]v0alpha1.User{"uid-a": mkUser("uid-a")},
+				[]v0alpha1.User{mkUser("uid-a")},
+			),
+			expectUIDs: []string{"uid-a"},
+		},
+		{
+			name:           "skips UIDs that are not found",
+			requesterOrgID: 1,
+			uids:           []string{"uid-a", "missing"},
+			serverResponse: makeHandler(map[string]v0alpha1.User{"uid-a": mkUser("uid-a")}, nil),
+			expectUIDs:     []string{"uid-a"},
+		},
+		{
+			name:           "skips internal IDs that resolve to no user",
+			requesterOrgID: 1,
+			ids:            []int64{99},
+			serverResponse: makeHandler(nil, nil),
+			expectUIDs:     []string{},
+		},
+		{
+			name:           "skips empty UID strings without calling the server",
+			requesterOrgID: 1,
+			uids:           []string{""},
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				t.Errorf("server should not be called for an empty UID")
+			},
+			expectUIDs: []string{},
+		},
+		{
+			name:           "propagates non-not-found error on UID get",
+			requesterOrgID: 1,
+			uids:           []string{"uid-a"},
+			serverResponse: serverErr,
+			expectErr:      true,
+		},
+		{
+			name:           "propagates error on internal ID list",
+			requesterOrgID: 1,
+			ids:            []int64{7},
+			serverResponse: serverErr,
+			expectErr:      true,
+		},
+		{
+			name:           "returns error when multiple users found for an internal ID",
+			requesterOrgID: 1,
+			ids:            []int64{5},
+			serverResponse: makeHandler(nil, []v0alpha1.User{mkUser("uid-a"), mkUser("uid-b")}),
+			expectErr:      true,
+		},
+		{
+			name:           "returns error when config provider not initialized",
+			requesterOrgID: 1,
+			uids:           []string{"uid-a"},
+			nilProvider:    true,
+			expectErr:      true,
+		},
+		{
+			name:           "returns error when no request context",
+			requesterOrgID: 1,
+			uids:           []string{"uid-a"},
+			noReqContext:   true,
+			expectErr:      true,
+		},
+		{
+			name:           "returns error when no requester in context",
+			requesterOrgID: 1,
+			uids:           []string{"uid-a"},
+			noRequester:    true,
+			expectErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, ctx := setupServiceAndCtx(t, svcTestSetup{
+				nilProvider:    tt.nilProvider,
+				noReqContext:   tt.noReqContext,
+				noRequester:    tt.noRequester,
+				requesterOrgID: tt.requesterOrgID,
+				serverResponse: tt.serverResponse,
+			})
+
+			result, err := svc.ListByIdOrUID(ctx, tt.uids, tt.ids)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			gotUIDs := make([]string, 0, len(result))
+			for _, u := range result {
+				gotUIDs = append(gotUIDs, u.UID)
+			}
+			assert.Equal(t, tt.expectUIDs, gotUIDs)
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does

`user.Service.ListByIdOrUID` was the only read method on the user service wrapper that ignored the `kubernetesUsersRedirect` path — it unconditionally queried the legacy SQL store. When the redirect is enabled, users are served from the apiserver, so resolving users by internal ID or UID through the legacy store returned no results.

This change:

- Implements `ListByIdOrUID` in the k8s user service (`userk8s`). It resolves users by k8s UID (resource name) and/or legacy internal ID, deduplicates users matched by both, and omits users that don't resolve — matching the legacy `WHERE uid IN (...) OR id IN (...)` semantics.
- Routes the wrapper `Service.ListByIdOrUID` to the k8s service when `kubernetesUsersRedirect` is enabled, falling back to the legacy service on error or for non-HTTP callers. This mirrors the existing routing for `GetByID`, `GetByUID`, and `GetByLogin`.

## Why

With `kubernetesUsersRedirect` enabled, every other user read method already honors the redirect, but `ListByIdOrUID` did not, leaving it inconsistent and unable to resolve users that only exist via the apiserver.

## Test plan

- New unit test `TestService_ListByIdOrUID` covering: routes to legacy when the redirect is disabled, routes to k8s when enabled, and falls back to legacy when the k8s call errors.
- `go test ./pkg/services/user/...`
- `go test ./pkg/tests/apis/iam/...`