### PR TITLE
Chore: Provisioning - Adding regression tests for PR URL and repository URL generation 

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -802,6 +802,7 @@ type TestRepo struct {
 	TokenUser                 string
 	WebhookSecret             string
 	WebhookBaseURL            string
+	WebhookDisabled           bool
 	GenerateName              string
 	GenerateDashboardPreviews bool
 
@@ -859,6 +860,8 @@ type GitHubRepositorySpec struct {
 	Token                     string
 	TokenUser                 string
 	WebhookSecret             string
+	WebhookBaseURL            string
+	WebhookDisabled           bool
 	GenerateDashboardPreviews bool
 	Workflows                 []string
 	WorkflowsJSON             string
@@ -1320,6 +1323,12 @@ func WithoutProvisioningFolderMetadata(opts *testinfra.GrafanaOpts) {
 func WithRepositoryTypes(types []string) GrafanaOption {
 	return func(opts *testinfra.GrafanaOpts) {
 		opts.ProvisioningRepositoryTypes = types
+	}
+}
+
+func WithProvisioningPublicRootURL(url string) GrafanaOption {
+	return func(opts *testinfra.GrafanaOpts) {
+		opts.ProvisioningPublicRootURL = url
 	}
 }
 
@@ -2858,11 +2867,26 @@ type GitTestHelper struct {
 	*ProvisioningTestHelper
 	gitServer       *gittest.Server
 	exportRepoInfos map[string]*exportRepoInfo
+	githubUserOnce  sync.Once
+	githubUser      *gittest.User
+	githubUserErr   error
 }
 
 // GitServer returns the underlying gittest.Server.
 func (h *GitTestHelper) GitServer() *gittest.Server {
 	return h.gitServer
+}
+
+func (h *GitTestHelper) githubTransportUser(t *testing.T) *gittest.User {
+	t.Helper()
+
+	h.githubUserOnce.Do(func() {
+		h.githubUser, h.githubUserErr = h.gitServer.CreateUser(context.Background(), gittest.WithUsername("git"))
+	})
+	require.NoError(t, h.githubUserErr, "failed to create github transport user")
+	require.NotNil(t, h.githubUser, "github transport user should be created")
+
+	return h.githubUser
 }
 
 // SharedGitEnv lazily starts and reuses one GitTestHelper across tests.
@@ -3031,9 +3055,6 @@ func (h *GitTestHelper) CreateSyncEnabledGitRepo(t *testing.T, repoName string, 
 }
 
 // CreateGithubRepo creates a github-type repository backed by the gittest server.
-// The repo will NOT become healthy (git auth uses default "git" user which doesn't
-// exist on gittest), but webhooks are created before the health check runs, so
-// Status.Webhook will be populated if the GitHub API mock is configured.
 // workflows is optional; defaults to ["write"].
 // webhookBaseURL is optional; pass it to enable webhook creation on the repo.
 func (h *GitTestHelper) CreateGithubRepo(t *testing.T, repoName string, initialFiles map[string][]byte, webhookBaseURL string, workflows ...string) (*gittest.RemoteRepository, *gittest.LocalRepo) {
@@ -3042,10 +3063,23 @@ func (h *GitTestHelper) CreateGithubRepo(t *testing.T, repoName string, initialF
 		extraValues["WebhookBaseURL"] = webhookBaseURL
 	}
 	return h.createRepo(t, repoName, "github", "instance", createRepoOpts{
-		waitForReady:      false,
+		waitForReady:      true,
 		initialFiles:      initialFiles,
 		templateVariables: extraValues,
+		user:              h.githubTransportUser(t),
 		workflows:         workflows,
+	})
+}
+
+func (h *GitTestHelper) CreateGithubRepoWithWebhookDisabled(t *testing.T, repoName string, initialFiles map[string][]byte, workflows ...string) (*gittest.RemoteRepository, *gittest.LocalRepo) {
+	return h.createRepo(t, repoName, "github", "instance", createRepoOpts{
+		waitForReady: true,
+		initialFiles: initialFiles,
+		templateVariables: map[string]any{
+			"WebhookDisabled": true,
+		},
+		user:      h.githubTransportUser(t),
+		workflows: workflows,
 	})
 }
 
@@ -3064,6 +3098,7 @@ type createRepoOpts struct {
 	exportRepo        bool
 	initialFiles      map[string][]byte
 	templateVariables map[string]any
+	user              *gittest.User
 	workflows         []string
 }
 
@@ -3078,8 +3113,12 @@ func (h *GitTestHelper) createRepo(
 
 	ctx := context.Background()
 
-	user, err := h.gitServer.CreateUser(ctx)
-	require.NoError(t, err, "failed to create user")
+	user := opts.user
+	if user == nil {
+		var err error
+		user, err = h.gitServer.CreateUser(ctx)
+		require.NoError(t, err, "failed to create user")
+	}
 
 	remote, err := h.gitServer.CreateRepo(ctx, repoName, user)
 	require.NoError(t, err, "failed to create remote repository")

--- a/pkg/tests/apis/provisioning/foldermetadata/github_urls_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/github_urls_test.go
@@ -1,0 +1,155 @@
+package foldermetadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v82/github"
+	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// githubHealthCheckMockClient mocks the GitHub API calls that still happen for
+// GitHub-typed repositories even though git transport is backed by local gittest.
+func githubHealthCheckMockClient() *http.Client {
+	return ghmock.NewMockedHTTPClient(
+		ghmock.WithRequestMatchHandler(
+			ghmock.GetReposBranchesProtectionByOwnerByRepoByBranch,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			}),
+		),
+		ghmock.WithRequestMatchHandler(
+			ghmock.GetReposRulesBranchesByOwnerByRepoByBranch,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode([]*github.RepositoryRule{})
+			}),
+		),
+	)
+}
+
+// TestIntegrationGitHubFiles_DashboardBranchURLs verifies that dashboard writes
+// through a healthy GitHub-typed gittest repo return GitHub URL wrappers for both
+// new branch creation and a later update to the same branch.
+func TestIntegrationGitHubFiles_DashboardBranchURLs(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+	helper.GetEnv().GithubRepoFactory.Client = githubHealthCheckMockClient()
+
+	const repoName = "github-dashboard-urls"
+	remote, _ := helper.CreateGithubRepo(t, repoName, nil, "", "write", "branch")
+
+	const branch = "feature-dashboard-urls"
+	const dashboardPath = "dashboard.json"
+
+	result := helper.AdminREST.Post().
+		Namespace(helper.Namespace).
+		Resource("repositories").
+		Name(repoName).
+		SubResource("files", dashboardPath).
+		Param("ref", branch).
+		Param("message", "Create dashboard on branch").
+		Body(common.DashboardJSON("github-url-dash", "GitHub URL Dashboard", 1)).
+		SetHeader("Content-Type", "application/json").
+		Do(ctx)
+	require.NoError(t, result.Error(), "should create dashboard on branch")
+	assertGitHubFileURLs(t, decodeResourceWrapperResult(t, result), remote.URL, branch, dashboardPath)
+
+	result = helper.AdminREST.Put().
+		Namespace(helper.Namespace).
+		Resource("repositories").
+		Name(repoName).
+		SubResource("files", dashboardPath).
+		Param("ref", branch).
+		Param("message", "Update dashboard on branch").
+		Body(common.DashboardJSON("github-url-dash", "GitHub URL Dashboard Updated", 2)).
+		SetHeader("Content-Type", "application/json").
+		Do(ctx)
+	require.NoError(t, result.Error(), "should update dashboard on existing branch")
+	assertGitHubFileURLs(t, decodeResourceWrapperResult(t, result), remote.URL, branch, dashboardPath)
+}
+
+// TestIntegrationGitHubFiles_FolderMetadataBranchURLs verifies the folder
+// metadata branch update path returns URLs for the concrete _folder.json file,
+// which is the regression surface for folder rename/update operations.
+func TestIntegrationGitHubFiles_FolderMetadataBranchURLs(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+	helper.GetEnv().GithubRepoFactory.Client = githubHealthCheckMockClient()
+
+	const repoName = "github-folder-urls"
+	remote, _ := helper.CreateGithubRepo(t, repoName, nil, "", "write", "branch")
+
+	resp := postFolderViaFilesAPI(t, helper, repoName, "team-a/", "", "Create folder")
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "creating folder on default branch should succeed: %s", string(body))
+
+	uid := readFolderFieldOnRef(t, helper, ctx, repoName, "team-a/_folder.json", "", "metadata", "name")
+	require.NotEmpty(t, uid, "setup: folder should have a UID")
+
+	const branch = "feature-folder-urls"
+	resp = putFolderViaFilesAPI(t, helper, repoName,
+		"team-a/", branch, "Rename folder on branch",
+		common.FolderBody(t, uid, "Team A Renamed"))
+	defer func() { _ = resp.Body.Close() }()
+	wrapper := decodeResourceWrapperResponse(t, resp)
+	assertGitHubFileURLs(t, wrapper, remote.URL, branch, "team-a/_folder.json")
+}
+
+// decodeResourceWrapperResult reads a Kubernetes REST result from the files
+// endpoint and decodes the ResourceWrapper returned by dashboard file writes.
+func decodeResourceWrapperResult(t *testing.T, result rest.Result) *provisioning.ResourceWrapper {
+	t.Helper()
+
+	raw, err := result.Raw()
+	require.NoError(t, err, "failed to read resource wrapper response")
+	return decodeResourceWrapperBytes(t, raw)
+}
+
+// decodeResourceWrapperResponse reads a raw HTTP response from folder file
+// helpers, which build URLs manually to preserve trailing slash folder paths.
+func decodeResourceWrapperResponse(t *testing.T, resp *http.Response) *provisioning.ResourceWrapper {
+	t.Helper()
+
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.NoError(t, err, "failed to read resource wrapper response")
+	require.Equal(t, http.StatusOK, resp.StatusCode, "expected successful files response: %s", string(body))
+	return decodeResourceWrapperBytes(t, body)
+}
+
+// decodeResourceWrapperBytes unmarshals a files API response body into the
+// typed wrapper and includes the raw body in failures for easier diagnosis.
+func decodeResourceWrapperBytes(t *testing.T, body []byte) *provisioning.ResourceWrapper {
+	t.Helper()
+
+	wrapper := &provisioning.ResourceWrapper{}
+	require.NoError(t, json.Unmarshal(body, wrapper), "failed to decode resource wrapper: %s", string(body))
+	return wrapper
+}
+
+// assertGitHubFileURLs checks the GitHub-specific URL wrapper fields for a file
+// on a non-default branch. gittest exposes clone URLs with .git, but Grafana's
+// GitHub URL helpers intentionally emit browser URLs without that suffix.
+func assertGitHubFileURLs(t *testing.T, wrapper *provisioning.ResourceWrapper, repoURL, branch, filePath string) {
+	t.Helper()
+
+	repoURL = strings.TrimSuffix(repoURL, ".git")
+
+	require.NotNil(t, wrapper.URLs, "expected GitHub repository URLs")
+	require.Contains(t, repoURL, wrapper.URLs.RepositoryURL)
+	require.Equal(t, fmt.Sprintf("%s/blob/%s/%s", repoURL, branch, filePath), wrapper.URLs.SourceURL)
+	require.Equal(t, fmt.Sprintf("%s/compare/main...%s", repoURL, branch), wrapper.URLs.CompareURL)
+	require.Equal(t, fmt.Sprintf("%s/compare/main...%s?quick_pull=1&labels=grafana", repoURL, branch), wrapper.URLs.NewPullRequestURL)
+}

