### PR TITLE
TimeComparison: Show notice for empty time comparison

### DIFF
--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
@@ -20,7 +20,6 @@ import {
   type SceneTimeRangeLike,
   type SceneTimeRangeState,
   SceneTimeRangeTransformerBase,
-  timeShiftAlignmentProcessor,
   VariableDependencyConfig,
   VizPanel,
 } from '@grafana/scenes';
@@ -30,7 +29,7 @@ import { type TimeOverrideResult } from 'app/features/dashboard/utils/panel';
 import { getDashboardSceneFor } from '../../utils/utils';
 
 import { getCompareOptions, PanelTimeRangeDrawer, type PanelTimeRangeZoomBehavior } from './PanelTimeRangeDrawer';
-import { getCompareTimeRange } from './utils';
+import { getCompareTimeRange, timeShiftAlignmentProcessor } from './utils';
 
 export interface PanelTimeRangeState extends SceneTimeRangeState {
   enabled?: boolean;

--- a/public/app/features/dashboard-scene/scene/panel-timerange/utils.test.ts
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/utils.test.ts
@@ -1,13 +1,10 @@
 import { lastValueFrom } from 'rxjs';
 
 import { dateTime, FieldType, toDataFrame, type DataFrame, type PanelData, type TimeRange } from '@grafana/data';
-import { getCompareSeriesRefId, timeShiftAlignmentProcessor } from '@grafana/scenes';
+import { getCompareSeriesRefId } from '@grafana/scenes';
 import { LoadingState } from '@grafana/schema';
 
-// The processor now lives in @grafana/scenes (core's private fork was deleted); these tests stay
-// as contract tests guarding the dependency against a regression to the old mutate-in-place behavior.
-
-import { getCompareTimeRange } from './utils';
+import { getCompareTimeRange, timeShiftAlignmentProcessor } from './utils';
 
 function makeTimeRange(fromIso: string, toIso: string): TimeRange {
   const from = dateTime(fromIso);
@@ -193,6 +190,54 @@ describe('panel-timerange/utils', () => {
       const result = await lastValueFrom(timeShiftAlignmentProcessor(makePanelData(primaryRange), secondary));
 
       expect(result.series[0].refId).toBe('-compare');
+    });
+
+    it('should emit a notice frame when the compare query returns no data and the primary query has data', async () => {
+      const primary = makePanelData(primaryRange, [
+        toDataFrame({
+          refId: 'A',
+          fields: [{ name: 'value', type: FieldType.number, values: [1] }],
+        }),
+      ]);
+      const secondary = {
+        ...makePanelData(secondaryRange),
+        request: {
+          targets: [{ refId: 'A' }],
+        },
+      } as PanelData;
+
+      const result = await lastValueFrom(timeShiftAlignmentProcessor(primary, secondary));
+
+      expect(result.series[0]).toMatchObject({
+        refId: 'A-compare',
+        length: 0,
+        fields: [],
+        meta: {
+          notices: [{ severity: 'info', text: 'No data returned for time comparison' }],
+          timeCompare: {
+            diffMs: expectedDiffMs,
+            isTimeShiftQuery: true,
+          },
+        },
+      });
+    });
+
+    it('should emit a notice frame when the compare query returns empty frames', async () => {
+      // Prometheus and other data sources return a frame without fields rather than no frames at all.
+      const primary = makePanelData(primaryRange, [
+        toDataFrame({
+          refId: 'A',
+          fields: [{ name: 'value', type: FieldType.number, values: [1] }],
+        }),
+      ]);
+      const secondary = makePanelData(secondaryRange, [toDataFrame({ refId: 'A', fields: [] })]);
+
+      const result = await lastValueFrom(timeShiftAlignmentProcessor(primary, secondary));
+
+      expect(result.series[0]).toMatchObject({
+        refId: 'A-compare',
+        meta: { notices: [{ severity: 'info', text: 'No data returned for time comparison' }] },
+      });
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/panel-timerange/utils.ts
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/utils.ts
@@ -1,6 +1,48 @@
+import { map } from 'rxjs';
+
 import { dateTime, type DateTime, rangeUtil, type TimeRange } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import {
+  type ExtraQueryDataProcessor,
+  getCompareSeriesRefId,
+  timeShiftAlignmentProcessor as scenesTimeShiftAlignmentProcessor,
+} from '@grafana/scenes';
 
 import type { PanelTimeRangeState } from './PanelTimeRange';
+
+export const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, secondary) => {
+  if (primary.series.every((frame) => frame.length === 0) || secondary.series.some((frame) => frame.length > 0)) {
+    return scenesTimeShiftAlignmentProcessor(primary, secondary);
+  }
+
+  const targetFrames = secondary.request?.targets.map((target) => ({
+    refId: getCompareSeriesRefId(target.refId),
+    fields: [],
+    length: 0,
+  }));
+  const series = secondary.series.length
+    ? secondary.series
+    : targetFrames?.length
+      ? targetFrames
+      : [{ fields: [], length: 0 }];
+  const notice = {
+    severity: 'info' as const,
+    text: t('dashboard.time-compare.no-data-notice', 'No data returned for time comparison'),
+  };
+
+  return scenesTimeShiftAlignmentProcessor(primary, { ...secondary, series }).pipe(
+    map((result) => ({
+      ...result,
+      series: result.series.map((frame) => ({
+        ...frame,
+        meta: {
+          ...frame.meta,
+          notices: [...(frame.meta?.notices ?? []), notice],
+        },
+      })),
+    }))
+  );
+};
 
 /**
  * Whether a panel should use a hover header, used when there's

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6335,6 +6335,9 @@
         "title-not-unique": "This title is not unique"
       }
     },
+    "time-compare": {
+      "no-data-notice": "No data returned for time comparison"
+    },
     "title": {
       "action": "Change dashboard title"
     },


### PR DESCRIPTION
**What is this feature?**

Adds an informational notice when a panel time comparison query returns no data while the primary query still has data.

**Why do we need this feature?**

Without this, the panel renders the primary data normally and gives no indication that the comparison query returned nothing. That makes the empty comparison result look like the feature silently failed.

**Who is this feature for?**

Users comparing panel data across time ranges.

**Which issue(s) does this PR fix?**:

Fixes #126825

**Special notes for your reviewer:**

The change keeps the normal panel no-data behavior unchanged. It only adds a zero-length comparison frame with an info notice when the primary query has data and the comparison query is empty.

### Before / After

Panel on `Last 15 minutes` with comparison set to "1 day before", against a Prometheus that has no data 24h back:

**Before** - the comparison silently returns no data, with nothing in the UI to say so:
<img width="2200" height="1240" alt="Notice icon in the panel header" src="https://github.com/user-attachments/assets/1312de49-4010-42b7-b32b-5487120966c0" />

**After** - an info notice in the panel header explains the missing comparison series:
<img width="2200" height="1240" alt="Tooltip: No data returned for time comparison" src="https://github.com/user-attachments/assets/e1080fd0-810e-45a6-bbcd-02a3e69fbf3f" />



Please check that:
  - [x] It works as expected from a user's perspective.
  - [x] If this is a pre-GA feature, it is behind a feature toggle.
  - [x] The docs are updated, and if this is a notable improvement, it's added to What's New doc.

Tests run:
  - `yarn jest --ci --runTestsByPath public/app/features/dashboard-scene/scene/panel-timerange/utils.test.ts --runInBand --silent=false`
  - `yarn jest --ci --runTestsByPath public/app/plugins/panel/timeseries/TimeSeriesPanel.test.tsx --runInBand --silent=false`
  - `yarn prettier --check public/app/features/dashboard-scene/scene/panel-timerange/utils.ts public/app/features/dashboard-scene/scene/panel-timerange/utils.test.ts`
  - `yarn eslint public/app/features/dashboard-scene/scene/panel-timerange/utils.ts public/app/features/dashboard-scene/scene/panel-timerange/utils.test.ts`
  - `git diff --check`
  - `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck`