### PR TITLE
Snapshots: Add lazy loading to the Snapshots list UI when using k8s API

### DIFF
--- a/public/app/features/dashboard/services/SnapshotSrv.ts
+++ b/public/app/features/dashboard/services/SnapshotSrv.ts
@@ -1,6 +1,7 @@
 import { lastValueFrom } from 'rxjs';
 
 import { config, getBackendSrv } from '@grafana/runtime';
+import { type ListMeta } from 'app/features/apiserver/types';
 import { type DashboardDataDTO, type DashboardDTO } from 'app/types/dashboard';
 
 import { getAPINamespace } from '../../../api/utils';
@@ -12,6 +13,15 @@ export interface Snapshot {
   external: boolean;
   externalUrl?: string;
   url?: string;
+}
+
+export interface SnapshotListPage {
+  items: Snapshot[];
+  continueToken?: string;
+}
+
+export interface SnapshotListOptions {
+  continue?: string;
 }
 
 export interface SnapshotSharingOptions {
@@ -36,7 +46,7 @@ export interface SnapshotCreateResponse {
 
 export interface DashboardSnapshotSrv {
   create: (cmd: SnapshotCreateCommand) => Promise<SnapshotCreateResponse>;
-  getSnapshots: () => Promise<Snapshot[]>;
+  getSnapshots: (opts?: SnapshotListOptions) => Promise<SnapshotListPage>;
   getSharingOptions: () => Promise<SnapshotSharingOptions>;
   deleteSnapshot: (key: string) => Promise<void>;
   getSnapshot: (key: string) => Promise<DashboardDTO>;
@@ -44,7 +54,10 @@ export interface DashboardSnapshotSrv {
 
 const legacyDashboardSnapshotSrv: DashboardSnapshotSrv = {
   create: (cmd: SnapshotCreateCommand) => getBackendSrv().post<SnapshotCreateResponse>('/api/snapshots', cmd),
-  getSnapshots: () => getBackendSrv().get<Snapshot[]>('/api/dashboard/snapshots'),
+  getSnapshots: async () => {
+    const items = await getBackendSrv().get<Snapshot[]>('/api/dashboard/snapshots');
+    return { items, continueToken: undefined };
+  },
   getSharingOptions: () => getBackendSrv().get<SnapshotSharingOptions>('/api/snapshot/shared-options'),
   deleteSnapshot: (key: string) => getBackendSrv().delete('/api/snapshots/' + key),
   getSnapshot: async (key: string) => {
@@ -79,6 +92,7 @@ interface K8sSnapshotResource {
 
 interface DashboardSnapshotList {
   items: K8sSnapshotResource[];
+  metadata?: ListMeta;
 }
 
 // Response from the /dashboard subresource - returns a Dashboard with raw dashboard data in spec
@@ -103,16 +117,15 @@ class K8sAPI implements DashboardSnapshotSrv {
     return getBackendSrv().post<SnapshotCreateResponse>(this.url + '/create', cmd);
   }
 
-  async getSnapshots(): Promise<Snapshot[]> {
-    const result = await getBackendSrv().get<DashboardSnapshotList>(this.url);
-    return result.items.map((r) => {
-      return {
-        key: r.metadata.name,
-        name: r.spec.title,
-        external: r.spec.external,
-        externalUrl: r.spec.externalUrl,
-      };
-    });
+  async getSnapshots(opts?: SnapshotListOptions): Promise<SnapshotListPage> {
+    const result = await getBackendSrv().get<DashboardSnapshotList>(this.url, { continue: opts?.continue });
+    const items = result.items.map((r) => ({
+      key: r.metadata.name,
+      name: r.spec.title,
+      external: r.spec.external,
+      externalUrl: r.spec.externalUrl,
+    }));
+    return { items, continueToken: result.metadata?.continue };
   }
 
   deleteSnapshot(uid: string) {

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.test.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.test.tsx
@@ -2,8 +2,12 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { getSnapshots, SnapshotListTable } from './SnapshotListTable';
+
+jest.mock('app/core/services/context_srv');
+const mockContextSrv = jest.mocked(contextSrv);
 
 const k8sUrl = '/apis/dashboard.grafana.app/v0alpha1/namespaces/default/snapshots';
 
@@ -48,12 +52,13 @@ const k8sSecondPage = {
 };
 
 const get = jest.fn();
+const del = jest.fn();
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => ({
     get: (...args: unknown[]) => get(...args),
-    delete: jest.fn(),
+    delete: (...args: unknown[]) => del(...args),
   }),
 }));
 
@@ -121,6 +126,9 @@ describe('SnapshotListTable', () => {
     config.appUrl = 'http://snapshots.grafana.com/';
     config.featureToggles.kubernetesSnapshots = false;
     get.mockReset();
+    del.mockReset().mockResolvedValue(undefined);
+    mockContextSrv.hasPermission.mockReturnValue(true);
+    mockContextSrv.hasPermissionInMetadata.mockReturnValue(true);
   });
 
   test('does not render Load More on the legacy path', async () => {
@@ -153,6 +161,38 @@ describe('SnapshotListTable', () => {
     // continue token is gone so button is no longer rendered
     expect(screen.queryByTestId('load-more-snapshots')).not.toBeInTheDocument();
     expect(get).toHaveBeenNthCalledWith(2, k8sUrl, { continue: 'tok-page-2' });
+  });
+
+  test('keeps Load More reachable when deleting the only loaded row leaves a continue token', async () => {
+    config.featureToggles.kubernetesSnapshots = true;
+    const singleItemFirstPage = {
+      items: [
+        {
+          metadata: { name: 'only-snap', namespace: 'default', resourceVersion: '1', creationTimestamp: '' },
+          spec: { title: 'Only Snap', external: false },
+        },
+      ],
+      metadata: { continue: 'tok-page-2', resourceVersion: '1' },
+    };
+    get.mockResolvedValueOnce(singleItemFirstPage).mockResolvedValueOnce(k8sSecondPage);
+
+    render(<SnapshotListTable />);
+
+    await waitFor(() => expect(screen.getByText('Only Snap')).toBeInTheDocument());
+
+    // Delete the only visible row
+    await userEvent.click(screen.getByRole('button', { name: '' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(screen.queryByText('Only Snap')).not.toBeInTheDocument());
+
+    // Empty state must not take over while a continue token is outstanding
+    expect(screen.queryByText("You haven't created any snapshots yet")).not.toBeInTheDocument();
+    const loadMore = screen.getByTestId('load-more-snapshots');
+    expect(loadMore).toBeInTheDocument();
+
+    await userEvent.click(loadMore);
+    await waitFor(() => expect(screen.getByText('K8s Snap 3')).toBeInTheDocument());
   });
 
   test('renders the empty state only after the first fetch resolves', async () => {

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.test.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.test.tsx
@@ -203,4 +203,21 @@ describe('SnapshotListTable', () => {
 
     await waitFor(() => expect(screen.getByText("You haven't created any snapshots yet")).toBeInTheDocument());
   });
+
+  test('shows a Retry button when the initial fetch fails and recovers on click', async () => {
+    config.featureToggles.kubernetesSnapshots = true;
+    get.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(k8sFirstPage);
+
+    const { user } = render(<SnapshotListTable />);
+
+    await waitFor(() => expect(screen.getByText('Failed to load snapshots')).toBeInTheDocument());
+    expect(screen.getByText('boom')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(screen.getByText('K8s Snap 1')).toBeInTheDocument());
+    expect(screen.getByText('K8s Snap 2')).toBeInTheDocument();
+    // error UI must be gone after a successful retry
+    expect(screen.queryByText('Failed to load snapshots')).not.toBeInTheDocument();
+  });
 });

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.test.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -137,29 +136,28 @@ describe('SnapshotListTable', () => {
     render(<SnapshotListTable />);
 
     await waitFor(() => expect(screen.getByText('Snap 1')).toBeInTheDocument());
-    expect(screen.queryByTestId('load-more-snapshots')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Show more snapshots' })).not.toBeInTheDocument();
   });
 
   test('renders Load More when k8s returns a continue token and appends the next page on click', async () => {
     config.featureToggles.kubernetesSnapshots = true;
     get.mockResolvedValueOnce(k8sFirstPage).mockResolvedValueOnce(k8sSecondPage);
 
-    render(<SnapshotListTable />);
+    const { user } = render(<SnapshotListTable />);
 
     await waitFor(() => expect(screen.getByText('K8s Snap 1')).toBeInTheDocument());
     expect(screen.getByText('K8s Snap 2')).toBeInTheDocument();
 
-    const button = screen.getByTestId('load-more-snapshots');
-    expect(button).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Show more snapshots' });
 
-    await userEvent.click(button);
+    await user.click(button);
 
     await waitFor(() => expect(screen.getByText('K8s Snap 3')).toBeInTheDocument());
     // first two rows remain visible
     expect(screen.getByText('K8s Snap 1')).toBeInTheDocument();
     expect(screen.getByText('K8s Snap 2')).toBeInTheDocument();
     // continue token is gone so button is no longer rendered
-    expect(screen.queryByTestId('load-more-snapshots')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Show more snapshots' })).not.toBeInTheDocument();
     expect(get).toHaveBeenNthCalledWith(2, k8sUrl, { continue: 'tok-page-2' });
   });
 
@@ -176,22 +174,21 @@ describe('SnapshotListTable', () => {
     };
     get.mockResolvedValueOnce(singleItemFirstPage).mockResolvedValueOnce(k8sSecondPage);
 
-    render(<SnapshotListTable />);
+    const { user } = render(<SnapshotListTable />);
 
     await waitFor(() => expect(screen.getByText('Only Snap')).toBeInTheDocument());
 
     // Delete the only visible row
-    await userEvent.click(screen.getByRole('button', { name: '' }));
-    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(screen.getByRole('button', { name: '' }));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
 
     await waitFor(() => expect(screen.queryByText('Only Snap')).not.toBeInTheDocument());
 
     // Empty state must not take over while a continue token is outstanding
     expect(screen.queryByText("You haven't created any snapshots yet")).not.toBeInTheDocument();
-    const loadMore = screen.getByTestId('load-more-snapshots');
-    expect(loadMore).toBeInTheDocument();
+    const loadMore = screen.getByRole('button', { name: 'Show more snapshots' });
 
-    await userEvent.click(loadMore);
+    await user.click(loadMore);
     await waitFor(() => expect(screen.getByText('K8s Snap 3')).toBeInTheDocument());
   });
 
@@ -204,8 +201,6 @@ describe('SnapshotListTable', () => {
     // no empty-state message before resolution
     expect(screen.queryByText("You haven't created any snapshots yet")).not.toBeInTheDocument();
 
-    await waitFor(() =>
-      expect(screen.getByText("You haven't created any snapshots yet")).toBeInTheDocument()
-    );
+    await waitFor(() => expect(screen.getByText("You haven't created any snapshots yet")).toBeInTheDocument());
   });
 });

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.test.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.test.tsx
@@ -1,35 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import { config } from '@grafana/runtime';
 
-import { getSnapshots } from './SnapshotListTable';
+import { getSnapshots, SnapshotListTable } from './SnapshotListTable';
+
+const k8sUrl = '/apis/dashboard.grafana.app/v0alpha1/namespaces/default/snapshots';
+
+const legacyResponse = [
+  {
+    name: 'Snap 1',
+    key: 'JRXqfKihKZek70FM6Xaq502NxH7OyyEs',
+    external: true,
+    externalUrl: 'https://www.externalSnapshotUrl.com',
+  },
+  {
+    id: 3,
+    name: 'Snap 2',
+    key: 'RziRfhlBDTjwyYGoHAjnWyrMNQ1zUg3j',
+    external: false,
+    externalUrl: '',
+  },
+];
+
+const k8sFirstPage = {
+  items: [
+    {
+      metadata: { name: 'k8s-snap-1', namespace: 'default', resourceVersion: '1', creationTimestamp: '' },
+      spec: { title: 'K8s Snap 1', external: false },
+    },
+    {
+      metadata: { name: 'k8s-snap-2', namespace: 'default', resourceVersion: '1', creationTimestamp: '' },
+      spec: { title: 'K8s Snap 2', external: false },
+    },
+  ],
+  metadata: { continue: 'tok-page-2', resourceVersion: '1' },
+};
+
+const k8sSecondPage = {
+  items: [
+    {
+      metadata: { name: 'k8s-snap-3', namespace: 'default', resourceVersion: '1', creationTimestamp: '' },
+      spec: { title: 'K8s Snap 3', external: false },
+    },
+  ],
+  metadata: { resourceVersion: '1' },
+};
+
+const get = jest.fn();
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => ({
-    get: jest.fn().mockResolvedValue([
-      {
-        name: 'Snap 1',
-        key: 'JRXqfKihKZek70FM6Xaq502NxH7OyyEs',
-        external: true,
-        externalUrl: 'https://www.externalSnapshotUrl.com',
-      },
-      {
-        id: 3,
-        name: 'Snap 2',
-        key: 'RziRfhlBDTjwyYGoHAjnWyrMNQ1zUg3j',
-        external: false,
-        externalUrl: '',
-      },
-    ]),
+    get: (...args: unknown[]) => get(...args),
+    delete: jest.fn(),
   }),
 }));
 
+jest.mock('../../../api/utils', () => ({
+  getAPINamespace: () => 'default',
+}));
+
 describe('getSnapshots', () => {
-  config.appUrl = 'http://snapshots.grafana.com/';
+  beforeEach(() => {
+    config.appUrl = 'http://snapshots.grafana.com/';
+    config.featureToggles.kubernetesSnapshots = false;
+    get.mockReset();
+  });
 
-  test('returns correct snapshot urls', async () => {
-    const results = await getSnapshots();
+  test('returns paginated shape with decorated urls (legacy)', async () => {
+    get.mockResolvedValueOnce(legacyResponse);
 
-    expect(results).toMatchInlineSnapshot(`
+    const result = await getSnapshots();
+
+    expect(result.continueToken).toBeUndefined();
+    expect(result.items).toMatchInlineSnapshot(`
       [
         {
           "external": true,
@@ -48,5 +93,79 @@ describe('getSnapshots', () => {
         },
       ]
     `);
+  });
+
+  test('propagates the k8s continue token', async () => {
+    config.featureToggles.kubernetesSnapshots = true;
+    get.mockResolvedValueOnce(k8sFirstPage);
+
+    const result = await getSnapshots();
+
+    expect(result.continueToken).toBe('tok-page-2');
+    expect(result.items).toHaveLength(2);
+    expect(get).toHaveBeenCalledWith(k8sUrl, { continue: undefined });
+  });
+
+  test('forwards the continue option to the k8s api', async () => {
+    config.featureToggles.kubernetesSnapshots = true;
+    get.mockResolvedValueOnce(k8sSecondPage);
+
+    await getSnapshots({ continue: 'tok-page-2' });
+
+    expect(get).toHaveBeenCalledWith(k8sUrl, { continue: 'tok-page-2' });
+  });
+});
+
+describe('SnapshotListTable', () => {
+  beforeEach(() => {
+    config.appUrl = 'http://snapshots.grafana.com/';
+    config.featureToggles.kubernetesSnapshots = false;
+    get.mockReset();
+  });
+
+  test('does not render Load More on the legacy path', async () => {
+    get.mockResolvedValueOnce(legacyResponse);
+
+    render(<SnapshotListTable />);
+
+    await waitFor(() => expect(screen.getByText('Snap 1')).toBeInTheDocument());
+    expect(screen.queryByTestId('load-more-snapshots')).not.toBeInTheDocument();
+  });
+
+  test('renders Load More when k8s returns a continue token and appends the next page on click', async () => {
+    config.featureToggles.kubernetesSnapshots = true;
+    get.mockResolvedValueOnce(k8sFirstPage).mockResolvedValueOnce(k8sSecondPage);
+
+    render(<SnapshotListTable />);
+
+    await waitFor(() => expect(screen.getByText('K8s Snap 1')).toBeInTheDocument());
+    expect(screen.getByText('K8s Snap 2')).toBeInTheDocument();
+
+    const button = screen.getByTestId('load-more-snapshots');
+    expect(button).toBeInTheDocument();
+
+    await userEvent.click(button);
+
+    await waitFor(() => expect(screen.getByText('K8s Snap 3')).toBeInTheDocument());
+    // first two rows remain visible
+    expect(screen.getByText('K8s Snap 1')).toBeInTheDocument();
+    expect(screen.getByText('K8s Snap 2')).toBeInTheDocument();
+    // continue token is gone so button is no longer rendered
+    expect(screen.queryByTestId('load-more-snapshots')).not.toBeInTheDocument();
+    expect(get).toHaveBeenNthCalledWith(2, k8sUrl, { continue: 'tok-page-2' });
+  });
+
+  test('renders the empty state only after the first fetch resolves', async () => {
+    config.featureToggles.kubernetesSnapshots = true;
+    get.mockResolvedValueOnce({ items: [], metadata: { resourceVersion: '1' } });
+
+    render(<SnapshotListTable />);
+
+    // no empty-state message before resolution
+    expect(screen.queryByText("You haven't created any snapshots yet")).not.toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByText("You haven't created any snapshots yet")).toBeInTheDocument()
+    );
   });
 });

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from 'react';
-import { useAsyncRetry } from 'react-use';
+import { useCallback, useEffect, useState } from 'react';
+import { useAsyncFn } from 'react-use';
 
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -27,32 +27,24 @@ export async function getSnapshots(opts?: SnapshotListOptions): Promise<Snapshot
 export const SnapshotListTable = () => {
   const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
   const [continueToken, setContinueToken] = useState<string | undefined>();
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [removeSnapshot, setRemoveSnapshot] = useState<Snapshot | undefined>();
 
-  const {
-    loading: isInitialLoading,
-    error: initialError,
-    retry: loadInitial,
-  } = useAsyncRetry(async () => {
-    const page = await getSnapshots();
-    setSnapshots(page.items);
-    setContinueToken(page.continueToken);
-  }, []);
-
-  const loadMore = useCallback(async () => {
-    if (isLoadingMore || !continueToken) {
-      return;
-    }
-    setIsLoadingMore(true);
-    try {
-      const page = await getSnapshots({ continue: continueToken });
-      setSnapshots((prev) => [...prev, ...page.items]);
+  const [{ loading, error }, loadSnapshots] = useAsyncFn(
+    async (token?: string) => {
+      const page = await getSnapshots(token ? { continue: token } : undefined);
+      setSnapshots((prev) => (token ? [...prev, ...page.items] : page.items));
       setContinueToken(page.continueToken);
-    } finally {
-      setIsLoadingMore(false);
-    }
-  }, [continueToken, isLoadingMore]);
+    },
+    [],
+    { loading: true }
+  );
+
+  useEffect(() => {
+    loadSnapshots();
+  }, [loadSnapshots]);
+
+  const isInitialLoading = loading && snapshots.length === 0;
+  const isLoadingMore = loading && snapshots.length > 0;
 
   const doRemoveSnapshot = useCallback(
     async (snapshot: Snapshot) => {
@@ -67,18 +59,18 @@ export const SnapshotListTable = () => {
     [snapshots]
   );
 
-  if (initialError && !isInitialLoading) {
+  if (error && snapshots.length === 0 && !continueToken) {
     return (
       <Alert
         severity="error"
         title={t('snapshot.load-error.title', 'Failed to load snapshots')}
         action={
-          <Button variant="secondary" onClick={loadInitial}>
+          <Button variant="secondary" onClick={() => loadSnapshots()}>
             <Trans i18nKey="snapshot.load-error.retry">Retry</Trans>
           </Button>
         }
       >
-        {initialError.message}
+        {error.message}
       </Alert>
     );
   }
@@ -143,7 +135,7 @@ export const SnapshotListTable = () => {
 
       {!isInitialLoading && continueToken && (
         <Box paddingTop={2}>
-          <LoadMoreButton onClick={loadMore} loading={isLoadingMore} />
+          <LoadMoreButton onClick={() => loadSnapshots(continueToken)} loading={isLoadingMore} />
         </Box>
       )}
 

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
@@ -1,9 +1,9 @@
-import { useState, useCallback } from 'react';
-import useAsync from 'react-use/lib/useAsync';
+import { useCallback, useState } from 'react';
+import { useAsyncRetry } from 'react-use';
 
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { Box, Button, ConfirmModal, EmptyState, ScrollContainer, TextLink } from '@grafana/ui';
+import { Alert, Box, Button, ConfirmModal, EmptyState, ScrollContainer, TextLink } from '@grafana/ui';
 import {
   getDashboardSnapshotSrv,
   type Snapshot,
@@ -27,17 +27,17 @@ export async function getSnapshots(opts?: SnapshotListOptions): Promise<Snapshot
 export const SnapshotListTable = () => {
   const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
   const [continueToken, setContinueToken] = useState<string | undefined>();
-  const [isInitialLoading, setIsInitialLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [removeSnapshot, setRemoveSnapshot] = useState<Snapshot | undefined>();
 
-  useAsync(async () => {
+  const {
+    loading: isInitialLoading,
+    error: initialError,
+    retry: loadInitial,
+  } = useAsyncRetry(async () => {
     const page = await getSnapshots();
     setSnapshots(page.items);
     setContinueToken(page.continueToken);
-    setIsInitialLoading(false);
-    setHasLoadedOnce(true);
   }, []);
 
   const loadMore = useCallback(async () => {
@@ -67,7 +67,23 @@ export const SnapshotListTable = () => {
     [snapshots]
   );
 
-  if (hasLoadedOnce && snapshots.length === 0 && !continueToken) {
+  if (initialError && !isInitialLoading) {
+    return (
+      <Alert
+        severity="error"
+        title={t('snapshot.load-error.title', 'Failed to load snapshots')}
+        action={
+          <Button variant="secondary" onClick={loadInitial}>
+            <Trans i18nKey="snapshot.load-error.retry">Retry</Trans>
+          </Button>
+        }
+      >
+        {initialError.message}
+      </Alert>
+    );
+  }
+
+  if (!isInitialLoading && snapshots.length === 0 && !continueToken) {
     return (
       <EmptyState
         variant="call-to-action"

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
@@ -67,7 +67,7 @@ export const SnapshotListTable = () => {
     [snapshots]
   );
 
-  if (hasLoadedOnce && snapshots.length === 0) {
+  if (hasLoadedOnce && snapshots.length === 0 && !continueToken) {
     return (
       <EmptyState
         variant="call-to-action"

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
@@ -3,7 +3,7 @@ import useAsync from 'react-use/lib/useAsync';
 
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { Box, Button, ConfirmModal, EmptyState, ScrollContainer, Stack, TextLink } from '@grafana/ui';
+import { Box, Button, ConfirmModal, EmptyState, ScrollContainer, TextLink } from '@grafana/ui';
 import {
   getDashboardSnapshotSrv,
   type Snapshot,
@@ -127,9 +127,7 @@ export const SnapshotListTable = () => {
 
       {!isInitialLoading && continueToken && (
         <Box paddingTop={2}>
-          <Stack>
-            <LoadMoreButton onClick={loadMore} loading={isLoadingMore} />
-          </Stack>
+          <LoadMoreButton onClick={loadMore} loading={isLoadingMore} />
         </Box>
       )}
 
@@ -159,13 +157,7 @@ interface LoadMoreButtonProps {
 
 function LoadMoreButton({ onClick, loading }: LoadMoreButtonProps) {
   return (
-    <Button
-      data-testid="load-more-snapshots"
-      type="button"
-      variant="secondary"
-      onClick={onClick}
-      disabled={loading}
-    >
+    <Button type="button" variant="secondary" onClick={onClick} disabled={loading}>
       {loading ? (
         <Trans i18nKey="snapshot.load-more.loading">Loading more snapshots…</Trans>
       ) : (

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
@@ -3,31 +3,56 @@ import useAsync from 'react-use/lib/useAsync';
 
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { ConfirmModal, EmptyState, ScrollContainer, TextLink } from '@grafana/ui';
-import { getDashboardSnapshotSrv, type Snapshot } from 'app/features/dashboard/services/SnapshotSrv';
+import { Box, Button, ConfirmModal, EmptyState, ScrollContainer, Stack, TextLink } from '@grafana/ui';
+import {
+  getDashboardSnapshotSrv,
+  type Snapshot,
+  type SnapshotListOptions,
+  type SnapshotListPage,
+} from 'app/features/dashboard/services/SnapshotSrv';
 
 import { SnapshotListTableRow } from './SnapshotListTableRow';
 
-export async function getSnapshots() {
-  return getDashboardSnapshotSrv()
-    .getSnapshots()
-    .then((result: Snapshot[]) => {
-      return result.map((snapshot) => ({
-        ...snapshot,
-        url: `${config.appUrl}dashboard/snapshot/${snapshot.key}`,
-      }));
-    });
+export async function getSnapshots(opts?: SnapshotListOptions): Promise<SnapshotListPage> {
+  const page = await getDashboardSnapshotSrv().getSnapshots(opts);
+  return {
+    items: page.items.map((snapshot) => ({
+      ...snapshot,
+      url: `${config.appUrl}dashboard/snapshot/${snapshot.key}`,
+    })),
+    continueToken: page.continueToken,
+  };
 }
+
 export const SnapshotListTable = () => {
   const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
-  const [isFetching, setIsFetching] = useState(false);
+  const [continueToken, setContinueToken] = useState<string | undefined>();
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [removeSnapshot, setRemoveSnapshot] = useState<Snapshot | undefined>();
+
   useAsync(async () => {
-    setIsFetching(true);
-    const response = await getSnapshots();
-    setIsFetching(false);
-    setSnapshots(response);
-  }, [setSnapshots]);
+    const page = await getSnapshots();
+    setSnapshots(page.items);
+    setContinueToken(page.continueToken);
+    setIsInitialLoading(false);
+    setHasLoadedOnce(true);
+  }, []);
+
+  const loadMore = useCallback(async () => {
+    if (isLoadingMore || !continueToken) {
+      return;
+    }
+    setIsLoadingMore(true);
+    try {
+      const page = await getSnapshots({ continue: continueToken });
+      setSnapshots((prev) => [...prev, ...page.items]);
+      setContinueToken(page.continueToken);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [continueToken, isLoadingMore]);
 
   const doRemoveSnapshot = useCallback(
     async (snapshot: Snapshot) => {
@@ -42,7 +67,7 @@ export const SnapshotListTable = () => {
     [snapshots]
   );
 
-  if (!isFetching && snapshots.length === 0) {
+  if (hasLoadedOnce && snapshots.length === 0) {
     return (
       <EmptyState
         variant="call-to-action"
@@ -82,7 +107,7 @@ export const SnapshotListTable = () => {
           </tr>
         </thead>
         <tbody>
-          {isFetching ? (
+          {isInitialLoading ? (
             <>
               <SnapshotListTableRow.Skeleton />
               <SnapshotListTableRow.Skeleton />
@@ -99,6 +124,14 @@ export const SnapshotListTable = () => {
           )}
         </tbody>
       </table>
+
+      {!isInitialLoading && continueToken && (
+        <Box paddingTop={2}>
+          <Stack>
+            <LoadMoreButton onClick={loadMore} loading={isLoadingMore} />
+          </Stack>
+        </Box>
+      )}
 
       <ConfirmModal
         isOpen={!!removeSnapshot}
@@ -118,3 +151,26 @@ export const SnapshotListTable = () => {
     </ScrollContainer>
   );
 };
+
+interface LoadMoreButtonProps {
+  onClick: () => void;
+  loading: boolean;
+}
+
+function LoadMoreButton({ onClick, loading }: LoadMoreButtonProps) {
+  return (
+    <Button
+      data-testid="load-more-snapshots"
+      type="button"
+      variant="secondary"
+      onClick={onClick}
+      disabled={loading}
+    >
+      {loading ? (
+        <Trans i18nKey="snapshot.load-more.loading">Loading more snapshots…</Trans>
+      ) : (
+        <Trans i18nKey="snapshot.load-more.label">Show more snapshots</Trans>
+      )}
+    </Button>
+  );
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14869,6 +14869,10 @@
       "more-info": "You can create a snapshot of any dashboard through the <1>Share</1> modal. <4>Learn more</4>"
     },
     "external-badge": "External",
+    "load-more": {
+      "label": "Show more snapshots",
+      "loading": "Loading more snapshots…"
+    },
     "name-column-header": "Name",
     "share": {
       "cancel-button": "Cancel",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14869,6 +14869,10 @@
       "more-info": "You can create a snapshot of any dashboard through the <1>Share</1> modal. <4>Learn more</4>"
     },
     "external-badge": "External",
+    "load-error": {
+      "retry": "Retry",
+      "title": "Failed to load snapshots"
+    },
     "load-more": {
       "label": "Show more snapshots",
       "loading": "Loading more snapshots…"


### PR DESCRIPTION
**What is this feature?**

  When `kubernetesSnapshots` is on, the snapshots list is served by the new k8s API (/apis/dashboard.grafana.app/v0alpha1/.../snapshots), which pages its response on a server-side byte limit (~2 MB) and signals more available via `metadata.continue`. Today the UI throws that token away, so users with many or big snapshots can be missing some of them.

  This PR plumbs the continue token through to the UI and adds a "Show more snapshots" button at the bottom of /dashboard/snapshots that fetches and appends the next page on click. The button is hidden on the final page (no continue token) and never renders on the legacy /api/dashboard/snapshots path, which has no pagination.

  Changes
  - SnapshotSrv.getSnapshots now takes { continue? } and returns { items, continueToken? }. Legacy returns continueToken: undefined; k8s reads it from metadata.continue and forwards it as a request param.
  - SnapshotListTable accumulates pages in state, splits initial-loading from load-more state, and renders the button (styled to match dashboard version history).
  - New en-US i18n keys: snapshot.load-more.{label,loading}.
  - Tests cover the legacy path (no button), the k8s path (button renders, click appends, button hides on final page), and the empty-state-only-after-first-fetch guard.

  No backend changes — the k8s API already supports `?continue=<token>`
The `Show more snapshots` button design was inspired by the Dashboards Versions load more button.

<img width="1267" height="689" alt="Screenshot 2026-06-19 at 11 29 46" src="https://github.com/user-attachments/assets/b688a4c0-cc51-4d25-8c79-cb40ff6e94fe" />

Current same pattern in Dashboard versions
<img width="1244" height="644" alt="Screenshot 2026-06-19 at 11 29 05" src="https://github.com/user-attachments/assets/22cf8cf0-bfe3-41f3-bf50-204d13922653" />

Fixes https://github.com/grafana/grafana/issues/125342

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
