### PR TITLE
Table: Safe filter expressions

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterList.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterList.test.tsx
@@ -37,7 +37,7 @@ describe('FilterList', () => {
       expect(screen.getByRole('checkbox', { name: 'cherry' })).toBeInTheDocument();
     });
 
-    it('only shows options whose label matches the search string', () => {
+    it('filters options by label regex match', () => {
       const options: SelectableValue[] = [
         { value: 'apple', label: 'apple' },
         { value: 'apricot', label: 'apricot' },
@@ -74,7 +74,7 @@ describe('FilterList', () => {
       expect(screen.queryByRole('checkbox', { name: 'apple' })).not.toBeInTheDocument();
     });
 
-    it('shows "No values" label when no options match the search', () => {
+    it('shows "No values" when no options match', () => {
       const options: SelectableValue[] = [{ value: 'apple', label: 'apple' }];
       render(
         <FilterList options={options} values={[]} onChange={jest.fn()} searchFilter="zzz" operator={containsOp()} />
@@ -83,9 +83,33 @@ describe('FilterList', () => {
     });
   });
 
-  describe('numeric comparison operators', () => {
-    it('EQUALS shows only the item with the matching numeric value', () => {
-      const options = numericOptions([10, 20, 30]);
+  describe('comparison operators (smoke tests — logic covered in filterExpression.test.ts)', () => {
+    it.each([
+      [FilterOperator.EQUALS, [20]],
+      [FilterOperator.NOT_EQUALS, [10, 30]],
+      [FilterOperator.GREATER, [30]],
+      [FilterOperator.GREATER_OR_EQUAL, [20, 30]],
+      [FilterOperator.LESS, [10]],
+      [FilterOperator.LESS_OR_EQUAL, [10, 20]],
+    ] as Array<[FilterOperator, number[]]>)('%s shows only matching options', (operator, visible) => {
+      const all = [10, 20, 30];
+      render(
+        <FilterList
+          options={numericOptions(all)}
+          values={[]}
+          onChange={jest.fn()}
+          searchFilter="20"
+          operator={op(operator)}
+        />
+      );
+      for (const n of all) {
+        const el = screen.queryByRole('checkbox', { name: String(n) });
+        visible.includes(n) ? expect(el).toBeInTheDocument() : expect(el).not.toBeInTheDocument();
+      }
+    });
+
+    it('excludes options with undefined value', () => {
+      const options: SelectableValue[] = [{ label: 'no-value' }, { value: '20', label: '20' }];
       render(
         <FilterList
           options={options}
@@ -95,98 +119,16 @@ describe('FilterList', () => {
           operator={op(FilterOperator.EQUALS)}
         />
       );
-      expect(screen.queryByRole('checkbox', { name: '10' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: 'no-value' })).not.toBeInTheDocument();
       expect(screen.getByRole('checkbox', { name: '20' })).toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: '30' })).not.toBeInTheDocument();
-    });
-
-    it('NOT_EQUALS excludes the item with the matching value', () => {
-      const options = numericOptions([10, 20, 30]);
-      render(
-        <FilterList
-          options={options}
-          values={[]}
-          onChange={jest.fn()}
-          searchFilter="20"
-          operator={op(FilterOperator.NOT_EQUALS)}
-        />
-      );
-      expect(screen.getByRole('checkbox', { name: '10' })).toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: '20' })).not.toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: '30' })).toBeInTheDocument();
-    });
-
-    it('GREATER shows only values strictly greater than the threshold', () => {
-      const options = numericOptions([10, 20, 30]);
-      render(
-        <FilterList
-          options={options}
-          values={[]}
-          onChange={jest.fn()}
-          searchFilter="20"
-          operator={op(FilterOperator.GREATER)}
-        />
-      );
-      expect(screen.queryByRole('checkbox', { name: '10' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: '20' })).not.toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: '30' })).toBeInTheDocument();
-    });
-
-    it('GREATER_OR_EQUAL shows values >= the threshold', () => {
-      const options = numericOptions([10, 20, 30]);
-      render(
-        <FilterList
-          options={options}
-          values={[]}
-          onChange={jest.fn()}
-          searchFilter="20"
-          operator={op(FilterOperator.GREATER_OR_EQUAL)}
-        />
-      );
-      expect(screen.queryByRole('checkbox', { name: '10' })).not.toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: '20' })).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: '30' })).toBeInTheDocument();
-    });
-
-    it('LESS shows only values strictly less than the threshold', () => {
-      const options = numericOptions([10, 20, 30]);
-      render(
-        <FilterList
-          options={options}
-          values={[]}
-          onChange={jest.fn()}
-          searchFilter="20"
-          operator={op(FilterOperator.LESS)}
-        />
-      );
-      expect(screen.getByRole('checkbox', { name: '10' })).toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: '20' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: '30' })).not.toBeInTheDocument();
-    });
-
-    it('LESS_OR_EQUAL shows values <= the threshold', () => {
-      const options = numericOptions([10, 20, 30]);
-      render(
-        <FilterList
-          options={options}
-          values={[]}
-          onChange={jest.fn()}
-          searchFilter="20"
-          operator={op(FilterOperator.LESS_OR_EQUAL)}
-        />
-      );
-      expect(screen.getByRole('checkbox', { name: '10' })).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: '20' })).toBeInTheDocument();
-      expect(screen.queryByRole('checkbox', { name: '30' })).not.toBeInTheDocument();
     });
   });
 
