### PR TITLE
Azure Monitor: Add azure batch api fallback logic

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1782,6 +1782,14 @@ var (
 			Expression:  "false",
 		},
 		{
+			Name:        "azureMonitor.batchFallback",
+			Description: "Falls back to the ARM batch endpoint when an Azure Monitor Metrics Batch API request fails with a retryable error",
+			Generate:    Generate{Go: true},
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaDataSourcesPlugins,
+			Expression:  "false",
+		},
+		{
 			Name:         "alertingRulePermanentlyDelete",
 			Description:  "Enables UI functionality to permanently delete alert rules",
 			Generate:     Generate{LegacyFrontend: true},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -207,6 +207,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,alertingMigrationWizardUI,experimental,@grafana/alerting-squad,false,false,true
 2025-04-02,azureMonitorLogsBuilderEditor,preview,@grafana/data-sources-plugins,false,false,false
 2026-06-01,azureMonitorBatchAPI,experimental,@grafana/data-sources-plugins,false,false,false
+2026-06-24,azureMonitor.batchFallback,experimental,@grafana/data-sources-plugins,false,false,false
 2025-04-03,alertingRulePermanentlyDelete,GA,@grafana/alerting-squad,false,false,true
 2025-03-27,alertingRuleRecoverDeleted,GA,@grafana/alerting-squad,false,false,false
 2025-04-02,multiTenantTempCredentials,experimental,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -566,6 +566,10 @@ const (
 	// Enables the Metrics Batch API for the Azure Monitor data source, allowing up to 50 resources to be queried in a single request
 	FlagAzureMonitorBatchAPI = "azureMonitorBatchAPI"
 
+	// FlagAzureMonitorBatchFallback
+	// Falls back to the ARM batch endpoint when an Azure Monitor Metrics Batch API request fails with a retryable error
+	FlagAzureMonitorBatchFallback = "azureMonitor.batchFallback"
+
 	// FlagAlertingRuleRecoverDeleted
 	// Enables the UI functionality to recover and view deleted alert rules
 	FlagAlertingRuleRecoverDeleted = "alertingRuleRecoverDeleted"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1046,6 +1046,19 @@
     },
     {
       "metadata": {
+        "name": "azureMonitor.batchFallback",
+        "resourceVersion": "1782263807585",
+        "creationTimestamp": "2026-06-24T01:16:47Z"
+      },
+      "spec": {
+        "description": "Falls back to the ARM batch endpoint when an Azure Monitor Metrics Batch API request fails with a retryable error",
+        "stage": "experimental",
+        "codeowner": "@grafana/data-sources-plugins",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "azureMonitorBatchAPI",
         "resourceVersion": "1780343527990",
         "creationTimestamp": "2026-06-01T19:52:07Z"

--- a/pkg/tsdb/azuremonitor/metrics/arm-batch-fallback.go
+++ b/pkg/tsdb/azuremonitor/metrics/arm-batch-fallback.go
@@ -1,0 +1,290 @@
+package metrics
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+
+	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
+	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/utils"
+)
+
+// The ARM /batch endpoint bundles many ARM reads into one request. It is undocumented and
+// used internally by the Azure Portal; the request/response contract below was verified
+// against live portal traffic. Because it has no official spec, it is gated behind a flag.
+// We use it as a fallback when the documented metrics:getBatch data-plane API fails with a
+// retryable error, wrapping each per-resource /metrics GET call as a sub-request.
+const armBatchAPIVersion = "2020-06-01"
+
+// maxARMBatchSize bounds sub-requests per ARM batch call. Above ~20 sub-requests the
+// endpoint switches to an async 202 + Location/poll flow; we stay at or under that to
+// keep a single synchronous response. The exact async threshold is unverified, so this
+// is deliberately conservative.
+const maxARMBatchSize = 20
+
+// armBatchSubRequest is one ARM read inside a batch. name is a correlation id echoed back
+// in the response; url is relative (begins with "/subscriptions/...") and includes the
+// inner api-version.
+type armBatchSubRequest struct {
+	HTTPMethod string `json:"httpMethod"`
+	Name       string `json:"name"`
+	URL        string `json:"url"`
+}
+
+type armBatchRequestBody struct {
+	Requests []armBatchSubRequest `json:"requests"`
+}
+
+// armBatchSubResponse is one result. The envelope's top-level key is "responses"; each item
+// carries its own httpStatusCode and the inner response body nested under "content".
+type armBatchSubResponse struct {
+	Name           string          `json:"name"`
+	HTTPStatusCode int             `json:"httpStatusCode"`
+	Content        json.RawMessage `json:"content"`
+}
+
+type armBatchResponseBody struct {
+	Responses []armBatchSubResponse `json:"responses"`
+}
+
+// executeARMBatch POSTs a set of sub-requests to the ARM /batch endpoint and returns the
+// parsed per-sub-request responses. Callers must keep len(subRequests) within
+// maxARMBatchSize to avoid the async path.
+func executeARMBatch(ctx context.Context, cli *http.Client, armBaseURL string, subRequests []armBatchSubRequest) (*armBatchResponseBody, error) {
+	body, err := json.Marshal(armBatchRequestBody{Requests: subRequests})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ARM batch request: %w", err)
+	}
+
+	rawURL := fmt.Sprintf("%s/batch?api-version=%s", strings.TrimRight(armBaseURL, "/"), armBatchAPIVersion)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ARM batch request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := cli.Do(req)
+	if err != nil {
+		return nil, backend.DownstreamError(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxBatchResponseBodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read ARM batch response body: %w", err)
+	}
+
+	// A 202 means we exceeded the synchronous threshold and would need to poll the
+	// Location header. We don't implement async polling; callers chunk to maxARMBatchSize
+	// to stay under the threshold, so treat a 202 as an error.
+	if resp.StatusCode == http.StatusAccepted {
+		return nil, fmt.Errorf("ARM batch returned 202 Accepted (async); async polling is not implemented")
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, utils.CreateResponseErrorFromStatusCode(resp.StatusCode, resp.Status, respBody)
+	}
+
+	var parsed armBatchResponseBody
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ARM batch response: %w", err)
+	}
+	return &parsed, nil
+}
+
+// buildFallbackSubRequests rebuilds per-resource /metrics GET sub-requests for the
+// resources in a single failed batch. It reuses fanOutByResource + buildQuery so the URL
+// and params (dimensions, namespace, time range, etc.) come from the same proven code the
+// legacy path uses; nothing is hand-reconstructed. Returns the sub-requests and a map
+// from each sub-request name to its originating query RefID, for routing the responses.
+//
+// Only the failed batch's own ResourceIDs are rebuilt, so resources that succeeded in
+// sibling batches are never re-fetched.
+func (e *AzureMonitorDatasource) buildFallbackSubRequests(batch Batch, originalByRefID map[string]backend.DataQuery, dsInfo types.DatasourceInfo) ([]armBatchSubRequest, map[string]*types.AzureMonitorQuery, error) {
+	wanted := make(map[string]bool, len(batch.ResourceIDs))
+	for _, id := range batch.ResourceIDs {
+		wanted[strings.ToLower(id)] = true
+	}
+
+	var subRequests []armBatchSubRequest
+	queriesByName := make(map[string]*types.AzureMonitorQuery)
+	seen := make(map[string]bool)
+
+	for _, q := range batch.Queries {
+		original, ok := originalByRefID[q.RefID]
+		if !ok {
+			continue
+		}
+		perResourceQueries, err := fanOutByResource(original)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, prq := range perResourceQueries {
+			azureQuery, err := e.buildQuery(prq, dsInfo)
+			if err != nil {
+				return nil, nil, err
+			}
+			for resourceURI := range azureQuery.Resources {
+				key := strings.ToLower(resourceURI)
+				if !wanted[key] || seen[key] {
+					continue
+				}
+				seen[key] = true
+				// GUID correlation name; keep the per-resource query so the
+				// response can be parsed with the existing parseResponse.
+				name := uuid.NewString()
+				queriesByName[name] = azureQuery
+				subRequests = append(subRequests, armBatchSubRequest{
+					HTTPMethod: http.MethodGet,
+					Name:       name,
+					URL:        relativeMetricsURL(azureQuery),
+				})
+			}
+		}
+	}
+	return subRequests, queriesByName, nil
+}
+
+// parseFallbackResponse converts an ARM /batch response into frames. Each sub-response's
+// content is a standard single-resource AzureMonitorResponse, so it's run through the
+// existing parseResponse; frames are routed back to the right query via the per-name
+// query map. Per-resource failures are joined into the returned error while frames from
+// the resources that succeeded are still returned.
+func (e *AzureMonitorDatasource) parseFallbackResponse(resp *armBatchResponseBody, queriesByName map[string]*types.AzureMonitorQuery, azurePortalURL string) (data.Frames, error) {
+	var frames data.Frames
+	var errs []error
+
+	for _, r := range resp.Responses {
+		query, ok := queriesByName[r.Name]
+		if !ok {
+			continue
+		}
+		if r.HTTPStatusCode/100 != 2 {
+			errs = append(errs, fmt.Errorf("fallback query %q failed (status %d): %s", query.RefID, r.HTTPStatusCode, string(r.Content)))
+			continue
+		}
+
+		var amr types.AzureMonitorResponse
+		if err := json.Unmarshal(r.Content, &amr); err != nil {
+			errs = append(errs, fmt.Errorf("failed to parse fallback response for %q: %w", query.RefID, err))
+			continue
+		}
+
+		// Reuse the single-resource parser; pass query.Subscription for {{subscription}}
+		// (the same value the batch path uses).
+		f, err := e.parseResponse(amr, query, azurePortalURL, query.Subscription)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		frames = append(frames, f...)
+	}
+
+	return frames, errors.Join(errs...)
+}
+
+// relativeMetricsURL renders a single-resource AzureMonitorQuery as the relative URL for
+// an ARM /batch sub-request. This is exactly what executeQuery would send for that query
+// (path + params buildQuery already populated: api-version, timespan, metricnames,
+// aggregation, and any dimension $filter); we just wrap it in a batch instead of GETting
+// it directly.
+func relativeMetricsURL(query *types.AzureMonitorQuery) string {
+	path := query.URL
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if encoded := query.Params.Encode(); encoded != "" {
+		return path + "?" + encoded
+	}
+	return path
+}
+
+// isRetryableStatus reports whether a failed metrics:getBatch request is worth retrying
+// via the fallback path. Throttling (429) and transient server errors (5xx, which
+// includes Azure's 529 metrics throttle) are retryable; a status of 0 means the request
+// never completed (e.g. a network error) and is also retryable. Other 4xx are client
+// errors a retry won't fix, so they are surfaced as-is.
+func isRetryableStatus(statusCode int) bool {
+	if statusCode == 0 {
+		return true
+	}
+	if statusCode == http.StatusTooManyRequests {
+		return true
+	}
+	return statusCode >= 500 && statusCode <= 599
+}
+
+// chunkSubRequests splits sub-requests into groups of at most size, keeping each ARM
+// /batch call under the synchronous threshold.
+func chunkSubRequests(subRequests []armBatchSubRequest, size int) [][]armBatchSubRequest {
+	var chunks [][]armBatchSubRequest
+	for i := 0; i < len(subRequests); i += size {
+		end := i + size
+		if end > len(subRequests) {
+			end = len(subRequests)
+		}
+		chunks = append(chunks, subRequests[i:end])
+	}
+	return chunks
+}
+
+// appendFrames routes frames to their RefID's response, preserving any already collected.
+func appendFrames(result *backend.QueryDataResponse, frames data.Frames) {
+	for _, frame := range frames {
+		dr := result.Responses[frame.RefID]
+		dr.Frames = append(dr.Frames, frame)
+		result.Responses[frame.RefID] = dr
+	}
+}
+
+// fallbackBatch re-fetches a failed batch's resources via the ARM /batch endpoint, chunked
+// to stay synchronous. If an ARM /batch chunk itself fails, the affected queries fail; we do
+// not fan out to individual requests, which would be more likely to hit the same throttling
+// that triggered the fallback. Results are written into result by RefID.
+func (e *AzureMonitorDatasource) fallbackBatch(ctx context.Context, br batchResult, originalByRefID map[string]backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, armURL, azurePortalURL string, result *backend.QueryDataResponse) {
+	e.Logger.Debug("metrics batch failed with a retryable error; falling back to ARM /batch",
+		"statusCode", br.StatusCode, "numResources", len(br.Batch.ResourceIDs))
+
+	subRequests, queriesByName, err := e.buildFallbackSubRequests(br.Batch, originalByRefID, dsInfo)
+	if err != nil {
+		// Can't build the fallback requests; surface the original batch error.
+		e.Logger.Warn("failed to build ARM /batch fallback requests; surfacing the original batch error", "err", err)
+		for _, q := range br.Batch.Queries {
+			attachErr(result, q.RefID, br.Err)
+		}
+		return
+	}
+
+	for _, chunk := range chunkSubRequests(subRequests, maxARMBatchSize) {
+		armResp, err := executeARMBatch(ctx, client, armURL, chunk)
+		if err != nil {
+			// The ARM /batch fallback itself failed; fail the affected queries.
+			e.Logger.Warn("ARM /batch fallback request failed", "err", err, "numSubRequests", len(chunk))
+			for _, sub := range chunk {
+				if q, ok := queriesByName[sub.Name]; ok {
+					attachErr(result, q.RefID, err)
+				}
+			}
+			continue
+		}
+
+		frames, parseErr := e.parseFallbackResponse(armResp, queriesByName, azurePortalURL)
+		appendFrames(result, frames)
+		if parseErr != nil {
+			e.Logger.Warn("ARM /batch fallback returned partial failures", "err", parseErr)
+			for _, sub := range chunk {
+				if q, ok := queriesByName[sub.Name]; ok {
+					attachErr(result, q.RefID, parseErr)
+				}
+			}
+		}
+	}
+}

--- a/pkg/tsdb/azuremonitor/metrics/batch-client.go
+++ b/pkg/tsdb/azuremonitor/metrics/batch-client.go
@@ -21,7 +21,7 @@ const batchAPIVersion = "2023-10-01"
 
 // validRegionRe matches valid Azure region names: non-empty sequences of ASCII
 // letters and digits (e.g. "eastus", "westeurope", "northcentralus").
-// An empty string is also accepted — it maps to the global endpoint.
+// An empty string is also accepted; it maps to the global endpoint.
 var validRegionRe = regexp.MustCompile(`^[a-zA-Z0-9]*$`)
 
 // maxConcurrentBatches limits how many Metrics Batch API requests run in parallel.
@@ -48,8 +48,8 @@ func executeBatchRequests(ctx context.Context, batches []Batch, cli *http.Client
 		go func(idx int, b Batch) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			resp, err := executeBatchRequest(ctx, b, cli)
-			results[idx] = batchResult{Batch: b, Response: resp, Err: err}
+			resp, status, err := executeBatchRequest(ctx, b, cli)
+			results[idx] = batchResult{Batch: b, Response: resp, StatusCode: status, Err: err}
 		}(i, batch)
 	}
 	wg.Wait()
