### PR TITLE
Dashboards: Use flex for dashboard controls

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditControls.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditControls.tsx
@@ -39,9 +39,7 @@ function getStyles(theme: GrafanaTheme2) {
     container: css({
       display: 'inline-flex',
       alignItems: 'center',
-      verticalAlign: 'middle',
       marginBottom: theme.spacing(1),
-      marginRight: theme.spacing(1),
       gap: theme.spacing(1),
     }),
   };

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -240,11 +240,14 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
       return (
         <>
           <div data-testid={selectors.pages.Dashboard.Controls} className={styles.controls}>
-            {!hideVariableControls && <VariableControls dashboard={dashboard} />}
-            <div className={styles.rightControls}>
-              <div className={styles.fixedControls}>
+            <div className={cx(styles.innerControls, styles.fixedControls)}>
+              <div>
                 <DashboardControlActions dashboard={dashboard} hidePlaylistNav={hidePlaylistNav} />
               </div>
+            </div>
+
+            <div className={styles.innerControls}>
+              {!hideVariableControls && <VariableControls dashboard={dashboard} />}
             </div>
           </div>
           <RenderHiddenVariables dashboard={dashboard} />
@@ -266,43 +269,46 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
       data-testid={selectors.pages.Dashboard.Controls}
       className={cx(styles.controls, editPanel && styles.controlsPanelEdit)}
     >
-      <div className={cx(styles.rightControls, editPanel && styles.rightControlsWrap)}>
+      <div className={cx(styles.innerControls, styles.fixedControls)}>
         {!hideTimeControls && (
-          <div className={styles.fixedControls}>
+          <div>
             <timePicker.Component model={timePicker} />
             <refreshPicker.Component model={refreshPicker} />
           </div>
         )}
         {config.featureToggles.dashboardNewLayouts && (
-          <div className={styles.fixedControls}>
+          <div>
             <DashboardControlActions dashboard={dashboard} hidePlaylistNav={hidePlaylistNav} />
           </div>
         )}
         {(config.featureToggles.dashboardFiltersOverview || config.featureToggles.dashboardUnifiedDrilldownControls) &&
           !config.featureToggles.dashboardNewLayouts && (
-            <div className={styles.fixedControls}>
+            <div>
               <DashboardFiltersOverviewPaneToggle dashboard={dashboard} />
             </div>
           )}
       </div>
-      {config.featureToggles.scopeFilters && !editPanel && (
-        <ContextualNavigationPaneToggle className={styles.contextualNavToggle} hideWhenOpen={true} />
-      )}
-      {!hideVariableControls && (
-        <>
-          <VariableControls dashboard={dashboard} variablesOverride={panelEditVariables} />
-          <DashboardDataLayerControls dashboard={dashboard} />
-        </>
-      )}
-      {!hideLinksControls && !editPanel && <DashboardLinksControls links={links} dashboard={dashboard} />}
-      {!hideDashboardControls && hasDashboardControls && <DashboardControlsButton dashboard={dashboard} />}
-      <DefaultControlsLoadingSkeleton
-        dashboard={dashboard}
-        hideVariableControls={hideVariableControls}
-        hideLinksControls={hideLinksControls}
-      />
-      {editPanel && <PanelEditControls panelEditor={editPanel} />}
-      {showDebugger && <SceneDebugger scene={model} key={'scene-debugger'} />}
+
+      <div className={styles.innerControls}>
+        {config.featureToggles.scopeFilters && !editPanel && (
+          <ContextualNavigationPaneToggle className={styles.contextualNavToggle} hideWhenOpen={true} />
+        )}
+        {!hideVariableControls && (
+          <>
+            <VariableControls dashboard={dashboard} variablesOverride={panelEditVariables} />
+            <DashboardDataLayerControls dashboard={dashboard} />
+          </>
+        )}
+        {!hideLinksControls && !editPanel && <DashboardLinksControls links={links} dashboard={dashboard} />}
+        {!hideDashboardControls && hasDashboardControls && <DashboardControlsButton dashboard={dashboard} />}
+        <DefaultControlsLoadingSkeleton
+          dashboard={dashboard}
+          hideVariableControls={hideVariableControls}
+          hideLinksControls={hideLinksControls}
+        />
+        {editPanel && <PanelEditControls panelEditor={editPanel} />}
+        {showDebugger && <SceneDebugger scene={model} key={'scene-debugger'} />}
+      </div>
     </div>
   );
 }
@@ -421,9 +427,7 @@ const getSkeletonStyles = (theme: GrafanaTheme2) => ({
   skeletonContainer: css({
     display: 'inline-flex',
     lineHeight: 1,
-    verticalAlign: 'middle',
     marginBottom: theme.spacing(1),
-    marginRight: theme.spacing(1),
   }),
 });
 
