### PR TITLE
Chore: Move team search into the team package

### DIFF
--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -88,7 +88,7 @@ type IdentityAccessManagementAPIBuilder struct {
 	unified                           resource.ResourceClient
 	userSearchClient                  resourcepb.ResourceIndexClient
 	userSearchHandler                 *user.SearchHandler
-	teamSearch                        *TeamSearchHandler
+	teamSearchHandler                 *team.SearchHandler
 	resourcePermissionsSearchHandler  *resourcepermission.ResourcePermissionsSearchHandler
 	externalGroupMappingSearchHandler externalgroupmapping.SearchHandler
 

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -162,7 +162,7 @@ func RegisterAPIService(
 		unified:                           unified,
 		userSearchClient: resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), iamv0.UserResourceInfo.GroupResource(),
 			unified, user.NewUserLegacySearchClient(orgService, tracing, cfg)),
-		teamSearch:                       NewTeamSearchHandler(tracing, dual, team.NewLegacyTeamSearchClient(legacyTeamSearchService(teamService), tracing), unified, features, accessClient),
+		teamSearchHandler:                team.NewSearchHandler(tracing, dual, team.NewLegacyTeamSearchClient(legacyTeamSearchService(teamService), tracing), unified, features, accessClient),
 		resourcePermissionsSearchHandler: newResourcePermissionsSearchHandler(resourcePermsSearchBackend, resourcePermsSearchAuthorizer),
 		tracing:                          tracing,
 		cfgProvider:                      cfgProvider,
