### PR TITLE
docs: document Git Sync admin-only jobs and repository subresource access

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/permissions-grafana.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/permissions-grafana.md
@@ -261,7 +261,14 @@ Git Sync operations run as jobs. You need the `provisioning.jobs:create` permiss
 
 ### Repository subresource access
 
-The repository API exposes several subresources. The following table shows the permission each one is gated on. Because the `repositories` resource has no Editor tier (`repositories:read` is granted to Viewer and above, while `write`, `create`, and `delete` are admin-only), the `refs` subresource accepts either an admin (`repositories:write`) or an editor (`jobs:create`) check.
+The repository API exposes several subresources. The following table shows the permission each one is gated on.
+
+The `refs` subresource lists the repository's branches and commits, and two distinct flows legitimately need it:
+
+- **Editors pushing changes**: When an editor saves changes or opens a pull request through the push-job flow, Grafana needs the branch list. This is authorized with `provisioning.jobs:create`.
+- **Admins configuring a repository**: When an admin or repository owner sets up or edits a repository and picks a target branch, Grafana updates the `Repository` resource info. This is authorized with `provisioning.repositories:write`.
+
+Because the `repositories` resource has no Editor tier (`repositories:read` is granted to Viewer and above, while `write`, `create`, and `delete` are admin-only), `refs` accepts either of these checks, and viewers satisfy neither.
 
 | Subresource                      | Purpose                                    | Required permission                                                     | Who can access it       |
 | -------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------- | ----------------------- |

--- a/docs/sources/as-code/observability-as-code/git-sync/permissions-grafana.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/permissions-grafana.md
@@ -123,7 +123,7 @@ Users with the `Editor` role can work with provisioned dashboards and folders. T
 - Push their dashboard and folder changes to Git, including opening pull requests, via the jobs API
 
 {{< admonition type="note" >}}
-Triggering a manual sync (**pull** from Git) and orphan-resource cleanup are admin-only operations. Editors can push their own changes but can't pull from Git on demand. Refer to [Job actions and required permissions](#job-actions-and-required-permissions).
+**Only Admins can trigger a manual sync (**pull** from Git) and orphan-resource clean-up**. Editors can push their own changes but can't pull from Git on demand. Refer to [Job actions and required permissions](#job-actions-and-required-permissions) for more details.
 {{< /admonition >}}
 
 **Resource access** depends on folder/dashboard permissions:
@@ -215,7 +215,7 @@ Users with the `Editor` role can manage sync operations but not infrastructure c
 | **Read-Only Access** | `provisioning.repositories:read`<br>`provisioning.settings:read`                                                  | View repository configurations<br>View Git Sync settings                                                     |
 
 {{< admonition type="note" >}}
