### PR TITLE
i18n: Mark up NoData component for translations

### DIFF
--- a/public/app/features/explore/NoData.tsx
+++ b/public/app/features/explore/NoData.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { useStyles2, PanelContainer } from '@grafana/ui';
 
 export const NoData = () => {
@@ -8,7 +9,9 @@ export const NoData = () => {
   return (
     <>
       <PanelContainer data-testid="explore-no-data" className={css.wrapper}>
-        <span className={css.message}>{'No data'}</span>
+        <span className={css.message}>
+          <Trans i18nKey="explore.no-data">No data</Trans>
+        </span>
       </PanelContainer>
     </>
   );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8624,6 +8624,7 @@
       "services": "Services: {{services}}",
       "services-span-filter-matches": "Services: {{total}}/{{services}}"
     },
+    "no-data": "No data",
     "no-data-source-call-to-action": {
       "cta-element": {
         "add-data-source": "Add data source"


### PR DESCRIPTION
### What is this feature?
This Pull Request adds proper internationalization (i18n) support to the `NoData.tsx` component located inside the `public/app/features/explore/ directory.

### Why do we need this feature?
Currently, when users switch their global Grafana profile language (e.g., to Spanish), the main workspace panel still displays the hardcoded English string 'No data' instead of rendering dynamically. This PR wraps the text using the `<Trans>` component and updates the localized catalog.

### Visual Proof
This is the specific UI component impacted by this change, it shows when no query data is returned in the Explore view:
<img width="898" height="597" alt="image" src="https://github.com/user-attachments/assets/7ebd9df3-1f45-4458-b9f6-f78ae1d4294b" />


### Which issue(s) does this PR fix?
Part of the /explore internationalization efforts under the Epic issue #73984.