### PR TITLE
TestDataSource: Add delay variability to flaky query scenario

### DIFF
--- a/pkg/tsdb/grafana-testdata-datasource/kinds/query.go
+++ b/pkg/tsdb/grafana-testdata-datasource/kinds/query.go
@@ -123,6 +123,10 @@ type TestDataQuery struct {
 	ErrorMessage     string  `json:"errorMessage,omitempty"`
 	ErrorStatusCode  int     `json:"errorStatusCode,omitempty"`
 
+	// Flaky query scenario: base delay (Go duration string) and jitter percentage (0-100)
+	QueryDelay            string  `json:"queryDelay,omitempty"`
+	QueryDelayVariability float64 `json:"queryDelayVariability,omitempty"`
+
 	Nodes     *NodesQuery      `json:"nodes,omitempty"`
 	PulseWave *PulseWaveQuery  `json:"pulseWave,omitempty"`
 	Sim       *SimulationQuery `json:"sim,omitempty"`

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -81,10 +81,9 @@ Timestamps will line up evenly on timeStepSeconds (For example, 60 seconds means
 	})
 
 	s.registerScenario(&Scenario{
-		ID:          kinds.TestDataQueryTypeFlakyQuery,
-		Name:        "Flaky Query",
-		StringInput: "5s",
-		handler:     s.handleFlakyQueryScenario,
+		ID:      kinds.TestDataQueryTypeFlakyQuery,
+		Name:    "Flaky Query",
+		handler: s.handleFlakyQueryScenario,
 	})
 
 	s.registerScenario(&Scenario{
@@ -486,9 +485,8 @@ func (s *Service) handleFlakyQueryScenario(ctx context.Context, req *backend.Que
 			continue
 		}
 
-		stringInput := model.StringInput
-		parsedInterval, _ := time.ParseDuration(stringInput)
-		time.Sleep(parsedInterval)
+		baseDelay, _ := time.ParseDuration(model.QueryDelay)
+		time.Sleep(flakyQueryDelay(baseDelay, model.QueryDelayVariability))
 
 		if shouldError {
 			status := backend.Status(model.ErrorStatusCode)
@@ -509,6 +507,24 @@ func (s *Service) handleFlakyQueryScenario(ctx context.Context, req *backend.Que
 	}
 
 	return resp, nil
+}
+
+// flakyQueryDelay applies a symmetric jitter to base, where variability is a
+// percentage (0-100). A variability of 100 yields a uniform delay in [0, 2*base].
+// The result is clamped to a non-negative duration.
+func flakyQueryDelay(base time.Duration, variability float64) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+
+	v := variability / 100
+	factor := 1 + (rand.Float64()*2-1)*v
+	delay := time.Duration(float64(base) * factor)
+	if delay < 0 {
+		return 0
+	}
+
+	return delay
 }
 
 func (s *Service) handleRandomWalkTableScenario(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
@@ -194,7 +194,7 @@ func TestTestdataScenarios(t *testing.T) {
 						Interval:      100 * time.Millisecond,
 						MaxDataPoints: 100,
 						JSON: []byte(fmt.Sprintf(
-							`{"stringInput":"0s","errorProbability":%v,"errorMessage":"test error","errorStatusCode":400,"errorSource":"downstream"}`,
+							`{"queryDelay":"0s","errorProbability":%v,"errorMessage":"test error","errorStatusCode":400,"errorSource":"downstream"}`,
 							probability,
 						)),
 					},
@@ -226,6 +226,37 @@ func TestTestdataScenarios(t *testing.T) {
 			require.NoError(t, dResp.Error)
 			require.Len(t, dResp.Frames, 1)
 		})
+	})
+}
+
+func TestFlakyQueryDelay(t *testing.T) {
+	t.Run("returns 0 for non-positive base", func(t *testing.T) {
+		require.Equal(t, time.Duration(0), flakyQueryDelay(0, 100))
+		require.Equal(t, time.Duration(0), flakyQueryDelay(-time.Second, 100))
+	})
+
+	t.Run("returns base unchanged with 0 variability", func(t *testing.T) {
+		base := time.Second
+		for i := 0; i < 100; i++ {
+			require.Equal(t, base, flakyQueryDelay(base, 0))
+		}
+	})
+
+	t.Run("stays within +/- variability percentage of base", func(t *testing.T) {
+		base := time.Second
+		// 100% variability => uniform in [0, 2*base]
+		for i := 0; i < 1000; i++ {
+			delay := flakyQueryDelay(base, 100)
+			require.GreaterOrEqual(t, delay, time.Duration(0))
+			require.LessOrEqual(t, delay, 2*base)
+		}
+
+		// 50% variability => uniform in [0.5*base, 1.5*base]
+		for i := 0; i < 1000; i++ {
+			delay := flakyQueryDelay(base, 50)
+			require.GreaterOrEqual(t, delay, base/2)
+			require.LessOrEqual(t, delay, base+base/2)
+		}
 	})
 }
 

--- a/public/app/plugins/datasource/grafana-testdata-datasource/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/QueryEditor.tsx
@@ -135,6 +135,8 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
         update.errorStatusCode = 400;
         update.errorSource = 'downstream';
         update.errorMessage = 'Flaky query error';
