### PR TITLE
Search: index created and updated as standard search fields

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -628,7 +628,12 @@ func StandardSearchFields() SearchableDocumentFields {
 			{
 				Name:        SEARCH_FIELD_CREATED,
 				Type:        resourcepb.ResourceTableColumnDefinition_INT64,
-				Description: "created timestamp", // date?
+				Description: "created timestamp (unix millis)",
+			},
+			{
+				Name:        SEARCH_FIELD_UPDATED,
+				Type:        resourcepb.ResourceTableColumnDefinition_INT64,
+				Description: "updated timestamp (unix millis)",
 			},
 			{
 				Name:        SEARCH_FIELD_CREATED_BY,

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"slices"
 	"strings"
 
@@ -224,12 +225,17 @@ type SearchFieldsProvider interface {
 	// when no preferred version has been registered.
 	PreferredVersion(group, resource string) string
 
-	// IndexAffectingHash returns a stable hex hash over every
-	// SearchFieldDefinition registered for (group, resource), across all
-	// versions. Only fields that change what gets indexed are mixed in:
-	// Name, Path, Type, Array, Capabilities (sorted), EmitZeroIfAbsent,
-	// CopyFromStandard. Description is intentionally excluded so
-	// presentation-only edits do not trigger a rebuild.
+	// IndexAffectingHash returns a stable hex hash that mixes both the
+	// shared StandardSearchFieldDefinitions and every per-(group, resource)
+	// SearchFieldDefinition across all registered versions. Only fields
+	// that change what gets indexed contribute: Name, Path, Type, Array,
+	// Capabilities (sorted), EmitZeroIfAbsent, CopyFromStandard.
+	// Description is intentionally excluded so presentation-only edits do
+	// not trigger a rebuild.
+	//
+	// Including the standard set means a change to the shared mapping
+	// shifts every registered kind's hash, which is the intended trigger
+	// for an automatic rebuild via IndexBuildInfo.SearchFieldsHash.
 	//
 	// Returns the empty string when no SearchFieldDefinitions are
 	// registered for the (group, resource). Callers treat "" as "no
@@ -248,6 +254,11 @@ type mapProvider struct {
 // NewMapProvider returns a SearchFieldsProvider backed by the given in-memory
 // maps. Both arguments may be nil. The provider takes ownership of the maps;
 // callers must not mutate them after the call.
+//
+// Panics if any SearchFieldDefinition violates validateSearchFieldDefinitions
+// (e.g. SearchCapabilitySort declared on a numeric or boolean type). Such a
+// declaration is a programmer error in static configuration; the process
+// cannot serve correct results with an invalid mapping.
 func NewMapProvider(fields map[schema.GroupVersionResource][]SearchFieldDefinition, preferredVersions map[schema.GroupResource]string) SearchFieldsProvider {
 	if fields == nil {
 		fields = map[schema.GroupVersionResource][]SearchFieldDefinition{}
@@ -255,10 +266,42 @@ func NewMapProvider(fields map[schema.GroupVersionResource][]SearchFieldDefiniti
 	if preferredVersions == nil {
 		preferredVersions = map[schema.GroupResource]string{}
 	}
+	for gvr, sfds := range fields {
+		if err := validateSearchFieldDefinitions(sfds); err != nil {
+			panic("invalid SearchFieldDefinitions for " + gvr.String() + ": " + err.Error())
+		}
+	}
 	return &mapProvider{
 		fields:           fields,
 		preferredVersion: preferredVersions,
 	}
+}
+
+// sortableTypes lists SearchFieldTypes that can carry SearchCapabilitySort
+// under today's bleve mapper. The mapper emits a keyword/text mapping for
+// every field regardless of Type, so sort works only for fields whose
+// extracted value is already string-shaped. The allowlist is intentionally
+// minimal: extend it when a concrete consumer needs sort on a new type.
+var sortableTypes = []SearchFieldType{
+	SearchFieldTypeString,
+}
+
+// validateSearchFieldDefinitions returns a non-nil error when any declaration
+// uses a capability that the current bleve mapper cannot honour. The only
+// rule enforced today is that SearchCapabilitySort requires a string-mapped
+// Type; numeric and boolean fields would otherwise be sorted lexically
+// because the mapper does not emit numeric mappings yet.
+func validateSearchFieldDefinitions(sfds []SearchFieldDefinition) error {
+	var violations []string
+	for _, sfd := range sfds {
+		if slices.Contains(sfd.Capabilities, SearchCapabilitySort) && !slices.Contains(sortableTypes, sfd.Type) {
+			violations = append(violations, "field "+sfd.Name+": sort capability is not supported for type "+string(sfd.Type))
+		}
+	}
+	if len(violations) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(violations, "; "))
 }
 
 func (p *mapProvider) Fields(gvr schema.GroupVersionResource) []SearchFieldDefinition {
@@ -292,6 +335,39 @@ type hashableVersion struct {
 	Fields  []hashableField `json:"f"`
 }
 
+// hashablePayload is the canonical hash input. Standard search fields
+// (shared by every kind) are mixed in alongside per-(group, resource)
+// versioned fields so that changes to the standard set shift every kind's
+// hash and trigger a rebuild via the SearchFieldsHash check.
+type hashablePayload struct {
+	Standard []hashableField   `json:"s"`
+	Versions []hashableVersion `json:"v"`
+}
+
+// canonicalHashableFields normalises a SearchFieldDefinition slice into
+// hashableField form: capabilities sorted, fields sorted by name, only the
+// index-affecting subset retained.
+func canonicalHashableFields(sfds []SearchFieldDefinition) []hashableField {
+	fields := make([]hashableField, 0, len(sfds))
+	for _, sfd := range sfds {
+		caps := slices.Clone(sfd.Capabilities)
+		slices.Sort(caps)
+		fields = append(fields, hashableField{
+			Name:             sfd.Name,
+			Path:             sfd.Path,
+			Type:             sfd.Type,
+			Array:            sfd.Array,
+			Capabilities:     caps,
+			EmitZeroIfAbsent: sfd.EmitZeroIfAbsent,
+			CopyFromStandard: sfd.CopyFromStandard,
+		})
+	}
+	slices.SortFunc(fields, func(a, b hashableField) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return fields
+}
+
 func (p *mapProvider) IndexAffectingHash(group, resource string) string {
 	var versions []string
 	for gvr := range p.fields {
@@ -304,28 +380,17 @@ func (p *mapProvider) IndexAffectingHash(group, resource string) string {
 	}
 	slices.Sort(versions)
 
-	payload := make([]hashableVersion, 0, len(versions))
+	versionPayloads := make([]hashableVersion, 0, len(versions))
 	for _, v := range versions {
 		gvr := schema.GroupVersionResource{Group: group, Version: v, Resource: resource}
-		sfds := p.fields[gvr]
-		fields := make([]hashableField, 0, len(sfds))
-		for _, sfd := range sfds {
-			caps := slices.Clone(sfd.Capabilities)
-			slices.Sort(caps)
-			fields = append(fields, hashableField{
-				Name:             sfd.Name,
-				Path:             sfd.Path,
-				Type:             sfd.Type,
-				Array:            sfd.Array,
-				Capabilities:     caps,
-				EmitZeroIfAbsent: sfd.EmitZeroIfAbsent,
-				CopyFromStandard: sfd.CopyFromStandard,
-			})
-		}
-		slices.SortFunc(fields, func(a, b hashableField) int {
-			return strings.Compare(a.Name, b.Name)
+		versionPayloads = append(versionPayloads, hashableVersion{
+			Version: v,
+			Fields:  canonicalHashableFields(p.fields[gvr]),
 		})
-		payload = append(payload, hashableVersion{Version: v, Fields: fields})
+	}
+	payload := hashablePayload{
+		Standard: canonicalHashableFields(StandardSearchFieldDefinitions()),
+		Versions: versionPayloads,
 	}
 
 	// json.Marshal can only return a non-nil error for inputs it cannot

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -271,14 +271,17 @@ func TestMapProvider_IndexAffectingHash(t *testing.T) {
 
 // TestMapProvider_IndexAffectingHash_GoldenHash pins the hash output for a
 // fixed reference input. The hash is computed from json.Marshal of a
-// canonical struct payload; Go's encoding/json output for plain string,
-// bool, and []string fields is stable in practice but not explicitly
-// pinned by the language spec. If a Go release ever shifts the canonical
-// form (struct field encoding order, HTML-escape default, string escape
-// rules, etc.), this test fails immediately in CI rather than silently
-// reindexing every kind that registers a SearchFieldsProvider. When that
-// happens, update the literal and document the Go version that caused
-// the shift.
+// canonical struct payload that includes both StandardSearchFieldDefinitions
+// and the per-(group, resource) declarations; Go's encoding/json output
+// for plain string, bool, and []string fields is stable in practice but
+// not explicitly pinned by the language spec.
+//
+// If a Go release ever shifts the canonical form (struct field encoding
+// order, HTML-escape default, string escape rules, etc.), or if the
+// standard set changes intentionally, this test fails immediately in CI
+// rather than silently reindexing every kind that registers a
+// SearchFieldsProvider. When that happens, update the literal and
+// document the cause (Go upgrade vs deliberate standard-set change).
 func TestMapProvider_IndexAffectingHash_GoldenHash(t *testing.T) {
 	const (
 		group    = "example.test"
@@ -291,7 +294,7 @@ func TestMapProvider_IndexAffectingHash_GoldenHash(t *testing.T) {
 		v0: {
 			{Name: "email", Path: "spec.email", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}},
 			{Name: "disabled", Path: "spec.disabled", Type: SearchFieldTypeBoolean, Capabilities: []SearchCapability{SearchCapabilityRetrieve}, EmitZeroIfAbsent: true},
-			{Name: "createdAt", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve, SearchCapabilitySort}, CopyFromStandard: StandardFieldCreated},
+			{Name: "createdAt", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}, CopyFromStandard: StandardFieldCreated},
 			{Name: "members", Path: "spec.members[*].name", Type: SearchFieldTypeString, Array: true, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}},
 		},
 		v1: {
@@ -299,7 +302,77 @@ func TestMapProvider_IndexAffectingHash_GoldenHash(t *testing.T) {
 		},
 	}, nil)
 
-	const expected = "d466508d55b135a18f8e2636815a459a3ae5f2011c5ca63749cf4d48dbe5db34"
+	const expected = "4cbe51ac08dd6cbc987b353d503f253a9aa0b478b4c7ef09ee0c5e5f29644a20"
 	assert.Equal(t, expected, p.IndexAffectingHash(group, resource),
 		"canonical hash drifted. If json.Marshal output changed (Go release), update the literal; otherwise a code change shifted the canonical form.")
+}
+
+func TestValidateSearchFieldDefinitions(t *testing.T) {
+	t.Run("string with sort is valid", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "title", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilitySort}},
+		})
+		require.NoError(t, err)
+	})
+	t.Run("date with sort is rejected (allowlist is minimal)", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "when", Type: SearchFieldTypeDate, Capabilities: []SearchCapability{SearchCapabilitySort}},
+		})
+		require.Error(t, err)
+	})
+	t.Run("unknown with sort is rejected (forces explicit Type)", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "x", Type: SearchFieldTypeUnknown, Capabilities: []SearchCapability{SearchCapabilitySort}},
+		})
+		require.Error(t, err)
+	})
+	t.Run("int64 with sort is rejected", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "created", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilitySort}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "created")
+		assert.Contains(t, err.Error(), "int64")
+	})
+	t.Run("boolean with sort is rejected", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "disabled", Type: SearchFieldTypeBoolean, Capabilities: []SearchCapability{SearchCapabilitySort}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boolean")
+	})
+	t.Run("double with sort is rejected", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "score", Type: SearchFieldTypeDouble, Capabilities: []SearchCapability{SearchCapabilitySort}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "double")
+	})
+	t.Run("numeric without sort is valid", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "created", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}},
+		})
+		require.NoError(t, err)
+	})
+	t.Run("multiple violations reported together", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "a", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilitySort}},
+			{Name: "b", Type: SearchFieldTypeBoolean, Capabilities: []SearchCapability{SearchCapabilitySort}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "a")
+		assert.Contains(t, err.Error(), "b")
+	})
+	t.Run("NewMapProvider panics on invalid declarations", func(t *testing.T) {
+		gvr := schema.GroupVersionResource{Group: "example.test", Version: "v0", Resource: "widgets"}
+		assert.Panics(t, func() {
+			NewMapProvider(map[schema.GroupVersionResource][]SearchFieldDefinition{
+				gvr: {{Name: "bad", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilitySort}}},
+			}, nil)
+		})
+	})
+	t.Run("StandardSearchFieldDefinitions passes validation", func(t *testing.T) {
+		err := validateSearchFieldDefinitions(StandardSearchFieldDefinitions())
+		require.NoError(t, err)
+	})
 }

