### PR TITLE
Authentication: Fixes JWT enable_login_token

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -137,9 +137,10 @@ func (hs *HTTPServer) LoginView(c *contextmodel.ReqContext) {
 	if c.IsSignedIn {
 		// Assign login token to auth proxy users if enable_login_token = true
 		// LDAP users authenticated by auth proxy are also assigned login token but their auth module is LDAP
+		// JWT validated users are also assigned a login token but come from the plain JWTModule
 		if hs.Cfg.AuthProxy.Enabled &&
 			hs.Cfg.AuthProxy.EnableLoginToken &&
-			c.IsAuthenticatedBy(loginservice.AuthProxyAuthModule, loginservice.LDAPAuthModule) {
+			c.IsAuthenticatedBy(loginservice.AuthProxyAuthModule, loginservice.LDAPAuthModule, loginservice.JWTModule) {
 			user := &user.User{ID: c.UserID, Email: c.Email, Login: c.Login}
 			err := hs.loginUserWithUser(user, c)
 			if err != nil {


### PR DESCRIPTION
**What is this feature?**

Adds the JWT module to the existing list of auth modules which can use `enable_login_token`

**Why do we need this feature?**

This used to work prior to [this PR](https://github.com/grafana/grafana/commit/7d559bc69a7c710473dd4d41d4b463e74cc87601#diff-0c18e4eaf4edcac3a4f221ea278e5c0f6d5018189ede89d665f555021fb9c19aR132)

**Who is this feature for?**

Those making use of SSO login options who also need a cookie set

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/126608

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
