### PR TITLE
MT annotations: extract reusable functions for POST /graphite

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	annotationapp "github.com/grafana/grafana/pkg/registry/apps/annotation"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -165,14 +166,6 @@ func (hs *HTTPServer) PostAnnotation(c *contextmodel.ReqContext) response.Respon
 	})
 }
 
-func formatGraphiteAnnotation(what string, data string) string {
-	text := what
-	if data != "" {
-		text = text + "\n" + data
-	}
-	return text
-}
-
 // swagger:route POST /annotations/graphite annotations postGraphiteAnnotation
 //
 // Create Annotation in Graphite format.
@@ -186,40 +179,16 @@ func formatGraphiteAnnotation(what string, data string) string {
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) PostGraphiteAnnotation(c *contextmodel.ReqContext) response.Response {
-	cmd := dtos.PostGraphiteAnnotationsCmd{}
+	cmd := annotationapp.PostGraphiteAnnotationsCmd{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	if cmd.What == "" {
-		err := &AnnotationError{"what field should not be empty"}
+	tagsArray, err := cmd.Validate()
+	if err != nil {
 		return response.Error(http.StatusBadRequest, "Failed to save Graphite annotation", err)
 	}
 
-	text := formatGraphiteAnnotation(cmd.What, cmd.Data)
-
-	// Support tags in prior to Graphite 0.10.0 format (string of tags separated by space)
-	var tagsArray []string
-	switch tags := cmd.Tags.(type) {
-	case string:
-		if tags != "" {
-			tagsArray = strings.Split(tags, " ")
-		} else {
-			tagsArray = []string{}
-		}
-	case []any:
-		for _, t := range tags {
-			if tagStr, ok := t.(string); ok {
-				tagsArray = append(tagsArray, tagStr)
-			} else {
-				err := &AnnotationError{"tag should be a string"}
-				return response.Error(http.StatusBadRequest, "Failed to save Graphite annotation", err)
-			}
-		}
-	default:
-		err := &AnnotationError{"unsupported tags format"}
-		return response.Error(http.StatusBadRequest, "Failed to save Graphite annotation", err)
-	}
-
+	text := annotationapp.FormatGraphiteText(cmd.What, cmd.Data)
 	userID, _ := identity.UserIdentifier(c.GetID())
 	item := annotations.Item{
 		OrgID:  c.GetOrgID(),
@@ -719,7 +688,7 @@ type PostAnnotationParams struct {
 type PostGraphiteAnnotationParams struct {
 	// in:body
 	// required:true
-	Body dtos.PostGraphiteAnnotationsCmd `json:"body"`
+	Body annotationapp.PostGraphiteAnnotationsCmd `json:"body"`
 }
 
 // swagger:parameters updateAnnotation

--- a/pkg/api/dtos/annotations.go
+++ b/pkg/api/dtos/annotations.go
@@ -38,10 +38,3 @@ type MassDeleteAnnotationsCmd struct {
 	AnnotationId int64  `json:"annotationId"`
 	DashboardUID string `json:"dashboardUID,omitempty"`
 }
-
-type PostGraphiteAnnotationsCmd struct {
-	When int64  `json:"when"`
-	What string `json:"what"`
-	Data string `json:"data"`
-	Tags any    `json:"tags"`
-}

--- a/pkg/registry/apps/annotation/graphite.go
+++ b/pkg/registry/apps/annotation/graphite.go
@@ -1,0 +1,56 @@
+package annotation
+
+import (
+	"errors"
+	"strings"
+)
+
+type PostGraphiteAnnotationsCmd struct {
+	When int64  `json:"when"`
+	What string `json:"what"`
+	Data string `json:"data"`
+	Tags any    `json:"tags"`
+}
+
+// Validate checks the required Graphite fields and returns the normalized tags.
+func (cmd PostGraphiteAnnotationsCmd) Validate() ([]string, error) {
+	if cmd.What == "" {
+		return nil, errors.New("what field should not be empty")
+	}
+	return parseGraphiteTags(cmd.Tags)
+}
+
+// FormatGraphiteText joins the Graphite `what` and `data` fields into the annotation text
+func FormatGraphiteText(what string, data string) string {
+	text := what
+	if data != "" {
+		text = text + "\n" + data
+	}
+	return text
+}
+
+// parseGraphiteTags normalizes the Graphite `tags` field: a single space-separated
+// string (Graphite prior to 0.10.0) or an array of strings; anything else (including a
+// missing value) is rejected.
+func parseGraphiteTags(raw any) ([]string, error) {
+	var tagsArray []string
+	switch tags := raw.(type) {
+	case string:
+		if tags != "" {
+			tagsArray = strings.Split(tags, " ")
+		} else {
+			tagsArray = []string{}
+		}
+	case []any:
+		for _, t := range tags {
+			tagStr, ok := t.(string)
+			if !ok {
+				return nil, errors.New("tag should be a string")
+			}
+			tagsArray = append(tagsArray, tagStr)
+		}
+	default:
+		return nil, errors.New("unsupported tags format")
+	}
+	return tagsArray, nil
+}

--- a/pkg/registry/apps/annotation/graphite.go
+++ b/pkg/registry/apps/annotation/graphite.go
@@ -29,9 +29,8 @@ func FormatGraphiteText(what string, data string) string {
 	return text
 }
 
-// parseGraphiteTags normalizes the Graphite `tags` field: a single space-separated
-// string (Graphite prior to 0.10.0) or an array of strings; anything else (including a
-// missing value) is rejected.
+// parseGraphiteTags normalizes the Graphite `tags` field.
+// Supports either a single space-separated string or an array of strings.
 func parseGraphiteTags(raw any) ([]string, error) {
 	var tagsArray []string
 	switch tags := raw.(type) {

--- a/pkg/registry/apps/annotation/graphite_test.go
+++ b/pkg/registry/apps/annotation/graphite_test.go
@@ -1,0 +1,67 @@
+package annotation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatGraphiteText(t *testing.T) {
+	assert.Equal(t, "deploy", FormatGraphiteText("deploy", ""))
+	assert.Equal(t, "deploy\nv1.2.3", FormatGraphiteText("deploy", "v1.2.3"))
+	assert.Equal(t, "", FormatGraphiteText("", ""))
+}
+
+func TestParseGraphiteTags(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         any
+		expected    []string
+		expectedErr bool
+	}{
+		{name: "space-separated string", raw: "release prod", expected: []string{"release", "prod"}},
+		{name: "empty string", raw: "", expected: []string{}},
+		{name: "string array", raw: []any{"release", "prod"}, expected: []string{"release", "prod"}},
+		{name: "empty array", raw: []any{}, expected: nil},
+		{name: "non-string element rejected", raw: []any{"ok", 123}, expectedErr: true},
+		{name: "missing/nil rejected", raw: nil, expectedErr: true},
+		{name: "unsupported type rejected", raw: 123, expectedErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := parseGraphiteTags(tt.raw)
+			if tt.expectedErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestPostGraphiteAnnotationsCmd_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmd         PostGraphiteAnnotationsCmd
+		expected    []string
+		expectedErr bool
+	}{
+		{name: "empty what rejected", cmd: PostGraphiteAnnotationsCmd{What: "", Tags: "release"}, expectedErr: true},
+		{name: "valid with space-separated tags", cmd: PostGraphiteAnnotationsCmd{What: "deploy", Tags: "release prod"}, expected: []string{"release", "prod"}},
+		{name: "valid with tag array", cmd: PostGraphiteAnnotationsCmd{What: "deploy", Tags: []any{"release", "prod"}}, expected: []string{"release", "prod"}},
+		{name: "valid what but invalid tags rejected", cmd: PostGraphiteAnnotationsCmd{What: "deploy", Tags: nil}, expectedErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := tt.cmd.Validate()
+			if tt.expectedErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Related to [#937](https://github.com/grafana/grafana-org/issues/937) 

Extract some reusable functions in the legacy `POST /graphite` API so that we could use the same functions in the new k8s API. This keeps the functions consistent as well as avoids introducing duplicate code.

For the actual implementation of the new k8s API, please refer to [this subsequent PR](https://github.com/grafana/grafana/pull/127093).