### PR TITLE
IAM: Populate externalAuthInfo at user login

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -709,7 +709,8 @@ func (s *UserSync) shouldSyncExternalAuthInfo(ctx context.Context) bool {
 }
 
 func mergeExternalAuthInfo(existing []user.ExternalAuthInfo, id *authn.Identity) ([]user.ExternalAuthInfo, bool) {
-	if id.AuthenticatedBy == "" || id.AuthenticatedBy == login.PasswordAuthModule {
+	switch id.AuthenticatedBy {
+	case "", login.PasswordAuthModule, login.APIKeyAuthModule, login.ExtendedJWTModule, login.RenderModule:
 		return existing, false
 	}
 

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -709,7 +709,7 @@ func (s *UserSync) shouldSyncExternalAuthInfo(ctx context.Context) bool {
 }
 
 func mergeExternalAuthInfo(existing []user.ExternalAuthInfo, id *authn.Identity) ([]user.ExternalAuthInfo, bool) {
-	if id.AuthenticatedBy == "" {
+	if id.AuthenticatedBy == "" || id.AuthenticatedBy == login.PasswordAuthModule {
 		return existing, false
 	}
 

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -16,7 +16,9 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 
+	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
@@ -563,6 +565,15 @@ func (s *UserSync) updateUserAttributes(ctx context.Context, usr *user.User, id 
 		}
 	}
 
+	// Sync the identity's external auth connection onto the k8s user's Spec.ExternalAuthInfo.
+	if s.shouldSyncExternalAuthInfo(ctx) {
+		if merged, changed := mergeExternalAuthInfo(usr.ExternalAuthInfo, id); changed {
+			updateCmd.ExternalAuthInfo = merged
+			usr.ExternalAuthInfo = merged
+			needsUpdate = true
+		}
+	}
+
 	span.SetAttributes(
 		attribute.String("identity.ID", id.ID),
 		attribute.String("identity.ExternalUID", id.ExternalUID),
@@ -663,13 +674,20 @@ func (s *UserSync) createUser(ctx context.Context, id *authn.Identity) (*user.Us
 		defaultOrgRole = string(id.GetOrgRole())
 	}
 
+	// Seed the k8s user's Spec.ExternalAuthInfo with the identity's auth connection.
+	var externalAuthInfo []user.ExternalAuthInfo
+	if s.shouldSyncExternalAuthInfo(ctx) {
+		externalAuthInfo, _ = mergeExternalAuthInfo(nil, id)
+	}
+
 	usr, err := s.userService.Create(ctx, &user.CreateUserCommand{
-		Login:          id.Login,
-		Email:          id.Email,
-		Name:           id.Name,
-		IsAdmin:        isAdmin,
-		DefaultOrgRole: defaultOrgRole,
-		SkipOrgSetup:   len(id.OrgRoles) > 0,
+		Login:            id.Login,
+		Email:            id.Email,
+		Name:             id.Name,
+		IsAdmin:          isAdmin,
+		DefaultOrgRole:   defaultOrgRole,
+		SkipOrgSetup:     len(id.OrgRoles) > 0,
+		ExternalAuthInfo: externalAuthInfo,
 	})
 	if err != nil {
 		return nil, err
@@ -680,6 +698,41 @@ func (s *UserSync) createUser(ctx context.Context, id *authn.Identity) (*user.Us
 	}
 
 	return usr, nil
+}
+
+func (s *UserSync) shouldSyncExternalAuthInfo(ctx context.Context) bool {
+	if !s.openFeatureClient.Boolean(ctx, featuremgmt.FlagKubernetesUsersRedirect, false, openfeature.TransactionContext(ctx)) {
+		return false
+	}
+	resCfg, ok := s.cfg.UnifiedStorage[iamv0alpha1.UserResourceInfo.GroupResource().String()]
+	return ok && resCfg.DualWriterMode >= grafanarest.Mode3
+}
+
+func mergeExternalAuthInfo(existing []user.ExternalAuthInfo, id *authn.Identity) ([]user.ExternalAuthInfo, bool) {
+	if id.AuthenticatedBy == "" {
+		return existing, false
+	}
+
+	entry := user.ExternalAuthInfo{
+		Module:      id.AuthenticatedBy,
+		AuthID:      id.AuthID,
+		ExternalUID: id.ExternalUID,
+	}
+
+	for i := range existing {
+		if existing[i].Module != entry.Module {
+			continue
+		}
+		if existing[i] == entry {
+			return existing, false
+		}
+		merged := make([]user.ExternalAuthInfo, len(existing))
+		copy(merged, existing)
+		merged[i] = entry
+		return merged, true
+	}
+
+	return append(append([]user.ExternalAuthInfo{}, existing...), entry), true
 }
 
 func (s *UserSync) getUser(ctx context.Context, identity *authn.Identity) (*user.User, *login.UserAuth, error) {

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -2589,10 +2589,17 @@ func TestMergeExternalAuthInfo(t *testing.T) {
 		assert.Equal(t, existing, got)
 	})
 
-	t.Run("does not record the internal password auth module", func(t *testing.T) {
-		got, changed := mergeExternalAuthInfo(nil, &authn.Identity{AuthenticatedBy: login.PasswordAuthModule, AuthID: "1"})
-		assert.False(t, changed)
-		assert.Nil(t, got)
+	t.Run("does not record internal auth modules", func(t *testing.T) {
+		for _, module := range []string{
+			login.PasswordAuthModule,
+			login.APIKeyAuthModule,
+			login.ExtendedJWTModule,
+			login.RenderModule,
+		} {
+			got, changed := mergeExternalAuthInfo(nil, &authn.Identity{AuthenticatedBy: module, AuthID: "1"})
+			assert.False(t, changed, "module %q must not be recorded", module)
+			assert.Nil(t, got, "module %q must not be recorded", module)
+		}
 	})
 
 	t.Run("appends a new connection", func(t *testing.T) {
@@ -2760,4 +2767,46 @@ func TestUserSync_SyncUserHook_PopulatesExternalAuthInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUserSync_SyncUserHook_SkipsAnonymousIdentity(t *testing.T) {
+	provider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagKubernetesUsersRedirect: setting.NewInMemoryFlag(featuremgmt.FlagKubernetesUsersRedirect, true),
+	})
+
+	createCalled, updateCalled := false, false
+	fakeUserSvc := &usertest.FakeUserService{
+		CreateFn: func(_ context.Context, _ *user.CreateUserCommand) (*user.User, error) {
+			createCalled = true
+			return &user.User{}, nil
+		},
+		UpdateFn: func(_ context.Context, _ *user.UpdateUserCommand) error {
+			updateCalled = true
+			return nil
+		},
+	}
+
+	cfg := setting.NewCfg()
+	cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+		iamv0alpha1.UserResourceInfo.GroupResource().String(): {DualWriterMode: grafanarest.Mode5},
+	}
+
+	s := ProvideUserSync(
+		fakeUserSvc,
+		&authinfoimpl.OSSUserProtectionImpl{},
+		&authinfotest.FakeService{},
+		&quotatest.FakeQuotaService{},
+		tracing.InitializeTracerForTest(),
+		featuremgmt.WithFeatures(),
+		cfg,
+		nil,
+	)
+
+	// Mirrors the anonymous client identity: SyncUser is not set.
+	anon := &authn.Identity{Type: claims.TypeAnonymous, ClientParams: authn.ClientParams{SyncPermissions: true}}
+	err := s.SyncUserHook(context.Background(), anon, nil)
+
+	require.NoError(t, err)
+	assert.False(t, createCalled, "anonymous identity must not create a user")
+	assert.False(t, updateCalled, "anonymous identity must not update a user")
 }

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	claims "github.com/grafana/authlib/types"
+	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/authn"
@@ -2301,6 +2303,8 @@ func TestUserSync_createUser_PassesOrgRoleAsDefaultOrgRole(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			provider.UsingFlags(t, defaultFeatureFlags)
+
 			var captured *user.CreateUserCommand
 			fakeUserSvc := &usertest.FakeUserService{
 				CreateFn: func(_ context.Context, cmd *user.CreateUserCommand) (*user.User, error) {
@@ -2573,4 +2577,181 @@ func TestSyncSignedInUserToIdentity_GroupsContract(t *testing.T) {
 		"Groups must be populated from usr.TeamUIDs")
 	assert.Equal(t, []string{"ldap-admins", "ldap-devs"}, id.ExternalGroups,
 		"ExternalGroups (set by the auth client) must not be clobbered by the user-sync hook")
+}
+
+func TestMergeExternalAuthInfo(t *testing.T) {
+	authProxy := &authn.Identity{AuthenticatedBy: login.AuthProxyAuthModule, AuthID: "jdoe", ExternalUID: "ext-1"}
+
+	t.Run("returns no change when identity has no auth module", func(t *testing.T) {
+		existing := []user.ExternalAuthInfo{{Module: login.LDAPAuthModule, AuthID: "x"}}
+		got, changed := mergeExternalAuthInfo(existing, &authn.Identity{})
+		assert.False(t, changed)
+		assert.Equal(t, existing, got)
+	})
+
+	t.Run("appends a new connection", func(t *testing.T) {
+		got, changed := mergeExternalAuthInfo(nil, authProxy)
+		assert.True(t, changed)
+		assert.Equal(t, []user.ExternalAuthInfo{{Module: login.AuthProxyAuthModule, AuthID: "jdoe", ExternalUID: "ext-1"}}, got)
+	})
+
+	t.Run("preserves connections from other modules", func(t *testing.T) {
+		existing := []user.ExternalAuthInfo{{Module: login.LDAPAuthModule, AuthID: "ldap-id"}}
+		got, changed := mergeExternalAuthInfo(existing, authProxy)
+		assert.True(t, changed)
+		assert.Equal(t, []user.ExternalAuthInfo{
+			{Module: login.LDAPAuthModule, AuthID: "ldap-id"},
+			{Module: login.AuthProxyAuthModule, AuthID: "jdoe", ExternalUID: "ext-1"},
+		}, got)
+		assert.Len(t, existing, 1, "input slice must not be mutated")
+	})
+
+	t.Run("updates an existing connection for the same module", func(t *testing.T) {
+		existing := []user.ExternalAuthInfo{{Module: login.AuthProxyAuthModule, AuthID: "old", ExternalUID: "old-uid"}}
+		got, changed := mergeExternalAuthInfo(existing, authProxy)
+		assert.True(t, changed)
+		assert.Equal(t, []user.ExternalAuthInfo{{Module: login.AuthProxyAuthModule, AuthID: "jdoe", ExternalUID: "ext-1"}}, got)
+	})
+
+	t.Run("returns no change when the connection already matches", func(t *testing.T) {
+		existing := []user.ExternalAuthInfo{{Module: login.AuthProxyAuthModule, AuthID: "jdoe", ExternalUID: "ext-1"}}
+		got, changed := mergeExternalAuthInfo(existing, authProxy)
+		assert.False(t, changed)
+		assert.Equal(t, existing, got)
+	})
+}
+
+func TestUserSync_SyncUserHook_PopulatesExternalAuthInfo(t *testing.T) {
+	email := "proxyuser@example.com"
+	loginName := "proxyuser"
+	wantEntry := user.ExternalAuthInfo{Module: login.AuthProxyAuthModule, AuthID: "proxyuser", ExternalUID: "ext-1"}
+
+	newIdentity := func() *authn.Identity {
+		return &authn.Identity{
+			Login:           loginName,
+			Email:           email,
+			Name:            "Proxy User",
+			AuthID:          "proxyuser",
+			ExternalUID:     "ext-1",
+			AuthenticatedBy: login.AuthProxyAuthModule,
+			ClientParams: authn.ClientParams{
+				SyncUser:     true,
+				AllowSignUp:  true,
+				LookUpParams: login.UserLookupParams{Email: &email, Login: &loginName},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                    string
+		kubernetesUsersRedirect bool
+		dualWriterMode          grafanarest.DualWriterMode
+		existing                *user.User
+		wantCreateInfo          []user.ExternalAuthInfo
+		wantUpdateInfo          []user.ExternalAuthInfo
+		wantUpdateCalled        bool
+	}{
+		{
+			name:                    "create seeds ExternalAuthInfo when flag enabled and unified storage",
+			kubernetesUsersRedirect: true,
+			dualWriterMode:          grafanarest.Mode5,
+			wantCreateInfo:          []user.ExternalAuthInfo{wantEntry},
+		},
+		{
+			name:                    "create omits ExternalAuthInfo when flag disabled",
+			kubernetesUsersRedirect: false,
+			dualWriterMode:          grafanarest.Mode5,
+			wantCreateInfo:          nil,
+		},
+		{
+			name:                    "create omits ExternalAuthInfo in legacy-read storage mode",
+			kubernetesUsersRedirect: true,
+			dualWriterMode:          grafanarest.Mode1,
+			wantCreateInfo:          nil,
+		},
+		{
+			name:                    "update adds ExternalAuthInfo when flag enabled and unified storage",
+			kubernetesUsersRedirect: true,
+			dualWriterMode:          grafanarest.Mode5,
+			existing:                &user.User{ID: 1, Login: loginName, Email: email, Name: "Proxy User"},
+			wantUpdateInfo:          []user.ExternalAuthInfo{wantEntry},
+			wantUpdateCalled:        true,
+		},
+		{
+			name:                    "update is skipped in legacy-read storage mode",
+			kubernetesUsersRedirect: true,
+			dualWriterMode:          grafanarest.Mode1,
+			existing:                &user.User{ID: 1, Login: loginName, Email: email, Name: "Proxy User"},
+			wantUpdateCalled:        false,
+		},
+		{
+			name:                    "update is skipped when the connection is already present",
+			kubernetesUsersRedirect: true,
+			dualWriterMode:          grafanarest.Mode5,
+			existing:                &user.User{ID: 1, Login: loginName, Email: email, Name: "Proxy User", ExternalAuthInfo: []user.ExternalAuthInfo{wantEntry}},
+			wantUpdateCalled:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
+				featuremgmt.FlagKubernetesUsersRedirect: setting.NewInMemoryFlag(featuremgmt.FlagKubernetesUsersRedirect, tt.kubernetesUsersRedirect),
+			})
+
+			cfg := setting.NewCfg()
+			cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+				iamv0alpha1.UserResourceInfo.GroupResource().String(): {DualWriterMode: tt.dualWriterMode},
+			}
+
+			var createCmd *user.CreateUserCommand
+			var updateCmd *user.UpdateUserCommand
+			fakeUserSvc := &usertest.FakeUserService{
+				ExpectedUser: tt.existing,
+				CreateFn: func(_ context.Context, cmd *user.CreateUserCommand) (*user.User, error) {
+					createCmd = cmd
+					return &user.User{ID: 99, UID: "99", Login: cmd.Login, Email: cmd.Email, Name: cmd.Name, OrgID: 1}, nil
+				},
+				UpdateFn: func(_ context.Context, cmd *user.UpdateUserCommand) error {
+					updateCmd = cmd
+					return nil
+				},
+			}
+			if tt.existing == nil {
+				fakeUserSvc.ExpectedError = user.ErrUserNotFound
+			}
+
+			s := ProvideUserSync(
+				fakeUserSvc,
+				&authinfoimpl.OSSUserProtectionImpl{},
+				&authinfotest.FakeService{
+					ExpectedError:    user.ErrUserNotFound,
+					SetAuthInfoFn:    func(_ context.Context, _ *login.SetAuthInfoCommand) error { return nil },
+					UpdateAuthInfoFn: func(_ context.Context, _ *login.UpdateAuthInfoCommand) error { return nil },
+				},
+				&quotatest.FakeQuotaService{},
+				tracing.InitializeTracerForTest(),
+				featuremgmt.WithFeatures(),
+				cfg,
+				nil,
+			)
+
+			err := s.SyncUserHook(context.Background(), newIdentity(), nil)
+			require.NoError(t, err)
+
+			if tt.existing == nil {
+				require.NotNil(t, createCmd)
+				assert.Equal(t, tt.wantCreateInfo, createCmd.ExternalAuthInfo)
+				assert.Nil(t, updateCmd)
+				return
+			}
+
+			if tt.wantUpdateCalled {
+				require.NotNil(t, updateCmd)
+				assert.Equal(t, tt.wantUpdateInfo, updateCmd.ExternalAuthInfo)
+			} else {
+				assert.Nil(t, updateCmd, "update should not be called when nothing changed")
+			}
+		})
+	}
 }

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -2589,6 +2589,12 @@ func TestMergeExternalAuthInfo(t *testing.T) {
 		assert.Equal(t, existing, got)
 	})
 
+	t.Run("does not record the internal password auth module", func(t *testing.T) {
+		got, changed := mergeExternalAuthInfo(nil, &authn.Identity{AuthenticatedBy: login.PasswordAuthModule, AuthID: "1"})
+		assert.False(t, changed)
+		assert.Nil(t, got)
+	})
+
 	t.Run("appends a new connection", func(t *testing.T) {
 		got, changed := mergeExternalAuthInfo(nil, authProxy)
 		assert.True(t, changed)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When a user signs in, write their external auth connection (module, authID and externalUID) into the k8s User resource `externalAuthInfo` during user sync. Connections are keyed by auth module, so logging in via a new provider adds an entry while preserving existing ones.

Update only runs when both:

- `kubernetesUsersRedirect` is enabled
- the users resource reads from unified storage (DualWriterMode >= Mode3)

Related to https://github.com/grafana/identity-access-team/issues/2164.

**Why do we need this feature?**

This is stage 2 toward locking profile fields (username/login/email) for externally-synced users under `kubernetesUsersRedirect`. Stage 1 added the new field to the user spec: https://github.com/grafana/grafana/pull/126533.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
