### PR TITLE
Dashboard Export: strip folder annotations from v2 resource export

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -5,6 +5,12 @@ import {
   defaultQueryGroupKind,
   defaultVizConfigSpec,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import {
+  AnnoKeyFolder,
+  AnnoKeyFolderTitle,
+  AnnoKeyFolderUrl,
+  AnnoKeyGrantPermissions,
+} from 'app/features/apiserver/types';
 import * as dashboardApiModule from 'app/features/dashboard/api/dashboard_api';
 import { ExportFormat, type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { type DashboardDataDTO } from 'app/types/dashboard';
@@ -207,6 +213,58 @@ describe('ShareExportTab', () => {
       if ('metadata' in result.json) {
         expect(result.json.metadata).not.toHaveProperty('resourceVersion');
         expect(result.json.metadata).not.toHaveProperty('namespace');
+      }
+    });
+
+    it('should strip folder annotations when sharing externally is off', async () => {
+      mockGetDashboardAPI(mockV1Spec, {
+        ...mockV2ResourceResponse,
+        metadata: {
+          ...mockV2ResourceResponse.metadata,
+          annotations: {
+            [AnnoKeyFolder]: 'folder-uid',
+            [AnnoKeyFolderTitle]: 'My Folder',
+            [AnnoKeyFolderUrl]: '/dashboards/f/my-folder',
+            [AnnoKeyGrantPermissions]: 'default',
+          },
+        },
+      });
+
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource, isSharingExternally: false });
+
+      const result = await tab.getExportableDashboardJson();
+
+      expect('metadata' in result.json && result.json.metadata?.annotations).toEqual({
+        [AnnoKeyGrantPermissions]: 'default',
+      });
+    });
+
+    it('should strip folder annotations when sharing externally is on', async () => {
+      mockGetDashboardAPI(mockV1Spec, {
+        ...mockV2ResourceResponse,
+        metadata: {
+          ...mockV2ResourceResponse.metadata,
+          annotations: {
+            [AnnoKeyFolder]: 'folder-uid',
+            [AnnoKeyFolderTitle]: 'My Folder',
+            [AnnoKeyFolderUrl]: '/dashboards/f/my-folder',
+            [AnnoKeyGrantPermissions]: 'default',
+          },
+        },
+      });
+
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource, isSharingExternally: true });
+
+      const result = await tab.getExportableDashboardJson();
+
+      if ('metadata' in result.json) {
+        const annotations = result.json.metadata?.annotations ?? {};
+        expect(annotations[AnnoKeyFolder]).toBeUndefined();
+        expect(annotations[AnnoKeyFolderTitle]).toBeUndefined();
+        expect(annotations[AnnoKeyFolderUrl]).toBeUndefined();
+        expect(annotations[AnnoKeyGrantPermissions]).toBeUndefined();
       }
     });
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -10,7 +10,7 @@ import { type SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { Button, ClipboardButton, CodeEditor, Modal } from '@grafana/ui';
-import { type ObjectMeta } from 'app/features/apiserver/types';
+import { AnnoKeyFolder, AnnoKeyFolderTitle, AnnoKeyFolderUrl, type ObjectMeta } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { ExportFormat } from 'app/features/dashboard/api/types';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
@@ -260,11 +260,23 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
   };
 }
 
+const FOLDER_EXPORT_ANNOTATIONS = [AnnoKeyFolder, AnnoKeyFolderTitle, AnnoKeyFolderUrl] as const;
+
+function stripFolderAnnotations(annotations: Record<string, string> | undefined) {
+  if (!annotations) {
+    return;
+  }
+  for (const key of FOLDER_EXPORT_ANNOTATIONS) {
+    delete annotations[key];
+  }
+}
+
 function stripMetadataForExport(metadata: ObjectMeta, isSharingExternally: boolean): Partial<ObjectMeta> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: Record<string, any> = cloneDeep(metadata);
 
   delete result['managedFields'];
+  stripFolderAnnotations(result['annotations']);
 
   if (isSharingExternally) {
     delete result['uid'];


### PR DESCRIPTION
V2 Resource dashboard export was including folder metadata when `Share dashboard with another instance == false` in `metadata.annotations` (`grafana.app/folder`, `grafana.app/folderTitle`, `grafana.app/folderUrl`). Classic export never included those fields, so GitOps workflows that export dashboards to git and re-provision them broke when folder UIDs changed after a DB reset or fresh install, the same failure described in [#126422](https://github.com/grafana/grafana/issues/126422). To summarize this issue, teams that commit exported dashboards to git and load them via file provisioning hit errors when folder UIDs change (Postgres rebuild, new SQLite volume on pod restart, etc.):

```text
dashboard folderUID ("abc") does not match provisioning provider folderUID ("def")
```

Fixes https://github.com/grafana/grafana/issues/126422


