### PR TITLE
auth: introduce a grace period for validating recently rotated tokens. 

### DIFF
--- a/pkg/services/auth/authimpl/auth_token.go
+++ b/pkg/services/auth/authimpl/auth_token.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/singleflight"
@@ -35,13 +36,17 @@ var (
 
 const SkipRotationTime = 5 * time.Second
 
+// PrevTokenGraceWindow is how long after a rotation the previous auth token is still accepted
+// without theft-detection re-rotation, absorbing in-flight requests. Must be >= SkipRotationTime.
+const PrevTokenGraceWindow = 30 * time.Second
+
 var _ auth.UserTokenService = (*UserAuthTokenService)(nil)
 
 func ProvideUserAuthTokenService(ctx context.Context, sqlStore db.DB,
 	serverLockService *serverlock.ServerLockService,
 	quotaService quota.Service, secretService secrets.Service, //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	cfgProvider configprovider.ConfigProvider, tracer tracing.Tracer,
-	features featuremgmt.FeatureToggles,
+	_ featuremgmt.FeatureToggles,
 ) (*UserAuthTokenService, error) {
 	s := &UserAuthTokenService{
 		sqlStore:          sqlStore,
@@ -49,7 +54,6 @@ func ProvideUserAuthTokenService(ctx context.Context, sqlStore db.DB,
 		cfgProvider:       cfgProvider,
 		log:               log.New("auth"),
 		singleflight:      new(singleflight.Group),
-		features:          features,
 		tracer:            tracer,
 	}
 
@@ -82,7 +86,6 @@ type UserAuthTokenService struct {
 	log                  log.Logger
 	externalSessionStore auth.ExternalSessionStore
 	singleflight         *singleflight.Group
-	features             featuremgmt.FeatureToggles
 	tracer               tracing.Tracer
 }
 
@@ -196,43 +199,60 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 		}
 	}
 
+	// Opt-in grace window so a previous token used by an in-flight request shortly after rotation
+	// is not treated as theft, which would force a re-rotation that logs the user out.
+	graceEnabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagAuthTokenRotationGracePeriod, false, openfeature.TransactionContext(ctx))
+
 	// Current incoming token is the previous auth token in the DB and the auth_token_seen is true
 	if model.AuthToken != hashedToken && model.PrevAuthToken == hashedToken && model.AuthTokenSeen {
-		model.AuthTokenSeen = false
-		model.RotatedAt = getTime().Add(-usertoken.UrgentRotateTime).Unix()
-
-		var affectedRows int64
-		err = s.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
-			affectedRows, err = dbSession.Where("id = ? AND prev_auth_token = ? AND rotated_at < ?",
-				model.Id,
-				model.PrevAuthToken,
-				model.RotatedAt).
-				AllCols().Update(&model)
-
-			return err
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		if affectedRows == 0 {
-			ctxLogger.Debug("Prev seen token unchanged", "tokenID", model.Id, "userID", model.UserId, "clientIP", model.ClientIp, "userAgent", model.UserAgent, "authToken", model.AuthToken)
+		// Within the grace window, accept the previous token as-is without mutating any state.
+		if graceEnabled && getTime().Unix()-model.RotatedAt < int64(PrevTokenGraceWindow.Seconds()) {
+			ctxLogger.Debug("Prev token used within grace window, treating as valid", "tokenID", model.Id, "userID", model.UserId, "clientIP", model.ClientIp, "userAgent", model.UserAgent)
 		} else {
-			ctxLogger.Debug("Prev seen token", "tokenID", model.Id, "userID", model.UserId, "clientIP", model.ClientIp, "userAgent", model.UserAgent, "authToken", model.AuthToken)
+			candidate := model
+			candidate.AuthTokenSeen = false
+			candidate.RotatedAt = getTime().Add(-usertoken.UrgentRotateTime).Unix()
+
+			var affectedRows int64
+			err = s.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+				affectedRows, err = dbSession.Where("id = ? AND prev_auth_token = ? AND rotated_at < ?",
+					candidate.Id,
+					candidate.PrevAuthToken,
+					candidate.RotatedAt).
+					AllCols().Update(&candidate)
+
+				return err
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			if affectedRows == 0 {
+				ctxLogger.Debug("Prev seen token unchanged", "tokenID", model.Id, "userID", model.UserId, "clientIP", model.ClientIp, "userAgent", model.UserAgent, "authToken", model.AuthToken)
+				// DB row unchanged: when enabled, keep the freshly-read model so NeedsRotation does
+				// not fire on a stale value; when disabled, keep the legacy backdated model.
+				if !graceEnabled {
+					model = candidate
+				}
+			} else {
+				model = candidate
+				ctxLogger.Debug("Prev seen token", "tokenID", model.Id, "userID", model.UserId, "clientIP", model.ClientIp, "userAgent", model.UserAgent, "authToken", model.AuthToken)
+			}
 		}
 	}
 
 	// Current incoming token is not seen and it is the latest valid auth token in the db
 	if !model.AuthTokenSeen && model.AuthToken == hashedToken {
-		model.AuthTokenSeen = true
-		model.SeenAt = getTime().Unix()
+		candidate := model
+		candidate.AuthTokenSeen = true
+		candidate.SeenAt = getTime().Unix()
 
 		var affectedRows int64
 		err = s.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
 			affectedRows, err = dbSession.Where("id = ? AND auth_token = ?",
-				model.Id,
-				model.AuthToken).
-				AllCols().Update(&model)
+				candidate.Id,
+				candidate.AuthToken).
+				AllCols().Update(&candidate)
 
 			return err
 		})
