### PR TITLE
PanelEditNext: Move location of drag handle

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/VizAndDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/VizAndDataPaneNext.tsx
@@ -140,11 +140,15 @@ function getStyles(theme: GrafanaTheme2, sidebarSize: SidebarSize) {
       position: 'absolute',
       top: 0,
       bottom: 0,
-      right: 0,
+      // Sit inside the grid gap between the sidebar and the data pane (width matches the
+      // gap) so the handle and its pill never overlap the sidebar's vertical scrollbar,
+      // which renders at the inner right edge of the sidebar box.
+      right: `-${theme.spacing(2)}`,
+      width: theme.spacing(2),
     }),
     resizeHandlePill: css({
       height: '100%',
-      width: 2,
+      // width: 2,
       // Pill (::after) is 200px by default. Shrink to half when sidebar is tight.
       '@container (max-height: 250px)': {
         '&::after': {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/VizAndDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/VizAndDataPaneNext.tsx
@@ -148,7 +148,6 @@ function getStyles(theme: GrafanaTheme2, sidebarSize: SidebarSize) {
     }),
     resizeHandlePill: css({
       height: '100%',
-      // width: 2,
       // Pill (::after) is 200px by default. Shrink to half when sidebar is tight.
       '@container (max-height: 250px)': {
         '&::after': {


### PR DESCRIPTION
## Description
Fixes the sidebar resize handle in the new panel editor (PanelEditNext) overlapping the sidebar's vertical scrollbar when the query/transformation list overflows (DPRO-137).

## Changes
* Moved the sidebar resize handle out of the sidebar's right edge and into the grid gap between the sidebar and data pane (`right: -16px`, `width: 16px`), so it no longer sits on top of the scrollbar.
* Dropped the `width: 2` override so the handle reclaims its full 16px `col-resize` hit target (matching the gap width), centering the drag pill in the gutter and improving the previously tiny grab area.

## Risks
* Low. CSS-only change scoped to the `sidebarResizeHandle`/`resizeHandlePill` styles in `VizAndDataPaneNext.tsx`. Most likely area to regress is sidebar resizing behavior; verify the drag handle still resizes correctly at `Mini` and `Full` sidebar sizes and in the scrolling-reflow layout.

## Demo
<!-- Before: pill overlaps scrollbar. After: pill centered in gutter, scrollbar clear. -->

https://github.com/user-attachments/assets/16d4becb-568d-4396-9ee9-5b98df79a8f2

## Testing Instructions
* Enable the `queryEditorNext` feature flag and open a panel in edit mode.
* Add enough queries/transformations to make the sidebar list overflow and show a vertical scrollbar.
* Confirm the resize handle pill sits in the gap between the sidebar and data pane (not on the scrollbar), and that dragging it still resizes the sidebar.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable