### PR TITLE
Provisioning: Generalize Github Repository to allow GHES 

### DIFF
--- a/apps/provisioning/pkg/repository/github/extra.go
+++ b/apps/provisioning/pkg/repository/github/extra.go
@@ -73,7 +73,7 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 		return nil, fmt.Errorf("error creating git repository: %w", err)
 	}
 
-	ghRepo, err := NewRepository(ctx, r, gitRepo, e.factory, token, "")
+	ghRepo, err := NewRepository(ctx, r, gitRepo, e.factory, token)
 	if err != nil {
 		return nil, fmt.Errorf("error creating github repository: %w", err)
 	}

--- a/apps/provisioning/pkg/repository/github/extra.go
+++ b/apps/provisioning/pkg/repository/github/extra.go
@@ -73,7 +73,7 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 		return nil, fmt.Errorf("error creating git repository: %w", err)
 	}
 
-	ghRepo, err := NewRepository(ctx, r, gitRepo, e.factory, token)
+	ghRepo, err := NewRepository(ctx, r, gitRepo, e.factory, token, "")
 	if err != nil {
 		return nil, fmt.Errorf("error creating github repository: %w", err)
 	}

--- a/apps/provisioning/pkg/repository/github/factory.go
+++ b/apps/provisioning/pkg/repository/github/factory.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/google/go-github/v82/github"
@@ -29,18 +30,27 @@ func ProvideFactory() *Factory {
 	}
 }
 
-func (r *Factory) New(ctx context.Context, owner, repo string, ghToken common.RawSecureValue) Client {
+func (r *Factory) New(ctx context.Context, owner, repo string, ghToken common.RawSecureValue, customServerURL string) (Client, error) {
 	if r.Client != nil {
-		return NewClient(github.NewClient(r.Client), owner, repo)
+		return NewClient(github.NewClient(r.Client), owner, repo), nil
 	}
 
+	httpClient := &http.Client{}
 	if !ghToken.IsZero() {
 		tokenSrc := oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: string(ghToken)},
 		)
-		tokenClient := oauth2.NewClient(ctx, tokenSrc)
-		return NewClient(github.NewClient(tokenClient), owner, repo)
+		httpClient = oauth2.NewClient(ctx, tokenSrc)
 	}
 
-	return NewClient(github.NewClient(&http.Client{}), owner, repo)
+	ghClient := github.NewClient(httpClient)
+	if customServerURL != "" {
+		enterprise, err := ghClient.WithEnterpriseURLs(customServerURL, customServerURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to configure Github Enterprise URLs for %s: %w", customServerURL, err)
+		}
+		ghClient = enterprise
+	}
+
+	return NewClient(ghClient, owner, repo), nil
 }

--- a/apps/provisioning/pkg/repository/github/factory.go
+++ b/apps/provisioning/pkg/repository/github/factory.go
@@ -30,7 +30,28 @@ func ProvideFactory() *Factory {
 	}
 }
 
