### PR TITLE
Provisioning: Refactor EnsureFolderTreeExists to options struct

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders.go
@@ -56,19 +56,24 @@ func ExportFolders(ctx context.Context, repoName string, options provisioning.Ex
 // selective export, which only assembles the folders that the requested
 // resources actually need.
 func writeFolderTree(ctx context.Context, options provisioning.ExportJobOptions, repositoryResources resources.RepositoryResources, tree resources.FolderTree, progress jobs.JobProgressRecorder) error {
-	return repositoryResources.EnsureFolderTreeExists(ctx, options.Branch, options.Path, tree, options.GenerateNewFolderIDs, func(folder resources.Folder, created bool, err error) error {
-		resultBuilder := jobs.NewFolderResult(folder.Path).WithName(folder.ID).WithAction(repository.FileActionCreated)
+	return repositoryResources.EnsureFolderTreeExists(ctx, tree, resources.EnsureFolderTreeExistsOptions{
+		Ref:                  options.Branch,
+		Path:                 options.Path,
+		GenerateNewFolderIDs: options.GenerateNewFolderIDs,
+		OnFolder: func(folder resources.Folder, created bool, err error) error {
+			resultBuilder := jobs.NewFolderResult(folder.Path).WithName(folder.ID).WithAction(repository.FileActionCreated)
 
-		if err != nil {
-			resultBuilder.WithError(fmt.Errorf("creating folder %s at path %s: %w", folder.ID, folder.Path, err))
-		}
+			if err != nil {
+				resultBuilder.WithError(fmt.Errorf("creating folder %s at path %s: %w", folder.ID, folder.Path, err))
+			}
 
-		if !created {
-			resultBuilder.WithAction(repository.FileActionIgnored)
-		}
-		progress.Record(ctx, resultBuilder.Build())
+			if !created {
+				resultBuilder.WithAction(repository.FileActionIgnored)
+			}
+			progress.Record(ctx, resultBuilder.Build())
 
-		return progress.TooManyErrors()
+			return progress.TooManyErrors()
+		},
 	})
 }
 

--- a/pkg/registry/apis/provisioning/jobs/export/folders_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders_test.go
@@ -83,7 +83,9 @@ func TestExportFolders(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, mock.Anything).Return()
 			},
 			setupResources: func(repoResources *resources.MockRepositoryResources) {
-				repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "grafana", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("failed to ensure folder tree"))
+				repoResources.On("EnsureFolderTreeExists", mock.Anything, mock.Anything, mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+					return opts.Ref == "feature/branch" && opts.Path == "grafana"
+				})).Return(fmt.Errorf("failed to ensure folder tree"))
 			},
 		},
 		{
@@ -137,11 +139,13 @@ func TestExportFolders(t *testing.T) {
 				progress.On("TooManyErrors").Return(nil)
 			},
 			setupResources: func(repoResources *resources.MockRepositoryResources) {
-				repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "grafana", mock.MatchedBy(func(tree resources.FolderTree) bool {
+				repoResources.On("EnsureFolderTreeExists", mock.Anything, mock.MatchedBy(func(tree resources.FolderTree) bool {
 					return tree.Count() == 2
-				}), mock.Anything, mock.MatchedBy(func(fn func(folder resources.Folder, created bool, err error) error) bool {
-					require.NoError(t, fn(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, true, nil))
-					require.NoError(t, fn(resources.Folder{ID: "folder-2-uid", Path: "grafana/folder-2"}, true, nil))
+				}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+					require.Equal(t, "feature/branch", opts.Ref)
+					require.Equal(t, "grafana", opts.Path)
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, true, nil))
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-2-uid", Path: "grafana/folder-2"}, true, nil))
 
 					return true
 				})).Return(nil)
@@ -198,11 +202,13 @@ func TestExportFolders(t *testing.T) {
 				progress.On("TooManyErrors").Return(nil)
 			},
 			setupResources: func(repoResources *resources.MockRepositoryResources) {
-				repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "grafana", mock.MatchedBy(func(tree resources.FolderTree) bool {
+				repoResources.On("EnsureFolderTreeExists", mock.Anything, mock.MatchedBy(func(tree resources.FolderTree) bool {
 					return tree.Count() == 2
-				}), mock.Anything, mock.MatchedBy(func(fn func(folder resources.Folder, created bool, err error) error) bool {
-					require.NoError(t, fn(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, false, errors.New("didn't work")))
-					require.NoError(t, fn(resources.Folder{ID: "folder-2-uid", Path: "grafana/folder-2"}, true, nil))
+				}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+					require.Equal(t, "feature/branch", opts.Ref)
+					require.Equal(t, "grafana", opts.Path)
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, false, errors.New("didn't work")))
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "folder-2-uid", Path: "grafana/folder-2"}, true, nil))
 
 					return true
 				})).Return(nil)
