### PR TITLE
Provisioning: make GitHub client repo-scoped

### DIFF
--- a/apps/provisioning/pkg/repository/github/client.go
+++ b/apps/provisioning/pkg/repository/github/client.go
@@ -10,27 +10,27 @@ import (
 //go:generate mockery --name Client --structname MockClient --inpackage --filename mock_client.go --with-expecter
 type Client interface {
 	// Repositories
-	GetRepository(ctx context.Context, owner, repository string) (Repository, error)
+	GetRepository(ctx context.Context) (Repository, error)
 
 	// Branch protection
-	GetBranchProtection(ctx context.Context, owner, repository, branch string) (*BranchProtection, error)
+	GetBranchProtection(ctx context.Context, branch string) (*BranchProtection, error)
 
 	// Repository rulesets
-	GetRulesets(ctx context.Context, owner, repository, branch string) (*Rulesets, error)
+	GetRulesets(ctx context.Context, branch string) (*Rulesets, error)
 
 	// Commits
-	Commits(ctx context.Context, owner, repository, path, branch string) ([]Commit, error)
+	Commits(ctx context.Context, path, branch string) ([]Commit, error)
 
 	// Webhooks
-	ListWebhooks(ctx context.Context, owner, repository string) ([]WebhookConfig, error)
-	CreateWebhook(ctx context.Context, owner, repository string, cfg WebhookConfig) (WebhookConfig, error)
-	GetWebhook(ctx context.Context, owner, repository string, webhookID int64) (WebhookConfig, error)
-	DeleteWebhook(ctx context.Context, owner, repository string, webhookID int64) error
-	EditWebhook(ctx context.Context, owner, repository string, cfg WebhookConfig) error
+	ListWebhooks(ctx context.Context) ([]WebhookConfig, error)
+	CreateWebhook(ctx context.Context, cfg WebhookConfig) (WebhookConfig, error)
+	GetWebhook(ctx context.Context, webhookID int64) (WebhookConfig, error)
+	DeleteWebhook(ctx context.Context, webhookID int64) error
+	EditWebhook(ctx context.Context, cfg WebhookConfig) error
 
 	// Pull requests
-	ListPullRequestFiles(ctx context.Context, owner, repository string, number int) ([]CommitFile, error)
-	CreatePullRequestComment(ctx context.Context, owner, repository string, number int, body string) error
+	ListPullRequestFiles(ctx context.Context, number int) ([]CommitFile, error)
+	CreatePullRequestComment(ctx context.Context, number int, body string) error
 }
 
 type Repository struct {

--- a/apps/provisioning/pkg/repository/github/factory.go
+++ b/apps/provisioning/pkg/repository/github/factory.go
@@ -29,9 +29,9 @@ func ProvideFactory() *Factory {
 	}
 }
 
-func (r *Factory) New(ctx context.Context, ghToken common.RawSecureValue) Client {
+func (r *Factory) New(ctx context.Context, owner, repo string, ghToken common.RawSecureValue) Client {
 	if r.Client != nil {
-		return NewClient(github.NewClient(r.Client))
+		return NewClient(github.NewClient(r.Client), owner, repo)
 	}
 
 	if !ghToken.IsZero() {
@@ -39,8 +39,8 @@ func (r *Factory) New(ctx context.Context, ghToken common.RawSecureValue) Client
 			&oauth2.Token{AccessToken: string(ghToken)},
 		)
 		tokenClient := oauth2.NewClient(ctx, tokenSrc)
-		return NewClient(github.NewClient(tokenClient))
+		return NewClient(github.NewClient(tokenClient), owner, repo)
 	}
 
-	return NewClient(github.NewClient(&http.Client{}))
+	return NewClient(github.NewClient(&http.Client{}), owner, repo)
 }

--- a/apps/provisioning/pkg/repository/github/impl.go
+++ b/apps/provisioning/pkg/repository/github/impl.go
@@ -15,11 +15,13 @@ import (
 )
 
 type githubClient struct {
-	gh *github.Client
+	gh    *github.Client
+	owner string
+	repo  string
 }
 
-func NewClient(client *github.Client) Client {
-	return &githubClient{client}
+func NewClient(client *github.Client, owner, repo string) Client {
+	return &githubClient{gh: client, owner: owner, repo: repo}
 }
 
 // translateGitHubError converts GitHub API errors into common repository errors
@@ -77,8 +79,8 @@ const (
 	maxPRFiles  = 1000 // Maximum number of files allowed in a pull request
 )
 
-func (r *githubClient) GetBranchProtection(ctx context.Context, owner, repository, branch string) (*BranchProtection, error) {
-	protection, _, err := r.gh.Repositories.GetBranchProtection(ctx, owner, repository, branch)
+func (r *githubClient) GetBranchProtection(ctx context.Context, branch string) (*BranchProtection, error) {
+	protection, _, err := r.gh.Repositories.GetBranchProtection(ctx, r.owner, r.repo, branch)
 	if err != nil {
 		// Branch has no protection rules at all - this is fine, skip the check.
 		if errors.Is(err, github.ErrBranchNotProtected) {
@@ -95,8 +97,8 @@ func (r *githubClient) GetBranchProtection(ctx context.Context, owner, repositor
 				// User lacks admin permissions to view branch protection.
 				// Skip check gracefully - if protection rules block pushes, they'll find out at push time.
 				logging.FromContext(ctx).Warn("Skipping branch protection check: token lacks Administration read permission",
-					slog.String("owner", owner),
-					slog.String("repository", repository),
+					slog.String("owner", r.owner),
+					slog.String("repository", r.repo),
 					slog.String("branch", branch))
 				return nil, nil
 			case http.StatusNotFound:
@@ -117,16 +119,16 @@ func (r *githubClient) GetBranchProtection(ctx context.Context, owner, repositor
 	return bp, nil
 }
 
-func (r *githubClient) GetRulesets(ctx context.Context, owner, repository, branch string) (*Rulesets, error) {
+func (r *githubClient) GetRulesets(ctx context.Context, branch string) (*Rulesets, error) {
 	// Create logger with base context
 	logger := logging.FromContext(ctx).With(
-		slog.String("owner", owner),
-		slog.String("repository", repository),
+		slog.String("owner", r.owner),
+		slog.String("repository", r.repo),
 		slog.String("branch", branch))
 
 	// Get all active rules that apply to this specific branch
 	// This API returns only active rules (no disabled/evaluate enforcement)
-	branchRules, _, err := r.gh.Repositories.GetRulesForBranch(ctx, owner, repository, branch, nil)
+	branchRules, _, err := r.gh.Repositories.GetRulesForBranch(ctx, r.owner, r.repo, branch, nil)
 	if err != nil {
 		// Handle common error cases
 		var ghErr *github.ErrorResponse
@@ -182,7 +184,7 @@ func (r *githubClient) GetRulesets(ctx context.Context, owner, repository, branc
 	}
 
 	for rulesetID := range rulesetIDs {
-		ruleset, _, err := r.gh.Repositories.GetRuleset(ctx, owner, repository, rulesetID, false)
+		ruleset, _, err := r.gh.Repositories.GetRuleset(ctx, r.owner, r.repo, rulesetID, false)
 		if err != nil {
 			// Fail-closed: a silent false negative would let the Repository save and
 			// then fail every subsequent sync push with a 403. Surfacing a block at
@@ -213,8 +215,8 @@ func (r *githubClient) GetRulesets(ctx context.Context, owner, repository, branc
 	return nil, nil
 }
 
-func (r *githubClient) GetRepository(ctx context.Context, owner, repository string) (Repository, error) {
-	repo, _, err := r.gh.Repositories.Get(ctx, owner, repository)
+func (r *githubClient) GetRepository(ctx context.Context) (Repository, error) {
+	repo, _, err := r.gh.Repositories.Get(ctx, r.owner, r.repo)
 	if err != nil {
 		return Repository{}, translateGitHubError(err)
 	}
@@ -227,9 +229,9 @@ func (r *githubClient) GetRepository(ctx context.Context, owner, repository stri
 }
 
 // Commits returns a list of commits for a given repository and branch.
-func (r *githubClient) Commits(ctx context.Context, owner, repository, path, branch string) ([]Commit, error) {
+func (r *githubClient) Commits(ctx context.Context, path, branch string) ([]Commit, error) {
 	listFn := func(ctx context.Context, opts *github.ListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
-		return r.gh.Repositories.ListCommits(ctx, owner, repository, &github.CommitsListOptions{
+		return r.gh.Repositories.ListCommits(ctx, r.owner, r.repo, &github.CommitsListOptions{
 			Path:        path,
 			SHA:         branch,
 			ListOptions: *opts,
@@ -285,9 +287,9 @@ func (r *githubClient) Commits(ctx context.Context, owner, repository, path, bra
 	return ret, nil
 }
 
-func (r *githubClient) ListWebhooks(ctx context.Context, owner, repository string) ([]WebhookConfig, error) {
+func (r *githubClient) ListWebhooks(ctx context.Context) ([]WebhookConfig, error) {
 	listFn := func(ctx context.Context, opts *github.ListOptions) ([]*github.Hook, *github.Response, error) {
-		return r.gh.Repositories.ListHooks(ctx, owner, repository, opts)
+		return r.gh.Repositories.ListHooks(ctx, r.owner, r.repo, opts)
 	}
 
 	hooks, err := paginatedList(
@@ -322,7 +324,7 @@ func (r *githubClient) ListWebhooks(ctx context.Context, owner, repository strin
 	return ret, nil
 }
 
-func (r *githubClient) CreateWebhook(ctx context.Context, owner, repository string, cfg WebhookConfig) (WebhookConfig, error) {
+func (r *githubClient) CreateWebhook(ctx context.Context, cfg WebhookConfig) (WebhookConfig, error) {
 	if cfg.ContentType == "" {
 		cfg.ContentType = "form"
 	}
@@ -338,7 +340,7 @@ func (r *githubClient) CreateWebhook(ctx context.Context, owner, repository stri
 		},
 	}
 
-	createdHook, _, err := r.gh.Repositories.CreateHook(ctx, owner, repository, hook)
+	createdHook, _, err := r.gh.Repositories.CreateHook(ctx, r.owner, r.repo, hook)
 	if err != nil {
 		return WebhookConfig{}, translateGitHubError(err)
 	}
@@ -355,8 +357,8 @@ func (r *githubClient) CreateWebhook(ctx context.Context, owner, repository stri
 	}, nil
 }
 
-func (r *githubClient) GetWebhook(ctx context.Context, owner, repository string, webhookID int64) (WebhookConfig, error) {
-	hook, _, err := r.gh.Repositories.GetHook(ctx, owner, repository, webhookID)
+func (r *githubClient) GetWebhook(ctx context.Context, webhookID int64) (WebhookConfig, error) {
+	hook, _, err := r.gh.Repositories.GetHook(ctx, r.owner, r.repo, webhookID)
 	if err != nil {
 		return WebhookConfig{}, translateGitHubError(err)
 	}
@@ -378,15 +380,15 @@ func (r *githubClient) GetWebhook(ctx context.Context, owner, repository string,
 	}, nil
 }
 
-func (r *githubClient) DeleteWebhook(ctx context.Context, owner, repository string, webhookID int64) error {
-	_, err := r.gh.Repositories.DeleteHook(ctx, owner, repository, webhookID)
+func (r *githubClient) DeleteWebhook(ctx context.Context, webhookID int64) error {
+	_, err := r.gh.Repositories.DeleteHook(ctx, r.owner, r.repo, webhookID)
 	if err != nil {
 		return translateGitHubError(err)
 	}
 	return nil
 }
 
-func (r *githubClient) EditWebhook(ctx context.Context, owner, repository string, cfg WebhookConfig) error {
+func (r *githubClient) EditWebhook(ctx context.Context, cfg WebhookConfig) error {
 	if cfg.ContentType == "" {
 		cfg.ContentType = "form"
 	}
@@ -401,16 +403,16 @@ func (r *githubClient) EditWebhook(ctx context.Context, owner, repository string
 			URL:         &cfg.URL,
 		},
 	}
-	_, _, err := r.gh.Repositories.EditHook(ctx, owner, repository, cfg.ID, hook)
+	_, _, err := r.gh.Repositories.EditHook(ctx, r.owner, r.repo, cfg.ID, hook)
 	if err != nil {
 		return translateGitHubError(err)
 	}
 	return nil
 }
 
-func (r *githubClient) ListPullRequestFiles(ctx context.Context, owner, repository string, number int) ([]CommitFile, error) {
+func (r *githubClient) ListPullRequestFiles(ctx context.Context, number int) ([]CommitFile, error) {
 	listFn := func(ctx context.Context, opts *github.ListOptions) ([]*github.CommitFile, *github.Response, error) {
-		return r.gh.PullRequests.ListFiles(ctx, owner, repository, number, opts)
+		return r.gh.PullRequests.ListFiles(ctx, r.owner, r.repo, number, opts)
 	}
 
 	files, err := paginatedList(
@@ -434,12 +436,12 @@ func (r *githubClient) ListPullRequestFiles(ctx context.Context, owner, reposito
 	return ret, nil
 }
 
-func (r *githubClient) CreatePullRequestComment(ctx context.Context, owner, repository string, number int, body string) error {
+func (r *githubClient) CreatePullRequestComment(ctx context.Context, number int, body string) error {
 	comment := &github.IssueComment{
 		Body: &body,
 	}
 
-	if _, _, err := r.gh.Issues.CreateComment(ctx, owner, repository, number, comment); err != nil {
+	if _, _, err := r.gh.Issues.CreateComment(ctx, r.owner, r.repo, number, comment); err != nil {
 		return translateGitHubError(err)
 	}
 

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -341,10 +341,10 @@ func TestGithubClient_GetCommits(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), "")
+			client := factory.New(context.Background(), tt.owner, tt.repository, "")
 
 			// Call the method being tested
-			commits, err := client.Commits(context.Background(), tt.owner, tt.repository, tt.branch, tt.path)
+			commits, err := client.Commits(context.Background(), tt.branch, tt.path)
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -518,10 +518,10 @@ func TestGithubClient_ListWebhooks(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), "")
+			client := factory.New(context.Background(), tt.owner, tt.repository, "")
 
 			// Call the method being tested
-			webhooks, err := client.ListWebhooks(context.Background(), tt.owner, tt.repository)
+			webhooks, err := client.ListWebhooks(context.Background())
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -722,10 +722,10 @@ func TestGithubClient_CreateWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), "")
+			client := factory.New(context.Background(), tt.owner, tt.repository, "")
 
 			// Call the method being tested
-			got, err := client.CreateWebhook(context.Background(), tt.owner, tt.repository, tt.config)
+			got, err := client.CreateWebhook(context.Background(), tt.config)
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -898,10 +898,10 @@ func TestGithubClient_GetWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), "")
+			client := factory.New(context.Background(), tt.owner, tt.repository, "")
 
 			// Call the method being tested
-			got, err := client.GetWebhook(context.Background(), tt.owner, tt.repository, tt.webhookID)
+			got, err := client.GetWebhook(context.Background(), tt.webhookID)
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -1040,10 +1040,10 @@ func TestGithubClient_DeleteWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), "")
+			client := factory.New(context.Background(), tt.owner, tt.repository, "")
 
 			// Call the method being tested
-			err := client.DeleteWebhook(context.Background(), tt.owner, tt.repository, tt.webhookID)
+			err := client.DeleteWebhook(context.Background(), tt.webhookID)
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -1233,10 +1233,10 @@ func TestGithubClient_EditWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), "")
+			client := factory.New(context.Background(), tt.owner, tt.repository, "")
 
 			// Call the method being tested
-			err := client.EditWebhook(context.Background(), tt.owner, tt.repository, tt.config)
+			err := client.EditWebhook(context.Background(), tt.config)
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -1416,10 +1416,10 @@ func TestGithubClient_ListPullRequestFiles(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), "")
+			client := factory.New(context.Background(), tt.owner, tt.repository, "")
 
 			// Call the method being tested
-			files, err := client.ListPullRequestFiles(context.Background(), tt.owner, tt.repository, tt.number)
+			files, err := client.ListPullRequestFiles(context.Background(), tt.number)
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -1535,10 +1535,10 @@ func TestCreatePullRequestComment(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), "")
+			client := factory.New(context.Background(), tt.owner, tt.repository, "")
 
 			// Call the method being tested
-			err := client.CreatePullRequestComment(context.Background(), tt.owner, tt.repository, tt.number, tt.body)
+			err := client.CreatePullRequestComment(context.Background(), tt.number, tt.body)
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -2296,10 +2296,12 @@ func TestGithubClient_GetRulesets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			client := &githubClient{
-				gh: github.NewClient(tt.mockHandler),
+				gh:    github.NewClient(tt.mockHandler),
+				owner: tt.owner,
+				repo:  tt.repository,
 			}
 
-			got, err := client.GetRulesets(ctx, tt.owner, tt.repository, tt.branch)
+			got, err := client.GetRulesets(ctx, tt.branch)
 
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -2354,8 +2356,8 @@ func TestGithubClient_GetRulesets_DeduplicatesParentRulesetFetch(t *testing.T) {
 		),
 	)
 
-	client := &githubClient{gh: github.NewClient(mockHandler)}
-	got, err := client.GetRulesets(context.Background(), "test-owner", "test-repo", "main")
+	client := &githubClient{gh: github.NewClient(mockHandler), owner: "test-owner", repo: "test-repo"}
+	got, err := client.GetRulesets(context.Background(), "main")
 
 	require.NoError(t, err)
 	assert.Nil(t, got)
@@ -2630,10 +2632,10 @@ func TestGithubClient_GetRepository(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), "")
+			client := factory.New(context.Background(), tt.owner, tt.repository, "")
 
 			// Call the method being tested
-			got, err := client.GetRepository(context.Background(), tt.owner, tt.repository)
+			got, err := client.GetRepository(context.Background())
 
 			// Check the error
 			if tt.wantErr != nil {

--- a/apps/provisioning/pkg/repository/github/mock_client.go
+++ b/apps/provisioning/pkg/repository/github/mock_client.go
@@ -21,9 +21,9 @@ func (_m *MockClient) EXPECT() *MockClient_Expecter {
 	return &MockClient_Expecter{mock: &_m.Mock}
 }
 
-// Commits provides a mock function with given fields: ctx, owner, repository, path, branch
-func (_m *MockClient) Commits(ctx context.Context, owner string, repository string, path string, branch string) ([]Commit, error) {
-	ret := _m.Called(ctx, owner, repository, path, branch)
+// Commits provides a mock function with given fields: ctx, path, branch
+func (_m *MockClient) Commits(ctx context.Context, path string, branch string) ([]Commit, error) {
+	ret := _m.Called(ctx, path, branch)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Commits")
@@ -31,19 +31,19 @@ func (_m *MockClient) Commits(ctx context.Context, owner string, repository stri
 
 	var r0 []Commit
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) ([]Commit, error)); ok {
-		return rf(ctx, owner, repository, path, branch)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) ([]Commit, error)); ok {
+		return rf(ctx, path, branch)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) []Commit); ok {
-		r0 = rf(ctx, owner, repository, path, branch)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) []Commit); ok {
+		r0 = rf(ctx, path, branch)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]Commit)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string) error); ok {
-		r1 = rf(ctx, owner, repository, path, branch)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, path, branch)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -58,17 +58,15 @@ type MockClient_Commits_Call struct {
 
 // Commits is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
 //   - path string
 //   - branch string
-func (_e *MockClient_Expecter) Commits(ctx interface{}, owner interface{}, repository interface{}, path interface{}, branch interface{}) *MockClient_Commits_Call {
-	return &MockClient_Commits_Call{Call: _e.mock.On("Commits", ctx, owner, repository, path, branch)}
+func (_e *MockClient_Expecter) Commits(ctx interface{}, path interface{}, branch interface{}) *MockClient_Commits_Call {
+	return &MockClient_Commits_Call{Call: _e.mock.On("Commits", ctx, path, branch)}
 }
 
-func (_c *MockClient_Commits_Call) Run(run func(ctx context.Context, owner string, repository string, path string, branch string)) *MockClient_Commits_Call {
+func (_c *MockClient_Commits_Call) Run(run func(ctx context.Context, path string, branch string)) *MockClient_Commits_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -78,22 +76,22 @@ func (_c *MockClient_Commits_Call) Return(_a0 []Commit, _a1 error) *MockClient_C
 	return _c
 }
 
-func (_c *MockClient_Commits_Call) RunAndReturn(run func(context.Context, string, string, string, string) ([]Commit, error)) *MockClient_Commits_Call {
+func (_c *MockClient_Commits_Call) RunAndReturn(run func(context.Context, string, string) ([]Commit, error)) *MockClient_Commits_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// CreatePullRequestComment provides a mock function with given fields: ctx, owner, repository, number, body
-func (_m *MockClient) CreatePullRequestComment(ctx context.Context, owner string, repository string, number int, body string) error {
-	ret := _m.Called(ctx, owner, repository, number, body)
+// CreatePullRequestComment provides a mock function with given fields: ctx, number, body
+func (_m *MockClient) CreatePullRequestComment(ctx context.Context, number int, body string) error {
+	ret := _m.Called(ctx, number, body)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreatePullRequestComment")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int, string) error); ok {
-		r0 = rf(ctx, owner, repository, number, body)
+	if rf, ok := ret.Get(0).(func(context.Context, int, string) error); ok {
+		r0 = rf(ctx, number, body)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -108,17 +106,15 @@ type MockClient_CreatePullRequestComment_Call struct {
 
 // CreatePullRequestComment is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
 //   - number int
 //   - body string
-func (_e *MockClient_Expecter) CreatePullRequestComment(ctx interface{}, owner interface{}, repository interface{}, number interface{}, body interface{}) *MockClient_CreatePullRequestComment_Call {
-	return &MockClient_CreatePullRequestComment_Call{Call: _e.mock.On("CreatePullRequestComment", ctx, owner, repository, number, body)}
+func (_e *MockClient_Expecter) CreatePullRequestComment(ctx interface{}, number interface{}, body interface{}) *MockClient_CreatePullRequestComment_Call {
+	return &MockClient_CreatePullRequestComment_Call{Call: _e.mock.On("CreatePullRequestComment", ctx, number, body)}
 }
 
-func (_c *MockClient_CreatePullRequestComment_Call) Run(run func(ctx context.Context, owner string, repository string, number int, body string)) *MockClient_CreatePullRequestComment_Call {
+func (_c *MockClient_CreatePullRequestComment_Call) Run(run func(ctx context.Context, number int, body string)) *MockClient_CreatePullRequestComment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(int), args[4].(string))
+		run(args[0].(context.Context), args[1].(int), args[2].(string))
 	})
 	return _c
 }
@@ -128,14 +124,14 @@ func (_c *MockClient_CreatePullRequestComment_Call) Return(_a0 error) *MockClien
 	return _c
 }
 
-func (_c *MockClient_CreatePullRequestComment_Call) RunAndReturn(run func(context.Context, string, string, int, string) error) *MockClient_CreatePullRequestComment_Call {
+func (_c *MockClient_CreatePullRequestComment_Call) RunAndReturn(run func(context.Context, int, string) error) *MockClient_CreatePullRequestComment_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// CreateWebhook provides a mock function with given fields: ctx, owner, repository, cfg
-func (_m *MockClient) CreateWebhook(ctx context.Context, owner string, repository string, cfg WebhookConfig) (WebhookConfig, error) {
-	ret := _m.Called(ctx, owner, repository, cfg)
+// CreateWebhook provides a mock function with given fields: ctx, cfg
+func (_m *MockClient) CreateWebhook(ctx context.Context, cfg WebhookConfig) (WebhookConfig, error) {
+	ret := _m.Called(ctx, cfg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateWebhook")
@@ -143,17 +139,17 @@ func (_m *MockClient) CreateWebhook(ctx context.Context, owner string, repositor
 
 	var r0 WebhookConfig
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, WebhookConfig) (WebhookConfig, error)); ok {
-		return rf(ctx, owner, repository, cfg)
+	if rf, ok := ret.Get(0).(func(context.Context, WebhookConfig) (WebhookConfig, error)); ok {
+		return rf(ctx, cfg)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, WebhookConfig) WebhookConfig); ok {
-		r0 = rf(ctx, owner, repository, cfg)
+	if rf, ok := ret.Get(0).(func(context.Context, WebhookConfig) WebhookConfig); ok {
+		r0 = rf(ctx, cfg)
 	} else {
 		r0 = ret.Get(0).(WebhookConfig)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, WebhookConfig) error); ok {
-		r1 = rf(ctx, owner, repository, cfg)
+	if rf, ok := ret.Get(1).(func(context.Context, WebhookConfig) error); ok {
+		r1 = rf(ctx, cfg)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -168,16 +164,14 @@ type MockClient_CreateWebhook_Call struct {
 
 // CreateWebhook is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
 //   - cfg WebhookConfig
-func (_e *MockClient_Expecter) CreateWebhook(ctx interface{}, owner interface{}, repository interface{}, cfg interface{}) *MockClient_CreateWebhook_Call {
-	return &MockClient_CreateWebhook_Call{Call: _e.mock.On("CreateWebhook", ctx, owner, repository, cfg)}
+func (_e *MockClient_Expecter) CreateWebhook(ctx interface{}, cfg interface{}) *MockClient_CreateWebhook_Call {
+	return &MockClient_CreateWebhook_Call{Call: _e.mock.On("CreateWebhook", ctx, cfg)}
 }
 
-func (_c *MockClient_CreateWebhook_Call) Run(run func(ctx context.Context, owner string, repository string, cfg WebhookConfig)) *MockClient_CreateWebhook_Call {
+func (_c *MockClient_CreateWebhook_Call) Run(run func(ctx context.Context, cfg WebhookConfig)) *MockClient_CreateWebhook_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(WebhookConfig))
+		run(args[0].(context.Context), args[1].(WebhookConfig))
 	})
 	return _c
 }
@@ -187,22 +181,22 @@ func (_c *MockClient_CreateWebhook_Call) Return(_a0 WebhookConfig, _a1 error) *M
 	return _c
 }
 
-func (_c *MockClient_CreateWebhook_Call) RunAndReturn(run func(context.Context, string, string, WebhookConfig) (WebhookConfig, error)) *MockClient_CreateWebhook_Call {
+func (_c *MockClient_CreateWebhook_Call) RunAndReturn(run func(context.Context, WebhookConfig) (WebhookConfig, error)) *MockClient_CreateWebhook_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DeleteWebhook provides a mock function with given fields: ctx, owner, repository, webhookID
-func (_m *MockClient) DeleteWebhook(ctx context.Context, owner string, repository string, webhookID int64) error {
-	ret := _m.Called(ctx, owner, repository, webhookID)
+// DeleteWebhook provides a mock function with given fields: ctx, webhookID
+func (_m *MockClient) DeleteWebhook(ctx context.Context, webhookID int64) error {
+	ret := _m.Called(ctx, webhookID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteWebhook")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64) error); ok {
-		r0 = rf(ctx, owner, repository, webhookID)
+	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
+		r0 = rf(ctx, webhookID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -217,16 +211,14 @@ type MockClient_DeleteWebhook_Call struct {
 
 // DeleteWebhook is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
 //   - webhookID int64
-func (_e *MockClient_Expecter) DeleteWebhook(ctx interface{}, owner interface{}, repository interface{}, webhookID interface{}) *MockClient_DeleteWebhook_Call {
-	return &MockClient_DeleteWebhook_Call{Call: _e.mock.On("DeleteWebhook", ctx, owner, repository, webhookID)}
+func (_e *MockClient_Expecter) DeleteWebhook(ctx interface{}, webhookID interface{}) *MockClient_DeleteWebhook_Call {
+	return &MockClient_DeleteWebhook_Call{Call: _e.mock.On("DeleteWebhook", ctx, webhookID)}
 }
 
-func (_c *MockClient_DeleteWebhook_Call) Run(run func(ctx context.Context, owner string, repository string, webhookID int64)) *MockClient_DeleteWebhook_Call {
+func (_c *MockClient_DeleteWebhook_Call) Run(run func(ctx context.Context, webhookID int64)) *MockClient_DeleteWebhook_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(int64))
+		run(args[0].(context.Context), args[1].(int64))
 	})
 	return _c
 }
@@ -236,22 +228,22 @@ func (_c *MockClient_DeleteWebhook_Call) Return(_a0 error) *MockClient_DeleteWeb
 	return _c
 }
 
-func (_c *MockClient_DeleteWebhook_Call) RunAndReturn(run func(context.Context, string, string, int64) error) *MockClient_DeleteWebhook_Call {
+func (_c *MockClient_DeleteWebhook_Call) RunAndReturn(run func(context.Context, int64) error) *MockClient_DeleteWebhook_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// EditWebhook provides a mock function with given fields: ctx, owner, repository, cfg
-func (_m *MockClient) EditWebhook(ctx context.Context, owner string, repository string, cfg WebhookConfig) error {
-	ret := _m.Called(ctx, owner, repository, cfg)
+// EditWebhook provides a mock function with given fields: ctx, cfg
+func (_m *MockClient) EditWebhook(ctx context.Context, cfg WebhookConfig) error {
+	ret := _m.Called(ctx, cfg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for EditWebhook")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, WebhookConfig) error); ok {
-		r0 = rf(ctx, owner, repository, cfg)
+	if rf, ok := ret.Get(0).(func(context.Context, WebhookConfig) error); ok {
+		r0 = rf(ctx, cfg)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -266,16 +258,14 @@ type MockClient_EditWebhook_Call struct {
 
 // EditWebhook is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
 //   - cfg WebhookConfig
-func (_e *MockClient_Expecter) EditWebhook(ctx interface{}, owner interface{}, repository interface{}, cfg interface{}) *MockClient_EditWebhook_Call {
-	return &MockClient_EditWebhook_Call{Call: _e.mock.On("EditWebhook", ctx, owner, repository, cfg)}
+func (_e *MockClient_Expecter) EditWebhook(ctx interface{}, cfg interface{}) *MockClient_EditWebhook_Call {
+	return &MockClient_EditWebhook_Call{Call: _e.mock.On("EditWebhook", ctx, cfg)}
 }
 
-func (_c *MockClient_EditWebhook_Call) Run(run func(ctx context.Context, owner string, repository string, cfg WebhookConfig)) *MockClient_EditWebhook_Call {
+func (_c *MockClient_EditWebhook_Call) Run(run func(ctx context.Context, cfg WebhookConfig)) *MockClient_EditWebhook_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(WebhookConfig))
+		run(args[0].(context.Context), args[1].(WebhookConfig))
 	})
 	return _c
 }
@@ -285,14 +275,14 @@ func (_c *MockClient_EditWebhook_Call) Return(_a0 error) *MockClient_EditWebhook
 	return _c
 }
 
-func (_c *MockClient_EditWebhook_Call) RunAndReturn(run func(context.Context, string, string, WebhookConfig) error) *MockClient_EditWebhook_Call {
+func (_c *MockClient_EditWebhook_Call) RunAndReturn(run func(context.Context, WebhookConfig) error) *MockClient_EditWebhook_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetBranchProtection provides a mock function with given fields: ctx, owner, repository, branch
-func (_m *MockClient) GetBranchProtection(ctx context.Context, owner string, repository string, branch string) (*BranchProtection, error) {
-	ret := _m.Called(ctx, owner, repository, branch)
+// GetBranchProtection provides a mock function with given fields: ctx, branch
+func (_m *MockClient) GetBranchProtection(ctx context.Context, branch string) (*BranchProtection, error) {
+	ret := _m.Called(ctx, branch)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBranchProtection")
@@ -300,19 +290,19 @@ func (_m *MockClient) GetBranchProtection(ctx context.Context, owner string, rep
 
 	var r0 *BranchProtection
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*BranchProtection, error)); ok {
-		return rf(ctx, owner, repository, branch)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*BranchProtection, error)); ok {
+		return rf(ctx, branch)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *BranchProtection); ok {
-		r0 = rf(ctx, owner, repository, branch)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *BranchProtection); ok {
+		r0 = rf(ctx, branch)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*BranchProtection)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, owner, repository, branch)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, branch)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -327,16 +317,14 @@ type MockClient_GetBranchProtection_Call struct {
 
 // GetBranchProtection is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
 //   - branch string
-func (_e *MockClient_Expecter) GetBranchProtection(ctx interface{}, owner interface{}, repository interface{}, branch interface{}) *MockClient_GetBranchProtection_Call {
-	return &MockClient_GetBranchProtection_Call{Call: _e.mock.On("GetBranchProtection", ctx, owner, repository, branch)}
+func (_e *MockClient_Expecter) GetBranchProtection(ctx interface{}, branch interface{}) *MockClient_GetBranchProtection_Call {
+	return &MockClient_GetBranchProtection_Call{Call: _e.mock.On("GetBranchProtection", ctx, branch)}
 }
 
-func (_c *MockClient_GetBranchProtection_Call) Run(run func(ctx context.Context, owner string, repository string, branch string)) *MockClient_GetBranchProtection_Call {
+func (_c *MockClient_GetBranchProtection_Call) Run(run func(ctx context.Context, branch string)) *MockClient_GetBranchProtection_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -346,14 +334,14 @@ func (_c *MockClient_GetBranchProtection_Call) Return(_a0 *BranchProtection, _a1
 	return _c
 }
 
-func (_c *MockClient_GetBranchProtection_Call) RunAndReturn(run func(context.Context, string, string, string) (*BranchProtection, error)) *MockClient_GetBranchProtection_Call {
+func (_c *MockClient_GetBranchProtection_Call) RunAndReturn(run func(context.Context, string) (*BranchProtection, error)) *MockClient_GetBranchProtection_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetRepository provides a mock function with given fields: ctx, owner, repository
-func (_m *MockClient) GetRepository(ctx context.Context, owner string, repository string) (Repository, error) {
-	ret := _m.Called(ctx, owner, repository)
+// GetRepository provides a mock function with given fields: ctx
+func (_m *MockClient) GetRepository(ctx context.Context) (Repository, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRepository")
@@ -361,17 +349,17 @@ func (_m *MockClient) GetRepository(ctx context.Context, owner string, repositor
 
 	var r0 Repository
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (Repository, error)); ok {
-		return rf(ctx, owner, repository)
+	if rf, ok := ret.Get(0).(func(context.Context) (Repository, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) Repository); ok {
-		r0 = rf(ctx, owner, repository)
+	if rf, ok := ret.Get(0).(func(context.Context) Repository); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(Repository)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, owner, repository)
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -386,15 +374,13 @@ type MockClient_GetRepository_Call struct {
 
 // GetRepository is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
-func (_e *MockClient_Expecter) GetRepository(ctx interface{}, owner interface{}, repository interface{}) *MockClient_GetRepository_Call {
-	return &MockClient_GetRepository_Call{Call: _e.mock.On("GetRepository", ctx, owner, repository)}
+func (_e *MockClient_Expecter) GetRepository(ctx interface{}) *MockClient_GetRepository_Call {
+	return &MockClient_GetRepository_Call{Call: _e.mock.On("GetRepository", ctx)}
 }
 
-func (_c *MockClient_GetRepository_Call) Run(run func(ctx context.Context, owner string, repository string)) *MockClient_GetRepository_Call {
+func (_c *MockClient_GetRepository_Call) Run(run func(ctx context.Context)) *MockClient_GetRepository_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -404,14 +390,14 @@ func (_c *MockClient_GetRepository_Call) Return(_a0 Repository, _a1 error) *Mock
 	return _c
 }
 
-func (_c *MockClient_GetRepository_Call) RunAndReturn(run func(context.Context, string, string) (Repository, error)) *MockClient_GetRepository_Call {
+func (_c *MockClient_GetRepository_Call) RunAndReturn(run func(context.Context) (Repository, error)) *MockClient_GetRepository_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetRulesets provides a mock function with given fields: ctx, owner, repository, branch
-func (_m *MockClient) GetRulesets(ctx context.Context, owner string, repository string, branch string) (*Rulesets, error) {
-	ret := _m.Called(ctx, owner, repository, branch)
+// GetRulesets provides a mock function with given fields: ctx, branch
+func (_m *MockClient) GetRulesets(ctx context.Context, branch string) (*Rulesets, error) {
+	ret := _m.Called(ctx, branch)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRulesets")
@@ -419,19 +405,19 @@ func (_m *MockClient) GetRulesets(ctx context.Context, owner string, repository 
 
 	var r0 *Rulesets
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*Rulesets, error)); ok {
-		return rf(ctx, owner, repository, branch)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*Rulesets, error)); ok {
+		return rf(ctx, branch)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *Rulesets); ok {
-		r0 = rf(ctx, owner, repository, branch)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *Rulesets); ok {
+		r0 = rf(ctx, branch)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Rulesets)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, owner, repository, branch)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, branch)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -446,16 +432,14 @@ type MockClient_GetRulesets_Call struct {
 
 // GetRulesets is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
 //   - branch string
-func (_e *MockClient_Expecter) GetRulesets(ctx interface{}, owner interface{}, repository interface{}, branch interface{}) *MockClient_GetRulesets_Call {
-	return &MockClient_GetRulesets_Call{Call: _e.mock.On("GetRulesets", ctx, owner, repository, branch)}
+func (_e *MockClient_Expecter) GetRulesets(ctx interface{}, branch interface{}) *MockClient_GetRulesets_Call {
+	return &MockClient_GetRulesets_Call{Call: _e.mock.On("GetRulesets", ctx, branch)}
 }
 
-func (_c *MockClient_GetRulesets_Call) Run(run func(ctx context.Context, owner string, repository string, branch string)) *MockClient_GetRulesets_Call {
+func (_c *MockClient_GetRulesets_Call) Run(run func(ctx context.Context, branch string)) *MockClient_GetRulesets_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -465,14 +449,14 @@ func (_c *MockClient_GetRulesets_Call) Return(_a0 *Rulesets, _a1 error) *MockCli
 	return _c
 }
 
-func (_c *MockClient_GetRulesets_Call) RunAndReturn(run func(context.Context, string, string, string) (*Rulesets, error)) *MockClient_GetRulesets_Call {
+func (_c *MockClient_GetRulesets_Call) RunAndReturn(run func(context.Context, string) (*Rulesets, error)) *MockClient_GetRulesets_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetWebhook provides a mock function with given fields: ctx, owner, repository, webhookID
-func (_m *MockClient) GetWebhook(ctx context.Context, owner string, repository string, webhookID int64) (WebhookConfig, error) {
-	ret := _m.Called(ctx, owner, repository, webhookID)
+// GetWebhook provides a mock function with given fields: ctx, webhookID
+func (_m *MockClient) GetWebhook(ctx context.Context, webhookID int64) (WebhookConfig, error) {
+	ret := _m.Called(ctx, webhookID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetWebhook")
@@ -480,17 +464,17 @@ func (_m *MockClient) GetWebhook(ctx context.Context, owner string, repository s
 
 	var r0 WebhookConfig
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64) (WebhookConfig, error)); ok {
-		return rf(ctx, owner, repository, webhookID)
+	if rf, ok := ret.Get(0).(func(context.Context, int64) (WebhookConfig, error)); ok {
+		return rf(ctx, webhookID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64) WebhookConfig); ok {
-		r0 = rf(ctx, owner, repository, webhookID)
+	if rf, ok := ret.Get(0).(func(context.Context, int64) WebhookConfig); ok {
+		r0 = rf(ctx, webhookID)
 	} else {
 		r0 = ret.Get(0).(WebhookConfig)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, int64) error); ok {
-		r1 = rf(ctx, owner, repository, webhookID)
+	if rf, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = rf(ctx, webhookID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -505,16 +489,14 @@ type MockClient_GetWebhook_Call struct {
 
 // GetWebhook is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
 //   - webhookID int64
-func (_e *MockClient_Expecter) GetWebhook(ctx interface{}, owner interface{}, repository interface{}, webhookID interface{}) *MockClient_GetWebhook_Call {
-	return &MockClient_GetWebhook_Call{Call: _e.mock.On("GetWebhook", ctx, owner, repository, webhookID)}
+func (_e *MockClient_Expecter) GetWebhook(ctx interface{}, webhookID interface{}) *MockClient_GetWebhook_Call {
+	return &MockClient_GetWebhook_Call{Call: _e.mock.On("GetWebhook", ctx, webhookID)}
 }
 
-func (_c *MockClient_GetWebhook_Call) Run(run func(ctx context.Context, owner string, repository string, webhookID int64)) *MockClient_GetWebhook_Call {
+func (_c *MockClient_GetWebhook_Call) Run(run func(ctx context.Context, webhookID int64)) *MockClient_GetWebhook_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(int64))
+		run(args[0].(context.Context), args[1].(int64))
 	})
 	return _c
 }
@@ -524,14 +506,14 @@ func (_c *MockClient_GetWebhook_Call) Return(_a0 WebhookConfig, _a1 error) *Mock
 	return _c
 }
 
-func (_c *MockClient_GetWebhook_Call) RunAndReturn(run func(context.Context, string, string, int64) (WebhookConfig, error)) *MockClient_GetWebhook_Call {
+func (_c *MockClient_GetWebhook_Call) RunAndReturn(run func(context.Context, int64) (WebhookConfig, error)) *MockClient_GetWebhook_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// ListPullRequestFiles provides a mock function with given fields: ctx, owner, repository, number
-func (_m *MockClient) ListPullRequestFiles(ctx context.Context, owner string, repository string, number int) ([]CommitFile, error) {
-	ret := _m.Called(ctx, owner, repository, number)
+// ListPullRequestFiles provides a mock function with given fields: ctx, number
+func (_m *MockClient) ListPullRequestFiles(ctx context.Context, number int) ([]CommitFile, error) {
+	ret := _m.Called(ctx, number)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListPullRequestFiles")
@@ -539,19 +521,19 @@ func (_m *MockClient) ListPullRequestFiles(ctx context.Context, owner string, re
 
 	var r0 []CommitFile
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int) ([]CommitFile, error)); ok {
-		return rf(ctx, owner, repository, number)
+	if rf, ok := ret.Get(0).(func(context.Context, int) ([]CommitFile, error)); ok {
+		return rf(ctx, number)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int) []CommitFile); ok {
-		r0 = rf(ctx, owner, repository, number)
+	if rf, ok := ret.Get(0).(func(context.Context, int) []CommitFile); ok {
+		r0 = rf(ctx, number)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]CommitFile)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, int) error); ok {
-		r1 = rf(ctx, owner, repository, number)
+	if rf, ok := ret.Get(1).(func(context.Context, int) error); ok {
+		r1 = rf(ctx, number)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -566,16 +548,14 @@ type MockClient_ListPullRequestFiles_Call struct {
 
 // ListPullRequestFiles is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
 //   - number int
-func (_e *MockClient_Expecter) ListPullRequestFiles(ctx interface{}, owner interface{}, repository interface{}, number interface{}) *MockClient_ListPullRequestFiles_Call {
-	return &MockClient_ListPullRequestFiles_Call{Call: _e.mock.On("ListPullRequestFiles", ctx, owner, repository, number)}
+func (_e *MockClient_Expecter) ListPullRequestFiles(ctx interface{}, number interface{}) *MockClient_ListPullRequestFiles_Call {
+	return &MockClient_ListPullRequestFiles_Call{Call: _e.mock.On("ListPullRequestFiles", ctx, number)}
 }
 
-func (_c *MockClient_ListPullRequestFiles_Call) Run(run func(ctx context.Context, owner string, repository string, number int)) *MockClient_ListPullRequestFiles_Call {
+func (_c *MockClient_ListPullRequestFiles_Call) Run(run func(ctx context.Context, number int)) *MockClient_ListPullRequestFiles_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(int))
+		run(args[0].(context.Context), args[1].(int))
 	})
 	return _c
 }
@@ -585,14 +565,14 @@ func (_c *MockClient_ListPullRequestFiles_Call) Return(_a0 []CommitFile, _a1 err
 	return _c
 }
 
-func (_c *MockClient_ListPullRequestFiles_Call) RunAndReturn(run func(context.Context, string, string, int) ([]CommitFile, error)) *MockClient_ListPullRequestFiles_Call {
+func (_c *MockClient_ListPullRequestFiles_Call) RunAndReturn(run func(context.Context, int) ([]CommitFile, error)) *MockClient_ListPullRequestFiles_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// ListWebhooks provides a mock function with given fields: ctx, owner, repository
-func (_m *MockClient) ListWebhooks(ctx context.Context, owner string, repository string) ([]WebhookConfig, error) {
-	ret := _m.Called(ctx, owner, repository)
+// ListWebhooks provides a mock function with given fields: ctx
+func (_m *MockClient) ListWebhooks(ctx context.Context) ([]WebhookConfig, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListWebhooks")
@@ -600,19 +580,19 @@ func (_m *MockClient) ListWebhooks(ctx context.Context, owner string, repository
 
 	var r0 []WebhookConfig
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) ([]WebhookConfig, error)); ok {
-		return rf(ctx, owner, repository)
+	if rf, ok := ret.Get(0).(func(context.Context) ([]WebhookConfig, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) []WebhookConfig); ok {
-		r0 = rf(ctx, owner, repository)
+	if rf, ok := ret.Get(0).(func(context.Context) []WebhookConfig); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]WebhookConfig)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, owner, repository)
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -627,15 +607,13 @@ type MockClient_ListWebhooks_Call struct {
 
 // ListWebhooks is a helper method to define mock.On call
 //   - ctx context.Context
-//   - owner string
-//   - repository string
-func (_e *MockClient_Expecter) ListWebhooks(ctx interface{}, owner interface{}, repository interface{}) *MockClient_ListWebhooks_Call {
-	return &MockClient_ListWebhooks_Call{Call: _e.mock.On("ListWebhooks", ctx, owner, repository)}
+func (_e *MockClient_Expecter) ListWebhooks(ctx interface{}) *MockClient_ListWebhooks_Call {
+	return &MockClient_ListWebhooks_Call{Call: _e.mock.On("ListWebhooks", ctx)}
 }
 
-func (_c *MockClient_ListWebhooks_Call) Run(run func(ctx context.Context, owner string, repository string)) *MockClient_ListWebhooks_Call {
+func (_c *MockClient_ListWebhooks_Call) Run(run func(ctx context.Context)) *MockClient_ListWebhooks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -645,7 +623,7 @@ func (_c *MockClient_ListWebhooks_Call) Return(_a0 []WebhookConfig, _a1 error) *
 	return _c
 }
 
-func (_c *MockClient_ListWebhooks_Call) RunAndReturn(run func(context.Context, string, string) ([]WebhookConfig, error)) *MockClient_ListWebhooks_Call {
+func (_c *MockClient_ListWebhooks_Call) RunAndReturn(run func(context.Context) ([]WebhookConfig, error)) *MockClient_ListWebhooks_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -60,7 +60,7 @@ func NewRepository(
 	return &githubRepository{
 		config:        config,
 		GitRepository: gitRepo,
-		gh:            factory.New(ctx, token), // TODO, baseURL from config
+		gh:            factory.New(ctx, owner, repo, token), // TODO, baseURL from config
 		owner:         owner,
 		repo:          repo,
 	}, nil
@@ -79,7 +79,7 @@ func (r *githubRepository) Client() Client {
 }
 
 func (r *githubRepository) GetDefaultBranch(ctx context.Context) (string, error) {
-	repo, err := r.gh.GetRepository(ctx, r.owner, r.repo)
+	repo, err := r.gh.GetRepository(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get repository metadata: %w", err)
 	}
@@ -192,7 +192,7 @@ func (r *githubRepository) checkBranchProtection(ctx context.Context) *provision
 	var allReasons []string
 
 	// Check classic branch protection rules
-	bp, err := r.gh.GetBranchProtection(ctx, r.owner, r.repo, r.GetCurrentBranch())
+	bp, err := r.gh.GetBranchProtection(ctx, r.GetCurrentBranch())
 	if err != nil {
 		// Failed to check branch protection - return error to user
 		return &provisioning.TestResults{
@@ -213,7 +213,7 @@ func (r *githubRepository) checkBranchProtection(ctx context.Context) *provision
 	}
 
 	// Check repository rulesets
-	rulesets, err := r.gh.GetRulesets(ctx, r.owner, r.repo, r.GetCurrentBranch())
+	rulesets, err := r.gh.GetRulesets(ctx, r.GetCurrentBranch())
 	if err != nil {
 		// Failed to check rulesets - return error to user
 		return &provisioning.TestResults{
@@ -264,7 +264,7 @@ func (r *githubRepository) History(ctx context.Context, path, ref string) ([]pro
 	}
 
 	finalPath := safepath.Join(r.config.Spec.GitHub.Path, path)
-	commits, err := r.gh.Commits(ctx, r.owner, r.repo, finalPath, ref)
+	commits, err := r.gh.Commits(ctx, finalPath, ref)
 	if err != nil {
 		if errors.Is(err, repository.ErrFileNotFound) {
 			return nil, repository.ErrFileNotFound

--- a/apps/provisioning/pkg/repository/github/repository_test.go
+++ b/apps/provisioning/pkg/repository/github/repository_test.go
@@ -305,7 +305,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 						CreatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					},
 				}
-				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "main").
+				m.On("Commits", mock.Anything, "dashboards/dashboard.json", "main").
 					Return(commits, nil)
 			},
 			expectedResult: []provisioning.HistoryItem{
@@ -336,7 +336,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 			path: "nonexistent.json",
 			ref:  "main",
 			mockSetup: func(m *MockClient) {
-				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/nonexistent.json", "main").
+				m.On("Commits", mock.Anything, "dashboards/nonexistent.json", "main").
 					Return(nil, repo.ErrFileNotFound)
 			},
 			expectedError: repo.ErrFileNotFound,
@@ -366,7 +366,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 						CreatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					},
 				}
-				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "main").
+				m.On("Commits", mock.Anything, "dashboards/dashboard.json", "main").
 					Return(commits, nil)
 			},
 			expectedResult: []provisioning.HistoryItem{
@@ -414,7 +414,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 						CreatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					},
 				}
-				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "main").
+				m.On("Commits", mock.Anything, "dashboards/dashboard.json", "main").
 					Return(commits, nil)
 			},
 			expectedResult: []provisioning.HistoryItem{
@@ -459,7 +459,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 						CreatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					},
 				}
-				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "main").
+				m.On("Commits", mock.Anything, "dashboards/dashboard.json", "main").
 					Return(commits, nil)
 			},
 			expectedResult: []provisioning.HistoryItem{
@@ -484,7 +484,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 			path: "dashboard.json",
 			ref:  "main",
 			mockSetup: func(m *MockClient) {
-				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "main").
+				m.On("Commits", mock.Anything, "dashboards/dashboard.json", "main").
 					Return(nil, errors.New("API error"))
 			},
 			expectedError: errors.New("get commits: API error"),
@@ -502,7 +502,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 			path: "dashboard.json",
 			ref:  "feature/my-branch",
 			mockSetup: func(m *MockClient) {
-				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "feature/my-branch").
+				m.On("Commits", mock.Anything, "dashboards/dashboard.json", "feature/my-branch").
 					Return([]Commit{}, nil)
 			},
 			expectedResult: []provisioning.HistoryItem{},
@@ -520,7 +520,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 			path: "dashboard.json",
 			ref:  "abc1234",
 			mockSetup: func(m *MockClient) {
-				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "abc1234").
+				m.On("Commits", mock.Anything, "dashboards/dashboard.json", "abc1234").
 					Return([]Commit{}, nil)
 			},
 			expectedResult: []provisioning.HistoryItem{},
@@ -538,7 +538,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 			path: "dashboard.json",
 			ref:  "abcdef0123456789abcdef0123456789abcdef01",
 			mockSetup: func(m *MockClient) {
-				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "abcdef0123456789abcdef0123456789abcdef01").
+				m.On("Commits", mock.Anything, "dashboards/dashboard.json", "abcdef0123456789abcdef0123456789abcdef01").
 					Return([]Commit{}, nil)
 			},
 			expectedResult: []provisioning.HistoryItem{},
@@ -556,7 +556,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 			path: "dashboard.json",
 			ref:  "abcdef",
 			mockSetup: func(m *MockClient) {
-				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "abcdef").
+				m.On("Commits", mock.Anything, "dashboards/dashboard.json", "abcdef").
 					Return([]Commit{}, nil)
 			},
 			expectedResult: []provisioning.HistoryItem{},
@@ -1114,7 +1114,7 @@ func TestGitHubRepository_GetDefaultBranch(t *testing.T) {
 		{
 			name: "successfully gets default branch",
 			mockSetup: func(m *MockClient) {
-				m.On("GetRepository", mock.Anything, "grafana", "grafana").
+				m.On("GetRepository", mock.Anything).
 					Return(Repository{DefaultBranch: "main"}, nil)
 			},
 			expectedBranch: "main",
@@ -1122,7 +1122,7 @@ func TestGitHubRepository_GetDefaultBranch(t *testing.T) {
 		{
 			name: "gets default branch as develop",
 			mockSetup: func(m *MockClient) {
-				m.On("GetRepository", mock.Anything, "grafana", "grafana").
+				m.On("GetRepository", mock.Anything).
 					Return(Repository{DefaultBranch: "develop"}, nil)
 			},
 			expectedBranch: "develop",
@@ -1130,7 +1130,7 @@ func TestGitHubRepository_GetDefaultBranch(t *testing.T) {
 		{
 			name: "gets default branch as master",
 			mockSetup: func(m *MockClient) {
-				m.On("GetRepository", mock.Anything, "grafana", "grafana").
+				m.On("GetRepository", mock.Anything).
 					Return(Repository{DefaultBranch: "master"}, nil)
 			},
 			expectedBranch: "master",
@@ -1138,7 +1138,7 @@ func TestGitHubRepository_GetDefaultBranch(t *testing.T) {
 		{
 			name: "handles API error",
 			mockSetup: func(m *MockClient) {
-				m.On("GetRepository", mock.Anything, "grafana", "grafana").
+				m.On("GetRepository", mock.Anything).
 					Return(Repository{}, errors.New("API rate limit exceeded"))
 			},
 			expectedError: "failed to get repository metadata: API rate limit exceeded",
@@ -1146,7 +1146,7 @@ func TestGitHubRepository_GetDefaultBranch(t *testing.T) {
 		{
 			name: "handles not found error",
 			mockSetup: func(m *MockClient) {
-				m.On("GetRepository", mock.Anything, "grafana", "grafana").
+				m.On("GetRepository", mock.Anything).
 					Return(Repository{}, repo.ErrFileNotFound)
 			},
 			expectedError: "failed to get repository metadata:",
@@ -1404,14 +1404,14 @@ func TestGitHubRepository_Test_BranchProtection(t *testing.T) {
 
 			if tt.expectBPCall {
 				mockClient.EXPECT().
-					GetBranchProtection(mock.Anything, "grafana", "grafana", tt.branch).
+					GetBranchProtection(mock.Anything, tt.branch).
 					Return(tt.bpResult, tt.bpError).
 					Once()
 
 				// If branch protection check succeeded, also expect rulesets check
 				if tt.bpError == nil {
 					mockClient.EXPECT().
-						GetRulesets(mock.Anything, "grafana", "grafana", tt.branch).
+						GetRulesets(mock.Anything, tt.branch).
 						Return(nil, nil).
 						Once()
 				}
@@ -1623,13 +1623,13 @@ func TestGitHubRepository_Test_Rulesets(t *testing.T) {
 
 			// Branch protection check always happens first
 			mockClient.EXPECT().
-				GetBranchProtection(mock.Anything, "grafana", "grafana", tt.branch).
+				GetBranchProtection(mock.Anything, tt.branch).
 				Return(nil, nil).
 				Maybe()
 
 			if tt.expectRulesetsCall {
 				mockClient.EXPECT().
-					GetRulesets(mock.Anything, "grafana", "grafana", tt.branch).
+					GetRulesets(mock.Anything, tt.branch).
 					Return(tt.rulesetsResult, tt.rulesetsError).
 					Once()
 			}
@@ -1777,14 +1777,14 @@ func TestGitHubRepository_Test_CombinedProtection(t *testing.T) {
 				Once()
 
 			mockClient.EXPECT().
-				GetBranchProtection(mock.Anything, "grafana", "grafana", tt.branch).
+				GetBranchProtection(mock.Anything, tt.branch).
 				Return(tt.bpResult, tt.bpError).
 				Once()
 
 			// Only call GetRulesets if branch protection didn't error
 			if tt.bpError == nil {
 				mockClient.EXPECT().
-					GetRulesets(mock.Anything, "grafana", "grafana", tt.branch).
+					GetRulesets(mock.Anything, tt.branch).
 					Return(tt.rulesetsResult, tt.rulesetsError).
 					Once()
 			}
@@ -1969,12 +1969,12 @@ func TestGitHubRepository_Test_EmptyBranch(t *testing.T) {
 			if tt.expectGetRepo {
 				if tt.getRepoError != nil {
 					mockClient.EXPECT().
-						GetRepository(mock.Anything, "grafana", "grafana").
+						GetRepository(mock.Anything).
 						Return(Repository{}, tt.getRepoError).
 						Once()
 				} else {
 					mockClient.EXPECT().
-						GetRepository(mock.Anything, "grafana", "grafana").
+						GetRepository(mock.Anything).
 						Return(Repository{DefaultBranch: tt.defaultBranch}, nil).
 						Once()
 

--- a/apps/provisioning/pkg/repository/github/webhook.go
+++ b/apps/provisioning/pkg/repository/github/webhook.go
@@ -229,7 +229,7 @@ func (r *githubWebhookRepository) parsePullRequestEvent(event *github.PullReques
 // CommentPullRequest adds a comment to a pull request.
 func (r *githubWebhookRepository) CommentPullRequest(ctx context.Context, prNumber int, comment string) error {
 	ctx, _ = r.logger(ctx, "")
-	return r.gh.CreatePullRequestComment(ctx, r.owner, r.repo, prNumber, comment)
+	return r.gh.CreatePullRequestComment(ctx, prNumber, comment)
 }
 
 func (r *githubWebhookRepository) createWebhook(ctx context.Context) (WebhookConfig, error) {
@@ -246,7 +246,7 @@ func (r *githubWebhookRepository) createWebhook(ctx context.Context) (WebhookCon
 		Active:      true,
 	}
 
-	hook, err := r.gh.CreateWebhook(ctx, r.owner, r.repo, cfg)
+	hook, err := r.gh.CreateWebhook(ctx, cfg)
 	if err != nil {
 		return WebhookConfig{}, err
 	}
@@ -269,7 +269,7 @@ func (r *githubWebhookRepository) updateWebhook(ctx context.Context) (WebhookCon
 		return hook, true, nil
 	}
 
-	hook, err := r.gh.GetWebhook(ctx, r.owner, r.repo, r.config.Status.Webhook.ID)
+	hook, err := r.gh.GetWebhook(ctx, r.config.Status.Webhook.ID)
 	switch {
 	case errors.Is(err, repository.ErrFileNotFound):
 		hook, err := r.createWebhook(ctx)
@@ -304,7 +304,7 @@ func (r *githubWebhookRepository) updateWebhook(ctx context.Context) (WebhookCon
 		return WebhookConfig{}, false, fmt.Errorf("could not generate secret: %w", err)
 	}
 	hook.Secret = secret.String()
-	if err := r.gh.EditWebhook(ctx, r.owner, r.repo, hook); err != nil {
+	if err := r.gh.EditWebhook(ctx, hook); err != nil {
 		return WebhookConfig{}, false, fmt.Errorf("edit webhook: %w", err)
 	}
 
@@ -319,7 +319,7 @@ func (r *githubWebhookRepository) deleteWebhook(ctx context.Context) error {
 
 	id := r.config.Status.Webhook.ID
 
-	err := r.gh.DeleteWebhook(ctx, r.owner, r.repo, id)
+	err := r.gh.DeleteWebhook(ctx, id)
 	if err != nil && !errors.Is(err, repository.ErrFileNotFound) && !errors.Is(err, repository.ErrUnauthorized) {
 		return fmt.Errorf("delete webhook: %w", err)
 	}
@@ -449,7 +449,7 @@ func (r *githubWebhookRepository) RotateWebhookSecret(ctx context.Context) ([]ma
 	ctx, logger := r.logger(ctx, "")
 	logger.Info("rotating webhook secret", "trigger", "rotation")
 
-	hook, err := r.gh.GetWebhook(ctx, r.owner, r.repo, r.config.Status.Webhook.ID)
+	hook, err := r.gh.GetWebhook(ctx, r.config.Status.Webhook.ID)
 	switch {
 	case errors.Is(err, repository.ErrFileNotFound):
 		return []map[string]any{{
@@ -467,7 +467,7 @@ func (r *githubWebhookRepository) RotateWebhookSecret(ctx context.Context) ([]ma
 	}
 	hook.Secret = secret.String()
 
-	if err := r.gh.EditWebhook(ctx, r.owner, r.repo, hook); err != nil {
+	if err := r.gh.EditWebhook(ctx, hook); err != nil {
 		return nil, fmt.Errorf("edit webhook during rotation: %w", err)
 	}
 

--- a/apps/provisioning/pkg/repository/github/webhook_test.go
+++ b/apps/provisioning/pkg/repository/github/webhook_test.go
@@ -1171,7 +1171,7 @@ func TestGitHubRepository_CommentPullRequest(t *testing.T) {
 		{
 			name: "successfully comment on pull request",
 			setupMock: func(m *MockClient) {
-				m.On("CreatePullRequestComment", mock.Anything, "grafana", "grafana", 123, "Test comment").
+				m.On("CreatePullRequestComment", mock.Anything, 123, "Test comment").
 					Return(nil)
 			},
 			prNumber:      123,
@@ -1181,7 +1181,7 @@ func TestGitHubRepository_CommentPullRequest(t *testing.T) {
 		{
 			name: "error commenting on pull request",
 			setupMock: func(m *MockClient) {
-				m.On("CreatePullRequestComment", mock.Anything, "grafana", "grafana", 456, "Error comment").
+				m.On("CreatePullRequestComment", mock.Anything, 456, "Error comment").
 					Return(fmt.Errorf("failed to create comment"))
 			},
 			prNumber:      456,
@@ -1239,7 +1239,7 @@ func TestGitHubRepository_OnCreate(t *testing.T) {
 		{
 			name: "successfully create webhook",
 			setupMock: func(m *MockClient) {
-				m.On("CreateWebhook", mock.Anything, "grafana", "grafana", mock.MatchedBy(func(cfg WebhookConfig) bool {
+				m.On("CreateWebhook", mock.Anything, mock.MatchedBy(func(cfg WebhookConfig) bool {
 					return cfg.URL == "https://example.com/webhook" &&
 						cfg.ContentType == "json" &&
 						cfg.Active == true
@@ -1283,7 +1283,7 @@ func TestGitHubRepository_OnCreate(t *testing.T) {
 		{
 			name: "error creating webhook",
 			setupMock: func(m *MockClient) {
-				m.On("CreateWebhook", mock.Anything, "grafana", "grafana", mock.Anything).
+				m.On("CreateWebhook", mock.Anything, mock.Anything).
 					Return(WebhookConfig{}, fmt.Errorf("failed to create webhook"))
 			},
 			config: &provisioning.Repository{
@@ -1398,7 +1398,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			name: "successfully update webhook when webhook exists",
 			setupMock: func(m *MockClient) {
 				// Mock getting the existing webhook
-				m.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("GetWebhook", mock.Anything, int64(123)).
 					Return(WebhookConfig{
 						ID:     123,
 						URL:    "https://example.com/webhook",
@@ -1406,7 +1406,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 					}, nil)
 
 				// Mock editing the webhook
-				m.On("EditWebhook", mock.Anything, "grafana", "grafana", mock.MatchedBy(func(hook WebhookConfig) bool {
+				m.On("EditWebhook", mock.Anything, mock.MatchedBy(func(hook WebhookConfig) bool {
 					return hook.ID == 123 && hook.URL == "https://example.com/webhook-updated" &&
 						slices.Equal(hook.Events, subscribedEvents)
 				})).Return(nil)
@@ -1437,11 +1437,11 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			name: "create webhook when it doesn't exist",
 			setupMock: func(m *MockClient) {
 				// Mock webhook not found
-				m.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("GetWebhook", mock.Anything, int64(123)).
 					Return(WebhookConfig{}, repo.ErrFileNotFound)
 
 				// Mock creating a new webhook
-				m.On("CreateWebhook", mock.Anything, "grafana", "grafana", mock.MatchedBy(func(hook WebhookConfig) bool {
+				m.On("CreateWebhook", mock.Anything, mock.MatchedBy(func(hook WebhookConfig) bool {
 					return hook.URL == "https://example.com/webhook" &&
 						hook.ContentType == "json" &&
 						slices.Equal(hook.Events, subscribedEvents) &&
@@ -1487,7 +1487,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 		{
 			name: "error getting webhook",
 			setupMock: func(m *MockClient) {
-				m.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("GetWebhook", mock.Anything, int64(123)).
 					Return(WebhookConfig{}, fmt.Errorf("failed to get webhook"))
 			},
 			config: &provisioning.Repository{
@@ -1512,7 +1512,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			name: "error editing webhook",
 			setupMock: func(m *MockClient) {
 				// Mock getting the existing webhook
-				m.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("GetWebhook", mock.Anything, int64(123)).
 					Return(WebhookConfig{
 						ID:     123,
 						URL:    "https://example.com/webhook",
@@ -1520,7 +1520,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 					}, nil)
 
 				// Mock editing the webhook with error
-				m.On("EditWebhook", mock.Anything, "grafana", "grafana", mock.Anything).
+				m.On("EditWebhook", mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed to edit webhook"))
 			},
 			config: &provisioning.Repository{
@@ -1545,7 +1545,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			name: "create webhook when webhook status is nil",
 			setupMock: func(m *MockClient) {
 				// Mock creating a new webhook
-				m.On("CreateWebhook", mock.Anything, "grafana", "grafana", mock.Anything).
+				m.On("CreateWebhook", mock.Anything, mock.Anything).
 					Return(WebhookConfig{
 						ID:          456,
 						URL:         "https://example.com/webhook",
@@ -1577,7 +1577,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			name: "create webhook when webhook ID is zero",
 			setupMock: func(m *MockClient) {
 				// Mock creating a new webhook
-				m.On("CreateWebhook", mock.Anything, "grafana", "grafana", mock.Anything).
+				m.On("CreateWebhook", mock.Anything, mock.Anything).
 					Return(WebhookConfig{
 						ID:          789,
 						URL:         "https://example.com/webhook",
@@ -1612,7 +1612,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			name: "error when creating webhook fails",
 			setupMock: func(m *MockClient) {
 				// Mock webhook creation failure
-				m.On("CreateWebhook", mock.Anything, "grafana", "grafana", mock.Anything).
+				m.On("CreateWebhook", mock.Anything, mock.Anything).
 					Return(WebhookConfig{}, fmt.Errorf("failed to create webhook"))
 			},
 			config: &provisioning.Repository{
@@ -1634,11 +1634,11 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			name: "creates webhook when repo.ErrFileNotFound",
 			setupMock: func(m *MockClient) {
 				// Mock webhook not found
-				m.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("GetWebhook", mock.Anything, int64(123)).
 					Return(WebhookConfig{}, repo.ErrFileNotFound)
 
 				// Mock creating a new webhook
-				m.On("CreateWebhook", mock.Anything, "grafana", "grafana", mock.MatchedBy(func(hook WebhookConfig) bool {
+				m.On("CreateWebhook", mock.Anything, mock.MatchedBy(func(hook WebhookConfig) bool {
 					return hook.URL == "https://example.com/webhook" &&
 						hook.ContentType == "json" &&
 						slices.Equal(hook.Events, subscribedEvents) &&
@@ -1675,11 +1675,11 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			name: "error on create when not found",
 			setupMock: func(m *MockClient) {
 				// Mock webhook not found
-				m.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("GetWebhook", mock.Anything, int64(123)).
 					Return(WebhookConfig{}, repo.ErrFileNotFound)
 
 				// Mock error when creating a new webhook
-				m.On("CreateWebhook", mock.Anything, "grafana", "grafana", mock.MatchedBy(func(hook WebhookConfig) bool {
+				m.On("CreateWebhook", mock.Anything, mock.MatchedBy(func(hook WebhookConfig) bool {
 					return hook.URL == "https://example.com/webhook" &&
 						hook.ContentType == "json" &&
 						slices.Equal(hook.Events, subscribedEvents) &&
@@ -1708,7 +1708,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			name: "no update needed when URL and events match",
 			setupMock: func(m *MockClient) {
 				// Mock getting the existing webhook with matching URL and events
-				m.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("GetWebhook", mock.Anything, int64(123)).
 					Return(WebhookConfig{
 						ID:     123,
 						URL:    "https://example.com/webhook",
@@ -1742,7 +1742,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 		{
 			name: "delete webhook when workflows are removed",
 			setupMock: func(m *MockClient) {
-				m.On("DeleteWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("DeleteWebhook", mock.Anything, int64(123)).
 					Return(nil)
 			},
 			config: &provisioning.Repository{
@@ -1877,7 +1877,7 @@ func TestGitHubRepository_OnDelete(t *testing.T) {
 		{
 			name: "successfully delete webhook",
 			setupMock: func(m *MockClient) {
-				m.On("DeleteWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("DeleteWebhook", mock.Anything, int64(123)).
 					Return(nil)
 			},
 			config: &provisioning.Repository{
@@ -1902,7 +1902,7 @@ func TestGitHubRepository_OnDelete(t *testing.T) {
 		{
 			name: "webhook not found during deletion",
 			setupMock: func(m *MockClient) {
-				m.On("DeleteWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("DeleteWebhook", mock.Anything, int64(123)).
 					Return(repo.ErrFileNotFound)
 			},
 			config: &provisioning.Repository{
@@ -1928,7 +1928,7 @@ func TestGitHubRepository_OnDelete(t *testing.T) {
 		{
 			name: "unauthorized to delete the webhook",
 			setupMock: func(m *MockClient) {
-				m.On("DeleteWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("DeleteWebhook", mock.Anything, int64(123)).
 					Return(repo.ErrUnauthorized)
 			},
 			config: &provisioning.Repository{
@@ -1992,7 +1992,7 @@ func TestGitHubRepository_OnDelete(t *testing.T) {
 			name: "error deleting webhook",
 			setupMock: func(m *MockClient) {
 				// Mock webhook deletion failure
-				m.On("DeleteWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+				m.On("DeleteWebhook", mock.Anything, int64(123)).
 					Return(fmt.Errorf("failed to delete webhook"))
 			},
 			config: &provisioning.Repository{
@@ -2053,9 +2053,9 @@ func TestGitHubRepository_OnDelete(t *testing.T) {
 func TestGitHubRepository_RotateWebhookSecret(t *testing.T) {
 	t.Run("successful rotation returns status and secure patch ops", func(t *testing.T) {
 		mockGH := NewMockClient(t)
-		mockGH.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+		mockGH.On("GetWebhook", mock.Anything, int64(123)).
 			Return(WebhookConfig{ID: 123, URL: "https://example.com/hook", Events: []string{"push"}}, nil)
-		mockGH.On("EditWebhook", mock.Anything, "grafana", "grafana", mock.MatchedBy(func(cfg WebhookConfig) bool {
+		mockGH.On("EditWebhook", mock.Anything, mock.MatchedBy(func(cfg WebhookConfig) bool {
 			return cfg.ID == 123 && cfg.Secret != ""
 		})).Return(nil)
 
@@ -2086,7 +2086,7 @@ func TestGitHubRepository_RotateWebhookSecret(t *testing.T) {
 
 	t.Run("webhook not found on remote clears status and returns error", func(t *testing.T) {
 		mockGH := NewMockClient(t)
-		mockGH.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+		mockGH.On("GetWebhook", mock.Anything, int64(123)).
 			Return(WebhookConfig{}, repo.ErrFileNotFound)
 
 		r := &githubWebhookRepository{
@@ -2110,7 +2110,7 @@ func TestGitHubRepository_RotateWebhookSecret(t *testing.T) {
 
 	t.Run("get webhook error returns error", func(t *testing.T) {
 		mockGH := NewMockClient(t)
-		mockGH.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+		mockGH.On("GetWebhook", mock.Anything, int64(123)).
 			Return(WebhookConfig{}, fmt.Errorf("api error"))
 
 		repo := &githubWebhookRepository{
@@ -2131,9 +2131,9 @@ func TestGitHubRepository_RotateWebhookSecret(t *testing.T) {
 
 	t.Run("edit webhook error returns error", func(t *testing.T) {
 		mockGH := NewMockClient(t)
-		mockGH.On("GetWebhook", mock.Anything, "grafana", "grafana", int64(123)).
+		mockGH.On("GetWebhook", mock.Anything, int64(123)).
 			Return(WebhookConfig{ID: 123, URL: "https://example.com/hook"}, nil)
-		mockGH.On("EditWebhook", mock.Anything, "grafana", "grafana", mock.Anything).
+		mockGH.On("EditWebhook", mock.Anything, mock.Anything).
 			Return(fmt.Errorf("edit failed"))
 
 		repo := &githubWebhookRepository{


### PR DESCRIPTION
**What is this feature?**

Binds `owner`/`repo` into the GitHub API client at construction instead of passing them on every call.

**Why do we need this feature?**

The auth token is already per-repo, so a repo-agnostic client buys nothing. Repo-scoped methods drop their provider-specific arguments, which is what lets a generic, provider-agnostic client interface exist (#126620).

**Who is this feature for?**

Maintainers of the provisioning git integration. No user-facing change — pure refactor.

**Special notes for your reviewer:**

No behavior change; covered by existing tests.

---
_PR description generated by Claude Code._
