### PR TITLE
MT annotations: Add max scope count validation for annotation creation and update

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1803,6 +1803,10 @@ retention_ttl = 2160h
 # Generate and persist grafana.app/legacyID labels for legacy API compatibility.
 enable_legacy_id = false
 
+# Maximum number of scopes that can be attached to a single annotation.
+# Set to 0 to disallow scopes entirely. Negative values are rejected.
+max_scope_count = 5
+
 # gRPC server address for remote annotation storage (only used when store_backend = "grpc")
 grpc_address = localhost:9090
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1734,6 +1734,10 @@ default_datasource_uid =
 # Generate and persist grafana.app/legacyID labels for legacy API compatibility.
 ;enable_legacy_id = false
 
+# Maximum number of scopes that can be attached to a single annotation.
+# Set to 0 to disallow scopes entirely. Negative values are rejected.
+;max_scope_count = 5
+
 # gRPC server address for remote annotation storage (only used when store_backend = "grpc")
 ;grpc_address = localhost:9090
 

--- a/pkg/registry/apps/annotation/config.go
+++ b/pkg/registry/apps/annotation/config.go
@@ -15,6 +15,9 @@ const (
 	// defaultRetentionTTL is the default retention period for annotations
 	// TODO: determine appropriate default TTL
 	defaultRetentionTTL = 90 * 24 * time.Hour
+	// defaultMaxScopeCount caps how many scopes can be attached to a single
+	// annotation. 0 means no scopes are allowed.
+	defaultMaxScopeCount = 5
 )
 
 // Config holds the store backend configuration for the annotation app.
@@ -42,6 +45,11 @@ type Config struct {
 	// for new annotations and persisted in the store.
 	EnableLegacyID bool
 
+	// MaxScopeCount caps how many scopes can be attached to a single
+	// annotation. 0 means no scopes are allowed. Negative values are
+	// rejected by the settings loader.
+	MaxScopeCount int
+
 	// CleanupSettings configures annotation pruning for the SQL backend's LifecycleManager.
 	// Zero value (all limits unset) disables cleanup. Not used by memory or gRPC backends.
 	CleanupSettings annotations.CleanupSettings
@@ -54,6 +62,8 @@ func (c *Config) AddFlags(flags *pflag.FlagSet) {
 
 	// General lifecycle flags
 	flags.DurationVar(&c.RetentionTTL, "annotation.retention-ttl", defaultRetentionTTL, "Retention TTL for annotations (old data will be cleaned up)")
+
+	flags.IntVar(&c.MaxScopeCount, "annotation.max-scope-count", defaultMaxScopeCount, "Maximum number of scopes that can be attached to a single annotation")
 
 	// gRPC flags
 	flags.StringVar(&c.GRPCAddress, "annotation.grpc-address", "", "gRPC server address for the annotation store")
@@ -80,6 +90,7 @@ func newConfigFromSettings(cfg *setting.Cfg) Config {
 		StoreBackend:   cfg.AnnotationAppPlatform.StoreBackend,
 		RetentionTTL:   retentionTTL,
 		EnableLegacyID: cfg.AnnotationAppPlatform.EnableLegacyID,
+		MaxScopeCount:  cfg.AnnotationAppPlatform.MaxScopeCount,
 
 		GRPCAddress:       cfg.AnnotationAppPlatform.GRPCAddress,
 		GRPCUseTLS:        cfg.AnnotationAppPlatform.GRPCUseTLS,

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -78,6 +78,11 @@ type k8sRESTAdapter struct {
 
 	snowflakeNode *snowflake.Node
 
+	// maxScopeCount caps how many scopes may be attached to a single
+	// annotation. 0 means no scopes are allowed. Negative values are
+	// rejected by the settings loader.
+	maxScopeCount int
+
 	tracer  trace.Tracer
 	metrics *Metrics
 	logger  log.Logger
@@ -224,6 +229,10 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 	}
 	if annotation.Name == "" && annotation.GenerateName != "" {
 		annotation.Name = annotation.GenerateName + util.GenerateShortUID()
+	}
+
+	if err := s.validateScopeCount(annotation); err != nil {
+		return nil, err
 	}
 
 	user, err := identity.GetRequester(ctx)
@@ -386,6 +395,14 @@ func parseFieldSelector(fs fields.Selector, opts *ListOptions) error {
 		default:
 			return fmt.Errorf("unsupported field selector: %s", r.Field)
 		}
+	}
+	return nil
+}
+
+func (s *k8sRESTAdapter) validateScopeCount(a *annotationV0.Annotation) error {
+	if len(a.Spec.Scopes) > s.maxScopeCount {
+		return apierrors.NewBadRequest(fmt.Sprintf(
+			"too many scopes: %d (max allowed %d)", len(a.Spec.Scopes), s.maxScopeCount))
 	}
 	return nil
 }

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -296,6 +296,10 @@ func (s *k8sRESTAdapter) Update(ctx context.Context,
 		return nil, false, apierrors.NewBadRequest("namespace in URL does not match namespace in body")
 	}
 
+	if err := s.validateScopeCount(resource); err != nil {
+		return nil, false, err
+	}
+
 	// Check authz on both existing and new body: prevents privilege escalation via scope changes.
 	allowed, err := canAccessAnnotation(ctx, s.accessClient, s.folderResolver, namespace, existing, utils.VerbUpdate)
 	if err != nil {

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -316,9 +316,10 @@ func TestK8sAdapter_List(t *testing.T) {
 	})
 }
 