-`provisioning.jobs:create` lets editors create jobs that push their changes (subject to the relevant `dashboards:*` and `folders:*` permissions), but it does **not** allow admin-only job actions such as a manual **pull** from Git or orphan-resource cleanup. Those require `provisioning.repositories:write`. Refer to [Job actions and required permissions](#job-actions-and-required-permissions).
+`provisioning.jobs:create` allows editors to create jobs to push their changes, subject to the relevant `dashboards:*` and `folders:*` permissions. However, **it doesn't allow admin-only job actions** such as a manual **pull** from Git or orphan-resource cleanup, which require the `provisioning.repositories:write` permission. Refer to [Job actions and required permissions](#job-actions-and-required-permissions) for more details.
 {{< /admonition >}}
 
 `Editors` can access resources based on the folder/dashboard assignments:
@@ -250,7 +250,7 @@ The following applies for Git Sync:
 
 ### Job actions and required permissions
 
-Git Sync operations run as jobs. While `provisioning.jobs:create` is required to create any job, some job actions are additionally restricted to administrators and are gated on `provisioning.repositories:write` (an admin-only action). This prevents editors from triggering repository-wide operations even though they hold `provisioning.jobs:create`.
+Git Sync operations run as jobs. You need the `provisioning.jobs:create` permission to create any job. Moreover, **some job actions are restricted to administrators** and require the `provisioning.repositories:write` permission. This prevents editors from triggering repository-wide operations even though they hold `provisioning.jobs:create`.
 
 | Job action                          | Required permission                                                                   | Who can run it                                            |
 | ----------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------- |

--- a/docs/sources/as-code/observability-as-code/git-sync/permissions-grafana.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/permissions-grafana.md
@@ -120,7 +120,11 @@ Users with the `Editor` role can work with provisioned dashboards and folders. T
 **Organization-level capabilities**:
 
 - View dashboard preview links in pull requests
-- Trigger manual sync operations via jobs API
+- Push their dashboard and folder changes to Git, including opening pull requests, via the jobs API
+
+{{< admonition type="note" >}}
+Triggering a manual sync (**pull** from Git) and orphan-resource cleanup are admin-only operations. Editors can push their own changes but can't pull from Git on demand. Refer to [Job actions and required permissions](#job-actions-and-required-permissions).
+{{< /admonition >}}
 
 **Resource access** depends on folder/dashboard permissions:
 
@@ -205,10 +209,14 @@ Users with the `Admin` role receive full access to Git Sync infrastructure:
 
 Users with the `Editor` role can manage sync operations but not infrastructure configuration:
 
-| Permission Category  | Specific Permissions                                                                                              | What This Allows                                                                              |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **Jobs**             | `provisioning.jobs:create`<br>`provisioning.jobs:read`<br>`provisioning.jobs:write`<br>`provisioning.jobs:delete` | Trigger manual syncs<br>View sync jobs<br>Modify sync job settings<br>Cancel/delete sync jobs |
-| **Read-Only Access** | `provisioning.repositories:read`<br>`provisioning.settings:read`                                                  | View repository configurations<br>View Git Sync settings                                      |
+| Permission Category  | Specific Permissions                                                                                              | What This Allows                                                                                             |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Jobs**             | `provisioning.jobs:create`<br>`provisioning.jobs:read`<br>`provisioning.jobs:write`<br>`provisioning.jobs:delete` | Push changes and open pull requests<br>View sync jobs<br>Modify sync job settings<br>Cancel/delete sync jobs |
+| **Read-Only Access** | `provisioning.repositories:read`<br>`provisioning.settings:read`                                                  | View repository configurations<br>View Git Sync settings                                                     |
+
+{{< admonition type="note" >}}
+`provisioning.jobs:create` lets editors create jobs that push their changes (subject to the relevant `dashboards:*` and `folders:*` permissions), but it does **not** allow admin-only job actions such as a manual **pull** from Git or orphan-resource cleanup. Those require `provisioning.repositories:write`. Refer to [Job actions and required permissions](#job-actions-and-required-permissions).
+{{< /admonition >}}
 
 `Editors` can access resources based on the folder/dashboard assignments:
 
@@ -239,6 +247,31 @@ The following applies for Git Sync:
 - Users do **not** need repository write/delete or connection permissions to edit dashboards
 - Dashboard-level permissions override folder-level permissions
 - Changes made by users with appropriate permissions automatically sync to Git
+
+### Job actions and required permissions
+
+Git Sync operations run as jobs. While `provisioning.jobs:create` is required to create any job, some job actions are additionally restricted to administrators and are gated on `provisioning.repositories:write` (an admin-only action). This prevents editors from triggering repository-wide operations even though they hold `provisioning.jobs:create`.
+
+| Job action                          | Required permission                                                                   | Who can run it                                            |
+| ----------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Push changes / open pull request    | `provisioning.jobs:create` plus the relevant `dashboards:*` / `folders:*` permissions | Editors and Admins, on the resources they can modify      |
+| Migrate resources                   | `provisioning.jobs:create` plus read/write on the affected resource types             | Editors and Admins with the required resource permissions |
+| Manual sync (pull from Git)         | `provisioning.repositories:write`                                                     | Admins only                                               |
+| Release / delete orphaned resources | `provisioning.repositories:write`                                                     | Admins only                                               |
+
+### Repository subresource access
+
+The repository API exposes several subresources. The following table shows the permission each one is gated on. Because the `repositories` resource has no Editor tier (`repositories:read` is granted to Viewer and above, while `write`, `create`, and `delete` are admin-only), the `refs` subresource accepts either an admin (`repositories:write`) or an editor (`jobs:create`) check.
+
+| Subresource                      | Purpose                                    | Required permission                                                     | Who can access it       |
+| -------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------- | ----------------------- |
+| `files`                          | Read and write provisioned resource files  | Authenticated access, then standard `dashboards:*` / `folders:*` checks | All authenticated users |
+| `refs`                           | List repository branches and commits       | `provisioning.repositories:write` **or** `provisioning.jobs:create`     | Admins and Editors      |
+| `resources`, `history`, `status` | Repository management and inspection views | `provisioning.repositories:write`                                       | Admins only             |
+
+{{< admonition type="note" >}}
+The management and inspection views (`resources`, `history`, `status`) are gated on `provisioning.repositories:write` rather than `repositories:read`, because there's no admin-only read action on the `repositories` resource. As a result, only users who can manage a repository can inspect its management views; Viewers and Editors can't access these views.
+{{< /admonition >}}
 
 ## Configure Git repository protection
 


### PR DESCRIPTION
## Summary

Updates the Git Sync permissions documentation to reflect the fine-grained authorization changes introduced in #124578. That PR pinned several authz checks to semantically-correct resources/verbs, which tightened who can run certain provisioning jobs and access certain repository subresources. The docs didn't describe this behavior, so this PR brings them in line.

## Changes

All in `docs/sources/as-code/observability-as-code/git-sync/permissions-grafana.md`:

- **Editor capabilities**: replaced the vague "Trigger manual sync operations via jobs API" with an accurate description — editors **push** changes and open PRs via the jobs API, but **manual pull and orphan-resource cleanup are admin-only**.
- **Editor jobs table**: added a note clarifying that `provisioning.jobs:create` covers push jobs (subject to `dashboards:*`/`folders:*` permissions) but **not** admin-only job actions.
- **New "Job actions and required permissions" table**: push/migrate (editors + admins) vs. manual pull and release/delete-orphaned resources (admin-only, gated on `provisioning.repositories:write`).
- **New "Repository subresource access" table**: documents the gating for `files` (all authenticated), `refs` (`repositories:write` **OR** `jobs:create` → admins + editors; viewers denied), and `resources`/`history`/`status` (admin-only `repositories:write`), with a note on why `write` and not `read` gates the inspection views.

## Behavior documented (from #124578)

- `authorizeAdminJob` now checks `repositories:write` (admin-only) instead of `jobs:create`, so editors can no longer trigger `pull`, `releaseResources`, or `deleteResources` jobs.
- `refs` subresource → `repositories:write` OR `jobs:create`; viewers denied.
- `resources`/`history`/`status` subresources → admin-only `repositories:write`.

## Testing

- Docs-only change; no code affected.
- Ran `prettier@3.6.2` (matches the repo `prettier:checkDocs` glob) — file is clean.

## Checklist

- [x] Documentation updated
- [x] No code/behavior changes (documents existing behavior from #124578)
- [x] Prettier-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)