@@ -120,41 +120,46 @@ type batchMetric struct {
 	ErrorCode string `json:"errorCode"`
 }
 
-// batchResult holds the outcome of executing a single batch request.
+// batchResult holds the outcome of executing a single batch request. StatusCode is the
+// HTTP status of the batch response (0 if the request never completed, e.g. a network
+// error); it is used to decide whether a failure is retryable via the fallback path.
 type batchResult struct {
-	Batch    Batch
-	Response *batchResponse
-	Err      error
+	Batch      Batch
+	Response   *batchResponse
+	StatusCode int
+	Err        error
 }
 
 // executeBatchRequest sends a single Metrics Batch API request and parses the response.
-func executeBatchRequest(ctx context.Context, batch Batch, cli *http.Client) (*batchResponse, error) {
+// It returns the HTTP status code alongside the result so callers can classify failures
+// (0 means the request never completed).
+func executeBatchRequest(ctx context.Context, batch Batch, cli *http.Client) (*batchResponse, int, error) {
 	req, err := buildBatchRequest(ctx, batch)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	resp, err := cli.Do(req)
 	if err != nil {
-		return nil, backend.DownstreamError(err)
+		return nil, 0, backend.DownstreamError(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBatchResponseBodyBytes))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read batch response body: %w", err)
+		return nil, resp.StatusCode, fmt.Errorf("failed to read batch response body: %w", err)
 	}
 
 	if resp.StatusCode/100 != 2 {
-		return nil, utils.CreateResponseErrorFromStatusCode(resp.StatusCode, resp.Status, body)
+		return nil, resp.StatusCode, utils.CreateResponseErrorFromStatusCode(resp.StatusCode, resp.Status, body)
 	}
 
 	var result batchResponse
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal batch response: %w", err)
+		return nil, resp.StatusCode, fmt.Errorf("failed to unmarshal batch response: %w", err)
 	}
 
