### PR TITLE
TraceView: add banner if the trace was restored by Adaptive Traces

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.test.tsx
+++ b/public/app/features/explore/TraceView/TraceView.test.tsx
@@ -1,17 +1,12 @@
-import { render, prettyDOM, screen, waitFor } from '@testing-library/react';
+import { render, prettyDOM, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { Provider } from 'react-redux';
+import { useAsync } from 'react-use';
 
 import { type DataFrame, MutableDataFrame } from '@grafana/data';
 import { mockTimeRange } from '@grafana/plugin-ui/test';
-import {
-  type DataSourceSrv,
-  isAppPluginInstalled,
-  setDataSourceSrv,
-  setPluginLinksHook,
-  setPluginComponentsHook,
-} from '@grafana/runtime';
+import { type DataSourceSrv, setDataSourceSrv, setPluginLinksHook, setPluginComponentsHook } from '@grafana/runtime';
 
 import { configureStore } from '../../../store/configureStore';
 
@@ -19,12 +14,12 @@ import { TraceView } from './TraceView';
 import { type TraceData, type TraceSpanData } from './components/types/trace';
 import { transformDataFrames } from './utils/transform';
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  isAppPluginInstalled: jest.fn(),
+jest.mock('react-use', () => ({
+  ...jest.requireActual('react-use'),
+  useAsync: jest.fn(),
 }));
 
-const mockIsAppPluginInstalled = isAppPluginInstalled as jest.MockedFunction<typeof isAppPluginInstalled>;
+const mockUseAsync = useAsync as jest.MockedFunction<typeof useAsync>;
 
 function getTraceView(frames: DataFrame[]) {
   const store = configureStore();
@@ -61,7 +56,15 @@ function renderTraceViewNew() {
 
 describe('TraceView', () => {
   beforeEach(() => {
-    mockIsAppPluginInstalled.mockImplementation(() => new Promise<boolean>(() => undefined));
+    mockUseAsync.mockReturnValue({
+      loading: false,
+      error: undefined,
+      value: undefined,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
   beforeAll(() => {
     setPluginLinksHook(() => ({
@@ -168,26 +171,36 @@ describe('TraceView', () => {
 
     it('does not render the banner when no span has the restored attribute', async () => {
       renderTraceView();
-      await waitFor(() => expect(mockIsAppPluginInstalled).toHaveBeenCalledWith('grafana-adaptivetraces-app'));
       expect(screen.queryByText(restoredBannerTitle)).not.toBeInTheDocument();
     });
 
     it('does not render the banner when grafana-adaptivetraces-app is not installed', async () => {
-      mockIsAppPluginInstalled.mockResolvedValue(false);
+      mockUseAsync.mockReturnValue({
+        loading: false,
+        error: undefined,
+        value: false,
+      });
       renderTraceView([frameRestoredByAdaptiveTraces]);
-      await waitFor(() => expect(mockIsAppPluginInstalled).toHaveBeenCalledWith('grafana-adaptivetraces-app'));
       expect(screen.queryByText(restoredBannerTitle)).not.toBeInTheDocument();
     });
 
     it('renders the banner when at least one span has grafana.adaptivetraces.restored=true', async () => {
-      mockIsAppPluginInstalled.mockResolvedValue(true);
+      mockUseAsync.mockReturnValue({
+        loading: false,
+        error: undefined,
+        value: true,
+      });
       renderTraceView([frameRestoredByAdaptiveTraces]);
       expect(await screen.findByText(restoredBannerTitle)).toBeInTheDocument();
       expect(screen.getByRole('link', { name: /documentation/ })).toBeInTheDocument();
     });
 
     it('hides the banner after the user dismisses it', async () => {
-      mockIsAppPluginInstalled.mockResolvedValue(true);
+      mockUseAsync.mockReturnValue({
+        loading: false,
+        error: undefined,
+        value: true,
+      });
       renderTraceView([frameRestoredByAdaptiveTraces]);
       expect(await screen.findByText(restoredBannerTitle)).toBeInTheDocument();
 

--- a/public/app/features/explore/TraceView/TraceView.test.tsx
+++ b/public/app/features/explore/TraceView/TraceView.test.tsx
@@ -1,17 +1,30 @@
-import { render, prettyDOM, screen } from '@testing-library/react';
+import { render, prettyDOM, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { Provider } from 'react-redux';
 
 import { type DataFrame, MutableDataFrame } from '@grafana/data';
 import { mockTimeRange } from '@grafana/plugin-ui/test';
-import { type DataSourceSrv, setDataSourceSrv, setPluginLinksHook, setPluginComponentsHook } from '@grafana/runtime';
+import {
+  type DataSourceSrv,
+  isAppPluginInstalled,
+  setDataSourceSrv,
+  setPluginLinksHook,
+  setPluginComponentsHook,
+} from '@grafana/runtime';
 
 import { configureStore } from '../../../store/configureStore';
 
 import { TraceView } from './TraceView';
 import { type TraceData, type TraceSpanData } from './components/types/trace';
 import { transformDataFrames } from './utils/transform';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  isAppPluginInstalled: jest.fn(),
+}));
+
+const mockIsAppPluginInstalled = isAppPluginInstalled as jest.MockedFunction<typeof isAppPluginInstalled>;
 
 function getTraceView(frames: DataFrame[]) {
   const store = configureStore();
@@ -47,6 +60,9 @@ function renderTraceViewNew() {
 }
 
 describe('TraceView', () => {
+  beforeEach(() => {
+    mockIsAppPluginInstalled.mockImplementation(() => new Promise<boolean>(() => undefined));
+  });
   beforeAll(() => {
     setPluginLinksHook(() => ({
       isLoading: false,
@@ -145,6 +161,39 @@ describe('TraceView', () => {
 
     rerender(getTraceView([frameNew]));
     expect(screen.queryByText(/Resource/)).not.toBeInTheDocument();
+  });
+
+  describe('Adaptive Traces restored banner', () => {
+    const restoredBannerTitle = /Trace restored by Adaptive Traces/;
+
+    it('does not render the banner when no span has the restored attribute', async () => {
+      renderTraceView();
+      await waitFor(() => expect(mockIsAppPluginInstalled).toHaveBeenCalledWith('grafana-adaptivetraces-app'));
+      expect(screen.queryByText(restoredBannerTitle)).not.toBeInTheDocument();
+    });
+
+    it('does not render the banner when grafana-adaptivetraces-app is not installed', async () => {
+      mockIsAppPluginInstalled.mockResolvedValue(false);
+      renderTraceView([frameRestoredByAdaptiveTraces]);
+      await waitFor(() => expect(mockIsAppPluginInstalled).toHaveBeenCalledWith('grafana-adaptivetraces-app'));
+      expect(screen.queryByText(restoredBannerTitle)).not.toBeInTheDocument();
+    });
+
+    it('renders the banner when at least one span has grafana.adaptivetraces.restored=true', async () => {
+      mockIsAppPluginInstalled.mockResolvedValue(true);
+      renderTraceView([frameRestoredByAdaptiveTraces]);
+      expect(await screen.findByText(restoredBannerTitle)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /documentation/ })).toBeInTheDocument();
+    });
+
+    it('hides the banner after the user dismisses it', async () => {
+      mockIsAppPluginInstalled.mockResolvedValue(true);
+      renderTraceView([frameRestoredByAdaptiveTraces]);
+      expect(await screen.findByText(restoredBannerTitle)).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /close alert/i }));
+      expect(screen.queryByText(restoredBannerTitle)).not.toBeInTheDocument();
+    });
   });
 });
 
@@ -357,6 +406,30 @@ const frameNew = new MutableDataFrame({
     },
     { name: 'warnings', values: [undefined, undefined] },
     { name: 'stackTraces', values: [undefined, undefined] },
+  ],
+  meta: {
+    preferredVisualisationType: 'trace',
+  },
+});
+
+const restoredResponse: TraceData & { spans: TraceSpanData[] } = {
+  ...response,
+  spans: response.spans.map((span, index) =>
+    index === 0
+      ? {
+          ...span,
+          tags: [...(span.tags ?? []), { key: 'grafana.adaptivetraces.restored', type: 'bool', value: true }],
+        }
+      : span
+  ),
+};
+
+const frameRestoredByAdaptiveTraces = new MutableDataFrame({
+  fields: [
+    {
+      name: 'trace',
+      values: [restoredResponse],
+    },
   ],
   meta: {
     preferredVisualisationType: 'trace',

--- a/public/app/features/explore/TraceView/TraceView.test.tsx
+++ b/public/app/features/explore/TraceView/TraceView.test.tsx
@@ -2,11 +2,16 @@ import { render, prettyDOM, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { Provider } from 'react-redux';
-import { useAsync } from 'react-use';
 
 import { type DataFrame, MutableDataFrame } from '@grafana/data';
 import { mockTimeRange } from '@grafana/plugin-ui/test';
-import { type DataSourceSrv, setDataSourceSrv, setPluginLinksHook, setPluginComponentsHook } from '@grafana/runtime';
+import {
+  type DataSourceSrv,
+  setDataSourceSrv,
+  setPluginLinksHook,
+  setPluginComponentsHook,
+  useAppPluginInstalled,
+} from '@grafana/runtime';
 
 import { configureStore } from '../../../store/configureStore';
 
@@ -14,12 +19,12 @@ import { TraceView } from './TraceView';
 import { type TraceData, type TraceSpanData } from './components/types/trace';
 import { transformDataFrames } from './utils/transform';
 
-jest.mock('react-use', () => ({
-  ...jest.requireActual('react-use'),
-  useAsync: jest.fn(),
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  useAppPluginInstalled: jest.fn(),
 }));
 
-const mockUseAsync = useAsync as jest.MockedFunction<typeof useAsync>;
+const mockUseAppPluginInstalled = jest.mocked(useAppPluginInstalled);
 
 function getTraceView(frames: DataFrame[]) {
   const store = configureStore();
@@ -56,7 +61,7 @@ function renderTraceViewNew() {
 
 describe('TraceView', () => {
   beforeEach(() => {
-    mockUseAsync.mockReturnValue({
+    mockUseAppPluginInstalled.mockReturnValue({
       loading: false,
       error: undefined,
       value: undefined,
@@ -175,7 +180,7 @@ describe('TraceView', () => {
     });
 
     it('does not render the banner when grafana-adaptivetraces-app is not installed', async () => {
-      mockUseAsync.mockReturnValue({
+      mockUseAppPluginInstalled.mockReturnValue({
         loading: false,
         error: undefined,
         value: false,
@@ -185,7 +190,7 @@ describe('TraceView', () => {
     });
 
     it('renders the banner when at least one span has grafana.adaptivetraces.restored=true', async () => {
-      mockUseAsync.mockReturnValue({
+      mockUseAppPluginInstalled.mockReturnValue({
         loading: false,
         error: undefined,
         value: true,
@@ -196,7 +201,7 @@ describe('TraceView', () => {
     });
 
     it('hides the banner after the user dismisses it', async () => {
-      mockUseAsync.mockReturnValue({
+      mockUseAppPluginInstalled.mockReturnValue({
         loading: false,
         error: undefined,
         value: true,

--- a/public/app/features/explore/TraceView/TraceView.test.tsx
+++ b/public/app/features/explore/TraceView/TraceView.test.tsx
@@ -212,6 +212,23 @@ describe('TraceView', () => {
       await userEvent.click(screen.getByRole('button', { name: /close alert/i }));
       expect(screen.queryByText(restoredBannerTitle)).not.toBeInTheDocument();
     });
+
+    it('shows the banner again after dismiss when navigating directly to a different restored trace', async () => {
+      mockUseAppPluginInstalled.mockReturnValue({
+        loading: false,
+        error: undefined,
+        value: true,
+      });
+      const { rerender } = render(getTraceView([frameRestoredByAdaptiveTraces]));
+      expect(await screen.findByText(restoredBannerTitle)).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: /close alert/i }));
+      expect(screen.queryByText(restoredBannerTitle)).not.toBeInTheDocument();
+
+      // Navigating straight from one restored trace to another must surface the banner again.
+      rerender(getTraceView([frameRestoredByAdaptiveTracesB]));
+      expect(await screen.findByText(restoredBannerTitle)).toBeInTheDocument();
+    });
   });
 });
 
@@ -447,6 +464,24 @@ const frameRestoredByAdaptiveTraces = new MutableDataFrame({
     {
       name: 'trace',
       values: [restoredResponse],
+    },
+  ],
+  meta: {
+    preferredVisualisationType: 'trace',
+  },
+});
+
+const restoredResponseB: TraceData & { spans: TraceSpanData[] } = {
+  ...restoredResponse,
+  traceID: '2bc49126597198db',
+  spans: restoredResponse.spans.map((span) => ({ ...span, traceID: '2bc49126597198db' })),
+};
+
+const frameRestoredByAdaptiveTracesB = new MutableDataFrame({
+  fields: [
+    {
+      name: 'trace',
+      values: [restoredResponseB],
     },
   ],
   meta: {

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { type RefObject, useMemo, useState } from 'react';
-import { useToggle } from 'react-use';
+import { useAsync, useToggle } from 'react-use';
 
 import {
   CoreApp,
@@ -19,7 +19,7 @@ import {
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { getTraceToLogsOptions, type TraceToMetricsData, type TraceToProfilesData } from '@grafana/o11y-ds-frontend';
-import { getTemplateSrv } from '@grafana/runtime';
+import { getTemplateSrv, isAppPluginInstalled } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
 import { type TempoQuery } from '@grafana-plugins/tempo/types';
@@ -30,6 +30,7 @@ import { useDispatch, useSelector } from 'app/types/store';
 import { changePanelState } from '../state/explorePane';
 
 import memoizedTraceCriticalPath from './components/CriticalPath';
+import { AdaptiveTracesRestoredBanner } from './components/TracePageHeader/AdaptiveTracesRestoredBanner';
 import { TracePageHeader } from './components/TracePageHeader/TracePageHeader';
 import TraceTimelineViewer from './components/TraceTimelineViewer';
 import { type TraceFlameGraphs } from './components/TraceTimelineViewer/SpanDetail';
@@ -43,6 +44,8 @@ import { useDetailState } from './useDetailState';
 import { useHoverIndentGuide } from './useHoverIndentGuide';
 import { useSearch } from './useSearch';
 import { useViewRange } from './useViewRange';
+
+const ADAPTIVE_TRACES_APP_PLUGIN_ID = 'grafana-adaptivetraces-app' as const;
 
 const getStyles = (theme: GrafanaTheme2) => ({
   noDataMsg: css({
@@ -103,6 +106,27 @@ export function TraceView(props: Props) {
   const { expandOne, collapseOne, childrenToggle, collapseAll, childrenHiddenIDs, expandAll } = useChildrenState();
 
   const criticalPath = useMemo(() => memoizedTraceCriticalPath(traceProp), [traceProp]);
+  const { value: isAdaptiveTracesAppInstalled } = useAsync(
+    () => isAppPluginInstalled(ADAPTIVE_TRACES_APP_PLUGIN_ID),
+    []
+  );
+
+  const isRestoredByAdaptiveTraces = useMemo(
+    () => {
+      if (!isAdaptiveTracesAppInstalled) {
+        return false;
+      }
+
+      return (
+        traceProp?.spans?.some((span) =>
+          span.tags?.some(
+            (tag) => tag.key === 'grafana.adaptivetraces.restored' && (tag.value === true || tag.value === 'true')
+          )
+        ) ?? false
+      );
+    },
+    [isAdaptiveTracesAppInstalled, traceProp]
+  );
   const { search, setSearch, spanFilterMatches } = useSearch(exploreId, traceProp?.spans, spanFilters, criticalPath);
 
   const [focusedSpanIdForSearch, setFocusedSpanIdForSearch] = useState('');
@@ -186,6 +210,8 @@ export function TraceView(props: Props) {
     <>
       {props.dataFrames?.length && traceProp ? (
         <>
+          {isRestoredByAdaptiveTraces && <AdaptiveTracesRestoredBanner />}
+
           <TracePageHeader
             trace={traceProp}
             data={props.dataFrames[0]}

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -111,22 +111,19 @@ export function TraceView(props: Props) {
     []
   );
 
-  const isRestoredByAdaptiveTraces = useMemo(
-    () => {
-      if (!isAdaptiveTracesAppInstalled) {
-        return false;
-      }
+  const isRestoredByAdaptiveTraces = useMemo(() => {
+    if (!isAdaptiveTracesAppInstalled) {
+      return false;
+    }
 
-      return (
-        traceProp?.spans?.some((span) =>
-          span.tags?.some(
-            (tag) => tag.key === 'grafana.adaptivetraces.restored' && (tag.value === true || tag.value === 'true')
-          )
-        ) ?? false
-      );
-    },
-    [isAdaptiveTracesAppInstalled, traceProp]
-  );
+    return (
+      traceProp?.spans?.some((span) =>
+        span.tags?.some(
+          (tag) => tag.key === 'grafana.adaptivetraces.restored' && (tag.value === true || tag.value === 'true')
+        )
+      ) ?? false
+    );
+  }, [isAdaptiveTracesAppInstalled, traceProp]);
   const { search, setSearch, spanFilterMatches } = useSearch(exploreId, traceProp?.spans, spanFilters, criticalPath);
 
   const [focusedSpanIdForSearch, setFocusedSpanIdForSearch] = useState('');

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { type RefObject, useMemo, useState } from 'react';
-import { useAsync, useToggle } from 'react-use';
+import { useToggle } from 'react-use';
 
 import {
   CoreApp,
@@ -19,7 +19,7 @@ import {
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { getTraceToLogsOptions, type TraceToMetricsData, type TraceToProfilesData } from '@grafana/o11y-ds-frontend';
-import { getTemplateSrv, isAppPluginInstalled } from '@grafana/runtime';
+import { getTemplateSrv, useAppPluginInstalled } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
 import { type TempoQuery } from '@grafana-plugins/tempo/types';
@@ -106,10 +106,7 @@ export function TraceView(props: Props) {
   const { expandOne, collapseOne, childrenToggle, collapseAll, childrenHiddenIDs, expandAll } = useChildrenState();
 
   const criticalPath = useMemo(() => memoizedTraceCriticalPath(traceProp), [traceProp]);
-  const { value: isAdaptiveTracesAppInstalled } = useAsync(
-    () => isAppPluginInstalled(ADAPTIVE_TRACES_APP_PLUGIN_ID),
-    []
-  );
+  const { value: isAdaptiveTracesAppInstalled } = useAppPluginInstalled(ADAPTIVE_TRACES_APP_PLUGIN_ID);
 
   const isRestoredByAdaptiveTraces = useMemo(() => {
     if (!isAdaptiveTracesAppInstalled) {

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -33,6 +33,7 @@ import memoizedTraceCriticalPath from './components/CriticalPath';
 import { AdaptiveTracesRestoredBanner } from './components/TracePageHeader/AdaptiveTracesRestoredBanner';
 import { TracePageHeader } from './components/TracePageHeader/TracePageHeader';
 import TraceTimelineViewer from './components/TraceTimelineViewer';
+import { spanHasAdaptiveTraceRestoredTag } from './components/TraceTimelineViewer/SpanBarRow';
 import { type TraceFlameGraphs } from './components/TraceTimelineViewer/SpanDetail';
 import { type SpanBarOptionsData } from './components/settings/SpanBarSettings';
 import type TTraceTimeline from './components/types/TTraceTimeline';
@@ -113,13 +114,7 @@ export function TraceView(props: Props) {
       return false;
     }
 
-    return (
-      traceProp?.spans?.some((span) =>
-        span.tags?.some(
-          (tag) => tag.key === 'grafana.adaptivetraces.restored' && (tag.value === true || tag.value === 'true')
-        )
-      ) ?? false
-    );
+    return traceProp?.spans?.some((span) => spanHasAdaptiveTraceRestoredTag(span.tags ?? []));
   }, [isAdaptiveTracesAppInstalled, traceProp]);
   const { search, setSearch, spanFilterMatches } = useSearch(exploreId, traceProp?.spans, spanFilters, criticalPath);
 

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -199,7 +199,8 @@ export function TraceView(props: Props) {
     <>
       {props.dataFrames?.length && traceProp ? (
         <>
-          {isRestoredByAdaptiveTraces && <AdaptiveTracesRestoredBanner />}
+          {/* Key by trace ID so the dismissed state resets when navigating directly between restored traces. */}
+          {isRestoredByAdaptiveTraces && <AdaptiveTracesRestoredBanner key={traceProp.traceID} />}
 
           <TracePageHeader
             trace={traceProp}

--- a/public/app/features/explore/TraceView/TraceViewContainer.test.tsx
+++ b/public/app/features/explore/TraceView/TraceViewContainer.test.tsx
@@ -18,6 +18,7 @@ jest.mock('@grafana/runtime', () => {
     ...jest.requireActual('@grafana/runtime'),
     reportInteraction: jest.fn(),
     usePluginLinks: jest.fn().mockReturnValue({ isLoading: false, links: [] }),
+    useAppPluginInstalled: jest.fn().mockReturnValue({ loading: false, error: undefined, value: false }),
   };
 });
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/AdaptiveTracesRestoredBanner.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/AdaptiveTracesRestoredBanner.tsx
@@ -1,0 +1,43 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { Alert, TextLink, useStyles2 } from '@grafana/ui';
+
+export const AdaptiveTracesRestoredBanner = () => {
+  const styles = useStyles2(getStyles);
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <Alert
+        severity="info"
+        title={t('explore.trace-view.adaptive-traces-restored.title', 'Trace restored by Adaptive Traces')}
+        onRemove={() => setDismissed(true)}
+      >
+        <Trans i18nKey="explore.trace-view.adaptive-traces-restored.body">
+          This trace was originally dropped by Adaptive Traces and has been restored. A restored trace is not included
+          in TraceQL queries and can only be queried by trace ID. Please review the{' '}
+          <TextLink
+            href="https://grafana.com/docs/grafana-cloud/adaptive-telemetry/adaptive-traces/query-dropped-traces/"
+            external
+          >
+            documentation
+          </TextLink>{' '}
+          for more details.
+        </Trans>
+      </Alert>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    padding: theme.spacing(0, 1, 1, 1),
+  }),
+});

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
@@ -38,7 +38,7 @@ import { type ViewedBoundsFunctionType } from './utils';
 
 const GRAFANA_ADAPTIVE_TRACES_RESTORED_TAG_KEY = 'grafana.adaptivetraces.restored';
 
-function spanHasAdaptiveTraceRestoredTag(tags: TraceKeyValuePair[]): boolean {
+export function spanHasAdaptiveTraceRestoredTag(tags: TraceKeyValuePair[]): boolean {
   const tag = tags.find((kv) => kv.key === GRAFANA_ADAPTIVE_TRACES_RESTORED_TAG_KEY);
   if (!tag) {
     return false;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8811,6 +8811,10 @@
       "url": "URL"
     },
     "trace-view": {
+      "adaptive-traces-restored": {
+        "body": "This trace was originally dropped by Adaptive Traces and has been restored. A restored trace is not included in TraceQL queries and can only be queried by trace ID. Please review the <2>documentation</2> for more details.",
+        "title": "Trace restored by Adaptive Traces"
+      },
       "aria-label-copy": "Copy to clipboard",
       "no-data": "No data",
       "tooltip-copy-icon": "Copied"


### PR DESCRIPTION
**What is this feature?**

Add a info message if the queried trace was restored by Adaptive Traces. This is a feature in which recently dropped are rehydrated and written to Tempo. The attribute `grafana.adaptivetraces.restored = true` will be present in that case.

<img width="2880" height="588" alt="image" src="https://github.com/user-attachments/assets/8525fd05-68f0-41c5-b1dc-9a4b3c7427c1" />

**Why do we need this feature?**

Rehydrated traces behave slightly different. As such it's useful to be informed when such a trace was queried.

**Who is this feature for?**

Users of Adaptive Traces. It will only show if the Adaptive Traces plugin is installed.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