--- a/pkg/storage/unified/resource/standard_search_fields.go
+++ b/pkg/storage/unified/resource/standard_search_fields.go
@@ -7,9 +7,9 @@ package resource
 // Not every standard field appears here. Fields excluded:
 //
 //   - Pseudo / wire-only columns (_id, _legacy_id, _score, _explain,
-//     _all_columns, rv, kind, namespace, group/resource, created): they exist
-//     solely to populate ResourceTable column metadata in the gRPC response
-//     and are not indexed.
+//     _all_columns, rv, kind, namespace, group/resource): they exist solely
+//     to populate ResourceTable column metadata in the gRPC response and are
+//     not indexed.
 //   - Sub-document fields under "manager." and "source.": nested documents
 //     whose bleve mappings are emitted hardcoded.
 //   - Fields under "labels." and "reference.": open key sets, served by
@@ -81,6 +81,34 @@ func StandardSearchFieldDefinitions() []SearchFieldDefinition {
 			Type:         SearchFieldTypeString,
 			Capabilities: []SearchCapability{SearchCapabilityFacet},
 			Description:  "Manager identity in format {kind}:{id}; used for faceting.",
+		},
+		// created and updated are advertised in the proto column list but were
+		// never indexed before this declaration. Capabilities here are a
+		// compromise:
+		//
+		//   - retrieve: the actual intent — surface the timestamp in search
+		//     results so clients can display it.
+		//   - filter: required only because the bleve capability mapper does
+		//     not currently emit a mapping for retrieve-only fields. Filter
+		//     gives us a keyword mapping with Store: true. Exact-ms equality
+		//     filters are not a useful query and we expect no consumer to rely
+		//     on them.
+		//   - sort: omitted because the mapper emits a keyword mapping
+		//     regardless of Type, so int64 values would sort lexically.
+		//
+		// The end state is store-only with proper numeric semantics; both
+		// require a type-aware mapper, tracked as a follow-up.
+		{
+			Name:         SEARCH_FIELD_CREATED,
+			Type:         SearchFieldTypeInt64,
+			Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve},
+			Description:  "Creation timestamp (unix millis).",
+		},
+		{
+			Name:         SEARCH_FIELD_UPDATED,
+			Type:         SearchFieldTypeInt64,
+			Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve},
+			Description:  "Update timestamp (unix millis).",
 		},
 	}
 }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -7,6 +7,19 @@
         "enabled": false,
         "dynamic": false
       },
