### PR TITLE
Access control: use Zanzana Read for merged user permissions

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -90,7 +90,7 @@ func ProvideService(
 
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if features != nil && features.IsEnabledGlobally(featuremgmt.FlagZanzanaMergeUserPermissions) && zanzanaClient != nil {
-		service.zanzanaResolver = NewZanzanaPermissionResolver(zanzanaClient, userService, cfg.IDUseExternalGroupsForGroupsClaim)
+		service.zanzanaResolver = NewZanzanaPermissionResolver(zanzanaClient, userService, actionResolver, cfg.IDUseExternalGroupsForGroupsClaim)
 	}
 
 	return service, nil

--- a/pkg/services/accesscontrol/acimpl/zanzana_merge_test.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_merge_test.go
@@ -8,6 +8,7 @@ import (
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	authlib "github.com/grafana/authlib/types"
+	dashboards "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +22,7 @@ import (
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/client"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
@@ -31,6 +33,9 @@ type fakeZanzanaClient struct {
 	client.NoopClient
 	listResp *authzv1.ListResponse
 	listErr  error
+	readResp *authzextv1.ReadResponse
+	readErr  error
+	readFunc func(req *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error)
 }
 
 func (f *fakeZanzanaClient) Check(context.Context, authlib.AuthInfo, authlib.CheckRequest, string) (authlib.CheckResponse, error) {
@@ -49,8 +54,17 @@ func (f *fakeZanzanaClient) List(context.Context, *authzv1.ListRequest) (*authzv
 	return f.listResp, f.listErr
 }
 
-func (f *fakeZanzanaClient) Read(context.Context, *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error) {
-	return nil, nil
+func (f *fakeZanzanaClient) Read(_ context.Context, req *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error) {
+	if f.readFunc != nil {
+		return f.readFunc(req)
+	}
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	if f.readResp != nil {
+		return f.readResp, nil
+	}
+	return &authzextv1.ReadResponse{}, nil
 }
 
 func (f *fakeZanzanaClient) Write(context.Context, *authzextv1.WriteRequest) error {
@@ -63,6 +77,27 @@ func (f *fakeZanzanaClient) Mutate(context.Context, *authzextv1.MutateRequest) e
 
 func (f *fakeZanzanaClient) Query(context.Context, *authzextv1.QueryRequest) (*authzextv1.QueryResponse, error) {
 	return nil, nil
+}
+
+func testActionResolver() accesscontrol.ActionResolver {
+	return resourcepermissions.NewActionSetService()
+}
+
+func readResponseForDashboard(subject, dashUID string) func(req *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error) {
+	gr := dashboards.DashboardResourceInfo.GroupResource()
+	tuple := common.NewResourceTuple(subject, common.RelationGet, gr.Group, gr.Resource, "", dashUID)
+	key := common.ToAuthzExtTupleKey(tuple)
+	return func(req *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error) {
+		if req.GetTupleKey().GetObject() != common.TypeResourcePrefix {
+			return &authzextv1.ReadResponse{}, nil
+		}
+		if req.GetTupleKey().GetUser() != subject {
+			return &authzextv1.ReadResponse{}, nil
+		}
+		return &authzextv1.ReadResponse{
+			Tuples: []*authzextv1.Tuple{{Key: key}},
+		}, nil
+	}
 }
 
 func sortPermissions(perms []accesscontrol.Permission) {
@@ -218,13 +253,16 @@ func TestZanzanaPermissionResolver_MergeCurrentUser(t *testing.T) {
 	})
 
 	t.Run("zanzana failure returns legacy only", func(t *testing.T) {
-		r := NewZanzanaPermissionResolver(&fakeZanzanaClient{listErr: errors.New("zanzana unavailable")}, &usertest.FakeUserService{}, false)
+		r := NewZanzanaPermissionResolver(&fakeZanzanaClient{readErr: errors.New("zanzana unavailable")}, &usertest.FakeUserService{}, testActionResolver(), false)
 		got := r.MergeCurrentUser(context.Background(), &user.SignedInUser{OrgID: 1, UserID: 1, UserUID: "user_test_uid"}, legacy, log.New("test"))
 		require.Equal(t, legacy, got)
 	})
 
 	t.Run("success unions zanzana permissions", func(t *testing.T) {
-		r := NewZanzanaPermissionResolver(&fakeZanzanaClient{listResp: &authzv1.ListResponse{Items: []string{"zanzana-dash"}}}, &usertest.FakeUserService{}, false)
+		subject := authlib.NewTypeID(authlib.TypeUser, "user_test_uid")
+		r := NewZanzanaPermissionResolver(&fakeZanzanaClient{
+			readFunc: readResponseForDashboard(subject, "zanzana-dash"),
+		}, &usertest.FakeUserService{}, testActionResolver(), false)
 		got := r.MergeCurrentUser(context.Background(), &user.SignedInUser{OrgID: 1, UserID: 1, UserUID: "user_test_uid"}, legacy, log.New("test"))
 		require.Contains(t, got, accesscontrol.Permission{Action: "dashboards:read", Scope: "dashboards:uid:legacy"})
 		require.Contains(t, got, accesscontrol.Permission{Action: "dashboards:read", Scope: "dashboards:uid:zanzana-dash"})
@@ -245,7 +283,7 @@ func TestZanzanaPermissionResolver_MergeSearch(t *testing.T) {
 	t.Run("zanzana failure returns legacy only", func(t *testing.T) {
 		mockUserSvc := usertest.NewMockService(t)
 		mockUserSvc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: 2}).Return(&user.User{ID: 2, UID: "user_2_uid"}, nil).Maybe()
-		r := NewZanzanaPermissionResolver(&fakeZanzanaClient{listErr: errors.New("zanzana unavailable")}, mockUserSvc, false)
+		r := NewZanzanaPermissionResolver(&fakeZanzanaClient{listErr: errors.New("zanzana unavailable")}, mockUserSvc, testActionResolver(), false)
 		got := r.MergeSearch(context.Background(), &user.SignedInUser{OrgID: 1}, 1, accesscontrol.SearchOptions{Action: "dashboards:read", UserID: 2}, legacy, log.New("test"))
 		require.Equal(t, legacy, got)
 	})
@@ -257,7 +295,7 @@ func TestZanzanaPermissionResolver_MergeSearch(t *testing.T) {
 		mockUserSvc := usertest.NewMockService(t)
 		mockUserSvc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: 2}).Return(&user.User{ID: 2, UID: "user_2_uid"}, nil)
 		// "legacy" overlaps an existing scope (must dedup), "zanzana" is new (must be added).
-		r := NewZanzanaPermissionResolver(&fakeZanzanaClient{listResp: &authzv1.ListResponse{Items: []string{"legacy", "zanzana"}}}, mockUserSvc, false)
+		r := NewZanzanaPermissionResolver(&fakeZanzanaClient{listResp: &authzv1.ListResponse{Items: []string{"legacy", "zanzana"}}}, mockUserSvc, testActionResolver(), false)
 
 		got := r.MergeSearch(context.Background(), &user.SignedInUser{OrgID: 1}, 1, accesscontrol.SearchOptions{Action: "dashboards:read", UserID: 2}, base, log.New("test"))
 
@@ -277,7 +315,7 @@ func setupServiceWithFakeStore(t *testing.T, store accesscontrol.Store, zClient 
 		nil, permreg.ProvidePermissionRegistry(), nil,
 	)
 	if zClient != nil {
-		svc.zanzanaResolver = NewZanzanaPermissionResolver(zClient, userSvc, false)
+		svc.zanzanaResolver = NewZanzanaPermissionResolver(zClient, userSvc, testActionResolver(), false)
 	}
 	return svc
 }
@@ -363,8 +401,9 @@ func TestService_GetUserPermissions_MergesLegacyAndZanzana(t *testing.T) {
 			{Action: "dashboards:read", Scope: "dashboards:uid:legacy"},
 		},
 	}
+	subject := authlib.NewTypeID(authlib.TypeUser, "user_test_uid")
 	zClient := &fakeZanzanaClient{
-		listResp: &authzv1.ListResponse{Items: []string{"zanzana-dash"}},
+		readFunc: readResponseForDashboard(subject, "zanzana-dash"),
 	}
 
 	svc := setupServiceWithFakeStore(t, store, zClient, &usertest.FakeUserService{})
@@ -399,7 +438,7 @@ func TestService_GetUserPermissions_UsesLegacyWhenZanzanaFails(t *testing.T) {
 		},
 	}
 	zClient := &fakeZanzanaClient{
-		listErr: errors.New("zanzana unavailable"),
+		readErr: errors.New("zanzana unavailable"),
 	}
 
 	svc := setupServiceWithFakeStore(t, store, zClient, &usertest.FakeUserService{})

--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
@@ -10,10 +10,12 @@ import (
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	claims "github.com/grafana/authlib/types"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -21,21 +23,24 @@ import (
 
 var logger = log.New("accesscontrol.zanzana_resolver")
 
+const (
+	readPageSize           = 100
+	maxConcurrentReadTasks = 8
+)
+
 // ZanzanaPermissionResolver handles resolving user permissions using Zanzana
 type ZanzanaPermissionResolver struct {
-	client  zanzana.Client
-	userSvc user.Service
-	// useExternalGroups mirrors cfg.IDUseExternalGroupsForGroupsClaim: it selects which
-	// team memberships are sent as Zanzana contextual tuples for the current user, so the
-	// merged permissions match what the forward Check path (which uses the groups claim)
-	// enforces.
+	client            zanzana.Client
+	userSvc           user.Service
+	actionResolver    ac.ActionResolver
 	useExternalGroups bool
 }
 
-func NewZanzanaPermissionResolver(client zanzana.Client, userSvc user.Service, useExternalGroups bool) *ZanzanaPermissionResolver {
+func NewZanzanaPermissionResolver(client zanzana.Client, userSvc user.Service, actionResolver ac.ActionResolver, useExternalGroups bool) *ZanzanaPermissionResolver {
 	return &ZanzanaPermissionResolver{
 		client:            client,
 		userSvc:           userSvc,
+		actionResolver:    actionResolver,
 		useExternalGroups: useExternalGroups,
 	}
 }
@@ -52,11 +57,130 @@ func (r *ZanzanaPermissionResolver) teamsForCurrentUser(usr identity.Requester) 
 	return usr.GetGroups()
 }
 
-// ResolveCurrentUserPermissions lists Zanzana-supported permissions for the signed-in identity.
+// ResolveCurrentUserPermissions reads direct stored Zanzana tuples for the signed-in identity
+// and maps them to legacy-shaped anchor permissions (no inherited subtree expansion).
 func (r *ZanzanaPermissionResolver) ResolveCurrentUserPermissions(ctx context.Context, usr identity.Requester) ([]ac.Permission, error) {
-	subject := usr.GetUID()
 	namespace := claims.OrgNamespaceFormatter(usr.GetOrgID())
-	return r.listAllWithPrefix(ctx, namespace, subject, r.teamsForCurrentUser(usr), "", "")
+	return r.resolveDirectGrants(ctx, namespace, r.subjectsFor(usr))
+}
+
+func (r *ZanzanaPermissionResolver) subjectsFor(usr identity.Requester) []string {
+	subjects := []string{usr.GetUID()}
+	for _, teamUID := range r.teamsForCurrentUser(usr) {
+		subjects = append(subjects, common.NewTupleEntry(common.TypeTeam, teamUID, common.RelationTeamMember))
+	}
+	for _, role := range ac.GetOrgRoles(usr) {
+		if basicRole := common.TranslateBasicRole(role); basicRole != "" {
+			subjects = append(subjects, common.NewTupleEntry(common.TypeRole, basicRole, common.RelationAssignee))
+		}
+	}
+	return subjects
+}
+
+var readObjectPrefixes = []string{
+	common.TypeFolderPrefix,
+	common.TypeResourcePrefix,
+	common.TypeGroupResoucePrefix,
+}
+
+func (r *ZanzanaPermissionResolver) resolveDirectGrants(ctx context.Context, namespace string, subjects []string) ([]ac.Permission, error) {
+	type readTask struct {
+		subject string
+		prefix  string
+	}
+
+	tasks := make([]readTask, 0, len(subjects)*len(readObjectPrefixes))
+	for _, subject := range subjects {
+		for _, prefix := range readObjectPrefixes {
+			tasks = append(tasks, readTask{subject: subject, prefix: prefix})
+		}
+	}
+
+	var (
+		mu          sync.Mutex
+		permissions []ac.Permission
+	)
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentReadTasks)
+	for _, task := range tasks {
+		task := task
+		g.Go(func() error {
+			tuples, err := r.readAllTuples(gctx, namespace, task.subject, task.prefix)
+			if err != nil {
+				return err
+			}
+			var batch []ac.Permission
+			for _, t := range tuples {
+				key := t.GetKey()
+				if key == nil {
+					continue
+				}
+				mapped, ok := common.PermissionsFromStoredTuple(key.GetObject(), key.GetRelation(), key.GetCondition())
+				if !ok {
+					continue
+				}
+				for _, m := range mapped {
+					batch = append(batch, ac.Permission{Action: m.Action, Scope: m.Scope})
+				}
+			}
+			if len(batch) > 0 {
+				mu.Lock()
+				permissions = append(permissions, batch...)
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	if r.actionResolver != nil {
+		permissions = r.actionResolver.ExpandActionSets(permissions)
+	}
+	return dedupePermissions(permissions), nil
+}
+
+func (r *ZanzanaPermissionResolver) readAllTuples(ctx context.Context, namespace, subject, objectPrefix string) ([]*authzextv1.Tuple, error) {
+	var out []*authzextv1.Tuple
+	token := ""
+	for {
+		req := &authzextv1.ReadRequest{
+			Namespace: namespace,
+			TupleKey: &authzextv1.ReadRequestTupleKey{
+				User:   subject,
+				Object: objectPrefix,
+			},
+			PageSize:          wrapperspb.Int32(readPageSize),
+			ContinuationToken: token,
+		}
+		res, err := r.client.Read(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("zanzana read failed: %w", err)
+		}
+		out = append(out, res.GetTuples()...)
+		token = res.GetContinuationToken()
+		if token == "" {
+			return out, nil
+		}
+	}
+}
+
+func dedupePermissions(permissions []ac.Permission) []ac.Permission {
+	if len(permissions) == 0 {
+		return permissions
+	}
+	seen := make(map[permKey]struct{}, len(permissions))
+	out := make([]ac.Permission, 0, len(permissions))
+	for _, p := range permissions {
+		k := permKey{p.Action, p.Scope}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, p)
+	}
+	return out
 }
 
 // searchUsersPermissions searches for users' permissions using Zanzana

--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver_test.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver_test.go
@@ -13,9 +13,24 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 )
+
+type capturingReadClient struct {
+	fakeZanzanaClient
+	mu        sync.Mutex
+	readCalls []*authzextv1.ReadRequest
+}
+
+func (c *capturingReadClient) Read(_ context.Context, req *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error) {
+	c.mu.Lock()
+	c.readCalls = append(c.readCalls, req)
+	c.mu.Unlock()
+	return &authzextv1.ReadResponse{}, nil
+}
 
 // capturingZanzanaClient records every ListRequest it receives so tests can
 // assert on the group / resource / verb / subject sent to Zanzana.
@@ -658,18 +673,17 @@ func TestLegacyZanzanaParity(t *testing.T) {
 	}
 }
 
-// TestResolveCurrentUserPermissions_PassesTeamsAsContextualGroups verifies the merge
-// resolver sends the signed-in user's team memberships as List `Teams`, so team-based
-// grants (resolved via contextual team:<name>#member tuples) surface in the merged
-// permissions. It mirrors the id token groups claim: external (proxy/IdP) groups when
-// id_use_external_groups_for_groups_claim is set, otherwise stored team memberships.
-func TestResolveCurrentUserPermissions_PassesTeamsAsContextualGroups(t *testing.T) {
+// TestResolveCurrentUserPermissions_ReadsTeamAndRoleSubjects verifies the merge
+// resolver issues Read requests for the signed-in user, their team memberships,
+// and org role subjects.
+func TestResolveCurrentUserPermissions_ReadsTeamAndRoleSubjects(t *testing.T) {
 	newReq := func(stored, external []string) identity.Requester {
 		return &identity.StaticRequester{
 			Type:           claims.TypeUser,
 			UserID:         1,
 			UserUID:        "u1",
 			OrgID:          1,
+			OrgRole:        identity.RoleAdmin,
 			Groups:         stored,
 			ExternalGroups: external,
 		}
@@ -678,29 +692,111 @@ func TestResolveCurrentUserPermissions_PassesTeamsAsContextualGroups(t *testing.
 	cases := []struct {
 		name              string
 		useExternalGroups bool
-		wantTeams         []string
+		wantTeamSubjects  []string
 	}{
-		{"external groups when configured", true, []string{"team_a", "everyone"}},
-		{"stored team memberships otherwise", false, []string{"stored-team"}},
+		{"external groups when configured", true, []string{
+			common.NewTupleEntry(common.TypeTeam, "team_a", common.RelationTeamMember),
+			common.NewTupleEntry(common.TypeTeam, "everyone", common.RelationTeamMember),
+		}},
+		{"stored team memberships otherwise", false, []string{
+			common.NewTupleEntry(common.TypeTeam, "stored-team", common.RelationTeamMember),
+		}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := &capturingZanzanaClient{}
-			cap.listResp = &authzv1.ListResponse{}
-			r := NewZanzanaPermissionResolver(cap, &usertest.FakeUserService{}, tc.useExternalGroups)
+			cap := &capturingReadClient{}
+			r := NewZanzanaPermissionResolver(cap, &usertest.FakeUserService{}, resourcepermissions.NewActionSetService(), tc.useExternalGroups)
 
 			_, err := r.ResolveCurrentUserPermissions(context.Background(), newReq([]string{"stored-team"}, []string{"team_a", "everyone"}))
 			require.NoError(t, err)
-			require.NotEmpty(t, cap.listCalls, "expected the resolver to issue List requests")
-			for _, c := range cap.listCalls {
-				require.Equal(t, tc.wantTeams, c.Teams, "every List request must carry the user's teams")
+			require.NotEmpty(t, cap.readCalls, "expected Read requests")
+
+			users := map[string]struct{}{}
+			for _, c := range cap.readCalls {
+				users[c.GetTupleKey().GetUser()] = struct{}{}
 			}
+			require.Contains(t, users, claims.NewTypeID(claims.TypeUser, "u1"))
+			for _, teamSubject := range tc.wantTeamSubjects {
+				require.Contains(t, users, teamSubject)
+			}
+			require.Contains(t, users, common.NewTupleEntry(common.TypeRole, common.TranslateBasicRole("Admin"), common.RelationAssignee))
 		})
 	}
 }
 
-// permScopes returns the scopes the resolver produced for the given action.
+func TestResolveCurrentUserPermissions_ReturnsAnchorOnly(t *testing.T) {
+	subject := claims.NewTypeID(claims.TypeUser, "u1")
+	folderObject := common.NewFolderIdent("top-folder")
+	var readCount int
+	client := &fakeZanzanaClient{
+		readFunc: func(req *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error) {
+			readCount++
+			if req.GetTupleKey().GetUser() == subject && req.GetTupleKey().GetObject() == common.TypeFolderPrefix {
+				return &authzextv1.ReadResponse{
+					Tuples: []*authzextv1.Tuple{{
+						Key: &authzextv1.TupleKey{
+							User:     subject,
+							Relation: common.RelationGet,
+							Object:   folderObject,
+						},
+					}},
+				}, nil
+			}
+			return &authzextv1.ReadResponse{}, nil
+		},
+	}
+	r := NewZanzanaPermissionResolver(client, &usertest.FakeUserService{}, resourcepermissions.NewActionSetService(), false)
+	perms, err := r.ResolveCurrentUserPermissions(context.Background(), &identity.StaticRequester{
+		Type:    claims.TypeUser,
+		UserUID: "u1",
+		OrgID:   1,
+		OrgRole: identity.RoleViewer,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []ac.Permission{
+		{Action: "folders:read", Scope: ac.Scope("folders", "uid", "top-folder")},
+	}, perms)
+	require.Greater(t, readCount, 0)
+}
+
+func TestResolveCurrentUserPermissions_ReadPagination(t *testing.T) {
+	subject := claims.NewTypeID(claims.TypeUser, "u1")
+	page := 0
+	client := &fakeZanzanaClient{
+		readFunc: func(req *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error) {
+			if req.GetTupleKey().GetUser() != subject || req.GetTupleKey().GetObject() != common.TypeFolderPrefix {
+				return &authzextv1.ReadResponse{}, nil
+			}
+			page++
+			if req.GetContinuationToken() == "" {
+				return &authzextv1.ReadResponse{
+					Tuples: []*authzextv1.Tuple{{
+						Key: &authzextv1.TupleKey{
+							User: subject, Relation: common.RelationGet, Object: common.NewFolderIdent("a"),
+						},
+					}},
+					ContinuationToken: "more",
+				}, nil
+			}
+			return &authzextv1.ReadResponse{
+				Tuples: []*authzextv1.Tuple{{
+					Key: &authzextv1.TupleKey{
+						User: subject, Relation: common.RelationGet, Object: common.NewFolderIdent("b"),
+					},
+				}},
+			}, nil
+		},
+	}
+	r := NewZanzanaPermissionResolver(client, &usertest.FakeUserService{}, resourcepermissions.NewActionSetService(), false)
+	perms, err := r.ResolveCurrentUserPermissions(context.Background(), &identity.StaticRequester{
+		Type: claims.TypeUser, UserUID: "u1", OrgID: 1, OrgRole: identity.RoleViewer,
+	})
+	require.NoError(t, err)
+	require.Len(t, perms, 2)
+	require.Equal(t, 2, page)
+}
+
 func permScopes(perms []ac.Permission, action string) []string {
 	var out []string
 	for _, p := range perms {

--- a/pkg/services/authz/zanzana/common/tuple_permissions.go
+++ b/pkg/services/authz/zanzana/common/tuple_permissions.go
@@ -1,0 +1,278 @@
+package common
+
+import (
+	"strings"
+
+	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+)
+
+// TupleScopeKind describes how a stored tuple maps to a legacy RBAC scope.
+type TupleScopeKind int
+
+const (
+	TupleScopeFolderOwn TupleScopeKind = iota
+	TupleScopeFolderDashboard
+	TupleScopeDirectDashboard
+	TupleScopeWildcardFolder
+	TupleScopeWildcardDashboard
+)
+
+// MappedTuplePermission is one legacy permission derived from a stored tuple.
+type MappedTuplePermission struct {
+	Action string
+	Scope  string
+}
+
+type tupleMappingKey struct {
+	objectType string
+	relation   string
+	groupRes   string // set for folder-scoped dashboard tuples; empty otherwise
+}
+
+var (
+	folderGroupResource    = FormatGroupResource(folderGroup, folderResource, "")
+	dashboardGroupResource = FormatGroupResource(dashboardGroup, dashboardResource, "")
+	storedTupleToActions   map[tupleMappingKey][]string
+)
+
+func init() {
+	storedTupleToActions = buildStoredTupleToActions()
+}
+
+func buildStoredTupleToActions() map[tupleMappingKey][]string {
+	out := make(map[tupleMappingKey][]string)
+
+	add := func(key tupleMappingKey, action string) {
+		out[key] = append(out[key], action)
+	}
+
+	for _, kind := range []string{KindFolders, KindDashboards} {
+		translation := resourceTranslations[kind]
+		for action, m := range translation.mapping {
+			switch translation.typ {
+			case TypeFolder:
+				if m.group != "" && m.resource != "" {
+					gr := FormatGroupResource(m.group, m.resource, m.subresource)
+					key := tupleMappingKey{
+						objectType: TypeFolder,
+						relation:   SubresourceRelation(m.relation),
+						groupRes:   gr,
+					}
+					add(key, action)
+					// Action-set subresource relations are stored without a condition.
+					if isSubresourceRelationSet(SubresourceRelation(m.relation)) {
+						keyNoCond := tupleMappingKey{
+							objectType: TypeFolder,
+							relation:   SubresourceRelation(m.relation),
+						}
+						add(keyNoCond, action)
+					}
+				} else {
+					key := tupleMappingKey{
+						objectType: TypeFolder,
+						relation:   m.relation,
+					}
+					add(key, action)
+				}
+			case TypeResource:
+				key := tupleMappingKey{
+					objectType: TypeResource,
+					relation:   m.relation,
+				}
+				add(key, action)
+			}
+		}
+	}
+
+	// Org-wide wildcards on group_resource objects.
+	for _, kind := range []string{KindFolders, KindDashboards} {
+		translation := resourceTranslations[kind]
+		for action, m := range translation.mapping {
+			gr := FormatGroupResource(translation.group, translation.resource, m.subresource)
+			if m.group != "" && m.resource != "" {
+				gr = FormatGroupResource(m.group, m.resource, m.subresource)
+			}
+			key := tupleMappingKey{
+				objectType: TypeGroupResouce,
+				relation:   m.relation,
+				groupRes:   gr,
+			}
+			add(key, action)
+		}
+	}
+
+	return out
+}
+
+func subresourceFilterMatches(condition *authzextv1.RelationshipCondition, wantGR string) bool {
+	if condition == nil || wantGR == "" {
+		return true
+	}
+	if condition.GetName() != "subresource_filter" {
+		return false
+	}
+	fields := condition.GetContext().GetFields()
+	subresources, ok := fields["subresources"]
+	if !ok {
+		return false
+	}
+	for _, v := range subresources.GetListValue().GetValues() {
+		if v.GetStringValue() == wantGR {
+			return true
+		}
+	}
+	return false
+}
+
+func groupFilterMatches(condition *authzextv1.RelationshipCondition, wantGR string) bool {
+	if condition == nil || wantGR == "" {
+		return true
+	}
+	if condition.GetName() != "group_filter" {
+		return false
+	}
+	fields := condition.GetContext().GetFields()
+	gr, ok := fields["group_resource"]
+	if !ok {
+		return false
+	}
+	return gr.GetStringValue() == wantGR
+}
+
+func lookupStoredActions(objectType, relation, groupRes string) []string {
+	if groupRes != "" {
+		if actions, ok := storedTupleToActions[tupleMappingKey{objectType: objectType, relation: relation, groupRes: groupRes}]; ok {
+			return actions
+		}
+	}
+	return storedTupleToActions[tupleMappingKey{objectType: objectType, relation: relation}]
+}
+
+// PermissionsFromStoredTuple maps a physically stored OpenFGA tuple to legacy RBAC permissions.
+// Returns false when the tuple is not a supported permission grant (e.g. folder parent edges).
+func PermissionsFromStoredTuple(object, relation string, condition *authzextv1.RelationshipCondition) ([]MappedTuplePermission, bool) {
+	switch {
+	case strings.HasPrefix(object, TypeFolderPrefix):
+		uid := strings.TrimPrefix(object, TypeFolderPrefix)
+		if uid == "" || relation == RelationParent {
+			return nil, false
+		}
+		if strings.HasPrefix(relation, "resource_") {
+			actions := lookupStoredActions(TypeFolder, relation, dashboardGroupResource)
+			if len(actions) == 0 {
+				actions = lookupStoredActions(TypeFolder, relation, "")
+			}
+			if len(actions) == 0 {
+				return nil, false
+			}
+			if condition != nil && !isSubresourceRelationSet(relation) && !subresourceFilterMatches(condition, dashboardGroupResource) {
+				return nil, false
+			}
+			return appendMapped(actions, uid, TupleScopeFolderDashboard), true
+		}
+		actions := lookupStoredActions(TypeFolder, relation, "")
+		if len(actions) == 0 {
+			return nil, false
+		}
+		return appendMapped(actions, uid, TupleScopeFolderOwn), true
+
+	case strings.HasPrefix(object, TypeResourcePrefix):
+		rest := strings.TrimPrefix(object, TypeResourcePrefix)
+		parts := strings.Split(rest, "/")
+		if len(parts) < 3 {
+			return nil, false
+		}
+		uid := parts[len(parts)-1]
+		gr := strings.Join(parts[:len(parts)-1], "/")
+		actions := lookupStoredActions(TypeResource, relation, "")
+		if len(actions) == 0 || !groupFilterMatches(condition, gr) {
+			return nil, false
+		}
+		return appendMapped(actions, uid, TupleScopeDirectDashboard), true
+
+	case strings.HasPrefix(object, TypeGroupResoucePrefix):
+		gr := strings.TrimPrefix(object, TypeGroupResoucePrefix)
+		actions := lookupStoredActions(TypeGroupResouce, relation, gr)
+		if len(actions) == 0 {
+			return nil, false
+		}
+		switch gr {
+		case folderGroupResource:
+			return appendMapped(actions, "", TupleScopeWildcardFolder), true
+		case dashboardGroupResource:
+			return appendWildcardDashboard(actions), true
+		default:
+			return nil, false
+		}
+	default:
+		return nil, false
+	}
+}
+
+func appendMapped(actions []string, uid string, kind TupleScopeKind) []MappedTuplePermission {
+	out := make([]MappedTuplePermission, 0, len(actions))
+	scope := legacyScope(kind, uid)
+	for _, action := range actions {
+		out = append(out, MappedTuplePermission{Action: action, Scope: scope})
+	}
+	return out
+}
+
+func appendWildcardDashboard(actions []string) []MappedTuplePermission {
+	var out []MappedTuplePermission
+	seen := make(map[string]struct{})
+	for _, action := range actions {
+		scopes := wildcardPermissionsForDashboardAction(action)
+		if len(scopes) == 0 {
+			out = append(out, MappedTuplePermission{Action: action, Scope: legacyScope(TupleScopeWildcardDashboard, "")})
+			continue
+		}
+		for _, s := range scopes {
+			key := action + "\x00" + s
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, MappedTuplePermission{Action: action, Scope: s})
+		}
+	}
+	return out
+}
+
+func legacyScope(kind TupleScopeKind, uid string) string {
+	switch kind {
+	case TupleScopeFolderOwn, TupleScopeFolderDashboard:
+		return scope("folders", "uid", uid)
+	case TupleScopeDirectDashboard:
+		return scope("dashboards", "uid", uid)
+	case TupleScopeWildcardFolder:
+		return scope("folders", "*")
+	case TupleScopeWildcardDashboard:
+		return scope("dashboards", "*")
+	default:
+		return ""
+	}
+}
+
+func scope(parts ...string) string {
+	return strings.Join(parts, ":")
+}
+
+func wildcardPermissionsForDashboardAction(action string) []string {
+	if !strings.HasPrefix(action, "dashboards:") {
+		return nil
+	}
+	return []string{"*", scope("dashboards", "*"), scope("folders", "*")}
+}
+
+// LegacyScope builds the legacy RBAC scope string for a mapped permission kind.
+// Deprecated: scopes are populated on MappedTuplePermission directly.
+func LegacyScope(kind TupleScopeKind, uid string) string {
+	return legacyScope(kind, uid)
+}
+
+// WildcardPermissionsForDashboardAction returns extra wildcard scopes emitted for org-wide
+// dashboard grants, mirroring listPermissions when resp.All is true.
+func WildcardPermissionsForDashboardAction(action string) []string {
+	return wildcardPermissionsForDashboardAction(action)
+}

--- a/pkg/services/authz/zanzana/common/tuple_permissions_test.go
+++ b/pkg/services/authz/zanzana/common/tuple_permissions_test.go
@@ -1,0 +1,81 @@
+package common
+
+import (
+	"testing"
+
+	dashboards "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestPermissionsFromStoredTuple_FolderOwn(t *testing.T) {
+	perms, ok := PermissionsFromStoredTuple(NewFolderIdent("top-folder"), RelationGet, nil)
+	require.True(t, ok)
+	require.Contains(t, perms, MappedTuplePermission{Action: "folders:read", Scope: "folders:uid:top-folder"})
+}
+
+func TestPermissionsFromStoredTuple_FolderScopedDashboard(t *testing.T) {
+	gr := dashboards.DashboardResourceInfo.GroupResource()
+	tuple := NewFolderResourceTuple("user:1", RelationGet, gr.Group, gr.Resource, "", "folder-a")
+	cond := tuple.GetCondition()
+	perms, ok := PermissionsFromStoredTuple(tuple.GetObject(), tuple.GetRelation(), ToAuthzExtTupleKey(tuple).GetCondition())
+	require.True(t, ok)
+	require.Contains(t, perms, MappedTuplePermission{Action: "dashboards:read", Scope: "folders:uid:folder-a"})
+	_ = cond
+}
+
+func TestPermissionsFromStoredTuple_DirectDashboard(t *testing.T) {
+	gr := dashboards.DashboardResourceInfo.GroupResource()
+	tuple := NewResourceTuple("user:1", RelationGet, gr.Group, gr.Resource, "", "dash-1")
+	key := ToAuthzExtTupleKey(tuple)
+	perms, ok := PermissionsFromStoredTuple(key.GetObject(), key.GetRelation(), key.GetCondition())
+	require.True(t, ok)
+	require.Contains(t, perms, MappedTuplePermission{Action: "dashboards:read", Scope: "dashboards:uid:dash-1"})
+}
+
+func TestPermissionsFromStoredTuple_WildcardDashboard(t *testing.T) {
+	gr := dashboards.DashboardResourceInfo.GroupResource()
+	obj := NewGroupResourceIdent(gr.Group, gr.Resource, "")
+	perms, ok := PermissionsFromStoredTuple(obj, RelationGet, nil)
+	require.True(t, ok)
+	require.Contains(t, perms, MappedTuplePermission{Action: "dashboards:read", Scope: "dashboards:*"})
+	require.Contains(t, perms, MappedTuplePermission{Action: "dashboards:read", Scope: "folders:*"})
+	require.Contains(t, perms, MappedTuplePermission{Action: "dashboards:read", Scope: "*"})
+}
+
+func TestPermissionsFromStoredTuple_WildcardFolder(t *testing.T) {
+	gr := folders.FolderResourceInfo.GroupResource()
+	obj := NewGroupResourceIdent(gr.Group, gr.Resource, "")
+	perms, ok := PermissionsFromStoredTuple(obj, RelationGet, nil)
+	require.True(t, ok)
+	require.Contains(t, perms, MappedTuplePermission{Action: "folders:read", Scope: "folders:*"})
+}
+
+func TestPermissionsFromStoredTuple_SkipsFolderParentEdge(t *testing.T) {
+	_, ok := PermissionsFromStoredTuple(NewFolderIdent("child"), RelationParent, nil)
+	require.False(t, ok)
+}
+
+func TestPermissionsFromStoredTuple_ActionSetRelation(t *testing.T) {
+	perms, ok := PermissionsFromStoredTuple(NewFolderIdent("f1"), RelationSetView, nil)
+	require.True(t, ok)
+	require.Contains(t, perms, MappedTuplePermission{Action: "folders:view", Scope: "folders:uid:f1"})
+}
+
+func TestPermissionsFromStoredTuple_ResourceConditionMismatch(t *testing.T) {
+	gr := dashboards.DashboardResourceInfo.GroupResource()
+	tuple := NewResourceTuple("user:1", RelationGet, gr.Group, gr.Resource, "", "dash-1")
+	key := ToAuthzExtTupleKey(tuple)
+	key.Condition = &authzextv1.RelationshipCondition{
+		Name: "group_filter",
+		Context: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"group_resource": structpb.NewStringValue("other.app/widgets"),
+			},
+		},
+	}
+	_, ok := PermissionsFromStoredTuple(key.GetObject(), key.GetRelation(), key.GetCondition())
+	require.False(t, ok)
+}


### PR DESCRIPTION
## Summary
- switch `ResolveCurrentUserPermissions` from `ListObjects` expansion to paginated `Read` over direct stored tuples for user, team-member, and basic-role subjects
- map tuple shapes (`folder`, `resource`, `group_resource`) back to legacy RBAC action/scope anchors, including wildcard handling for dashboard/folder scopes
- keep `SearchUsersPermissions` on the existing `List` path while adding targeted unit/integration tests for anchor-only behavior, pagination, subject resolution, and tuple mapping

## Test plan
- [x] `go test ./pkg/services/accesscontrol/acimpl/... ./pkg/services/authz/zanzana/common/...`
- [x] verify `origin/main..HEAD` contains exactly one commit on branch `acimpl-zanzana-read-anchors`
- [ ] exercise merged permissions in a Grafana instance with Zanzana merge enabled (`FlagZanzanaMergeUserPermissions`) and validate anchor-only scopes for nested folders/dashboards