### PR TITLE
Canvas: Fix CI test failure

### DIFF
--- a/public/app/plugins/panel/canvas/CanvasPanel.integration.test.tsx
+++ b/public/app/plugins/panel/canvas/CanvasPanel.integration.test.tsx
@@ -1092,13 +1092,16 @@ describe('Canvas', () => {
               // And then double click to trigger the field mapping select to get added to the UI
               await user.dblClick(metricPointerTarget);
               // Inline editor replaces the placeholder after editModeEnabled & React update
-              await waitFor(async () => {
-                const doubleClickElement = screen.queryByText(/Double click to set field/i);
-                if (doubleClickElement === null) {
-                  await user.dblClick(metricPointerTarget);
-                }
-                expect(doubleClickElement).not.toBeInTheDocument();
-              });
+              await waitFor(
+                async () => {
+                  const doubleClickElement = screen.queryByText(/Double click to set field/i);
+                  if (doubleClickElement !== null) {
+                    await user.dblClick(metricPointerTarget);
+                  }
+                  expect(doubleClickElement).not.toBeInTheDocument();
+                },
+                { timeout: 5000 }
+              );
 
               // Click into the select combobox
               const metricFieldCombo = within(metricTarget).getByPlaceholderText('Select field');


### PR DESCRIPTION
**What is this feature?**

`Metric value mapping sets element background color using field mapping config` test suddenly started failing consistently in CI, but only in the frontend coverage check. Passes locally and in regular frontend tests in CI. Don't know what (if anything) changed, but it looks like the original attempt to address flake might have gotten it backward.

**Special notes for your reviewer:**


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