-// TestK8sAdapter_MaxScopeCount pins the contract for Spec.Scopes cardinality:
+// TestK8sAdapter_MaxScopeCount pins the contract for Spec.Scopes cardinality
+// on both Create and Update:
 // - len(Scopes) <= maxScopeCount succeeds;
-// - over the limit returns 400 BadRequest and the annotation is not persisted.
+// - over the limit returns 400 BadRequest and the annotation is not persisted/mutated.
 // maxScopeCount = 0 is the configured "no scopes allowed" mode.
 func TestK8sAdapter_MaxScopeCount(t *testing.T) {
 	ns := "org-1"
@@ -371,6 +372,34 @@ func TestK8sAdapter_MaxScopeCount(t *testing.T) {
 			assert.ErrorIs(t, getErr, ErrNotFound, "annotation should not have been persisted")
 		})
 	}
+
+	t.Run("update over limit rejected", func(t *testing.T) {
+		store := NewMemoryStore()
+		adapter := newTestAdapter(store, allowAll)
+		adapter.maxScopeCount = 2
+		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
+
+		name := "original"
+		orig := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       annotationV0.AnnotationSpec{Text: "hello", Time: 1000, Scopes: buildScopes(1)},
+		}
+		_, err := adapter.Create(ctx, orig, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		updated := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       annotationV0.AnnotationSpec{Text: "hello", Time: 1000, Scopes: buildScopes(3)},
+		}
+		_, _, err = adapter.Update(ctx, name, &updatedObjectInfo{obj: updated}, nil, nil, false, &metav1.UpdateOptions{})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsBadRequest(err), "expected 400 BadRequest, got %v", err)
+		assert.Contains(t, err.Error(), "max allowed")
+
+		stored, getErr := store.Get(ctx, ns, name)
+		require.NoError(t, getErr, "original annotation must still exist")
+		assert.Len(t, stored.Spec.Scopes, 1, "stored annotation must not have been mutated")
+	})
 }
 
 // compile-time assertion that errStore implements Store

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -316,6 +316,63 @@ func TestK8sAdapter_List(t *testing.T) {
 	})
 }
 
