### PR TITLE
[release-13.0.3] Provisioning: Fix PR comments on multi-org Grafana instances

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
+	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/logging"
 	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -114,6 +116,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 		MissingImageRenderer: !rendererAvailable,
 	}
 	screenshotBaseURL := e.urls.Public(ctx, cfg.Namespace)
+	orgID := orgIDForLinks(cfg.Namespace)
 
 	logger := logging.FromContext(ctx)
 
@@ -127,7 +130,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 
 		progress.SetMessage(ctx, fmt.Sprintf("process %s", change.Path))
 		logger.With("action", change.Action).With("path", change.Path)
-		info.Changes = append(info.Changes, e.evaluateFile(ctx, repo, info.GrafanaBaseURL, screenshotBaseURL, change, opts, parser, shouldRender))
+		info.Changes = append(info.Changes, e.evaluateFile(ctx, repo, info.GrafanaBaseURL, screenshotBaseURL, orgID, change, opts, parser, shouldRender))
 	}
 
 	return info, nil
@@ -135,9 +138,21 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 
 var dashboardKind = dashboard.DashboardResourceInfo.GroupVersionKind().Kind
 
-func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, baseURL string, screenshotBaseURL string, change repository.VersionedFileChange, opts provisioning.PullRequestJobOptions, parser resources.Parser, shouldRender bool) fileChangeInfo {
+// orgIDForLinks returns the org to pin on PR-comment links when the repo lives
+// in a non-primary org (on-prem org-N, N>=2). Main org (default), Cloud
+// (stacks-N) and unresolved namespaces return 0, leaving links unscoped since
+// the viewer's default org already resolves them.
+func orgIDForLinks(namespace string) int64 {
+	ns, err := authlib.ParseNamespace(namespace)
+	if err != nil || ns.OrgID <= 1 {
+		return 0
+	}
+	return ns.OrgID
+}
+
+func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, baseURL string, screenshotBaseURL string, orgID int64, change repository.VersionedFileChange, opts provisioning.PullRequestJobOptions, parser resources.Parser, shouldRender bool) fileChangeInfo {
 	if change.Action == repository.FileActionDeleted {
-		return e.evaluateDeletedFile(ctx, repo, baseURL, change, parser)
+		return e.evaluateDeletedFile(ctx, repo, baseURL, orgID, change, parser)
 	}
 
 	info := fileChangeInfo{Change: change}
@@ -179,6 +194,11 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 
 		if info.Parsed.Existing != nil {
 			grafanaURL := urlBuilder.JoinPath("d", obj.GetName(), slugify.Slugify(info.Title))
+			if orgID > 0 {
+				query := url.Values{}
+				query.Set("orgId", strconv.FormatInt(orgID, 10))
+				grafanaURL.RawQuery = query.Encode()
+			}
 			info.GrafanaURL = grafanaURL.String()
 		}
 
@@ -190,6 +210,9 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 		query.Set("ref", info.Parsed.Info.Ref)
 		if opts.URL != "" {
 			query.Set("pull_request_url", url.QueryEscape(opts.URL))
+		}
+		if orgID > 0 {
+			query.Set("orgId", strconv.FormatInt(orgID, 10))
 		}
 		info.PreviewURL += "?" + query.Encode()
 		if shouldRender {
@@ -214,7 +237,7 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 
 // evaluateDeletedFile is best-effort: it tries to read and parse the file at
 // the previous ref to extract metadata (kind, title, GrafanaURL)
-func (e *evaluator) evaluateDeletedFile(ctx context.Context, repo repository.Reader, baseURL string, change repository.VersionedFileChange, parser resources.Parser) fileChangeInfo {
+func (e *evaluator) evaluateDeletedFile(ctx context.Context, repo repository.Reader, baseURL string, orgID int64, change repository.VersionedFileChange, parser resources.Parser) fileChangeInfo {
 	info := fileChangeInfo{Change: change}
 
 	fileInfo, err := repo.Read(ctx, change.Path, change.PreviousRef)
@@ -237,6 +260,11 @@ func (e *evaluator) evaluateDeletedFile(ctx context.Context, repo repository.Rea
 		}
 		if info.Parsed.Existing != nil {
 			grafanaURL := urlBuilder.JoinPath("d", obj.GetName(), slugify.Slugify(info.Title))
+			if orgID > 0 {
+				query := url.Values{}
+				query.Set("orgId", strconv.FormatInt(orgID, 10))
+				grafanaURL.RawQuery = query.Encode()
+			}
 			info.GrafanaURL = grafanaURL.String()
 		}
 	}
@@ -261,7 +289,13 @@ func renderScreenshotFromGrafanaURL(ctx context.Context,
 		logging.FromContext(ctx).Warn("invalid", "url", grafanaURL, "err", err)
 		return "", err
 	}
-	snap, err := renderer.RenderScreenshot(ctx, repo, strings.TrimPrefix(parsed.Path, "/"), parsed.Query())
+	// orgId belongs only on the human-facing comment link, where OrgRedirect
+	// switches the viewer's org on click. The render callback already
+	// authenticates in the repository's org via the render-service identity, so
+	// an orgId here would make OrgRedirect try to switch the render user instead.
+	query := parsed.Query()
+	query.Del("orgId")
+	snap, err := renderer.RenderScreenshot(ctx, repo, strings.TrimPrefix(parsed.Path, "/"), query)
 	if err != nil {
 		logging.FromContext(ctx).Warn("render failed", "url", grafanaURL, "err", err)
 		return "", fmt.Errorf("error rendering screenshot: %w", err)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -99,6 +100,84 @@ func TestCalculateChanges(t *testing.T) {
 					},
 					GrafanaURL:           "http://host/d/the-uid/hello-world",
 					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
+					GrafanaScreenshotURL: "https://cdn2.thecatapi.com/images/9e2.jpg",
+					PreviewScreenshotURL: "https://cdn2.thecatapi.com/images/9e2.jpg",
+				}},
+			},
+		},
+		{
+			name: "non-default org strips orgId from render callback but keeps it on comment links",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				finfo := &repository.FileInfo{
+					Path: "path/to/file.json",
+					Ref:  "ref",
+					Data: []byte("xxxx"),
+				}
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": resources.DashboardResource.GroupVersion().String(),
+						"kind":       dashboardKind,
+						"metadata": map[string]interface{}{
+							"name": "the-uid",
+						},
+						"spec": map[string]interface{}{
+							"title": "hello world",
+						},
+					},
+				}
+				meta, _ := utils.MetaAccessor(obj)
+
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "org-2",
+					},
+					Spec: provisioning.RepositorySpec{
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							GenerateDashboardPreviews: true,
+						},
+					},
+				})
+				parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+					Info: finfo,
+					Repo: provisioning.ResourceRepositoryInfo{
+						Namespace: "org-2",
+						Name:      "y",
+					},
+					GVK: schema.GroupVersionKind{
+						Kind: dashboardKind,
+					},
+					Obj:            obj,
+					Existing:       obj,
+					Meta:           meta,
+					DryRunResponse: obj,
+				}, nil)
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(true)
+				// The render callback must NOT carry orgId: it would make
+				// OrgRedirect try to switch the render user's org. orgId stays
+				// only on the comment-facing links below.
+				renderer.On("RenderScreenshot", mock.Anything, mock.Anything, mock.Anything,
+					mock.MatchedBy(func(v url.Values) bool { return !v.Has("orgId") })).
+					Return(getDummyRenderedURL("x"), nil)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+			},
+			changes: []repository.VersionedFileChange{{
+				Action: repository.FileActionCreated,
+				Path:   "path/to/file.json",
+				Ref:    "ref",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action: repository.FileActionCreated,
+						Path:   "path/to/file.json",
+						Ref:    "ref",
+					},
+					GrafanaURL:           "http://host/d/the-uid/hello-world?orgId=2",
+					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?orgId=2&pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
 					GrafanaScreenshotURL: "https://cdn2.thecatapi.com/images/9e2.jpg",
 					PreviewScreenshotURL: "https://cdn2.thecatapi.com/images/9e2.jpg",
 				}},
