### PR TITLE
PanelEditNext: Resolve dashboard per-row datasource variables

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
@@ -937,6 +937,29 @@ describe('PanelDataPaneNext', () => {
       expect(testDataPane.state.dsError).toBeUndefined();
     });
 
+    it('loads a section-scoped variable datasource by forwarding the panel scene scope', async () => {
+      const variableRef = { uid: '${metrics_source}', type: 'prometheus' };
+      mockQueryRunnerState.datasource = variableRef;
+
+      const resolvesWithScope = (ref: { uid?: string } | undefined, scopedVars: unknown) =>
+        ref?.uid === variableRef.uid && Boolean((scopedVars as { __sceneObject?: unknown } | undefined)?.__sceneObject);
+
+      mockGet.mockImplementation((ref: { uid?: string } | undefined, scopedVars: unknown) =>
+        resolvesWithScope(ref, scopedVars)
+          ? Promise.resolve(promDatasource)
+          : Promise.reject(new Error('Datasource not found'))
+      );
+      mockGetInstanceSettings.mockImplementation((ref: { uid?: string } | undefined, scopedVars: unknown) =>
+        resolvesWithScope(ref, scopedVars) ? promSettings : undefined
+      );
+
+      await callLoadDatasource();
+
+      expect(testDataPane.state.datasource).toBe(promDatasource);
+      expect(testDataPane.state.dsSettings).toBe(promSettings);
+      expect(testDataPane.state.dsError).toBeUndefined();
+    });
+
     it('should store the datasource in localStorage after a successful load', async () => {
       const mockStore = jest.spyOn(
         require('app/features/datasources/components/picker/utils'),
@@ -1065,7 +1088,10 @@ describe('PanelDataPaneNext', () => {
 
       await callLoadDatasource();
 
-      expect(mockGet).toHaveBeenCalledWith({ uid: 'prom-uid', type: 'prometheus' });
+      expect(mockGet).toHaveBeenCalledWith(
+        { uid: 'prom-uid', type: 'prometheus' },
+        expect.objectContaining({ __sceneObject: expect.anything() })
+      );
       expect(testDataPane.state.datasource).toBe(promDatasource);
     });
   });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -7,6 +7,7 @@ import {
   type DataTransformerConfig,
   getDataSourceRef,
   getNextRefId,
+  type ScopedVars,
 } from '@grafana/data';
 import { config, getDataSourceSrv, isExpressionReference, reportInteraction } from '@grafana/runtime';
 import {
@@ -29,7 +30,7 @@ import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
 import { getDashboardSceneFor, getQueryRunnerFor } from '../../utils/utils';
 
 import { QueryEditorContent } from './QueryEditor/QueryEditorContent';
-import { filterDataTransformerConfigs } from './QueryEditor/utils';
+import { filterDataTransformerConfigs, getPanelScopedVars } from './QueryEditor/utils';
 import { TRANSFORMATION_EDIT_INTERACTION_THROTTLE_TIME } from './constants';
 
 const reportTransformationEditInteraction = throttle((context: string, type: string) => {
@@ -104,6 +105,11 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
   public constructor(state: PanelDataPaneNextState) {
     super(state);
     this.addActivationHandler(() => this.onActivate());
+  }
+
+  /** Scene scope for resolving section-scoped (row/tab) datasource variables. See {@link getPanelScopedVars}. */
+  private getPanelContext(): ScopedVars {
+    return getPanelScopedVars(this.state.panelRef.resolve());
   }
 
   private onActivate() {
@@ -192,8 +198,9 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
         return;
       }
 
-      const datasource = await getDataSourceSrv().get(datasourceToLoad);
-      const dsSettings = getDataSourceSrv().getInstanceSettings(datasourceToLoad);
+      const panelContext = this.getPanelContext();
+      const datasource = await getDataSourceSrv().get(datasourceToLoad, panelContext);
+      const dsSettings = getDataSourceSrv().getInstanceSettings(datasourceToLoad, panelContext);
 
       // Treat a missing dsSettings as a load failure so the catch block can attempt the
       // default fallback — same recovery path as a rejected get() call.
@@ -389,7 +396,8 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       return;
     }
 
-    const newDataSource = getDataSourceSrv().getInstanceSettings(dsRef);
+    const panelContext = this.getPanelContext();
+    const newDataSource = getDataSourceSrv().getInstanceSettings(dsRef, panelContext);
     if (!newDataSource) {
       this.setState({ dsError: new Error(`Datasource not found: ${dsRef.uid ?? dsRef.type}`) });
       return;
@@ -397,7 +405,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
 
     let defaultQuery: Partial<DataQuery> | undefined;
     try {
-      const ds = await getDataSourceSrv().get(dsRef);
+      const ds = await getDataSourceSrv().get(dsRef, panelContext);
       defaultQuery = ds.getDefaultQuery?.(CoreApp.PanelEditor);
     } catch {
       this.setState({ dsError: new Error(`Failed to load datasource: ${newDataSource.name ?? newDataSource.uid}`) });
@@ -410,7 +418,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     const remapQuery = (query: DataQuery, fallbackDsRef?: DataSourceRef): DataQuery => {
       if (refIdSet.has(query.refId)) {
         const previousDataSource = query.datasource
-          ? getDataSourceSrv().getInstanceSettings(query.datasource)
+          ? getDataSourceSrv().getInstanceSettings(query.datasource, panelContext)
           : undefined;
         const shouldUseDefaultQuery = !previousDataSource || previousDataSource.type !== newDataSource.type;
         if (shouldUseDefaultQuery && defaultQuery) {
@@ -581,7 +589,8 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       return;
     }
 
-    const newDataSource = getDataSourceSrv().getInstanceSettings(dsRef);
+    const panelContext = this.getPanelContext();
+    const newDataSource = getDataSourceSrv().getInstanceSettings(dsRef, panelContext);
     if (!newDataSource) {
       // Surface the failure in the editor rather than throwing — the caller (sidebar DS picker)
       // does not wrap changeDataSource in a try/catch, so a thrown error would be silently swallowed.
@@ -597,7 +606,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
 
     const targetQuery = queries[targetIndex];
     const previousDataSource = targetQuery.datasource
-      ? getDataSourceSrv().getInstanceSettings(targetQuery.datasource)
+      ? getDataSourceSrv().getInstanceSettings(targetQuery.datasource, panelContext)
       : undefined;
 
     const shouldUseDefaultQuery = !previousDataSource || previousDataSource.type !== newDataSource.type;
@@ -605,7 +614,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     let updatedQuery: DataQuery;
     if (shouldUseDefaultQuery) {
       try {
-        const ds = await getDataSourceSrv().get(dsRef);
+        const ds = await getDataSourceSrv().get(dsRef, panelContext);
         updatedQuery = { ...ds.getDefaultQuery?.(CoreApp.PanelEditor), ...targetQuery, datasource: dsRef };
       } catch {
         this.setState({ dsError: new Error(`Failed to load datasource: ${newDataSource.name ?? newDataSource.uid}`) });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.test.tsx
@@ -1,0 +1,82 @@
+import { render } from '@testing-library/react';
+
+import { type DataSourceInstanceSettings, type DataSourcePluginMeta, type ScopedVars } from '@grafana/data';
+import { type DataQuery } from '@grafana/schema';
+
+import { QueryEditorType } from '../../constants';
+
+import { ContentHeader } from './ContentHeader';
+
+// Capture the picker props so we can assert how `current` and `scopedVars` are resolved.
+const mockDataSourcePicker = jest.fn();
+
+jest.mock('app/features/datasources/components/picker/DataSourcePicker', () => ({
+  DataSourcePicker: (props: { current?: unknown; scopedVars?: unknown }) => {
+    mockDataSourcePicker(props);
+    return null;
+  },
+}));
+
+// These read from QueryEditor context, which is out of scope for these prop-based wiring tests.
+jest.mock('./HeaderActions', () => ({ HeaderActions: () => null }));
+jest.mock('./EditableQueryName', () => ({ EditableQueryName: () => null }));
+
+const resolvedSettings: DataSourceInstanceSettings = {
+  uid: '${metrics_source}',
+  name: '${metrics_source}',
+  type: 'prometheus',
+  meta: { id: 'prometheus', name: 'Prometheus' } as DataSourcePluginMeta,
+  access: 'proxy',
+  jsonData: {},
+  readOnly: false,
+};
+
+function renderHeader(
+  query: DataQuery,
+  props: { currentDatasource?: DataSourceInstanceSettings; scopedVars?: ScopedVars } = {}
+) {
+  return render(
+    <ContentHeader
+      selectedAlert={null}
+      selectedQuery={query}
+      selectedTransformation={null}
+      queries={[query]}
+      cardType={QueryEditorType.Query}
+      onChangeDataSource={jest.fn()}
+      onUpdateQuery={jest.fn()}
+      {...props}
+    />
+  );
+}
+
+const pickerProps = () => mockDataSourcePicker.mock.lastCall?.[0];
+
+describe('ContentHeader datasource picker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the resolved effective datasource for an inherited query (parity with v1)', () => {
+    // The query has no explicit ref, so the picker must show the resolved datasource (a
+    // section-scoped variable here) rather than falling back to the default — matching v1.
+    renderHeader({ refId: 'A' }, { currentDatasource: resolvedSettings });
+
+    expect(pickerProps().current).toBe(resolvedSettings);
+  });
+
+  it('falls back to the raw query datasource ref when no resolved datasource is provided', () => {
+    const queryRef = { uid: '${metrics_source}', type: 'prometheus' };
+    renderHeader({ refId: 'A', datasource: queryRef });
+
+    expect(pickerProps().current).toBe(queryRef);
+  });
+
+  it('forwards the scene scope so the picker can resolve section-scoped variables', () => {
+    // Without this the picker only sees dashboard-level variables and renders "Select data source"
+    // for a row/tab-scoped datasource variable.
+    const scopedVars: ScopedVars = { __sceneObject: { value: {} } };
+    renderHeader({ refId: 'A' }, { scopedVars });
+
+    expect(pickerProps().scopedVars).toBe(scopedVars);
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { upperFirst } from 'lodash';
 import { type RefObject, useMemo, useRef } from 'react';
 
-import { type DataSourceInstanceSettings, type GrafanaTheme2 } from '@grafana/data';
+import { type DataSourceInstanceSettings, type GrafanaTheme2, type ScopedVars } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { type DataQuery } from '@grafana/schema';
 import { Button, Icon, Text, useStyles2, useTheme2 } from '@grafana/ui';
@@ -17,6 +17,7 @@ import {
   useQueryRunnerContext,
   useQueryEditorTypeConfig,
 } from '../QueryEditorContext';
+import { usePanelScopedVars } from '../hooks/usePanelScopedVars';
 import { type AlertRule, type Transformation } from '../types';
 import { getEditorBorderColor } from '../utils';
 
@@ -26,14 +27,22 @@ import { HeaderActions } from './HeaderActions';
 interface DatasourceSectionProps {
   selectedQuery: DataQuery;
   onChange: (ds: DataSourceInstanceSettings) => void;
+  currentDatasource?: DataSourceInstanceSettings;
+  scopedVars?: ScopedVars;
 }
 
-function DatasourceSection({ selectedQuery, onChange }: DatasourceSectionProps) {
+function DatasourceSection({ selectedQuery, onChange, currentDatasource, scopedVars }: DatasourceSectionProps) {
   const styles = useStyles2(getDatasourceSectionStyles);
 
   return (
     <div className={styles.dataSourcePickerWrapper}>
-      <DataSourcePicker dashboard={true} variables={true} current={selectedQuery.datasource} onChange={onChange} />
+      <DataSourcePicker
+        dashboard={true}
+        variables={true}
+        current={currentDatasource ?? selectedQuery.datasource}
+        onChange={onChange}
+        scopedVars={scopedVars}
+      />
     </div>
   );
 }
@@ -87,6 +96,8 @@ interface ContentHeaderProps {
   onChangeDataSource: (ds: DataSourceInstanceSettings, refId: string) => void;
   onUpdateQuery: (updatedQuery: DataQuery, originalRefId: string) => void;
   isMultiSelection?: boolean;
+  currentDatasource?: DataSourceInstanceSettings;
+  scopedVars?: ScopedVars;
   /**
    * Optional callback to render additional elements in the header's left section.
    *
@@ -118,7 +129,7 @@ interface ContentHeaderProps {
  * All data and callbacks are passed via props, making it reusable across
  * different architectural patterns.
  */
-function ContentHeader({
+export function ContentHeader({
   selectedAlert,
   selectedQuery,
   selectedTransformation,
@@ -134,6 +145,8 @@ function ContentHeader({
   renderHeaderExtras,
   containerRef: externalContainerRef,
   typeConfig: typeConfigProp,
+  currentDatasource,
+  scopedVars,
 }: ContentHeaderProps) {
   // Fallback ref if none provided (for saved queries positioning)
   const internalContainerRef = useRef<HTMLDivElement>(null);
@@ -196,6 +209,8 @@ function ContentHeader({
             <DatasourceSection
               selectedQuery={selectedQuery}
               onChange={(ds) => onChangeDataSource(ds, selectedQuery.refId)}
+              currentDatasource={currentDatasource}
+              scopedVars={scopedVars}
             />
             <NavToolbarSeparator />
           </>
@@ -265,10 +280,12 @@ export function ContentHeaderSceneWrapper({
     setPendingExpression,
     pendingTransformation,
     setPendingTransformation,
+    selectedQueryDsData,
   } = useQueryEditorUIContext();
   const { queries } = useQueryRunnerContext();
   const { changeDataSource, updateSelectedQuery } = useActionsContext();
   const typeConfig = useQueryEditorTypeConfig();
+  const scopedVars = usePanelScopedVars();
 
   return (
     <ContentHeader
@@ -286,6 +303,8 @@ export function ContentHeaderSceneWrapper({
       isMultiSelection={multiSelectMode && (selectedQueryRefIds.length > 0 || selectedTransformationIds.length > 0)}
       renderHeaderExtras={renderHeaderExtras}
       typeConfig={typeConfig}
+      currentDatasource={selectedQueryDsData?.dsSettings}
+      scopedVars={scopedVars}
     />
   );
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -352,7 +352,7 @@ export function QueryEditorContextWrapper({
     Boolean(pendingExpression) || Boolean(pendingTransformation)
   );
 
-  const { selectedQueryDsData, selectedQueryDsLoading } = useSelectedQueryDatasource(selectedQuery, dsSettings);
+  const { selectedQueryDsData, selectedQueryDsLoading } = useSelectedQueryDatasource(selectedQuery, dsSettings, panel);
 
   const uiState = useMemo(
     () => ({

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -95,9 +95,10 @@ describe('QueryEditorRenderer', () => {
     expect(screen.getByText(/loading datasource/i)).toBeInTheDocument();
   });
 
-  it('shows an error when the datasource fails to load', () => {
+  it('shows an actionable error when the datasource fails to load', () => {
     renderRenderer(queryA, { selectedQueryDsData: null });
     expect(screen.getByText(/failed to load datasource for this query/i)).toBeInTheDocument();
+    expect(screen.getByText(/select a datasource for this query/i)).toBeInTheDocument();
   });
 
   it('renders the query editor for the selected query', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
@@ -76,7 +76,9 @@ export function QueryEditorPanel({
       <Alert
         severity="error"
         title={t('query-editor-renderer.datasource-load-error-title', 'Failed to load datasource for this query')}
-      />
+      >
+        {t('query-editor-renderer.datasource-load-error-body', 'Select a datasource for this query to continue.')}
+      </Alert>
     );
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/QueryCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/QueryCard.tsx
@@ -11,6 +11,7 @@ import {
   useQueryRunnerContext,
   useQueryEditorTypeConfig,
 } from '../../QueryEditorContext';
+import { usePanelScopedVars } from '../../hooks/usePanelScopedVars';
 import { getEditorType } from '../../utils';
 
 import { CardTitle } from './CardTitle';
@@ -19,7 +20,8 @@ import { SidebarCard } from './SidebarCard';
 
 export const QueryCard = ({ query }: { query: DataQuery }) => {
   const editorType = getEditorType(query);
-  const queryDsSettings = useDatasource(query.datasource);
+  const scopedVars = usePanelScopedVars();
+  const queryDsSettings = useDatasource(query.datasource, scopedVars);
   const {
     selectedQuery,
     setSelectedQuery,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedItem.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedItem.tsx
@@ -71,9 +71,10 @@ export function StackedQueryItem({ query, headingId }: StackedQueryItemProps) {
 
   const typeConfig = useQueryEditorTypeConfig();
   const { dsSettings } = useDatasourceContext();
+  const { panel } = usePanelContext();
   const { queries, data } = useQueryRunnerContext();
   const { updateSelectedQuery, addQuery, runQueries } = useActionsContext();
-  const { queryDsData, queryDsLoading } = useQueryDatasource(query, dsSettings);
+  const { queryDsData, queryDsLoading } = useQueryDatasource(query, dsSettings, panel);
 
   const editorType = getStackedQueryEditorType(query);
   const isExpression = editorType === QueryEditorType.Expression;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePanelScopedVars.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePanelScopedVars.test.ts
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react';
+
+import { VizPanel } from '@grafana/scenes';
+
+import { usePanelContext } from '../QueryEditorContext';
+
+import { usePanelScopedVars } from './usePanelScopedVars';
+
+jest.mock('../QueryEditorContext', () => ({
+  usePanelContext: jest.fn(),
+}));
+
+const mockUsePanelContext = jest.mocked(usePanelContext);
+
+describe('usePanelScopedVars', () => {
+  it('returns scoped vars whose __sceneObject resolves to the panel from context', () => {
+    const panel = new VizPanel({ key: 'panel-1' });
+    mockUsePanelContext.mockReturnValue({ panel, transformations: [] });
+
+    const { result } = renderHook(() => usePanelScopedVars());
+
+    // Unwrapping the scene object must yield the same panel, so datasource interpolation walks that
+    // panel's local scope (row/tab section-scoped variables), not just dashboard-level variables.
+    expect(result.current.__sceneObject?.value.valueOf()).toBe(panel);
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePanelScopedVars.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePanelScopedVars.ts
@@ -1,0 +1,10 @@
+import { type ScopedVars } from '@grafana/data';
+
+import { usePanelContext } from '../QueryEditorContext';
+import { getPanelScopedVars } from '../utils';
+
+/** React-context counterpart of {@link getPanelScopedVars}, reading the panel from QueryEditor context. */
+export function usePanelScopedVars(): ScopedVars {
+  const { panel } = usePanelContext();
+  return getPanelScopedVars(panel);
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useQueryDatasource.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useQueryDatasource.ts
@@ -2,14 +2,24 @@ import { useAsync } from 'react-use';
 
 import { type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
+import { type VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
+
+import { getPanelScopedVars } from '../utils';
 
 /**
  * Loads the datasource for a query. Falls back to the panel's datasource if the query doesn't
  * specify one. Returns `queryDsError` when the lookup throws so consumers can distinguish a
  * configuration gap (no datasource resolved) from an actual load failure.
+ *
+ * `panel` is forwarded as scene scope so section-scoped (row/tab) datasource variables resolve,
+ * not just dashboard-level ones. See {@link getPanelScopedVars}.
  */
-export function useQueryDatasource(query: DataQuery | null, panelDsSettings: DataSourceInstanceSettings | undefined) {
+export function useQueryDatasource(
+  query: DataQuery | null,
+  panelDsSettings: DataSourceInstanceSettings | undefined,
+  panel?: VizPanel
+) {
   const { value, loading, error } = useAsync(async () => {
     if (!query) {
       return undefined;
@@ -33,16 +43,19 @@ export function useQueryDatasource(query: DataQuery | null, panelDsSettings: Dat
       return undefined;
     }
 
-    const queryDsSettings = getDataSourceSrv().getInstanceSettings(dsRef);
+    const scopedVars = panel ? getPanelScopedVars(panel) : undefined;
+
+    const queryDsSettings = getDataSourceSrv().getInstanceSettings(dsRef, scopedVars);
     if (!queryDsSettings) {
       throw new Error(`Datasource settings not found for ${JSON.stringify(dsRef)}`);
     }
 
-    const queryDatasource = await getDataSourceSrv().get(dsRef);
+    const queryDatasource = await getDataSourceSrv().get(dsRef, scopedVars);
     return { datasource: queryDatasource, dsSettings: queryDsSettings };
     // Narrow deps are intentional: widening to [query, panelDsSettings] would re-run on every
     // field change (SQL text, refId, hide flag), flickering `loading` and briefly clearing
     // `queryDsData` on every keystroke. Only datasource-identity changes should invalidate.
+    // `panel` is omitted: its identity is stable for the editor's lifetime.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     query?.refId,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.test.ts
@@ -2,6 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 
 import { type DataSourceApi, type DataSourceInstanceSettings, type DataSourcePluginMeta } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
+import { VizPanel } from '@grafana/scenes';
 import { type DataQuery, type DataSourceJsonData } from '@grafana/schema';
 
 import { useSelectedQueryDatasource } from './useSelectedQueryDatasource';
@@ -310,6 +311,63 @@ describe('useSelectedQueryDatasource', () => {
       // surface the error (see useSelectedQueryDatasource), so consumers see `data: null` here.
       const query: DataQuery = { refId: 'A', datasource: { uid: 'unknown-uid', type: 'unknown' } };
 
+      const { result } = renderHook(() => useSelectedQueryDatasource(query, mockTestDataSettings));
+
+      await waitFor(() => expect(result.current.selectedQueryDsLoading).toBe(false));
+
+      expect(result.current.selectedQueryDsData).toBeNull();
+    });
+  });
+
+  describe('section (row/tab) scoped datasource variables', () => {
+    // A row/tab-scoped variable only resolves through the panel's scene scope. The hook must
+    // forward the panel; without it resolution fails ("Datasource ${metrics_source} was not found").
+    const variableDatasourceRef = { uid: '${metrics_source}', type: 'prometheus' };
+
+    // The panel the hook forwards as scene scope; its contents are irrelevant to this wiring.
+    const panel = new VizPanel({ key: 'panel-1' });
+
+    /** Resolves the variable only when the lookup receives the panel scene scope (`__sceneObject`). */
+    function createSectionScopedDataSourceSrv() {
+      const resolvableWithSceneScope = (ref: unknown, scopedVars: unknown) => {
+        const uid = typeof ref === 'string' ? ref : (ref as { uid?: string })?.uid;
+        const hasSceneScope = Boolean((scopedVars as { __sceneObject?: unknown } | undefined)?.__sceneObject);
+        return uid === '${metrics_source}' && hasSceneScope;
+      };
+
+      return createMockDataSourceSrv({
+        get: jest.fn().mockImplementation((ref: unknown, scopedVars: unknown) => {
+          if (resolvableWithSceneScope(ref, scopedVars)) {
+            return Promise.resolve(mockPrometheusDatasource as DataSourceApi);
+          }
+          return Promise.reject(new Error('Unknown datasource'));
+        }),
+        getInstanceSettings: jest.fn().mockImplementation((ref: unknown, scopedVars: unknown) => {
+          if (resolvableWithSceneScope(ref, scopedVars)) {
+            return mockPrometheusSettings;
+          }
+          return undefined;
+        }),
+      });
+    }
+
+    it('resolves a section-scoped datasource variable when the panel scene scope is provided', async () => {
+      mockGetDataSourceSrv.mockReturnValue(createSectionScopedDataSourceSrv());
+      const query: DataQuery = { refId: 'A', datasource: variableDatasourceRef };
+
+      const { result } = renderHook(() => useSelectedQueryDatasource(query, mockTestDataSettings, panel));
+
+      await waitFor(() => expect(result.current.selectedQueryDsLoading).toBe(false));
+
+      expect(result.current.selectedQueryDsData?.datasource).toBe(mockPrometheusDatasource);
+      expect(result.current.selectedQueryDsData?.dsSettings.uid).toBe('prometheus-uid');
+    });
+
+    it('fails to resolve a section-scoped datasource variable without the panel scene scope (regression guard)', async () => {
+      mockGetDataSourceSrv.mockReturnValue(createSectionScopedDataSourceSrv());
+      const query: DataQuery = { refId: 'A', datasource: variableDatasourceRef };
+
+      // No panel → no scene scope → the variable can't be interpolated (the original failure).
       const { result } = renderHook(() => useSelectedQueryDatasource(query, mockTestDataSettings));
 
       await waitFor(() => expect(result.current.selectedQueryDsLoading).toBe(false));

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
@@ -1,4 +1,5 @@
 import { type DataSourceInstanceSettings } from '@grafana/data';
+import { type VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 
 import { useQueryDatasource } from './useQueryDatasource';
@@ -6,12 +7,15 @@ import { useQueryDatasource } from './useQueryDatasource';
 /**
  * Hook to load the datasource for the currently selected query.
  * Falls back to the panel's datasource if the query doesn't specify one.
+ *
+ * `panel` is forwarded so section-scoped (row/tab) datasource variables resolve.
  */
 export function useSelectedQueryDatasource(
   selectedQuery: DataQuery | null,
-  panelDsSettings: DataSourceInstanceSettings | undefined
+  panelDsSettings: DataSourceInstanceSettings | undefined,
+  panel?: VizPanel
 ) {
-  const { queryDsData, queryDsLoading } = useQueryDatasource(selectedQuery, panelDsSettings);
+  const { queryDsData, queryDsLoading } = useQueryDatasource(selectedQuery, panelDsSettings, panel);
 
   return {
     selectedQueryDsData: queryDsData,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -1,6 +1,12 @@
-import { type AlertState, type DataTransformerConfig, type GrafanaTheme2, TransformerCategory } from '@grafana/data';
+import {
+  type AlertState,
+  type DataTransformerConfig,
+  type GrafanaTheme2,
+  type ScopedVars,
+  TransformerCategory,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { type CustomTransformerDefinition } from '@grafana/scenes';
+import { type CustomTransformerDefinition, SafeSerializableSceneObject, type VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 
@@ -8,6 +14,10 @@ import { getAlertStateColor, getQueryEditorTypeConfig, QueryEditorType } from '.
 
 import { type PendingExpression, type PendingTransformation } from './QueryEditorContext';
 import { type AlertRule, type Transformation } from './types';
+
+export function getPanelScopedVars(panel: VizPanel): ScopedVars {
+  return { __sceneObject: new SafeSerializableSceneObject(panel) };
+}
 
 export function getEditorType(
   card: DataQuery | Transformation | AlertRule | null,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14259,6 +14259,7 @@
     }
   },
   "query-editor-renderer": {
+    "datasource-load-error-body": "Select a datasource for this query to continue.",
     "datasource-load-error-title": "Failed to load datasource for this query",
     "loading-datasource": "Loading datasource",
     "no-query-editor-component": "Data source plugin does not export any query editor component"


### PR DESCRIPTION
## Description
Fixes the v2 query editor failing to resolve **row/tab (section) scoped datasource variables** (e.g. `${metrics_source}`), which errored with "Datasource ${metrics_source} was not found" — even though dashboard-level variables worked and v1 handled both. Brings v2 to parity with v1.

## Changes
* Added `getPanelScopedVars(panel)` as the single source of truth for the `__sceneObject` scene scope, plus a `usePanelScopedVars` hook for component contexts.
* Threaded that scope through every datasource lookup that resolves a user ref: `PanelDataPaneNext` (load / change / bulk-change), `useQueryDatasource`/`useSelectedQueryDatasource`, the `DataSourcePicker` in `ContentHeader`, and the sidebar logo in `QueryCard`. Lookups for `config.defaultDatasource`/last-used UIDs are intentionally left unscoped (literals never interpolate).
* Datasource picker now shows the resolved effective datasource (`currentDatasource ?? raw ref`) so inherited section-scoped variables display correctly instead of "Select data source" (v1 parity).
* Polished the unresolvable-datasource alert with an actionable body line.

## Risks
* Scope is narrow and additive — it only passes `scopedVars` where they were previously omitted, so existing dashboard-level and explicit-datasource flows are unchanged.
* Most likely surface for regression is the **datasource picker `current` value** in the v2 editor (now derived from the resolved DS rather than the raw ref); Mixed-datasource and inherited-datasource panels are the cases to watch.

## Demo
<!-- Attach before/after screen recording: v2 editor with a row-scoped `${metrics_source}` variable erroring (before) vs. resolving + displaying in the picker (after). -->

#### Before

https://github.com/user-attachments/assets/5133c26d-1bbc-4815-8653-553bc848cc9a

#### After

https://github.com/user-attachments/assets/438ae531-aed7-4049-aef3-541c4d7ca776

## Testing Instructions
* Create a dashboard with a **row-scoped** datasource variable (row repeat / section variable, not dashboard-level), e.g. `${metrics_source}`.
* Add a panel in that row using the variable as its datasource; open the **v2 query editor**.
* Confirm the query editor loads, the picker shows the variable's resolved datasource (not "Select data source"), and the sidebar logo is correct.
* Rename/break the variable → confirm the actionable "Failed to load datasource… Select a datasource to continue" alert appears.

## Reviewer Checklist
- [x] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable