### PR TITLE
Alerting: Improve Config singleton seeding + lock down creation

### DIFF
--- a/pkg/registry/apps/alerting/notifications/config/authorize.go
+++ b/pkg/registry/apps/alerting/notifications/config/authorize.go
@@ -13,11 +13,17 @@ import (
 // Authorize maps k8s verbs on Config (and its /status subresource) to RBAC
 // actions. Config is a per-org singleton:
 //   - get/list/watch → read (Viewer)
-//   - create/patch/update → update (Admin). create is gated by the update
-//     permission (not rejected) because the singleton must be creatable via the
-//     API — and an upsert (PUT/apply to a missing object) is authorized by the
-//     apiserver as create. The singleton-name check lives in the admission
-//     validator, not here.
+//   - patch/update → update (Admin).
+//   - create → service identity only. The singleton is seeded automatically by
+//     the sync worker, so humans never create it — they only read/update the
+//     already-seeded object. Gated on IsServiceIdentity rather than RBAC because
+//     both humans and the service identity hold configs:update; we can't simply
+//     deny create (that would block the seeder, which creates through this same
+//     authorizer) nor drop it (it would fall through to the org-role authorizer,
+//     which allows Admins). This also covers GitOps create-on-update: a PUT/apply
+//     to a *missing* object is re-authorized by the apiserver as create, so it's
+//     denied here too; once the object exists a PUT/apply is an update and is
+//     allowed. The singleton-name check lives in the admission validator, not here.
 //   - delete/deletecollection → always rejected (deleting the singleton would
 //     nuke every admin setting it carries; reset individual fields via update)
 //   - status writes → service identity only (sync worker owns it; see
@@ -50,7 +56,14 @@ func Authorize(ctx context.Context, ac accesscontrol.AccessControl, attr authori
 		switch attr.GetVerb() {
 		case "get", "list", "watch":
 			action = accesscontrol.EvalPermission(accesscontrol.ActionAlertingConfigRead, scope)
-		case "create", "patch", "update":
+		case "create":
+			// The singleton is seeded automatically by the sync worker (service
+			// identity); humans/GitOps update the seeded object, never create it.
+			if !identity.IsServiceIdentity(ctx) {
+				return authorizer.DecisionDeny, "Config is a singleton seeded automatically; it cannot be created via the API", nil
+			}
+			action = accesscontrol.EvalPermission(accesscontrol.ActionAlertingConfigUpdate, scope)
+		case "patch", "update":
 			action = accesscontrol.EvalPermission(accesscontrol.ActionAlertingConfigUpdate, scope)
 		case "delete", "deletecollection":
 			return authorizer.DecisionDeny, "Config is a singleton and cannot be deleted", nil

--- a/pkg/registry/apps/alerting/notifications/config/authorize_test.go
+++ b/pkg/registry/apps/alerting/notifications/config/authorize_test.go
@@ -90,10 +90,13 @@ func TestAuthorize(t *testing.T) {
 		{name: "status patch permitted", id: idHuman, verb: "patch", subresource: "status", rbac: true, wantAction: accesscontrol.ActionAlertingConfigStatusUpdate, want: authorizer.DecisionAllow},
 		{name: "status create permitted", id: idHuman, verb: "create", subresource: "status", rbac: true, wantAction: accesscontrol.ActionAlertingConfigStatusUpdate, want: authorizer.DecisionAllow},
 
-		// create is gated by the update permission: the singleton must be creatable
-		// via the API, and an upsert (PUT to a missing object) is authorized as create.
-		{name: "create permitted with update", id: idHuman, verb: "create", rbac: true, wantAction: accesscontrol.ActionAlertingConfigUpdate, want: authorizer.DecisionAllow},
-		{name: "create denied without update", id: idHuman, verb: "create", rbac: false, wantAction: accesscontrol.ActionAlertingConfigUpdate, want: authorizer.DecisionDeny},
+		// create is service-identity only: the singleton is seeded automatically, so
+		// humans/GitOps are denied (without consulting RBAC) and update the seeded
+		// object instead. The service identity (the seeder) is gated on the update
+		// permission like any other write.
+		{name: "human create denied even with update", id: idHuman, verb: "create", rbac: true, want: authorizer.DecisionDeny, wantReason: "Config is a singleton seeded automatically; it cannot be created via the API"},
+		{name: "service create permitted with update", id: idService, verb: "create", rbac: true, wantAction: accesscontrol.ActionAlertingConfigUpdate, want: authorizer.DecisionAllow},
+		{name: "service create denied without update", id: idService, verb: "create", rbac: false, wantAction: accesscontrol.ActionAlertingConfigUpdate, want: authorizer.DecisionDeny},
 
 		// delete/deletecollection are always rejected (destructive on a singleton).
 		{name: "delete denied", id: idService, verb: "delete", rbac: true, want: authorizer.DecisionDeny},

--- a/pkg/services/ngalert/notifier/external_am_syncer.go
+++ b/pkg/services/ngalert/notifier/external_am_syncer.go
@@ -56,13 +56,13 @@ type mimirConfigResponse struct {
 // status.conditions[] without collision.
 const conditionTypeExternalAlertmanagerSynced = "ExternalAlertmanagerSynced"
 
-// conditionReasonSyncSucceeded is the success-branch reason. Failure
-// reasons come from SyncReason.ConditionReason().
-const conditionReasonSyncSucceeded = "SyncSucceeded"
-
-// conditionReasonMergeCommitted is the terminal reason once the config was
-// imported as a managed route: sync stops and the admin owns it from here.
-const conditionReasonMergeCommitted = "MergeCommitted"
+// ExternalAlertmanagerSynced condition reasons (failure reasons come from
+// SyncReason.ConditionReason()).
+const (
+	conditionReasonSyncSucceeded  = "SyncSucceeded"  // a sync attempt succeeded
+	conditionReasonMergeCommitted = "MergeCommitted" // imported as a managed route; sync stops
+	conditionReasonNotConfigured  = "NotConfigured"  // flag on, but no UID configured → Synced=Unknown
+)
 
 const mergeCommittedMessage = "The external Alertmanager configuration has already been merged into Grafana; automatic sync from the datasource has stopped."
 
@@ -297,8 +297,9 @@ func (s *ExternalAMSyncer) FetchExtraConfig(ctx context.Context, orgID int64) (*
 	}
 	if uid == "" {
 		// Flag on but sync isn't configured here (no ini override, no spec UID):
-		// seed the singleton so it reliably exists without a manual create.
-		s.ensureConfigSeeded(ctx, orgID)
+		// record Unknown/NotConfigured, which also seeds the singleton (writeStatus
+		// creates on missing) so it reliably exists without a manual create.
+		s.recordNotConfigured(ctx, orgID)
 		return nil, 0
 	}
 
@@ -415,36 +416,13 @@ func (s *ExternalAMSyncer) recordMergeCommitted(ctx context.Context, orgID int64
 	})
 }
 
-// ensureConfigSeeded creates the org's Config singleton with an empty doc if it
-// does not yet exist, so the resource reliably exists without a manual create.
-// Called on the flag-on-but-unconfigured path. Best-effort: failures are logged
-// and never block the sync loop — an empty doc is semantically identical to an
-// absent one, so a missed seed is harmless and the next tick retries.
-func (s *ExternalAMSyncer) ensureConfigSeeded(ctx context.Context, orgID int64) {
-	c, err := s.resolveCfgClient()
-	if err != nil {
-		s.logger.Warn("Failed to resolve Config client for seeding", "org_id", orgID, "error", err)
-		return
-	}
-	nsCtx, ns := s.orgServiceContext(ctx, orgID)
-	if ns == "" {
-		return
-	}
-	id := resource.Identifier{Namespace: ns, Name: alertingnotifv0alpha1.ConfigSingletonName}
-
-	if _, getErr := c.Get(nsCtx, id); getErr == nil {
-		return // already exists
-	} else if !k8serrors.IsNotFound(getErr) {
-		s.logger.Warn("Failed to check Config singleton for seeding", "org_id", orgID, "error", getErr)
-		return
-	}
-
-	r := &alertingnotifv0alpha1.Config{
-		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: alertingnotifv0alpha1.ConfigSingletonName},
-	}
-	if _, createErr := c.Create(nsCtx, r, resource.CreateOptions{}); createErr != nil && !k8serrors.IsAlreadyExists(createErr) {
-		s.logger.Warn("Failed to seed Config singleton", "org_id", orgID, "error", createErr)
-	}
+// recordNotConfigured records Synced=Unknown/NotConfigured for the org, seeding
+// the singleton if absent (writeStatus creates on missing). Best-effort.
+func (s *ExternalAMSyncer) recordNotConfigured(ctx context.Context, orgID int64) {
+	now := time.Now()
+	s.writeStatus(ctx, orgID, func(prev *alertingnotifv0alpha1.ConfigStatus) alertingnotifv0alpha1.ConfigStatus {
+		return computeNotConfiguredStatus(prev, now)
+	})
 }
 
 // writeStatus upserts the org's Config.status using compute(prev), creating the
@@ -506,6 +484,40 @@ func computeSyncStatus(prev *alertingnotifv0alpha1.ConfigStatus, uid string, ori
 // stays True (so the synced-at timestamp is kept), reason flips to MergeCommitted.
 func computeCommittedStatus(prev *alertingnotifv0alpha1.ConfigStatus, uid string, origin externalSyncOrigin, now time.Time) alertingnotifv0alpha1.ConfigStatus {
 	return buildSyncStatus(prev, uid, origin, alertingnotifv0alpha1.ConfigConditionStatusTrue, conditionReasonMergeCommitted, mergeCommittedMessage, now)
+}
+
+// computeNotConfiguredStatus returns prev with only the ExternalAlertmanagerSynced
+// condition updated to Unknown/NotConfigured (used when the flag is on but no UID
+// is configured). Everything else rides through unchanged: observedGeneration,
+// externalAlertmanagerSync (kept as the last-attempt context, its documented
+// meaning) and any sibling conditions. The Synced condition is a current-state
+// snapshot — no preserved MergeCommitted/SyncSucceeded — and its lastTransitionTime
+// advances only on a flip to Unknown, so consecutive not-configured ticks produce
+// an identical status that dedups to no write.
+func computeNotConfiguredStatus(prev *alertingnotifv0alpha1.ConfigStatus, now time.Time) alertingnotifv0alpha1.ConfigStatus {
+	st := alertingnotifv0alpha1.ConfigStatus{}
+	if prev != nil {
+		st = *prev
+		st.Conditions = append([]alertingnotifv0alpha1.ConfigCondition(nil), prev.Conditions...)
+	}
+
+	synced := alertingnotifv0alpha1.ConfigCondition{
+		Type:               conditionTypeExternalAlertmanagerSynced,
+		Status:             alertingnotifv0alpha1.ConfigConditionStatusUnknown,
+		LastTransitionTime: now.UTC().Format(time.RFC3339),
+		Reason:             conditionReasonNotConfigured,
+	}
+	for i, c := range st.Conditions {
+		if c.Type == conditionTypeExternalAlertmanagerSynced {
+			if c.Status == alertingnotifv0alpha1.ConfigConditionStatusUnknown {
+				synced.LastTransitionTime = c.LastTransitionTime // no flip → keep the timestamp
+			}
+			st.Conditions[i] = synced
+			return st
+		}
+	}
+	st.Conditions = append(st.Conditions, synced)
+	return st
 }
 
 // buildSyncStatus folds an ExternalAlertmanagerSynced condition into prev. k8s

--- a/pkg/services/ngalert/notifier/external_am_syncer.go
+++ b/pkg/services/ngalert/notifier/external_am_syncer.go
@@ -296,6 +296,9 @@ func (s *ExternalAMSyncer) FetchExtraConfig(ctx context.Context, orgID int64) (*
 		return nil, 0
 	}
 	if uid == "" {
+		// Flag on but sync isn't configured here (no ini override, no spec UID):
+		// seed the singleton so it reliably exists without a manual create.
+		s.ensureConfigSeeded(ctx, orgID)
 		return nil, 0
 	}
 
@@ -410,6 +413,38 @@ func (s *ExternalAMSyncer) recordMergeCommitted(ctx context.Context, orgID int64
 	s.writeStatus(ctx, orgID, func(prev *alertingnotifv0alpha1.ConfigStatus) alertingnotifv0alpha1.ConfigStatus {
 		return computeCommittedStatus(prev, uid, origin, now)
 	})
+}
+
+// ensureConfigSeeded creates the org's Config singleton with an empty doc if it
+// does not yet exist, so the resource reliably exists without a manual create.
+// Called on the flag-on-but-unconfigured path. Best-effort: failures are logged
+// and never block the sync loop — an empty doc is semantically identical to an
+// absent one, so a missed seed is harmless and the next tick retries.
+func (s *ExternalAMSyncer) ensureConfigSeeded(ctx context.Context, orgID int64) {
+	c, err := s.resolveCfgClient()
+	if err != nil {
+		s.logger.Warn("Failed to resolve Config client for seeding", "org_id", orgID, "error", err)
+		return
+	}
+	nsCtx, ns := s.orgServiceContext(ctx, orgID)
+	if ns == "" {
+		return
+	}
+	id := resource.Identifier{Namespace: ns, Name: alertingnotifv0alpha1.ConfigSingletonName}
+
+	if _, getErr := c.Get(nsCtx, id); getErr == nil {
+		return // already exists
+	} else if !k8serrors.IsNotFound(getErr) {
+		s.logger.Warn("Failed to check Config singleton for seeding", "org_id", orgID, "error", getErr)
+		return
+	}
+
+	r := &alertingnotifv0alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: alertingnotifv0alpha1.ConfigSingletonName},
+	}
+	if _, createErr := c.Create(nsCtx, r, resource.CreateOptions{}); createErr != nil && !k8serrors.IsAlreadyExists(createErr) {
+		s.logger.Warn("Failed to seed Config singleton", "org_id", orgID, "error", createErr)
+	}
 }
 
 // writeStatus upserts the org's Config.status using compute(prev), creating the

--- a/pkg/services/ngalert/notifier/external_am_syncer_status_test.go
+++ b/pkg/services/ngalert/notifier/external_am_syncer_status_test.go
@@ -307,3 +307,134 @@ func TestComputeCommittedStatus(t *testing.T) {
 		assert.Equal(t, nowRFC, c.LastTransitionTime, "flip False->True advances the timestamp")
 	})
 }
