### PR TITLE
Provisioning: Force-delete folders in cleanup to fix index-lag flake

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -67,12 +67,10 @@ const (
 	waitTimeoutCleanup = 2 * WaitTimeoutDefault
 
 	// waitTimeoutFolderCleanup is the budget for the folders step in
-	// CleanupAllResources. Folder admission validates "folder is empty"
-	// against the resource search index, which is eventually consistent
-	// with respect to dashboard deletes. Under SQLite write contention that
-	// lag has been observed to exceed waitTimeoutCleanup, so folders alone
-	// get a larger budget — bumping every step would slow the common case
-	// for no benefit.
+	// CleanupAllResources. Folders are force-deleted, so this is no longer
+	// gated on the eventually-consistent empty-folder check; the larger budget
+	// is a safety margin for the delete/list round-trips under SQLite write
+	// contention when many folders are left over.
 	waitTimeoutFolderCleanup = 4 * WaitTimeoutDefault
 )
 
@@ -1371,6 +1369,11 @@ func defaultGrafanaOpts(provisioningPath string) testinfra.GrafanaOpts {
 		EnableFeatureToggles: []string{
 			featuremgmt.FlagProvisioning,
 			featuremgmt.FlagProvisioningExport,
+			// Lets CleanupAllResources force-delete folders (gracePeriodSeconds=0),
+			// bypassing the eventually-consistent "folder is empty" admission check.
+			// Normal (non-force) deletes still enforce the check, so test behavior
+			// outside cleanup is unchanged.
+			featuremgmt.FlagKubernetesFolderCascadeDelete,
 		},
 		// Provisioning requires resources to be fully migrated to unified storage.
 		// Mode5 ensures reads/writes go to unified storage, and EnableMigration
@@ -1510,8 +1513,10 @@ func runGrafanaShared(t *testing.T, options ...GrafanaOption) (*ProvisioningTest
 
 // deleteAndWait deletes all resources from a dynamic client and polls until
 // none remain. It retries deletes on each iteration to handle transient
-// resource-version conflicts from concurrent controller updates.
-func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeout time.Duration) error {
+// resource-version conflicts from concurrent controller updates. deleteOpts is
+// applied to every delete (e.g. gracePeriodSeconds=0 to force-delete folders
+// past the empty-folder admission check).
+func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeout time.Duration, deleteOpts metav1.DeleteOptions) error {
 	list, err := client.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("deleteAndWait: initial list: %w", err)
@@ -1522,7 +1527,7 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 
 	var lastErr error
 	for _, item := range list.Items {
-		if err := client.Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		if err := client.Delete(ctx, item.GetName(), deleteOpts); err != nil && !apierrors.IsNotFound(err) {
 			lastErr = fmt.Errorf("deleteAndWait: delete %q: %w", item.GetName(), err)
 		}
 	}
@@ -1541,7 +1546,7 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 			return nil
 		}
 		for _, item := range remaining.Items {
-			if err := client.Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			if err := client.Delete(ctx, item.GetName(), deleteOpts); err != nil && !apierrors.IsNotFound(err) {
 				lastErr = fmt.Errorf("deleteAndWait: delete %q: %w", item.GetName(), err)
 			}
 		}
@@ -1567,24 +1572,32 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 // a previous test don't leak into the next one.
 // Failures are fatal because cleanup is the primary test-isolation mechanism.
 //
-// Every step uses waitTimeoutCleanup because each one can be blocked by an
-// eventually-consistent signal: repository finalizers draining orphan
-// resources, dashboards freeing their folder reference in the search index,
-// and folder admission rejecting deletion until that index catches up. Under
-// SQLite write contention these lags routinely exceed short timeouts.
+// Repositories, connections, and dashboards can be briefly blocked by an
+// eventually-consistent signal (finalizers draining orphans, the search index
+// catching up), so they get waitTimeoutCleanup.
+//
+// Folders are force-deleted (gracePeriodSeconds=0, enabled by
+// FlagKubernetesFolderCascadeDelete). The default folder delete is rejected
+// until the search index reflects that the folder is empty, and that index lag
+// is unbounded under SQLite write contention — repeatedly bumping the timeout
+// (see git history) only masks it. Cleanup deletes every folder anyway, so the
+// empty-folder check serves no purpose here; bypassing it makes folder cleanup
+// deterministic instead of racing the index.
 func (h *ProvisioningTestHelper) CleanupAllResources(t *testing.T, ctx context.Context) {
 	t.Helper()
+	forceDelete := metav1.DeleteOptions{GracePeriodSeconds: new(int64)} // gracePeriodSeconds=0
 	for _, c := range []struct {
-		name    string
-		client  dynamic.ResourceInterface
-		timeout time.Duration
+		name       string
+		client     dynamic.ResourceInterface
+		timeout    time.Duration
+		deleteOpts metav1.DeleteOptions
 	}{
-		{"repositories", h.Repositories.Resource, waitTimeoutCleanup},
-		{"connections", h.Connections.Resource, waitTimeoutCleanup},
-		{"dashboards", h.DashboardsV1.Resource, waitTimeoutCleanup},
-		{"folders", h.Folders.Resource, waitTimeoutFolderCleanup},
+		{"repositories", h.Repositories.Resource, waitTimeoutCleanup, metav1.DeleteOptions{}},
+		{"connections", h.Connections.Resource, waitTimeoutCleanup, metav1.DeleteOptions{}},
+		{"dashboards", h.DashboardsV1.Resource, waitTimeoutCleanup, metav1.DeleteOptions{}},
+		{"folders", h.Folders.Resource, waitTimeoutFolderCleanup, forceDelete},
 	} {
-		if err := deleteAndWait(ctx, c.client, c.timeout); err != nil {
+		if err := deleteAndWait(ctx, c.client, c.timeout, c.deleteOpts); err != nil {
 			t.Fatalf("CleanupAllResources(%s): %v", c.name, err)
 		}
 	}


### PR DESCRIPTION
## Summary

`TestIntegrationProvisioning_BlockManagerChange` flakes in **cleanup**, not in the test body. Provisioning integration tests share one Grafana server and clean up the *previous* test's resources at the start of each test (`GetCleanHelper`). The preceding `TestIntegrationFolderManagerConsistency` leaves behind several unmanaged/nested folders.

`CleanupAllResources` deletes dashboards, then folders. But the folder-delete admission check (`validateOnDelete`) rejects deletion until the **eventually-consistent search index** reports the folder empty. Under SQLite write contention that index lag is effectively unbounded, so the folders step timed out with `folder is not empty` after 240s:

```
helper_test.go:19: CleanupAllResources(folders): deleteAndWait: timed out with 6 items remaining
  (last delete error: deleteAndWait: delete "unmanaged-folder-kxx7g": Folder cannot be deleted: folder is not empty)
```

This had already been "fixed" twice by bumping the timeout (#123902 → 2×, #124046 → 4×). Raising it again only moves the goalpost.

## Changes

Make folder cleanup **deterministic** instead of racing the index:

- Thread a `metav1.DeleteOptions` parameter through `deleteAndWait` and pass `gracePeriodSeconds=0` for the **folders step only**, which bypasses the empty-folder admission check. Cleanup issues a delete to *every* folder anyway, so the check serves no purpose there.
- Enable `FlagKubernetesFolderCascadeDelete` in the shared test env (`defaultGrafanaOpts`). This flag only affects force-deletes, so normal (non-force) deletes still enforce the empty-folder check — **test behavior outside cleanup is unchanged**.
- Update now-stale comments on the cleanup timeout constants.

## Testing

- `go build` / `go vet` / `gofmt` clean.
- `TestIntegrationFolderManagerConsistency` + `TestIntegrationProvisioning_BlockManagerChange`: pass. `BlockManagerChange` cleanup now runs in ~1.8s instead of timing out at 248s.
- Same two tests with `-count=5` (10 cleanup cycles): pass.
- Full `pkg/tests/apis/provisioning` package: pass in 47s (down from the 294s failing run).

## Checklist

- [x] Tests pass
- [x] No breaking changes (flag only affects force-deletes; non-cleanup behavior unchanged)
- [ ] N/A — no docs/user-facing changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)