### PR TITLE
unified-storage: fix flake in lease expiration handoff test

### DIFF
--- a/pkg/storage/unified/testing/lease.go
+++ b/pkg/storage/unified/testing/lease.go
@@ -242,7 +242,11 @@ func runLeaseExpiration(t *testing.T, store kv.KV) {
 		// Wait past TTL with a small buffer for timer slack.
 		time.Sleep(ttl + 50*time.Millisecond)
 
-		leaseB, err := b.Acquire(ctx, "expiration/handoff", lease.WithTTL(ttl))
+		// Acquire with a generous TTL for the second holder. The test only
+		// verifies that b can take over once a's short-lived lease expires.
+		// A short TTL here would race b's own expiry against its release on a
+		// slow machine and fail with ErrLeaseLost.
+		leaseB, err := b.Acquire(ctx, "expiration/handoff", lease.WithTTL(time.Minute))
 		require.NoError(t, err, "second holder should be able to acquire after TTL elapsed")
 		require.NotNil(t, leaseB)
 		require.NoError(t, b.Release(ctx, leaseB))


### PR DESCRIPTION
Fixes a flaky failure in `TestIntegrationLease*/expiration/different_holder_can_acquire_after_TTL`.

The subtest checks that holder `b` can take over a lease once holder `a`'s short-lived lease expires. Both holders used the same 50ms TTL, so `b` acquired with that 50ms TTL and then released immediately. The release path does real work first (start a trace span, sync on a channel, read from the store), and on a loaded CI runner that can take longer than 50ms. When it does, `b`'s own lease has already expired by the time it tries to release, so the release returns `ErrLeaseLost` and the test fails.

This is a test-timing race, not a product bug — releasing an expired lease is supposed to return `ErrLeaseLost`.

The fix gives holder `b` a long TTL on acquire so its release no longer races its own expiry. Holder `a` keeps the short TTL, so the handoff scenario is still exercised.

Verified by running both the Badger and SQLite variants of the test repeatedly with no failures.