### PR TITLE
Geomap: Fix fit to data after route subselection

### DIFF
--- a/public/app/plugins/panel/geomap/GeomapPanel.test.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.test.tsx
@@ -183,6 +183,8 @@ describe('GeomapPanel - View Listener', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    const { centerPointRegistry } = require('./view');
+    centerPointRegistry.getIfExists.mockReturnValue(null);
 
     // Suppress expected React warnings about setState before mount
     jest.spyOn(console, 'error').mockImplementation((message) => {
@@ -491,9 +493,27 @@ describe('GeomapPanel - View Listener', () => {
       expect(mockMap.updateSize).toHaveBeenCalled();
     });
 
-    it('should handle data changes', async () => {
+    it('should not handle data changes before new props are committed', async () => {
+      const { applyLayerFilter } = require('./utils/layers');
+      const { centerPointRegistry } = require('./view');
+      centerPointRegistry.getIfExists.mockImplementation((id: string) =>
+        id === 'fit' ? { id: 'fit' } : null
+      );
+
+      panel = new GeomapPanel({
+        ...props,
+        options: {
+          ...props.options,
+          view: {
+            ...props.options.view,
+            id: 'fit',
+          },
+        },
+      });
+
       const div = document.createElement('div');
       await panel.initMapAsync(div);
+      jest.clearAllMocks();
 
       const newData = {
         ...props.data,
@@ -506,7 +526,8 @@ describe('GeomapPanel - View Listener', () => {
       };
 
       panel.shouldComponentUpdate(newProps);
-      expect(panel.props.data).not.toBe(newData);
+      expect(applyLayerFilter).not.toHaveBeenCalled();
+      expect(mockMap.setView).not.toHaveBeenCalled();
     });
 
     it('should handle componentDidUpdate for dimension changes', async () => {
@@ -765,7 +786,43 @@ describe('GeomapPanel - View Listener', () => {
       panel.dataChanged(newData);
       // Verify applyLayerFilter is called via mock
       const { applyLayerFilter } = require('./utils/layers');
-      expect(applyLayerFilter).toHaveBeenCalled();
+      expect(applyLayerFilter).toHaveBeenCalledWith(expect.anything(), expect.anything(), newData);
+    });
+
+    it('should refit to data after the new panel data is committed', async () => {
+      const { applyLayerFilter } = require('./utils/layers');
+      const { centerPointRegistry } = require('./view');
+      centerPointRegistry.getIfExists.mockImplementation((id: string) =>
+        id === 'fit' ? { id: 'fit' } : null
+      );
+
+      panel = new GeomapPanel({
+        ...props,
+        options: {
+          ...props.options,
+          view: {
+            ...props.options.view,
+            id: 'fit',
+          },
+        },
+      });
+
+      const div = document.createElement('div');
+      await panel.initMapAsync(div);
+      jest.clearAllMocks();
+
+      const prevProps = props;
+      const newData = {
+        ...props.data,
+        series: [{ fields: [], length: 0 }],
+      };
+
+      Object.assign(panel.props, { data: newData });
+
+      panel.componentDidUpdate(prevProps);
+
+      expect(applyLayerFilter).toHaveBeenCalledWith(expect.anything(), expect.anything(), newData);
+      expect(mockMap.setView).toHaveBeenCalledWith(mockView);
     });
   });
 

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -152,11 +152,6 @@ export class GeomapPanel extends Component<Props, State> {
       }
     }
 
-    // External data changed
-    if (this.props.data !== nextProps.data) {
-      this.dataChanged(nextProps.data);
-    }
-
     return true; // always?
   }
 
@@ -246,11 +241,8 @@ export class GeomapPanel extends Component<Props, State> {
    * Called when PanelData changes (query results etc)
    */
   dataChanged(data: PanelData) {
-    // Only update if panel data matches component data
-    if (data === this.props.data) {
-      for (const state of this.layers) {
-        applyLayerFilter(state.handler, state.options, this.props.data);
-      }
+    for (const state of this.layers) {
+      applyLayerFilter(state.handler, state.options, data);
     }
 
     // Because data changed, check map view and change if needed (data fit)

--- a/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
@@ -29,6 +29,7 @@ import { StyleEditor } from '../../editor/StyleEditor';
 import { routeStyle } from '../../style/markers';
 import { defaultStyleConfig, type StyleConfig } from '../../style/types';
 import { getStyleConfigState } from '../../style/utils';
+import { EXCLUDE_FROM_FIT_TO_DATA } from '../../utils/getLayersExtent';
 import { getStyleDimension, isSegmentVisible } from '../../utils/utils';
 
 // Configuration options for Circle overlays
@@ -215,6 +216,7 @@ export const routeLayer: MapLayerRegistryItem<RouteConfig> = {
       }),
       style: crosshairStyle,
     });
+    crosshairLayer.set(EXCLUDE_FROM_FIT_TO_DATA, true);
 
     const linesLayer = new VectorImage({
       source: new VectorSource({
@@ -222,6 +224,7 @@ export const routeLayer: MapLayerRegistryItem<RouteConfig> = {
       }),
       style: lineStyle,
     });
+    linesLayer.set(EXCLUDE_FROM_FIT_TO_DATA, true);
 
     const layer = new LayerGroup({
       layers: [vectorLayer, crosshairLayer, linesLayer],

--- a/public/app/plugins/panel/geomap/utils/getLayersExtent.test.ts
+++ b/public/app/plugins/panel/geomap/utils/getLayersExtent.test.ts
@@ -7,7 +7,7 @@ import VectorSource from 'ol/source/Vector';
 
 import { type MapLayerState } from '../types';
 
-import { getLayerGroupExtent, getLayersExtent } from './getLayersExtent';
+import { EXCLUDE_FROM_FIT_TO_DATA, getLayerGroupExtent, getLayersExtent } from './getLayersExtent';
 
 type TestVectorLayer = VectorLayer<VectorSource<Feature<Geometry>>>;
 
@@ -85,5 +85,27 @@ describe('getLayerGroupExtent', () => {
 
     const extents = getLayerGroupExtent(group, true);
     expect(extents[0]).toEqual([9, 9, 9, 9]);
+  });
+
+  it('should skip helper layers excluded from fit-to-data extents', () => {
+    const dataSource = new VectorSource({ features: [new Feature(new Point([10, 10]))] });
+    const dataLayer = new VectorLayer({ source: dataSource });
+
+    const helperSource = new VectorSource({
+      features: [
+        new Feature(
+          new LineString([
+            [0, 0],
+            [100, 100],
+          ])
+        ),
+      ],
+    });
+    const helperLayer = new VectorLayer({ source: helperSource });
+    helperLayer.set(EXCLUDE_FROM_FIT_TO_DATA, true);
+
+    const group = new LayerGroup({ layers: [dataLayer, helperLayer] });
+
+    expect(getLayerGroupExtent(group, false)).toEqual([dataSource.getExtent()]);
   });
 });

--- a/public/app/plugins/panel/geomap/utils/getLayersExtent.ts
+++ b/public/app/plugins/panel/geomap/utils/getLayersExtent.ts
@@ -1,10 +1,13 @@
 import { createEmpty, extend, type Extent } from 'ol/extent';
+import type BaseLayer from 'ol/layer/Base';
 import LayerGroup from 'ol/layer/Group';
 import VectorLayer from 'ol/layer/Vector';
 import VectorImage from 'ol/layer/VectorImage';
 import WebGLPointsLayer from 'ol/layer/WebGLPoints.js';
 
 import { type MapLayerState } from '../types';
+
+export const EXCLUDE_FROM_FIT_TO_DATA = 'excludeFromFitToData';
 
 export function getLayersExtent(
   layers: MapLayerState[] = [],
@@ -52,7 +55,11 @@ export function getLayerGroupExtent(lg: LayerGroup, lastOnly: boolean) {
   return lg
     .getLayers()
     .getArray()
-    .filter((l) => l instanceof VectorLayer || l instanceof VectorImage || l instanceof WebGLPointsLayer)
+    .filter(
+      (l) =>
+        (l instanceof VectorLayer || l instanceof VectorImage || l instanceof WebGLPointsLayer) &&
+        isIncludedInFitToData(l)
+    )
     .map((l) => {
       if (l instanceof VectorLayer || l instanceof VectorImage || l instanceof WebGLPointsLayer) {
         if (lastOnly) {
@@ -77,4 +84,8 @@ export function getLayerGroupExtent(lg: LayerGroup, lastOnly: boolean) {
         return [];
       }
     });
+}
+
+function isIncludedInFitToData(layer: BaseLayer) {
+  return layer.get(EXCLUDE_FROM_FIT_TO_DATA) !== true;
 }


### PR DESCRIPTION
**What is this feature?**

Updates the Geomap panel so Fit to data refits route layers after dashboard time range subselections or drill-downs. Route crosshair helper layers are excluded from fit extent calculations, and panel data updates are applied after the new data props are committed.

**Why do we need this feature?**

When a dashboard graph subselection narrows the time range, route layer data updates but the map viewport can stay fitted to the previous, larger route extent.

**Who is this feature for?**

Users who rely on Geomap route layers with Fit to data and dashboard time range drill-downs.

**Which issue(s) does this PR fix?**:

Fixes #112009

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a notable improvement, it's added to the What's New doc.

Tests:
- yarn jest --no-watch public/app/plugins/panel/geomap/GeomapPanel.test.tsx public/app/plugins/panel/geomap/utils/getLayersExtent.test.ts
- yarn eslint --no-error-on-unmatched-pattern public/app/plugins/panel/geomap/GeomapPanel.tsx public/app/plugins/panel/geomap/GeomapPanel.test.tsx public/app/plugins/panel/geomap/layers/data/routeLayer.tsx public/app/plugins/panel/geomap/utils/getLayersExtent.ts public/app/plugins/panel/geomap/utils/getLayersExtent.test.ts