### PR TITLE
Loki: restore /prometheus/* ruler read routes for data-source-managed alerting

### DIFF
--- a/public/app/plugins/datasource/loki/plugin.json
+++ b/public/app/plugins/datasource/loki/plugin.json
@@ -69,6 +69,19 @@
     { "method": "POST", "path": "/api/v1/rules", "reqRole": "Editor", "reqAction": "alert.rules.external:write" },
     { "method": "DELETE", "path": "/api/v1/rules", "reqRole": "Editor", "reqAction": "alert.rules.external:write" },
 
+    {
+      "method": "GET",
+      "path": "/prometheus/api/v1/rules",
+      "reqRole": "Viewer",
+      "reqAction": "alert.rules.external:read"
+    },
+    {
+      "method": "GET",
+      "path": "/prometheus/api/v1/alerts",
+      "reqRole": "Viewer",
+      "reqAction": "alert.rules.external:read"
+    },
+
     { "method": "GET", "path": "/loki/api/v1/rules", "reqRole": "Viewer", "reqAction": "alert.rules.external:read" },
     { "method": "POST", "path": "/loki/api/v1/rules", "reqRole": "Editor", "reqAction": "alert.rules.external:write" },
     {


### PR DESCRIPTION
## What

Adds two read-only routes to the Loki data source's `plugin.json` proxy allowlist:

```json
{ "method": "GET", "path": "/prometheus/api/v1/rules",  "reqAction": "alert.rules.external:read" }
{ "method": "GET", "path": "/prometheus/api/v1/alerts", "reqAction": "alert.rules.external:read" }
```

## Why

#125752 moved the Loki data source proxy route allowlist from dynamic registration into a static `routes` block in `plugin.json`. The new block enumerated the ruler **config** endpoints (`/loki/api/v1/rules`, `/api/prom/rules`, `/rules`, `/api/v1/rules`) but omitted the **Prometheus-compatible read** endpoints.

The Alerting UI lists data-source-managed rule **state** and **active alerts** for Loki via `LotexProm`, which targets (`pkg/services/ngalert/api/lotex_prom.go`):

```go
lokiEndpoints = promEndpoints{
    rules:  "/prometheus/api/v1/rules",
    alerts: "/prometheus/api/v1/alerts",
}
```

Route matching in the data source proxy is prefix-based (`pkg/api/pluginproxy/ds_proxy.go`), and none of the allowlisted routes is a prefix of `/prometheus/api/v1/rules`. With no matching RBAC-covered route, the proxy treats the request as not covered and denies it, so the call never reaches Loki and the UI receives an error. The result: **Loki data-source-managed alert rules and alerts stopped appearing in the Alerting UI**.

Not affected (and the reason this was easy to miss): rule **evaluation**, **notifications**, and the ruler **config/CRUD** API all keep working, because `LotexRuler` uses `lokiPrefix = "/api/prom/rules"` (`lotex_ruler.go`), which *was* included in the allowlist. So rule editing works while listing/state does not.

## Why add the route rather than repath the proxy

`/prometheus/*` and `/loki/*` are different APIs, not interchangeable:

- `/prometheus/api/v1/rules` + `/prometheus/api/v1/alerts` — Prometheus-compatible **state** API (firing/pending, health, `lastEvaluation`, active alerts). Not deprecated; mirrors what Mimir/Cortex serve.
- `/loki/api/v1/rules` — ruler **config** API (rule-group definitions only, no runtime state). `/api/prom/rules` is the legacy alias of *this* config API.

There is no `/loki/*` endpoint that returns Prometheus-format rule state, so the `LotexProm` proxy cannot be repointed without losing state/health/alerts. Restoring the missing routes is the correct fix.

## Scope of impact

Affects any stack with Loki data-source-managed alert rules on a build that includes #125752 — visibility/management in the UI only; no alert-delivery impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
