### PR TITLE
Playlists: Show the managed badge on provisioned playlists

### DIFF
--- a/public/app/features/playlist/PlaylistCard.test.tsx
+++ b/public/app/features/playlist/PlaylistCard.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import { contextSrv } from 'app/core/services/context_srv';
+
+import { type Playlist } from '../../api/clients/playlist/v1';
+
+import { PlaylistCard } from './PlaylistCard';
+
+function getPlaylist(annotations?: Record<string, string>): Playlist {
+  return {
+    apiVersion: 'playlist.grafana.app/v1',
+    kind: 'Playlist',
+    metadata: {
+      name: 'foo',
+      ...(annotations ? { annotations } : {}),
+    },
+    spec: {
+      title: 'Test Playlist',
+      interval: '5m',
+      items: [],
+    },
+  };
+}
+
+function setup(playlist: Playlist) {
+  jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+  return render(
+    <TestProvider>
+      <PlaylistCard playlist={playlist} setStartPlaylist={jest.fn()} setPlaylistToDelete={jest.fn()} />
+    </TestProvider>
+  );
+}
+
+describe('PlaylistCard', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not render the provisioned badge for an unmanaged playlist', () => {
+    setup(getPlaylist());
+
+    expect(screen.getByText('Test Playlist')).toBeInTheDocument();
+    expect(screen.queryByTestId('icon-exchange-alt')).not.toBeInTheDocument();
+  });
+
+  it('renders the provisioned badge for a managed playlist', () => {
+    setup(
+      getPlaylist({
+        'grafana.app/managedBy': 'repo',
+        'grafana.app/managerId': 'foo-repo',
+      })
+    );
+
+    expect(screen.getByTestId('icon-exchange-alt')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/playlist/PlaylistCard.tsx
+++ b/public/app/features/playlist/PlaylistCard.tsx
@@ -6,6 +6,8 @@ import { t, Trans } from '@grafana/i18n';
 import { Button, Card, LinkButton, ModalsController, Stack, useStyles2 } from '@grafana/ui';
 import { attachSkeleton, type SkeletonComponent } from '@grafana/ui/unstable';
 import { DashNavButton } from 'app/features/dashboard/components/DashNav/DashNavButton';
+import { ManagedBadge } from 'app/features/provisioning/components/ManagedBadge';
+import { getManagerIdentity, getManagerKind, isManaged } from 'app/features/provisioning/utils/managedResource';
 
 import { type Playlist } from '../../api/clients/playlist/v1';
 
@@ -21,7 +23,14 @@ interface Props {
 const PlaylistCardComponent = ({ playlist, setStartPlaylist, setPlaylistToDelete }: Props) => {
   return (
     <Card noMargin>
-      <Card.Heading>{playlist.spec?.title}</Card.Heading>
+      <Card.Heading>
+        <Stack direction="row" gap={1} alignItems="center">
+          {playlist.spec?.title}
+          {isManaged(playlist) && (
+            <ManagedBadge managerKind={getManagerKind(playlist)} name={getManagerIdentity(playlist)} />
+          )}
+        </Stack>
+      </Card.Heading>
       <Card.Actions>
         <Button variant="secondary" icon="play" onClick={() => setStartPlaylist(playlist)}>
           <Trans i18nKey="playlist-page.card.start">Start playlist</Trans>

--- a/public/app/features/playlist/PlaylistCard.tsx
+++ b/public/app/features/playlist/PlaylistCard.tsx
@@ -24,7 +24,7 @@ const PlaylistCardComponent = ({ playlist, setStartPlaylist, setPlaylistToDelete
   return (
     <Card noMargin>
       <Card.Heading>
-        <Stack direction="row" gap={1} alignItems="center">
+        <Stack direction="row" gap={1} alignItems="center" wrap>
           {playlist.spec?.title}
           {isManaged(playlist) && (
             <ManagedBadge managerKind={getManagerKind(playlist)} name={getManagerIdentity(playlist)} />

--- a/public/app/features/playlist/PlaylistEditPage.test.tsx
+++ b/public/app/features/playlist/PlaylistEditPage.test.tsx
@@ -21,7 +21,7 @@ jest.mock('app/core/components/TagFilter/TagFilter', () => ({
   },
 }));
 
-async function getTestContext() {
+async function getTestContext(annotations?: Record<string, string>) {
   jest.clearAllMocks();
 
   const backendSrvMock = jest.spyOn(backendSrv, 'fetch').mockImplementation(() =>
@@ -34,6 +34,7 @@ async function getTestContext() {
         },
         metadata: {
           name: 'foo',
+          ...(annotations ? { annotations } : {}),
         },
       })
     )
@@ -56,6 +57,23 @@ describe('PlaylistEditPage', () => {
       expect(await screen.findByRole('textbox', { name: /name/i })).toHaveValue('Test Playlist');
       expect(screen.getByRole('textbox', { name: /interval/i })).toHaveValue('5s');
       expect(screen.getAllByRole('row')).toHaveLength(1);
+    });
+
+    it('then it should not render the provisioned badge for an unmanaged playlist', async () => {
+      await getTestContext();
+
+      expect(await screen.findByRole('heading', { name: /edit playlist/i })).toBeInTheDocument();
+      expect(screen.queryByTestId('icon-exchange-alt')).not.toBeInTheDocument();
+    });
+
+    it('then it should render the provisioned badge for a managed playlist', async () => {
+      await getTestContext({
+        'grafana.app/managedBy': 'repo',
+        'grafana.app/managerId': 'foo-repo',
+      });
+
+      expect(await screen.findByRole('heading', { name: /edit playlist/i })).toBeInTheDocument();
+      expect(await screen.findByTestId('icon-exchange-alt')).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/playlist/PlaylistEditPage.tsx
+++ b/public/app/features/playlist/PlaylistEditPage.tsx
@@ -3,7 +3,10 @@ import { useParams } from 'react-router-dom-v5-compat';
 import { type NavModelItem } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
+import { Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
+import { ManagedBadge } from 'app/features/provisioning/components/ManagedBadge';
+import { getManagerIdentity, getManagerKind, isManaged } from 'app/features/provisioning/utils/managedResource';
 
 import { type Playlist, useGetPlaylistQuery, useReplacePlaylistMutation } from '../../api/clients/playlist/v1';
 
@@ -42,6 +45,11 @@ export const PlaylistEditPage = () => {
             <Trans i18nKey="playlist-edit.error-prefix">Error loading playlist:</Trans>
             {JSON.stringify(error)}
           </div>
+        )}
+        {data && isManaged(data) && (
+          <Stack direction="row" gap={1} alignItems="center">
+            <ManagedBadge managerKind={getManagerKind(data)} name={getManagerIdentity(data)} />
+          </Stack>
         )}
         {data && <PlaylistForm onSubmit={onSubmit} playlist={data} />}
       </Page.Contents>

--- a/public/app/features/playlist/PlaylistEditPage.tsx
+++ b/public/app/features/playlist/PlaylistEditPage.tsx
@@ -38,7 +38,7 @@ export const PlaylistEditPage = () => {
   };
 
   const renderTitle = (title: string) => (
-    <Stack direction="row" gap={1} alignItems="center">
+    <Stack direction="row" gap={1} alignItems="center" wrap>
       <h1>{title}</h1>
       {data && isManaged(data) && <ManagedBadge managerKind={getManagerKind(data)} name={getManagerIdentity(data)} />}
     </Stack>

--- a/public/app/features/playlist/PlaylistEditPage.tsx
+++ b/public/app/features/playlist/PlaylistEditPage.tsx
@@ -37,19 +37,21 @@ export const PlaylistEditPage = () => {
     ),
   };
 
+  const renderTitle = (title: string) => (
+    <Stack direction="row" gap={1} alignItems="center">
+      <h1>{title}</h1>
+      {data && isManaged(data) && <ManagedBadge managerKind={getManagerKind(data)} name={getManagerIdentity(data)} />}
+    </Stack>
+  );
+
   return (
-    <Page navId="dashboards/playlists" pageNav={pageNav}>
+    <Page navId="dashboards/playlists" pageNav={pageNav} renderTitle={renderTitle}>
       <Page.Contents isLoading={isLoading}>
         {isError && (
           <div>
             <Trans i18nKey="playlist-edit.error-prefix">Error loading playlist:</Trans>
             {JSON.stringify(error)}
           </div>
-        )}
-        {data && isManaged(data) && (
-          <Stack direction="row" gap={1} alignItems="center">
-            <ManagedBadge managerKind={getManagerKind(data)} name={getManagerIdentity(data)} />
-          </Stack>
         )}
         {data && <PlaylistForm onSubmit={onSubmit} playlist={data} />}
       </Page.Contents>


### PR DESCRIPTION
## Summary

Show the shared `ManagedBadge` on playlists that are managed by an external system, so users can tell at a glance that a playlist is provisioned (and by what). This mirrors the badge already shown for dashboards and folders.

The badge appears in two places:
- **Listing page** — next to the title on each playlist card (`PlaylistCard`).
- **Edit page** — above the form (`PlaylistEditPage`).

It reuses the existing `ManagedBadge` component and `managedResource` helpers (`isManaged`, `getManagerKind`, `getManagerIdentity`) introduced in #126382, so no new component or i18n keys are needed. The badge renders for any manager kind (repository, terraform, kubectl, plugin, ...) and falls back to a generic "Provisioned" badge for unknown kinds.

## Changes

- `PlaylistCard.tsx` — render `<ManagedBadge>` next to the card title when `isManaged(playlist)`.
- `PlaylistEditPage.tsx` — render `<ManagedBadge>` above the form when `isManaged(data)`.
- `PlaylistCard.test.tsx` (new) — badge shown for a managed playlist, hidden for an unmanaged one.
- `PlaylistEditPage.test.tsx` — same two cases added.

## Scope

Intentionally limited to **displaying the managed badge**. Read-only badges, disabling Edit/Delete for read-only resources, and the source link are out of scope here.

## Testing

- `yarn jest public/app/features/playlist/PlaylistCard.test.tsx public/app/features/playlist/PlaylistEditPage.test.tsx` — 6/6 pass
- `yarn typecheck` ✓
- `yarn eslint` (changed files) ✓
- `yarn prettier --check` (changed files) ✓

## Checklist

- [x] Tests added/updated
- [x] No new i18n keys / docs needed
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)