### PR TITLE
Provisioning: Mirror branch and pullRequest options on RepositoryView

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/settings.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/settings.go
@@ -79,6 +79,14 @@ type RepositoryView struct {
 
 	// Commit message options. Mirrors the same-named field on the repository spec.
 	Commit *CommitOptions `json:"commit,omitempty"`
+
+	// Branch naming options. Mirrors spec.branch. Exposed under `branchOptions`
+	// rather than `branch` because the view already uses `branch` for the git
+	// target branch name.
+	BranchOptions *BranchOptions `json:"branchOptions,omitempty"`
+
+	// Pull request options. Mirrors the same-named field on the repository spec.
+	PullRequest *PullRequestOptions `json:"pullRequest,omitempty"`
 }
 
 func (RepositoryView) OpenAPIModelName() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.deepcopy.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.deepcopy.go
@@ -1253,6 +1253,16 @@ func (in *RepositoryView) DeepCopyInto(out *RepositoryView) {
 		*out = new(CommitOptions)
 		**out = **in
 	}
+	if in.BranchOptions != nil {
+		in, out := &in.BranchOptions, &out.BranchOptions
+		*out = new(BranchOptions)
+		**out = **in
+	}
+	if in.PullRequest != nil {
+		in, out := &in.PullRequest, &out.PullRequest
+		*out = new(PullRequestOptions)
+		**out = **in
+	}
 	return
 }
 

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -2686,12 +2686,24 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryView(ref common.ReferenceCa
 							Ref:         ref(CommitOptions{}.OpenAPIModelName()),
 						},
 					},
