### PR TITLE
AccessControl: Cache Zanzana current-user permissions

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -170,7 +170,27 @@ func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requeste
 		return nil, err
 	}
 
-	return s.zanzanaResolver.MergeCurrentUser(ctx, user, permissions, s.log), nil
+	return s.mergeZanzanaUserPermissions(ctx, user, permissions, options), nil
+}
+
+func (s *Service) mergeZanzanaUserPermissions(ctx context.Context, user identity.Requester, legacy []accesscontrol.Permission, options accesscontrol.Options) []accesscontrol.Permission {
+	if s.zanzanaResolver == nil {
+		return legacy
+	}
+	if !s.cfg.RBAC.PermissionCache || !user.HasUniqueId() {
+		return s.zanzanaResolver.MergeCurrentUser(ctx, user, legacy, s.log)
+	}
+
+	zPerms, err := s.getCachedPermissions(ctx, accesscontrol.GetZanzanaUserPermissionCacheKey(user),
+		func(ctx context.Context) ([]accesscontrol.Permission, error) {
+			return s.zanzanaResolver.ResolveCurrentUserPermissions(ctx, user)
+		}, options)
+	if err != nil {
+		s.log.Warn("could not get zanzana user permissions, using legacy only", "error", err)
+		return legacy
+	}
+
+	return MergeUserPermissions(legacy, zPerms)
 }
 
 func (s *Service) getUserPermissions(ctx context.Context, user identity.Requester, _ accesscontrol.Options) ([]accesscontrol.Permission, error) {
@@ -474,6 +494,7 @@ func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.R
 
 func (s *Service) ClearUserPermissionCache(user identity.Requester) {
 	s.cache.ExclusiveDelete(accesscontrol.GetUserDirectPermissionCacheKey(user))
+	s.cache.ExclusiveDelete(accesscontrol.GetZanzanaUserPermissionCacheKey(user))
 }
 
 func (s *Service) DeleteUserPermissions(ctx context.Context, orgID int64, userID int64) error {

--- a/pkg/services/accesscontrol/acimpl/zanzana_merge_test.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_merge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"sync"
 	"testing"
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
@@ -63,6 +64,25 @@ func (f *fakeZanzanaClient) Mutate(context.Context, *authzextv1.MutateRequest) e
 
 func (f *fakeZanzanaClient) Query(context.Context, *authzextv1.QueryRequest) (*authzextv1.QueryResponse, error) {
 	return nil, nil
+}
+
+type countingZanzanaClient struct {
+	fakeZanzanaClient
+	mu        sync.Mutex
+	listCalls int
+}
+
+func (c *countingZanzanaClient) List(ctx context.Context, req *authzv1.ListRequest) (*authzv1.ListResponse, error) {
+	c.mu.Lock()
+	c.listCalls++
+	c.mu.Unlock()
+	return c.fakeZanzanaClient.List(ctx, req)
+}
+
+func (c *countingZanzanaClient) ListCallCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.listCalls
 }
 
 func sortPermissions(perms []accesscontrol.Permission) {
@@ -280,6 +300,105 @@ func setupServiceWithFakeStore(t *testing.T, store accesscontrol.Store, zClient 
 		svc.zanzanaResolver = NewZanzanaPermissionResolver(zClient, userSvc, nil, false)
 	}
 	return svc
+}
+
+func setupServiceWithPermissionCache(t *testing.T, store accesscontrol.Store, zClient zanzana.Client, userSvc user.Service, cacheEnabled bool) *Service {
+	svc := setupServiceWithFakeStore(t, store, zClient, userSvc)
+	svc.cfg.RBAC.PermissionCache = cacheEnabled
+	return svc
+}
+
+func testSignedInUser() *user.SignedInUser {
+	return &user.SignedInUser{
+		OrgID:       1,
+		UserID:      1,
+		UserUID:     "user_test_uid",
+		Permissions: map[int64]map[string][]string{},
+	}
+}
+
+func TestService_GetUserPermissions_CachesZanzanaPermissions(t *testing.T) {
+	store := &actest.FakeStore{
+		ExpectedUserPermissions: []accesscontrol.Permission{
+			{Action: "dashboards:read", Scope: "dashboards:uid:legacy"},
+		},
+	}
+	zClient := &countingZanzanaClient{
+		fakeZanzanaClient: fakeZanzanaClient{
+			listResp: &authzv1.ListResponse{Items: []string{"zanzana-dash"}},
+		},
+	}
+	svc := setupServiceWithPermissionCache(t, store, zClient, &usertest.FakeUserService{}, true)
+	siu := testSignedInUser()
+
+	_, err := svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+	firstCalls := zClient.ListCallCount()
+	require.NotZero(t, firstCalls, "first resolve should call Zanzana List")
+
+	_, err = svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+	require.Equal(t, firstCalls, zClient.ListCallCount(), "cached second call should not re-resolve Zanzana permissions")
+}
+
+func TestService_GetUserPermissions_ReloadCacheBypassesZanzanaCache(t *testing.T) {
+	store := &actest.FakeStore{}
+	zClient := &countingZanzanaClient{
+		fakeZanzanaClient: fakeZanzanaClient{
+			listResp: &authzv1.ListResponse{Items: []string{"zanzana-dash"}},
+		},
+	}
+	svc := setupServiceWithPermissionCache(t, store, zClient, &usertest.FakeUserService{}, true)
+	siu := testSignedInUser()
+
+	_, err := svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+	firstCalls := zClient.ListCallCount()
+
+	_, err = svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{ReloadCache: true})
+	require.NoError(t, err)
+	require.Greater(t, zClient.ListCallCount(), firstCalls, "ReloadCache should bypass Zanzana cache")
+}
+
+func TestService_GetUserPermissions_ClearUserPermissionCacheBypassesZanzanaCache(t *testing.T) {
+	store := &actest.FakeStore{}
+	zClient := &countingZanzanaClient{
+		fakeZanzanaClient: fakeZanzanaClient{
+			listResp: &authzv1.ListResponse{Items: []string{"zanzana-dash"}},
+		},
+	}
+	svc := setupServiceWithPermissionCache(t, store, zClient, &usertest.FakeUserService{}, true)
+	siu := testSignedInUser()
+
+	_, err := svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+	firstCalls := zClient.ListCallCount()
+
+	svc.ClearUserPermissionCache(siu)
+
+	_, err = svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+	require.Greater(t, zClient.ListCallCount(), firstCalls, "ClearUserPermissionCache should invalidate Zanzana cache")
+}
+
+func TestService_GetUserPermissions_DoesNotCacheZanzanaWhenPermissionCacheDisabled(t *testing.T) {
+	store := &actest.FakeStore{}
+	zClient := &countingZanzanaClient{
+		fakeZanzanaClient: fakeZanzanaClient{
+			listResp: &authzv1.ListResponse{Items: []string{"zanzana-dash"}},
+		},
+	}
+	svc := setupServiceWithPermissionCache(t, store, zClient, &usertest.FakeUserService{}, false)
+	siu := testSignedInUser()
+
+	_, err := svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+	firstCalls := zClient.ListCallCount()
+	require.NotZero(t, firstCalls)
+
+	_, err = svc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+	require.Greater(t, zClient.ListCallCount(), firstCalls, "PermissionCache disabled should resolve Zanzana on every call")
 }
 
 func TestService_SearchUsersPermissions_MergesLegacyAndZanzana(t *testing.T) {

--- a/pkg/services/accesscontrol/cacheutils.go
+++ b/pkg/services/accesscontrol/cacheutils.go
@@ -43,6 +43,10 @@ func GetUserDirectPermissionCacheKey(user identity.Requester) string {
 	return fmt.Sprintf("rbac-permissions-direct-%s", user.GetCacheKey())
 }
 
+func GetZanzanaUserPermissionCacheKey(user identity.Requester) string {
+	return fmt.Sprintf("rbac-zanzana-permissions-%s", user.GetCacheKey())
+}
+
 func GetBasicRolePermissionCacheKey(role string, orgID int64) string {
 	roleKey := strings.ReplaceAll(role, " ", "_")
 	roleKey = strings.ToLower(roleKey)


### PR DESCRIPTION
## Summary

`GetUserPermissions` resolves Zanzana-backed permissions on every call (via `MergeCurrentUser` -> `ResolveCurrentUserPermissions`), while the legacy SQL permissions are already cached. This adds caching for the Zanzana side, reusing the existing `Service` cache infrastructure.

- New `mergeZanzanaUserPermissions` helper wraps `ResolveCurrentUserPermissions` with the existing `getCachedPermissions` helper (reuses `s.cache`, the 60s `cacheTTL`, `options.ReloadCache` handling, and hit/miss metrics).
- Dedicated per-user cache key `GetZanzanaUserPermissionCacheKey` (keyed by `user.GetCacheKey()`), kept separate from the legacy permission caches.
- `ClearUserPermissionCache` now also invalidates the Zanzana entry.
- The resolver itself is unchanged.

## Behavior

- Cache is only used when `RBAC.PermissionCache` is enabled and the user has a unique id; otherwise the unchanged `MergeCurrentUser` path runs (identical to before).
- On a Zanzana lookup error, we log and fall back to legacy-only permissions, matching the previous behavior. Errors are not cached.

### Accepted tradeoff (staleness)

The key is `orgID-type-id` only (no team/group hash), matching how `getCachedUserDirectPermissions` already keys. A user's team/group-membership change is reflected on the next `ClearUserPermissionCache` or within the 60s TTL. A value-stored team hash is a possible later refinement.

## Scope

OSS only. The enterprise `Service` has its own `GetUserPermissions`/cache and is unaffected; enterprise caching can be a follow-up.

## Test plan

- [x] `go test ./pkg/services/accesscontrol/acimpl/...`
- [x] `go vet ./pkg/services/accesscontrol/...`
- New tests in `zanzana_merge_test.go`: cache hit avoids re-resolve, `ReloadCache` bypasses cache, `ClearUserPermissionCache` invalidates, and cache-disabled resolves every call.