@@ -242,7 +262,13 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 
 		if affectedRows == 0 {
 			ctxLogger.Debug("Seen wrong token", "tokenID", model.Id, "userID", model.UserId, "clientIP", model.ClientIp, "userAgent", model.UserAgent, "authToken", model.AuthToken)
+			// DB row unchanged: when enabled, keep the freshly-read model so the returned token
+			// matches what was persisted; when disabled, keep the legacy candidate.
+			if !graceEnabled {
+				model = candidate
+			}
 		} else {
+			model = candidate
 			ctxLogger.Debug("Seen token", "tokenID", model.Id, "userID", model.UserId, "clientIP", model.ClientIp, "userAgent", model.UserAgent, "authToken", model.AuthToken)
 		}
 	}

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -6,9 +6,12 @@ import (
 	"errors"
 	"net"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -21,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -697,6 +701,165 @@ func TestIntegrationUserAuthToken(t *testing.T) {
 		utMap := utJSON.MustMap()
 
 		require.True(t, reflect.DeepEqual(utMap, uatMap))
+	})
+}
+
+// TestIntegrationUserAuthTokenRotationGrace covers the grace window that prevents the rotation
+// race from logging users out and ensures LookupToken never diverges from the persisted row.
+func TestIntegrationUserAuthTokenRotationGrace(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	usr := &user.User{ID: int64(10)}
+	now := time.Date(2018, 12, 13, 13, 45, 0, 0, time.UTC)
+	defer func() { getTime = time.Now }()
+
+	// rotateOnce creates and rotates a token once, returning the previous (in-flight) unhashed
+	// token, the rotated token, and the rotation time.
+	rotateOnce := func(t *testing.T, ctx *testContext) (prevUnhashed string, rotated *auth.UserToken, rotatedAt int64) {
+		t.Helper()
+		getTime = func() time.Time { return now }
+		gen0, err := ctx.tokenService.CreateToken(context.Background(), &auth.CreateTokenCommand{
+			User: usr, ClientIP: net.ParseIP("192.168.10.11"), UserAgent: "agent",
+		})
+		require.NoError(t, err)
+		_, err = ctx.tokenService.LookupToken(context.Background(), gen0.UnhashedToken)
+		require.NoError(t, err)
+
+		getTime = func() time.Time { return now.Add(SkipRotationTime + time.Second) }
+		gen1, err := ctx.tokenService.RotateToken(context.Background(), auth.RotateCommand{UnHashedToken: gen0.UnhashedToken})
+		require.NoError(t, err)
+		require.NotEqual(t, gen0.UnhashedToken, gen1.UnhashedToken)
+		_, err = ctx.tokenService.LookupToken(context.Background(), gen1.UnhashedToken)
+		require.NoError(t, err)
+
+		return gen0.UnhashedToken, gen1, now.Add(SkipRotationTime + time.Second).Unix()
+	}
+
+	withGrace := func(t *testing.T) {
+		setupOpenFeatureFlag(t, featuremgmt.FlagAuthTokenRotationGracePeriod, true)
+	}
+
+	t.Run("prev token within grace window is accepted without re-rotation", func(t *testing.T) {
+		ctx := createTestContext(t)
+		withGrace(t)
+		prevUnhashed, gen1, rotatedAt := rotateOnce(t, ctx)
+
+		// In-flight request with the previous token, still within the grace window.
+		prevLookup, err := ctx.tokenService.LookupToken(context.Background(), prevUnhashed)
+		require.NoError(t, err)
+		require.NotNil(t, prevLookup)
+		// The returned token must not be marked unseen or backdated, otherwise the
+		// session middleware's NeedsRotation check would force a spurious rotation.
+		require.True(t, prevLookup.AuthTokenSeen)
+		require.Equal(t, rotatedAt, prevLookup.RotatedAt)
+
+		// The DB row must be untouched by the in-flight lookup.
+		model, err := ctx.getAuthTokenByID(gen1.Id)
+		require.NoError(t, err)
+		require.True(t, model.AuthTokenSeen)
+		require.Equal(t, rotatedAt, model.RotatedAt)
+	})
+
+	t.Run("stale model is not returned when theft update is a no-op", func(t *testing.T) {
+		ctx := createTestContext(t)
+		withGrace(t)
+		prevUnhashed, gen1, rotatedAt := rotateOnce(t, ctx)
+
+		// Past the grace window but within UrgentRotateTime: the theft update matches no rows, so
+		// the returned token must reflect the persisted state, not the locally-backdated candidate.
+		getTime = func() time.Time { return now.Add(SkipRotationTime + time.Second + PrevTokenGraceWindow + time.Second) }
+		prevLookup, err := ctx.tokenService.LookupToken(context.Background(), prevUnhashed)
+		require.NoError(t, err)
+		require.NotNil(t, prevLookup)
+		require.True(t, prevLookup.AuthTokenSeen)
+		require.Equal(t, rotatedAt, prevLookup.RotatedAt)
+
+		model, err := ctx.getAuthTokenByID(gen1.Id)
+		require.NoError(t, err)
+		require.True(t, model.AuthTokenSeen)
+		require.Equal(t, rotatedAt, model.RotatedAt)
+	})
+
+	t.Run("prev token outside grace window still triggers theft re-rotation", func(t *testing.T) {
+		ctx := createTestContext(t)
+		withGrace(t)
+		prevUnhashed, gen1, _ := rotateOnce(t, ctx)
+
+		// Well past both the grace window and UrgentRotateTime: using the previous token
+		// now is treated as suspicious and forces an urgent re-rotation (unseen + backdated).
+		getTime = func() time.Time { return now.Add(SkipRotationTime + time.Second + 2*time.Minute) }
+		prevLookup, err := ctx.tokenService.LookupToken(context.Background(), prevUnhashed)
+		require.NoError(t, err)
+		require.NotNil(t, prevLookup)
+		require.False(t, prevLookup.AuthTokenSeen)
+
+		model, err := ctx.getAuthTokenByID(gen1.Id)
+		require.NoError(t, err)
+		require.False(t, model.AuthTokenSeen)
+	})
+
+	t.Run("prev token within window is marked unseen when grace period is disabled", func(t *testing.T) {
+		// Feature toggle off: legacy theft-detection still applies within the would-be grace
+		// window, marking the token unseen to drive a re-rotation.
+		ctx := createTestContext(t)
+		prevUnhashed, _, _ := rotateOnce(t, ctx)
+
+		prevLookup, err := ctx.tokenService.LookupToken(context.Background(), prevUnhashed)
+		require.NoError(t, err)
+		require.NotNil(t, prevLookup)
+		require.False(t, prevLookup.AuthTokenSeen)
+	})
+
+	t.Run("concurrent seen-marking of the current token stays benign", func(t *testing.T) {
+		getTime = func() time.Time { return now }
+		ctx := createTestContext(t)
+		withGrace(t)
+		token, err := ctx.tokenService.CreateToken(context.Background(), &auth.CreateTokenCommand{
+			User: usr, ClientIP: net.ParseIP("192.168.10.11"), UserAgent: "agent",
+		})
+		require.NoError(t, err)
+
+		const goroutines = 8
+		var wg sync.WaitGroup
+		results := make([]*auth.UserToken, goroutines)
+		errs := make([]error, goroutines)
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				results[idx], errs[idx] = ctx.tokenService.LookupToken(context.Background(), token.UnhashedToken)
+			}(i)
+		}
+		wg.Wait()
+
+		for i := 0; i < goroutines; i++ {
+			require.NoError(t, errs[i])
+			require.NotNil(t, results[i])
+		}
+
+		model, err := ctx.getAuthTokenByID(token.Id)
+		require.NoError(t, err)
+		require.True(t, model.AuthTokenSeen)
+	})
+}
+
+var openfeatureTestMutex sync.Mutex
+
+func setupOpenFeatureFlag(t *testing.T, flag string, value bool) {
+	t.Helper()
+	openfeatureTestMutex.Lock()
+
+	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
+		flag: setting.NewInMemoryFlag(flag, value),
+	})
+	require.NoError(t, err)
+
+	err = openfeature.SetProviderAndWait(provider)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+		openfeatureTestMutex.Unlock()
 	})
 }
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3146,6 +3146,7 @@ var (
 			Generate:     Generate{Go: true},
 		},
 		{
+
 			Name:         "table.protoRowParser",
 			Description:  "Enables a new internal parser for table panel which doesn't rely on constructing a dynamic function and works in more browser environments.",
 			Stage:        FeatureStageExperimental,
@@ -3162,6 +3163,14 @@ var (
 			HideFromDocs: true,
 			Expression:   "false",
 			Generate:     Generate{React: true},
+		},
+		{
+			Name:        "auth.tokenRotationGracePeriod",
+			Description: "Accepts the previous session token as valid for a short grace period after rotation instead of forcing an immediate re-rotation, reducing race-condition logouts",
+			Stage:       FeatureStageExperimental,
+			Owner:       identityAccessTeam,
+			Expression:  "false",
+			Generate:    Generate{Go: true},
 		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -368,3 +368,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-19,splunk.useLegacyResultsApi,experimental,@grafana/data-sources-plugins,false,false,false
 2026-06-22,table.protoRowParser,experimental,@grafana/dataviz-squad,false,false,true
 2026-06-23,dataviz.experimentalColorSchemes,experimental,@grafana/dataviz-squad,false,false,true
+2026-06-22,auth.tokenRotationGracePeriod,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -965,4 +965,8 @@ const (
 	// FlagSplunkUseLegacyResultsApi
 	// Makes the Splunk data source use the deprecated REST API v1 search result endpoints instead of v2
 	FlagSplunkUseLegacyResultsApi = "splunk.useLegacyResultsApi"
+
+	// FlagAuthTokenRotationGracePeriod
+	// Accepts the previous session token as valid for a short grace period after rotation instead of forcing an immediate re-rotation, reducing race-condition logouts
+	FlagAuthTokenRotationGracePeriod = "auth.tokenRotationGracePeriod"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -993,6 +993,19 @@
     },
     {
       "metadata": {
+        "name": "auth.tokenRotationGracePeriod",
+        "resourceVersion": "1782116990701",
+        "creationTimestamp": "2026-06-22T08:29:50Z"
+      },
+      "spec": {
+        "description": "Accepts the previous session token as valid for a short grace period after rotation instead of forcing an immediate re-rotation, reducing race-condition logouts",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "authZGRPCServer",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2024-06-13T09:41:35Z"


### PR DESCRIPTION
This PR introduces a short graceperiod where the old token is accepted even if it has been rotated and mark as seen. 

The goal  is that people with multiple tabs should not be logged out due to race condition triggered by all tabs trying to claim a new token. I vagule remeber us supporting _something_ like this before so maybe there is a reason we removed it?