-	return &result, nil
+	return &result, resp.StatusCode, nil
 }
 
 // buildBatchRequest creates the HTTP POST request for a Metrics Batch API call.

--- a/pkg/tsdb/azuremonitor/metrics/batch-client_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/batch-client_test.go
@@ -242,7 +242,7 @@ func TestExecuteBatchRequest(t *testing.T) {
 		batch := makeBatch("westus2", "sub-123", "Microsoft.Compute/virtualMachines", "Percentage CPU",
 			"PT1M", "Average", "", from, to, []string{"/sub/rg/vm1"}, nil)
 
-		resp, err := executeBatchRequest(context.Background(), batch, redirectToServer(srv))
+		resp, _, err := executeBatchRequest(context.Background(), batch, redirectToServer(srv))
 		require.NoError(t, err)
 		require.Len(t, resp.Values, 1)
 		assert.Equal(t, "/sub/rg/vm1", resp.Values[0].ResourceID)
@@ -258,7 +258,7 @@ func TestExecuteBatchRequest(t *testing.T) {
 		batch := makeBatch("westus2", "sub-123", "Microsoft.Compute/virtualMachines", "Percentage CPU",
 			"PT1M", "Average", "", from, to, []string{"/sub/rg/vm1"}, nil)
 
-		_, err := executeBatchRequest(context.Background(), batch, redirectToServer(srv))
+		_, _, err := executeBatchRequest(context.Background(), batch, redirectToServer(srv))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "403")
 	})
