### PR TITLE
Docs: clarify Grafana version floor for the externalised Elasticsearch plugin

### DIFF
--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -70,6 +70,8 @@ The following documentation helps you set up and use the Elasticsearch data sour
 
 Starting with Grafana v13.0, the Elasticsearch data source is a standalone plugin, pre-installed in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
 
+The standalone plugin requires Grafana 12.2.0 or later. The Elasticsearch data source bundled with Grafana 12.1 and earlier continues to work as before — these versions are unaffected by the externalisation. Users running Grafana 12.2.x through 12.6.x can install the standalone plugin from the plugin catalog if they want the latest features ahead of Grafana 13.0.
+
 To adjust this behavior:
 
 - **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).

--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -94,7 +94,7 @@ preinstall_sync = elasticsearch
 
 After you have configured the Elasticsearch data source, you can:
 
-- Use [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) to run ad hoc queries against your Elasticsearch data.
+- Use [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) to run user-written queries against your Elasticsearch data.
 - Configure and use [template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/elasticsearch/template-variables/) for dynamic dashboards.
 - Add [Transformations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/) to process query results.
 - [Build dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/) to visualize your Elasticsearch data.

--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -70,12 +70,25 @@ The following documentation helps you set up and use the Elasticsearch data sour
 
 Starting with Grafana v13.0, the Elasticsearch data source is a standalone plugin, pre-installed in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
 
-The standalone plugin requires Grafana 12.2.0 or later. The Elasticsearch data source bundled with Grafana 12.1 and earlier continues to work as before — these versions are unaffected by the externalisation. Users running Grafana 12.2.x through 12.6.x can install the standalone plugin from the plugin catalog if they want the latest features ahead of Grafana 13.0.
-
 To adjust this behavior:
 
 - **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
 - **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
+
+The standalone plugin requires Grafana 12.2.0 or later. The Elasticsearch data source bundled with Grafana 12.1 and earlier continues to work as before — these versions are unaffected by the externalisation.
+
+Users running Grafana 12.2.x through 12.4.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.0. To use the standalone plugin with Grafana 12.2.x through 12.4.x, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
+
+```ini
+[plugin.elasticsearch]
+as_external = true
+
+[plugins]
+; Install the latest version on startup:
+preinstall_sync = elasticsearch
+; Or install a specific version:
+; preinstall_sync = elasticsearch@<version>
+```
 
 ## Additional resources
 

--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -92,7 +92,7 @@ preinstall_sync = elasticsearch
 
 ## Additional resources
 
-Once you have configured the Elasticsearch data source, you can:
+After you have configured the Elasticsearch data source, you can:
 
 - Use [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) to run ad hoc queries against your Elasticsearch data.
 - Configure and use [template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/elasticsearch/template-variables/) for dynamic dashboards.


### PR DESCRIPTION
## Summary

Clarifies in the Elasticsearch data source docs that the **externalised standalone plugin** requires Grafana 12.2.0 or later, while the **bundled in-tree datasource** that ships with Grafana 12.1 and earlier is unaffected.

## Why

The externalised Elasticsearch plugin (in [grafana/grafana-elasticsearch-datasource](https://github.com/grafana/grafana-elasticsearch-datasource)) bumped its \`grafanaDependency\` floor to \`>=12.2.0-0\` (see [grafana/grafana-elasticsearch-datasource#312](https://github.com/grafana/grafana-elasticsearch-datasource/pull/312)). The previous \`>=11.6.0\` floor was misleading — the plugin's runtime deps already pin \`@grafana/ui\` and \`@grafana/runtime\` to \`^12.3.0\`, so it can't actually run on 11.x. **12.2.x is the oldest version of the 12.x line still receiving updates per Grafana's [when-to-upgrade policy](https://grafana.com/docs/grafana/latest/upgrade-guide/when-to-upgrade/)**.

The grafana/grafana docs already noted "Starting with Grafana v13.0, the Elasticsearch data source is a standalone plugin" but didn't state the minimum Grafana version for users wanting to install the standalone plugin ahead of 13.0. This PR adds that line, and explicitly reassures users on older Grafana versions that the bundled datasource is unchanged.

## Changes

- **[docs/sources/datasources/elasticsearch/_index.md](docs/sources/datasources/elasticsearch/_index.md)** — extends the "Plugin updates" section with the version floor and the in-tree vs. standalone distinction.