### PR TITLE
Dashboards: Handle removed users in version history

### DIFF
--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -235,6 +235,22 @@ describe('VersionsEditView', () => {
 
       expect(await screen.findByText('user:uid-unknown')).toBeInTheDocument();
     });
+
+    it('should not crash when display is null', async () => {
+      mockListDashboardHistory.mockResolvedValue({
+        metadata: { continue: '' },
+        items: [createTestResource(1, '2024-01-01T00:00:00Z', 'user:uid-unknown')],
+      });
+
+      mockUseGetDisplayMappingQuery.mockReturnValue({
+        data: { keys: ['user:uid-unknown'], display: null, invalidKeys: ['user:uid-unknown'] },
+      });
+
+      const { versionsView } = await buildTestScene();
+      render(<versionsView.Component model={versionsView} />);
+
+      expect(await screen.findByText('user:uid-unknown')).toBeInTheDocument();
+    });
   });
 
   describe('Template dashboards', () => {

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -225,7 +225,7 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
       return model.versions;
     }
     const displayMap = new Map<string, string>();
-    for (const item of displayData.display) {
+    for (const item of displayData.display || []) {
       displayMap.set(`${item.identity.type}:${item.identity.name}`, item.displayName);
       if (item.internalId) {
         displayMap.set(String(item.internalId), item.displayName);


### PR DESCRIPTION
Fixes: #126763

Prevents the dashboard version history from crashing with TypeError: displayData.display is not iterable.       

**Why it happens ?**

In the version history we map each version's author to a display name and loop over the result. The backend can actually send `"display": null` we should take into account.

See also: https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1781701577593389