### PR TITLE
Dashboards Mutation API: align dashboard settings commands with the v2 spec

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/README.md
+++ b/public/app/features/dashboard-scene/mutation-api/README.md
@@ -922,11 +922,40 @@ For section scope, `changes[0].path` is prefixed (for example `"/rows/0/variable
 
 ---
 
+## Settings
+
+### `UPDATE_DASHBOARD_SETTINGS`
+
+Update dashboard-level settings. Requires edit permissions. All fields are optional; only the fields provided are changed. `tags` and `links` replace the full list.
+
+**Request:**
+
+```json
+{
+  "type": "UPDATE_DASHBOARD_SETTINGS",
+  "payload": {
+    "title": "Production Overview",
+    "description": "Key production service metrics",
+    "tags": ["production", "sre"],
+    "editable": true,
+    "refresh": "1m",
+    "timeRange": { "from": "now-7d", "to": "now" },
+    "timezone": "utc",
+    "cursorSync": "Crosshair",
+    "links": [{ "title": "Runbook", "url": "https://runbooks.example.com", "type": "link", "targetBlank": true }]
+  }
+}
+```
+
+`cursorSync` accepts `"Off"`, `"Crosshair"`, or `"Tooltip"`. When the dashboard has no `CursorSync` behavior, a warning is returned. The response `data` contains the updated settings (same shape as `GET_DASHBOARD_INFO`).
+
+---
+
 ## Metadata
 
 ### `GET_DASHBOARD_INFO`
 
-Get dashboard metadata. Read-only, no permissions required.
+Get dashboard identity/folder metadata plus every dashboard-level setting that `UPDATE_DASHBOARD_SETTINGS` can write. Read-only, no permissions required.
 
 **Request:**
 
@@ -942,8 +971,14 @@ Get dashboard metadata. Read-only, no permissions required.
   "data": {
     "title": "My Dashboard",
     "description": "Dashboard description",
-    "uid": "abc123",
     "tags": ["production", "monitoring"],
+    "editable": true,
+    "refresh": "30s",
+    "timeRange": { "from": "now-6h", "to": "now" },
+    "timezone": "utc",
+    "cursorSync": "Crosshair",
+    "links": [{ "title": "Runbook", "url": "https://runbooks.example.com", "type": "link" }],
+    "uid": "abc123",
     "folderTitle": "Infrastructure",
     "folderUid": "folder-1",
     "created": "2025-01-15T10:00:00Z",

--- a/public/app/features/dashboard-scene/mutation-api/README.md
+++ b/public/app/features/dashboard-scene/mutation-api/README.md
@@ -926,7 +926,7 @@ For section scope, `changes[0].path` is prefixed (for example `"/rows/0/variable
 
 ### `UPDATE_DASHBOARD_SETTINGS`
 
-Update dashboard-level settings. Requires edit permissions. All fields are optional; only the fields provided are changed. `tags` and `links` replace the full list.
+Update dashboard-level settings. Requires edit permissions. All fields are optional; only the fields provided are changed. `tags` and `links` replace the full list. Time-related fields are nested under `timeSettings` (matching the v2 dashboard spec).
 
 **Request:**
 
@@ -938,16 +938,16 @@ Update dashboard-level settings. Requires edit permissions. All fields are optio
     "description": "Key production service metrics",
     "tags": ["production", "sre"],
     "editable": true,
-    "refresh": "1m",
-    "timeRange": { "from": "now-7d", "to": "now" },
-    "timezone": "utc",
     "cursorSync": "Crosshair",
-    "links": [{ "title": "Runbook", "url": "https://runbooks.example.com", "type": "link", "targetBlank": true }]
+    "links": [{ "title": "Runbook", "url": "https://runbooks.example.com", "type": "link", "targetBlank": true }],
+    "timeSettings": { "from": "now-7d", "to": "now", "autoRefresh": "1m", "timezone": "utc" },
+    "liveNow": false,
+    "preload": true
   }
 }
 ```
 
-`cursorSync` accepts `"Off"`, `"Crosshair"`, or `"Tooltip"`. When the dashboard has no `CursorSync` behavior, a warning is returned. The response `data` contains the updated settings (same shape as `GET_DASHBOARD_INFO`).
+`cursorSync` accepts `"Off"`, `"Crosshair"`, or `"Tooltip"`. `cursorSync` and `liveNow` are behavior-based; when the dashboard has no `CursorSync` / `LiveNowTimer` behavior a warning is returned. The response `data` contains the updated settings (same shape as `GET_DASHBOARD_INFO`).
 
 ---
 
@@ -973,11 +973,11 @@ Get dashboard identity/folder metadata plus every dashboard-level setting that `
     "description": "Dashboard description",
     "tags": ["production", "monitoring"],
     "editable": true,
-    "refresh": "30s",
-    "timeRange": { "from": "now-6h", "to": "now" },
-    "timezone": "utc",
     "cursorSync": "Crosshair",
     "links": [{ "title": "Runbook", "url": "https://runbooks.example.com", "type": "link" }],
+    "timeSettings": { "from": "now-6h", "to": "now", "autoRefresh": "30s", "timezone": "utc" },
+    "liveNow": false,
+    "preload": true,
     "uid": "abc123",
     "folderTitle": "Infrastructure",
     "folderUid": "folder-1",

--- a/public/app/features/dashboard-scene/mutation-api/commands/dashboardSettingsUtils.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/dashboardSettingsUtils.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared helpers for reading dashboard-level settings off the DashboardScene.
+ *
+ * Used by UPDATE_DASHBOARD_SETTINGS (to diff before/after) and GET_DASHBOARD_INFO
+ * (to report current values), so the set of settings stays in sync between the
+ * command that writes them and the command that reads them.
+ */
+
+import { behaviors, sceneGraph } from '@grafana/scenes';
+
+import {
+  type DashboardCursorSync,
+  type DashboardLink,
+} from '../../../../../../packages/grafana-schema/src/schema/dashboard/v2';
+import { transformCursorSynctoEnum } from '../../serialization/transformToV2TypesUtils';
+
+import type { MutationContext } from './types';
+
+export interface DashboardSettings {
+  title: string;
+  description: string;
+  tags: string[];
+  editable: boolean;
+  refresh: string;
+  timeRange: { from: string; to: string };
+  timezone: string;
+  cursorSync: DashboardCursorSync;
+  links: DashboardLink[];
+}
+
+export function findCursorSyncBehavior(scene: MutationContext['scene']): behaviors.CursorSync | undefined {
+  return scene.state.$behaviors?.find((b): b is behaviors.CursorSync => b instanceof behaviors.CursorSync);
+}
+
+export function readDashboardSettings(scene: MutationContext['scene']): DashboardSettings {
+  const timeRange = sceneGraph.getTimeRange(scene);
+  const refreshPicker = scene.state.controls?.state.refreshPicker;
+
+  return {
+    title: scene.state.title ?? '',
+    description: scene.state.description ?? '',
+    tags: scene.state.tags ?? [],
+    editable: scene.state.editable ?? true,
+    refresh: refreshPicker?.state.refresh ?? '',
+    timeRange: {
+      from: timeRange.state.from,
+      to: timeRange.state.to,
+    },
+    timezone: timeRange.state.timeZone ?? '',
+    cursorSync: transformCursorSynctoEnum(findCursorSyncBehavior(scene)?.state.sync),
+    links: scene.state.links ?? [],
+  };
+}