@@ -433,14 +437,16 @@ function getStyles(theme: GrafanaTheme2, isQueryEditorNext: boolean) {
     controls: css({
       gap: theme.spacing(1),
       padding: theme.spacing(2, 2, 1, 2),
-      flexDirection: 'row',
+      flexDirection: 'row-reverse',
       flexWrap: 'nowrap',
       position: 'relative',
       width: '100%',
       marginLeft: 'auto',
-      display: 'inline-block',
+      display: 'flex',
+      justifyContent: 'space-between',
+
       [theme.breakpoints.down('sm')]: {
-        flexDirection: 'column-reverse',
+        flexDirection: 'column',
         alignItems: 'stretch',
       },
 
@@ -449,7 +455,6 @@ function getStyles(theme: GrafanaTheme2, isQueryEditorNext: boolean) {
       },
     }),
     controlsPanelEdit: css({
-      flexWrap: 'wrap-reverse',
       ...(isQueryEditorNext && {
         padding: 0,
         marginBottom: theme.spacing(-1),
@@ -461,31 +466,27 @@ function getStyles(theme: GrafanaTheme2, isQueryEditorNext: boolean) {
       position: 'unset',
     }),
     // Original rightControls style
-    rightControls: css({
+    innerControls: css({
       display: 'flex',
       gap: theme.spacing(1),
-      float: 'right',
       alignItems: 'flex-start',
       flexWrap: 'wrap',
       maxWidth: '100%',
-      minWidth: 0,
+      minWidth: 'min-content',
     }),
     fixedControls: css({
-      display: 'flex',
       justifyContent: 'flex-end',
-      gap: theme.spacing(1),
-      marginBottom: theme.spacing(1),
-      order: 2,
-      marginLeft: 'auto',
-      flexShrink: 0,
-      alignSelf: 'flex-start',
+
+      '& > div': {
+        display: 'flex',
+        gap: theme.spacing(1),
+        marginBottom: theme.spacing(1),
+        order: 2,
+        flexShrink: 0,
+      },
     }),
     dashboardControlsButton: css({
       order: 2,
-      marginLeft: 'auto',
-    }),
-    rightControlsWrap: css({
-      flexWrap: 'wrap',
       marginLeft: 'auto',
     }),
     contextualNavToggle: css({

--- a/public/app/features/dashboard-scene/scene/DashboardDataLayerControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDataLayerControls.tsx
@@ -79,8 +79,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     label: 'dashboard-data-layer-controls',
     display: 'inline-flex',
     alignItems: 'center',
-    verticalAlign: 'middle',
     marginBottom: theme.spacing(1),
-    marginRight: theme.spacing(1),
   }),
 });

--- a/public/app/features/dashboard-scene/scene/DashboardLinkRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLinkRenderer.tsx
@@ -99,7 +99,6 @@ function getStyles(theme: GrafanaTheme2) {
     linkContainer: css({
       display: 'inline-flex',
       alignItems: 'center',
-      verticalAlign: 'middle',
       lineHeight: 1,
       flexWrap: 'wrap',
       gap: theme.spacing(1),

--- a/public/app/features/dashboard-scene/scene/DashboardLinksControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLinksControls.tsx
@@ -53,12 +53,8 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'inline-flex',
       alignItems: 'center',
       gap: theme.spacing(1),
-      marginRight: theme.spacing(1),
       marginBottom: theme.spacing(1),
       flexWrap: 'wrap',
-      // Match variable/annotation alignment in the controls row
-      alignSelf: 'flex-start',
-      verticalAlign: 'middle',
     }),
   };
 }

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -249,14 +249,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
     display: 'inline-flex',
     alignItems: 'center',
-    verticalAlign: 'middle',
     // No border for second element (inputs) as label and input border is shared
     '> :nth-child(2)': css({
       borderTopLeftRadius: 'unset',
       borderBottomLeftRadius: 'unset',
     }),
     marginBottom: theme.spacing(1),
-    marginRight: theme.spacing(1),
   }),
   verticalContainer: css({
     display: 'flex',

--- a/public/app/features/dashboard-scene/scene/VariableControlsAddButton.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControlsAddButton.tsx
@@ -49,8 +49,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   addButton: css({
     display: 'inline-flex',
     alignItems: 'center',
-    verticalAlign: 'middle',
     marginBottom: theme.spacing(1),
-    marginRight: theme.spacing(1),
   }),
 });

--- a/public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenuButton.tsx
+++ b/public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenuButton.tsx
@@ -75,7 +75,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
   dropdownButton: css({
     display: 'inline-flex',
     marginBottom: theme.spacing(1),
-    marginRight: theme.spacing(1),
-    verticalAlign: 'middle',
   }),
 });

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
@@ -180,7 +180,6 @@ function getStyles(theme: GrafanaTheme2) {
     linkContainer: css({
       display: 'inline-flex',
       alignItems: 'center',
-      verticalAlign: 'middle',
     }),
   };
 }


### PR DESCRIPTION
**What is this feature?**

Replaces the current reliance on `float: 'right'` + `verticalAlign: 'middle'` + `marginRight: theme.spacing(1)` for the dashboard controls with a flex container, using `order: 1` + `marginLeft: 'auto'` for the controls that were previously floated.

**Why do we need this feature?**

Removes the usage of `float: 'right'`, which required all other elements to use `verticalAlign: 'middle'`, which sometimes was forgotten: #126989

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