@@ -241,10 +247,12 @@ func TestExportFolders(t *testing.T) {
 				progress.On("TooManyErrors").Return(fmt.Errorf("too many errors encountered"))
 			},
 			setupResources: func(repoResources *resources.MockRepositoryResources) {
-				repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "grafana", mock.MatchedBy(func(tree resources.FolderTree) bool {
+				repoResources.On("EnsureFolderTreeExists", mock.Anything, mock.MatchedBy(func(tree resources.FolderTree) bool {
 					return tree.Count() == 1
-				}), mock.Anything, mock.MatchedBy(func(fn func(folder resources.Folder, created bool, err error) error) bool {
-					require.Error(t, fn(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, true, nil), "too many errors encountered")
+				}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+					require.Equal(t, "feature/branch", opts.Ref)
+					require.Equal(t, "grafana", opts.Path)
+					require.Error(t, opts.OnFolder(resources.Folder{ID: "folder-1-uid", Path: "grafana/folder-1"}, true, nil), "too many errors encountered")
 					return true
 				})).Return(fmt.Errorf("too many errors encountered"))
 			},
@@ -307,11 +315,13 @@ func TestExportFolders(t *testing.T) {
 				progress.On("TooManyErrors").Return(nil)
 			},
 			setupResources: func(repoResources *resources.MockRepositoryResources) {
-				repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "grafana", mock.MatchedBy(func(tree resources.FolderTree) bool {
+				repoResources.On("EnsureFolderTreeExists", mock.Anything, mock.MatchedBy(func(tree resources.FolderTree) bool {
 					return tree.Count() == 2
-				}), mock.Anything, mock.MatchedBy(func(fn func(folder resources.Folder, created bool, err error) error) bool {
-					require.NoError(t, fn(resources.Folder{ID: "parent-folder", Path: "grafana/parent-folder"}, true, nil))
-					require.NoError(t, fn(resources.Folder{ID: "child-folder", Path: "grafana/parent-folder/child-folder"}, true, nil))
+				}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+					require.Equal(t, "feature/branch", opts.Ref)
+					require.Equal(t, "grafana", opts.Path)
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "parent-folder", Path: "grafana/parent-folder"}, true, nil))
+					require.NoError(t, opts.OnFolder(resources.Folder{ID: "child-folder", Path: "grafana/parent-folder/child-folder"}, true, nil))
 
 					return true
 				})).Return(nil)
@@ -387,9 +397,11 @@ func TestFolderMetaAccessor(t *testing.T) {
 		}
 
 		mockRepoResources := resources.NewMockRepositoryResources(t)
-		mockRepoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "grafana", mock.MatchedBy(func(tree resources.FolderTree) bool {
+		mockRepoResources.On("EnsureFolderTreeExists", mock.Anything, mock.MatchedBy(func(tree resources.FolderTree) bool {
 			return tree.Count() == 0 // Should be 0 since folder is managed by other manager
-		}), mock.Anything, mock.Anything).Return(nil)
+		}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+			return opts.Ref == "feature/branch" && opts.Path == "grafana"
+		})).Return(nil)
 
 		progress := jobs.NewMockJobProgressRecorder(t)
 		progress.On("SetMessage", mock.Anything, mock.Anything).Return().Twice()