@@ -399,6 +478,78 @@ func TestCalculateChanges(t *testing.T) {
 					},
 					GrafanaURL:           "http://host/d/the-uid/hello-world",
 					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
+					GrafanaScreenshotURL: "",
+					PreviewScreenshotURL: "",
+				}},
+			},
+		},
+		{
+			name: "non-default org pins orgId on links",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				finfo := &repository.FileInfo{
+					Path: "path/to/file.json",
+					Ref:  "ref",
+					Data: []byte("xxxx"),
+				}
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": resources.DashboardResource.GroupVersion().String(),
+						"kind":       dashboardKind,
+						"metadata": map[string]interface{}{
+							"name": "the-uid",
+						},
+						"spec": map[string]interface{}{
+							"title": "hello world",
+						},
+					},
+				}
+				meta, _ := utils.MetaAccessor(obj)
+
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "org-2",
+					},
+					Spec: provisioning.RepositorySpec{
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							GenerateDashboardPreviews: true,
+						},
+					},
+				})
+				parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+					Info: finfo,
+					Repo: provisioning.ResourceRepositoryInfo{
+						Namespace: "org-2",
+						Name:      "y",
+					},
+					GVK: schema.GroupVersionKind{
+						Kind: dashboardKind,
+					},
+					Obj:            obj,
+					Existing:       obj,
+					Meta:           meta,
+					DryRunResponse: obj,
+				}, nil)
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+			},
+			changes: []repository.VersionedFileChange{{
+				Action: repository.FileActionCreated,
+				Path:   "path/to/file.json",
+				Ref:    "ref",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action: repository.FileActionCreated,
+						Path:   "path/to/file.json",
+						Ref:    "ref",
+					},
+					GrafanaURL:           "http://host/d/the-uid/hello-world?orgId=2",
+					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?orgId=2&pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
 					GrafanaScreenshotURL: "",
 					PreviewScreenshotURL: "",
 				}},