@@ -543,8 +543,8 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateTeamsAPIGroup(opts builder.AP
 
 	storage[teamResource.StoragePath("members")] = team.NewTeamMembersREST(b.teamGetter, b.tracing, b.features)
 
-	if b.teamSearch != nil {
-		b.teamSearch.teamGetter = b.teamGetter
+	if b.teamSearchHandler != nil {
+		b.teamSearchHandler.SetTeamGetter(b.teamGetter)
 	}
 
 	// addmember / removemember mutate a single Spec.Members entry through
@@ -942,8 +942,8 @@ func (b *IdentityAccessManagementAPIBuilder) GetAPIRoutes(gv schema.GroupVersion
 		searchRoutes = append(searchRoutes, b.userSearchHandler.GetAPIRoutes(defs))
 	}
 
-	if enableTeamsApi && b.teamSearch != nil {
-		searchRoutes = append(searchRoutes, b.teamSearch.GetAPIRoutes(defs))
+	if enableTeamsApi && b.teamSearchHandler != nil {
+		searchRoutes = append(searchRoutes, b.teamSearchHandler.GetAPIRoutes(defs))
 	}
 
 	if enableResourcePermissionsApi && b.resourcePermissionsSearchHandler != nil {

--- a/pkg/registry/apis/iam/team/search.go
+++ b/pkg/registry/apis/iam/team/search.go
@@ -1,4 +1,4 @@
-package iam
+package team
 
 import (
 	"context"
@@ -60,7 +60,7 @@ var teamAccessControlChecks = []teamAccessControlCheck{
 	{action: "teams.roles:read", group: iamv0alpha1.GROUP, resource: "rolebindings", verb: utils.VerbList},
 }
 
-type TeamSearchHandler struct {
+type SearchHandler struct {
 	log          log.Logger
 	client       resourcepb.ResourceIndexClient
 	tracer       trace.Tracer
@@ -69,10 +69,10 @@ type TeamSearchHandler struct {
 	teamGetter   k8srest.Getter
 }
 
-func NewTeamSearchHandler(tracer trace.Tracer, dual dualwrite.Service, legacyTeamSearcher resourcepb.ResourceIndexClient, resourceClient resource.ResourceClient, features featuremgmt.FeatureToggles, accessClient authlib.AccessClient) *TeamSearchHandler {
+func NewSearchHandler(tracer trace.Tracer, dual dualwrite.Service, legacyTeamSearcher resourcepb.ResourceIndexClient, resourceClient resource.ResourceClient, features featuremgmt.FeatureToggles, accessClient authlib.AccessClient) *SearchHandler {
 	searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), iamv0alpha1.TeamResourceInfo.GroupResource(), resourceClient, legacyTeamSearcher)
 
-	return &TeamSearchHandler{
+	return &SearchHandler{
 		client:       searchClient,
 		log:          log.New("grafana-apiserver.teams.search"),
 		tracer:       tracer,
@@ -81,7 +81,12 @@ func NewTeamSearchHandler(tracer trace.Tracer, dual dualwrite.Service, legacyTea
 	}
 }
 
-func (s *TeamSearchHandler) GetAPIRoutes(defs map[string]k8scommon.OpenAPIDefinition) *builder.APIRoutes {
+// SetTeamGetter sets the getter used to resolve teams for member-count enrichment.
+func (s *SearchHandler) SetTeamGetter(getter k8srest.Getter) {
+	s.teamGetter = getter
+}
+
+func (s *SearchHandler) GetAPIRoutes(defs map[string]k8scommon.OpenAPIDefinition) *builder.APIRoutes {
 	searchResults := defs["github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1.GetSearchTeams"].Schema
 
 	return &builder.APIRoutes{
@@ -255,7 +260,7 @@ func (s *TeamSearchHandler) GetAPIRoutes(defs map[string]k8scommon.OpenAPIDefini
 }
 
 // nolint:gocyclo
-func (s *TeamSearchHandler) DoTeamSearch(w http.ResponseWriter, r *http.Request) {
+func (s *SearchHandler) DoTeamSearch(w http.ResponseWriter, r *http.Request) {
 	ctx, span := s.tracer.Start(r.Context(), "team.search")
 	defer span.End()
 
@@ -428,7 +433,7 @@ func (s *TeamSearchHandler) DoTeamSearch(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-func (s *TeamSearchHandler) stampAccessControl(ctx context.Context, requester identity.Requester, hits []iamv0alpha1.GetSearchTeamsTeamHit) error {
+func (s *SearchHandler) stampAccessControl(ctx context.Context, requester identity.Requester, hits []iamv0alpha1.GetSearchTeamsTeamHit) error {
 	namespace := requester.GetNamespace()
 
 	items := func(yield func(teamAccessControlCheck) bool) {
@@ -474,7 +479,7 @@ func (s *TeamSearchHandler) stampAccessControl(ctx context.Context, requester id
 // from len(team.Spec.Members) — the team is the source of truth for membership.
 // errgroup is used as a bounded concurrency pool (SetLimit); the first error
 // from any goroutine is propagated to the caller.
-func (s *TeamSearchHandler) enrichWithMemberCounts(ctx context.Context, namespace string, hits []iamv0alpha1.GetSearchTeamsTeamHit) error {
+func (s *SearchHandler) enrichWithMemberCounts(ctx context.Context, namespace string, hits []iamv0alpha1.GetSearchTeamsTeamHit) error {
 	if len(hits) == 0 {
 		return nil
 	}
@@ -505,7 +510,7 @@ func (s *TeamSearchHandler) enrichWithMemberCounts(ctx context.Context, namespac
 	return g.Wait()
 }
 
-func (s *TeamSearchHandler) write(w http.ResponseWriter, obj any) error {
+func (s *SearchHandler) write(w http.ResponseWriter, obj any) error {
 	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(obj)
 }

--- a/pkg/registry/apis/iam/team/search_test.go
+++ b/pkg/registry/apis/iam/team/search_test.go
@@ -1,4 +1,4 @@
-package iam
+package team
 
 import (
 	"context"
@@ -60,7 +60,7 @@ func TestTeamSearchFallback(t *testing.T) {
 				},
 			}
 			dual := dualwrite.ProvideServiceForTests(cfg)
-			searchHandler := NewTeamSearchHandler(tracing.NewNoopTracerService(), dual, mockLegacyClient, mockClient, nil, nil)
+			searchHandler := NewSearchHandler(tracing.NewNoopTracerService(), dual, mockLegacyClient, mockClient, nil, nil)
 
 			rr := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/teams/search", nil)
@@ -79,12 +79,12 @@ func TestTeamSearchFallback(t *testing.T) {
 	}
 }
 
-func TestTeamSearchHandler(t *testing.T) {
+func TestSearchHandler(t *testing.T) {
 	t.Run("search using default team search fields", func(t *testing.T) {
 		mockClient := &MockClient{}
 
 		features := featuremgmt.WithFeatures()
-		searchHandler := TeamSearchHandler{
+		searchHandler := SearchHandler{
 			log:      log.New("grafana-apiserver.teams.search"),
 			client:   mockClient,
 			tracer:   tracing.NewNoopTracerService(),
@@ -119,7 +119,7 @@ func TestTeamSearchHandler(t *testing.T) {
 		}
 
 		features := featuremgmt.WithFeatures()
-		searchHandler := TeamSearchHandler{
+		searchHandler := SearchHandler{
 			log:      log.New("grafana-apiserver.teams.search"),
 			client:   mockClient,
 			tracer:   tracing.NewNoopTracerService(),
@@ -203,7 +203,7 @@ func TestTeamSearchHandler(t *testing.T) {
 				},
 			}
 			dual := dualwrite.ProvideServiceForTests(cfg)
-			searchHandler := NewTeamSearchHandler(tracing.NewNoopTracerService(), dual, mockClient, mockClient, nil, nil)
+			searchHandler := NewSearchHandler(tracing.NewNoopTracerService(), dual, mockClient, mockClient, nil, nil)
 
 			rr := httptest.NewRecorder()
 			endpoint := fmt.Sprintf("/teams/search?limit=%d", limit)
@@ -232,7 +232,7 @@ func TestTeamSearchHandler(t *testing.T) {
 	t.Run("returns 400 for invalid sort field", func(t *testing.T) {
 		mockClient := &MockClient{}
 
-		searchHandler := &TeamSearchHandler{
+		searchHandler := &SearchHandler{
 			log:      log.New("grafana-apiserver.teams.search"),
 			client:   mockClient,
 			tracer:   tracing.NewNoopTracerService(),
@@ -255,7 +255,7 @@ func TestTeamSearchHandler(t *testing.T) {
 			t.Run(sortParam, func(t *testing.T) {
 				mockClient := &MockClient{}
 
-				searchHandler := &TeamSearchHandler{
+				searchHandler := &SearchHandler{
 					log:      log.New("grafana-apiserver.teams.search"),
 					client:   mockClient,
 					tracer:   tracing.NewNoopTracerService(),
@@ -427,7 +427,7 @@ func TestTeamAccessControl(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			searchHandler := &TeamSearchHandler{
+			searchHandler := &SearchHandler{
 				log:          log.New("grafana-apiserver.teams.search"),
 				client:       mockTeamClientWithHits(),
 				tracer:       tracing.NewNoopTracerService(),
@@ -462,7 +462,7 @@ func TestTeamSearchMemberCount(t *testing.T) {
 	}
 
 	t.Run("membercount absent - no member counts on hits", func(t *testing.T) {
-		searchHandler := &TeamSearchHandler{
+		searchHandler := &SearchHandler{
 			log:        log.New("grafana-apiserver.teams.search"),
 			client:     mockTeamClientWithHits(),
 			tracer:     tracing.NewNoopTracerService(),
@@ -488,7 +488,7 @@ func TestTeamSearchMemberCount(t *testing.T) {
 	})
 
 	t.Run("membercount=false - no member counts on hits", func(t *testing.T) {
-		searchHandler := &TeamSearchHandler{
+		searchHandler := &SearchHandler{
 			log:        log.New("grafana-apiserver.teams.search"),
 			client:     mockTeamClientWithHits(),
 			tracer:     tracing.NewNoopTracerService(),
@@ -514,7 +514,7 @@ func TestTeamSearchMemberCount(t *testing.T) {
 	})
 
 	t.Run("membercount=true - member counts populated", func(t *testing.T) {
-		searchHandler := &TeamSearchHandler{
+		searchHandler := &SearchHandler{
 			log:        log.New("grafana-apiserver.teams.search"),
 			client:     mockTeamClientWithHits(),
 			tracer:     tracing.NewNoopTracerService(),
@@ -547,7 +547,7 @@ func TestTeamSearchMemberCount(t *testing.T) {
 			},
 		}
 
-		searchHandler := &TeamSearchHandler{
+		searchHandler := &SearchHandler{
 			log:        log.New("grafana-apiserver.teams.search"),
 			client:     mockTeamClientWithHits(),
 			tracer:     tracing.NewNoopTracerService(),
@@ -581,7 +581,7 @@ func TestEnrichWithMemberCounts(t *testing.T) {
 			},
 		}
 
-		handler := &TeamSearchHandler{
+		handler := &SearchHandler{
 			log:        log.New("test"),
 			tracer:     tracing.NewNoopTracerService(),
 			teamGetter: mockGetter,
@@ -610,7 +610,7 @@ func TestEnrichWithMemberCounts(t *testing.T) {
 			},
 		}
 
-		handler := &TeamSearchHandler{
+		handler := &SearchHandler{
 			log:        log.New("test"),
 			tracer:     tracing.NewNoopTracerService(),
 			teamGetter: mockGetter,
@@ -634,7 +634,7 @@ func TestEnrichWithMemberCounts(t *testing.T) {
 			},
 		}
 
-		handler := &TeamSearchHandler{
+		handler := &SearchHandler{
 			log:        log.New("test"),
 			tracer:     tracing.NewNoopTracerService(),
 			teamGetter: mockGetter,


### PR DESCRIPTION
## What

Moves the team search handler out of the top-level `iam` package and into the `team` subpackage, and gives it package-appropriate names:

- `pkg/registry/apis/iam/team_search.go` → `pkg/registry/apis/iam/team/search.go`
- `pkg/registry/apis/iam/team_search_test.go` → `pkg/registry/apis/iam/team/search_test.go`
- `TeamSearchHandler` → `team.SearchHandler`, `NewTeamSearchHandler` → `team.NewSearchHandler`
- Added `SearchHandler.SetTeamGetter` so the registry can inject the team getter across the package boundary.

Pure code move + rename; no behavior change.

## Test plan

- `go build ./pkg/registry/apis/iam/...`
- `go test ./pkg/tests/apis/iam/...`