### PR TITLE
TraceView: Fix nondeterministic SpanDetail attribute columns

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
@@ -14,6 +14,14 @@
 
 jest.mock('../../utils/date');
 
+// Controls the measured container width so the two-column layout decision is
+// deterministic in tests (real measurement needs layout jsdom doesn't do).
+let mockMeasuredWidth = 0;
+jest.mock('react-use/lib/useMeasure', () => ({
+  __esModule: true,
+  default: () => [jest.fn(), { width: mockMeasuredWidth }],
+}));
+
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -160,6 +168,7 @@ describe('<SpanDetail>', () => {
   ];
 
   beforeEach(() => {
+    mockMeasuredWidth = 0;
     jest.mocked(formatDuration).mockReset();
     props.tagsToggle.mockReset();
     props.processToggle.mockReset();
@@ -183,6 +192,20 @@ describe('<SpanDetail>', () => {
 
   it('renders without exploding', () => {
     expect(() => render(<SpanDetail {...(props as unknown as SpanDetailProps)} />)).not.toThrow();
+  });
+
+  describe('attribute card layout', () => {
+    it('uses two columns when the container is wider than 1000px', () => {
+      mockMeasuredWidth = 1200;
+      render(<SpanDetail {...(props as unknown as SpanDetailProps)} />);
+      expect(screen.getAllByTestId('span-detail-cards-column')).toHaveLength(2);
+    });
+
+    it('uses a single column when the container is 1000px or narrower', () => {
+      mockMeasuredWidth = 800;
+      render(<SpanDetail {...(props as unknown as SpanDetailProps)} />);
+      expect(screen.getAllByTestId('span-detail-cards-column')).toHaveLength(1);
+    });
   });
 
   it('shows the operation name', () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -14,7 +14,8 @@
 
 import { css, cx } from '@emotion/css';
 import { SpanStatusCode } from '@opentelemetry/api';
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import useMeasure from 'react-use/lib/useMeasure';
 
 import {
   type CoreApp,
@@ -349,7 +350,7 @@ export default function SpanDetail(props: SpanDetailProps) {
       : []),
   ];
 
-  const mainContainerRef = useRef<HTMLDivElement>(null);
+  const [mainContainerRef, { width: mainContainerWidth }] = useMeasure<HTMLDivElement>();
 
   const styles = useStyles2(getStyles);
   if (span.kind) {
@@ -532,7 +533,7 @@ export default function SpanDetail(props: SpanDetailProps) {
         </div>
       </div>
       <div className={styles.content}>
-        <CardsContainer listOfContentCards={listOfContentCards} mainContainerRef={mainContainerRef} />
+        <CardsContainer listOfContentCards={listOfContentCards} containerWidth={mainContainerWidth} />
 
         <small className={styles.debugInfo}>
           {/* TODO: fix keyboard a11y */}
@@ -571,20 +572,19 @@ export const getAbsoluteTime = (startTime: number, timeZone: TimeZone) => {
 
 const CardsContainer = ({
   listOfContentCards,
-  mainContainerRef,
+  containerWidth,
 }: {
   listOfContentCards: React.ReactNode[];
-  mainContainerRef?: React.RefObject<HTMLDivElement | null>;
+  containerWidth: number;
 }) => {
   const styles = useStyles2(getStyles);
 
-  const useTwoColumns =
-    mainContainerRef && mainContainerRef.current && mainContainerRef.current.getBoundingClientRect().width > 1000;
+  const useTwoColumns = containerWidth > 1000;
 
   if (useTwoColumns) {
     return (
       <>
-        <div className={css({ float: 'left', width: '50%' })}>
+        <div data-testid="span-detail-cards-column" className={css({ float: 'left', width: '50%' })}>
           {listOfContentCards.map((card, index) =>
             index % 2 === 0 ? (
               <div className={styles.card} key={index}>
@@ -594,7 +594,7 @@ const CardsContainer = ({
           )}
         </div>
 
-        <div className={css({ float: 'right', width: '50%' })}>
+        <div data-testid="span-detail-cards-column" className={css({ float: 'right', width: '50%' })}>
           {listOfContentCards.map((card, index) =>
             index % 2 === 1 ? (
               <div className={styles.card} key={index}>
@@ -608,7 +608,7 @@ const CardsContainer = ({
   }
 
   return (
-    <div className={css({ clear: 'both', width: '100%' })}>
+    <div data-testid="span-detail-cards-column" className={css({ clear: 'both', width: '100%' })}>
       {listOfContentCards.map((card, index) => (
         <div className={styles.card} key={index}>
           {card}


### PR DESCRIPTION
Fixes a pre-existing nondeterministic layout bug in the trace SpanDetail panel: the **Span attributes** and **Resource attributes** cards sometimes render stacked in one column and sometimes side-by-side in two, for spans of identical width.

## Root cause

`CardsContainer` decided its two-column layout by reading `mainContainerRef.current.getBoundingClientRect().width > 1000` **during render**. On first render the ref is still `null`, so it defaults to a single stacked column; it only switches to two columns if a later re-render (e.g. when `usePluginLinks` resolves) happens to coincide with a populated, wide ref. That's a race, so the column count is effectively random per span.

## Fix

Measure the container width with `useMeasure` (ResizeObserver-backed) into state, and drive the column decision off that measured width. Deterministic, and it now also re-flows when the drawer is resized.

## Testing

- New tests in `index.test.tsx` mock `react-use/lib/useMeasure` to assert two columns above 1000px and a single column at/below it.
- Full SpanDetail suite passes (14), typecheck + lint clean.

## Notes

- Independent of the summary-span work in #127111; surfaced during manual review there because summary spans reliably lost the race, but the bug affects all spans.