+					"branchOptions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Branch naming options. Mirrors spec.branch. Exposed under `branchOptions` rather than `branch` because the view already uses `branch` for the git target branch name.",
+							Ref:         ref(BranchOptions{}.OpenAPIModelName()),
+						},
+					},
+					"pullRequest": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Pull request options. Mirrors the same-named field on the repository spec.",
+							Ref:         ref(PullRequestOptions{}.OpenAPIModelName()),
+						},
+					},
 				},
 				Required: []string{"name", "title", "type", "target", "workflows"},
 			},
 		},
 		Dependencies: []string{
-			CommitOptions{}.OpenAPIModelName()},
+			BranchOptions{}.OpenAPIModelName(), CommitOptions{}.OpenAPIModelName(), PullRequestOptions{}.OpenAPIModelName()},
 	}
 }
 

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -2182,12 +2182,16 @@ export type SupportedResource = {
 export type RepositoryView = {
   /** For git, this is the target branch */
   branch?: string;
+  /** Branch naming options. Mirrors spec.branch. Exposed under `branchOptions` rather than `branch` because the view already uses `branch` for the git target branch name. */
+  branchOptions?: BranchOptions;
   /** Commit message options. Mirrors the same-named field on the repository spec. */
   commit?: CommitOptions;
   /** The k8s name for this repository */
   name: string;
   /** For git, this is the target path */
   path?: string;
+  /** Pull request options. Mirrors the same-named field on the repository spec. */
+  pullRequest?: PullRequestOptions;
   /** When syncing, where values are saved
     
     Possible enum values:

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -5406,6 +5406,14 @@
             "description": "For git, this is the target branch",
             "type": "string"
           },
+          "branchOptions": {
+            "description": "Branch naming options. Mirrors spec.branch. Exposed under `branchOptions` rather than `branch` because the view already uses `branch` for the git target branch name.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BranchOptions"
+              }
+            ]
+          },
           "commit": {
             "description": "Commit message options. Mirrors the same-named field on the repository spec.",
             "allOf": [
@@ -5422,6 +5430,14 @@
           "path": {
             "description": "For git, this is the target path",
             "type": "string"
+          },
+          "pullRequest": {
+            "description": "Pull request options. Mirrors the same-named field on the repository spec.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PullRequestOptions"
+              }
+            ]
           },
           "target": {
             "description": "When syncing, where values are saved\n\nPossible enum values:\n - `\"folder\"` Resources will be saved into a folder managed by this repository It will contain a copy of everything from the remote The folder k8s name will be the same as the repository k8s name\n - `\"folderless\"` Resources are saved at the top level without a wrapper folder. Like `folder`, multiple `folderless` repositories may coexist with each other, with `folder` repositories, and with unprovisioned resources. Unlike `folder`, no repo-named container folder is created: files at the repository path root become top-level resources and subdirectories become top-level folders. Ownership is tracked per-resource via manager annotations rather than by folder containment.\n - `\"instance\"` Resources are saved in the global context Only one repository may specify the `instance` target When this exists, the UI will promote writing to the instance repo rather than the grafana database (where possible)",

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -5017,6 +5017,14 @@
             "description": "For git, this is the target branch",
             "type": "string"
           },
+          "branchOptions": {
+            "description": "Branch naming options. Mirrors spec.branch. Exposed under `branchOptions` rather than `branch` because the view already uses `branch` for the git target branch name.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BranchOptions"
+              }
+            ]
+          },
           "commit": {
             "description": "Commit message options. Mirrors the same-named field on the repository spec.",
             "allOf": [
@@ -5033,6 +5041,14 @@
           "path": {
             "description": "For git, this is the target path",
             "type": "string"
+          },
+          "pullRequest": {
+            "description": "Pull request options. Mirrors the same-named field on the repository spec.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PullRequestOptions"
+              }
+            ]
           },
           "target": {
             "description": "When syncing, where values are saved\n\nPossible enum values:\n - `\"folder\"` Resources will be saved into a folder managed by this repository It will contain a copy of everything from the remote The folder k8s name will be the same as the repository k8s name\n - `\"folderless\"` Resources are saved at the top level without a wrapper folder. Like `folder`, multiple `folderless` repositories may coexist with each other, with `folder` repositories, and with unprovisioned resources. Unlike `folder`, no repo-named container folder is created: files at the repository path root become top-level resources and subdirectories become top-level folders. Ownership is tracked per-resource via manager annotations rather than by folder containment.\n - `\"instance\"` Resources are saved in the global context Only one repository may specify the `instance` target When this exists, the UI will promote writing to the instance repo rather than the grafana database (where possible)",

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -1544,6 +1544,28 @@ spec:
 	}
 	oas.Components.Schemas[compBase+"RepositoryView"].Properties["commit"] = commitSchema
 
+	// Re-attach the RepositoryView.branchOptions ref for the same reason as commit above.
+	branchOptionsSchema := oas.Components.Schemas[compBase+"RepositoryView"].Properties["branchOptions"]
+	branchOptionsSchema.AllOf = []spec.Schema{
+		{
+			SchemaProps: spec.SchemaProps{
+				Ref: spec.MustCreateRef("#/components/schemas/" + compBase + "BranchOptions"),
+			},
+		},
+	}
+	oas.Components.Schemas[compBase+"RepositoryView"].Properties["branchOptions"] = branchOptionsSchema
+
+	// Re-attach the RepositoryView.pullRequest ref for the same reason as commit above.
+	pullRequestSchema := oas.Components.Schemas[compBase+"RepositoryView"].Properties["pullRequest"]
+	pullRequestSchema.AllOf = []spec.Schema{
+		{
+			SchemaProps: spec.SchemaProps{
+				Ref: spec.MustCreateRef("#/components/schemas/" + compBase + "PullRequestOptions"),
+			},
+		},
+	}
+	oas.Components.Schemas[compBase+"RepositoryView"].Properties["pullRequest"] = pullRequestSchema
+
 	countSpec := &spec.SchemaOrArray{
 		Schema: &spec.Schema{
 			SchemaProps: spec.SchemaProps{

--- a/pkg/registry/apis/provisioning/routes.go
+++ b/pkg/registry/apis/provisioning/routes.go
@@ -194,15 +194,17 @@ func (b *APIBuilder) handleSettings(w http.ResponseWriter, r *http.Request) {
 		path := val.Path()
 
 		settings.Items[i] = provisioning.RepositoryView{
-			Name:      val.Name,
-			Title:     val.Spec.Title,
-			Type:      val.Spec.Type,
-			Target:    val.Spec.Sync.Target,
-			Branch:    branch,
-			URL:       url,
-			Path:      path,
-			Workflows: val.Spec.Workflows,
-			Commit:    val.Spec.Commit,
+			Name:          val.Name,
+			Title:         val.Spec.Title,
+			Type:          val.Spec.Type,
+			Target:        val.Spec.Sync.Target,
+			Branch:        branch,
+			URL:           url,
+			Path:          path,
+			Workflows:     val.Spec.Workflows,
+			Commit:        val.Spec.Commit,
+			BranchOptions: val.Spec.Branch,
+			PullRequest:   val.Spec.PullRequest,
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -5842,6 +5842,14 @@
             "description": "For git, this is the target branch",
             "type": "string"
           },
+          "branchOptions": {
+            "description": "Branch naming options. Mirrors spec.branch. Exposed under `branchOptions` rather than `branch` because the view already uses `branch` for the git target branch name.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v0alpha1.BranchOptions"
+              }
+            ]
+          },
           "commit": {
             "description": "Commit message options. Mirrors the same-named field on the repository spec.",
             "allOf": [
@@ -5858,6 +5866,14 @@
           "path": {
             "description": "For git, this is the target path",
             "type": "string"
+          },
+          "pullRequest": {
+            "description": "Pull request options. Mirrors the same-named field on the repository spec.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v0alpha1.PullRequestOptions"
+              }
+            ]
           },
           "target": {
             "description": "When syncing, where values are saved\n\nPossible enum values:\n - `\"folder\"` Resources will be saved into a folder managed by this repository It will contain a copy of everything from the remote The folder k8s name will be the same as the repository k8s name\n - `\"folderless\"` Resources are saved at the top level without a wrapper folder. Like `folder`, multiple `folderless` repositories may coexist with each other, with `folder` repositories, and with unprovisioned resources. Unlike `folder`, no repo-named container folder is created: files at the repository path root become top-level resources and subdirectories become top-level folders. Ownership is tracked per-resource via manager annotations rather than by folder containment.\n - `\"instance\"` Resources are saved in the global context Only one repository may specify the `instance` target When this exists, the UI will promote writing to the instance repo rather than the grafana database (where possible)",

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -5453,6 +5453,14 @@
             "description": "For git, this is the target branch",
             "type": "string"
           },
+          "branchOptions": {
+            "description": "Branch naming options. Mirrors spec.branch. Exposed under `branchOptions` rather than `branch` because the view already uses `branch` for the git target branch name.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v1beta1.BranchOptions"
+              }
+            ]
+          },
           "commit": {
             "description": "Commit message options. Mirrors the same-named field on the repository spec.",
             "allOf": [
@@ -5469,6 +5477,14 @@
           "path": {
             "description": "For git, this is the target path",
             "type": "string"
+          },
+          "pullRequest": {
+            "description": "Pull request options. Mirrors the same-named field on the repository spec.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v1beta1.PullRequestOptions"
+              }
+            ]
           },
           "target": {
             "description": "When syncing, where values are saved\n\nPossible enum values:\n - `\"folder\"` Resources will be saved into a folder managed by this repository It will contain a copy of everything from the remote The folder k8s name will be the same as the repository k8s name\n - `\"folderless\"` Resources are saved at the top level without a wrapper folder. Like `folder`, multiple `folderless` repositories may coexist with each other, with `folder` repositories, and with unprovisioned resources. Unlike `folder`, no repo-named container folder is created: files at the repository path root become top-level resources and subdirectories become top-level folders. Ownership is tracked per-resource via manager annotations rather than by folder containment.\n - `\"instance\"` Resources are saved in the global context Only one repository may specify the `instance` target When this exists, the UI will promote writing to the instance repo rather than the grafana database (where possible)",


### PR DESCRIPTION
## Summary

`spec.branch` (`BranchOptions`) and `spec.pullRequest` (`PullRequestOptions`) were added to `RepositorySpec` but never mirrored onto `RepositoryView`. The frontend reads per-repository options from the **view** — as it already does for the commit template — so these two option groups were invisible to it.

This adds them to `RepositoryView`, following the exact pattern PR #123166 used to expose `commit`.

Related: grafana/git-ui-sync-project#1195

## Changes

- **`RepositoryView`** (`settings.go`): add `branchOptions` (`*BranchOptions`) and `pullRequest` (`*PullRequestOptions`).
  - `BranchOptions` is surfaced under **`branchOptions`** rather than `branch` because the view already uses the flat `branch` field for the git **target-branch name** (consumed by `RepositoryPullStatusCard` / `ResourceTreeView`). This matches the existing `RepositoryFormData.branchOptions` naming on the frontend. `PullRequestOptions` keeps the spec key `pullRequest`.
- **`handleSettings`** (`routes.go`): populate both from `val.Spec.Branch` / `val.Spec.PullRequest`.
- **`PostProcessOpenAPI`** (`register.go`): re-attach the `$ref`s for `branchOptions` and `pullRequest`, same fix the `commit` field required.
- **Generated**: `zz_generated.deepcopy.go`, `zz_generated.openapi.go`, the OpenAPI snapshots (v0alpha1 + v1beta1), the `grafana-openapi` specs, and the RTK frontend client (`endpoints.gen.ts`).

Resulting frontend type:

```ts
export type RepositoryView = {
  branch?: string;                  // git target branch (unchanged)
  branchOptions?: BranchOptions;    // NEW
  commit?: CommitOptions;
  pullRequest?: PullRequestOptions; // NEW
  ...
};
```

## Testing

- `go build` + `go vet` on the touched provisioning packages — clean.
- `TestIntegrationOpenAPIs` regenerated and validated the v0alpha1/v1beta1 OpenAPI snapshots.
- Frontend client regenerated via `yarn workspace @grafana/api-clients generate-apis`.

## Notes

This is the backend half (Go types + the derived generated client artifacts, bundled the same way #123166 did it). The frontend **wiring** — reading `repository.branchOptions` / `repository.pullRequest` from the view in the Save drawers — is a follow-up, matching how the commit-template frontend work was a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)