### PR TITLE
Alerting: add ManagedTemplates storage field, migrate from TemplateFiles

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -710,11 +710,12 @@ func (mr *ManagedRoutes) UnmarshalJSON(b []byte) error {
 
 // swagger:model
 type PostableUserConfig struct {
-	TemplateFiles          map[string]string         `yaml:"template_files" json:"template_files"`
-	AlertmanagerConfig     PostableApiAlertingConfig `yaml:"alertmanager_config" json:"alertmanager_config"`
-	ExtraConfigs           []ExtraConfiguration      `yaml:"extra_config,omitempty" json:"extra_config,omitempty"`
-	ManagedRoutes          ManagedRoutes             `yaml:"managed_routes,omitempty" json:"managed_routes,omitempty"`                     // TODO: Move to ConfigRevision?
-	ManagedInhibitionRules ManagedInhibitionRules    `yaml:"managed_inhibition_rules,omitempty" json:"managed_inhibition_rules,omitempty"` // TODO: Move to ConfigRevision?
+	TemplateFiles          map[string]string                         `yaml:"template_files,omitempty" json:"template_files,omitempty"`
+	ManagedTemplates       map[string]definition.PostableApiTemplate `yaml:"managed_templates,omitempty" json:"managed_templates,omitempty"`
+	AlertmanagerConfig     PostableApiAlertingConfig                 `yaml:"alertmanager_config" json:"alertmanager_config"`
+	ExtraConfigs           []ExtraConfiguration                      `yaml:"extra_config,omitempty" json:"extra_config,omitempty"`
+	ManagedRoutes          ManagedRoutes                             `yaml:"managed_routes,omitempty" json:"managed_routes,omitempty"`                     // TODO: Move to ConfigRevision?
+	ManagedInhibitionRules ManagedInhibitionRules                    `yaml:"managed_inhibition_rules,omitempty" json:"managed_inhibition_rules,omitempty"` // TODO: Move to ConfigRevision?
 }
 
 func (c *PostableUserConfig) UnmarshalJSON(b []byte) error {

--- a/pkg/services/ngalert/notifier/alertmanager_config_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config_test.go
@@ -243,7 +243,7 @@ receivers:
 		require.NoError(t, err)
 		require.Equal(t, identifier, result.AddedRoute)
 		require.Contains(t, result.AddedReceivers, "promoted-receiver")
-		require.Contains(t, result.AddedTemplates, "promoted.tmpl")
+		require.Len(t, result.AddedTemplates, 1, "one template UID should be reported as added")
 
 		gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false)
 		require.NoError(t, err)

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
@@ -20,8 +20,17 @@ func ToModel(in *definitions.PostableUserConfig) *AMConfigV1 {
 	if in == nil {
 		return nil
 	}
+	// Merge legacy TemplateFiles and new ManagedTemplates into the internal model.
+	// ManagedTemplates entries overwrite TemplateFiles entries with the same UID (same name+kind).
+	templates := TemplateFilesToTemplates(in.TemplateFiles, TemplateKindGrafana)
+	if len(in.ManagedTemplates) > 0 {
+		if templates == nil {
+			templates = make(map[ResourceUID]TemplateGroup, len(in.ManagedTemplates))
+		}
+		maps.Copy(templates, ManagedTemplatesToTemplates(in.ManagedTemplates))
+	}
 	return &AMConfigV1{
-		Templates:          TemplateFilesToTemplates(in.TemplateFiles, TemplateKindGrafana),
+		Templates:          templates,
 		InhibitionRules:    InhibitionRulesToModel(in.ManagedInhibitionRules),
 		AlertmanagerConfig: PostableApiAlertingConfigToModel(in.AlertmanagerConfig),
 		ExtraConfigs:       ExtraConfigsToModel(in.ExtraConfigs),
@@ -211,7 +220,7 @@ func ToDBModel(in *AMConfigV1) (*AMConfigDB, error) {
 		return nil, nil
 	}
 	dbModel := AMConfigDB{
-		TemplateFiles:      TemplatesToTemplateFiles(in.Templates),
+		ManagedTemplates:   TemplatesToManagedTemplates(in.Templates),
 		AlertmanagerConfig: PostableApiAlertingConfigToDB(in.AlertmanagerConfig),
 		ExtraConfigs:       ExtraConfigsToDB(in.ExtraConfigs),
 		ManagedRoutes:      ManagedRoutesToDB(in.ManagedRoutes),

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat_test.go
@@ -42,9 +42,9 @@ inhibit_rules:
       - instance
 `
 	configJSON := fmt.Sprintf(`{
-		"template_files": {
-			"template1.tmpl": "{{ define \"test\" }}Hello {{ .CommonLabels.alertname }}{{ end }}",
-			"template2.tmpl": "{{ define \"test2\" }}Alert: {{ .Status }}{{ end }}"
+		"managed_templates": {
+			"template1.tmpl": {"name":"template1.tmpl","content":"{{ define \"test\" }}Hello {{ .CommonLabels.alertname }}{{ end }}","kind":"grafana"},
+			"template2.tmpl": {"name":"template2.tmpl","content":"{{ define \"test2\" }}Alert: {{ .Status }}{{ end }}","kind":"grafana"}
 		},
 		"alertmanager_config": {
 			"route": {
@@ -246,6 +246,70 @@ inhibit_rules:
 
 	require.JSONEq(t, configJSON, string(convertedJSON),
 		"Round-trip conversion should be lossless")
+}
+
+func TestMigrationFromTemplateFiles(t *testing.T) {
+	// Old configs stored templates in template_files. Verify they load correctly
+	// and are converted to managed_templates on save.
+	input := &AMConfigDB{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"template_files": {
+			"tmpl.tmpl": "{{ define \"alert\" }}hello{{ end }}"
+		},
+		"alertmanager_config": {
+			"route": {"receiver": "recv"},
+			"receivers": [{"name": "recv"}]
+		}
+	}`), input))
+
+	model := ToModel(input)
+	require.NotNil(t, model)
+	require.Len(t, model.Templates, 1)
+
+	output, err := ToDBModel(model)
+	require.NoError(t, err)
+	require.Nil(t, output.TemplateFiles, "TemplateFiles must be wiped on write")
+	require.Len(t, output.ManagedTemplates, 1)
+
+	expectedUID := string(TemplateUID(TemplateKindGrafana, "tmpl.tmpl"))
+	mt, ok := output.ManagedTemplates[expectedUID]
+	require.True(t, ok)
+	assert.Equal(t, "tmpl.tmpl", mt.Name)
+	assert.Equal(t, definition.GrafanaTemplateKind, mt.Kind)
+}
+
+func TestToModel_TemplateConflicts(t *testing.T) {
+	minimalAMConfig := `{"route":{"receiver":"recv"},"receivers":[{"name":"recv"}]}`
+
+	t.Run("managed_templates_wins_on_uid_conflict", func(t *testing.T) {
+		// A template present in both fields with the same UID: ManagedTemplates must win.
+		conflictUID := string(TemplateUID(TemplateKindGrafana, "tmpl.tmpl"))
+		input := &AMConfigDB{}
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"template_files": {"tmpl.tmpl": "{{ define \"alert\" }}old{{ end }}"},
+			"managed_templates": {"`+conflictUID+`": {"name":"tmpl.tmpl","content":"{{ define \"alert\" }}new{{ end }}","kind":"grafana"}},
+			"alertmanager_config": `+minimalAMConfig+`
+		}`), input))
+
+		model := ToModel(input)
+		require.Len(t, model.Templates, 1)
+		assert.Equal(t, `{{ define "alert" }}new{{ end }}`, model.Templates[ResourceUID(conflictUID)].Content)
+	})
+
+	t.Run("no_conflict_both_templates_present", func(t *testing.T) {
+		// Different UIDs: both templates should be in the merged result.
+		input := &AMConfigDB{}
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"template_files": {"a.tmpl": "{{ define \"a\" }}A{{ end }}"},
+			"managed_templates": {"`+string(TemplateUID(TemplateKindGrafana, "b.tmpl"))+`": {"name":"b.tmpl","content":"{{ define \"b\" }}B{{ end }}","kind":"grafana"}},
+			"alertmanager_config": `+minimalAMConfig+`
+		}`), input))
+
+		model := ToModel(input)
+		require.Len(t, model.Templates, 2)
+		assert.Contains(t, model.Templates, TemplateUID(TemplateKindGrafana, "a.tmpl"))
+		assert.Contains(t, model.Templates, TemplateUID(TemplateKindGrafana, "b.tmpl"))
+	})
 }
 
 func TestPostableMimirReceiverToPostableGrafanaReceiver(t *testing.T) {

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/templates.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/templates.go
@@ -119,6 +119,35 @@ func TemplatesToTemplateFiles(templates map[ResourceUID]TemplateGroup) map[strin
 	return templateFiles
 }
 
+// ManagedTemplatesToTemplates converts a ManagedTemplates map (keyed by UID) to the internal TemplateGroup map.
+func ManagedTemplatesToTemplates(managed map[string]definition.PostableApiTemplate) map[ResourceUID]TemplateGroup {
+	if managed == nil {
+		return nil
+	}
+	out := make(map[ResourceUID]TemplateGroup, len(managed))
+	for uid, t := range managed {
+		tmpl := NewTemplateGroup(ResourceUID(uid), t.Name, t.Content, TemplateKind(t.Kind), models.ProvenanceNone)
+		out[ResourceUID(uid)] = tmpl
+	}
+	return out
+}
+
+// TemplatesToManagedTemplates converts the internal TemplateGroup map to a ManagedTemplates map keyed by UID.
+func TemplatesToManagedTemplates(templates map[ResourceUID]TemplateGroup) map[string]definition.PostableApiTemplate {
+	if templates == nil {
+		return nil
+	}
+	out := make(map[string]definition.PostableApiTemplate, len(templates))
+	for uid, tg := range templates {
+		out[string(uid)] = definition.PostableApiTemplate{
+			Name:    tg.Title,
+			Content: tg.Content,
+			Kind:    definition.TemplateKind(tg.Kind),
+		}
+	}
+	return out
+}
+
 // TemplateUID generates a deterministic UID for a template based on its name.
 func TemplateUID(kind TemplateKind, name string) ResourceUID {
 	return ResourceUID(models.NameToUid(fmt.Sprintf("%s|%s", string(kind), name)))

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -254,7 +254,7 @@ func TestMultiOrgAlertmanager_ActivateHistoricalConfiguration(t *testing.T) {
 	require.Equal(t, defaultConfig, cfgs[3].AlertmanagerConfiguration)
 
 	// Now let's save a new config for org 2.
-	newConfig := `{"template_files":null,"alertmanager_config":{"route":{"receiver":"grafana-default-email","group_by":["grafana_folder","alertname"]},"receivers":[{"name":"grafana-default-email","grafana_managed_receiver_configs":[{"uid":"","name":"some other name","type":"email","disableResolveMessage":false,"settings":{"addresses":"\u003cexample@example.com\u003e"}}]}]}}`
+	newConfig := `{"alertmanager_config":{"route":{"receiver":"grafana-default-email","group_by":["grafana_folder","alertname"]},"receivers":[{"name":"grafana-default-email","grafana_managed_receiver_configs":[{"uid":"","name":"some other name","type":"email","disableResolveMessage":false,"settings":{"addresses":"\u003cexample@example.com\u003e"}}]}]}}`
 	postable, err := Load([]byte(newConfig))
 	require.NoError(t, err)
 
@@ -406,7 +406,6 @@ func setupMam(t *testing.T, cfg *setting.Cfg) *MultiOrgAlertmanager {
 
 var defaultConfig = `
 {
-	"template_files": null,
 	"alertmanager_config": {
 		"route": {
 			"receiver": "grafana-default-email",

--- a/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
@@ -403,7 +403,7 @@ receivers:
 		require.NotNil(t, rawResp.Stats)
 		require.Equal(t, identifier, rawResp.Stats.AddedRoute)
 		require.Contains(t, rawResp.Stats.AddedReceivers, "promoted-webhook")
-		require.Contains(t, rawResp.Stats.AddedTemplates, "promoted.tmpl")
+		require.Len(t, rawResp.Stats.AddedTemplates, 1, "one template UID should be reported as added")
 
 		// Promoted config must not be stored in ExtraConfigs.
 		_, status, _ = apiClient.RawConvertPrometheusGetAlertmanagerConfig(t, map[string]string{

--- a/pkg/tests/apis/alerting/notifications/templategroup/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/templategroup/imported_test.go
@@ -127,3 +127,71 @@ func TestIntegrationImportedTemplates(t *testing.T) {
 		assert.Equal(t, "template", templates.Items[3].Spec.Title)
 	})
 }
+
+func TestIntegrationPromotedTemplates(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		EnableFeatureToggles: []string{
+			featuremgmt.FlagAlertingMultiplePolicies,
+			featuremgmt.FlagAlertingImportAlertmanagerAPI,
+		},
+	})
+
+	client, err := v1beta1.NewTemplateGroupClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
+
+	cliCfg := helper.Org1.Admin.NewRestConfig()
+	alertingApi := alerting.NewAlertingLegacyAPIClient(helper.GetEnv().Server.HTTPServer.Listener.Addr().String(), cliCfg.Username, cliCfg.Password)
+
+	identifier := "test-promote-templates"
+
+	amConfig := apimodels.AlertmanagerUserConfig{
+		AlertmanagerConfig: `
+route:
+  receiver: sinkhole
+receivers:
+  - name: sinkhole
+`,
+		TemplateFiles: map[string]string{
+			"imported": `{{ define "imported" }}
+{{ end }}`,
+			"template": `{{ define "template" }}
+  {{ template "imported" . }}
+{{ end }}`,
+		},
+	}
+
+	response := alertingApi.ConvertPrometheusPostAlertmanagerConfig(t, amConfig, map[string]string{
+		"Content-Type":                         "application/yaml",
+		"X-Grafana-Alerting-Config-Identifier": identifier,
+		"X-Grafana-Alerting-Promote":           "true",
+	})
+	require.Equal(t, "success", response.Status)
+
+	// After promote the config must not be stored as an extra config.
+	_, status, _ := alertingApi.RawConvertPrometheusGetAlertmanagerConfig(t, map[string]string{
+		"X-Grafana-Alerting-Config-Identifier": identifier,
+	})
+	require.Equal(t, 404, status)
+
+	// Promoted templates must appear via the k8s API.
+	templates, err := client.List(context.Background(), apis.DefaultNamespace, resource.ListOptions{})
+	require.NoError(t, err)
+
+	// Find the two promoted templates (default Grafana template is always present).
+	var promoted []v1beta1.TemplateGroup
+	for _, tpl := range templates.Items {
+		if tpl.Spec.Title == "imported" || tpl.Spec.Title == "template" {
+			promoted = append(promoted, tpl)
+		}
+	}
+	require.Len(t, promoted, 2, "both promoted templates must be visible via k8s API")
+
+	for _, tpl := range promoted {
+		assert.Equal(t, v1beta1.TemplateGroupTemplateKindMimir, tpl.Spec.Kind,
+			"promoted Mimir template must have Mimir kind, got %q for %q", tpl.Spec.Kind, tpl.Spec.Title)
+		assert.EqualValues(t, models.ProvenanceNone, tpl.GetProvenanceStatus(),
+			"promoted template must have no provenance (not locked)")
+	}
+}


### PR DESCRIPTION
## Why

`TemplateFiles map[string]string` (the legacy storage field) stores only template name and content — it has no `kind` field. This meant promoted Mimir/Prometheus templates were indistinguishable from native Grafana templates after being stored.

`ManagedTemplates` mirrors the structure already used by `ManagedRoutes` and `ManagedInhibitionRules`: a richer map that includes `Kind`, allowing the storage layer to preserve whether a template originated from Grafana or a Mimir import.

## What

- Adds `ManagedTemplates map[string]PostableApiTemplate` to `PostableUserConfig` (parallel to `ManagedRoutes` / `ManagedInhibitionRules`)
- **Write rule**: `ToDBModel` serialises templates only to `ManagedTemplates`; `TemplateFiles` is left nil (`omitempty` keeps it absent from JSON)
- **Read rule**: `ToModel` merges both fields — legacy `TemplateFiles` entries are read on load, `ManagedTemplates` entries overwrite on UID collision — so old DB rows migrate forward transparently on the next save
- Added `ManagedTemplatesToTemplates` / `TemplatesToManagedTemplates` converters

## Migration behaviour

Old records (only `template_files` key in DB JSON) load correctly and are re-written as `managed_templates` on the next save. No data migration job needed.

## Test plan

- [ ] `TestRoundTripConversion` — full lossless round-trip with `managed_templates` as the storage field
- [ ] `TestMigrationFromTemplateFiles` — old `template_files` input converts to `managed_templates` output with nil `TemplateFiles`
- [ ] `TestToModel_TemplateConflicts` — UID conflict: `ManagedTemplates` wins; no conflict: both survive
- [ ] `TestMultiOrgAlertmanager_ActivateHistoricalConfiguration` — historical config restore through save/load cycle
- [ ] `TestIntegrationPromotedTemplates` — import+promote with templates, read via k8s API, verify `TemplateKindMimir` and `ProvenanceNone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)