+      "created": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "createdBy": {
         "enabled": true,
         "dynamic": true,
@@ -223,6 +236,19 @@
             "analyzer": "keyword",
             "index": true,
             "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "updated": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
             "skip_freq_norm": true
           }
         ]

--- a/pkg/storage/unified/search/testdata/bleve_mapping_filterable_string.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_filterable_string.json
@@ -7,6 +7,19 @@
         "enabled": false,
         "dynamic": false
       },
+      "created": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "createdBy": {
         "enabled": true,
         "dynamic": true,
@@ -238,6 +251,19 @@
             "analyzer": "keyword",
             "index": true,
             "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "updated": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
             "skip_freq_norm": true
           }
         ]

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -7,6 +7,19 @@
         "enabled": false,
         "dynamic": false
       },
+      "created": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "createdBy": {
         "enabled": true,
         "dynamic": true,
@@ -251,6 +264,19 @@
             "analyzer": "keyword",
             "index": true,
             "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "updated": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
             "skip_freq_norm": true
           }
         ]

--- a/pkg/storage/unified/search/testdata/manual-dashboard.json
+++ b/pkg/storage/unified/search/testdata/manual-dashboard.json
@@ -40,7 +40,7 @@
       "name": "created",
       "type": "number",
       "format": "int64",
