### PR TITLE
Table: Make cell tooltips dynamic height so content is not cut off

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/golden_checksums.json
+++ b/apps/dashboard/pkg/migration/testdata/golden_checksums.json
@@ -95,7 +95,7 @@
   "dev-dashboards-output/panel-stat/panel-stat-tests.v42.json": "fb29a81844c4f108e1211ee4c86417a36104934576c494a73efdc79778060ce5",
   "dev-dashboards-output/panel-status-history/status-history-thresholds-mappings.v42.json": "45a9a269e039f8185fd0d02f7f07161ad8b3d9370cef6590791eadfd9cc4019b",
   "dev-dashboards-output/panel-table/table_footer.v42.json": "46ee3c13168a5e3861203d538ec510e5a440fd6b9be08dac6621d27a8d53c100",
-  "dev-dashboards-output/panel-table/table_kitchen_sink.v42.json": "2dcb9c684f71e32ebfa6a2e460da39c09493def44413ab843f4ea8278b6e0800",
+  "dev-dashboards-output/panel-table/table_kitchen_sink.v42.json": "1b3767bb972c26bd22b8816b912ba4066dd59d8b6ae23d5af63eb1ca8df9e91a",
   "dev-dashboards-output/panel-table/table_markdown.v42.json": "b5b25bcace7cbf11553b5df708e29af768c1c30fe3a8351f72d3fd411d22473a",
   "dev-dashboards-output/panel-table/table_nested.v42.json": "414fb44a0952dfc5c33b7a1d9ed3c95435cebd56e8f90a2ddc5234f5c56486ac",
   "dev-dashboards-output/panel-table/table_pagination.v42.json": "da64e181f9bcda639b0f0b39aa0a3f9d265c24e896468eb87117b6050c3b90c4",

