### PR TITLE
Chore: Add deprecation notice to parca datasource

### DIFF
--- a/public/app/plugins/datasource/parca/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/parca/ConfigEditor.tsx
@@ -10,9 +10,11 @@ import {
   convertLegacyAuthProps,
 } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
-import { Divider, SecureSocksProxySettings, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, Divider, SecureSocksProxySettings, Stack, TextLink, useStyles2 } from '@grafana/ui';
 
 import { type ParcaDataSourceOptions } from './types';
+
+const DEPRECATION_DATE = '2st of January 2027';
 
 interface Props extends DataSourcePluginOptionsEditorProps<ParcaDataSourceOptions> {}
 
@@ -22,6 +24,16 @@ export const ConfigEditor = (props: Props) => {
 
   return (
     <div className={styles.container}>
+      <Alert severity="warning" title="Parca data source is deprecated">
+        The built-in Parca data source will be removed from Grafana after v13.1.0. You can use the external Parca data
+        source plugin instead:{' '}
+        <TextLink href="https://github.com/grafana/grafana-parca-datasource" external>
+          https://github.com/grafana/grafana-parca-datasource
+        </TextLink>
+        . Please note that as part of its deprecation path, this plugin is not supported on Grafana Cloud. The plugin is
+        scheduled for deprecation on {DEPRECATION_DATE} and will no longer receive updates after that time.
+      </Alert>
+
       <DataSourceDescription
         dataSourceName="Parca"
         docsLink="https://grafana.com/docs/grafana/latest/datasources/parca"

--- a/public/app/plugins/datasource/parca/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/parca/ConfigEditor.tsx
@@ -14,7 +14,7 @@ import { Alert, Divider, SecureSocksProxySettings, Stack, TextLink, useStyles2 }
 
 import { type ParcaDataSourceOptions } from './types';
 
-const DEPRECATION_DATE = '2st of January 2027';
+const DEPRECATION_DATE = '2nd of January 2027';
 
 interface Props extends DataSourcePluginOptionsEditorProps<ParcaDataSourceOptions> {}
 

--- a/public/app/plugins/datasource/parca/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/parca/QueryEditor/QueryEditor.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react';
 import { useMount } from 'react-use';
 
 import { CoreApp, type QueryEditorProps } from '@grafana/data';
-import { ButtonCascader, type CascaderOption } from '@grafana/ui';
+import { Alert, ButtonCascader, type CascaderOption, TextLink } from '@grafana/ui';
 
 import { defaultParcaDataQuery, defaultParcaQueryType, type ParcaDataQuery as Parca } from '../dataquery.gen';
 import { type ParcaDataSource } from '../datasource';
@@ -15,6 +15,8 @@ import { LabelsEditor } from './LabelsEditor';
 import { QueryOptions } from './QueryOptions';
 
 export type Props = QueryEditorProps<ParcaDataSource, Query, ParcaDataSourceOptions>;
+
+const DEPRECATION_DATE = '2nd of January 2027';
 
 const defaultQuery: Partial<Parca> = {
   ...defaultParcaDataQuery,
@@ -84,28 +86,43 @@ export function QueryEditor(props: Props) {
   let query = normalizeQuery(props.query, props.app);
 
   return (
-    <EditorRows>
-      <EditorRow stackProps={{ wrap: false, gap: 1 }}>
-        <ButtonCascader onChange={onProfileTypeChange} options={cascaderOptions} buttonProps={{ variant: 'secondary' }}>
-          {selectedProfileName}
-        </ButtonCascader>
-        <LabelsEditor
-          value={query.labelSelector}
-          onChange={onLabelSelectorChange}
-          datasource={props.datasource}
-          onRunQuery={handleRunQuery}
-        />
-      </EditorRow>
-      <EditorRow>
-        <QueryOptions
-          query={query}
-          onQueryTypeChange={(val) => {
-            props.onChange({ ...query, queryType: val });
-          }}
-          app={props.app}
-        />
-      </EditorRow>
-    </EditorRows>
+    <>
+      <Alert severity="warning" title="Parca data source is deprecated">
+        The built-in Parca data source will be removed from Grafana after v13.1.0. You can use the external Parca data
+        source plugin instead:{' '}
+        <TextLink href="https://github.com/grafana/grafana-parca-datasource" external>
+          https://github.com/grafana/grafana-parca-datasource
+        </TextLink>
+        . Please note that as part of its deprecation path, this plugin is not supported on Grafana Cloud. The plugin is
+        scheduled for deprecation on {DEPRECATION_DATE} and will no longer receive updates after that time.
+      </Alert>
+      <EditorRows>
+        <EditorRow stackProps={{ wrap: false, gap: 1 }}>
+          <ButtonCascader
+            onChange={onProfileTypeChange}
+            options={cascaderOptions}
+            buttonProps={{ variant: 'secondary' }}
+          >
+            {selectedProfileName}
+          </ButtonCascader>
+          <LabelsEditor
+            value={query.labelSelector}
+            onChange={onLabelSelectorChange}
+            datasource={props.datasource}
+            onRunQuery={handleRunQuery}
+          />
+        </EditorRow>
+        <EditorRow>
+          <QueryOptions
+            query={query}
+            onQueryTypeChange={(val) => {
+              props.onChange({ ...query, queryType: val });
+            }}
+            app={props.app}
+          />
+        </EditorRow>
+      </EditorRows>
+    </>
   );
 }
 

--- a/public/app/plugins/datasource/parca/README.md
+++ b/public/app/plugins/datasource/parca/README.md
@@ -1,3 +1,9 @@
 # Grafana Parca data source
 
 Grafana plugin for the Parca data source.
+
+---
+
+# Grafana Parca data source is deprecated
+
+The built-in Parca data source will be removed from Grafana after v13.1.0. You can use the external Parca data source plugin instead: https://github.com/grafana/grafana-parca-datasource. Please note that as part of its deprecation path, this plugin is not supported on Grafana Cloud. The plugin is scheduled for deprecation on 2st of January 2027 and will no longer receive updates after that time.


### PR DESCRIPTION
**What is this feature?**

Add deprecation notice to parca datasource in ConfigEditor and QueryEditor

<img width="937" height="536" alt="grafik" src="https://github.com/user-attachments/assets/1507a749-6067-4f06-a640-73ce01f272fe" />


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
