### PR TITLE
fix(provisioning): ignore terminating repositories on connection delete

### DIFF
--- a/apps/provisioning/pkg/connection/delete_validator.go
+++ b/apps/provisioning/pkg/connection/delete_validator.go
@@ -53,18 +53,28 @@ func (v *ReferencedByRepositoriesValidator) Validate(ctx context.Context, a admi
 		return fmt.Errorf("failed to check for referencing repositories: %w", err)
 	}
 
-	if len(repos) > 0 {
-		repoNames := make([]string, len(repos))
-		for i, repo := range repos {
-			repoNames[i] = repo.GetName()
+	// Only repositories that are not themselves being deleted block the connection
+	// delete. Repository deletion is asynchronous (finalizer-driven): a repository
+	// keeps appearing in this listing, with its DeletionTimestamp set, until its
+	// finalizers complete. Counting such a terminating repository would reject the
+	// connection delete during that eventual-consistency window — e.g. when a client
+	// deletes a repository and the connection it references back-to-back — even
+	// though the reference is already on its way out.
+	var blockingNames []string
+	for _, repo := range repos {
+		if repo.GetDeletionTimestamp() != nil {
+			continue
 		}
+		blockingNames = append(blockingNames, repo.GetName())
+	}
 
+	if len(blockingNames) > 0 {
 		return apierrors.NewInvalid(
 			provisioning.ConnectionResourceInfo.GroupVersionKind().GroupKind(),
 			connectionName,
 			field.ErrorList{field.Forbidden(
 				field.NewPath("metadata", "name"),
-				fmt.Sprintf("cannot delete connection: referenced by %d repository(s): %v", len(repos), repoNames),
+				fmt.Sprintf("cannot delete connection: referenced by %d repository(s): %v", len(blockingNames), blockingNames),
 			)},
 		)
 	}

--- a/apps/provisioning/pkg/connection/delete_validator_test.go
+++ b/apps/provisioning/pkg/connection/delete_validator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -122,6 +123,49 @@ func TestReferencedByRepositoriesValidator_Validate(t *testing.T) {
 			},
 			wantErr:         true,
 			wantErrContains: "referenced by 2 repository(s)",
+		},
+		{
+			name:           "allows deletion when the only referencing repository is being deleted",
+			connectionName: "test-connection",
+			namespace:      "default",
+			operation:      admission.Delete,
+			repos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "repo-1",
+						DeletionTimestamp: &metav1.Time{Time: time.Unix(1, 0)},
+					},
+					Spec: provisioning.RepositorySpec{
+						Connection: &provisioning.ConnectionInfo{Name: "test-connection"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "blocks deletion counting only repositories that are not being deleted",
+			connectionName: "test-connection",
+			namespace:      "default",
+			operation:      admission.Delete,
+			repos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "repo-deleting",
+						DeletionTimestamp: &metav1.Time{Time: time.Unix(1, 0)},
+					},
+					Spec: provisioning.RepositorySpec{
+						Connection: &provisioning.ConnectionInfo{Name: "test-connection"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "repo-live"},
+					Spec: provisioning.RepositorySpec{
+						Connection: &provisioning.ConnectionInfo{Name: "test-connection"},
+					},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "referenced by 1 repository(s): [repo-live]",
 		},
 		{
 			name:           "allows deletion when repositories reference different connections",


### PR DESCRIPTION
## Summary

`terraform destroy` of a Git Sync connection together with a repository that references it (`spec.connection.name`) intermittently fails with:

```
Error: invalid value for field "metadata.name":
  * Forbidden: cannot delete connection: referenced by 1 repository(s): [...]
```

Terraform deletes the **repository first**, then the **connection**. Repository deletion is asynchronous (finalizer-driven): the repository `DELETE` returns `200` while its finalizers run, so the connection `DELETE` ~100ms later still observes the reference and the admission validator rejects it with a `422`. A moment later the repository is fully gone and the same delete succeeds — it's an eventual-consistency window, not a real dependency violation.

This is the minimal, synchronous fix: the connection delete validator now **ignores repositories that are themselves terminating** (`DeletionTimestamp` set).

Addresses the backend root cause behind grafana/git-ui-sync-project#977 / support-escalations#22908 (roche).

## Changes

- `delete_validator.go`: when checking whether a connection is still referenced, skip repositories whose `DeletionTimestamp` is set. Only repositories that are **not** being deleted block the connection delete.

## Behaviour

| Scenario | Result |
|---|---|
| Connection referenced by a **live** repository | Blocked with the same `422` — unchanged |
| Connection's only referencing repos are **terminating** (the destroy race) | Allowed |
| Connection with **no** references | Allowed — unchanged (still synchronous) |

The protection against deleting a connection that live repositories depend on is intact; only a repository that has *already* been asked to delete stops counting as a blocker.

## Testing

- `go test ./apps/provisioning/pkg/connection/` — pass.
- `go vet` / `gofmt` — clean. (`golangci-lint` could not run in this env due to a Go-version mismatch in the pinned binary.)
- Unit tests added: the only referencing repository being deleted allows the delete; a mix counts only the non-terminating repositories in the error.

## Scope

Connection deletion remains **synchronous** — no finalizers, no `Terminating` window, no behavioural change for the common case. A separate PR explores a finalizer that makes a connection physically outlive a terminating repository (a stronger guarantee at the cost of asynchronous deletion); this PR is the small, self-contained fix for the reported issue.

## Checklist

- [x] Tests added/updated
- [x] No docs/schema changes required
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)