### PR TITLE
[release-12.2.10] Chore(deps): Pin transitive lodash to 4.18.1 (CVE-2026-4800)

### DIFF
--- a/package.json
+++ b/package.json
@@ -431,6 +431,7 @@
     "underscore": "1.13.7",
     "@types/slate": "0.47.11",
     "axios": "1.15.2",
+    "lodash@npm:~4.17.21": "4.18.1",
     "semver@npm:~7.3.5": "^7.3.5",
     "debug@npm:^0.7.2": "2.6.9",
     "debug@npm:^0.7.4": "2.6.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22703,17 +22703,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4, lodash@npm:^4.1.1, lodash@npm:^4.15.0, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.18.1":
+"lodash@npm:4.18.1, lodash@npm:^4, lodash@npm:^4.1.1, lodash@npm:^4.15.0, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
-  languageName: node
-  linkType: hard
-
-"lodash@npm:~4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Fully clears **CVE-2026-4800** (lodash `_.template` code injection, CVSS 9.8) on `release-12.2.10`.

Production lodash was already patched to 4.18.1 (earlier #122689 / #122681), but a single residual `lodash@4.17.21` remained — pulled only by `pa11y-ci@4.0.0` via `~4.17.21` (dev/CI accessibility tooling), which the scanners still flagged.

## How

The `~4.17.21` tilde caps below the fixed 4.18.0, so it can't be lifted in-range. A targeted resolution forces it to 4.18.1:

```
"lodash@npm:~4.17.21": "4.18.1"
```

This collapses the tree to a single `lodash@4.18.1` entry. lodash 4.17→4.18 is a minor (the `_.template` fix), API-compatible; pa11y-ci is dev/CI-only.

## Validation

- `yarn install` succeeds; `yarn.lock` resolves a single `lodash@npm:4.18.1` (no 4.17.21 remaining).

🤖 Generated with [Claude Code](https://claude.com/claude-code)