### PR TITLE
IAM: Lock profile fields for externally synced users on k8s path

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -79,13 +79,18 @@ func (hs *HTTPServer) getUserUserProfile(c *contextmodel.ReqContext, userID int6
 		return response.Error(http.StatusInternalServerError, "Failed to get user", err)
 	}
 
-	getAuthQuery := login.GetAuthInfoQuery{UserId: userID}
 	userProfile.AuthLabels = []string{}
-	if authInfo, err := hs.authInfoService.GetAuthInfo(c.Req.Context(), &getAuthQuery); err == nil {
-		authLabel := login.GetAuthProviderLabel(authInfo.AuthModule)
-		userProfile.AuthLabels = append(userProfile.AuthLabels, authLabel)
+	if len(userProfile.AuthModules) > 0 {
 		userProfile.IsExternal = true
-
+		for _, authModule := range userProfile.AuthModules {
+			userProfile.AuthLabels = append(userProfile.AuthLabels, login.GetAuthProviderLabel(authModule))
+			userProfile.IsExternallySynced = userProfile.IsExternallySynced || hs.isExternallySynced(hs.Cfg, authModule)
+			userProfile.IsGrafanaAdminExternallySynced = userProfile.IsGrafanaAdminExternallySynced || hs.isGrafanaAdminExternallySynced(hs.Cfg, authModule)
+		}
+	} else if authInfo, err := hs.authInfoService.GetAuthInfo(c.Req.Context(), &login.GetAuthInfoQuery{UserId: userID}); err == nil {
+		// Legacy fallback: extract auth info from the user_auth table.
+		userProfile.AuthLabels = append(userProfile.AuthLabels, login.GetAuthProviderLabel(authInfo.AuthModule))
+		userProfile.IsExternal = true
 		userProfile.IsExternallySynced = hs.isExternallySynced(hs.Cfg, authInfo.AuthModule)
 		userProfile.IsGrafanaAdminExternallySynced = hs.isGrafanaAdminExternallySynced(hs.Cfg, authInfo.AuthModule)
 	}

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -446,6 +446,82 @@ func Test_GetUserByID(t *testing.T) {
 	}
 }
 
+func Test_GetUserByID_ExternalAuthInfoFromSpec(t *testing.T) {
+	testcases := []struct {
+		name                       string
+		authModules                []string
+		samlEnabled                bool
+		samlSkipOrgRoleSync        bool
+		expectedIsExternallySynced bool
+	}{
+		{
+			name:                       "auth proxy module marks the user external but not externally synced",
+			authModules:                []string{login.AuthProxyAuthModule},
+			expectedIsExternallySynced: false,
+		},
+		{
+			name:                       "SAML module is externally synced when enabled and org roles are synced",
+			authModules:                []string{login.SAMLAuthModule},
+			samlEnabled:                true,
+			samlSkipOrgRoleSync:        false,
+			expectedIsExternallySynced: true,
+		},
+		{
+			name:                       "multiple modules are externally synced if any one is",
+			authModules:                []string{login.AuthProxyAuthModule, login.SAMLAuthModule},
+			samlEnabled:                true,
+			samlSkipOrgRoleSync:        false,
+			expectedIsExternallySynced: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// user_auth returns not-found, so auth flags must come from the Kubernetes
+			// spec.externalAuthInfo modules, not the legacy fallback.
+			authInfoService := &authinfotest.FakeService{ExpectedError: user.ErrUserNotFound}
+			userService := &usertest.FakeUserService{ExpectedUserProfileDTO: &user.UserProfileDTO{AuthModules: tc.authModules}}
+			authnService := &authntest.FakeService{
+				ExpectedClientConfig: &authntest.FakeSSOClientConfig{
+					ExpectedIsSkipOrgRoleSyncEnabled: tc.samlSkipOrgRoleSync,
+				},
+				EnabledClients: []string{},
+			}
+			if tc.samlEnabled {
+				authnService.EnabledClients = []string{authn.ClientSAML}
+			}
+
+			hs := &HTTPServer{
+				Cfg:             setting.NewCfg(),
+				authInfoService: authInfoService,
+				SocialService:   &socialtest.FakeSocialService{},
+				userService:     userService,
+				authnService:    authnService,
+			}
+
+			sc := setupScenarioContext(t, "/api/users/1")
+			sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+				sc.context = c
+				return hs.GetUserByID(c)
+			})
+			sc.m.Get("/api/users/:id", sc.defaultHandler)
+			sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
+
+			var resp user.UserProfileDTO
+			require.Equal(t, http.StatusOK, sc.resp.Code)
+			require.NoError(t, json.Unmarshal(sc.resp.Body.Bytes(), &resp))
+
+			expectedLabels := make([]string, 0, len(tc.authModules))
+			for _, m := range tc.authModules {
+				expectedLabels = append(expectedLabels, login.GetAuthProviderLabel(m))
+			}
+
+			assert.True(t, resp.IsExternal, "user with spec auth modules must be external")
+			assert.Equal(t, expectedLabels, resp.AuthLabels)
+			assert.Equal(t, tc.expectedIsExternallySynced, resp.IsExternallySynced)
+		})
+	}
+}
+
 func TestIntegrationHTTPServer_UpdateUser(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Extract user's external-auth flags (isExternal, authLabels, isExternallySynced, isGrafanaAdminExternallySynced) on the profile endpoint from the User resource's `spec.externalAuthInfo`, falling back to the legacy user_auth lookup when those aren't present.

This is stage 3 of 3. [Stage 1](https://github.com/grafana/grafana/pull/126533) added the externalAuthInfo field and [stage 2](https://github.com/grafana/grafana/pull/126869) populated it at sign-in. With this change, externally-synced users are correctly flagged as external, so the profile UI locks the username/login/email fields.

I considered moving this fix into `UserK8sService.GetProfile` to keep the handler thin, but kept it in the API handler because it needs `authnService`. `isExternallySynced` must query the dynamic SSO client registry for SAML/OAuth providers. `UserK8sService` has no `authnService`.

**Why do we need this feature?**

To lock the profile fields in UI for externally synced users.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/2164.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
