### PR TITLE
[DO NOT MERGE] Authz: provisioning permissions — alternative to #124578 (for discussion)

### DIFF
--- a/pkg/apimachinery/identity/context.go
+++ b/pkg/apimachinery/identity/context.go
@@ -192,10 +192,7 @@ var serviceIdentityTokenPermissions = []string{
 	"query.grafana.app:*",
 	"datasource.grafana.app:*",
 	"iam.grafana.app:*",
-	"provisioning.grafana.app/repositories:read",
-	"provisioning.grafana.app/repositories:watch",
-	"provisioning.grafana.app/settings:read",
-	"provisioning.grafana.app/settings:watch",
+	"provisioning.grafana.app:*", // repositories, connections, jobs, historicjobs, settings, stats
 	"preferences.grafana.app:*", // user, team, and org preferences
 	"collections.grafana.app:*", // user stars
 	"plugins.grafana.app:*",

--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -381,12 +381,20 @@ func (c *jobsConnector) authorizeResourceRefs(ctx context.Context, authorizer re
 }
 
 // authorizeAdminJob checks that the requesting user has admin privileges.
-// Used for job types that are restricted to administrators.
+// Used for job types that are restricted to administrators: pull,
+// releaseResources, and deleteResources.
+//
+// These are gated on repositories:write (VerbUpdate) - an admin-only action -
+// rather than jobs:create. jobs:create is granted to Editor (editors legitimately
+// create move/delete/push jobs), and there is no way to distinguish admin-only jobs
+// from editor jobs at the jobs:create level. Requiring "can manage the repository"
+// is therefore the gate for these destructive/repository-wide operations. The Admin
+// fallback role still admits admins whose fine-grained RBAC is not explicitly set up.
 func (c *jobsConnector) authorizeAdminJob(ctx context.Context, cfg *provisioning.Repository) error {
 	return c.access.WithFallbackRole(identity.RoleAdmin).Check(ctx, authlib.CheckRequest{
-		Verb:      "create",
+		Verb:      utils.VerbUpdate,
 		Group:     provisioning.GROUP,
-		Resource:  provisioning.JobResourceInfo.GetName(),
+		Resource:  provisioning.RepositoryResourceInfo.GetName(),
 		Namespace: cfg.Namespace,
 	}, "")
 }

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -978,9 +978,9 @@ func TestAuthorizeAdminJob(t *testing.T) {
 	t.Run("admin is authorized", func(t *testing.T) {
 		adminChecker := auth.NewMockAccessChecker(t)
 		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
-			return req.Verb == "create" &&
+			return req.Verb == utils.VerbUpdate &&
 				req.Group == provisioning.GROUP &&
-				req.Resource == provisioning.JobResourceInfo.GetName() &&
+				req.Resource == provisioning.RepositoryResourceInfo.GetName() &&
 				req.Namespace == cfg.Namespace
 		}), "").Return(nil)
 
@@ -995,9 +995,9 @@ func TestAuthorizeAdminJob(t *testing.T) {
 	t.Run("non-admin is forbidden", func(t *testing.T) {
 		adminChecker := auth.NewMockAccessChecker(t)
 		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
-			return req.Verb == "create" &&
+			return req.Verb == utils.VerbUpdate &&
 				req.Group == provisioning.GROUP &&
-				req.Resource == provisioning.JobResourceInfo.GetName()
+				req.Resource == provisioning.RepositoryResourceInfo.GetName()
 		}), "").Return(apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("admin role is required")))
 
 		accessMock := auth.NewMockAccessChecker(t)

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -543,20 +543,48 @@ func (b *APIBuilder) authorizeRepositorySubresource(ctx context.Context, a autho
 	case "files":
 		return authorizer.DecisionAllow, "", nil
 
-	// refs subresource - editors need to see branches to push changes
+	// refs subresource - lists the branches/commits of the repository.
+	//
+	// Two distinct flows legitimately need refs, and the repositories resource has no
+	// Editor tier to express both (repositories:read is granted to Viewer, write/create/
+	// delete to Admin), so we authorize with an OR of two semantically-correct checks:
+	//   1. Admins / repository owners setting up or editing a repository pick a target
+	//      branch -> repositories:write (VerbUpdate), scoped to this repository.
+	//   2. Editors saving changes or opening a PR via the files/push-job flow need the
+	//      branch list -> jobs:create (VerbCreate), namespace-scoped (as authorizeAdminJob).
+	// Viewers satisfy neither and are denied, which is the intended tightening. Each check
+	// uses its own correct resource, so this stays coherent under future per-repository
+	// scoping (unlike borrowing the jobs resource with the repository name).
 	case "refs":
-		return toAuthorizerDecision(b.accessWithEditor.Check(ctx, authlib.CheckRequest{
-			Verb:      apiutils.VerbGet,
+		if err := b.accessWithAdmin.Check(ctx, authlib.CheckRequest{
+			Verb:      apiutils.VerbUpdate,
 			Group:     provisioning.GROUP,
 			Resource:  provisioning.RepositoryResourceInfo.GetName(),
 			Name:      a.GetName(),
 			Namespace: a.GetNamespace(),
+		}, ""); err == nil {
+			return authorizer.DecisionAllow, "", nil
+		}
+		return toAuthorizerDecision(b.accessWithEditor.Check(ctx, authlib.CheckRequest{
+			Verb:      apiutils.VerbCreate,
+			Group:     provisioning.GROUP,
+			Resource:  provisioning.JobResourceInfo.GetName(),
+			Namespace: a.GetNamespace(),
 		}, ""))
 
-	// Read-only subresources: resources, history, status (admin only)
+	// Read-only subresources: resources, history, status (admin only).
+	//
+	// These expose repository management/inspection views and must be admin-only. We gate
+	// on repositories:write (VerbUpdate) - an admin-only action - rather than
+	// repositories:read, which is granted to Viewer and would expose these views to
+	// viewers/editors. There is no admin-only *read* action on the repositories resource,
+	// so write is the honest gate ("you can inspect a repository's management views if you
+	// can manage it"). We keep the repositories resource with the repository Name rather
+	// than proxying through an unrelated resource (e.g. stats), so this remains correct if
+	// access is later scoped to individual repositories.
 	case "resources", "history", "status":
 		return toAuthorizerDecision(b.accessWithAdmin.Check(ctx, authlib.CheckRequest{
-			Verb:      apiutils.VerbGet,
+			Verb:      apiutils.VerbUpdate,
 			Group:     provisioning.GROUP,
 			Resource:  provisioning.RepositoryResourceInfo.GetName(),
 			Name:      a.GetName(),

--- a/pkg/registry/apis/provisioning/register_authz_test.go
+++ b/pkg/registry/apis/provisioning/register_authz_test.go
@@ -1,0 +1,115 @@
+package provisioning
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+)
+
+func mockForbidden() error {
+	return apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("forbidden"))
+}
+
+func subresourceAttrs(sub, name, ns string) authorizer.Attributes {
+	return authorizer.AttributesRecord{
+		Subresource: sub,
+		Name:        name,
+		Namespace:   ns,
+		Verb:        "get",
+	}
+}
+
+// TestAuthorizeRepositorySubresource verifies the refs and admin-view subresource gates.
+//
+// refs must be available to editors (push/PR flow) and to repository managers/admins
+// (repo setup), but NOT to viewers. Since the repositories resource has no Editor tier,
+// it is authorized as repositories:write (admin) OR jobs:create (editor).
+//
+// resources/history/status are admin-only and gated on repositories:write so that the
+// repository-scoped Name is preserved (rather than proxying through an unrelated resource).
+func TestAuthorizeRepositorySubresource(t *testing.T) {
+	ctx := context.Background()
+	const ns, name = "default", "my-repo"
+
+	repoWriteReq := func(req authlib.CheckRequest) bool {
+		return req.Verb == utils.VerbUpdate &&
+			req.Group == provisioning.GROUP &&
+			req.Resource == provisioning.RepositoryResourceInfo.GetName() &&
+			req.Name == name &&
+			req.Namespace == ns
+	}
+	jobsCreateReq := func(req authlib.CheckRequest) bool {
+		return req.Verb == utils.VerbCreate &&
+			req.Group == provisioning.GROUP &&
+			req.Resource == provisioning.JobResourceInfo.GetName() &&
+			req.Namespace == ns
+	}
+
+	t.Run("refs: repository writer (admin) is allowed without consulting jobs", func(t *testing.T) {
+		adminChecker := auth.NewMockAccessChecker(t)
+		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(repoWriteReq), "").Return(nil)
+
+		b := &APIBuilder{accessWithAdmin: adminChecker, accessWithEditor: auth.NewMockAccessChecker(t)}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, subresourceAttrs("refs", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+	})
+
+	t.Run("refs: editor who can create jobs is allowed", func(t *testing.T) {
+		adminChecker := auth.NewMockAccessChecker(t)
+		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(repoWriteReq), "").Return(mockForbidden())
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(jobsCreateReq), "").Return(nil)
+
+		b := &APIBuilder{accessWithAdmin: adminChecker, accessWithEditor: editorChecker}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, subresourceAttrs("refs", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+	})
+
+	t.Run("refs: viewer (neither repo write nor jobs create) is denied", func(t *testing.T) {
+		adminChecker := auth.NewMockAccessChecker(t)
+		adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(repoWriteReq), "").Return(mockForbidden())
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(jobsCreateReq), "").Return(mockForbidden())
+
+		b := &APIBuilder{accessWithAdmin: adminChecker, accessWithEditor: editorChecker}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, subresourceAttrs("refs", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+	})
+
+	for _, sub := range []string{"resources", "history", "status"} {
+		t.Run(sub+": admin (repositories:write) is allowed", func(t *testing.T) {
+			adminChecker := auth.NewMockAccessChecker(t)
+			adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(repoWriteReq), "").Return(nil)
+
+			b := &APIBuilder{accessWithAdmin: adminChecker}
+			decision, _, err := b.authorizeRepositorySubresource(ctx, subresourceAttrs(sub, name, ns))
+			require.NoError(t, err)
+			assert.Equal(t, authorizer.DecisionAllow, decision)
+		})
+
+		t.Run(sub+": non-admin is denied", func(t *testing.T) {
+			adminChecker := auth.NewMockAccessChecker(t)
+			adminChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(repoWriteReq), "").Return(mockForbidden())
+
+			b := &APIBuilder{accessWithAdmin: adminChecker}
+			decision, _, err := b.authorizeRepositorySubresource(ctx, subresourceAttrs(sub, name, ns))
+			require.NoError(t, err)
+			assert.Equal(t, authorizer.DecisionDeny, decision)
+		})
+	}
+}


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE — communication only.** This PR exists purely to make the proposed approach concrete and reviewable side-by-side with #124578. It is **not** intended to be merged. Fold any/all of it into #124578 instead.

> **Discussion alternative to #124578 — not necessarily what lands.** This is a communication vehicle to make the proposed approach concrete and reviewable side-by-side. Happy to fold any/all of it into #124578 instead.

## What this is

An alternative implementation of the provisioning authorization fixes in #124578. It fixes the **same real bugs** but keeps every authorization check pinned to a **semantically-correct resource/verb** instead of borrowing an unrelated resource whose RBAC grant happens to match the desired role tier.

## The bugs are real (agreement, not disagreement)

The original checks used actions whose RBAC grant didn't match the intended gate, and `WithFallbackRole` is an **OR** (allowed if RBAC-granted **OR** org-role ≥ R), so it can only *widen* access, never tighten below the RBAC grant:

- `resources/history/status` used `repositories:read` (granted to **Viewer**) → any viewer could read admin-only views.
- `authorizeAdminJob` (pull, releaseResources, deleteResources) used `jobs:create` (granted to **Editor**) → any editor could trigger admin-only jobs.
- `refs` used `repositories:read` (Viewer) → viewers could list branches.

So the *direction* (admin-only / editor-only) is correct. This PR only changes the *technique*.

## Root cause of the awkwardness

The `repositories` resource has only a **Viewer tier** (`read`) and an **Admin tier** (`write`/`create`/`delete`) — there is **no Editor tier**. That's why the original borrowed `jobs` and `stats` to express "editor+" and "admin-only". Borrowing works today (fixed roles are scope-less) but is incoherent (`Resource: jobs` with `Name: <repo-uid>`) and breaks the day we scope access to individual repositories.

## Changes

| Area | #124578 | This branch |
|---|---|---|
| Service identity token | `provisioning.grafana.app:*` | same (agreed) |
| `authorizeAdminJob` | `jobs` + `VerbUpdate` | `repositories:write` (admin-only), single check, **documented** |
| `resources/history/status` | resource `"stats"` (proxy) | `repositories:write`, keeps repository resource + `Name` → scope-safe |
| `refs` | `jobs` resource + repo `Name` | `repositories:write` (admin/owner) **OR** `jobs:create` (editor) — each correctly named |

### Why `refs` is an OR
Two distinct flows legitimately need refs and the `repositories` resource can't express both:
1. **Admins / repo owners** setting up or editing a repository (pick a target branch) → `repositories:write`, scoped to the repository.
2. **Editors** saving changes / opening a PR via the files or push-job flow (need the branch list) → `jobs:create`, namespace-scoped.

Viewers satisfy neither and are denied — the intended tightening. Gating `refs` on `repositories:write` *alone* would wrongly lock editors out of a flow the docs promise.

## Follow-up worth filing
A real **Editor-tier read action on `repositories`** (e.g. a dedicated `repositories:refs`) would let the `refs` OR collapse to one clean check. Heavier (changes the RBAC surface), so out of scope here.

## Notes
- I did **not** duplicate the `service_identity_permissions_test.go` coverage test from #124578 — it's good and uncontroversial; keep it from there.
- Docs (`git-sync/permissions-grafana`) should be aligned: pull = admin; resources/history/status = admin; refs available to editors. (@ferruvich noted the "pull is admin" wording is already being updated.)

## Tests
- `register_authz_test.go` (new): `refs` allows admin + editor, denies viewer; `resources/history/status` admin-only.
- `jobs_test.go`: updated for the new `authorizeAdminJob` gate.
- `go build` clean; `go test ./pkg/registry/apis/provisioning/` and `./pkg/apimachinery/identity/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