@@ -430,7 +442,9 @@ func TestFolderMetaAccessor(t *testing.T) {
 		mockRepoResources := resources.NewMockRepositoryResources(t)
 		progress := jobs.NewMockJobProgressRecorder(t)
 		progress.On("SetMessage", mock.Anything, mock.Anything).Return().Twice()
-		mockRepoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "grafana", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockRepoResources.On("EnsureFolderTreeExists", mock.Anything, mock.Anything, mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+			return opts.Ref == "feature/branch" && opts.Path == "grafana"
+		})).Return(nil)
 
 		err = ExportFolders(context.Background(), "test-repo", v0alpha1.ExportJobOptions{
 			Path:   "grafana",
@@ -492,9 +506,11 @@ func TestFolderMetaAccessor(t *testing.T) {
 		mockRepoResources := resources.NewMockRepositoryResources(t)
 		progress := jobs.NewMockJobProgressRecorder(t)
 		progress.On("SetMessage", mock.Anything, mock.Anything).Return().Twice()
-		mockRepoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "grafana", mock.MatchedBy(func(tree resources.FolderTree) bool {
+		mockRepoResources.On("EnsureFolderTreeExists", mock.Anything, mock.MatchedBy(func(tree resources.FolderTree) bool {
 			return tree.Count() == 0 // Should be empty since folder was skipped
-		}), mock.Anything, mock.Anything).Return(nil)
+		}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+			return opts.Ref == "feature/branch" && opts.Path == "grafana"
+		})).Return(nil)
 
 		err = ExportFolders(context.Background(), "test-repo", v0alpha1.ExportJobOptions{
 			Path:   "grafana",

--- a/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources_specific_test.go
@@ -290,11 +290,13 @@ func TestExportSpecificResources_FolderKindIsExported(t *testing.T) {
 	}}
 
 	repoResources := resources.NewMockRepositoryResources(t)
-	repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "", mock.MatchedBy(func(tree resources.FolderTree) bool {
+	repoResources.On("EnsureFolderTreeExists", mock.Anything, mock.MatchedBy(func(tree resources.FolderTree) bool {
 		return tree.Count() == 2
-	}), mock.Anything, mock.MatchedBy(func(fn func(folder resources.Folder, created bool, err error) error) bool {
-		require.NoError(t, fn(resources.Folder{ID: "parent", Path: "parent"}, true, nil))
-		require.NoError(t, fn(resources.Folder{ID: "child", Path: "parent/child"}, true, nil))
+	}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+		require.Equal(t, "feature/branch", opts.Ref)
+		require.Empty(t, opts.Path)
+		require.NoError(t, opts.OnFolder(resources.Folder{ID: "parent", Path: "parent"}, true, nil))
+		require.NoError(t, opts.OnFolder(resources.Folder{ID: "child", Path: "parent/child"}, true, nil))
 		return true
 	})).Return(nil)
 
@@ -340,11 +342,13 @@ func TestExportSpecificResources_GeneratesFolderForDashboard(t *testing.T) {
 	repoResources := resources.NewMockRepositoryResources(t)
 	// Both ancestor folders are assembled into the tree before the dashboard is
 	// written.
-	repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "", mock.MatchedBy(func(tree resources.FolderTree) bool {
+	repoResources.On("EnsureFolderTreeExists", mock.Anything, mock.MatchedBy(func(tree resources.FolderTree) bool {
 		return tree.Count() == 2
-	}), mock.Anything, mock.MatchedBy(func(fn func(folder resources.Folder, created bool, err error) error) bool {
-		require.NoError(t, fn(resources.Folder{ID: "parent", Path: "parent"}, true, nil))
-		require.NoError(t, fn(resources.Folder{ID: "child", Path: "parent/child"}, true, nil))
+	}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+		require.Equal(t, "feature/branch", opts.Ref)
+		require.Empty(t, opts.Path)
+		require.NoError(t, opts.OnFolder(resources.Folder{ID: "parent", Path: "parent"}, true, nil))
+		require.NoError(t, opts.OnFolder(resources.Folder{ID: "child", Path: "parent/child"}, true, nil))
 		return true
 	})).Return(nil)
 	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
@@ -392,9 +396,11 @@ func TestExportSpecificResources_ManagedFolderAncestryIsSkipped(t *testing.T) {
 
 	repoResources := resources.NewMockRepositoryResources(t)
 	// The managed folder must not appear in the exported tree.
-	repoResources.On("EnsureFolderTreeExists", mock.Anything, "feature/branch", "", mock.MatchedBy(func(tree resources.FolderTree) bool {
+	repoResources.On("EnsureFolderTreeExists", mock.Anything, mock.MatchedBy(func(tree resources.FolderTree) bool {
 		return tree.Count() == 0
-	}), mock.Anything, mock.Anything).Return(nil)
+	}), mock.MatchedBy(func(opts resources.EnsureFolderTreeExistsOptions) bool {
+		return opts.Ref == "feature/branch" && opts.Path == ""
+	})).Return(nil)
 	repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
 		return obj.GetName() == "dash-1"
 	}), mock.Anything).Return("dash-1.json", nil)

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -558,55 +558,73 @@ func (fm *FolderManager) RenameFolderPath(ctx context.Context, previousPath, pre
 	return oldFolder.ID, nil
 }
 
+// EnsureFolderTreeExistsOptions configures EnsureFolderTreeExists.
+type EnsureFolderTreeExistsOptions struct {
+	// Ref is the repository ref (branch) the folders are written to.
+	Ref string
+	// Path is the base path within the repository under which the tree is written.
+	Path string
+	// GenerateNewFolderIDs, when true, writes each newly created folder's
+	// metadata (_folder.json) with a freshly generated UID instead of the
+	// original folder identifier. See EnsureFolderTreeExists for details.
+	GenerateNewFolderIDs bool
+	// OnFolder is called for each folder in the tree. It is called with created
+	// set to false when the folder already exists in the repository, and true
+	// when the folder is created.
+	OnFolder func(folder Folder, created bool, err error) error
+}
+
 // EnsureFolderTreeExists replicates the folder tree to the repository.
-// The function fn is called for each folder.
+// opts.OnFolder is called for each folder.
 // If the folder already exists, the function is called with created set to false.
 // If the folder is created, the function is called with created set to true.
 //
-// When generateNewFolderIDs is true, each folder's metadata (_folder.json) is
-// written with a freshly generated UID instead of the original folder identifier.
-// The in-memory tree keeps the original IDs so resources still resolve to their
-// folder path, and parent nesting is unaffected (it derives from directory
-// structure); only the manifest's metadata.name carries the new UID. This has no
-// effect when folder metadata is not written, since no UID is materialized then.
-func (fm *FolderManager) EnsureFolderTreeExists(ctx context.Context, ref, path string, tree FolderTree, generateNewFolderIDs bool, fn func(folder Folder, created bool, err error) error) error {
+// When opts.GenerateNewFolderIDs is true, each newly created folder's metadata
+// (_folder.json) is written with a freshly generated UID instead of the original
+// folder identifier; folders that already exist in the repository are left
+// untouched. The in-memory tree keeps the original IDs so resources still resolve
+// to their folder path, and parent nesting is unaffected (it derives from
+// directory structure); only the manifest's metadata.name carries the new UID.
+// This has no effect when folder metadata is not written, since no UID is
+// materialized then.
+func (fm *FolderManager) EnsureFolderTreeExists(ctx context.Context, tree FolderTree, opts EnsureFolderTreeExistsOptions) error {
 	return tree.Walk(ctx, func(ctx context.Context, folder Folder, parent string) error {
 		p := folder.Path
-		if path != "" {
-			p = safepath.Join(path, p)
+		if opts.Path != "" {
+			p = safepath.Join(opts.Path, p)
 		}
 		if !safepath.IsDir(p) {
 			p = p + "/" // trailing slash indicates folder
 		}
 
-		_, err := fm.repo.Read(ctx, p, ref)
+		_, err := fm.repo.Read(ctx, p, opts.Ref)
 		if err != nil && (!errors.Is(err, repository.ErrFileNotFound) && !apierrors.IsNotFound(err)) {
-			return fn(folder, false, fmt.Errorf("check if folder exists before writing: %w", err))
+			return opts.OnFolder(folder, false, fmt.Errorf("check if folder exists before writing: %w", err))
 		} else if err == nil {
 			// Folder already exists in repository, add it to tree so resources can find it
 			fm.tree.Add(folder, parent)
-			return fn(folder, false, nil)
+			return opts.OnFolder(folder, false, nil)
 		}
 
 		if fm.folderMetadataEnabled {
 			manifestID := folder.ID
-			if generateNewFolderIDs {
+			if opts.GenerateNewFolderIDs {
 				manifestID = grafanautil.GenerateShortUID()
 			}
 			msg := fmt.Sprintf("Add folder and folder metadata %s", p)
 			manifest := NewFolderManifest(manifestID, folder.Title, fm.folderGVK)
-			if _, err := WriteFolderMetadata(ctx, fm.repo, p, manifest, ref, msg); err != nil {
-				return fn(folder, true, err)
+			if _, err := WriteFolderMetadata(ctx, fm.repo, p, manifest, opts.Ref, msg); err != nil {
+				return opts.OnFolder(folder, true, err)
 			}
 		} else {
 			msg := fmt.Sprintf("Add folder %s", p)
-			if err := fm.repo.Create(ctx, p, ref, nil, msg); err != nil {
-				return fn(folder, true, fmt.Errorf("write folder in repo: %w", err))
+			if err := fm.repo.Create(ctx, p, opts.Ref, nil, msg); err != nil {
+				return opts.OnFolder(folder, true, fmt.Errorf("write folder in repo: %w", err))
 			}
 		}
 		// Add it to the existing tree
 		fm.tree.Add(folder, parent)
 
-		return fn(folder, true, nil)
+		return opts.OnFolder(folder, true, nil)
 	})
 }

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -2188,7 +2188,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 		fm := NewFolderManager(repo, &fakeDynamicResourceClient{}, NewEmptyFolderTree(), FolderKind)
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "", inputTree, false, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, OnFolder: recordingFn(&calls)})
 
 		require.NoError(t, err)
 		require.Len(t, calls, 1)
@@ -2206,7 +2206,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 		fm := NewFolderManager(repo, &fakeDynamicResourceClient{}, NewEmptyFolderTree(), FolderKind)
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "", inputTree, false, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, OnFolder: recordingFn(&calls)})
 
 		require.NoError(t, err)
 		require.Len(t, calls, 1)
@@ -2225,7 +2225,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 			WithFolderMetadataEnabled(true))
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "", inputTree, false, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, OnFolder: recordingFn(&calls)})
 
 		require.NoError(t, err)
 		require.Len(t, calls, 1)
@@ -2244,7 +2244,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 			WithFolderMetadataEnabled(true))
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "", inputTree, false, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, OnFolder: recordingFn(&calls)})
 
 		require.NoError(t, err)
 		require.Len(t, calls, 1)