+        update.queryDelay = '5s';
+        update.queryDelayVariability = 0;
     }
 
     onUpdate(update);

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/FlakyQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/FlakyQueryEditor.tsx
@@ -68,6 +68,29 @@ const FlakyQueryEditor = ({ query, onChange }: EditorProps) => {
         </InlineField>
       </InlineFieldRow>
       <InlineFieldRow>
+        <InlineField labelWidth={14} label="Query delay" tooltip="Base delay applied to each request (e.g. 1s, 500ms)">
+          <Input width={8} name="queryDelay" placeholder="5s" value={query.queryDelay} onChange={onInputChange} />
+        </InlineField>
+        <InlineField
+          labelWidth={20}
+          label="Delay variability"
+          tooltip="Randomizes the query delay by +/- this percentage. 100% on a 1s delay sleeps between 0 and 2s"
+        >
+          <Input
+            type="number"
+            min={0}
+            max={100}
+            step={5}
+            width={8}
+            onChange={onInputChange}
+            name="queryDelayVariability"
+            placeholder="0"
+            value={query.queryDelayVariability}
+            suffix={<Icon name="percentage" />}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
         <InlineField labelWidth={14} label="Error message" grow>
           <Input
             width={64}

--- a/public/app/plugins/datasource/grafana-testdata-datasource/dataquery.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/dataquery.ts
@@ -128,4 +128,6 @@ export interface TestDataDataQuery extends common.DataQuery {
   errorProbability?: number;
   errorMessage?: string;
   errorStatusCode?: number;
+  queryDelay?: string;
+  queryDelayVariability?: number;
 }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/mocks/scenarios.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/mocks/scenarios.ts
@@ -114,7 +114,7 @@ export const scenarios = [
     description: '',
     id: TestDataQueryType.FlakyQuery,
     name: 'Flaky Query',
-    stringInput: '5s',
+    stringInput: '',
   },
   {
     description: '',

--- a/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1.json
@@ -270,6 +270,11 @@
                 },
                 "type": "object"
               },
+              "queryDelay": {
+                "description": "Flaky query scenario: base delay (Go duration string) and jitter percentage (0-100)",
+                "type": "string"
+              },
+              "queryDelayVariability": { "type": "number" },
               "rawFrameContent": { "type": "string" },
               "scenarioId": {
                 "description": "Possible enum values:\n - `\"annotations\"` \n - `\"arrow\"` \n - `\"csv_content\"` \n - `\"csv_file\"` \n - `\"csv_metric_values\"` \n - `\"datapoints_outside_range\"` \n - `\"error_with_source\"` \n - `\"flaky_query\"` \n - `\"exponential_heatmap_bucket_data\"` \n - `\"flame_graph\"` \n - `\"grafana_api\"` \n - `\"linear_heatmap_bucket_data\"` \n - `\"live\"` \n - `\"logs\"` \n - `\"manual_entry\"` \n - `\"no_data_points\"` \n - `\"node_graph\"` \n - `\"predictable_csv_wave\"` \n - `\"predictable_pulse\"` \n - `\"query_meta\"` \n - `\"random_walk\"` \n - `\"random_walk_table\"` \n - `\"random_walk_with_error\"` \n - `\"raw_frame\"` \n - `\"server_error_500\"` \n - `\"steps\"` \n - `\"simulation\"` \n - `\"slow_query\"` \n - `\"streaming_client\"` \n - `\"table_static\"` \n - `\"trace\"` \n - `\"usa\"` \n - `\"variables-query\"` ",

--- a/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1/query.types.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1/query.types.json
@@ -144,6 +144,13 @@
               },
               "type": "object"
             },
+            "queryDelay": {
+              "description": "Flaky query scenario: base delay (Go duration string) and jitter percentage (0-100)",
+              "type": "string"
+            },
+            "queryDelayVariability": {
+              "type": "number"
+            },
             "rawFrameContent": {
               "type": "string"
             },


### PR DESCRIPTION
**What is this feature?**
Following up on https://github.com/grafana/grafana/pull/126827 to better test panel behavior with requests that don't all resolve at the same time.

Adds a new "Delay variability" input to the "Flaky Query" scenario which will randomly jitter the "Query delay" by the percentage defined in this new input. e.g. a delay of 5s with a variability of 100% will randomly add 0-10s of delay to each request. 

<img width="1693" height="248" alt="image" src="https://github.com/user-attachments/assets/5a2e06f2-d6f9-4d04-9514-60a6835e5cad" />

**Why do we need this feature?**
Make it easier for panel developers to test queries that are more representative of how requests behave with real data sources. 

**Who is this feature for?**

Panel developers

**Special notes for your reviewer:**
Made a small breaking change to https://github.com/grafana/grafana/pull/126827 which was using the default test datasource "String input" field. This allows the UI to show "query delay" instead of "string input" in the label without mucking around in the test datasource internals that could impact other scenarios. 
This just means that folks that have saved results since https://github.com/grafana/grafana/pull/126827 was released will need to re-enter the query delay.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
