### PR TITLE
Table: Honor target blank data links

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -836,6 +836,64 @@ describe('TableNG utils', () => {
       expect(onClickHandler).toHaveBeenCalledWith(event, { field, rowIndex: 0 });
     });
 
+    it('should keep target blank links as browser-handled links', () => {
+      const onClickHandler = jest.fn();
+      const mockLinks: LinkModel[] = [
+        {
+          title: 'Internal new tab link',
+          href: '/explore?left=%7B%7D',
+          onClick: onClickHandler,
+          target: '_blank',
+          origin: { datasourceUid: 'test' },
+        },
+      ];
+
+      const field: Field = {
+        name: 'test',
+        type: FieldType.string,
+        config: {},
+        values: ['value1'],
+        getLinks: () => mockLinks,
+      };
+
+      const links = getCellLinks(field, 0);
+
+      expect(links?.[0].href).toBe('/explore?left=%7B%7D');
+      expect(links?.[0].target).toBe('_blank');
+      expect(links?.[0].onClick).toBeUndefined();
+      expect(onClickHandler).not.toHaveBeenCalled();
+    });
+
+    it('should keep target blank click handlers when href is missing', () => {
+      const onClickHandler = jest.fn();
+      const mockLinks: LinkModel[] = [
+        {
+          title: 'Internal action link',
+          href: '',
+          onClick: onClickHandler,
+          target: '_blank',
+          origin: { datasourceUid: 'test' },
+        },
+      ];
+
+      const field: Field = {
+        name: 'test',
+        type: FieldType.string,
+        config: {},
+        values: ['value1'],
+        getLinks: () => mockLinks,
+      };
+
+      const links = getCellLinks(field, 0);
+      const event = new MouseEvent('click', { bubbles: true });
+      jest.spyOn(event, 'preventDefault');
+
+      links?.[0].onClick?.(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(onClickHandler).toHaveBeenCalledWith(event, { field, rowIndex: 0 });
+    });
+
     it.each([
       { keyName: 'metaKey', eventOverride: { metaKey: true } },
       { keyName: 'ctrlKey', eventOverride: { ctrlKey: true } },

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -603,10 +603,16 @@ export const getCellLinks = (field: Field, rowIdx: number) => {
   }
 
   for (let i = 0; i < links?.length; i++) {
-    if (links[i].onClick) {
-      const origOnClick = links[i].onClick;
+    const link = links[i];
+    if (link.onClick) {
+      if (link.target === '_blank' && link.href) {
+        link.onClick = undefined;
+        continue;
+      }
 
-      links[i].onClick = (event: MouseEvent) => {
+      const origOnClick = link.onClick;
+
+      link.onClick = (event: MouseEvent) => {
         // Allow opening in new tab
         if (!(event.ctrlKey || event.metaKey || event.shiftKey)) {
           event.preventDefault();


### PR DESCRIPTION
Fixes #126854.

### What changed
- Let TableNG data links with `target: _blank` and an `href` use normal browser navigation instead of invoking the in-app click handler.
- Preserve click-handler-only links when no `href` is available.
- Added regression coverage for `_blank` links with and without `href`.

### Debug panel
- https://gist.githubusercontent.com/mturac/a0ba3bba3bc9d570288fc3ca334825b7/raw/grafana-126903-debug-panel.json

### Tests
- `yarn jest packages/grafana-ui/src/components/Table/TableNG/utils.test.ts --ci --runInBand`
- `yarn nx run @grafana/ui:typecheck`
- `git diff --check origin/main...HEAD`