### PR TITLE
Dashboards: Remove dashgpt feature toggle checks from frontend

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelOptions.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptions.test.tsx
@@ -20,6 +20,13 @@ import * as utils from '../utils/utils';
 import { PanelOptions } from './PanelOptions';
 import { PanelOptionsPane } from './PanelOptionsPane';
 
+jest.mock('app/features/dashboard/components/GenAI/GenAIPanelTitleButton', () => ({
+  GenAIPanelTitleButton: () => null,
+}));
+jest.mock('app/features/dashboard/components/GenAI/GenAIPanelDescriptionButton', () => ({
+  GenAIPanelDescriptionButton: () => null,
+}));
+
 const OptionsPaneSelector = selectors.components.PanelEditor.OptionsPane;
 
 standardEditorsRegistry.setInit(getAllOptionEditors);

--- a/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
@@ -82,7 +82,7 @@ export function getPanelFrameOptions(panel: VizPanel): OptionsPaneCategoryDescri
         render: function renderTitle(descriptor) {
           return <PanelFrameTitleInput id={descriptor.props.id} panel={panel} />;
         },
-        addon: config.featureToggles.dashgpt && (
+        addon: (
           <GenAIPanelTitleButton
             onGenerate={(title) => editPanelTitleAction(panel, title)}
             panel={vizPanelToPanel(panel)}
@@ -99,7 +99,7 @@ export function getPanelFrameOptions(panel: VizPanel): OptionsPaneCategoryDescri
         render: function renderDescription(descriptor) {
           return <PanelDescriptionTextArea id={descriptor.props.id} panel={panel} />;
         },
-        addon: config.featureToggles.dashgpt && (
+        addon: (
           <GenAIPanelDescriptionButton
             onGenerate={(description) => panel.setState({ description })}
             panel={vizPanelToPanel(panel)}

--- a/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
@@ -227,12 +227,6 @@ function TitleFieldLabel(props: TitleLabelProps) {
       <Label htmlFor="description">
         <Trans i18nKey="dashboard-scene.title-field-label.title">Title</Trans>
       </Label>
-      {/* {config.featureToggles.dashgpt && isNew && (
-                <GenAIDashDescriptionButton
-                  onGenerate={(description) => field.onChange(description)}
-                  dashboard={dashboard}
-                />
-              )} */}
     </Stack>
   );
 }
@@ -247,12 +241,6 @@ function DescriptionLabel(props: DescriptionLabelProps) {
       <Label htmlFor="description">
         <Trans i18nKey="dashboard-scene.description-label.description">Description</Trans>
       </Label>
-      {/* {config.featureToggles.dashgpt && isNew && (
-                <GenAIDashDescriptionButton
-                  onGenerate={(description) => field.onChange(description)}
-                  dashboard={dashboard}
-                />
-              )} */}
     </Stack>
   );
 }

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -272,9 +272,7 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
                 <Label htmlFor="title-input">
                   <Trans i18nKey="dashboard-settings.general.title-label">Title</Trans>
                 </Label>
-                {config.featureToggles.dashgpt && (
-                  <GenAIDashTitleButton onGenerate={(title) => model.onTitleChange(title)} />
-                )}
+                <GenAIDashTitleButton onGenerate={(title) => model.onTitleChange(title)} />
               </Stack>
             }
           >
@@ -292,9 +290,7 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
                 <Label htmlFor="description-input">
                   {t('dashboard-settings.general.description-label', 'Description')}
                 </Label>
-                {config.featureToggles.dashgpt && (
-                  <GenAIDashDescriptionButton onGenerate={(description) => model.onDescriptionChange(description)} />
-                )}
+                <GenAIDashDescriptionButton onGenerate={(description) => model.onDescriptionChange(description)} />
               </Stack>
             }
           >

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -3,7 +3,6 @@ import { connect, type ConnectedProps } from 'react-redux';
 
 import { type TimeZone } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import {
   CollapsableSection,
   Field,
@@ -139,7 +138,7 @@ export function GeneralSettingsUnconnected({
                   <Trans i18nKey="dashboard-settings.general.title-label">Title</Trans>
                 </Label>
 
-                {config.featureToggles.dashgpt && <GenAIDashTitleButton onGenerate={onTitleChange} />}
+                <GenAIDashTitleButton onGenerate={onTitleChange} />
               </Stack>
             }
           >
@@ -157,7 +156,7 @@ export function GeneralSettingsUnconnected({
                   {t('dashboard-settings.general.description-label', 'Description')}
                 </Label>
 
-                {config.featureToggles.dashgpt && <GenAIDashDescriptionButton onGenerate={onDescriptionChange} />}
+                <GenAIDashDescriptionButton onGenerate={onDescriptionChange} />
               </Stack>
             }
           >

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -23,6 +23,13 @@ import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardF
 import { OptionsPaneOptions } from './OptionsPaneOptions';
 import { dataOverrideTooltipDescription, overrideRuleTooltipDescription } from './state/getOptionOverrides';
 
+jest.mock('../GenAI/GenAIPanelTitleButton', () => ({
+  GenAIPanelTitleButton: () => null,
+}));
+jest.mock('../GenAI/GenAIPanelDescriptionButton', () => ({
+  GenAIPanelDescriptionButton: () => null,
+}));
+
 standardEditorsRegistry.setInit(getAllOptionEditors);
 standardFieldConfigEditorRegistry.setInit(getAllStandardFieldConfigs);
 

--- a/public/app/features/dashboard/components/PanelEditor/getPanelFrameOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getPanelFrameOptions.tsx
@@ -1,6 +1,5 @@
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { DataLinksInlineEditor, Input, RadioButtonGroup, Select, Switch, TextArea } from '@grafana/ui';
 import { getPanelLinksVariableSuggestions } from 'app/features/panel/panellinks/link_srv';
 
@@ -56,7 +55,7 @@ export function getPanelFrameCategory(props: OptionPaneRenderProps): OptionsPane
             />
           );
         },
-        addon: config.featureToggles.dashgpt && (
+        addon: (
           <GenAIPanelTitleButton
             onGenerate={setPanelTitle}
             panel={panel.getSaveModel()}
@@ -81,9 +80,7 @@ export function getPanelFrameCategory(props: OptionPaneRenderProps): OptionsPane
             />
           );
         },
-        addon: config.featureToggles.dashgpt && (
-          <GenAIPanelDescriptionButton onGenerate={setPanelDescription} panel={panel.getSaveModel()} />
-        ),
+        addon: <GenAIPanelDescriptionButton onGenerate={setPanelDescription} panel={panel.getSaveModel()} />,
       })
     )
     .addItem(

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -1,7 +1,6 @@
 import { type ChangeEvent } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Button, Input, Switch, Form, Field, InputControl, Label, TextArea, Stack } from '@grafana/ui';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
