### PR TITLE
Plugins: add debug logs for legacy fallbacks and error logs for updat…

### DIFF
--- a/packages/grafana-runtime/src/services/pluginSettings/getPluginSettings.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/getPluginSettings.ts
@@ -65,6 +65,7 @@ export async function getPluginSettings(pluginId: string, showErrorAlert = false
 
   const meta = await getPluginMetaFromCache(pluginId);
   if (!meta) {
+    logPluginSettingsDebug('PluginSettings: falling back to getting legacy plugin settings', { pluginId });
     return getCachedLegacySettings(pluginId, showErrorAlert);
   }
 

--- a/packages/grafana-runtime/src/services/pluginSettings/refetchPluginSettings.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/refetchPluginSettings.ts
@@ -6,6 +6,7 @@ import { getCachedPromiseWithArgs } from '../../utils/getCachedPromise';
 import { refetchPluginMeta } from '../pluginMeta/plugins';
 
 import { getAppPluginSettings, getLegacySettings } from './getPluginSettings';
+import { logPluginSettingsDebug } from './logging';
 import { getSettingsMapper } from './mappers/mappers';
 import { getCacheKey, getLegacyCacheKey } from './utils';
 
@@ -16,6 +17,7 @@ export async function refetchPluginSettings(pluginId: string): Promise<PluginMet
 
   const meta = await refetchPluginMeta(pluginId);
   if (!meta) {
+    logPluginSettingsDebug('PluginSettings: falling back to refetching legacy plugin settings', { pluginId });
     return refetchCachedLegacySettings(pluginId, false);
   }
 

--- a/packages/grafana-runtime/src/services/pluginSettings/updateAppPluginSettings.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/updateAppPluginSettings.ts
@@ -8,7 +8,7 @@ import { replaceCachedPromise } from '../../utils/getCachedPromise';
 import { getBackendSrv } from '../backendSrv';
 import { refetchPluginMeta } from '../pluginMeta/plugins';
 
-import { logPluginSettingsDebug } from './logging';
+import { logPluginSettingsDebug, logPluginSettingsError } from './logging';
 import { getSettingsMapper } from './mappers/mappers';
 import { inlineSecureValuesMapper, settingsSpecMapper } from './mappers/v0alpha1SettingsMapper';
 import { refetchCachedAppSettings, refetchCachedLegacySettings } from './refetchPluginSettings';
@@ -17,7 +17,12 @@ import { getApiVersion, getCacheKey, getNamespace } from './utils';
 
 function updateLegacySettings(pluginId: string, data: Partial<PluginMeta>): Promise<void> {
   logPluginSettingsDebug('PluginSettings: updating legacy plugin settings', { pluginId });
-  return getBackendSrv().post<void>(`/api/plugins/${pluginId}/settings`, data, { validatePath: true });
+  return getBackendSrv()
+    .post<void>(`/api/plugins/${pluginId}/settings`, data, { validatePath: true })
+    .catch((err) => {
+      logPluginSettingsError('PluginSettings: updating legacy plugin settings failed', err, { pluginId });
+      return Promise.reject(err);
+    });
 }
 
 async function internalUpdateAppPluginSettings(pluginId: string, data: Partial<PluginMeta>): Promise<v0alpha1Settings> {
@@ -35,16 +40,17 @@ async function internalUpdateAppPluginSettings(pluginId: string, data: Partial<P
   const patch = [test, ...compare(stored, update)];
   logPluginSettingsDebug('PluginSettings: updating plugin settings', { pluginId });
 
-  const updated = await getBackendSrv().patch<v0alpha1Settings>(
-    `/apis/${pluginId}/${getApiVersion()}/namespaces/${getNamespace()}/app/instance`,
-    patch,
-    {
+  const updated = await getBackendSrv()
+    .patch<v0alpha1Settings>(`/apis/${pluginId}/${getApiVersion()}/namespaces/${getNamespace()}/app/instance`, patch, {
       validatePath: true,
       headers: {
         'Content-Type': 'application/json-patch+json',
       },
-    }
-  );
+    })
+    .catch((err) => {
+      logPluginSettingsError('PluginSettings: updating plugin settings failed', err, { pluginId });
+      return Promise.reject(err);
+    });
 
   return updated;
 }
@@ -63,6 +69,7 @@ export async function updateAppPluginSettings(pluginId: string, data: Partial<Pl
 
   const meta = await refetchPluginMeta(pluginId);
   if (!meta) {
+    logPluginSettingsDebug('PluginSettings: falling back to updating legacy plugin settings', { pluginId });
     await updateLegacySettings(pluginId, data);
     return refetchCachedLegacySettings(pluginId, false);
   }


### PR DESCRIPTION
**What is this feature?**

Adds debug logs for legacy plugin settings fallback paths and error logs when `updateLegacySettings` or `internalUpdateAppPluginSettings` fail.

**Why do we need this feature?**

So we can trace when and why plugin settings fall back to the legacy path.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