@@ -2263,7 +2263,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 			WithFolderMetadataEnabled(true))
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "", inputTree, false, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, OnFolder: recordingFn(&calls)})
 
 		require.NoError(t, err)
 		require.Len(t, calls, 1)
@@ -2283,7 +2283,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 			WithFolderMetadataEnabled(true))
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "", inputTree, false, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, OnFolder: recordingFn(&calls)})
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, createErr)
@@ -2304,7 +2304,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 			WithFolderMetadataEnabled(true))
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "", inputTree, false, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, OnFolder: recordingFn(&calls)})
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, createErr)
@@ -2324,7 +2324,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 			WithFolderMetadataEnabled(true))
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "grafana", inputTree, false, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, Path: "grafana", OnFolder: recordingFn(&calls)})
 
 		require.NoError(t, err)
 		require.Len(t, calls, 1)
@@ -2350,7 +2350,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 			WithFolderMetadataEnabled(true))
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "", inputTree, false, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, OnFolder: recordingFn(&calls)})
 
 		require.NoError(t, err)
 		require.Len(t, calls, 2)
@@ -2382,7 +2382,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 			WithFolderMetadataEnabled(true))
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "", inputTree, true, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, GenerateNewFolderIDs: true, OnFolder: recordingFn(&calls)})
 
 		require.NoError(t, err)
 		require.Len(t, calls, 1)
