### PR TITLE
Scopes: Remove useScopeSingleNodeEndpoint frontend feature toggle

### DIFF
--- a/public/app/features/scopes/ScopesApiClient.test.ts
+++ b/public/app/features/scopes/ScopesApiClient.test.ts
@@ -44,7 +44,6 @@ describe('ScopesApiClient', () => {
   beforeEach(() => {
     apiClient = new ScopesApiClient();
     config.featureToggles.useMultipleScopeNodesEndpoint = true;
-    config.featureToggles.useScopeSingleNodeEndpoint = true;
     jest.clearAllMocks();
   });
 
@@ -277,17 +276,6 @@ describe('ScopesApiClient', () => {
 
       // Validate: result matches the expected node from MOCK_NODES
       expect(result).toEqual(expectedNode);
-    });
-
-    it('should return undefined when feature toggle is disabled', async () => {
-      config.featureToggles.useScopeSingleNodeEndpoint = false;
-
-      const result = await apiClient.fetchScopeNode('applications-grafana');
-
-      expect(result).toBeUndefined();
-
-      // Restore feature toggle
-      config.featureToggles.useScopeSingleNodeEndpoint = true;
     });
 
     it('should return undefined on API error', async () => {

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -268,10 +268,6 @@ export class ScopesApiClient {
   };
 
   public fetchScopeNode = async (scopeNodeId: string): Promise<ScopeNode | undefined> => {
-    if (!config.featureToggles.useScopeSingleNodeEndpoint) {
-      return Promise.resolve(undefined);
-    }
-
     const subscription = dispatch(
       scopeAPIv0alpha1.endpoints.getScopeNode.initiate({ name: scopeNodeId }, { subscribe: false })
     );

--- a/public/app/features/scopes/selector/ScopesSelectorService.test.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.test.ts
@@ -18,10 +18,6 @@ jest.mock('@grafana/runtime', () => ({
   config: {
     ...jest.requireActual('@grafana/runtime').config,
     buildInfo: { version: 'test-version' },
-    featureToggles: {
-      ...jest.requireActual('@grafana/runtime').config.featureToggles,
-      useScopeSingleNodeEndpoint: true,
-    },
   },
 }));
 

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -425,7 +425,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       let newNodesState = { ...this.state.nodes };
       let scopeNode = scopes[0]?.scopeNodeId ? this.state.nodes[scopes[0]?.scopeNodeId] : undefined;
 
-      if (!scopeNode && config.featureToggles.useScopeSingleNodeEndpoint && scopes[0]?.scopeNodeId) {
+      if (!scopeNode && scopes[0]?.scopeNodeId) {
         scopeNode = await this.apiClient.fetchScopeNode(scopes[0]?.scopeNodeId);
         if (scopeNode) {
           newNodesState[scopeNode.metadata.name] = scopeNode;
@@ -547,11 +547,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     }
 
     // If the scopeNode isn't avilable, fetch it and add it to the nodes cache
-    if (
-      config.featureToggles.useScopeSingleNodeEndpoint &&
-      this.state.selectedScopes[0]?.scopeNodeId &&
-      !this.state.nodes[this.state.selectedScopes[0].scopeNodeId]
-    ) {
+    if (this.state.selectedScopes[0]?.scopeNodeId && !this.state.nodes[this.state.selectedScopes[0].scopeNodeId]) {
       const scopeNode = await this.apiClient.fetchScopeNode(this.state.selectedScopes[0].scopeNodeId);
       if (scopeNode) {
         this.updateState({ nodes: { ...this.state.nodes, [scopeNode.metadata.name]: scopeNode } });

--- a/public/app/features/scopes/tests/selector.test.ts
+++ b/public/app/features/scopes/tests/selector.test.ts
@@ -51,7 +51,6 @@ describe('Selector', () => {
   beforeAll(() => {
     config.featureToggles.scopeFilters = true;
     config.featureToggles.groupByVariable = true;
-    config.featureToggles.useScopeSingleNodeEndpoint = true;
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
## Summary

`useScopeSingleNodeEndpoint` is a Public Preview frontend feature toggle that defaults to `true`, so the single-node-endpoint behavior is already the only behavior in practice. This removes the `config.featureToggles.useScopeSingleNodeEndpoint` checks in the scopes API client and selector service, making the behavior unconditional. No user-facing change.

Part of the multi-tenant frontend effort to remove legacy `config.featureToggles.X` toggles (grafana/grafana-frontend-platform#187).

This is the **frontend** half. The registry entry and generated types are removed in a separate **backend** PR that must merge *after* this one — deleting the registry entry first would make `config.featureToggles.useScopeSingleNodeEndpoint` undefined and re-trigger the (now-removed) guards.

## Test plan

- [ ] `yarn jest public/app/features/scopes/` passes
- [ ] Scopes selector still fetches scope nodes via the single-node endpoint