+// TestK8sAdapter_MaxScopeCount pins the contract for Spec.Scopes cardinality:
+// - len(Scopes) <= maxScopeCount succeeds;
+// - over the limit returns 400 BadRequest and the annotation is not persisted.
+// maxScopeCount = 0 is the configured "no scopes allowed" mode.
+func TestK8sAdapter_MaxScopeCount(t *testing.T) {
+	ns := "org-1"
+	allowAll := &fakeAccessClient{fn: func(_ authtypes.BatchCheckItem) bool { return true }}
+
+	buildScopes := func(n int) []string {
+		s := make([]string, n)
+		for i := range n {
+			s[i] = fmt.Sprintf("scope-%d", i)
+		}
+		return s
+	}
+
+	cases := []struct {
+		name          string
+		maxScopeCount int
+		scopeCount    int
+		expectErr     bool
+	}{
+		{"at limit succeeds", 3, 3, false},
+		{"over limit rejected", 3, 4, true},
+		{"zero allows no scopes", 0, 0, false},
+		{"zero rejects any scopes", 0, 1, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewMemoryStore()
+			adapter := newTestAdapter(store, allowAll)
+			adapter.maxScopeCount = tc.maxScopeCount
+			ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
+
+			name := "anno"
+			obj := &annotationV0.Annotation{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec:       annotationV0.AnnotationSpec{Text: "hello", Time: 1000, Scopes: buildScopes(tc.scopeCount)},
+			}
+			_, err := adapter.Create(ctx, obj, nil, &metav1.CreateOptions{})
+
+			if !tc.expectErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.True(t, apierrors.IsBadRequest(err), "expected 400 BadRequest, got %v", err)
+			assert.Contains(t, err.Error(), "max allowed")
+
+			_, getErr := store.Get(ctx, ns, name)
+			assert.ErrorIs(t, getErr, ErrNotFound, "annotation should not have been persisted")
+		})
+	}
+}
+
 // compile-time assertion that errStore implements Store
 var _ Store = (*errStore)(nil)
 

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -124,6 +124,7 @@ func NewAppInstaller(
 		folderResolver: folderResolver,
 		installer:      installer,
 		snowflakeNode:  sfNode,
+		maxScopeCount:  cfg.MaxScopeCount,
 		tracer:         installer.tracer,
 		metrics:        installer.metrics,
 		logger:         logger,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1060,7 +1060,11 @@ func (cfg *Cfg) readAnnotationSettings() error {
 	section := cfg.Raw.Section("annotations")
 	cfg.AnnotationCleanupJobBatchSize = section.Key("cleanupjob_batchsize").MustInt64(100)
 	cfg.AnnotationMaximumTagsLength = section.Key("tags_length").MustInt64(500)
-	cfg.AnnotationAppPlatform = loadAnnotationAppPlatformSettings(cfg.Raw)
+	annotationAppPlatformSettings, err := loadAnnotationAppPlatformSettings(cfg.Raw)
+	if err != nil {
+		return err
+	}
+	cfg.AnnotationAppPlatform = annotationAppPlatformSettings
 
 	switch {
 	case cfg.AnnotationMaximumTagsLength > 4096:
@@ -1144,15 +1148,21 @@ type AnnotationAppPlatformSettings struct {
 	// EnableLegacyID controls whether a grafana.app/legacyID label is generated
 	// for new annotations.
 	EnableLegacyID bool
+
+	// MaxScopeCount caps how many scopes may be attached to a single
+	// annotation. 0 means no scopes are allowed. Negative values are
+	// rejected at load time. Default 5.
+	MaxScopeCount int
 }
 
-func loadAnnotationAppPlatformSettings(cfg *ini.File) AnnotationAppPlatformSettings {
+func loadAnnotationAppPlatformSettings(cfg *ini.File) (AnnotationAppPlatformSettings, error) {
 	appPlatformSection := cfg.Section("annotations.app_platform")
-	return AnnotationAppPlatformSettings{
+	settings := AnnotationAppPlatformSettings{
 		Enabled:        appPlatformSection.Key("enabled").MustBool(false),
 		StoreBackend:   appPlatformSection.Key("store_backend").MustString("legacy-sql"),
 		RetentionTTL:   appPlatformSection.Key("retention_ttl").MustDuration(2160 * time.Hour),
 		EnableLegacyID: appPlatformSection.Key("enable_legacy_id").MustBool(false),
+		MaxScopeCount:  appPlatformSection.Key("max_scope_count").MustInt(5),
 
 		GRPCAddress:       appPlatformSection.Key("grpc_address").MustString("localhost:9090"),
 		GRPCUseTLS:        appPlatformSection.Key("grpc_use_tls").MustBool(false),
@@ -1167,6 +1177,12 @@ func loadAnnotationAppPlatformSettings(cfg *ini.File) AnnotationAppPlatformSetti
 		PostgresTagCacheTTL:      appPlatformSection.Key("postgres_tag_cache_ttl").MustDuration(60 * time.Second),
 		PostgresTagCacheSize:     appPlatformSection.Key("postgres_tag_cache_size").MustInt(1000),
 	}
+
+	if settings.MaxScopeCount < 0 {
+		return AnnotationAppPlatformSettings{}, fmt.Errorf("[annotations.app_platform.max_scope_count] must not be negative")
+	}
+
+	return settings, nil
 }
 
 // envNameFromIniName converts an ini-style name (section or key) to the

--- a/pkg/setting/setting_annotations_test.go
+++ b/pkg/setting/setting_annotations_test.go
@@ -9,36 +9,37 @@ import (
 )
 
 func TestLoadAnnotationAppPlatformSettings_MaxScopeCount(t *testing.T) {
-	tests := []struct {
-		name      string
-		iniValue  *string // nil means no key set
-		expected  int
-		expectErr bool
+	cases := []struct {
+		name                  string
+		iniValue              *string // nil means no key set
+		expectedMaxScopeCount int
+		expectErr             bool
 	}{
-		{name: "default when key absent", expected: 5},
-		{name: "explicit positive", iniValue: new("10"), expected: 10},
-		{name: "zero is accepted", iniValue: new("0"), expected: 0},
+		{name: "default when key absent", expectedMaxScopeCount: 5},
+		{name: "explicit positive", iniValue: new("10"), expectedMaxScopeCount: 10},
+		{name: "zero is accepted", iniValue: new("0"), expectedMaxScopeCount: 0},
 		{name: "negative is rejected", iniValue: new("-1"), expectErr: true},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := ini.Empty()
-			if tt.iniValue != nil {
-				s, err := f.NewSection("annotations.app_platform")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			iniFile := ini.Empty()
+			if tc.iniValue != nil {
+				section, err := iniFile.NewSection("annotations.app_platform")
 				require.NoError(t, err)
-				_, err = s.NewKey("max_scope_count", *tt.iniValue)
+
+				_, err = section.NewKey("max_scope_count", *tc.iniValue)
 				require.NoError(t, err)
 			}
 
-			got, err := loadAnnotationAppPlatformSettings(f)
-			if tt.expectErr {
+			settings, err := loadAnnotationAppPlatformSettings(iniFile)
+			if tc.expectErr {
 				assert.Error(t, err)
 				return
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, got.MaxScopeCount)
+			assert.Equal(t, tc.expectedMaxScopeCount, settings.MaxScopeCount)
 		})
 	}
 }

--- a/pkg/setting/setting_annotations_test.go
+++ b/pkg/setting/setting_annotations_test.go
@@ -1,0 +1,44 @@
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
+)
+
+func TestLoadAnnotationAppPlatformSettings_MaxScopeCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		iniValue  *string // nil means no key set
+		expected  int
+		expectErr bool
+	}{
+		{name: "default when key absent", expected: 5},
+		{name: "explicit positive", iniValue: new("10"), expected: 10},
+		{name: "zero is accepted", iniValue: new("0"), expected: 0},
+		{name: "negative is rejected", iniValue: new("-1"), expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := ini.Empty()
+			if tt.iniValue != nil {
+				s, err := f.NewSection("annotations.app_platform")
+				require.NoError(t, err)
+				_, err = s.NewKey("max_scope_count", *tt.iniValue)
+				require.NoError(t, err)
+			}
+
+			got, err := loadAnnotationAppPlatformSettings(f)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got.MaxScopeCount)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR proposes to add a new configuration option `max_scope_count` under `[annotations.app_platform]` with a default value `5`, which caps how many entries [AnnotationSpec.Scopes](https://github.com/grafana/grafana/blob/718716e76c851c03dc2f04a20101bed36d470d9f/apps/annotation/kinds/annotation.cue#L14) may contain. 

This feature is enforced in both the `Create` and `Update` functions for annotations where over-limit creates return `BadRequest` with `too many scopes: N (max allowed M)` message and the annotation is not persisted / mutated.

<img width="1321" height="618" alt="Screenshot 2026-06-18 at 2 51 36 PM" src="https://github.com/user-attachments/assets/33df16ca-9df9-4700-bb89-68304cfe0821" />

Settings contract:
  - Positive value → enforces the limit.
  - 0 → no scopes allowed at all.
  - Negative → rejected at config load with `[annotations.app_platform.max_scope_count] must not be negative` message.

**Why do we need this feature?**

Limit what we need to store in cloud, while allowing self-serve users to configure higher limits for the number of scopes an annotation may be associated with.

**Which issue(s) does this PR fix?**: 

[#938](https://github.com/grafana/grafana-org/issues/938)

<!--
**Who is this feature for?**

[Add information on what kind of user the feature is for.]



- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
-->
