### PR TITLE
chore: switch scopes api registration to config based params

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -646,6 +646,7 @@ type Cfg struct {
 	NewsFeedEnabled bool
 
 	// Experimental scope settings
+	ScopesApiEnabled        bool
 	ScopesListScopesURL     string
 	ScopesListDashboardsURL string
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1802,6 +1802,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	// read experimental scopes settings.
 	scopesSection := iniFile.Section("scopes")
+	cfg.ScopesApiEnabled = scopesSection.Key("api_enabled").MustBool(false)
 	cfg.ScopesListScopesURL = scopesSection.Key("list_scopes_endpoint").MustString("")
 	cfg.ScopesListDashboardsURL = scopesSection.Key("list_dashboards_endpoint").MustString("")
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -947,6 +947,14 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = section.NewKey("runtime_config", opts.APIServerRuntimeConfig)
 		require.NoError(t, err)
 	}
+
+	if opts.ScopesApiEnabled {
+		section, err := getOrCreateSection("scopes")
+		require.NoError(t, err)
+		_, err = section.NewBooleanKey("api_enabled")
+		require.NoError(t, err)
+	}
+
 	dbSection, err := getOrCreateSection("database")
 	require.NoError(t, err)
 	_, err = dbSection.NewKey("query_retries", fmt.Sprintf("%d", queryRetries))
@@ -1072,6 +1080,9 @@ type GrafanaOpts struct {
 	HASingleNodeEvaluation bool
 
 	EnableAnnotationAppPlatform bool
+
+	// Enables Scope Api
+	ScopesApiEnabled bool
 }
 
 func CreateUser(t *testing.T, store db.DB, cfg *setting.Cfg, cmd user.CreateUserCommand) *user.User {

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -951,7 +951,7 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 	if opts.ScopesApiEnabled {
 		section, err := getOrCreateSection("scopes")
 		require.NoError(t, err)
-		_, err = section.NewBooleanKey("api_enabled")
+		_, err = section.NewKey("api_enabled", "true")
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
Old FeatureToggles serice had been deprecated some time ago, we need to move on/off lever controlling scope api to grafana config parfameters.