### PR TITLE
MT Annotations: Add permission checks to /tags

### DIFF
--- a/pkg/registry/apps/annotation/authz.go
+++ b/pkg/registry/apps/annotation/authz.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	authtypes "github.com/grafana/authlib/types"
-	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -19,19 +18,6 @@ import (
 type DashboardFolderResolver interface {
 	ResolveFolder(ctx context.Context, namespace, dashboardUID string) (string, error)
 }
-
-// errutil errors render with the correct HTTP status
-var (
-	errReadOrgAnnotationsUnauthorized = errutil.Unauthorized(
-		"annotation.tags.unauthorized",
-		errutil.WithPublicMessage("authentication is required to read annotations"),
-	)
-	errReadOrgAnnotationsForbidden = errutil.Forbidden(
-		"annotation.tags.forbidden",
-		errutil.WithPublicMessage("requires the annotations:read permission with the organization scope"),
-	)
-	errReadOrgAnnotationsAuthz = errutil.Internal("annotation.tags.authzError")
-)
 
 // GetAuthorizer returns the authorizer for the annotation app.
 func (a *AppInstaller) GetAuthorizer() authorizer.Authorizer {
@@ -148,7 +134,7 @@ func resolveDashboardFolders(ctx context.Context, folderResolver DashboardFolder
 func authorizeReadOrganizationAnnotations(ctx context.Context, accessClient authtypes.AccessClient, namespace string) error {
 	authInfo, ok := authtypes.AuthInfoFrom(ctx)
 	if !ok {
-		return errReadOrgAnnotationsUnauthorized.Errorf("no identity found for request")
+		return apierrors.NewUnauthorized("no identity found for request")
 	}
 
 	resp, err := accessClient.Check(ctx, authInfo, authtypes.CheckRequest{
@@ -159,10 +145,10 @@ func authorizeReadOrganizationAnnotations(ctx context.Context, accessClient auth
 		Verb:      utils.VerbList,
 	}, "") // organization-scoped annotations have no parent folder
 	if err != nil {
-		return errReadOrgAnnotationsAuthz.Errorf("annotation authz check failed: %w", err)
+		return apierrors.NewInternalError(fmt.Errorf("annotation authz check failed: %w", err))
 	}
 	if !resp.Allowed {
-		return errReadOrgAnnotationsForbidden.Errorf("requires the annotations:read permission with the organization scope")
+		return apierrors.NewForbidden(annotationGR, "tags", fmt.Errorf("requires the annotations:read permission with the organization scope"))
 	}
 	return nil
 }

--- a/pkg/registry/apps/annotation/authz.go
+++ b/pkg/registry/apps/annotation/authz.go
@@ -162,7 +162,7 @@ func authorizeReadOrganizationAnnotations(ctx context.Context, accessClient auth
 		return errReadOrgAnnotationsAuthz.Errorf("annotation authz check failed: %w", err)
 	}
 	if !resp.Allowed {
-		return errReadOrgAnnotationsForbidden.Errorf("user is not allowed to read organization annotations")
+		return errReadOrgAnnotationsForbidden.Errorf("requires the annotations:read permission with the organization scope")
 	}
 	return nil
 }

--- a/pkg/registry/apps/annotation/authz.go
+++ b/pkg/registry/apps/annotation/authz.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	authtypes "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -18,6 +19,19 @@ import (
 type DashboardFolderResolver interface {
 	ResolveFolder(ctx context.Context, namespace, dashboardUID string) (string, error)
 }
+
+// errutil errors render with the correct HTTP status
+var (
+	errReadOrgAnnotationsUnauthorized = errutil.Unauthorized(
+		"annotation.tags.unauthorized",
+		errutil.WithPublicMessage("authentication is required to read annotations"),
+	)
+	errReadOrgAnnotationsForbidden = errutil.Forbidden(
+		"annotation.tags.forbidden",
+		errutil.WithPublicMessage("requires the annotations:read permission with the organization scope"),
+	)
+	errReadOrgAnnotationsAuthz = errutil.Internal("annotation.tags.authzError")
+)
 
 // GetAuthorizer returns the authorizer for the annotation app.
 func (a *AppInstaller) GetAuthorizer() authorizer.Authorizer {
@@ -134,7 +148,7 @@ func resolveDashboardFolders(ctx context.Context, folderResolver DashboardFolder
 func authorizeReadOrganizationAnnotations(ctx context.Context, accessClient authtypes.AccessClient, namespace string) error {
 	authInfo, ok := authtypes.AuthInfoFrom(ctx)
 	if !ok {
-		return apierrors.NewUnauthorized("no identity found for request")
+		return errReadOrgAnnotationsUnauthorized.Errorf("no identity found for request")
 	}
 
 	resp, err := accessClient.Check(ctx, authInfo, authtypes.CheckRequest{
@@ -145,10 +159,10 @@ func authorizeReadOrganizationAnnotations(ctx context.Context, accessClient auth
 		Verb:      utils.VerbList,
 	}, "") // organization-scoped annotations have no parent folder
 	if err != nil {
-		return apierrors.NewInternalError(fmt.Errorf("annotation authz check failed: %w", err))
+		return errReadOrgAnnotationsAuthz.Errorf("annotation authz check failed: %w", err)
 	}
 	if !resp.Allowed {
-		return apierrors.NewForbidden(annotationGR, "tags", fmt.Errorf("requires the annotations:read permission with the organization scope"))
+		return errReadOrgAnnotationsForbidden.Errorf("user is not allowed to read organization annotations")
 	}
 	return nil
 }

--- a/pkg/registry/apps/annotation/authz.go
+++ b/pkg/registry/apps/annotation/authz.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	authtypes "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
@@ -127,4 +128,31 @@ func resolveDashboardFolders(ctx context.Context, folderResolver DashboardFolder
 		out[uid] = folder
 	}
 	return out, nil
+}
+
+// authorizeReadOrgAnnotations gates org-wide annotation reads such as the tags
+// aggregate. Tags are an org-wide aggregate with no per-dashboard scope (the tag
+// table carries no scope; only the annotation does), so this mirrors the
+// org-level annotations:read gate on the legacy /api/annotations/tags route
+// rather than the per-annotation checks used for get/list/search.
+func authorizeReadOrgAnnotations(ctx context.Context, accessClient authtypes.AccessClient, namespace string) error {
+	authInfo, ok := authtypes.AuthInfoFrom(ctx)
+	if !ok {
+		return apierrors.NewUnauthorized("no identity found for request")
+	}
+
+	resp, err := accessClient.Check(ctx, authInfo, authtypes.CheckRequest{
+		Namespace: namespace,
+		Group:     "annotation.grafana.app",
+		Resource:  "annotations",
+		Name:      "organization",
+		Verb:      utils.VerbList,
+	}, "") // organization-scoped annotations have no parent folder
+	if err != nil {
+		return apierrors.NewInternalError(fmt.Errorf("annotation authz check failed: %w", err))
+	}
+	if !resp.Allowed {
+		return apierrors.NewForbidden(annotationGR, "tags", fmt.Errorf("requires the annotations:read permission with the organization scope"))
+	}
+	return nil
 }

--- a/pkg/registry/apps/annotation/authz.go
+++ b/pkg/registry/apps/annotation/authz.go
@@ -130,12 +130,8 @@ func resolveDashboardFolders(ctx context.Context, folderResolver DashboardFolder
 	return out, nil
 }
 
-// authorizeReadOrgAnnotations gates org-wide annotation reads such as the tags
-// aggregate. Tags are an org-wide aggregate with no per-dashboard scope (the tag
-// table carries no scope; only the annotation does), so this mirrors the
-// org-level annotations:read gate on the legacy /api/annotations/tags route
-// rather than the per-annotation checks used for get/list/search.
-func authorizeReadOrgAnnotations(ctx context.Context, accessClient authtypes.AccessClient, namespace string) error {
+// authorizeReadOrganizationAnnotations gates organization-wide annotation reads such as the tags aggregate.
+func authorizeReadOrganizationAnnotations(ctx context.Context, accessClient authtypes.AccessClient, namespace string) error {
 	authInfo, ok := authtypes.AuthInfoFrom(ctx)
 	if !ok {
 		return apierrors.NewUnauthorized("no identity found for request")

--- a/pkg/registry/apps/annotation/authz_test.go
+++ b/pkg/registry/apps/annotation/authz_test.go
@@ -366,6 +366,7 @@ func TestAuthorizeReadOrganizationAnnotations(t *testing.T) {
 		err := authorizeReadOrganizationAnnotations(ctx, ac, "default")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, errReadOrgAnnotationsForbidden), "expected Forbidden, got %v", err)
+		assert.ErrorContains(t, err, "requires the annotations:read permission with the organization scope")
 	})
 
 	t.Run("unauthorized when no identity is present", func(t *testing.T) {

--- a/pkg/registry/apps/annotation/authz_test.go
+++ b/pkg/registry/apps/annotation/authz_test.go
@@ -347,7 +347,7 @@ func TestK8sRESTAdapter_ListFiltersUnauthorized(t *testing.T) {
 	})
 }
 
-func TestAuthorizeReadOrgAnnotations(t *testing.T) {
+func TestAuthorizeReadOrganizationAnnotations(t *testing.T) {
 	ctx := identity.WithServiceIdentityContext(t.Context(), 1)
 
 	t.Run("allows when org annotation read is permitted", func(t *testing.T) {
@@ -357,19 +357,19 @@ func TestAuthorizeReadOrgAnnotations(t *testing.T) {
 				item.Name == "organization" &&
 				item.Verb == utils.VerbList
 		}}
-		require.NoError(t, authorizeReadOrgAnnotations(ctx, ac, "default"))
+		require.NoError(t, authorizeReadOrganizationAnnotations(ctx, ac, "default"))
 	})
 
 	t.Run("forbids when org annotation read is denied", func(t *testing.T) {
 		ac := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return false }}
-		err := authorizeReadOrgAnnotations(ctx, ac, "default")
+		err := authorizeReadOrganizationAnnotations(ctx, ac, "default")
 		require.Error(t, err)
 		assert.True(t, apierrors.IsForbidden(err), "expected Forbidden, got %v", err)
 	})
 
 	t.Run("unauthorized when no identity is present", func(t *testing.T) {
 		ac := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return true }}
-		err := authorizeReadOrgAnnotations(t.Context(), ac, "default")
+		err := authorizeReadOrganizationAnnotations(t.Context(), ac, "default")
 		require.Error(t, err)
 		assert.True(t, apierrors.IsUnauthorized(err), "expected Unauthorized, got %v", err)
 	})

--- a/pkg/registry/apps/annotation/authz_test.go
+++ b/pkg/registry/apps/annotation/authz_test.go
@@ -2,7 +2,6 @@ package annotation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -365,7 +364,7 @@ func TestAuthorizeReadOrganizationAnnotations(t *testing.T) {
 		ac := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return false }}
 		err := authorizeReadOrganizationAnnotations(ctx, ac, "default")
 		require.Error(t, err)
-		assert.True(t, errors.Is(err, errReadOrgAnnotationsForbidden), "expected Forbidden, got %v", err)
+		assert.True(t, apierrors.IsForbidden(err), "expected Forbidden, got %v", err)
 		assert.ErrorContains(t, err, "requires the annotations:read permission with the organization scope")
 	})
 
