### PR TITLE
Search: drive bleve mapping from SearchFieldsProvider

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -48,12 +48,20 @@ type DocumentBuilderInfo struct {
 
 	// SearchFieldsHash is a stable hex hash over the SearchFieldDefinition
 	// slices registered for GroupResource across every version. The hash is
-	// stored in IndexBuildInfo when an index is built and re-checked on
-	// startup so the index is rebuilt automatically when index-affecting
-	// search-field metadata changes.
+	// stored in IndexBuildInfo when an index is built and re-checked
+	// whenever a rebuild is considered, so the index is rebuilt
+	// automatically when index-affecting search-field metadata changes.
 	//
 	// Empty when the builder does not use a SearchFieldsProvider.
 	SearchFieldsHash string
+
+	// SearchFieldsProvider is the manifest-driven source of truth for this
+	// builder's search fields. When non-nil, the bleve mapping for
+	// GroupResource is built from the provider's SearchFieldDefinition
+	// declarations rather than from the legacy Fields (column-definition)
+	// translation. Fields may still be populated alongside the provider for
+	// downstream consumers that read column metadata directly.
+	SearchFieldsProvider SearchFieldsProvider
 }
 
 // SearchFieldsHashesForBuilders returns a lower-cased "group/resource" map
@@ -68,6 +76,22 @@ func SearchFieldsHashesForBuilders(builders []DocumentBuilderInfo) map[string]st
 		}
 		key := strings.ToLower(b.GroupResource.Group + "/" + b.GroupResource.Resource)
 		out[key] = b.SearchFieldsHash
