### PR TITLE
Preferences: Call new API from theme drawer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -905,7 +905,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/services/PreferencesService.ts @grafana/grafana-frontend-platform
 /public/app/core/services/ResponseQueue* @grafana/grafana-frontend-platform
 /public/app/core/services/StateManagerBase.ts @grafana/grafana-frontend-platform
-/public/app/core/services/theme.ts @grafana/grafana-frontend-platform
+/public/app/core/services/theme* @grafana/grafana-frontend-platform
 /public/app/core/specs/backend_srv.test.ts @grafana/grafana-frontend-platform
 /public/app/core/specs/factors.test.ts @grafana/dashboards-squad
 /public/app/core/specs/flatten.test.ts @grafana/grafana-frontend-platform

--- a/public/app/core/components/ThemeSelector/ThemeSelectorDrawer.tsx
+++ b/public/app/core/components/ThemeSelector/ThemeSelectorDrawer.tsx
@@ -1,12 +1,9 @@
 import { css } from '@emotion/css';
 
-import { useUpdatePreferencesMutation } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
 import { type GrafanaTheme2, type ThemeRegistryItem } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
-import { useFlagGrafanaNewPreferencesPage } from '@grafana/runtime/internal';
 import { Drawer, TextLink, useStyles2, useTheme2 } from '@grafana/ui';
-import { contextSrv } from 'app/core/services/context_srv';
 import { changeTheme } from 'app/core/services/theme';
 
 import { ThemeCard } from './ThemeCard';
