### PR TITLE
CI: Fix backport workflow permissions by using two apps

### DIFF
--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -20,11 +20,19 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - name: Get GitHub App token
-        id: get-github-app-token
+      - name: Get GitHub App token (Push)
+        id: get-github-app-token-push
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        with:
+          github_app: grafana-writer
+          permission_set: push
+
+      - name: Get GitHub App token (Open PR)
+        id: get-github-app-token-open-pr
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
           github_app: grafana-pr-automation
+          permission_set: open_pr
 
       - name: Download PR info artifact
         uses: actions/download-artifact@v8
@@ -61,9 +69,10 @@ jobs:
           persist-credentials: false
 
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@6782bcaa01680648bdbba76cce1847e1862dbb22
+        uses: grafana/grafana-github-actions-go/backport@4dbc1c626300965fd1ffdafc95c6aee36ff26056
         with:
-          token: ${{ steps.get-github-app-token.outputs.token }}
+          git_push_token: ${{ steps.get-github-app-token-push.outputs.token }}
+          pr_open_token: ${{ steps.get-github-app-token-open-pr.outputs.token }}
           # If triggered by being labelled, only backport that label.
           # Otherwise, the action will backport all labels.
           pr_label: ${{ steps.pr-info.outputs.action == 'labeled' && steps.pr-info.outputs.label || '' }}


### PR DESCRIPTION
The `grafana-pr-automation` app alone does not have permissions to perform the full backport action. So we split the responsibility between two apps that can, adding `grafana-writer`!