### PR TITLE
Alerting: add "default" as alias for default routing tree

### DIFF
--- a/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1/routingtree_ext.go
+++ b/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1/routingtree_ext.go
@@ -1,7 +1,5 @@
 package v1beta1
 
-const UserDefinedRoutingTreeName = "user-defined"
-
 func (o *RoutingTree) GetProvenanceStatus() string {
 	if o == nil || o.Annotations == nil {
 		return ProvenanceStatusNone

--- a/pkg/services/ngalert/accesscontrol/routes.go
+++ b/pkg/services/ngalert/accesscontrol/routes.go
@@ -104,7 +104,7 @@ func defaultRouteOnly[T models.Identified](eval ac.Evaluator) actionAccess[T] {
 		authorizeSome: eval,                  // satisfies pre-condition — user can access at least the default route
 		authorizeAll:  ac.EvalPermission(""), // never satisfied — does NOT grant access to all routes
 		authorizeOne: func(route models.Identified) ac.Evaluator {
-			if route.GetUID() == legacy_storage.UserDefinedRoutingTreeName {
+			if models.IsDefaultRoutingTreeName(route.GetUID()) {
 				return eval
 			}
 			return ac.EvalPermission("") // never satisfied — does not apply to non-default routes
@@ -252,17 +252,17 @@ func (s RouteAccess[T]) AuthorizeDelete(ctx context.Context, user identity.Reque
 
 // AuthorizeDeleteByUID checks if user has access to delete a route by name.
 func (s RouteAccess[T]) AuthorizeDeleteByUID(ctx context.Context, user identity.Requester, name string) error {
-	return s.delete.Authorize(ctx, user, identified{uid: name})
+	return s.delete.Authorize(ctx, user, identified{uid: models.CanonicalizeRoutingTreeName(name)})
 }
 
 // AuthorizeUpdateByUID checks if user has access to update a route by name.
 func (s RouteAccess[T]) AuthorizeUpdateByUID(ctx context.Context, user identity.Requester, name string) error {
-	return s.update.Authorize(ctx, user, identified{uid: name})
+	return s.update.Authorize(ctx, user, identified{uid: models.CanonicalizeRoutingTreeName(name)})
 }
 
 // AuthorizeReadByUID checks if user has access to read a route by name.
 func (s RouteAccess[T]) AuthorizeReadByUID(ctx context.Context, user identity.Requester, name string) error {
-	return s.read.Authorize(ctx, user, identified{uid: name})
+	return s.read.Authorize(ctx, user, identified{uid: models.CanonicalizeRoutingTreeName(name)})
 }
 
 func (s RouteAccess[T]) DeleteAllPermissions(ctx context.Context, orgID int64, route *legacy_storage.ManagedRoute) error {

--- a/pkg/services/ngalert/accesscontrol/routes_test.go
+++ b/pkg/services/ngalert/accesscontrol/routes_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/services/org"
 )
@@ -23,7 +22,7 @@ func (r testRoute) GetUID() string {
 }
 
 func TestRouteAccess(t *testing.T) {
-	defaultRoute := testRoute{name: legacy_storage.UserDefinedRoutingTreeName}
+	defaultRoute := testRoute{name: models.DefaultRoutingTreeName}
 	route1 := testRoute{name: "route-1"}
 	route2 := testRoute{name: "route-2"}
 
@@ -387,7 +386,7 @@ func TestRouteAccess(t *testing.T) {
 }
 
 func TestRouteAccessFilterRead(t *testing.T) {
-	defaultRoute := testRoute{name: legacy_storage.UserDefinedRoutingTreeName}
+	defaultRoute := testRoute{name: models.DefaultRoutingTreeName}
 	route1 := testRoute{name: "route-1"}
 	route2 := testRoute{name: "route-2"}
 
@@ -486,7 +485,7 @@ func TestRouteAccessFilterRead(t *testing.T) {
 }
 
 func TestRouteAccessAuthorizeLegacy(t *testing.T) {
-	defaultRoute := testRoute{name: legacy_storage.UserDefinedRoutingTreeName}
+	defaultRoute := testRoute{name: models.DefaultRoutingTreeName}
 	route1 := testRoute{name: "route-1"}
 
 	user := func(perms ...ac.Permission) identity.Requester {
@@ -880,7 +879,7 @@ func TestRouteAccessAuthorizeScoped(t *testing.T) {
 }
 
 func TestRouteAccessAuthorizeProvisioning(t *testing.T) {
-	defaultRoute := testRoute{name: legacy_storage.UserDefinedRoutingTreeName}
+	defaultRoute := testRoute{name: models.DefaultRoutingTreeName}
 	route1 := testRoute{name: "route-1"}
 
 	user := func(perms ...ac.Permission) identity.Requester {

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -2095,7 +2095,7 @@ func TestApiNotificationPolicyExportSnapshot(t *testing.T) {
 	p := newFakeNotificationPolicyService(rev)
 	sut.policies = p
 
-	policies := []string{legacy_storage.UserDefinedRoutingTreeName} //nolint:prealloc
+	policies := []string{models.DefaultRoutingTreeName} //nolint:prealloc
 	for policy := range policy_exports.Config().ManagedRoutes {
 		policies = append(policies, policy)
 	}

--- a/pkg/services/ngalert/models/notifications.go
+++ b/pkg/services/ngalert/models/notifications.go
@@ -17,8 +17,34 @@ import (
 // GroupByAll is a special value defined by alertmanager that can be used in a Route's GroupBy field to aggregate by all possible labels.
 const GroupByAll = "..."
 
+// DefaultRoutingTreeName is the name the API uses for the default (root) routing tree in both
+// responses (e.g. the default entry in LIST) and as its stable identity for RBAC scopes.
+// The future canonical name is accepted on input via DefaultRoutingTreeNameAlias. A later change can flip this
+// to the alias once clients recognize it.
 const DefaultRoutingTreeName = "user-defined"
+
+// DefaultRoutingTreeNameAlias is the future canonical name for the default (root) routing tree.
+// It is accepted on API input as an alias for DefaultRoutingTreeName so newer clients can use it,
+// but it is not yet emitted in LIST responses or used as an RBAC identifier.
+const DefaultRoutingTreeNameAlias = "default"
+
 const NamedRouteLabel = "__grafana_managed_route__"
+
+// IsDefaultRoutingTreeName reports whether name refers to the default (root) routing tree,
+// accepting both the emitted name and the alias.
+func IsDefaultRoutingTreeName(name string) bool {
+	return name == DefaultRoutingTreeName || name == DefaultRoutingTreeNameAlias
+}
+
+// CanonicalizeRoutingTreeName maps the default-tree alias to the emitted default-tree name and
+// returns any other name unchanged. Used as a stable identity for RBAC scope, so both names resolve to the same
+// permission.
+func CanonicalizeRoutingTreeName(name string) string {
+	if name == DefaultRoutingTreeNameAlias {
+		return DefaultRoutingTreeName
+	}
+	return name
+}
 
 // NotificationSettingsType is an enum of the notification settings configurations a rule may have.
 // It is used by ListAlertRulesQuery to filter rules by the type of notification settings configured.
@@ -325,14 +351,14 @@ func (s *PolicyRouting) Validate() error {
 	if s.Policy == "" {
 		return errors.New("policy must be specified")
 	}
-	if s.Policy == DefaultRoutingTreeName {
+	if IsDefaultRoutingTreeName(s.Policy) {
 		return fmt.Errorf("policy routing should not explicitly point to the default tree: %q", DefaultRoutingTreeName)
 	}
 	return nil
 }
 
 func (s *PolicyRouting) IsDefault() bool {
-	return s.Policy == "" || s.Policy == DefaultRoutingTreeName
+	return s.Policy == "" || IsDefaultRoutingTreeName(s.Policy)
 }
 
 func (s *PolicyRouting) Equals(other *PolicyRouting) bool {

--- a/pkg/services/ngalert/notifier/legacy_storage/routes.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ualert"
 )
 
-const UserDefinedRoutingTreeName = models.DefaultRoutingTreeName
 const NamedRouteMatcher = models.NamedRouteLabel
 
 type ManagedRoute struct {
@@ -175,7 +174,7 @@ func (rev *ConfigRevision) GetManagedRoutes(includeManagedRoutes bool) ManagedRo
 			managedRoutes = append(managedRoutes, NewManagedRoute(k, rev.Config.ManagedRoutes[k]))
 		}
 	}
-	managedRoutes = append(managedRoutes, NewManagedRoute(UserDefinedRoutingTreeName, rev.Config.AlertmanagerConfig.Route))
+	managedRoutes = append(managedRoutes, NewManagedRoute(models.DefaultRoutingTreeName, rev.Config.AlertmanagerConfig.Route))
 
 	return managedRoutes
 }
@@ -277,7 +276,7 @@ func (rev *ConfigRevision) ResetUserDefinedRoute(defaultCfg *v1.AMConfigV1) (*Ma
 		rev.Config.AlertmanagerConfig.Receivers = append(rev.Config.AlertmanagerConfig.Receivers, defaultRcv)
 	}
 
-	return rev.UpdateNamedRoute(UserDefinedRoutingTreeName, *defaultCfg.AlertmanagerConfig.Route)
+	return rev.UpdateNamedRoute(models.DefaultRoutingTreeName, *defaultCfg.AlertmanagerConfig.Route)
 }
 
 func (rev *ConfigRevision) ValidateRoute(route v1.Route) error {

--- a/pkg/services/ngalert/notifier/legacy_storage/routes.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes.go
@@ -56,7 +56,7 @@ func (r *ManagedRoute) GeneratedSubRoute() *v1.Route {
 		ri := model.Duration(defaultOpts.RepeatInterval)
 		amRoute.RepeatInterval = &ri
 	}
-	if r.Name != UserDefinedRoutingTreeName {
+	if !models.IsDefaultRoutingTreeName(r.Name) {
 		// Set label matcher.
 		amRoute.ObjectMatchers = v1.ObjectMatchers{managedRouteMatcher(r.Name)}
 	}
@@ -64,7 +64,9 @@ func (r *ManagedRoute) GeneratedSubRoute() *v1.Route {
 }
 
 func (r *ManagedRoute) GetUID() string {
-	return r.Name
+	// Canonicalize so the default tree has a single stable identity regardless of whether
+	// it was addressed by its canonical name or the legacy alias. This identity backs RBAC scopes.
+	return models.CanonicalizeRoutingTreeName(r.Name)
 }
 
 func (r *ManagedRoute) ResourceType() string {
@@ -72,8 +74,8 @@ func (r *ManagedRoute) ResourceType() string {
 }
 
 func (r *ManagedRoute) ResourceID() string {
-	if r.Name == UserDefinedRoutingTreeName {
-		// Backwards compatibility with legacy user-defined routing tree.
+	if models.IsDefaultRoutingTreeName(r.Name) {
+		// Backwards compatibility with the legacy default (root) routing tree.
 		return ""
 	}
 	return r.Name
@@ -107,12 +109,12 @@ func managedRouteMatcher(name string) *labels.Matcher {
 type ManagedRoutes []*ManagedRoute
 
 func (m ManagedRoutes) Sort() {
-	// Sort the keys of the map to ensure consistent ordering. Always ensure that the legacy user-defined routing tree is last.
+	// Sort the keys of the map to ensure consistent ordering. Always ensure that the default routing tree is last.
 	slices.SortFunc(m, func(a, b *ManagedRoute) int {
-		if a.Name == UserDefinedRoutingTreeName {
+		if models.IsDefaultRoutingTreeName(a.Name) {
 			return 1
 		}
-		if b.Name == UserDefinedRoutingTreeName {
+		if models.IsDefaultRoutingTreeName(b.Name) {
 			return -1
 		}
 		return strings.Compare(a.Name, b.Name)
@@ -137,21 +139,23 @@ func WithManagedRoutes(root *v1.Route, managedRoutes map[string]*v1.Route) *v1.R
 	newManagedRoutes := make([]*v1.Route, 0, len(newRoot.Routes)+len(managedRoutes))
 	for _, k := range slices.Sorted(maps.Keys(managedRoutes)) {
 		// On the off chance that the route is nil or invalid managed route with the restricted name, we skip it.
-		if managedRoutes[k] == nil || k == UserDefinedRoutingTreeName {
+		if managedRoutes[k] == nil || models.IsDefaultRoutingTreeName(k) {
 			continue
 		}
 		newManagedRoutes = append(newManagedRoutes, NewManagedRoute(k, managedRoutes[k]).GeneratedSubRoute())
 	}
 
-	// Add the user-defined routing tree at the end.
+	// Add the default routing tree at the end.
 	newManagedRoutes = append(newManagedRoutes, newRoot.Routes...)
 	newRoot.Routes = newManagedRoutes
 	return &newRoot
 }
 
 func (rev *ConfigRevision) GetManagedRoute(name string) *ManagedRoute {
-	if name == UserDefinedRoutingTreeName {
-		return NewManagedRoute(UserDefinedRoutingTreeName, rev.Config.AlertmanagerConfig.Route)
+	if models.IsDefaultRoutingTreeName(name) {
+		// Echo the requested name (canonical or alias) so the response preserves the name
+		// the client used, while GetUID/ResourceID canonicalize for identity purposes.
+		return NewManagedRoute(name, rev.Config.AlertmanagerConfig.Route)
 	}
 	route, ok := rev.Config.ManagedRoutes[name]
 	if !ok {
@@ -165,7 +169,7 @@ func (rev *ConfigRevision) GetManagedRoutes(includeManagedRoutes bool) ManagedRo
 	if includeManagedRoutes {
 		for _, k := range slices.Sorted(maps.Keys(rev.Config.ManagedRoutes)) {
 			// On the off chance that the route is nil or invalid managed route with the restricted name, we skip it.
-			if rev.Config.ManagedRoutes[k] == nil || k == UserDefinedRoutingTreeName {
+			if rev.Config.ManagedRoutes[k] == nil || models.IsDefaultRoutingTreeName(k) {
 				continue
 			}
 			managedRoutes = append(managedRoutes, NewManagedRoute(k, rev.Config.ManagedRoutes[k]))
@@ -203,8 +207,8 @@ func (rev *ConfigRevision) CreateManagedRoute(name string, subtree v1.Route) (*M
 		return nil, models.MakeErrRouteInvalidFormat(err)
 	}
 
-	if name == UserDefinedRoutingTreeName {
-		return nil, models.ErrRouteExists.Errorf("cannot create a managed route with the name %q, this name is reserved for the user-defined routing tree", UserDefinedRoutingTreeName)
+	if models.IsDefaultRoutingTreeName(name) {
+		return nil, models.ErrRouteExists.Errorf("cannot create a managed route with the name %q, this name is reserved for the default routing tree", name)
 	}
 
 	if _, exists := rev.Config.ManagedRoutes[name]; exists {
@@ -244,7 +248,7 @@ func (rev *ConfigRevision) UpdateNamedRoute(name string, subtree v1.Route) (*Man
 		return nil, models.MakeErrRouteInvalidFormat(err)
 	}
 
-	if name == UserDefinedRoutingTreeName {
+	if models.IsDefaultRoutingTreeName(name) {
 		rev.Config.AlertmanagerConfig.Route = &amRoute
 	} else {
 		if rev.Config.ManagedRoutes == nil {

--- a/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
@@ -222,6 +222,40 @@ func TestConfigRevision_GetManagedRoute(t *testing.T) {
 	})
 }
 
+func TestConfigRevision_DefaultRoutingTreeAliases(t *testing.T) {
+	// The default (root) tree must be addressable by both its canonical name and the alias
+	// so existing clients that reference "user-defined" keep working.
+	require.Equal(t, models.DefaultRoutingTreeName, UserDefinedRoutingTreeName)
+
+	t.Run("both names resolve to the root route and echo the requested name", func(t *testing.T) {
+		for _, name := range []string{models.DefaultRoutingTreeName, models.DefaultRoutingTreeNameAlias} {
+			t.Run(name, func(t *testing.T) {
+				rev := testConfig()
+				got := rev.GetManagedRoute(name)
+				require.NotNil(t, got)
+				// Name echoes the requested alias so the API response preserves the client's name.
+				assert.Equal(t, name, got.Name)
+				// The underlying route is the root route regardless of which alias was used.
+				assert.Equal(t, NewManagedRoute(name, rev.Config.AlertmanagerConfig.Route), got)
+				// Identity is canonical so RBAC scopes and provenance keys are stable across aliases.
+				assert.Equal(t, models.DefaultRoutingTreeName, got.GetUID())
+				assert.Equal(t, "", got.ResourceID())
+			})
+		}
+	})
+
+	t.Run("both names are reserved and cannot be created as managed routes", func(t *testing.T) {
+		subtree := v1.Route{Receiver: testConfig().Config.AlertmanagerConfig.Receivers[0].Name}
+		for _, name := range []string{models.DefaultRoutingTreeName, models.DefaultRoutingTreeNameAlias} {
+			t.Run(name, func(t *testing.T) {
+				_, err := testConfig().CreateManagedRoute(name, subtree)
+				assert.ErrorIs(t, err, models.ErrRouteExists)
+				assert.ErrorContains(t, err, "reserved")
+			})
+		}
+	})
+}
+
 func TestConfigRevision_GetManagedRoutes(t *testing.T) {
 	rev := testConfig()
 

--- a/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
@@ -37,7 +37,7 @@ func TestManagedRoute_GeneratedSubRoute_DefaultsAndMatcher(t *testing.T) {
 
 func TestManagedRoute_GeneratedSubRoute_UserDefinedHasNoMatcher(t *testing.T) {
 	mr := &ManagedRoute{
-		Name:     UserDefinedRoutingTreeName,
+		Name:     models.DefaultRoutingTreeName,
 		Receiver: "receiver",
 	}
 
@@ -90,7 +90,7 @@ func TestManagedRoute_GeneratedSubRoute_PreservesFields(t *testing.T) {
 func TestManagedRoutes_Sort(t *testing.T) {
 	routes := ManagedRoutes{
 		{Name: "x"},
-		{Name: UserDefinedRoutingTreeName},
+		{Name: models.DefaultRoutingTreeName},
 		{Name: "z"},
 	}
 
@@ -98,18 +98,18 @@ func TestManagedRoutes_Sort(t *testing.T) {
 
 	require.Equal(t, "x", routes[0].Name)
 	require.Equal(t, "z", routes[1].Name)
-	require.Equal(t, UserDefinedRoutingTreeName, routes[2].Name)
+	require.Equal(t, models.DefaultRoutingTreeName, routes[2].Name)
 }
 
 func TestManagedRoutes_Contains(t *testing.T) {
 	routes := ManagedRoutes{
 		{Name: "x"},
-		{Name: UserDefinedRoutingTreeName},
+		{Name: models.DefaultRoutingTreeName},
 		{Name: "z"},
 	}
 	assert.True(t, routes.Contains("x"))
 	assert.True(t, routes.Contains("z"))
-	assert.True(t, routes.Contains(UserDefinedRoutingTreeName))
+	assert.True(t, routes.Contains(models.DefaultRoutingTreeName))
 	assert.False(t, routes.Contains("missing"))
 }
 
@@ -211,10 +211,10 @@ func TestConfigRevision_GetManagedRoute(t *testing.T) {
 	}
 
 	t.Run("returns user-defined route", func(t *testing.T) {
-		got := rev.GetManagedRoute(UserDefinedRoutingTreeName)
+		got := rev.GetManagedRoute(models.DefaultRoutingTreeName)
 		require.NotNil(t, got)
-		assert.Equal(t, UserDefinedRoutingTreeName, got.Name)
-		assert.Equal(t, NewManagedRoute(UserDefinedRoutingTreeName, rev.Config.AlertmanagerConfig.Route), got)
+		assert.Equal(t, models.DefaultRoutingTreeName, got.Name)
+		assert.Equal(t, NewManagedRoute(models.DefaultRoutingTreeName, rev.Config.AlertmanagerConfig.Route), got)
 	})
 
 	t.Run("returns nil if not found", func(t *testing.T) {
@@ -223,10 +223,8 @@ func TestConfigRevision_GetManagedRoute(t *testing.T) {
 }
 
 func TestConfigRevision_DefaultRoutingTreeAliases(t *testing.T) {
-	// The default (root) tree must be addressable by both its canonical name and the alias
-	// so existing clients that reference "user-defined" keep working.
-	require.Equal(t, models.DefaultRoutingTreeName, UserDefinedRoutingTreeName)
-
+	// The default (root) tree must be addressable by both its canonical name and the legacy alias
+	// so existing clients (e.g. Terraform) that reference "user-defined" keep working.
 	t.Run("both names resolve to the root route and echo the requested name", func(t *testing.T) {
 		for _, name := range []string{models.DefaultRoutingTreeName, models.DefaultRoutingTreeNameAlias} {
 			t.Run(name, func(t *testing.T) {
@@ -266,7 +264,7 @@ func TestConfigRevision_GetManagedRoutes(t *testing.T) {
 		for name, mr := range rev.Config.ManagedRoutes {
 			expected = append(expected, NewManagedRoute(name, mr))
 		}
-		expected = append(expected, NewManagedRoute(UserDefinedRoutingTreeName, rev.Config.AlertmanagerConfig.Route))
+		expected = append(expected, NewManagedRoute(models.DefaultRoutingTreeName, rev.Config.AlertmanagerConfig.Route))
 
 		assert.Len(t, routes, len(expected))
 		assert.ElementsMatch(t, routes, expected)
@@ -277,7 +275,7 @@ func TestConfigRevision_GetManagedRoutes(t *testing.T) {
 		routes := rev.GetManagedRoutes(false)
 
 		assert.Len(t, routes, 1)
-		assert.Equal(t, routes[0], NewManagedRoute(UserDefinedRoutingTreeName, rev.Config.AlertmanagerConfig.Route))
+		assert.Equal(t, routes[0], NewManagedRoute(models.DefaultRoutingTreeName, rev.Config.AlertmanagerConfig.Route))
 	})
 }
 
@@ -330,9 +328,9 @@ func TestConfigRevision_CreateManagedRoute(t *testing.T) {
 	})
 
 	t.Run("rejects reserved name", func(t *testing.T) {
-		_, err := testConfig().CreateManagedRoute(UserDefinedRoutingTreeName, subtree)
+		_, err := testConfig().CreateManagedRoute(models.DefaultRoutingTreeName, subtree)
 		assert.ErrorContains(t, err, "reserved")
-		assert.ErrorContains(t, err, UserDefinedRoutingTreeName)
+		assert.ErrorContains(t, err, models.DefaultRoutingTreeName)
 		assert.ErrorIs(t, err, models.ErrRouteExists)
 	})
 
@@ -374,7 +372,7 @@ func TestConfigRevision_UpdateNamedRoute(t *testing.T) {
 
 	t.Run("reserved name updates default", func(t *testing.T) {
 		rev := testConfig()
-		_, err := rev.UpdateNamedRoute(UserDefinedRoutingTreeName, subtree)
+		_, err := rev.UpdateNamedRoute(models.DefaultRoutingTreeName, subtree)
 		assert.NoError(t, err)
 		assert.Equal(t, &subtree, rev.Config.AlertmanagerConfig.Route)
 	})
@@ -424,7 +422,7 @@ func TestConfigRevision_ResetUserDefinedRoute(t *testing.T) {
 	mr, err := rev.ResetUserDefinedRoute(&defaultCfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, mr)
-	assert.Equal(t, UserDefinedRoutingTreeName, mr.Name)
+	assert.Equal(t, models.DefaultRoutingTreeName, mr.Name)
 
 	assert.Equal(t, &newRoute, rev.Config.AlertmanagerConfig.Route)
 	assert.NotEqual(t, original, rev.Config.AlertmanagerConfig.Route)
@@ -455,7 +453,7 @@ func TestConfigRevision_ResetUserDefinedRoute(t *testing.T) {
 	mr, err = rev.ResetUserDefinedRoute(&defaultCfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, mr)
-	assert.Equal(t, UserDefinedRoutingTreeName, mr.Name)
+	assert.Equal(t, models.DefaultRoutingTreeName, mr.Name)
 
 	assert.Equal(t, &newRoute, rev.Config.AlertmanagerConfig.Route)
 	assert.NotEqual(t, original, rev.Config.AlertmanagerConfig.Route)

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -122,7 +122,7 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1, provenance models.P
 		return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("failed to get mimir alertmanager config: %w", err)
 	}
 
-	if _, ok := cfg.ManagedRoutes[mimirCfg.Identifier]; ok || mimirCfg.Identifier == models.DefaultRoutingTreeName {
+	if _, ok := cfg.ManagedRoutes[mimirCfg.Identifier]; ok || models.IsDefaultRoutingTreeName(mimirCfg.Identifier) {
 		return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("cannot merge because config %s because it conflicts with existing managed route", mimirCfg.Identifier)
 	}
 

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -109,7 +109,7 @@ func (nps *Service) GetManagedRoute(ctx context.Context, orgID int64, name strin
 	defer span.End()
 
 	// Backwards compatibility when managed routes FF is disabled. Only allow the default route.
-	if !nps.managedRoutesEnabled() && name != legacy_storage.UserDefinedRoutingTreeName {
+	if !nps.managedRoutesEnabled() && !models.IsDefaultRoutingTreeName(name) {
 		return legacy_storage.ManagedRoute{}, models.ErrRouteNotFound.Errorf("route %q not found", name)
 	}
 
@@ -217,7 +217,7 @@ func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name st
 		attribute.Bool("include_imported", nps.includeImported()),
 	))
 	// Backwards compatibility when managed routes FF is disabled. Only allow the default route.
-	if !nps.managedRoutesEnabled() && name != legacy_storage.UserDefinedRoutingTreeName {
+	if !nps.managedRoutesEnabled() && !models.IsDefaultRoutingTreeName(name) {
 		return nil, models.ErrRouteNotFound.Errorf("route %q not found", name)
 	}
 
@@ -299,7 +299,7 @@ func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name st
 	defer span.End()
 
 	// Backwards compatibility when managed routes FF is disabled. Only allow the default route.
-	if !nps.managedRoutesEnabled() && name != legacy_storage.UserDefinedRoutingTreeName {
+	if !nps.managedRoutesEnabled() && !models.IsDefaultRoutingTreeName(name) {
 		return models.ErrRouteNotFound.Errorf("route %q not found", name)
 	}
 
@@ -342,7 +342,7 @@ func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name st
 	}
 
 	action := "Deleted"
-	if name == legacy_storage.UserDefinedRoutingTreeName {
+	if models.IsDefaultRoutingTreeName(name) {
 		defaultCfg, err := legacy_storage.DeserializeAlertmanagerConfig([]byte(nps.settings.DefaultConfiguration))
 		if err != nil {
 			return fmt.Errorf("failed to parse default alertmanager config: %w", err)
@@ -361,7 +361,7 @@ func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name st
 		if err := nps.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		if name != legacy_storage.UserDefinedRoutingTreeName { // do not delete permissions on reset of default route
+		if !models.IsDefaultRoutingTreeName(name) { // do not delete permissions on reset of default route
 			if err := nps.routeAccess.DeleteAllPermissions(ctx, orgID, existing); err != nil {
 				return err
 			}

--- a/pkg/services/ngalert/notifier/routes/service_test.go
+++ b/pkg/services/ngalert/notifier/routes/service_test.go
@@ -460,3 +460,79 @@ func TestDeleteManagedRoute(t *testing.T) {
 		assert.Equal(t, []string{"AuthorizeDeleteByUID"}, authz.Calls.Methods())
 	})
 }
+
+// TestManagedRouteCRUD_DefaultTreeAlias verifies the CRUD methods accept the legacy/canonical alias
+// (models.DefaultRoutingTreeNameAlias, "default") as a reference to the default (root) routing tree,
+// behaving exactly as they do for the emitted name (models.DefaultRoutingTreeName, "user-defined").
+func TestManagedRouteCRUD_DefaultTreeAlias(t *testing.T) {
+	orgID := int64(1)
+	user := &user.SignedInUser{OrgID: 1}
+
+	newSut := func(rev *legacy_storage.ConfigRevision, features featuremgmt.FeatureToggles, authz routeAccessControl) *Service {
+		configStore := &legacy_storage.AlertmanagerConfigStoreFake{
+			GetFn: func(_ context.Context, _ int64) (*legacy_storage.ConfigRevision, error) {
+				return rev, nil
+			},
+		}
+		return createServiceSut(configStore, fakes.NewFakeProvisioningStore(), features, authz)
+	}
+
+	t.Run("Get via alias resolves to the default route", func(t *testing.T) {
+		rev := configRevisionWithManagedRoutes()
+		sut := newSut(rev, featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies), &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
+
+		route, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, user)
+		require.NoError(t, err)
+		// The response echoes the requested alias, but the route resolves to the root route...
+		assert.Equal(t, models.DefaultRoutingTreeNameAlias, route.Name)
+		assert.Equal(t, rev.Config.AlertmanagerConfig.Route.Receiver, route.Receiver)
+		// ...and its identity canonicalizes to the default tree, so RBAC scopes are stable across names.
+		assert.Equal(t, models.DefaultRoutingTreeName, route.GetUID())
+	})
+
+	t.Run("Get via alias resolves to the default route even when the managed routes flag is disabled", func(t *testing.T) {
+		rev := configRevisionWithManagedRoutes()
+		sut := newSut(rev, featuremgmt.WithFeatures(), &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
+
+		route, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, user)
+		require.NoError(t, err)
+		assert.Equal(t, models.DefaultRoutingTreeNameAlias, route.Name)
+	})
+
+	t.Run("Update via alias updates the root route, not a managed route", func(t *testing.T) {
+		rev := configRevisionWithManagedRoutes()
+		sut := newSut(rev, featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies), &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
+
+		// Fetch the current version so the optimistic concurrency check passes.
+		current, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, user)
+		require.NoError(t, err)
+
+		updated, err := sut.UpdateManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, v1.Route{Receiver: "empty"}, models.ProvenanceNone, current.Version, user)
+		require.NoError(t, err)
+		assert.Equal(t, models.DefaultRoutingTreeNameAlias, updated.Name)
+		assert.Equal(t, models.DefaultRoutingTreeName, updated.GetUID())
+		// The root route was modified in place; no managed route was created under the alias.
+		assert.Equal(t, "empty", rev.Config.AlertmanagerConfig.Route.Receiver)
+		assert.NotContains(t, rev.Config.ManagedRoutes, models.DefaultRoutingTreeNameAlias)
+	})
+
+	t.Run("Delete via alias resets the default route and does not delete permissions", func(t *testing.T) {
+		rev := configRevisionWithManagedRoutes()
+		authz := &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{}
+		sut := newSut(rev, featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies), authz)
+
+		err := sut.DeleteManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, models.ProvenanceNone, "", user)
+		require.NoError(t, err)
+		// Same as deleting by the emitted name: it resets (not deletes) and keeps the route's permissions.
+		assert.Equal(t, []string{"AuthorizeDeleteByUID"}, authz.Calls.Methods())
+	})
+
+	t.Run("Create with the alias is rejected as a reserved name", func(t *testing.T) {
+		rev := configRevisionWithManagedRoutes()
+		sut := newSut(rev, featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies), &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
+
+		_, err := sut.CreateManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, v1.Route{Receiver: "grafana-default"}, models.ProvenanceNone, user)
+		require.ErrorIs(t, err, models.ErrRouteExists)
+		assert.NotContains(t, rev.Config.ManagedRoutes, models.DefaultRoutingTreeNameAlias)
+	})
+}

--- a/pkg/services/ngalert/notifier/routes/service_test.go
+++ b/pkg/services/ngalert/notifier/routes/service_test.go
@@ -165,7 +165,7 @@ func TestGetManagedRoute(t *testing.T) {
 
 		sut := createServiceSut(configStore, provStore, features, &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
-		route, err := sut.GetManagedRoute(context.Background(), orgID, legacy_storage.UserDefinedRoutingTreeName, user)
+		route, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, user)
 		require.NoError(t, err)
 
 		assert.Equal(t, models.ProvenanceAPI, route.Provenance)
@@ -194,7 +194,7 @@ func TestGetManagedRoute(t *testing.T) {
 
 		sut := createServiceSut(configStore, provStore, features, &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
-		_, err := sut.GetManagedRoute(context.Background(), orgID, legacy_storage.UserDefinedRoutingTreeName, user)
+		_, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, user)
 		require.ErrorIs(t, err, expectedErr)
 	})
 
@@ -257,7 +257,7 @@ func TestGetManagedRoute(t *testing.T) {
 		features := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies)
 		sut := createServiceSut(configStore, provStore, features, acfakes.NewDenyAllRouteAccessService[*legacy_storage.ManagedRoute]())
 
-		_, err := sut.GetManagedRoute(context.Background(), orgID, legacy_storage.UserDefinedRoutingTreeName, user)
+		_, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, user)
 		require.ErrorIs(t, err, ac.ErrAuthorizationBase)
 	})
 }
@@ -291,8 +291,8 @@ func TestGetManagedRoutes(t *testing.T) {
 		provStore := fakes.NewFakeProvisioningStore()
 		features := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies)
 		allowedNames := map[string]struct{}{
-			legacy_storage.UserDefinedRoutingTreeName: {},
-			"route-a": {},
+			models.DefaultRoutingTreeName: {},
+			"route-a":                     {},
 		}
 		sut := createServiceSut(configStore, provStore, features, &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{
 			FilterReadFunc: func(_ context.Context, _ identity.Requester, routes ...*legacy_storage.ManagedRoute) ([]*legacy_storage.ManagedRoute, error) {
@@ -313,7 +313,7 @@ func TestGetManagedRoutes(t *testing.T) {
 		for _, r := range routes {
 			names = append(names, r.Name)
 		}
-		assert.ElementsMatch(t, []string{legacy_storage.UserDefinedRoutingTreeName, "route-a"}, names)
+		assert.ElementsMatch(t, []string{models.DefaultRoutingTreeName, "route-a"}, names)
 	})
 
 	t.Run("returns empty list when user has no access to any route", func(t *testing.T) {
@@ -401,7 +401,7 @@ func TestUpdateManagedRoute(t *testing.T) {
 		features := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies)
 		sut := createServiceSut(configStore, provStore, features, acfakes.NewDenyAllRouteAccessService[*legacy_storage.ManagedRoute]())
 
-		_, err := sut.UpdateManagedRoute(context.Background(), orgID, legacy_storage.UserDefinedRoutingTreeName, v1.Route{Receiver: "grafana-default"}, models.ProvenanceNone, "v1", user)
+		_, err := sut.UpdateManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, v1.Route{Receiver: "grafana-default"}, models.ProvenanceNone, "v1", user)
 		require.ErrorIs(t, err, ac.ErrAuthorizationBase)
 	})
 }
@@ -416,7 +416,7 @@ func TestDeleteManagedRoute(t *testing.T) {
 		features := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies)
 		sut := createServiceSut(configStore, provStore, features, acfakes.NewDenyAllRouteAccessService[*legacy_storage.ManagedRoute]())
 
-		err := sut.DeleteManagedRoute(context.Background(), orgID, legacy_storage.UserDefinedRoutingTreeName, models.ProvenanceNone, "v1", user)
+		err := sut.DeleteManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, models.ProvenanceNone, "v1", user)
 		require.ErrorIs(t, err, ac.ErrAuthorizationBase)
 	})
 

--- a/pkg/services/ngalert/notifier/validation.go
+++ b/pkg/services/ngalert/notifier/validation.go
@@ -97,6 +97,7 @@ func NewNotificationSettingsValidator(cfg *v1.AMConfigV1) NotificationSettingsVa
 		availableRoutes[routeName] = struct{}{}
 	}
 	availableRoutes[models.DefaultRoutingTreeName] = struct{}{}
+	availableRoutes[models.DefaultRoutingTreeNameAlias] = struct{}{}
 	if len(cfg.ExtraConfigs) > 0 {
 		availableRoutes[cfg.ExtraConfigs[0].Identifier] = struct{}{}
 	}

--- a/pkg/tests/apis/alerting/notifications/common/testing.go
+++ b/pkg/tests/apis/alerting/notifications/common/testing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/notifications/routingtree"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/tests/apis"
@@ -70,7 +71,7 @@ func UpdateDefaultRoute(t *testing.T, user apis.User, r *definitions.Route) {
 	t.Helper()
 	routeClient, err := v1beta1.NewRoutingTreeClientFromGenerator(user.GetClientRegistry())
 	require.NoError(t, err)
-	route := legacy_storage.NewManagedRoute(v1beta1.UserDefinedRoutingTreeName, v1.RouteToModel(r))
+	route := legacy_storage.NewManagedRoute(models.DefaultRoutingTreeName, v1.RouteToModel(r))
 	route.Version = "" // Avoid version conflict.
 	v1route, err := routingtree.ConvertToK8sResource(user.Identity.GetOrgID(), route, func(int64) string { return apis.DefaultNamespace }, nil)
 	require.NoError(t, err)

--- a/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
@@ -49,7 +49,7 @@ import (
 
 var defaultTreeIdentifier = resource.Identifier{
 	Namespace: apis.DefaultNamespace,
-	Name:      v1beta1.UserDefinedRoutingTreeName,
+	Name:      models.DefaultRoutingTreeName,
 }
 
 var defaultPolicy = v1model.Route{
@@ -571,7 +571,7 @@ func TestIntegrationDataConsistency(t *testing.T) {
 		t.Helper()
 		routeClient, err := v1beta1.NewRoutingTreeClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
 		require.NoError(t, err)
-		managedRoute := legacy_storage.NewManagedRoute(v1beta1.UserDefinedRoutingTreeName, &route)
+		managedRoute := legacy_storage.NewManagedRoute(models.DefaultRoutingTreeName, &route)
 		managedRoute.Version = "" // Avoid version conflict.
 		v1Route, err := routingtree.ConvertToK8sResource(helper.Org1.Admin.Identity.GetOrgID(), managedRoute, func(int64) string { return "default" }, nil)
 		require.NoError(t, err)
@@ -977,12 +977,12 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 
 		t.Run("Create default policy fails", func(t *testing.T) {
 			// Attempting to create a route with name UserDefinedRoutingTreeName fails.
-			_, err = adminClient.Create(ctx, k8sRoute(t, v1beta1.UserDefinedRoutingTreeName, &defaultPolicy), resource.CreateOptions{})
+			_, err = adminClient.Create(ctx, k8sRoute(t, models.DefaultRoutingTreeName, &defaultPolicy), resource.CreateOptions{})
 			require.Error(t, err)
 		})
 
 		t.Run("Get Default Policy", func(t *testing.T) {
-			validateGetEqual(t, v1beta1.UserDefinedRoutingTreeName, k8sRoute(t, v1beta1.UserDefinedRoutingTreeName, &defaultPolicy))
+			validateGetEqual(t, models.DefaultRoutingTreeName, k8sRoute(t, models.DefaultRoutingTreeName, &defaultPolicy))
 		})
 	})
 
@@ -993,8 +993,8 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 			_ = db.SetProvenance(ctx, legacy_storage.NewManagedRoute(name, &v1model.Route{}), org1.OrgID, "") // Just in case it was provisioned.
 			_ = adminClient.Delete(ctx, nameToIdentifier(name), resource.DeleteOptions{})
 		}
-		_ = db.SetProvenance(ctx, legacy_storage.NewManagedRoute(v1beta1.UserDefinedRoutingTreeName, &v1model.Route{}), org1.OrgID, "")
-		_ = adminClient.Delete(ctx, nameToIdentifier(v1beta1.UserDefinedRoutingTreeName), resource.DeleteOptions{})
+		_ = db.SetProvenance(ctx, legacy_storage.NewManagedRoute(models.DefaultRoutingTreeName, &v1model.Route{}), org1.OrgID, "")
+		_ = adminClient.Delete(ctx, nameToIdentifier(models.DefaultRoutingTreeName), resource.DeleteOptions{})
 
 		// Recreate them.
 		created := make(map[string]*v1beta1.RoutingTree, len(cfg.ManagedRoutes))
@@ -1008,7 +1008,7 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 
 	t.Run("Provisioned Get should include provenance", func(t *testing.T) {
 		allCreatedRoutes := resetPolicies(t)
-		allCreatedRoutes[v1beta1.UserDefinedRoutingTreeName] = k8sRoute(t, v1beta1.UserDefinedRoutingTreeName, &defaultPolicy)
+		allCreatedRoutes[models.DefaultRoutingTreeName] = k8sRoute(t, models.DefaultRoutingTreeName, &defaultPolicy)
 
 		for name, route := range allCreatedRoutes {
 			require.NoError(t, db.SetProvenance(ctx, legacy_storage.NewManagedRoute(name, &v1model.Route{}), org1.OrgID, "API"))
@@ -1051,7 +1051,7 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 
 	t.Run("Update", func(t *testing.T) {
 		policies := resetPolicies(t)
-		policies[v1beta1.UserDefinedRoutingTreeName] = k8sRoute(t, v1beta1.UserDefinedRoutingTreeName, policy_exports.Legacy())
+		policies[models.DefaultRoutingTreeName] = k8sRoute(t, models.DefaultRoutingTreeName, policy_exports.Legacy())
 
 		// Update all policies to the same definition.
 		currentVersion := ""
@@ -1106,7 +1106,7 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 
 	t.Run("Delete", func(t *testing.T) {
 		policies := resetPolicies(t)
-		policies[v1beta1.UserDefinedRoutingTreeName] = k8sRoute(t, v1beta1.UserDefinedRoutingTreeName, &defaultPolicy)
+		policies[models.DefaultRoutingTreeName] = k8sRoute(t, models.DefaultRoutingTreeName, &defaultPolicy)
 
 		for name, route := range policies {
 			t.Run(fmt.Sprintf("Policy %s", name), func(t *testing.T) {
@@ -1130,8 +1130,8 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 				t.Run("Correct ResourceVersion should succeed", func(t *testing.T) {
 					err := adminClient.Delete(ctx, nameToIdentifier(name), resource.DeleteOptions{Preconditions: resource.DeleteOptionsPreconditions{ResourceVersion: route.ResourceVersion}})
 					require.NoError(t, err)
-					if name == v1beta1.UserDefinedRoutingTreeName {
-						validateGetEqual(t, name, k8sRoute(t, v1beta1.UserDefinedRoutingTreeName, &defaultPolicy)) // Default policy only resets, it doesn't delete.
+					if name == models.DefaultRoutingTreeName {
+						validateGetEqual(t, name, k8sRoute(t, models.DefaultRoutingTreeName, &defaultPolicy)) // Default policy only resets, it doesn't delete.
 					} else {
 						validateGetErr(t, name, v1.StatusReasonNotFound)
 					}
@@ -1143,8 +1143,8 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 				t.Run("Empty ResourceVersion should succeed", func(t *testing.T) {
 					err := adminClient.Delete(ctx, nameToIdentifier(name), resource.DeleteOptions{Preconditions: resource.DeleteOptionsPreconditions{ResourceVersion: ""}})
 					require.NoError(t, err)
-					if name == v1beta1.UserDefinedRoutingTreeName {
-						validateGetEqual(t, name, k8sRoute(t, v1beta1.UserDefinedRoutingTreeName, &defaultPolicy)) // Default policy only resets, it doesn't delete.
+					if name == models.DefaultRoutingTreeName {
+						validateGetEqual(t, name, k8sRoute(t, models.DefaultRoutingTreeName, &defaultPolicy)) // Default policy only resets, it doesn't delete.
 					} else {
 						validateGetErr(t, name, v1.StatusReasonNotFound)
 					}
@@ -1464,7 +1464,7 @@ func TestIntegrationMultipleRoutesReferentialIntegrity(t *testing.T) {
 		}},
 	}
 	// Default route.
-	_, err = adminClient.Update(ctx, k8sRoute(t, v1beta1.UserDefinedRoutingTreeName, &routeDef), resource.UpdateOptions{})
+	_, err = adminClient.Update(ctx, k8sRoute(t, models.DefaultRoutingTreeName, &routeDef), resource.UpdateOptions{})
 	require.NoError(t, err)
 
 	// Named route.

--- a/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
@@ -252,7 +252,7 @@ func TestIntegrationAccessControl(t *testing.T) {
 					list, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 					require.NoError(t, err)
 					require.Len(t, list.Items, 1)
-					require.Equal(t, v1beta1.UserDefinedRoutingTreeName, list.Items[0].Name)
+					require.Equal(t, models.DefaultRoutingTreeName, list.Items[0].Name)
 				})
 
 				t.Run("should be able to read routing trees by resource identifier", func(t *testing.T) {
@@ -926,7 +926,7 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 	list, err := adminClient.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, list.Items, 1)
-	require.Equal(t, v1beta1.UserDefinedRoutingTreeName, list.Items[0].Name)
+	require.Equal(t, models.DefaultRoutingTreeName, list.Items[0].Name)
 
 	validateGetErr := func(t *testing.T, name string, expectedErrReason v1.StatusReason) {
 		t.Helper()
@@ -1034,7 +1034,7 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 			for _, route := range allCreatedRoutes {
 				expectedRoutes = append(expectedRoutes, *route)
 			}
-			expectedRoutes = append(expectedRoutes, *k8sRoute(t, v1beta1.UserDefinedRoutingTreeName, &defaultPolicy))
+			expectedRoutes = append(expectedRoutes, *k8sRoute(t, models.DefaultRoutingTreeName, &defaultPolicy))
 
 			for i := range expectedRoutes {
 				expectedRoutes[i].TypeMeta = v1.TypeMeta{
@@ -1045,7 +1045,7 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 			assert.ElementsMatch(t, expectedRoutes, list.Items)
 		})
 		t.Run("Default policy last", func(t *testing.T) {
-			assert.Equal(t, v1beta1.UserDefinedRoutingTreeName, list.Items[len(cfg.ManagedRoutes)].Name)
+			assert.Equal(t, models.DefaultRoutingTreeName, list.Items[len(cfg.ManagedRoutes)].Name)
 		})
 	})
 


### PR DESCRIPTION
### What
The default (root) routing tree is currently addressable by the name `user-defined`. This change makes the backend **also accept `default`** as an alias for that tree across all CRUD operations, while continuing to **emit `user-defined`** in LIST responses and as RBAC identifier.

### Why
We're moving toward `default` as the canonical name for the default routing tree. Keeping `user-defined` as the emitted/identity name means existing clients keep working unchanged, while newer callers can already use `default`. A later change can flip the emitted name to `default` once the frontend recognizes it.

### How
- Added `DefaultRoutingTreeNameAlias = "default"` alongside `DefaultRoutingTreeName = "user-defined"`, plus `IsDefaultRoutingTreeName()` / `CanonicalizeRoutingTreeName()` helpers (`models/notifications.go`).
- Routed all default-tree comparisons through `IsDefaultRoutingTreeName` (legacy_storage, routes service, accesscontrol, merge); `GetManagedRoute` echoes the requested name while `GetUID()` canonicalizes to `user-defined` for RBAC scopes.
- Provenance keys are already canonicalized to an empty string.
- Creating a managed route named either `default` or `user-defined` is rejected (both reserved).
- Also cleans up some redundant constants all referring to the default routing tree name.