@@ -20,23 +17,14 @@ export function ThemeSelectorDrawer({ onClose }: Props) {
   const styles = useStyles2(getStyles);
   const themes = getSelectableThemes();
   const currentTheme = useTheme2();
-  const newPrefsEnabled = useFlagGrafanaNewPreferencesPage();
-  const [updatePreferences] = useUpdatePreferencesMutation();
 
   const onChange = (theme: ThemeRegistryItem) => {
     reportInteraction('grafana_preferences_theme_changed', {
       toTheme: theme.id,
       preferenceType: 'theme_drawer',
     });
-
-    if (newPrefsEnabled) {
-      // Apply the theme at runtime, then persist via the k8s preferences API.
-      changeTheme(theme.id, true);
-      const resourceName = contextSrv.user.uid ? `user-${contextSrv.user.uid}` : 'user';
-      updatePreferences({ patch: { spec: { theme: theme.id } }, name: resourceName });
-    } else {
-      changeTheme(theme.id, false);
-    }
+    // changeTheme persists via the legacy or k8s preferences API depending on the newPreferencesPage flag.
+    changeTheme(theme.id, false);
   };
 
   const subTitle = (

--- a/public/app/core/components/ThemeSelector/ThemeSelectorDrawer.tsx
+++ b/public/app/core/components/ThemeSelector/ThemeSelectorDrawer.tsx
@@ -1,9 +1,12 @@
 import { css } from '@emotion/css';
 
+import { useUpdatePreferencesMutation } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
 import { type GrafanaTheme2, type ThemeRegistryItem } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
+import { useFlagGrafanaNewPreferencesPage } from '@grafana/runtime/internal';
 import { Drawer, TextLink, useStyles2, useTheme2 } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
 import { changeTheme } from 'app/core/services/theme';
 
 import { ThemeCard } from './ThemeCard';
@@ -17,13 +20,23 @@ export function ThemeSelectorDrawer({ onClose }: Props) {
   const styles = useStyles2(getStyles);
   const themes = getSelectableThemes();
   const currentTheme = useTheme2();
+  const newPrefsEnabled = useFlagGrafanaNewPreferencesPage();
+  const [updatePreferences] = useUpdatePreferencesMutation();
 
   const onChange = (theme: ThemeRegistryItem) => {
     reportInteraction('grafana_preferences_theme_changed', {
       toTheme: theme.id,
       preferenceType: 'theme_drawer',
     });
-    changeTheme(theme.id, false);
+
+    if (newPrefsEnabled) {
+      // Apply the theme at runtime, then persist via the k8s preferences API.
+      changeTheme(theme.id, true);
+      const resourceName = contextSrv.user.uid ? `user-${contextSrv.user.uid}` : 'user';
+      updatePreferences({ patch: { spec: { theme: theme.id } }, name: resourceName });
+    } else {
+      changeTheme(theme.id, false);
+    }
   };
 
   const subTitle = (

--- a/public/app/core/services/theme.test.ts
+++ b/public/app/core/services/theme.test.ts
@@ -1,0 +1,78 @@
+import { generatedAPI as preferencesAPI } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
+import { config } from '@grafana/runtime';
+import { FlagKeys } from '@grafana/runtime/internal';
+import { setTestFlags } from '@grafana/test-utils/unstable';
+
+import { backendSrv } from './backend_srv';
+import { contextSrv } from './context_srv';
+import { changeTheme } from './theme';
+
+jest.mock('app/store/store', () => ({
+  dispatch: jest.fn(() => ({ unwrap: () => Promise.resolve({}) })),
+}));
+
+describe('changeTheme', () => {
+  const originalSignedIn = contextSrv.isSignedIn;
+  const originalUid = contextSrv.user.uid;
+
+  beforeEach(() => {
+    contextSrv.isSignedIn = true;
+    contextSrv.user.uid = 'abc123';
+    // changeTheme swaps the stylesheet <link> when the colour mode changes, reading these asset URLs.
+    config.bootData.assets = { ...config.bootData.assets, light: 'light.css', dark: 'dark.css' };
+    jest.spyOn(backendSrv, 'patch').mockResolvedValue({});
+    jest.spyOn(preferencesAPI.endpoints.updatePreferences, 'initiate');
+  });
+
+  afterEach(() => {
+    contextSrv.isSignedIn = originalSignedIn;
+    contextSrv.user.uid = originalUid;
+    setTestFlags({});
+    jest.restoreAllMocks();
+  });
+
+  it('does not persist when runtimeOnly is set', async () => {
+    await changeTheme('light', true);
+    expect(backendSrv.patch).not.toHaveBeenCalled();
+    expect(preferencesAPI.endpoints.updatePreferences.initiate).not.toHaveBeenCalled();
+  });
+
+  it('does not persist when the user is not signed in', async () => {
+    contextSrv.isSignedIn = false;
+    await changeTheme('light', false);
+    expect(backendSrv.patch).not.toHaveBeenCalled();
+    expect(preferencesAPI.endpoints.updatePreferences.initiate).not.toHaveBeenCalled();
+  });
+
+  describe('when the newPreferencesPage flag is off', () => {
+    it('persists via the legacy preferences API', async () => {
+      await changeTheme('light', false);
+      expect(backendSrv.patch).toHaveBeenCalledWith('/api/user/preferences', { theme: 'light' });
+      expect(preferencesAPI.endpoints.updatePreferences.initiate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the newPreferencesPage flag is on', () => {
+    beforeEach(() => {
+      setTestFlags({ [FlagKeys.GrafanaNewPreferencesPage]: true });
+    });
+
+    it('persists to the user resource via the k8s preferences API', async () => {
+      await changeTheme('light', false);
+      expect(preferencesAPI.endpoints.updatePreferences.initiate).toHaveBeenCalledWith({
+        name: 'user-abc123',
+        patch: { spec: { theme: 'light' } },
+      });
+      expect(backendSrv.patch).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the "user" resource name when the user has no uid', async () => {
+      contextSrv.user.uid = '';
+      await changeTheme('light', false);
+      expect(preferencesAPI.endpoints.updatePreferences.initiate).toHaveBeenCalledWith({
+        name: 'user',
+        patch: { spec: { theme: 'light' } },
+      });
+    });
+  });
+});

--- a/public/app/core/services/theme.ts
+++ b/public/app/core/services/theme.ts
@@ -1,5 +1,8 @@
+import { generatedAPI as preferencesAPI } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
 import { getThemeById } from '@grafana/data/internal';
 import { config, ThemeChangedEvent } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+import { dispatch } from 'app/store/store';
 
 import { appEvents } from '../app_events';
 import { contextSrv } from '../services/context_srv';
@@ -44,10 +47,20 @@ export async function changeTheme(themeId: string, runtimeOnly?: boolean) {
   }
 
   // Persist new theme
-  const service = new PreferencesService('user');
-  await service.patch({
-    theme: themeId,
-  });
+  if (getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaNewPreferencesPage, false)) {
+    const resourceName = contextSrv.user.uid ? `user-${contextSrv.user.uid}` : 'user';
+    await dispatch(
+      preferencesAPI.endpoints.updatePreferences.initiate({
+        name: resourceName,
+        patch: { spec: { theme: themeId } },
+      })
+    ).unwrap();
+  } else {
+    const service = new PreferencesService('user');
+    await service.patch({
+      theme: themeId,
+    });
+  }
 }
 
 export async function toggleTheme(runtimeOnly: boolean) {


### PR DESCRIPTION
Routes individual theme preference changes through the new K8s Preferences API when the `newPreferencesPage` flag is enabled. Updates `changeTheme()` rather than each individual component, so everyone is covered uniformly:

- The theme drawer
- The `c` `t` keyboard shortcut
- The command palette "change theme" actions

When the flag is enabled, even though `changeTheme` is not a react hook, it dispatches the RTKQ mutation imperatively via `dispatch(updatePreferences.initiate(...))`, similar to [`shortlinks.ts`](https://github.com/grafana/grafana/blob/0f5c809662579bbafece652b308be132485b9cbd/public/app/core/utils/shortLinks.ts#L50-L61).

Part of https://github.com/grafana/grafana-frontend-platform/issues/87