@@ -861,6 +1012,71 @@ func TestCalculateChanges(t *testing.T) {
 			},
 		},
 		{
+			name: "deleted file pins orgId on links for non-default org",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				finfo := &repository.FileInfo{
+					Path: "path/to/file.json",
+					Ref:  "base-ref",
+					Data: []byte("xxxx"),
+				}
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": resources.DashboardResource.GroupVersion().String(),
+						"kind":       dashboardKind,
+						"metadata": map[string]interface{}{
+							"name": "the-uid",
+						},
+						"spec": map[string]interface{}{
+							"title": "hello world",
+						},
+					},
+				}
+				meta, _ := utils.MetaAccessor(obj)
+
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "org-2",
+					},
+				})
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "base-ref").Return(finfo, nil)
+				parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+					Info: finfo,
+					Repo: provisioning.ResourceRepositoryInfo{
+						Namespace: "org-2",
+						Name:      "y",
+					},
+					GVK: schema.GroupVersionKind{
+						Kind: dashboardKind,
+					},
+					Obj:      obj,
+					Existing: obj,
+					Meta:     meta,
+				}, nil)
+			},
+			changes: []repository.VersionedFileChange{{
+				Action:      repository.FileActionDeleted,
+				Path:        "path/to/file.json",
+				Ref:         "ref",
+				PreviousRef: "base-ref",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action:      repository.FileActionDeleted,
+						Path:        "path/to/file.json",
+						Ref:         "ref",
+						PreviousRef: "base-ref",
+					},
+					Title:      "hello world",
+					GrafanaURL: "http://host/d/the-uid/hello-world?orgId=2",
+				}},
+			},
+		},
+		{
 			name: "deleted file with read error degrades gracefully",
 			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
 				reader.On("Config").Return(&provisioning.Repository{
@@ -1316,6 +1532,27 @@ func TestRenderScreenshotFromGrafanaURL(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tt.wantSnap, got)
+		})
+	}
+}
+
+func TestOrgIDForLinks(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		want      int64
+	}{
+		{"on-prem non-default org", "org-2", 2},
+		{"on-prem high org id", "org-7", 7},
+		{"main org default namespace", "default", 0},
+		{"cloud stack maps to org 1", "stacks-9", 0},
+		{"org-1 is rejected by parser", "org-1", 0},
+		{"empty namespace", "", 0},
+		{"unparseable namespace", "x", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, orgIDForLinks(tt.namespace))
 		})
 	}
 }

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/render.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/render.go
@@ -60,13 +60,30 @@ func (r *screenshotRenderer) RenderScreenshot(ctx context.Context, repo provisio
 	} else {
 		path = path + "?kiosk"
 	}
