### PR TITLE
[release-12.4.5] Snapshots: Fix error handling on duplicated keys

### DIFF
--- a/pkg/services/dashboardsnapshots/database/database.go
+++ b/pkg/services/dashboardsnapshots/database/database.go
@@ -67,10 +67,15 @@ func (d *DashboardSnapshotStore) CreateDashboardSnapshot(ctx context.Context, cm
 			Created:            time.Now(),
 			Updated:            time.Now(),
 		}
-		_, err := sess.Insert(snapshot)
-		result = snapshot
+		if _, err := sess.Insert(snapshot); err != nil {
+			if d.store.GetDialect().IsUniqueConstraintViolation(err) {
+				return dashboardsnapshots.ErrDashboardSnapshotAlreadyExists.Errorf("snapshot with the same key already exists")
+			}
+			return err
+		}
 
-		return err
+		result = snapshot
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/services/dashboardsnapshots/database/database_test.go
+++ b/pkg/services/dashboardsnapshots/database/database_test.go
@@ -159,6 +159,56 @@ func TestIntegrationDashboardSnapshotDBAccess(t *testing.T) {
 	})
 }
 
+func TestIntegrationDashboardSnapshotDuplicateKey(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sqlstore := db.InitTestDB(t)
+	dashStore := NewStore(sqlstore)
+
+	t.Run("inserting a snapshot with a duplicate key returns ErrDashboardSnapshotAlreadyExists", func(t *testing.T) {
+		first := dashboardsnapshots.CreateDashboardSnapshotCommand{
+			Key: "dupkey", DeleteKey: "del-a", UserID: 1000, OrgID: 1,
+		}
+		_, err := dashStore.CreateDashboardSnapshot(context.Background(), &first)
+		require.NoError(t, err)
+
+		second := dashboardsnapshots.CreateDashboardSnapshotCommand{
+			Key: "dupkey", DeleteKey: "del-b", UserID: 1000, OrgID: 1,
+		}
+		_, err = dashStore.CreateDashboardSnapshot(context.Background(), &second)
+		require.ErrorIs(t, err, dashboardsnapshots.ErrDashboardSnapshotAlreadyExists)
+	})
+
+	t.Run("inserting a snapshot with a duplicate delete_key returns ErrDashboardSnapshotAlreadyExists", func(t *testing.T) {
+		first := dashboardsnapshots.CreateDashboardSnapshotCommand{
+			Key: "key-a", DeleteKey: "dupdelete", UserID: 1000, OrgID: 1,
+		}
+
+		_, err := dashStore.CreateDashboardSnapshot(context.Background(), &first)
+		require.NoError(t, err)
+
+		second := dashboardsnapshots.CreateDashboardSnapshotCommand{
+			Key: "key-b", DeleteKey: "dupdelete", UserID: 1000, OrgID: 1,
+		}
+		_, err = dashStore.CreateDashboardSnapshot(context.Background(), &second)
+		require.ErrorIs(t, err, dashboardsnapshots.ErrDashboardSnapshotAlreadyExists)
+	})
+
+	t.Run("inserting snapshots with unique keys succeeds", func(t *testing.T) {
+		first := dashboardsnapshots.CreateDashboardSnapshotCommand{
+			Key: "unique-a", DeleteKey: "unique-del-a", UserID: 1000, OrgID: 1,
+		}
+		_, err := dashStore.CreateDashboardSnapshot(context.Background(), &first)
+		require.NoError(t, err)
+
+		second := dashboardsnapshots.CreateDashboardSnapshotCommand{
+			Key: "unique-b", DeleteKey: "unique-del-b", UserID: 1000, OrgID: 1,
+		}
+		_, err = dashStore.CreateDashboardSnapshot(context.Background(), &second)
+		require.NoError(t, err)
+	})
+}
+
 func TestIntegrationDeleteExpiredSnapshots(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 

--- a/pkg/services/dashboardsnapshots/errors.go
+++ b/pkg/services/dashboardsnapshots/errors.go
@@ -5,3 +5,5 @@ import (
 )
 
 var ErrBaseNotFound = errutil.NotFound("dashboardsnapshots.not-found", errutil.WithPublicMessage("Snapshot not found"))
+
+var ErrDashboardSnapshotAlreadyExists = errutil.Conflict("dashboardsnapshots.keyAlreadyExists", errutil.WithPublicMessage("Snapshot key already exists"))

--- a/pkg/services/dashboardsnapshots/service.go
+++ b/pkg/services/dashboardsnapshots/service.go
@@ -165,7 +165,7 @@ func prepareLocalSnapshot(cmd *CreateDashboardSnapshotCommand, originalDashboard
 func saveAndRespond(c *contextmodel.ReqContext, svc Service, cmd CreateDashboardSnapshotCommand, snapshotURL string) {
 	result, err := svc.CreateDashboardSnapshot(c.Req.Context(), &cmd)
 	if err != nil {
-		c.JsonApiErr(http.StatusInternalServerError, "Failed to create snapshot", err)
+		c.WriteErrOrFallback(http.StatusInternalServerError, "Failed to create snapshot", err)
 		return
 	}
 

--- a/pkg/services/dashboardsnapshots/service_test.go
+++ b/pkg/services/dashboardsnapshots/service_test.go
@@ -2,6 +2,7 @@ package dashboardsnapshots
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -226,6 +227,136 @@ func TestCreateDashboardSnapshot(t *testing.T) {
 		assert.Equal(t, "local-delete-key", response["deleteKey"])
 		assert.Contains(t, response["url"], "dashboard/snapshot/local-key")
 		assert.Contains(t, response["deleteUrl"], "api/snapshots-delete/local-delete-key")
+	})
+
+	t.Run("should return 409 when snapshot key already exists", func(t *testing.T) {
+		mockService := NewMockService(t)
+		cfg := snapshot.SnapshotSharingOptions{
+			SnapshotsEnabled: true,
+		}
+		testUser := createTestUser()
+		dashboard := createTestDashboard(t)
+
+		cmd := CreateDashboardSnapshotCommand{
+			DashboardCreateCommand: snapshot.DashboardCreateCommand{
+				Dashboard: dashboard,
+				Name:      "Test Local Snapshot",
+			},
+			Key:       "local-key",
+			DeleteKey: "local-delete-key",
+		}
+
+		mockService.On("ValidateDashboardExists", mock.Anything, int64(1), "test-dashboard-uid").
+			Return(nil)
+		// The .Errorf arg simulates the raw DB string the store wraps; the test asserts
+		// it never reaches the client.
+		mockService.On("CreateDashboardSnapshot", mock.Anything, mock.Anything).
+			Return(nil, ErrDashboardSnapshotAlreadyExists.Errorf("insert dashboard_snapshot: UNIQUE constraint failed"))
+
+		req, _ := http.NewRequest("POST", "/api/snapshots", nil)
+		req = req.WithContext(identity.WithRequester(req.Context(), testUser))
+		ctx, recorder := createReqContext(t, req, testUser)
+
+		CreateDashboardSnapshot(ctx, cfg, cmd, mockService)
+
+		mockService.AssertExpectations(t)
+		assert.Equal(t, http.StatusConflict, recorder.Code)
+
+		var response map[string]any
+		err := json.Unmarshal(recorder.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, "dashboardsnapshots.keyAlreadyExists", response["messageId"])
+		assert.Equal(t, "Snapshot key already exists", response["message"])
+		// The raw DB error must not leak to the client.
+		assert.NotContains(t, response["message"], "UNIQUE constraint")
+	})
+
+	t.Run("should return 500 when the store fails with a generic error", func(t *testing.T) {
+		mockService := NewMockService(t)
+		cfg := snapshot.SnapshotSharingOptions{
+			SnapshotsEnabled: true,
+		}
+		testUser := createTestUser()
+		dashboard := createTestDashboard(t)
+
+		cmd := CreateDashboardSnapshotCommand{
+			DashboardCreateCommand: snapshot.DashboardCreateCommand{
+				Dashboard: dashboard,
+				Name:      "Test Local Snapshot",
+			},
+			Key:       "local-key",
+			DeleteKey: "local-delete-key",
+		}
+
+		//pass the dashboard-exists check
+		mockService.On("ValidateDashboardExists", mock.Anything, int64(1), "test-dashboard-uid").
+			Return(nil)
+
+		// make store return a plain error (not the sentinel)
+
+		mockService.On("CreateDashboardSnapshot", mock.Anything, mock.Anything).
+			Return(nil, errors.New("connection refused"))
+
+		req, _ := http.NewRequest("POST", "/api/snapshots", nil)
+		req = req.WithContext(identity.WithRequester(req.Context(), testUser))
+		ctx, recorder := createReqContext(t, req, testUser)
+
+		CreateDashboardSnapshot(ctx, cfg, cmd, mockService)
+
+		mockService.AssertExpectations(t)
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+
+		var response map[string]any
+		err := json.Unmarshal(recorder.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, "Failed to create snapshot", response["message"])
+		assert.NotContains(t, response["message"], "connection refused")
+	})
+
+	t.Run("should generate a key when none is supplied and return 200", func(t *testing.T) {
+		mockService := NewMockService(t)
+		cfg := snapshot.SnapshotSharingOptions{
+			SnapshotsEnabled: true,
+		}
+		testUser := createTestUser()
+		dashboard := createTestDashboard(t)
+
+		// No Key / DeleteKey supplied — the handler must generate them.
+		cmd := CreateDashboardSnapshotCommand{
+			DashboardCreateCommand: snapshot.DashboardCreateCommand{
+				Dashboard: dashboard,
+				Name:      "Test Local Snapshot",
+			},
+		}
+
+		mockService.On("ValidateDashboardExists", mock.Anything, int64(1), "test-dashboard-uid").
+			Return(nil)
+
+		// Capture the command the handler passes to the store so we can prove the keys
+		// were generated server-side before the insert.
+		var capturedCmd *CreateDashboardSnapshotCommand
+		mockService.On("CreateDashboardSnapshot", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				capturedCmd = args.Get(1).(*CreateDashboardSnapshotCommand)
+			}).
+			Return(&DashboardSnapshot{
+				Key:       "server-generated-key",
+				DeleteKey: "server-generated-delete-key",
+			}, nil)
+
+		req, _ := http.NewRequest("POST", "/api/snapshots", nil)
+		req = req.WithContext(identity.WithRequester(req.Context(), testUser))
+		ctx, recorder := createReqContext(t, req, testUser)
+
+		CreateDashboardSnapshot(ctx, cfg, cmd, mockService)
+
+		mockService.AssertExpectations(t)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		// The request supplied no keys, so the server must have generated them.
+		require.NotNil(t, capturedCmd)
+		assert.NotEmpty(t, capturedCmd.Key)
+		assert.NotEmpty(t, capturedCmd.DeleteKey)
 	})
 }
 


