### PR TITLE
Share Externally: Re-enable and de-flake share externally create e2e test

### DIFF
--- a/e2e-playwright/dashboards-suite/dashboard-share-externally-create.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-share-externally-create.spec.ts
@@ -15,6 +15,16 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
+    test.beforeEach(async ({ request }) => {
+      const existingResponse = await request.get(`/api/dashboards/uid/${DASHBOARD_UID_2}/public-dashboards`);
+      if (existingResponse.ok()) {
+        const existing = await existingResponse.json();
+        if (existing?.uid) {
+          await request.delete(`/api/dashboards/uid/${DASHBOARD_UID_2}/public-dashboards/${existing.uid}`);
+        }
+      }
+    });
+
     test('Close share externally drawer', async ({ page, gotoDashboardPage, selectors }) => {
       const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_UID });
 

--- a/e2e-playwright/dashboards-suite/dashboard-share-externally-create.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-share-externally-create.spec.ts
@@ -9,7 +9,7 @@ test.use({
 const DASHBOARD_UID = 'd41dbaa2-a39e-4536-ab2b-caca52f1a9c8';
 const DASHBOARD_UID_2 = 'edediimbjhdz4b';
 
-test.skip(
+test.describe(
   'Shared dashboards',
   {
     tag: ['@dashboards'],
@@ -45,6 +45,10 @@ test.skip(
       selectors,
       request,
     }) => {
+      // This flow chains several backend round-trips (create, read, disable, read) under a single
+      // test, so give it more headroom than the 30s default to avoid timing out on a loaded runner.
+      test.setTimeout(60_000);
+
       const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_UID_2 });
 
       // Open share externally drawer
@@ -95,7 +99,7 @@ test.skip(
       ).toBeEnabled();
       await dashboardPage
         .getByGrafanaSelector(selectors.pages.ShareDashboardDrawer.ShareExternally.Creation.willBePublicCheckbox)
-        .click({ force: true });
+        .check({ force: true });
 
       // Create shared dashboard
       const createResponse = page.waitForResponse(
@@ -117,9 +121,13 @@ test.skip(
       let response = await createResponse;
       let publicDashboard = await response.json();
 
-      // Test API access with the created dashboard
-      let apiResponse = await request.get(`/api/public/dashboards/${publicDashboard.accessToken}`);
-      expect(apiResponse.status()).toBe(200);
+      // Test API access with the created dashboard. Poll because the public dashboard read view can
+      // lag slightly behind the create response, which would make a single request flake.
+      await expect
+        .poll(async () => (await request.get(`/api/public/dashboards/${publicDashboard.accessToken}`)).status(), {
+          message: 'public dashboard should become readable after creation',
+        })
+        .toBe(200);
 
       // These elements shouldn't be rendered after creating public dashboard
       await expect(
@@ -182,9 +190,13 @@ test.skip(
 
       publicDashboard = await response.json();
 
-      // Test that API access is now forbidden
-      apiResponse = await request.get(`/api/public/dashboards/${publicDashboard.accessToken}`);
-      expect(apiResponse.status()).toBe(403);
+      // Test that API access is now forbidden. Poll because disabling can take a moment to propagate
+      // to the public dashboard read path.
+      await expect
+        .poll(async () => (await request.get(`/api/public/dashboards/${publicDashboard.accessToken}`)).status(), {
+          message: 'public dashboard should be forbidden after disabling',
+        })
+        .toBe(403);
     });
   }
 );


### PR DESCRIPTION
**What is this feature?**

This re-enables and stabilizes the previously skipped `dashboard-share-externally-create.spec.ts` Playwright e2e test (the `Shared dashboards` block). It makes the following changes:

- **Un-skips the test** — `test.skip(...)` → `test.describe(...)`.
- **Raises the timeout** of the `Create and disable a shared dashboard and check API` test to 60s (`test.setTimeout(60_000)`). This flow chains several backend round-trips (create → read → disable → read) under a single test, and the recorded CI failures were `Test timeout of 30000ms exceeded`.
- **Replaces the bare read-after-write API assertions with `expect.poll`** for both the `200` (after create) and `403` (after disable) checks, so they retry until the public-dashboard read view is consistent instead of asserting once and flaking.
- **Switches the acknowledge checkbox from `.click({ force: true })` to `.check({ force: true })`**, which is idempotent and asserts the resulting checked state, removing a click-timing race.

**Why do we need this feature?**

The test was skipped in #121844 ("Share Externally: Skip flaky test") with no documented root cause. Reviewing the CI history just before the skip, the test failed intermittently with `Test timeout of 30000ms exceeded` / `apiRequestContext.get: Request context disposed`, dying at different `await` points across runs (the read-after-create check on one run, the disable check on another). The root cause is that the full create/disable flow occasionally exceeds the 30s budget on a loaded runner, and the raw `request.get(...)` API checks had no tolerance for read-after-write propagation lag. The changes above address both, so we can restore coverage instead of leaving it disabled.

**Who is this feature for?**

Grafana developers — restores e2e coverage for the dashboard "share externally" / public dashboards create + disable flow and removes a source of CI flakiness.

**Which issue(s) does this PR fix?**

<!-- No tracking issue was filed for the original skip. -->

**Special notes for your reviewer:**

The fix was validated by analyzing the pre-skip CI logs (e.g. PR #121335's e2e run and a main-branch run on 2026-04-02) to confirm the exact failure mode before changing the test.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Fixes https://github.com/grafana/grafana/issues/127066
