### PR TITLE
Provisioning: fix folder UID-change full-sync test flake

### DIFF
--- a/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
@@ -550,6 +550,14 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange(t *testing.T) 
 		helper.SyncAndWait(t, repo, nil)
 		requireRepoFolderTitle(t, helper, repo, "my-folder", "My Folder")
 
+		// Wait until the dashboard is parented and visible before the second
+		// sync. The second sync's compare diffs against the managed-resources
+		// index; if the dashboard has not been indexed yet, the folder UID
+		// change cannot re-parent it and the old-folder cleanup deletes it.
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"my-folder/dashboard.json": "original-uid",
+		})
+
 		// Change UID in _folder.json, keep title the same.
 		updatedContent := folderMetadataJSON("new-uid", "My Folder")
 		writeToProvisioningPath(t, helper, "my-folder/_folder.json", updatedContent)


### PR DESCRIPTION
## Summary

Fixes a flake in `TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange/UID_change_replaces_folder_and_re-parents_dashboard` (seen on the SQLite integration shards), which intermittently fails with:

```
dashboard with sourcePath "my-folder/dashboard.json" not found
```

## Root cause

The subtest only asserted the *folder* was present after the first sync (`requireRepoFolderTitle`), never the dashboard, before editing `_folder.json` to change the folder UID and triggering the second sync.

The second sync's `Compare` diffs against the **eventually-consistent managed-resources index** (`ListManagedObjects`). When the dashboard written by the first sync had not been indexed yet:

1. `emitDirectChildrenChanges` could not find the dashboard in the `target` list, so the folder UID change emitted **no re-parent change** for it.
2. The new folder (`new-uid`) was created and the dashboard was left parented to the old folder (`original-uid`).
3. The deferred old-folder cleanup then deleted `original-uid`, removing the un-reparented dashboard with it.

When the index happened to be caught up in time (most runs) the dashboard was re-parented and survived — hence the flake.

## Changes

- Wait for the dashboard to be visible and parented to `original-uid` after the first sync, before mutating the UID. This guarantees the second sync's compare sees the dashboard so it gets re-parented instead of cleaned up.

This is the same post-first-sync assertion pattern already used by the sibling subtests in the same function; the failing subtest was the only one missing it.

## Testing

- `go vet ./pkg/tests/apis/provisioning/foldermetadata/` passes.
- Test-only change; no product code touched. The underlying sync behavior is correct once the index reflects the prior sync.

## Checklist

- [x] Tests updated
- [x] No product/behavioral changes
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)