### PR TITLE
VizLegend: Add unit tests for css width and name wrapping

### DIFF
--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.test.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.test.tsx
@@ -251,6 +251,81 @@ describe('VizLayout', () => {
       );
       expect(children).toHaveBeenCalledWith(800, 600);
     });
+
+    describe('with a string (css) legend width', () => {
+      it('applies the string width as-is to the legend element', () => {
+        render(
+          <VizLayout
+            width={800}
+            height={600}
+            legend={
+              <VizLayout.Legend placement="right" width="35%">
+                <div />
+              </VizLayout.Legend>
+            }
+          >
+            {() => null}
+          </VizLayout>
+        );
+        expect(screen.getByTestId(selectors.components.VizLayout.legend)).toHaveStyle({ width: '35%' });
+      });
+
+      it('does not apply maxWidth when a string width is set', () => {
+        render(
+          <VizLayout
+            width={800}
+            height={600}
+            legend={
+              <VizLayout.Legend placement="right" width="35%" maxWidth="50%">
+                <div />
+              </VizLayout.Legend>
+            }
+          >
+            {() => null}
+          </VizLayout>
+        );
+        expect(screen.getByTestId(selectors.components.VizLayout.legend)).not.toHaveStyle({ maxWidth: '50%' });
+      });
+
+      it('does not subtract a fixed pixel amount from the chart width for a string width', () => {
+        // With a css width the legend size is not known up-front, so the chart
+        // width comes solely from the measured legend, not from the width prop.
+        mockUseMeasure.mockReturnValue([jest.fn(), { ...noMeasure, width: 150 }]);
+        const children = jest.fn().mockReturnValue(null);
+        render(
+          <VizLayout
+            width={800}
+            height={600}
+            legend={
+              <VizLayout.Legend placement="right" width="35%">
+                <div />
+              </VizLayout.Legend>
+            }
+          >
+            {children}
+          </VizLayout>
+        );
+        expect(children).toHaveBeenCalledWith(650, 600);
+      });
+
+      it('still applies maxWidth when width is a number', () => {
+        render(
+          <VizLayout
+            width={800}
+            height={600}
+            legend={
+              <VizLayout.Legend placement="right" width={200} maxWidth="50%">
+                <div />
+              </VizLayout.Legend>
+            }
+          >
+            {() => null}
+          </VizLayout>
+        );
+        const el = screen.getByTestId(selectors.components.VizLayout.legend);
+        expect(el).toHaveStyle({ width: '200px', maxWidth: '50%' });
+      });
+    });
   });
 
   describe('small screen behavior', () => {

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.test.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.test.tsx
@@ -69,4 +69,21 @@ describe('LegendTableItem', () => {
     await userEvent.click(screen.getByRole('button'));
     expect(onLabelClick).not.toHaveBeenCalled();
   });
+
+  describe('overflow', () => {
+    it('keeps the label on a single line (nowrap) by default', () => {
+      renderInTable();
+      expect(screen.getByRole('button')).toHaveStyle({ whiteSpace: 'nowrap' });
+    });
+
+    it('keeps the label on a single line (nowrap) when overflow is "ellipsis"', () => {
+      renderInTable({ overflow: 'ellipsis' });
+      expect(screen.getByRole('button')).toHaveStyle({ whiteSpace: 'nowrap' });
+    });
+
+    it('allows the label to wrap (normal) when overflow is "wrap"', () => {
+      renderInTable({ overflow: 'wrap' });
+      expect(screen.getByRole('button')).toHaveStyle({ whiteSpace: 'normal' });
+    });
+  });
 });

