### PR TITLE
[codex] Stabilize storage migration tests

### DIFF
--- a/pkg/storage/unified/migrations/testcases/stars.go
+++ b/pkg/storage/unified/migrations/testcases/stars.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	authlib "github.com/grafana/authlib/types"
@@ -79,12 +82,18 @@ func (tc *starsTestCase) Setup(t *testing.T, helper *apis.K8sTestHelper) bool {
 		})
 		require.NoError(t, err)
 
-		res, err := stars.GetByUser(context.Background(), &star.GetUserStarsQuery{
-			UserID: userID,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, res)
-		require.Len(t, res.UserStars, 2)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			res, err := stars.GetByUser(context.Background(), &star.GetUserStarsQuery{
+				UserID: userID,
+			})
+			if !assert.NoError(c, err) {
+				return
+			}
+			if !assert.NotNil(c, res) {
+				return
+			}
+			assert.Len(c, res.UserStars, 2)
+		}, 5*time.Second, 100*time.Millisecond)
 	}
 
 	return true // will exist in mode0
@@ -116,12 +125,18 @@ func (tc *starsTestCase) Verify(t *testing.T, helper *apis.K8sTestHelper, should
 			GVR:       collectionsV1.GroupVersion.WithResource("stars"),
 		})
 
-		found, err := client.Resource.Get(ctx, "user-"+id, v1.GetOptions{})
 		if !shouldExist {
+			_, err := client.Resource.Get(ctx, "user-"+id, v1.GetOptions{})
 			require.Error(t, err, "should not get star for user %s", user)
 			continue
 		}
-		require.NoError(t, err)
+
+		var found *unstructured.Unstructured
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			var err error
+			found, err = client.Resource.Get(ctx, "user-"+id, v1.GetOptions{})
+			assert.NoError(c, err)
+		}, 5*time.Second, 100*time.Millisecond)
 
 		tmp, err := found.MarshalJSON()
 		require.NoError(t, err)

--- a/pkg/storage/unified/migrations/testcases/testcases.go
+++ b/pkg/storage/unified/migrations/testcases/testcases.go
@@ -72,10 +72,14 @@ func verifyResourceCount(t *testing.T, client *apis.K8sResourceClient, expectedC
 func verifyResource(t *testing.T, client *apis.K8sResourceClient, uid string, shouldExist bool) {
 	t.Helper()
 
-	v, err := client.Resource.Get(context.Background(), uid, metav1.GetOptions{})
 	if shouldExist {
-		require.NoError(t, err, "expecting to find: "+uid)
-	} else {
-		require.Error(t, err, "should not find: %+v", v)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			_, err := client.Resource.Get(context.Background(), uid, metav1.GetOptions{})
+			assert.NoError(c, err, "expecting to find: "+uid)
+		}, 5*time.Second, 100*time.Millisecond)
+		return
 	}
+
+	v, err := client.Resource.Get(context.Background(), uid, metav1.GetOptions{})
+	require.Error(t, err, "should not find: %+v", v)
 }


### PR DESCRIPTION
## What changed

This PR reduces flakiness in unified storage migration tests by making positive read assertions tolerate short visibility delays:

- Retry shared migration resource `Get` assertions when the resource is expected to exist.
- Retry the stars migration setup and verification reads, which use custom paths outside the shared helper.

Negative assertions remain immediate, so opt-out and not-migrated checks still fail if resources unexpectedly appear.

## Why

The daily CI report flagged `pkg/storage/unified/migrations/migrator_test.go` as flaky on main. This package already had a recent retry for list/count assertions due to SQLite/authz/read visibility timing. The remaining immediate `Get` assertions had the same exposure.

## Validation

- `go test ./pkg/storage/unified/migrations -run 'TestIntegrationMigrations' -count=1 -v`
- `go test ./pkg/storage/unified/migrations -count=1`