+
+func TestComputeNotConfiguredStatus(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	earlier := time.Date(2026, 5, 19, 9, 0, 0, 0, time.UTC)
+	nowRFC := now.UTC().Format(time.RFC3339)
+	earlRFC := earlier.UTC().Format(time.RFC3339)
+
+	findSynced := func(t *testing.T, st alertingnotifv0alpha1.ConfigStatus) alertingnotifv0alpha1.ConfigCondition {
+		t.Helper()
+		for _, c := range st.Conditions {
+			if c.Type == conditionTypeExternalAlertmanagerSynced {
+				return c
+			}
+		}
+		t.Fatalf("expected Synced condition, got: %+v", st.Conditions)
+		return alertingnotifv0alpha1.ConfigCondition{}
+	}
+
+	t.Run("from clean state emits Synced=Unknown/NotConfigured with current timestamp", func(t *testing.T) {
+		got := computeNotConfiguredStatus(nil, now)
+
+		synced := findSynced(t, got)
+		assert.Equal(t, alertingnotifv0alpha1.ConfigConditionStatusUnknown, synced.Status)
+		assert.Equal(t, conditionReasonNotConfigured, synced.Reason)
+		assert.Equal(t, nowRFC, synced.LastTransitionTime)
+		assert.Nil(t, synced.Message)
+		assert.Nil(t, got.ExternalAlertmanagerSync, "no datasource context when unconfigured")
+	})
+
+	t.Run("after a prior success flips to Unknown and advances lastTransitionTime", func(t *testing.T) {
+		prev := &alertingnotifv0alpha1.ConfigStatus{
+			Conditions: []alertingnotifv0alpha1.ConfigCondition{{
+				Type:               conditionTypeExternalAlertmanagerSynced,
+				Status:             alertingnotifv0alpha1.ConfigConditionStatusTrue,
+				LastTransitionTime: earlRFC,
+				Reason:             conditionReasonSyncSucceeded,
+			}},
+		}
+
+		synced := findSynced(t, computeNotConfiguredStatus(prev, now))
+		assert.Equal(t, alertingnotifv0alpha1.ConfigConditionStatusUnknown, synced.Status)
+		assert.Equal(t, conditionReasonNotConfigured, synced.Reason)
+		assert.Equal(t, nowRFC, synced.LastTransitionTime, "flip True->Unknown advances the timestamp")
+	})
+
+	t.Run("consecutive not-configured ticks preserve lastTransitionTime", func(t *testing.T) {
+		prev := &alertingnotifv0alpha1.ConfigStatus{
+			Conditions: []alertingnotifv0alpha1.ConfigCondition{{
+				Type:               conditionTypeExternalAlertmanagerSynced,
+				Status:             alertingnotifv0alpha1.ConfigConditionStatusUnknown,
+				LastTransitionTime: earlRFC,
+				Reason:             conditionReasonNotConfigured,
+			}},
+		}
+
+		synced := findSynced(t, computeNotConfiguredStatus(prev, now))
+		assert.Equal(t, earlRFC, synced.LastTransitionTime, "status stayed Unknown, so the timestamp is preserved")
+	})
+
+	t.Run("a prior MergeCommitted flips to Unknown when the UID is removed", func(t *testing.T) {
+		// No special-case: when sync is no longer configured the Synced condition is
+		// a current-state snapshot, so even a terminal MergeCommitted flips. The merge
+		// artifact still lives in the AM config; this condition only tracks sync.
+		prev := &alertingnotifv0alpha1.ConfigStatus{
+			Conditions: []alertingnotifv0alpha1.ConfigCondition{{
+				Type:               conditionTypeExternalAlertmanagerSynced,
+				Status:             alertingnotifv0alpha1.ConfigConditionStatusTrue,
+				LastTransitionTime: earlRFC,
+				Reason:             conditionReasonMergeCommitted,
+			}},
+		}
+
+		synced := findSynced(t, computeNotConfiguredStatus(prev, now))
+		assert.Equal(t, alertingnotifv0alpha1.ConfigConditionStatusUnknown, synced.Status)
+		assert.Equal(t, conditionReasonNotConfigured, synced.Reason)
+		assert.Equal(t, nowRFC, synced.LastTransitionTime, "flip True->Unknown advances the timestamp")
+	})
+
+	t.Run("root fields ride through unchanged", func(t *testing.T) {
+		gen := int64(7)
+		uidLast := "uid-last"
+		originLast := originAPI
+		prev := &alertingnotifv0alpha1.ConfigStatus{
+			ObservedGeneration: &gen,
+			ExternalAlertmanagerSync: &alertingnotifv0alpha1.ConfigV0alpha1StatusExternalAlertmanagerSync{
+				DatasourceUid: &uidLast,
+				Origin:        &originLast,
+			},
+			Conditions: []alertingnotifv0alpha1.ConfigCondition{{
+				Type:               conditionTypeExternalAlertmanagerSynced,
+				Status:             alertingnotifv0alpha1.ConfigConditionStatusTrue,
+				LastTransitionTime: earlRFC,
+				Reason:             conditionReasonSyncSucceeded,
+			}},
+		}
+
+		got := computeNotConfiguredStatus(prev, now)
+		// observedGeneration and the last-attempt externalAlertmanagerSync context are
+		// preserved; only the Synced condition flips.
+		require.NotNil(t, got.ObservedGeneration)
+		assert.Equal(t, gen, *got.ObservedGeneration)
+		require.NotNil(t, got.ExternalAlertmanagerSync)
+		require.NotNil(t, got.ExternalAlertmanagerSync.DatasourceUid)
+		assert.Equal(t, "uid-last", *got.ExternalAlertmanagerSync.DatasourceUid)
+		synced := findSynced(t, got)
+		assert.Equal(t, alertingnotifv0alpha1.ConfigConditionStatusUnknown, synced.Status)
+		assert.Equal(t, conditionReasonNotConfigured, synced.Reason)
+	})
+
+	t.Run("other condition types are preserved", func(t *testing.T) {
+		prev := &alertingnotifv0alpha1.ConfigStatus{
+			Conditions: []alertingnotifv0alpha1.ConfigCondition{{
+				Type:               "RoutingApplied",
+				Status:             alertingnotifv0alpha1.ConfigConditionStatusTrue,
+				LastTransitionTime: earlRFC,
+				Reason:             "RoutingApplied",
+			}},
+		}
+
+		got := computeNotConfiguredStatus(prev, now)
+		require.Len(t, got.Conditions, 2)
+		var sawRouting bool
+		for _, c := range got.Conditions {
+			if c.Type == "RoutingApplied" {
+				sawRouting = true
+				assert.Equal(t, earlRFC, c.LastTransitionTime, "unrelated condition untouched")
+			}
+		}
+		assert.True(t, sawRouting)
+	})
+}