--- a/public/app/features/dashboard-scene/mutation-api/commands/getDashboardInfo.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/getDashboardInfo.test.ts
@@ -12,9 +12,18 @@ jest.mock('@grafana/scenes', () => {
       this.state = state;
     }
   }
+  class LiveNowTimer {
+    public state: { enabled: boolean };
+    constructor(state: { enabled: boolean }) {
+      this.state = state;
+    }
+    public get isEnabled() {
+      return this.state.enabled;
+    }
+  }
   return {
     sceneGraph: { getTimeRange: jest.fn() },
-    behaviors: { CursorSync },
+    behaviors: { CursorSync, LiveNowTimer },
   };
 });
 
@@ -22,6 +31,7 @@ function buildTestScene() {
   const timeRange = { state: { from: 'now-12h', to: 'now', timeZone: 'utc' } };
   const refreshPicker = { state: { refresh: '30s' } };
   const cursorSync = new behaviors.CursorSync({ sync: DashboardCursorSync.Crosshair });
+  const liveNowTimer = new behaviors.LiveNowTimer({ enabled: true });
 
   const scene = {
     state: {
@@ -29,10 +39,11 @@ function buildTestScene() {
       description: 'desc',
       tags: ['a', 'b'],
       editable: false,
+      preload: true,
       links: [{ title: 'Runbook', url: 'https://x' }],
       uid: 'dash-1',
       meta: { folderTitle: 'General', folderUid: 'f1', created: 'c', updated: 'u' },
-      $behaviors: [cursorSync],
+      $behaviors: [cursorSync, liveNowTimer],
       controls: { state: { refreshPicker } },
     },
   };
@@ -62,11 +73,11 @@ describe('GET_DASHBOARD_INFO', () => {
       description: 'desc',
       tags: ['a', 'b'],
       editable: false,
-      refresh: '30s',
-      timeRange: { from: 'now-12h', to: 'now' },
-      timezone: 'utc',
       cursorSync: 'Crosshair',
       links: [{ title: 'Runbook', url: 'https://x' }],
+      timeSettings: { from: 'now-12h', to: 'now', timezone: 'utc', autoRefresh: '30s' },
+      liveNow: true,
+      preload: true,
     });
   });
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/getDashboardInfo.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/getDashboardInfo.test.ts
@@ -1,0 +1,72 @@
+import { behaviors, sceneGraph } from '@grafana/scenes';
+import { DashboardCursorSync } from '@grafana/schema';
+
+import type { DashboardScene } from '../../scene/DashboardScene';
+
+import { getDashboardInfoCommand } from './getDashboardInfo';
+
+jest.mock('@grafana/scenes', () => {
+  class CursorSync {
+    public state: { sync: number };
+    constructor(state: { sync: number }) {
+      this.state = state;
+    }
+  }
+  return {
+    sceneGraph: { getTimeRange: jest.fn() },
+    behaviors: { CursorSync },
+  };
+});
+
+function buildTestScene() {
+  const timeRange = { state: { from: 'now-12h', to: 'now', timeZone: 'utc' } };
+  const refreshPicker = { state: { refresh: '30s' } };
+  const cursorSync = new behaviors.CursorSync({ sync: DashboardCursorSync.Crosshair });
+
+  const scene = {
+    state: {
+      title: 'My Dashboard',
+      description: 'desc',
+      tags: ['a', 'b'],
+      editable: false,
+      links: [{ title: 'Runbook', url: 'https://x' }],
+      uid: 'dash-1',
+      meta: { folderTitle: 'General', folderUid: 'f1', created: 'c', updated: 'u' },
+      $behaviors: [cursorSync],
+      controls: { state: { refreshPicker } },
+    },
+  };
+
+  (sceneGraph.getTimeRange as jest.Mock).mockReturnValue(timeRange);
+
+  return { scene: scene as unknown as DashboardScene };
+}
+
+describe('GET_DASHBOARD_INFO', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns identity/folder metadata plus all UPDATE_DASHBOARD_SETTINGS fields', async () => {
+    const { scene } = buildTestScene();
+    const result = await getDashboardInfoCommand.handler({}, { scene });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      // identity + folder
+      uid: 'dash-1',
+      folderTitle: 'General',
+      folderUid: 'f1',
+      // settings writable via UPDATE_DASHBOARD_SETTINGS
+      title: 'My Dashboard',
+      description: 'desc',
+      tags: ['a', 'b'],
+      editable: false,
+      refresh: '30s',
+      timeRange: { from: 'now-12h', to: 'now' },
+      timezone: 'utc',
+      cursorSync: 'Crosshair',
+      links: [{ title: 'Runbook', url: 'https://x' }],
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/mutation-api/commands/getDashboardInfo.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/getDashboardInfo.ts
@@ -1,12 +1,15 @@
 /**
  * GET_DASHBOARD_INFO command
  *
- * Returns dashboard metadata (title, description, uid, tags, folder info,
- * timestamps) from the DashboardScene state. Read-only, no permissions required.
+ * Returns dashboard identity/folder metadata plus every dashboard-level setting
+ * that UPDATE_DASHBOARD_SETTINGS can write (title, description, tags, editable,
+ * refresh, time range, timezone, cursorSync, links), read from the
+ * DashboardScene state. Read-only, no permissions required.
  */
 
 import { payloads } from './schemas';
 import { readOnly, type MutationCommand } from './types';
+import { readDashboardSettings } from './updateDashboardSettings';
 
 export const getDashboardInfoCommand: MutationCommand<Record<string, never>> = {
   name: 'GET_DASHBOARD_INFO',
@@ -20,15 +23,13 @@ export const getDashboardInfoCommand: MutationCommand<Record<string, never>> = {
     const { scene } = context;
 
     try {
-      const { title, description, uid, tags, meta } = scene.state;
+      const { uid, meta } = scene.state;
 
       return {
         success: true,
         data: {
-          title: title ?? '',
-          description: description ?? '',
+          ...readDashboardSettings(scene),
           uid: uid ?? '',
-          tags: tags ?? [],
           ...(meta && {
             folderTitle: meta.folderTitle,
             folderUid: meta.folderUid,

--- a/public/app/features/dashboard-scene/mutation-api/commands/getDashboardInfo.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/getDashboardInfo.ts
@@ -7,8 +7,8 @@
  * DashboardScene state. Read-only, no permissions required.
  */
 
-import { readDashboardSettings } from './dashboardSettingsUtils';
 import { payloads } from './schemas';
+import { readDashboardSettings } from './shared';
 import { readOnly, type MutationCommand } from './types';
 
 export const getDashboardInfoCommand: MutationCommand<Record<string, never>> = {

--- a/public/app/features/dashboard-scene/mutation-api/commands/getDashboardInfo.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/getDashboardInfo.ts
@@ -7,9 +7,9 @@
  * DashboardScene state. Read-only, no permissions required.
  */
 
+import { readDashboardSettings } from './dashboardSettingsUtils';
 import { payloads } from './schemas';
 import { readOnly, type MutationCommand } from './types';
-import { readDashboardSettings } from './updateDashboardSettings';
 
 export const getDashboardInfoCommand: MutationCommand<Record<string, never>> = {
   name: 'GET_DASHBOARD_INFO',

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -1135,6 +1135,10 @@ const dashboardLinkSchema = z.object({
   includeVars: z.boolean().optional().describe('Append current template variable values to the link'),
   keepTime: z.boolean().optional().describe('Append the current time range to the link'),
   tags: z.array(z.string()).optional().describe('Tags used when type is "dashboards"'),
+  placement: z
+    .literal('inControlsMenu')
+    .optional()
+    .describe('Render the link in the dashboard controls dropdown menu instead of above the panels'),
 });
 
 const updateDashboardSettingsPayloadSchema = z.object({

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -1141,22 +1141,22 @@ const dashboardLinkSchema = z.object({
     .describe('Render the link in the dashboard controls dropdown menu instead of above the panels'),
 });
 
+const timeSettingsSchema = z
+  .object({
+    from: z.string().optional().describe('Start of time range (e.g. "now-6h")'),
+    to: z.string().optional().describe('End of time range (e.g. "now")'),
+    autoRefresh: z
+      .string()
+      .optional()
+      .describe('Auto-refresh interval (e.g. "5s", "1m", "5m", "15m", "30m", "1h", "2h", "1d", "" to disable)'),
+    timezone: z.string().optional().describe('Timezone ("browser", "utc", or IANA timezone)'),
+  })
+  .describe('Dashboard time settings. Partial update: only the provided fields change.');
+
 const updateDashboardSettingsPayloadSchema = z.object({
   title: z.string().optional().describe('Dashboard title'),
   description: z.string().optional().describe('Dashboard description'),
   tags: z.array(z.string()).optional().describe('Dashboard tags'),
-  refresh: z
-    .string()
-    .optional()
-    .describe('Auto-refresh interval (e.g. "5s", "1m", "5m", "15m", "30m", "1h", "2h", "1d", "" to disable)'),
-  timeRange: z
-    .object({
-      from: z.string().describe('Start of time range (e.g. "now-6h")'),
-      to: z.string().describe('End of time range (e.g. "now")'),
-    })
-    .optional()
-    .describe('Dashboard time range'),
-  timezone: z.string().optional().describe('Timezone ("browser", "utc", or IANA timezone)'),
   editable: z.boolean().optional().describe('Whether the dashboard is editable'),
   cursorSync: z
     .enum(['Off', 'Crosshair', 'Tooltip'])
@@ -1166,6 +1166,9 @@ const updateDashboardSettingsPayloadSchema = z.object({
     .array(dashboardLinkSchema)
     .optional()
     .describe('Replaces the full dashboard links list. Pass [] to clear all links.'),
+  timeSettings: timeSettingsSchema.optional(),
+  liveNow: z.boolean().optional().describe('Continuously redraw panels to keep live data moving left'),
+  preload: z.boolean().optional().describe('Load all panels when the dashboard loads'),
 });
 
 /**
@@ -1206,9 +1209,9 @@ export const payloads = {
     'Move a panel to a different group or reposition within the current group'
   ),
   getDashboardInfo: emptyPayloadSchema.describe(
-    'Get dashboard identity/folder metadata plus all settings (title, description, tags, editable, refresh, time range, timezone, cursorSync, links)'
+    'Get dashboard identity/folder metadata plus all settings (title, description, tags, editable, cursorSync, links, timeSettings, liveNow, preload)'
   ),
   updateDashboardSettings: updateDashboardSettingsPayloadSchema.describe(
-    'Update dashboard settings (title, description, tags, refresh, time range, timezone, editable, cursorSync, links)'
+    'Update dashboard settings (title, description, tags, editable, cursorSync, links, timeSettings, liveNow, preload)'
   ),
 };

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -1120,6 +1120,23 @@ const movePanelPayloadSchema = z.object({
   position: gridPositionSchema.optional().describe('DEPRECATED: Use layoutItem instead.'),
 });
 
+const dashboardLinkSchema = z.object({
+  title: z.string().describe('Link label shown in the dashboard top bar'),
+  url: z.string().optional().describe('Link target URL (required when type is "link")'),
+  type: z
+    .enum(['link', 'dashboards'])
+    .optional()
+    .default('link')
+    .describe('Link type: "link" (single URL) or "dashboards" (by tags)'),
+  tooltip: z.string().optional().describe('Hover tooltip'),
+  icon: z.string().optional().describe('Icon name, e.g. "external link"'),
+  targetBlank: z.boolean().optional().describe('Open in a new tab'),
+  asDropdown: z.boolean().optional().describe('Render tag-based links as a dropdown'),
+  includeVars: z.boolean().optional().describe('Append current template variable values to the link'),
+  keepTime: z.boolean().optional().describe('Append the current time range to the link'),
+  tags: z.array(z.string()).optional().describe('Tags used when type is "dashboards"'),
+});
+
 const updateDashboardSettingsPayloadSchema = z.object({
   title: z.string().optional().describe('Dashboard title'),
   description: z.string().optional().describe('Dashboard description'),
@@ -1137,6 +1154,14 @@ const updateDashboardSettingsPayloadSchema = z.object({
     .describe('Dashboard time range'),
   timezone: z.string().optional().describe('Timezone ("browser", "utc", or IANA timezone)'),
   editable: z.boolean().optional().describe('Whether the dashboard is editable'),
+  cursorSync: z
+    .enum(['Off', 'Crosshair', 'Tooltip'])
+    .optional()
+    .describe('Shared crosshair/tooltip behavior across panels'),
+  links: z
+    .array(dashboardLinkSchema)
+    .optional()
+    .describe('Replaces the full dashboard links list. Pass [] to clear all links.'),
 });
 
 /**
@@ -1178,6 +1203,6 @@ export const payloads = {
   ),
   getDashboardInfo: emptyPayloadSchema.describe('Get dashboard metadata (title, description, uid, tags, folder info)'),
   updateDashboardSettings: updateDashboardSettingsPayloadSchema.describe(
-    'Update dashboard settings (title, description, tags, refresh, time range, timezone, editable)'
+    'Update dashboard settings (title, description, tags, refresh, time range, timezone, editable, cursorSync, links)'
   ),
 };

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -1205,7 +1205,9 @@ export const payloads = {
   movePanel: movePanelPayloadSchema.describe(
     'Move a panel to a different group or reposition within the current group'
   ),
-  getDashboardInfo: emptyPayloadSchema.describe('Get dashboard metadata (title, description, uid, tags, folder info)'),
+  getDashboardInfo: emptyPayloadSchema.describe(
+    'Get dashboard identity/folder metadata plus all settings (title, description, tags, editable, refresh, time range, timezone, cursorSync, links)'
+  ),
   updateDashboardSettings: updateDashboardSettingsPayloadSchema.describe(
     'Update dashboard settings (title, description, tags, refresh, time range, timezone, editable, cursorSync, links)'
   ),

--- a/public/app/features/dashboard-scene/mutation-api/commands/shared.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/shared.ts
@@ -1,9 +1,10 @@
 /**
- * Shared helpers for reading dashboard-level settings off the DashboardScene.
+ * Helpers shared between mutation commands.
  *
- * Used by UPDATE_DASHBOARD_SETTINGS (to diff before/after) and GET_DASHBOARD_INFO
- * (to report current values), so the set of settings stays in sync between the
- * command that writes them and the command that reads them.
+ * readDashboardSettings/findCursorSyncBehavior are used by UPDATE_DASHBOARD_SETTINGS
+ * (to diff before/after) and GET_DASHBOARD_INFO (to report current values), so the
+ * set of settings stays in sync between the command that writes them and the one
+ * that reads them.
  */
 
 import { behaviors, sceneGraph } from '@grafana/scenes';

--- a/public/app/features/dashboard-scene/mutation-api/commands/shared.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/shared.ts
@@ -3,6 +3,7 @@ import { behaviors, sceneGraph } from '@grafana/scenes';
 import {
   type DashboardCursorSync,
   type DashboardLink,
+  type TimeSettingsSpec,
 } from '../../../../../../packages/grafana-schema/src/schema/dashboard/v2';
 import { transformCursorSynctoEnum } from '../../serialization/transformToV2TypesUtils';
 
@@ -13,15 +14,19 @@ export interface DashboardSettings {
   description: string;
   tags: string[];
   editable: boolean;
-  refresh: string;
-  timeRange: { from: string; to: string };
-  timezone: string;
   cursorSync: DashboardCursorSync;
   links: DashboardLink[];
+  timeSettings: Partial<TimeSettingsSpec>;
+  liveNow: boolean;
+  preload: boolean;
 }
 
 export function findCursorSyncBehavior(scene: MutationContext['scene']): behaviors.CursorSync | undefined {
   return scene.state.$behaviors?.find((b): b is behaviors.CursorSync => b instanceof behaviors.CursorSync);
+}
+
+export function findLiveNowBehavior(scene: MutationContext['scene']): behaviors.LiveNowTimer | undefined {
+  return scene.state.$behaviors?.find((b): b is behaviors.LiveNowTimer => b instanceof behaviors.LiveNowTimer);
 }
 
 export function readDashboardSettings(scene: MutationContext['scene']): DashboardSettings {
@@ -33,13 +38,15 @@ export function readDashboardSettings(scene: MutationContext['scene']): Dashboar
     description: scene.state.description ?? '',
     tags: scene.state.tags ?? [],
     editable: scene.state.editable ?? true,
-    refresh: refreshPicker?.state.refresh ?? '',
-    timeRange: {
-      from: timeRange.state.from,
-      to: timeRange.state.to,
-    },
-    timezone: timeRange.state.timeZone ?? '',
     cursorSync: transformCursorSynctoEnum(findCursorSyncBehavior(scene)?.state.sync),
     links: scene.state.links ?? [],
+    timeSettings: {
+      from: timeRange.state.from,
+      to: timeRange.state.to,
+      timezone: timeRange.state.timeZone ?? '',
+      autoRefresh: refreshPicker?.state.refresh ?? '',
+    },
+    liveNow: findLiveNowBehavior(scene)?.isEnabled ?? false,
+    preload: scene.state.preload ?? false,
   };
 }

--- a/public/app/features/dashboard-scene/mutation-api/commands/shared.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/shared.ts
@@ -1,12 +1,3 @@
-/**
- * Helpers shared between mutation commands.
- *
- * readDashboardSettings/findCursorSyncBehavior are used by UPDATE_DASHBOARD_SETTINGS
- * (to diff before/after) and GET_DASHBOARD_INFO (to report current values), so the
- * set of settings stays in sync between the command that writes them and the one
- * that reads them.
- */
-
 import { behaviors, sceneGraph } from '@grafana/scenes';
 
 import {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.test.ts
@@ -1,15 +1,28 @@
-import { sceneGraph } from '@grafana/scenes';
+import { behaviors, sceneGraph } from '@grafana/scenes';
+import { DashboardCursorSync } from '@grafana/schema';
 
 import type { DashboardControls } from '../../scene/DashboardControls';
 import type { DashboardScene } from '../../scene/DashboardScene';
 
 import { updateDashboardSettingsCommand } from './updateDashboardSettings';
 
-jest.mock('@grafana/scenes', () => ({
-  sceneGraph: {
-    getTimeRange: jest.fn(),
-  },
-}));
+jest.mock('@grafana/scenes', () => {
+  class CursorSync {
+    public state: { sync: number };
+    constructor(state: { sync: number }) {
+      this.state = state;
+    }
+    public setState = jest.fn((partial: Record<string, unknown>) => {
+      Object.assign(this.state, partial);
+    });
+  }
+  return {
+    sceneGraph: {
+      getTimeRange: jest.fn(),
+    },
+    behaviors: { CursorSync },
+  };
+});
 
 function buildTestScene(
   overrides: Partial<{
@@ -18,8 +31,11 @@ function buildTestScene(
     tags: string[];
     editable: boolean;
     isEditing: boolean;
+    links: unknown[];
+    withCursorSync: boolean;
   }> = {}
 ) {
+  const { withCursorSync = true, links: linksOverride, ...stateOverrides } = overrides;
   const timeRangeState: Record<string, unknown> = {
     from: 'now-6h',
     to: 'now',
@@ -44,6 +60,8 @@ function buildTestScene(
   const controlsState = { refreshPicker };
   const controls = { state: controlsState } as unknown as DashboardControls;
 
+  const cursorSync = new behaviors.CursorSync({ sync: DashboardCursorSync.Off });
+
   const state: Record<string, unknown> = {
     title: 'Test Dashboard',
     description: '',
@@ -52,7 +70,9 @@ function buildTestScene(
     isEditing: false,
     $timeRange: timeRange,
     controls,
-    ...overrides,
+    links: linksOverride ?? [],
+    $behaviors: withCursorSync ? [cursorSync] : [],
+    ...stateOverrides,
   };
 
   const scene = {
@@ -69,7 +89,7 @@ function buildTestScene(
 
   (sceneGraph.getTimeRange as jest.Mock).mockReturnValue(timeRange);
 
-  return { scene: scene as unknown as DashboardScene, timeRange, refreshPicker };
+  return { scene: scene as unknown as DashboardScene, timeRange, refreshPicker, cursorSync };
 }
 
 describe('UPDATE_DASHBOARD_SETTINGS', () => {
@@ -163,6 +183,57 @@ describe('UPDATE_DASHBOARD_SETTINGS', () => {
     expect(result.success).toBe(true);
     expect(timeRange.setState).toHaveBeenCalledWith({ timeZone: 'America/New_York' });
     expect(result.data).toMatchObject({ timezone: 'America/New_York' });
+  });
+
+  it('updates cursorSync via the CursorSync behavior', async () => {
+    const { scene, cursorSync } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler({ cursorSync: 'Crosshair' }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(cursorSync.setState).toHaveBeenCalledWith({ sync: DashboardCursorSync.Crosshair });
+    expect(result.data).toMatchObject({ cursorSync: 'Crosshair' });
+  });
+
+  it('warns when cursorSync is requested but the CursorSync behavior is missing', async () => {
+    const { scene } = buildTestScene({ withCursorSync: false });
+    const result = await updateDashboardSettingsCommand.handler({ cursorSync: 'Tooltip' }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toContain('cursorSync could not be set: CursorSync behavior not found in scene');
+  });
+
+  it('replaces dashboard links and fills the full link shape', async () => {
+    const { scene } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler(
+      { links: [{ title: 'Runbook', url: 'https://runbooks.example.com', type: 'link', targetBlank: true }] },
+      { scene }
+    );
+
+    expect(result.success).toBe(true);
+    expect(scene.setState).toHaveBeenCalledWith({
+      links: [
+        {
+          title: 'Runbook',
+          url: 'https://runbooks.example.com',
+          type: 'link',
+          tooltip: '',
+          icon: '',
+          tags: [],
+          asDropdown: false,
+          targetBlank: true,
+          includeVars: false,
+          keepTime: false,
+        },
+      ],
+    });
+  });
+
+  it('clears links with an empty array', async () => {
+    const { scene } = buildTestScene({ links: [{ title: 'old', url: 'https://x' }] });
+    const result = await updateDashboardSettingsCommand.handler({ links: [] }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(scene.setState).toHaveBeenCalledWith({ links: [] });
   });
 
   it('applies multiple settings at once', async () => {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.test.ts
@@ -16,11 +16,23 @@ jest.mock('@grafana/scenes', () => {
       Object.assign(this.state, partial);
     });
   }
+  class LiveNowTimer {
+    public state: { enabled: boolean };
+    constructor(state: { enabled: boolean }) {
+      this.state = state;
+    }
+    public get isEnabled() {
+      return this.state.enabled;
+    }
+    public setState = jest.fn((partial: Record<string, unknown>) => {
+      Object.assign(this.state, partial);
+    });
+  }
   return {
     sceneGraph: {
       getTimeRange: jest.fn(),
     },
-    behaviors: { CursorSync },
+    behaviors: { CursorSync, LiveNowTimer },
   };
 });
 
@@ -30,12 +42,14 @@ function buildTestScene(
     description: string;
     tags: string[];
     editable: boolean;
+    preload: boolean;
     isEditing: boolean;
     links: unknown[];
     withCursorSync: boolean;
+    withLiveNow: boolean;
   }> = {}
 ) {
-  const { withCursorSync = true, links: linksOverride, ...stateOverrides } = overrides;
+  const { withCursorSync = true, withLiveNow = true, links: linksOverride, ...stateOverrides } = overrides;
   const timeRangeState: Record<string, unknown> = {
     from: 'now-6h',
     to: 'now',
@@ -61,17 +75,19 @@ function buildTestScene(
   const controls = { state: controlsState } as unknown as DashboardControls;
 
   const cursorSync = new behaviors.CursorSync({ sync: DashboardCursorSync.Off });
+  const liveNowTimer = new behaviors.LiveNowTimer({ enabled: false });
 
   const state: Record<string, unknown> = {
     title: 'Test Dashboard',
     description: '',
     tags: [],
     editable: true,
+    preload: false,
     isEditing: false,
     $timeRange: timeRange,
     controls,
     links: linksOverride ?? [],
-    $behaviors: withCursorSync ? [cursorSync] : [],
+    $behaviors: [...(withCursorSync ? [cursorSync] : []), ...(withLiveNow ? [liveNowTimer] : [])],
     ...stateOverrides,
   };
 
@@ -89,7 +105,7 @@ function buildTestScene(
 
   (sceneGraph.getTimeRange as jest.Mock).mockReturnValue(timeRange);
 
-  return { scene: scene as unknown as DashboardScene, timeRange, refreshPicker, cursorSync };
+  return { scene: scene as unknown as DashboardScene, timeRange, refreshPicker, cursorSync, liveNowTimer };
 }
 
 describe('UPDATE_DASHBOARD_SETTINGS', () => {
@@ -135,54 +151,66 @@ describe('UPDATE_DASHBOARD_SETTINGS', () => {
     expect(result.data).toMatchObject({ editable: false });
   });
 
-  it('updates refresh interval', async () => {
+  it('updates preload', async () => {
+    const { scene } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler({ preload: true }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(scene.setState).toHaveBeenCalledWith({ preload: true });
+    expect(result.data).toMatchObject({ preload: true });
+  });
+
+  it('updates the auto-refresh interval via timeSettings', async () => {
     const { scene, refreshPicker } = buildTestScene();
-    const result = await updateDashboardSettingsCommand.handler({ refresh: '5m' }, { scene });
+    const result = await updateDashboardSettingsCommand.handler({ timeSettings: { autoRefresh: '5m' } }, { scene });
 
     expect(result.success).toBe(true);
     expect(refreshPicker.setState).toHaveBeenCalledWith({ refresh: '5m' });
-    expect(result.data).toMatchObject({ refresh: '5m' });
+    expect(result.data).toMatchObject({ timeSettings: { autoRefresh: '5m' } });
   });
 
-  it('disables refresh with empty string', async () => {
+  it('disables auto-refresh with an empty string', async () => {
     const { scene, refreshPicker } = buildTestScene();
     refreshPicker.state.refresh = '1m';
 
-    const result = await updateDashboardSettingsCommand.handler({ refresh: '' }, { scene });
+    const result = await updateDashboardSettingsCommand.handler({ timeSettings: { autoRefresh: '' } }, { scene });
 
     expect(result.success).toBe(true);
     expect(refreshPicker.setState).toHaveBeenCalledWith({ refresh: '' });
-    expect(result.data).toMatchObject({ refresh: '' });
+    expect(result.data).toMatchObject({ timeSettings: { autoRefresh: '' } });
   });
 
-  it('updates time range', async () => {
+  it('updates the time range via timeSettings', async () => {
     const { scene, timeRange } = buildTestScene();
     const result = await updateDashboardSettingsCommand.handler(
-      { timeRange: { from: 'now-1h', to: 'now' } },
+      { timeSettings: { from: 'now-1h', to: 'now' } },
       { scene }
     );
 
     expect(result.success).toBe(true);
     expect(timeRange.setState).toHaveBeenCalledWith({ from: 'now-1h', to: 'now' });
-    expect(result.data).toMatchObject({ timeRange: { from: 'now-1h', to: 'now' } });
+    expect(result.data).toMatchObject({ timeSettings: { from: 'now-1h', to: 'now' } });
   });
 
-  it('updates timezone', async () => {
+  it('updates the timezone via timeSettings', async () => {
     const { scene, timeRange } = buildTestScene();
-    const result = await updateDashboardSettingsCommand.handler({ timezone: 'utc' }, { scene });
+    const result = await updateDashboardSettingsCommand.handler({ timeSettings: { timezone: 'utc' } }, { scene });
 
     expect(result.success).toBe(true);
     expect(timeRange.setState).toHaveBeenCalledWith({ timeZone: 'utc' });
-    expect(result.data).toMatchObject({ timezone: 'utc' });
+    expect(result.data).toMatchObject({ timeSettings: { timezone: 'utc' } });
   });
 
-  it('updates timezone with IANA string', async () => {
+  it('updates the timezone with an IANA string', async () => {
     const { scene, timeRange } = buildTestScene();
-    const result = await updateDashboardSettingsCommand.handler({ timezone: 'America/New_York' }, { scene });
+    const result = await updateDashboardSettingsCommand.handler(
+      { timeSettings: { timezone: 'America/New_York' } },
+      { scene }
+    );
 
     expect(result.success).toBe(true);
     expect(timeRange.setState).toHaveBeenCalledWith({ timeZone: 'America/New_York' });
-    expect(result.data).toMatchObject({ timezone: 'America/New_York' });
+    expect(result.data).toMatchObject({ timeSettings: { timezone: 'America/New_York' } });
   });
 
   it('updates cursorSync via the CursorSync behavior', async () => {
@@ -200,6 +228,23 @@ describe('UPDATE_DASHBOARD_SETTINGS', () => {
 
     expect(result.success).toBe(true);
     expect(result.warnings).toContain('cursorSync could not be set: CursorSync behavior not found in scene');
+  });
+
+  it('updates liveNow via the LiveNowTimer behavior', async () => {
+    const { scene, liveNowTimer } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler({ liveNow: true }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(liveNowTimer.setState).toHaveBeenCalledWith({ enabled: true });
+    expect(result.data).toMatchObject({ liveNow: true });
+  });
+
+  it('warns when liveNow is requested but the LiveNowTimer behavior is missing', async () => {
+    const { scene } = buildTestScene({ withLiveNow: false });
+    const result = await updateDashboardSettingsCommand.handler({ liveNow: true }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toContain('liveNow could not be set: LiveNowTimer behavior not found in scene');
   });
 
   it('replaces dashboard links and fills the full link shape', async () => {
@@ -242,28 +287,27 @@ describe('UPDATE_DASHBOARD_SETTINGS', () => {
       {
         title: 'Sales Overview',
         tags: ['sales'],
-        refresh: '5m',
-        timeRange: { from: 'now-24h', to: 'now' },
-        timezone: 'utc',
+        preload: true,
+        timeSettings: { from: 'now-24h', to: 'now', timezone: 'utc', autoRefresh: '5m' },
       },
       { scene }
     );
 
     expect(result.success).toBe(true);
-    expect(scene.setState).toHaveBeenCalledWith({ title: 'Sales Overview', tags: ['sales'] });
+    expect(scene.setState).toHaveBeenCalledWith({ title: 'Sales Overview', tags: ['sales'], preload: true });
     expect(timeRange.setState).toHaveBeenCalledWith({ from: 'now-24h', to: 'now', timeZone: 'utc' });
     expect(refreshPicker.setState).toHaveBeenCalledWith({ refresh: '5m' });
   });
 
-  it('warns when refresh is requested but refreshPicker is not present', async () => {
+  it('warns when auto-refresh is requested but refreshPicker is not present', async () => {
     const { scene } = buildTestScene();
     // Remove refreshPicker from scene controls
     (scene.state as unknown as Record<string, unknown>).controls = undefined;
 
-    const result = await updateDashboardSettingsCommand.handler({ refresh: '5m' }, { scene });
+    const result = await updateDashboardSettingsCommand.handler({ timeSettings: { autoRefresh: '5m' } }, { scene });
 
     expect(result.success).toBe(true);
-    expect(result.warnings).toContain('refresh interval could not be set: refresh picker not found in scene controls');
+    expect(result.warnings).toContain('autoRefresh could not be set: refresh picker not found in scene controls');
   });
 
   it('empty payload is a no-op', async () => {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -1,15 +1,15 @@
 import { type z } from 'zod';
 
 import { textUtil } from '@grafana/data';
-import { behaviors, sceneGraph } from '@grafana/scenes';
+import { sceneGraph } from '@grafana/scenes';
 
 import {
   type DashboardLink,
   defaultDashboardLink,
 } from '../../../../../../packages/grafana-schema/src/schema/dashboard/v2';
 import { transformCursorSyncV2ToV1 } from '../../serialization/transformToV1TypesUtils';
-import { transformCursorSynctoEnum } from '../../serialization/transformToV2TypesUtils';
 
+import { findCursorSyncBehavior, readDashboardSettings } from './dashboardSettingsUtils';
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
 
@@ -17,7 +17,6 @@ const updateDashboardSettingsPayloadSchema = payloads.updateDashboardSettings;
 
 export type UpdateDashboardSettingsPayload = z.infer<typeof updateDashboardSettingsPayloadSchema>;
 
-type CursorSyncValue = NonNullable<UpdateDashboardSettingsPayload['cursorSync']>;
 type DashboardLinkPayload = NonNullable<UpdateDashboardSettingsPayload['links']>[number];
 
 // URLs are sanitized because links render as clickable and the input is
@@ -36,44 +35,6 @@ function normalizeDashboardLink(link: DashboardLinkPayload): DashboardLink {
     includeVars: link.includeVars ?? defaults.includeVars,
     keepTime: link.keepTime ?? defaults.keepTime,
     ...(link.placement !== undefined && { placement: link.placement }),
-  };
-}
-
-export interface DashboardSettings {
-  title: string;
-  description: string;
-  tags: string[];
-  editable: boolean;
-  refresh: string;
-  timeRange: { from: string; to: string };
-  timezone: string;
-  cursorSync: CursorSyncValue;
-  links: DashboardLink[];
-}
-
-function findCursorSyncBehavior(
-  scene: Parameters<MutationCommand['handler']>[1]['scene']
-): behaviors.CursorSync | undefined {
-  return scene.state.$behaviors?.find((b): b is behaviors.CursorSync => b instanceof behaviors.CursorSync);
-}
-
-export function readDashboardSettings(scene: Parameters<MutationCommand['handler']>[1]['scene']): DashboardSettings {
-  const timeRange = sceneGraph.getTimeRange(scene);
-  const refreshPicker = scene.state.controls?.state.refreshPicker;
-
-  return {
-    title: scene.state.title ?? '',
-    description: scene.state.description ?? '',
-    tags: scene.state.tags ?? [],
-    editable: scene.state.editable ?? true,
-    refresh: refreshPicker?.state.refresh ?? '',
-    timeRange: {
-      from: timeRange.state.from,
-      to: timeRange.state.to,
-    },
-    timezone: timeRange.state.timeZone ?? '',
-    cursorSync: transformCursorSynctoEnum(findCursorSyncBehavior(scene)?.state.sync),
-    links: scene.state.links ?? [],
   };
 }
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -39,7 +39,7 @@ function normalizeDashboardLink(link: DashboardLinkPayload): DashboardLink {
   };
 }
 
-interface DashboardSettings {
+export interface DashboardSettings {
   title: string;
   description: string;
   tags: string[];
@@ -57,7 +57,7 @@ function findCursorSyncBehavior(
   return scene.state.$behaviors?.find((b): b is behaviors.CursorSync => b instanceof behaviors.CursorSync);
 }
 
-function readCurrentSettings(scene: Parameters<MutationCommand['handler']>[1]['scene']): DashboardSettings {
+export function readDashboardSettings(scene: Parameters<MutationCommand['handler']>[1]['scene']): DashboardSettings {
   const timeRange = sceneGraph.getTimeRange(scene);
   const refreshPicker = scene.state.controls?.state.refreshPicker;
 
@@ -90,7 +90,7 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
     enterEditModeIfNeeded(scene);
 
     try {
-      const previousValue = readCurrentSettings(scene);
+      const previousValue = readDashboardSettings(scene);
       const warnings: string[] = [];
 
       const sceneUpdates: Record<string, unknown> = {};
@@ -147,7 +147,7 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
         scene.setState({ links: payload.links.map(normalizeDashboardLink) });
       }
 
-      const newValue = readCurrentSettings(scene);
+      const newValue = readDashboardSettings(scene);
 
       return {
         success: true,

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -9,8 +9,8 @@ import {
 } from '../../../../../../packages/grafana-schema/src/schema/dashboard/v2';
 import { transformCursorSyncV2ToV1 } from '../../serialization/transformToV1TypesUtils';
 
-import { findCursorSyncBehavior, readDashboardSettings } from './dashboardSettingsUtils';
 import { payloads } from './schemas';
+import { findCursorSyncBehavior, readDashboardSettings } from './shared';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
 
 const updateDashboardSettingsPayloadSchema = payloads.updateDashboardSettings;

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -10,7 +10,7 @@ import {
 import { transformCursorSyncV2ToV1 } from '../../serialization/transformToV1TypesUtils';
 
 import { payloads } from './schemas';
-import { findCursorSyncBehavior, readDashboardSettings } from './shared';
+import { findCursorSyncBehavior, findLiveNowBehavior, readDashboardSettings } from './shared';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
 
 const updateDashboardSettingsPayloadSchema = payloads.updateDashboardSettings;
@@ -67,6 +67,12 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
       if (payload.editable !== undefined) {
         sceneUpdates.editable = payload.editable;
       }
+      if (payload.preload !== undefined) {
+        sceneUpdates.preload = payload.preload;
+      }
+      if (payload.links !== undefined) {
+        sceneUpdates.links = payload.links.map(normalizeDashboardLink);
+      }
 
       if (Object.keys(sceneUpdates).length > 0) {
         scene.setState(sceneUpdates);
@@ -74,24 +80,26 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
 
       const timeRange = sceneGraph.getTimeRange(scene);
       const timeRangeUpdates: Record<string, unknown> = {};
-      if (payload.timeRange !== undefined) {
-        timeRangeUpdates.from = payload.timeRange.from;
-        timeRangeUpdates.to = payload.timeRange.to;
+      if (payload.timeSettings?.from !== undefined) {
+        timeRangeUpdates.from = payload.timeSettings.from;
       }
-      if (payload.timezone !== undefined) {
-        timeRangeUpdates.timeZone = payload.timezone;
+      if (payload.timeSettings?.to !== undefined) {
+        timeRangeUpdates.to = payload.timeSettings.to;
+      }
+      if (payload.timeSettings?.timezone !== undefined) {
+        timeRangeUpdates.timeZone = payload.timeSettings.timezone;
       }
 
       if (Object.keys(timeRangeUpdates).length > 0) {
         timeRange.setState(timeRangeUpdates);
       }
 
-      if (payload.refresh !== undefined) {
+      if (payload.timeSettings?.autoRefresh !== undefined) {
         const refreshPicker = scene.state.controls?.state.refreshPicker;
         if (refreshPicker) {
-          refreshPicker.setState({ refresh: payload.refresh });
+          refreshPicker.setState({ refresh: payload.timeSettings.autoRefresh });
         } else {
-          warnings.push('refresh interval could not be set: refresh picker not found in scene controls');
+          warnings.push('autoRefresh could not be set: refresh picker not found in scene controls');
         }
       }
 
@@ -104,8 +112,13 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
         }
       }
 
-      if (payload.links !== undefined) {
-        scene.setState({ links: payload.links.map(normalizeDashboardLink) });
+      if (payload.liveNow !== undefined) {
+        const liveNowBehavior = findLiveNowBehavior(scene);
+        if (liveNowBehavior) {
+          liveNowBehavior.setState({ enabled: payload.liveNow });
+        } else {
+          warnings.push('liveNow could not be set: LiveNowTimer behavior not found in scene');
+        }
       }
 
       const newValue = readDashboardSettings(scene);

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -2,9 +2,11 @@ import { type z } from 'zod';
 
 import { textUtil } from '@grafana/data';
 import { behaviors, sceneGraph } from '@grafana/scenes';
-import { type DashboardLink } from '@grafana/schema';
 
-import { defaultDashboardLink } from '../../../../../../packages/grafana-schema/src/schema/dashboard/v2';
+import {
+  type DashboardLink,
+  defaultDashboardLink,
+} from '../../../../../../packages/grafana-schema/src/schema/dashboard/v2';
 import { transformCursorSyncV2ToV1 } from '../../serialization/transformToV1TypesUtils';
 import { transformCursorSynctoEnum } from '../../serialization/transformToV2TypesUtils';
 
@@ -18,9 +20,10 @@ export type UpdateDashboardSettingsPayload = z.infer<typeof updateDashboardSetti
 type CursorSyncValue = NonNullable<UpdateDashboardSettingsPayload['cursorSync']>;
 type DashboardLinkPayload = NonNullable<UpdateDashboardSettingsPayload['links']>[number];
 
-// The payload links are partial; fill the full DashboardLink shape from the
-// shared defaults (mirrors transformSceneToSaveModelSchemaV2) and sanitize the
-// URL since these render as clickable links and the input is model-controlled.
+// The payload links are partial v2 DashboardLinks; fill the full shape from the
+// shared v2 defaults and sanitize the URL since these render as clickable links
+// and the input is model-controlled. The completed v2 links are assigned onto
+// the scene directly, the same way transformSaveModelSchemaV2ToScene does.
 function normalizeDashboardLink(link: DashboardLinkPayload): DashboardLink {
   const defaults = defaultDashboardLink();
   return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -20,10 +20,8 @@ export type UpdateDashboardSettingsPayload = z.infer<typeof updateDashboardSetti
 type CursorSyncValue = NonNullable<UpdateDashboardSettingsPayload['cursorSync']>;
 type DashboardLinkPayload = NonNullable<UpdateDashboardSettingsPayload['links']>[number];
 
-// The payload links are partial v2 DashboardLinks; fill the full shape from the
-// shared v2 defaults and sanitize the URL since these render as clickable links
-// and the input is model-controlled. The completed v2 links are assigned onto
-// the scene directly, the same way transformSaveModelSchemaV2ToScene does.
+// URLs are sanitized because links render as clickable and the input is
+// model-controlled (could carry a javascript:/data: scheme).
 function normalizeDashboardLink(link: DashboardLinkPayload): DashboardLink {
   const defaults = defaultDashboardLink();
   return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -2,7 +2,11 @@ import { type z } from 'zod';
 
 import { textUtil } from '@grafana/data';
 import { behaviors, sceneGraph } from '@grafana/scenes';
-import { DashboardCursorSync, type DashboardLink } from '@grafana/schema';
+import { type DashboardLink } from '@grafana/schema';
+
+import { defaultDashboardLink } from '../../../../../../packages/grafana-schema/src/schema/dashboard/v2';
+import { transformCursorSyncV2ToV1 } from '../../serialization/transformToV1TypesUtils';
+import { transformCursorSynctoEnum } from '../../serialization/transformToV2TypesUtils';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
@@ -14,37 +18,23 @@ export type UpdateDashboardSettingsPayload = z.infer<typeof updateDashboardSetti
 type CursorSyncValue = NonNullable<UpdateDashboardSettingsPayload['cursorSync']>;
 type DashboardLinkPayload = NonNullable<UpdateDashboardSettingsPayload['links']>[number];
 
-const CURSOR_SYNC_TO_ENUM: Record<CursorSyncValue, DashboardCursorSync> = {
-  Off: DashboardCursorSync.Off,
-  Crosshair: DashboardCursorSync.Crosshair,
-  Tooltip: DashboardCursorSync.Tooltip,
-};
-
-function cursorSyncToString(sync?: DashboardCursorSync): CursorSyncValue {
-  switch (sync) {
-    case DashboardCursorSync.Crosshair:
-      return 'Crosshair';
-    case DashboardCursorSync.Tooltip:
-      return 'Tooltip';
-    default:
-      return 'Off';
-  }
-}
-
-// The payload links are partial; fill the full DashboardLink shape and sanitize
-// the URL since these render as clickable links and the input is model-controlled.
+// The payload links are partial; fill the full DashboardLink shape from the
+// shared defaults (mirrors transformSceneToSaveModelSchemaV2) and sanitize the
+// URL since these render as clickable links and the input is model-controlled.
 function normalizeDashboardLink(link: DashboardLinkPayload): DashboardLink {
+  const defaults = defaultDashboardLink();
   return {
-    title: link.title,
-    url: link.url ? textUtil.sanitizeUrl(link.url) : '',
-    type: link.type ?? 'link',
-    tooltip: link.tooltip ?? '',
-    icon: link.icon ?? '',
-    tags: link.tags ?? [],
-    asDropdown: link.asDropdown ?? false,
-    targetBlank: link.targetBlank ?? false,
-    includeVars: link.includeVars ?? false,
-    keepTime: link.keepTime ?? false,
+    title: link.title ?? defaults.title,
+    url: link.url ? textUtil.sanitizeUrl(link.url) : defaults.url,
+    type: link.type ?? defaults.type,
+    icon: link.icon ?? defaults.icon,
+    tooltip: link.tooltip ?? defaults.tooltip,
+    tags: link.tags ?? defaults.tags,
+    asDropdown: link.asDropdown ?? defaults.asDropdown,
+    targetBlank: link.targetBlank ?? defaults.targetBlank,
+    includeVars: link.includeVars ?? defaults.includeVars,
+    keepTime: link.keepTime ?? defaults.keepTime,
+    ...(link.placement !== undefined && { placement: link.placement }),
   };
 }
 
@@ -81,7 +71,7 @@ function readCurrentSettings(scene: Parameters<MutationCommand['handler']>[1]['s
       to: timeRange.state.to,
     },
     timezone: timeRange.state.timeZone ?? '',
-    cursorSync: cursorSyncToString(findCursorSyncBehavior(scene)?.state.sync),
+    cursorSync: transformCursorSynctoEnum(findCursorSyncBehavior(scene)?.state.sync),
     links: scene.state.links ?? [],
   };
 }
@@ -146,7 +136,7 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
       if (payload.cursorSync !== undefined) {
         const cursorSyncBehavior = findCursorSyncBehavior(scene);
         if (cursorSyncBehavior) {
-          cursorSyncBehavior.setState({ sync: CURSOR_SYNC_TO_ENUM[payload.cursorSync] });
+          cursorSyncBehavior.setState({ sync: transformCursorSyncV2ToV1(payload.cursorSync) });
         } else {
           warnings.push('cursorSync could not be set: CursorSync behavior not found in scene');
         }

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -1,6 +1,8 @@
 import { type z } from 'zod';
 
-import { sceneGraph } from '@grafana/scenes';
+import { textUtil } from '@grafana/data';
+import { behaviors, sceneGraph } from '@grafana/scenes';
+import { DashboardCursorSync, type DashboardLink } from '@grafana/schema';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
@@ -8,6 +10,43 @@ import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './typ
 const updateDashboardSettingsPayloadSchema = payloads.updateDashboardSettings;
 
 export type UpdateDashboardSettingsPayload = z.infer<typeof updateDashboardSettingsPayloadSchema>;
+
+type CursorSyncValue = NonNullable<UpdateDashboardSettingsPayload['cursorSync']>;
+type DashboardLinkPayload = NonNullable<UpdateDashboardSettingsPayload['links']>[number];
+
+const CURSOR_SYNC_TO_ENUM: Record<CursorSyncValue, DashboardCursorSync> = {
+  Off: DashboardCursorSync.Off,
+  Crosshair: DashboardCursorSync.Crosshair,
+  Tooltip: DashboardCursorSync.Tooltip,
+};
+
+function cursorSyncToString(sync?: DashboardCursorSync): CursorSyncValue {
+  switch (sync) {
+    case DashboardCursorSync.Crosshair:
+      return 'Crosshair';
+    case DashboardCursorSync.Tooltip:
+      return 'Tooltip';
+    default:
+      return 'Off';
+  }
+}
+
+// The payload links are partial; fill the full DashboardLink shape and sanitize
+// the URL since these render as clickable links and the input is model-controlled.
+function normalizeDashboardLink(link: DashboardLinkPayload): DashboardLink {
+  return {
+    title: link.title,
+    url: link.url ? textUtil.sanitizeUrl(link.url) : '',
+    type: link.type ?? 'link',
+    tooltip: link.tooltip ?? '',
+    icon: link.icon ?? '',
+    tags: link.tags ?? [],
+    asDropdown: link.asDropdown ?? false,
+    targetBlank: link.targetBlank ?? false,
+    includeVars: link.includeVars ?? false,
+    keepTime: link.keepTime ?? false,
+  };
+}
 
 interface DashboardSettings {
   title: string;
@@ -17,6 +56,14 @@ interface DashboardSettings {
   refresh: string;
   timeRange: { from: string; to: string };
   timezone: string;
+  cursorSync: CursorSyncValue;
+  links: DashboardLink[];
+}
+
+function findCursorSyncBehavior(
+  scene: Parameters<MutationCommand['handler']>[1]['scene']
+): behaviors.CursorSync | undefined {
+  return scene.state.$behaviors?.find((b): b is behaviors.CursorSync => b instanceof behaviors.CursorSync);
 }
 
 function readCurrentSettings(scene: Parameters<MutationCommand['handler']>[1]['scene']): DashboardSettings {
@@ -34,6 +81,8 @@ function readCurrentSettings(scene: Parameters<MutationCommand['handler']>[1]['s
       to: timeRange.state.to,
     },
     timezone: timeRange.state.timeZone ?? '',
+    cursorSync: cursorSyncToString(findCursorSyncBehavior(scene)?.state.sync),
+    links: scene.state.links ?? [],
   };
 }
 
@@ -92,6 +141,19 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
         } else {
           warnings.push('refresh interval could not be set: refresh picker not found in scene controls');
         }
+      }
+
+      if (payload.cursorSync !== undefined) {
+        const cursorSyncBehavior = findCursorSyncBehavior(scene);
+        if (cursorSyncBehavior) {
+          cursorSyncBehavior.setState({ sync: CURSOR_SYNC_TO_ENUM[payload.cursorSync] });
+        } else {
+          warnings.push('cursorSync could not be set: CursorSync behavior not found in scene');
+        }
+      }
+
+      if (payload.links !== undefined) {
+        scene.setState({ links: payload.links.map(normalizeDashboardLink) });
       }
 
       const newValue = readCurrentSettings(scene);


### PR DESCRIPTION
## What

Expand and align the dashboard **settings** commands of the Dashboard Mutation API with the v2 `DashboardSpec`:

- `UPDATE_DASHBOARD_SETTINGS` now sets `cursorSync` and `links` (previously unsupported), plus `liveNow` and `preload`.
- Time-related fields move to the v2 `timeSettings` object (`from` / `to` / `autoRefresh` / `timezone`), replacing the flat `refresh` / `timeRange` / `timezone`.
- `GET_DASHBOARD_INFO` now returns every setting `UPDATE_DASHBOARD_SETTINGS` can write (title, description, tags, editable, cursorSync, links, timeSettings, liveNow, preload) alongside identity/folder metadata. The shared scene reader lives in `commands/shared.ts`.

## Why

The Grafana Assistant uses a single `manage_dashboard_settings` tool that must read and write the same shape on both workspace draft dashboards and live dashboards. Aligning the settings payloads on the v2 spec gives one consistent shape across both runtimes (companion change: grafana/grafana-assistant-app#7449).

## Notes

- `cursorSync` and `liveNow` map to scene behaviors (`CursorSync` / `LiveNowTimer`); a warning is returned if the behavior is absent. `preload` is a plain scene-state field.
- Partial updates: only the fields provided change; `tags` and `links` replace the full list.
- Link URLs are sanitized before being applied.
- `mutation-api/README.md` updated with the new shape.