@@ -2404,7 +2404,7 @@ func TestEnsureFolderTreeExists(t *testing.T) {
 		fm := NewFolderManager(repo, &fakeDynamicResourceClient{}, NewEmptyFolderTree(), FolderKind)
 
 		var calls []fnCall
-		err := fm.EnsureFolderTreeExists(ctx, ref, "", inputTree, true, recordingFn(&calls))
+		err := fm.EnsureFolderTreeExists(ctx, inputTree, EnsureFolderTreeExistsOptions{Ref: ref, GenerateNewFolderIDs: true, OnFolder: recordingFn(&calls)})
 
 		require.NoError(t, err)
 		require.Len(t, calls, 1)

--- a/pkg/registry/apis/provisioning/resources/repository.go
+++ b/pkg/registry/apis/provisioning/resources/repository.go
@@ -27,7 +27,7 @@ type RepositoryResources interface {
 	SetTree(tree FolderTree)
 	EnsureFolderPathExist(ctx context.Context, filePath, ref string, opts ...EnsurePathOption) (parent string, err error)
 	EnsureFolderExists(ctx context.Context, folder Folder, parentID string) error
-	EnsureFolderTreeExists(ctx context.Context, ref, path string, tree FolderTree, generateNewFolderIDs bool, fn func(folder Folder, created bool, err error) error) error
+	EnsureFolderTreeExists(ctx context.Context, tree FolderTree, opts EnsureFolderTreeExistsOptions) error
 	RemoveFolderFromTree(folderID string)
 	RemoveFolder(ctx context.Context, folderName string) error
 	RenameFolderPath(ctx context.Context, previousPath, previousRef, newPath, newRef string, opts ...EnsurePathOption) (string, error)

--- a/pkg/registry/apis/provisioning/resources/repository_resources_mock.go
+++ b/pkg/registry/apis/provisioning/resources/repository_resources_mock.go
@@ -146,17 +146,17 @@ func (_c *MockRepositoryResources_EnsureFolderPathExist_Call) RunAndReturn(run f
 	return _c
 }
 
-// EnsureFolderTreeExists provides a mock function with given fields: ctx, ref, path, tree, generateNewFolderIDs, fn
-func (_m *MockRepositoryResources) EnsureFolderTreeExists(ctx context.Context, ref string, path string, tree FolderTree, generateNewFolderIDs bool, fn func(Folder, bool, error) error) error {
-	ret := _m.Called(ctx, ref, path, tree, generateNewFolderIDs, fn)
+// EnsureFolderTreeExists provides a mock function with given fields: ctx, tree, opts
+func (_m *MockRepositoryResources) EnsureFolderTreeExists(ctx context.Context, tree FolderTree, opts EnsureFolderTreeExistsOptions) error {
+	ret := _m.Called(ctx, tree, opts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for EnsureFolderTreeExists")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, FolderTree, bool, func(Folder, bool, error) error) error); ok {
-		r0 = rf(ctx, ref, path, tree, generateNewFolderIDs, fn)
+	if rf, ok := ret.Get(0).(func(context.Context, FolderTree, EnsureFolderTreeExistsOptions) error); ok {
+		r0 = rf(ctx, tree, opts)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -171,18 +171,15 @@ type MockRepositoryResources_EnsureFolderTreeExists_Call struct {
 
 // EnsureFolderTreeExists is a helper method to define mock.On call
 //   - ctx context.Context
-//   - ref string
-//   - path string
 //   - tree FolderTree
-//   - generateNewFolderIDs bool
-//   - fn func(Folder , bool , error) error
-func (_e *MockRepositoryResources_Expecter) EnsureFolderTreeExists(ctx interface{}, ref interface{}, path interface{}, tree interface{}, generateNewFolderIDs interface{}, fn interface{}) *MockRepositoryResources_EnsureFolderTreeExists_Call {
-	return &MockRepositoryResources_EnsureFolderTreeExists_Call{Call: _e.mock.On("EnsureFolderTreeExists", ctx, ref, path, tree, generateNewFolderIDs, fn)}
+//   - opts EnsureFolderTreeExistsOptions
+func (_e *MockRepositoryResources_Expecter) EnsureFolderTreeExists(ctx interface{}, tree interface{}, opts interface{}) *MockRepositoryResources_EnsureFolderTreeExists_Call {
+	return &MockRepositoryResources_EnsureFolderTreeExists_Call{Call: _e.mock.On("EnsureFolderTreeExists", ctx, tree, opts)}
 }
 
-func (_c *MockRepositoryResources_EnsureFolderTreeExists_Call) Run(run func(ctx context.Context, ref string, path string, tree FolderTree, generateNewFolderIDs bool, fn func(Folder, bool, error) error)) *MockRepositoryResources_EnsureFolderTreeExists_Call {
+func (_c *MockRepositoryResources_EnsureFolderTreeExists_Call) Run(run func(ctx context.Context, tree FolderTree, opts EnsureFolderTreeExistsOptions)) *MockRepositoryResources_EnsureFolderTreeExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(FolderTree), args[4].(bool), args[5].(func(Folder, bool, error) error))
+		run(args[0].(context.Context), args[1].(FolderTree), args[2].(EnsureFolderTreeExistsOptions))
 	})
 	return _c
 }
@@ -192,7 +189,7 @@ func (_c *MockRepositoryResources_EnsureFolderTreeExists_Call) Return(_a0 error)
 	return _c
 }
 
-func (_c *MockRepositoryResources_EnsureFolderTreeExists_Call) RunAndReturn(run func(context.Context, string, string, FolderTree, bool, func(Folder, bool, error) error) error) *MockRepositoryResources_EnsureFolderTreeExists_Call {
+func (_c *MockRepositoryResources_EnsureFolderTreeExists_Call) RunAndReturn(run func(context.Context, FolderTree, EnsureFolderTreeExistsOptions) error) *MockRepositoryResources_EnsureFolderTreeExists_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary

Follow-up to #126935 addressing review feedback from @ferruvich:

1. **Collapse the growing argument list** of `EnsureFolderTreeExists` into an `EnsureFolderTreeExistsOptions` struct, as suggested for a follow-up. The signature went from `(ctx, ref, path, tree, generateNewFolderIDs, fn)` to `(ctx, tree, opts)`.
2. **Clarify the doc comment** — `GenerateNewFolderIDs` only affects **newly created** folders; folders already present in the repository are left untouched.

## Changes

- `resources/folders.go`: new `EnsureFolderTreeExistsOptions` struct (`Ref`, `Path`, `GenerateNewFolderIDs`, `OnFolder`), reworked method body, clarified doc comment
- `resources/repository.go`: updated `RepositoryResources` interface signature
- `resources/repository_resources_mock.go`: regenerated mock (hand-edited — mockery v2.53 cannot parse go1.26 sources)
- `jobs/export/folders.go`: updated the production caller to pass the options struct
- Tests: migrated direct calls in `resources/folders_test.go` and mock matchers in `jobs/export/folders_test.go` + `resources_specific_test.go`. The new `opts` matchers assert `Ref`/`Path` and invoke `OnFolder`, preserving the previous coverage.

## Testing

- `go test ./pkg/registry/apis/provisioning/resources/... ./pkg/registry/apis/provisioning/jobs/export/... ./pkg/registry/apis/provisioning/jobs/migrate/...` — all pass
- `gofmt` clean; `go build ./pkg/registry/apis/provisioning/...` passes

## Checklist
- [x] Tests updated
- [x] Pure refactor — no behavior change
- [x] No breaking changes (internal API only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)