### PR TITLE
Provisioning: add option to disable webhook in repository and connection

### DIFF
--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -85,7 +85,7 @@ export function ConfigForm({ data }: ConfigFormProps) {
   const [tokenConfigured, setTokenConfigured] = useState(isEdit);
   const [isLoading, setIsLoading] = useState(false);
   const [submitError, setSubmitError] = useState<string | undefined>();
-  const [type, readOnly] = watch(['type', 'readOnly']);
+  const [type, readOnly, watchedConnectionName] = watch(['type', 'readOnly', 'connectionName']);
   const targetOptions = useMemo(() => getTargetOptions(settings.data?.allowedTargets || ['folder']), [settings.data]);
   const isGitBased = isGitProvider(type);
 
@@ -95,7 +95,20 @@ export function ConfigForm({ data }: ConfigFormProps) {
   const connectionName = data?.spec?.connection?.name;
   const usesGitHubApp = Boolean(connectionName && type === 'github');
 
-  const { options: connectionOptions, isLoading: connectionsLoading } = useConnectionOptions(usesGitHubApp);
+  const {
+    options: connectionOptions,
+    isLoading: connectionsLoading,
+    connections,
+  } = useConnectionOptions(usesGitHubApp);
+
+  const selectedConnection = connections.find((c) => c.metadata?.name === watchedConnectionName);
+  const connectionWebhookDisabled = Boolean(selectedConnection?.spec?.webhook?.disabled);
+
+  useEffect(() => {
+    if (connectionWebhookDisabled) {
+      setValue('webhook.disabled', true);
+    }
+  }, [connectionWebhookDisabled, setValue]);
 
   const {
     data: refsData,
@@ -418,8 +431,10 @@ export function ConfigForm({ data }: ConfigFormProps) {
         {type === 'github' && (
           <WebhookSection<RepositoryFormData>
             register={register}
+            control={control}
             name="webhook.baseUrl"
             disabledName="webhook.disabled"
+            connectionWebhookDisabled={connectionWebhookDisabled}
           />
         )}
 

--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -415,7 +415,13 @@ export function ConfigForm({ data }: ConfigFormProps) {
             )}
           </>
         )}
-        {type === 'github' && <WebhookSection<RepositoryFormData> register={register} name="webhook.baseUrl" />}
+        {type === 'github' && (
+          <WebhookSection<RepositoryFormData>
+            register={register}
+            name="webhook.baseUrl"
+            disabledName="webhook.disabled"
+          />
+        )}
 
         {isGitBased && (
           <ControlledCollapse

--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -107,8 +107,6 @@ export function ConfigForm({ data }: ConfigFormProps) {
   useEffect(() => {
     if (connectionWebhookDisabled) {
       setValue('webhook.disabled', true);
-    } else {
-      setValue('webhook.disabled', false);
     }
   }, [connectionWebhookDisabled, setValue]);
 
@@ -437,6 +435,7 @@ export function ConfigForm({ data }: ConfigFormProps) {
             name="webhook.baseUrl"
             disabledName="webhook.disabled"
             connectionWebhookDisabled={connectionWebhookDisabled}
+            disabledError={errors?.webhook?.disabled?.message}
           />
         )}
 

--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -107,6 +107,8 @@ export function ConfigForm({ data }: ConfigFormProps) {
   useEffect(() => {
     if (connectionWebhookDisabled) {
       setValue('webhook.disabled', true);
+    } else {
+      setValue('webhook.disabled', false);
     }
   }, [connectionWebhookDisabled, setValue]);
 

--- a/public/app/features/provisioning/Config/WebhookSection.test.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.test.tsx
@@ -8,8 +8,10 @@ import { type RepositoryFormData } from '../types';
 import { WebhookSection } from './WebhookSection';
 
 function Wrapper() {
-  const { register } = useForm<RepositoryFormData>();
-  return <WebhookSection register={register} name="webhook.baseUrl" disabledName="webhook.disabled" />;
+  const { register, control } = useForm<RepositoryFormData>();
+  return (
+    <WebhookSection register={register} control={control} name="webhook.baseUrl" disabledName="webhook.disabled" />
+  );
 }
 
 describe('WebhookSection', () => {
@@ -30,6 +32,18 @@ describe('WebhookSection', () => {
     expect(screen.queryByText('Webhook URL')).not.toBeInTheDocument();
   });
 
+  it('renders the disable webhook checkbox under webhook.disabled when expanded', async () => {
+    const { user } = render(<Wrapper />);
+
+    await user.click(screen.getByText('Webhook options'));
+
+    expect(screen.getByText('Disable webhook integration')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /disable webhook integration/i })).toHaveAttribute(
+      'name',
+      'webhook.disabled'
+    );
+  });
+
   it('registers the webhook URL input under webhook.baseUrl when expanded', async () => {
     const { user } = render(<Wrapper />);
 
@@ -37,6 +51,15 @@ describe('WebhookSection', () => {
 
     expect(screen.getByText('Webhook URL')).toBeInTheDocument();
     expect(screen.getByRole('textbox')).toHaveAttribute('name', 'webhook.baseUrl');
+  });
+
+  it('disables the webhook URL input when the disable checkbox is checked', async () => {
+    const { user } = render(<Wrapper />);
+
+    await user.click(screen.getByText('Webhook options'));
+    await user.click(screen.getByRole('checkbox', { name: /disable webhook integration/i }));
+
+    expect(screen.getByRole('textbox')).toBeDisabled();
   });
 
   it('shows the learn more link on private instances', async () => {

--- a/public/app/features/provisioning/Config/WebhookSection.test.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.test.tsx
@@ -7,10 +7,16 @@ import { type RepositoryFormData } from '../types';
 
 import { WebhookSection } from './WebhookSection';
 
-function Wrapper() {
+function Wrapper({ connectionWebhookDisabled }: { connectionWebhookDisabled?: boolean }) {
   const { register, control } = useForm<RepositoryFormData>();
   return (
-    <WebhookSection register={register} control={control} name="webhook.baseUrl" disabledName="webhook.disabled" />
+    <WebhookSection
+      register={register}
+      control={control}
+      name="webhook.baseUrl"
+      disabledName="webhook.disabled"
+      connectionWebhookDisabled={connectionWebhookDisabled}
+    />
   );
 }
 
@@ -69,6 +75,35 @@ describe('WebhookSection', () => {
     await user.click(screen.getByText('Webhook options'));
 
     expect(screen.getByRole('link', { name: 'Learn more' })).toBeInTheDocument();
+  });
+
+  describe('connectionWebhookDisabled', () => {
+    it('disables the checkbox when connectionWebhookDisabled is true', async () => {
+      const { user } = render(<Wrapper connectionWebhookDisabled={true} />);
+
+      await user.click(screen.getByText('Webhook options'));
+
+      expect(screen.getByRole('checkbox', { name: /disable webhook integration/i })).toBeDisabled();
+    });
+
+    it('disables the URL input when connectionWebhookDisabled is true', async () => {
+      const { user } = render(<Wrapper connectionWebhookDisabled={true} />);
+
+      await user.click(screen.getByText('Webhook options'));
+
+      expect(screen.getByRole('textbox')).toBeDisabled();
+    });
+
+    it('enables the checkbox and shows the normal description when connectionWebhookDisabled is false', async () => {
+      const { user } = render(<Wrapper connectionWebhookDisabled={false} />);
+
+      await user.click(screen.getByText('Webhook options'));
+
+      expect(screen.getByRole('checkbox', { name: /disable webhook integration/i })).not.toBeDisabled();
+      expect(
+        screen.getByText(/when checked, grafana will not register or receive webhook events/i)
+      ).toBeInTheDocument();
+    });
   });
 
   it('hides the learn more link on public instances', async () => {

--- a/public/app/features/provisioning/Config/WebhookSection.test.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.test.tsx
@@ -9,7 +9,7 @@ import { WebhookSection } from './WebhookSection';
 
 function Wrapper() {
   const { register } = useForm<RepositoryFormData>();
-  return <WebhookSection register={register} name="webhook.baseUrl" />;
+  return <WebhookSection register={register} name="webhook.baseUrl" disabledName="webhook.disabled" />;
 }
 
 describe('WebhookSection', () => {

--- a/public/app/features/provisioning/Config/WebhookSection.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.tsx
@@ -1,7 +1,7 @@
 import { type FieldValues, type Path, type UseFormRegister } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
-import { ControlledCollapse, Field, Input, Stack, TextLink } from '@grafana/ui';
+import { Checkbox, ControlledCollapse, Field, Input, Stack, TextLink } from '@grafana/ui';
 
 import { checkPublicAccess } from '../GettingStarted/features';
 import { GETTING_STARTED_URL } from '../constants';
@@ -9,14 +9,25 @@ import { GETTING_STARTED_URL } from '../constants';
 export interface WebhookSectionProps<T extends FieldValues> {
   register: UseFormRegister<T>;
   name: Path<T>;
+  disabledName: Path<T>;
 }
 
-export function WebhookSection<T extends FieldValues>({ register, name }: WebhookSectionProps<T>) {
+export function WebhookSection<T extends FieldValues>({ register, name, disabledName }: WebhookSectionProps<T>) {
   const isPublic = checkPublicAccess();
 
   return (
     <ControlledCollapse label={t('provisioning.webhook-section.label-webhook', 'Webhook options')} isOpen={false}>
       <Stack direction="column" gap={2}>
+        <Field noMargin>
+          <Checkbox
+            {...register(disabledName)}
+            label={t('provisioning.webhook-section.label-webhook-disabled', 'Disable webhook integration')}
+            description={t(
+              'provisioning.webhook-section.description-webhook-disabled',
+              'When enabled, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.'
+            )}
+          />
+        </Field>
         <Field
           noMargin
           label={t('provisioning.webhook-section.label-webhook-url', 'Webhook URL')}

--- a/public/app/features/provisioning/Config/WebhookSection.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.tsx
@@ -1,4 +1,4 @@
-import { type FieldValues, type Path, type UseFormRegister } from 'react-hook-form';
+import { type Control, type FieldValues, type Path, type UseFormRegister, useWatch } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
 import { Checkbox, ControlledCollapse, Field, Input, Stack, TextLink } from '@grafana/ui';
@@ -8,28 +8,54 @@ import { GETTING_STARTED_URL } from '../constants';
 
 export interface WebhookSectionProps<T extends FieldValues> {
   register: UseFormRegister<T>;
+  control: Control<T>;
   name: Path<T>;
   disabledName: Path<T>;
+  connectionWebhookDisabled?: boolean;
 }
 
-export function WebhookSection<T extends FieldValues>({ register, name, disabledName }: WebhookSectionProps<T>) {
+export function WebhookSection<T extends FieldValues>({
+  register,
+  control,
+  name,
+  disabledName,
+  connectionWebhookDisabled,
+}: WebhookSectionProps<T>) {
   const isPublic = checkPublicAccess();
+  const webhookDisabled = Boolean(useWatch({ control, name: disabledName }));
+  const urlDisabled = webhookDisabled || Boolean(connectionWebhookDisabled);
 
   return (
     <ControlledCollapse label={t('provisioning.webhook-section.label-webhook', 'Webhook options')} isOpen={false}>
       <Stack direction="column" gap={2}>
-        <Field noMargin>
+        <Field
+          noMargin
+          description={
+            connectionWebhookDisabled
+              ? t(
+                  'provisioning.webhook-section.description-webhook-disabled-forced',
+                  'Webhook integration is disabled because the referenced GitHub App connection has webhook integration disabled.'
+                )
+              : undefined
+          }
+        >
           <Checkbox
             {...register(disabledName)}
+            disabled={connectionWebhookDisabled}
             label={t('provisioning.webhook-section.label-webhook-disabled', 'Disable webhook integration')}
-            description={t(
-              'provisioning.webhook-section.description-webhook-disabled',
-              'When enabled, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.'
-            )}
+            description={
+              connectionWebhookDisabled
+                ? undefined
+                : t(
+                    'provisioning.webhook-section.description-webhook-disabled',
+                    'When checked, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.'
+                  )
+            }
           />
         </Field>
         <Field
           noMargin
+          disabled={urlDisabled}
           label={t('provisioning.webhook-section.label-webhook-url', 'Webhook URL')}
           description={
             <>
@@ -49,6 +75,7 @@ export function WebhookSection<T extends FieldValues>({ register, name, disabled
         >
           <Input
             {...register(name)}
+            disabled={urlDisabled}
             placeholder={t('provisioning.webhook-section.placeholder-webhook-url', 'https://grafana.example.com')}
           />
         </Field>

--- a/public/app/features/provisioning/Config/WebhookSection.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.tsx
@@ -12,6 +12,7 @@ export interface WebhookSectionProps<T extends FieldValues> {
   name: Path<T>;
   disabledName: Path<T>;
   connectionWebhookDisabled?: boolean;
+  disabledError?: string;
 }
 
 export function WebhookSection<T extends FieldValues>({
@@ -20,6 +21,7 @@ export function WebhookSection<T extends FieldValues>({
   name,
   disabledName,
   connectionWebhookDisabled,
+  disabledError,
 }: WebhookSectionProps<T>) {
   const isPublic = checkPublicAccess();
   const webhookDisabled = Boolean(useWatch({ control, name: disabledName }));
@@ -30,6 +32,8 @@ export function WebhookSection<T extends FieldValues>({
       <Stack direction="column" gap={2}>
         <Field
           noMargin
+          invalid={!!disabledError}
+          error={disabledError}
           description={
             connectionWebhookDisabled
               ? t(
@@ -55,7 +59,6 @@ export function WebhookSection<T extends FieldValues>({
         </Field>
         <Field
           noMargin
-          disabled={urlDisabled}
           label={t('provisioning.webhook-section.label-webhook-url', 'Webhook URL')}
           description={
             <>

--- a/public/app/features/provisioning/Connection/ConnectionForm.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.tsx
@@ -48,7 +48,7 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
     reset,
     register,
     control,
-    formState: { isDirty },
+    formState: { isDirty, errors },
     getValues,
     setError,
   } = formMethods;
@@ -149,7 +149,11 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
 
           <GitHubConnectionFields required={!isEdit} privateKeyConfigured={Boolean(privateKey)} />
 
-          <WebhookDisabledField registration={register('webhookDisabled')} />
+          <WebhookDisabledField
+            registration={register('webhookDisabled')}
+            invalid={!!errors.webhookDisabled}
+            error={errors.webhookDisabled?.message}
+          />
 
           <Stack gap={2}>
             <Button type="submit" disabled={request.isLoading}>

--- a/public/app/features/provisioning/Connection/ConnectionForm.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { t } from '@grafana/i18n';
 import { isFetchError, reportInteraction } from '@grafana/runtime';
-import { Alert, Button, Combobox, Field, Stack } from '@grafana/ui';
+import { Alert, Button, Checkbox, Combobox, Field, Stack } from '@grafana/ui';
 import { type Connection } from 'app/api/clients/provisioning/v0alpha1';
 import { extractErrorMessage } from 'app/api/utils';
 import { FormPrompt } from 'app/core/components/FormPrompt/FormPrompt';
@@ -38,12 +38,14 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
       appID: data?.spec?.github?.appID || '',
       installationID: data?.spec?.github?.installationID || '',
       privateKey: '',
+      webhookDisabled: data?.spec?.webhook?.disabled ?? false,
     },
   });
 
   const {
     handleSubmit,
     reset,
+    register,
     control,
     formState: { isDirty },
     getValues,
@@ -87,6 +89,7 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
           appID: form.appID,
           installationID: form.installationID,
         },
+        ...(form.webhookDisabled ? { webhook: { disabled: true } } : {}),
       };
 
       await submitData(spec, form.privateKey);
@@ -144,6 +147,17 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
           </Field>
 
           <GitHubConnectionFields required={!isEdit} privateKeyConfigured={Boolean(privateKey)} />
+
+          <Field noMargin>
+            <Checkbox
+              {...register('webhookDisabled')}
+              label={t('provisioning.connection-form.label-webhook-disabled', 'Disable webhook integration')}
+              description={t(
+                'provisioning.connection-form.description-webhook-disabled',
+                'When enabled, the GitHub App does not require webhooks:write permission and Grafana will not register or receive webhook events. Use this when Grafana is not reachable from the public internet.'
+              )}
+            />
+          </Field>
 
           <Stack gap={2}>
             <Button type="submit" disabled={request.isLoading}>

--- a/public/app/features/provisioning/Connection/ConnectionForm.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.tsx
@@ -4,12 +4,13 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { t } from '@grafana/i18n';
 import { isFetchError, reportInteraction } from '@grafana/runtime';
-import { Alert, Button, Checkbox, Combobox, Field, Stack } from '@grafana/ui';
+import { Alert, Button, Combobox, Field, Stack } from '@grafana/ui';
 import { type Connection } from 'app/api/clients/provisioning/v0alpha1';
 import { extractErrorMessage } from 'app/api/utils';
 import { FormPrompt } from 'app/core/components/FormPrompt/FormPrompt';
 
 import { GitHubConnectionFields } from '../components/Shared/GitHubConnectionFields';
+import { WebhookDisabledField } from '../components/Shared/WebhookDisabledField';
 import { CONNECTIONS_TAB_URL } from '../constants';
 import { useCreateOrUpdateConnection } from '../hooks/useCreateOrUpdateConnection';
 import { type ConnectionFormData } from '../types';
@@ -148,16 +149,7 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
 
           <GitHubConnectionFields required={!isEdit} privateKeyConfigured={Boolean(privateKey)} />
 
-          <Field noMargin>
-            <Checkbox
-              {...register('webhookDisabled')}
-              label={t('provisioning.connection-form.label-webhook-disabled', 'Disable webhook integration')}
-              description={t(
-                'provisioning.connection-form.description-webhook-disabled',
-                'When enabled, the GitHub App does not require webhooks:write permission and Grafana will not register or receive webhook events. Use this when Grafana is not reachable from the public internet.'
-              )}
-            />
-          </Field>
+          <WebhookDisabledField registration={register('webhookDisabled')} />
 
           <Stack gap={2}>
             <Button type="submit" disabled={request.isLoading}>

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -146,7 +146,13 @@ export const FinishStep = memo(function FinishStep() {
         </>
       )}
 
-      {isGithub && <WebhookSection<WizardFormData> register={register} name="repository.webhook.baseUrl" />}
+      {isGithub && (
+        <WebhookSection<WizardFormData>
+          register={register}
+          name="repository.webhook.baseUrl"
+          disabledName="repository.webhook.disabled"
+        />
+      )}
     </Stack>
   );
 });

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -1,4 +1,5 @@
-import { memo, useEffect } from 'react';
+import { skipToken } from '@reduxjs/toolkit/query';
+import { memo, useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { t } from '@grafana/i18n';
@@ -9,6 +10,7 @@ import { CommitOptionsSection } from '../Config/CommitOptionsSection';
 import { EnablePushToConfiguredBranchOption } from '../Config/EnablePushToConfiguredBranchOption';
 import { PullRequestOptionsSection } from '../Config/PullRequestOptionsSection';
 import { WebhookSection } from '../Config/WebhookSection';
+import { useConnectionList } from '../hooks/useConnectionList';
 import { isGitProvider } from '../utils/repositoryTypes';
 
 import { useStepStatus } from './StepStatusContext';
@@ -25,15 +27,35 @@ export const FinishStep = memo(function FinishStep() {
     formState: { errors },
   } = useFormContext<WizardFormData>();
 
-  const [type, readOnly] = watch(['repository.type', 'repository.readOnly']);
+  const [type, readOnly, wizardConnectionName] = watch([
+    'repository.type',
+    'repository.readOnly',
+    'githubApp.connectionName',
+  ]);
 
   const isGithub = type === 'github';
   const isGitBased = isGitProvider(type);
+
+  const [connections] = useConnectionList(isGithub ? {} : skipToken);
+  const connectionWebhookDisabled = useMemo(() => {
+    if (!wizardConnectionName || !connections) {
+      return false;
+    }
+    const conn = connections.find((c) => c.metadata?.name === wizardConnectionName);
+    return Boolean(conn?.spec?.webhook?.disabled);
+  }, [wizardConnectionName, connections]);
 
   // Set sync enabled by default
   useEffect(() => {
     setValue('repository.sync.enabled', true);
   }, [setValue]);
+
+  // Auto-set webhook disabled when the selected connection requires it
+  useEffect(() => {
+    if (connectionWebhookDisabled) {
+      setValue('repository.webhook.disabled', true);
+    }
+  }, [connectionWebhookDisabled, setValue]);
 
   useEffect(() => {
     if (!hasStepError) {
@@ -149,8 +171,10 @@ export const FinishStep = memo(function FinishStep() {
       {isGithub && (
         <WebhookSection<WizardFormData>
           register={register}
+          control={control}
           name="repository.webhook.baseUrl"
           disabledName="repository.webhook.disabled"
+          connectionWebhookDisabled={connectionWebhookDisabled}
         />
       )}
     </Stack>

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -27,10 +27,11 @@ export const FinishStep = memo(function FinishStep() {
     formState: { errors },
   } = useFormContext<WizardFormData>();
 
-  const [type, readOnly, wizardConnectionName] = watch([
+  const [type, readOnly, wizardConnectionName, githubAuthType] = watch([
     'repository.type',
     'repository.readOnly',
     'githubApp.connectionName',
+    'githubAuthType',
   ]);
 
   const isGithub = type === 'github';
@@ -38,22 +39,24 @@ export const FinishStep = memo(function FinishStep() {
 
   const [connections] = useConnectionList(isGithub ? {} : skipToken);
   const connectionWebhookDisabled = useMemo(() => {
-    if (!wizardConnectionName || !connections) {
+    if (githubAuthType !== 'github-app' || !wizardConnectionName || !connections) {
       return false;
     }
     const conn = connections.find((c) => c.metadata?.name === wizardConnectionName);
     return Boolean(conn?.spec?.webhook?.disabled);
-  }, [wizardConnectionName, connections]);
+  }, [githubAuthType, wizardConnectionName, connections]);
 
   // Set sync enabled by default
   useEffect(() => {
     setValue('repository.sync.enabled', true);
   }, [setValue]);
 
-  // Auto-set webhook disabled when the selected connection requires it
+  // Auto-set webhook disabled when the selected connection requires it, clear when it no longer does
   useEffect(() => {
     if (connectionWebhookDisabled) {
       setValue('repository.webhook.disabled', true);
+    } else {
+      setValue('repository.webhook.disabled', false);
     }
   }, [connectionWebhookDisabled, setValue]);
 

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -37,7 +37,7 @@ export const FinishStep = memo(function FinishStep() {
   const isGithub = type === 'github';
   const isGitBased = isGitProvider(type);
 
-  const [connections] = useConnectionList(isGithub ? {} : skipToken);
+  const [connections] = useConnectionList(isGithub && githubAuthType === 'github-app' ? {} : skipToken);
   const connectionWebhookDisabled = useMemo(() => {
     if (githubAuthType !== 'github-app' || !wizardConnectionName || !connections) {
       return false;
@@ -51,12 +51,10 @@ export const FinishStep = memo(function FinishStep() {
     setValue('repository.sync.enabled', true);
   }, [setValue]);
 
-  // Auto-set webhook disabled when the selected connection requires it, clear when it no longer does
+  // Force webhook disabled when the selected connection requires it
   useEffect(() => {
     if (connectionWebhookDisabled) {
       setValue('repository.webhook.disabled', true);
-    } else {
-      setValue('repository.webhook.disabled', false);
     }
   }, [connectionWebhookDisabled, setValue]);
 
@@ -178,6 +176,7 @@ export const FinishStep = memo(function FinishStep() {
           name="repository.webhook.baseUrl"
           disabledName="repository.webhook.disabled"
           connectionWebhookDisabled={connectionWebhookDisabled}
+          disabledError={errors?.repository?.webhook?.disabled?.message}
         />
       )}
     </Stack>

--- a/public/app/features/provisioning/Wizard/GitHubAppFields.tsx
+++ b/public/app/features/provisioning/Wizard/GitHubAppFields.tsx
@@ -224,7 +224,11 @@ export function GitHubAppFields({ onGitHubAppSubmit }: GitHubAppFieldsProps) {
             onNewConnectionCreation={handleCreateConnection}
             isCreating={connectionRequest.isLoading}
           />
-          <WebhookDisabledField registration={credentialForm.register('webhookDisabled')} />
+          <WebhookDisabledField
+            registration={credentialForm.register('webhookDisabled')}
+            invalid={!!credentialForm.formState.errors.webhookDisabled}
+            error={credentialForm.formState.errors.webhookDisabled?.message}
+          />
         </FormProvider>
       )}
     </Stack>

--- a/public/app/features/provisioning/Wizard/GitHubAppFields.tsx
+++ b/public/app/features/provisioning/Wizard/GitHubAppFields.tsx
@@ -5,12 +5,13 @@ import { Controller, FormProvider, useForm, useFormContext } from 'react-hook-fo
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
-import { Alert, Checkbox, Combobox, Field, RadioButtonGroup, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, Combobox, Field, RadioButtonGroup, Stack, useStyles2 } from '@grafana/ui';
 import { type ConnectionSpec } from 'app/api/clients/provisioning/v0alpha1';
 import { extractErrorMessage } from 'app/api/utils';
 
 import { ConnectionStatusBadge } from '../Connection/ConnectionStatusBadge';
 import { GitHubConnectionFields } from '../components/Shared/GitHubConnectionFields';
+import { WebhookDisabledField } from '../components/Shared/WebhookDisabledField';
 import { useConnectionOptions } from '../hooks/useConnectionOptions';
 import { useConnectionStatus } from '../hooks/useConnectionStatus';
 import { useCreateOrUpdateConnection } from '../hooks/useCreateOrUpdateConnection';
@@ -223,16 +224,7 @@ export function GitHubAppFields({ onGitHubAppSubmit }: GitHubAppFieldsProps) {
             onNewConnectionCreation={handleCreateConnection}
             isCreating={connectionRequest.isLoading}
           />
-          <Field noMargin>
-            <Checkbox
-              {...credentialForm.register('webhookDisabled')}
-              label={t('provisioning.connection-form.label-webhook-disabled', 'Disable webhook integration')}
-              description={t(
-                'provisioning.connection-form.description-webhook-disabled',
-                'When enabled, the GitHub App does not require webhooks:write permission and Grafana will not register or receive webhook events. Use this when Grafana is not reachable from the public internet.'
-              )}
-            />
-          </Field>
+          <WebhookDisabledField registration={credentialForm.register('webhookDisabled')} />
         </FormProvider>
       )}
     </Stack>

--- a/public/app/features/provisioning/Wizard/GitHubAppFields.tsx
+++ b/public/app/features/provisioning/Wizard/GitHubAppFields.tsx
@@ -5,7 +5,7 @@ import { Controller, FormProvider, useForm, useFormContext } from 'react-hook-fo
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
-import { Alert, Combobox, Field, RadioButtonGroup, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, Checkbox, Combobox, Field, RadioButtonGroup, Stack, useStyles2 } from '@grafana/ui';
 import { type ConnectionSpec } from 'app/api/clients/provisioning/v0alpha1';
 import { extractErrorMessage } from 'app/api/utils';
 
@@ -45,6 +45,7 @@ export function GitHubAppFields({ onGitHubAppSubmit }: GitHubAppFieldsProps) {
       appID: '',
       installationID: '',
       privateKey: '',
+      webhookDisabled: false,
     },
   });
 
@@ -77,12 +78,13 @@ export function GitHubAppFields({ onGitHubAppSubmit }: GitHubAppFieldsProps) {
       return;
     }
 
-    const { title, description, appID, installationID, privateKey } = credentialForm.getValues();
+    const { title, description, appID, installationID, privateKey, webhookDisabled } = credentialForm.getValues();
     const spec: ConnectionSpec = {
       type: 'github',
       title,
       ...(description && { description }),
       github: { appID, installationID },
+      ...(webhookDisabled ? { webhook: { disabled: true } } : {}),
     };
 
     const defaultErrorMessage = t(
@@ -221,6 +223,16 @@ export function GitHubAppFields({ onGitHubAppSubmit }: GitHubAppFieldsProps) {
             onNewConnectionCreation={handleCreateConnection}
             isCreating={connectionRequest.isLoading}
           />
+          <Field noMargin>
+            <Checkbox
+              {...credentialForm.register('webhookDisabled')}
+              label={t('provisioning.connection-form.label-webhook-disabled', 'Disable webhook integration')}
+              description={t(
+                'provisioning.connection-form.description-webhook-disabled',
+                'When enabled, the GitHub App does not require webhooks:write permission and Grafana will not register or receive webhook events. Use this when Grafana is not reachable from the public internet.'
+              )}
+            />
+          </Field>
         </FormProvider>
       )}
     </Stack>

--- a/public/app/features/provisioning/components/Shared/WebhookDisabledField.tsx
+++ b/public/app/features/provisioning/components/Shared/WebhookDisabledField.tsx
@@ -1,0 +1,23 @@
+import { type UseFormRegisterReturn } from 'react-hook-form';
+
+import { t } from '@grafana/i18n';
+import { Checkbox, Field } from '@grafana/ui';
+
+interface Props {
+  registration: UseFormRegisterReturn;
+}
+
+export function WebhookDisabledField({ registration }: Props) {
+  return (
+    <Field noMargin>
+      <Checkbox
+        {...registration}
+        label={t('provisioning.connection-form.label-webhook-disabled', 'Disable webhook integration')}
+        description={t(
+          'provisioning.connection-form.description-webhook-disabled',
+          'When enabled, the GitHub App does not require webhooks:write permission and Grafana will not register or receive webhook events. Use this when Grafana is not reachable from the public internet.'
+        )}
+      />
+    </Field>
+  );
+}

--- a/public/app/features/provisioning/components/Shared/WebhookDisabledField.tsx
+++ b/public/app/features/provisioning/components/Shared/WebhookDisabledField.tsx
@@ -5,11 +5,13 @@ import { Checkbox, Field } from '@grafana/ui';
 
 interface Props {
   registration: UseFormRegisterReturn;
+  invalid?: boolean;
+  error?: string;
 }
 
-export function WebhookDisabledField({ registration }: Props) {
+export function WebhookDisabledField({ registration, invalid, error }: Props) {
   return (
-    <Field noMargin>
+    <Field noMargin invalid={invalid} error={error}>
       <Checkbox
         {...registration}
         label={t('provisioning.connection-form.label-webhook-disabled', 'Disable webhook integration')}

--- a/public/app/features/provisioning/types.ts
+++ b/public/app/features/provisioning/types.ts
@@ -49,6 +49,7 @@ export type ConnectionFormData = {
   appID: string;
   installationID: string;
   privateKey?: string;
+  webhookDisabled?: boolean;
 };
 
 // Added to DashboardDTO to help editor

--- a/public/app/features/provisioning/utils/data.test.ts
+++ b/public/app/features/provisioning/utils/data.test.ts
@@ -188,7 +188,29 @@ describe('provisioning data mapping', () => {
       expect(spec.webhook).toBeUndefined();
     });
 
-    it('reads webhook from spec to form data', () => {
+    it('sets disabled:true and omits baseUrl when disabled is true', () => {
+      const formData = makeFormData('github');
+      formData.webhook = { disabled: true, baseUrl: 'https://grafana.example.com' };
+      const spec = dataToSpec(formData);
+      expect(spec.webhook).toEqual({ disabled: true });
+      expect(spec.webhook).not.toHaveProperty('baseUrl');
+    });
+
+    it('sets disabled:true and omits baseUrl when disabled is true and baseUrl is absent', () => {
+      const formData = makeFormData('github');
+      formData.webhook = { disabled: true };
+      const spec = dataToSpec(formData);
+      expect(spec.webhook).toEqual({ disabled: true });
+    });
+
+    it('omits disabled when disabled is false and includes baseUrl', () => {
+      const formData = makeFormData('github');
+      formData.webhook = { disabled: false, baseUrl: 'https://grafana.example.com' };
+      const spec = dataToSpec(formData);
+      expect(spec.webhook).toEqual({ baseUrl: 'https://grafana.example.com' });
+    });
+
+    it('reads webhook baseUrl from spec to form data', () => {
       const spec: RepositorySpec = {
         type: 'github',
         title: 'repo',
@@ -199,6 +221,20 @@ describe('provisioning data mapping', () => {
       };
       const data = specToData(spec);
       expect(data.webhook?.baseUrl).toBe('https://grafana.example.com');
+    });
+
+    it('reads webhook disabled:true from spec to form data', () => {
+      const spec: RepositorySpec = {
+        type: 'github',
+        title: 'repo',
+        sync: baseSync,
+        workflows: [],
+        github: { url: 'https://github.com/owner/repo', branch: 'main', path: '' },
+        webhook: { disabled: true },
+      };
+      const data = specToData(spec);
+      expect(data.webhook?.disabled).toBe(true);
+      expect(data.webhook?.baseUrl).toBeUndefined();
     });
   });
 

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -109,8 +109,11 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
     spec.pullRequest = pullRequest;
   }
 
-  if (data.webhook?.baseUrl) {
-    spec.webhook = { baseUrl: data.webhook.baseUrl };
+  if (data.webhook?.baseUrl || data.webhook?.disabled) {
+    spec.webhook = {
+      ...(data.webhook.baseUrl ? { baseUrl: data.webhook.baseUrl } : {}),
+      ...(data.webhook.disabled ? { disabled: true } : {}),
+    };
   }
 
   const baseConfig = {

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -110,9 +110,10 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
   }
 
   if (data.webhook?.baseUrl || data.webhook?.disabled) {
+    const webhookDisabled = Boolean(data.webhook?.disabled);
     spec.webhook = {
-      ...(data.webhook.baseUrl ? { baseUrl: data.webhook.baseUrl } : {}),
-      ...(data.webhook.disabled ? { disabled: true } : {}),
+      ...(webhookDisabled ? { disabled: true } : {}),
+      ...(!webhookDisabled && data.webhook?.baseUrl ? { baseUrl: data.webhook.baseUrl } : {}),
     };
   }
 

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -109,12 +109,10 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
     spec.pullRequest = pullRequest;
   }
 
-  if (data.webhook?.baseUrl || data.webhook?.disabled) {
-    const webhookDisabled = Boolean(data.webhook?.disabled);
-    spec.webhook = {
-      ...(webhookDisabled ? { disabled: true } : {}),
-      ...(!webhookDisabled && data.webhook?.baseUrl ? { baseUrl: data.webhook.baseUrl } : {}),
-    };
+  if (data.webhook?.disabled) {
+    spec.webhook = { disabled: true };
+  } else if (data.webhook?.baseUrl) {
+    spec.webhook = { baseUrl: data.webhook.baseUrl };
   }
 
   const baseConfig = {

--- a/public/app/features/provisioning/utils/getFormErrors.ts
+++ b/public/app/features/provisioning/utils/getFormErrors.ts
@@ -7,7 +7,10 @@ import { type WizardFormData } from '../Wizard/types';
 import { type ConnectionFormData, type RepositoryFormData } from '../types';
 
 type RepositoryField = keyof WizardFormData['repository'];
-type RepositoryFormPath = `repository.${RepositoryField}` | 'repository.sync.intervalSeconds';
+type RepositoryFormPath =
+  | `repository.${RepositoryField}`
+  | 'repository.sync.intervalSeconds'
+  | 'repository.webhook.disabled';
 
 type GenericFormPath = string;
 type GenericFormErrors<T extends GenericFormPath> = Array<[T, { message: string }]>;
@@ -114,6 +117,7 @@ export const getFormErrors = (data: ErrorDetails[] | Status): FormErrors => {
     'git.branch': 'repository.branch',
     'git.url': 'repository.url',
     'sync.intervalSeconds': 'repository.sync.intervalSeconds',
+    'webhook.disabled': 'repository.webhook.disabled',
   };
 
   const errors = extractFormErrors(data);
@@ -155,6 +159,7 @@ export const getConnectionFormErrors = (data: ErrorDetails[] | Status): Connecti
     'github.installationID': 'installationID',
     'secure.privateKey': 'privateKey',
     privateKey: 'privateKey',
+    'webhook.disabled': 'webhookDisabled',
   };
 
   const errors = extractFormErrors(data);

--- a/public/app/features/provisioning/utils/getFormErrors.ts
+++ b/public/app/features/provisioning/utils/getFormErrors.ts
@@ -132,6 +132,7 @@ export const getConfigFormErrors = (data: ErrorDetails[] | Status): ConfigFormEr
     token: 'token',
     tokenUser: 'tokenUser',
     'sync.intervalSeconds': 'sync.intervalSeconds',
+    'webhook.disabled': 'webhook.disabled',
   };
 
   const errors = extractFormErrors(data);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13745,7 +13745,8 @@
       "error-title": "Live updates unavailable"
     },
     "webhook-section": {
-      "description-webhook-disabled": "When enabled, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.",
+      "description-webhook-disabled": "When checked, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.",
+      "description-webhook-disabled-forced": "Webhook integration is disabled because the referenced GitHub App connection has webhook integration disabled.",
       "description-webhook-url": "Overrides the auto-detected URL for registering webhooks.",
       "description-webhook-url-learn-more": "Learn more",
       "label-webhook": "Webhook options",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13067,6 +13067,7 @@
       "description-private-key": "The private key for your GitHub App in PEM format",
       "description-provider": "Select the provider type",
       "description-title": "A human-readable name for this connection",
+      "description-webhook-disabled": "When enabled, the GitHub App does not require webhooks:write permission and Grafana will not register or receive webhook events. Use this when Grafana is not reachable from the public internet.",
       "error-delete-connection": "Failed to delete connection",
       "error-required": "This field is required",
       "error-save-connection": "Failed to save connection",
@@ -13078,6 +13079,7 @@
       "label-private-key": "Private Key (PEM)",
       "label-provider": "Provider",
       "label-title": "Title",
+      "label-webhook-disabled": "Disable webhook integration",
       "not-found": "Connection not found",
       "not-found-description": "The connection you are looking for does not exist.",
       "page-subtitle": "Configure a connection to authenticate with external providers",
@@ -13743,9 +13745,11 @@
       "error-title": "Live updates unavailable"
     },
     "webhook-section": {
+      "description-webhook-disabled": "When enabled, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.",
       "description-webhook-url": "Overrides the auto-detected URL for registering webhooks.",
       "description-webhook-url-learn-more": "Learn more",
       "label-webhook": "Webhook options",
+      "label-webhook-disabled": "Disable webhook integration",
       "label-webhook-url": "Webhook URL",
       "placeholder-webhook-url": "https://grafana.example.com"
     },


### PR DESCRIPTION
**What is this feature?**

Adds a "Disable webhook integration" checkbox to the GitHub App connection
form, the repository config form, and the repository setup wizard. This
exposes `webhook.disabled` in the UI, completing the work started in
#126129, #126330, and #126757.

**Why do we need this feature?**

The `webhook.disabled` field was previously only settable via the API.
Users running Grafana in a private network with a GitHub App that lacks
`webhooks:write` permission had no way to configure polling-only sync
through the UI.

**Who is this feature for?**

Users running Grafana in a private network who want to use polling-based
Git Sync instead of webhooks, configured directly through the UI rather
than the API.

**Which issue(s) does this PR fix?**

Part of #125833

**Changes**

- `WebhookSection.tsx` — add a `disabledName` prop and render a checkbox
  to toggle `webhook.disabled`, shown above the webhook URL field
- `ConfigForm.tsx` — pass `disabledName="webhook.disabled"` to
  `WebhookSection` for repository config
- `FinishStep.tsx` — pass `disabledName="repository.webhook.disabled"` to
  `WebhookSection` in the setup wizard
- `ConnectionForm.tsx` — add a standalone checkbox for
  `webhook.disabled` on the GitHub App connection form, since connections
  don't use `WebhookSection`
- `types.ts` — add `webhookDisabled?: boolean` to `ConnectionFormData`
- `utils/data.ts` — include `disabled` in the constructed `webhook` spec
  when set
- `WebhookSection.test.tsx` — update test to pass the new required
  `disabledName` prop

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

### How to test

1. Create a new GitHub App connection and check "Disable webhook
   integration." Save and confirm `spec.webhook.disabled: true` is set.
2. Create or edit a GitHub repository using a connection with
   `webhook.disabled: true`, and confirm the checkbox is available.
3. Run through the setup wizard for a GitHub repository and confirm the
   checkbox appears in the finish step's webhook section.