### PR TITLE
CloudMonitoring: classify invalid query JSON as downstream errors

### DIFF
--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
@@ -275,7 +275,7 @@ func migrateRequest(req *backend.QueryDataRequest) error {
 			var mq dataquery.TimeSeriesList
 			err = json.Unmarshal(q.JSON, &mq)
 			if err != nil {
-				return err
+				return backend.DownstreamError(fmt.Errorf("could not unmarshal legacy CloudMonitoring query: %w", err))
 			}
 			q.QueryType = string(dataquery.QueryTypeTIMESERIESLIST)
 			gq := grafanaQuery{
@@ -323,7 +323,7 @@ func migrateRequest(req *backend.QueryDataRequest) error {
 				tsl := &dataquery.TimeSeriesList{}
 				err = json.Unmarshal(tslb, tsl)
 				if err != nil {
-					return err
+					return backend.DownstreamError(fmt.Errorf("could not unmarshal metric query: %w", err))
 				}
 				if metricQuery["metricType"] != nil {
 					// metricType should be a filter
@@ -387,7 +387,6 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		return nil, backend.DownstreamError(errors.New(forwardOAuthIdentityAlertingNotSupportedMessage))
 	}
 
-	// There aren't any possible downstream errors here
 	queries, err := s.buildQueryExecutors(logger, req)
 	if err != nil {
 		return nil, err
@@ -429,7 +428,7 @@ func queryModel(query backend.DataQuery) (grafanaQuery, error) {
 	var q grafanaQuery
 	err := json.Unmarshal(query.JSON, &q)
 	if err != nil {
-		return grafanaQuery{}, err
+		return grafanaQuery{}, backend.DownstreamError(fmt.Errorf("could not unmarshal CloudMonitoringQuery json: %w", err))
 	}
 	return q, nil
 }
@@ -443,7 +442,7 @@ func (s *Service) buildQueryExecutors(logger log.Logger, req *backend.QueryDataR
 		durationSeconds := int(endTime.Sub(startTime).Seconds())
 		q, err := queryModel(query)
 		if err != nil {
-			return nil, fmt.Errorf("could not unmarshal CloudMonitoringQuery json: %w", err)
+			return nil, err
 		}
 
 		var queryInterface cloudMonitoringQueryExecutor

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
@@ -1343,3 +1343,33 @@ func TestQueryData_forwardOAuthIdentity(t *testing.T) {
 		}
 	})
 }
+
+func TestQueryData_invalidQueryJSONIsDownstreamError(t *testing.T) {
+	im := datasource.NewInstanceManager(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+		return &datasourceInfo{
+			authenticationType: jwtAuthentication,
+			defaultProject:     "p1",
+		}, nil
+	})
+	service := &Service{im: im, logger: backend.NewLoggerWith("logger", "test")}
+
+	_, err := service.QueryData(context.Background(), &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+		},
+		Queries: []backend.DataQuery{
+			{
+				RefID:     "A",
+				QueryType: string(dataquery.QueryTypeTIMESERIESLIST),
+				JSON: json.RawMessage(`{
+					"timeSeriesList": {
+						"filters": "resource.type=\"gce_instance\""
+					}
+				}`),
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not unmarshal CloudMonitoringQuery json")
+	assert.True(t, backend.IsDownstreamError(err))
+}


### PR DESCRIPTION
After a conversation in slack, decided that the query failing to unmarshal because of being malformed should be a downstream error
## Summary
- Wrap Cloud Monitoring query JSON unmarshal failures in `backend.DownstreamError` so malformed dashboard/provisioned queries (e.g. `filters` stored as a string instead of an array) are attributed as downstream rather than plugin errors in Grafana metrics
- Add test coverage for the string `filters` unmarshal case

## Test plan
- [x] `go test -run TestQueryData_invalidQueryJSONIsDownstreamError ./pkg/tsdb/cloud-monitoring/`
- [ ] Verify plugin request metrics report `statusSource=downstream` for dashboards with invalid query JSON

fixes: https://github.com/grafana/grafana/issues/126610


Made with [Cursor](https://cursor.com)