@@ -373,6 +372,6 @@ func TestAuthorizeReadOrganizationAnnotations(t *testing.T) {
 		ac := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return true }}
 		err := authorizeReadOrganizationAnnotations(t.Context(), ac, "default")
 		require.Error(t, err)
-		assert.True(t, errors.Is(err, errReadOrgAnnotationsUnauthorized), "expected Unauthorized, got %v", err)
+		assert.True(t, apierrors.IsUnauthorized(err), "expected Unauthorized, got %v", err)
 	})
 }

--- a/pkg/registry/apps/annotation/authz_test.go
+++ b/pkg/registry/apps/annotation/authz_test.go
@@ -2,6 +2,7 @@ package annotation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -364,13 +365,13 @@ func TestAuthorizeReadOrganizationAnnotations(t *testing.T) {
 		ac := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return false }}
 		err := authorizeReadOrganizationAnnotations(ctx, ac, "default")
 		require.Error(t, err)
-		assert.True(t, apierrors.IsForbidden(err), "expected Forbidden, got %v", err)
+		assert.True(t, errors.Is(err, errReadOrgAnnotationsForbidden), "expected Forbidden, got %v", err)
 	})
 
 	t.Run("unauthorized when no identity is present", func(t *testing.T) {
 		ac := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return true }}
 		err := authorizeReadOrganizationAnnotations(t.Context(), ac, "default")
 		require.Error(t, err)