+	}
+	return out
+}
+
+// SearchFieldProvidersForBuilders returns a lower-cased "group/resource" map
+// of SearchFieldsProvider values collected from the given DocumentBuilderInfo
+// entries. Builders with a nil provider are skipped, so the map's keys list
+// the kinds whose bleve mapping is provider-driven.
+func SearchFieldProvidersForBuilders(builders []DocumentBuilderInfo) map[string]SearchFieldsProvider {
+	out := map[string]SearchFieldsProvider{}
+	for _, b := range builders {
+		if b.SearchFieldsProvider == nil {
+			continue
+		}
+		key := strings.ToLower(b.GroupResource.Group + "/" + b.GroupResource.Resource)
+		out[key] = b.SearchFieldsProvider
 	}
 	return out
 }

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -211,13 +211,15 @@ func searchFieldTypeFromProto(t resourcepb.ResourceTableColumnDefinition_ColumnT
 // to PreferredVersion. That fallback is the consumer's responsibility; the
 // Fields method itself does not perform it.
 type SearchFieldsProvider interface {
-	// Fields returns the declared search fields for the exact
-	// GroupVersionResource. Returns nil if nothing is registered for that
-	// key; the caller decides how to handle missing versions (usually by
-	// retrying with PreferredVersion).
+	// Fields returns the declared search fields for a GroupVersionResource.
+	// With a non-empty Version only that version's fields are returned.
+	// With an empty Version Fields returns every field declared by any
+	// version of (group, resource); a field declared in multiple versions
+	// appears once, with the preferred version's shape.
 	//
-	// The returned slice is owned by the provider; callers must not mutate
-	// it.
+	// Two versions declaring a field with different shapes are not yet
+	// validated; a later check will reject mismatches. The returned slice
+	// is owned by the provider; do not mutate it.
 	Fields(gvr schema.GroupVersionResource) []SearchFieldDefinition
 
 	// PreferredVersion returns the served version that callers should use
@@ -286,16 +288,36 @@ var sortableTypes = []SearchFieldType{
 	SearchFieldTypeString,
 }
 
+// stringOnlyCapabilities lists capabilities that require a string-mapped
+// Type. These rely on text/keyword analysis under the bleve text engine
+// and have no meaningful semantics on numeric or boolean fields.
+var stringOnlyCapabilities = []SearchCapability{
+	SearchCapabilityText,
+	SearchCapabilityPartial,
+	SearchCapabilityFacet,
+}
+
 // validateSearchFieldDefinitions returns a non-nil error when any declaration
 // uses a capability that the current bleve mapper cannot honour. The only
 // rule enforced today is that SearchCapabilitySort requires a string-mapped
 // Type; numeric and boolean fields would otherwise be sorted lexically
-// because the mapper does not emit numeric mappings yet.
+// because the mapper does not emit numeric mappings yet. The validator
+// also rejects text/partial/facet capabilities on non-string fields:
+// these capabilities rely on text or keyword analysis that has no
+// meaning on numeric or boolean values.
 func validateSearchFieldDefinitions(sfds []SearchFieldDefinition) error {
 	var violations []string
 	for _, sfd := range sfds {
+		isStringTyped := sfd.Type == SearchFieldTypeString
 		if slices.Contains(sfd.Capabilities, SearchCapabilitySort) && !slices.Contains(sortableTypes, sfd.Type) {
 			violations = append(violations, "field "+sfd.Name+": sort capability is not supported for type "+string(sfd.Type))
+		}
+		if !isStringTyped {
+			for _, cap := range stringOnlyCapabilities {
+				if slices.Contains(sfd.Capabilities, cap) {
+					violations = append(violations, "field "+sfd.Name+": "+string(cap)+" capability requires a string-typed field (got "+string(sfd.Type)+")")
+				}
+			}
 		}
 	}
 	if len(violations) == 0 {
@@ -305,7 +327,39 @@ func validateSearchFieldDefinitions(sfds []SearchFieldDefinition) error {
 }
 
 func (p *mapProvider) Fields(gvr schema.GroupVersionResource) []SearchFieldDefinition {
-	return p.fields[gvr]
+	if gvr.Version != "" {
+		return p.fields[gvr]
+	}
+	// Empty version: return the union across every registered version of
+	// (gvr.Group, gvr.Resource), deduplicated by Name. Preferred version
+	// goes first so its shape wins on collisions; other versions are
+	// iterated in sorted order for determinism.
+	var out []SearchFieldDefinition
+	seen := map[string]bool{}
+	appendNew := func(sfds []SearchFieldDefinition) {
+		for _, sfd := range sfds {
+			if seen[sfd.Name] {
+				continue
+			}
+			seen[sfd.Name] = true
+			out = append(out, sfd)
+		}
+	}
+	pref := p.PreferredVersion(gvr.Group, gvr.Resource)
+	if pref != "" {
+		appendNew(p.fields[schema.GroupVersionResource{Group: gvr.Group, Version: pref, Resource: gvr.Resource}])
+	}
+	var otherVersions []string
+	for key := range p.fields {
+		if key.Group == gvr.Group && key.Resource == gvr.Resource && key.Version != pref {
+			otherVersions = append(otherVersions, key.Version)
+		}
+	}
+	slices.Sort(otherVersions)
+	for _, v := range otherVersions {
+		appendNew(p.fields[schema.GroupVersionResource{Group: gvr.Group, Version: v, Resource: gvr.Resource}])
+	}
+	return out
 }
 
 func (p *mapProvider) PreferredVersion(group, resource string) string {

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -167,6 +167,46 @@ func TestMapProvider_PreferredVersionFallback(t *testing.T) {
 	assert.Equal(t, "", p.PreferredVersion("other.grafana.app", "things"))
 }
 
+func TestMapProvider_FieldsUnionAcrossVersions(t *testing.T) {
+	gr := schema.GroupResource{Group: "example.test", Resource: "widgets"}
+	v1 := schema.GroupVersionResource{Group: gr.Group, Version: "v1", Resource: gr.Resource}
+	v2 := schema.GroupVersionResource{Group: gr.Group, Version: "v2", Resource: gr.Resource}
+
+	p := NewMapProvider(
+		map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {
+				{Name: "shared", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}},
+				{Name: "only_v1", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}},
+			},
+			v2: {
+				{Name: "shared", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityText}},
+				{Name: "only_v2", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}},
+			},
+		},
+		map[schema.GroupResource]string{gr: "v1"},
+	)
+
+	// Per-version lookup is unchanged.
+	assert.Len(t, p.Fields(v1), 2)
+	assert.Len(t, p.Fields(v2), 2)
+
+	// Empty-version lookup returns the union deduped by Name.
+	union := p.Fields(schema.GroupVersionResource{Group: gr.Group, Resource: gr.Resource})
+	names := make([]string, 0, len(union))
+	for _, sfd := range union {
+		names = append(names, sfd.Name)
+	}
+	assert.ElementsMatch(t, []string{"shared", "only_v1", "only_v2"}, names)
+
+	// Preferred version (v1) wins on Name collisions: the shape of `shared`
+	// comes from v1, not v2.
+	for _, sfd := range union {
+		if sfd.Name == "shared" {
+			assert.Equal(t, []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}, sfd.Capabilities)
+		}
+	}
+}
+
 func TestMapProvider_IndexAffectingHash(t *testing.T) {
 	const (
 		group    = "iam.grafana.app"
@@ -373,6 +413,40 @@ func TestValidateSearchFieldDefinitions(t *testing.T) {
 	})
 	t.Run("StandardSearchFieldDefinitions passes validation", func(t *testing.T) {
 		err := validateSearchFieldDefinitions(StandardSearchFieldDefinitions())
+		require.NoError(t, err)
+	})
+	t.Run("text on int64 is rejected", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "created", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityText}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "text")
+		assert.Contains(t, err.Error(), "int64")
+	})
+	t.Run("partial on boolean is rejected", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "disabled", Type: SearchFieldTypeBoolean, Capabilities: []SearchCapability{SearchCapabilityPartial}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "partial")
+	})
+	t.Run("facet on double is rejected", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "score", Type: SearchFieldTypeDouble, Capabilities: []SearchCapability{SearchCapabilityFacet}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "facet")
+	})
+	t.Run("text on string is valid", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "title", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityText}},
+		})
+		require.NoError(t, err)
+	})
+	t.Run("facet on string is valid", func(t *testing.T) {
+		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
+			{Name: "tag", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFacet}},
+		})
 		require.NoError(t, err)
 	})
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -92,6 +92,13 @@ type BleveOptions struct {
 	// can detect drift and rebuild. Keys must be lower-case.
 	SearchFieldsHashesForKinds map[string]string
 
+	// Map "group/resource" -> SearchFieldsProvider that drives the bleve
+	// mapping for that (group, resource). When a provider is registered
+	// for a kind, the bleve mapping is built from the provider's
+	// SearchFieldDefinitions rather than from the legacy column-definition
+	// list carried by SearchableDocumentFields. Keys must be lower-case.
+	SearchFieldsProvidersForKinds map[string]resource.SearchFieldsProvider
+
 	// Snapshot configures remote index snapshot download at build time.
 	// If Snapshot.Store is nil, the feature is disabled and BuildIndex behaves exactly as before.
 	Snapshot SnapshotOptions
@@ -175,8 +182,9 @@ type bleveBackend struct {
 
 	indexMetrics *resource.BleveIndexMetrics
 
-	selectableFields   map[string][]string
-	searchFieldsHashes map[string]string
+	selectableFields     map[string][]string
+	searchFieldsHashes   map[string]string
+	searchFieldsProvider map[string]resource.SearchFieldsProvider
 
 	// Parsed opts.BuildVersion for snapshot tier comparisons. Nil if BuildVersion
 	// is empty. Guaranteed non-nil when opts.Snapshot.Store is set.
@@ -258,6 +266,7 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 		indexMetrics:            indexMetrics,
 		selectableFields:        opts.SelectableFieldsForKinds,
 		searchFieldsHashes:      opts.SearchFieldsHashesForKinds,
+		searchFieldsProvider:    opts.SearchFieldsProvidersForKinds,
 		runningBuildVersion:     runningBuildVersion,
 		maxSupportedIndexFormat: maxSupportedFormat,
 		lastUploadTime:          map[resource.NamespacedResource]time.Time{},
@@ -739,8 +748,9 @@ func (b *bleveBackend) BuildIndex(
 	sfKey := strings.ToLower(fmt.Sprintf("%s/%s", key.Group, key.Resource))
 	selectableFields := b.selectableFields[sfKey]
 	searchFieldsHash := b.searchFieldsHashes[sfKey]
+	searchFieldsProvider := b.searchFieldsProvider[sfKey]
 
-	mapper, err := GetBleveMappings(fields, selectableFields)
+	mapper, err := GetBleveMappings(fields, searchFieldsProvider, key.Group, key.Resource, selectableFields)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -8,10 +8,38 @@ import (
 	"github.com/blevesearch/bleve/v2/analysis/analyzer/standard"
 	"github.com/blevesearch/bleve/v2/mapping"
 	index "github.com/blevesearch/bleve_index_api"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
+
+// fieldDefinitionsForMapping returns the SearchFieldDefinition slice that
+// drives the per-kind fields.* sub-document mapping. Provider declarations
+// win when present for (group, kindResource); otherwise the legacy
+// column-definition list is translated. Anything the helper does not emit
+// a mapping for (e.g. retrieve-only fields, or non-string fields with only
+// filter/facet under the type-aware mapper) is left to Bleve's dynamic
+// mapping at index time, which matches the previous behaviour for
+// non-filterable fields.
+func fieldDefinitionsForMapping(fields resource.SearchableDocumentFields, provider resource.SearchFieldsProvider, group, kindResource string) []resource.SearchFieldDefinition {
+	if provider != nil {
+		if defs := provider.Fields(schema.GroupVersionResource{Group: group, Resource: kindResource}); len(defs) > 0 {
+			return defs
+		}
+	}
+	if fields == nil {
+		return nil
+	}
+	names := fields.Fields()
+	cols := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(names))
+	for _, name := range names {
+		if def := fields.Field(name); def != nil {
+			cols = append(cols, def)
+		}
+	}
+	return resource.SearchFieldsFromTableColumns(cols)
+}
 
 // addCapabilityFieldMappings adds bleve field mappings to parent for a single
 // declared search field. The field is placed under parent using def.Name as
@@ -49,7 +77,16 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 	hasRetrieve := def.HasCapability(resource.SearchCapabilityRetrieve)
 	hasUnranked := def.HasCapability(resource.SearchCapabilityUnranked)
 
+	// Non-string fields skip the explicit keyword under a dynamic parent;
+	// bleve's dynamic path produces the right shape (numeric, boolean)
+	// which keyword analysis would break. Static parents (top-level
+	// mapper) still emit an explicit keyword. Sort is validated as
+	// string-only, so hasSort cannot reach here for non-strings.
+	isStringTyped := def.Type == resource.SearchFieldTypeString
 	needKeyword := hasFilter || hasFacet || hasSort
+	if needKeyword && !isStringTyped && parent.Dynamic {
+		needKeyword = false
+	}
 	keywordName := keywordVariantName(def.Name, hasText)
 
 	if needKeyword {
@@ -109,7 +146,13 @@ func keywordVariantName(name string, hasText bool) string {
 	return name
 }
 
-func GetBleveMappings(fields resource.SearchableDocumentFields, selectableFields []string) (mapping.IndexMapping, error) {
+// GetBleveMappings returns the bleve index mapping for a single
+// (group, resource). When provider is non-nil and has SearchFieldDefinitions
+// registered for the (group, resource), the per-kind fields.* sub-document
+// mapping is built from those declarations. Otherwise the legacy fields
+// (SearchableDocumentFields, derived from in-tree column definitions) drive
+// the mapping. Passing both is allowed: provider wins.
+func GetBleveMappings(fields resource.SearchableDocumentFields, provider resource.SearchFieldsProvider, group, kindResource string, selectableFields []string) (mapping.IndexMapping, error) {
 	mapper := bleve.NewIndexMapping()
 	mapper.DocValuesDynamic = false // only folder and title_phrase need DocValues
 	mapper.ScoringModel = index.BM25Scoring
@@ -118,12 +161,12 @@ func GetBleveMappings(fields resource.SearchableDocumentFields, selectableFields
 	if err != nil {
 		return nil, err
 	}
-	mapper.DefaultMapping = getBleveDocMappings(fields, selectableFields)
+	mapper.DefaultMapping = getBleveDocMappings(fields, provider, group, kindResource, selectableFields)
 
 	return mapper, nil
 }
 
-func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFields []string) *mapping.DocumentMapping {
+func getBleveDocMappings(fields resource.SearchableDocumentFields, provider resource.SearchFieldsProvider, group, kindResource string, selectableFields []string) *mapping.DocumentMapping {
 	mapper := bleve.NewDocumentStaticMapping()
 
 	// Standard top-level search fields are declared as SearchFieldDefinitions
@@ -147,22 +190,8 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 	mapper.AddSubDocumentMapping(resource.SEARCH_FIELD_LABELS, labelMapper)
 
 	fieldMapper := bleve.NewDocumentMapping()
-	if fields != nil {
-		// Collect the per-kind column definitions so they can be translated
-		// in one shot. Anything the helper does not emit a mapping for (no
-		// filter/text/partial/facet/sort capability) is left to Bleve's
-		// dynamic mapping at index time, which is the previous behaviour for
-		// non-filterable fields.
-		names := fields.Fields()
-		cols := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(names))
-		for _, name := range names {
-			if def := fields.Field(name); def != nil {
-				cols = append(cols, def)
-			}
-		}
-		for _, def := range resource.SearchFieldsFromTableColumns(cols) {
-			addCapabilityFieldMappings(fieldMapper, def)
-		}
+	for _, def := range fieldDefinitionsForMapping(fields, provider, group, kindResource) {
+		addCapabilityFieldMappings(fieldMapper, def)
 	}
 
 	mapper.AddSubDocumentMapping(strings.TrimSuffix(resource.SEARCH_FIELD_PREFIX, "."), fieldMapper)

--- a/pkg/storage/unified/search/bleve_mappings_golden_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_golden_test.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/storage/unified/search"
+	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
 )
 
 // Run with -update-golden to regenerate the JSON snapshots after an
@@ -23,19 +25,34 @@ import (
 var updateGolden = flag.Bool("update-golden", false, "regenerate bleve mapping golden JSON files")
 
 // TestBleveMappingsGoldenJSON pins the bleve index mapping shape produced by
-// GetBleveMappings to JSON snapshots committed under testdata. The snapshots
-// were generated from origin/main at commit 518fecc6df7 (the last commit
-// before the manifest-driven search-fields work started) so this test serves
-// as a regression guard: any future change that alters the on-disk index
-// mapping shape will fail this test, forcing an explicit review and
-// -update-golden regeneration.
+// GetBleveMappings to JSON snapshots committed under testdata. Each snapshot
+// captures the current on-disk shape; when an intentional change to the
+// mapping ships, regenerate with -update-golden and review the diff. Any
+// unintended drift trips this test.
 //
 // The standard search fields (title, title_phrase, title_ngram, description,
 // tags, folder, ownerReferences, createdBy, managedBy, manager.*, source.*,
-// labels.*, reference.*) are part of the mapping returned by
-// GetBleveMappings even with nil inputs, so the "empty" case below already
+// labels.*, reference.*, created, updated) are part of the mapping returned
+// by GetBleveMappings even with nil inputs, so the "empty" case below already
 // captures their full bleve representation. A separate snapshot of the
 // raw StandardSearchFields column definitions would not add information.
+//
+// The per-kind cases (dashboard, user, team, team_binding,
+// external_group_mapping) call each in-tree builder and feed the resulting
+// DocumentBuilderInfo through GetBleveMappings the same way BuildIndex does
+// in production: when DocumentBuilderInfo.SearchFieldsProvider is non-nil,
+// the test passes it through, exercising the provider-driven mapping path.
+// Dashboard's builder does not set a provider yet, so it continues to drive
+// the mapping from its column-definition-derived Fields. The per-kind
+// snapshots guard against accidental shape drift while the manifest-driven
+// search-fields work moves the source of truth from column definitions to
+// SearchFieldsProvider declarations.
+//
+// Because the IAM builders return a non-nil provider, the user, team,
+// team_binding, and external_group_mapping goldens prove that turning the
+// provider on for these kinds produces the same on-disk mapping shape as
+// the legacy column-definition path. Search server and client can deploy
+// separately, so this byte-identical guarantee matters.
 func TestBleveMappingsGoldenJSON(t *testing.T) {
 	filterableStringFields := func(t *testing.T) resource.SearchableDocumentFields {
 		t.Helper()
@@ -64,9 +81,44 @@ func TestBleveMappingsGoldenJSON(t *testing.T) {
 		return f
 	}
 
+	// builderInfoFor returns the DocumentBuilderInfo for an in-tree kind so
+	// the test can mirror BuildIndex: pass Fields, SearchFieldsProvider,
+	// Group, and Resource through to GetBleveMappings together.
+	builderInfoFor := func(t *testing.T, fn func() (resource.DocumentBuilderInfo, error)) resource.DocumentBuilderInfo {
+		t.Helper()
+		info, err := fn()
+		require.NoError(t, err)
+		return info
+	}
+	dashboardInfo := func(t *testing.T) resource.DocumentBuilderInfo {
+		return builderInfoFor(t, func() (resource.DocumentBuilderInfo, error) { return builders.DashboardBuilder(nil) })
+	}
+	userInfo := func(t *testing.T) resource.DocumentBuilderInfo {
+		return builderInfoFor(t, builders.GetUserBuilder)
+	}
+	teamInfo := func(t *testing.T) resource.DocumentBuilderInfo {
+		return builderInfoFor(t, builders.GetTeamSearchBuilder)
+	}
+	teamBindingInfo := func(t *testing.T) resource.DocumentBuilderInfo {
+		return builderInfoFor(t, builders.GetTeamBindingBuilder)
+	}
+	externalGroupMappingInfo := func(t *testing.T) resource.DocumentBuilderInfo {
+		return builderInfoFor(t, builders.GetExternalGroupMappingBuilder)
+	}
+
 	cases := []struct {
-		name             string
+		name string
+		// builder returns the DocumentBuilderInfo for a real in-tree kind.
+		// When set, the test passes info.Fields, info.SearchFieldsProvider,
+		// info.GroupResource.{Group,Resource} to GetBleveMappings together,
+		// matching production.
+		builder func(t *testing.T) resource.DocumentBuilderInfo
+		// providerExpected, when true, asserts builder() returns a non-nil
+		// SearchFieldsProvider so a future regression in builder wiring
+		// (silently dropping the provider) is caught here.
+		providerExpected bool
 		fields           func(t *testing.T) resource.SearchableDocumentFields
+		provider         func(t *testing.T) (resource.SearchFieldsProvider, string, string)
 		selectableFields []string
 		path             string
 	}{
@@ -84,16 +136,91 @@ func TestBleveMappingsGoldenJSON(t *testing.T) {
 			selectableFields: []string{"spec.title", "spec.description"},
 			path:             "testdata/bleve_mapping_selectable_fields.json",
 		},
+		{
+			// Dashboard's builder does not set SearchFieldsProvider yet (a
+			// follow-up migration will). Until then the mapping is driven by
+			// the column-definition-derived Fields, so providerExpected stays
+			// false and this case keeps the legacy path covered.
+			name:             "dashboard",
+			builder:          dashboardInfo,
+			providerExpected: false,
+			path:             "testdata/bleve_mapping_dashboard.json",
+		},
+		{
+			name:             "user",
+			builder:          userInfo,
+			providerExpected: true,
+			path:             "testdata/bleve_mapping_user.json",
+		},
+		{
+			name:             "team",
+			builder:          teamInfo,
+			providerExpected: true,
+			path:             "testdata/bleve_mapping_team.json",
+		},
+		{
+			name:             "team_binding",
+			builder:          teamBindingInfo,
+			providerExpected: true,
+			path:             "testdata/bleve_mapping_team_binding.json",
+		},
+		{
+			name:             "external_group_mapping",
+			builder:          externalGroupMappingInfo,
+			providerExpected: true,
+			path:             "testdata/bleve_mapping_external_group_mapping.json",
+		},
+		{
+			// Provider-driven path: a kind whose bleve mapping comes from
+			// SearchFieldDefinitions rather than column definitions. Exercises
+			// the type-aware filter rule: string+filter emits an explicit
+			// keyword mapping, non-string+filter falls back to dynamic.
+			name: "provider_driven",
+			provider: func(t *testing.T) (resource.SearchFieldsProvider, string, string) {
+				t.Helper()
+				gvr := schema.GroupVersionResource{Group: "example.test", Version: "v0", Resource: "widgets"}
+				p := resource.NewMapProvider(
+					map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+						gvr: {
+							{Name: "label", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+							{Name: "count", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+							{Name: "active", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+							{Name: "description", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityRetrieve}},
+						},
+					},
+					map[schema.GroupResource]string{
+						gvr.GroupResource(): gvr.Version,
+					},
+				)
+				return p, gvr.Group, gvr.Resource
+			},
+			path: "testdata/bleve_mapping_provider_driven.json",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var fields resource.SearchableDocumentFields
-			if tc.fields != nil {
+			var provider resource.SearchFieldsProvider
+			var group, kindResource string
+
+			switch {
+			case tc.builder != nil:
+				info := tc.builder(t)
+				fields = info.Fields
+				provider = info.SearchFieldsProvider
+				group = info.GroupResource.Group
+				kindResource = info.GroupResource.Resource
+				if tc.providerExpected {
+					require.NotNil(t, provider, "builder for %q must return a non-nil SearchFieldsProvider so the golden exercises the provider-driven mapping path used in production", tc.name)
+				}
+			case tc.provider != nil:
+				provider, group, kindResource = tc.provider(t)
+			case tc.fields != nil:
 				fields = tc.fields(t)
 			}
 
-			mappings, err := search.GetBleveMappings(fields, tc.selectableFields)
+			mappings, err := search.GetBleveMappings(fields, provider, group, kindResource, tc.selectableFields)
 			require.NoError(t, err)
 
 			got, err := json.MarshalIndent(mappings, "", "  ")

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -176,10 +176,13 @@ func TestAddCapabilityFieldMappings_NonTitleFullSet(t *testing.T) {
 }
 
 func TestAddCapabilityFieldMappings_SortWithoutFilter(t *testing.T) {
-	// sort on its own still needs a keyword variant to back DocValues.
+	// sort on its own still needs a keyword variant to back DocValues. Sort
+	// is validated as string-only at provider construction time (the bleve
+	// mapper emits keyword regardless of declared Type, so non-strings
+	// would sort lexically), so this test uses a string-typed field.
 	got := flatMappings(t, resource.SearchFieldDefinition{
 		Name: "lastSeenAt",
-		Type: resource.SearchFieldTypeInt64,
+		Type: resource.SearchFieldTypeString,
 		Capabilities: []resource.SearchCapability{
 			resource.SearchCapabilitySort,
 			resource.SearchCapabilityRetrieve,

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestDocumentMapping(t *testing.T) {
-	mappings, err := search.GetBleveMappings(nil, nil)
+	mappings, err := search.GetBleveMappings(nil, nil, "", "", nil)
 	require.NoError(t, err)
 	data := resource.IndexableDocument{
 		Title:       "title",
@@ -61,7 +61,7 @@ func TestDocumentMapping(t *testing.T) {
 }
 
 func TestTermVectorsAndFreqNorm(t *testing.T) {
-	mappings, err := search.GetBleveMappings(nil, nil)
+	mappings, err := search.GetBleveMappings(nil, nil, "", "", nil)
 	require.NoError(t, err)
 
 	data := resource.IndexableDocument{
@@ -134,7 +134,7 @@ func TestTermVectorsAndFreqNorm(t *testing.T) {
 }
 
 func TestStoredTitleSurvivesMergeAfterDelete(t *testing.T) {
-	mappings, err := search.GetBleveMappings(nil, nil)
+	mappings, err := search.GetBleveMappings(nil, nil, "", "", nil)
 	require.NoError(t, err)
 
 	idx, err := bleve.NewUsing(t.TempDir(), mappings, bleve.Config.DefaultIndexType, bleve.Config.DefaultKVStore, nil)
@@ -202,7 +202,7 @@ func TestStoredTitleSurvivesMergeAfterDelete(t *testing.T) {
 
 func TestDocValuesConfiguration(t *testing.T) {
 	t.Run("DocValuesDynamic is disabled", func(t *testing.T) {
-		mappings, err := search.GetBleveMappings(nil, nil)
+		mappings, err := search.GetBleveMappings(nil, nil, "", "", nil)
 		require.NoError(t, err)
 
 		impl, ok := mappings.(*mapping.IndexMappingImpl)
@@ -211,7 +211,7 @@ func TestDocValuesConfiguration(t *testing.T) {
 	})
 
 	t.Run("only folder and title_phrase have DocValues", func(t *testing.T) {
-		mappings, err := search.GetBleveMappings(nil, nil)
+		mappings, err := search.GetBleveMappings(nil, nil, "", "", nil)
 		require.NoError(t, err)
 
 		data := resource.IndexableDocument{

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1062,7 +1062,7 @@ func withSearchFieldsHashesForKinds(m map[string]string) setupOption {
 }
 
 func TestMemoryBleveIndexCanBeCopiedToFilesystem(t *testing.T) {
-	mapper, err := GetBleveMappings(nil, nil)
+	mapper, err := GetBleveMappings(nil, nil, "", "", nil)
 	require.NoError(t, err)
 
 	buildTime := time.Date(2026, 5, 18, 10, 0, 0, 0, time.UTC)

--- a/pkg/storage/unified/search/builders/external_group_mapping.go
+++ b/pkg/storage/unified/search/builders/external_group_mapping.go
@@ -62,9 +62,10 @@ func GetExternalGroupMappingBuilder() (resource.DocumentBuilderInfo, error) {
 
 	gr := iamv0.ExternalGroupMappingResourceInfo.GroupResource()
 	return resource.DocumentBuilderInfo{
-		GroupResource:    gr,
-		Fields:           fields,
-		Builder:          resource.StandardDocumentBuilderWithFields(iamManifests, provider),
-		SearchFieldsHash: provider.IndexAffectingHash(gr.Group, gr.Resource),
+		GroupResource:        gr,
+		Fields:               fields,
+		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
+		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
+		SearchFieldsProvider: provider,
 	}, nil
 }

--- a/pkg/storage/unified/search/builders/team.go
+++ b/pkg/storage/unified/search/builders/team.go
@@ -92,9 +92,10 @@ func GetTeamSearchBuilder() (resource.DocumentBuilderInfo, error) {
 
 	gr := v0alpha1.TeamResourceInfo.GroupResource()
 	return resource.DocumentBuilderInfo{
-		GroupResource:    gr,
-		Fields:           fields,
-		Builder:          resource.StandardDocumentBuilderWithFields(iamManifests, provider),
-		SearchFieldsHash: provider.IndexAffectingHash(gr.Group, gr.Resource),
+		GroupResource:        gr,
+		Fields:               fields,
+		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
+		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
+		SearchFieldsProvider: provider,
 	}, nil
 }

--- a/pkg/storage/unified/search/builders/teambinding.go
+++ b/pkg/storage/unified/search/builders/teambinding.go
@@ -72,9 +72,10 @@ func GetTeamBindingBuilder() (resource.DocumentBuilderInfo, error) {
 
 	gr := iamv0.TeamBindingResourceInfo.GroupResource()
 	return resource.DocumentBuilderInfo{
-		GroupResource:    gr,
-		Fields:           fields,
-		Builder:          resource.StandardDocumentBuilderWithFields(iamManifests, provider),
-		SearchFieldsHash: provider.IndexAffectingHash(gr.Group, gr.Resource),
+		GroupResource:        gr,
+		Fields:               fields,
+		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
+		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
+		SearchFieldsProvider: provider,
 	}, nil
 }

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -127,9 +127,10 @@ func GetUserBuilder() (resource.DocumentBuilderInfo, error) {
 
 	gr := iamv0.UserResourceInfo.GroupResource()
 	return resource.DocumentBuilderInfo{
-		GroupResource:    gr,
-		Fields:           fields,
-		Builder:          resource.StandardDocumentBuilderWithFields(iamManifests, provider),
-		SearchFieldsHash: provider.IndexAffectingHash(gr.Group, gr.Resource),
+		GroupResource:        gr,
+		Fields:               fields,
+		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
+		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
+		SearchFieldsProvider: provider,
 	}, nil
 }

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -94,6 +94,15 @@ var UserTableColumnDefinitions = map[string]*resourcepb.ResourceTableColumnDefin
 // createdAt mirrors the standard IndexableDocument.Created field into the
 // per-kind fields.* sub-document because the top-level created field has no
 // bleve mapping today. See PR #126405 for context.
+//
+// lastSeenAt (int64) and disabled (boolean) declare SearchCapabilityFilter to
+// record that these fields are intended to be filterable, and to drive the
+// bleve mapping (numeric / boolean under dynamic mapping). End-to-end
+// numeric and boolean equality filters in ResourceSearchRequest are still a
+// follow-up: the query path treats filter values as strings, so a request
+// against these fields would not match a numeric-indexed term yet. No
+// in-tree client filters by lastSeenAt or disabled today, so this is a
+// known gap rather than a rollout concern.
 var UserSearchFields = []resource.SearchFieldDefinition{
 	{Name: USER_EMAIL, Path: "spec.email", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
 	{Name: USER_LOGIN, Path: "spec.login", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},

--- a/pkg/storage/unified/search/disk_cleanup_test.go
+++ b/pkg/storage/unified/search/disk_cleanup_test.go
@@ -127,7 +127,7 @@ func TestRunDiskCleanup_OwnedResource_KeepsCachedActive(t *testing.T) {
 	// its Name() like it would in production. Sibling "20240101-000000" stays
 	// a bare directory — it would normally be a stale leftover that the sweep
 	// is meant to clean up.
-	mapper, err := GetBleveMappings(nil, nil)
+	mapper, err := GetBleveMappings(nil, nil, "", "", nil)
 	require.NoError(t, err)
 	activeDir := filepath.Join(resourceDir, "20240301-120000")
 	activeIdx, err := newBleveIndex(activeDir, mapper, time.Now(), buildVersion, nil, "")
@@ -168,7 +168,7 @@ func TestRunDiskCleanup_UnownedResource_KeepsCachedActive(t *testing.T) {
 	resourceDir := b.getResourceDir(ns)
 	require.NoError(t, os.MkdirAll(resourceDir, 0o750))
 
-	mapper, err := GetBleveMappings(nil, nil)
+	mapper, err := GetBleveMappings(nil, nil, "", "", nil)
 	require.NoError(t, err)
 	activeDir := filepath.Join(resourceDir, "20240301-120000")
 	activeIdx, err := newBleveIndex(activeDir, mapper, time.Now(), buildVersion, nil, "")

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -90,12 +90,14 @@ func NewSearchOptions(
 		// hash check is a no-op rather than a nil deref. Real callers always
 		// pass a non-nil supplier.
 		var searchFieldsHashes map[string]string
+		var searchFieldsProviders map[string]resource.SearchFieldsProvider
 		if docs != nil {
 			builders, err := docs.GetDocumentBuilders()
 			if err != nil {
 				return resource.SearchOptions{}, err
 			}
 			searchFieldsHashes = resource.SearchFieldsHashesForBuilders(builders)
+			searchFieldsProviders = resource.SearchFieldProvidersForBuilders(builders)
 		}
 
 		bleve, err := NewBleveBackend(BleveOptions{
@@ -107,6 +109,7 @@ func NewSearchOptions(
 			IndexMinUpdateInterval:         cfg.IndexMinUpdateInterval,
 			SelectableFieldsForKinds:       resource.SelectableFields(),
 			SearchFieldsHashesForKinds:     searchFieldsHashes,
+			SearchFieldsProvidersForKinds:  searchFieldsProviders,
 			Snapshot:                       snapshot,
 			DiskCleanupInterval:            cfg.DiskIndexCleanupInterval,
 			DiskCleanupGracePeriod:         cfg.DiskIndexCleanupGracePeriod,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
@@ -1,0 +1,302 @@
+{
+  "default_mapping": {
+    "enabled": true,
+    "dynamic": false,
+    "properties": {
+      "_all": {
+        "enabled": false,
+        "dynamic": false
+      },
+      "created": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "createdBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "description": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "fields": {
+        "enabled": true,
+        "dynamic": true,
+        "properties": {
+          "panel_types": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "folder": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "labels": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "managedBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "manager": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "id": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "kind": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "name": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "ownerReferences": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "reference": {
+        "enabled": true,
+        "dynamic": true,
+        "default_analyzer": "keyword"
+      },
+      "selectableFields": {
+        "enabled": true,
+        "dynamic": false
+      },
+      "source": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "checksum": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "path": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "timestampMillis": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true,
+                "include_in_all": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "tags": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "title": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true
+          }
+        ]
+      },
+      "title_ngram": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "title_analyzer",
+            "index": true
+          }
+        ]
+      },
+      "title_phrase": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "updated": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      }
+    }
+  },
+  "type_field": "_type",
+  "default_type": "_default",
+  "default_analyzer": "standard",
+  "default_datetime_parser": "dateTimeOptional",
+  "scoring_model": "bm25",
+  "default_field": "_all",
+  "store_dynamic": true,
+  "index_dynamic": true,
+  "docvalues_dynamic": false,
+  "analysis": {
+    "token_filters": {
+      "ngram_filter": {
+        "max": 10,
+        "min": 3,
+        "type": "ngram"
+      }
+    },
+    "analyzers": {
+      "title_analyzer": {
+        "token_filters": [
+          "ngram_filter",
+          "to_lower",
+          "unique"
+        ],
+        "tokenizer": "whitespace",
+        "type": "custom"
+      }
+    }
+  }
+}

--- a/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
@@ -1,0 +1,315 @@
+{
+  "default_mapping": {
+    "enabled": true,
+    "dynamic": false,
+    "properties": {
+      "_all": {
+        "enabled": false,
+        "dynamic": false
+      },
+      "created": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "createdBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "description": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "fields": {
+        "enabled": true,
+        "dynamic": true,
+        "properties": {
+          "external_group": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "team": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "folder": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "labels": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "managedBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "manager": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "id": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "kind": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "name": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "ownerReferences": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "reference": {
+        "enabled": true,
+        "dynamic": true,
+        "default_analyzer": "keyword"
+      },
+      "selectableFields": {
+        "enabled": true,
+        "dynamic": false
+      },
+      "source": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "checksum": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "path": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "timestampMillis": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true,
+                "include_in_all": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "tags": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "title": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true
+          }
+        ]
+      },
+      "title_ngram": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "title_analyzer",
+            "index": true
+          }
+        ]
+      },
+      "title_phrase": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "updated": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      }
+    }
+  },
+  "type_field": "_type",
+  "default_type": "_default",
+  "default_analyzer": "standard",
+  "default_datetime_parser": "dateTimeOptional",
+  "scoring_model": "bm25",
+  "default_field": "_all",
+  "store_dynamic": true,
+  "index_dynamic": true,
+  "docvalues_dynamic": false,
+  "analysis": {
+    "token_filters": {
+      "ngram_filter": {
+        "max": 10,
+        "min": 3,
+        "type": "ngram"
+      }
+    },
+    "analyzers": {
+      "title_analyzer": {
+        "token_filters": [
+          "ngram_filter",
+          "to_lower",
+          "unique"
+        ],
+        "tokenizer": "whitespace",
+        "type": "custom"
+      }
+    }
+  }
+}

--- a/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
@@ -1,0 +1,314 @@
+{
+  "default_mapping": {
+    "enabled": true,
+    "dynamic": false,
+    "properties": {
+      "_all": {
+        "enabled": false,
+        "dynamic": false
+      },
+      "created": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "createdBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "description": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "fields": {
+        "enabled": true,
+        "dynamic": true,
+        "properties": {
+          "description": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "standard",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "label": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "folder": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "labels": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "managedBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "manager": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "id": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "kind": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "name": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "ownerReferences": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "reference": {
+        "enabled": true,
+        "dynamic": true,
+        "default_analyzer": "keyword"
+      },
+      "selectableFields": {
+        "enabled": true,
+        "dynamic": false
+      },
+      "source": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "checksum": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "path": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "timestampMillis": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true,
+                "include_in_all": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "tags": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "title": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true
+          }
+        ]
+      },
+      "title_ngram": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "title_analyzer",
+            "index": true
+          }
+        ]
+      },
+      "title_phrase": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "updated": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      }
+    }
+  },
+  "type_field": "_type",
+  "default_type": "_default",
+  "default_analyzer": "standard",
+  "default_datetime_parser": "dateTimeOptional",
+  "scoring_model": "bm25",
+  "default_field": "_all",
+  "store_dynamic": true,
+  "index_dynamic": true,
+  "docvalues_dynamic": false,
+  "analysis": {
+    "token_filters": {
+      "ngram_filter": {
+        "max": 10,
+        "min": 3,
+        "type": "ngram"
+      }
+    },
+    "analyzers": {
+      "title_analyzer": {
+        "token_filters": [
+          "ngram_filter",
+          "to_lower",
+          "unique"
+        ],
+        "tokenizer": "whitespace",
+        "type": "custom"
+      }
+    }
+  }
+}

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team.json
@@ -1,0 +1,315 @@
+{
+  "default_mapping": {
+    "enabled": true,
+    "dynamic": false,
+    "properties": {
+      "_all": {
+        "enabled": false,
+        "dynamic": false
+      },
+      "created": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "createdBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "description": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "fields": {
+        "enabled": true,
+        "dynamic": true,
+        "properties": {
+          "externalGroups": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "members": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "folder": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "labels": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "managedBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "manager": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "id": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "kind": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "name": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "ownerReferences": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "reference": {
+        "enabled": true,
+        "dynamic": true,
+        "default_analyzer": "keyword"
+      },
+      "selectableFields": {
+        "enabled": true,
+        "dynamic": false
+      },
+      "source": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "checksum": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "path": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "timestampMillis": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true,
+                "include_in_all": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "tags": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "title": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true
+          }
+        ]
+      },
+      "title_ngram": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "title_analyzer",
+            "index": true
+          }
+        ]
+      },
+      "title_phrase": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "updated": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      }
+    }
+  },
+  "type_field": "_type",
+  "default_type": "_default",
+  "default_analyzer": "standard",
+  "default_datetime_parser": "dateTimeOptional",
+  "scoring_model": "bm25",
+  "default_field": "_all",
+  "store_dynamic": true,
+  "index_dynamic": true,
+  "docvalues_dynamic": false,
+  "analysis": {
+    "token_filters": {
+      "ngram_filter": {
+        "max": 10,
+        "min": 3,
+        "type": "ngram"
+      }
+    },
+    "analyzers": {
+      "title_analyzer": {
+        "token_filters": [
+          "ngram_filter",
+          "to_lower",
+          "unique"
+        ],
+        "tokenizer": "whitespace",
+        "type": "custom"
+      }
+    }
+  }
+}

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
@@ -1,0 +1,315 @@
+{
+  "default_mapping": {
+    "enabled": true,
+    "dynamic": false,
+    "properties": {
+      "_all": {
+        "enabled": false,
+        "dynamic": false
+      },
+      "created": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "createdBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "description": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "fields": {
+        "enabled": true,
+        "dynamic": true,
+        "properties": {
+          "subject": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "team": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "folder": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "labels": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "managedBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "manager": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "id": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "kind": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "name": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "ownerReferences": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "reference": {
+        "enabled": true,
+        "dynamic": true,
+        "default_analyzer": "keyword"
+      },
+      "selectableFields": {
+        "enabled": true,
+        "dynamic": false
+      },
+      "source": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "checksum": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "path": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "timestampMillis": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true,
+                "include_in_all": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "tags": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "title": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true
+          }
+        ]
+      },
+      "title_ngram": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "title_analyzer",
+            "index": true
+          }
+        ]
+      },
+      "title_phrase": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "updated": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      }
+    }
+  },
+  "type_field": "_type",
+  "default_type": "_default",
+  "default_analyzer": "standard",
+  "default_datetime_parser": "dateTimeOptional",
+  "scoring_model": "bm25",
+  "default_field": "_all",
+  "store_dynamic": true,
+  "index_dynamic": true,
+  "docvalues_dynamic": false,
+  "analysis": {
+    "token_filters": {
+      "ngram_filter": {
+        "max": 10,
+        "min": 3,
+        "type": "ngram"
+      }
+    },
+    "analyzers": {
+      "title_analyzer": {
+        "token_filters": [
+          "ngram_filter",
+          "to_lower",
+          "unique"
+        ],
+        "tokenizer": "whitespace",
+        "type": "custom"
+      }
+    }
+  }
+}

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -1,0 +1,328 @@
+{
+  "default_mapping": {
+    "enabled": true,
+    "dynamic": false,
+    "properties": {
+      "_all": {
+        "enabled": false,
+        "dynamic": false
+      },
+      "created": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "createdBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "description": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "fields": {
+        "enabled": true,
+        "dynamic": true,
+        "properties": {
+          "email": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "login": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "role": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "folder": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "labels": {
+        "enabled": true,
+        "dynamic": true
+      },
+      "managedBy": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "manager": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "id": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "kind": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "name": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "ownerReferences": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "reference": {
+        "enabled": true,
+        "dynamic": true,
+        "default_analyzer": "keyword"
+      },
+      "selectableFields": {
+        "enabled": true,
+        "dynamic": false
+      },
+      "source": {
+        "enabled": true,
+        "dynamic": false,
+        "properties": {
+          "checksum": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "path": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "timestampMillis": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true,
+                "include_in_all": true,
+                "skip_freq_norm": true
+              }
+            ]
+          }
+        }
+      },
+      "tags": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "title": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "standard",
+            "store": true,
+            "index": true
+          }
+        ]
+      },
+      "title_ngram": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "title_analyzer",
+            "index": true
+          }
+        ]
+      },
+      "title_phrase": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "index": true,
+            "docvalues": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
+      "updated": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "text",
+            "analyzer": "keyword",
+            "store": true,
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      }
+    }
+  },
+  "type_field": "_type",
+  "default_type": "_default",
+  "default_analyzer": "standard",
+  "default_datetime_parser": "dateTimeOptional",
+  "scoring_model": "bm25",
+  "default_field": "_all",
+  "store_dynamic": true,
+  "index_dynamic": true,
+  "docvalues_dynamic": false,
+  "analysis": {
+    "token_filters": {
+      "ngram_filter": {
+        "max": 10,
+        "min": 3,
+        "type": "ngram"
+      }
+    },
+    "analyzers": {
+      "title_analyzer": {
+        "token_filters": [
+          "ngram_filter",
+          "to_lower",
+          "unique"
+        ],
+        "tokenizer": "whitespace",
+        "type": "custom"
+      }
+    }
+  }
+}


