### PR TITLE
Restore dashboards: fetch the dashboard at the RV before delete

### DIFF
--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.test.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.test.tsx
@@ -1,10 +1,11 @@
-import type { ComponentProps } from 'react';
+import { act, type ComponentProps } from 'react';
 import { render, screen } from 'test/test-utils';
 
 import { DataFrameView, FieldType, toDataFrame } from '@grafana/data';
 import { setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
 import { backendSrv } from 'app/core/services/backend_srv';
+import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 
 import { deletedDashboardsCache } from '../../search/service/deletedDashboardsCache';
 import { type DashboardQueryResult } from '../../search/service/types';
@@ -18,6 +19,13 @@ import { RestoreModal } from './RestoreModal';
 jest.mock('../api/useRecentlyDeletedStateManager');
 jest.mock('../state/hooks');
 jest.mock('../../search/service/deletedDashboardsCache');
+jest.mock('app/features/dashboard/api/dashboard_api', () => ({
+  getDashboardAPI: jest.fn(),
+}));
+jest.mock('../api/browseDashboardsAPI', () => ({
+  ...jest.requireActual('../api/browseDashboardsAPI'),
+  useRestoreDashboardMutation: () => [jest.fn().mockResolvedValue({ data: { name: 'dashboard-1' } })],
+}));
 jest.mock('./RestoreModal', () => ({
   RestoreModal: jest.fn(() => null),
 }));
@@ -30,6 +38,7 @@ const mockUseRecentlyDeletedStateManager = useRecentlyDeletedStateManager as jes
 >;
 const mockUseActionSelectionState = useActionSelectionState as jest.MockedFunction<typeof useActionSelectionState>;
 const mockRestoreModal = RestoreModal as jest.MockedFunction<typeof RestoreModal>;
+const mockGetDashboardAPI = getDashboardAPI as jest.MockedFunction<typeof getDashboardAPI>;
 
 describe('RecentlyDeletedActions', () => {
   beforeEach(() => {
@@ -107,6 +116,49 @@ describe('RecentlyDeletedActions', () => {
     expect(getRestoreModalProps().originCandidate).toBe('');
   });
 
+  it('fetches the dashboard at the resource version before the delete event when restoring', async () => {
+    // The trash listing returns the delete event's RV. The fix subtracts one
+    // so the GET resolves to the live dashboard, not the tombstone.
+    const deleteRV = '2067893224188780544';
+    const previousRV = '2067893224188780543';
+
+    (deletedDashboardsCache.getAsTable as jest.Mock).mockResolvedValueOnce({
+      rows: [
+        {
+          cells: [],
+          object: {
+            metadata: { name: 'dashboard-1', resourceVersion: deleteRV, creationTimestamp: '2024-01-01T00:00:00Z' },
+          },
+        },
+      ],
+      columnDefinitions: [],
+      metadata: { resourceVersion: deleteRV },
+    });
+
+    mockUseActionSelectionState.mockReturnValue({
+      dashboard: { 'dashboard-1': true },
+      folder: {},
+    });
+
+    const getDashboard = jest.fn().mockResolvedValue({
+      metadata: { name: 'dashboard-1', annotations: {} },
+      spec: {},
+    });
+    // Only `getDashboard` is exercised by onRestore; the rest of the API is unused here.
+    mockGetDashboardAPI.mockResolvedValue({ getDashboard } as unknown as Awaited<ReturnType<typeof getDashboardAPI>>);
+
+    const { user } = render(<RecentlyDeletedActions />);
+    await user.click(screen.getByRole('button', { name: 'Restore' }));
+
+    const onConfirm = getRestoreModalProps().onConfirm;
+    expect(onConfirm).toBeDefined();
+    await act(async () => {
+      await onConfirm!('folder-target');
+    });
+
+    expect(getDashboard).toHaveBeenCalledWith('dashboard-1', { resourceVersion: previousRV });
+  });
+
   it('does not preselect a folder when selected dashboards have mixed origins', async () => {
     setRecentlyDeletedState({
       uids: ['dashboard-1', 'dashboard-2'],
@@ -144,6 +196,7 @@ function setRecentlyDeletedState({ uids, locations }: { uids: string[]; location
   const mockView = new DataFrameView<DashboardQueryResult>(mockDataFrame);
 
   const mockStateManager = {
+    doSearch: jest.fn().mockResolvedValue(undefined),
     doSearchWithDebounce: jest.fn(),
     state: {
       query: '',

--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
@@ -98,8 +98,18 @@ export function RecentlyDeletedActions() {
         return { uid, error: 'not_found' };
       }
 
+      const deleteRV = row.object.metadata.resourceVersion;
+      if (!deleteRV) {
+        console.warn(`Dashboard ${uid} is missing a resourceVersion in the trash listing`);
+        return { uid, error: 'not_found' };
+      }
+      // The RV on a trash row is the delete event's RV, which points at the
+      // tombstone (and on some storage backends returns 404). Step back by one
+      // so the read resolves to the dashboard as it was just before delete.
+      const previousRV = (BigInt(deleteRV) - 1n).toString();
+
       const api = await getDashboardAPI();
-      const dashboard = await api.getDashboard(uid, { resourceVersion: row.object.metadata.resourceVersion });
+      const dashboard = await api.getDashboard(uid, { resourceVersion: previousRV });
 
       const copy = structuredClone(dashboard);
       copy.metadata = {

--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
@@ -106,7 +106,7 @@ export function RecentlyDeletedActions() {
       // The RV on a trash row is the delete event's RV, which points at the
       // tombstone (and on some storage backends returns 404). Step back by one
       // so the read resolves to the dashboard as it was just before delete.
-      const previousRV = (BigInt(deleteRV) - 1n).toString();
+      const previousRV = (BigInt(deleteRV) - BigInt(1)).toString();
 
       const api = await getDashboardAPI();
       const dashboard = await api.getDashboard(uid, { resourceVersion: previousRV });


### PR DESCRIPTION
#124797 switched the restore flow to fetch each deleted dashboard's spec separately, using `metadata.resourceVersion` from the trash listing. That RV points at the delete event, so reading it returns the tombstone — and on the unified-storage KV backend it returns 404, because the read path skips entries whose latest action is a delete. Restore then fails.

This subtracts one from that RV before issuing the GET, so the read resolves to the dashboard as it was just before the delete. Works on both SQL and KV backends; no storage changes needed.