### PR TITLE
test: fix flaky TestIntegrationProvisioning_MoveResources

### DIFF
--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"strings"
 	"testing"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -315,9 +316,16 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 	})
 
 	t.Run("move directory on configured branch should return MethodNotAllowed", func(t *testing.T) {
-		// Create some files in a directory first using existing testdata files
-		helper.CopyToProvisioningPath(t, "testdata/timeline-demo.json", "source-dir/timeline-demo.json")
-		helper.CopyToProvisioningPath(t, "testdata/text-options.json", "source-dir/text-options.json")
+		// Create some files in a directory first using existing testdata files.
+		// Rewrite their UIDs to be unique: the default timeline-demo/text-options
+		// UIDs already exist in the repo from earlier subtests (deep/nested/timeline.json
+		// and updated/content-updated.json). Two files mapping to the same dashboard UID
+		// are written in parallel by the full sync below and would race into an
+		// optimistic-lock conflict ("the object has been modified").
+		timelineContent := strings.Replace(string(helper.LoadFile("testdata/timeline-demo.json")), `"uid": "mIJjFy8Kz"`, `"uid": "move-dir-timeline"`, 1)
+		helper.WriteToProvisioningPath(t, "source-dir/timeline-demo.json", []byte(timelineContent))
+		textOptionsContent := strings.Replace(string(helper.LoadFile("testdata/text-options.json")), `"uid": "WZ7AhQiVz"`, `"uid": "move-dir-text"`, 1)
+		helper.WriteToProvisioningPath(t, "source-dir/text-options.json", []byte(textOptionsContent))
 
 		// Sync to ensure files are recognized
 		helper.SyncAndWait(t, repo, nil)


### PR DESCRIPTION
## Summary

Fixes a flake in `TestIntegrationProvisioning_MoveResources` ([example failure](https://github.com/grafana/grafana/actions/runs/27755391948/job/82115831503)):

```
--- FAIL: .../move_directory_on_configured_branch_should_return_MethodNotAllowed
sync job "move-test-repo-sync" ended in error state; errors: [writing resource from file
source-dir/timeline-demo.json: Operation cannot be fulfilled on dashboards.dashboard.grafana.app
"mIJjFy8Kz": the object has been modified; please apply your changes to the latest version and try again]
```

## Root cause

The subtests in this test share a single repository and accumulate files. By the time the `move directory … MethodNotAllowed` subtest runs `SyncAndWait`, the repo contains **two pairs of files with the same dashboard UID**:

- `deep/nested/timeline.json` + `source-dir/timeline-demo.json` → both UID `mIJjFy8Kz`
- `updated/content-updated.json` + `source-dir/text-options.json` → both UID `WZ7AhQiVz`

The full sync applies file creations in parallel (`applyResourcesInParallel` in `pkg/registry/apis/provisioning/jobs/sync/full.go`). Two files mapping to the same dashboard UID get written concurrently, so the second write hits a stale resourceVersion and fails with an optimistic-lock conflict. It only fails intermittently because it depends on the parallel write ordering.

## Changes

- Rewrite the `source-dir/` files with unique dashboard UIDs (via `strings.Replace`, matching the existing pattern in `quota/sync_quota_test.go`) so no two files in the repo resolve to the same dashboard during sync.

The subtest's actual intent — verifying a directory move returns `MethodNotAllowed` — is unchanged. Test-only change, no production behavior touched.

## Testing

- `go test -c ./pkg/tests/apis/provisioning/` compiles.
- `go vet ./pkg/tests/apis/provisioning/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)