### PR TITLE
search: fix flaky TestIntegrationBleveSnapshotRoundTrip

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -1147,8 +1147,12 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 
 	snapshotDir := filepath.Join(t.TempDir(), "snapshot")
 	require.NoError(t, writeFakeSnapshot(snapshotDir, &meta))
-	_, err := UploadIndexSnapshot(ctx, store, key, snapshotDir, meta, testLogger)
+	uploadedKey, err := UploadIndexSnapshot(ctx, store, key, snapshotDir, meta, testLogger)
 	require.NoError(t, err)
+	// UploadIndexSnapshot derives the persisted UploadTimestamp from a freshly
+	// generated ULID, not from the caller's meta. Use that as the expected value
+	// so the assertion below is exact and not subject to scheduling delays.
+	expectedUploadedAt := ulid.Time(uploadedKey.Time())
 
 	// Fresh backend pointing at the same bucket should download instead of building.
 	metrics := resource.ProvideIndexMetrics(prometheus.NewRegistry())
@@ -1183,7 +1187,8 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 
 	trackedAt, tracked := be.getUploadTracking(key)
 	require.True(t, tracked)
-	assert.WithinDuration(t, meta.UploadTimestamp, trackedAt, time.Second)
+	assert.True(t, expectedUploadedAt.Equal(trackedAt),
+		"trackedAt %s should equal manifest UploadTimestamp %s", trackedAt, expectedUploadedAt)
 
 	mutationCount, err := readSnapshotMutationCount(bi.index)
 	require.NoError(t, err)


### PR DESCRIPTION
The test compared `meta.UploadTimestamp` (captured before the upload) to the timestamp stored in the downloaded manifest, with a 1s `WithinDuration` tolerance. `UploadIndexSnapshot` overwrites the persisted `UploadTimestamp` with one derived from a freshly generated ULID created later, after `writeFakeSnapshot`'s file I/O. On a slow runner the two `time.Now()` reads drift by more than 1s and the assertion fails.

Observed failure: https://github.com/grafana/grafana/actions/runs/27693245661/job/81909773246

Fix: capture the ULID returned by `UploadIndexSnapshot` and compare against `ulid.Time(uploadedKey.Time())` — the exact value stored in the manifest.