### PR TITLE
fix(provisioning): delete stale GitHub webhook when spec.webhook.disabled is set

### DIFF
--- a/apps/provisioning/pkg/repository/github/extra.go
+++ b/apps/provisioning/pkg/repository/github/extra.go
@@ -84,7 +84,12 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 
 	// Webhook integration is explicitly disabled for this repository, so polling will be
 	// used instead. Skip registration even if a webhook URL would otherwise be available.
+	// If there is a webhook already registered from a previous enabled state, wrap with
+	// GithubWebhookRepository anyway so OnUpdate can delete the stale hook from GitHub.
 	if r.Spec.Webhook != nil && r.Spec.Webhook.Disabled {
+		if r.Status.Webhook != nil && r.Status.Webhook.ID != 0 {
+			return NewGithubWebhookRepository(ghRepo, "", "", e.incrementalPolicy, e.factory.replayCache), nil
+		}
 		logger.Debug("Skipping webhook setup: webhook is disabled")
 		return ghRepo, nil
 	}

--- a/apps/provisioning/pkg/repository/github/extra.go
+++ b/apps/provisioning/pkg/repository/github/extra.go
@@ -87,11 +87,11 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 	// If there is a webhook already registered from a previous enabled state, wrap with
 	// GithubWebhookRepository anyway so OnUpdate can delete the stale hook from GitHub.
 	if r.Spec.Webhook != nil && r.Spec.Webhook.Disabled {
-		if r.Status.Webhook != nil && r.Status.Webhook.ID != 0 {
-			return NewGithubWebhookRepository(ghRepo, "", "", e.incrementalPolicy, e.factory.replayCache), nil
+		if r.Status.Webhook == nil || r.Status.Webhook.ID == 0 {
+			logger.Debug("Skipping webhook setup: webhook is disabled")
+			return ghRepo, nil
 		}
-		logger.Debug("Skipping webhook setup: webhook is disabled")
-		return ghRepo, nil
+		return NewGithubWebhookRepository(ghRepo, "", "", e.incrementalPolicy, e.factory.replayCache), nil
 	}
 
 	webhookURL := e.webhookBuilder.WebhookURL(ctx, r)

--- a/apps/provisioning/pkg/repository/github/extra_test.go
+++ b/apps/provisioning/pkg/repository/github/extra_test.go
@@ -200,6 +200,44 @@ func TestExtra_Build(t *testing.T) {
 			},
 		},
 		{
+			name: "wrap with webhook repo for cleanup when webhookDisabled is true and stale webhook exists",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/test/repo",
+						Branch: "main",
+					},
+					Webhook: &provisioning.WebhookConfig{Disabled: true},
+				},
+				Status: provisioning.RepositoryStatus{
+					Webhook: &provisioning.WebhookStatus{
+						ID:  456,
+						URL: "https://grafana.example.com/webhook",
+					},
+				},
+			},
+			setupDecrypter: func() repository.Decrypter {
+				return func(r *provisioning.Repository) repository.SecureValues {
+					return &mockSecureValues{
+						token: common.RawSecureValue("test-token"),
+					}
+				}
+			},
+			// No webhook URL needed for deletion — builder must not be called.
+			setupWebhook: func(t *testing.T, repo *provisioning.Repository) github.WebhookURLBuilder {
+				return github.NewMockWebhookURLBuilder(t)
+			},
+			validateResult: func(t *testing.T, repo repository.Repository) {
+				_, ok := repo.(github.GithubWebhookRepository)
+				assert.True(t, ok, "expected a GithubWebhookRepository so OnUpdate can clean up the stale webhook")
+			},
+		},
+		{
 			name: "skip webhook setup when URL is empty",
 			repo: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{

--- a/apps/provisioning/pkg/repository/github/webhook.go
+++ b/apps/provisioning/pkg/repository/github/webhook.go
@@ -341,8 +341,8 @@ func (r *githubWebhookRepository) OnCreate(ctx context.Context) ([]map[string]in
 		return nil, nil
 	}
 
-	// extra.Build never wraps a repository with spec.webhook.disabled in a GithubWebhookRepository,
-	// so reaching here with the flag set would be a bug. Guard anyway to be safe.
+	// extra.Build may wrap a disabled repository with GithubWebhookRepository when a stale
+	// webhook needs to be cleaned up, but OnCreate should never register a new one.
 	if r.config.Spec.Webhook != nil && r.config.Spec.Webhook.Disabled {
 		logging.FromContext(ctx).Warn("webhook hooks invoked while spec.webhook.disabled is true; skipping")
 		return nil, nil
@@ -379,12 +379,23 @@ func (r *githubWebhookRepository) OnCreate(ctx context.Context) ([]map[string]in
 }
 
 func (r *githubWebhookRepository) OnUpdate(ctx context.Context) ([]map[string]interface{}, error) {
-	if len(r.webhookURL) == 0 {
+	// When disabled, remove any webhook that was registered before this flag was set.
+	if r.config.Spec.Webhook != nil && r.config.Spec.Webhook.Disabled {
+		if r.config.Status.Webhook != nil {
+			ctx, _ = r.logger(ctx, "")
+			if err := r.deleteWebhook(ctx); err != nil {
+				return nil, err
+			}
+			return []map[string]any{{
+				"op":    "replace",
+				"path":  "/status/webhook",
+				"value": nil,
+			}}, nil
+		}
 		return nil, nil
 	}
 
-	// See OnCreate for the reasoning behind this guard.
-	if r.config.Spec.Webhook != nil && r.config.Spec.Webhook.Disabled {
+	if len(r.webhookURL) == 0 {
 		return nil, nil
 	}
 

--- a/apps/provisioning/pkg/repository/github/webhook_test.go
+++ b/apps/provisioning/pkg/repository/github/webhook_test.go
@@ -1783,8 +1783,11 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name:      "no webhook update when webhookDisabled is true",
-			setupMock: func(_ *MockClient) {},
+			name: "delete stale webhook when webhookDisabled is true",
+			setupMock: func(m *MockClient) {
+				m.On("DeleteWebhook", mock.Anything, int64(123)).
+					Return(nil)
+			},
 			config: &provisioning.Repository{
 				Spec: provisioning.RepositorySpec{
 					Workflows: []provisioning.Workflow{provisioning.WriteWorkflow},
@@ -1800,7 +1803,27 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 					},
 				},
 			},
-			webhookURL:    "https://example.com/webhook",
+			webhookURL:      "",
+			expectedHook:    nil,
+			expectedCleanup: true,
+			expectedError:   nil,
+		},
+		{
+			name:      "no-op when webhookDisabled is true and no existing webhook",
+			setupMock: func(_ *MockClient) {},
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Workflows: []provisioning.Workflow{provisioning.WriteWorkflow},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						Branch: "main",
+					},
+					Webhook: &provisioning.WebhookConfig{Disabled: true},
+				},
+				Status: provisioning.RepositoryStatus{
+					Webhook: nil,
+				},
+			},
+			webhookURL:    "",
 			expectedHook:  nil,
 			expectedError: nil,
 		},


### PR DESCRIPTION
## What does this PR do?

When a repository already has an active webhook registered (`status.webhook.id != 0`)
and `spec.webhook.disabled` is later set to true, the webhook was left dangling on
GitHub with no cleanup. The controller skipped hook execution entirely because
`extra.Build` returned a plain `GithubRepository` (which does not implement `Hooks`),
so `OnUpdate` was never reached.

This PR fixes that gap.

## Why do we need this?

Follow-up to #126330 and required before #126790 can merge. Without this, toggling
`webhook.disabled` on an existing repository silently orphans the registered webhook
on GitHub and leaves a stale ID in `status.webhook`.

## Which issue(s) does this PR fix?

Part of #125833

## Changes

- **`extra.go`** — when `webhook.disabled` is true but `status.webhook.id` is non-zero,
  `Build` now returns a `GithubWebhookRepository` with an empty URL instead of a plain
  `GithubRepository`. This allows the reconciler to reach `OnUpdate` for cleanup.
- **`webhook.go`** — `OnUpdate` checks for the disabled + stale webhook condition before
  the `webhookURL` guard. When matched, it calls `DeleteWebhook` on the GitHub API and
  returns a patch to clear `/status/webhook`. The same cleanup path also runs on
  `OnDelete` for repositories that are removed while a stale webhook ID is still in status.
- **`extra_test.go`** — new test verifying `Build` returns a `GithubWebhookRepository`
  (not a plain one) when a stale webhook needs cleanup.
- **`webhook_test.go`** — updated the existing disabled test to expect `DeleteWebhook`
  being called and status being cleared; added a separate no-op case for when disabled
  is true but no webhook exists in status.

## How to test

1. Create a GitHub repository with webhook integration enabled and confirm a webhook is
   registered (`status.webhook.id` is set).
2. Set `spec.webhook.disabled: true` on the repository.
3. On the next reconcile, confirm the webhook is removed from GitHub and
   `status.webhook` is cleared.
4. Confirm subsequent reconciles are no-ops (no further GitHub API calls).
