### PR TITLE
Provisioning: don't stamp a folder on org-scoped resources when writing

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -436,15 +436,19 @@ func (r *DualReadWriter) createOrUpdate(ctx context.Context, create bool, opts D
 			})
 		}
 
-		parent, err := r.folders.EnsureFolderPathExist(ctx, opts.Path, opts.Ref)
-		if err != nil {
-			return nil, fmt.Errorf("ensure folder path exists: %w", err)
-		}
+		// Only folder-scoped kinds carry a folder annotation; org-scoped kinds (e.g. playlists)
+		// must not have one stamped onto them, or the apiserver rejects the write.
+		if parsed.FolderScoped {
+			parent, err := r.folders.EnsureFolderPathExist(ctx, opts.Path, opts.Ref)
+			if err != nil {
+				return nil, fmt.Errorf("ensure folder path exists: %w", err)
+			}
 
-		// In case the parent folder has a different ID than the one from the initially parsed resource,
-		// e.g. when the folder metadata has been generated as part of the create operation, we need to update it.
-		if parsed.Meta.GetFolder() != parent {
-			parsed.Meta.SetFolder(parent)
+			// In case the parent folder has a different ID than the one from the initially parsed resource,
+			// e.g. when the folder metadata has been generated as part of the create operation, we need to update it.
+			if parsed.Meta.GetFolder() != parent {
+				parsed.Meta.SetFolder(parent)
+			}
 		}
 
 		if err := parsed.Run(ctx); err != nil {
@@ -707,15 +711,19 @@ func (r *DualReadWriter) moveFile(ctx context.Context, opts DualWriteOptions) (*
 
 	// Update the grafana database if this is the main branch
 	if r.shouldUpdateGrafanaDB(opts, newParsed) {
-		parent, err := r.folders.EnsureFolderPathExist(ctx, opts.Path, opts.Ref)
-		if err != nil {
-			return nil, fmt.Errorf("ensure folder path exists: %w", err)
-		}
+		// Only folder-scoped kinds carry a folder annotation; org-scoped kinds (e.g. playlists)
+		// must not have one stamped onto them, or the apiserver rejects the write.
+		if newParsed.FolderScoped {
+			parent, err := r.folders.EnsureFolderPathExist(ctx, opts.Path, opts.Ref)
+			if err != nil {
+				return nil, fmt.Errorf("ensure folder path exists: %w", err)
+			}
 
-		// In case the parent folder has a different ID than the one from the initially parsed resource,
-		// e.g. when the folder metadata has been generated as part of the move operation, we need to update it.
-		if newParsed.Meta.GetFolder() != parent {
-			newParsed.Meta.SetFolder(parent)
+			// In case the parent folder has a different ID than the one from the initially parsed resource,
+			// e.g. when the folder metadata has been generated as part of the move operation, we need to update it.
+			if newParsed.Meta.GetFolder() != parent {
+				newParsed.Meta.SetFolder(parent)
+			}
 		}
 
 		// Delete the old resource from grafana if name changed

--- a/pkg/registry/apis/provisioning/resources/dualwriter_folderscope_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_folderscope_test.go
@@ -1,0 +1,126 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+)
+
+// stubAuthorizer satisfies Authorizer by embedding the interface and overriding only the two
+// methods createOrUpdate exercises. Any other method would panic (nil embed) if called, which
+// keeps the test honest about the write path it covers.
+type stubAuthorizer struct{ Authorizer }
+
+func (stubAuthorizer) AuthorizeWrite(context.Context, string) error { return nil }
+
+func (stubAuthorizer) AuthorizeResource(context.Context, *ParsedResource, string) error { return nil }
+
+// TestDualReadWriter_FolderScopeGuard verifies the write path stamps a grafana.app/folder
+// annotation onto a resource living in a subdirectory only when the kind is folder-scoped.
+// Org-scoped kinds (e.g. playlists) must never get one: their apiserver rejects it with
+// "folders are not supported for playlists.playlist.grafana.app". This is the regression the
+// FolderScoped gating in createOrUpdate prevents — before it, the dual writer re-stamped a
+// folder onto every resource via EnsureFolderPathExist + SetFolder.
+func TestDualReadWriter_FolderScopeGuard(t *testing.T) {
+	const (
+		repoName = "repo"
+		subPath  = "team-a/resource.json"
+	)
+
+	playlistGVK := schema.GroupVersionKind{Group: "playlist.grafana.app", Version: "v1", Kind: "Playlist"}
+	playlistGVR := schema.GroupVersionResource{Group: "playlist.grafana.app", Version: "v1", Resource: "playlists"}
+
+	// The folder team-a/ resolves to, pre-seeded into the tree so EnsureFolderPathExist
+	// returns it without having to create folders through a client.
+	teamAFolder := ParseFolder("team-a/", repoName)
+
+	newParsed := func(t *testing.T, folderScoped bool, client *MockDynamicResourceInterface) *ParsedResource {
+		t.Helper()
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "playlist.grafana.app/v1",
+			"kind":       "Playlist",
+			"metadata":   map[string]any{"name": "res-1", "namespace": "default"},
+			"spec":       map[string]any{"title": "Res"},
+		}}
+		meta, err := utils.MetaAccessor(obj)
+		require.NoError(t, err)
+		meta.SetManagerProperties(utils.ManagerProperties{Kind: utils.ManagerKindRepo, Identity: repoName})
+
+		return &ParsedResource{
+			Info:         &repository.FileInfo{Path: subPath},
+			Obj:          obj,
+			Meta:         meta,
+			GVK:          playlistGVK,
+			GVR:          playlistGVR,
+			Client:       client,
+			FolderScoped: folderScoped,
+			Repo:         provisioning.ResourceRepositoryInfo{Name: repoName, Namespace: "default"},
+			Action:       provisioning.ResourceActionUpdate,
+			// Existing + DryRunResponse are pre-set so Run goes straight to the update call
+			// (managed by the same repo, so the ownership check passes).
+			Existing:       obj.DeepCopy(),
+			DryRunResponse: obj.DeepCopy(),
+		}
+	}
+
+	setup := func(t *testing.T, folderScoped bool) (*DualReadWriter, *ParsedResource, *repository.MockReaderWriter) {
+		t.Helper()
+
+		client := &MockDynamicResourceInterface{}
+		client.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(&unstructured.Unstructured{}, nil)
+
+		parsed := newParsed(t, folderScoped, client)
+
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(newSyncEnabledConfig(repoName))
+		rw.On("Update", mock.Anything, subPath, "", mock.Anything, "msg").Return(nil)
+		rw.On("Read", mock.Anything, subPath, "").Return(&repository.FileInfo{Path: subPath, Hash: "h"}, nil)
+
+		parser := NewMockParser(t)
+		parser.On("Parse", mock.Anything, mock.Anything).Return(parsed, nil)
+
+		tree := NewEmptyFolderTree()
+		tree.Add(teamAFolder, "")
+		fm := NewFolderManager(rw, nil, tree, FolderKind)
+
+		dw := NewDualReadWriter(rw, parser, fm, stubAuthorizer{}, false)
+		return dw, parsed, rw
+	}
+
+	t.Run("org-scoped resource is written without a folder annotation", func(t *testing.T) {
+		dw, parsed, rw := setup(t, false)
+
+		_, err := dw.UpdateResource(context.Background(), DualWriteOptions{
+			Path:       subPath,
+			Message:    "msg",
+			SkipDryRun: true,
+		})
+		require.NoError(t, err)
+		require.Empty(t, parsed.Meta.GetFolder(),
+			"org-scoped resource must not have a folder annotation stamped onto it")
+		// The folder resolution must be skipped entirely, so no _folder.json read happens.
+		rw.AssertNotCalled(t, "Read", mock.Anything, "team-a/_folder.json", mock.Anything)
+	})
+
+	t.Run("folder-scoped resource is written with the resolved folder annotation", func(t *testing.T) {
+		dw, parsed, _ := setup(t, true)
+
+		_, err := dw.UpdateResource(context.Background(), DualWriteOptions{
+			Path:       subPath,
+			Message:    "msg",
+			SkipDryRun: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, teamAFolder.ID, parsed.Meta.GetFolder(),
+			"folder-scoped resource must be parented to the resolved subdirectory folder")
+	})
+}

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -138,6 +138,11 @@ type ParsedResource struct {
 	// Client that can talk to this resource
 	Client dynamic.ResourceInterface
 
+	// FolderScoped reports whether this resource's kind carries the folder annotation
+	// (i.e. lives in folders). Org-scoped kinds such as playlists are not folder-scoped
+	// and must never have a folder annotation stamped onto them.
+	FolderScoped bool
+
 	// The Existing object (same name)
 	// ?? do we need/want the whole thing??
 	Existing *unstructured.Unstructured
@@ -250,7 +255,8 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 	// are contained in folders. Org-scoped resources (those not folder-scoped in the
 	// configured supported set) must not have a folder annotation stamped onto them:
 	// it would be meaningless and possibly dangling.
-	if info.Path != "" && supportsFolderAnnotation(r.clients.SupportedResources(), parsed.GVK) {
+	parsed.FolderScoped = supportsFolderAnnotation(r.clients.SupportedResources(), parsed.GVK)
+	if info.Path != "" && parsed.FolderScoped {
 		parsed.Meta.SetFolder(r.resolveFolderID(ctx, info))
 	}
 

--- a/pkg/registry/apis/provisioning/resources/parser_test.go
+++ b/pkg/registry/apis/provisioning/resources/parser_test.go
@@ -202,6 +202,7 @@ spec:
 `),
 		})
 		require.NoError(t, err)
+		require.True(t, parsed.FolderScoped, "folder-capable kinds must be marked folder-scoped")
 		require.Equal(t, ParseFolder("team-a/", "repo").ID, parsed.Meta.GetFolder(),
 			"dashboards must continue to get a folder annotation")
 		require.Equal(t, ParseFolder("team-a/", "repo").ID, parsed.Obj.GetAnnotations()[utils.AnnoKeyFolder])
@@ -219,6 +220,8 @@ spec:
 `),
 		})
 		require.NoError(t, err)
+		require.False(t, parsed.FolderScoped,
+			"org-scoped kinds must be marked not folder-scoped so the dual writer skips folder stamping")
 		require.Empty(t, parsed.Meta.GetFolder(),
 			"org-scoped resources must not have a folder annotation stamped on them")
 		_, hasFolder := parsed.Obj.GetAnnotations()[utils.AnnoKeyFolder]

--- a/pkg/tests/apis/provisioning/resourcekinds/files_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/files_test.go
@@ -21,10 +21,10 @@ import (
 // the existing object's resourceVersion into the update so these operations round-trip cleanly
 // (git-ui-sync-project#1199).
 //
-// The move stays at the repository root on purpose: org-scoped kinds (e.g. playlists) cannot be
-// moved into a subdirectory through this path, because that derives a grafana.app/folder
-// annotation their apiserver forbids. That folder-scoping gap is independent of the
-// resourceVersion round-trip exercised here.
+// This test keeps its writes at the repository root to isolate the resourceVersion round-trip.
+// Subdirectory writes — where folder scoping matters, since org-scoped kinds (e.g. playlists)
+// must not derive a grafana.app/folder annotation their apiserver forbids — are covered by
+// TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope.
 func TestIntegrationProvisioning_ResourceKinds_FilesEndpoint(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()

--- a/pkg/tests/apis/provisioning/resourcekinds/folder_scope_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/folder_scope_test.go
@@ -1,0 +1,97 @@
+package resourcekinds
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope asserts that writing a
+// resource into a subdirectory through the files endpoint stamps a grafana.app/folder
+// annotation only for folder-scoped kinds.
+//
+// This is the regression guard for the dual-writer folder-scope fix: an org-scoped kind such as
+// a playlist must round-trip through a subdirectory (create + move) without ever receiving a
+// folder annotation, because its apiserver rejects one
+// ("folders are not supported for playlists.playlist.grafana.app"). Before the fix the dual
+// writer re-stamped a folder onto every resource regardless of kind, so this whole flow failed
+// for org-scoped kinds and the harness deliberately kept its writes at the repository root.
+func TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	for _, rk := range resourceKinds {
+		rk := rk
+		t.Run(rk.name, func(t *testing.T) {
+			client := rk.client(t, helper)
+
+			repo := rk.name + "-folderscope-repo"
+			name := rk.name + "-folderscope"
+			subPath := "team-a/" + rk.name + ".json"
+			helper.CreateLocalRepo(t, common.TestRepo{
+				Name:                   repo,
+				SyncTarget:             "instance",
+				Workflows:              []string{"write"},
+				SkipResourceAssertions: true,
+			})
+			t.Cleanup(func() { _ = client.Resource.Delete(ctx, name, metav1.DeleteOptions{}) })
+
+			// Create the resource inside a subdirectory. For org-scoped kinds this previously
+			// failed because the dual writer stamped a forbidden folder annotation. The files
+			// subresource REST client disallows '/' in the path segment, so this goes through the
+			// raw POST helper (which also exercises the same dual-writer create path).
+			createResp := helper.PostFilesRequest(t, repo, common.FilesPostOptions{
+				TargetPath: subPath,
+				Message:    "create " + rk.name,
+				Body:       string(common.ResourceToJSON(t, rk.newResource(t, name, "Folderscope "+rk.kind))),
+			})
+			require.NoError(t, createResp.Body.Close())
+			require.Equalf(t, 200, createResp.StatusCode, "%s create in a subdirectory should succeed", rk.name)
+			require.Contains(t, repositoryFilePaths(t, ctx, helper, repo), subPath, "the file should exist in the repository subdirectory")
+
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				got, err := client.Resource.Get(ctx, name, metav1.GetOptions{})
+				if !assert.NoError(collect, err) {
+					return
+				}
+				folder := got.GetAnnotations()[utils.AnnoKeyFolder]
+				if rk.folderScoped {
+					assert.NotEmpty(collect, folder, "folder-scoped %s must be parented to its subdirectory folder", rk.kind)
+				} else {
+					assert.Empty(collect, folder, "org-scoped %s must not carry a folder annotation", rk.kind)
+				}
+			}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "%s should be provisioned from the subdirectory", rk.name)
+
+			// Move within the subdirectory tree: still must not gain a folder annotation for org-scoped kinds.
+			movedPath := "team-a/" + rk.name + "-moved.json"
+			moveResp := helper.PostFilesRequest(t, repo, common.FilesPostOptions{
+				TargetPath:   movedPath,
+				OriginalPath: subPath,
+				Message:      "move " + rk.name,
+			})
+			require.NoError(t, moveResp.Body.Close())
+			require.Equalf(t, 200, moveResp.StatusCode, "%s move within a subdirectory should succeed", rk.name)
+
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				got, err := client.Resource.Get(ctx, name, metav1.GetOptions{})
+				if !assert.NoError(collect, err) {
+					return
+				}
+				assert.Equal(collect, movedPath, got.GetAnnotations()[utils.AnnoKeySourcePath],
+					"the source-path annotation should follow the move")
+				folder := got.GetAnnotations()[utils.AnnoKeyFolder]
+				if rk.folderScoped {
+					assert.NotEmpty(collect, folder, "folder-scoped %s must stay parented after a move", rk.kind)
+				} else {
+					assert.Empty(collect, folder, "org-scoped %s must not gain a folder annotation on move", rk.kind)
+				}
+			}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "%s should be re-provisioned after the move", rk.name)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Backend fix for the error seen when committing a **playlist** (or any org-scoped resource) to a repository:

```
Playlist.playlist.grafana.app "..." is invalid: metadata.annotations[grafana.app/folder]:
Forbidden: folders are not supported for playlists.playlist.grafana.app
```

The parser already skips the folder annotation for kinds that aren't folder-scoped (`parser.go` → `supportsFolderAnnotation`), but the **dual writer** unconditionally called `EnsureFolderPathExist` + `SetFolder(parent)` on the create/update and move paths, re-stamping a folder onto the resource. The apiserver (`apistore.verifyFolder`, with `EnableFolderSupport=false` for playlists) then rejected the write.

## Changes

- `ParsedResource` gains a `FolderScoped` field, set by the parser from `supportsFolderAnnotation(...)` (single source of truth for the folder-scope decision).
- The dual writer's folder handling (create/update path and move path) is gated on `parsed.FolderScoped`, so org-scoped resources are written without a folder annotation.

## Testing

Both new tests fail when the `FolderScoped` guard is removed (verified by reverting the fix).

- **Unit** — `resources/dualwriter_folderscope_test.go` (new): drives `UpdateResource` → `createOrUpdate` for a resource in a subdirectory. With `FolderScoped: false` no folder annotation is stamped and folder resolution is skipped entirely; with `FolderScoped: true` the resource is parented to the resolved subdirectory folder.
- **Unit** — `resources/parser_test.go` (extended `TestParser_FolderAnnotationGuard`): asserts the new `ParsedResource.FolderScoped` field is `true` for dashboards and `false` for playlists — locking the contract the dual writer reads.
- **Integration** — `tests/apis/provisioning/resourcekinds/folder_scope_test.go` (new): creates *and moves* a resource through a **subdirectory** via the files endpoint against a live apiserver, asserting org-scoped kinds (playlist) never receive a `grafana.app/folder` annotation through either create or move, while folder-scoped kinds do. The now-obsolete comment in `files_test.go` (which claimed org-scoped subdirectory moves were impossible) is updated to point at this test.
- `go test ./pkg/registry/apis/provisioning/resources/...` and `./pkg/tests/apis/provisioning/resourcekinds/...` pass.

## Notes

- Backend-only. Pairs with the frontend playlist-provisioning work in #127128 (separate PR per the FE/BE deploy-cadence rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)