@@ -272,7 +272,7 @@ func TestExecuteBatchRequest(t *testing.T) {
 		batch := makeBatch("westus2", "sub-123", "Microsoft.Compute/virtualMachines", "Percentage CPU",
 			"PT1M", "Average", "", from, to, []string{"/sub/rg/vm1"}, nil)
 
-		_, err := executeBatchRequest(context.Background(), batch, redirectToServer(srv))
+		_, _, err := executeBatchRequest(context.Background(), batch, redirectToServer(srv))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to unmarshal")
 	})

--- a/pkg/tsdb/azuremonitor/metrics/batch-execution_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/batch-execution_test.go
@@ -3,9 +3,11 @@ package metrics
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +41,14 @@ func (t *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error)
 func batchCtx() context.Context {
 	cfg := config.NewGrafanaCfg(map[string]string{
 		featuretoggles.EnabledFeatures: "azureMonitorBatchAPI",
+	})
+	return config.WithGrafanaConfig(context.Background(), cfg)
+}
+
+// batchFallbackCtx enables both the batch API and the ARM /batch fallback flags.
+func batchFallbackCtx() context.Context {
+	cfg := config.NewGrafanaCfg(map[string]string{
+		featuretoggles.EnabledFeatures: "azureMonitorBatchAPI,azureMonitor.batchFallback",
 	})
 	return config.WithGrafanaConfig(context.Background(), cfg)
 }
