### PR TITLE
Provisioning: Regenerate API client for generateNewFolderIDs option

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1650,6 +1650,8 @@ export type FixFolderMetadataJobOptions = {
   ref?: string;
 };
 export type MigrateJobOptions = {
+  /** GenerateNewFolderIDs writes a freshly generated identifier into each exported folder's metadata (_folder.json) instead of preserving the existing folder UID. The subsequent pull creates new folders rather than taking over the originals. Has no effect when folder metadata is not written. */
+  generateNewFolderIDs?: boolean;
   /** Message to use when committing the changes in a single commit. Deprecated: set JobSpec.Message instead. This field is kept for backwards compatibility and is only used when JobSpec.Message is empty. */
   message?: string;
   /** Resources to migrate. When empty, every unmanaged resource in the namespace is migrated (legacy behavior). When non-empty, only the listed resources are exported to the repository — the folder hierarchy is still emitted so parent paths resolve, and the subsequent pull phase only takes ownership of those resources. Currently only unmanaged Dashboards are supported. */
@@ -1684,6 +1686,8 @@ export type ExportJobOptions = {
   branch?: string;
   /** The source folder (or empty) to export */
   folder?: string;
+  /** GenerateNewFolderIDs writes a freshly generated identifier into each exported folder's metadata (_folder.json) instead of preserving the existing folder UID. Use this to produce a portable export that creates new folders on a subsequent sync rather than taking over the originals. Has no effect when folder metadata is not written. */
+  generateNewFolderIDs?: boolean;
   /** Message to use when committing the changes in a single commit. Deprecated: set JobSpec.Message instead. This field is kept for backwards compatibility and is only used when JobSpec.Message is empty. */
   message?: string;
   /** FIXME: we should validate this in admission hooks Prefix in target file system */

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -4106,6 +4106,10 @@
             "description": "The source folder (or empty) to export",
             "type": "string"
           },
+          "generateNewFolderIDs": {
+            "description": "GenerateNewFolderIDs writes a freshly generated identifier into each exported folder's metadata (_folder.json) instead of preserving the existing folder UID. Use this to produce a portable export that creates new folders on a subsequent sync rather than taking over the originals. Has no effect when folder metadata is not written.",
+            "type": "boolean"
+          },
           "message": {
             "description": "Message to use when committing the changes in a single commit. Deprecated: set JobSpec.Message instead. This field is kept for backwards compatibility and is only used when JobSpec.Message is empty.",
             "type": "string"
@@ -4879,6 +4883,10 @@
       "MigrateJobOptions": {
         "type": "object",
         "properties": {
+          "generateNewFolderIDs": {
+            "description": "GenerateNewFolderIDs writes a freshly generated identifier into each exported folder's metadata (_folder.json) instead of preserving the existing folder UID. The subsequent pull creates new folders rather than taking over the originals. Has no effect when folder metadata is not written.",
+            "type": "boolean"
+          },
           "message": {
             "description": "Message to use when committing the changes in a single commit. Deprecated: set JobSpec.Message instead. This field is kept for backwards compatibility and is only used when JobSpec.Message is empty.",
             "type": "string"

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -4009,6 +4009,10 @@
             "description": "The source folder (or empty) to export",
             "type": "string"
           },
+          "generateNewFolderIDs": {
+            "description": "GenerateNewFolderIDs writes a freshly generated identifier into each exported folder's metadata (_folder.json) instead of preserving the existing folder UID. Use this to produce a portable export that creates new folders on a subsequent sync rather than taking over the originals. Has no effect when folder metadata is not written.",
+            "type": "boolean"
+          },
           "message": {
             "description": "Message to use when committing the changes in a single commit. Deprecated: set JobSpec.Message instead. This field is kept for backwards compatibility and is only used when JobSpec.Message is empty.",
             "type": "string"
@@ -4654,6 +4658,10 @@
       "MigrateJobOptions": {
         "type": "object",
         "properties": {
+          "generateNewFolderIDs": {
+            "description": "GenerateNewFolderIDs writes a freshly generated identifier into each exported folder's metadata (_folder.json) instead of preserving the existing folder UID. The subsequent pull creates new folders rather than taking over the originals. Has no effect when folder metadata is not written.",
+            "type": "boolean"
+          },
           "message": {
             "description": "Message to use when committing the changes in a single commit. Deprecated: set JobSpec.Message instead. This field is kept for backwards compatibility and is only used when JobSpec.Message is empty.",
             "type": "string"


### PR DESCRIPTION
## Summary

Regenerates the provisioning RTK Query client and processed OpenAPI specs to expose the new `generateNewFolderIDs` field on `ExportJobOptions` and `MigrateJobOptions`.

This is the **frontend half** of the `generateNewFolderIDs` change — split per the repo convention of separate FE/BE PRs (deployed at different cadences).

## Changes

- `packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts`
- `packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json`
- `packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json`

Generated via `yarn workspace @grafana/api-clients generate-apis`.

## Depends on

Backend PR #126935 (adds the field to the served spec). **Merge after that PR** — otherwise regenerating against `main` would drop the field.

## Testing

- Pure codegen output; no hand edits.

## Checklist
- [x] Generated via the standard codegen flow
- [x] No breaking changes (new optional field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)