### PR TITLE
[release-12.2.10] Chore(deps): Upgrade basic-ftp to 5.3.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12339,9 +12339,9 @@ __metadata:
   linkType: hard
 
 "basic-ftp@npm:^5.0.2":
-  version: 5.0.5
-  resolution: "basic-ftp@npm:5.0.5"
-  checksum: 10/3dc56b2092b10d67e84621f5b9bbb0430469499178e857869194184d46fbdd367a9aa9fad660084388744b074b5f540e6ac8c22c0826ebba4fcc86a9d1c324e2
+  version: 5.3.1
+  resolution: "basic-ftp@npm:5.3.1"
+  checksum: 10/9232ee155114efafadf5adee86a6750208653a9071e53e9803dceac61a66b3ba3974771ff2490ff28f1a118fdfb806ffcc488f64609e61a9cedb52480b312843
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Bumps the transitive `basic-ftp` dependency from 5.0.5 to **5.3.1** on `release-12.2.10` to clear **CVE-2026-27699** (path traversal in `downloadToDir()`, CVSS 9.8).

## How

`basic-ftp` is dev/test-only — pulled in via `puppeteer`/`pa11y` → `proxy-agent` → `pac-proxy-agent` → `get-uri` → `basic-ftp`, never shipped in production artifacts. It resolves through a single caret range (`^5.0.2`) with no exact pin, so `yarn up -R basic-ftp` lifts it cleanly to the latest 5.x (5.3.1) — no `resolutions` entry or manifest change required (lockfile-only, 3-line diff).

The whole basic-ftp chain was already removed from `main` via the pa11y / jsdom-testing-mocks cleanups; this clears it on the frozen release line where that cleanup wasn't backported.

## Validation

- `yarn up -R basic-ftp` → single `basic-ftp@npm:5.3.1` entry, no 5.0.5 remaining.
- Install succeeds; no other package descriptors added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)