### PR TITLE
Frontend Service: Populate licensing settings via index data hooks

### DIFF
--- a/devenv/frontend-service/Tiltfile
+++ b/devenv/frontend-service/Tiltfile
@@ -30,7 +30,7 @@ local_resource(
 
 local_resource(
   'yarn start',
-  cmd='rm -rf public/build/assets-manifest.json',
+  cmd='rm -rf public/build/assets-manifest-react19.json',
   serve_cmd='yarn start:noLint',
   resource_deps=['yarn install'],
 
@@ -39,7 +39,7 @@ local_resource(
   readiness_probe=probe(
     initial_delay_secs=10,
     period_secs=1,
-    exec=exec_action(["bash", "-c", "stat public/build/assets-manifest.json"]),
+    exec=exec_action(["bash", "-c", "stat public/build/assets-manifest-react19.json"]),
   ),
   allow_parallel=True,
   labels=["local"]
@@ -150,7 +150,7 @@ docker_build('grafana-fs-dev',
     'public/views',
     'public/dashboards',
     'public/app/plugins',
-    'public/build/assets-manifest.json',
+    'public/build/assets-manifest-react19.json',
     'public/build/boot.js',
     'public/gazetteer',
     'public/maps',
@@ -166,7 +166,7 @@ docker_build('grafana-fs-dev',
     sync('../../public/views', '/grafana/public/views'),
     sync('../../public/dashboards', '/grafana/public/dashboards'),
     sync('../../public/app/plugins', '/grafana/public/app/plugins'),
-    sync('../../public/build/assets-manifest.json', '/grafana/public/build/assets-manifest.json'),
+    sync('../../public/build/assets-manifest-react19.json', '/grafana/public/build/assets-manifest-react19.json'),
     sync('../../public/build/boot.js', '/grafana/public/build/boot.js'),
     sync('./provisioning', '/ignore/provisioning'),  # Just to trigger a restart instead of rebuild
     sync('./configs/grafana-api.local.ini', '/ignore/grafana-api.local.ini'),  # Just to trigger a restart instead of rebuild

--- a/devenv/frontend-service/goff-flags.yaml
+++ b/devenv/frontend-service/goff-flags.yaml
@@ -1,9 +1,9 @@
-flagName:
+react19:
   variations:
     enabled: true
     disabled: false
   defaultRule:
-    variation: disabled
+    variation: enabled
 
 reportRenderBinding:
   variations:
@@ -53,4 +53,4 @@ frontendService.reducedBootDataAPI:
     enabled: true
     disabled: false
   defaultRule:
-    variation: disabled
+    variation: enabled

--- a/devenv/frontend-service/goff-flags.yaml
+++ b/devenv/frontend-service/goff-flags.yaml
@@ -53,4 +53,4 @@ frontendService.reducedBootDataAPI:
     enabled: true
     disabled: false
   defaultRule:
-    variation: enabled
+    variation: disabled

--- a/devenv/frontend-service/grafana-fs-dev.dockerfile
+++ b/devenv/frontend-service/grafana-fs-dev.dockerfile
@@ -31,7 +31,7 @@ COPY public/img/icons public/img/icons
 
 ADD devenv/frontend-service/build/grafana bin/grafana
 
-COPY public/build/assets-manifest.json public/build/assets-manifest.json
+COPY public/build/assets-manifest-react19.json public/build/assets-manifest-react19.json
 COPY public/build/boot.js public/build/boot.js
 
 ENTRYPOINT ["bin/grafana", "server"]

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -202,10 +202,15 @@ func (p *IndexProvider) runIndexDataHooks(reqCtx *contextmodel.ReqContext, data 
 	legacyIndexViewData := dtos.IndexViewData{
 		Settings: &dtos.FrontendSettingsDTO{
 			BuildInfo: data.Settings.BuildInfo,
+			Licensing: &dtos.FrontendSettingsLicensingDTO{},
 		},
 	}
 
 	p.hooksService.RunIndexDataHooks(&legacyIndexViewData, reqCtx)
 
 	data.Settings.BuildInfo = legacyIndexViewData.Settings.BuildInfo
+
+	if data.FullSettings != nil {
+		data.FullSettings.Licensing = legacyIndexViewData.Settings.Licensing
+	}
 }


### PR DESCRIPTION
## What

The frontend service's `runIndexDataHooks` now seeds a `Licensing` DTO and copies the hook result into `FullSettings.Licensing`, so the reduced boot data API serves licensing information. Previously licensing settings were not populated on this path.

A second commit updates the devenv frontend-service to build against the React 19 asset manifest (`assets-manifest-react19.json`) and enables the `react19` and `frontendService.reducedBootDataAPI` flags by default, so the reduced-boot-data codepath (and the licensing fix) is exercised in local dev.

## Why

Licensing settings were missing from the reduced boot data API response served by the frontend service.

## Notes

- Split into two commits: the licensing fix and the devenv defaults.
- The devenv change flips local frontend-service dev defaults to React 19 + reduced boot data API.