### PR TITLE
Mutation API: Fix panel id reassignment when moving panels between layouts

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
@@ -817,9 +817,10 @@ describe('Layout mutation commands', () => {
 
       const panels = (scene.state.body as unknown as RowsLayoutManager).state.rows[0].state.layout.getVizPanels();
       expect(panels).toHaveLength(3);
-      // Panel ids are preserved (no bump) ...
-      expect(panels.map((p) => p.state.key).sort()).toEqual(['panel-1', 'panel-2', 'panel-3']);
-      // ... and each grid item key stays unique (no React duplicate-key collision).
+
+      const keyToTitle = Object.fromEntries(panels.map((p) => [p.state.key, p.state.title]));
+      expect(keyToTitle).toEqual({ 'panel-1': 'P1', 'panel-2': 'P2', 'panel-3': 'P3' });
+
       const gridItemKeys = panels.map((p) => p.parent?.state.key);
       expect(new Set(gridItemKeys).size).toBe(3);
     });

--- a/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
@@ -781,30 +781,7 @@ describe('Layout mutation commands', () => {
       expect(body.state.rows[1].state.layout.getVizPanels()).toHaveLength(2);
     });
 
-    it('preserves the panel id when moving between rows', async () => {
-      const scene = buildRowsSceneWithPanels();
-      const executor = new DashboardMutationClient(scene);
-      const body = scene.state.body as unknown as RowsLayoutManager;
-
-      const result = await executor.execute({
-        type: 'MOVE_PANEL',
-        payload: {
-          element: { name: 'elem-a' },
-          toParent: '/rows/1',
-        },
-      });
-
-      expect(result.success).toBe(true);
-
-      const movedPanel = body.state.rows[1].state.layout.getVizPanels().find((p) => p.state.title === 'Panel A')!;
-      expect(movedPanel.state.key).toBe('panel-1');
-    });
-
-    it('keeps grid item keys unique when moving several low-id panels into one row', async () => {
-      // Reproduces the duplicate-key crash: addPanel() keys the wrapping grid
-      // item via getNextPanelId(), which keeps returning the same value once the
-      // moved panels have their (low) ids restored — every grid item would
-      // collide on the same key.
+    it('preserves panel ids and keeps grid item keys unique when moving panels', async () => {
       const panel1 = new VizPanel({ key: 'panel-1', title: 'P1', pluginId: 'timeseries' });
       const panel2 = new VizPanel({ key: 'panel-2', title: 'P2', pluginId: 'timeseries' });
       const panel3 = new VizPanel({ key: 'panel-3', title: 'P3', pluginId: 'timeseries' });
@@ -840,7 +817,9 @@ describe('Layout mutation commands', () => {
 
       const panels = (scene.state.body as unknown as RowsLayoutManager).state.rows[0].state.layout.getVizPanels();
       expect(panels).toHaveLength(3);
+      // Panel ids are preserved (no bump) ...
       expect(panels.map((p) => p.state.key).sort()).toEqual(['panel-1', 'panel-2', 'panel-3']);
+      // ... and each grid item key stays unique (no React duplicate-key collision).
       const gridItemKeys = panels.map((p) => p.parent?.state.key);
       expect(new Set(gridItemKeys).size).toBe(3);
     });

--- a/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
@@ -781,6 +781,70 @@ describe('Layout mutation commands', () => {
       expect(body.state.rows[1].state.layout.getVizPanels()).toHaveLength(2);
     });
 
+    it('preserves the panel id when moving between rows', async () => {
+      const scene = buildRowsSceneWithPanels();
+      const executor = new DashboardMutationClient(scene);
+      const body = scene.state.body as unknown as RowsLayoutManager;
+
+      const result = await executor.execute({
+        type: 'MOVE_PANEL',
+        payload: {
+          element: { name: 'elem-a' },
+          toParent: '/rows/1',
+        },
+      });
+
+      expect(result.success).toBe(true);
+
+      const movedPanel = body.state.rows[1].state.layout.getVizPanels().find((p) => p.state.title === 'Panel A')!;
+      expect(movedPanel.state.key).toBe('panel-1');
+    });
+
+    it('keeps grid item keys unique when moving several low-id panels into one row', async () => {
+      // Reproduces the duplicate-key crash: addPanel() keys the wrapping grid
+      // item via getNextPanelId(), which keeps returning the same value once the
+      // moved panels have their (low) ids restored — every grid item would
+      // collide on the same key.
+      const panel1 = new VizPanel({ key: 'panel-1', title: 'P1', pluginId: 'timeseries' });
+      const panel2 = new VizPanel({ key: 'panel-2', title: 'P2', pluginId: 'timeseries' });
+      const panel3 = new VizPanel({ key: 'panel-3', title: 'P3', pluginId: 'timeseries' });
+      const row = new RowItem({
+        title: 'Row',
+        layout: DefaultGridLayoutManager.fromVizPanels([panel1, panel2, panel3]),
+      });
+      const body = new RowsLayoutManager({ rows: [row] });
+      const state: Record<string, unknown> = { uid: 'test-dash', isEditing: false, body };
+      const scene = {
+        state,
+        serializer: mockSerializer({ 'panel-1': 1, 'panel-2': 2, 'panel-3': 3 }),
+        canEditDashboard: jest.fn(() => true),
+        onEnterEditMode: jest.fn(() => {
+          state.isEditing = true;
+        }),
+        forceRender: jest.fn(),
+        setState: jest.fn((partial: Record<string, unknown>) => {
+          Object.assign(state, partial);
+        }),
+      };
+      currentTestScene = scene;
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const executor = new DashboardMutationClient(scene as unknown as DashboardScene);
+
+      for (const name of ['panel-1', 'panel-2', 'panel-3']) {
+        const result = await executor.execute({
+          type: 'MOVE_PANEL',
+          payload: { element: { name }, toParent: '/rows/0', position: { x: 0, y: 0, width: 24, height: 8 } },
+        });
+        expect(result.success).toBe(true);
+      }
+
+      const panels = (scene.state.body as unknown as RowsLayoutManager).state.rows[0].state.layout.getVizPanels();
+      expect(panels).toHaveLength(3);
+      expect(panels.map((p) => p.state.key).sort()).toEqual(['panel-1', 'panel-2', 'panel-3']);
+      const gridItemKeys = panels.map((p) => p.parent?.state.key);
+      expect(new Set(gridItemKeys).size).toBe(3);
+    });
+
     it('returns no-op when toParent is omitted and no position is provided', async () => {
       const scene = buildRowsSceneWithPanels();
       const executor = new DashboardMutationClient(scene);

--- a/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
@@ -15,7 +15,7 @@ import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayo
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { getElements } from '../../serialization/layoutSerializers/utils';
-import { getLayoutManagerFor, getVizPanelKeyForPanelId } from '../../utils/utils';
+import { getGridItemKeyForPanelId, getLayoutManagerFor, getVizPanelKeyForPanelId } from '../../utils/utils';
 
 import { resolveLayoutPath } from './layoutPathResolver';
 import { serializeResultLayoutItem } from './panelSerialization';
@@ -197,6 +197,9 @@ export const movePanelCommand: MutationCommand<MovePanelPayload> = {
       currentLayout.removePanel(vizPanel);
 
       targetLayout.addPanel(panelClone);
+
+      panelClone.setState({ key: getVizPanelKeyForPanelId(panelId) });
+      panelClone.parent?.setState({ key: getGridItemKeyForPanelId(panelId) });
 
       if (effectivePosition) {
         if (isTargetAutoGrid) {

--- a/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
@@ -196,6 +196,7 @@ export const movePanelCommand: MutationCommand<MovePanelPayload> = {
       }
       currentLayout.removePanel(vizPanel);
 
+      // TODO: share id-preserving logic with movePanelsHelper.ts.
       targetLayout.addPanel(panelClone);
 
       panelClone.setState({ key: getVizPanelKeyForPanelId(panelId) });


### PR DESCRIPTION
**What is this feature?**

Fixes the `MOVE_PANEL` mutation command so that moving a panel between layouts preserves the panel's id. 

**Why do we need this feature?**

Two bugs stemmed from the re-keying:

1. **Id bumping** — moving a panel renamed it (e.g. `panel-1` → `panel-4`), so any element reference held by the caller (e.g. the dashboard mutation API used by Grafana Assistant) became stale, causing "Panel not found" errors on subsequent operations and ids that climbed on every move cycle.
2. **Duplicate grid-item keys** — `addPanel()` derives both the panel key and the wrapping grid-item key from `getNextPanelId()`. Once ids were restored to low values, `getNextPanelId()` returned the same value on every move, so multiple grid items collided on the same React key (`grid-item-N`). React dropped the duplicates, rendering fewer panels than expected.

Restoring both keys from the original panel id keeps the panel and its grid-item wrapper aligned

