### PR TITLE
fix: use crypto/rand instead of math/rand for non-cryptographic randomness

### DIFF
--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -2,10 +2,11 @@ package annotation
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"math/rand/v2"
+	"math/big"
 	"os"
 	"sync"
 
@@ -111,7 +112,11 @@ func NewAppInstaller(
 
 	var sfNode *snowflake.Node
 	if cfg.EnableLegacyID {
-		node, err := snowflake.NewNode(rand.Int64N(1024))
+		randN, err := rand.Int(rand.Reader, big.NewInt(1024))
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate random snowflake node ID: %w", err)
+		}
+		node, err := snowflake.NewNode(randN.Int64())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create snowflake node: %w", err)
 		}

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -2,8 +2,9 @@ package sqlstore
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand/v2"
+	"math/big"
 	"time"
 
 	"github.com/grafana/grafana/pkg/util/xorm"
@@ -31,7 +32,11 @@ const (
 func txnRetryBackoff(retry int) time.Duration {
 	retry = min(retry, 10)
 	delay := min(txnRetryBaseDelay<<retry, txnRetryMaxDelay)
-	return rand.N(delay)
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(delay)))
+	if err != nil {
+		return delay / 2 // fallback to half the delay on error
+	}
+	return time.Duration(n.Int64())
 }
 
 // WithTransactionalDbSession calls the callback with a session within a transaction.


### PR DESCRIPTION
## What this PR does / why we need it

Replaces `math/rand/v2` with `crypto/rand` in two files flagged by the `semgrep-code-grafana` bot:

- `pkg/services/sqlstore/transactions.go` — retry jitter computation
- `pkg/registry/apps/annotation/register.go` — snowflake node ID selection

Both usages are non-cryptographic, but Grafana's Semgrep policy requires `crypto/rand` unconditionally. These changes were originally included in #121270 in response to the bot's blocking findings, but @dmihai correctly pointed out they are out of scope there.

## Related

Part of the semgrep findings originally surfaced in #121270 (Auth: Add configurable timeout for OAuth token exchange).