--- a/pkg/tests/apis/provisioning/foldermetadata/helper_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/helper_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var env = common.NewSharedGitEnv(
-	common.WithRepositoryTypes([]string{"git", "local"}),
+	common.WithRepositoryTypes([]string{"git", "github", "local"}),
 )
 
 func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {

--- a/pkg/tests/apis/provisioning/git/webhook/helper_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/helper_test.go
@@ -8,6 +8,7 @@ import (
 
 var env = common.NewSharedGitEnv(
 	common.WithoutProvisioningFolderMetadata,
+	common.WithProvisioningPublicRootURL("https://grafana.example.com"),
 	common.WithRepositoryTypes([]string{"git", "github"}),
 )
 

--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -2,9 +2,15 @@ package webhook
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-github/v82/github"
@@ -12,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -50,12 +57,19 @@ func webhookCreationMocks(hookID int64) []ghmock.MockBackendOption {
 		),
 		ghmock.WithRequestMatchHandler(
 			ghmock.PostReposHooksByOwnerByRepo,
-			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var hook github.Hook
+				if err := json.NewDecoder(r.Body).Decode(&hook); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
 				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(&github.Hook{
-					ID:     new(hookID),
-					URL:    new("https://grafana.example.com/hook"),
-					Events: []string{"pull_request", "push"},
+					ID:     github.Ptr(hookID),
+					URL:    hook.GetConfig().URL,
+					Config: hook.Config,
+					Events: hook.Events,
+					Active: hook.Active,
 				})
 			}),
 		),
