### PR TITLE
FS: Remove frontendServiceUseSettingsService feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1426,11 +1426,6 @@ export interface FeatureToggles {
   */
   react19?: boolean;
   /**
-  * Enables the frontend service to fetch tenant-specific settings overrides from the settings service
-  * @default false
-  */
-  frontendServiceUseSettingsService?: boolean;
-  /**
   * Enables managed plugins v2 (expanded rollout, community plugin coverage)
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2627,15 +2627,6 @@ var (
 			Expression:  "true",
 		},
 		{
-			Name:         "frontendServiceUseSettingsService",
-			Description:  "Enables the frontend service to fetch tenant-specific settings overrides from the settings service",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaFrontendPlatformSquad,
-			Expression:   "false",
-			HideFromDocs: true,
-			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:         "frontendService.settingsSourceFilter",
 			Description:  "Adds a label filter for source=us when fetching settings from the settings service in the frontend service",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -305,7 +305,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,alertingNotificationHistoryTriage,experimental,@grafana/alerting-squad,false,false,false
 2026-05-22,alertingNotificationHistoryDetail,experimental,@grafana/alerting-squad,false,false,false
 2026-05-22,react19,GA,@grafana/grafana-frontend-platform,false,false,false
-2026-05-22,frontendServiceUseSettingsService,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-05-22,frontendService.settingsSourceFilter,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-05-22,managedPluginsV2,experimental,@grafana/grafana-catalog,false,false,false
 2026-05-22,rememberUserOrgForSso,GA,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -826,10 +826,6 @@ const (
 	// Whether to use the new React 19 runtime
 	FlagReact19 = "react19"
 
-	// FlagFrontendServiceUseSettingsService
-	// Enables the frontend service to fetch tenant-specific settings overrides from the settings service
-	FlagFrontendServiceUseSettingsService = "frontendServiceUseSettingsService"
-
 	// FlagFrontendServiceSettingsSourceFilter
 	// Adds a label filter for source=us when fetching settings from the settings service in the frontend service
 	FlagFrontendServiceSettingsSourceFilter = "frontendService.settingsSourceFilter"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2294,7 +2294,8 @@
       "metadata": {
         "name": "frontendServiceUseSettingsService",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "deletionTimestamp": "2026-06-20T16:13:44Z"
       },
       "spec": {
         "description": "Enables the frontend service to fetch tenant-specific settings overrides from the settings service",

--- a/pkg/services/frontend/frontend_service_test.go
+++ b/pkg/services/frontend/frontend_service_test.go
@@ -589,8 +589,6 @@ func TestFrontendService_CSP(t *testing.T) {
 	})
 
 	t.Run("should apply per-tenant allow_embedding_hosts override to CSP header", func(t *testing.T) {
-		enableSettingsOverridesToggle(t)
-
 		cfg := &setting.Cfg{
 			Raw:            ini.Empty(),
 			HTTPPort:       "3000",
@@ -701,8 +699,6 @@ func TestFrontendService_CSP(t *testing.T) {
 	})
 
 	t.Run("should apply per-tenant form_action_additional_hosts override to CSP header", func(t *testing.T) {
-		enableSettingsOverridesToggle(t)
-
 		cfg := &setting.Cfg{
 			Raw:            ini.Empty(),
 			HTTPPort:       "3000",

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -52,10 +52,8 @@ func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, sett
 				requestConfig.FullFrontendSettings.Namespace = request.NamespaceValue(ctx)
 			}
 
-			// Fetch tenant-specific configuration if the feature toggle is enabled and namespace is present
-			settingsEnabled, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagFrontendServiceUseSettingsService, false, openfeature.TransactionContext(ctx))
-
-			if settingsService != nil && settingsEnabled {
+			// Fetch tenant-specific configuration if the settings service is configured and namespace is present
+			if settingsService != nil {
 				namespace, ok := request.NamespaceFrom(ctx)
 
 				if ok && namespace != "" {

--- a/pkg/services/frontend/request_config_middleware_test.go
+++ b/pkg/services/frontend/request_config_middleware_test.go
@@ -46,39 +46,10 @@ func setupTestContext(r *http.Request, namespace string) *http.Request {
 
 var openfeatureTestMutex sync.Mutex
 
-func enableSettingsOverridesToggle(t *testing.T) {
+func enableSourceFilterToggle(t *testing.T) {
 	t.Helper()
 	openfeatureTestMutex.Lock()
 
-	flag := memprovider.InMemoryFlag{
-		Key:            featuremgmt.FlagFrontendServiceUseSettingsService,
-		DefaultVariant: "on",
-		Variants:       map[string]any{"on": true, "off": false},
-	}
-
-	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
-		featuremgmt.FlagFrontendServiceUseSettingsService: flag,
-	})
-	require.NoError(t, err)
-
-	err = openfeature.SetProviderAndWait(provider)
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
-		openfeatureTestMutex.Unlock()
-	})
-}
-
-func enableSettingsOverridesAndSourceFilterToggle(t *testing.T) {
-	t.Helper()
-	openfeatureTestMutex.Lock()
-
-	settingsFlag := memprovider.InMemoryFlag{
-		Key:            featuremgmt.FlagFrontendServiceUseSettingsService,
-		DefaultVariant: "on",
-		Variants:       map[string]any{"on": true, "off": false},
-	}
 	sourceFilterFlag := memprovider.InMemoryFlag{
 		Key:            featuremgmt.FlagFrontendServiceSettingsSourceFilter,
 		DefaultVariant: "on",
@@ -86,7 +57,6 @@ func enableSettingsOverridesAndSourceFilterToggle(t *testing.T) {
 	}
 
 	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
-		featuremgmt.FlagFrontendServiceUseSettingsService:   settingsFlag,
 		featuremgmt.FlagFrontendServiceSettingsSourceFilter: sourceFilterFlag,
 	})
 	require.NoError(t, err)
@@ -205,8 +175,6 @@ func TestRequestConfigMiddleware(t *testing.T) {
 	})
 
 	t.Run("should fetch and apply tenant overrides from settings service", func(t *testing.T) {
-		enableSettingsOverridesToggle(t)
-
 		// Create mock settings service that returns CSP overrides
 		mockSettingsService := &mockSettingsService{
 			settings: []*settingservice.Setting{
@@ -259,8 +227,6 @@ func TestRequestConfigMiddleware(t *testing.T) {
 	})
 
 	t.Run("should fallback to base config on settings service error", func(t *testing.T) {
-		enableSettingsOverridesToggle(t)
-
 		// Create mock that returns an error
 		mockSettingsService := &mockSettingsService{
 			err: assert.AnError,
@@ -310,8 +276,6 @@ func TestRequestConfigMiddleware(t *testing.T) {
 	})
 
 	t.Run("should not call settings service when no namespace is present", func(t *testing.T) {
-		enableSettingsOverridesToggle(t)
-
 		mockSettingsService := &mockSettingsService{}
 
 		license := &licensing.OSSLicensingService{}
@@ -340,49 +304,8 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		assert.False(t, mockSettingsService.called)
 	})
 
-	t.Run("should not call settings service when feature toggle is disabled", func(t *testing.T) {
-		// No call to enableSettingsOverridesToggle - toggle defaults to off
-		mockSettingsService := &mockSettingsService{}
-
-		license := &licensing.OSSLicensingService{}
-		cfg := &setting.Cfg{
-			Raw:         ini.Empty(),
-			HTTPPort:    "1234",
-			CSPEnabled:  true,
-			CSPTemplate: "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS",
-			AppURL:      "https://grafana.example.com",
-		}
-
-		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService, nil)
-
-		var capturedConfig FSRequestConfig
-		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var err error
-			capturedConfig, err = FSRequestConfigFromContext(r.Context())
-			require.NoError(t, err)
-			w.WriteHeader(http.StatusOK)
-		})
-
-		handler := middleware(testHandler)
-
-		req := httptest.NewRequest("GET", "/", nil)
-		req = setupTestContext(req, "stacks-123")
-		recorder := httptest.NewRecorder()
-
-		handler.ServeHTTP(recorder, req)
-
-		assert.Equal(t, http.StatusOK, recorder.Code)
-
-		// Settings service should not be called when toggle is off
-		assert.False(t, mockSettingsService.called)
-
-		// Base config should be used unchanged
-		assert.True(t, capturedConfig.CSPEnabled)
-		assert.Equal(t, "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS", capturedConfig.CSPTemplate)
-	})
-
 	t.Run("should include source filter in selector when source filter toggle is enabled", func(t *testing.T) {
-		enableSettingsOverridesAndSourceFilterToggle(t)
+		enableSourceFilterToggle(t)
 
 		mockSettingsService := &mockSettingsService{
 			settings: []*settingservice.Setting{},
@@ -421,8 +344,6 @@ func TestRequestConfigMiddleware(t *testing.T) {
 	})
 
 	t.Run("should not include source filter in selector when source filter toggle is disabled", func(t *testing.T) {
-		enableSettingsOverridesToggle(t)
-
 		mockSettingsService := &mockSettingsService{
 			settings: []*settingservice.Setting{},
 		}


### PR DESCRIPTION
**What is this feature?**

Removes the `frontendServiceUseSettingsService` experimental feature toggle from the frontend service. Fetching settings overrides from the settings service is now the default and only behaviour: the request config middleware applies overrides whenever a settings service is configured and a namespace is present.

**Why do we need this feature?**

The toggle has served its rollout purpose, so removing it deletes a now-redundant branch and simplifies the middleware and its tests.

**Who is this feature for?**

Operators and developers of the frontend service.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

The `frontendService.settingsSourceFilter` toggle is intentionally left in place; only `frontendServiceUseSettingsService` is removed. The generated feature-toggle files were regenerated with `make gen-feature-toggles`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