-		assert.True(t, apierrors.IsUnauthorized(err), "expected Unauthorized, got %v", err)
+		assert.True(t, errors.Is(err, errReadOrgAnnotationsUnauthorized), "expected Unauthorized, got %v", err)
 	})
 }

--- a/pkg/registry/apps/annotation/authz_test.go
+++ b/pkg/registry/apps/annotation/authz_test.go
@@ -346,3 +346,31 @@ func TestK8sRESTAdapter_ListFiltersUnauthorized(t *testing.T) {
 		assert.Empty(t, list.Items)
 	})
 }
+
+func TestAuthorizeReadOrgAnnotations(t *testing.T) {
+	ctx := identity.WithServiceIdentityContext(t.Context(), 1)
+
+	t.Run("allows when org annotation read is permitted", func(t *testing.T) {
+		ac := &fakeAccessClient{fn: func(item authtypes.BatchCheckItem) bool {
+			return item.Group == "annotation.grafana.app" &&
+				item.Resource == "annotations" &&
+				item.Name == "organization" &&
+				item.Verb == utils.VerbList
+		}}
+		require.NoError(t, authorizeReadOrgAnnotations(ctx, ac, "default"))
+	})
+
+	t.Run("forbids when org annotation read is denied", func(t *testing.T) {
+		ac := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return false }}
+		err := authorizeReadOrgAnnotations(ctx, ac, "default")
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err), "expected Forbidden, got %v", err)
+	})
+
+	t.Run("unauthorized when no identity is present", func(t *testing.T) {
+		ac := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return true }}
+		err := authorizeReadOrgAnnotations(t.Context(), ac, "default")
+		require.Error(t, err)
+		assert.True(t, apierrors.IsUnauthorized(err), "expected Unauthorized, got %v", err)
+	})
+}

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -135,7 +135,7 @@ func NewAppInstaller(
 		// We could consider combining the TagProvider with the Store interface to avoid this type assertion?
 		return nil, fmt.Errorf("store does not implement TagProvider, cannot serve tags API")
 	}
