### PR TITLE
Dashboards: seed default permissions for root-folder dashboards created via k8s API

### DIFF
--- a/pkg/storage/unified/apistore/permissions.go
+++ b/pkg/storage/unified/apistore/permissions.go
@@ -21,14 +21,12 @@ func afterCreatePermissionCreator(ctx context.Context,
 	obj runtime.Object,
 	setter DefaultPermissionSetter,
 ) (permissionCreatorFunc, error) {
-	if grantPermisions == "" {
-		return nil, nil
-	}
-	if grantPermisions != utils.AnnoGrantPermissionsDefault {
+	if grantPermisions != "" && grantPermisions != utils.AnnoGrantPermissionsDefault {
 		return nil, fmt.Errorf("invalid permissions value. only '%s' supported", utils.AnnoGrantPermissionsDefault)
 	}
+	// When no permission setter is configured there is nothing to do, regardless of the annotation.
 	if setter == nil {
-		return nil, fmt.Errorf("missing default permission creator")
+		return nil, nil
 	}
 	val, err := utils.MetaAccessor(obj)
 	if err != nil {

--- a/pkg/storage/unified/apistore/permissions_test.go
+++ b/pkg/storage/unified/apistore/permissions_test.go
@@ -9,6 +9,7 @@ import (
 	authtypes "github.com/grafana/authlib/types"
 
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -18,31 +19,46 @@ func TestAfterCreatePermissionCreator(t *testing.T) {
 		return nil
 	}
 
-	t.Run("should return nil when grantPermissions is empty", func(t *testing.T) {
-		creator, err := afterCreatePermissionCreator(context.Background(), nil, "", nil, mockSetter)
+	t.Run("no setter returns nil regardless of annotation", func(t *testing.T) {
+		creator, err := afterCreatePermissionCreator(context.Background(), nil, "", nil, nil)
+		require.NoError(t, err)
+		require.Nil(t, creator)
+
+		creator, err = afterCreatePermissionCreator(context.Background(), nil, utils.AnnoGrantPermissionsDefault, nil, nil)
 		require.NoError(t, err)
 		require.Nil(t, creator)
 	})
 
-	t.Run("should error with invalid grantPermissions value", func(t *testing.T) {
+	t.Run("invalid annotation value returns error", func(t *testing.T) {
 		creator, err := afterCreatePermissionCreator(context.Background(), nil, "invalid", nil, mockSetter)
 		require.Error(t, err)
 		require.Nil(t, creator)
 		require.Contains(t, err.Error(), "invalid permissions value")
 	})
 
-	t.Run("should error when setter is nil", func(t *testing.T) {
-		creator, err := afterCreatePermissionCreator(context.Background(), nil, utils.AnnoGrantPermissionsDefault, nil, nil)
-		require.Error(t, err)
-		require.Nil(t, creator)
-		require.Contains(t, err.Error(), "missing default permission creator")
+	t.Run("setter configured without annotation still invokes setter", func(t *testing.T) {
+		ctx := authtypes.WithAuthInfo(context.Background(), &identity.StaticRequester{})
+		obj := &v0alpha1.Dashboard{}
+		obj.Name = "test-dashboard"
+		creator, err := afterCreatePermissionCreator(ctx, nil, "", obj, mockSetter)
+		require.NoError(t, err)
+		require.NotNil(t, creator)
 	})
 
-	t.Run("should error when auth info is missing", func(t *testing.T) {
+	t.Run("missing auth info returns error when setter is configured", func(t *testing.T) {
 		obj := &v0alpha1.Dashboard{}
-		creator, err := afterCreatePermissionCreator(context.Background(), nil, utils.AnnoGrantPermissionsDefault, obj, mockSetter)
+		creator, err := afterCreatePermissionCreator(context.Background(), nil, "", obj, mockSetter)
 		require.Error(t, err)
 		require.Nil(t, creator)
 		require.Contains(t, err.Error(), "missing auth info")
+	})
+
+	t.Run("setter configured with annotation invokes setter", func(t *testing.T) {
+		ctx := authtypes.WithAuthInfo(context.Background(), &identity.StaticRequester{})
+		obj := &v0alpha1.Dashboard{}
+		obj.Name = "test-dashboard"
+		creator, err := afterCreatePermissionCreator(ctx, nil, utils.AnnoGrantPermissionsDefault, obj, mockSetter)
+		require.NoError(t, err)
+		require.NotNil(t, creator)
 	})
 }


### PR DESCRIPTION
fixes #126697

when a dashboard is created in the root folder via the k8s-compatible API (e.g. using gcx or kubectl), the `grafana.app/grant-permissions` annotation is not included in the request payload. `afterCreatePermissionCreator` was gating on that annotation being present before invoking the configured permission setter, so `SetDefaultPermissionsAfterCreate` never ran, and no Viewer/Editor permission rows were seeded.

the legacy HTTP API path works fine because `saveDashboardThroughK8s` explicitly sets that annotation before writing through the k8s layer.

the fix removes the early-return on empty annotation. if a permission setter is registered on the resource (which dashboards and folders both are), it now runs unconditionally on create. an invalid annotation value still returns an error. the setter itself already handles nested dashboards by returning early when a folder is set, so behavior for those is unchanged.