--- a/pkg/services/ngalert/notifier/external_am_syncer_test.go
+++ b/pkg/services/ngalert/notifier/external_am_syncer_test.go
@@ -361,13 +361,21 @@ func TestSyncExternalAMs_SeedsSingletonWhenUnconfigured(t *testing.T) {
 
 	moa.SyncAlertmanagersForOrgs(context.Background(), []int64{1})
 
-	// The singleton now exists, with an empty spec/status (an empty doc is
-	// semantically identical to an absent one).
+	// The singleton now exists, carrying Synced=Unknown/NotConfigured (sync is on
+	// but nothing is configured for this org) and no spec.
 	obj, err := adminCfg.lookup("org-1")
 	require.NoError(t, err, "singleton should have been seeded by the sync tick")
 	assert.Equal(t, alertingnotifv0alpha1.ConfigSingletonName, obj.GetName())
 	assert.Nil(t, obj.Spec.ExternalAlertmanagerSync, "seeded doc carries no spec config")
-	assert.Empty(t, obj.Status.Conditions, "seeded doc carries no status conditions")
+	var synced *alertingnotifv0alpha1.ConfigCondition
+	for i := range obj.Status.Conditions {
+		if obj.Status.Conditions[i].Type == conditionTypeExternalAlertmanagerSynced {
+			synced = &obj.Status.Conditions[i]
+		}
+	}
+	require.NotNil(t, synced, "expected an ExternalAlertmanagerSynced condition on the seeded doc")
+	assert.Equal(t, alertingnotifv0alpha1.ConfigConditionStatusUnknown, synced.Status)
+	assert.Equal(t, conditionReasonNotConfigured, synced.Reason)
 
 	// No sync happened (nothing to sync) — the seed is the only side effect.
 	assertNoExtraConfigSaved(t, cs, 1)

--- a/pkg/services/ngalert/notifier/external_am_syncer_test.go
+++ b/pkg/services/ngalert/notifier/external_am_syncer_test.go
@@ -347,6 +347,53 @@ func TestSyncExternalAMs_NoUID_Skipped(t *testing.T) {
 	assertNoExtraConfigSaved(t, cs, 1)
 }
 
+func TestSyncExternalAMs_SeedsSingletonWhenUnconfigured(t *testing.T) {
+	// Fresh stack: flag on, no ini override, no spec UID, and the Config
+	// singleton does NOT exist yet (no setUID call). The sync worker must seed
+	// the empty singleton so it reliably exists without a manual create.
+	adminCfg := newFakeConfigClient()
+
+	moa, cs := buildSyncTestMOA(t, adminCfg, &dsfakes.FakeDataSourceService{}, true, "", []int64{1})
+
+	// Precondition: nothing seeded the singleton during bootstrap.
+	_, err := adminCfg.lookup("org-1")
+	require.True(t, k8serrors.IsNotFound(err), "singleton should be absent before the sync tick")
+
+	moa.SyncAlertmanagersForOrgs(context.Background(), []int64{1})
+
+	// The singleton now exists, with an empty spec/status (an empty doc is
+	// semantically identical to an absent one).
+	obj, err := adminCfg.lookup("org-1")
+	require.NoError(t, err, "singleton should have been seeded by the sync tick")
+	assert.Equal(t, alertingnotifv0alpha1.ConfigSingletonName, obj.GetName())
+	assert.Nil(t, obj.Spec.ExternalAlertmanagerSync, "seeded doc carries no spec config")
+	assert.Empty(t, obj.Status.Conditions, "seeded doc carries no status conditions")
+
+	// No sync happened (nothing to sync) — the seed is the only side effect.
+	assertNoExtraConfigSaved(t, cs, 1)
+}
+
+func TestSyncExternalAMs_SeedDoesNotClobberExistingConfig(t *testing.T) {
+	// The singleton already exists (carrying a spec UID). The seed-on-missing
+	// path must be a no-op: an empty spec must not overwrite the configured one.
+	// (Operator ini is empty so resolution falls through to the spec UID.)
+	mimirSrv := startMimirServer(t, "route:\n  receiver: mimir-receiver\nreceivers:\n  - name: mimir-receiver")
+	ds := makeMimirDS("mimir-uid", 1, mimirSrv.URL)
+	dsSvc := &dsfakes.FakeDataSourceService{DataSources: []*datasources.DataSource{ds}}
+
+	adminCfg := newFakeConfigClient()
+	adminCfg.setUID(1, "mimir-uid")
+
+	moa, _ := buildSyncTestMOA(t, adminCfg, dsSvc, true, "", []int64{1})
+	moa.SyncAlertmanagersForOrgs(context.Background(), []int64{1})
+
+	obj, err := adminCfg.lookup("org-1")
+	require.NoError(t, err)
+	require.NotNil(t, obj.Spec.ExternalAlertmanagerSync, "existing spec UID must be preserved")
+	require.NotNil(t, obj.Spec.ExternalAlertmanagerSync.DatasourceUid)
+	assert.Equal(t, "mimir-uid", *obj.Spec.ExternalAlertmanagerSync.DatasourceUid)
+}
+
 func TestSyncExternalAMs_DisabledOrgSkipped(t *testing.T) {
 	// Org 1 enabled, org 2 disabled. Both have admin config UIDs, but only org 1
 	// has its DS registered in the fake DS service. If the syncer respected the

--- a/pkg/tests/apis/alerting/notifications/config/config_test.go
+++ b/pkg/tests/apis/alerting/notifications/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -106,13 +107,24 @@ func newConfig(name string) *alertingnotifv0alpha1.Config {
 	}
 }
 
-// seedSingleton creates the "default" singleton (admins may create it) so tests
-// that operate on an existing object have one. Creating from scratch — via both
-// POST and the PUT upsert — is covered explicitly by TestIntegrationConfigCreate.
+// seedSingleton brings the "default" singleton into existence the way production
+// does — by driving the sync worker's flag-on-but-unconfigured pass, which seeds
+// it. Human create is denied, so this is the only way to get an existing object
+// for the read/update tests. The pass is re-run until the singleton is readable to
+// absorb boot-time ordering (the seed pass skips an org until its Alertmanager has
+// been created) and unified-storage read-after-write lag.
 func seedSingleton(t *testing.T, ctx context.Context, helper *apis.K8sTestHelper) {
 	t.Helper()
-	_, err := newConfigClient(t, helper.Org1.Admin).Create(ctx, newConfig(alertingnotifv0alpha1.ConfigSingletonName), resource.CreateOptions{})
-	require.NoError(t, err)
+	moa := helper.GetEnv().Server.HTTPServer.AlertNG.MultiOrgAlertmanager
+	require.NotNil(t, moa, "MultiOrgAlertmanager must be wired in the test env")
+	adminClient := newConfigClient(t, helper.Org1.Admin)
+	require.Eventually(t, func() bool {
+		if err := moa.LoadAndSyncAlertmanagersForOrgs(ctx); err != nil {
+			return false
+		}
+		_, err := adminClient.Get(ctx, singletonID)
+		return err == nil
+	}, 30*time.Second, 500*time.Millisecond, "sync worker did not seed the Config singleton")
 }
 
 func requireForbidden(t *testing.T, err error, msgContains string) {
@@ -122,15 +134,6 @@ func requireForbidden(t *testing.T, err error, msgContains string) {
 	if msgContains != "" {
 		require.Contains(t, err.Error(), msgContains)
 	}
-}
-
-// requireSingletonRejection asserts the admission validator rejected a write for
-// violating the singleton-name rule. The status code isn't pinned because the
-// message is the stable contract.
-func requireSingletonRejection(t *testing.T, err error) {
-	t.Helper()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "singleton")
 }
 
 // configWildcardPermission grants the given Config actions over the all-uid
@@ -147,7 +150,9 @@ func configWildcardPermission(actions ...string) resourcepermissions.SetResource
 
 // TestIntegrationConfigAccessControl pins down the custom authorizer behavior:
 //   - get/list gated by configs:get (read), granted to Viewer and Admin.
-//   - create/patch/update gated by configs:update, granted to Admin only.
+//   - patch/update gated by configs:update, granted to Admin only.
+//   - create is service-identity only: forbidden for every human (the singleton is
+//     seeded by the sync worker).
 //   - delete/deletecollection is rejected for everyone ("cannot be deleted").
 //   - /status writes require the service-identity-only configs/status:update and
 //     are forbidden for every human, including Admin.
@@ -222,20 +227,13 @@ func TestIntegrationConfigAccessControl(t *testing.T) {
 				})
 			}
 