@@ -76,22 +90,19 @@ func waitForWebhook(t *testing.T, helper *common.GitTestHelper, repoName string,
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "webhook should be created")
 }
 
-func TestIntegrationProvisioning_GithubRepoNoWebhookWithoutURL(t *testing.T) {
+func TestIntegrationProvisioning_GithubRepoNoWebhookWhenDisabled(t *testing.T) {
 	helper := sharedGitHelper(t)
 	ctx := context.Background()
 
-	// No webhook URL → no webhook created. Health check mocks not needed since
-	// we don't wait for healthy, but the controller will still attempt health check.
+	// The package enables a public root URL so webhook delivery can be tested;
+	// this repo opts out explicitly and should not register a webhook.
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient(githubHealthCheckMocks()...)
 
-	const repoName = "github-no-webhook"
-	helper.CreateGithubRepo(t, repoName, map[string][]byte{
+	const repoName = "github-webhook-disabled"
+	helper.CreateGithubRepoWithWebhookDisabled(t, repoName, map[string][]byte{
 		"dashboard.json": common.DashboardJSON("gh-dash", "GitHub Dashboard", 1),
-	}, "", "write")
+	}, "write")
 
-	// Give the controller time to reconcile, then check webhook is still nil.
-	// We can't wait for "healthy" since the repo won't be healthy (git auth fails).
-	// Instead, wait for the controller to have processed it (observedGeneration set).
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		obj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
@@ -115,6 +126,165 @@ func TestIntegrationProvisioning_GithubRepoWebhookCreated(t *testing.T) {
 	}, "https://grafana.example.com", "write")
 
 	waitForWebhook(t, helper, repoName, 456)
+}
+
+// TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment verifies the
+// end-to-end PR webhook path without a real GitHub PR: a pushed gittest feature
+// branch supplies the diff, the webhook payload supplies PR metadata, and the
+// mocked GitHub comments endpoint captures the PR worker's generated comment.
+func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+
+	var commentsMu sync.Mutex
+	var comments []string
+	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(654)...)
+	mockOpts = append(mockOpts, ghmock.WithRequestMatchHandler(
+		ghmock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var comment github.IssueComment
+			if err := json.NewDecoder(r.Body).Decode(&comment); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			// Capture the exact PR comment body so the test can verify what the
+			// pull request worker would post to GitHub.
+			commentsMu.Lock()
+			comments = append(comments, comment.GetBody())
+			commentsMu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(&github.IssueComment{
+				ID:   github.Ptr(int64(1)),
+				Body: github.Ptr(comment.GetBody()),
+			})
+		}),
+	))
+	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient(mockOpts...)
+
+	const repoName = "github-pr-comment"
+	const dashboardPath = "dashboard.json"
+	_, local := helper.CreateGithubRepo(t, repoName, map[string][]byte{
+		dashboardPath: common.DashboardJSON("gh-pr-comment-dash", "GitHub PR Comment Dashboard", 1),
+	}, "https://grafana.example.com", "write")
+	waitForWebhook(t, helper, repoName, 654)
+	helper.SyncAndWait(t, repoName)
+
+	const branchName = "feature-pr-comment"
+	_, err := local.Git("checkout", "-b", branchName)
+	require.NoError(t, err, "failed to create feature branch")
+	err = local.UpdateFile(dashboardPath, string(common.DashboardJSON("gh-pr-comment-dash", "GitHub PR Comment Dashboard Updated", 2)))
+	require.NoError(t, err, "failed to update dashboard")
+	_, err = local.Git("add", dashboardPath)
+	require.NoError(t, err, "failed to add dashboard")
+	_, err = local.Git("commit", "-m", "Update dashboard")
+	require.NoError(t, err, "failed to commit dashboard update")
+	headSHA, err := local.Git("rev-parse", "HEAD")
+	require.NoError(t, err, "failed to resolve feature branch SHA")
+	_, err = local.Git("push", "-u", "origin", branchName)
+	require.NoError(t, err, "failed to push feature branch")
+
+	prURL := fmt.Sprintf("https://github.example.com/git/%s/pull/123", repoName)
+	payload, err := json.Marshal(map[string]any{
+		"action": "opened",
+		"repository": map[string]any{
+			"full_name": fmt.Sprintf("git/%s", repoName),
+		},
+		"pull_request": map[string]any{
+			"number":   123,
+			"html_url": prURL,
+			"base": map[string]any{
+				"ref": "main",
+			},
+			"head": map[string]any{
+				"ref": branchName,
+				"sha": strings.TrimSpace(headSHA),
+			},
+		},
+	})
+	require.NoError(t, err, "failed to marshal pull request payload")
+
+	// Sign with the webhook secret Grafana persisted for this repository,
+	// because the webhook handler validates against that decrypted value.
+	obj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+	require.NoError(t, err, "failed to read repository")
+	repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
+	secretName := repo.Secure.WebhookSecret.Name
+	require.NotEmpty(t, secretName, "webhook secret should be stored")
+
+	decrypted, err := helper.GetEnv().DecryptService.Decrypt(ctx, provisioning.GROUP, repo.Namespace, secretName)
+	require.NoError(t, err, "failed to decrypt webhook secret")
+	require.Len(t, decrypted, 1)
+	result, ok := decrypted[secretName]
+	require.True(t, ok, "decrypted webhook secret should be returned")
+	require.NoError(t, result.Error(), "webhook secret decrypt result should not contain an error")
+	value := result.Value()
+	require.NotNil(t, value, "webhook secret value should be present")
+
+	mac := hmac.New(sha256.New, []byte(value.DangerouslyExposeAndConsumeValue()))
+	_, _ = mac.Write(payload)
+	signature := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	// Post the signed PR event and wait for the queued worker before reading
+	// the captured comment.
+	code := 0
+	webhookResult := helper.AdminREST.Post().
+		Namespace(helper.Namespace).
+		Resource("repositories").
+		Name(repoName).
+		SubResource("webhook").
+		Body(payload).
+		SetHeader("Content-Type", "application/json").
+		SetHeader(github.EventTypeHeader, "pull_request").
+		SetHeader(github.DeliveryIDHeader, fmt.Sprintf("%s-delivery", repoName)).
+		SetHeader(github.SHA256SignatureHeader, signature).
+		Do(ctx).
+		StatusCode(&code)
+
+	require.NoError(t, webhookResult.Error(), "webhook should accept pull request payload")
+	require.Equal(t, http.StatusAccepted, code, "webhook should queue a pull request job")
+
+	jobObj, err := webhookResult.Get()
+	require.NoError(t, err, "webhook response should include the queued job")
+	job, ok := jobObj.(*unstructured.Unstructured)
+	require.True(t, ok, "webhook response should be an unstructured job, got %T", jobObj)
+	helper.AwaitJobSuccess(t, ctx, job)
+
+	commentsMu.Lock()
+	capturedComments := append([]string(nil), comments...)
+	commentsMu.Unlock()
+	require.Len(t, capturedComments, 1, "expected one pull request comment")
+
+	comment := capturedComments[0]
+	require.Contains(t, comment, "Grafana spotted some changes to your dashboard")
+	require.Contains(t, comment, dashboardPath)
+
+	// Verify the dashboard and preview links the PR worker posted are
+	// well-formed and carry the context needed by the reviewer UI.
+	originalMarker := "[original]("
+	originalStart := strings.Index(comment, originalMarker)
+	require.NotEqualf(t, -1, originalStart, "comment should contain original link:\n%s", comment)
+	originalRemainder := comment[originalStart+len(originalMarker):]
+	originalEnd := strings.Index(originalRemainder, ")")
+	require.NotEqualf(t, -1, originalEnd, "comment should close original link:\n%s", comment)
+	originalURL, err := url.Parse(originalRemainder[:originalEnd])
+	require.NoError(t, err, "comment should contain a valid original URL")
+	require.Equal(t, "/d/gh-pr-comment-dash/github-pr-comment-dashboard-updated", originalURL.Path)
+
+	previewMarker := "[preview]("
+	previewStart := strings.Index(comment, previewMarker)
+	require.NotEqualf(t, -1, previewStart, "comment should contain preview link:\n%s", comment)
+	previewRemainder := comment[previewStart+len(previewMarker):]
+	previewEnd := strings.Index(previewRemainder, ")")
+	require.NotEqualf(t, -1, previewEnd, "comment should close preview link:\n%s", comment)
+	previewURL, err := url.Parse(previewRemainder[:previewEnd])
+	require.NoError(t, err, "comment should contain a valid preview URL")
+	require.Equal(t, fmt.Sprintf("/admin/provisioning/%s/dashboard/preview/%s", repoName, dashboardPath), previewURL.Path)
+	require.Equal(t, branchName, previewURL.Query().Get("ref"))
+	require.Equal(t, url.QueryEscape(prURL), previewURL.Query().Get("pull_request_url"))
+	require.Contains(t, previewURL.RawQuery, "pull_request_url="+url.QueryEscape(url.QueryEscape(prURL)))
 }
 
 func TestIntegrationProvisioning_GithubRepoWebhookRecreatedWhenMissing(t *testing.T) {
@@ -196,8 +366,8 @@ func TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired(t *testing.T) {
 			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(&github.Hook{
-					ID:     new(int64(200)),
-					URL:    new("https://grafana.example.com/hook"),
+					ID:     github.Ptr(int64(200)),
+					URL:    github.Ptr("https://grafana.example.com/hook"),
 					Events: []string{"pull_request", "push"},
 				})
 			}),
