### PR TITLE
Unified storage: make KV snapshot chunk size configurable

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -684,6 +684,7 @@ type Cfg struct {
 	IndexSnapshotBucketURL                     string        // Go CDK bucket URL for snapshot storage (s3://, gs://, azblob://, mem://, file:///)
 	IndexSnapshotStorageKV                     bool          // Store snapshots in the same KV used by the storage backend instead of an object-storage bucket. Mutually exclusive with index_snapshot_bucket_url; requires enable_kv_leases.
 	IndexSnapshotKVChunkConcurrency            int           // Per-file chunk I/O fan-out for KV-backed snapshots. 0 / 1 = serial. Used only when index_snapshot_storage_kv is true.
+	IndexSnapshotKVChunkSizeMiB                int           // Size in MiB of a single KV value used to store snapshot file data. Files larger than this are split into chunks. 0 = use built-in default. Valid range: 1..1024 MiB. Used only when index_snapshot_storage_kv is true.
 	IndexSnapshotThreshold                     int           // Min doc count to use remote snapshots (must be >= IndexFileThreshold, default: 5000)
 	IndexSnapshotMaxAge                        time.Duration // Max snapshot age before deletion (must be >= MaxFileIndexAge, default: 7d)
 	IndexSnapshotCleanupGracePeriod            time.Duration // Time a new snapshot must exist before its predecessor in the same Grafana-version group is eligible for cleanup (default: 30m)

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -263,6 +263,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.IndexSnapshotBucketURL = section.Key("index_snapshot_bucket_url").String()
 	cfg.IndexSnapshotStorageKV = section.Key("index_snapshot_storage_kv").MustBool(false)
 	cfg.IndexSnapshotKVChunkConcurrency = section.Key("index_snapshot_kv_chunk_concurrency").MustInt(1)
+	cfg.IndexSnapshotKVChunkSizeMiB = section.Key("index_snapshot_kv_chunk_size_mib").MustInt(0)
 	cfg.IndexSnapshotThreshold = section.Key("index_snapshot_threshold").MustInt(5000)
 	if cfg.IndexSnapshotThreshold < cfg.IndexFileThreshold {
 		cfg.Logger.Warn("index_snapshot_threshold is smaller than index_file_threshold, overriding", "configured", cfg.IndexSnapshotThreshold, "index_file_threshold", cfg.IndexFileThreshold)

--- a/pkg/storage/unified/search/kv_remote_index_store.go
+++ b/pkg/storage/unified/search/kv_remote_index_store.go
@@ -46,9 +46,8 @@ const (
 	kvDeleteBatchSize = kv.MaxBatchOps
 
 	// defaultKVChunkSize bounds the size of a single value written to the
-	// underlying KV. 10 MiB sits well under the per-value limit on every
-	// supported KV backend.
-	defaultKVChunkSize int64 = 10 * 1024 * 1024
+	// underlying KV.
+	defaultKVChunkSize int64 = 5 * 1024 * 1024
 
 	// minKVChunkSize / maxKVChunkSize bound user-supplied ChunkSize
 	// values. The bounds are sanity guards: anything in this range works

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -629,6 +629,7 @@ func BuildKVSnapshotStore(cfg *setting.Cfg, backend resource.StorageBackend, log
 	store, err := search.NewKVRemoteIndexStore(search.KVRemoteIndexStoreConfig{
 		KV:               kvBackend.KV(),
 		LeaseManager:     leaseMgr,
+		ChunkSize:        int64(cfg.IndexSnapshotKVChunkSizeMiB) * 1024 * 1024,
 		ChunkConcurrency: cfg.IndexSnapshotKVChunkConcurrency,
 	})
 	if err != nil {


### PR DESCRIPTION
Adds a new `index_snapshot_kv_chunk_size_mib` option under `[unified_storage]` so operators can tune the size of individual KV values used for snapshot data. This matters for KV backends with a smaller per-value cap than the previous hard-coded chunk size.

The built-in default drops from 10 MiB to 5 MiB so the out-of-the-box behavior fits comfortably under tighter backend limits. Operators who want a different value can now set it explicitly.

Setting the option to `0` keeps the built-in default. Values outside the supported range (`1..1024` MiB) are rejected at process start.

Only applies when `index_snapshot_storage_kv = true`.