### PR TITLE
DataSourcePicker: Fix selected datasource not being highlighted

### DIFF
--- a/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
@@ -65,6 +65,51 @@ describe('DataSourcePicker', () => {
     });
   });
 
+  describe('selected option', () => {
+    it('should mark the current datasource as selected when its uid differs from its name', async () => {
+      const datasourceName = 'grafanacloud-demokitcloudamersandbox-prom';
+      const currentUid = 'grafanacloud-prom';
+      const mockDs: DataSourceInstanceSettings = {
+        uid: currentUid,
+        name: datasourceName,
+        type: 'prometheus',
+        meta: {
+          id: 'prometheus',
+          name: 'Prometheus',
+          type: 'datasource',
+          info: {
+            logos: {
+              small: 'prometheus_logo.svg',
+              large: 'prometheus_logo.svg',
+            },
+            author: { name: 'Grafana Labs' },
+            description: 'Prometheus data source',
+            links: [],
+            screenshots: [],
+            updated: '2021-01-01',
+            version: '1.0.0',
+          },
+          module: 'core:plugin/prometheus',
+          baseUrl: '',
+        } as DataSourcePluginMeta,
+        readOnly: false,
+        jsonData: {},
+        access: 'proxy',
+      };
+
+      mockGetInstanceSettings.mockReturnValue(mockDs);
+      mockGetList.mockReturnValue([mockDs]);
+
+      render(<DataSourcePicker current={currentUid} onChange={jest.fn()} />);
+
+      await userEvent.click(screen.getByLabelText('Select a data source'));
+
+      // react-select marks the option matching the current value as selected. The orange-bar
+      // styling is driven by this state, so asserting on aria-selected guards the regression.
+      expect(screen.getByTestId('data-testid Select option')).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
   describe('onClear', () => {
     it('should call onClear when function is passed', async () => {
       const onClear = jest.fn();

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -136,7 +136,7 @@ export const DataSourcePicker = memo(function DataSourcePicker({
     return dataSourceSrv
       .getList({ alerting, tracing, metrics, logs, dashboard, mixed, variables, annotations, pluginId, filter, type })
       .map((ds) => ({
-        value: ds.name,
+        value: ds.uid,
         label: `${ds.name}${ds.isDefault ? ' (default)' : ''}`,
         imgUrl: ds.meta.info.logos.small,
         meta: ds.meta,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The runtime `DataSourcePicker` built its current value keyed on the datasource `uid` but its option list keyed on the `name`. `react-select` marks an option as selected by matching the current value against each option's `value`, so the selected indicator ("orange bar") only appeared when a datasource's `uid` happened to equal its `name`. Key the options off `uid` so both sides agree.

**Why do we need this feature?**

To have a consistent UX using the `DataSourcePicker` component.

**Who is this feature for?**

Users of the `DataSourcePicker` component, e.g. users of DBo11y app.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #99974 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