@@ -269,7 +279,7 @@ func TestExecuteBatchTimeSeriesQuery(t *testing.T) {
 		})
 
 		cli := &http.Client{Transport: &redirectTransport{target: mustParseURL(srv.URL)}}
-		// Context has the feature flag but BatchAPIEnabled is false — should NOT use batch path
+		// Context has the feature flag but BatchAPIEnabled is false; should NOT use batch path
 		resp, err := ds.ExecuteTimeSeriesQuery(batchCtx(), []backend.DataQuery{q}, dsInfo, cli, srv.URL, false)
 		require.NoError(t, err)
 		assert.Contains(t, resp.Responses, "A")
@@ -307,4 +317,233 @@ func TestIsBatchableQuery(t *testing.T) {
 			assert.Equal(t, tt.want, isBatchableQuery(makeQuery(tt.metricNamespace, tt.customNamespace)))
 		})
 	}
+}
+
+func TestExecuteBatchTimeSeriesQueryFallback(t *testing.T) {
+	ds := &AzureMonitorDatasource{Logger: log.NewNullLogger()}
+	armResponse := loadTestFile(t, "azuremonitor/1-azure-monitor-response-avg.json")
+	armContent, _ := json.Marshal(armResponse)
+
+	// armBatchOK echoes each incoming sub-request name with a 200 + the metrics fixture,
+	// imitating the undocumented ARM /batch response envelope.
+	armBatchOK := func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Requests []struct {
+				Name string `json:"name"`
+			} `json:"requests"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		type sub struct {
+			Name           string          `json:"name"`
+			HTTPStatusCode int             `json:"httpStatusCode"`
+			Content        json.RawMessage `json:"content"`
+		}
+		out := struct {
+			Responses []sub `json:"responses"`
+		}{}
+		for _, req := range body.Requests {
+			out.Responses = append(out.Responses, sub{Name: req.Name, HTTPStatusCode: 200, Content: armContent})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		b, _ := json.Marshal(out)
+		_, _ = w.Write(b)
+	}
+
+	oneResource := []dataquery.AzureMonitorResource{
+		{Subscription: strPtr("sub-123"), ResourceGroup: strPtr("rg"), ResourceName: strPtr("vm1"), Region: strPtr("eastus")},
+	}
+
+	t.Run("retryable failure falls back to ARM /batch and returns frames", func(t *testing.T) {
+		var batchHit, fallbackHit bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.Contains(r.URL.Path, "metrics:getBatch"):
+				batchHit = true
+				http.Error(w, `{"error":{"code":"TooManyRequests"}}`, http.StatusTooManyRequests)
+			case strings.HasSuffix(r.URL.Path, "/batch"):
+				fallbackHit = true
+				armBatchOK(w, r)
+			default:
+				t.Errorf("unexpected request path: %s", r.URL.Path)
+			}
+		}))
+		defer srv.Close()
+
+		dsInfo := makeBatchDsInfo(srv)
+		q := makeBatchQuery("A", "sub-123", "eastus", oneResource)
+		cli := &http.Client{Transport: &redirectTransport{target: mustParseURL(srv.URL)}}
+
+		resp, err := ds.ExecuteTimeSeriesQuery(batchFallbackCtx(), []backend.DataQuery{q}, dsInfo, cli, srv.URL, false)
+		require.NoError(t, err)
+		assert.True(t, batchHit, "metrics:getBatch should have been attempted")
+		assert.True(t, fallbackHit, "ARM /batch fallback should have been called")
+		dr := resp.Responses["A"]
+		assert.Nil(t, dr.Error)
+		assert.NotEmpty(t, dr.Frames, "fallback should have produced frames")
+	})
+
+	t.Run("fallback flag off: error surfaced, no ARM /batch call", func(t *testing.T) {
+		var fallbackHit bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/batch") {
+				fallbackHit = true
+			}
+			http.Error(w, `{"error":{"code":"TooManyRequests"}}`, http.StatusTooManyRequests)
+		}))
+		defer srv.Close()
+
+		dsInfo := makeBatchDsInfo(srv)
+		q := makeBatchQuery("A", "sub-123", "eastus", oneResource)
+		cli := &http.Client{Transport: &redirectTransport{target: mustParseURL(srv.URL)}}
+
+		// batchCtx() enables the batch API but NOT the fallback flag.
+		resp, err := ds.ExecuteTimeSeriesQuery(batchCtx(), []backend.DataQuery{q}, dsInfo, cli, srv.URL, false)
+		require.NoError(t, err)
+		assert.False(t, fallbackHit, "fallback must not run when the flag is off")
+		assert.NotNil(t, resp.Responses["A"].Error, "the batch error should be surfaced")
+	})
+
+	t.Run("non-retryable failure (400): no fallback", func(t *testing.T) {
+		var fallbackHit bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/batch") {
+				fallbackHit = true
+			}
+			http.Error(w, `{"error":{"code":"BadRequest"}}`, http.StatusBadRequest)
+		}))
+		defer srv.Close()
+
+		dsInfo := makeBatchDsInfo(srv)
+		q := makeBatchQuery("A", "sub-123", "eastus", oneResource)
+		cli := &http.Client{Transport: &redirectTransport{target: mustParseURL(srv.URL)}}
+
+		resp, err := ds.ExecuteTimeSeriesQuery(batchFallbackCtx(), []backend.DataQuery{q}, dsInfo, cli, srv.URL, false)
+		require.NoError(t, err)
+		assert.False(t, fallbackHit, "400 is not retryable; fallback must not run")
+		assert.NotNil(t, resp.Responses["A"].Error)
+	})
+
+	t.Run("ARM /batch itself fails: query fails, no fan-out to individual", func(t *testing.T) {
+		var individualHit bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.Contains(r.URL.Path, "metrics:getBatch"):
+				http.Error(w, `{"error":{}}`, http.StatusTooManyRequests)
+			case strings.HasSuffix(r.URL.Path, "/batch"):
+				http.Error(w, `{"error":{}}`, http.StatusInternalServerError) // ARM /batch fails
+			case strings.Contains(r.URL.Path, "/providers/microsoft.insights/metrics"):
+				individualHit = true
+				w.Header().Set("Content-Type", "application/json")
+				b, _ := json.Marshal(armResponse)
+				_, _ = w.Write(b)
+			default:
+				// subscription-details lookup used for legend formatting
+				_, _ = w.Write([]byte(`{"displayName":"Test Sub"}`))
+			}
+		}))
+		defer srv.Close()
+
+		dsInfo := makeBatchDsInfo(srv)
+		q := makeBatchQuery("A", "sub-123", "eastus", oneResource)
+		cli := &http.Client{Transport: &redirectTransport{target: mustParseURL(srv.URL)}}
+
+		resp, err := ds.ExecuteTimeSeriesQuery(batchFallbackCtx(), []backend.DataQuery{q}, dsInfo, cli, srv.URL, false)
+		require.NoError(t, err)
+		assert.False(t, individualHit, "must not fan out to individual /metrics when ARM /batch fails")
+		assert.NotNil(t, resp.Responses["A"].Error, "query should fail when the ARM /batch fallback fails")
+	})
+
+	t.Run("more than maxARMBatchSize resources: fallback chunks into multiple ARM /batch calls", func(t *testing.T) {
+		const resourceCount = maxARMBatchSize + 5 // 25 -> chunks of 20 + 5
+		resources := make([]dataquery.AzureMonitorResource, 0, resourceCount)
+		for i := 0; i < resourceCount; i++ {
+			resources = append(resources, dataquery.AzureMonitorResource{
+				Subscription:  strPtr("sub-123"),
+				ResourceGroup: strPtr("rg"),
+				ResourceName:  strPtr(fmt.Sprintf("vm%d", i)),
+				Region:        strPtr("eastus"),
+			})
+		}
+
+		// The single failed batch fans out after wg.Wait(), so this counter is only
+		// ever touched from the calling goroutine.
+		var batchCalls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.Contains(r.URL.Path, "metrics:getBatch"):
+				http.Error(w, `{"error":{"code":"TooManyRequests"}}`, http.StatusTooManyRequests)
+			case strings.HasSuffix(r.URL.Path, "/batch"):
+				batchCalls++
+				armBatchOK(w, r)
+			default:
+				t.Errorf("unexpected request path: %s", r.URL.Path)
+			}
+		}))
+		defer srv.Close()
+
+		dsInfo := makeBatchDsInfo(srv)
+		q := makeBatchQuery("A", "sub-123", "eastus", resources)
+		cli := &http.Client{Transport: &redirectTransport{target: mustParseURL(srv.URL)}}
+
+		resp, err := ds.ExecuteTimeSeriesQuery(batchFallbackCtx(), []backend.DataQuery{q}, dsInfo, cli, srv.URL, false)
+		require.NoError(t, err)
+		assert.Equal(t, 2, batchCalls, "25 resources should chunk into two ARM /batch calls (20 + 5)")
+		dr := resp.Responses["A"]
+		assert.Nil(t, dr.Error)
+		assert.NotEmpty(t, dr.Frames)
+	})
+
+	t.Run("partial failure in ARM /batch response: failed resource errors, others still return frames", func(t *testing.T) {
+		resources := []dataquery.AzureMonitorResource{
+			{Subscription: strPtr("sub-123"), ResourceGroup: strPtr("rg"), ResourceName: strPtr("vm1"), Region: strPtr("eastus")},
+			{Subscription: strPtr("sub-123"), ResourceGroup: strPtr("rg"), ResourceName: strPtr("vm2"), Region: strPtr("eastus")},
+		}
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.Contains(r.URL.Path, "metrics:getBatch"):
+				http.Error(w, `{"error":{}}`, http.StatusTooManyRequests)
+			case strings.HasSuffix(r.URL.Path, "/batch"):
+				// Return 200 for the first sub-request and 403 for the rest, so the
+				// response is a successful envelope carrying a per-resource failure.
+				var body struct {
+					Requests []struct {
+						Name string `json:"name"`
+					} `json:"requests"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				type sub struct {
+					Name           string          `json:"name"`
+					HTTPStatusCode int             `json:"httpStatusCode"`
+					Content        json.RawMessage `json:"content"`
+				}
+				out := struct {
+					Responses []sub `json:"responses"`
+				}{}
+				for i, req := range body.Requests {
+					if i == 0 {
+						out.Responses = append(out.Responses, sub{Name: req.Name, HTTPStatusCode: 200, Content: armContent})
+					} else {
+						out.Responses = append(out.Responses, sub{Name: req.Name, HTTPStatusCode: 403, Content: json.RawMessage(`{"error":{"code":"Forbidden"}}`)})
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				b, _ := json.Marshal(out)
+				_, _ = w.Write(b)
+			default:
+				t.Errorf("unexpected request path: %s", r.URL.Path)
+			}
+		}))
+		defer srv.Close()
+
+		dsInfo := makeBatchDsInfo(srv)
+		q := makeBatchQuery("A", "sub-123", "eastus", resources)
+		cli := &http.Client{Transport: &redirectTransport{target: mustParseURL(srv.URL)}}
+
+		resp, err := ds.ExecuteTimeSeriesQuery(batchFallbackCtx(), []backend.DataQuery{q}, dsInfo, cli, srv.URL, false)
+		require.NoError(t, err)
+		dr := resp.Responses["A"]
+		assert.NotNil(t, dr.Error, "the failed sub-response should surface an error")
+		assert.NotEmpty(t, dr.Frames, "the successful sub-response should still produce frames")
+	})
 }

