### PR TITLE
Auth: Don't strip org memberships when auth proxy sends a Role header

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -55,6 +55,12 @@ type ClientParams struct {
 	SyncTeams bool
 	// SyncOrgRoles will sync the roles from the identity to orgs in grafana
 	SyncOrgRoles bool
+	// SyncOrgRolesAdditive, when true, makes org sync only add and update the orgs
+	// present in OrgRoles and skip removing memberships that are not listed.
+	// Clients that can only assert a single org role (e.g. auth proxy) must not be
+	// treated as the authoritative set of memberships, otherwise they would strip
+	// the user from every other org on each login.
+	SyncOrgRolesAdditive bool
 	// CacheAuthProxyKey  if this key is set we will try to cache the user id for proxy client
 	CacheAuthProxyKey string
 	// LookUpParams are the arguments used to look up the entity in the DB.

--- a/pkg/services/authn/authnimpl/sync/org_sync.go
+++ b/pkg/services/authn/authnimpl/sync/org_sync.go
@@ -119,21 +119,24 @@ func (s *OrgSync) SyncOrgRolesHook(ctx context.Context, id *authn.Identity, _ *a
 		orgIDs = append(orgIDs, orgId)
 	}
 
-	// delete any removed org roles
-	for _, orgID := range deleteOrgIds {
-		ctxLogger.Debug("Removing user's organization membership as part of syncing with OAuth login", "orgId", orgID)
-		cmd := &org.RemoveOrgUserCommand{OrgID: orgID, UserID: userID}
-		if err := s.orgService.RemoveOrgUser(ctx, cmd); err != nil {
-			ctxLogger.Error("Failed to remove user from org", "orgId", orgID, "error", err)
-			if errors.Is(err, org.ErrLastOrgAdmin) {
-				continue
+	// delete any removed org roles, unless the client only syncs additively (it
+	// can't assert the full set of memberships, so unlisted orgs must be kept)
+	if !id.ClientParams.SyncOrgRolesAdditive {
+		for _, orgID := range deleteOrgIds {
+			ctxLogger.Debug("Removing user's organization membership as part of syncing org roles", "orgId", orgID)
+			cmd := &org.RemoveOrgUserCommand{OrgID: orgID, UserID: userID}
+			if err := s.orgService.RemoveOrgUser(ctx, cmd); err != nil {
+				ctxLogger.Error("Failed to remove user from org", "orgId", orgID, "error", err)
+				if errors.Is(err, org.ErrLastOrgAdmin) {
+					continue
+				}
+
+				return err
 			}
 
-			return err
-		}
-
-		if err := s.accessControl.DeleteUserPermissions(ctx, orgID, cmd.UserID); err != nil {
-			ctxLogger.Error("Failed to delete permissions for user", "orgId", orgID, "error", err)
+			if err := s.accessControl.DeleteUserPermissions(ctx, orgID, cmd.UserID); err != nil {
+				ctxLogger.Error("Failed to delete permissions for user", "orgId", orgID, "error", err)
+			}
 		}
 	}
 

--- a/pkg/services/authn/authnimpl/sync/org_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/org_sync_test.go
@@ -139,6 +139,50 @@ func TestOrgSync_SyncOrgRolesHook(t *testing.T) {
 	}
 }
 
+func TestOrgSync_SyncOrgRolesHook_Additive(t *testing.T) {
+	// Additive clients (e.g. auth proxy with a Role header) can only assert a
+	// single org role, so org sync must update that org's role without removing
+	// the user from the other orgs they belong to.
+	orgService := &orgtest.MockService{}
+	orgService.On("GetUserOrgList", mock.Anything, mock.Anything).Return([]*org.UserOrgDTO{
+		{OrgID: 1, Role: org.RoleEditor},
+		{OrgID: 2, Role: org.RoleViewer},
+	}, nil)
+	orgService.On("UpdateOrgUser", mock.Anything, mock.MatchedBy(func(cmd *org.UpdateOrgUserCommand) bool {
+		return cmd.OrgID == 1 && cmd.UserID == 1 && cmd.Role == org.RoleAdmin
+	})).Return(nil)
+
+	userService := &usertest.FakeUserService{ExpectedUser: &user.User{ID: 1, Login: "test"}}
+
+	s := &OrgSync{
+		userService:   userService,
+		orgService:    orgService,
+		accessControl: &actest.FakeService{},
+		cfg:           setting.NewCfg(),
+		log:           log.NewNopLogger(),
+		tracer:        tracing.InitializeTracerForTest(),
+	}
+
+	id := &authn.Identity{
+		ID:       "1",
+		Type:     claims.TypeUser,
+		Login:    "test",
+		OrgRoles: map[int64]identity.RoleType{1: org.RoleAdmin},
+		ClientParams: authn.ClientParams{
+			SyncOrgRoles:         true,
+			SyncOrgRolesAdditive: true,
+		},
+	}
+
+	err := s.SyncOrgRolesHook(context.Background(), id, nil)
+	require.NoError(t, err)
+
+	// The role in org 1 is updated, but the user is NOT removed from org 2.
+	orgService.AssertCalled(t, "UpdateOrgUser", mock.Anything, mock.Anything)
+	orgService.AssertNotCalled(t, "RemoveOrgUser", mock.Anything, mock.Anything)
+	assert.Equal(t, int64(1), id.OrgID)
+}
+
 func TestOrgSync_SyncOrgRolesHook_SkipsWhenSingleOrgAndKubernetesUsersRedirect(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -49,6 +49,10 @@ func (c *Grafana) AuthenticateProxy(ctx context.Context, r *authn.Request, usern
 			SyncOrgRoles:    true,
 			SyncPermissions: true,
 			AllowSignUp:     c.cfg.AuthProxy.AutoSignUp,
+			// The Role header can only assert a single org role (the default org), so
+			// org sync must not treat it as the authoritative membership set and remove
+			// the user from every other org they belong to.
+			SyncOrgRolesAdditive: true,
 		},
 	}
 

--- a/pkg/services/authn/clients/grafana_test.go
+++ b/pkg/services/authn/clients/grafana_test.go
@@ -50,11 +50,12 @@ func TestGrafana_AuthenticateProxy(t *testing.T) {
 				AuthID:          "test",
 				ExternalGroups:  []string{"grp1", "grp2"},
 				ClientParams: authn.ClientParams{
-					SyncUser:        true,
-					SyncTeams:       true,
-					AllowSignUp:     true,
-					FetchSyncedUser: true,
-					SyncOrgRoles:    true,
+					SyncUser:             true,
+					SyncTeams:            true,
+					AllowSignUp:          true,
+					FetchSyncedUser:      true,
+					SyncOrgRoles:         true,
+					SyncOrgRolesAdditive: true,
 					LookUpParams: login.UserLookupParams{
 						Email: new("email@example.com"),
 						Login: new("test"),
@@ -73,10 +74,11 @@ func TestGrafana_AuthenticateProxy(t *testing.T) {
 				AuthenticatedBy: login.AuthProxyAuthModule,
 				AuthID:          "test@test.com",
 				ClientParams: authn.ClientParams{
-					SyncUser:     true,
-					SyncTeams:    true,
-					AllowSignUp:  true,
-					SyncOrgRoles: true,
+					SyncUser:             true,
+					SyncTeams:            true,
+					AllowSignUp:          true,
+					SyncOrgRoles:         true,
+					SyncOrgRolesAdditive: true,
 					LookUpParams: login.UserLookupParams{
 						Email: new("test@test.com"),
 						Login: new("test@test.com"),
@@ -116,6 +118,8 @@ func TestGrafana_AuthenticateProxy(t *testing.T) {
 				assert.Equal(t, tt.expectedIdentity.ClientParams.AllowSignUp, identity.ClientParams.AllowSignUp)
 				assert.Equal(t, tt.expectedIdentity.ClientParams.SyncTeams, identity.ClientParams.SyncTeams)
 				assert.Equal(t, tt.expectedIdentity.ClientParams.EnableUser, identity.ClientParams.EnableUser)
+				assert.Equal(t, tt.expectedIdentity.ClientParams.SyncOrgRoles, identity.ClientParams.SyncOrgRoles)
+				assert.Equal(t, tt.expectedIdentity.ClientParams.SyncOrgRolesAdditive, identity.ClientParams.SyncOrgRolesAdditive)
 
 				assert.EqualValues(t, tt.expectedIdentity.ClientParams.LookUpParams.Email, identity.ClientParams.LookUpParams.Email)
 				assert.EqualValues(t, tt.expectedIdentity.ClientParams.LookUpParams.Login, identity.ClientParams.LookUpParams.Login)


### PR DESCRIPTION
A bug fix for Grafana-managed org membership sync when authenticating via auth proxy.

The auth proxy `Role` header (`headers = Role:X-WEBAUTH-ROLE`) only ever asserts a
single org role, keyed to the default org. Org sync treats `OrgRoles` as the
*authoritative* set of memberships and removes the user from any org not listed.
As a result, an existing user who belongs to a non-default org was stripped of
every other org membership (and its permissions) on each login that carried the
Role header — regardless of `auto_sign_up = false` / `auto_assign_org = false`.

This PR adds a `SyncOrgRolesAdditive` client param and sets it for the auth proxy
client. In additive mode, org sync only **adds and updates** the listed org roles
and no longer **removes** unlisted memberships. Authoritative sync for
OAuth/LDAP/JWT is unchanged (the param defaults to `false`).

**Why do we need this feature?**

Today, simply sending the Role header silently deletes a user's other org
memberships and permissions on every login (every login when `sync_ttl = 0`).
The data loss is undocumented and surprising, and there is no way to set a role
via auth proxy without it. Omitting the header avoids the wipe, but then the role
can't be synced at all. This restores the documented intent (the Role applies to
the default org) without destroying the rest of the user's memberships.

**Who is this feature for?**

Operators using `[auth.proxy]` with the `Role` header where users belong to more
than one organization (OSS/GEX).

**Which issue(s) does this PR fix?**:

Fixes #126836

**Special notes for your reviewer:**

- Root cause is two-fold: the proxy builds `OrgRoles` with only the default org
  (`clients/utils.go` `getRoles` → `OrgRoles[cfg.DefaultOrgID()]`), and `org_sync`
  removes any current membership not present in `OrgRoles`
  (`authnimpl/sync/org_sync.go`). The fix gates only the removal pass for the
  proxy path; add/update behavior (so the default-org role still updates) is kept.
- No feature toggle: this fixes destructive, undocumented behavior. Gating it
  behind an off-by-default toggle would keep deleting users' org memberships by
  default, which is the bug.
- Out of scope: the reporter's secondary ask for an org-selection header (e.g.
  `X-Grafana-Org-Id`) for multi-org users — that's a separate enhancement.
- Behavior note: in additive mode the user's other memberships are preserved; the
  active/default org still resolves to the synced (default) org via the existing
  default-org logic, which is unchanged.

Verification:
- New `TestOrgSync_SyncOrgRolesHook_Additive`: org role is updated, user is **not**
  removed from their other org.
- Existing `TestOrgSync_SyncOrgRolesHook` still removes unlisted orgs — proves
  OAuth/LDAP/JWT authoritative sync is untouched.
- `TestGrafana_AuthenticateProxy` asserts the proxy client sets the additive param.
- `go build`, `go vet`, `gofmt`, and the `clients` + `authnimpl/sync` package tests
  all pass.

Please check that:
- [x] It works as expected from a user's perspective. *(covered by unit tests; no manual env run)*
- [ ] ~~If this is a pre-GA feature, it is behind a feature toggle.~~ N/A — bug fix, not a feature.
- [ ] The docs are updated. The current auth-proxy docs don't describe the old (buggy) removal behavior, so no doc change is strictly required; happy to add a clarifying note if you'd prefer.