### PR DESCRIPTION
Backport a67a764fe55c8fa11ecce64510b1519e4edcd8de from #126086

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
In legacy and k8s snapshots apis we were returning error 500 for existing `Key` and `DeleteKey` instead of 409, this PR fixes that issue and add unit tests.

Coming from: https://github.com/grafana/support-escalations/issues/22707

### Manual Test (legacy path)

This fix is exercised on the legacy snapshot path, so ensure kubernetesSnapshots is off (it routes /api/snapshots to the apiserver otherwise):

#### conf/custom.ini
```
[feature_toggles]
kubernetesSnapshots = false
```

1. Create a snapshot against an existing dashboard and note the returned key:
```
curl -s -u admin:admin -X POST http://localhost:3000/api/snapshots \
  -H 'Content-Type: application/json' \
  -d '{"dashboard":{"uid":"<existing-dashboard-uid>"},"name":"test"}' \
  -w '
HTTP %{http_code}
'
```
Take a look at the response→ HTTP 200 with {"key":"...","deleteKey":"...", ...}

2. Replay the request with that key to force a duplicate:
```
curl -s -u admin:admin -X POST http://localhost:3000/api/snapshots \
  -H 'Content-Type: application/json' \
  -d '{"dashboard":{"uid":"<existing-dashboard-uid>"},"name":"test","key":"<key-from-step-1>"}' \
  -w '
HTTP %{http_code}
'
```

  - Before: HTTP 500 {"message":"Failed to create snapshot"}
  - After: HTTP 409 {"message":"Snapshot key already exists","messageId":"dashboardsnapshots.keyAlreadyExists"}

3. Regression: a normal create (no key) still returns HTTP 200.

The uid must be an existing dashboard, or the request returns 400 "Dashboard not found" before reaching the insert.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