+	// Render as the worker identity already on the context (set by the job
+	// driver for the repository's org) so the dashboard resolves in
+	// multi-org/Cloud setups. The render key carries only {OrgID, UserID,
+	// OrgRole}; the worker identity supplies UserID 0, which the render authn
+	// client maps to a synthetic render-service identity pinned to that org. A
+	// real user id would instead make OrgRedirect try to switch that user's
+	// active org while rendering.
+	orgID, userID, orgRole := int64(1), int64(0), identity.RoleAdmin
+	if requester, err := identity.GetRequester(ctx); err == nil {
+		if id := requester.GetOrgID(); id > 0 {
+			orgID = id
+			if uid, idErr := requester.GetInternalID(); idErr == nil {
+				userID = uid
+			}
+			orgRole = requester.GetOrgRole()
+		}
+	}
 	result, err := r.render.Render(ctx, rendering.RenderPNG, rendering.Opts{
 		CommonOpts: rendering.CommonOpts{
 			Path: path,
 			AuthOpts: rendering.AuthOpts{
-				OrgID:   1, // TODO!!!, use the worker identity
-				UserID:  1,
-				OrgRole: identity.RoleAdmin,
+				OrgID:   orgID,
+				UserID:  userID,
+				OrgRole: orgRole,
 			},
 			TimeoutOpts: rendering.TimeoutOpts{
 				Timeout: time.Second * 30,

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/render_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/render_test.go
@@ -126,7 +126,7 @@ func TestScreenshotRenderer_RenderScreenshot(t *testing.T) {
 					DoAndReturn(func(_ context.Context, _ rendering.RenderType, opts rendering.Opts) (*rendering.RenderResult, error) {
 						require.Equal(t, "test?kiosk", opts.Path)
 						require.Equal(t, int64(1), opts.OrgID)
-						require.Equal(t, int64(1), opts.UserID)
+						require.Equal(t, int64(0), opts.UserID)
 						require.Equal(t, 1024, opts.Width)
 						require.Equal(t, -1, opts.Height)
 						require.Equal(t, models.ThemeDark, opts.Theme)
@@ -235,6 +235,72 @@ func TestScreenshotRenderer_RenderScreenshot(t *testing.T) {
 			expectedURL: "apis/provisioning.grafana.app/v0alpha1/namespaces/test-ns/repositories/test-repo/render/test-uid",
 		},
 		{
+			name: "should render as the render-service identity in the org that owns the repository namespace",
+			path: "test",
+			repoInfo: provisioning.ResourceRepositoryInfo{
+				Name:      "test-repo",
+				Namespace: "org-3",
+			},
+			setupRender: func(ctrl *gomock.Controller) rendering.Service {
+				tmpFile, cleanup := setupTempFile(t)
+				t.Cleanup(cleanup)
+				render := rendering.NewMockService(ctrl)
+				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ rendering.RenderType, opts rendering.Opts) (*rendering.RenderResult, error) {
+						require.Equal(t, int64(3), opts.OrgID)
+						// UserID 0 selects the synthetic render-service identity
+						// rather than a real user, so OrgRedirect never fires.
+						require.Equal(t, int64(0), opts.UserID)
+						require.Equal(t, identity.RoleAdmin, opts.OrgRole)
+						return &rendering.RenderResult{
+							FilePath: tmpFile,
+						}, nil
+					})
+				return render
+			},
+			setupBlobstore: func(t *testing.T) BlobStoreClient {
+				blobstore := NewMockBlobStoreClient(t)
+				blobstore.On("PutBlob", mock.Anything, mock.Anything).
+					Return(&resourcepb.PutBlobResponse{
+						Uid: "test-uid",
+					}, nil)
+				return blobstore
+			},
+			expectedURL: "apis/provisioning.grafana.app/v0alpha1/namespaces/org-3/repositories/test-repo/render/test-uid",
+		},
+		{
+			name: "should render in org 1 as the render-service identity for the default namespace",
+			path: "test",
+			repoInfo: provisioning.ResourceRepositoryInfo{
+				Name:      "test-repo",
+				Namespace: "default",
+			},
+			setupRender: func(ctrl *gomock.Controller) rendering.Service {
+				tmpFile, cleanup := setupTempFile(t)
+				t.Cleanup(cleanup)
+				render := rendering.NewMockService(ctrl)
+				render.EXPECT().Render(gomock.Any(), rendering.RenderPNG, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ rendering.RenderType, opts rendering.Opts) (*rendering.RenderResult, error) {
+						require.Equal(t, int64(1), opts.OrgID)
+						require.Equal(t, int64(0), opts.UserID)
+						require.Equal(t, identity.RoleAdmin, opts.OrgRole)
+						return &rendering.RenderResult{
+							FilePath: tmpFile,
+						}, nil
+					})
+				return render
+			},
+			setupBlobstore: func(t *testing.T) BlobStoreClient {
+				blobstore := NewMockBlobStoreClient(t)
+				blobstore.On("PutBlob", mock.Anything, mock.Anything).
+					Return(&resourcepb.PutBlobResponse{
+						Uid: "test-uid",
+					}, nil)
+				return blobstore
+			},
+			expectedURL: "apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/test-repo/render/test-uid",
+		},
+		{
 			name: "should append query parameters correctly",
 			path: "test",
 			queryParams: url.Values{
@@ -273,8 +339,15 @@ func TestScreenshotRenderer_RenderScreenshot(t *testing.T) {
 			render := tc.setupRender(ctrl)
 			blobstore := tc.setupBlobstore(t)
 
+			// Mirror production: the job driver stamps the worker identity for the
+			// repository's org onto the context before the renderer runs.
+			ctx := context.Background()
+			if identityCtx, _, idErr := identity.WithProvisioningIdentity(ctx, tc.repoInfo.Namespace); idErr == nil {
+				ctx = identityCtx
+			}
+
 			renderer := NewScreenshotRenderer(render, blobstore)
-			url, err := renderer.RenderScreenshot(context.Background(), tc.repoInfo, tc.path, tc.queryParams)
+			url, err := renderer.RenderScreenshot(ctx, tc.repoInfo, tc.path, tc.queryParams)
 
 			if tc.expectedError != "" {
 				require.Error(t, err)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/render_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/render_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"


### PR DESCRIPTION
Backport 2e2329b7ae0e27a97a4b189032916c8342a19750 from #126700

---

## Summary
- When a provisioning repository lives in a non-default org (`org-N`, N≥2), PR-comment links (dashboard URL, preview URL) now include `?orgId=N` so the OrgRedirect middleware switches the viewer to the correct org on click
- Screenshot rendering uses the repository's org ID instead of hardcoded `1`, so dashboards resolve correctly in multi-org and Cloud setups
- No change for default-org or Cloud (`stacks-N`) namespaces — links stay unscoped


https://github.com/user-attachments/assets/45a43611-7925-416d-b62d-76f40fe24d39

## Test plan
- [x] Unit tests for `orgIDForLinks` covering on-prem multi-org, default, cloud, edge cases
- [x] Unit test for `evaluateFile` with `org-2` namespace verifying `?orgId=2` on both GrafanaURL and PreviewURL
- [x] Unit test for `evaluateDeletedFile` with `org-2` namespace verifying `?orgId=2` on GrafanaURL
- [x] Unit test for `RenderScreenshot` verifying `OrgID: 3` passed to render service for `org-3` namespace
- [x] Manual: trigger webhook for repo in org-2, verify PR comment links contain `?orgId=2`

Fixes https://github.com/grafana/grafana/issues/126377
