### PR TITLE
Provisioning: Limit selective export to 100 resources

### DIFF
--- a/apps/provisioning/pkg/jobs/validator.go
+++ b/apps/provisioning/pkg/jobs/validator.go
@@ -136,11 +136,23 @@ func validateMigrateJobOptions(opts *provisioning.MigrateJobOptions, supportedRe
 	return list
 }
 
+// MaxSelectiveExportResources caps how many resources a single export-style job
+// (push or migrate) may explicitly request. Selective export fetches each resource
+// individually, so an unbounded list would translate into an unbounded number of
+// per-resource lookups; this bound keeps a single job's work predictable.
+const MaxSelectiveExportResources = 100
+
 // validateExportResourceRefs enforces the rules shared by export-style resource
 // lists (push and migrate): name + kind are required, and each kind/group must
 // match an active entry in the configured supported-resource set.
 func validateExportResourceRefs(base *field.Path, refs []provisioning.ResourceRef, supportedResources []provisioning.SupportedResource) field.ErrorList {
 	list := field.ErrorList{}
+
+	if len(refs) > MaxSelectiveExportResources {
+		list = append(list, field.TooMany(base, len(refs), MaxSelectiveExportResources))
+		return list
+	}
+
 	supported := activeExportResources(supportedResources)
 	for i, r := range refs {
 		path := base.Index(i)

--- a/apps/provisioning/pkg/jobs/validator_test.go
+++ b/apps/provisioning/pkg/jobs/validator_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -903,6 +904,56 @@ func TestValidateJob(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "push action at the selective export limit",
+			job: &provisioning.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+				Spec: provisioning.JobSpec{
+					Action:     provisioning.JobActionPush,
+					Repository: "test-repo",
+					Push: &provisioning.ExportJobOptions{
+						Resources: makeDashboardRefs(MaxSelectiveExportResources),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "push action over the selective export limit",
+			job: &provisioning.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+				Spec: provisioning.JobSpec{
+					Action:     provisioning.JobActionPush,
+					Repository: "test-repo",
+					Push: &provisioning.ExportJobOptions{
+						Resources: makeDashboardRefs(MaxSelectiveExportResources + 1),
+					},
+				},
+			},
+			wantErr: true,
+			validateError: func(t *testing.T, err error) {
+				require.Contains(t, err.Error(), "spec.push.resources")
+				require.Contains(t, err.Error(), "must have at most 100 items")
+			},
+		},
+		{
+			name: "migrate action over the selective export limit",
+			job: &provisioning.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+				Spec: provisioning.JobSpec{
+					Action:     provisioning.JobActionMigrate,
+					Repository: "test-repo",
+					Migrate: &provisioning.MigrateJobOptions{
+						Resources: makeDashboardRefs(MaxSelectiveExportResources + 1),
+					},
+				},
+			},
+			wantErr: true,
+			validateError: func(t *testing.T, err error) {
+				require.Contains(t, err.Error(), "spec.migrate.resources")
+				require.Contains(t, err.Error(), "must have at most 100 items")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1124,6 +1175,15 @@ func TestHistoricJobAdmissionValidator_Validate(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// makeDashboardRefs builds n valid dashboard resource refs for limit tests.
+func makeDashboardRefs(n int) []provisioning.ResourceRef {
+	refs := make([]provisioning.ResourceRef, n)
+	for i := range refs {
+		refs[i] = provisioning.ResourceRef{Name: fmt.Sprintf("dash-%d", i), Kind: "Dashboard"}
+	}
+	return refs
 }
 
 func newHistoricJobAdmissionTestAttributes(obj runtime.Object, op admission.Operation) admission.Attributes {

--- a/pkg/tests/apis/provisioning/jobs/job_validation_test.go
+++ b/pkg/tests/apis/provisioning/jobs/job_validation_test.go
@@ -29,6 +29,15 @@ func TestIntegrationProvisioning_JobValidation(t *testing.T) {
 	}
 	helper.CreateLocalRepo(t, testRepo)
 
+	// Build a resource list that exceeds the selective-export cap (100).
+	overLimitResources := make([]map[string]interface{}, 101)
+	for i := range overLimitResources {
+		overLimitResources[i] = map[string]interface{}{
+			"name": fmt.Sprintf("dash-%d", i),
+			"kind": "Dashboard",
+		}
+	}
+
 	tests := []struct {
 		name        string
 		jobSpec     map[string]interface{}
@@ -259,6 +268,28 @@ func TestIntegrationProvisioning_JobValidation(t *testing.T) {
 				},
 			},
 			expectedErr: "spec.push.resources[0].kind: Invalid value: \"LibraryPanel\": kind is not supported for export",
+		},
+		{
+			name: "push job exceeding the selective export resource limit",
+			jobSpec: map[string]interface{}{
+				"action":     string(provisioning.JobActionPush),
+				"repository": repo,
+				"push": map[string]interface{}{
+					"resources": overLimitResources,
+				},
+			},
+			expectedErr: "spec.push.resources: Too many: 101: must have at most 100 items",
+		},
+		{
+			name: "migrate job exceeding the selective export resource limit",
+			jobSpec: map[string]interface{}{
+				"action":     string(provisioning.JobActionMigrate),
+				"repository": repo,
+				"migrate": map[string]interface{}{
+					"resources": overLimitResources,
+				},
+			},
+			expectedErr: "spec.migrate.resources: Too many: 101: must have at most 100 items",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Selective export (push and migrate jobs that carry an explicit `Resources` list) fetches each requested resource with an individual `Get` call. An unbounded list therefore translates into an unbounded number of per-resource lookups for a single job.

This change caps the selective export resource list at **100** and rejects oversized jobs at admission time, before any worker picks them up.

## Changes

- Add `MaxSelectiveExportResources = 100` constant in `apps/provisioning/pkg/jobs/validator.go`.
- Enforce the cap in `validateExportResourceRefs`, the validation shared by both push (`ExportJobOptions`) and migrate (`MigrateJobOptions`). Over-limit lists fail with a `field.TooMany` error and return early.
- Add tests covering at-limit (valid), over-limit push, and over-limit migrate.

## Testing

- `go test ./apps/provisioning/pkg/jobs/` — passes.
- New cases assert 100 resources is accepted and 101 is rejected with a `must have at most 100 items` error for both push and migrate.

## Notes

- Backend-only change. Per the repo's separate-FE/BE-PR convention, UI enforcement (preventing selection of >100 resources) would be a follow-up frontend PR.
- delete/move jobs share the `ResourceRef` shape but go through different validators and are intentionally left unchanged — this is scoped to selective *export*.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [x] No breaking changes (or documented)

🤖 Generated with Claude Code