-			// create is gated by the update permission. The singleton already exists
-			// (seeded), so an update-holder gets AlreadyExists while a user without
-			// update is forbidden.
-			if tc.canUpdate {
-				t.Run("create returns AlreadyExists (singleton already created)", func(t *testing.T) {
-					_, err := client.Create(ctx, newConfig(alertingnotifv0alpha1.ConfigSingletonName), resource.CreateOptions{})
-					require.Truef(t, errors.IsAlreadyExists(err), "expected AlreadyExists but got: %v", err)
-				})
-			} else {
-				t.Run("is forbidden to create", func(t *testing.T) {
-					_, err := client.Create(ctx, newConfig(alertingnotifv0alpha1.ConfigSingletonName), resource.CreateOptions{})
-					requireForbidden(t, err, "")
-				})
-			}
+			// create is service-identity only: every human is forbidden regardless of
+			// update permission. The singleton is brought into existence by the sync
+			// worker; humans only read/update the seeded object.
+			t.Run("is forbidden to create", func(t *testing.T) {
+				_, err := client.Create(ctx, newConfig(alertingnotifv0alpha1.ConfigSingletonName), resource.CreateOptions{})
+				requireForbidden(t, err, "seeded automatically")
+			})
 
 			t.Run("is forbidden to delete", func(t *testing.T) {
 				err := client.Delete(ctx, singletonID, resource.DeleteOptions{})
@@ -252,51 +250,25 @@ func TestIntegrationConfigAccessControl(t *testing.T) {
 	}
 }
 
-// TestIntegrationConfigCreate verifies an admin can bring the singleton into
-// existence from scratch via both supported paths — a POST create and a PUT
-// upsert (create-on-update, the path a GitOps apply uses). Each subtest uses a
-// fresh server because the singleton cannot be deleted once created.
+// TestIntegrationConfigCreate verifies that humans cannot bring the singleton into
+// existence — it is seeded by the sync worker, and human create is denied on every
+// path. A POST is rejected by the authorizer (verb=create); a PUT upsert to the
+// missing object is re-authorized by the apiserver as create and rejected the same
+// way. Each subtest uses a fresh server so the singleton does not yet exist.
 func TestIntegrationConfigCreate(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 	ctx := context.Background()
 
-	t.Run("via POST create", func(t *testing.T) {
+	t.Run("POST create is forbidden for humans", func(t *testing.T) {
 		helper := getTestHelper(t)
-		got, err := newConfigClient(t, helper.Org1.Admin).Create(ctx, newConfig(alertingnotifv0alpha1.ConfigSingletonName), resource.CreateOptions{})
-		require.NoError(t, err)
-		require.Equal(t, alertingnotifv0alpha1.ConfigSingletonName, got.Name)
+		_, err := newConfigClient(t, helper.Org1.Admin).Create(ctx, newConfig(alertingnotifv0alpha1.ConfigSingletonName), resource.CreateOptions{})
+		requireForbidden(t, err, "seeded automatically")
 	})
 
-	t.Run("via PUT upsert (create-on-update)", func(t *testing.T) {
+	t.Run("PUT upsert (create-on-update) is forbidden for humans", func(t *testing.T) {
 		helper := getTestHelper(t)
-		got, err := rawUpdate(t, ctx, helper.Org1.Admin, newConfig(alertingnotifv0alpha1.ConfigSingletonName))
-		require.NoError(t, err)
-		require.Equal(t, alertingnotifv0alpha1.ConfigSingletonName, got.Name)
-	})
-}
-
-// TestIntegrationConfigSingleton verifies the singleton admission validator: the
-// only valid name is "default". A non-default name is rejected on both the
-// create and the update (upsert) paths.
-func TestIntegrationConfigSingleton(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	ctx := context.Background()
-	helper := getTestHelper(t)
-	admin := helper.Org1.Admin
-	adminClient := newConfigClient(t, admin)
-
-	t.Run("update with a non-default name is rejected as a singleton violation", func(t *testing.T) {
-		_, err := rawUpdate(t, ctx, admin, newConfig("not-the-singleton"))
-		requireSingletonRejection(t, err)
-	})
-
-	// create is allowed for admins (gated by the update permission), so a
-	// non-default create reaches the admission validator and is rejected for
-	// violating the singleton-name rule — same as the update path above.
-	t.Run("create with a non-default name is rejected as a singleton violation", func(t *testing.T) {
-		_, err := adminClient.Create(ctx, newConfig("not-the-singleton"), resource.CreateOptions{})
-		requireSingletonRejection(t, err)
+		_, err := rawUpdate(t, ctx, helper.Org1.Admin, newConfig(alertingnotifv0alpha1.ConfigSingletonName))
+		requireForbidden(t, err, "")
 	})
 }
 


### PR DESCRIPTION
# Alerting: Improve Config singleton seeding + lock down creation

Builds on #125185. The `Config` singleton now reliably exists without a manual create, and its creation is owned by the system (users only read and update it).

Three commits:

1. **Seed the Config singleton from the sync worker.** The per-org sync pass seeds the singleton when the flag is on but nothing is configured (no ini override, no spec UID). Best-effort and idempotent.
2. **Restrict creation to the system.** `create` is service-identity only. Users are denied create (including a PUT/apply to a missing object, which the apiserver re-authorizes as create) and may only update the seeded object.
3. **Record a not-configured sync status.** Writes `ExternalAlertmanagerSynced=Unknown/NotConfigured` (which also seeds the singleton), so a client can tell sync is intentionally idle rather than never evaluated. Steady-state ticks dedup to no write, and root fields ride through unchanged.

Tested with unit and integration coverage. `go vet` and `gofmt` clean.
