### PR TITLE
Passkey: frontend (login button + profile management) — PR2

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,6 +306,7 @@
     "@react-aria/utils": "3.31.0",
     "@react-awesome-query-builder/ui": "6.6.15",
     "@reduxjs/toolkit": "2.10.1",
+    "@simplewebauthn/browser": "^13.3.0",
     "@tanstack/react-virtual": "^3.5.1",
     "@visx/event": "3.12.0",
     "@visx/gradient": "3.12.0",

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -348,6 +348,9 @@ export interface GrafanaConfig {
     enabled: boolean;
     presenceIndicatorsDisabled?: boolean;
   };
+  passkey?: {
+    enabled: boolean;
+  };
 }
 
 interface SqlConnectionLimits {

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -224,6 +224,9 @@ export class GrafanaBootConfig {
     enabled: true,
     presenceIndicatorsDisabled: false,
   };
+  passkey?: {
+    enabled: boolean;
+  };
   googleAnalyticsId?: string;
   googleAnalytics4Id?: string;
   googleAnalytics4SendManualPageViews = false;

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -95,6 +95,10 @@ type FrontendSettingsAnalyticsDTO struct {
 	PresenceIndicatorsDisabled bool `json:"presenceIndicatorsDisabled,omitempty"`
 }
 
+type FrontendSettingsPasskeyDTO struct {
+	Enabled bool `json:"enabled"`
+}
+
 type FrontendSettingsUnifiedAlertingStateHistoryDTO struct {
 	Backend                       string `json:"backend,omitempty"`
 	Primary                       string `json:"primary,omitempty"`
@@ -282,6 +286,7 @@ type FrontendSettingsDTO struct {
 	RecordedQueries         FrontendSettingsRecordedQueriesDTO `json:"recordedQueries"`
 	Reporting               FrontendSettingsReportingDTO       `json:"reporting"`
 	Analytics               FrontendSettingsAnalyticsDTO       `json:"analytics"`
+	Passkey                 *FrontendSettingsPasskeyDTO        `json:"passkey,omitempty"`
 	UnifiedAlertingEnabled  bool                               `json:"unifiedAlertingEnabled"`
 	UnifiedAlerting         FrontendSettingsUnifiedAlertingDTO `json:"unifiedAlerting"`
 	Oauth                   map[string]any                     `json:"oauth"`

--- a/pkg/api/frontendsettings/frontendsettings.go
+++ b/pkg/api/frontendsettings/frontendsettings.go
@@ -174,6 +174,7 @@ func GetBaseFrontendSettings(reqCtx *contextmodel.ReqContext, cfg *setting.Cfg, 
 		Analytics: dtos.FrontendSettingsAnalyticsDTO{
 			Enabled: cfg.SectionWithEnvOverrides("analytics").Key("enabled").MustBool(true),
 		},
+		Passkey: passkeyFrontendSettings(cfg),
 
 		UnifiedAlerting: dtos.FrontendSettingsUnifiedAlertingDTO{
 			MinInterval: cfg.UnifiedAlerting.MinInterval.String(),
@@ -240,6 +241,16 @@ func GetBaseFrontendSettings(reqCtx *contextmodel.ReqContext, cfg *setting.Cfg, 
 
 func isSupportBundlesEnabled(cfg *setting.Cfg) bool {
 	return cfg.SectionWithEnvOverrides("support_bundles").Key("enabled").MustBool(true)
+}
+
+// passkeyFrontendSettings returns the passkey block for bootData, or nil when the
+// feature is off. Returning nil keeps the field out of the JSON entirely so the
+// frontend's `config.passkey?.enabled` check resolves to false without ambiguity.
+func passkeyFrontendSettings(cfg *setting.Cfg) *dtos.FrontendSettingsPasskeyDTO {
+	if !cfg.Passkey.Enabled {
+		return nil
+	}
+	return &dtos.FrontendSettingsPasskeyDTO{Enabled: true}
 }
 
 func getShortCommitHash(commitHash string, maxLength int) string {

--- a/public/app/core/components/Login/LoginServiceButtons.tsx
+++ b/public/app/core/components/Login/LoginServiceButtons.tsx
@@ -6,6 +6,13 @@ import { Trans } from '@grafana/i18n';
 import { Icon, type IconName, LinkButton, Stack, useStyles2, useTheme2 } from '@grafana/ui';
 import config from 'app/core/config';
 
+import { PasskeyLoginButton } from './PasskeyLoginButton';
+
+const PASSKEY_KEY = 'passkey';
+
+const isPasskeyEnabled = () =>
+  Boolean(config.passkey?.enabled) && typeof window !== 'undefined' && 'PublicKeyCredential' in window;
+
 export interface LoginService {
   bgColor: string;
   enabled: boolean;
@@ -71,6 +78,15 @@ const loginServices: () => LoginServices = () => {
       name: config.oauth?.generic_oauth?.name || 'OAuth',
       icon: config.oauth?.generic_oauth?.icon || ('signin' as const),
       hrefName: 'generic_oauth',
+    },
+    // Passkey is rendered as an action button (LinkButton replacement) in the
+    // map below — the descriptor only carries `enabled`, the other fields are
+    // unused for this entry.
+    [PASSKEY_KEY]: {
+      bgColor: '#262628',
+      enabled: isPasskeyEnabled(),
+      name: 'Passkey',
+      icon: 'key-skeleton-alt' as const,
     },
   };
 };
@@ -148,6 +164,9 @@ export const LoginServiceButtons = () => {
       <Stack direction={'column'} width={'100%'}>
         <LoginDivider />
         {Object.entries(enabledServices).map(([key, service]) => {
+          if (key === PASSKEY_KEY) {
+            return <PasskeyLoginButton key={key} />;
+          }
           const serviceName = service.name;
           return (
             <LinkButton

--- a/public/app/core/components/Login/PasskeyLoginButton.test.tsx
+++ b/public/app/core/components/Login/PasskeyLoginButton.test.tsx
@@ -1,0 +1,141 @@
+import { startAuthentication } from '@simplewebauthn/browser';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { getBackendSrv } from '@grafana/runtime';
+import config from 'app/core/config';
+
+import { PasskeyLoginButton } from './PasskeyLoginButton';
+
+jest.mock('@simplewebauthn/browser', () => ({
+  startAuthentication: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime', () => {
+  const original = jest.requireActual('@grafana/runtime');
+  return {
+    ...original,
+    getBackendSrv: jest.fn(),
+  };
+});
+
+const mockStartAuthentication = startAuthentication as jest.MockedFunction<typeof startAuthentication>;
+
+const setLocation = (value: { assign: jest.Mock }) => {
+  Object.defineProperty(window, 'location', { value, writable: true });
+};
+
+const beginResponse = {
+  sessionID: 'sess-1',
+  options: { challenge: 'aGVsbG8', rpId: 'localhost', timeout: 60000, userVerification: 'required' },
+};
+
+const finishResponse = { message: 'ok', redirectUrl: '/d/home' };
+
+const makeBackendSrv = (overrides: Partial<{ begin: unknown; finish: unknown }> = {}) => {
+  const post = jest.fn((url: string) => {
+    if (url.endsWith('/login/begin')) {
+      return overrides.begin instanceof Error
+        ? Promise.reject(overrides.begin)
+        : Promise.resolve(overrides.begin ?? beginResponse);
+    }
+    if (url.endsWith('/login/finish')) {
+      return overrides.finish instanceof Error
+        ? Promise.reject(overrides.finish)
+        : Promise.resolve(overrides.finish ?? finishResponse);
+    }
+    return Promise.reject(new Error(`unexpected url ${url}`));
+  });
+  (getBackendSrv as jest.Mock).mockReturnValue({ post });
+  return post;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  config.passkey = { enabled: true };
+  // PublicKeyCredential is required for the capability check.
+  Object.defineProperty(window, 'PublicKeyCredential', { value: function () {}, configurable: true });
+  setLocation({ assign: jest.fn() });
+});
+
+afterEach(() => {
+  delete config.passkey;
+});
+
+describe('PasskeyLoginButton', () => {
+  it('renders nothing when the feature flag is disabled', () => {
+    config.passkey = { enabled: false };
+    const { container } = render(<PasskeyLoginButton />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the browser lacks PublicKeyCredential', () => {
+    // @ts-expect-error — deleting an intrinsic for the test environment.
+    delete window.PublicKeyCredential;
+    const { container } = render(<PasskeyLoginButton />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('redirects on a successful login ceremony', async () => {
+    const post = makeBackendSrv();
+    const assertion = { id: 'cred-1', response: {} };
+    mockStartAuthentication.mockResolvedValueOnce(assertion as never);
+
+    render(<PasskeyLoginButton />);
+    await userEvent.click(screen.getByTestId('passkey-login-button'));
+
+    await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
+    expect(post).toHaveBeenCalledWith('/api/auth/passkey/login/begin', undefined, { showErrorAlert: false });
+    expect(mockStartAuthentication).toHaveBeenCalledWith({ optionsJSON: beginResponse.options });
+    expect(post).toHaveBeenCalledWith(
+      '/api/auth/passkey/login/finish',
+      { sessionID: 'sess-1', response: assertion },
+      { showErrorAlert: false }
+    );
+    expect(window.location.assign).toHaveBeenCalledWith('/d/home');
+  });
+
+  it('re-enables silently when the user cancels the ceremony', async () => {
+    makeBackendSrv();
+    mockStartAuthentication.mockRejectedValueOnce(new DOMException('cancelled', 'NotAllowedError'));
+
+    render(<PasskeyLoginButton />);
+    const button = screen.getByTestId('passkey-login-button');
+    await userEvent.click(button);
+
+    await waitFor(() => expect(button).not.toBeDisabled());
+    expect(screen.queryByTestId('passkey-login-error')).not.toBeInTheDocument();
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+
+  it('shows the credential-not-found message when the backend rejects', async () => {
+    const err = Object.assign(new Error('not found'), {
+      status: 404,
+      data: { messageId: 'passkey.credential-not-found' },
+      config: { url: '' },
+    });
+    makeBackendSrv({ finish: err });
+    mockStartAuthentication.mockResolvedValueOnce({ id: 'cred-1', response: {} } as never);
+
+    render(<PasskeyLoginButton />);
+    await userEvent.click(screen.getByTestId('passkey-login-button'));
+
+    expect(await screen.findByTestId('passkey-login-error')).toHaveTextContent(/no passkey was found/i);
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+
+  it('shows the expired message on a 410 response', async () => {
+    const err = Object.assign(new Error('gone'), {
+      status: 410,
+      data: { messageId: 'passkey.challenge-expired' },
+      config: { url: '' },
+    });
+    makeBackendSrv({ finish: err });
+    mockStartAuthentication.mockResolvedValueOnce({ id: 'cred-1', response: {} } as never);
+
+    render(<PasskeyLoginButton />);
+    await userEvent.click(screen.getByTestId('passkey-login-button'));
+
+    expect(await screen.findByTestId('passkey-login-error')).toHaveTextContent(/took too long/i);
+  });
+});

--- a/public/app/core/components/Login/PasskeyLoginButton.tsx
+++ b/public/app/core/components/Login/PasskeyLoginButton.tsx
@@ -1,0 +1,145 @@
+import {
+  startAuthentication,
+  type AuthenticationResponseJSON,
+  type PublicKeyCredentialRequestOptionsJSON,
+} from '@simplewebauthn/browser';
+import { useCallback, useState } from 'react';
+
+import { t, Trans } from '@grafana/i18n';
+import { type FetchError, getBackendSrv, isFetchError } from '@grafana/runtime';
+import { Alert, Button, Icon, Stack } from '@grafana/ui';
+import config from 'app/core/config';
+
+import { type LoginDTO } from './types';
+
+interface BeginResponse {
+  sessionID: string;
+  options: PublicKeyCredentialRequestOptionsJSON;
+}
+
+interface FinishRequest {
+  sessionID: string;
+  response: AuthenticationResponseJSON;
+}
+
+const BEGIN_URL = '/api/auth/passkey/login/begin';
+const FINISH_URL = '/api/auth/passkey/login/finish';
+
+export const PasskeyLoginButton = () => {
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+  const redirectAfterLogin = useCallback((result: LoginDTO) => {
+    if (result.redirectUrl) {
+      if (config.appSubUrl !== '' && !result.redirectUrl.startsWith(config.appSubUrl)) {
+        window.location.assign(config.appSubUrl + result.redirectUrl);
+      } else {
+        window.location.assign(result.redirectUrl);
+      }
+    } else {
+      window.location.assign(config.appSubUrl + '/');
+    }
+  }, []);
+
+  const onClick = useCallback(async () => {
+    setErrorMessage(undefined);
+    setIsAuthenticating(true);
+
+    try {
+      const begin = await getBackendSrv().post<BeginResponse>(BEGIN_URL, undefined, {
+        showErrorAlert: false,
+      });
+
+      const assertion = await startAuthentication({ optionsJSON: begin.options });
+
+      const finishBody: FinishRequest = { sessionID: begin.sessionID, response: assertion };
+      const result = await getBackendSrv().post<LoginDTO>(FINISH_URL, finishBody, {
+        showErrorAlert: false,
+      });
+
+      redirectAfterLogin(result);
+    } catch (err) {
+      setIsAuthenticating(false);
+      // User dismissed the OS prompt, no credential available, or the browser
+      // timed out the ceremony — silent re-enable, no error message.
+      if (isWebAuthnAbort(err)) {
+        return;
+      }
+      setErrorMessage(toErrorMessage(err));
+    }
+  }, [redirectAfterLogin]);
+
+  if (!isPasskeyAvailable()) {
+    return null;
+  }
+
+  return (
+    <Stack direction="column" width="100%" gap={1}>
+      <Button
+        variant="secondary"
+        fill="outline"
+        fullWidth
+        disabled={isAuthenticating}
+        onClick={onClick}
+        data-testid="passkey-login-button"
+      >
+        <Stack direction="row" gap={1} alignItems="center">
+          <Icon name="key-skeleton-alt" />
+          {isAuthenticating ? (
+            <Trans i18nKey="login.passkey.signing-in">Signing in…</Trans>
+          ) : (
+            <Trans i18nKey="login.passkey.sign-in">Sign in with a passkey</Trans>
+          )}
+        </Stack>
+      </Button>
+      {errorMessage && (
+        <Alert
+          severity="error"
+          title={t('login.passkey.error.title', 'Passkey sign-in failed')}
+          onRemove={() => setErrorMessage(undefined)}
+          data-testid="passkey-login-error"
+        >
+          {errorMessage}
+        </Alert>
+      )}
+    </Stack>
+  );
+};
+
+function isPasskeyAvailable(): boolean {
+  return Boolean(config.passkey?.enabled) && typeof window !== 'undefined' && 'PublicKeyCredential' in window;
+}
+
+function isWebAuthnAbort(err: unknown): boolean {
+  return err instanceof DOMException && (err.name === 'NotAllowedError' || err.name === 'AbortError');
+}
+
+function toErrorMessage(err: unknown): string {
+  if (isFetchError(err)) {
+    return (
+      mapBackendError(err) ?? t('login.passkey.error.unknown', 'Could not sign in with passkey. Please try again.')
+    );
+  }
+  return t('login.passkey.error.unknown', 'Could not sign in with passkey. Please try again.');
+}
+
+function mapBackendError(err: FetchError<undefined | { messageId?: string; message?: string }>): string | undefined {
+  // 410 Gone is the contract for an expired/unknown session challenge (spec §4.5).
+  if (err.status === 410 || err.data?.messageId === 'passkey.challenge-expired') {
+    return t('login.passkey.error.expired', 'That took too long. Please try again.');
+  }
+  switch (err.data?.messageId) {
+    case 'passkey.credential-not-found':
+      return t(
+        'login.passkey.error.credential-not-found',
+        'No passkey was found for this site. Sign in with your password to register one.'
+      );
+    case 'login-attempt.blocked':
+      return t(
+        'login.error.blocked',
+        'You have exceeded the number of login attempts for this user. Please try again later.'
+      );
+    default:
+      return err.data?.message;
+  }
+}

--- a/public/app/features/profile/PasskeyEnrollButton.test.tsx
+++ b/public/app/features/profile/PasskeyEnrollButton.test.tsx
@@ -1,0 +1,136 @@
+import { startRegistration } from '@simplewebauthn/browser';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { getBackendSrv } from '@grafana/runtime';
+
+import { PasskeyEnrollButton } from './PasskeyEnrollButton';
+
+jest.mock('@simplewebauthn/browser', () => ({
+  startRegistration: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime', () => {
+  const original = jest.requireActual('@grafana/runtime');
+  return {
+    ...original,
+    getBackendSrv: jest.fn(),
+  };
+});
+
+const mockStartRegistration = startRegistration as jest.MockedFunction<typeof startRegistration>;
+
+const beginResponse = {
+  sessionID: 'sess-1',
+  options: { rp: { id: 'localhost', name: 'Grafana' }, user: {}, challenge: 'aGVsbG8' },
+};
+
+const installBackendSrv = (overrides: { begin?: unknown; finish?: unknown } = {}) => {
+  const post = jest.fn((url: string) => {
+    if (url.endsWith('/register/begin')) {
+      return overrides.begin instanceof Error
+        ? Promise.reject(overrides.begin)
+        : Promise.resolve(overrides.begin ?? beginResponse);
+    }
+    if (url.endsWith('/register/finish')) {
+      return overrides.finish instanceof Error
+        ? Promise.reject(overrides.finish)
+        : Promise.resolve(overrides.finish ?? { ok: true });
+    }
+    return Promise.reject(new Error(`unexpected url ${url}`));
+  });
+  (getBackendSrv as jest.Mock).mockReturnValue({ post });
+  return post;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PasskeyEnrollButton', () => {
+  it('opens a modal with a default name when clicked', async () => {
+    installBackendSrv();
+    render(<PasskeyEnrollButton onEnrolled={jest.fn()} />);
+
+    await userEvent.click(screen.getByTestId('passkey-enroll-button'));
+
+    const input = await screen.findByLabelText('Passkey name');
+    expect((input as HTMLInputElement).value).toMatch(/^Passkey \(/);
+  });
+
+  it('runs the registration ceremony and fires onEnrolled on success', async () => {
+    const post = installBackendSrv();
+    const credential = { id: 'cred-1', rawId: 'cred-1', response: {} };
+    mockStartRegistration.mockResolvedValueOnce(credential as never);
+    const onEnrolled = jest.fn();
+
+    render(<PasskeyEnrollButton onEnrolled={onEnrolled} />);
+    await userEvent.click(screen.getByTestId('passkey-enroll-button'));
+
+    const input = await screen.findByLabelText('Passkey name');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Work laptop');
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => expect(onEnrolled).toHaveBeenCalled());
+    expect(post).toHaveBeenCalledWith(
+      '/api/user/passkey/register/begin',
+      { name: 'Work laptop' },
+      { showErrorAlert: false }
+    );
+    expect(mockStartRegistration).toHaveBeenCalledWith({ optionsJSON: beginResponse.options });
+    expect(post).toHaveBeenCalledWith(
+      '/api/user/passkey/register/finish',
+      { sessionID: 'sess-1', name: 'Work laptop', response: credential },
+      { showErrorAlert: false }
+    );
+  });
+
+  it('keeps the modal open and stays silent when the user cancels the OS prompt', async () => {
+    installBackendSrv();
+    mockStartRegistration.mockRejectedValueOnce(new DOMException('cancelled', 'NotAllowedError'));
+    const onEnrolled = jest.fn();
+
+    render(<PasskeyEnrollButton onEnrolled={onEnrolled} />);
+    await userEvent.click(screen.getByTestId('passkey-enroll-button'));
+    await userEvent.click(await screen.findByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => expect(mockStartRegistration).toHaveBeenCalled());
+    expect(onEnrolled).not.toHaveBeenCalled();
+    expect(screen.queryByText(/could not register passkey/i)).not.toBeInTheDocument();
+    // Modal still open — name input is still present.
+    expect(screen.getByLabelText('Passkey name')).toBeInTheDocument();
+  });
+
+  it('blocks submission with a field-level error when the user hits Enter on an empty name', async () => {
+    const post = installBackendSrv();
+
+    render(<PasskeyEnrollButton onEnrolled={jest.fn()} />);
+    await userEvent.click(screen.getByTestId('passkey-enroll-button'));
+
+    const input = await screen.findByLabelText('Passkey name');
+    await userEvent.clear(input);
+    await userEvent.type(input, '{Enter}');
+
+    expect(await screen.findByText(/please enter a name/i)).toBeInTheDocument();
+    // The form-level alert with its title never appears for client-side validation.
+    expect(screen.queryByText('Could not register passkey')).not.toBeInTheDocument();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('shows the duplicate message when the backend rejects an already-registered credential', async () => {
+    const err = Object.assign(new Error('dup'), {
+      status: 409,
+      data: { messageId: 'passkey.credential-already-registered' },
+      config: { url: '' },
+    });
+    installBackendSrv({ finish: err });
+    mockStartRegistration.mockResolvedValueOnce({ id: 'cred-1', response: {} } as never);
+
+    render(<PasskeyEnrollButton onEnrolled={jest.fn()} />);
+    await userEvent.click(screen.getByTestId('passkey-enroll-button'));
+    await userEvent.click(await screen.findByRole('button', { name: 'Continue' }));
+
+    expect(await screen.findByText(/already registered/i)).toBeInTheDocument();
+  });
+});

--- a/public/app/features/profile/PasskeyEnrollButton.tsx
+++ b/public/app/features/profile/PasskeyEnrollButton.tsx
@@ -1,0 +1,167 @@
+import {
+  startRegistration,
+  type PublicKeyCredentialCreationOptionsJSON,
+  type RegistrationResponseJSON,
+} from '@simplewebauthn/browser';
+import { useCallback, useState } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { type FetchError, getBackendSrv, isFetchError } from '@grafana/runtime';
+import { Alert, Button, Field, Icon, Input, Modal, Stack } from '@grafana/ui';
+
+interface Props {
+  onEnrolled: () => void;
+}
+
+interface BeginResponse {
+  sessionID: string;
+  options: PublicKeyCredentialCreationOptionsJSON;
+}
+
+interface FinishRequest {
+  sessionID: string;
+  name: string;
+  response: RegistrationResponseJSON;
+}
+
+const BEGIN_URL = '/api/user/passkey/register/begin';
+const FINISH_URL = '/api/user/passkey/register/finish';
+
+const defaultName = () => {
+  const date = new Date().toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  return `Passkey (${date})`;
+};
+
+export const PasskeyEnrollButton = ({ onEnrolled }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [name, setName] = useState(defaultName);
+  const [isEnrolling, setIsEnrolling] = useState(false);
+  const [nameError, setNameError] = useState<string | undefined>();
+  const [submitError, setSubmitError] = useState<string | undefined>();
+
+  const reset = useCallback(() => {
+    setIsOpen(false);
+    setIsEnrolling(false);
+    setNameError(undefined);
+    setSubmitError(undefined);
+    setName(defaultName());
+  }, []);
+
+  const enroll = useCallback(async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setNameError(t('user-passkeys.enroll.error.name-required', 'Please enter a name for your passkey.'));
+      return;
+    }
+
+    setIsEnrolling(true);
+    setNameError(undefined);
+    setSubmitError(undefined);
+
+    try {
+      const begin = await getBackendSrv().post<BeginResponse>(BEGIN_URL, { name: trimmed }, { showErrorAlert: false });
+      const response = await startRegistration({ optionsJSON: begin.options });
+      const finishBody: FinishRequest = { sessionID: begin.sessionID, name: trimmed, response };
+      await getBackendSrv().post(FINISH_URL, finishBody, { showErrorAlert: false });
+
+      onEnrolled();
+      reset();
+    } catch (err) {
+      setIsEnrolling(false);
+      if (isWebAuthnAbort(err)) {
+        // User dismissed the OS prompt — keep the modal open so they can retry without re-typing the name.
+        return;
+      }
+      setSubmitError(toErrorMessage(err));
+    }
+  }, [name, onEnrolled, reset]);
+
+  return (
+    <>
+      <Button variant="primary" icon="plus" onClick={() => setIsOpen(true)} data-testid="passkey-enroll-button">
+        <Trans i18nKey="user-passkeys.enroll.button">Add passkey</Trans>
+      </Button>
+
+      {isOpen && (
+        <Modal
+          title={t('user-passkeys.enroll.modal.title', 'Add a passkey')}
+          isOpen
+          onDismiss={isEnrolling ? () => {} : reset}
+        >
+          <Stack direction="column" gap={2}>
+            {submitError && (
+              <Alert
+                severity="error"
+                title={t('user-passkeys.enroll.error.title', 'Could not register passkey')}
+                onRemove={() => setSubmitError(undefined)}
+              >
+                {submitError}
+              </Alert>
+            )}
+            <Field
+              noMargin
+              label={t('user-passkeys.enroll.modal.name-label', 'Name')}
+              description={t(
+                'user-passkeys.enroll.modal.name-description',
+                'A label to help you recognise this passkey later, e.g. "Work laptop" or "Yubikey".'
+              )}
+              invalid={Boolean(nameError)}
+              error={nameError}
+            >
+              <Input
+                value={name}
+                onChange={(e) => setName(e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    enroll();
+                  }
+                }}
+                autoFocus
+                disabled={isEnrolling}
+                aria-label={t('user-passkeys.enroll.modal.name-input', 'Passkey name')}
+              />
+            </Field>
+            <Stack direction="row" justifyContent="flex-end" gap={1}>
+              <Button variant="secondary" fill="outline" onClick={reset} disabled={isEnrolling}>
+                <Trans i18nKey="user-passkeys.enroll.modal.cancel">Cancel</Trans>
+              </Button>
+              <Button variant="primary" onClick={enroll} disabled={isEnrolling || !name.trim()}>
+                {isEnrolling ? (
+                  <Stack direction="row" gap={1} alignItems="center">
+                    <Icon name="fa fa-spinner" />
+                    <Trans i18nKey="user-passkeys.enroll.modal.in-progress">Waiting for device…</Trans>
+                  </Stack>
+                ) : (
+                  <Trans i18nKey="user-passkeys.enroll.modal.continue">Continue</Trans>
+                )}
+              </Button>
+            </Stack>
+          </Stack>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+function isWebAuthnAbort(err: unknown): boolean {
+  return err instanceof DOMException && (err.name === 'NotAllowedError' || err.name === 'AbortError');
+}
+
+function toErrorMessage(err: unknown): string {
+  if (isFetchError(err)) {
+    return (
+      mapBackendError(err) ?? t('user-passkeys.enroll.error.unknown', 'Could not register passkey. Please try again.')
+    );
+  }
+  return t('user-passkeys.enroll.error.unknown', 'Could not register passkey. Please try again.');
+}
+
+function mapBackendError(err: FetchError<undefined | { messageId?: string; message?: string }>): string | undefined {
+  if (err.status === 410 || err.data?.messageId === 'passkey.challenge-expired') {
+    return t('user-passkeys.enroll.error.expired', 'That took too long. Please try again.');
+  }
+  if (err.data?.messageId === 'passkey.credential-already-registered') {
+    return t('user-passkeys.enroll.error.duplicate', 'This passkey is already registered to your account.');
+  }
+  return err.data?.message;
+}

--- a/public/app/features/profile/UserPasskeys.test.tsx
+++ b/public/app/features/profile/UserPasskeys.test.tsx
@@ -77,7 +77,13 @@ describe('UserPasskeys', () => {
 
     const modal = await screen.findByRole('dialog');
     expect(within(modal).getByText(/cannot be undone/i)).toBeInTheDocument();
-    await userEvent.click(within(modal).getByRole('button', { name: 'Delete' }));
+
+    // The confirm button is disabled until the user types the confirmation text.
+    const confirmButton = within(modal).getByRole('button', { name: 'Delete' });
+    expect(confirmButton).toBeDisabled();
+    await userEvent.type(within(modal).getByRole('textbox'), 'Delete');
+    expect(confirmButton).toBeEnabled();
+    await userEvent.click(confirmButton);
 
     await waitFor(() => expect(del).toHaveBeenCalledWith('/api/user/passkey/credentials/1'));
   });

--- a/public/app/features/profile/UserPasskeys.test.tsx
+++ b/public/app/features/profile/UserPasskeys.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { getBackendSrv } from '@grafana/runtime';
+
+import { UserPasskeys, type UserPasskey } from './UserPasskeys';
+
+jest.mock('@grafana/runtime', () => {
+  const original = jest.requireActual('@grafana/runtime');
+  return {
+    ...original,
+    getBackendSrv: jest.fn(),
+  };
+});
+
+const samplePasskeys: UserPasskey[] = [
+  { id: 1, name: 'Yubikey', created: '2026-01-15T10:00:00Z', lastUsed: '2026-06-20T08:30:00Z' },
+  { id: 2, name: 'MacBook Touch ID', created: '2026-03-02T12:00:00Z' },
+];
+
+const installBackendSrv = (overrides: { get?: jest.Mock; patch?: jest.Mock; delete?: jest.Mock } = {}) => {
+  const get = overrides.get ?? jest.fn().mockResolvedValue(samplePasskeys);
+  const patch = overrides.patch ?? jest.fn().mockResolvedValue(undefined);
+  const del = overrides.delete ?? jest.fn().mockResolvedValue(undefined);
+  (getBackendSrv as jest.Mock).mockReturnValue({ get, patch, delete: del });
+  return { get, patch, delete: del };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('UserPasskeys', () => {
+  it('renders the list of registered passkeys', async () => {
+    installBackendSrv();
+    render(<UserPasskeys />);
+    expect(await screen.findByText('Yubikey')).toBeInTheDocument();
+    expect(screen.getByText('MacBook Touch ID')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the user has no passkeys', async () => {
+    installBackendSrv({ get: jest.fn().mockResolvedValue([]) });
+    render(<UserPasskeys />);
+    expect(await screen.findByText(/haven't registered any passkeys/i)).toBeInTheDocument();
+  });
+
+  it('renames a passkey via PATCH and refreshes the list', async () => {
+    const get = jest
+      .fn()
+      .mockResolvedValueOnce(samplePasskeys)
+      .mockResolvedValueOnce([{ ...samplePasskeys[0], name: 'Renamed' }, samplePasskeys[1]]);
+    const { patch } = installBackendSrv({ get });
+
+    render(<UserPasskeys />);
+    await screen.findByText('Yubikey');
+
+    const yubikeyRow = screen.getByText('Yubikey').closest('tr')!;
+    await userEvent.click(within(yubikeyRow).getByLabelText('Rename passkey'));
+    const input = within(yubikeyRow).getByLabelText('Passkey name');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Renamed');
+    await userEvent.click(within(yubikeyRow).getByLabelText('Save'));
+
+    await waitFor(() => expect(patch).toHaveBeenCalledWith('/api/user/passkey/credentials/1', { name: 'Renamed' }));
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('opens a confirmation modal before deleting and calls DELETE on confirm', async () => {
+    const get = jest.fn().mockResolvedValueOnce(samplePasskeys).mockResolvedValueOnce([samplePasskeys[1]]);
+    const { delete: del } = installBackendSrv({ get });
+
+    render(<UserPasskeys />);
+    await screen.findByText('Yubikey');
+
+    const yubikeyRow = screen.getByText('Yubikey').closest('tr')!;
+    await userEvent.click(within(yubikeyRow).getByLabelText('Delete passkey'));
+
+    const modal = await screen.findByRole('dialog');
+    expect(within(modal).getByText(/cannot be undone/i)).toBeInTheDocument();
+    await userEvent.click(within(modal).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(del).toHaveBeenCalledWith('/api/user/passkey/credentials/1'));
+  });
+
+  it('does not call DELETE when the user cancels the modal', async () => {
+    installBackendSrv();
+    const { delete: del } = installBackendSrv();
+
+    render(<UserPasskeys />);
+    await screen.findByText('Yubikey');
+    const yubikeyRow = screen.getByText('Yubikey').closest('tr')!;
+    await userEvent.click(within(yubikeyRow).getByLabelText('Delete passkey'));
+
+    await userEvent.click(within(await screen.findByRole('dialog')).getByRole('button', { name: 'Cancel' }));
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the empty state when the list fetch fails', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    installBackendSrv({ get: jest.fn().mockRejectedValue(new Error('boom')) });
+
+    render(<UserPasskeys />);
+
+    expect(await screen.findByText(/haven't registered any passkeys/i)).toBeInTheDocument();
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to load passkeys', expect.any(Error));
+    consoleSpy.mockRestore();
+  });
+});

--- a/public/app/features/profile/UserPasskeys.tsx
+++ b/public/app/features/profile/UserPasskeys.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { memo, useCallback, useEffect, useState } from 'react';
 
+import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { getBackendSrv } from '@grafana/runtime';
 import {
@@ -17,6 +18,8 @@ import {
   useStyles2,
 } from '@grafana/ui';
 import { formatDate } from 'app/core/internationalization/dates';
+
+import { PasskeyEnrollButton } from './PasskeyEnrollButton';
 
 export interface UserPasskey {
   id: number;
@@ -169,6 +172,10 @@ export const UserPasskeys = memo(() => {
         </ScrollContainer>
       )}
 
+      <div className={styles.actions}>
+        <PasskeyEnrollButton onEnrolled={load} />
+      </div>
+
       {pendingDelete && (
         <ConfirmModal
           isOpen
@@ -235,9 +242,12 @@ const PasskeyNameEditor = ({ initialValue, onSave, onCancel }: EditorProps) => {
   );
 };
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({
     maxWidth: '100%',
+  }),
+  actions: css({
+    marginTop: theme.spacing(2),
   }),
 });
 

--- a/public/app/features/profile/UserPasskeys.tsx
+++ b/public/app/features/profile/UserPasskeys.tsx
@@ -1,0 +1,244 @@
+import { css } from '@emotion/css';
+import { memo, useCallback, useEffect, useState } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  Alert,
+  Button,
+  ConfirmModal,
+  Icon,
+  IconButton,
+  Input,
+  LoadingPlaceholder,
+  ScrollContainer,
+  Stack,
+  Text,
+  useStyles2,
+} from '@grafana/ui';
+import { formatDate } from 'app/core/internationalization/dates';
+
+export interface UserPasskey {
+  id: number;
+  name: string;
+  created: string;
+  lastUsed?: string;
+}
+
+const LIST_URL = '/api/user/passkey/credentials';
+
+export const UserPasskeys = memo(() => {
+  const styles = useStyles2(getStyles);
+  const [passkeys, setPasskeys] = useState<UserPasskey[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>();
+  const [editingId, setEditingId] = useState<number | undefined>();
+  const [pendingDelete, setPendingDelete] = useState<UserPasskey | undefined>();
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(undefined);
+    try {
+      const result = await getBackendSrv().get<UserPasskey[]>(LIST_URL);
+      setPasskeys(result ?? []);
+    } catch (err) {
+      // Treat load failures as an empty list — the empty state is friendlier than
+      // a blocking alert, and it's the right UX whether the user has no passkeys
+      // or the endpoint is temporarily unreachable. Mutation errors (rename/delete)
+      // still surface via the alert below.
+      console.error('Failed to load passkeys', err);
+      setPasskeys([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const rename = useCallback(
+    async (id: number, name: string) => {
+      try {
+        await getBackendSrv().patch(`${LIST_URL}/${id}`, { name });
+        setEditingId(undefined);
+        await load();
+      } catch (err) {
+        setError(t('user-passkeys.error.rename', 'Could not rename passkey.'));
+      }
+    },
+    [load]
+  );
+
+  const remove = useCallback(
+    async (id: number) => {
+      try {
+        await getBackendSrv().delete(`${LIST_URL}/${id}`);
+        setPendingDelete(undefined);
+        await load();
+      } catch (err) {
+        setError(t('user-passkeys.error.delete', 'Could not delete passkey.'));
+      }
+    },
+    [load]
+  );
+
+  if (isLoading) {
+    return <LoadingPlaceholder text={<Trans i18nKey="user-passkeys.loading">Loading passkeys...</Trans>} />;
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <div className="page-sub-heading">
+        <Text variant="h3" element="h2">
+          <Trans i18nKey="user-passkeys.heading">Passkeys</Trans>
+        </Text>
+      </div>
+
+      {error && <Alert severity="error" title={error} onRemove={() => setError(undefined)} />}
+
+      {passkeys.length === 0 ? (
+        <Text color="secondary">
+          <Trans i18nKey="user-passkeys.empty">You haven&apos;t registered any passkeys yet.</Trans>
+        </Text>
+      ) : (
+        <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
+          <table className="filter-table form-inline" data-testid="user-passkeys-table">
+            <thead>
+              <tr>
+                <th>
+                  <Trans i18nKey="user-passkeys.name-column">Name</Trans>
+                </th>
+                <th>
+                  <Trans i18nKey="user-passkeys.created-column">Registered</Trans>
+                </th>
+                <th>
+                  <Trans i18nKey="user-passkeys.last-used-column">Last used</Trans>
+                </th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {passkeys.map((passkey) => (
+                <tr key={passkey.id}>
+                  <td>
+                    {editingId === passkey.id ? (
+                      <PasskeyNameEditor
+                        initialValue={passkey.name}
+                        onSave={(name) => rename(passkey.id, name)}
+                        onCancel={() => setEditingId(undefined)}
+                      />
+                    ) : (
+                      <Stack direction="row" gap={1} alignItems="center">
+                        <span>{passkey.name}</span>
+                        <IconButton
+                          name="pen"
+                          size="sm"
+                          tooltip={t('user-passkeys.rename', 'Rename passkey')}
+                          aria-label={t('user-passkeys.rename', 'Rename passkey')}
+                          onClick={() => setEditingId(passkey.id)}
+                        />
+                      </Stack>
+                    )}
+                  </td>
+                  <td>{formatDate(passkey.created, { dateStyle: 'long' })}</td>
+                  <td>
+                    {passkey.lastUsed ? (
+                      formatDate(passkey.lastUsed, { dateStyle: 'long' })
+                    ) : (
+                      <Text color="secondary">
+                        <Trans i18nKey="user-passkeys.never-used">Never</Trans>
+                      </Text>
+                    )}
+                  </td>
+                  <td>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      tooltip={t('user-passkeys.delete', 'Delete passkey')}
+                      onClick={() => setPendingDelete(passkey)}
+                      aria-label={t('user-passkeys.delete', 'Delete passkey')}
+                    >
+                      <Icon name="trash-alt" />
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </ScrollContainer>
+      )}
+
+      {pendingDelete && (
+        <ConfirmModal
+          isOpen
+          title={t('user-passkeys.delete-modal.title', 'Delete passkey?')}
+          body={t(
+            'user-passkeys.delete-modal.body',
+            'You will not be able to sign in with "{{name}}" again. This cannot be undone.',
+            { name: pendingDelete.name }
+          )}
+          confirmText={t('user-passkeys.delete-modal.confirm', 'Delete')}
+          dismissText={t('user-passkeys.delete-modal.cancel', 'Cancel')}
+          onConfirm={() => remove(pendingDelete.id)}
+          onDismiss={() => setPendingDelete(undefined)}
+        />
+      )}
+    </div>
+  );
+});
+
+UserPasskeys.displayName = 'UserPasskeys';
+
+interface EditorProps {
+  initialValue: string;
+  onSave: (name: string) => void;
+  onCancel: () => void;
+}
+
+const PasskeyNameEditor = ({ initialValue, onSave, onCancel }: EditorProps) => {
+  const [value, setValue] = useState(initialValue);
+  const trimmed = value.trim();
+  const canSave = trimmed.length > 0 && trimmed !== initialValue;
+
+  return (
+    <Stack direction="row" gap={1} alignItems="center">
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.currentTarget.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && canSave) {
+            onSave(trimmed);
+          } else if (e.key === 'Escape') {
+            onCancel();
+          }
+        }}
+        autoFocus
+        aria-label={t('user-passkeys.name-input', 'Passkey name')}
+      />
+      <IconButton
+        name="check"
+        size="sm"
+        disabled={!canSave}
+        tooltip={t('user-passkeys.save', 'Save')}
+        aria-label={t('user-passkeys.save', 'Save')}
+        onClick={() => onSave(trimmed)}
+      />
+      <IconButton
+        name="times"
+        size="sm"
+        tooltip={t('user-passkeys.cancel', 'Cancel')}
+        aria-label={t('user-passkeys.cancel', 'Cancel')}
+        onClick={onCancel}
+      />
+    </Stack>
+  );
+};
+
+const getStyles = () => ({
+  wrapper: css({
+    maxWidth: '100%',
+  }),
+});
+
+export default UserPasskeys;

--- a/public/app/features/profile/UserPasskeys.tsx
+++ b/public/app/features/profile/UserPasskeys.tsx
@@ -185,6 +185,7 @@ export const UserPasskeys = memo(() => {
             'You will not be able to sign in with "{{name}}" again. This cannot be undone.',
             { name: pendingDelete.name }
           )}
+          confirmationText={t('user-passkeys.delete-modal.confirmation', 'Delete')}
           confirmText={t('user-passkeys.delete-modal.confirm', 'Delete')}
           dismissText={t('user-passkeys.delete-modal.cancel', 'Cancel')}
           onConfirm={() => remove(pendingDelete.id)}

--- a/public/app/features/profile/UserPasskeys.tsx
+++ b/public/app/features/profile/UserPasskeys.tsx
@@ -251,5 +251,3 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginTop: theme.spacing(2),
   }),
 });
-
-export default UserPasskeys;

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -7,9 +7,11 @@ import { useFlagGrafanaNewPreferencesPage } from '@grafana/runtime/internal';
 import { Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { SharedPreferences } from 'app/core/components/SharedPreferences/SharedPreferences';
+import config from 'app/core/config';
 import { type StoreState } from 'app/types/store';
 
 import UserOrganizations from './UserOrganizations';
+import { UserPasskeys } from './UserPasskeys';
 import UserProfileEditForm from './UserProfileEditForm';
 import { UserProfileEditTabs } from './UserProfileEditTabs';
 import UserSessions from './UserSessions';
@@ -76,6 +78,7 @@ export function UserProfileEditPage({
               <UserTeams isLoading={teamsAreLoading} teams={teams} />
               <UserOrganizations isLoading={orgsAreLoading} setUserOrg={changeUserOrg} orgs={orgs} user={user} />
               <UserSessions isLoading={sessionsAreLoading} revokeUserSession={revokeUserSession} sessions={sessions} />
+              {config.passkey?.enabled && <UserPasskeys />}
             </Stack>
           </Stack>
         </UserProfileEditTabs>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10983,6 +10983,16 @@
     "layout": {
       "update-password": "Update your password"
     },
+    "passkey": {
+      "error": {
+        "credential-not-found": "No passkey was found for this site. Sign in with your password to register one.",
+        "expired": "That took too long. Please try again.",
+        "title": "Passkey sign-in failed",
+        "unknown": "Could not sign in with passkey. Please try again."
+      },
+      "sign-in": "Sign in with a passkey",
+      "signing-in": "Signing in…"
+    },
     "services": {
       "sing-in-with-prefix": "Sign in with {{serviceName}}"
     },
@@ -16428,6 +16438,50 @@
     "role-column": "Role",
     "select-org-button": "Select organisation",
     "title": "Organizations"
+  },
+  "user-passkeys": {
+    "cancel": "Cancel",
+    "created-column": "Registered",
+    "delete": "Delete passkey",
+    "delete-modal": {
+      "body": "You will not be able to sign in with \"{{name}}\" again. This cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete",
+      "confirmation": "Delete",
+      "title": "Delete passkey?"
+    },
+    "empty": "You haven't registered any passkeys yet.",
+    "enroll": {
+      "button": "Add passkey",
+      "error": {
+        "duplicate": "This passkey is already registered to your account.",
+        "expired": "That took too long. Please try again.",
+        "name-required": "Please enter a name for your passkey.",
+        "title": "Could not register passkey",
+        "unknown": "Could not register passkey. Please try again."
+      },
+      "modal": {
+        "cancel": "Cancel",
+        "continue": "Continue",
+        "in-progress": "Waiting for device…",
+        "name-description": "A label to help you recognise this passkey later, e.g. \"Work laptop\" or \"Yubikey\".",
+        "name-input": "Passkey name",
+        "name-label": "Name",
+        "title": "Add a passkey"
+      }
+    },
+    "error": {
+      "delete": "Could not delete passkey.",
+      "rename": "Could not rename passkey."
+    },
+    "heading": "Passkeys",
+    "last-used-column": "Last used",
+    "loading": "Loading passkeys...",
+    "name-column": "Name",
+    "name-input": "Passkey name",
+    "never-used": "Never",
+    "rename": "Rename passkey",
+    "save": "Save"
   },
   "user-picker": {
     "noOptionsMessage-no-users-found": "No users found",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7956,6 +7956,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@simplewebauthn/browser@npm:^13.3.0":
+  version: 13.3.0
+  resolution: "@simplewebauthn/browser@npm:13.3.0"
+  checksum: 10/1490c566017145f705e06f7f4d08822d19a616ce1ce8a152fcad1e4d88b418df3a4fa5c1f24e4ce142f41079ecbe3f9b77f3f3889e0cc1a4655e6f2ef2756228
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
@@ -18609,6 +18616,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.10.1"
     "@rsdoctor/webpack-plugin": "npm:^1.0.0"
     "@rtk-query/codegen-openapi": "npm:^2.0.0"
+    "@simplewebauthn/browser": "npm:^13.3.0"
     "@stylistic/eslint-plugin-ts": "npm:^4.0.0"
     "@swc/core": "npm:1.13.3"
     "@swc/helpers": "npm:0.5.17"


### PR DESCRIPTION
## Summary

Implements PR2 (frontend) from the passkey hackathon plan, plus B-Boot since it was needed to bridge B2 (config) to F-Boot (frontend typing).

**Login surface** — a \"Sign in with a passkey\" button in `LoginServiceButtons`, gated on `config.passkey?.enabled && window.PublicKeyCredential`. Runs the WebAuthn assertion ceremony via `@simplewebauthn/browser`'s `startAuthentication` and submits to `/api/auth/passkey/login/finish`. Distinct error messages for user-cancel (silent), `credential-not-found`, `challenge-expired` (410), and generic.

**Profile surface** — a \"Passkeys\" section below `UserSessions`, gated on `config.passkey?.enabled`. Lists registered passkeys with inline rename + type-to-confirm delete, plus an \"Add passkey\" modal that runs `startRegistration` against `/api/user/passkey/register/{begin,finish}`. Errors split: name-validation under the input, API/ceremony errors as a top-of-modal Alert.

**Backend (B-Boot)** — adds `FrontendSettingsPasskeyDTO` and a `Passkey *…DTO` field (`omitempty`) on `FrontendSettingsDTO`. Populated only when `cfg.Passkey.Enabled` is true.

## Backend coordination needed (B14)

`@simplewebauthn/browser` consumes the WebAuthn JSON spec shape for begin responses (base64url-encoded `challenge`, `user.id`, `allowCredentials[].id`, etc.). `go-webauthn` produces this shape via `protocol.CredentialAssertion.Response` / `protocol.CredentialCreation.Response` — its JSON tags already match. When wiring B14, please return the inner `.Response` object (the options) directly, not the outer wrapper.

Frontend expects:
```
POST /api/auth/passkey/login/begin             → { sessionID, options }
POST /api/auth/passkey/login/finish            body { sessionID, response }      → LoginDTO
POST /api/user/passkey/register/begin          body { name }                     → { sessionID, options }
POST /api/user/passkey/register/finish         body { sessionID, name, response }
GET    /api/user/passkey/credentials                                              → UserPasskey[]
PATCH  /api/user/passkey/credentials/:id       body { name }
DELETE /api/user/passkey/credentials/:id
```
```ts
type UserPasskey = { id: number; name: string; created: string; lastUsed?: string }
```

## Dependency

Adds `@simplewebauthn/browser@^13.3.0` (zero runtime deps).

## Tasks covered

F-Boot, F2, F3, F4, F5, F6 (partial — list + enroll button render, awaits real backend), F7, B-Boot.

## Test plan

- [ ] \`yarn jest public/app/core/components/Login/PasskeyLoginButton.test.tsx\` (6 cases)
- [ ] \`yarn jest public/app/features/profile/UserPasskeys.test.tsx\` (6 cases)
- [ ] \`yarn jest public/app/features/profile/PasskeyEnrollButton.test.tsx\` (5 cases)
- [ ] Set \`[auth.passkey] enabled = true\`, \`rp_id = localhost\`, \`rp_origins = http://localhost:3000\` + enable \`passkeyAuthn\` feature toggle → button appears on \`/login\` and Passkeys section appears on \`/profile\`
- [ ] Without the config → both surfaces hidden
- [ ] End-to-end ceremony **blocked on B9 + B14** — currently the buttons fire requests that 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)