### PR TITLE
Canvas: Load external canvas plugin not core based on feature flag

### DIFF
--- a/packages/grafana-runtime/src/services/pluginMeta/test-fixtures/config.panels.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/test-fixtures/config.panels.ts
@@ -249,7 +249,7 @@ export const panels: PanelPluginMetas = structuredClone({
   annolist: {
     id: 'annolist',
     name: 'Annotations list',
-    aliasIds: ['ryantxu-annolist-panel'],
+    aliasIDs: ['ryantxu-annolist-panel'],
     info: {
       author: {
         name: 'Grafana Labs',

--- a/pkg/api/bootdata_test.go
+++ b/pkg/api/bootdata_test.go
@@ -884,3 +884,19 @@ func TestIntegrationHTTPServer_GetFrontendSettings_publicDashboardDataSourceFilt
 
 	require.ElementsMatch(t, []string{"Prom", "Loki"}, names)
 }
+
+func TestPanelDTO_AliasIDsJSONKey(t *testing.T) {
+	dto := plugins.PanelDTO{
+		ID:       "grafana-canvas-panel",
+		AliasIDs: []string{"canvas"},
+	}
+
+	b, err := json.Marshal(dto)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+
+	assert.Equal(t, []any{"canvas"}, m["aliasIDs"], "PanelDTO should serialize AliasIDs with uppercase D to match the TypeScript PanelPluginMeta type")
+	assert.Nil(t, m["aliasIds"], "PanelDTO should not serialize with lowercase aliasIds")
+}

--- a/pkg/api/dtos/plugins.go
+++ b/pkg/api/dtos/plugins.go
@@ -39,6 +39,7 @@ type PluginListItem struct {
 	Name            string                  `json:"name"`
 	Type            string                  `json:"type"`
 	Id              string                  `json:"id"`
+	AliasIDs        []string                `json:"aliasIDs,omitempty"`
 	Enabled         bool                    `json:"enabled"`
 	Pinned          bool                    `json:"pinned"`
 	Info            plugins.Info            `json:"info"`

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -139,6 +139,7 @@ func (hs *HTTPServer) GetPluginList(c *contextmodel.ReqContext) response.Respons
 			Id:              pluginDef.ID,
 			Name:            pluginDef.Name,
 			Type:            string(pluginDef.Type),
+			AliasIDs:        pluginDef.AliasIDs,
 			Category:        pluginDef.Category,
 			Info:            pluginDef.Info,
 			Dependencies:    pluginDef.Dependencies,

--- a/pkg/plugins/config/config.go
+++ b/pkg/plugins/config/config.go
@@ -22,6 +22,17 @@ type PluginManagementCfg struct {
 	GrafanaAppURL string
 
 	Features Features
+
+	// ActiveExternalOverrides is the set of external plugin overrides whose feature flags are currently enabled,
+	// or whose stage is OverrideStagePermanent. It is the single source of truth for the pipeline and
+	// bootstrap stages, avoiding re-derivation from PluginSettings.
+	ActiveExternalOverrides []ExternalOverride
+}
+
+// ExternalOverride carries the IDs needed at pipeline time for an active external plugin override.
+type ExternalOverride struct {
+	CorePluginID     string
+	ExternalPluginID string
 }
 
 // Features contains the feature toggles used for the plugin management system.
@@ -40,18 +51,20 @@ type PluginSettings map[string]map[string]string
 func NewPluginManagementCfg(devMode bool, pluginsPaths []string, pluginSettings PluginSettings, pluginsAllowUnsigned []string,
 	pluginsCDNURLTemplate string, appURL string, features Features,
 	grafanaComAPIURL string, disablePlugins []string, forwardHostEnvVars []string, grafanaComAPIToken string,
+	activeExternalOverrides []ExternalOverride,
 ) *PluginManagementCfg {
 	return &PluginManagementCfg{
-		PluginsPaths:          pluginsPaths,
-		DevMode:               devMode,
-		PluginSettings:        pluginSettings,
-		PluginsAllowUnsigned:  pluginsAllowUnsigned,
-		DisablePlugins:        disablePlugins,
-		PluginsCDNURLTemplate: pluginsCDNURLTemplate,
-		GrafanaComAPIURL:      grafanaComAPIURL,
-		GrafanaAppURL:         appURL,
-		Features:              features,
-		ForwardHostEnvVars:    forwardHostEnvVars,
-		GrafanaComAPIToken:    grafanaComAPIToken,
+		PluginsPaths:            pluginsPaths,
+		DevMode:                 devMode,
+		PluginSettings:          pluginSettings,
+		PluginsAllowUnsigned:    pluginsAllowUnsigned,
+		DisablePlugins:          disablePlugins,
+		PluginsCDNURLTemplate:   pluginsCDNURLTemplate,
+		GrafanaComAPIURL:        grafanaComAPIURL,
+		GrafanaAppURL:           appURL,
+		Features:                features,
+		ForwardHostEnvVars:      forwardHostEnvVars,
+		GrafanaComAPIToken:      grafanaComAPIToken,
+		ActiveExternalOverrides: activeExternalOverrides,
 	}
 }

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -314,7 +314,7 @@ type DataSourceDTO struct {
 type PanelDTO struct {
 	ID              string            `json:"id"`
 	Name            string            `json:"name"`
-	AliasIDs        []string          `json:"aliasIds,omitempty"`
+	AliasIDs        []string          `json:"aliasIDs,omitempty"`
 	Info            Info              `json:"info"`
 	HideFromList    bool              `json:"hideFromList"`
 	Sort            int               `json:"sort"`

--- a/pkg/services/pluginsintegration/externaloverrides/overrides.go
+++ b/pkg/services/pluginsintegration/externaloverrides/overrides.go
@@ -11,7 +11,8 @@ type OverrideStage int
 const (
 	// OverrideStageFlagged: migration gated by a feature flag; core suppressed when on, external blocked when off.
 	OverrideStageFlagged OverrideStage = iota
-	// OverrideStagePermanent: flag retired, core deleted; alias injected unconditionally for dashboard backwards compat.
+	// OverrideStagePermanent: flag retired, core deleted; alias injected and plugin preinstalled unconditionally.
+	// FeatureFlag should be left empty ("").
 	OverrideStagePermanent
 )
 

--- a/pkg/services/pluginsintegration/externaloverrides/overrides.go
+++ b/pkg/services/pluginsintegration/externaloverrides/overrides.go
@@ -1,0 +1,36 @@
+package externaloverrides
+
+// FeatureFlagName is the name of a feature toggle. Using a named type instead of a plain string
+// prevents accidental assignment of arbitrary strings and makes the intent explicit at call sites.
+// We cannot import featuremgmt here due to an import cycle via setting_plugins.go.
+type FeatureFlagName string
+
+// OverrideStage describes the lifecycle stage of a core-to-external plugin migration.
+type OverrideStage int
+
+const (
+	// OverrideStageFlagged: migration gated by a feature flag; core suppressed when on, external blocked when off.
+	OverrideStageFlagged OverrideStage = iota
+	// OverrideStagePermanent: flag retired, core deleted; alias injected unconditionally for dashboard backwards compat.
+	OverrideStagePermanent
+)
+
+// Override describes a core plugin being replaced by an external one.
+type Override struct {
+	Stage            OverrideStage
+	FeatureFlag      FeatureFlagName // only consulted when Stage == OverrideStageFlagged
+	CorePluginID     string          // ID of the core plugin to suppress (e.g. "canvas")
+	ExternalPluginID string          // conformant published plugin ID (e.g. "grafana-canvas-panel")
+}
+
+// Overrides is the list of all core-to-external plugin migrations.
+// To add a plugin: append an entry with OverrideStageFlagged.
+// When the flag is retired and the core plugin deleted: change to OverrideStagePermanent and omit FeatureFlag (leave as "").
+var Overrides = []Override{
+	{
+		Stage:            OverrideStageFlagged,
+		FeatureFlag:      "canvasExternalPlugin",
+		CorePluginID:     "canvas",
+		ExternalPluginID: "grafana-canvas-panel",
+	},
+}

--- a/pkg/services/pluginsintegration/pipeline/pipeline.go
+++ b/pkg/services/pluginsintegration/pipeline/pipeline.go
@@ -52,7 +52,7 @@ func ProvideBootstrapStage(cfg *config.PluginManagementCfg, sc plugins.Signature
 
 	return bootstrap.New(cfg, bootstrap.Opts{
 		ConstructFunc: bootstrap.DefaultConstructFunc(cfg, sc, ap),
-		DecorateFuncs: append(bootstrap.DefaultDecorateFuncs(cfg, cdn), disableAlertingForTempoDecorateFunc),
+		DecorateFuncs: append(bootstrap.DefaultDecorateFuncs(cfg, cdn), disableAlertingForTempoDecorateFunc, ExternalPluginOverridesDecorateFunc(cfg.ActiveExternalOverrides)),
 	})
 }
 

--- a/pkg/services/pluginsintegration/pipeline/steps.go
+++ b/pkg/services/pluginsintegration/pipeline/steps.go
@@ -302,6 +302,21 @@ func (c *AsExternal) Filter(cl plugins.Class, bundles []*plugins.FoundBundle) ([
 	return bundles, nil
 }
 
+// ExternalPluginOverridesDecorateFunc returns a DecorateFunc that injects core plugin IDs as aliases
+// into their external replacement plugins, based on the active external overrides. This ensures that
+// existing dashboards and data sources continue to work without migration when a core plugin is
+// replaced by an external one.
+func ExternalPluginOverridesDecorateFunc(activeOverrides []config.ExternalOverride) func(context.Context, *plugins.Plugin) (*plugins.Plugin, error) {
+	return func(_ context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+		for _, o := range activeOverrides {
+			if p.ID == o.ExternalPluginID {
+				p.AliasIDs = append(p.AliasIDs, o.CorePluginID)
+			}
+		}
+		return p, nil
+	}
+}
+
 // DuplicatePluginIDValidation is a filter step that will filter out any plugins that are already registered with the same
 // plugin ID. This includes both the primary plugin and child plugins, which are matched using the plugin.json plugin
 // ID field.

--- a/pkg/services/pluginsintegration/pipeline/steps_test.go
+++ b/pkg/services/pluginsintegration/pipeline/steps_test.go
@@ -176,3 +176,35 @@ func TestDuplicatePluginIDValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestExternalPluginOverridesDecorateFunc(t *testing.T) {
+	override := config.ExternalOverride{
+		CorePluginID:     "canvas",
+		ExternalPluginID: "grafana-canvas-panel",
+	}
+
+	newCanvasPanel := func() *plugins.Plugin {
+		return &plugins.Plugin{JSONData: plugins.JSONData{ID: "grafana-canvas-panel"}}
+	}
+	newOtherPanel := func() *plugins.Plugin {
+		return &plugins.Plugin{JSONData: plugins.JSONData{ID: "other-panel"}}
+	}
+
+	t.Run("injects core alias when override is active", func(t *testing.T) {
+		p, err := ExternalPluginOverridesDecorateFunc([]config.ExternalOverride{override})(context.Background(), newCanvasPanel())
+		require.NoError(t, err)
+		require.Contains(t, p.AliasIDs, "canvas")
+	})
+
+	t.Run("does not inject alias when no overrides are active", func(t *testing.T) {
+		p, err := ExternalPluginOverridesDecorateFunc(nil)(context.Background(), newCanvasPanel())
+		require.NoError(t, err)
+		require.NotContains(t, p.AliasIDs, "canvas")
+	})
+
+	t.Run("does not inject alias on non-matching plugins", func(t *testing.T) {
+		p, err := ExternalPluginOverridesDecorateFunc([]config.ExternalOverride{override})(context.Background(), newOtherPanel())
+		require.NoError(t, err)
+		require.NotContains(t, p.AliasIDs, "canvas")
+	})
+}

--- a/pkg/services/pluginsintegration/pluginconfig/config.go
+++ b/pkg/services/pluginsintegration/pluginconfig/config.go
@@ -21,10 +21,19 @@ func ProvidePluginManagementConfig(cfg *setting.Cfg, settingProvider setting.Pro
 		allowedUnsigned = strings.Split(plugins.KeyValue("allow_loading_unsigned_plugins").Value(), ",")
 	}
 
+	pluginSettings := extractPluginSettings(settingProvider)
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if features.IsEnabledGlobally(featuremgmt.FlagCanvasExternalPlugin) {
+		if pluginSettings["canvas"] == nil {
+			pluginSettings["canvas"] = make(map[string]string)
+		}
+		pluginSettings["canvas"]["as_external"] = "true"
+	}
+
 	return config.NewPluginManagementCfg(
 		settingProvider.KeyValue("", "app_mode").MustBool(cfg.Env == setting.Dev),
 		cfg.PluginsPaths,
-		extractPluginSettings(settingProvider),
+		pluginSettings,
 		allowedUnsigned,
 		cfg.PluginsCDNURLTemplate,
 		cfg.AppURL,

--- a/pkg/services/pluginsintegration/pluginconfig/config.go
+++ b/pkg/services/pluginsintegration/pluginconfig/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/plugins/config"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/externaloverrides"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -22,12 +23,25 @@ func ProvidePluginManagementConfig(cfg *setting.Cfg, settingProvider setting.Pro
 	}
 
 	pluginSettings := extractPluginSettings(settingProvider)
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if features.IsEnabledGlobally(featuremgmt.FlagCanvasExternalPlugin) {
-		if pluginSettings["canvas"] == nil {
-			pluginSettings["canvas"] = make(map[string]string)
+	var activeOverrides []config.ExternalOverride
+	for _, o := range externaloverrides.Overrides {
+		//nolint:staticcheck // not yet migrated to OpenFeature
+		active := o.Stage == externaloverrides.OverrideStagePermanent ||
+			features.IsEnabledGlobally(string(o.FeatureFlag))
+		if active {
+			if o.Stage == externaloverrides.OverrideStageFlagged {
+				if pluginSettings[o.CorePluginID] == nil {
+					pluginSettings[o.CorePluginID] = make(map[string]string)
+				}
+				pluginSettings[o.CorePluginID]["as_external"] = "true"
+			}
+			activeOverrides = append(activeOverrides, config.ExternalOverride{
+				CorePluginID:     o.CorePluginID,
+				ExternalPluginID: o.ExternalPluginID,
+			})
+		} else {
+			cfg.DisablePlugins = append(cfg.DisablePlugins, o.ExternalPluginID)
 		}
-		pluginSettings["canvas"]["as_external"] = "true"
 	}
 
 	return config.NewPluginManagementCfg(
@@ -46,6 +60,7 @@ func ProvidePluginManagementConfig(cfg *setting.Cfg, settingProvider setting.Pro
 		cfg.DisablePlugins,
 		cfg.ForwardHostEnvVars,
 		cfg.GrafanaComProxyAPIToken,
+		activeOverrides,
 	), nil
 }
 

--- a/pkg/services/pluginsintegration/pluginconfig/config.go
+++ b/pkg/services/pluginsintegration/pluginconfig/config.go
@@ -24,6 +24,7 @@ func ProvidePluginManagementConfig(cfg *setting.Cfg, settingProvider setting.Pro
 
 	pluginSettings := extractPluginSettings(settingProvider)
 	var activeOverrides []config.ExternalOverride
+	var disabledExternalPlugins []string
 	for _, o := range externaloverrides.Overrides {
 		//nolint:staticcheck // not yet migrated to OpenFeature
 		active := o.Stage == externaloverrides.OverrideStagePermanent ||
@@ -40,7 +41,7 @@ func ProvidePluginManagementConfig(cfg *setting.Cfg, settingProvider setting.Pro
 				ExternalPluginID: o.ExternalPluginID,
 			})
 		} else {
-			cfg.DisablePlugins = append(cfg.DisablePlugins, o.ExternalPluginID)
+			disabledExternalPlugins = append(disabledExternalPlugins, o.ExternalPluginID)
 		}
 	}
 
@@ -57,7 +58,7 @@ func ProvidePluginManagementConfig(cfg *setting.Cfg, settingProvider setting.Pro
 			TempoAlertingEnabled: features.IsEnabledGlobally(featuremgmt.FlagTempoAlerting),
 		},
 		cfg.GrafanaComAPIURL,
-		cfg.DisablePlugins,
+		append(cfg.DisablePlugins, disabledExternalPlugins...),
 		cfg.ForwardHostEnvVars,
 		cfg.GrafanaComProxyAPIToken,
 		activeOverrides,

--- a/pkg/services/pluginsintegration/pluginconfig/config_test.go
+++ b/pkg/services/pluginsintegration/pluginconfig/config_test.go
@@ -5,10 +5,30 @@ import (
 
 	"gopkg.in/ini.v1"
 
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestProvidePluginManagementConfig_canvasExternalPlugin(t *testing.T) {
+	raw, err := ini.Load([]byte(`[plugins]`))
+	require.NoError(t, err)
+	cfg := setting.NewCfg()
+	cfg.Raw = raw
+
+	t.Run("sets canvas as_external when canvasExternalPlugin flag is enabled", func(t *testing.T) {
+		pCfg, err := ProvidePluginManagementConfig(cfg, setting.ProvideProvider(cfg), featuremgmt.WithFeatures(featuremgmt.FlagCanvasExternalPlugin))
+		require.NoError(t, err)
+		require.Equal(t, "true", pCfg.PluginSettings["canvas"]["as_external"])
+	})
+
+	t.Run("does not set canvas as_external when canvasExternalPlugin flag is disabled", func(t *testing.T) {
+		pCfg, err := ProvidePluginManagementConfig(cfg, setting.ProvideProvider(cfg), featuremgmt.WithFeatures())
+		require.NoError(t, err)
+		require.NotEqual(t, "true", pCfg.PluginSettings["canvas"]["as_external"])
+	})
+}
 
 func TestPluginSettings(t *testing.T) {
 	raw, err := ini.Load([]byte(`

--- a/pkg/services/pluginsintegration/pluginconfig/config_test.go
+++ b/pkg/services/pluginsintegration/pluginconfig/config_test.go
@@ -17,16 +17,22 @@ func TestProvidePluginManagementConfig_canvasExternalPlugin(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.Raw = raw
 
-	t.Run("sets canvas as_external when canvasExternalPlugin flag is enabled", func(t *testing.T) {
+	t.Run("sets canvas as_external and populates ActiveExternalOverrides when flag is enabled", func(t *testing.T) {
 		pCfg, err := ProvidePluginManagementConfig(cfg, setting.ProvideProvider(cfg), featuremgmt.WithFeatures(featuremgmt.FlagCanvasExternalPlugin))
 		require.NoError(t, err)
 		require.Equal(t, "true", pCfg.PluginSettings["canvas"]["as_external"])
+		require.Len(t, pCfg.ActiveExternalOverrides, 1)
+		require.Equal(t, "canvas", pCfg.ActiveExternalOverrides[0].CorePluginID)
+		require.Equal(t, "grafana-canvas-panel", pCfg.ActiveExternalOverrides[0].ExternalPluginID)
+		require.NotContains(t, pCfg.DisablePlugins, "grafana-canvas-panel")
 	})
 
-	t.Run("does not set canvas as_external when canvasExternalPlugin flag is disabled", func(t *testing.T) {
+	t.Run("disables external plugin and has no active overrides when flag is disabled", func(t *testing.T) {
 		pCfg, err := ProvidePluginManagementConfig(cfg, setting.ProvideProvider(cfg), featuremgmt.WithFeatures())
 		require.NoError(t, err)
 		require.NotEqual(t, "true", pCfg.PluginSettings["canvas"]["as_external"])
+		require.Empty(t, pCfg.ActiveExternalOverrides)
+		require.Contains(t, pCfg.DisablePlugins, "grafana-canvas-panel")
 	})
 }
 

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -162,7 +162,9 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 			preinstallPluginsAsync["grafana-pathfinder-app"] = InstallPlugin{"grafana-pathfinder-app", "", ""}
 		}
 		for _, o := range externaloverrides.Overrides {
-			if cfg.IsFeatureToggleEnabled(string(o.FeatureFlag)) { // Use literal string to avoid circular dependency
+			// FeatureFlagName cast to string; featuremgmt cannot be imported here due to import cycle.
+			// OverrideStagePermanent entries always preinstall — the core plugin is gone and there is no fallback.
+			if o.Stage == externaloverrides.OverrideStagePermanent || cfg.IsFeatureToggleEnabled(string(o.FeatureFlag)) {
 				preinstallPluginsAsync[o.ExternalPluginID] = InstallPlugin{o.ExternalPluginID, "", ""}
 			}
 		}

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -160,6 +160,9 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 		if cfg.IsFeatureToggleEnabled("interactiveLearning") { // Use literal string to avoid circular dependency
 			preinstallPluginsAsync["grafana-pathfinder-app"] = InstallPlugin{"grafana-pathfinder-app", "", ""}
 		}
+		if cfg.IsFeatureToggleEnabled("canvasExternalPlugin") { // Use literal string to avoid circular dependency
+			preinstallPluginsAsync["canvas"] = InstallPlugin{"canvas", "", ""}
+		}
 		if cfg.IsEnterprise {
 			preinstallPluginsAsync["grafana-assistant-app"] = InstallPlugin{"grafana-assistant-app", "", ""}
 		}

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/ini.v1"
 
 	"github.com/grafana/grafana/pkg/plugins/config"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/externaloverrides"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -160,8 +161,10 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 		if cfg.IsFeatureToggleEnabled("interactiveLearning") { // Use literal string to avoid circular dependency
 			preinstallPluginsAsync["grafana-pathfinder-app"] = InstallPlugin{"grafana-pathfinder-app", "", ""}
 		}
-		if cfg.IsFeatureToggleEnabled("canvasExternalPlugin") { // Use literal string to avoid circular dependency
-			preinstallPluginsAsync["canvas"] = InstallPlugin{"canvas", "", ""}
+		for _, o := range externaloverrides.Overrides {
+			if cfg.IsFeatureToggleEnabled(string(o.FeatureFlag)) { // Use literal string to avoid circular dependency
+				preinstallPluginsAsync[o.ExternalPluginID] = InstallPlugin{o.ExternalPluginID, "", ""}
+			}
 		}
 		if cfg.IsEnterprise {
 			preinstallPluginsAsync["grafana-assistant-app"] = InstallPlugin{"grafana-assistant-app", "", ""}

--- a/pkg/setting/setting_plugins_test.go
+++ b/pkg/setting/setting_plugins_test.go
@@ -281,6 +281,30 @@ func Test_readPluginSettings(t *testing.T) {
 	})
 }
 
+func TestCanvasExternalPluginPreinstall(t *testing.T) {
+	t.Run("adds canvas to preinstall when canvasExternalPlugin flag is enabled", func(t *testing.T) {
+		cfg := NewCfgWithFeatures(func(key string) bool { return key == "canvasExternalPlugin" })
+		_, err := cfg.Raw.NewSection("plugins")
+		require.NoError(t, err)
+
+		err = cfg.readPluginSettings(cfg.Raw)
+		require.NoError(t, err)
+
+		assert.Contains(t, cfg.PreinstallPluginsAsync, InstallPlugin{"canvas", "", ""})
+	})
+
+	t.Run("does not add canvas to preinstall when canvasExternalPlugin flag is disabled", func(t *testing.T) {
+		cfg := NewCfgWithFeatures(func(key string) bool { return false })
+		_, err := cfg.Raw.NewSection("plugins")
+		require.NoError(t, err)
+
+		err = cfg.readPluginSettings(cfg.Raw)
+		require.NoError(t, err)
+
+		assert.NotContains(t, cfg.PreinstallPluginsAsync, InstallPlugin{"canvas", "", ""})
+	})
+}
+
 func Test_readGrafanaComSettings_GrafanaComProxyAPIToken(t *testing.T) {
 	t.Run("reads proxy_token into GrafanaComProxyAPIToken when set", func(t *testing.T) {
 		t.Setenv("GF_GRAFANA_COM_PROXY_TOKEN", "test-gnet-proxy-token")

--- a/pkg/setting/setting_plugins_test.go
+++ b/pkg/setting/setting_plugins_test.go
@@ -281,8 +281,8 @@ func Test_readPluginSettings(t *testing.T) {
 	})
 }
 
-func TestCanvasExternalPluginPreinstall(t *testing.T) {
-	t.Run("adds canvas to preinstall when canvasExternalPlugin flag is enabled", func(t *testing.T) {
+func TestExternalOverridePreinstall(t *testing.T) {
+	t.Run("adds external plugin to preinstall when its feature flag is enabled", func(t *testing.T) {
 		cfg := NewCfgWithFeatures(func(key string) bool { return key == "canvasExternalPlugin" })
 		_, err := cfg.Raw.NewSection("plugins")
 		require.NoError(t, err)
@@ -290,10 +290,10 @@ func TestCanvasExternalPluginPreinstall(t *testing.T) {
 		err = cfg.readPluginSettings(cfg.Raw)
 		require.NoError(t, err)
 
-		assert.Contains(t, cfg.PreinstallPluginsAsync, InstallPlugin{"canvas", "", ""})
+		assert.Contains(t, cfg.PreinstallPluginsAsync, InstallPlugin{"grafana-canvas-panel", "", ""})
 	})
 
-	t.Run("does not add canvas to preinstall when canvasExternalPlugin flag is disabled", func(t *testing.T) {
+	t.Run("does not add external plugin to preinstall when its feature flag is disabled", func(t *testing.T) {
 		cfg := NewCfgWithFeatures(func(key string) bool { return false })
 		_, err := cfg.Raw.NewSection("plugins")
 		require.NoError(t, err)
@@ -301,7 +301,7 @@ func TestCanvasExternalPluginPreinstall(t *testing.T) {
 		err = cfg.readPluginSettings(cfg.Raw)
 		require.NoError(t, err)
 
-		assert.NotContains(t, cfg.PreinstallPluginsAsync, InstallPlugin{"canvas", "", ""})
+		assert.NotContains(t, cfg.PreinstallPluginsAsync, InstallPlugin{"grafana-canvas-panel", "", ""})
 	})
 }
 

--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -114,6 +114,9 @@
     "name": "Annotations list",
     "type": "panel",
     "id": "annolist",
+    "aliasIDs": [
+      "ryantxu-annolist-panel"
+    ],
     "enabled": true,
     "pinned": false,
     "info": {
@@ -745,6 +748,9 @@
     "name": "Grafana Pyroscope",
     "type": "datasource",
     "id": "grafana-pyroscope-datasource",
+    "aliasIDs": [
+      "phlare"
+    ],
     "enabled": true,
     "pinned": false,
     "info": {
@@ -1486,6 +1492,9 @@
     "name": "PostgreSQL",
     "type": "datasource",
     "id": "grafana-postgresql-datasource",
+    "aliasIDs": [
+      "postgres"
+    ],
     "enabled": true,
     "pinned": false,
     "info": {
@@ -1790,6 +1799,9 @@
     "name": "TestData",
     "type": "datasource",
     "id": "grafana-testdata-datasource",
+    "aliasIDs": [
+      "testdata"
+    ],
     "enabled": true,
     "pinned": false,
     "info": {

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -27,7 +27,7 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
     getLocalPluginChangelog(id),
   ]);
 
-  const local = localPlugins.find((p) => p.id === id);
+  const local = localPlugins.find((p) => p.id === id || p.aliasIDs?.includes(id));
   const dependencies = local?.dependencies || remote?.json?.dependencies;
 
   // Add installed version to the list if it's missing (could be deprecated/deleted)

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -222,7 +222,8 @@ export function mapLocalToCatalog(plugin: LocalPlugin, error?: PluginError): Cat
 // TODO: change the signature by removing the optionals for local and remote.
 export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, error?: PluginError): CatalogPlugin {
   const installedVersion = local?.info.version;
-  const id = local?.id || remote?.slug || '';
+  const matchedViaAlias = remote && local && local.aliasIDs?.includes(remote.slug);
+  const id = matchedViaAlias ? local.id : remote?.slug || local?.id || '';
   const type = local?.type || remote?.typeCode;
   const isDisabled = !!error;
   const keywords = remote?.keywords || local?.info.keywords || [];
@@ -231,8 +232,6 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
     small: `/public/build/img/icn-${type}.svg`,
     large: `/public/build/img/icn-${type}.svg`,
   };
-
-  const matchedViaAlias = remote && local && local.aliasIDs?.includes(remote.slug);
   if (matchedViaAlias && local.info.logos) {
     logos = local.info.logos;
   } else if (remote) {

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -36,6 +36,7 @@ export function mergeLocalsAndRemotes({
 
   const remoteSet = new Set<string>(remote?.map((plugin) => plugin.slug));
   const localMap = new Map<string, LocalPlugin>(local.map((plugin) => [plugin.id, plugin]));
+  local.forEach((plugin) => plugin.aliasIDs?.forEach((alias) => localMap.set(alias, plugin)));
   const instancesMap = new Map<string, InstancePlugin>(instance?.map((plugin) => [plugin.pluginSlug, plugin]));
   const provisionedSet = new Set<string>(provisioned?.map((plugin) => plugin.slug));
 
@@ -43,7 +44,7 @@ export function mergeLocalsAndRemotes({
   local.forEach((localPlugin) => {
     const error = errorByPluginId[localPlugin.id];
 
-    if (!remoteSet.has(localPlugin.id)) {
+    if (!remoteSet.has(localPlugin.id) && !localPlugin.aliasIDs?.some((alias) => remoteSet.has(alias))) {
       let catalogPlugin = mergeLocalAndRemote(localPlugin, undefined, error);
       if (config.pluginAdminExternalManageEnabled) {
         catalogPlugin = mergeCloudState(
@@ -221,7 +222,7 @@ export function mapLocalToCatalog(plugin: LocalPlugin, error?: PluginError): Cat
 // TODO: change the signature by removing the optionals for local and remote.
 export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, error?: PluginError): CatalogPlugin {
   const installedVersion = local?.info.version;
-  const id = remote?.slug || local?.id || '';
+  const id = local?.id || remote?.slug || '';
   const type = local?.type || remote?.typeCode;
   const isDisabled = !!error;
   const keywords = remote?.keywords || local?.info.keywords || [];
@@ -231,12 +232,16 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
     large: `/public/build/img/icn-${type}.svg`,
   };
 
-  if (remote) {
+  const matchedViaAlias = remote && local && remote.slug !== local.id;
+  if (matchedViaAlias && local.info.logos) {
+    logos = local.info.logos;
+  } else if (remote) {
+    const remoteSlug = remote.slug || id;
     logos = {
-      small: `${config.appSubUrl}/api/gnet/plugins/${id}/versions/${remote.version}/logos/small`,
-      large: `${config.appSubUrl}/api/gnet/plugins/${id}/versions/${remote.version}/logos/large`,
+      small: `${config.appSubUrl}/api/gnet/plugins/${remoteSlug}/versions/${remote.version}/logos/small`,
+      large: `${config.appSubUrl}/api/gnet/plugins/${remoteSlug}/versions/${remote.version}/logos/large`,
     };
-  } else if (local && local.info.logos) {
+  } else if (local?.info.logos) {
     logos = local.info.logos;
   }
 
@@ -247,6 +252,7 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
     downloads: remote?.downloads || 0,
     hasUpdate: local?.hasUpdate || false,
     id,
+    aliasIDs: local?.aliasIDs,
     info: {
       logos,
       keywords,

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -232,7 +232,7 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
     large: `/public/build/img/icn-${type}.svg`,
   };
 
-  const matchedViaAlias = remote && local && remote.slug !== local.id;
+  const matchedViaAlias = remote && local && local.aliasIDs?.includes(remote.slug);
   if (matchedViaAlias && local.info.logos) {
     logos = local.info.logos;
   } else if (remote) {

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -27,6 +27,7 @@ import {
   type LocalPlugin,
   type InstancePlugin,
   type ProvisionedPlugin,
+  type PluginCatalogStoreState,
   PluginStatus,
 } from '../types';
 
@@ -157,14 +158,16 @@ export const fetchRemotePlugins = createAsyncThunk<RemotePlugin[], void, { rejec
   }
 );
 
-export const fetchDetails = createAsyncThunk<Update<CatalogPlugin, string>, string>(
+export const fetchDetails = createAsyncThunk<Update<CatalogPlugin, string>, string, { state: PluginCatalogStoreState }>(
   `${STATE_PREFIX}/fetchDetails`,
   async (id, thunkApi) => {
     try {
       const details = await getPluginDetails(id);
-
+      const state = thunkApi.getState();
+      const allPlugins = Object.values(state.plugins.items.entities);
+      const canonical = allPlugins.find((p) => p?.aliasIDs?.includes(id));
       return {
-        id,
+        id: canonical?.id ?? id,
         changes: { details },
       };
     } catch (e) {

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -31,6 +31,8 @@ import {
   PluginStatus,
 } from '../types';
 
+import { selectByIdOrAlias } from './selectors';
+
 // Fetches
 export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, thunkApi) => {
   try {
@@ -163,11 +165,9 @@ export const fetchDetails = createAsyncThunk<Update<CatalogPlugin, string>, stri
   async (id, thunkApi) => {
     try {
       const details = await getPluginDetails(id);
-      const state = thunkApi.getState();
-      const allPlugins = Object.values(state.plugins.items.entities);
-      const canonical = allPlugins.find((p) => p?.aliasIDs?.includes(id));
+      const canonicalId = selectByIdOrAlias(thunkApi.getState(), id)?.id ?? id;
       return {
-        id: canonical?.id ?? id,
+        id: canonicalId,
         changes: { details },
       };
     } catch (e) {

--- a/public/app/features/plugins/admin/state/hooks.ts
+++ b/public/app/features/plugins/admin/state/hooks.ts
@@ -19,6 +19,7 @@ import {
 import {
   selectPlugins,
   selectById,
+  selectByIdOrAlias,
   selectIsRequestPending,
   selectRequestError,
   selectIsRequestNotFetched,
@@ -57,7 +58,7 @@ export const useGetSingle = (id: string, version?: string): CatalogPlugin | unde
   useFetchAll();
   useFetchDetails(id);
 
-  return useSelector((state) => selectById(state, id));
+  return useSelector((state) => selectByIdOrAlias(state, id));
 };
 
 export const useGetPluginInsights = (id: string, version: string | undefined): CatalogPlugin | undefined => {
@@ -158,7 +159,7 @@ export const useFetchAllLocal = () => {
 
 export const useFetchDetails = (id: string) => {
   const dispatch = useDispatch();
-  const plugin = useSelector((state) => selectById(state, id));
+  const plugin = useSelector((state) => selectByIdOrAlias(state, id));
   const isNotFetching = !useSelector(selectIsRequestPending(fetchDetails.typePrefix));
   const shouldFetch = isNotFetching && plugin && !plugin.details;
 

--- a/public/app/features/plugins/admin/state/selectors.ts
+++ b/public/app/features/plugins/admin/state/selectors.ts
@@ -17,6 +17,14 @@ const { selectAll, selectById } = pluginsAdapter.getSelectors(selectItems);
 
 export { selectById };
 
+export const selectByIdOrAlias = (state: PluginCatalogStoreState, id: string) => {
+  const direct = selectById(state, id);
+  if (direct) {
+    return direct;
+  }
+  return selectAll(state).find((p) => p.aliasIDs?.includes(id));
+};
+
 const debouncedTrackSearch = debounce((count) => {
   reportInteraction('plugins_search', {
     resultsCount: count,

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -29,6 +29,7 @@ export interface CatalogPlugin extends WithAccessControlMetadata {
   downloads: number;
   hasUpdate: boolean;
   id: string;
+  aliasIDs?: string[];
   info: CatalogPluginInfo;
   isDev: boolean;
   isCore: boolean;
@@ -219,6 +220,7 @@ export type LocalPlugin = WithAccessControlMetadata & {
     updated: string;
   };
   name: string;
+  aliasIDs?: string[];
   pinned: boolean;
   signature: PluginSignatureStatus;
   signatureOrg: string;

--- a/public/app/features/plugins/built_in_plugins.test.ts
+++ b/public/app/features/plugins/built_in_plugins.test.ts
@@ -1,0 +1,23 @@
+describe('built_in_plugins', () => {
+  describe('canvas panel', () => {
+    it('is included when canvasExternalPlugin is disabled', () => {
+      jest.isolateModules(() => {
+        jest.mock('@grafana/runtime', () => ({
+          config: { featureToggles: { canvasExternalPlugin: false } },
+        }));
+        const { default: builtInPlugins } = require('./built_in_plugins');
+        expect('core:plugin/canvas' in builtInPlugins).toBe(true);
+      });
+    });
+
+    it('is excluded when canvasExternalPlugin is enabled', () => {
+      jest.isolateModules(() => {
+        jest.mock('@grafana/runtime', () => ({
+          config: { featureToggles: { canvasExternalPlugin: true } },
+        }));
+        const { default: builtInPlugins } = require('./built_in_plugins');
+        expect('core:plugin/canvas' in builtInPlugins).toBe(false);
+      });
+    });
+  });
+});

--- a/public/app/features/plugins/built_in_plugins.ts
+++ b/public/app/features/plugins/built_in_plugins.ts
@@ -1,3 +1,5 @@
+import { config } from '@grafana/runtime';
+
 const cloudwatchPlugin = async () =>
   await import(/* webpackChunkName: "cloudwatchPlugin" */ 'app/plugins/datasource/cloudwatch/module');
 const dashboardDSPlugin = async () =>
@@ -82,7 +84,7 @@ const builtInPlugins: Record<string, System.Module | (() => Promise<System.Modul
   'core:plugin/candlestick': candlestickPanel,
   'core:plugin/xychart': xychartPanel,
   'core:plugin/geomap': geomapPanel,
-  'core:plugin/canvas': canvasPanel,
+  ...(config.featureToggles.canvasExternalPlugin ? {} : { 'core:plugin/canvas': canvasPanel }),
   'core:plugin/dashlist': dashListPanel,
   'core:plugin/alertlist': alertListPanel,
   'core:plugin/annolist': annoListPanel,


### PR DESCRIPTION
**What is this feature?**

This change introduces a way to feature flag if the internal Grafana core version of the `Canvas` panel visualization is loaded, or the newly (WIP) externalized version of the `Canvas` visualization, based on a feature flag.

**Why do we need this feature?**

Enable us to externalize the `Canvas` panel visualization safely, and quickly.

**Who is this feature for?**

Grafana data visualization engineers for now, eventually for everyone.

**Which issue(s) does this PR fix?**:

🎟️  Fixes # https://github.com/grafana/grafana/issues/126208

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
