### PR TITLE
Home: Omit unviewed dashboards from most used

### DIFF
--- a/public/app/features/browse-dashboards/api/mostUsed.ts
+++ b/public/app/features/browse-dashboards/api/mostUsed.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 
@@ -21,8 +22,7 @@ export async function getMostUsedDashboards(maxItems: number) {
     .toArray()
     .filter(
       (item) =>
-        item.field &&
-        typeof item.field === 'object' &&
+        isObject(item.field) &&
         'views_last_30_days' in item.field &&
         typeof item.field.views_last_30_days === 'number' &&
         item.field.views_last_30_days > 0

--- a/public/app/features/browse-dashboards/api/mostUsed.ts
+++ b/public/app/features/browse-dashboards/api/mostUsed.ts
@@ -17,5 +17,14 @@ export async function getMostUsedDashboards(maxItems: number) {
     sort: MOST_USED_SORT,
     limit: maxItems,
   });
-  return response.view.toArray();
+  return response.view
+    .toArray()
+    .filter(
+      (item) =>
+        item.field &&
+        typeof item.field === 'object' &&
+        'views_last_30_days' in item.field &&
+        typeof item.field.views_last_30_days === 'number' &&
+        item.field.views_last_30_days > 0
+    );
 }

--- a/public/app/features/home/DashboardTabs/DashboardTabs.test.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.test.tsx
@@ -35,6 +35,7 @@ function makeDashboardHit(overrides: Partial<DashboardHit> & { name: string; tit
   return {
     resource: 'dashboards',
     folder: 'general',
+    field: {},
     ...overrides,
   };
 }
@@ -51,8 +52,9 @@ const starredHits: DashboardHit[] = [
 ];
 
 const mostUsedHits: DashboardHit[] = [
-  makeDashboardHit({ name: 'most-used-1', title: 'Most Used Dashboard 1' }),
-  makeDashboardHit({ name: 'most-used-2', title: 'Most Used Dashboard 2' }),
+  makeDashboardHit({ name: 'most-used-1', title: 'Most Used Dashboard 1', field: { views_last_30_days: 100 } }),
+  makeDashboardHit({ name: 'most-used-2', title: 'Most Used Dashboard 2', field: { views_last_30_days: 50 } }),
+  makeDashboardHit({ name: 'most-used-3', title: 'Most Used Dashboard 3', field: { views_last_30_days: null } }),
 ];
 
 function seedRecent(uids: string[]) {
@@ -193,6 +195,19 @@ describe('DashboardTabs', () => {
       expect(await screen.findByText('Recent Dashboard 1')).toBeInTheDocument();
 
       expect(screen.queryByRole('tab', { name: /most used/i })).not.toBeInTheDocument();
+    });
+
+    it('does not render dashboards with no views in the last 30 days', async () => {
+      config.licenseInfo.enabledFeatures = { analytics: true };
+      seedRecent(['recent-1', 'recent-2']);
+      server.use(getCustomSearchHandler(allHits));
+
+      const { user } = render(<DashboardTabs />);
+
+      await user.click(await screen.findByRole('tab', { name: /most used/i }));
+
+      expect(await screen.findByText('Most Used Dashboard 1')).toBeInTheDocument();
+      expect(screen.queryByText('Most Used Dashboard 3')).not.toBeInTheDocument();
     });
 
     it('auto-switches to Most used when recent is empty and most-used has items', async () => {

--- a/public/app/features/home/DashboardTabs/MostUsedDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/MostUsedDashboardsTab.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 
-import { t } from '@grafana/i18n';
-import { EmptyState, useStyles2 } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
+import { EmptyState, Stack, useStyles2 } from '@grafana/ui';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { type DashboardQueryResult, type LocationInfo } from 'app/features/search/service/types';
 import { DashListItem } from 'app/plugins/panel/dashlist/DashListItem';
@@ -20,13 +20,13 @@ export function MostUsedDashboardsTab({ dashboards, loading, error, retry, folde
   const styles = useStyles2(getStyles);
 
   if (loading) {
-    return <PageLoader text={t('home.most-used-dashboards-tab.loading', 'Loading most viewed dashboards...')} />;
+    return <PageLoader text={t('home.most-used-dashboards-tab.loading', 'Loading most used dashboards...')} />;
   }
 
   if (error) {
     return (
       <DashboardTabError
-        title={t('home.most-used-dashboards-tab.error-title', 'Could not load most viewed dashboards')}
+        title={t('home.most-used-dashboards-tab.error-title', 'Could not load most used dashboards')}
         retry={retry}
       />
     );
@@ -34,14 +34,18 @@ export function MostUsedDashboardsTab({ dashboards, loading, error, retry, folde
 
   if (dashboards.length === 0) {
     return (
-      <EmptyState
-        hideImage
-        variant="completed"
-        message={t(
-          'home.most-used-dashboards-tab.empty',
-          'Most viewed dashboards in your organization will appear here once usage data is collected.'
-        )}
-      />
+      <Stack grow={1} direction="column" alignItems="center" justifyContent="center">
+        <EmptyState
+          hideImage
+          variant="completed"
+          message={t('home.most-used-dashboards-tab.empty', 'Most used dashboards will appear here.')}
+        >
+          <Trans i18nKey="home.most-used-dashboards-tab.empty-description">
+            Once your organization has dashboards and usage data has been collected, dashboards with the most views over
+            the last 30 days will be displayed here.
+          </Trans>
+        </EmptyState>
+      </Stack>
     );
   }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10605,9 +10605,10 @@
       "placeholder": "Welcome to {{edition}}."
     },
     "most-used-dashboards-tab": {
-      "empty": "Most viewed dashboards in your organization will appear here once usage data is collected.",
-      "error-title": "Could not load most viewed dashboards",
-      "loading": "Loading most viewed dashboards..."
+      "empty": "Most used dashboards will appear here.",
+      "empty-description": "Once your organization has dashboards and usage data has been collected, dashboards with the most views over the last 30 days will be displayed here.",
+      "error-title": "Could not load most used dashboards",
+      "loading": "Loading most used dashboards..."
     },
     "recent-dashboards-tab": {
       "browse": "Browse dashboards",


### PR DESCRIPTION
**What is this feature?**

Omits any dashboards that do not have any associated views when querying for the most used dashboards on the instance.

Also, updates the empty state to match our other ones a bit closer:

| Before | After |
|-|-|
| <img width="2624" height="512" alt="image" src="https://github.com/user-attachments/assets/7424cdfb-958a-495b-a32e-d92d182eeb50" /> | <img width="2624" height="512" alt="image" src="https://github.com/user-attachments/assets/951c0f9e-9434-4f58-80ba-68a58b99c5a9" /> |

**Why do we need this feature?**

Dashboards were being returned + shown that had no views for fresh instances.

<img width="640" height="167" alt="image" src="https://github.com/user-attachments/assets/0bf2f995-c0f8-476a-8ea8-d1ce377c71c7" />

We should instead be showing the learn tab for fresh instances, where there are no recent/starred/most used dashboards.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana/issues/124136 https://github.com/grafana/grafana/issues/126391 https://github.com/grafana/grafana/pull/125719

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