--- a/packages/grafana-ui/src/options/builder/legend.test.tsx
+++ b/packages/grafana-ui/src/options/builder/legend.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { PanelOptionsEditorBuilder, standardEditorsRegistry } from '@grafana/data';
+import { LegendDisplayMode, type OptionsWithLegend } from '@grafana/schema';
+
+import { addLegendOptions } from './legend';
+
+// The builder resolves the editor component for built-in editors (boolean/radio/number)
+// from the standard editors registry, which the grafana-ui package can't populate from
+// public/app. Stub the ids addLegendOptions needs — the custom width editor under test is
+// inline and doesn't use the registry.
+const StubEditor = () => null;
+standardEditorsRegistry.setInit(() =>
+  ['boolean', 'radio', 'number', 'stats-picker'].map((id) => ({ id, name: id, editor: StubEditor }))
+);
+
+type LegendConfig = OptionsWithLegend['legend'];
+type LegendEditorItem = ReturnType<typeof buildItems>[number];
+
+function buildItems() {
+  const builder = new PanelOptionsEditorBuilder<OptionsWithLegend>();
+  addLegendOptions(builder);
+  return builder.getItems();
+}
+
+function getItem(path: string) {
+  const item = buildItems().find((i) => i.path === path);
+  if (!item) {
+    throw new Error(`no editor registered for path "${path}"`);
+  }
+  return item;
+}
+
+function legend(overrides: Partial<LegendConfig> = {}): LegendConfig {
+  return {
+    showLegend: true,
+    displayMode: LegendDisplayMode.List,
+    placement: 'bottom',
+    calcs: [],
+    ...overrides,
+  };
+}
+
+function showIf(item: LegendEditorItem, l: LegendConfig) {
+  // showIf is optional on the editor item; every editor under test defines one.
+  return item.showIf!({ legend: l }, undefined);
+}
+
+describe('addLegendOptions', () => {
+  describe('width editor', () => {
+    function renderWidthEditor(initialValue: number | string | undefined = undefined) {
+      const item = getItem('legend.width');
+      const onChange = jest.fn();
+      const Editor = item.editor;
+      render(<Editor value={initialValue} onChange={onChange} item={item} context={{ data: [] }} />);
+      return { onChange, input: screen.getByRole('textbox') };
+    }
+
+    // The editor's onInputCapture stops propagation of the native `input` event, which is
+    // what userEvent.type relies on to reach React's onChange — so it never fires under
+    // userEvent. A `change` event bypasses that capture handler, so fireEvent.change is the
+    // correct tool here.
+    /* eslint-disable testing-library/prefer-user-event */
+    it('parses a bare numeric value into a number', () => {
+      const { onChange, input } = renderWidthEditor();
+      fireEvent.change(input, { target: { value: '220' } });
+      expect(onChange).toHaveBeenCalledWith(220);
+    });
+
+    it('keeps a percentage value as a string', () => {
+      const { onChange, input } = renderWidthEditor();
+      fireEvent.change(input, { target: { value: '35%' } });
+      expect(onChange).toHaveBeenCalledWith('35%');
+    });
+
+    it('keeps a value with a px suffix as a string', () => {
+      const { onChange, input } = renderWidthEditor();
+      fireEvent.change(input, { target: { value: '220px' } });
+      expect(onChange).toHaveBeenCalledWith('220px');
+    });
+
+    it('emits undefined when the value is cleared (auto)', () => {
+      const { onChange, input } = renderWidthEditor(220);
+      fireEvent.change(input, { target: { value: '' } });
+      expect(onChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('trims surrounding whitespace before parsing', () => {
+      const { onChange, input } = renderWidthEditor();
+      fireEvent.change(input, { target: { value: '  220  ' } });
+      expect(onChange).toHaveBeenCalledWith(220);
+    });
+
+    it('emits undefined for a whitespace-only value', () => {
+      const { onChange, input } = renderWidthEditor();
+      fireEvent.change(input, { target: { value: '   ' } });
+      expect(onChange).toHaveBeenCalledWith(undefined);
+    });
+    /* eslint-enable testing-library/prefer-user-event */
+
+    it('is shown only for a visible legend placed on the right', () => {
+      const item = getItem('legend.width');
+      expect(showIf(item, legend({ showLegend: true, placement: 'right' }))).toBe(true);
+      expect(showIf(item, legend({ showLegend: true, placement: 'bottom' }))).toBe(false);
+      expect(showIf(item, legend({ showLegend: false, placement: 'right' }))).toBe(false);
+    });
+  });
+
+  describe('overflow editor', () => {
+    it('defaults to ellipsis', () => {
+      expect(getItem('legend.overflow').defaultValue).toBe('ellipsis');
+    });
+
+    it('offers ellipsis and wrap options', () => {
+      const item = getItem('legend.overflow');
+      const values = (item.settings as { options: Array<{ value: string }> }).options.map((o) => o.value);
+      expect(values).toEqual(['ellipsis', 'wrap']);
+    });
+
+    it('is shown only for a visible legend in table display mode', () => {
+      const item = getItem('legend.overflow');
+      expect(showIf(item, legend({ showLegend: true, displayMode: LegendDisplayMode.Table }))).toBe(true);
+      expect(showIf(item, legend({ showLegend: true, displayMode: LegendDisplayMode.List }))).toBe(false);
+      expect(showIf(item, legend({ showLegend: false, displayMode: LegendDisplayMode.Table }))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Adds unit tests for the new behavior introduced in #126198 (VizLegend css width + name wrapping). Targets that PR's branch so the tests can be merged into it.

## Coverage

**`VizLayout.test.tsx`** — right-placement legend with a string (css) width:
- string width (e.g. `35%`) applied verbatim to the legend element
- `maxWidth` suppressed for string widths, still applied for numeric widths
- string width does not subtract a fixed pixel amount from the chart (the new branch in `VizLayout.tsx`)

**`VizLegendTableItem.test.tsx`** — `overflow`:
- label is `nowrap` by default and for `ellipsis`
- label is `normal` (wraps) for `wrap`

**`legend.test.tsx`** (new) — the option-builder logic:
- width editor parsing: `"220"` → `220`, `"35%"`/`"220px"` → string, cleared/whitespace → `undefined`, whitespace trimmed
- width editor `showIf` (visible legend + right placement)
- overflow radio: default `ellipsis`, offers `ellipsis`/`wrap`, `showIf` (visible legend + table mode)

## Notes
- The builder resolves built-in editors from `standardEditorsRegistry`, which `grafana-ui` can't populate from `public/app`, so the needed editor ids are stubbed.
- The width editor's `onInputCapture` stops propagation of the native `input` event, which breaks `userEvent.type`; `fireEvent.change` (a `change` event bypasses that handler) is used with a justified eslint-disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)