--- a/pkg/tsdb/azuremonitor/metrics/batch-executor.go
+++ b/pkg/tsdb/azuremonitor/metrics/batch-executor.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/config"
 
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
@@ -17,7 +18,7 @@ import (
 // isBatchableQuery reports whether a backend query can be sent to the Metrics
 // Batch API. Queries that use a custom namespace (custom metrics, Application
 // Insights custom telemetry) or a Guest OS / Windows Azure Diagnostics (WAD)
-// namespace must fall back to the legacy ARM metrics endpoint — those metrics
+// namespace must fall back to the legacy ARM metrics endpoint; those metrics
 // are not exposed via the metrics-batch data plane.
 func isBatchableQuery(query backend.DataQuery) bool {
 	var model dataquery.AzureMonitorQuery
@@ -159,7 +160,7 @@ func (e *AzureMonitorDatasource) buildQueriesForBatch(query backend.DataQuery, d
 		groupedResources[key] = append(groupedResources[key], r)
 	}
 
-	// All resources share the same (subscription, region) — no splitting needed.
+	// All resources share the same (subscription, region); no splitting needed.
 	if len(orderedKeys) == 1 {
 		q, err := e.buildQuery(query, dsInfo)
 		if err != nil {
@@ -269,26 +270,36 @@ func (e *AzureMonitorDatasource) executeBatchTimeSeriesQuery(ctx context.Context
 	batches := createBatches(groupQueriesForBatch(azureQueries))
 	batchResults := executeBatchRequests(ctx, batches, batchClient)
 
+	// When a batch fails with a retryable error, fall back to re-fetching that batch's
+	// resources via the ARM /batch endpoint (gated behind a flag). Build a RefID to original
+	// query map so the fallback can rebuild per-resource queries.
+	fallbackEnabled := config.GrafanaConfigFromContext(ctx).FeatureToggles().IsEnabled("azureMonitor.batchFallback")
+	originalByRefID := make(map[string]backend.DataQuery, len(batchableQueries))
+	for _, q := range batchableQueries {
+		originalByRefID[q.RefID] = q
+	}
+
 	// For each batch: distribute frames to their RefID responses, then attribute
 	// any error (HTTP failure or per-metric parse error) to the affected queries.
 	// Frames from successful batches are preserved even when another batch fails.
 	azurePortalURL := dsInfo.Routes[types.RouteAzurePortal].URL
 	for _, br := range batchResults {
 		if br.Err != nil {
-			// HTTP-level failure: attribute the error to every query in the batch.
-			for _, q := range br.Batch.Queries {
-				attachErr(result, q.RefID, br.Err)
+			if fallbackEnabled && isRetryableStatus(br.StatusCode) {
+				e.fallbackBatch(ctx, br, originalByRefID, dsInfo, client, armURL, azurePortalURL, result)
+			} else {
+				// Not retryable (or fallback disabled): attribute the error to every
+				// query in the batch.
+				for _, q := range br.Batch.Queries {
+					attachErr(result, q.RefID, br.Err)
+				}
 			}
 			continue
 		}
 
 		// Successful HTTP response: parse and distribute frames.
 		frames, parseErr := parseBatchResponse(br, azurePortalURL)
-		for _, frame := range frames {
-			dr := result.Responses[frame.RefID]
-			dr.Frames = append(dr.Frames, frame)
-			result.Responses[frame.RefID] = dr
-		}
+		appendFrames(result, frames)
 		if parseErr != nil {
 			// Per-metric or parse error: surface to every query in the batch so
 			// users see it in the Grafana UI rather than it being silently dropped.

--- a/pkg/tsdb/azuremonitor/metrics/batch-response-parser.go
+++ b/pkg/tsdb/azuremonitor/metrics/batch-response-parser.go
@@ -17,7 +17,7 @@ func parseBatchResponse(result batchResult, azurePortalURL string) (data.Frames,
 	var frames data.Frames
 	var errs []error
 
-	// Build a lookup from lowercase resource ID -> query.
+	// Build a lookup from lowercase resource ID to query.
 	// Keys in query.Resources are already stored lowercase (see buildQuery).
 	resourceToQuery := make(map[string]*types.AzureMonitorQuery)
 	for _, query := range result.Batch.Queries {

--- a/pkg/tsdb/azuremonitor/metrics/batch-response-parser_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/batch-response-parser_test.go
@@ -338,7 +338,7 @@ func TestFramesFromBatchResponseValueAlias(t *testing.T) {
 // TestParseResponseLegacyBatchEquivalence is the key guard for the shared-builder
 // refactor: for the same logical resource/metric/series, the single-resource ARM
 // parser and the batch parser must produce equivalent frames (field names,
-// labels, config, and values) — for both default and GrafanaSql queries.
+// labels, config, and values); for both default and GrafanaSql queries.
 func TestParseResponseLegacyBatchEquivalence(t *testing.T) {
 	const fullID = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1"
 	const lowerID = "/subscriptions/sub/resourcegroups/rg/providers/microsoft.compute/virtualmachines/vm1"


### PR DESCRIPTION
**What this does**

When a `metrics:getBatch` (Metrics Batch API) request fails with a **retryable** error such as throttling (429), Azure's 529 metrics throttle, 5xx, or a network failure, this re-fetches that batch's resources via the **ARM `/batch` endpoint** (`management.azure.com/batch?api-version=2020-06-01`) instead of failing the query.

The whole behavior is gated behind a new experimental feature flag: **`azureMonitor.batchFallback`**.

**How it works**

1. A batch fails with a retryable status (`isRetryableStatus`: `0`/`429`/`5xx`).
2. We rebuild per-resource `/metrics` GET sub-requests **for that failed batch only** — reusing the existing `buildQuery`/`fanOutByResource` code so the URLs and params are identical to the legacy path (nothing is hand-reconstructed).
3. Those sub-requests are sent to ARM `/batch`, chunked to ≤20 per call to stay on the synchronous path.
4. Responses are parsed through the same `parseResponse` the single-resource path uses; per-resource failures are surfaced per-RefID while successful resources still return frames.

**Notes**

- **Only retryable failures trigger it.** Client errors (e.g. 400) are surfaced as-is.
- **If the ARM `/batch` call itself fails, the query fails.** 
- Uses the **ARM-audience client** against `management.azure.com`, not the metrics data-plane client.