### PR TITLE
refactor(mt-annotations): use goose provider with session lock for migrations

### DIFF
--- a/pkg/registry/apps/annotation/postgres_schema.go
+++ b/pkg/registry/apps/annotation/postgres_schema.go
@@ -196,9 +196,11 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger log.Logger) e
 	}
 
 	// Run all pending migrations
-	if _, err := provider.Up(ctx); err != nil {
+	results, err := provider.Up(ctx)
+	if err != nil {
 		return fmt.Errorf("failed to run migrations: %w", err)
 	}
+	logger.Info("Database migrations complete", "applied", len(results))
 
 	return nil
 }

--- a/pkg/registry/apps/annotation/postgres_schema.go
+++ b/pkg/registry/apps/annotation/postgres_schema.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"io/fs"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -12,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
+	"github.com/pressly/goose/v3/lock"
 )
 
 //go:embed migrations/*.sql
@@ -171,15 +173,30 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger log.Logger) e
 		}
 	}()
 
-	// Configure goose to use embedded migrations
-	goose.SetBaseFS(embedMigrations)
+	// The provider reads from the root of the fs, so re-root onto the migrations dir.
+	migrationsFS, err := fs.Sub(embedMigrations, "migrations")
+	if err != nil {
+		return fmt.Errorf("failed to sub migrations fs: %w", err)
+	}
 
-	if err := goose.SetDialect("postgres"); err != nil {
-		return fmt.Errorf("failed to set goose dialect: %w", err)
+	// Use Postgres advisory locks to prevent multiple instances from running migrations concurrently
+	locker, err := lock.NewPostgresSessionLocker()
+	if err != nil {
+		return fmt.Errorf("failed to create session locker: %w", err)
+	}
+
+	provider, err := goose.NewProvider(
+		goose.DialectPostgres,
+		db,
+		migrationsFS,
+		goose.WithSessionLocker(locker),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create goose provider: %w", err)
 	}
 
 	// Run all pending migrations
-	if err := goose.UpContext(ctx, db, "migrations"); err != nil {
+	if _, err := provider.Up(ctx); err != nil {
 		return fmt.Errorf("failed to run migrations: %w", err)
 	}
 


### PR DESCRIPTION
This PR updates the `runMigrations` function for the annotations app platform API's postgres store to leverage goose's session locking capabilities to prevent multiple Grafana instances from running the same migrations concurrently. This uses postgres's session-level advisory lock mechanism under the hood.

Refs:
* https://pressly.github.io/goose/documentation/provider/#withsessionlocker
* https://pkg.go.dev/github.com/pressly/goose/v3@v3.20.0/lock#NewPostgresSessionLocker