### PR TITLE
instrumentation: add per-resource metrics for dashboard and folder APIs

### DIFF
--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -221,21 +221,15 @@ func ProvideService(
 	return s, nil
 }
 
-// registerAPIServerRoutes registers the explicit route patterns that proxy to the
-// k8s-style API server. Each per-group pattern gives that resource its own `handler`
-// label in grafana_http_request_duration_seconds; without an explicit pattern a group
-// falls through to the catch-all and is merged into the generic `/apis/*` bucket,
-// making per-resource latency/traffic impossible to observe.
+// registerAPIServerRoutes registers the explicit proxy route patterns. Each per-group
+// pattern gives that resource its own `handler` label instead of the generic /apis/* bucket.
 func registerAPIServerRoutes(k8sRoute routing.RouteRegister, handler web.Handler) {
 	k8sRoute.Any("/features.grafana.app/v0alpha1/*", handler)
 	k8sRoute.Any("/dashboard.grafana.app/*", middleware.ReqSignedIn, handler)
 	k8sRoute.Any("/folder.grafana.app/*", middleware.ReqSignedIn, handler)
 
-	// Allow unauthenticated GET access to snapshots and the dashboard subresource.
-	// Snapshots are shared via URL with the key, so they are always publicly accessible.
-	// Authorization is enforced by the snapshot authorizer. These patterns are more
-	// specific than the dashboard.grafana.app wildcard above, so the router matches them
-	// first and they remain unauthenticated.
+	// Unauthenticated GET access to snapshots (shared via URL key; authz enforced by the
+	// snapshot authorizer). More specific than the dashboard wildcard, so matched first.
 	snapshotPath := "/" + dashv0.GROUP + "/" + dashv0.VERSION + "/namespaces/:namespace/snapshots/:name"
 	k8sRoute.Get(snapshotPath, handler)
 	k8sRoute.Get(snapshotPath+"/dashboard", handler)

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -55,6 +55,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var (
@@ -204,16 +205,7 @@ func ProvideService(
 			resp := responsewriter.WrapForHTTP1Or2(c.Resp)
 			s.handler.ServeHTTP(resp, req)
 		}
-		k8sRoute.Any("/features.grafana.app/v0alpha1/*", handler)
-		// Allow unauthenticated GET access to snapshots and the dashboard subresource.
-		// Snapshots are shared via URL with the key, so they are always publicly accessible.
-		// Authorization is enforced by the snapshot authorizer.
-		snapshotPath := "/" + dashv0.GROUP + "/" + dashv0.VERSION + "/namespaces/:namespace/snapshots/:name"
-		k8sRoute.Get(snapshotPath, handler)
-		k8sRoute.Get(snapshotPath+"/dashboard", handler)
-
-		k8sRoute.Any("/", middleware.ReqSignedIn, handler)
-		k8sRoute.Any("/*", middleware.ReqSignedIn, handler)
+		registerAPIServerRoutes(k8sRoute, handler)
 	}
 
 	s.rr.Group("/apis", proxyHandler)
@@ -227,6 +219,29 @@ func ProvideService(
 	close(eventualRestConfigProvider.ready)
 
 	return s, nil
+}
+
+// registerAPIServerRoutes registers the explicit route patterns that proxy to the
+// k8s-style API server. Each per-group pattern gives that resource its own `handler`
+// label in grafana_http_request_duration_seconds; without an explicit pattern a group
+// falls through to the catch-all and is merged into the generic `/apis/*` bucket,
+// making per-resource latency/traffic impossible to observe.
+func registerAPIServerRoutes(k8sRoute routing.RouteRegister, handler web.Handler) {
+	k8sRoute.Any("/features.grafana.app/v0alpha1/*", handler)
+	k8sRoute.Any("/dashboard.grafana.app/*", middleware.ReqSignedIn, handler)
+	k8sRoute.Any("/folder.grafana.app/*", middleware.ReqSignedIn, handler)
+
+	// Allow unauthenticated GET access to snapshots and the dashboard subresource.
+	// Snapshots are shared via URL with the key, so they are always publicly accessible.
+	// Authorization is enforced by the snapshot authorizer. These patterns are more
+	// specific than the dashboard.grafana.app wildcard above, so the router matches them
+	// first and they remain unauthenticated.
+	snapshotPath := "/" + dashv0.GROUP + "/" + dashv0.VERSION + "/namespaces/:namespace/snapshots/:name"
+	k8sRoute.Get(snapshotPath, handler)
+	k8sRoute.Get(snapshotPath+"/dashboard", handler)
+
+	k8sRoute.Any("/", middleware.ReqSignedIn, handler)
+	k8sRoute.Any("/*", middleware.ReqSignedIn, handler)
 }
 
 func (s *service) GetRestConfig(ctx context.Context) (*clientrest.Config, error) {

--- a/pkg/services/apiserver/service_routes_test.go
+++ b/pkg/services/apiserver/service_routes_test.go
@@ -11,9 +11,8 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
-// capturedRoute records a single registered route so tests can assert both the pattern
-// (which becomes the `handler` label in grafana_http_request_duration_seconds) and the
-// middleware chain (which determines whether the route requires authentication).
+// capturedRoute records a registered route so tests can assert its pattern (the `handler`
+// label) and middleware chain (which determines whether the route requires authentication).
 type capturedRoute struct {
 	method   string
 	handlers []web.Handler
@@ -46,31 +45,11 @@ func registerForTest(t *testing.T) *captureRouter {
 	return cr
 }
 
-func TestRegisterAPIServerRoutes_PerResourcePatterns(t *testing.T) {
-	cr := registerForTest(t)
-
-	// Each resource needs its own explicit route pattern so it gets a distinct
-	// `handler` label in grafana_http_request_duration_seconds instead of being merged
-	// into the generic /apis/* bucket.
-	for _, pattern := range []string{
-		"/apis/features.grafana.app/v0alpha1/*",
-		"/apis/dashboard.grafana.app/*",
-		"/apis/folder.grafana.app/*",
-		"/apis/*", // catch-all must still exist for every other group
-	} {
-		_, ok := cr.routes[pattern]
-		require.True(t, ok, "expected route %q to be registered", pattern)
-	}
-}
-
 func TestRegisterAPIServerRoutes_AuthIsPreserved(t *testing.T) {
 	cr := registerForTest(t)
 
-	// The named ProvideRouteOperationName middleware is prepended to every route, so an
-	// unauthenticated route carries [routeName, handler] while an authenticated one
-	// carries [routeName, ReqSignedIn, handler]. Comparing chain lengths guards that the
-	// new dashboard/folder wildcards keep ReqSignedIn (matching the catch-all they used
-	// to fall through), while the public snapshot routes stay unauthenticated.
+	// ProvideRouteOperationName is prepended to every route, so an unauthenticated chain is
+	// [routeName, handler] (len 2) and an authenticated one adds ReqSignedIn (len 3).
 	const unauthenticated = 2
 	const authenticated = 3
 

--- a/pkg/services/apiserver/service_routes_test.go
+++ b/pkg/services/apiserver/service_routes_test.go
@@ -1,0 +1,96 @@
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/middleware"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+// capturedRoute records a single registered route so tests can assert both the pattern
+// (which becomes the `handler` label in grafana_http_request_duration_seconds) and the
+// middleware chain (which determines whether the route requires authentication).
+type capturedRoute struct {
+	method   string
+	handlers []web.Handler
+}
+
+// captureRouter implements routing.Router and records every route registered against it.
+type captureRouter struct {
+	routes map[string]capturedRoute
+}
+
+var _ routing.Router = (*captureRouter)(nil)
+
+func (r *captureRouter) Handle(method, pattern string, handlers []web.Handler) {
+	r.routes[pattern] = capturedRoute{method: method, handlers: handlers}
+}
+
+func (r *captureRouter) Get(pattern string, handlers ...web.Handler) {
+	r.routes[pattern] = capturedRoute{method: "GET", handlers: handlers}
+}
+
+func registerForTest(t *testing.T) *captureRouter {
+	t.Helper()
+	rr := routing.NewRouteRegister(middleware.ProvideRouteOperationName)
+	rr.Group("/apis", func(k8sRoute routing.RouteRegister) {
+		registerAPIServerRoutes(k8sRoute, func(*contextmodel.ReqContext) {})
+	})
+
+	cr := &captureRouter{routes: map[string]capturedRoute{}}
+	rr.Register(cr)
+	return cr
+}
+
+func TestRegisterAPIServerRoutes_PerResourcePatterns(t *testing.T) {
+	cr := registerForTest(t)
+
+	// Each resource needs its own explicit route pattern so it gets a distinct
+	// `handler` label in grafana_http_request_duration_seconds instead of being merged
+	// into the generic /apis/* bucket.
+	for _, pattern := range []string{
+		"/apis/features.grafana.app/v0alpha1/*",
+		"/apis/dashboard.grafana.app/*",
+		"/apis/folder.grafana.app/*",
+		"/apis/*", // catch-all must still exist for every other group
+	} {
+		_, ok := cr.routes[pattern]
+		require.True(t, ok, "expected route %q to be registered", pattern)
+	}
+}
+
+func TestRegisterAPIServerRoutes_AuthIsPreserved(t *testing.T) {
+	cr := registerForTest(t)
+
+	// The named ProvideRouteOperationName middleware is prepended to every route, so an
+	// unauthenticated route carries [routeName, handler] while an authenticated one
+	// carries [routeName, ReqSignedIn, handler]. Comparing chain lengths guards that the
+	// new dashboard/folder wildcards keep ReqSignedIn (matching the catch-all they used
+	// to fall through), while the public snapshot routes stay unauthenticated.
+	const unauthenticated = 2
+	const authenticated = 3
+
+	snapshot := "/apis/dashboard.grafana.app/v0alpha1/namespaces/:namespace/snapshots/:name"
+	cases := []struct {
+		pattern  string
+		method   string
+		handlers int
+	}{
+		{"/apis/dashboard.grafana.app/*", "*", authenticated},
+		{"/apis/folder.grafana.app/*", "*", authenticated},
+		{"/apis/*", "*", authenticated},
+		{"/apis/features.grafana.app/v0alpha1/*", "*", unauthenticated},
+		{snapshot, "GET", unauthenticated},
+		{snapshot + "/dashboard", "GET", unauthenticated},
+	}
+	for _, tc := range cases {
+		route, ok := cr.routes[tc.pattern]
+		require.True(t, ok, "expected route %q to be registered", tc.pattern)
+		require.Equal(t, tc.method, route.method, "unexpected method for %q", tc.pattern)
+		require.Len(t, route.handlers, tc.handlers, "unexpected middleware chain for %q", tc.pattern)
+	}
+}


### PR DESCRIPTION
instrumenting all app platform requests under `/apis/*` makes it hard to understand what might be slow. Regardless if the requests is process by standalone Grafana or a downstream MT API server its useful to instrument them the same way.

That said Im still not certain this is the right way... Should we monitor all resources by default or only the app that we opt in for? How do we deal with custom handler?

```
curl http://localhost:3000/metrics | grep "/apis/dashboard.grafana.app/*"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="0.005"} 0
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="0.01"} 0
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="0.025"} 1
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="0.05"} 4
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="0.1"} 4
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="0.25"} 4
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="0.5"} 4
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="1"} 4
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="2.5"} 4
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="5"} 4
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="10"} 4
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="25"} 4
grafana_http_request_duration_seconds_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="+Inf"} 4
grafana_http_request_duration_seconds_sum{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server"} 0.089244876
grafana_http_request_duration_seconds_count{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server"} 4
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="128"} 1
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="256"} 2
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="512"} 3
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="1024"} 3
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="2048"} 3
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="4096"} 3
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="8192"} 3
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="16384"} 3
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="32768"} 3
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="65536"} 4
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="131072"} 4
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="262144"} 4
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="524288"} 4
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="1.048576e+06"} 4
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="2.097152e+06"} 4
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="4.194304e+06"} 4
grafana_http_response_size_bytes_bucket{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server",le="+Inf"} 4
grafana_http_response_size_bytes_sum{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server"} 44437
grafana_http_response_size_bytes_count{handler="/apis/dashboard.grafana.app/*",method="GET",slo_group="high-fast",status_code="200",status_source="server"} 4
100  843k    0  843k    0     0  32.5M      0 --:--:-- --:--:-- --:--:-- 32.9M

```