### PR TITLE
[release-12.2.10] Chore(deps): Upgrade immutable to >= 5.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-pseudo": "^2.2.1",
     "immer": "10.1.1",
-    "immutable": "5.1.3",
+    "immutable": "^5.1.5",
     "infinite-viewer": "^0.29.1",
     "ix": "^7.0.0",
     "jquery": "3.7.1",

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -23,7 +23,7 @@
     "@grafana/runtime": "12.2.11",
     "@grafana/ui": "12.2.11",
     "@react-awesome-query-builder/ui": "6.6.15",
-    "immutable": "5.1.3",
+    "immutable": "^5.1.5",
     "lodash": "^4.18.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -93,7 +93,7 @@
     "hoist-non-react-statics": "3.3.2",
     "i18next": "^25.0.0",
     "i18next-browser-languagedetector": "^8.0.0",
-    "immutable": "5.1.3",
+    "immutable": "^5.1.5",
     "is-hotkey": "0.2.0",
     "jquery": "3.7.1",
     "lodash": "^4.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3582,7 +3582,7 @@ __metadata:
     "@types/systemjs": "npm:6.15.3"
     "@types/uuid": "npm:10.0.0"
     i18next-parser: "npm:9.3.0"
-    immutable: "npm:5.1.3"
+    immutable: "npm:^5.1.5"
     jest: "npm:^29.6.4"
     lodash: "npm:^4.18.1"
     react: "npm:18.3.1"
@@ -3709,7 +3709,7 @@ __metadata:
     hoist-non-react-statics: "npm:3.3.2"
     i18next: "npm:^25.0.0"
     i18next-browser-languagedetector: "npm:^8.0.0"
-    immutable: "npm:5.1.3"
+    immutable: "npm:^5.1.5"
     is-hotkey: "npm:0.2.0"
     jquery: "npm:3.7.1"
     lodash: "npm:^4.18.1"
@@ -18791,7 +18791,7 @@ __metadata:
     i18next-parser: "npm:9.3.0"
     i18next-pseudo: "npm:^2.2.1"
     immer: "npm:10.1.1"
-    immutable: "npm:5.1.3"
+    immutable: "npm:^5.1.5"
     infinite-viewer: "npm:^0.29.1"
     ini: "npm:^5.0.0"
     ix: "npm:^7.0.0"
@@ -19841,24 +19841,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:5.1.3, immutable@npm:^5.0.2":
-  version: 5.1.3
-  resolution: "immutable@npm:5.1.3"
-  checksum: 10/6d29b29036143e7ea1e7f7be581c71bca873ea77c175d33c6c839bf4017265a58c41ec269e3ffcd7b483797fc7fa9c928b4ed3d6edfeeb1b5711d84f60d04090
-  languageName: node
-  linkType: hard
-
 "immutable@npm:^3.8.2, immutable@npm:^3.x.x":
-  version: 3.8.2
-  resolution: "immutable@npm:3.8.2"
-  checksum: 10/8a94647c769e97c9685be1b89d5e1b3171e8c1361fb9061fbcf78f630f70bf60e4de0bfca8bdd24a54b1fb814a945a76a30b11b7ee08967f9802a138a54498a2
+  version: 3.8.3
+  resolution: "immutable@npm:3.8.3"
+  checksum: 10/29db366d4dff83b0b296150c351b08db24837005909a71c123d860c1d2a40605f19a3ecd56d1e96be9799e947ddf7906897a28fa2e81f0b8c63c652b6bfe5550
   languageName: node
   linkType: hard
 
 "immutable@npm:^4.3.6":
-  version: 4.3.7
-  resolution: "immutable@npm:4.3.7"
-  checksum: 10/37d963c5050f03ae5f3714ba7a43d469aa482051087f4c65d673d1501c309ea231d87480c792e19fa85e2eaf965f76af5d0aa92726505f3cfe4af91619dfb80b
+  version: 4.3.8
+  resolution: "immutable@npm:4.3.8"
+  checksum: 10/27a134cec0089ba60c5f50fdd08a0296533c9ce6d112188461c89a6bb3c720368e4363dc5f8d40440c6f9120400867e9cf86bd7463c7d3ee12d4ad44f797d4cc
+  languageName: node
+  linkType: hard
+
+"immutable@npm:^5.0.2, immutable@npm:^5.1.5":
+  version: 5.1.6
+  resolution: "immutable@npm:5.1.6"
+  checksum: 10/4ba416dac4cc9d1cab4155bd6aefa54d5ca25e56bfee8a1d4edc3f23115b599486edafe76e91f83d22961bd065754fd705b04f052809ec967ccd71817c8dac2a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Upgrades `immutable` to patched versions on `release-12.2.10` to clear **CVE-2026-29063** (immutable.js prototype pollution via `mergeDeep()`/`merge()`/`Map.toJS()`, CVSS 9.8). The advisory is flagged across all three major lines present in this branch's tree, so all three are lifted:

| Line | Before | After | Pulled in by |
|------|--------|-------|--------------|
| 5.x | 5.1.3 | 5.1.6 | `@grafana/ui`, `@grafana/sql`, root, sass (`^5.0.2`) |
| 4.x | 4.3.7 | 4.3.8 | `@react-awesome-query-builder` |
| 3.x | 3.8.2 | 3.8.3 | `swagger-ui-react` |

## How

- Direct 5.x declarations bumped to `^5.1.5` in `package.json`, `packages/grafana-ui/package.json`, `packages/grafana-sql/package.json`.
- Transitive 3.x/4.x copies and sass's `^5.0.2` range lifted to the patched in-range versions in the lockfile via `yarn up -R immutable`.

A 5.x-only bump would leave the 3.x/4.x copies flagged, so all three are required to clear the SLO.

## Validation

- `yarn install` succeeds against the updated lockfile.
- `yarn why immutable` resolves only to 3.8.3 / 4.3.8 / 5.1.6 (no 3.8.2 / 4.3.7 / 5.1.3 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)