### PR TITLE
Chore: Improve spans frontend settings/bootdata methods

### DIFF
--- a/pkg/api/bootdata.go
+++ b/pkg/api/bootdata.go
@@ -123,8 +123,8 @@ func (hs *HTTPServer) GetFrontendSettings(c *contextmodel.ReqContext) {
 //
 //nolint:gocyclo
 func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.FrontendSettingsDTO, error) {
-	c, endSpan := hs.injectSpanScoped(c, "api.getFrontendSettings")
-	defer endSpan()
+	c, span := hs.injectSpanScoped(c, "api.getFrontendSettings")
+	defer span.End()
 
 	frontendSettings, err := frontendsettings.GetBaseFrontendSettings(c, hs.Cfg, hs.License, hs.pluginsCDNService)
 
@@ -223,8 +223,8 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 
 //nolint:gocyclo
 func (hs *HTTPServer) getFSDataSources(c *contextmodel.ReqContext, availablePlugins AvailablePlugins) (map[string]plugins.DataSourceDTO, error) {
-	c, endSpan := hs.injectSpanScoped(c, "api.getFSDataSources")
-	defer endSpan()
+	c, span := hs.injectSpanScoped(c, "api.getFSDataSources")
+	defer span.End()
 
 	orgDataSources := make([]*datasources.DataSource, 0)
 	if c.GetOrgID() != 0 {
@@ -386,8 +386,8 @@ func (hs *HTTPServer) getFSDataSources(c *contextmodel.ReqContext, availablePlug
 }
 
 func (hs *HTTPServer) getFSPanels(c *contextmodel.ReqContext, availablePanels map[string]*availablePluginDTO) map[string]plugins.PanelDTO {
-	c, endSpan := hs.injectSpanScoped(c, "api.getFSPanels")
-	defer endSpan()
+	c, span := hs.injectSpanScoped(c, "api.getFSPanels")
+	defer span.End()
 
 	panels := make(map[string]plugins.PanelDTO)
 	for _, ap := range availablePanels {
@@ -420,8 +420,8 @@ func (hs *HTTPServer) getFSPanels(c *contextmodel.ReqContext, availablePanels ma
 }
 
 func (hs *HTTPServer) getFSApps(c *contextmodel.ReqContext, availableApps map[string]*availablePluginDTO) map[string]*plugins.AppDTO {
-	c, endSpan := hs.injectSpanScoped(c, "api.getFSApps")
-	defer endSpan()
+	c, span := hs.injectSpanScoped(c, "api.getFSApps")
+	defer span.End()
 
 	apps := make(map[string]*plugins.AppDTO, 0)
 	for _, ap := range availableApps {

--- a/pkg/api/bootdata.go
+++ b/pkg/api/bootdata.go
@@ -123,8 +123,8 @@ func (hs *HTTPServer) GetFrontendSettings(c *contextmodel.ReqContext) {
 //
 //nolint:gocyclo
 func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.FrontendSettingsDTO, error) {
-	c, span := hs.injectSpan(c, "api.getFrontendSettings")
-	defer span.End()
+	c, endSpan := hs.injectSpanScoped(c, "api.getFrontendSettings")
+	defer endSpan()
 
 	frontendSettings, err := frontendsettings.GetBaseFrontendSettings(c, hs.Cfg, hs.License, hs.pluginsCDNService)
 
@@ -137,46 +137,14 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		return nil, err
 	}
 
-	apps := make(map[string]*plugins.AppDTO, 0)
-	for _, ap := range availablePlugins[plugins.TypeApp] {
-		apps[ap.Plugin.ID] = hs.newAppDTO(
-			c.Req.Context(),
-			ap.Plugin,
-			ap.Settings,
-		)
-	}
+	apps := hs.getFSApps(c, availablePlugins[plugins.TypeApp])
 
 	dataSources, err := hs.getFSDataSources(c, availablePlugins)
 	if err != nil {
 		return nil, err
 	}
 
-	panels := make(map[string]plugins.PanelDTO)
-	for _, ap := range availablePlugins[plugins.TypePanel] {
-		panel := ap.Plugin
-		if panel.State == plugins.ReleaseStateAlpha && !hs.Cfg.PluginsEnableAlpha {
-			continue
-		}
-
-		panels[panel.ID] = plugins.PanelDTO{
-			ID:              panel.ID,
-			Name:            panel.Name,
-			AliasIDs:        panel.AliasIDs,
-			Info:            panel.Info,
-			Module:          panel.Module,
-			ModuleHash:      hs.pluginAssets.ModuleHash(c.Req.Context(), panel),
-			BaseURL:         panel.BaseURL,
-			SkipDataQuery:   panel.SkipDataQuery,
-			Suggestions:     panel.Suggestions,
-			HideFromList:    panel.HideFromList,
-			ReleaseState:    string(panel.State),
-			Signature:       string(panel.Signature),
-			Sort:            getPanelSort(panel.ID),
-			Angular:         panel.Angular,
-			LoadingStrategy: panel.LoadingStrategy,
-			Translations:    panel.Translations,
-		}
-	}
+	panels := hs.getFSPanels(c, availablePlugins[plugins.TypePanel])
 
 	frontendSettings.Apps = apps
 	frontendSettings.Datasources = dataSources
@@ -255,8 +223,8 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 
 //nolint:gocyclo
 func (hs *HTTPServer) getFSDataSources(c *contextmodel.ReqContext, availablePlugins AvailablePlugins) (map[string]plugins.DataSourceDTO, error) {
-	c, span := hs.injectSpan(c, "api.getFSDataSources")
-	defer span.End()
+	c, endSpan := hs.injectSpanScoped(c, "api.getFSDataSources")
+	defer endSpan()
 
 	orgDataSources := make([]*datasources.DataSource, 0)
 	if c.GetOrgID() != 0 {
@@ -415,6 +383,56 @@ func (hs *HTTPServer) getFSDataSources(c *contextmodel.ReqContext, availablePlug
 	}
 
 	return dataSources, nil
+}
+
+func (hs *HTTPServer) getFSPanels(c *contextmodel.ReqContext, availablePanels map[string]*availablePluginDTO) map[string]plugins.PanelDTO {
+	c, endSpan := hs.injectSpanScoped(c, "api.getFSPanels")
+	defer endSpan()
+
+	panels := make(map[string]plugins.PanelDTO)
+	for _, ap := range availablePanels {
+		panel := ap.Plugin
+		if panel.State == plugins.ReleaseStateAlpha && !hs.Cfg.PluginsEnableAlpha {
+			continue
+		}
+
+		panels[panel.ID] = plugins.PanelDTO{
+			ID:              panel.ID,
+			Name:            panel.Name,
+			AliasIDs:        panel.AliasIDs,
+			Info:            panel.Info,
+			Module:          panel.Module,
+			ModuleHash:      hs.pluginAssets.ModuleHash(c.Req.Context(), panel),
+			BaseURL:         panel.BaseURL,
+			SkipDataQuery:   panel.SkipDataQuery,
+			Suggestions:     panel.Suggestions,
+			HideFromList:    panel.HideFromList,
+			ReleaseState:    string(panel.State),
+			Signature:       string(panel.Signature),
+			Sort:            getPanelSort(panel.ID),
+			Angular:         panel.Angular,
+			LoadingStrategy: panel.LoadingStrategy,
+			Translations:    panel.Translations,
+		}
+	}
+
+	return panels
+}
+
+func (hs *HTTPServer) getFSApps(c *contextmodel.ReqContext, availableApps map[string]*availablePluginDTO) map[string]*plugins.AppDTO {
+	c, endSpan := hs.injectSpanScoped(c, "api.getFSApps")
+	defer endSpan()
+
+	apps := make(map[string]*plugins.AppDTO, 0)
+	for _, ap := range availableApps {
+		apps[ap.Plugin.ID] = hs.newAppDTO(
+			c.Req.Context(),
+			ap.Plugin,
+			ap.Settings,
+		)
+	}
+
+	return apps
 }
 
 func (hs *HTTPServer) newAppDTO(ctx context.Context, plugin pluginstore.Plugin, settings pluginsettings.InfoDTO) *plugins.AppDTO {

--- a/pkg/api/bootdata.go
+++ b/pkg/api/bootdata.go
@@ -123,7 +123,7 @@ func (hs *HTTPServer) GetFrontendSettings(c *contextmodel.ReqContext) {
 //
 //nolint:gocyclo
 func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.FrontendSettingsDTO, error) {
-	c, span := hs.injectSpanScoped(c, "api.getFrontendSettings")
+	c, span := hs.injectSpan(c, "api.getFrontendSettings")
 	defer span.End()
 
 	frontendSettings, err := frontendsettings.GetBaseFrontendSettings(c, hs.Cfg, hs.License, hs.pluginsCDNService)
@@ -223,7 +223,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 
 //nolint:gocyclo
 func (hs *HTTPServer) getFSDataSources(c *contextmodel.ReqContext, availablePlugins AvailablePlugins) (map[string]plugins.DataSourceDTO, error) {
-	c, span := hs.injectSpanScoped(c, "api.getFSDataSources")
+	c, span := hs.injectSpan(c, "api.getFSDataSources")
 	defer span.End()
 
 	orgDataSources := make([]*datasources.DataSource, 0)
@@ -386,7 +386,7 @@ func (hs *HTTPServer) getFSDataSources(c *contextmodel.ReqContext, availablePlug
 }
 
 func (hs *HTTPServer) getFSPanels(c *contextmodel.ReqContext, availablePanels map[string]*availablePluginDTO) map[string]plugins.PanelDTO {
-	c, span := hs.injectSpanScoped(c, "api.getFSPanels")
+	c, span := hs.injectSpan(c, "api.getFSPanels")
 	defer span.End()
 
 	panels := make(map[string]plugins.PanelDTO)
@@ -420,7 +420,7 @@ func (hs *HTTPServer) getFSPanels(c *contextmodel.ReqContext, availablePanels ma
 }
 
 func (hs *HTTPServer) getFSApps(c *contextmodel.ReqContext, availableApps map[string]*availablePluginDTO) map[string]*plugins.AppDTO {
-	c, span := hs.injectSpanScoped(c, "api.getFSApps")
+	c, span := hs.injectSpan(c, "api.getFSApps")
 	defer span.End()
 
 	apps := make(map[string]*plugins.AppDTO, 0)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -47,7 +47,7 @@ func getURLPrefs(c *contextmodel.ReqContext) URLPrefs {
 }
 
 func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexViewData, error) {
-	c, span := hs.injectSpanScoped(c, "api.setIndexViewData")
+	c, span := hs.injectSpan(c, "api.setIndexViewData")
 	defer span.End()
 
 	settings, err := hs.getFrontendSettings(c)
@@ -62,7 +62,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		OrgID:  c.GetOrgID(),
 		Teams:  c.TeamIDs, // nolint:staticcheck
 	}
-	c, prefsSpan := hs.injectSpanScoped(c, "api.setIndexViewData.preferences")
+	c, prefsSpan := hs.injectSpan(c, "api.setIndexViewData.preferences")
 	prefs, err := hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)
 	prefsSpan.End()
 	if err != nil {
@@ -236,7 +236,7 @@ func (hs *HTTPServer) getUserOrgCount(c *contextmodel.ReqContext, userID int64) 
 		return 1
 	}
 
-	c, span := hs.injectSpanScoped(c, "api.getUserOrgCount")
+	c, span := hs.injectSpan(c, "api.getUserOrgCount")
 	defer span.End()
 
 	userOrgs, err := hs.orgService.GetUserOrgList(c.Req.Context(), &org.GetUserOrgListQuery{UserID: userID})

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -47,8 +47,8 @@ func getURLPrefs(c *contextmodel.ReqContext) URLPrefs {
 }
 
 func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexViewData, error) {
-	c, span := hs.injectSpan(c, "api.setIndexViewData")
-	defer span.End()
+	c, endSpan := hs.injectSpanScoped(c, "api.setIndexViewData")
+	defer endSpan()
 
 	settings, err := hs.getFrontendSettings(c)
 	if err != nil {
@@ -62,7 +62,9 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		OrgID:  c.GetOrgID(),
 		Teams:  c.TeamIDs, // nolint:staticcheck
 	}
+	c, endPrefsSpan := hs.injectSpanScoped(c, "api.setIndexViewData.preferences")
 	prefs, err := hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)
+	endPrefsSpan()
 	if err != nil {
 		return nil, err
 	}
@@ -233,6 +235,9 @@ func (hs *HTTPServer) getUserOrgCount(c *contextmodel.ReqContext, userID int64) 
 	if userID == 0 {
 		return 1
 	}
+
+	c, endSpan := hs.injectSpanScoped(c, "api.getUserOrgCount")
+	defer endSpan()
 
 	userOrgs, err := hs.orgService.GetUserOrgList(c.Req.Context(), &org.GetUserOrgListQuery{UserID: userID})
 	if err != nil {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -47,8 +47,8 @@ func getURLPrefs(c *contextmodel.ReqContext) URLPrefs {
 }
 
 func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexViewData, error) {
-	c, endSpan := hs.injectSpanScoped(c, "api.setIndexViewData")
-	defer endSpan()
+	c, span := hs.injectSpanScoped(c, "api.setIndexViewData")
+	defer span.End()
 
 	settings, err := hs.getFrontendSettings(c)
 	if err != nil {
@@ -62,9 +62,9 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		OrgID:  c.GetOrgID(),
 		Teams:  c.TeamIDs, // nolint:staticcheck
 	}
-	c, endPrefsSpan := hs.injectSpanScoped(c, "api.setIndexViewData.preferences")
+	c, prefsSpan := hs.injectSpanScoped(c, "api.setIndexViewData.preferences")
 	prefs, err := hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)
-	endPrefsSpan()
+	prefsSpan.End()
 	if err != nil {
 		return nil, err
 	}
@@ -236,8 +236,8 @@ func (hs *HTTPServer) getUserOrgCount(c *contextmodel.ReqContext, userID int64) 
 		return 1
 	}
 
-	c, endSpan := hs.injectSpanScoped(c, "api.getUserOrgCount")
-	defer endSpan()
+	c, span := hs.injectSpanScoped(c, "api.getUserOrgCount")
+	defer span.End()
 
 	userOrgs, err := hs.orgService.GetUserOrgList(c.Req.Context(), &org.GetUserOrgListQuery{UserID: userID})
 	if err != nil {

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -71,20 +71,33 @@ func (hs *HTTPServer) injectSpan(c *contextmodel.ReqContext, name string) (*cont
 	return c, span
 }
 
+// scopedSpan wraps a trace.Span so that ending it also restores the request
+// context that injectSpanScoped temporarily replaced on the ReqContext.
+type scopedSpan struct {
+	trace.Span
+	c       *contextmodel.ReqContext
+	prevReq *http.Request
+}
+
+// End ends the underlying span and restores the previous request context. The
+// variadic options are forwarded so callers retain the full trace.Span API.
+func (s scopedSpan) End(options ...trace.SpanEndOption) {
+	s.Span.End(options...)
+	s.c.Req = s.prevReq
+}
+
 // injectSpanScoped starts a child span named `name` and scopes c's request
 // context to it, so that work done by callees that read c.Req.Context()
 // (database queries, access-control evaluations, etc.) is grouped under the
-// span in traces. The returned function ends the span and restores the previous
-// request context; callers must call it — via defer to scope a whole function,
-// or explicitly to close a single step. Restoring the context keeps sibling
-// steps as siblings rather than nesting them under a span that has already
-// ended, which is what makes these traces readable.
-func (hs *HTTPServer) injectSpanScoped(c *contextmodel.ReqContext, name string) (*contextmodel.ReqContext, func()) {
+// span in traces. The returned span behaves like a normal trace.Span — callers
+// can set attributes, record errors, etc. — but ending it also restores the
+// previous request context. Callers must end it — via defer to scope a whole
+// function, or explicitly to close a single step. Restoring the context keeps
+// sibling steps as siblings rather than nesting them under a span that has
+// already ended, which is what makes these traces readable.
+func (hs *HTTPServer) injectSpanScoped(c *contextmodel.ReqContext, name string) (*contextmodel.ReqContext, trace.Span) {
 	prevReq := c.Req
 	ctx, span := hs.tracer.Start(c.Req.Context(), name)
 	c.Req = c.Req.WithContext(ctx)
-	return c, func() {
-		span.End()
-		c.Req = prevReq
-	}
+	return c, scopedSpan{Span: span, c: c, prevReq: prevReq}
 }

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -65,14 +65,8 @@ func ValidateAndNormalizeEmail(email string) (string, error) {
 	return e.Address, nil
 }
 
-func (hs *HTTPServer) injectSpan(c *contextmodel.ReqContext, name string) (*contextmodel.ReqContext, trace.Span) {
-	ctx, span := hs.tracer.Start(c.Req.Context(), name)
-	c.Req = c.Req.WithContext(ctx)
-	return c, span
-}
-
 // scopedSpan wraps a trace.Span so that ending it also restores the request
-// context that injectSpanScoped temporarily replaced on the ReqContext.
+// context that injectSpan temporarily replaced on the ReqContext.
 type scopedSpan struct {
 	trace.Span
 	c       *contextmodel.ReqContext
@@ -86,7 +80,7 @@ func (s scopedSpan) End(options ...trace.SpanEndOption) {
 	s.c.Req = s.prevReq
 }
 
-// injectSpanScoped starts a child span named `name` and scopes c's request
+// injectSpan starts a child span named `name` and scopes c's request
 // context to it, so that work done by callees that read c.Req.Context()
 // (database queries, access-control evaluations, etc.) is grouped under the
 // span in traces. The returned span behaves like a normal trace.Span — callers
@@ -95,7 +89,7 @@ func (s scopedSpan) End(options ...trace.SpanEndOption) {
 // function, or explicitly to close a single step. Restoring the context keeps
 // sibling steps as siblings rather than nesting them under a span that has
 // already ended, which is what makes these traces readable.
-func (hs *HTTPServer) injectSpanScoped(c *contextmodel.ReqContext, name string) (*contextmodel.ReqContext, trace.Span) {
+func (hs *HTTPServer) injectSpan(c *contextmodel.ReqContext, name string) (*contextmodel.ReqContext, trace.Span) {
 	prevReq := c.Req
 	ctx, span := hs.tracer.Start(c.Req.Context(), name)
 	c.Req = c.Req.WithContext(ctx)

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -70,3 +70,21 @@ func (hs *HTTPServer) injectSpan(c *contextmodel.ReqContext, name string) (*cont
 	c.Req = c.Req.WithContext(ctx)
 	return c, span
 }
+
+// injectSpanScoped starts a child span named `name` and scopes c's request
+// context to it, so that work done by callees that read c.Req.Context()
+// (database queries, access-control evaluations, etc.) is grouped under the
+// span in traces. The returned function ends the span and restores the previous
+// request context; callers must call it — via defer to scope a whole function,
+// or explicitly to close a single step. Restoring the context keeps sibling
+// steps as siblings rather than nesting them under a span that has already
+// ended, which is what makes these traces readable.
+func (hs *HTTPServer) injectSpanScoped(c *contextmodel.ReqContext, name string) (*contextmodel.ReqContext, func()) {
+	prevReq := c.Req
+	ctx, span := hs.tracer.Start(c.Req.Context(), name)
+	c.Req = c.Req.WithContext(ctx)
+	return c, func() {
+		span.End()
+		c.Req = prevReq
+	}
+}

--- a/pkg/api/webassets/webassets.go
+++ b/pkg/api/webassets/webassets.go
@@ -16,7 +16,11 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/httpclient"
 	"github.com/open-feature/go-sdk/openfeature"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 )
+
+var tracer = otel.Tracer("github.com/grafana/grafana/pkg/api/webassets")
 
 type ManifestInfo struct {
 	FilePath  string `json:"src,omitempty"`
@@ -43,6 +47,9 @@ var (
 )
 
 func GetWebAssets(ctx context.Context, cfg *setting.Cfg, license licensing.Licensing) (*dtos.EntryPointAssets, error) {
+	ctx, span := tracer.Start(ctx, "webassets.GetWebAssets")
+	defer span.End()
+
 	entryPointAssetsCacheMu.RLock()
 	ret := entryPointAssetsCache
 	entryPointAssetsCacheMu.RUnlock()
@@ -90,6 +97,10 @@ func GetWebAssets(ctx context.Context, cfg *setting.Cfg, license licensing.Licen
 	}
 
 	entryPointAssetsCache = result
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
 	return entryPointAssetsCache, err
 }
 

--- a/pkg/plugins/pluginassets/modulehash/modulehash.go
+++ b/pkg/plugins/pluginassets/modulehash/modulehash.go
@@ -9,6 +9,11 @@ import (
 	"path/filepath"
 	"sync"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/config"
 	"github.com/grafana/grafana/pkg/plugins/log"
@@ -23,6 +28,7 @@ type Calculator struct {
 	cdn       *pluginscdn.Service
 	signature *signature.Signature
 	log       log.Logger
+	tracer    trace.Tracer
 
 	moduleHashCache sync.Map
 }
@@ -34,6 +40,7 @@ func NewCalculator(cfg *config.PluginManagementCfg, reg registry.Service, cdn *p
 		cdn:       cdn,
 		signature: signature,
 		log:       log.New("modulehash"),
+		tracer:    otel.Tracer("github.com/grafana/grafana/pkg/plugins/pluginassets/modulehash"),
 	}
 }
 
@@ -49,12 +56,23 @@ func (c *Calculator) ModuleHash(ctx context.Context, pluginID, pluginVersion str
 		return ""
 	}
 	k := c.moduleHashCacheKey(pluginID, pluginVersion)
-	cachedValue, ok := c.moduleHashCache.Load(k)
-	if ok {
+	if cachedValue, ok := c.moduleHashCache.Load(k); ok {
 		return cachedValue.(string)
 	}
+
+	// Only cache misses reach the manifest read below. Cache hits are not traced
+	// so span volume stays proportional to real work, even though ModuleHash is
+	// called once per plugin on every index/bootdata request.
+	ctx, span := c.tracer.Start(ctx, "modulehash.compute", trace.WithAttributes(
+		attribute.String("plugin.id", pluginID),
+		attribute.String("plugin.version", pluginVersion),
+	))
+	defer span.End()
+
 	mh, err := c.moduleHash(ctx, p, "")
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		c.log.Error("Failed to calculate module hash", "pluginId", p.ID, "error", err)
 	}
 	c.moduleHashCache.Store(k, mh)

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -89,10 +89,7 @@ func ProvideService(cfg *setting.Cfg, accessControl ac.AccessControl, pluginStor
 
 //nolint:gocyclo
 func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Preference) (*navtree.NavTreeRoot, error) {
-	// Building the nav tree performs many access-control evaluations. Scope the
-	// request context to a span so they're grouped under it in traces rather than
-	// appearing as a flat list of accesscontrol.acimpl.Evaluate spans. The context
-	// is restored on return so the span doesn't leak to sibling operations.
+	// The context is restored on the ReqContext return so the span doesn't leak to sibling operations.
 	ctx, span := tracer.Start(c.Req.Context(), "navtree.GetNavTree")
 	defer span.End()
 	prevReq := c.Req

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -3,6 +3,8 @@ package navtreeimpl
 import (
 	"sort"
 
+	"go.opentelemetry.io/otel"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
@@ -28,6 +30,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlesimpl"
 	"github.com/grafana/grafana/pkg/setting"
 )
+
+var tracer = otel.Tracer("github.com/grafana/grafana/pkg/services/navtree/navtreeimpl")
 
 type ServiceImpl struct {
 	cfg                  *setting.Cfg
@@ -85,6 +89,16 @@ func ProvideService(cfg *setting.Cfg, accessControl ac.AccessControl, pluginStor
 
 //nolint:gocyclo
 func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Preference) (*navtree.NavTreeRoot, error) {
+	// Building the nav tree performs many access-control evaluations. Scope the
+	// request context to a span so they're grouped under it in traces rather than
+	// appearing as a flat list of accesscontrol.acimpl.Evaluate spans. The context
+	// is restored on return so the span doesn't leak to sibling operations.
+	ctx, span := tracer.Start(c.Req.Context(), "navtree.GetNavTree")
+	defer span.End()
+	prevReq := c.Req
+	c.Req = c.Req.WithContext(ctx)
+	defer func() { c.Req = prevReq }()
+
 	hasAccess := ac.HasAccess(s.accessControl, c)
 	treeRoot := &navtree.NavTreeRoot{}
 


### PR DESCRIPTION
Adds and improve spans across the `/bootdata` request path to the time spent rendering it is better attributed in spans:

- Wraps `webassets.GetWebAssets` in a span. _Locally_ this was the single largest unmeasured chunk of the request.
- Adds a span to the plugin `moduleHash` calculation for cache misses only. It's suspected this takes a lot of time in deployments for the initial call.
- Extracts apps/panel DTO contruction in `setIndexViewData` into separate methods so they get their own span
- Adds a span to `navtree.GetNavTree` - there's a bunch of permissions evaluations under this that would be good to scope to a more specific span

Additionally, and what I'm the most unsure about, it adds a `hs.injectSpanScoped` helper to address a context leak that `hs.injectSpan` introduces that apparently produces misshaped traces. Claude spotted this with:

> The existing `injectSpan` helper _permanently_ mutates `c.Req` and never restores it. So once a sub-call like `getFrontendSettings` or `getFSDataSources` returned and its span ended, every later sibling operation got mis-parented under that already-ended span — which is exactly what produces a confusing, flat-looking trace where spans dangle past their parents.

> The fix. A new `injectSpanScoped` helper that starts a child span, scopes `c.Req` to it, **and returns a cleanup that both ends the span and restores the previous request context**.

Instead of separate `injectSpan`/`injectSpanScoped` implementations, I just refactored `injectSpan` into this fixed one with the `c.Req` restoring behaviour.

This seems reasonable, but I don't know enough about the various parts here to know exactly. Is this refactor correct to do?