-      "description": "created timestamp",
+      "description": "created timestamp (unix millis)",
       "priority": 0
     },
     {

--- a/pkg/storage/unified/search/testdata/manual-folder.json
+++ b/pkg/storage/unified/search/testdata/manual-folder.json
@@ -40,7 +40,7 @@
       "name": "created",
       "type": "number",
       "format": "int64",
-      "description": "created timestamp",
+      "description": "created timestamp (unix millis)",
       "priority": 0
     },
     {


### PR DESCRIPTION
This unblocks IAM user-search consumer cleanup. #126328 exposed that the proto column list advertises `created` as a top-level int64 but the bleve mapping never indexes it; #126405 worked around that with a per-kind `USER_CREATED` declaration and a `CopyFromStandard` line in `UserSearchFields`. This PR adds `created` and `updated` to the standard set so every kind gets them indexed and retrievable; the IAM per-kind workaround can be removed in a separate follow-up. `updated` was missing from both proto and mapping sides and gets added at the same time.

Both fields ship with `[filter, retrieve]`. Retrieve is the intent; filter is a workaround because the bleve mapper emits no mapping for retrieve-only declarations today, so filter is the only way to get a stored keyword variant. Exact-ms equality filters are not a useful query. Sort is omitted because the mapper emits keyword/text regardless of declared type, so int64 values would sort lexically. Both compromises go away once the mapper learns to honour `SearchFieldDefinition.Type`, tracked as a follow-up.

`IndexAffectingHash` is extended so the shared standard set contributes alongside per-kind declarations, otherwise a change to standard fields would not trigger the automatic rebuild added in #126576. Kinds with a registered `SearchFieldsProvider` reindex automatically on rollout; others inherit the new mapping through the existing build-version cycle.

A new validator rejects `SearchCapabilitySort` on non-string-mapped types at provider construction time (panic — programmer-error semantics, caught at startup). The allowlist is intentionally minimal: only `SearchFieldTypeString`, extended when a concrete consumer needs sort on a new type.
