### PR TITLE
Home: Link to alert rules when none firing

### DIFF
--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
@@ -247,9 +247,17 @@ function FiringAlertsCardInner() {
               variant="secondary"
               size="sm"
               fill="text"
-              href={`/alerting/groups?${ALERTMANAGER_NAME_QUERY_KEY}=${GRAFANA_RULES_SOURCE_NAME}`}
+              href={
+                alerts?.length
+                  ? `/alerting/groups?${ALERTMANAGER_NAME_QUERY_KEY}=${GRAFANA_RULES_SOURCE_NAME}`
+                  : `/alerting/list?search=source:${GRAFANA_RULES_SOURCE_NAME}`
+              }
             >
-              <Trans i18nKey="home.firing-alerts-card.view-all">View all firing alerts</Trans>
+              {alerts?.length ? (
+                <Trans i18nKey="home.firing-alerts-card.view-all">View all firing alerts</Trans>
+              ) : (
+                <Trans i18nKey="home.firing-alerts-card.view-rules">View all alert rules</Trans>
+              )}
             </LinkButton>
           </Stack>
         )}

--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -241,6 +241,7 @@ export function DashboardTabs() {
 const getStyles = (theme: GrafanaTheme2) => ({
   tabContent: css({
     padding: 0,
+    background: theme.colors.background.primary,
     borderRadius: theme.shape.radius.default,
   }),
   linkTabsSpacer: css({

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10587,7 +10587,8 @@
       "severity-minor": "Minor",
       "severity-unknown": "Unknown severity",
       "title": "Firing alerts",
-      "view-all": "View all firing alerts"
+      "view-all": "View all firing alerts",
+      "view-rules": "View all alert rules"
     },
     "home-page": {
       "edition": {


### PR DESCRIPTION
**What is this feature?**

When no alerts are firing, switch the link to alert rules.

_Also, sneaks in a missing background on the dashboard tabs, to match the design on the Cloud homepage currently._

**Why do we need this feature?**

Linking to firing alerts when there are none is rather redundant.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana/issues/124136 https://github.com/grafana/grafana/issues/126391 https://github.com/grafana/grafana/pull/125719

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