-func (r *Factory) New(ctx context.Context, owner, repo string, ghToken common.RawSecureValue, customServerURL string) (Client, error) {
+// ClientOptions holds the optional configuration for a GitHub client.
+type ClientOptions struct {
+	customServerURL string
+}
+
+// ClientOption customizes how a GitHub client is created.
+type ClientOption func(*ClientOptions)
+
+// WithCustomServerURL targets a GitHub Enterprise Server instance at the given
+// base URL. An empty url is ignored, keeping the default github.com client.
+func WithCustomServerURL(url string) ClientOption {
+	return func(o *ClientOptions) {
+		o.customServerURL = url
+	}
+}
+
+func (r *Factory) New(ctx context.Context, owner, repo string, ghToken common.RawSecureValue, opts ...ClientOption) (Client, error) {
+	var options ClientOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	if r.Client != nil {
 		return NewClient(github.NewClient(r.Client), owner, repo), nil
 	}
@@ -44,10 +65,10 @@ func (r *Factory) New(ctx context.Context, owner, repo string, ghToken common.Ra
 	}
 
 	ghClient := github.NewClient(httpClient)
-	if customServerURL != "" {
-		enterprise, err := ghClient.WithEnterpriseURLs(customServerURL, customServerURL)
+	if options.customServerURL != "" {
+		enterprise, err := ghClient.WithEnterpriseURLs(options.customServerURL, options.customServerURL)
 		if err != nil {
-			return nil, fmt.Errorf("failed to configure Github Enterprise URLs for %s: %w", customServerURL, err)
+			return nil, fmt.Errorf("failed to configure GitHub Enterprise URLs for %q: %w", options.customServerURL, err)
 		}
 		ghClient = enterprise
 	}

--- a/apps/provisioning/pkg/repository/github/factory.go
+++ b/apps/provisioning/pkg/repository/github/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/google/go-github/v82/github"
 	"golang.org/x/oauth2"
@@ -39,10 +40,19 @@ type ClientOptions struct {
 type ClientOption func(*ClientOptions)
 
 // WithCustomServerURL targets a GitHub Enterprise Server instance at the given
-// base URL. An empty url is ignored, keeping the default github.com client.
-func WithCustomServerURL(url string) ClientOption {
+// base URL. An empty url or the default `https://github.com` is ignored, keeping the default github.com client.
+func WithCustomServerURL(serverURL string) ClientOption {
 	return func(o *ClientOptions) {
-		o.customServerURL = url
+		u, err := url.Parse(serverURL)
+		if err != nil {
+			return
+		}
+
+		if u.Host == "github.com" {
+			return
+		}
+
+		o.customServerURL = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 	}
 }
 

--- a/apps/provisioning/pkg/repository/github/factory.go
+++ b/apps/provisioning/pkg/repository/github/factory.go
@@ -48,7 +48,7 @@ func WithCustomServerURL(serverURL string) ClientOption {
 			return
 		}
 
-		if u.Host == "github.com" {
+		if u.Host == "" || u.Host == "github.com" {
 			return
 		}
 

--- a/apps/provisioning/pkg/repository/github/factory_test.go
+++ b/apps/provisioning/pkg/repository/github/factory_test.go
@@ -1,0 +1,39 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithCustomServerURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		serverURL string
+		expected  string
+	}{
+		{
+			name:      "default github.com is ignored",
+			serverURL: "https://github.com",
+			expected:  "",
+		},
+		{
+			name:      "github.com with path is ignored",
+			serverURL: "https://github.com/example/test",
+			expected:  "",
+		},
+		{
+			name:      "GitHub Enterprise Server url is kept",
+			serverURL: "https://ghes.example.com/example/test",
+			expected:  "https://ghes.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var options ClientOptions
+			WithCustomServerURL(tt.serverURL)(&options)
+			assert.Equal(t, tt.expected, options.customServerURL)
+		})
+	}
+}

--- a/apps/provisioning/pkg/repository/github/factory_test.go
+++ b/apps/provisioning/pkg/repository/github/factory_test.go
@@ -23,6 +23,11 @@ func TestWithCustomServerURL(t *testing.T) {
 			expected:  "",
 		},
 		{
+			name:      "empty url is ignored",
+			serverURL: "",
+			expected:  "",
+		},
+		{
 			name:      "GitHub Enterprise Server url is kept",
 			serverURL: "https://ghes.example.com/example/test",
 			expected:  "https://ghes.example.com",

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -341,7 +341,7 @@ func TestGithubClient_GetCommits(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -519,7 +519,7 @@ func TestGithubClient_ListWebhooks(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -724,7 +724,7 @@ func TestGithubClient_CreateWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -901,7 +901,7 @@ func TestGithubClient_GetWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -1044,7 +1044,7 @@ func TestGithubClient_DeleteWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -1238,7 +1238,7 @@ func TestGithubClient_EditWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -1422,7 +1422,7 @@ func TestGithubClient_ListPullRequestFiles(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -1542,7 +1542,7 @@ func TestCreatePullRequestComment(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested
@@ -2640,7 +2640,7 @@ func TestGithubClient_GetRepository(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "")
 			assert.NoError(t, err)
 
 			// Call the method being tested

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -341,7 +341,8 @@ func TestGithubClient_GetCommits(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), tt.owner, tt.repository, "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			assert.NoError(t, err)
 
 			// Call the method being tested
 			commits, err := client.Commits(context.Background(), tt.branch, tt.path)
@@ -518,7 +519,8 @@ func TestGithubClient_ListWebhooks(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), tt.owner, tt.repository, "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			assert.NoError(t, err)
 
 			// Call the method being tested
 			webhooks, err := client.ListWebhooks(context.Background())
@@ -722,7 +724,8 @@ func TestGithubClient_CreateWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), tt.owner, tt.repository, "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			assert.NoError(t, err)
 
 			// Call the method being tested
 			got, err := client.CreateWebhook(context.Background(), tt.config)
@@ -898,7 +901,8 @@ func TestGithubClient_GetWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), tt.owner, tt.repository, "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			assert.NoError(t, err)
 
 			// Call the method being tested
 			got, err := client.GetWebhook(context.Background(), tt.webhookID)
@@ -1040,10 +1044,11 @@ func TestGithubClient_DeleteWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), tt.owner, tt.repository, "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			assert.NoError(t, err)
 
 			// Call the method being tested
-			err := client.DeleteWebhook(context.Background(), tt.webhookID)
+			err = client.DeleteWebhook(context.Background(), tt.webhookID)
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -1233,10 +1238,11 @@ func TestGithubClient_EditWebhook(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), tt.owner, tt.repository, "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			assert.NoError(t, err)
 
 			// Call the method being tested
-			err := client.EditWebhook(context.Background(), tt.config)
+			err = client.EditWebhook(context.Background(), tt.config)
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -1416,7 +1422,8 @@ func TestGithubClient_ListPullRequestFiles(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), tt.owner, tt.repository, "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			assert.NoError(t, err)
 
 			// Call the method being tested
 			files, err := client.ListPullRequestFiles(context.Background(), tt.number)
@@ -1535,10 +1542,11 @@ func TestCreatePullRequestComment(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), tt.owner, tt.repository, "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			assert.NoError(t, err)
 
 			// Call the method being tested
-			err := client.CreatePullRequestComment(context.Background(), tt.number, tt.body)
+			err = client.CreatePullRequestComment(context.Background(), tt.number, tt.body)
 
 			// Check the error
 			if tt.wantErr != nil {
@@ -2632,7 +2640,8 @@ func TestGithubClient_GetRepository(t *testing.T) {
 			// Create a mock client
 			factory := ProvideFactory()
 			factory.Client = tt.mockHandler
-			client := factory.New(context.Background(), tt.owner, tt.repository, "")
+			client, err := factory.New(context.Background(), tt.owner, tt.repository, "", "")
+			assert.NoError(t, err)
 
 			// Call the method being tested
 			got, err := client.GetRepository(context.Background())

--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -53,20 +53,7 @@ func NewRepository(
 	factory *Factory,
 	token common.RawSecureValue,
 ) (GithubRepository, error) {
-	return newRepository(ctx, config, gitRepo, factory, token)
-}
-
-// NewRepositoryWithCustomURL builds a repository client targeting a GitHub
-// Enterprise Server instance at the given customServerURL.
-func NewRepositoryWithCustomURL(
-	ctx context.Context,
-	config *provisioning.Repository,
-	gitRepo git.GitRepository,
-	factory *Factory,
-	token common.RawSecureValue,
-	customServerURL string,
-) (GithubRepository, error) {
-	return newRepository(ctx, config, gitRepo, factory, token, WithCustomServerURL(customServerURL))
+	return newRepository(ctx, config, gitRepo, factory, token, WithCustomServerURL(gitRepo.URL()))
 }
 
 func newRepository(

--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -58,7 +58,7 @@ func NewRepository(
 		return nil, fmt.Errorf("parse owner and repo: %w", err)
 	}
 
-	ghClient, err := factory.New(ctx, owner, repo, token, customServerURL)
+	ghClient, err := factory.New(ctx, owner, repo, token, WithCustomServerURL(customServerURL))
 	if err != nil {
 		return nil, fmt.Errorf("create github client: %w", err)
 	}

--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -45,7 +45,20 @@ type GithubRepository interface {
 	Client() Client
 }
 
+// NewRepository builds a github.com repository client.
 func NewRepository(
+	ctx context.Context,
+	config *provisioning.Repository,
+	gitRepo git.GitRepository,
+	factory *Factory,
+	token common.RawSecureValue,
+) (GithubRepository, error) {
+	return newRepository(ctx, config, gitRepo, factory, token)
+}
+
+// NewRepositoryWithCustomURL builds a repository client targeting a GitHub
+// Enterprise Server instance at the given customServerURL.
+func NewRepositoryWithCustomURL(
 	ctx context.Context,
 	config *provisioning.Repository,
 	gitRepo git.GitRepository,
@@ -53,12 +66,23 @@ func NewRepository(
 	token common.RawSecureValue,
 	customServerURL string,
 ) (GithubRepository, error) {
+	return newRepository(ctx, config, gitRepo, factory, token, WithCustomServerURL(customServerURL))
+}
+
+func newRepository(
+	ctx context.Context,
+	config *provisioning.Repository,
+	gitRepo git.GitRepository,
+	factory *Factory,
+	token common.RawSecureValue,
+	opts ...ClientOption,
+) (GithubRepository, error) {
 	owner, repo, err := ParseOwnerRepoGithub(gitRepo.URL())
 	if err != nil {
 		return nil, fmt.Errorf("parse owner and repo: %w", err)
 	}
 
-	ghClient, err := factory.New(ctx, owner, repo, token, WithCustomServerURL(customServerURL))
+	ghClient, err := factory.New(ctx, owner, repo, token, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create github client: %w", err)
 	}

--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -22,7 +22,7 @@ import (
 type githubRepository struct {
 	git.GitRepository
 	config *provisioning.Repository
-	gh     Client // assumes github.com base URL
+	gh     Client
 
 	owner string
 	repo  string
@@ -51,16 +51,22 @@ func NewRepository(
 	gitRepo git.GitRepository,
 	factory *Factory,
 	token common.RawSecureValue,
+	customServerURL string,
 ) (GithubRepository, error) {
-	owner, repo, err := ParseOwnerRepoGithub(config.Spec.GitHub.URL)
+	owner, repo, err := ParseOwnerRepoGithub(gitRepo.URL())
 	if err != nil {
 		return nil, fmt.Errorf("parse owner and repo: %w", err)
+	}
+
+	ghClient, err := factory.New(ctx, owner, repo, token, customServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("create github client: %w", err)
 	}
 
 	return &githubRepository{
 		config:        config,
 		GitRepository: gitRepo,
-		gh:            factory.New(ctx, owner, repo, token), // TODO, baseURL from config
+		gh:            ghClient,
 		owner:         owner,
 		repo:          repo,
 	}, nil
@@ -87,7 +93,7 @@ func (r *githubRepository) GetDefaultBranch(ctx context.Context) (string, error)
 }
 
 func (r *githubRepository) GetCurrentBranch() string {
-	return r.config.Spec.GitHub.Branch
+	return r.config.Branch()
 }
 
 func (r *githubRepository) SetBranch(branch string) {
@@ -114,18 +120,18 @@ func ParseOwnerRepoGithub(giturl string) (owner string, repo string, err error) 
 
 // Test implements provisioning.Repository.
 func (r *githubRepository) Test(ctx context.Context) (*provisioning.TestResults, error) {
-	url := r.config.Spec.GitHub.URL
+	url := r.config.URL()
 	_, _, err := ParseOwnerRepoGithub(url)
 	if err != nil {
 		return repository.FromFieldError(field.Invalid(
-			field.NewPath("spec", "github", "url"), url, err.Error())), nil
+			field.NewPath("spec", r.config.Spec.Type.String(), "url"), url, err.Error())), nil
 	}
 
 	// For Github repositories, in case the branch is empty, we get the default branch and set it up for testing.
 	if r.GetCurrentBranch() == "" {
 		branch, err := r.GetDefaultBranch(ctx)
 		if err != nil {
-			return testResultFromGetDefaultBranchError(url, err), nil
+			return r.testResultFromGetDefaultBranchError(err), nil
 		}
 
 		r.SetBranch(branch)
@@ -147,8 +153,9 @@ func (r *githubRepository) Test(ctx context.Context) (*provisioning.TestResults,
 // user-facing TestResults. The /test endpoint is the onboarding entry point; surfacing
 // these as bare Go errors turns recoverable conditions (wrong URL, missing token scope,
 // transient GitHub outage) into opaque HTTP 500s.
-func testResultFromGetDefaultBranchError(url string, err error) *provisioning.TestResults {
-	path := field.NewPath("spec", "github", "url")
+func (r *githubRepository) testResultFromGetDefaultBranchError(err error) *provisioning.TestResults {
+	url := r.config.URL()
+	path := field.NewPath("spec", r.config.Spec.Type.String(), "url")
 	code := http.StatusBadRequest
 	var detail string
 
@@ -156,11 +163,11 @@ func testResultFromGetDefaultBranchError(url string, err error) *provisioning.Te
 	case errors.Is(err, repository.ErrFileNotFound):
 		detail = fmt.Sprintf("repository %q not found, or the configured token does not have access to it", url)
 	case errors.Is(err, repository.ErrUnauthorized):
-		path = field.NewPath("spec", "github", "token")
+		path = field.NewPath("spec", r.config.Spec.Type.String(), "token")
 		code = http.StatusUnauthorized
 		detail = "authentication failed: the configured token is invalid or expired"
 	case errors.Is(err, repository.ErrPermissionDenied):
-		path = field.NewPath("spec", "github", "token")
+		path = field.NewPath("spec", r.config.Spec.Type.String(), "token")
 		code = http.StatusForbidden
 		detail = fmt.Sprintf("the configured token lacks permission to access %q", url)
 	case errors.Is(err, repository.ErrServerUnavailable):
@@ -200,7 +207,7 @@ func (r *githubRepository) checkBranchProtection(ctx context.Context) *provision
 			Success: false,
 			Errors: []provisioning.ErrorDetails{{
 				Type:   metav1.CauseTypeFieldValueInvalid,
-				Field:  field.NewPath("spec", "github", "branch").String(),
+				Field:  field.NewPath("spec", r.config.Spec.Type.String(), "branch").String(),
 				Detail: fmt.Sprintf("failed to check branch protection for branch %q: %v", r.GetCurrentBranch(), err),
 			}},
 		}
@@ -221,7 +228,7 @@ func (r *githubRepository) checkBranchProtection(ctx context.Context) *provision
 			Success: false,
 			Errors: []provisioning.ErrorDetails{{
 				Type:   metav1.CauseTypeFieldValueInvalid,
-				Field:  field.NewPath("spec", "github", "branch").String(),
+				Field:  field.NewPath("spec", r.config.Spec.Type.String(), "branch").String(),
 				Detail: fmt.Sprintf("failed to check repository rulesets for branch %q: %v", r.GetCurrentBranch(), err),
 			}},
 		}
@@ -260,7 +267,7 @@ func (r *githubRepository) hasWriteWorkflow() bool {
 
 func (r *githubRepository) History(ctx context.Context, path, ref string) ([]provisioning.HistoryItem, error) {
 	if ref == "" {
-		ref = r.config.Spec.GitHub.Branch
+		ref = r.config.Branch()
 	}
 
 	finalPath := safepath.Join(r.config.Spec.GitHub.Path, path)
@@ -311,7 +318,7 @@ func (r *githubRepository) ListRefs(ctx context.Context) ([]provisioning.RefItem
 	}
 
 	for i := range refs {
-		refs[i].RefURL = fmt.Sprintf("%s/tree/%s", r.config.Spec.GitHub.URL, refs[i].Name)
+		refs[i].RefURL = fmt.Sprintf("%s/tree/%s", r.config.URL(), refs[i].Name)
 	}
 
 	return refs, nil
@@ -319,23 +326,24 @@ func (r *githubRepository) ListRefs(ctx context.Context) ([]provisioning.RefItem
 
 // ResourceURLs implements RepositoryWithURLs.
 func (r *githubRepository) ResourceURLs(ctx context.Context, file *repository.FileInfo) (*provisioning.RepositoryURLs, error) {
-	cfg := r.config.Spec.GitHub
-	if file.Path == "" || cfg == nil {
+	url := r.config.URL()
+	branch := r.config.Branch()
+	if file.Path == "" || url == "" {
 		return nil, nil
 	}
 
 	ref := file.Ref
 	if ref == "" {
-		ref = cfg.Branch
+		ref = branch
 	}
 
 	urls := &provisioning.RepositoryURLs{
-		RepositoryURL: cfg.URL,
-		SourceURL:     fmt.Sprintf("%s/blob/%s/%s", cfg.URL, ref, file.Path),
+		RepositoryURL: r.config.URL(),
+		SourceURL:     fmt.Sprintf("%s/blob/%s/%s", url, ref, file.Path),
 	}
 
-	if ref != cfg.Branch {
-		urls.CompareURL = fmt.Sprintf("%s/compare/%s...%s", cfg.URL, cfg.Branch, ref)
+	if ref != branch {
+		urls.CompareURL = fmt.Sprintf("%s/compare/%s...%s", url, branch, ref)
 
 		// Create a new pull request
 		urls.NewPullRequestURL = fmt.Sprintf("%s?quick_pull=1&labels=grafana", urls.CompareURL)
@@ -346,19 +354,22 @@ func (r *githubRepository) ResourceURLs(ctx context.Context, file *repository.Fi
 
 // RefURLs implements RepositoryWithURLs.
 func (r *githubRepository) RefURLs(ctx context.Context, ref string) (*provisioning.RepositoryURLs, error) {
-	cfg := r.config.Spec.GitHub
-	if cfg == nil || ref == "" {
+	url := r.config.URL()
+	branch := r.config.Branch()
+	if url == "" || ref == "" {
 		return nil, nil
 	}
 
 	urls := &provisioning.RepositoryURLs{
-		SourceURL: fmt.Sprintf("%s/tree/%s", cfg.URL, ref),
+		SourceURL: fmt.Sprintf("%s/tree/%s", url, ref),
 	}
 
-	if ref != cfg.Branch {
-		urls.CompareURL = fmt.Sprintf("%s/compare/%s...%s", cfg.URL, cfg.Branch, ref)
+	if ref != branch {
+		urls.CompareURL = fmt.Sprintf("%s/compare/%s...%s", url, branch, ref)
 		urls.NewPullRequestURL = fmt.Sprintf("%s?quick_pull=1&labels=grafana", urls.CompareURL)
 	}
 
 	return urls, nil
 }
+
+var _ (GithubRepository) = (*githubRepository)(nil)

--- a/apps/provisioning/pkg/repository/github/repository_test.go
+++ b/apps/provisioning/pkg/repository/github/repository_test.go
@@ -91,7 +91,6 @@ func TestNewGitHub(t *testing.T) {
 				gitRepo,
 				factory,
 				common.RawSecureValue(tt.token),
-				"",
 			)
 
 			// Check results

--- a/apps/provisioning/pkg/repository/github/repository_test.go
+++ b/apps/provisioning/pkg/repository/github/repository_test.go
@@ -36,6 +36,7 @@ func TestNewGitHub(t *testing.T) {
 						URL:    "https://github.com/grafana/grafana",
 						Branch: "main",
 					},
+					Type: provisioning.GitHubRepositoryType,
 				},
 			},
 			token:         "token123",
@@ -51,6 +52,7 @@ func TestNewGitHub(t *testing.T) {
 						URL:    "invalid-url",
 						Branch: "main",
 					},
+					Type: provisioning.GitHubRepositoryType,
 				},
 			},
 			token:         "token123",
@@ -64,6 +66,7 @@ func TestNewGitHub(t *testing.T) {
 						URL:    "https://github.com/grafana/grafana.git",
 						Branch: "main",
 					},
+					Type: provisioning.GitHubRepositoryType,
 				},
 			},
 			token:         "token123",
@@ -79,6 +82,7 @@ func TestNewGitHub(t *testing.T) {
 			factory.Client = http.DefaultClient
 
 			gitRepo := git.NewMockGitRepository(t)
+			gitRepo.EXPECT().URL().Return(tt.config.Spec.GitHub.URL).Maybe()
 
 			// Call the function under test
 			repo, err := NewRepository(
@@ -87,6 +91,7 @@ func TestNewGitHub(t *testing.T) {
 				gitRepo,
 				factory,
 				common.RawSecureValue(tt.token),
+				"",
 			)
 
 			// Check results
@@ -176,6 +181,7 @@ func TestGitHubRepositoryTest(t *testing.T) {
 						URL:    "https://github.com/grafana/grafana",
 						Branch: "main",
 					},
+					Type: provisioning.GitHubRepositoryType,
 				},
 				Secure: provisioning.SecureValues{
 					Token: common.InlineSecureValue{
@@ -202,6 +208,7 @@ func TestGitHubRepositoryTest(t *testing.T) {
 						URL:    "invalid-url",
 						Branch: "main",
 					},
+					Type: provisioning.GitHubRepositoryType,
 				},
 				Secure: provisioning.SecureValues{
 					Token: common.InlineSecureValue{
@@ -349,6 +356,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 						Branch: "main",
 						Path:   "dashboards",
 					},
+					Type: provisioning.GitHubRepositoryType,
 				},
 			},
 			path: "dashboard.json",
@@ -680,6 +688,7 @@ func TestGitHubRepositoryResourceURLs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt.config.Spec.Type = provisioning.GitHubRepositoryType
 			repo := &githubRepository{
 				config: tt.config,
 				owner:  "grafana",
@@ -766,6 +775,7 @@ func TestGitHubRepositoryRefURLs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt.config.Spec.Type = provisioning.GitHubRepositoryType
 			repo := &githubRepository{
 				config: tt.config,
 				owner:  "grafana",
@@ -795,6 +805,7 @@ func TestGitHubRepositoryDelegation(t *testing.T) {
 				URL:    "https://github.com/grafana/grafana",
 				Branch: "main",
 			},
+			Type: provisioning.GitHubRepositoryType,
 		},
 		Secure: provisioning.SecureValues{
 			Token: common.InlineSecureValue{
@@ -1016,6 +1027,7 @@ func TestGitHubRepositoryAccessors(t *testing.T) {
 				URL:    "https://github.com/grafana/grafana",
 				Branch: "main",
 			},
+			Type: provisioning.GitHubRepositoryType,
 		},
 	}
 
@@ -1073,6 +1085,7 @@ func TestGitHubRepositoryAccessors(t *testing.T) {
 					URL:    "https://github.com/grafana/grafana",
 					Branch: "",
 				},
+				Type: provisioning.GitHubRepositoryType,
 			},
 		}
 
@@ -1394,6 +1407,7 @@ func TestGitHubRepository_Test_BranchProtection(t *testing.T) {
 						URL:    "https://github.com/grafana/grafana",
 						Branch: tt.branch,
 					},
+					Type: provisioning.GitHubRepositoryType,
 				},
 			}
 
@@ -1613,6 +1627,7 @@ func TestGitHubRepository_Test_Rulesets(t *testing.T) {
 						URL:    "https://github.com/grafana/grafana",
 						Branch: tt.branch,
 					},
+					Type: provisioning.GitHubRepositoryType,
 				},
 			}
 
@@ -1768,6 +1783,7 @@ func TestGitHubRepository_Test_CombinedProtection(t *testing.T) {
 						URL:    "https://github.com/grafana/grafana",
 						Branch: tt.branch,
 					},
+					Type: provisioning.GitHubRepositoryType,
 				},
 			}
 
@@ -1954,6 +1970,7 @@ func TestGitHubRepository_Test_EmptyBranch(t *testing.T) {
 						Branch: tt.initialBranch,
 						Path:   "grafana/",
 					},
+					Type: provisioning.GitHubRepositoryType,
 				},
 			}
 


### PR DESCRIPTION
**What is this feature?**
Generalizing the Github Repository to accept a customServerURL so the repository interface works with both github + github enterprise server. 

Corresponding enterprise: https://github.com/grafana/grafana-enterprise/pull/12358
**Why do we need this feature?**
Supporting github repos on github enterprise servers (self-hosted)

**Who is this feature for?**

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/git-ui-sync-project/issues/1139

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.