### PR TITLE
Faro: fall back to legacy feature toggle for session replay

### DIFF
--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -9,7 +9,7 @@ import {
   type Instrumentation,
 } from '@grafana/faro-web-sdk';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
-import { type EchoBackend, type EchoEvent, EchoEventType } from '@grafana/runtime';
+import { config, type EchoBackend, type EchoEvent, EchoEventType } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 
 import { EchoSrvTransport } from './EchoSrvTransport';
@@ -98,7 +98,10 @@ export class GrafanaJavascriptAgentBackend
 
     const faro = initializeFaro(grafanaJavaScriptAgentOptions);
 
-    if (faro && getFeatureFlagClient().getBooleanValue(FlagKeys.FaroSessionReplay, false)) {
+    const replayEnabled =
+      getFeatureFlagClient().getBooleanValue(FlagKeys.FaroSessionReplay, false) ||
+      config.featureToggles.faroSessionReplay;
+    if (faro && replayEnabled) {
       this.initReplayAfterDomRendered(faro);
     }
   }


### PR DESCRIPTION
## Summary

`initOpenFeature()` is gated on `contextSrv.user.isSignedIn` (`app.ts:155`), so when auth is disabled the OpenFeature client has no provider and `getBooleanValue("faroSessionReplay", false)` returns the default `false` even when the flag is enabled via `GF_FEATURE_TOGGLES_ENABLE`.

This adds a fallback to `config.featureToggles.faroSessionReplay`, which the backend embeds in the page HTML regardless of auth state.

Not a regression. Replay has used OpenFeature exclusively since #117569 so it never worked without a signed-in user.

## Test plan

- [x] Existing unit tests pass (5/5)
- [ ] With `faroSessionReplay` enabled, `GF_LOG_FRONTEND_ENABLED=true`, and auth disabled: `window.faro.instrumentations.instrumentations` includes replay
- [ ] `faro.session_recording.started` event fires