-  describe('EXPRESSION operator', () => {
-    it('evaluates a JS expression where $ is the column value', () => {
-      const options = numericOptions([5, 15, 25]);
+  describe('EXPRESSION operator (smoke tests — logic covered in filterExpression.test.ts)', () => {
+    it('filters options using a compound && expression', () => {
       render(
         <FilterList
-          options={options}
+          options={numericOptions([5, 15, 25])}
           values={[]}
           onChange={jest.fn()}
           searchFilter="$ > 10 && $ < 20"
@@ -198,16 +140,27 @@ describe('FilterList', () => {
       expect(screen.queryByRole('checkbox', { name: '25' })).not.toBeInTheDocument();
     });
 
-    it('shows "No values" when the expression throws a syntax error', () => {
-      const options = numericOptions([10, 20]);
-      // "$ ===" is a valid regex (won't throw new RegExp) but an invalid JS expression
-      // ("return $ ===;" throws SyntaxError in the Function constructor).
+    it('shows "No values" for an unparseable expression', () => {
+      render(
+        <FilterList
+          options={numericOptions([10, 20])}
+          values={[]}
+          onChange={jest.fn()}
+          searchFilter="$ ==="
+          operator={op(FilterOperator.EXPRESSION)}
+        />
+      );
+      expect(screen.getByText('No values')).toBeInTheDocument();
+    });
+
+    it('returns false when option.value is undefined', () => {
+      const options: SelectableValue[] = [{ label: 'no-value' }];
       render(
         <FilterList
           options={options}
           values={[]}
           onChange={jest.fn()}
-          searchFilter="$ ==="
+          searchFilter="$ > 0"
           operator={op(FilterOperator.EXPRESSION)}
         />
       );
@@ -251,7 +204,7 @@ describe('FilterList', () => {
       expect(onChange.mock.calls[0][0]).toEqual([]);
     });
 
-    it('only removes the currently visible items when deselecting, preserving hidden selections', async () => {
+    it('preserves hidden selections when deselecting visible items', async () => {
       const user = userEvent.setup();
       const options: SelectableValue[] = [
         { value: 'apple', label: 'apple' },
@@ -259,7 +212,6 @@ describe('FilterList', () => {
         { value: 'banana', label: 'banana' },
       ];
       const onChange = jest.fn();
-      // All three are selected, but search filters to only "ap*" items
       render(
         <FilterList options={options} values={options} onChange={onChange} searchFilter="ap" operator={containsOp()} />
       );
@@ -267,7 +219,6 @@ describe('FilterList', () => {
       const selectAll = screen.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll);
       await user.click(selectAll.querySelector('input')!);
 
-      // banana should be preserved because it was not visible
       const remaining: SelectableValue[] = onChange.mock.calls[0][0];
       expect(remaining.map((v) => v.value)).toEqual(['banana']);
     });

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterList.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterList.test.tsx
@@ -153,6 +153,22 @@ describe('FilterList', () => {
       expect(screen.getByText('No values')).toBeInTheDocument();
     });
 
+    it('shows "No values" and does not fall back to regex when expression is invalid', () => {
+      render(
+        <FilterList
+          options={[
+            { value: '1', label: 'foo' },
+            { value: '2', label: 'foobar' },
+          ]}
+          values={[]}
+          onChange={jest.fn()}
+          searchFilter="foo"
+          operator={op(FilterOperator.EXPRESSION)}
+        />
+      );
+      expect(screen.getByText('No values')).toBeInTheDocument();
+    });
+
     it('returns false when option.value is undefined', () => {
       const options: SelectableValue[] = [{ label: 'no-value' }];
       render(

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterList.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterList.tsx
@@ -34,9 +34,9 @@ export const FilterList = ({ options, values, caseSensitive, onChange, searchFil
       return null;
     }
     if (operator.value === FilterOperator.EXPRESSION) {
-      return parseExpression(searchFilter);
+      return parseExpression(searchFilter) ?? (() => false);
     }
-    return parseExpression(`$ ${operator.value} ${searchFilter}`);
+    return parseExpression(`$ ${operator.value} ${searchFilter}`) ?? (() => false);
   }, [searchFilter, operator]);
 
   const items = useMemo(

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterList.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterList.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react';
 import * as React from 'react';
 import { FixedSizeList as List, type ListChildComponentProps } from 'react-window';
 
-import { type GrafanaTheme2, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
+import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 
@@ -12,6 +12,7 @@ import { useStyles2, useTheme2 } from '../../../../themes/ThemeContext';
 import { Checkbox } from '../../../Forms/Checkbox';
 import { Label } from '../../../Forms/Label';
 import { Stack } from '../../../Layout/Stack/Stack';
+import { comparableValue, parseExpression } from '../../filterExpression';
 import { FilterOperator } from '../types';
 
 interface Props {
@@ -26,78 +27,30 @@ interface Props {
 const ITEM_HEIGHT = 32;
 const MIN_HEIGHT = ITEM_HEIGHT * 4.5; // split an item in the middle to imply there are more items to scroll
 
-const comparableValue = (value: string): string | number | Date | boolean => {
-  value = value.trim().replace(/\\/g, '');
-
-  // Does it look like a Date (Starting with pattern YYYY-MM-DD* or YYYY/MM/DD*)?
-  if (/^(\d{4}-\d{2}-\d{2}|\d{4}\/\d{2}\/\d{2})/.test(value)) {
-    const date = new Date(value);
-    if (!isNaN(date.getTime())) {
-      const fmt = getValueFormat('dateTimeAsIso');
-      return formattedValueToString(fmt(date.getTime()));
-    }
-  }
-  // Does it look like a Number?
-  const num = parseFloat(value);
-  if (!isNaN(num)) {
-    return num;
-  }
-  // Does it look like a Bool?
-  const lvalue = value.toLowerCase();
-  if (lvalue === 'true' || lvalue === 'false') {
-    return lvalue === 'true';
-  }
-  // Anything else
-  return value;
-};
-
 export const FilterList = ({ options, values, caseSensitive, onChange, searchFilter, operator }: Props) => {
   const regex = useMemo(() => new RegExp(searchFilter, caseSensitive ? undefined : 'i'), [searchFilter, caseSensitive]);
+  const predicate = useMemo(() => {
+    if (!searchFilter || operator.value === FilterOperator.CONTAINS) {
+      return null;
+    }
+    if (operator.value === FilterOperator.EXPRESSION) {
+      return parseExpression(searchFilter);
+    }
+    return parseExpression(`$ ${operator.value} ${searchFilter}`);
+  }, [searchFilter, operator]);
+
   const items = useMemo(
     () =>
       options.filter((option) => {
         if (!searchFilter || operator.value === FilterOperator.CONTAINS) {
-          if (option.label === undefined) {
-            return false;
-          }
-          return regex.test(option.label);
-        } else if (operator.value === FilterOperator.EXPRESSION) {
-          if (option.value === undefined) {
-            return false;
-          }
-          try {
-            const xpr = searchFilter.replace(/\\/g, '');
-            const fnc = new Function('$', `'use strict'; return ${xpr};`);
-            const val = comparableValue(option.value);
-            return fnc(val);
-          } catch (_) {}
-          return false;
-        } else {
-          if (option.value === undefined) {
-            return false;
-          }
-
-          const value1 = comparableValue(option.value);
-          const value2 = comparableValue(searchFilter);
-
-          switch (operator.value) {
-            case '=':
-              return value1 === value2;
-            case '!=':
-              return value1 !== value2;
-            case '>':
-              return value1 > value2;
-            case '>=':
-              return value1 >= value2;
-            case '<':
-              return value1 < value2;
-            case '<=':
-              return value1 <= value2;
-          }
+          return option.label !== undefined && regex.test(option.label);
+        }
+        if (option.value === undefined || predicate === null) {
           return false;
         }
+        return predicate(comparableValue(option.value));
       }),
-    [options, regex, operator, searchFilter]
+    [options, regex, operator, searchFilter, predicate]
   );
   const selectedItems = useMemo(() => items.filter((item) => values.includes(item)), [items, values]);
 

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterList.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/FilterList.tsx
@@ -42,15 +42,15 @@ export const FilterList = ({ options, values, caseSensitive, onChange, searchFil
   const items = useMemo(
     () =>
       options.filter((option) => {
-        if (!searchFilter || operator.value === FilterOperator.CONTAINS) {
+        if (predicate === null) {
           return option.label !== undefined && regex.test(option.label);
         }
-        if (option.value === undefined || predicate === null) {
+        if (option.value === undefined) {
           return false;
         }
         return predicate(comparableValue(option.value));
       }),
-    [options, regex, operator, searchFilter, predicate]
+    [options, regex, predicate]
   );
   const selectedItems = useMemo(() => items.filter((item) => values.includes(item)), [items, values]);
 

--- a/packages/grafana-ui/src/components/Table/TableRT/FilterList.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FilterList.test.tsx
@@ -1,0 +1,261 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { type SelectableValue } from '@grafana/data';
+
+import { FilterList, REGEX_OPERATOR } from './FilterList';
+
+const XPR_OPERATOR: SelectableValue<string> = { label: 'Expression', value: 'Expression' };
+
+const referenceElement = document.createElement('div');
+
+function numericOptions(values: number[]): SelectableValue[] {
+  return values.map((n) => ({ value: String(n), label: String(n) }));
+}
+
+function renderFilterList(overrides: Partial<React.ComponentProps<typeof FilterList>> = {}) {
+  const defaults: React.ComponentProps<typeof FilterList> = {
+    options: [],
+    values: [],
+    onChange: jest.fn(),
+    searchFilter: '',
+    setSearchFilter: jest.fn(),
+    operator: REGEX_OPERATOR,
+    setOperator: jest.fn(),
+    referenceElement,
+    showOperators: false,
+    caseSensitive: false,
+  };
+  return render(<FilterList {...defaults} {...overrides} />);
+}
+
+describe('FilterList (TableRT)', () => {
+  describe('CONTAINS / regex operator', () => {
+    it('shows all options when search is empty', () => {
+      const options: SelectableValue[] = [
+        { value: 'apple', label: 'apple' },
+        { value: 'banana', label: 'banana' },
+        { value: 'cherry', label: 'cherry' },
+      ];
+      renderFilterList({ options, showOperators: true, searchFilter: '' });
+      expect(screen.getByRole('checkbox', { name: 'apple' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'banana' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'cherry' })).toBeInTheDocument();
+    });
+
+    it('filters options by label regex match', () => {
+      const options: SelectableValue[] = [
+        { value: 'apple', label: 'apple' },
+        { value: 'apricot', label: 'apricot' },
+        { value: 'banana', label: 'banana' },
+      ];
+      renderFilterList({ options, showOperators: true, searchFilter: 'ap' });
+      expect(screen.getByRole('checkbox', { name: 'apple' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'apricot' })).toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: 'banana' })).not.toBeInTheDocument();
+    });
+
+    it('matches case-insensitively by default', () => {
+      const options: SelectableValue[] = [{ value: 'apple', label: 'apple' }];
+      renderFilterList({ options, showOperators: true, searchFilter: 'APPLE', caseSensitive: false });
+      expect(screen.getByRole('checkbox', { name: 'apple' })).toBeInTheDocument();
+    });
+
+    it('respects case when caseSensitive=true', () => {
+      const options: SelectableValue[] = [{ value: 'apple', label: 'apple' }];
+      renderFilterList({ options, showOperators: true, searchFilter: 'APPLE', caseSensitive: true });
+      expect(screen.queryByRole('checkbox', { name: 'apple' })).not.toBeInTheDocument();
+    });
+
+    it('shows "No values" when no options match', () => {
+      const options: SelectableValue[] = [{ value: 'apple', label: 'apple' }];
+      renderFilterList({ options, showOperators: true, searchFilter: 'zzz' });
+      expect(screen.getByText('No values')).toBeInTheDocument();
+    });
+
+    it('still filters by regex when showOperators is false', () => {
+      const options: SelectableValue[] = [
+        { value: 'apple', label: 'apple' },
+        { value: 'banana', label: 'banana' },
+      ];
+      renderFilterList({ options, showOperators: false, searchFilter: 'ap' });
+      expect(screen.getByRole('checkbox', { name: 'apple' })).toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: 'banana' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('comparison operators (smoke tests — logic covered in filterExpression.test.ts)', () => {
+    it.each([
+      ['=', [20]],
+      ['!=', [10, 30]],
+      ['>', [30]],
+      ['>=', [20, 30]],
+      ['<', [10]],
+      ['<=', [10, 20]],
+    ] as Array<[string, number[]]>)('%s shows only matching options', (op, visible) => {
+      const all = [10, 20, 30];
+      renderFilterList({
+        options: numericOptions(all),
+        showOperators: true,
+        searchFilter: '20',
+        operator: { value: op },
+      });
+      for (const n of all) {
+        const el = screen.queryByRole('checkbox', { name: String(n) });
+        visible.includes(n) ? expect(el).toBeInTheDocument() : expect(el).not.toBeInTheDocument();
+      }
+    });
+
+    it('excludes options with undefined value', () => {
+      const options: SelectableValue[] = [{ label: 'no-value' }, { value: '20', label: '20' }];
+      renderFilterList({ options, showOperators: true, searchFilter: '20', operator: { value: '=' } });
+      expect(screen.queryByRole('checkbox', { name: 'no-value' })).not.toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: '20' })).toBeInTheDocument();
+    });
+  });
+
+  describe('EXPRESSION operator (smoke tests — logic covered in filterExpression.test.ts)', () => {
+    it('filters options using a compound && expression', () => {
+      renderFilterList({
+        options: numericOptions([5, 15, 25]),
+        showOperators: true,
+        searchFilter: '$ > 10 && $ < 20',
+        operator: XPR_OPERATOR,
+      });
+      expect(screen.queryByRole('checkbox', { name: '5' })).not.toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: '15' })).toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: '25' })).not.toBeInTheDocument();
+    });
+
+    it('shows "No values" for an unparseable expression', () => {
+      renderFilterList({
+        options: numericOptions([10, 20]),
+        showOperators: true,
+        searchFilter: '$ ===',
+        operator: XPR_OPERATOR,
+      });
+      expect(screen.getByText('No values')).toBeInTheDocument();
+    });
+
+    it('returns false when option.value is undefined', () => {
+      const options: SelectableValue[] = [{ label: 'no-value' }];
+      renderFilterList({ options, showOperators: true, searchFilter: '$ > 0', operator: XPR_OPERATOR });
+      expect(screen.getByText('No values')).toBeInTheDocument();
+    });
+  });
+
+  describe('select all / deselect all', () => {
+    it('calls onChange with all visible items when none are selected', async () => {
+      const user = userEvent.setup();
+      const options: SelectableValue[] = [
+        { value: 'a', label: 'Alpha' },
+        { value: 'b', label: 'Beta' },
+      ];
+      const onChange = jest.fn();
+      renderFilterList({ options, values: [], onChange, searchFilter: '' });
+
+      await user.click(screen.getByRole('checkbox', { name: /Select all/ }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const newValues: SelectableValue[] = onChange.mock.calls[0][0];
+      expect(newValues.map((v) => v.value)).toEqual(expect.arrayContaining(['a', 'b']));
+    });
+
+    it('calls onChange removing all visible items when all are already selected', async () => {
+      const user = userEvent.setup();
+      const options: SelectableValue[] = [
+        { value: 'a', label: 'Alpha' },
+        { value: 'b', label: 'Beta' },
+      ];
+      const onChange = jest.fn();
+      renderFilterList({ options, values: options, onChange, searchFilter: '' });
+
+      await user.click(screen.getByRole('checkbox', { name: /2 selected/ }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toEqual([]);
+    });
+
+    it('preserves hidden selections when deselecting visible items', async () => {
+      const user = userEvent.setup();
+      const options: SelectableValue[] = [
+        { value: 'apple', label: 'apple' },
+        { value: 'apricot', label: 'apricot' },
+        { value: 'banana', label: 'banana' },
+      ];
+      const onChange = jest.fn();
+      renderFilterList({ options, values: options, onChange, showOperators: true, searchFilter: 'ap' });
+
+      await user.click(screen.getByRole('checkbox', { name: /2 selected/ }));
+
+      const remaining: SelectableValue[] = onChange.mock.calls[0][0];
+      expect(remaining.map((v) => v.value)).toEqual(['banana']);
+    });
+  });
+
+  describe('individual item selection', () => {
+    it('adds the item to values when its checkbox is checked', async () => {
+      const user = userEvent.setup();
+      const options: SelectableValue[] = [
+        { value: 'a', label: 'Alpha' },
+        { value: 'b', label: 'Beta' },
+      ];
+      const onChange = jest.fn();
+      renderFilterList({ options, values: [], onChange, searchFilter: '' });
+
+      await user.click(screen.getByRole('checkbox', { name: 'Alpha' }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0].map((v: SelectableValue) => v.value)).toContain('a');
+    });
+
+    it('removes the item from values when its checkbox is unchecked', async () => {
+      const user = userEvent.setup();
+      const alphaOption = { value: 'a', label: 'Alpha' };
+      const betaOption = { value: 'b', label: 'Beta' };
+      const onChange = jest.fn();
+      renderFilterList({
+        options: [alphaOption, betaOption],
+        values: [alphaOption, betaOption],
+        onChange,
+        searchFilter: '',
+      });
+
+      await user.click(screen.getByRole('checkbox', { name: 'Alpha' }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const newValues: SelectableValue[] = onChange.mock.calls[0][0];
+      expect(newValues.map((v) => v.value)).not.toContain('a');
+      expect(newValues.map((v) => v.value)).toContain('b');
+    });
+  });
+
+  describe('"Select all" checkbox label', () => {
+    it('shows "Select all" when no values are selected', () => {
+      const options: SelectableValue[] = [{ value: 'a', label: 'Alpha' }];
+      renderFilterList({ options, values: [], searchFilter: '' });
+      expect(screen.getByRole('checkbox', { name: /Select all/ })).toBeInTheDocument();
+    });
+
+    it('shows the selected count when some values are selected', () => {
+      const options: SelectableValue[] = [
+        { value: 'a', label: 'Alpha' },
+        { value: 'b', label: 'Beta' },
+      ];
+      renderFilterList({ options, values: [options[0]], searchFilter: '' });
+      expect(screen.getByRole('checkbox', { name: /1 selected/ })).toBeInTheDocument();
+    });
+  });
+
+  describe('operator UI', () => {
+    it('renders the filter input when showOperators is true', () => {
+      renderFilterList({ showOperators: true, options: [], searchFilter: '' });
+      expect(screen.getByPlaceholderText('Filter values')).toBeInTheDocument();
+    });
+
+    it('renders the filter input when showOperators is false', () => {
+      renderFilterList({ showOperators: false, options: [], searchFilter: '' });
+      expect(screen.getByPlaceholderText('Filter values')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/Table/TableRT/FilterList.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FilterList.test.tsx
@@ -142,6 +142,19 @@ describe('FilterList (TableRT)', () => {
       renderFilterList({ options, showOperators: true, searchFilter: '$ > 0', operator: XPR_OPERATOR });
       expect(screen.getByText('No values')).toBeInTheDocument();
     });
+
+    it('shows "No values" and does not fall back to regex when expression is invalid', () => {
+      renderFilterList({
+        options: [
+          { value: '1', label: 'foo' },
+          { value: '2', label: 'foobar' },
+        ],
+        showOperators: true,
+        searchFilter: 'foo',
+        operator: XPR_OPERATOR,
+      });
+      expect(screen.getByText('No values')).toBeInTheDocument();
+    });
   });
 
   describe('select all / deselect all', () => {

--- a/packages/grafana-ui/src/components/Table/TableRT/FilterList.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FilterList.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 import * as React from 'react';
 import { FixedSizeList as List, type ListChildComponentProps } from 'react-window';
 
-import { type GrafanaTheme2, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
+import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 
 import { useStyles2, useTheme2 } from '../../../themes/ThemeContext';
@@ -12,6 +12,7 @@ import { FilterInput } from '../../FilterInput/FilterInput';
 import { Checkbox } from '../../Forms/Checkbox';
 import { Label } from '../../Forms/Label';
 import { Stack } from '../../Layout/Stack/Stack';
+import { comparableValue, parseExpression } from '../filterExpression';
 
 interface Props {
   values: SelectableValue[];
@@ -47,31 +48,6 @@ const OPERATORS = Object.values(operatorSelectableValues);
 export const REGEX_OPERATOR = operatorSelectableValues['Contains'];
 const XPR_OPERATOR = operatorSelectableValues['Expression'];
 
-const comparableValue = (value: string): string | number | Date | boolean => {
-  value = value.trim().replace(/\\/g, '');
-
-  // Does it look like a Date (Starting with pattern YYYY-MM-DD* or YYYY/MM/DD*)?
-  if (/^(\d{4}-\d{2}-\d{2}|\d{4}\/\d{2}\/\d{2})/.test(value)) {
-    const date = new Date(value);
-    if (!isNaN(date.getTime())) {
-      const fmt = getValueFormat('dateTimeAsIso');
-      return formattedValueToString(fmt(date.getTime()));
-    }
-  }
-  // Does it look like a Number?
-  const num = parseFloat(value);
-  if (!isNaN(num)) {
-    return num;
-  }
-  // Does it look like a Bool?
-  const lvalue = value.toLowerCase();
-  if (lvalue === 'true' || lvalue === 'false') {
-    return lvalue === 'true';
-  }
-  // Anything else
-  return value;
-};
-
 export const FilterList = ({
   options,
   values,
@@ -85,51 +61,28 @@ export const FilterList = ({
   referenceElement,
 }: Props) => {
   const regex = useMemo(() => new RegExp(searchFilter, caseSensitive ? undefined : 'i'), [searchFilter, caseSensitive]);
+  const predicate = useMemo(() => {
+    if (!showOperators || !searchFilter || operator.value === REGEX_OPERATOR.value) {
+      return null;
+    }
+    if (operator.value === XPR_OPERATOR.value) {
+      return parseExpression(searchFilter);
+    }
+    return parseExpression(`$ ${operator.value} ${searchFilter}`);
+  }, [showOperators, searchFilter, operator]);
+
   const items = useMemo(
     () =>
       options.filter((option) => {
         if (!showOperators || !searchFilter || operator.value === REGEX_OPERATOR.value) {
-          if (option.label === undefined) {
-            return false;
-          }
-          return regex.test(option.label);
-        } else if (operator.value === XPR_OPERATOR.value) {
-          if (option.value === undefined) {
-            return false;
-          }
-          try {
-            const xpr = searchFilter.replace(/\\/g, '');
-            const fnc = new Function('$', `'use strict'; return ${xpr};`);
-            const val = comparableValue(option.value);
-            return fnc(val);
-          } catch (_) {}
-          return false;
-        } else {
-          if (option.value === undefined) {
-            return false;
-          }
-
-          const value1 = comparableValue(option.value);
-          const value2 = comparableValue(searchFilter);
-
-          switch (operator.value) {
-            case '=':
-              return value1 === value2;
-            case '!=':
-              return value1 !== value2;
-            case '>':
-              return value1 > value2;
-            case '>=':
-              return value1 >= value2;
-            case '<':
-              return value1 < value2;
-            case '<=':
-              return value1 <= value2;
-          }
+          return option.label !== undefined && regex.test(option.label);
+        }
+        if (option.value === undefined || predicate === null) {
           return false;
         }
+        return predicate(comparableValue(option.value));
       }),
-    [options, regex, showOperators, operator, searchFilter]
+    [options, regex, showOperators, operator, searchFilter, predicate]
   );
   const selectedItems = useMemo(() => items.filter((item) => values.includes(item)), [items, values]);
 

--- a/packages/grafana-ui/src/components/Table/TableRT/FilterList.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FilterList.tsx
@@ -66,9 +66,9 @@ export const FilterList = ({
       return null;
     }
     if (operator.value === XPR_OPERATOR.value) {
-      return parseExpression(searchFilter);
+      return parseExpression(searchFilter) ?? (() => false);
     }
-    return parseExpression(`$ ${operator.value} ${searchFilter}`);
+    return parseExpression(`$ ${operator.value} ${searchFilter}`) ?? (() => false);
   }, [showOperators, searchFilter, operator]);
 
   const items = useMemo(

--- a/packages/grafana-ui/src/components/Table/TableRT/FilterList.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FilterList.tsx
@@ -74,15 +74,15 @@ export const FilterList = ({
   const items = useMemo(
     () =>
       options.filter((option) => {
-        if (!showOperators || !searchFilter || operator.value === REGEX_OPERATOR.value) {
+        if (predicate === null) {
           return option.label !== undefined && regex.test(option.label);
         }
-        if (option.value === undefined || predicate === null) {
+        if (option.value === undefined) {
           return false;
         }
         return predicate(comparableValue(option.value));
       }),
-    [options, regex, showOperators, operator, searchFilter, predicate]
+    [options, regex, predicate]
   );
   const selectedItems = useMemo(() => items.filter((item) => values.includes(item)), [items, values]);
 

--- a/packages/grafana-ui/src/components/Table/filterExpression.test.ts
+++ b/packages/grafana-ui/src/components/Table/filterExpression.test.ts
@@ -1,0 +1,264 @@
+import { ExpressionOperator, comparableValue, makeComparator, parseExpression } from './filterExpression';
+
+describe('comparableValue', () => {
+  it('parses integers', () => {
+    expect(comparableValue('42')).toBe(42);
+  });
+
+  it('parses floats', () => {
+    expect(comparableValue('3.14')).toBe(3.14);
+  });
+
+  it('parses true as boolean', () => {
+    expect(comparableValue('true')).toBe(true);
+  });
+
+  it('parses false as boolean', () => {
+    expect(comparableValue('false')).toBe(false);
+  });
+
+  it('parses boolean case-insensitively', () => {
+    expect(comparableValue('TRUE')).toBe(true);
+    expect(comparableValue('FALSE')).toBe(false);
+  });
+
+  it('parses ISO date strings as a numeric timestamp', () => {
+    const result = comparableValue('2024-01-15');
+    expect(typeof result).toBe('number');
+    expect(new Date(result as number).getFullYear()).toBe(2024);
+  });
+
+  it('parses slash-format date strings as a numeric timestamp', () => {
+    const result = comparableValue('2024/01/15');
+    expect(typeof result).toBe('number');
+    expect(new Date(result as number).getFullYear()).toBe(2024);
+  });
+
+  it('returns a numeric timestamp for a valid ISO date string', () => {
+    const result = comparableValue('2024-01-15');
+    expect(typeof result).toBe('number');
+    expect(result).toBe(new Date('2024-01-15').getTime());
+  });
+
+  it('returns plain strings as-is', () => {
+    expect(comparableValue('hello')).toBe('hello');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(comparableValue('  42  ')).toBe(42);
+  });
+
+  it('strips backslashes', () => {
+    expect(comparableValue('hel\\lo')).toBe('hello');
+  });
+});
+
+describe('makeComparator', () => {
+  describe(ExpressionOperator.EQ, () => {
+    it('returns true when values are equal', () => {
+      expect(makeComparator(ExpressionOperator.EQ, 20)(20)).toBe(true);
+    });
+    it('returns false when values differ', () => {
+      expect(makeComparator(ExpressionOperator.EQ, 20)(10)).toBe(false);
+    });
+  });
+
+  describe(ExpressionOperator.DOUBLE_EQ, () => {
+    it('returns true when values are equal', () => {
+      expect(makeComparator(ExpressionOperator.DOUBLE_EQ, 20)(20)).toBe(true);
+    });
+    it('returns false when values differ', () => {
+      expect(makeComparator(ExpressionOperator.DOUBLE_EQ, 20)(10)).toBe(false);
+    });
+  });
+
+  describe(ExpressionOperator.STRICT_EQ, () => {
+    it('returns true when values are equal', () => {
+      expect(makeComparator(ExpressionOperator.STRICT_EQ, 20)(20)).toBe(true);
+    });
+    it('returns false when values differ', () => {
+      expect(makeComparator(ExpressionOperator.STRICT_EQ, 20)(10)).toBe(false);
+    });
+  });
+
+  describe(ExpressionOperator.NOT_EQ, () => {
+    it('returns true when values differ', () => {
+      expect(makeComparator(ExpressionOperator.NOT_EQ, 20)(10)).toBe(true);
+    });
+    it('returns false when values are equal', () => {
+      expect(makeComparator(ExpressionOperator.NOT_EQ, 20)(20)).toBe(false);
+    });
+  });
+
+  describe(ExpressionOperator.STRICT_NOT_EQ, () => {
+    it('returns true when values differ', () => {
+      expect(makeComparator(ExpressionOperator.STRICT_NOT_EQ, 20)(10)).toBe(true);
+    });
+    it('returns false when values are equal', () => {
+      expect(makeComparator(ExpressionOperator.STRICT_NOT_EQ, 20)(20)).toBe(false);
+    });
+  });
+
+  describe(ExpressionOperator.GT, () => {
+    it('returns true when value is strictly greater', () => {
+      expect(makeComparator(ExpressionOperator.GT, 20)(21)).toBe(true);
+    });
+    it('returns false when value is equal', () => {
+      expect(makeComparator(ExpressionOperator.GT, 20)(20)).toBe(false);
+    });
+    it('returns false when value is less', () => {
+      expect(makeComparator(ExpressionOperator.GT, 20)(19)).toBe(false);
+    });
+  });
+
+  describe(ExpressionOperator.GTE, () => {
+    it('returns true when value is greater', () => {
+      expect(makeComparator(ExpressionOperator.GTE, 20)(21)).toBe(true);
+    });
+    it('returns true when value is equal', () => {
+      expect(makeComparator(ExpressionOperator.GTE, 20)(20)).toBe(true);
+    });
+    it('returns false when value is less', () => {
+      expect(makeComparator(ExpressionOperator.GTE, 20)(19)).toBe(false);
+    });
+  });
+
+  describe(ExpressionOperator.LT, () => {
+    it('returns true when value is strictly less', () => {
+      expect(makeComparator(ExpressionOperator.LT, 20)(19)).toBe(true);
+    });
+    it('returns false when value is equal', () => {
+      expect(makeComparator(ExpressionOperator.LT, 20)(20)).toBe(false);
+    });
+    it('returns false when value is greater', () => {
+      expect(makeComparator(ExpressionOperator.LT, 20)(21)).toBe(false);
+    });
+  });
+
+  describe(ExpressionOperator.LTE, () => {
+    it('returns true when value is less', () => {
+      expect(makeComparator(ExpressionOperator.LTE, 20)(19)).toBe(true);
+    });
+    it('returns true when value is equal', () => {
+      expect(makeComparator(ExpressionOperator.LTE, 20)(20)).toBe(true);
+    });
+    it('returns false when value is greater', () => {
+      expect(makeComparator(ExpressionOperator.LTE, 20)(21)).toBe(false);
+    });
+  });
+
+  it('returns a non-matching predicate for an unknown operator', () => {
+    expect(makeComparator('??', 20)(20)).toBe(false);
+  });
+});
+
+describe('parseExpression', () => {
+  describe('string RHS quoting', () => {
+    it('matches double-quoted string RHS', () => {
+      expect(parseExpression('$ === "foo"')!('foo')).toBe(true);
+      expect(parseExpression('$ === "foo"')!('bar')).toBe(false);
+    });
+
+    it('matches single-quoted string RHS', () => {
+      expect(parseExpression("$ === 'foo'")!('foo')).toBe(true);
+      expect(parseExpression("$ === 'foo'")!('bar')).toBe(false);
+    });
+
+    it('matches backtick-quoted string RHS', () => {
+      expect(parseExpression('$ === `foo`')!('foo')).toBe(true);
+      expect(parseExpression('$ === `foo`')!('bar')).toBe(false);
+    });
+  });
+
+  describe('boolean and date RHS', () => {
+    it('matches boolean true RHS', () => {
+      expect(parseExpression('$ = true')!(true)).toBe(true);
+      expect(parseExpression('$ = true')!(false)).toBe(false);
+    });
+
+    it('matches boolean false RHS', () => {
+      expect(parseExpression('$ = false')!(false)).toBe(true);
+      expect(parseExpression('$ = false')!(true)).toBe(false);
+    });
+
+    it('matches date string RHS', () => {
+      const result = parseExpression('$ = 2024-01-01');
+      const match = comparableValue('2024-01-01');
+      const nonMatch = comparableValue('2024-06-15');
+      expect(result!(match)).toBe(true);
+      expect(result!(nonMatch)).toBe(false);
+    });
+  });
+
+  describe('compound expressions', () => {
+    it('&& requires all clauses to match', () => {
+      const pred = parseExpression('$ > 10 && $ < 20')!;
+      expect(pred(15)).toBe(true);
+      expect(pred(5)).toBe(false);
+      expect(pred(25)).toBe(false);
+    });
+
+    it('pure || matches any clause', () => {
+      const pred = parseExpression('$ = 1 || $ = 10')!;
+      expect(pred(1)).toBe(true);
+      expect(pred(10)).toBe(true);
+      expect(pred(5)).toBe(false);
+    });
+
+    it('mixed && and || respects AND-before-OR precedence', () => {
+      const pred = parseExpression('$ > 5 && $ < 10 || $ > 20')!;
+      expect(pred(7)).toBe(true);
+      expect(pred(25)).toBe(true);
+      expect(pred(3)).toBe(false);
+      expect(pred(15)).toBe(false);
+    });
+  });
+
+  describe('DOUBLE_EQ operator via expression syntax', () => {
+    it('parses $ == 20 and matches equal values', () => {
+      const pred = parseExpression('$ == 20');
+      expect(pred).not.toBeNull();
+      expect(pred!(20)).toBe(true);
+      expect(pred!(10)).toBe(false);
+    });
+
+    it('parses $ == 20 and does not match unequal values', () => {
+      const pred = parseExpression('$ == 20');
+      expect(pred).not.toBeNull();
+      expect(pred!(30)).toBe(false);
+    });
+  });
+
+  describe('invalid expressions', () => {
+    it('"$ ===" parses as == against the string "=" (greedy operator match)', () => {
+      const pred = parseExpression('$ ===');
+      expect(pred).not.toBeNull();
+      expect(pred!('=')).toBe(true);
+      expect(pred!(42)).toBe(false);
+    });
+
+    it('returns null for a clause that does not match CLAUSE_REGEX', () => {
+      expect(parseExpression('not a valid clause')).toBeNull();
+    });
+
+    it('does not evaluate arbitrary function expressions', () => {
+      expect(parseExpression('(function() { return true; })()')).toBeNull();
+    });
+
+    it('does not evaluate arrow function expressions', () => {
+      expect(parseExpression('(() => true)()')).toBeNull();
+    });
+
+    it('does not evaluate arbitrary JS method calls', () => {
+      expect(parseExpression('Math.random() > 0')).toBeNull();
+    });
+
+    it('returns null when any clause in an && group is invalid', () => {
+      expect(parseExpression('$ > 10 && invalid')).toBeNull();
+    });
+
+    it('returns null when any OR group is invalid', () => {
+      expect(parseExpression('$ > 10 || invalid')).toBeNull();
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/Table/filterExpression.test.ts
+++ b/packages/grafana-ui/src/components/Table/filterExpression.test.ts
@@ -253,6 +253,22 @@ describe('parseExpression', () => {
       expect(parseExpression('Math.random() > 0')).toBeNull();
     });
 
+    it('does not execute an IIFE injected via ||', () => {
+      expect(parseExpression('$ > 0 || (function(){ return true; })()')).toBeNull();
+    });
+
+    it('does not execute an IIFE injected via &&', () => {
+      expect(parseExpression('$ > 0 && (function(){ return true; })()')).toBeNull();
+    });
+
+    it('does not expose window globals', () => {
+      expect(parseExpression('window.SECRET')).toBeNull();
+    });
+
+    it('does not expose globalThis', () => {
+      expect(parseExpression('globalThis.fetch')).toBeNull();
+    });
+
     it('returns null when any clause in an && group is invalid', () => {
       expect(parseExpression('$ > 10 && invalid')).toBeNull();
     });

--- a/packages/grafana-ui/src/components/Table/filterExpression.ts
+++ b/packages/grafana-ui/src/components/Table/filterExpression.ts
@@ -1,0 +1,127 @@
+const BACKSLASH_REGEX = /\\/g;
+const AND_SPLIT_REGEX = /\s*&&\s*/;
+const OR_SPLIT_REGEX = /\s*\|\|\s*/;
+const CLAUSE_REGEX = /^\$\s*(>=|<=|!==|!=|===|==|>|<|=)\s*(.+)$/;
+
+export enum ExpressionOperator {
+  EQ = '=',
+  DOUBLE_EQ = '==',
+  STRICT_EQ = '===',
+  NOT_EQ = '!=',
+  STRICT_NOT_EQ = '!==',
+  GT = '>',
+  GTE = '>=',
+  LT = '<',
+  LTE = '<=',
+}
+const QUOTED_STRING_REGEX = /^(['"`])(.*)\1$/;
+const DATE_REGEX = /^(\d{4}-\d{2}-\d{2}|\d{4}\/\d{2}\/\d{2})/;
+
+export type ComparableValue = string | number | boolean;
+export type Predicate = (v: ComparableValue) => boolean;
+
+const COMPARABLE_VALUE_CACHE_MAX = 2048;
+const comparableValueCache = new Map<string, ComparableValue>();
+
+const parseComparableValue = (value: string): ComparableValue => {
+  if (DATE_REGEX.test(value)) {
+    const ms = new Date(value).getTime();
+    if (!isNaN(ms)) {
+      return ms;
+    }
+  }
+
+  const num = parseFloat(value);
+  if (!isNaN(num)) {
+    return num;
+  }
+
+  const lvalue = value.toLowerCase();
+  if (lvalue === 'true' || lvalue === 'false') {
+    return lvalue === 'true';
+  }
+
+  return value;
+};
+
+export const comparableValue = (value: string): ComparableValue => {
+  const key = value.trim().replace(BACKSLASH_REGEX, '');
+  const cached = comparableValueCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const result = parseComparableValue(key);
+  if (comparableValueCache.size >= COMPARABLE_VALUE_CACHE_MAX) {
+    comparableValueCache.clear();
+  }
+  comparableValueCache.set(key, result);
+  return result;
+};
+
+export const makeComparator = (op: string, rhs: ComparableValue): Predicate => {
+  switch (op) {
+    case ExpressionOperator.EQ:
+    case ExpressionOperator.DOUBLE_EQ:
+    case ExpressionOperator.STRICT_EQ:
+      return (v) => v === rhs;
+
+    case ExpressionOperator.GT:
+      return (v) => v > rhs;
+    case ExpressionOperator.GTE:
+      return (v) => v >= rhs;
+
+    case ExpressionOperator.LT:
+      return (v) => v < rhs;
+    case ExpressionOperator.LTE:
+      return (v) => v <= rhs;
+
+    case ExpressionOperator.NOT_EQ:
+    case ExpressionOperator.STRICT_NOT_EQ:
+      return (v) => v !== rhs;
+
+    default:
+      return () => false;
+  }
+};
+
+const parseClause = (clause: string): Predicate | null => {
+  const match = clause.trim().match(CLAUSE_REGEX);
+
+  if (!match) {
+    return null;
+  }
+
+  const raw = match[2].trim();
+  const quoted = raw.match(QUOTED_STRING_REGEX);
+  const rhs = quoted ? quoted[2] : comparableValue(raw);
+  return makeComparator(match[1], rhs);
+};
+
+export const parseExpression = (xpr: string): Predicate | null => {
+  const andGroups = xpr
+    .replace(BACKSLASH_REGEX, '')
+    .split(OR_SPLIT_REGEX)
+    .map((group) => {
+      const clauses = group.split(AND_SPLIT_REGEX).map(parseClause);
+
+      if (clauses.some((p) => p === null)) {
+        return null;
+      }
+
+      const fns = clauses.filter((p): p is Predicate => p !== null);
+      if (fns.length === 1) {
+        return fns[0];
+      }
+      return (v: ComparableValue) => fns.every((p) => p(v));
+    });
+
+  if (andGroups.some((g) => g === null)) {
+    return null;
+  }
+
+  const groups = andGroups.filter((g): g is Predicate => g !== null);
+  if (groups.length === 1) {
+    return groups[0];
+  }
+  return (v: ComparableValue) => groups.some((g) => g(v));
+};


### PR DESCRIPTION
**What is this feature?**

This change refactors `TableNG` and `TableRT` filter expressions to avoid the use of `new Function(...)`.

**Why do we need this feature?**

Removing `new Function(...)` reduces our exposure to arbitrary code execution. While not currently known to be exploitable, there's not much value in risking it.

**Who is this feature for?**

All users of Grafana, and consumers of the Table panel.

**Which issue(s) does this PR fix?**:

Fixes 🔐  `N/A`

**Special notes for your reviewer:**

Runtime performance should be a consideration in evaluating this change.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
