### PR TITLE
[release-13.0.3] Docs: FY27 Q2 Prometheus updates

### DIFF
--- a/docs/sources/datasources/prometheus/_index.md
+++ b/docs/sources/datasources/prometheus/_index.md
@@ -15,70 +15,60 @@ labels:
 menuTitle: Prometheus
 title: Prometheus data source
 weight: 1300
+review_date: 2026-05-07
 ---
 
 # Prometheus data source
 
-Prometheus is an open source database that uses a telemetry collector agent to scrape and store metrics used for monitoring and alerting.
+Prometheus is an open source monitoring system and time series database that scrapes and stores metrics used for monitoring and alerting.
 
-Grafana provides native support for Prometheus, so you don't need to install a plugin.
+Grafana includes built-in support for Prometheus, so you don't need to install a plugin. Write queries using [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/) in the query editor, or use [Metrics Drilldown](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/metrics/) to explore metrics without writing queries. The Prometheus data source also works with other projects that implement the [Prometheus querying API](https://prometheus.io/docs/prometheus/latest/querying/api/), including [Grafana Mimir](/docs/mimir/latest/) and [Thanos](https://thanos.io/tip/components/query.md/).
 
-The following documentation will help you get started working with Prometheus and Grafana:
+## Supported features
+
+| Feature         | Supported |
+| --------------- | --------- |
+| Metrics         | Yes       |
+| Alerting        | Yes       |
+| Annotations     | Yes       |
+| Recording rules | Yes       |
+| Exemplars       | Yes       |
+
+## Get started
+
+The following documents help you set up and use the Prometheus data source:
+
+- [Configure the Prometheus data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/)
+- [Prometheus query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/query-editor/)
+- [Template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/template-variables/)
+- [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/annotations/)
+- [Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/alerting/)
+- [Troubleshooting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/)
+
+## Additional features
+
+After you configure the Prometheus data source, you can:
+
+- Use [Metrics Drilldown](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/metrics/) to browse and explore your Prometheus metrics without writing PromQL
+- Use [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) to query data without building a dashboard
+- Add [transformations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/) to manipulate query results
+- Create [recorded queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/recorded-queries/) for pre-aggregated data
+- Build a wide variety of [visualizations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/)
+
+## Cloud-managed Prometheus services
+
+{{< admonition type="note" >}}
+In Grafana 13, the core Prometheus data source no longer supports SigV4 (AWS) or Azure AD authentication. These authentication methods have been migrated to dedicated plugins:
+
+- **Amazon Managed Service for Prometheus** — Use the [Amazon Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/). For migration details, refer to [AWS authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/aws-authentication/).
+- **Azure Monitor Managed Service for Prometheus** — Use the [Azure Monitor Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-azureprometheus-datasource/). For migration details, refer to [Azure authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/azure-authentication/).
+
+Existing data sources using these methods are automatically migrated on startup.
+{{< /admonition >}}
+
+## Related resources
 
 - [What is Prometheus?](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/intro-to-prometheus/)
 - [Prometheus data model](https://prometheus.io/docs/concepts/data_model/)
-- [Getting started](https://prometheus.io/docs/prometheus/latest/getting_started/)
-- [Configure the Prometheus data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure)
-- [Prometheus query editor](query-editor/)
-- [Template variables](template-variables/)
-- [Troubleshooting](troubleshooting/)
-
-## Exemplars
-
-In Prometheus, an **exemplar** is a specific trace that represents a measurement taken within a given time interval. While metrics provide an aggregated view of your system, and traces offer a detailed view of individual requests, exemplars serve as a bridge between the two, linking high-level metrics to specific traces for deeper insights.
-
-Exemplars associate higher-cardinality metadata from a specific event with traditional time series data. Refer to [Introduction to exemplars](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/) in the Prometheus documentation for detailed information on how they work.
-
-Grafana can show exemplar data alongside a metric both in Explore and in Dashboards.
-
-{{< figure src="/static/img/docs/v74/exemplars.png" class="docs-image--no-shadow" caption="Exemplar window" >}}
-
-You add exemplars when you configure the Prometheus data source.
-
-{{< figure src="/static/img/docs/prometheus/exemplars-10-1.png" max-width="500px" class="docs-image--no-shadow" >}}
-
-## Prometheus API
-
-The Prometheus data source also works with other projects that implement the [Prometheus querying API](https://prometheus.io/docs/prometheus/latest/querying/api/).
-
-For more information on how to query other Prometheus-compatible projects from Grafana, refer to the specific product's documentation:
-
-- [Grafana Mimir](/docs/mimir/latest/)
-- [Thanos](https://thanos.io/tip/components/query.md/)
-
-## View Grafana metrics with Prometheus
-
-Grafana exposes metrics for Prometheus on the `/metrics` endpoint and includes a pre-built dashboard to help you start visualizing your metrics immediately.
-
-Complete the following steps to import the pre-built dashboard:
-
-1. Navigate to the Prometheus [configuration page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure).
-1. Click the **Dashboards** tab.
-1. Locate the **Grafana metrics** dashboard in the list and click **Import**.
-
-For details about these metrics, refer to [Internal Grafana metrics](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/set-up-grafana-monitoring/).
-
-## Amazon Managed Service for Prometheus
-
-Grafana has deprecated the Prometheus data source for Amazon Managed Service for Prometheus. Use the [Amazon Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/) instead. The linked documentation outlines the migration steps.
-
-## Get the most out of the Prometheus data source
-
-After you install and configure Prometheus you can:
-
-- Create a wide variety of [visualizations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/)
-- Configure and use [templates and variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/)
-- Add [transformations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/)
-- Add [annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/)
-- Set up [alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/)
-- Create [recorded queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/recorded-queries/)
+- [Getting started with Prometheus](https://prometheus.io/docs/prometheus/latest/getting_started/)
+- [Grafana community forum](https://community.grafana.com/)

--- a/docs/sources/datasources/prometheus/alerting/index.md
+++ b/docs/sources/datasources/prometheus/alerting/index.md
@@ -1,0 +1,298 @@
+---
+description: Using Grafana Alerting with the Prometheus data source
+keywords:
+  - grafana
+  - prometheus
+  - alerting
+  - alerts
+  - promql
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Alerting
+title: Prometheus alerting
+weight: 550
+review_date: 2026-05-07
+---
+
+# Prometheus alerting
+
+You can use Grafana Alerting with Prometheus to create alerts based on your time-series data. This allows you to monitor metrics, detect anomalies, and receive notifications when specific conditions are met.
+
+For general information about Grafana Alerting, refer to [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/).
+
+## Before you begin
+
+Before creating alerts with Prometheus, ensure you have:
+
+- A Prometheus data source configured in Grafana
+- Appropriate permissions to create alert rules
+- Understanding of the PromQL metrics you want to monitor
+
+## Alert rule types
+
+Prometheus supports two alerting workflows in Grafana:
+
+| Type                            | Description                                                                                                                                                                                                                                                                      |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Grafana-managed alert rules** | Alert rules defined and evaluated within Grafana, using Prometheus as the query data source. You create and manage these entirely in the Grafana Alerting UI.                                                                                                                    |
+| **Data source-managed rules**   | Alerting rules defined in Prometheus itself (in `prometheus.yml` or rule files). When **Manage alerts via Alerting UI** is enabled in the data source configuration, Grafana displays these existing rules in the Alerting UI. For Prometheus (unlike Mimir), this is read-only. |
+
+## Create a Grafana-managed alert rule
+
+To create a Grafana-managed alert rule using Prometheus:
+
+1. Navigate to **Alerting** > **Alert rules**.
+1. Click **New alert rule**.
+1. Enter a name for the alert rule.
+1. Select your **Prometheus** data source.
+1. Write a PromQL query in the query editor.
+1. Configure the alert condition (for example, when the last value is above a threshold).
+1. Set the evaluation interval and pending period.
+1. Configure notifications and labels.
+1. Click **Save rule**.
+
+For detailed instructions, refer to [Create a Grafana-managed alert rule](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/).
+
+## View data source-managed rules
+
+When **Manage alerts via Alerting UI** is enabled in the Prometheus data source configuration, Grafana fetches and displays alerting rules defined in Prometheus. These appear in the Alerting UI alongside Grafana-managed rules but are marked as data source-managed.
+
+For Prometheus data sources, this view is read-only. To modify these rules, update your Prometheus rule files directly.
+
+{{< admonition type="note" >}}
+For Mimir and Cortex data sources, the Alerting UI supports both viewing and creating data source-managed rules. Prometheus only supports viewing.
+{{< /admonition >}}
+
+## Evaluation groups and intervals
+
+Alert rules are organized into evaluation groups. Each group has an evaluation interval that determines how frequently the rules in that group are evaluated. For example, an evaluation interval of `1m` means the alert query runs every 60 seconds.
+
+The **pending period** determines how long a condition must be continuously true before the alert fires. For example, with a 1-minute evaluation interval and a 5-minute pending period, the condition must be true for 5 consecutive evaluations before firing.
+
+Choose evaluation intervals based on your use case:
+
+- **15s–30s** — Critical infrastructure alerts where fast detection matters.
+- **1m** — Standard monitoring alerts (recommended default).
+- **5m** — Non-urgent or noisy metrics where you want to reduce evaluation load.
+
+## Example alert queries
+
+The following examples show common alerting scenarios with Prometheus. Each example shows the PromQL query and how to configure the alert condition.
+
+### Alert on high CPU usage
+
+Monitor CPU usage and alert when it exceeds 90%:
+
+**Query A:**
+
+```promql
+100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[$__rate_interval])) * 100)
+```
+
+**Condition:** Set the threshold to alert when the last value of **A** is above `90`.
+
+This approach separates the metric query from the threshold, making it easier to adjust the threshold later without editing the PromQL.
+
+### Alert on high memory usage
+
+Monitor memory usage across nodes:
+
+**Query A:**
+
+```promql
+(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100
+```
+
+**Condition:** Alert when the last value of **A** exceeds `85`.
+
+### Alert on high error rate
+
+Monitor HTTP error rates per service:
+
+**Query A:**
+
+```promql
+sum(rate(http_requests_total{status=~"5.."}[$__rate_interval])) by (job)
+  /
+sum(rate(http_requests_total[$__rate_interval])) by (job)
+  * 100
+```
+
+**Condition:** Alert when the last value of **A** exceeds `5` (meaning error rate above 5%).
+
+### Alert on target down
+
+Monitor whether Prometheus scrape targets are reachable:
+
+**Query A:**
+
+```promql
+up{job="myservice"}
+```
+
+**Condition:** Alert when the last value of **A** is below `1`.
+
+### Alert when a metric disappears
+
+Use `absent()` to detect when a metric stops being scraped entirely — for example, when a service crashes and no longer reports metrics:
+
+**Query A:**
+
+```promql
+absent(up{job="myservice"})
+```
+
+**Condition:** Alert when the last value of **A** equals `1` (the `absent()` function returns 1 when the metric is missing, and nothing when the metric exists).
+
+For detecting staleness over a time window (metric exists but hasn't reported recently):
+
+```promql
+absent_over_time(up{job="myservice"}[5m])
+```
+
+### Multi-condition alert (high latency AND high traffic)
+
+Use multiple queries and expressions to alert only when multiple conditions are true simultaneously. This reduces noise by avoiding alerts during low-traffic periods.
+
+**Query A** — P95 latency:
+
+```promql
+histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job="api"}[$__rate_interval])) by (le))
+```
+
+**Query B** — Request rate:
+
+```promql
+sum(rate(http_requests_total{job="api"}[$__rate_interval]))
+```
+
+**Expression C** — Math (both conditions must be true):
+
+```
+$A > 2 && $B > 100
+```
+
+**Condition:** Alert when **C** has a value (it only returns data when both latency exceeds 2 seconds AND request rate exceeds 100 req/s).
+
+## Recording rules
+
+[Grafana-managed recording rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/) pre-compute expensive PromQL expressions on a schedule and write the results back to a Prometheus-compatible data source as a new metric. This lets you query the pre-aggregated metric instead of re-evaluating the expensive expression on every dashboard load or alert evaluation.
+
+### When to use recording rules
+
+- **Dashboard panels that query the same expensive expression repeatedly** — pre-compute it once and query the result.
+- **Alert rules on complex expressions** — simplify the alert query by alerting on the pre-aggregated metric.
+- **High-cardinality aggregations** — reduce thousands of series to a handful of pre-computed series.
+
+### Set up Grafana-managed recording rules for Prometheus
+
+1. **Enable the data source as a recording rules target:** In the Prometheus data source configuration, verify that **Allow as recording rules target** is toggled on (it's on by default). This allows Grafana to write recording rule results back to this instance.
+
+1. **Verify write access:** The Prometheus-compatible backend must support remote write. Grafana Cloud Metrics (Mimir) and self-hosted Mimir support this natively. Standard Prometheus requires the `--web.enable-remote-write-receiver` flag (Prometheus 2.33+).
+
+1. **Create a recording rule:**
+   1. Navigate to **Alerting** > **Alert rules**.
+   1. Click **New alert rule**.
+   1. Select **Recording rule** as the rule type (under the Grafana-managed section).
+   1. Enter the PromQL expression you want to pre-compute:
+
+      ```promql
+      sum(rate(http_requests_total[$__rate_interval])) by (service)
+      ```
+
+   1. Enter a metric name for the result (for example, `service:http_requests:rate5m`). Follow the Prometheus [recording rule naming convention](https://prometheus.io/docs/practices/rules/#naming-and-aggregation): `level:metric:operations`.
+   1. Select the **Target data source** — the Prometheus instance where results will be written.
+   1. Set the evaluation interval (for example, every 1 minute).
+   1. Click **Save rule**.
+
+1. **Query the recorded metric:** After the first evaluation, the new metric is available for dashboards and alerts:
+
+   ```promql
+   service:http_requests:rate5m{service="api"}
+   ```
+
+### Recording rules with PDC
+
+If your Prometheus instance is behind [Private data source connect (PDC)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/#private-data-source-connect), Grafana can write recording rule results through the PDC tunnel. No additional configuration is needed — PDC supports both reads and writes.
+
+### Limitations
+
+- Recording rules require the target data source to support remote write. Standard Prometheus needs the `--web.enable-remote-write-receiver` flag.
+- Thanos does not support recording rules as a write target (refer to the [Prometheus type comparison](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/#performance)).
+- Recording rule evaluation uses the configured evaluation interval, not dashboard time ranges. Use a fixed range vector (for example, `[5m]`) rather than `$__rate_interval`.
+
+For more information, refer to [Create Grafana-managed recording rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/).
+
+## Limitations
+
+When using Prometheus with Grafana Alerting, be aware of the following limitations.
+
+### Template variables not supported
+
+Alert queries don't support template variables. Grafana evaluates alert rules on the backend without dashboard context, so variables like `$instance` or `$job` aren't resolved.
+
+If your dashboard query uses template variables, create a separate query for alerting with hard-coded values or use label matchers directly.
+
+### Query complexity
+
+Complex queries with many nested functions or large result sets may timeout or fail to evaluate. Simplify queries for alerting by:
+
+- Reducing the time range used in range vectors
+- Using appropriate aggregation to limit the number of returned series
+- Adding label filters to narrow the data scanned
+- Using recording rules to pre-compute expensive expressions
+
+### OAuth token handling differs between Explore and Alerting
+
+When using OAuth-authenticated Prometheus endpoints (Google Managed Prometheus, Azure Managed Prometheus), queries may succeed in Explore and dashboards but fail intermittently during alert evaluation. This happens because the alerting backend handles token refresh differently from the interactive query path.
+
+If you're using GCP, consider the **datasource-syncer** pattern — a sidecar process that refreshes OAuth tokens and updates the data source credentials on a schedule shorter than the token lifetime.
+
+For detailed troubleshooting steps, refer to [OAuth token expiration errors](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#oauth-token-expiration-errors-gcp-and-azure).
+
+### Data source-managed rules are read-only
+
+Grafana can display Prometheus alerting rules but can't create or modify them through the UI. To manage Prometheus-native alerting rules, edit your Prometheus rule files directly and reload the configuration.
+
+## Configure alert state for execution errors
+
+By default, when a Grafana-managed alert rule encounters an execution error or timeout (such as a network blip, i/o timeout, or a transient 502 from Prometheus), the rule enters an **Error** state — which fires the alert. This can cause false alarms and spam on-call teams when the underlying issue is a brief connectivity interruption rather than a genuine threshold breach.
+
+To prevent false positives from transient errors, configure the **Alert state if execution error or timeout** setting on each alert rule:
+
+1. Open the alert rule for editing.
+1. In the alert conditions section, locate **Alert state if execution error or timeout**.
+1. Change the value from **Alerting** (default) to one of:
+   - **Keep Last State** — The alert retains its previous state (firing or normal) until a successful evaluation occurs. This is the recommended setting for most Prometheus alert rules.
+   - **OK** — The alert is set to normal during the error, preventing it from firing.
+1. Click **Save rule**.
+
+{{< admonition type="note" >}}
+If your alert rules frequently enter an error state, investigate the root cause (network stability, Prometheus resource limits, query timeout settings) rather than relying solely on this setting to suppress notifications.
+{{< /admonition >}}
+
+Common transient errors that trigger this behavior include:
+
+- `sse.dependencyError` or `sse.dataQueryError` in alert state history
+- "context deadline exceeded" or "i/o timeout" messages
+- HTTP 502 or 500 responses from the Prometheus server
+
+For more details on troubleshooting these errors, refer to [Troubleshoot Prometheus data source issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#transient-alert-errors-triggering-false-alarms).
+
+## Best practices
+
+Follow these best practices when creating Prometheus alerts:
+
+- **Configure error state handling:** Set **Alert state if execution error or timeout** to **Keep Last State** to prevent transient backend errors from triggering false alarms.
+- **Use `$__rate_interval`:** When using `rate()` or `increase()` in alert queries, use `$__rate_interval` to ensure the range window is always large enough relative to the scrape interval. Grafana resolves this variable based on the evaluation interval and scrape interval configuration.
+- **Add label filters:** Include specific label matchers to focus on relevant data and improve query performance.
+- **Set realistic pending periods:** Use the pending period to avoid alerting on brief spikes. For example, set a 5-minute pending period so the condition must persist before firing.
+- **Test queries first:** Verify your query returns expected results in Explore before creating an alert.
+- **Use meaningful names:** Give alert rules descriptive names that indicate what they monitor and the severity.
+- **Pre-aggregate with recording rules:** For complex or frequently evaluated expressions, create recording rules and alert on the pre-aggregated metric.
+- **Use `absent()` for availability monitoring:** Detect when metrics stop being reported, which often indicates a crashed or unresponsive service.
+
+If you encounter errors when creating or evaluating alert rules, refer to [Troubleshoot Prometheus data source issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#alerting-errors).

--- a/docs/sources/datasources/prometheus/annotations/index.md
+++ b/docs/sources/datasources/prometheus/annotations/index.md
@@ -1,0 +1,201 @@
+---
+description: Using annotations with the Prometheus data source in Grafana
+keywords:
+  - grafana
+  - prometheus
+  - annotations
+  - events
+  - promql
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Annotations
+title: Prometheus annotations
+weight: 500
+review_date: 2026-05-07
+---
+
+# Prometheus annotations
+
+Annotations overlay event data on your dashboard graphs, helping you correlate events with metrics. You can use Prometheus as a data source for annotations to display events such as deployments, alerts, or threshold crossings on your visualizations.
+
+For general information about annotations, refer to [Annotate visualizations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/).
+
+## Before you begin
+
+Before creating Prometheus annotations, ensure you have:
+
+- A configured Prometheus data source in Grafana
+- Metrics in Prometheus that represent the events you want to annotate
+- Read access to the Prometheus instance
+
+## Create an annotation query
+
+To add a Prometheus annotation to your dashboard:
+
+1. Navigate to your dashboard and click **Dashboard settings** (gear icon).
+1. Select **Annotations** in the left menu.
+1. Click **Add annotation query**.
+1. Enter a **Name** for the annotation.
+1. Select your **Prometheus** data source from the **Data source** drop-down.
+1. Enter a PromQL expression in the query field.
+1. Set the **Min step** to control annotation density (a larger step means fewer annotations).
+1. Configure the field mappings to control what appears in the annotation tooltip.
+1. Optionally, select a **Color** for the annotation markers to distinguish different annotation types visually.
+1. Click **Save dashboard**.
+
+## How Prometheus annotations work
+
+Prometheus annotations work differently from SQL-based annotations. Instead of querying a table of events, you write a PromQL expression that returns time-series data. Grafana converts the query results into annotation events using these rules:
+
+- Grafana executes the PromQL query as a range query over the dashboard's time window.
+- **Every data point returned creates an annotation.** There is no automatic filtering of zero values — if you only want annotations at specific moments, your PromQL expression must filter the results (for example, using `> 0` or the `ALERTS` metric).
+- Grafana uses the field mapping configuration to determine what text, title, and tags to display for each annotation.
+- If the query returns multiple time series, each series produces its own set of annotations.
+
+{{< admonition type="note" >}}
+Because every returned data point creates an annotation, queries that return continuous data (like `node_cpu_seconds_total`) will produce an annotation at every step interval, flooding your dashboard. Always use expressions that return data only at the moments you want annotated.
+{{< /admonition >}}
+
+## Field mappings
+
+After entering your PromQL expression, use the field mapping drop-downs to control how query results are displayed as annotations. Grafana shows mapping options for:
+
+| Field       | Description                                                                                          | Default behavior                                                                  |
+| ----------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Time**    | The timestamp for the annotation.                                                                    | Uses the first time-type field (always present).                                  |
+| **TimeEnd** | An end timestamp for range annotations, which display as a shaded region instead of a vertical line. | Not set (produces point annotations).                                             |
+| **Title**   | Short label displayed on the annotation marker.                                                      | Not set.                                                                          |
+| **Text**    | The annotation description displayed when you hover over it.                                         | Uses the first string-type field, or the metric/label display name if configured. |
+| **Tags**    | Comma-separated tags for the annotation. Helps categorize and filter annotations.                    | Not set.                                                                          |
+
+To configure field mappings, select the appropriate field name from each drop-down, or enter a fixed text value.
+
+## Example annotation queries
+
+The following examples show common annotation patterns with Prometheus.
+
+### Alert-based annotations using `ALERTS`
+
+The most common and reliable way to create Prometheus annotations. Prometheus automatically generates an `ALERTS` metric for all configured alerting rules.
+
+```promql
+ALERTS{alertstate="firing"}
+```
+
+This creates an annotation at every step interval where an alert is firing. The `ALERTS` metric includes labels such as:
+
+- `alertname` — The name of the alerting rule
+- `alertstate` — Either `firing` or `pending`
+- Any labels defined on the alerting rule
+
+To limit to specific alerts or severity levels:
+
+```promql
+ALERTS{alertname="HighCPUUsage", severity="critical"}
+```
+
+Configure the field mappings:
+
+- **Text:** `alertname` (displays the alert name on hover)
+- **Tags:** `severity` (allows filtering by severity)
+
+### Service restart annotations
+
+Display annotations when a process restarts. The `changes()` function detects when a value changes, and `> 0` ensures annotations only appear at the moment of change:
+
+```promql
+changes(process_start_time_seconds{job="myservice"}[5m]) > 0
+```
+
+### Deployment annotations
+
+If you track deployments by pushing a timestamp metric via `Pushgateway` or a recording rule:
+
+```promql
+changes(deployment_timestamp_seconds{environment="production"}[10m]) > 0
+```
+
+Configure the field mappings:
+
+- **Text:** `environment` (shows which environment was deployed)
+- **Tags:** `environment`
+
+### Threshold crossing annotations
+
+Display annotations when available memory drops below 10%:
+
+```promql
+node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.1
+```
+
+{{< admonition type="note" >}}
+Comparison operators in PromQL act as filters — they only return data points where the condition is true. This means the expression above only returns data when memory is below 10%, and annotations only appear at those times. There's no need to add an outer `> 0` wrapper.
+{{< /admonition >}}
+
+### Scaling event annotations
+
+Display annotations when the number of running pods changes:
+
+```promql
+changes(kube_deployment_status_replicas{deployment="my-app"}[5m]) > 0
+```
+
+### Error spike annotations
+
+Display annotations when the error rate exceeds a threshold:
+
+```promql
+sum(rate(http_requests_total{status=~"5.."}[5m])) by (job) / sum(rate(http_requests_total[5m])) by (job) > 0.05
+```
+
+This creates annotations when the error rate exceeds 5%.
+
+### Version or build change annotations
+
+If you expose build metadata using a metric like `build_info` (common in Go services), annotate when the version changes:
+
+```promql
+changes(build_info{job="myservice"}[10m]) > 0
+```
+
+Configure the field mappings:
+
+- **Text:** `version` (shows the new version in the annotation tooltip)
+- **Tags:** `job`
+
+If your build info metric uses a `version` label (for example, `build_info{version="1.2.3"}`), the annotation tooltip displays the version that was deployed.
+
+## Control annotation density
+
+The **Min step** setting controls how many data points the query returns, which directly affects how many annotations appear. A larger step means fewer annotations:
+
+- **Min step `1m`** — Up to one annotation per minute (good for short time ranges).
+- **Min step `5m`** — Up to one annotation per 5 minutes (good for day-range dashboards).
+- **Min step `1h`** — Up to one annotation per hour (good for week-range dashboards).
+
+If your dashboard shows too many annotation markers, increase the Min step or add more specific filters to your query.
+
+## Use template variables in annotations
+
+You can use template variables in your annotation queries to filter annotations based on dashboard variable selections:
+
+```promql
+ALERTS{alertstate="firing", instance=~"$instance"}
+```
+
+```promql
+changes(process_start_time_seconds{job="$job"}[5m]) > 0
+```
+
+Template variables in annotations are resolved at query time using the current dashboard variable values.
+
+## Range annotations
+
+Range annotations display as shaded regions rather than vertical lines, representing events with duration. To create range annotations, the query result must include a **TimeEnd** field mapping.
+
+Because PromQL doesn't natively return start/end time pairs, range annotations with Prometheus are limited to scenarios where you have separate metrics for start and end times (for example, via recording rules or custom metrics pushed to `Pushgateway`). For most use cases, point annotations (using the examples in this page) are the practical approach.
+
+If your annotations aren't appearing or you encounter errors, refer to [Troubleshoot Prometheus data source issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#annotation-errors).

--- a/docs/sources/datasources/prometheus/configure/_index.md
+++ b/docs/sources/datasources/prometheus/configure/_index.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Configure
 title: Configure the Prometheus data source
 weight: 200
+review_date: 2026-05-07
 ---
 
 # Configure the Prometheus data source
@@ -23,9 +24,7 @@ This document provides instructions for configuring the Prometheus data source a
 
 ## Before you begin
 
-- You need the `Organization administrator` role to configure the data source. You can also [configure it via YAML](#provision-the-prometheus-data-source) using Grafana provisioning.
-
-- Grafana includes a built-in Prometheus data source; no plugin installation is required.
+- You need the `Organization administrator` role to configure the data source. You can also [configure it via YAML](#provision-the-data-source) using Grafana provisioning or [using Terraform](#terraform).
 
 - Know which type of Prometheus-compatible database you're connecting to (Prometheus, Mimir, Cortex, or Thanos), as the configuration options vary by type.
 
@@ -33,7 +32,7 @@ This document provides instructions for configuring the Prometheus data source a
 
 - If using Basic authentication, have your username and password ready.
 
-## Configure the data source using the UI
+## Add the data source
 
 {{< shared id="add-prom-data-source" >}}
 
@@ -47,29 +46,31 @@ To add the Prometheus data source, complete the following steps:
 
 {{< /shared >}}
 
-Grafana takes you to the **Settings** tab where you will set up your Prometheus configuration.
+Grafana takes you to the **Settings** tab where you set up your Prometheus configuration.
 
 ## Configuration options
 
-Following is a list of configuration options for Prometheus.
+The following sections describe the configuration options available on the Settings tab. These sections follow the order in which they appear in the UI.
 
-- **Name** - The data source name. Sets the name you use to refer to the data source in panels and queries. Examples: prometheus-1, prom-metrics.
-- **Default** - Toggle to select as the default name in dashboard panels. When you go to a dashboard panel this will be the default selected data source.
+### Name and default
 
-**Connection:**
+- **Name** - The data source name. Sets the name you use to refer to the data source in panels and queries. Examples: `prometheus-1`, `prom-metrics`.
+- **Default** - Toggle to select as the default data source in dashboard panels.
+
+### Connection
 
 - **Prometheus server URL** - The URL of your Prometheus server. {{< shared id="prom-data-source-url" >}}
-  If Prometheus is running locally, use `http://localhost:9090`. If it's hosted on a networked server, provide the server’s URL along with the port where Prometheus is running. Example: `http://prometheus.example.orgname:9090`.
+  If Prometheus is running locally, use `http://localhost:9090`. If it's hosted on a networked server, provide the server's URL along with the port where Prometheus is running. Example: `http://prometheus.example.orgname:9090`.
 
 {{< admonition type="note" >}}
-When running Grafana and Prometheus in separate containers, localhost refers to each container’s own network namespace. This means that `localhost:9090` points to port 9090 inside the Grafana container, not on the host machine.
+When running Grafana and Prometheus in separate containers, localhost refers to each container's own network namespace. This means that `localhost:9090` points to port 9090 inside the Grafana container, not on the host machine.
 
 Use the IP address of the Prometheus container, or the hostname if you are using Docker Compose. Alternatively, you can use `http://host.docker.internal:9090` to reference the host machine.
 {{< /admonition >}}
 
 {{< /shared >}}
 
-**Authentication:**
+### Authentication
 
 There are three authentication options for the Prometheus data source.
 
@@ -81,7 +82,21 @@ There are three authentication options for the Prometheus data source.
 
 - **No authentication** - Allows access to the data source without any authentication.
 
-**TLS settings:**
+Additional authentication methods (Azure AD, AWS SigV4) are available depending on your deployment:
+
+{{< admonition type="warning" >}}
+Azure AD and SigV4 authentication on the core Prometheus data source are **deprecated** in Grafana 13. Existing data sources using these methods are automatically migrated to dedicated plugins on startup. For new setups, use the [Azure Monitor Managed Service for Prometheus](https://grafana.com/grafana/plugins/grafana-azureprometheus-datasource/) or [Amazon Managed Service for Prometheus](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/) plugins instead. For migration details, refer to [Azure authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/azure-authentication/) or [AWS authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/aws-authentication/).
+{{< /admonition >}}
+
+- **Azure AD authentication** - Available in Grafana Enterprise and self-managed instances where `azure_auth_enabled = true` is configured. On Grafana Cloud, this option requires a server-side feature flag that isn't enabled by default — contact [Grafana Support](https://grafana.com/profile/org#support) to request it be enabled for your stack. Refer to [Azure authentication settings](#azure-authentication-settings-deprecated) for configuration details.
+
+- **AWS SigV4 authentication** - Available in self-managed Grafana instances where `sigv4_auth_enabled = true` is configured. On Grafana Cloud, this option isn't available by default — contact [Grafana Support](https://grafana.com/profile/org#support) to request it be enabled for your stack.
+
+{{< admonition type="note" >}}
+If Azure AD or SigV4 options don't appear in the authentication drop-down, the required feature flag isn't enabled on your instance. For Grafana Cloud, submit a support request. For self-managed instances, update the Grafana configuration file.
+{{< /admonition >}}
+
+### TLS settings
 
 {{< admonition type="note" >}}
 Use TLS (Transport Layer Security) for an additional layer of security when working with Prometheus. For information on setting up TLS encryption with Prometheus refer to [Securing Prometheus API and UI Endpoints Using TLS Encryption](https://prometheus.io/docs/guides/tls-encryption/). You must add TLS settings to your Prometheus configuration file **prior** to setting these options in Grafana.
@@ -91,97 +106,128 @@ Use TLS (Transport Layer Security) for an additional layer of security when work
   - **CA certificate** - Add your certificate.
 - **TLS client authentication** - Check the box to enable TLS client authentication.
   - **Server name** - Add the server name, which is used to verify the hostname on the returned certificate.
-  - **Client certificate** - The client certificate is generated from a Certificate Authority or its self-signed. Follow the instructions of the CA (Certificate Authority) to download the certificate file.
-  - **Client key** - Add your client key, which can also be generated from a Certificate Authority (CA) or be self-signed. The client key encrypts data between the client and server.
+  - **Client certificate** - The client certificate is generated from a Certificate Authority or is self-signed. Follow the instructions of the CA to download the certificate file.
+  - **Client key** - Add your client key, which can also be generated from a CA or be self-signed. The client key encrypts data between the client and server.
 - **Skip TLS verify** - Toggle on to bypass TLS certificate validation. Skipping TLS certificate validation is not recommended unless absolutely necessary or for testing purposes.
 
-**HTTP headers:**
+### HTTP headers
 
 Pass along additional information and metadata about the request or response.
 
 - **Header** - Add a custom header. This allows custom headers to be passed based on the needs of your Prometheus instance.
 - **Value** - The value of the header.
 
-**Advanced settings:**
+### Advanced HTTP settings
 
-Following are optional configuration settings you can configure for more control over your data source.
+- **Allowed cookies** - Specify cookies by name that should be forwarded to the data source. The Grafana proxy deletes all forwarded cookies by default.
+- **Timeout** - The HTTP request timeout in seconds.
 
-- **Advanced HTTP settings:**
-  - **Allowed cookies** - Specify cookies by name that should be forwarded to the data source. The Grafana proxy deletes all forwarded cookies by default.
-  - **Timeout** - The HTTP request timeout, must be in seconds.
+### Alerting
 
-**Alerting:**
+- **Manage alerts via Alerting UI** - Toggled on by default. This enables [data source-managed rules in Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/) for this data source. For `Mimir`, it enables managing data source-managed rules and alerts. For `Prometheus`, it only supports viewing existing rules and alerts, which are displayed as data source-managed. Change this by setting the [`default_manage_alerts_ui_toggle`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#default_manage_alerts_ui_toggle) option in the `grafana.ini` configuration file.
 
-- **Manage alerts via Alerting UI** -Toggled on by default. This enables [data source-managed rules in Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/) for this data source. For `Mimir`, it enables managing data source-managed rules and alerts. For `Prometheus`, it only supports viewing existing rules and alerts, which are displayed as data source-managed. Change this by setting the [`default_manage_alerts_ui_toggle`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#default_manage_alerts_ui_toggle) option in the `grafana.ini` configuration file.
+- **Allow as recording rules target** - Toggled on by default. This allows the data source to be selected as a target destination for writing [Grafana-managed recording rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/). When enabled, this data source appears in the target data source list when creating or importing recording rules. Change this by setting the [`default_allow_recording_rules_target_alerts_ui_toggle`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#default_allow_recording_rules_target_alerts_ui_toggle) option in the `grafana.ini` configuration file.
 
-- **Allow as recording rules target** - Toggled on by default. This allows the data source to be selected as a target destination for writing [Grafana-managed recording rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/). When enabled, this data source will appear in the target data source list when creating or importing recording rules. When disabled, the data source will be filtered out from recording rules target selection. Change this by setting the [`default_allow_recording_rules_target_alerts_ui_toggle`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#default_allow_recording_rules_target_alerts_ui_toggle) option in the `grafana.ini` configuration file.
+### Interval behavior
 
-**Interval behavior:**
-
-- **Scrape interval** - Sets the standard scrape and evaluation interval in Prometheus. The default is `15s`. This interval determines how often Prometheus scrapes targets. Set it to match the typical scrape and evaluation interval in your Prometheus configuration file. If you set a higher value than your Prometheus configuration, Grafana will evaluate data at this interval, resulting in fewer data points.
+- **Scrape interval** - Sets the standard scrape and evaluation interval in Prometheus. The default is `15s`. Set it to match the typical scrape and evaluation interval in your Prometheus configuration file. If you set a higher value than your Prometheus configuration, Grafana evaluates data at this interval, resulting in less data points.
 - **Query timeout** - Sets the Prometheus query timeout. The default is `60s`. Without a timeout, complex or inefficient queries can run indefinitely, consuming CPU and memory resources.
 
-**Query editor:**
+### Query editor
 
-- **Default editor** - Sets the default query editor. Options are `Builder` or `Code`. `Builder` mode helps you build queries using a visual interface. `Code` mode is geared for the experienced Prometheus user with prior expertise in PromQL. For more details on editor types refer to [Prometheus query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/query-editor). You can switch easily code editors in the Query editor UI.
+- **Default editor** - Sets the default query editor. Options are `Builder` or `Code`. `Builder` mode helps you build queries using a visual interface. `Code` mode is geared for the experienced Prometheus user with prior expertise in PromQL. For more details on editor types, refer to [Prometheus query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/query-editor). You can switch between editors in the query editor UI.
 - **Disable metrics lookup** - Toggle on to disable the metrics chooser and metric and label support in the query field's autocomplete. This can improve performance for large Prometheus instances.
 
-**Performance:**
+### Performance
 
-- **Prometheus type** - Select the type of your Prometheus-compatible database, such as Prometheus, Cortex, Mimir, or Thanos. Changing this setting will save your current configuration. Different database types support different APIs. For example, some allow `regex` matching for label queries to improve performance, while others provide a metadata API. Setting this incorrectly may cause unexpected behavior when querying metrics and labels. Refer to your Prometheus documentation to ensure you select the correct type.
-- **Cache level** - Sets the browser caching level for editor queries. There are four options: `Low`, `Medium`, `High`, or `None`. Higher cache settings are recommended for high cardinality data sources.
-- **Incremental querying (beta)** - Toggle on to enable incremental querying. Enabling this feature changes the default behavior of relative queries. Instead of always requesting fresh data from the Prometheus instance, Grafana will cache query results and only fetch new records. This helps reduce database and network load.
-  - **Query overlap window** - If you are using incremental querying, specify a duration (e.g., 10m, 120s, or 0s). The default is `10m`. This is a buffer of time added to incremental queries and this value is added to the duration of each incremental request.
-- **Disable recording rules (beta)** - Toggle on to disable the recording rules. When recording rules are disabled, Grafana won't fetch and parse recording rules from Prometheus, improving dashboard performance by reducing processing overhead..
+- **Prometheus type** - Select the type of your Prometheus-compatible database. Setting this incorrectly may cause unexpected behavior when querying metrics and labels. Cortex is end-of-life; if you're running Cortex, consider migrating to [Mimir](https://grafana.com/oss/mimir/).
 
-**Other settings:**
+  | Capability                                   | Prometheus  | Mimir           | Thanos    | Cortex     |
+  | -------------------------------------------- | ----------- | --------------- | --------- | ---------- |
+  | Regex label matching in variable queries     | No          | Yes             | No        | Yes        |
+  | Metadata API (metric type/help)              | Yes (2.4+)  | Yes             | No        | Yes        |
+  | Exemplars                                    | Yes (2.26+) | Yes             | No        | No         |
+  | Data source-managed alert rules (read/write) | Read only   | Read/Write      | Read only | Read/Write |
+  | Recording rules target (write-back)          | Yes         | Yes             | No        | Yes        |
+  | LBAC (Team-based access control)             | No          | Yes (Cloud/GEM) | No        | No         |
+  | Native histograms                            | Yes (2.40+) | Yes             | No        | No         |
 
-- **Custom query parameters** - Add custom parameters to the Prometheus query URL, which allow for more control over how queries are executed. Examples: `timeout`, `partial_response`, `dedup`, or `max_source_resolution`. Multiple parameters should be joined using `&`.
-- **HTTP method** - Select either the `POST` or `GET` HTTP method to query your data source. `POST`is recommended and selected by default, as it supports larger queries. Select `GET` if you're using Prometheus version 2.1 or older, or if your network restricts `POST` requests.
-  Toggle on
-- **Series limit** - Number of maximum returned series. The limit applies to all resources (metrics, labels, and values) for both endpoints (series and labels). Leave the field empty to use the default limit (40000). Set to 0 to disable the limit and fetch everything — this may cause performance issues. Default limit is 40000.
-- **Use series endpoint** - Enabling this option makes Grafana use the series endpoint (/api/v1/series) with the match[] parameter instead of the label values endpoint (/api/v1/label/<label_name>/values). While the label values endpoint is generally more performant, some users may prefer the series endpoint because it supports the `POST` method, whereas the label values endpoint only allows `GET` requests.
+  Grafana uses this setting to determine which API endpoints and features to enable. For example, when set to Mimir, Grafana uses regular expression-optimized label queries that significantly improve autocomplete and variable loading performance for large metric sets.
 
-**Exemplars:**
+{{< admonition type="note" >}}
+Team-based Label-Based Access Control (LBAC) for the Prometheus data source requires the backend to be **Grafana Cloud Metrics (Mimir)** or **Grafana Enterprise Metrics (GEM)**. LBAC doesn't work with external Prometheus-compatible endpoints such as Google Managed Prometheus, self-hosted Prometheus, or Thanos, even if you enable the `teamHttpHeadersMimir` setting. The LBAC enforcement relies on Mimir-specific HTTP headers that other backends don't support.
+{{< /admonition >}}
 
-Support for exemplars is available only for the Prometheus data source. For more information on exemplars refer to [Introduction to exemplars](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/). An exemplar is a trace that represents a specific measurement taken within a given time interval.
+- **Cache level** - Sets the browser caching level for editor queries. Options: `Low`, `Medium`, `High`, or `None`. Higher cache settings are recommended for high-cardinality data sources.
+- **Incremental querying (beta)** - Toggle on to enable incremental querying. Instead of always requesting fresh data from the Prometheus instance, Grafana caches query results and only fetches new records. This helps reduce database and network load.
+  - **Query overlap window** - Specify a duration (for example, `10m`, `120s`, or `0s`). The default is `10m`. This buffer is added to each incremental request to account for delayed data ingestion.
+- **Disable recording rules (beta)** - Toggle on to disable recording rules. When disabled, Grafana won't fetch and parse recording rules from Prometheus, improving dashboard performance by reducing processing overhead.
+
+### Other
+
+- **Custom query parameters** - Add custom parameters to the Prometheus query URL for more control over query execution. Examples: `timeout`, `partial_response`, `dedup`, or `max_source_resolution`. Join multiple parameters with `&`.
+- **HTTP method** - Select either the `POST` or `GET` HTTP method to query your data source. `POST` is recommended and selected by default, as it supports larger queries. Select `GET` if your network restricts `POST` requests.
+- **Series limit** - Maximum number of returned series. The limit applies to all resources (metrics, labels, and values) for both endpoints (series and labels). Leave empty to use the default limit (40000). Set to `0` to disable the limit — this may cause performance issues.
+- **Use series endpoint** - Toggle on to use the series endpoint (`/api/v1/series`) with the `match[]` parameter instead of the label values endpoint (`/api/v1/label/<label_name>/values`). The label values endpoint is generally more performant, but the series endpoint supports the `POST` method.
+
+### Exemplars
+
+Support for exemplars is available only for the Prometheus data source. An exemplar is a trace that represents a specific measurement taken within a given time interval. For more information, refer to [Introduction to exemplars](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/).
 
 Click the **+ sign** to add exemplars.
 
-- **Internal link** - Toggle on to enable an internal link. This will display the data source selector, where you can choose the backend tracing data store for your exemplar data.
-- **URL** - _(Visible if you **disable** `Internal link`)_ Defines the external link's URL trace backend. You can interpolate the value from the field by using the [`${__value.raw}` macro](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-data-links/#value-variables).
-- **Data source** - _(Visible when`Internal link` is enabled.)_ Select the data source that the exemplar will link to from the drop-down.
+- **Internal link** - Toggle on to enable an internal link. This displays the data source selector, where you can choose the backend tracing data store for your exemplar data.
+- **URL** - _(Visible if you disable `Internal link`)_ Defines the external link's URL trace backend. You can interpolate the value from the field by using the [`${__value.raw}` macro](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-data-links/#value-variables).
+- **Data source** - _(Visible when `Internal link` is enabled)_ Select the tracing data source that the exemplar links to.
 - **URL label** - Adds a custom display label to override the value of the `Label name` field.
 - **Label name** - The name of the field in the `labels` object used to obtain the traceID property.
 - **Remove exemplar link** - Click the **X** to remove existing links.
 
-You can add multiple exemplars.
+You can add multiple exemplar configurations.
 
-- **Private data source connect** - _Only for Grafana Cloud users._ Private data source connect, or PDC, allows you to establish a private, secured connection between a Grafana Cloud instance, or stack, and data sources secured within a private network. Click the drop-down to locate the URL for PDC. For more information regarding Grafana PDC refer to [Private data source connect (PDC)](/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) and [Configure Grafana private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#configure-grafana-private-data-source-connect-pdc) for steps on setting up a PDC connection.
+### Private data source connect
 
-  If you use PDC with SIGv4 (AWS Signature Version 4 Authentication), the PDC agent must allow internet egress to`sts.<region>.amazonaws.com:443`.
+{{< admonition type="note" >}}
+Private data source connect (PDC) is only available for Grafana Cloud users.
+{{< /admonition >}}
 
-  Click **Manage private data source connect** to open your PDC connection page and view your configuration details.
+PDC allows you to establish a private, secured connection between a Grafana Cloud instance and data sources within a private network without opening the network to inbound traffic.
 
-After you have configured your Prometheus data source options, click **Save & test** at the bottom to test out your data source connection.
+- **Private data source connect network** - Select the PDC network where your data source is available.
 
-You should see a confirmation dialog box that says:
+PDC supports both querying and writing to Prometheus-compatible data sources. This means [Grafana-managed recording rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/) can write their results to a Prometheus or Mimir instance behind a PDC connection.
+
+If you use PDC with SigV4 (AWS Signature Version 4 Authentication), the PDC agent must allow internet egress to `sts.<region>.amazonaws.com:443`.
+
+Click **Manage private data source connect networks** to view your PDC configuration details.
+
+For more information, refer to [Private data source connect (PDC)](/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) and [Configure PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#configure-grafana-private-data-source-connect-pdc).
+
+For troubleshooting PDC connectivity issues (DNS resolution, "host unreachable" errors, or parallel connection tuning), refer to [PDC connectivity errors](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#pdc-connectivity-errors).
+
+## Save and test
+
+After you have configured your Prometheus data source options, click **Save & test** at the bottom to test your data source connection.
+
+You should see a confirmation message:
 
 **Successfully queried the Prometheus API.**
 
-**Next, you can start to visualize data by building a dashboard, or by querying data in the Explore view.**
-
 You can also remove a connection by clicking **Delete**.
 
-## Provision the Prometheus data source
+## Provision the data source
 
-You can define and configure the data source in YAML files as part of the Grafana provisioning system. For more information about provisioning, and for available configuration options, refer to [Provision Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/).
+You can define and configure the data source in YAML files as part of the Grafana provisioning system, or use Terraform with the Grafana provider.
 
 {{< admonition type="note" >}}
-After you have provisioned a data source you cannot edit it.
+After you have provisioned a data source, you cannot edit it through the UI.
 {{< /admonition >}}
 
-**Example of a Prometheus data source configuration:**
+### Provision with YAML
+
+For more information about provisioning, and for available configuration options, refer to [Provision Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/).
+
+**Example Prometheus data source configuration:**
 
 ```yaml
 apiVersion: 1
@@ -200,26 +246,83 @@ datasources:
       cacheLevel: 'High'
       disableRecordingRules: false
       seriesEndpoint: false
-      timeInterval: 10s # Prometheus scrape interval
+      timeInterval: 10s
       incrementalQueryOverlapWindow: 10m
       exemplarTraceIdDestinations:
-        # Field with internal link pointing to data source in Grafana.
-        # datasourceUid value can be anything, but it should be unique across all defined data source uids.
         - datasourceUid: my_jaeger_uid
           name: traceID
-
-        # Field with external link.
         - name: traceID
           url: 'http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Jaeger%22,%7B%22query%22:%22$${__value.raw}%22%7D%5D'
 ```
 
-## Azure authentication settings
+### Provision with Terraform
 
-The Prometheus data source works with Azure authentication. To configure Azure authentication refer to [Configure Azure Active Directory (AD) authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/azure-monitor/#configure-azure-active-directory-ad-authentication).
+You can configure the Prometheus data source using [Terraform](https://www.terraform.io/) with the [Grafana Terraform provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs).
 
-In Grafana Enterprise, you need to update the .ini configuration file. Refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#configuration-file-location) to locate your .ini file.
+For more information about provisioning resources with Terraform, refer to [Grafana as code using Terraform](https://grafana.com/docs/grafana-cloud/developer-resources/infrastructure-as-code/terraform/).
 
-Add the following setting in the **[auth]** section of the .ini configuration file:
+The following example creates a Prometheus data source with common settings:
+
+```hcl
+resource "grafana_data_source" "prometheus" {
+  name = "Prometheus"
+  type = "prometheus"
+  url  = "http://localhost:9090"
+
+  json_data_encoded = jsonencode({
+    httpMethod                    = "POST"
+    manageAlerts                  = true
+    prometheusType                = "Prometheus"
+    prometheusVersion             = "3.3.0"
+    cacheLevel                    = "High"
+    disableRecordingRules         = false
+    incrementalQuerying           = true
+    incrementalQueryOverlapWindow = "10m"
+    timeInterval                  = "15s"
+    exemplarTraceIdDestinations = [{
+      datasourceUid = "my_tempo_uid"
+      name          = "traceID"
+    }]
+  })
+}
+```
+
+The following example creates a Prometheus data source with basic authentication:
+
+```hcl
+resource "grafana_data_source" "prometheus_auth" {
+  name = "Prometheus (authenticated)"
+  type = "prometheus"
+  url  = "https://prometheus.example.com:9090"
+
+  basic_auth_enabled  = true
+  basic_auth_username = "grafana"
+
+  json_data_encoded = jsonencode({
+    httpMethod     = "POST"
+    prometheusType = "Mimir"
+    timeInterval   = "15s"
+  })
+
+  secure_json_data_encoded = jsonencode({
+    basicAuthPassword = var.prometheus_password
+  })
+}
+```
+
+For all available configuration options, refer to the [Grafana provider data source resource documentation](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source).
+
+## Azure authentication settings (deprecated)
+
+{{< admonition type="warning" >}}
+Azure AD authentication on the core Prometheus data source is **deprecated** in Grafana 13. Data sources using this method are automatically migrated to the dedicated [Azure Monitor Managed Service for Prometheus](https://grafana.com/grafana/plugins/grafana-azureprometheus-datasource/) plugin on startup. For migration details, refer to [Azure authentication (deprecated)](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure/azure-authentication/).
+{{< /admonition >}}
+
+If you still need to configure Azure AD authentication on the core Prometheus data source (for example, on older Grafana versions), refer to [Configure Azure Active Directory (AD) authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/azure-monitor/#configure-azure-active-directory-ad-authentication).
+
+In Grafana Enterprise or self-managed OSS, update the `.ini` configuration file. Refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#configuration-file-location) to locate your `.ini` file.
+
+Add the following setting in the **[auth]** section:
 
 ```bash
 [auth]
@@ -230,14 +333,6 @@ azure_auth_enabled = true
 If you are using Azure authentication, don't enable `Forward OAuth identity`. Both methods use the same HTTP authorization headers, and the OAuth token will override your Azure credentials.
 {{< /admonition >}}
 
-## Recording rules (beta)
+## Troubleshooting
 
-You can configure the Prometheus data source to disable recording rules in the data source configuration or provisioning file under `disableRecordingRules` in jsonData.
-
-## Troubleshooting configuration issues
-
-Refer to the following troubleshooting information as needed.
-
-**Data doesn't appear in Metrics Drilldown:**
-
-If you have successfully tested the connection to a Prometheus data source or are sending metrics to Grafana Cloud and there is no metric data appearing in Explore, make sure you've selected the correct data source from the data source drop-down menu. When using `remote_write` to send metrics to Grafana Cloud, the data source name follows the convention `grafanacloud-stackname-prom`.
+If you encounter issues after configuring your Prometheus data source, refer to [Troubleshoot Prometheus data source issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/).

--- a/docs/sources/datasources/prometheus/configure/aws-authentication.md
+++ b/docs/sources/datasources/prometheus/configure/aws-authentication.md
@@ -2,137 +2,140 @@
 aliases:
   - ../data-sources/prometheus/
   - ../features/datasources/prometheus/
-description: Guide for authenticating with Amazon Managed Service for Prometheus in Grafana
+description: Migrating from Prometheus SigV4 authentication to the Amazon Managed Service for Prometheus data source
 keywords:
   - grafana
   - prometheus
-  - guide
+  - aws
+  - sigv4
+  - amazon managed prometheus
+  - migration
 labels:
   products:
     - cloud
     - enterprise
     - oss
-menuTitle: Authenticating with SigV4
-title: Configure the Prometheus data source
-weight: 200
+menuTitle: AWS authentication (deprecated)
+title: Migrate from Prometheus SigV4 to Amazon Managed Service for Prometheus
+weight: 210
+review_date: 2026-05-07
 ---
 
-# Connect to Amazon Managed Service for Prometheus
+# Migrate from Prometheus SigV4 to Amazon Managed Service for Prometheus
 
-1. In the data source configuration page, locate the **Auth** section
-2. Enable **SigV4 auth**
-3. Configure the following settings:
-
-   | Setting                     | Description                                    | Example                                                         |
-   | --------------------------- | ---------------------------------------------- | --------------------------------------------------------------- |
-   | **Authentication Provider** | Choose your auth method                        | `AWS SDK Default`, `Access & secret key`, or `Credentials file` |
-   | **Default Region**          | AWS region for your workspace                  | `us-west-2`                                                     |
-   | **Access Key ID**           | Your AWS access key (if using access key auth) | `AKIA...`                                                       |
-   | **Secret Access Key**       | Your AWS secret key (if using access key auth) | `wJalrXUtn...`                                                  |
-   | **Assume Role ARN**         | IAM role ARN (optional)                        | `arn:aws:iam::123456789:role/GrafanaRole`                       |
-
-4. Set the **HTTP URL** to your Amazon Managed Service for Prometheus workspace endpoint: `https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-12345678-1234-1234-1234-123456789012/`
-
-5. Click **Save & test** to verify the connection
-
-## Example configuration
-
-```yaml
-# Example provisioning configuration
-apiVersion: 1
-datasources:
-  - name: 'Amazon Managed Prometheus'
-    type: 'grafana-amazonprometheus-datasource'
-    url: 'https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-12345678-1234-1234-1234-123456789012/'
-    jsonData:
-      httpMethod: 'POST'
-      sigV4Auth: true
-      sigV4AuthType: 'keys'
-      sigV4Region: 'us-east-2'
-    secureJsonData:
-      sigV4AccessKey: '<access key>'
-      sigV4SecretKey: '<secret key>'
-```
-
-## Migrate to Amazon Managed Service for Prometheus
-
-Learn more about why this is happening: [Prometheus data source update: Redefining our big tent philosophy](https://grafana.com/blog/2025/06/16/prometheus-data-source-update-redefining-our-big-tent-philosophy/)
-
-Before you begin, ensure you have the organization administrator role. If you are self-hosting Grafana, back up your existing dashboard configurations and queries.
-
-Grafana Cloud users will be automatically migrated to the relevant version of Prometheus, so no action needs to be taken.
-
-For air-gapped environments, download and install [Amazon Managed Service for Prometheus](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/), then follow the standard migration process.
-
-### Migrate
-
-1. Enable the `prometheusTypeMigration` feature toggle. For more information on feature toggles, refer to [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#manage-feature-toggles).
-2. Restart Grafana for the changes to take effect.
-
-{{< admonition type="note" >}}
-This feature toggle will be removed in Grafana 13, and the migration will be automatic.
+{{< admonition type="warning" >}}
+Using SigV4 authentication with the core Prometheus data source for Amazon Managed Service for Prometheus is **deprecated**. In Grafana 13, the migration to the dedicated [Amazon Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/) is automatic. Existing data sources using SigV4 are migrated on startup.
 {{< /admonition >}}
 
-### Check migration status
+For background on this change, refer to [Prometheus data source update: Redefining our big tent philosophy](https://grafana.com/blog/2025/06/16/prometheus-data-source-update-redefining-our-big-tent-philosophy/).
+
+## What changed in Grafana 13
+
+In Grafana 13, the `prometheusTypeMigration` feature toggle is enabled by default and deprecated. This means:
+
+- Prometheus data sources configured with SigV4 authentication are **automatically migrated** to the dedicated Amazon Managed Service for Prometheus plugin on Grafana startup.
+- You no longer need to manually enable the feature toggle.
+- Grafana Cloud users are migrated automatically with no action required.
+- Dashboards, alerts, and queries continue to work after migration without changes.
+
+## Check migration status
 
 To determine if your Prometheus data sources have been migrated:
 
-1. Navigate to **Connections** > **Data sources**
-2. Select your Prometheus data source
-3. Look for a migration banner at the top of the configuration page
+1. Navigate to **Connections** > **Data sources**.
+1. Select your Prometheus data source.
+1. Look for a migration banner at the top of the configuration page.
 
 The banner displays one of the following messages:
 
-- **"Migration Notice"** - The data source has already been migrated
-- **"Deprecation Notice"** - The data source has not been migrated
-- **No banner** - No migration is needed for this data source
+- **"Migration Notice"** — The data source has been migrated to the Amazon Managed Service for Prometheus plugin.
+- **"Deprecation Notice"** — The data source hasn't been migrated yet.
+- **No banner** — No migration is needed (the data source doesn't use SigV4).
 
-## Common migration issues
+## Configure the Amazon Managed Service for Prometheus data source
 
-The following sections contain troubleshooting guidance.
+After migration (or for new setups), configure the dedicated plugin:
 
-**Migration banner not appearing**
+1. Navigate to **Connections** > **Data sources**.
+1. Select your Amazon Managed Service for Prometheus data source.
+1. In the **Auth** section, configure SigV4 authentication:
 
-- Verify the `prometheusTypeMigration` feature toggle is enabled
-- Restart Grafana after enabling the feature toggle
+| Setting                     | Description                                    | Example                                                         |
+| --------------------------- | ---------------------------------------------- | --------------------------------------------------------------- |
+| **Authentication Provider** | Choose your auth method                        | `AWS SDK Default`, `Access & secret key`, or `Credentials file` |
+| **Default Region**          | AWS region for your workspace                  | `us-west-2`                                                     |
+| **Access Key ID**           | Your AWS access key (if using access key auth) | `AKIA...`                                                       |
+| **Secret Access Key**       | Your AWS secret key (if using access key auth) | `wJalrXUtn...`                                                  |
+| **Assume Role ARN**         | IAM role ARN (optional)                        | `arn:aws:iam::123456789:role/GrafanaRole`                       |
 
-**Amazon Managed Service for Prometheus is not installed**
+4. Set the **HTTP URL** to your Amazon Managed Service for Prometheus workspace endpoint:
+   `https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-12345678-1234-1234-1234-123456789012/`
 
-- Verify that Amazon Managed Service for Prometheus is installed by going to **Connections** > **Add new connection** and search for "Amazon Managed Service for Prometheus"
-- Install Amazon Managed Service for Prometheus if not already installed
+5. Click **Save & test** to verify the connection.
 
-**After migrating, my data source returns "401 Unauthorized"**
+## Provision the data source
 
-- If you are using self-hosted Grafana, check your .ini for `grafana-amazonprometheus-datasource` is included in `forward_settings_to_plugins` under the `[aws]` heading.
-- If you are using Grafana Cloud, contact Grafana support.
+```yaml
+apiVersion: 1
+datasources:
+  - name: Amazon Managed Prometheus
+    type: grafana-amazonprometheus-datasource
+    url: https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-12345678-1234-1234-1234-123456789012/
+    jsonData:
+      httpMethod: POST
+      sigV4Auth: true
+      sigV4AuthType: keys
+      sigV4Region: us-east-2
+    secureJsonData:
+      sigV4AccessKey: <ACCESS_KEY>
+      sigV4SecretKey: <SECRET_KEY>
+```
 
-### Rollback self-hosted Grafana without a backup
+Replace `<ACCESS_KEY>` and `<SECRET_KEY>` with your AWS credentials.
 
-If you don’t have a backup of your Grafana instance before the migration, remove the `prometheusTypeMigration` feature toggle, and run the following script. It reverts all Amazon Managed Service for Prometheus data sources back to core Prometheus.
+## Troubleshoot migration issues
 
-To revert the migration:
+### Amazon Managed Service for Prometheus plugin not installed
 
-1. Disable the `prometheusTypeMigration` feature toggle. For more information on feature toggles, refer to [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#manage-feature-toggles).
-2. Obtain a bearer token that has `read` and `write` permissions for your Grafana data source API. For more information on the data source API, refer to [Data source API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/data_source/).
-3. Run the script below. Make sure to provide your Grafana URL and bearer token.
-4. (Optional) Report the issue you were experiencing on the [Grafana repository](https://github.com/grafana/grafana/issues). Tag the issue with "datasource/migrate-prometheus-type"
+**Symptom:** Migration doesn't occur or the data source type is missing.
 
-```bash
+**Solution:**
+
+1. Navigate to **Connections** > **Add new connection** and search for "Amazon Managed Service for Prometheus".
+1. Install the plugin if it isn't already installed.
+1. For air-gapped environments, download the plugin from [the Grafana plugin catalog](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/) and install it manually.
+
+### "401 Unauthorized" after migration
+
+**Symptom:** The migrated data source returns authentication errors.
+
+**Solution:**
+
+1. **Self-hosted Grafana:** Verify that `grafana-amazonprometheus-datasource` is included in `forward_settings_to_plugins` under the `[aws]` heading in your `.ini` configuration file.
+1. **Grafana Cloud:** Contact [Grafana Support](https://grafana.com/profile/org#support).
+
+### Rollback the migration
+
+If you need to revert migrated data sources back to the core Prometheus type:
+
+1. Set `prometheusTypeMigration` to `false` in your Grafana configuration feature toggles. For more information, refer to [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#manage-feature-toggles).
+1. Restart Grafana.
+1. Obtain a bearer token with `read` and `write` permissions for the data source API. For more information, refer to [Data source API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/data_source/).
+1. Run the following rollback script, providing your Grafana URL and bearer token:
+
+```sh
 #!/bin/bash
 
-# Configuration
 GRAFANA_URL=""
 BEARER_TOKEN=""
-LOG_FILE="grafana_migration_$(date +%Y%m%d_%H%M%S).log"
+LOG_FILE="grafana_migration_rollback_$(date +%Y%m%d_%H%M%S).log"
 
-# Function to log messages to both console and file
 log_message() {
     local message="$1"
     local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
     echo "[$timestamp] $message" | tee -a "$LOG_FILE"
 }
 
-# Function to update a data source
 update_data_source() {
     local uid="$1"
     local data="$2"
@@ -147,125 +150,58 @@ update_data_source() {
     response_body=$(echo "$response" | sed '$d')
 
     if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
-        log_message "$uid successful"
+        log_message "$uid reverted successfully"
     else
         log_message "$uid error: HTTP $http_code - $response_body"
     fi
 }
 
-# Function to process and update data source types
-update_data_source_type() {
-    local result="$1"
-    local processed_count=0
-    local updated_count=0
-    local readonly_count=0
-    local skipped_count=0
-
-    # Use jq to parse and process JSON
-    echo "$result" | jq -c '.[]' | while read -r data; do
-        uid=$(echo "$data" | jq -r '.uid')
-        prometheus_type_migration=$(echo "$data" | jq -r '.jsonData["prometheus-type-migration"] // false')
-        data_type=$(echo "$data" | jq -r '.type')
-        read_only=$(echo "$data" | jq -r '.readOnly // false')
-
-        processed_count=$((processed_count + 1))
-
-        # Check conditions
-        if [[ "$prometheus_type_migration" != "true" ]] || [[ "$data_type" != "grafana-amazonprometheus-datasource" ]]; then
-            skipped_count=$((skipped_count + 1))
-            continue
-        fi
-
-        if [[ "$read_only" == "true" ]]; then
-            readonly_count=$((readonly_count + 1))
-            log_message "$uid is readOnly. If this data source is provisioned, edit the data source type to be \`prometheus\` in the provisioning file."
-            continue
-        fi
-
-        # Update the data
-        updated_data=$(echo "$data" | jq '.type = "prometheus" | .jsonData["prometheus-type-migration"] = false')
-        update_data_source "$uid" "$updated_data"
-        updated_count=$((updated_count + 1))
-
-        # Log the raw data for debugging (optional - uncomment if needed)
-        # log_message "DEBUG - Updated data for $uid: $updated_data"
-    done
-
-    # Note: These counts won't work in the while loop due to subshell
-    # Moving summary to the main function instead
-}
-
-# Function to get summary statistics
-get_summary_stats() {
-    local result="$1"
-    local total_datasources=$(echo "$result" | jq '. | length')
-    local migration_candidates=$(echo "$result" | jq '[.[] | select(.jsonData["prometheus-type-migration"] == true and .type == "grafana-amazonprometheus-datasource")] | length')
-    local readonly_candidates=$(echo "$result" | jq '[.[] | select(.jsonData["prometheus-type-migration"] == true and .type == "grafana-amazonprometheus-datasource" and .readOnly == true)] | length')
-    local updateable_candidates=$(echo "$result" | jq '[.[] | select(.jsonData["prometheus-type-migration"] == true and .type == "grafana-amazonprometheus-datasource" and (.readOnly == false or .readOnly == null))] | length')
-
-    log_message "=== MIGRATION SUMMARY ==="
-    log_message "Total data sources found: $total_datasources"
-    log_message "Migration candidates found: $migration_candidates"
-    log_message "Read-only candidates (will be skipped): $readonly_candidates"
-    log_message "Updateable candidates: $updateable_candidates"
-    log_message "=========================="
-}
-
-# Main function to remove Prometheus type migration
-remove_prometheus_type_migration() {
-    log_message "Starting remove Azure Prometheus migration"
-    log_message "Log file: $LOG_FILE"
-    log_message "Grafana URL: $GRAFANA_URL"
-
-    response=$(curl -s -w "\n%{http_code}" -X GET \
-        -H "Content-Type: application/json" \
-        -H "Authorization: Bearer $BEARER_TOKEN" \
-        "$GRAFANA_URL/api/datasources/")
-
-    http_code=$(echo "$response" | tail -n1)
-    response_body=$(echo "$response" | sed '$d')
-
-    if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
-        log_message "Successfully fetched data sources"
-        get_summary_stats "$response_body"
-        update_data_source_type "$response_body"
-        log_message "Migration process completed"
-    else
-        log_message "error fetching data sources: HTTP $http_code - $response_body"
-    fi
-}
-
-# Function to initialize log file
-initialize_log() {
-    echo "=== Grafana Azure Prometheus Migration Log ===" > "$LOG_FILE"
-    echo "Started at: $(date)" >> "$LOG_FILE"
-    echo "=============================================" >> "$LOG_FILE"
-    echo "" >> "$LOG_FILE"
-}
-
-# Check if jq is installed
 if ! command -v jq &> /dev/null; then
-    echo "Error: jq is required but not installed. Please install jq to run this script."
+    echo "Error: jq is required but not installed."
     exit 1
 fi
 
-# Check if required variables are set
 if [[ -z "$GRAFANA_URL" || -z "$BEARER_TOKEN" ]]; then
-    echo "Error: Please set GRAFANA_URL and BEARER_TOKEN variables at the top of the script."
+    echo "Error: Set GRAFANA_URL and BEARER_TOKEN variables at the top of the script."
     exit 1
 fi
 
-# Initialize log file
-initialize_log
+log_message "Starting AMP to Prometheus rollback"
 
-# Execute main function
-log_message "Script started"
-remove_prometheus_type_migration
-log_message "Script completed"
+response=$(curl -s -w "\n%{http_code}" -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $BEARER_TOKEN" \
+    "$GRAFANA_URL/api/datasources/")
 
-# Final log message
-echo ""
-echo "Migration completed. Full log available at: $LOG_FILE"
+http_code=$(echo "$response" | tail -n1)
+response_body=$(echo "$response" | sed '$d')
+
+if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    log_message "Error fetching data sources: HTTP $http_code"
+    exit 1
+fi
+
+total=$(echo "$response_body" | jq '[.[] | select(.jsonData["prometheus-type-migration"] == true and .type == "grafana-amazonprometheus-datasource")] | length')
+log_message "Found $total data sources to revert"
+
+echo "$response_body" | jq -c '.[] | select(.jsonData["prometheus-type-migration"] == true and .type == "grafana-amazonprometheus-datasource")' | while read -r data; do
+    uid=$(echo "$data" | jq -r '.uid')
+    read_only=$(echo "$data" | jq -r '.readOnly // false')
+
+    if [[ "$read_only" == "true" ]]; then
+        log_message "$uid is readOnly — edit the type to 'prometheus' in the provisioning file instead."
+        continue
+    fi
+
+    updated_data=$(echo "$data" | jq '.type = "prometheus" | .jsonData["prometheus-type-migration"] = false')
+    update_data_source "$uid" "$updated_data"
+done
+
+log_message "Rollback complete. Log: $LOG_FILE"
 ```
 
-If you continue to experience issues, check the Grafana server logs for detailed error messages and contact [Grafana Support](https://grafana.com/help/) with your troubleshooting results.
+{{< admonition type="note" >}}
+Provisioned data sources (`readOnly`) can't be reverted via the API. Update the `type` field to `prometheus` in your provisioning YAML file instead.
+{{< /admonition >}}
+
+If you continue to experience issues, check the Grafana server logs for detailed error messages and contact [Grafana Support](https://grafana.com/help/).

--- a/docs/sources/datasources/prometheus/configure/azure-authentication.md
+++ b/docs/sources/datasources/prometheus/configure/azure-authentication.md
@@ -2,32 +2,77 @@
 aliases:
   - ../data-sources/prometheus/
   - ../features/datasources/prometheus/
-description: Guide for authenticating with Azure Monitor Managed Service for Prometheus in Grafana
+description: Migrating from Prometheus Azure AD authentication to the Azure Monitor Managed Service for Prometheus data source
 keywords:
   - grafana
   - prometheus
-  - guide
+  - azure
+  - azure ad
+  - azure monitor
+  - managed prometheus
+  - migration
 labels:
   products:
     - cloud
     - enterprise
     - oss
-menuTitle: Authenticating with Azure
-title: Configure the Prometheus data source
+menuTitle: Azure authentication (deprecated)
+title: Migrate from Prometheus Azure AD to Azure Monitor Managed Service for Prometheus
 weight: 200
+review_date: 2026-05-07
 ---
 
-# Connect to Azure Monitor Managed Service for Prometheus
+# Migrate from Prometheus Azure AD to Azure Monitor Managed Service for Prometheus
 
-After creating a Azure Monitor Managed Service for Prometheus data source:
+{{< admonition type="warning" >}}
+Using Azure AD authentication with the core Prometheus data source for Azure Monitor Managed Service for Prometheus is **deprecated**. In Grafana 13, the migration to the dedicated [Azure Monitor Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-azureprometheus-datasource/) is automatic. Existing data sources using Azure AD authentication are migrated on startup.
+{{< /admonition >}}
 
-1. In the data source configuration page, locate the **Authentication** section
-2. Select your authentication method:
-   - **Managed Identity**: For Azure-hosted Grafana instances. To learn more about Entra login for Grafana, refer to [Configure Entra ID/Entra ID OAuth authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-access/configure-authentication/azuread/#configure-azure-adentra-id-oauth-authentication)
-   - **App Registration**: For service principal authentication
-   - **Current User**: Uses the current user's Entra ID credentials
+For background on this change, refer to [Prometheus data source update: Redefining our big tent philosophy](https://grafana.com/blog/2025/06/16/prometheus-data-source-update-redefining-our-big-tent-philosophy/).
 
-3. Configure based on your chosen method:
+## What changed in Grafana 13
+
+In Grafana 13, the `prometheusTypeMigration` feature toggle is enabled by default and deprecated. This means:
+
+- Prometheus data sources configured with Azure AD authentication are **automatically migrated** to the dedicated Azure Monitor Managed Service for Prometheus plugin on Grafana startup.
+- You no longer need to manually enable the feature toggle.
+- Grafana Cloud users are migrated automatically with no action required.
+- Dashboards, alerts, and queries continue to work after migration without changes.
+
+## Check migration status
+
+To determine if your Prometheus data sources have been migrated:
+
+1. Navigate to **Connections** > **Data sources**.
+1. Select your Prometheus data source.
+1. Look for a migration banner at the top of the configuration page.
+
+The banner displays one of the following messages:
+
+- **"Migration Notice"** — The data source has been migrated to the Azure Monitor Managed Service for Prometheus plugin.
+- **"Deprecation Notice"** — The data source hasn't been migrated yet.
+- **No banner** — No migration is needed (the data source doesn't use Azure AD authentication).
+
+## Configure the Azure Monitor Managed Service for Prometheus data source
+
+After migration (or for new setups), configure the dedicated plugin:
+
+1. Navigate to **Connections** > **Data sources**.
+1. Select your Azure Monitor Managed Service for Prometheus data source.
+1. In the **Authentication** section, select your authentication method:
+
+| Method               | Use case                            | Additional configuration required                   |
+| -------------------- | ----------------------------------- | --------------------------------------------------- |
+| **Managed Identity** | Azure-hosted Grafana instances      | None (system-assigned) or Client ID (user-assigned) |
+| **App Registration** | Service principal authentication    | Directory ID, Application ID, Client secret         |
+| **Current User**     | Current user's Entra ID credentials | None                                                |
+
+For Managed Identity authentication:
+
+- No additional configuration is required if using a system-assigned identity.
+- For a user-assigned identity, provide the **Client ID**.
+
+For App Registration authentication:
 
 | Setting                     | Description                     | Example                                |
 | --------------------------- | ------------------------------- | -------------------------------------- |
@@ -35,10 +80,7 @@ After creating a Azure Monitor Managed Service for Prometheus data source:
 | **Application (client) ID** | Your app registration client ID | `87654321-4321-4321-4321-210987654321` |
 | **Client secret**           | Your app registration secret    | `your-client-secret`                   |
 
-When using Managed Identity for authentication:
-
-- No additional configuration required if using system-assigned identity.
-- For user-assigned identity, provide the **Client ID**.
+To learn more about Entra ID authentication for Grafana, refer to [Configure Entra ID OAuth authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-access/configure-authentication/azuread/#configure-azure-adentra-id-oauth-authentication).
 
 4. Set the **Prometheus server URL** to your Azure Monitor workspace endpoint:
 
@@ -46,105 +88,72 @@ When using Managed Identity for authentication:
    https://your-workspace.eastus2.prometheus.monitor.azure.com
    ```
 
-5. Click **Save & test** to verify the connection
+5. Click **Save & test** to verify the connection.
 
-## Example configuration
+## Provision the data source
 
 ```yaml
-# Example provisioning configuration for App Registration
 apiVersion: 1
 datasources:
-  - name: 'Azure Monitor Prometheus'
-    type: 'grafana-azureprometheus-datasource'
-    url: 'https://your-workspace.eastus2.prometheus.monitor.azure.com'
+  - name: Azure Monitor Prometheus
+    type: grafana-azureprometheus-datasource
+    url: https://your-workspace.eastus2.prometheus.monitor.azure.com
     jsonData:
       azureCredentials:
-        authType: 'clientsecret'
-        azureCloud: 'AzureCloud'
-        clientId: '<client_id>'
-        httpMethod: 'POST'
-        tenantId: '<tenant_id>'
+        authType: clientsecret
+        azureCloud: AzureCloud
+        clientId: <CLIENT_ID>
+        tenantId: <TENANT_ID>
+      httpMethod: POST
     secureJsonData:
-      clientSecret: 'your-client-secret'
+      azureClientSecret: <CLIENT_SECRET>
 ```
 
-## Migrate to Azure Monitor Managed Service for Prometheus
+Replace `<CLIENT_ID>`, `<TENANT_ID>`, and `<CLIENT_SECRET>` with your Azure credentials.
 
-Learn more about why this is happening: [Prometheus data source update: Redefining our big tent philosophy](https://grafana.com/blog/2025/06/16/prometheus-data-source-update-redefining-our-big-tent-philosophy/)
+## Troubleshoot migration issues
 
-Before you begin, ensure you have the organization administrator role. If you are self-hosting Grafana, back up your existing dashboard configurations and queries.
+### Azure Monitor Managed Service for Prometheus plugin not installed
 
-Grafana Cloud users will be automatically migrated to the relevant version of Prometheus, so no action needs to be taken.
+**Symptom:** Migration doesn't occur or the data source type is missing.
 
-For air-gapped environments, download and install [Azure Monitor Managed Service for Prometheus](https://grafana.com/grafana/plugins/grafana-azureprometheus-datasource/), then follow the standard migration process.
+**Solution:**
 
-### Migrate
+1. Navigate to **Connections** > **Add new connection** and search for "Azure Monitor Managed Service for Prometheus".
+1. Install the plugin if it isn't already installed.
+1. For air-gapped environments, download the plugin from [the Grafana plugin catalog](https://grafana.com/grafana/plugins/grafana-azureprometheus-datasource/) and install it manually.
 
-1. Enable the `prometheusTypeMigration` feature toggle. For more information on feature toggles, refer to [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#manage-feature-toggles).
-2. Restart Grafana for the changes to take effect.
+### "401 Unauthorized" after migration
 
-{{< admonition type="note" >}}
-This feature toggle will be removed in Grafana 13, and the migration will be automatic.
-{{< /admonition >}}
+**Symptom:** The migrated data source returns authentication errors.
 
-To determine if your Prometheus data sources have been migrated:
+**Solution:**
 
-1. Navigate to **Connections** > **Data sources**
-2. Select your Prometheus data source
-3. Look for a migration banner at the top of the configuration page
+1. **Self-hosted Grafana:** Verify that `grafana-azureprometheus-datasource` is included in `forward_settings_to_plugins` under the `[azure]` heading in your `.ini` configuration file.
+1. **Grafana Cloud:** Contact [Grafana Support](https://grafana.com/profile/org#support).
 
-The banner displays one of the following messages:
+### Rollback the migration
 
-- **"Migration Notice"** - The data source has already been migrated
-- **"Deprecation Notice"** - The data source has not been migrated
-- **No banner** - No migration is needed for this data source
+If you need to revert migrated data sources back to the core Prometheus type:
 
-## Common migration issues
+1. Set `prometheusTypeMigration` to `false` in your Grafana configuration feature toggles. For more information, refer to [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#manage-feature-toggles).
+1. Restart Grafana.
+1. Obtain a bearer token with `read` and `write` permissions for the data source API. For more information, refer to [Data source API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/data_source/).
+1. Run the following rollback script, providing your Grafana URL and bearer token:
 
-The following sections contain troubleshooting guidance.
-
-**Migration banner not appearing**
-
-- Verify the `prometheusTypeMigration` feature toggle is enabled.
-- Restart Grafana after enabling the feature toggle
-
-**Azure Monitor Managed Service for Prometheus is not installed**
-
-- Verify that Azure Monitor Managed Service for Prometheus is installed by going to **Connections** > **Add new connection** and search for "Azure Monitor Managed Service for Prometheus"
-- Install Azure Monitor Managed Service for Prometheus if not already installed
-
-**After migrating, my data source returns "401 Unauthorized"**
-
-- If you are using self-hosted Grafana, check your .ini for `grafana-azureprometheus-datasource` is included in `forward_settings_to_plugins` under the `[azure]` heading.
-- If you are using Grafana Cloud, contact Grafana support.
-
-### Rollback self-hosted Grafana without a backup
-
-If you don’t have a backup of your Grafana instance before the migration, remove the `prometheusTypeMigration` feature toggle, and run the following script. It reverts all the Azure Monitor Managed Service data source instances back to core Prometheus.
-
-To revert the migration:
-
-1. Disable the `prometheusTypeMigration` feature toggle. For more information on feature toggles, refer to [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#manage-feature-toggles).
-2. Obtain a bearer token that has `read` and `write` permissions for your Grafana data source API. For more information on the data source API, refer to [Data source API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/data_source/).
-3. Run the script below. Make sure to provide your Grafana URL and bearer token.
-4. (Optional) Report the issue you were experiencing on the [Grafana repository](https://github.com/grafana/grafana/issues). Tag the issue with "datasource/migrate-prometheus-type"
-
-```bash
+```sh
 #!/bin/bash
 
-# Configuration
 GRAFANA_URL=""
 BEARER_TOKEN=""
-LOG_FILE="grafana_migration_$(date +%Y%m%d_%H%M%S).log"
+LOG_FILE="grafana_azure_migration_rollback_$(date +%Y%m%d_%H%M%S).log"
 
-# Function to log messages to both console and file
 log_message() {
     local message="$1"
     local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
     echo "[$timestamp] $message" | tee -a "$LOG_FILE"
 }
 
-# Function to update a data source
 update_data_source() {
     local uid="$1"
     local data="$2"
@@ -159,125 +168,58 @@ update_data_source() {
     response_body=$(echo "$response" | sed '$d')
 
     if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
-        log_message "$uid successful"
+        log_message "$uid reverted successfully"
     else
         log_message "$uid error: HTTP $http_code - $response_body"
     fi
 }
 
-# Function to process and update data source types
-update_data_source_type() {
-    local result="$1"
-    local processed_count=0
-    local updated_count=0
-    local readonly_count=0
-    local skipped_count=0
-
-    # Use jq to parse and process JSON
-    echo "$result" | jq -c '.[]' | while read -r data; do
-        uid=$(echo "$data" | jq -r '.uid')
-        prometheus_type_migration=$(echo "$data" | jq -r '.jsonData["prometheus-type-migration"] // false')
-        data_type=$(echo "$data" | jq -r '.type')
-        read_only=$(echo "$data" | jq -r '.readOnly // false')
-
-        processed_count=$((processed_count + 1))
-
-        # Check conditions
-        if [[ "$prometheus_type_migration" != "true" ]] || [[ "$data_type" != "grafana-azureprometheus-datasource" ]]; then
-            skipped_count=$((skipped_count + 1))
-            continue
-        fi
-
-        if [[ "$read_only" == "true" ]]; then
-            readonly_count=$((readonly_count + 1))
-            log_message "$uid is readOnly. If this data source is provisioned, edit the data source type to be \`prometheus\` in the provisioning file."
-            continue
-        fi
-
-        # Update the data
-        updated_data=$(echo "$data" | jq '.type = "prometheus" | .jsonData["prometheus-type-migration"] = false')
-        update_data_source "$uid" "$updated_data"
-        updated_count=$((updated_count + 1))
-
-        # Log the raw data for debugging (optional - uncomment if needed)
-        # log_message "DEBUG - Updated data for $uid: $updated_data"
-    done
-
-    # Note: These counts won't work in the while loop due to subshell
-    # Moving summary to the main function instead
-}
-
-# Function to get summary statistics
-get_summary_stats() {
-    local result="$1"
-    local total_datasources=$(echo "$result" | jq '. | length')
-    local migration_candidates=$(echo "$result" | jq '[.[] | select(.jsonData["prometheus-type-migration"] == true and .type == "grafana-azureprometheus-datasource")] | length')
-    local readonly_candidates=$(echo "$result" | jq '[.[] | select(.jsonData["prometheus-type-migration"] == true and .type == "grafana-azureprometheus-datasource" and .readOnly == true)] | length')
-    local updateable_candidates=$(echo "$result" | jq '[.[] | select(.jsonData["prometheus-type-migration"] == true and .type == "grafana-azureprometheus-datasource" and (.readOnly == false or .readOnly == null))] | length')
-
-    log_message "=== MIGRATION SUMMARY ==="
-    log_message "Total data sources found: $total_datasources"
-    log_message "Migration candidates found: $migration_candidates"
-    log_message "Read-only candidates (will be skipped): $readonly_candidates"
-    log_message "Updateable candidates: $updateable_candidates"
-    log_message "=========================="
-}
-
-# Main function to remove Prometheus type migration
-remove_prometheus_type_migration() {
-    log_message "Starting remove Azure Prometheus migration"
-    log_message "Log file: $LOG_FILE"
-    log_message "Grafana URL: $GRAFANA_URL"
-
-    response=$(curl -s -w "\n%{http_code}" -X GET \
-        -H "Content-Type: application/json" \
-        -H "Authorization: Bearer $BEARER_TOKEN" \
-        "$GRAFANA_URL/api/datasources/")
-
-    http_code=$(echo "$response" | tail -n1)
-    response_body=$(echo "$response" | sed '$d')
-
-    if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
-        log_message "Successfully fetched data sources"
-        get_summary_stats "$response_body"
-        update_data_source_type "$response_body"
-        log_message "Migration process completed"
-    else
-        log_message "error fetching data sources: HTTP $http_code - $response_body"
-    fi
-}
-
-# Function to initialize log file
-initialize_log() {
-    echo "=== Grafana Azure Prometheus Migration Log ===" > "$LOG_FILE"
-    echo "Started at: $(date)" >> "$LOG_FILE"
-    echo "=============================================" >> "$LOG_FILE"
-    echo "" >> "$LOG_FILE"
-}
-
-# Check if jq is installed
 if ! command -v jq &> /dev/null; then
-    echo "Error: jq is required but not installed. Please install jq to run this script."
+    echo "Error: jq is required but not installed."
     exit 1
 fi
 
-# Check if required variables are set
 if [[ -z "$GRAFANA_URL" || -z "$BEARER_TOKEN" ]]; then
-    echo "Error: Please set GRAFANA_URL and BEARER_TOKEN variables at the top of the script."
+    echo "Error: Set GRAFANA_URL and BEARER_TOKEN variables at the top of the script."
     exit 1
 fi
 
-# Initialize log file
-initialize_log
+log_message "Starting Azure Prometheus to core Prometheus rollback"
 
-# Execute main function
-log_message "Script started"
-remove_prometheus_type_migration
-log_message "Script completed"
+response=$(curl -s -w "\n%{http_code}" -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $BEARER_TOKEN" \
+    "$GRAFANA_URL/api/datasources/")
 
-# Final log message
-echo ""
-echo "Migration completed. Full log available at: $LOG_FILE"
+http_code=$(echo "$response" | tail -n1)
+response_body=$(echo "$response" | sed '$d')
+
+if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    log_message "Error fetching data sources: HTTP $http_code"
+    exit 1
+fi
+
+total=$(echo "$response_body" | jq '[.[] | select(.jsonData["prometheus-type-migration"] == true and .type == "grafana-azureprometheus-datasource")] | length')
+log_message "Found $total data sources to revert"
+
+echo "$response_body" | jq -c '.[] | select(.jsonData["prometheus-type-migration"] == true and .type == "grafana-azureprometheus-datasource")' | while read -r data; do
+    uid=$(echo "$data" | jq -r '.uid')
+    read_only=$(echo "$data" | jq -r '.readOnly // false')
+
+    if [[ "$read_only" == "true" ]]; then
+        log_message "$uid is readOnly — edit the type to 'prometheus' in the provisioning file instead."
+        continue
+    fi
+
+    updated_data=$(echo "$data" | jq '.type = "prometheus" | .jsonData["prometheus-type-migration"] = false')
+    update_data_source "$uid" "$updated_data"
+done
+
+log_message "Rollback complete. Log: $LOG_FILE"
 ```
 
-If you continue to experience issues, check the Grafana server logs for detailed error messages and contact [Grafana Support](https://grafana.com/help/) with your troubleshooting results.
+{{< admonition type="note" >}}
+Provisioned data sources (`readOnly`) can't be reverted via the API. Update the `type` field to `prometheus` in your provisioning YAML file instead.
+{{< /admonition >}}
+
+If you continue to experience issues, check the Grafana server logs for detailed error messages and contact [Grafana Support](https://grafana.com/help/).

--- a/docs/sources/datasources/prometheus/query-editor/_index.md
+++ b/docs/sources/datasources/prometheus/query-editor/_index.md
@@ -5,8 +5,9 @@ description: Guide for using the Prometheus data source's query editor
 keywords:
   - grafana
   - prometheus
-  - logs
+  - metrics
   - queries
+  - promql
 labels:
   products:
     - cloud
@@ -15,190 +16,349 @@ labels:
 menuTitle: Query editor
 title: Prometheus query editor
 weight: 300
+review_date: 2026-05-07
 ---
 
 # Prometheus query editor
 
-Grafana provides a query editor for the Prometheus data source to create queries in PromQL. For more information about PromQL, see [Querying Prometheus](http://prometheus.io/docs/querying/basics/). The Prometheus query editor is located on the [Explore page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/). You can also access the PostgreSQL query editor from a dashboard panel. Click the ellipsis in the upper right of the panel and select **Edit**.
+The Prometheus query editor lets you write PromQL queries against your Prometheus-compatible data sources. It includes a visual query builder for constructing queries without writing PromQL, a code editor with autocomplete and syntax highlighting, and configurable output formats for different visualization types.
 
-For general documentation on querying data sources in Grafana, refer to [Query and transform data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/). For options and functions common to all query editors, refer to [Query editors](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/).
+You can access the query editor from the [Explore page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) or from any dashboard panel by clicking the panel title and selecting **Edit**. For general documentation on querying data sources in Grafana, refer to [Query and transform data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/). For more information about PromQL, see [Querying Prometheus](http://prometheus.io/docs/querying/basics/).
 
-The Prometheus query editor has two modes:
+The query editor has two modes:
 
-- [Builder mode](#builder-mode)
-- [Code mode](#code-mode)
+- [Builder mode](#builder-mode) — Visual interface for constructing queries without writing PromQL directly.
+- [Code mode](#code-mode) — Text editor with autocomplete for writing PromQL directly.
 
 ![Query editor mode](/media/docs/prometheus/builder-code-v11-mode.png)
 
 Grafana synchronizes both modes, allowing you to switch between them. Grafana also displays a warning message if it detects an issue with the query while switching modes.
 
-You can configure Prometheus-specific options in the query editor by setting several options regardless of mode.
+## Query options
 
-{{< figure src="/static/img/docs/prometheus/options.png" max-width="500px" class="docs-image--no-shadow" caption="Options" >}}
+The following options are available in both Builder and Code modes. They control how the query is executed and how results are displayed.
+
+{{< figure src="/static/img/docs/prometheus/options.png" max-width="500px" class="docs-image--no-shadow" caption="Query options" >}}
+
+### Legend
+
+Controls the display name for time series in the panel legend.
+
+- **Auto** — Displays unique labels only, hiding labels that are common across all returned series. This produces cleaner legends when many series share the same labels.
+- **Verbose** — Displays all label names for every series.
+- **Custom** — Lets you define the legend using label templates. For example, `{{hostname}}` is replaced with the value of the `hostname` label. To switch to a different legend mode, clear the input and click outside the field.
+
+### Min step
+
+Sets the minimum interval between data points returned by the query. For example, setting this to `1h` means data is returned at hourly intervals at minimum. This setting supports the `$__interval` and `$__rate_interval` macros.
+
+{{< admonition type="note" >}}
+The time range of the query is aligned to the step size, which may adjust the actual start and end times of the returned data.
+{{< /admonition >}}
+
+### Format
+
+Determines how query results are interpreted and displayed in a panel.
+
+- **Time series** — The default format. Returns data as time-indexed series suitable for graph panels.
+- **Table** — Displays data in a tabular format. Works only in a [Table panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/table/).
+- **Heatmap** — Displays histogram-type metrics in a [Heatmap panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/heatmap/) by converting cumulative histograms to regular ones and sorting the series by bucket boundary.
+
+### Type
+
+Determines the query type.
+
+- **Both** — The default. Runs both a Range query and an Instant query and returns combined results.
+- **Range** — Returns a set of time series where each series includes multiple data points over the selected time range. Use this for graph visualizations (lines, bars, points, stacked).
+- **Instant** — Returns a single data point per series (the most recent value within the selected time range). Use this for stat panels, tables, or gauges. To visualize instant query results in a time series panel, add a field override with the `Transform` property set to `Constant`. For more information, refer to [Time Series Transform option](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/time-series/#transform).
+
+{{< admonition type="note" >}}
+Grafana adjusts the query time range to align with the dynamically calculated step interval. This ensures consistent metric visualization and supports Prometheus result caching. However, this alignment can cause minor visual differences, such as a slight gap at the graph's right edge or a shifted start time. For example, a `15s` step aligns timestamps to Unix times divisible by 15 seconds. A `1w` Min step aligns the range to the start of the week (Thursday at 00:00 UTC in Prometheus).
+{{< /admonition >}}
+
+### Exemplars
+
+Toggle on to include exemplars in the graph. Exemplars link aggregated metric data to specific trace examples, letting you jump from a spike directly to a relevant trace. For more information, see [Introduction to exemplars](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/).
+
+{{< admonition type="note" >}}
+Exemplars are not available with Instant query types.
+{{< /admonition >}}
 
 ## Builder mode
 
-**Builder mode** helps you build queries using a visual interface. This option is best for users who have limited experience working with Prometheus and PromQL.
-
-The following video demonstrates how to use the visual Prometheus query builder:
-
-{{< vimeo 720004179 >}}
+**Builder mode** helps you build queries using a visual interface. This option is best for users who have limited experience with PromQL.
 
 Builder mode contains the following components:
 
-- **Kick start your query** - Click to view a list of predefined operation patterns that help you quickly build queries with multiple operations. These include:
+- **Kick start your query** — Click to view predefined operation patterns that help you quickly build queries with multiple operations:
   - Rate query starters
   - Histogram query starters
   - Binary query starters
 
-Click the arrow next to each to see the available options to add to your query.
+  Click the arrow next to each to see the available options.
 
-- **Explain** - Toggle on to display a step-by-step explanation of all query components and operations.
+- **Explain** — Toggle on to display a step-by-step explanation of all query components and operations.
 
 {{< figure src="/static/img/docs/prometheus/explain-results.png" max-width="500px" class="docs-image--no-shadow" caption="Explain results" >}}
 
-- **Builder/Code** - Click the corresponding **Builder** or **Code** tab on the toolbar to select an editor mode.
-
-If you select Builder mode you will see the following options:
-
-- **Metric** - Select a metric from the drop-down. Click the icon to open Metrics explorer, where you can search for metrics by name and filter by type if your instance has a large number of metrics. Refer to [Metrics explorer](#metrics-explorer) for more detail on using this feature.
-- **Label filters** - Select label filters from the drop-down. Select an operator and a value.
-  Select desired labels and their values from the drop-down list.
-  When a metric is selected, the data source requests available labels and their values from the server.
-  Use the `+` button to add a label, and the `x` button to remove a label.
-
-Click **+ Operations** to select from a list of operations including Aggregations, Range functions, Functions, Binary operations, Trigonometric and Time functions. You can select multiple operations. Refer to [Operations](#operations) for more detail.
-
-**Options:**
-
-- **Legend**- Lets you customize the name for the time series. You can use a predefined or custom format.
-  - **Auto** - Displays unique labels. Also displays all overlapping labels if a series has multiple labels.
-  - **Verbose** - Displays all label names.
-  - **Custom** - Lets you customize the legend using label templates. For example, `{{hostname}}` is replaced with the value of the `hostname` label. To switch to a different legend mode, clear the input and click outside the field.
-
-- **Min step** - Sets the minimum interval between data points returned by the query. For example, setting this to `1h` suggests that data is collected or displayed at hourly intervals. This setting supports the `$__interval` and `$__rate_interval` macros. Note that the time range of the query is aligned to this step size, which may adjust the actual start and end times of the returned data.
-
-- **Format** - Determines how the data from your Prometheus query is interpreted and visualized in a panel. Choose from the following format options:
-  - **Time series** - The default format. Refer to [Time series kind formats](https://grafana.com/developers/dataplane/timeseries/) for information on time series data frames and how time and value fields are structured.
-  - **Table** - Displays data in table format. This format works only in a [Table panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/table/).
-  - **Heatmap** - Displays Histogram-type metrics in a [Heatmap panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/heatmap/) by converting cumulative histograms to regular ones and sorting the series by the bucket bound. Converts cumulative histogram data into regular histogram format and sorts the series by bucket boundaries for proper display.
-
-- **Type** - This setting determines the query type. These include:
-  - **Both** - The default option. Returns results for both a **Range** query and an **Instant** query.
-  - **Range** - Returns a range vector - a set of time series
-    a set of time series where each series includes multiple data points over a period of time. You can choose to visualize the data as lines, bars, points, stacked lines, or stacked bars.
-  - **Instant** - Returns a single data point per series — the most recent value within the selected time range. The results can be displayed in a table or as raw data. To visualize instant query results in a time series panel, start by adding field override, then add a property to the override called `Transform`, and set the Transform value to `Constant` in the drop-down. For more information, refer to the [Time Series Transform option documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/time-series/#transform).
-
-{{< admonition type="note" >}}
-Grafana adjusts the query time range to align with the dynamically calculated step interval. This alignment ensures consistent metric visualization and supports Prometheus's result caching requirements. However, this alignment can cause minor visual differences, such as a slight gap at the graph's right edge or a shifted start time. For example, a `15s` step aligns timestamps to Unix times divisible by 15 seconds. A `1w` `minstep` aligns the range to the start of the week, which for Prometheus is Thursday at 00:00 UTC.
-{{< /admonition >}}
-
-- **Exemplars** - Toggle on to run a query that includes exemplars in the graph. Exemplars are unique to Prometheus. For more information see [Introduction to exemplars](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/).
-
-{{< admonition type="note" >}}
-There is no option to add exemplars with an **Instant** query type.
-{{< /admonition >}}
-
-### Filter metrics
+### Select a metric
 
 {{< figure src="/static/img/docs/prometheus/metrics-and-labels.png" max-width="500px" class="docs-image--no-shadow" caption="Metric and label filters" >}}
 
-When you are ready to create a query, you can choose the specific metric name from the drop-down list under **Metric**.
-The data source provides the list of available metrics based on the selected time range.
-You can also enter text into the selector when the drop-down is open to search and filter the list.
+- **Metric** — Select a metric from the drop-down. The data source provides available metrics based on the selected time range. You can type to search and filter the list. Click the book icon to open [Metrics explorer](#metrics-explorer).
+- **Label filters** — Select labels and values to filter the metric. Use the `+` button to add filters and the `x` button to remove them. When a metric is selected, the data source requests available labels and their values from the server.
 
-#### Metrics explorer in Builder mode
-
-{{< figure src="/static/img/docs/prometheus/screenshot-grafana-prometheus-metrics-explorer-2.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
-
-Click the **Open book icon** to open the Metrics explorer, where you can search for and filter all the metrics in your instance.
-
-If you would like to explore your metrics in the query builder further, you can open the **Metrics explorer** by clicking the first option in the metric select component of the query builder.
-
-The Metrics explorer displays all metrics in a paginated table list. The list shows the total number of metrics, as well as the name, type, and description for each metric. You can enter text into the search input to filter results.
-You can also filter by type.
-
-The following options are included under the **Additional Settings** drop-down:
-
-- **Include description in search**: Toggle on to search by both name and description.
-- **Include results with no metadata**: Toggle on to include metrics that lack type or description metadata.
-- **Disable text wrap**: Toggle on to disable text wrapping.
-- **Enable regex search**: Toggle on to filter metric names by regex search, which uses an additional call on the Prometheus API.
-
-{{< admonition type="note" >}}
-The Metrics explorer (Builder mode) and [Metrics browser (Code mode)](#metrics-browser-in-code-mode) are separate elements. The Metrics explorer does not have the ability to browse labels yet, but the Metrics browser can display all labels on a metric name.
-{{< /admonition >}}
-
-### Operations
+### Add operations
 
 {{< figure src="/static/img/docs/prometheus/operations.png" max-width="500px" class="docs-image--no-shadow" caption="Operations" >}}
 
-Select the **+ Operations** button to add operations to your query.
+Click **+ Operations** to add operations to your query. The query editor groups operations into the following categories:
 
-The query editor groups operations into the following sections:
+- [Aggregations](https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators) — `sum`, `avg`, `count`, `min`, `max`, etc.
+- [Range functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#functions) — `rate`, `increase`, `irate`, `avg_over_time`, etc.
+- [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#functions) — `abs`, `ceil`, `histogram_quantile`, etc.
+- [Binary operations](https://prometheus.io/docs/prometheus/latest/querying/operators/#binary-operators) — arithmetic and comparison operators.
+- [Trigonometric functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#trigonometric-functions) — `acos`, `asin`, `atan`, etc.
+- Time functions — `time`, `timestamp`, `day_of_week`, etc.
 
-- Aggregations - for additional information see [Aggregation operators](https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators).
-- Range functions - for additional information see [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#functions).
-- Functions - for additional information see [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#functions).
-- Binary operations - for additional information see [Binary operators](https://prometheus.io/docs/prometheus/latest/querying/operators/#binary-operators).
-- Trigonometric - for additional information see [Trigonometric functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#trigonometric-functions).
-- Time functions - for additional information see [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#functions).
-
-All operations have function parameters under the operation header. Click the `operator` to see a full list of supported functions. Some operations allow you to apply specific labels to functions.
+All operations display function parameters beneath the operation header. Some operations allow you to apply specific labels (for example, `by` or `without` clauses).
 
 {{< figure src="/static/img/docs/prometheus/use-function-by-label-9-5.png" max-width="500px" class="docs-image--no-shadow" caption="Functions and labels" >}}
 
-Some operations are only valid when used in a specific order. If you add an operation in a way that would create an invalid or illogical query, the query editor automatically places it in the correct position to maintain a valid query structure.
+If you add an operation in a way that would create an invalid query, the query editor automatically places it in the correct position to maintain a valid query structure.
 
 ### Hints
 
-The query editor can detect which operations are most appropriate for certain selected metrics.
-When it does, it displays a hint next to the **+ Operations** button.
-
-To add the operation to your query, click the **Hint**.
+The query editor can detect which operations are most appropriate for certain selected metrics. When it does, it displays a hint next to the **+ Operations** button. Click the hint to add the suggested operation.
 
 {{< figure src="/static/img/docs/prometheus/hint-example.png" max-width="500px" class="docs-image--no-shadow" caption="Hint" >}}
 
-When you are satisfied with your query, click **Run query**.
+### Metrics explorer
+
+{{< figure src="/static/img/docs/prometheus/screenshot-grafana-prometheus-metrics-explorer-2.png" max-width="500px" class="docs-image--no-shadow" caption="Metrics explorer" >}}
+
+Click the book icon next to the metric selector to open the Metrics explorer. It displays all metrics in a paginated list showing the name, type, and description for each metric.
+
+The following options are available under **Additional Settings**:
+
+- **Include description in search** — Search by both name and description.
+- **Include results with no metadata** — Include metrics that lack type or description metadata.
+- **Disable text wrap** — Disable text wrapping for long metric names.
+- **Enable regex search** — Filter metric names by regular expression, which uses an additional API call.
+
+{{< admonition type="note" >}}
+The Metrics explorer (Builder mode) and [Metrics browser (Code mode)](#metrics-browser) are separate components. The Metrics explorer does not browse labels, but the Metrics browser can display all labels on a metric.
+{{< /admonition >}}
 
 ## Code mode
 
-**Code mode** is for the experienced Prometheus user with prior expertise in PromQL, Prometheus' query language. The Code mode editor allows you to create queries just as you would in Prometheus. For more information about PromQL see [Querying Prometheus](http://prometheus.io/docs/querying/basics/).
+**Code mode** is for experienced Prometheus users who prefer writing PromQL directly. For more information about PromQL, see [Querying Prometheus](http://prometheus.io/docs/querying/basics/).
 
 {{< figure src="/static/img/docs/prometheus/code-mode.png" max-width="500px" class="docs-image--no-shadow" caption="Code mode" >}}
 
-The user interface (UI) also lets you select metrics, labels, filters, and operations.
+Code mode provides:
 
-You can write complex queries using the text editor with autocompletion features and syntax highlighting. Code mode's autocomplete feature works automatically while typing. The query editor can autocomplete static functions, aggregations, keywords, and also dynamic items like metrics and labels. The autocompletion drop-down includes documentation for the suggested items where available.
+- **Autocomplete** — Suggests metrics, labels, functions, aggregations, and keywords as you type. The drop-down includes documentation for suggested items where available.
+- **Syntax highlighting** — Color-codes PromQL syntax for readability.
+- **Metrics browser** — Click the arrow next to **Metrics browser** to open it.
 
-It also contains a [Metrics browser](#metrics-browser-in-code-mode) to further help you write queries. To open the Metrics browser, click the arrow next to **Metrics browser**.
+### Metrics browser
 
-### Metrics browser in Code mode
+The Metrics browser helps you build basic queries by exploring available metrics and labels.
 
-The Metrics browser locates metrics and selects relevant labels to help you build basic queries.
-When you click **Metrics browser** in `Code` mode, it displays all available metrics and labels.
-If supported by your Prometheus instance, each metric also displays its `HELP` and `TYPE` as a tooltip.
+{{< figure alt="Prometheus query editor metrics browser" src="/media/docs/prometheus/Metrics-browser-V10-prom-query-editor.png" caption="Metrics browser" >}}
 
-{{< figure alt="Prometheus query editor metrics browser"  src="/media/docs/prometheus/Metrics-browser-V10-prom-query-editor.png" caption="Metrics browser" >}}
-
-When you select a metric under **Step 1**, the browser narrows down the available labels to show only the ones applicable to the metric.
-You can then select one or more labels shown in **Step 2**.
-Select one or more values in **Step 3** for each label to tighten your query scope.
-In **Step 4**, you can select **Use query** to run the query, **Use as rate query** to add the rate operation to your query (`$__rate_interval`), **Validate selector** to verify the selector is valid and show the number of series found, or **Clear** to clear your selections and start over.
+1. **Step 1** — Select a metric. The browser narrows available labels to those applicable to the metric.
+2. **Step 2** — Select one or more labels.
+3. **Step 3** — Select values for each label to tighten the query scope.
+4. **Step 4** — Choose an action:
+   - **Use query** — Insert the selector into the query editor.
+   - **Use as rate query** — Insert the selector wrapped in `rate(...[$__rate_interval])`.
+   - **Validate selector** — Verify the selector is valid and display the number of matching series.
+   - **Clear** — Reset your selections.
 
 {{< admonition type="note" >}}
-If you don't remember the exact metric name, you can start by selecting a few labels to filter the list. This helps you find relevant label values and narrow down your options.
+If you don't remember the exact metric name, start by selecting a few labels to filter the list and narrow down your options.
 {{< /admonition >}}
 
-All lists in the Metrics browser include a search field to quickly filter metrics or labels by keyword.
-In the **Values** section, there's a single search field that filters across all selected labels, making it easier to find matching values. For example, if you have labels like `app`, `job`, and `job_name`, only one of them might contain the value you're looking for.
+All lists in the Metrics browser include a search field. In the **Values** section, a single search field filters across all selected labels.
 
-When you are satisfied with your query, click **Run query**.
+## Common query patterns
 
-## Incremental dashboard queries (beta)
+The following examples show frequently used PromQL patterns. Each example includes the PromQL expression and guidance on which query options to use.
 
-Starting with Grafana v10, the Prometheus data source supports incremental querying for live dashboards. Instead of re-querying the entire time range on each refresh, Grafana can fetch only new data since the last query.
+### Request rate per service
 
-You can enable or disable this feature in the data source configuration or provisioning file using the `incrementalQuerying` field in `jsonData`.
+Calculate the per-second rate of HTTP requests, broken down by service:
 
-You can also control the overlap between consecutive incremental queries using the `incrementalQueryOverlapWindow` field in `jsonData`. By default, this is set to `10m` (10 minutes). Increasing the `incrementalQueryOverlapWindow` value increases the time range covered by each incremental query. This can help in environments where the most recent data may be delayed or incomplete.
+```promql
+sum(rate(http_requests_total[$__rate_interval])) by (service)
+```
+
+| Option   | Setting                          |
+| -------- | -------------------------------- |
+| Legend   | `{{service}}` (Custom)           |
+| Type     | Range                            |
+| Min step | Leave empty (uses `$__interval`) |
+
+**Builder mode steps:** Select `http_requests_total` → Add operation **Range functions > Rate** → Add operation **Aggregations > Sum** → Set `by` label to `service`.
+
+### Error rate percentage
+
+Calculate the percentage of requests that returned 5xx errors:
+
+```promql
+sum(rate(http_requests_total{status=~"5.."}[$__rate_interval])) / sum(rate(http_requests_total[$__rate_interval])) * 100
+```
+
+| Option | Setting                 |
+| ------ | ----------------------- |
+| Legend | `Error rate %` (Custom) |
+| Type   | Range                   |
+| Format | Time series             |
+
+### Histogram quantile (p95 latency)
+
+Calculate the 95th percentile request duration from a histogram metric:
+
+```promql
+histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[$__rate_interval])) by (le))
+```
+
+| Option | Setting                |
+| ------ | ---------------------- |
+| Legend | `p95 latency` (Custom) |
+| Type   | Range                  |
+
+**Builder mode steps:** Select `http_request_duration_seconds_bucket` → Add **Range functions > Rate** → Add **Aggregations > Sum** with `by` label `le` → Add **Functions > Histogram quantile** with value `0.95`.
+
+### Aggregation by label (CPU usage per instance)
+
+Calculate average CPU usage percentage, grouped by instance:
+
+```promql
+100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[$__rate_interval])) * 100)
+```
+
+| Option   | Setting                            |
+| -------- | ---------------------------------- |
+| Legend   | `{{instance}}` (Custom)            |
+| Type     | Range                              |
+| Min step | `15s` (match your scrape interval) |
+
+### Multi-query expressions (available memory percentage)
+
+Use multiple queries and expressions to calculate derived values. In the query editor, add multiple queries (A, B) and a math expression (C):
+
+**Query A** — Total memory:
+
+```promql
+node_memory_MemTotal_bytes
+```
+
+**Query B** — Available memory:
+
+```promql
+node_memory_MemAvailable_bytes
+```
+
+**Expression C** — Percentage available (click **+ Expression** → **Math**):
+
+```
+$B / $A * 100
+```
+
+Set queries A and B to **Type: Instant** and hide them from visualization (click the eye icon). Display only expression C.
+
+### Alert-compatible query (target down)
+
+A simple alert query that fires when a scrape target is down:
+
+```promql
+up{job="my-service"} == 0
+```
+
+| Option | Setting     |
+| ------ | ----------- |
+| Type   | Both        |
+| Format | Time series |
+
+{{< admonition type="note" >}}
+Alert queries don't support template variables (`$variable`). Use fixed label values when writing queries intended for alert rules.
+{{< /admonition >}}
+
+## Use the query inspector
+
+The query inspector helps you debug queries that return unexpected results or no data. To open it:
+
+1. Click **Query inspector** in the panel edit view (below the query editor).
+1. Review the following tabs:
+   - **Query** — Shows the exact request sent to Prometheus, including the evaluated PromQL expression, time range, and step interval. Use this to verify that template variables resolved correctly.
+   - **Data** — Shows the raw response data. If empty, your query matched no series.
+   - **Stats** — Shows request timing and response size.
+
+Common debugging steps:
+
+1. **No data returned** — Check the Query tab to see if template variables resolved to empty values. Try the query directly in the Prometheus built-in expression browser (`/graph`) to rule out Grafana-specific issues.
+1. **Fewer series than expected** — Check that your label filters aren't too restrictive. Remove filters one at a time to isolate which filter is excluding data.
+1. **"Too many data points" or timeout** — Reduce the time range, increase the Min step, or add aggregations to reduce cardinality. Refer to [Query high-cardinality data](#query-high-cardinality-data).
+
+## Query high-cardinality data
+
+High-cardinality metrics (those with many unique label combinations) can cause queries to timeout or exceed memory limits when queried over long time ranges. Follow these practices to query high-cardinality data effectively:
+
+- **Aggregate first, then filter** — Use `sum()`, `avg()`, or `count()` to reduce the number of series before applying other operations. For example, `sum(rate(metric[5m])) by (service)` is far cheaper than querying all individual pod-level series.
+- **Use recording rules for repeated queries** — If a dashboard panel queries the same expensive expression on every load, create a [Prometheus recording rule](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) to pre-compute the result.
+- **Scope with template variables** — Use dashboard [template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/template-variables/) to select a specific `namespace`, `cluster`, or `job` rather than querying all labels at once.
+- **Increase Min step for overview panels** — For panels showing trends over days or weeks, set a higher **Min step** (for example, `5m` or `15m`) to reduce the number of data points requested.
+- **Set Max data points** — Use the **Max data points** query option to cap resolution for wide time ranges.
+- **Use Adaptive Metrics (Grafana Cloud)** — [Adaptive Metrics](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics/) automatically reduces the cardinality of metrics that aren't queried at full resolution.
+
+If your queries hit memory or sample limits, refer to [Memory limit exceeded for high-cardinality queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#memory-limit-exceeded-for-high-cardinality-queries).
+
+## Expected PromQL behaviors
+
+The following behaviors are frequently misinterpreted as bugs but are expected Prometheus behavior.
+
+### `increase()` returns fractional values on integer counters
+
+`increase()` uses linear interpolation to estimate the increase over the specified time window. Because scrape timestamps rarely align exactly with the window boundaries, the result is interpolated — which produces fractional values even for integer counters.
+
+This is expected. If you need integer results, wrap the expression in `ceil()` or `floor()`:
+
+```promql
+ceil(increase(http_requests_total[5m]))
+```
+
+### `rate()` appears to grow over time
+
+If `rate()` shows an ever-increasing value instead of a steady per-second rate, the most common cause is multiple instances writing to the same time series without unique distinguishing labels. Prometheus merges these into a single series with an artificially growing counter.
+
+To fix this, ensure every scrape target has unique labels (for example, `instance`, `pod`, or `node`). Then aggregate explicitly:
+
+```promql
+sum(rate(http_requests_total[5m])) by (job)
+```
+
+If you see this after a deployment or scaling event, verify your service discovery is assigning unique `instance` labels to each target.
+
+### Counter reset spikes after pod restarts
+
+When a monitored process restarts, its counters reset to zero. Prometheus handles this with counter reset detection — `rate()` and `increase()` account for resets and don't produce negative values. However, you may still see a brief spike at the reset point because the first scrape after a restart reports the full counter value accumulated since the restart.
+
+To minimize the visual impact:
+
+- Use `rate()` over a window that spans multiple scrape intervals (for example, `$__rate_interval`) so the spike is averaged out.
+- For critical dashboards, apply smoothing with a longer range vector or use `avg_over_time()` on top of `rate()`.
+- If you're seeing large spikes from frequent pod restarts, investigate the restart frequency rather than trying to hide the spikes in queries.
+
+### Label cardinality causes "too many time series" errors
+
+If adding a label filter doesn't reduce the result count, you may have high-cardinality labels (such as `request_id` or `user_id`) on your metrics. Use the Prometheus TSDB status page (`/tsdb-status`) or the Grafana Metrics explorer to identify high-cardinality label combinations, then either drop unnecessary labels at scrape time or use aggregation in your queries.
+
+## Related resources
+
+- [Template variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/template-variables/) — Use variables like `$namespace` or `$job` to create dynamic, reusable dashboards.
+- [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/annotations/) — Overlay Prometheus events on your panels.
+- [Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/alerting/) — Create alert rules from your Prometheus queries.
+- [Troubleshooting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/) — Resolve common query errors and performance issues.

--- a/docs/sources/datasources/prometheus/template-variables/_index.md
+++ b/docs/sources/datasources/prometheus/template-variables/_index.md
@@ -8,6 +8,7 @@ keywords:
   - templates
   - variables
   - queries
+  - rate_interval
 labels:
   products:
     - cloud
@@ -16,132 +17,210 @@ labels:
 menuTitle: Template variables
 title: Prometheus template variables
 weight: 400
+review_date: 2026-05-07
 ---
 
 # Prometheus template variables
 
-Instead of hard-coding details such as server, application, and sensor names in metric queries, you can use variables. Grafana refers to such variables as **template** variables.
-Grafana lists these variables in dropdown select boxes at the top of the dashboard to help you change the displayed data.
+Template variables let you create dynamic, reusable dashboards by replacing hard-coded values (such as server names, namespaces, or job labels) with selectable variables. Grafana displays these variables as dropdown menus at the top of the dashboard, letting viewers change the displayed data without editing queries.
 
 For an introduction to templating and template variables, refer to [Templating](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/) and [Add and manage variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/).
 
-## Use query variables
+## Query variable types
 
-Grafana supports several types of variables, but Query variables are specifically used to query Prometheus. They can return a list of metrics, labels, label values, query results, or series.
+Query variables query Prometheus to populate dropdown values. When creating a query variable, select a Prometheus data source and choose a query type:
 
-Select a Prometheus data source query type and enter the required inputs:
+| Query Type        | Required inputs                         | Description                                                                     | Example                                                                                 |
+| ----------------- | --------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **Label names**   | `metric` (optional)                     | Returns all label names, optionally filtered by metric regular expression.      | Metric: `http_requests_total` → returns `job`, `instance`, `method`, `status`, etc.     |
+| **Label values**  | `label` (required), `metric` (optional) | Returns values for a specific label, optionally filtered by metric.             | Label: `job`, Metric: `http_requests_total` → returns `api-server`, `web`, `worker`     |
+| **Metrics**       | `metric` (optional)                     | Returns metric names matching the specified regular expression.                 | Metric: `node_.*` → returns `node_cpu_seconds_total`, `node_memory_MemFree_bytes`, etc. |
+| **Query result**  | `query` (required)                      | Runs a PromQL query and returns the results as variable values.                 | `query_result(up{job="prometheus"})`                                                    |
+| **Series query**  | `metric`, `label`, or both              | Returns time series matching the specified metric and/or label selectors.       | Metric: `http_requests_total`, Label: `job="api"`                                       |
+| **Classic query** | query string                            | _Deprecated._ Legacy syntax using functions like `label_values(metric, label)`. | `label_values(http_requests_total, job)`                                                |
 
-| Query Type      | Input(\* required)        | Description                                                                                                                                                   | Used API endpoints                             |
-| --------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| `Label names`   | `metric`                  | Returns a list of all label names matching the specified `metric` regex.                                                                                      | /api/v1/labels                                 |
-| `Label values`  | `label`\*, `metric`       | Returns a list of label values for the `label` in all metrics or the optional metric.                                                                         | /api/v1/label/`label`/values or /api/v1/series |
-| `Metrics`       | `metric`                  | Returns a list of metrics matching the specified `metric` regex.                                                                                              | /api/v1/label/\_\_name\_\_/values              |
-| `Query result`  | `query`                   | Returns a list of Prometheus query result for the `query`.                                                                                                    | /api/v1/query                                  |
-| `Series query`  | `metric`, `label` or both | Returns a list of time series associated with the entered data.                                                                                               | /api/v1/series                                 |
-| `Classic query` | classic query string      | Deprecated, classic version of variable query editor. Enter a string with the query type using a syntax like the following: `label_values(<metric>, <label>)` | all                                            |
+For details on metric names, label names, and label values, refer to the [Prometheus data model](http://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 
-For details on `metric names`, `label names`, and `label values`, refer to the [Prometheus documentation](http://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
+### Query type examples
+
+**Label values — Populate a dropdown with all jobs:**
+
+1. Create a new variable with **Type: Query**.
+1. Select your Prometheus data source.
+1. Set **Query type** to `Label values`.
+1. Set **Label** to `job`.
+1. Leave **Metric** empty to query across all metrics.
+
+The variable dropdown now shows all unique `job` label values.
+
+**Label values — Filtered by metric:**
+
+Set **Label** to `instance` and **Metric** to `node_cpu_seconds_total` to show only instances that report CPU metrics.
+
+**Metrics — Find available metrics by pattern:**
+
+Set **Query type** to `Metrics` and enter `http_.*_total` in the **Metric** field to populate the dropdown with all HTTP counter metrics.
+
+**Query result — Dynamic top-N filtering:**
+
+Set **Query type** to `Query result` and enter:
+
+```promql
+query_result(topk(5, sum(rate(http_requests_total[$__range])) by (instance)))
+```
+
+Set **Regex** to `/"([^"]+)"/` to extract the instance values from the result.
+
+Set **Refresh** to `On time range change` so the top 5 instances update as you change the dashboard time range.
 
 ### Query options
 
-With the query variable type, you can set the following query options:
-
-| Option                | Description                                                                                             |
-| --------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Data source**       | Select your data source from the drop-down list.                                                        |
-| **Select query type** | Options are `default`, `value` and `metric name`. Each query type hits a different Prometheus endpoint. |
-| **Regex**             | Optional, if you want to extract part of a series name or metric node segment.                          |
-| **Sort**              | Default is `disabled`. Options include `alphabetical`, `numerical`, and `alphabetical case-sensitive`.  |
-| **Refresh**           | When to update the values for the variable. Options are `On dashboard load` and `On time range change`. |
+| Option          | Description                                                                                                                                                                                                      |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Data source** | The Prometheus data source to query.                                                                                                                                                                             |
+| **Regex**       | Optional regular expression to extract a portion of the returned values. Use capture groups — for example, `/.*instance="([^"]+)".*/` extracts the instance label value from a series string.                    |
+| **Sort**        | Sort order for dropdown values: `Disabled`, `Alphabetical (asc)`, `Alphabetical (desc)`, `Numerical (asc)`, `Numerical (desc)`, `Alphabetical (case-insensitive, asc)`, `Alphabetical (case-insensitive, desc)`. |
+| **Refresh**     | When to update values: `On dashboard load` or `On time range change`. Use `On time range change` for variables that depend on `$__range`.                                                                        |
 
 ### Selection options
 
-The following selection options are available:
+- **Multi-value** — Allows selecting multiple values at once. Grafana joins them with a pipe (`|`) for regular expression matching.
+- **Include All option** — Adds an "All" option that selects every value. Combined with multi-value, this generates a regular expression like `value1|value2|value3`.
 
-- **Multi-value** - Check this option to enable multiple values to be selected at the same time.
+{{< admonition type="note" >}}
+When **Multi-value** or **Include All** is enabled, use `=~` (regular expression match) instead of `=` (exact match) in your queries, since the variable value becomes a regex pattern.
+{{< /admonition >}}
 
-- **Include All option** - Check this option to include all variables.
+**Example with multi-value:**
+
+```promql
+rate(http_requests_total{job=~"$job"}[$__rate_interval])
+```
 
 ### Use interval and range variables
 
-You can use global built-in variables in query variables, including the following:
+You can use global built-in variables in query variable definitions:
 
-- `$__interval`
-- `$__interval_ms`
-- `$__range`
-- `$__range_s`
-- `$__range_ms`
+| Variable         | Description                                                       |
+| ---------------- | ----------------------------------------------------------------- |
+| `$__interval`    | Calculated interval based on time range and panel width.          |
+| `$__interval_ms` | Same as `$__interval` in milliseconds.                            |
+| `$__range`       | Duration of the current dashboard time range (for example, `1h`). |
+| `$__range_s`     | Duration in seconds.                                              |
+| `$__range_ms`    | Duration in milliseconds.                                         |
 
 For details, refer to [Global built-in variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#global-variables).
-The `label_values` function doesn't support queries, so you can use these variables in conjunction with the `query_result` function to filter variable queries.
 
-Configure the variable’s `refresh` setting to `On Time Range Change` to ensure it dynamically queries and displays the correct instances when the dashboard time range is modified.
+The `label_values` function (Classic query type) doesn't support these variables. Use `Query result` type with `query_result()` instead:
 
-**Example:**
-
-Populate a variable with the top 5 busiest request instances ranked by average QPS over the dashboard's selected time range:
-
-```
-query_result(topk(5, sum(rate(http_requests_total[$__range])) by (instance)))
-Regex: /"([^"]+)"/
+```promql
+query_result(max_over_time(up{job="$job"}[${__range_s}s]) == 1)
 ```
 
-Populate a variable with the instances having a certain state over the time range shown in the dashboard, using `$__range_s`:
+Set the variable's **Refresh** to `On time range change` to update values when the time range changes.
 
-```
-query_result(max_over_time(<metric>[${__range_s}s]) != <state>)
-Regex:
-```
+<!-- vale Grafana.Spelling = NO -->
 
 ## Use `$__rate_interval`
 
-Grafana recommends using `$__rate_interval` with the `rate` and `increase` functions instead of `$__interval` or a fixed interval value.
-Since `$__rate_interval` is always at least four times the scrape interval, it helps avoid issues specific to Prometheus, such as gaps or inaccuracies in query results.
+<!-- vale Grafana.Spelling = YES -->
 
-For example, instead of using the following:
+`$__rate_interval` is a Grafana-specific variable designed for use with `rate()` and `increase()`. It guarantees a range window large enough to capture at least four scrape samples, preventing gaps or inaccuracies in results.
 
-```
-rate(http_requests_total[5m])
-```
+**Always use `$__rate_interval` instead of a fixed interval or `$__interval`:**
 
-or:
-
-```
-rate(http_requests_total[$__interval])
-```
-
-Use the following:
-
-```
+```promql
 rate(http_requests_total[$__rate_interval])
 ```
 
-<!-- The value of `$__rate_interval` is defined as
-*max(`$__interval` + *Scrape interval*, 4 \* *Scrape interval*)*,
-where _Scrape interval_ is the "Min step" setting (also known as `query*interval`, a setting per PromQL query) if any is set.
-Otherwise, Grafana uses the Prometheus data source's `scrape interval` setting. -->
+Not:
 
-The value of `$__rate_interval` is calculated as:
+```promql
+rate(http_requests_total[5m])       # breaks at different zoom levels
+rate(http_requests_total[$__interval])  # can be too small for rate()
+```
+
+<!-- vale Grafana.Spelling = NO -->
+
+### How `$__rate_interval` is calculated
+
+<!-- vale Grafana.Spelling = YES -->
 
 ```
 max($__interval + scrape_interval, 4 * scrape_interval)
 ```
 
-Here, `scrape_interval` refers to the `min step` setting (also known as `query_interval`) specified per PromQL query, if set. If not, Grafana falls back to the Prometheus data source’s scrape interval setting.
+Where `scrape_interval` is:
 
-The `min interval` setting in the panel is modified by the resolution setting, and therefore doesn't have any effect on `scrape interval`.
+1. The per-query **Min step** setting, if set.
+2. Otherwise, the data source's **Scrape interval** setting (under Interval behavior in the data source configuration).
 
-For details, refer to the Grafana blog [$\_\_rate_interval for Prometheus rate queries that just work](https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/).
+The panel-level `min interval` is affected by the resolution setting and doesn't factor into this calculation.
 
-## Choose a variable syntax
+<!-- vale Grafana.Spelling = NO -->
 
-The Prometheus data source supports two variable syntaxes for use in the **Query** field:
+### Configure `$__rate_interval` correctly
 
-- `$<varname>`, for example `rate(http_requests_total{job=~"$job"}[$_rate_interval])`, which is easier to read and write but does not allow you to use a variable in the middle of a word.
-- `[[varname]]`, for example `rate(http_requests_total{job=~"[[job]]"}[$_rate_interval])`
+<!-- vale Grafana.Spelling = YES -->
 
-If you've enabled the `Multi-value` or `Include all value` options, Grafana converts the labels from plain text to a regex-compatible string, which requires you to use `=~` instead of `=`.
+For `$__rate_interval` to produce reliable results, the scrape interval must match your actual Prometheus scrape configuration:
 
-## Use the filters variable type
+1. Open the Prometheus data source configuration.
+1. Under **Interval behavior**, set the **Scrape interval** to match the `scrape_interval` in your Prometheus configuration file (for example, `30s` or `1m`).
+1. If different targets have different scrape intervals, set the data source scrape interval to the **longest** interval in use, or use the per-query **Min step** to override on specific panels.
 
-Prometheus supports the special [filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters) variable type, which allows you to dynamically apply label/value filters across your dashboards. These filters are automatically added to all Prometheus queries, allowing dynamic filtering without modifying individual queries.
+### Common pitfalls
+
+- **Missing or incorrect scrape interval setting:** If the data source scrape interval is left at the default `15s` but your actual Prometheus scrape interval is `60s`, `$__rate_interval` calculates too small a window. This causes `rate()` to return no data because there aren't enough data points in the window.
+
+- **Different values in edit mode versus dashboard:** When editing a query, the panel displays at full width. On the dashboard, the panel may be narrower, which increases `$__interval` and therefore `$__rate_interval`. Queries that work in edit mode may produce different results (or gaps) on the dashboard.
+
+- **LBAC-enabled data sources:** Data sources using Label-Based Access Control (LBAC) may not inherit the scrape interval setting from the parent data source. Set the **Min step** explicitly on each query panel to ensure a correct `$__rate_interval` calculation.
+
+- **Recording rules with fixed intervals:** If you use `$__rate_interval` in a recording rule query, the interval depends on the evaluation context. For recording rules, use a fixed interval (for example, `[5m]`) rather than `$__rate_interval`.
+
+For troubleshooting `$__rate_interval` issues, refer to [`$__rate_interval` returns no data or incorrect values](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/#rate_interval-returns-no-data-or-incorrect-values).
+
+For additional background, refer to [$\_\_rate_interval for Prometheus rate queries that just work](https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/).
+
+## Variable syntax
+
+The Prometheus data source supports three variable syntaxes:
+
+| Syntax        | Example                                                       | Use case                                                                         |
+| ------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `$varname`    | `rate(http_requests_total{job=~"$job"}[$__rate_interval])`    | Simple, readable. Cannot be used mid-word.                                       |
+| `${varname}`  | `rate(http_requests_total{job=~"${job}"}[$__rate_interval])`  | Use when the variable is adjacent to other text (for example, `${env}-cluster`). |
+| `[[varname]]` | `rate(http_requests_total{job=~"[[job]]"}[$__rate_interval])` | Legacy syntax. Supported for backward compatibility.                             |
+
+{{< admonition type="note" >}}
+If **Multi-value** or **Include All** is enabled, the variable value becomes a regular expression pattern (for example, `value1|value2`). Use `=~` instead of `=` in your label matchers.
+{{< /admonition >}}
+
+## Filters variable
+
+Prometheus supports the [Filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters) variable type (formerly called "ad hoc filters"), which lets dashboard viewers dynamically add label filters without editing queries.
+
+{{< admonition type="note" >}}
+The **Filter and Group by** feature extends the Filters variable by adding grouping support for Prometheus and Loki data sources. For more information, refer to [Filter and Group by](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/filter-group-by/).
+{{< /admonition >}}
+
+To set up a Filters variable:
+
+1. Create a new variable with **Type: Filters**.
+1. Select your Prometheus data source.
+1. Save the dashboard.
+
+After you add the variable, a filter bar appears at the top of the dashboard. Viewers can add filters by selecting a label, operator (`=`, `!=`, `=~`, `!~`), and value. Grafana automatically applies these filters to **all** Prometheus queries on the dashboard.
+
+**Example:** A viewer adds the filter `namespace = production`. All queries on the dashboard now include `{namespace="production"}` without any query modifications.
+
+{{< admonition type="note" >}}
+Filters are applied to all queries using the selected data source. You cannot selectively apply them to specific panels.
+{{< /admonition >}}
+
+## Related resources
+
+- [Query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/query-editor/) — Use variables in PromQL queries.
+- [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/annotations/) — Use template variables in annotation queries.
+- [Troubleshooting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/troubleshooting/) — Resolve variable-related query issues.

--- a/docs/sources/datasources/prometheus/troubleshooting/index.md
+++ b/docs/sources/datasources/prometheus/troubleshooting/index.md
@@ -16,6 +16,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot Prometheus data source issues
 weight: 600
+review_date: 2026-05-07
 ---
 
 # Troubleshoot Prometheus data source issues
@@ -69,6 +70,73 @@ The following errors occur when Grafana cannot establish or maintain a connectio
 1. Ensure the URL includes the protocol (`http://` or `https://`).
 1. Remove any trailing slashes or invalid characters from the URL.
 
+### Data doesn't appear in Metrics Drilldown or Explore
+
+**Symptom:** You've successfully tested the data source connection, but no metric data appears in Explore or Metrics Drilldown.
+
+**Cause:** The wrong data source is selected, or the data source name doesn't match expectations.
+
+**Solution:**
+
+1. Verify you've selected the correct data source from the data source drop-down menu.
+1. When using `remote_write` to send metrics to Grafana Cloud, the data source name follows the convention `grafanacloud-<stackname>-prom`.
+1. Check that metrics are being actively scraped by querying `up` in the Explore view.
+1. If using Grafana Cloud, verify the `remote_write` endpoint URL and credentials are correct.
+
+### PDC connectivity errors
+
+**Error messages:** "host unreachable", "EOF", "network unreachable", "connection reset by peer", "dial tcp: lookup ... no such host"
+
+**Symptom:** Prometheus queries fail intermittently or consistently when using Private data source connect (PDC) to reach a Prometheus instance behind a private network. The data source test may pass occasionally but queries fail under load.
+
+**Cause:** PDC tunnels traffic through an SSH connection between Grafana Cloud and your PDC agent. Connectivity failures are most commonly caused by DNS resolution issues, network configuration on the customer side, or the PDC agent's default connection limits being too low for the query volume.
+
+**Solutions:**
+
+1. **Verify DNS resolution from the PDC agent host.** The PDC agent must be able to resolve the Prometheus hostname from the machine it runs on. Run `nslookup` or `dig` for the Prometheus URL from the agent host to confirm.
+1. **Check network connectivity from the agent.** Ensure the PDC agent can reach the Prometheus endpoint directly (for example, `curl http://prometheus-host:9090/-/healthy` from the agent machine).
+1. **Increase parallel SSH connections.** The PDC agent defaults to 1 parallel SSH connection, which can bottleneck under load from multiple alert evaluations or dashboard queries. Increase this by setting the `--ssh-connections` flag (or `PDC_SSH_CONNECTIONS` environment variable) to a higher value (for example, 4 or 8):
+
+   ```sh
+   pdc-agent --ssh-connections=4
+   ```
+
+1. **Check firewall rules.** Ensure the PDC agent's outbound SSH connection to Grafana Cloud isn't being interrupted by firewall rules, NAT gateways, or idle connection timeouts.
+1. **Verify the PDC agent is running and healthy.** Check agent logs for connection errors or restarts. The agent must maintain a persistent connection to Grafana Cloud.
+1. **Check for idle timeout issues.** If the connection drops after periods of inactivity, configure TCP keepalives on the host or add a keepalive setting to the PDC agent configuration.
+
+{{< admonition type="note" >}}
+PDC connectivity issues are almost always caused by networking on the customer side (DNS, firewall rules, routing), not by Grafana Cloud. The data source test passing doesn't guarantee sustained connectivity under load — it only verifies a single query succeeds.
+{{< /admonition >}}
+
+For general PDC setup and configuration, refer to [Private data source connect (PDC)](/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) and [Configure PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/).
+
+### Certificate verification failed
+
+**Error message:** "x509: certificate signed by unknown authority" or "certificate verify failed"
+
+**Cause:** Grafana cannot verify the TLS certificate presented by Prometheus.
+
+**Solution:**
+
+1. If using a self-signed certificate, enable **Add self-signed certificate** in the TLS settings and add your CA certificate.
+1. Verify the certificate chain is complete and valid.
+1. Ensure the certificate has not expired.
+1. As a temporary workaround for testing, enable **Skip TLS verify** (not recommended for production).
+
+### TLS handshake error
+
+**Error message:** "TLS: handshake failure" or "connection reset"
+
+**Cause:** The TLS handshake between Grafana and Prometheus failed.
+
+**Solution:**
+
+1. Verify that Prometheus is configured to use TLS.
+1. Check that the TLS version and cipher suites are compatible.
+1. If using client certificates, ensure they are correctly configured in the **TLS client authentication** section.
+1. Verify the server name matches the certificate's Common Name or Subject Alternative Name.
+
 ## Authentication errors
 
 The following errors occur when there are issues with authentication credentials or permissions.
@@ -85,6 +153,64 @@ The following errors occur when there are issues with authentication credentials
 1. Check that the authentication method selected matches your Prometheus configuration.
 1. If using a reverse proxy with authentication, verify the credentials are correct.
 1. For AWS SigV4 authentication, verify the IAM credentials and permissions. Alternatively, consider using the [Amazon Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/) for simplified AWS authentication.
+
+### OAuth token expiration errors (GCP and Azure)
+
+**Error messages:** "ACCESS_TOKEN_EXPIRED", "401 Unauthorized" in alerting but not in Explore
+
+**Symptom:** Queries in Explore and dashboards work correctly, but alert rule evaluations fail intermittently with 401 errors. This is most common with Google Managed Prometheus (GMP) and Azure-managed Prometheus endpoints using OAuth/OIDC authentication.
+
+**Cause:** The Grafana alerting backend and the interactive query path (Explore, dashboards) handle credential refreshes differently. The alerting evaluator can use a cached OAuth token beyond its expiry window due to a token staleness check issue in the Prometheus data source. This causes alerting to fail with expired credentials while interactive queries succeed because they trigger a fresh token exchange.
+
+**Solutions:**
+
+For Google Managed Prometheus (GMP):
+
+1. Use the **GCP datasource-syncer** pattern: run a sidecar process that refreshes OAuth tokens and updates the Grafana data source credentials on a schedule shorter than the token lifetime (typically every 45 minutes for a 60-minute token). This ensures the stored token is always valid when the alerting backend uses it.
+1. Alternatively, use the [Google Cloud Monitor data source](https://grafana.com/grafana/plugins/stackdriver/) with its built-in GCP credential management rather than pointing the core Prometheus data source at a GMP endpoint.
+1. If running on GKE with Workload Identity, ensure the Kubernetes service account token refresh is functioning and the projected token volume is mounted correctly.
+
+For Azure Managed Prometheus:
+
+1. Verify the Azure AD app registration's client secret hasn't expired.
+1. If using Managed Identity, ensure the Grafana instance's identity has the **Monitoring Data Reader** role on the Azure Monitor workspace.
+1. Check that **Forward OAuth identity** is not enabled alongside Azure AD authentication — both use the same HTTP authorization headers and conflict with each other.
+
+General steps:
+
+1. Check the Grafana server logs for token refresh errors around the time alerts fail.
+1. Verify the data source test (**Save & test**) passes — this confirms current credentials are valid but doesn't guarantee the alerting backend has a fresh token.
+1. If the issue persists, set **Alert state if execution error or timeout** to **Keep Last State** to prevent false alarms while investigating. Refer to [Configure alert state for execution errors](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/alerting/#configure-alert-state-for-execution-errors).
+
+{{< admonition type="note" >}}
+This token caching behavior is a known issue that has received code fixes in recent Grafana releases. If you're experiencing this on an older Grafana version, upgrading may resolve it. Check the [Grafana changelog](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/whatsnew/) for relevant fixes.
+{{< /admonition >}}
+
+### LBAC not restricting data on non-Mimir backends
+
+**Symptom:** You've enabled `teamHttpHeadersMimir` and configured Team LBAC rules, but users can still see all metrics regardless of their team assignments.
+
+**Cause:** Label-Based Access Control (LBAC) for the Prometheus data source only works when the backend is **Grafana Cloud Metrics (Mimir)** or **Grafana Enterprise Metrics (GEM)**. It doesn't work with Google Managed Prometheus, self-hosted Prometheus, Thanos, or other Prometheus-compatible endpoints. The LBAC enforcement relies on Mimir-specific HTTP headers (`X-Scope-OrgID` and team-scoped label matchers) that other backends ignore.
+
+**Solution:**
+
+1. Verify your backend is Grafana Cloud Metrics or GEM. If you're using a different Prometheus-compatible backend, LBAC isn't supported.
+1. For Google Managed Prometheus or other external endpoints, use [data source permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/#data-source-permissions) to control which teams can access the data source entirely, rather than per-label access control.
+1. If you need per-label restrictions on a non-Mimir backend, consider proxying through a Mimir instance or using a separate data source per team with different credentials scoped to the appropriate data.
+
+### Azure AD or SigV4 authentication options not available
+
+**Symptom:** The Azure AD or SigV4 authentication options don't appear in the authentication drop-down when configuring the Prometheus data source.
+
+**Cause:** These authentication methods require server-side feature flags that aren't enabled by default, particularly on Grafana Cloud.
+
+**Solution:**
+
+1. **Grafana Cloud:** Contact [Grafana Support](https://grafana.com/profile/org#support) to request the feature flag be enabled for your stack. This isn't a self-service setting.
+1. **Self-managed Grafana:** Add the required setting to your Grafana configuration file:
+   - For Azure AD: set `azure_auth_enabled = true` under `[auth]`
+   - For SigV4: set `sigv4_auth_enabled = true` under `[auth]`
+1. **For Amazon Managed Prometheus:** Consider using the dedicated [Amazon Managed Service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/) instead, which handles AWS authentication natively without needing the SigV4 flag.
 
 ### Forbidden (403)
 
@@ -162,6 +288,49 @@ The following errors occur when there are issues with PromQL syntax or query exe
 1. Use aggregation functions to combine time series.
 1. Adjust the **Series limit** setting in the data source configuration under **Other settings**.
 
+### Memory limit exceeded for high-cardinality queries
+
+**Error messages:** "max-estimated-memory-consumption-per-query limit exceeded", "query requires too much memory", "max samples limit reached"
+
+**Symptom:** Queries against high-cardinality metrics (thousands of unique label combinations) over long time ranges (days or weeks) fail with memory or sample limit errors. Short time ranges may work but expanding the range causes the failure.
+
+**Cause:** Prometheus and Mimir enforce per-query memory and sample limits to protect the system from resource exhaustion. High-cardinality metrics (for example, metrics with a `pod`, `request_id`, or `user_id` label) multiplied by long time ranges produce result sets that exceed these limits.
+
+**Solutions:**
+
+1. **Reduce the query scope:**
+   - Shorten the time range.
+   - Add label matchers to select fewer series (for example, filter to a specific `namespace` or `job`).
+   - Increase the **Min step** or use a larger step interval to reduce the number of data points per series.
+
+1. **Use recording rules to pre-aggregate:**
+   Create [recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) that pre-compute the aggregation you need. For example, if you commonly query `sum(rate(http_requests_total[5m])) by (service)`, create a recording rule for it and query the pre-aggregated metric instead.
+
+   ```yaml
+   groups:
+     - name: aggregations
+       rules:
+         - record: service:http_requests_total:rate5m
+           expr: sum(rate(http_requests_total[5m])) by (service)
+   ```
+
+1. **Use Adaptive Metrics (Grafana Cloud):**
+   If you're on Grafana Cloud, [Adaptive Metrics](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics/) automatically identifies and aggregates high-cardinality metrics that aren't being queried at full resolution, reducing storage and query costs.
+
+1. **Restructure dashboards for high-cardinality data:**
+   - Use template variables to scope queries to a subset of labels rather than querying all series at once.
+   - Split long-range overviews (weekly/monthly) into separate panels that use pre-aggregated recording rules.
+   - Use the **Max data points** setting in the query options to cap the resolution for overview panels.
+
+1. **Increase limits (self-managed only):**
+   If you have admin access to Prometheus or Mimir, you can increase limits in the server configuration:
+   - Prometheus: `--query.max-samples` flag
+   - Mimir: `-querier.max-samples`, `-querier.max-estimated-memory-consumption-per-query`
+
+   {{< admonition type="note" >}}
+   Increasing limits allows larger queries to succeed but also increases the risk of resource exhaustion. Prefer reducing query scope or using recording rules over raising limits.
+   {{< /admonition >}}
+
 ### Invalid function or aggregation
 
 **Error message:** "unknown function" or "parse error: unexpected aggregation"
@@ -174,6 +343,32 @@ The following errors occur when there are issues with PromQL syntax or query exe
 1. Check that you are using the correct syntax for the function.
 1. Ensure your Prometheus version supports the function you are using.
 1. Refer to the [PromQL functions documentation](https://prometheus.io/docs/prometheus/latest/querying/functions/) for available functions.
+
+### `rate()` or `increase()` returning unexpected values
+
+**Symptom:** `increase()` returns fractional values on integer counters, `rate()` shows an ever-increasing value instead of a steady per-second rate, or counter resets cause large spikes in visualizations.
+
+**Possible causes and solutions:**
+
+| Cause                                         | Solution                                                                                                                                              |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `increase()` fractional values                | Expected behavior — Prometheus uses linear interpolation. Use `ceil()` or `floor()` if you need integers.                                             |
+| `rate()` grows over time                      | Multiple instances write to the same series without unique labels. Ensure each target has unique `instance`/`pod` labels and aggregate with `sum by`. |
+| Counter reset spikes after pod restarts       | Use `$__rate_interval` or a longer range vector to smooth spikes. Investigate frequent restarts as the root cause.                                    |
+| Values differ between edit mode and dashboard | Panel width affects `$__interval` which affects `rate()` window calculations. Set a **Min step** on the query.                                        |
+
+For detailed explanations of these behaviors, refer to [Expected PromQL behaviors](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/query-editor/#expected-promql-behaviors).
+
+### Aggregation by labels with dots
+
+**Symptom:** Queries that aggregate by label names containing dots (for example, `container.name`) return incorrect or incomplete results.
+
+**Cause:** Prior to Grafana 13, there was a bug where labels with dots in their names were not handled correctly during aggregation operations like `sum by` or `avg by`.
+
+**Solution:**
+
+1. Upgrade to Grafana 13 or later, which correctly handles labels with dots in aggregation queries.
+1. Verify your query uses the correct label name with dots (for example, `sum by (container.name) (metric_name)`).
 
 ## Configuration errors
 
@@ -201,103 +396,164 @@ The following errors occur when the data source is not configured correctly.
 
 1. Check your Prometheus configuration file for the `scrape_interval` setting.
 1. Update the **Scrape interval** in the Grafana data source configuration under **Interval behavior** to match.
-1. Use `$__rate_interval` instead of hardcoded time windows in `rate()` queries. This variable automatically adjusts based on your scrape interval.
+1. Use `$__rate_interval` instead of hard-coded time windows in `rate()` queries. This variable automatically adjusts based on your scrape interval.
 1. For more information, refer to [$\_\_rate_interval for Prometheus rate queries that just work](https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/).
 
-## TLS and certificate errors
+<!-- vale Grafana.Spelling = NO -->
 
-The following errors occur when there are issues with TLS configuration.
+### `$__rate_interval` returns no data or incorrect values
 
-### Certificate verification failed
+<!-- vale Grafana.Spelling = YES -->
 
-**Error message:** "x509: certificate signed by unknown authority" or "certificate verify failed"
+**Symptom:** Queries using `$__rate_interval` return no data, return different values in edit mode versus the dashboard, or produce unexpected gaps.
 
-**Cause:** Grafana cannot verify the TLS certificate presented by Prometheus.
+**Cause:** `$__rate_interval` is calculated as `max($__interval + scrape_interval, 4 * scrape_interval)`. If any input to this formula is incorrect, the resulting window is wrong — either too small (no data) or inconsistent across contexts.
 
-**Solution:**
+**Common causes and solutions:**
 
-1. If using a self-signed certificate, enable **Add self-signed certificate** in the TLS settings and add your CA certificate.
-1. Verify the certificate chain is complete and valid.
-1. Ensure the certificate has not expired.
-1. As a temporary workaround for testing, enable **Skip TLS verify** (not recommended for production).
+| Cause                                                                                                                    | Solution                                                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Data source scrape interval left at default `15s` while actual Prometheus scrape interval is longer (for example, `60s`) | Set the **Scrape interval** under **Interval behavior** in the data source configuration to match your Prometheus `scrape_interval`.      |
+| Query works in edit mode but shows gaps on the dashboard                                                                 | Panel size affects `$__interval`. Smaller panels produce larger intervals. Set a **Min step** on the query to enforce a consistent floor. |
+| LBAC-enabled data source doesn't inherit scrape interval                                                                 | Set the **Min step** explicitly on each query panel rather than relying on data source inheritance.                                       |
+| Using `$__rate_interval` in recording rules or alerting                                                                  | Use a fixed interval (for example, `[5m]`) instead of `$__rate_interval` in contexts without a panel/dashboard.                           |
 
-### TLS handshake error
+**To debug the current value:**
 
-**Error message:** "TLS: handshake failure" or "connection reset"
+1. Open the query inspector in a panel (click the panel title, then **Inspect** > **Query**).
+1. Look at the expanded query sent to Prometheus — the actual interval value replacing `$__rate_interval` is visible in the request.
+1. Compare this value against your actual scrape interval. If it's smaller than your scrape interval, you need to configure the data source scrape interval or set a Min step.
 
-**Cause:** The TLS handshake between Grafana and Prometheus failed.
+For detailed documentation on how `$__rate_interval` works and how to configure it, refer to [Use `$__rate_interval`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/template-variables/#use-__rate_interval).
 
-**Solution:**
+## Performance issues
 
-1. Verify that Prometheus is configured to use TLS.
-1. Check that the TLS version and cipher suites are compatible.
-1. If using client certificates, ensure they are correctly configured in the **TLS client authentication** section.
-1. Verify the server name matches the certificate's Common Name or Subject Alternative Name.
-
-## Other common issues
-
-The following issues don't produce specific error messages but are commonly encountered.
-
-### Empty query results
-
-**Cause:** The query returns no data.
-
-**Solution:**
-
-1. Verify the time range includes data in Prometheus.
-1. Check that the metric and label names are correct.
-1. Test the query directly in the Prometheus expression browser.
-1. Ensure label filters are not excluding all data.
-1. For rate or increase functions, ensure the time range is at least twice the scrape interval.
+The following issues affect query speed and data freshness.
 
 ### Slow query performance
 
-**Cause:** Queries take a long time to execute.
+**Symptom:** Queries take a long time to execute, dashboards are slow to load, or the loading spinner persists.
+
+**Cause:** Queries scan too much data, the Prometheus server is overloaded, or the network connection is slow.
 
 **Solution:**
 
 1. Reduce the time range of your query.
 1. Add more specific label filters to limit the data scanned.
-1. Increase the **Min interval** in the query options.
+1. Increase the **Min step** in the query options to reduce the number of data points.
 1. Check Prometheus server performance and resource utilization.
 1. Enable **Disable metrics lookup** in the data source configuration for large Prometheus instances.
 1. Enable **Incremental querying (beta)** to cache query results.
-1. Consider using recording rules to pre-aggregate frequently queried data.
+1. Use recording rules to pre-aggregate frequently queried data.
+1. For high-cardinality metrics, refer to [Memory limit exceeded for high-cardinality queries](#memory-limit-exceeded-for-high-cardinality-queries).
 
 ### Data appears delayed or missing recent points
 
-**Cause:** The visualization doesn't show the most recent data.
+**Symptom:** The visualization doesn't show the most recent data, even after refreshing.
+
+**Cause:** Scrape timing, clock drift, or dashboard refresh settings.
 
 **Solution:**
 
 1. Check the dashboard time range and refresh settings.
-1. Verify the **Scrape interval** is configured correctly.
-1. Ensure Prometheus has finished scraping the target.
-1. Check for clock synchronization issues between Grafana and Prometheus.
-1. For `rate()` and similar functions, remember that they need at least two data points to calculate.
+1. Verify the **Scrape interval** is configured correctly in the data source settings.
+1. Ensure Prometheus has finished scraping the target (there's a delay between the scrape interval and data availability).
+1. Check for clock synchronization issues between Grafana and Prometheus (use NTP).
+1. For `rate()` and similar functions, the most recent partial scrape interval won't have enough data points — this is expected.
 
 ### Exemplars not showing
 
-**Cause:** Exemplar data is not appearing in visualizations.
+**Symptom:** Exemplar data doesn't appear on graphs even though you expect it.
+
+**Cause:** Exemplars require specific configuration in both the data source and the query editor.
 
 **Solution:**
 
-1. Verify that exemplars are enabled in the data source configuration under **Exemplars**.
+1. Verify that exemplars are configured in the data source settings under **Exemplars** (at least one exemplar link must be defined).
 1. Check that your Prometheus version supports exemplars (2.26+).
-1. Ensure your instrumented application is sending exemplar data.
+1. Ensure your instrumented application is actually sending exemplar data with metrics.
 1. Verify the tracing data source is correctly configured for the exemplar link.
-1. Enable the **Exemplars** toggle in the query editor.
+1. Enable the **Exemplars** toggle in the query editor for the specific query.
+1. Exemplars only appear with **Range** query type, not **Instant**.
 
-### Alerting rules not visible
+## Annotation errors
 
-**Cause:** Prometheus alerting rules are not appearing in the Grafana Alerting UI.
+The following issues occur when using Prometheus as a data source for annotations.
+
+### Annotations not appearing
+
+**Symptom:** You've configured a Prometheus annotation query, but no annotations appear on your dashboard.
+
+**Possible causes and solutions:**
+
+| Cause                                                | Solution                                                                                                                                                                                                                        |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Query returns no data in the current time range      | Verify the query returns results in Explore for the dashboard's time range.                                                                                                                                                     |
+| Query returns continuous data (too many annotations) | Every returned data point creates an annotation. If the query returns hundreds of points, annotations may render but are too dense to see. Increase the **Min step** or refine your query to only return data at event moments. |
+| Wrong data source selected                           | Verify the correct Prometheus data source is selected in the annotation configuration.                                                                                                                                          |
+| Annotation is disabled                               | Check that the annotation toggle is enabled (eye icon) in the dashboard's annotation settings.                                                                                                                                  |
+| Time range mismatch                                  | Expand the dashboard time range to include the events you expect to see.                                                                                                                                                        |
+
+{{< admonition type="note" >}}
+Prometheus annotations create a marker for **every data point** returned by the query. There's no automatic filtering of zero values. If you only want annotations at specific moments, your PromQL expression must return data only at those times (for example, using `> 0`, `changes() > 0`, or the `ALERTS` metric).
+{{< /admonition >}}
+
+For more information on configuring annotations, refer to [Prometheus annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/annotations/).
+
+## Alerting errors
+
+The following issues occur when using Prometheus with Grafana Alerting.
+
+### Transient alert errors triggering false alarms
+
+**Error messages:** `sse.dependencyError`, `sse.dataQueryError`, "context deadline exceeded", "i/o timeout"
+
+**Symptom:** Alert rules intermittently fire due to execution errors rather than genuine threshold breaches. On-call teams receive false positive notifications. Alert state history shows error states caused by transient backend issues (network blips, HTTP 502/500 responses, timeouts) rather than actual metric conditions being met.
+
+**Cause:** By default, when an alert rule encounters an execution error or timeout, Grafana sets the alert state to **Alerting** — which fires the alert. Transient connectivity issues between Grafana and Prometheus (i/o timeouts, deadline exceeded, brief outages) trigger this behavior even though the underlying metric hasn't crossed its threshold.
+
+**Solution:**
+
+1. Open each affected alert rule for editing.
+1. In the alert conditions section, change **Alert state if execution error or timeout** from **Alerting** to **Keep Last State**.
+1. Save the rule.
+
+This ensures the alert retains its previous state during transient errors and only fires when a successful evaluation confirms the threshold is breached.
+
+**If errors are frequent**, also investigate:
+
+1. Network stability between Grafana and Prometheus.
+1. Prometheus resource utilization (CPU, memory, disk I/O).
+1. The **Query timeout** setting in the data source configuration — increase it if complex queries regularly exceed the limit.
+1. Query complexity — simplify queries or use recording rules to pre-compute expensive expressions.
+
+For configuration details, refer to [Configure alert state for execution errors](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/alerting/#configure-alert-state-for-execution-errors).
+
+### Alert rule fails to evaluate
+
+**Symptom:** An alert rule using a Prometheus query shows evaluation errors or remains in a "No Data" state.
+
+**Possible causes and solutions:**
+
+| Cause                       | Solution                                                                                            |
+| --------------------------- | --------------------------------------------------------------------------------------------------- |
+| Template variables in query | Alert queries don't support template variables. Replace variables with hard-coded values.           |
+| Query timeout               | Simplify the query or increase the evaluation timeout. Use recording rules for complex expressions. |
+| Data source unreachable     | Verify the Prometheus data source connection is working (test it in the data source settings).      |
+| No data in range            | Ensure the metric has recent data. Check that Prometheus is actively scraping the target.           |
+
+### Data source-managed rules not visible
+
+**Symptom:** Prometheus alerting rules don't appear in the Grafana Alerting UI.
 
 **Solution:**
 
 1. Verify that **Manage alerts via Alerting UI** is enabled in the data source configuration.
-1. Check that Prometheus has alerting rules configured.
-1. Ensure Grafana can access the Prometheus rules API endpoint.
-1. Note that for Prometheus (unlike Mimir), the Alerting UI only supports viewing existing rules, not creating new ones.
+1. Check that Prometheus has alerting rules configured in its rule files.
+1. Ensure Grafana can access the Prometheus rules API endpoint (`/api/v1/rules`).
+1. For Prometheus (unlike Mimir), the Alerting UI only supports viewing existing rules, not creating new ones.
+
+For more information on alerting with Prometheus, refer to [Prometheus alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/alerting/).
 
 ## Get additional help
 


### PR DESCRIPTION
Backport 78e960e62b4d89e9fac7f0798e475afdee54b3ce from #124499

---

Comprehensive documentation overhaul for the Prometheus data source, aligned with data source documentation conventions. Adds annotations and alerting topic pages, restructures existing pages to follow the UI flow, incorporates Grafana v13 changes, and addresses high-priority troubleshooting content.

Manual backport: resolved cherry-pick conflicts in `configure/_index.md` (PDC section) and `template-variables/_index.md` (Filters variable section) by taking the updated content from main.