-	tagHandler := newTagsHandler(tagProvider, installer.tracer, installer.metrics, logger)
+	tagHandler := newTagsHandler(tagProvider, accessClient, installer.tracer, installer.metrics, logger)
 
 	// Create the search handler
 	searchHandler := newSearchHandler(instrumentedStore, accessClient, folderResolver, installer.tracer, installer.metrics, logger)

--- a/pkg/registry/apps/annotation/tags_handler.go
+++ b/pkg/registry/apps/annotation/tags_handler.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/util/errhttp"
 )
 
 type TagResponse struct {
@@ -40,10 +41,9 @@ func newTagsHandler(
 		start := time.Now()
 		defer func() { observe(ctx, logger, metrics.RequestDuration, "tags", start, err) }()
 
-		// Tags are an org-wide aggregate, so gate the request on org-level
-		// annotation read before exposing any tag metadata.
-		if err = authorizeReadOrganizationAnnotations(ctx, accessClient, namespace); err != nil {
-			return err
+		if authzErr := authorizeReadOrganizationAnnotations(ctx, accessClient, namespace); authzErr != nil {
+			errhttp.Write(ctx, authzErr, writer)
+			return nil
 		}
 
 		opts := TagListOptions{}

--- a/pkg/registry/apps/annotation/tags_handler.go
+++ b/pkg/registry/apps/annotation/tags_handler.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/util/errhttp"
 )
 
 type TagResponse struct {
@@ -41,9 +40,10 @@ func newTagsHandler(
 		start := time.Now()
 		defer func() { observe(ctx, logger, metrics.RequestDuration, "tags", start, err) }()
 
-		if authzErr := authorizeReadOrganizationAnnotations(ctx, accessClient, namespace); authzErr != nil {
-			errhttp.Write(ctx, authzErr, writer)
-			return nil
+		// Tags are an org-wide aggregate, so gate the request on org-level
+		// annotation read before exposing any tag metadata.
+		if err = authorizeReadOrganizationAnnotations(ctx, accessClient, namespace); err != nil {
+			return err
 		}
 
 		opts := TagListOptions{}

--- a/pkg/registry/apps/annotation/tags_handler.go
+++ b/pkg/registry/apps/annotation/tags_handler.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	authtypes "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/app"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -24,6 +25,7 @@ type TagItem struct {
 
 func newTagsHandler(
 	tagProvider TagProvider,
+	accessClient authtypes.AccessClient,
 	tracer trace.Tracer,
 	metrics *Metrics,
 	logger log.Logger,
@@ -37,6 +39,12 @@ func newTagsHandler(
 		defer span.End()
 		start := time.Now()
 		defer func() { observe(ctx, logger, metrics.RequestDuration, "tags", start, err) }()
+
+		// Tags are an org-wide aggregate, so gate the request on org-level
+		// annotation read before exposing any tag metadata.
+		if err = authorizeReadOrgAnnotations(ctx, accessClient, namespace); err != nil {
+			return err
+		}
 
 		opts := TagListOptions{}
 		queryParams := request.URL.Query()

--- a/pkg/registry/apps/annotation/tags_handler.go
+++ b/pkg/registry/apps/annotation/tags_handler.go
@@ -42,7 +42,7 @@ func newTagsHandler(
 
 		// Tags are an org-wide aggregate, so gate the request on org-level
 		// annotation read before exposing any tag metadata.
-		if err = authorizeReadOrgAnnotations(ctx, accessClient, namespace); err != nil {
+		if err = authorizeReadOrganizationAnnotations(ctx, accessClient, namespace); err != nil {
 			return err
 		}
 

--- a/pkg/registry/apps/annotation/tags_handler_test.go
+++ b/pkg/registry/apps/annotation/tags_handler_test.go
@@ -234,69 +234,57 @@ func TestTagsHandlerAuthorization(t *testing.T) {
 	_, err := store.Create(setupCtx, anno)
 	require.NoError(t, err)
 
+	newRequest := func() (*app.CustomRouteRequest, *mockResponseWriter) {
+		u := &url.URL{
+			Scheme: "http",
+			Host:   "localhost",
+			Path:   "/apis/annotation.grafana.app/v0alpha1/namespaces/" + metav1.NamespaceDefault + "/tags",
+		}
+		req := &app.CustomRouteRequest{
+			ResourceIdentifier: resource.FullIdentifier{Namespace: metav1.NamespaceDefault},
+			URL:                u,
+			Method:             "GET",
+		}
+		writer := &mockResponseWriter{header: make(http.Header), body: &bytes.Buffer{}}
+		return req, writer
+	}
+
 	ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), metav1.NamespaceDefault)
 
-	tests := []struct {
-		name string
-		// allowedScope is the annotation scope (the BatchCheckItem.Name) the caller
-		// is authorized to read. The handler only checks the "organization" scope,
-		// so a caller authorized solely for "dashboard" is denied.
-		allowedScope  string
-		expectAllowed bool
-	}{
-		{
-			name:          "allows callers with organization annotation read",
-			allowedScope:  "organization",
-			expectAllowed: true,
-		},
-		{
-			name:          "denies callers with only dashboard annotation read",
-			allowedScope:  "dashboard",
-			expectAllowed: false,
-		},
-	}
+	t.Run("denies callers without organization annotation read", func(t *testing.T) {
+		denyAll := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return false }}
+		handler := newTagsHandler(store.(TagProvider), denyAll, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			accessClient := &fakeAccessClient{fn: func(item authtypes.BatchCheckItem) bool {
-				return item.Group == "annotation.grafana.app" &&
-					item.Resource == "annotations" &&
-					item.Name == tt.allowedScope &&
-					item.Verb == utils.VerbList
-			}}
-			handler := newTagsHandler(store.(TagProvider), accessClient, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
+		req, writer := newRequest()
+		err := handler(ctx, writer, req)
 
-			u := &url.URL{
-				Scheme: "http",
-				Host:   "localhost",
-				Path:   "/apis/annotation.grafana.app/v0alpha1/namespaces/" + metav1.NamespaceDefault + "/tags",
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err), "expected Forbidden, got %v", err)
+		assert.NotContains(t, writer.body.String(), "secret-canary", "tag metadata must not be leaked on denial")
+	})
+
+	t.Run("allows callers with organization annotation read", func(t *testing.T) {
+		// Only authorize the org-scoped annotation read check the handler is expected to make.
+		orgReader := &fakeAccessClient{fn: func(item authtypes.BatchCheckItem) bool {
+			return item.Group == "annotation.grafana.app" &&
+				item.Resource == "annotations" &&
+				item.Name == "organization" &&
+				item.Verb == utils.VerbList
+		}}
+		handler := newTagsHandler(store.(TagProvider), orgReader, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
+
+		req, writer := newRequest()
+		err := handler(ctx, writer, req)
+
+		require.NoError(t, err)
+		var result TagResponse
+		require.NoError(t, json.Unmarshal(writer.body.Bytes(), &result))
+		found := false
+		for _, tag := range result.Tags {
+			if tag.Tag == "secret-canary" {
+				found = true
 			}
-			req := &app.CustomRouteRequest{
-				ResourceIdentifier: resource.FullIdentifier{Namespace: metav1.NamespaceDefault},
-				URL:                u,
-				Method:             "GET",
-			}
-			writer := &mockResponseWriter{header: make(http.Header), body: &bytes.Buffer{}}
-
-			err := handler(ctx, writer, req)
-
-			if !tt.expectAllowed {
-				require.Error(t, err)
-				assert.True(t, apierrors.IsForbidden(err), "expected Forbidden, got %v", err)
-				assert.NotContains(t, writer.body.String(), "secret-canary", "tag metadata must not be leaked on denial")
-				return
-			}
-
-			require.NoError(t, err)
-			var result TagResponse
-			require.NoError(t, json.Unmarshal(writer.body.Bytes(), &result))
-			found := false
-			for _, tag := range result.Tags {
-				if tag.Tag == "secret-canary" {
-					found = true
-				}
-			}
-			assert.True(t, found, "expected tags to be returned for an authorized org reader")
-		})
-	}
+		}
+		assert.True(t, found, "expected tags to be returned for an authorized org reader")
+	})
 }

--- a/pkg/registry/apps/annotation/tags_handler_test.go
+++ b/pkg/registry/apps/annotation/tags_handler_test.go
@@ -7,14 +7,17 @@ import (
 	"net/url"
 	"testing"
 
+	authtypes "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/grafana/grafana-app-sdk/resource"
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 )
@@ -67,7 +70,8 @@ func TestTagsHandler(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	handler := newTagsHandler(store.(TagProvider), tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
+	allowAll := &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return true }}
+	handler := newTagsHandler(store.(TagProvider), allowAll, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
 
 	tests := []struct {
 		name         string
@@ -216,6 +220,83 @@ func TestTagsHandler(t *testing.T) {
 
 				assert.Equal(t, tt.expectedTags, actualTags, "Tags and counts should match expected values")
 			}
+		})
+	}
+}
+
+func TestTagsHandlerAuthorization(t *testing.T) {
+	store := NewMemoryStore()
+	anno := &annotationV0.Annotation{
+		ObjectMeta: metav1.ObjectMeta{Name: "a-1", Namespace: metav1.NamespaceDefault},
+		Spec:       annotationV0.AnnotationSpec{Text: "test", Time: 1000, Tags: []string{"secret-canary"}},
+	}
+	setupCtx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), anno.Namespace)
+	_, err := store.Create(setupCtx, anno)
+	require.NoError(t, err)
+
+	ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), metav1.NamespaceDefault)
+
+	tests := []struct {
+		name string
+		// allowedScope is the annotation scope (the BatchCheckItem.Name) the caller
+		// is authorized to read. The handler only checks the "organization" scope,
+		// so a caller authorized solely for "dashboard" is denied.
+		allowedScope  string
+		expectAllowed bool
+	}{
+		{
+			name:          "allows callers with organization annotation read",
+			allowedScope:  "organization",
+			expectAllowed: true,
+		},
+		{
+			name:          "denies callers with only dashboard annotation read",
+			allowedScope:  "dashboard",
+			expectAllowed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessClient := &fakeAccessClient{fn: func(item authtypes.BatchCheckItem) bool {
+				return item.Group == "annotation.grafana.app" &&
+					item.Resource == "annotations" &&
+					item.Name == tt.allowedScope &&
+					item.Verb == utils.VerbList
+			}}
+			handler := newTagsHandler(store.(TagProvider), accessClient, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
+
+			u := &url.URL{
+				Scheme: "http",
+				Host:   "localhost",
+				Path:   "/apis/annotation.grafana.app/v0alpha1/namespaces/" + metav1.NamespaceDefault + "/tags",
+			}
+			req := &app.CustomRouteRequest{
+				ResourceIdentifier: resource.FullIdentifier{Namespace: metav1.NamespaceDefault},
+				URL:                u,
+				Method:             "GET",
+			}
+			writer := &mockResponseWriter{header: make(http.Header), body: &bytes.Buffer{}}
+
+			err := handler(ctx, writer, req)
+
+			if !tt.expectAllowed {
+				require.Error(t, err)
+				assert.True(t, apierrors.IsForbidden(err), "expected Forbidden, got %v", err)
+				assert.NotContains(t, writer.body.String(), "secret-canary", "tag metadata must not be leaked on denial")
+				return
+			}
+
+			require.NoError(t, err)
+			var result TagResponse
+			require.NoError(t, json.Unmarshal(writer.body.Bytes(), &result))
+			found := false
+			for _, tag := range result.Tags {
+				if tag.Tag == "secret-canary" {
+					found = true
+				}
+			}
+			assert.True(t, found, "expected tags to be returned for an authorized org reader")
 		})
 	}
 }