--- a/devenv/dev-dashboards/panel-table/table_kitchen_sink.json
+++ b/devenv/dev-dashboards/panel-table/table_kitchen_sink.json
@@ -2088,6 +2088,107 @@
       ],
       "title": "Multi-frame table",
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Long Text"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom.viz",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Info"
+            },
+            "properties": [
+              {
+                "id": "custom.tooltip.field",
+                "value": "Long Text"
+              },
+              {
+                "id": "custom.tooltip.placement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 12,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "refId": "A",
+          "scenarioId": "random_walk_table"
+        },
+        {
+          "csvContent": "Info,Long Text\ndown,\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse tempus et augue et lacinia. Interdum et malesuada fames ac ante ipsum primis in faucibus.\"\nup,\"Sed imperdiet eget diam sit amet fringilla. Curabitur quis lacus blandit, mollis diam non, accumsan tortor.\"\nup fast,\"Proin ac libero vulputate ex vulputate pharetra ut vel lacus. Phasellus quis dolor sed leo finibus scelerisque. Ut vel finibus leo, sed viverra ipsum.\"\ndown fast,\"Nullam in pulvinar justo. Nunc dictum arcu ac pellentesque bibendum. Sed in erat turpis. Vestibulum eu orci ac ligula lobortis tempus.\"",
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "refId": "B",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Tooltip from field",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "Info",
+            "mode": "outerTabular"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "A": "Value",
+              "Max A": "Max",
+              "Min A": "Min",
+              "State A": "State",
+              "Time A": "Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "preload": false,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -823,9 +823,12 @@ export function TableNG(props: TableNGProps) {
 
             const tooltipCellStyleOptions = {
               textAlign: getAlignment(tooltipField),
-              textWrap: shouldTextWrap(tooltipField),
+              // tooltips are free-floating overlays that should reveal the full value, so we
+              // always wrap their content and never inherit the per-row cell-height clamp
+              // (which would line-clamp/cut off the content).
+              textWrap: true,
               shouldOverflow: false,
-              maxHeight: maxRowHeight,
+              maxHeight: undefined,
             } satisfies TableCellStyleOptions;
             const tooltipCanBeColorized = canFieldBeColorized(tooltipCellOptions.type, applyToRowBgFn);
             const tooltipDefaultStyles = getDefaultCellStyles(theme, tooltipCellStyleOptions);
@@ -861,7 +864,6 @@ export function TableNG(props: TableNGProps) {
               gridRef,
               placement,
               renderer: tooltipFieldRenderer,
-              tooltipField,
               theme,
               width: tooltipWidth,
             } satisfies Partial<React.ComponentProps<typeof TableCellTooltip>>;

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -828,7 +828,6 @@ export function TableNG(props: TableNGProps) {
               // (which would line-clamp/cut off the content).
               textWrap: true,
               shouldOverflow: false,
-              maxHeight: undefined,
             } satisfies TableCellStyleOptions;
             const tooltipCanBeColorized = canFieldBeColorized(tooltipCellOptions.type, applyToRowBgFn);
             const tooltipDefaultStyles = getDefaultCellStyles(theme, tooltipCellStyleOptions);

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellTooltip.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellTooltip.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { type RefObject } from 'react';
 
 import { createTheme, type DataFrame, type Field, FieldType, toDataFrame } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { type DataGridHandle } from '@grafana/react-data-grid';
 import { TableCellDisplayMode } from '@grafana/schema';
 
@@ -18,15 +19,6 @@ const TestRenderer: TableCellRenderer = ({ value }) => <div data-testid="tooltip
 
 function makeField(values: unknown[] = ['hello']): Field {
   return { name: 'Status', type: FieldType.string, values, config: {} };
-}
-
-function makeTooltipField(dynamicHeight = false): Field {
-  return {
-    name: 'Status',
-    type: FieldType.string,
-    values: ['hello'],
-    config: { custom: { cellOptions: { dynamicHeight } } },
-  };
 }
 
 function makeData(values: unknown[] = ['hello']): DataFrame {
@@ -45,7 +37,6 @@ function makeProps(overrides: Partial<TableCellTooltipProps> = {}): Omit<TableCe
     classes: defaultClasses,
     data: makeData(),
     field: makeField(),
-    tooltipField: makeTooltipField(),
     getActions: () => [],
     getTextColorForBackground: () => '#000',
     gridRef: makeGridRef(),
@@ -282,6 +273,17 @@ describe('TableCellTooltip', () => {
       });
       await user.click(screen.getByRole('button', { name: CARET_LABEL }));
       expect(screen.getByText('row-one')).toBeInTheDocument();
+    });
+
+    // The tooltip is a free-floating overlay that should size to its content, so the
+    // popover container must never be constrained to a fixed height (which would clip
+    // content taller than the originating cell's row height).
+    it('does not apply a fixed height to the popover wrapper', async () => {
+      const user = userEvent.setup();
+      renderInRdgCell({ height: 32 });
+      await user.click(screen.getByRole('button', { name: CARET_LABEL }));
+      const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.TableNG.Tooltip.Wrapper);
+      expect(wrapper).not.toHaveStyle({ height: '32px' });
     });
 
     it('the Popover is not rendered when there is no .rdg-cell ancestor', async () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellTooltip.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellTooltip.tsx
@@ -36,7 +36,6 @@ export interface TableCellTooltipProps {
   renderer: TableCellRenderer;
   rowIdx: number;
   style?: CSSProperties;
-  tooltipField: Field;
   theme: GrafanaTheme2;
   width?: number;
 }
@@ -59,7 +58,6 @@ export const TableCellTooltip = memo(
     rowIdx,
     style,
     theme,
-    tooltipField,
     width = 300,
   }: TableCellTooltipProps) => {
     const rawValue = field.values[rowIdx];
@@ -69,7 +67,6 @@ export const TableCellTooltip = memo(
     const [pinned, setPinned] = useState(false);
 
     const show = hovered || pinned;
-    const dynamicHeight = tooltipField.config.custom?.cellOptions?.dynamicHeight;
 
     useEffect(() => {
       if (pinned) {
@@ -154,7 +151,7 @@ export const TableCellTooltip = memo(
             placement={placement}
             wrapperClassName={classes.tooltipWrapper}
             className={className}
-            style={{ ...style, width, ...(!dynamicHeight && { height }) }}
+            style={{ ...style, width }}
             referenceElement={cellElement}
             onMouseLeave={onMouseLeave}
             onMouseEnter={onMouseEnter}


### PR DESCRIPTION
Tooltip content rendered from a "tooltip from field" was being clipped: the popover was given a fixed height (the originating row's height), its content never wrapped, and a maxHeight clamp triggered WebkitLineClamp.

The tooltip is a free-floating overlay, so its container never needs a fixed height. Always size it to content (as markdown already did), always wrap tooltip text, and drop the per-row cell-height clamp. A numeric height still flows to the renderer so BarGauge/Image cells size themselves.

To test:

- added a new panel on the kitchen sink dashboard which has tooltip from field which is taller than the row height of the underlying cells, which on main would have been cut off, and on this branch will look correct. (see screenshot)
- on the gdev dashboard for markdown cell, you can add an override for the number column to make the markdown column the tooltip from field and test that the dynamic height tooltips still work as expected.

<img width="731" height="302" alt="Screenshot 2026-06-24 at 4 56 42 PM" src="https://github.com/user-attachments/assets/00c7b4f4-ec96-449d-bcb1-4f896683ef6b" />