@@ -115,9 +114,7 @@ export const SaveDashboardAsForm = ({
                     <Label htmlFor="title">
                       <Trans i18nKey="dashboard.save-dashboard-as-form.title">Title</Trans>
                     </Label>
-                    {config.featureToggles.dashgpt && isNew && (
-                      <GenAIDashTitleButton onGenerate={(title) => field.onChange(title)} />
-                    )}
+                    {isNew && <GenAIDashTitleButton onGenerate={(title) => field.onChange(title)} />}
                   </Stack>
                 }
                 invalid={!!errors.title}
@@ -148,9 +145,7 @@ export const SaveDashboardAsForm = ({
                     <Label htmlFor="description">
                       <Trans i18nKey="dashboard.save-dashboard-as-form.description">Description</Trans>
                     </Label>
-                    {config.featureToggles.dashgpt && isNew && (
-                      <GenAIDashDescriptionButton onGenerate={(description) => field.onChange(description)} />
-                    )}
+                    {isNew && <GenAIDashDescriptionButton onGenerate={(description) => field.onChange(description)} />}
                   </Stack>
                 }
                 invalid={!!errors.description}


### PR DESCRIPTION
## What this PR does

The `dashgpt` feature toggle is **GA and enabled by default** (`expression: "true"`). This PR removes the frontend `config.featureToggles.dashgpt` checks so the GenAI title/description buttons render unconditionally.

This is the **frontend portion** of the toggle removal. A follow-up PR removes the toggle definition itself from the backend registry and generated metadata/types — split out because frontend and backend are deployed at different cadences.

## Changes

Removed the `config.featureToggles.dashgpt &&` guard around the GenAI buttons in:

- **Legacy dashboard** — `GeneralSettings.tsx`, `SaveDashboard/forms/SaveDashboardAsForm.tsx`, `PanelEditor/getPanelFrameOptions.tsx`
- **Dashboard scene** — `settings/GeneralSettingsEditView.tsx`, `panel-edit/getPanelFrameOptions.tsx`

Also:
- In `SaveDashboardAsForm` the `isNew` condition is preserved (only the toggle check was dropped).
- Removed the now-unused `config` import where it was only used for this check.
- Cleaned up two stale commented-out `dashgpt` blocks in `dashboard-scene/saving/SaveDashboardAsForm.tsx`.

No behavior change for users — these AI features were already on by default everywhere.

## Notes for reviewers

- The generated type `featureToggles.gen.ts` still declares `dashgpt?: boolean` on this branch; it's removed in the backend PR, which is stacked on top of this one so CI stays green.