### PR DESCRIPTION
After this change, `SearchFieldsProvider` declarations drive the per-kind bleve mapping. Until now they only drove extraction and the rebuild-trigger hash; the bleve mapping was still built from the legacy column-definition list, which silently drops the `filter` capability for non-string fields. So a kind that declares `[filter, retrieve]` on an int64 field has the declaration silently ignored by the mapper. With the provider now the source of truth for extraction, hash, *and* mapping, declarations flow end-to-end. Migrating other kinds (next: dashboards) becomes a small follow-up rather than a duplication exercise.

The bleve mapper becomes type-aware: an explicit keyword field is emitted only for string fields, and only where bleve's dynamic mapping isn't already running. The per-kind `fields.*` sub-document is dynamic, so non-string fields like `lastSeenAt` (int64) and `disabled` (boolean) are indexed by bleve as numbers or booleans — range queries and numeric sort keep working. Top-level standard fields use a static mapping, so `created` and `updated` still get an explicit keyword. The validator gains a related rule rejecting `text`/`partial`/`facet` on non-string fields. `SearchFieldsProvider.Fields(gvr)` with an empty Version now returns the union of declarations across every registered version, deduplicated by name with the preferred version winning on collisions; a multi-version kind's mapping declares every field any served version emits.

No on-disk mapping changes for any registered kind. Five new bleve mapping golden files (dashboard, user, team, team binding, external group mapping) plus a new provider-driven case pin the output; all five existing-kind goldens are byte-identical with main.
