### PR TITLE
[release-12.2.10] Chore(deps): Upgrade axios to >= 1.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -430,6 +430,7 @@
   "resolutions": {
     "underscore": "1.13.7",
     "@types/slate": "0.47.11",
+    "axios": "1.15.2",
     "semver@npm:~7.3.5": "^7.3.5",
     "debug@npm:^0.7.2": "2.6.9",
     "debug@npm:^0.7.4": "2.6.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12043,14 +12043,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.0, axios@npm:^1, axios@npm:^1.10.0, axios@npm:^1.6.1, axios@npm:^1.8.3, axios@npm:^1.9.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:1.15.2":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
+  checksum: 10/eebbd8cb777316d4252cd994a06ec9fb956ef519214a62dab6c5443ae8b753b5116e9a770502316789e6cdef1101e6aae53b6936d6a3791b2d66d75f4d7d2462
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Pins `axios` to **1.15.2** on `release-12.2.10` to clear three advisories on the transitive axios dependency:

| CVE | CVSS | Issue | Fixed in |
|-----|------|-------|----------|
| CVE-2026-42043 | 10.0 | NO_PROXY loopback-subnet (127.0.0.0/8) bypass | 1.15.1 |
| CVE-2026-42264 | 9.1 | Prototype-pollution read-side gadgets in the HTTP adapter | 1.15.2 |
| CVE-2026-42044 | 9.1 | Prototype-pollution gadget via `parseReviver` | 1.15.2 |

## How

axios is purely transitive here (dev/build tooling: `@crowdin/crowdin-api-client`, `@rsdoctor/*`, `nx`/`lerna`, `swagger-ui-react` build, `@storybook/test-runner`). Because **`nx` pins axios to exactly `1.15.0`**, `yarn up -R axios` lifts the caret consumers but strands nx's copy at the vulnerable 1.15.0. A `resolutions` entry (`"axios": "1.15.2"`) is therefore required to force every copy to the patched version — collapsing the tree to a single `axios@1.15.2`.

## Validation

- `yarn install` succeeds against the updated lockfile.
- Lockfile resolves a single `axios@npm:1.15.2` (no 1.15.0 remaining).

🤖 Generated with [Claude Code](https://claude.com/claude-code)