### PR TITLE
Scopes: Remove useMultipleScopeNodesEndpoint frontend feature toggle

### DIFF
--- a/public/app/features/commandPalette/scopes/scopeActions.test.tsx
+++ b/public/app/features/commandPalette/scopes/scopeActions.test.tsx
@@ -37,7 +37,7 @@ const mockScopeServicesState = {
   deselectScope: jest.fn(),
   apply: jest.fn(),
   searchAllNodes: jest.fn(),
-  getScopeNodes: jest.fn(),
+  getScopeNodes: jest.fn().mockResolvedValue([]),
   scopes: {},
 };
 
@@ -259,12 +259,13 @@ describe('useRegisterScopesActions', () => {
       expect(mockScopeServicesState.searchAllNodes).toHaveBeenCalledWith('scopes1', 10);
     });
 
-    // Checking the second call as first one registers just the global scopes action
-    expect((useRegisterActions as jest.Mock).mock.calls[1][0]).toHaveLength(2);
-    expect((useRegisterActions as jest.Mock).mock.calls[1][0]).toMatchObject([
-      { id: 'scopes' },
-      { id: 'scopes/scope1' },
-    ]);
+    // Checking the second call as first one registers just the global scopes action.
+    // The action registration happens after getScopeNodes resolves, so wait for it.
+    await waitFor(() => {
+      const registeredActions = (useRegisterActions as jest.Mock).mock.calls[1]?.[0];
+      expect(registeredActions).toHaveLength(2);
+      expect(registeredActions).toMatchObject([{ id: 'scopes' }, { id: 'scopes/scope1' }]);
+    });
   });
 
   it('should not use global scope search when searching in some deeper scope category', async () => {
@@ -384,8 +385,7 @@ describe('useRegisterScopesActions', () => {
     expect(result.current.scopesRow).toBeDefined();
   });
 
-  it('should handle useGlobalScopesSearch when useMultipleScopeNodesEndpoint is enabled', async () => {
-    config.featureToggles.useMultipleScopeNodesEndpoint = true;
+  it('should resolve parent node titles via getScopeNodes during global search', async () => {
     const mockGetScopeNodes = jest.fn().mockResolvedValue([
       {
         metadata: { name: 'parent1' },
@@ -413,10 +413,25 @@ describe('useRegisterScopesActions', () => {
     });
 
     await waitFor(() => {
-      expect(mockGetScopeNodes).toHaveBeenCalled();
+      expect(mockGetScopeNodes).toHaveBeenCalledWith(['parent1']);
     });
 
-    config.featureToggles.useMultipleScopeNodesEndpoint = false;
+    // The leaf node's subtitle resolves to the parent node's title (not its raw parentName).
+    const actions = [
+      rootScopeAction,
+      {
+        id: 'scopes/scope1',
+        keywords: 'Scope 1 scope1',
+        name: 'Scope 1',
+        perform: expect.any(Function),
+        priority: 8,
+        section: 'Scopes',
+        subtitle: 'Parent 1',
+      },
+    ];
+    await waitFor(() => {
+      expect(useRegisterActions).toHaveBeenLastCalledWith(actions, [actions]);
+    });
   });
 
   it('should clear actions when search query changes quickly (race condition)', async () => {

--- a/public/app/features/commandPalette/scopes/scopeActions.tsx
+++ b/public/app/features/commandPalette/scopes/scopeActions.tsx
@@ -152,32 +152,23 @@ function useGlobalScopesSearch(searchQuery: string, parentId?: string | null) {
 
           const parentNodesMap = new Map<string | undefined, string>();
 
-          if (config.featureToggles.useMultipleScopeNodesEndpoint) {
-            // Make sure we only request unqiue parent node names
-            const uniqueParentNodeNames = [
-              ...new Set(nodes.map((node) => node.spec.parentName).filter((name) => name !== undefined)),
-            ];
-            getScopeNodes(uniqueParentNodeNames).then((parentNodes) => {
-              for (const parentNode of parentNodes) {
-                parentNodesMap.set(parentNode.metadata.name, parentNode.spec.title);
-              }
+          // Make sure we only request unqiue parent node names
+          const uniqueParentNodeNames = [
+            ...new Set(nodes.map((node) => node.spec.parentName).filter((name) => name !== undefined)),
+          ];
+          getScopeNodes(uniqueParentNodeNames).then((parentNodes) => {
+            for (const parentNode of parentNodes) {
+              parentNodesMap.set(parentNode.metadata.name, parentNode.spec.title);
+            }
 
-              const leafNodes = nodes.filter((node) => node.spec.nodeType === 'leaf');
-              const actions = [getScopesParentAction()];
-              for (const node of leafNodes) {
-                const parentName = parentNodesMap.get(node.spec.parentName);
-                actions.push(mapScopeNodeToAction(node, selectScope, parentId || undefined, parentName || undefined));
-              }
-              setActions(actions);
-            });
-          } else {
             const leafNodes = nodes.filter((node) => node.spec.nodeType === 'leaf');
             const actions = [getScopesParentAction()];
             for (const node of leafNodes) {
-              actions.push(mapScopeNodeToAction(node, selectScope, parentId || undefined));
+              const parentName = parentNodesMap.get(node.spec.parentName);
+              actions.push(mapScopeNodeToAction(node, selectScope, parentId || undefined, parentName || undefined));
             }
             setActions(actions);
-          }
+          });
         }
       });
     } else {

--- a/public/app/features/scopes/ScopesApiClient.test.ts
+++ b/public/app/features/scopes/ScopesApiClient.test.ts
@@ -1,4 +1,3 @@
-import { config } from '@grafana/runtime';
 import { MOCK_NODES, MOCK_SCOPES } from '@grafana/test-utils/unstable';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 
@@ -43,7 +42,6 @@ describe('ScopesApiClient', () => {
 
   beforeEach(() => {
     apiClient = new ScopesApiClient();
-    config.featureToggles.useMultipleScopeNodesEndpoint = true;
     jest.clearAllMocks();
   });
 
@@ -181,17 +179,6 @@ describe('ScopesApiClient', () => {
       const result = await apiClient.fetchMultipleScopeNodes([]);
 
       expect(result).toEqual([]);
-    });
-
-    it('should return empty array when feature toggle is disabled', async () => {
-      config.featureToggles.useMultipleScopeNodesEndpoint = false;
-
-      const result = await apiClient.fetchMultipleScopeNodes(['applications-grafana']);
-
-      expect(result).toEqual([]);
-
-      // Restore feature toggle
-      config.featureToggles.useMultipleScopeNodesEndpoint = true;
     });
 
     it('should handle API errors gracefully', async () => {

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -1,5 +1,4 @@
 import { type Scope, type ScopeDashboardBinding, type ScopeNode } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import { getMessageFromError } from 'app/core/utils/errors';
 import { dispatch } from 'app/store/store';
@@ -93,7 +92,7 @@ export class ScopesApiClient {
   }
 
   async fetchMultipleScopeNodes(names: string[]): Promise<ScopeNode[]> {
-    if (!config.featureToggles.useMultipleScopeNodesEndpoint || names.length === 0) {
+    if (names.length === 0) {
       return Promise.resolve([]);
     }
 


### PR DESCRIPTION
## Summary

`useMultipleScopeNodesEndpoint` is a Public Preview frontend feature toggle that defaults to `true`, so the batched scope-nodes path is already the only behavior in practice. This removes the `config.featureToggles.useMultipleScopeNodesEndpoint` checks in the scopes API client and command palette, making the behavior unconditional. No user-facing change.

The command palette global search now always resolves parent node titles via `getScopeNodes` (the former flag-off branch fell back to the raw `parentName`; `mapScopeNodeToAction` preserves that fallback when a parent isn't found). The affected tests are updated for the now-unconditional async lookup, and one test is strengthened to assert the parent title is used as the action subtitle.

Part of the multi-tenant frontend effort to remove legacy `config.featureToggles.X` toggles (grafana/grafana-frontend-platform#187).

This is the **frontend** half. The registry entry and generated types are removed in a separate **backend** PR that must merge *after* this one — deleting the registry entry first would make `config.featureToggles.useMultipleScopeNodesEndpoint` undefined and re-trigger the (now-removed) guards.

## Test plan

- [ ] `yarn jest public/app/features/scopes/ public/app/features/commandPalette/scopes/` passes
- [ ] Command palette global scope search still shows results with parent titles as subtitles