### PR TITLE
Docs: wrongfully deprecated Grafonnet (#125785)

### DIFF
--- a/contribute/feature-toggles.md
+++ b/contribute/feature-toggles.md
@@ -159,7 +159,7 @@ If using non-boolean flags (a unique feature of the new feature flag system), ex
 
 For advanced, non-React contexts (utilities, class methods, callbacks), you can use the OpenFeature client directly.
 
-However, because this is seperate from the React render loop there are important caveats you must be aware of:
+However, because this is separate from the React render loop there are important caveats you must be aware of:
 
 - Flag values are loaded asynchronously, so you cannot call `getBooleanValue()` just at the top-level of a module. You must wait until `app.ts` has initialised until you call a flag otherwise you will only get the default value
 - Flag values can change over the lifetime of the session, so do not store or cache the result. Always evaluate flags just in time when you use them, preferably in the if statement, for example.

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -120,7 +120,7 @@ Backporting is the process of copying the pull request into the version branch o
 
 Backporting should be a rare exception, reserved only for critical bug fixes, and must be initiated by a Grafana Labs employee. We generally avoid automatic backports, as these changes carry some risk: they typically receive less manual testing than changes included in regular point releases.
 
-If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, seperate backport PRs will automatically be creataed.
+If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, separate backport PRs will automatically be created.
 
 #### Required labels
 

--- a/docs/sources/as-code/observability-as-code/_index.md
+++ b/docs/sources/as-code/observability-as-code/_index.md
@@ -85,4 +85,4 @@ If you're already using established [Infrastructure as code](ref:infra-as-code) 
   - Manage dashboards, folders, and data sources via Kubernetes Custom Resources.
   - Integrate with GitOps workflows for seamless version control and deployment.
 - [Crossplane](https://github.com/grafana/crossplane-provider-grafana) lets you manage Grafana resources using Kubernetes manifests with the Grafana Crossplane provider.
-- [Grafonnet (deprecated)](https://github.com/grafana/grafonnet) is a Jsonnet library for generating Grafana dashboard JSON definitions programmatically.
+- [Grafonnet](https://github.com/grafana/grafonnet) is a Jsonnet library for generating Grafana dashboard JSON definitions programmatically.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -187,7 +187,7 @@ On this screen, you'll sync the external resources you specified in the previous
 
 To set up synchronization:
 
-1. Select wether you want to store synced resources in a **new folder or at root level** in Grafana. For more information on these options, refer to [Sync targets](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts#sync-targets/). The UI provides information about the available resources you can sync.
+1. Select whether you want to store synced resources in a **new folder or at root level** in Grafana. For more information on these options, refer to [Sync targets](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts#sync-targets/). The UI provides information about the available resources you can sync.
 1. Enter a **Display name** for your repository connection. All the synced resources from this Git Sync connection will appear under the this name in the Grafana UI.
 1. Click **Synchronize with external storage** to continue.
 1. You can repeat this process for up to 10 connections.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR corrects the Observability as code documentation by removing the incorrect "deprecated" label from Grafonnet. Grafonnet remains an active Jsonnet library for programmatically generating Grafana dashboard JSON definitions, and the docs should reflect its current supported status.


**Why do we need this feature?**

The Observability as code overview page incorrectly marks Grafonnet as deprecated. This is misleading for users and teams who rely on Grafonnet for dashboard generation in their IaC workflows. The Grafonnet maintainers have also confirmed that the project is not deprecated. This change restores accurate documentation and prevents users from unnecessarily migrating away from a still-supported tool.

**Who is this feature for?**

This is for users and teams who use Grafonnet as part of their Infrastructure as Code or Observability as Code workflows, especially those evaluating Grafana’s programmatic dashboard tooling and consulting the official documentation for guidance.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes [125785](https://github.com/grafana/grafana/issues/125785)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