@@ -207,8 +377,8 @@ func TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired(t *testing.T) {
 			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(&github.Hook{
-					ID:     new(int64(200)),
-					URL:    new("https://grafana.example.com/hook"),
+					ID:     github.Ptr(int64(200)),
+					URL:    github.Ptr("https://grafana.example.com/hook"),
 					Events: []string{"pull_request", "push"},
 				})
 			}),

--- a/pkg/tests/apis/provisioning/testdata/github.json.tmpl
+++ b/pkg/tests/apis/provisioning/testdata/github.json.tmpl
@@ -22,6 +22,9 @@
         "workflows": {{ .WorkflowsJSON }}{{ if .WebhookBaseURL }},
         "webhook": {
             "baseUrl": "{{ .WebhookBaseURL }}"
+        }{{ else if .WebhookDisabled }},
+        "webhook": {
+            "disabled": true
         }{{ end }}
     },
     "secure": {

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -826,6 +826,12 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = provisioningSect.NewKey("allow_insecure", "true")
 		require.NoError(t, err)
 	}
+	if opts.ProvisioningPublicRootURL != "" {
+		provisioningSect, err := getOrCreateSection("provisioning")
+		require.NoError(t, err)
+		_, err = provisioningSect.NewKey("public_root_url", opts.ProvisioningPublicRootURL)
+		require.NoError(t, err)
+	}
 	if len(opts.ProvisioningRepositoryTypes) > 0 {
 		provisioningSect, err := getOrCreateSection("provisioning")
 		require.NoError(t, err)
@@ -1026,6 +1032,7 @@ type GrafanaOpts struct {
 	PermittedProvisioningPaths                           string
 	ProvisioningAllowedTargets                           []string
 	ProvisioningAllowInsecure                            bool
+	ProvisioningPublicRootURL                            string
 	ProvisioningRepositoryTypes                          []string
 	ProvisioningResources                                []string
 	ProvisioningMaxResourcesPerRepository                int64


### PR DESCRIPTION
## Summary

Add integration coverage for GitHub-typed provisioning repositories so regressions in PR/repository URL generation are caught in the end-to-end Git Sync flow.

## What Changed

- Added GitHub-typed gittest helper support that reuses a cached `git` transport user and waits for GitHub repositories to become healthy;
- Added optional provisioning `public_root_url` support in testinfra so webhook receiver behavior can be enabled in integration environments;
- Added support for explicitly disabled GitHub webhooks in the test repository template;
- Added GitHub webhook coverage for PR events:
  - pushes a real feature branch to local gittest;
  - sends a signed `pull_request` webhook payload using the persisted webhook secret;
  - captures the mocked GitHub PR comment;
  - asserts the generated comment includes well-formed original and preview links.
- Added GitHub URL regression coverage for branch workflow writes:
  - dashboard write on a feature branch;
  - dashboard update on the same existing branch;
  - folder metadata update where `sourceURL` must point to `_folder.json`.

## Why

PR and repository URL generation in Git Sync is fragile because it depends on repository type, branch state, resource paths, webhook payloads, and PR worker behavior. A previous regression linked users to the wrong PR after folder metadata changes. These tests cover the user-visible URL contract in the integration path rather than only isolated helpers.

Fixes https://github.com/grafana/git-ui-sync-project/issues/1222
