### PR TITLE
fix: bad MySQL query in datasource_type column migration

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/datasource_type_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/datasource_type_migrator.go
@@ -29,9 +29,8 @@ const backfillDatasourceTypeSQL = `
 UPDATE permission AS p
 SET datasource_type = (
 	SELECT ds.type
-	FROM data_source AS ds
-	INNER JOIN role AS r ON r.id = p.role_id
-	WHERE ds.uid = p.identifier AND ds.org_id = r.org_id
+	FROM data_source AS ds, role AS r
+	WHERE r.id = p.role_id AND ds.uid = p.identifier AND ds.org_id = r.org_id
 	LIMIT 1
 )
 WHERE p.kind = 'datasources' AND p.attribute = 'uid'`


### PR DESCRIPTION
MySQL [docs states](https://dev.mysql.com/doc/refman/8.0/en/correlated-subqueries.html):

>  A correlated column can be present only in the subquery's WHERE clause (and not in the SELECT list, a JOIN or ORDER BY clause, a GROUP BY list, or a HAVING clause). Nor can there be any correlated column inside a derived table in the subquery's FROM list. 

The query in question happens to work in MySQL 8.0.24 due to a change in the optimizer. But it doesn't work in MySQL < 8.0.24 which we still support, and could stop working abruptly in the future too given the claim above from their documentation. This PR fixes such query.

It's usually not advised to change queries in migrations, but in this case it's fine. Any instances that ran the query successfully will simply not get this change as the migration will be skipped. Any instances that did NOT run this migration yet will run the updated version, which produces the same table state.