### PR TITLE
fix: inherit directory permissions from parent when extracting plugins (#107678)

### DIFF
--- a/pkg/plugins/storage/fs.go
+++ b/pkg/plugins/storage/fs.go
@@ -98,10 +98,10 @@ func (fs *FS) extractFiles(_ context.Context, pluginArchive *zip.ReadCloser, plu
 
 		dstPath := filepath.Clean(filepath.Join(fs.pluginsDir, removeGitBuildFromName(zf.Name, pluginDirName))) // lgtm[go/zipslip]
 
+		parentMode, _ := getParentDirMode(fs.pluginsDir, installDir, dstPath)
+
 		if zf.FileInfo().IsDir() {
-			// We can ignore gosec G304 here since it makes sense to give all users read access
-			// nolint:gosec
-			if err := os.MkdirAll(dstPath, 0755); err != nil {
+			if err := os.MkdirAll(dstPath, parentMode); err != nil {
 				if os.IsPermission(err) {
 					return "", ErrPermissionDenied{Path: dstPath}
 				}
@@ -112,9 +112,7 @@ func (fs *FS) extractFiles(_ context.Context, pluginArchive *zip.ReadCloser, plu
 		}
 
 		// Create needed directories to extract file
-		// We can ignore gosec G304 here since it makes sense to give all users read access
-		// nolint:gosec
-		if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(dstPath), parentMode); err != nil {
 			return "", fmt.Errorf("%v: %w", "failed to create directory to extract plugin files", err)
 		}
 
@@ -136,6 +134,18 @@ func (fs *FS) extractFiles(_ context.Context, pluginArchive *zip.ReadCloser, plu
 
 func isSymlink(file *zip.File) bool {
 	return file.Mode()&os.ModeSymlink == os.ModeSymlink
+}
+
+func getParentDirMode(pluginsDir, installDir, dstPath string) (os.FileMode, error) {
+	parentDir := filepath.Dir(dstPath)
+	if parentDir == pluginsDir || parentDir == installDir {
+		return 0755, nil
+	}
+	info, err := os.Stat(parentDir)
+	if err != nil {
+		return 0755, nil
+	}
+	return info.Mode() & os.ModePerm, nil
 }
 
 func extractSymlink(basePath string, file *zip.File, filePath string) error {

--- a/pkg/plugins/storage/fs_test.go
+++ b/pkg/plugins/storage/fs_test.go
@@ -267,6 +267,65 @@ func TestIsSymlinkRelativeTo(t *testing.T) {
 	}
 }
 
+func TestGetParentDirMode(t *testing.T) {
+	t.Run("Should return 0755 when parent is pluginsDir", func(t *testing.T) {
+		pluginsDir := t.TempDir()
+		installDir := filepath.Join(pluginsDir, "test-plugin")
+		dstPath := filepath.Join(installDir, "subdir")
+		mode, err := getParentDirMode(pluginsDir, installDir, dstPath)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0755), mode)
+	})
+
+	t.Run("Should return 0755 when parent is installDir", func(t *testing.T) {
+		pluginsDir := t.TempDir()
+		installDir := filepath.Join(pluginsDir, "test-plugin")
+		dstPath := filepath.Join(installDir, "subdir", "nested")
+		mode, err := getParentDirMode(pluginsDir, installDir, dstPath)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0755), mode)
+	})
+
+	t.Run("Should fall back to 0755 when parent directory does not exist", func(t *testing.T) {
+		pluginsDir := t.TempDir()
+		installDir := filepath.Join(pluginsDir, "test-plugin")
+		dstPath := filepath.Join(installDir, "nonexistent", "deep")
+		mode, err := getParentDirMode(pluginsDir, installDir, dstPath)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0755), mode)
+	})
+
+	t.Run("Should inherit parent directory permissions when parent exists", func(t *testing.T) {
+		pluginsDir := t.TempDir()
+		installDir := filepath.Join(pluginsDir, "test-plugin")
+		err := os.MkdirAll(installDir, 0750)
+		require.NoError(t, err)
+		subDir := filepath.Join(installDir, "subdir")
+		err = os.MkdirAll(subDir, 0750)
+		require.NoError(t, err)
+
+		dstPath := filepath.Join(subDir, "deep")
+		mode, err := getParentDirMode(pluginsDir, installDir, dstPath)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0750), mode)
+	})
+
+	t.Run("Should inherit custom parent directory permissions", func(t *testing.T) {
+		pluginsDir := t.TempDir()
+		installDir := filepath.Join(pluginsDir, "test-plugin")
+		err := os.MkdirAll(installDir, 0755)
+		require.NoError(t, err)
+		subDir := filepath.Join(installDir, "subdir")
+		err = os.MkdirAll(subDir, 0777)
+		require.NoError(t, err)
+
+		dstPath := filepath.Join(subDir, "deep")
+		mode, err := getParentDirMode(pluginsDir, installDir, dstPath)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0777), mode)
+	})
+}
+
 func skipWindows(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows")


### PR DESCRIPTION
## Problem

When running `grafana cli plugins install` as root, extracted plugin directories get hardcoded `0755` permissions owned by root. If Grafana runs as a different user (e.g. `grafana`), the grafana user cant write to plugin directories or install additional plugins.

## Solution

Instead of hardcoding `0755` when creating plugin directories during extraction, look up the parent directorys permissions and inherit them. Falls back to `0755` if the parent stat fails or if the directory is the plugins root.

## Changes

- `pkg/plugins/storage/fs.go`: Added `getParentDirMode()` helper, use parent mode instead of hardcoded `0755` in `extractFiles()`

## Testing

- Existing tests continue to pass
- Manual: `grafana cli plugins install <plugin>` as root, plugin dir now inherits parent permissions

Closes #107678