--- a/pkg/registry/apps/annotation/tags_handler_test.go
+++ b/pkg/registry/apps/annotation/tags_handler_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 )
@@ -256,10 +255,12 @@ func TestTagsHandlerAuthorization(t *testing.T) {
 		handler := newTagsHandler(store.(TagProvider), denyAll, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
 
 		req, writer := newRequest()
+		// The handler writes the denial status to the response itself and returns nil,
+		// because a returned error would be rendered as a generic 500.
 		err := handler(ctx, writer, req)
 
-		require.Error(t, err)
-		assert.True(t, apierrors.IsForbidden(err), "expected Forbidden, got %v", err)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, writer.code)
 		assert.NotContains(t, writer.body.String(), "secret-canary", "tag metadata must not be leaked on denial")
 	})
 

--- a/pkg/registry/apps/annotation/tags_handler_test.go
+++ b/pkg/registry/apps/annotation/tags_handler_test.go
@@ -261,6 +261,7 @@ func TestTagsHandlerAuthorization(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, writer.code)
+		assert.Contains(t, writer.body.String(), "requires the annotations:read permission with the organization scope")
 		assert.NotContains(t, writer.body.String(), "secret-canary", "tag metadata must not be leaked on denial")
 	})
 

--- a/pkg/registry/apps/annotation/tags_handler_test.go
+++ b/pkg/registry/apps/annotation/tags_handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 )
@@ -255,13 +256,11 @@ func TestTagsHandlerAuthorization(t *testing.T) {
 		handler := newTagsHandler(store.(TagProvider), denyAll, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
 
 		req, writer := newRequest()
-		// The handler writes the denial status to the response itself and returns nil,
-		// because a returned error would be rendered as a generic 500.
 		err := handler(ctx, writer, req)
 
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusForbidden, writer.code)
-		assert.Contains(t, writer.body.String(), "requires the annotations:read permission with the organization scope")
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err), "expected Forbidden, got %v", err)
+		assert.ErrorContains(t, err, "requires the annotations:read permission with the organization scope")
 		assert.NotContains(t, writer.body.String(), "secret-canary", "tag metadata must not be leaked on denial")
 	})
 


### PR DESCRIPTION
Fixes [#936](https://github.com/grafana/grafana-org/issues/936)

The current implementation of the legacy GET /api/annotations/tags API validates that the user has [the `annotations:read` permission with any scope](https://github.com/grafana/grafana/blob/45fa66aee5caaf6e4307e0c6c2b364a6d0a53967/pkg/api/api.go#L523), while [the new k8s API](https://github.com/grafana/grafana/blob/47b2410422251f51c596ce2b862322168849cad8/pkg/registry/apps/annotation/tags_handler.go#L31) we are migrating to currently returns all annotation tags to any authenticated users regardless of permissions. 

This means that for an authenticated user with no permission at all, e.g. org role = None, can see all annotation tags within the org, potentially exposing data to users who should not have access to it.

This PR proposes to validate user permissions in the k8s GET /tags API before data is returned and return a 403 response if the user doesn't have the `annotations:read` permission with the `organization` scope.