### PR TITLE
Bleve search: prefix-wildcard fallback for short queries

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2196,6 +2196,15 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 		}
 	}
 
+	// Queries shorter than NGRAM_MIN_TOKEN can't hit the title_ngram index. Without this
+	// rewrite, 1-char queries fell through to MatchAllQuery and 2-char queries usually returned
+	// nothing. Treat them as a prefix wildcard ("f" → "f*") so search-as-you-type matches by
+	// prefix via the existing wildcard branch. Callers that already passed a wildcard are left
+	// alone.
+	if q := req.Query; q != "" && len(q) < NGRAM_MIN_TOKEN && !strings.Contains(q, "*") {
+		req.Query = q + "*"
+	}
+
 	if len(req.Query) > 1 {
 		if strings.Contains(req.Query, "*") {
 			// Wildcard query is expensive, should be used with caution.

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -171,10 +171,27 @@ func TestCanSearchByTitle(t *testing.T) {
 
 		// word that doesn't exist
 		checkSearchQuery(t, index, newTestQuery("cats"), nil)
-		// string shorter than 3 chars (ngram min)
-		checkSearchQuery(t, index, newTestQuery("ma"), nil)
 		// substring that doesn't exist
 		checkSearchQuery(t, index, newTestQuery("A01"), nil)
+	})
+
+	t.Run("queries shorter than ngram min are rewritten as prefix wildcards", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "First Team",
+			"name2": "Team Alpha",
+			"name3": "Team Beta",
+			"name4": "mash potato",
+		})
+
+		// 1- and 2-char queries can't hit the n-gram index, so we rewrite them as
+		// a prefix wildcard ("f" → "f*"). The wildcard matches any token starting
+		// with the prefix, giving search-as-you-type prefix matching for short input.
+		checkSearchQuery(t, index, newTestQuery("f"), []string{"name1"})
+		checkSearchQuery(t, index, newTestQuery("fi"), []string{"name1"})
+		checkSearchQuery(t, index, newTestQuery("ma"), []string{"name4"})
+		// no word in any title starts with "zz" — prefix wildcard matches nothing.
+		checkSearchQuery(t, index, newTestQuery("zz"), nil)
 	})
 
 	t.Run("title filter ignores empty tokens from split values", func(t *testing.T) {
@@ -319,13 +336,16 @@ func TestTitleNgramFieldSearch(t *testing.T) {
 		checkSearchQuery(t, index, newNgramOnlyQuery("hello"), []string{"name1"})
 	})
 
-	t.Run("title_ngram field does not match short terms below ngram min", func(t *testing.T) {
+	t.Run("queries shorter than ngram min match via prefix wildcard", func(t *testing.T) {
 		index := newTestDashboardsIndex(t, threshold, 2, noop)
 		indexDocumentsWithTitles(t, index, key, map[string]string{
 			"name1": "dashboard",
+			"name2": "unrelated",
 		})
-		// "da" is 2 chars, below NGRAM_MIN_TOKEN (3) — removeSmallTerms strips it
-		checkSearchQuery(t, index, newNgramOnlyQuery("da"), nil)
+		// "da" is 2 chars, below NGRAM_MIN_TOKEN (3). The query is rewritten to
+		// "da*" and matched as a wildcard against the title_ngram tokens — only
+		// the n-gram tokens starting with "da" match (e.g. "das", "dash", "dashb").
+		checkSearchQuery(t, index, newNgramOnlyQuery("da"), []string{"name1"})
 	})
 }
 


### PR DESCRIPTION
Short queries (1–2 chars) against Bleve-backed search behaved inconsistently:

- `f` → returned **all** items (match-all fallthrough).
- `fi` → returned **empty** list.
- `fir` → returned expected matches.

Queries shorter than `NGRAM_MIN_TOKEN` (3) can't hit the `title_ngram` index. We now rewrite them to a prefix wildcard (`f` → `f*`) and route them through the existing wildcard branch, so search-as-you-type returns meaningful prefix matches. Callers that already include `*` are left untouched (so IAM's `*<query>*` semantics are unchanged).

Tracking issue: grafana/search-and-storage-team#832.
