### PR TITLE
SessionReplay: start rrweb after route content commits

### DIFF
--- a/public/app/core/navigation/GrafanaRoute.test.tsx
+++ b/public/app/core/navigation/GrafanaRoute.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { lazy, type ComponentType } from 'react';
 import { render } from 'test/test-utils';
 
@@ -7,6 +7,7 @@ import { setEchoSrv } from '@grafana/runtime';
 import { Echo } from '../services/echo/Echo';
 
 import { GrafanaRoute, type Props } from './GrafanaRoute';
+import { GRAFANA_ROUTE_CONTENT_READY_EVENT, type RouteContentReadyEventDetail } from './routeContentReady';
 import { type GrafanaRouteComponentProps } from './types';
 
 const mockLocation = {
@@ -66,5 +67,63 @@ describe('GrafanaRoute', () => {
 
     expect(await screen.findByRole('heading', { name: 'An unexpected error happened' })).toBeInTheDocument();
     expect(consoleError).toHaveBeenCalled();
+  });
+
+  describe('route-content-ready event', () => {
+    let events: Array<CustomEvent<RouteContentReadyEventDetail>>;
+    const handler = (e: Event) => events.push(e as CustomEvent<RouteContentReadyEventDetail>);
+
+    beforeEach(() => {
+      events = [];
+      window.addEventListener(GRAFANA_ROUTE_CONTENT_READY_EVENT, handler);
+    });
+
+    afterEach(() => {
+      window.removeEventListener(GRAFANA_ROUTE_CONTENT_READY_EVENT, handler);
+    });
+
+    it('dispatches once route content has committed', async () => {
+      setup({ location: mockLocation, route: { component: () => <div>content</div>, path: '/' } });
+
+      await screen.findByText('content');
+      await waitFor(() => expect(events).toHaveLength(1));
+      expect(events[0].detail).toEqual({ pathname: '', search: '?query=hello&test=asd', hash: '' });
+    });
+
+    it('does not dispatch while the route is suspended on the loading fallback', async () => {
+      const PageComponent = lazy(() => new Promise<{ default: ComponentType }>(() => {}));
+
+      setup({ route: { component: PageComponent, path: '' } });
+
+      expect(await screen.findByLabelText('Loading')).toBeInTheDocument();
+      expect(events).toHaveLength(0);
+    });
+
+    it('dispatches after a suspended lazy route resolves', async () => {
+      let resolve!: (value: { default: ComponentType }) => void;
+      const PageComponent = lazy(() => new Promise<{ default: ComponentType }>((r) => (resolve = r)));
+
+      setup({ route: { component: PageComponent, path: '' } });
+
+      expect(await screen.findByLabelText('Loading')).toBeInTheDocument();
+      expect(events).toHaveLength(0);
+
+      resolve({ default: () => <div>resolved content</div> });
+
+      await screen.findByText('resolved content');
+      await waitFor(() => expect(events).toHaveLength(1));
+    });
+
+    it('dispatches when the route renders an error page', async () => {
+      const PageComponent = () => {
+        throw new Error('Page threw error');
+      };
+      jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+      setup({ route: { component: PageComponent, path: '' } });
+
+      await screen.findByRole('heading', { name: 'An unexpected error happened' });
+      await waitFor(() => expect(events).toHaveLength(1));
+    });
   });
 });

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -11,6 +11,7 @@ import { contextSrv } from '../services/context_srv';
 
 import { GrafanaRouteError } from './GrafanaRouteError';
 import { GrafanaRouteLoading } from './GrafanaRouteLoading';
+import { GRAFANA_ROUTE_CONTENT_READY_EVENT, type RouteContentReadyEventDetail } from './routeContentReady';
 import { type GrafanaRouteComponentProps, type RouteDescriptor } from './types';
 
 export interface Props extends Pick<GrafanaRouteComponentProps, 'route' | 'location'> {}
@@ -51,17 +52,42 @@ export function GrafanaRoute(props: Props) {
     <ErrorBoundary boundaryName="grafana-route" dependencies={[props.route]}>
       {({ error, errorInfo }) => {
         if (error) {
-          return <GrafanaRouteError error={error} errorInfo={errorInfo} />;
+          return (
+            <>
+              <GrafanaRouteError error={error} errorInfo={errorInfo} />
+              <RouteContentReadySignal location={props.location} />
+            </>
+          );
         }
 
         return (
           <Suspense fallback={<GrafanaRouteLoading />}>
             <props.route.component {...props} queryParams={locationSearchToObject(props.location.search)} />
+            <RouteContentReadySignal location={props.location} />
           </Suspense>
         );
       }}
     </ErrorBoundary>
   );
+}
+
+/**
+ * Renders nothing; on commit it signals that real route content (the lazily-loaded
+ * route component or its error page) is now in the DOM. Placed INSIDE the Suspense
+ * boundary so its effect cannot run while the loading fallback is showing — i.e. it
+ * fires only once the lazy route chunk has resolved and committed.
+ */
+function RouteContentReadySignal({ location }: Pick<Props, 'location'>) {
+  useEffect(() => {
+    const detail: RouteContentReadyEventDetail = {
+      pathname: location.pathname,
+      search: location.search,
+      hash: location.hash,
+    };
+    window.dispatchEvent(new CustomEvent<RouteContentReadyEventDetail>(GRAFANA_ROUTE_CONTENT_READY_EVENT, { detail }));
+  }, [location.pathname, location.search, location.hash]);
+
+  return null;
 }
 
 export function GrafanaRouteWrapper({ route }: Pick<Props, 'route'>) {

--- a/public/app/core/navigation/routeContentReady.ts
+++ b/public/app/core/navigation/routeContentReady.ts
@@ -1,0 +1,20 @@
+/**
+ * Dispatched on `window` once a `GrafanaRoute` content boundary has committed to
+ * the DOM — i.e. the route's lazily-loaded component (or its error page) has
+ * rendered, not merely the Suspense loading fallback.
+ *
+ * The Faro/rrweb session replay backend listens for this to defer starting the
+ * rrweb recorder until real route content exists, so the recorder's initial DOM
+ * snapshot is taken against the rendered UI rather than a near-empty app.
+ *
+ * Guarantee: this fires when the first route-content boundary has committed, NOT
+ * when the whole page (nested Suspense boundaries, async data, panels, plugins)
+ * has fully settled.
+ */
+export const GRAFANA_ROUTE_CONTENT_READY_EVENT = 'grafana:route-content-ready';
+
+export interface RouteContentReadyEventDetail {
+  pathname: string;
+  search: string;
+  hash: string;
+}

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -1,6 +1,7 @@
 import { type BuildInfo } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { type Faro, type Instrumentation } from '@grafana/faro-core';
+import { ReplayInstrumentation } from '@grafana/faro-instrumentation-replay';
 import * as faroWebSdkModule from '@grafana/faro-web-sdk';
 import {
   type BrowserConfig,
@@ -13,10 +14,16 @@ import {
   NavigationInstrumentation,
 } from '@grafana/faro-web-sdk';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
+import * as runtimeInternal from '@grafana/runtime/internal';
+import { GRAFANA_ROUTE_CONTENT_READY_EVENT } from 'app/core/navigation/routeContentReady';
 
 import { EchoSrvTransport } from './EchoSrvTransport';
 import { GrafanaJavascriptAgentBackend, TRACKING_URLS } from './GrafanaJavascriptAgentBackend';
 import { type GrafanaJavascriptAgentBackendOptions } from './types';
+
+jest.mock('@grafana/faro-instrumentation-replay', () => ({
+  ReplayInstrumentation: jest.fn(),
+}));
 
 describe('GrafanaJavascriptAgentEchoBackend', () => {
   let mockedSetUser: jest.Mock;
@@ -227,4 +234,109 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
   //     // check that our custom backend got it too
   //     expect(myCustomErrorBackend.addEvent).toHaveBeenCalledTimes(1);
   //   });
+
+  describe('session replay initialization', () => {
+    let rafCallbacks: Map<number, FrameRequestCallback>;
+    let nextRafId: number;
+    // Tracked so we can remove backends' listeners between tests: a backend
+    // registered with the flag on but never started would otherwise leak its
+    // listener onto window and fire alongside the next test's backend.
+    let routeReadyListeners: EventListenerOrEventListenerObject[];
+    // Captured up front so the addEventListener spy can call through to the real
+    // implementation without recursing into itself across tests.
+    const nativeAddEventListener = EventTarget.prototype.addEventListener;
+    const nativeRemoveEventListener = EventTarget.prototype.removeEventListener;
+
+    const getAddInstrumentation = () => initializeFaroMock.mock.results[0].value.instrumentations.add;
+
+    const flushAnimationFrame = () => {
+      const callbacks = [...rafCallbacks.entries()];
+      rafCallbacks.clear();
+      callbacks.forEach(([, cb]) => cb(performance.now()));
+    };
+
+    beforeEach(() => {
+      rafCallbacks = new Map();
+      nextRafId = 0;
+      routeReadyListeners = [];
+
+      jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        const id = ++nextRafId;
+        rafCallbacks.set(id, cb);
+        return id;
+      });
+      jest.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+        rafCallbacks.delete(id);
+      });
+
+      jest.spyOn(window, 'addEventListener').mockImplementation((type, listener, options) => {
+        if (type === GRAFANA_ROUTE_CONTENT_READY_EVENT && listener) {
+          routeReadyListeners.push(listener);
+        }
+        return nativeAddEventListener.call(window, type, listener, options);
+      });
+
+      // The replay path is gated behind the FaroSessionReplay feature flag.
+      jest
+        .spyOn(runtimeInternal, 'getFeatureFlagClient')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockReturnValue({ getBooleanValue: () => true } as any);
+    });
+
+    afterEach(() => {
+      routeReadyListeners.forEach((listener) =>
+        nativeRemoveEventListener.call(window, GRAFANA_ROUTE_CONTENT_READY_EVENT, listener)
+      );
+    });
+
+    it('does not start replay before route content is ready', () => {
+      new GrafanaJavascriptAgentBackend(options);
+
+      expect(getAddInstrumentation()).not.toHaveBeenCalled();
+      expect(ReplayInstrumentation).not.toHaveBeenCalled();
+    });
+
+    it('starts replay once after the route-content-ready event and two animation frames', () => {
+      new GrafanaJavascriptAgentBackend(options);
+
+      window.dispatchEvent(new CustomEvent(GRAFANA_ROUTE_CONTENT_READY_EVENT));
+      expect(getAddInstrumentation()).not.toHaveBeenCalled();
+
+      flushAnimationFrame(); // first frame schedules the second
+      expect(getAddInstrumentation()).not.toHaveBeenCalled();
+
+      flushAnimationFrame(); // second frame starts replay
+      expect(getAddInstrumentation()).toHaveBeenCalledTimes(1);
+      expect(ReplayInstrumentation).toHaveBeenCalledTimes(1);
+    });
+
+    it('starts replay only once even if the event fires repeatedly', () => {
+      new GrafanaJavascriptAgentBackend(options);
+
+      window.dispatchEvent(new CustomEvent(GRAFANA_ROUTE_CONTENT_READY_EVENT));
+      flushAnimationFrame();
+      // A second event arrives before the start completes (e.g. an immediate redirect).
+      window.dispatchEvent(new CustomEvent(GRAFANA_ROUTE_CONTENT_READY_EVENT));
+      flushAnimationFrame();
+      flushAnimationFrame();
+
+      // And another after replay has already started.
+      window.dispatchEvent(new CustomEvent(GRAFANA_ROUTE_CONTENT_READY_EVENT));
+      flushAnimationFrame();
+      flushAnimationFrame();
+
+      expect(getAddInstrumentation()).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops listening for the event after replay has started', () => {
+      new GrafanaJavascriptAgentBackend(options);
+      const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+      window.dispatchEvent(new CustomEvent(GRAFANA_ROUTE_CONTENT_READY_EVENT));
+      flushAnimationFrame();
+      flushAnimationFrame();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(GRAFANA_ROUTE_CONTENT_READY_EVENT, expect.any(Function));
+    });
+  });
 });

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -11,6 +11,7 @@ import {
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 import { type EchoBackend, type EchoEvent, EchoEventType } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+import { GRAFANA_ROUTE_CONTENT_READY_EVENT } from 'app/core/navigation/routeContentReady';
 
 import { EchoSrvTransport } from './EchoSrvTransport';
 import { beforeSendHandler } from './beforeSendHandler';
@@ -99,25 +100,32 @@ export class GrafanaJavascriptAgentBackend
     const faro = initializeFaro(grafanaJavaScriptAgentOptions);
 
     if (faro && getFeatureFlagClient().getBooleanValue(FlagKeys.FaroSessionReplay, false)) {
-      this.initReplayAfterDomRendered(faro);
+      this.initReplayAfterRouteContentRendered(faro);
     }
   }
 
   /**
-   * Defer rrweb session replay until React has committed its initial render.
+   * Defer rrweb session replay until Grafana's first route content has rendered.
    *
    * rrweb's record() takes a full DOM snapshot on start and then tracks
-   * incremental mutations. If it starts before React renders, the snapshot
-   * captures an empty #reactRoot and the entire first render arrives as one
-   * massive mutation batch — which triggers a known rrweb bug where the
-   * MutationBuffer.emit() addList silently drops nodes it cannot resolve.
-   * Those dropped nodes later surface as "[replayer] Node with id 'X' not found."
+   * incremental mutations. If it starts before the real UI is in the DOM, the
+   * snapshot captures a near-empty app and the entire first render arrives as
+   * one massive mutation batch — which triggers a known rrweb bug where the
+   * MutationBuffer.emit() addList silently drops nodes it cannot resolve (and
+   * nodes detached mid-batch are lost). Those dropped nodes later surface as
+   * "[replayer] Node with id 'X' not found."
    *
-   * By observing #reactRoot for its first child, we start rrweb only after
-   * React has committed, so the snapshot contains the real UI and the
-   * problematic initial mutation batch never occurs.
+   * Grafana's routes are lazily loaded (React.lazy), so the app commits an empty
+   * shell, then a Suspense loading fallback, and only later the real route
+   * content once its chunk resolves. We therefore start rrweb on the
+   * GRAFANA_ROUTE_CONTENT_READY_EVENT that GrafanaRoute dispatches from inside its
+   * Suspense boundary — i.e. only once real route content has committed — and
+   * wait two animation frames so the browser has painted it before snapshotting.
+   *
+   * This guarantees the snapshot captures the first committed route content; it
+   * does not wait for nested Suspense boundaries or async data within a route.
    */
-  private initReplayAfterDomRendered(faro: Faro): void {
+  private initReplayAfterRouteContentRendered(faro: Faro): void {
     const addReplay = () => {
       faro.instrumentations.add(
         new ReplayInstrumentation({
@@ -132,18 +140,46 @@ export class GrafanaJavascriptAgentBackend
       );
     };
 
-    const reactRoot = document.getElementById('reactRoot');
-    if (reactRoot && reactRoot.childNodes.length > 0) {
-      requestAnimationFrame(addReplay);
-      return;
+    let started = false;
+    let raf1 = 0;
+    let raf2 = 0;
+
+    function cancelPending() {
+      if (raf1) {
+        cancelAnimationFrame(raf1);
+        raf1 = 0;
+      }
+      if (raf2) {
+        cancelAnimationFrame(raf2);
+        raf2 = 0;
+      }
     }
 
-    const observer = new MutationObserver((_mutations, obs) => {
-      obs.disconnect();
-      requestAnimationFrame(addReplay);
-    });
+    function startReplay() {
+      if (started) {
+        return;
+      }
+      started = true;
+      cancelPending();
+      window.removeEventListener(GRAFANA_ROUTE_CONTENT_READY_EVENT, scheduleReplayStart);
+      addReplay();
+    }
 
-    observer.observe(reactRoot ?? document.body, { childList: true });
+    // Wait two animation frames after route content commits so it has painted
+    // before rrweb snapshots. A later route-ready event (e.g. an immediate
+    // redirect) supersedes a still-pending start so we snapshot the final route.
+    function scheduleReplayStart() {
+      if (started) {
+        return;
+      }
+      cancelPending();
+      raf1 = requestAnimationFrame(() => {
+        raf1 = 0;
+        raf2 = requestAnimationFrame(startReplay);
+      });
+    }
+
+    window.addEventListener(GRAFANA_ROUTE_CONTENT_READY_EVENT, scheduleReplayStart);
   }
 
   // noop because the EchoSrvTransport registered in Faro will already broadcast all signals emitted by the Faro API


### PR DESCRIPTION
<!-- Draft — under validation in the dem-dev devstack. -->

## What this PR does / why we need it

Session replay recordings can be missing DOM elements — parts of the page visible during recording don't render on replay, surfacing as `[replayer] Node with id 'X' not found`.

rrweb's `record()` takes a full DOM snapshot on start and then tracks incremental mutations. If it starts before the real UI is in the DOM, the snapshot captures a near-empty app and the entire first render arrives as one massive mutation batch — the condition under which rrweb drops nodes it can't resolve, and loses nodes that get detached (a subtree unmounting) before they're serialized.

The previous mitigation (#117917) observed `#reactRoot` for its first child. But that first child is the `AppWrapper` shell, which first renders with `ready === false` and therefore **no routes** (`AppWrapper.tsx`). The real route tree mounts later, deep inside `.grafana-app` — never as a direct child of `#reactRoot` — so the observer fired on the empty shell and rrweb still snapshotted a near-empty app.

Because Grafana's routes are lazily loaded (`React.lazy` via `SafeDynamicImport`), even waiting for the shell (or the preloader) is too early: the `Suspense` loading fallback can commit while the route chunk is still being fetched.

### Approach

Start rrweb only once **real route content has committed**:

- `GrafanaRoute` dispatches a `grafana:route-content-ready` `CustomEvent` from a marker rendered **inside** its `Suspense` boundary (and in the error branch), so it can only fire once the lazy route content — not the loading fallback — has committed.
- The Faro backend starts `ReplayInstrumentation` on that event, after two animation frames (so the content has painted). A later event (e.g. an immediate redirect) supersedes a still-pending start. No timers / time constants.

This captures the first committed route content rather than an empty app. It intentionally does **not** wait for nested `Suspense` boundaries or async data within a route; that would require domain-specific readiness.

## Which issue(s) this PR fixes

<!-- link issue -->

## Special notes for your reviewer

- Frontend-only. Behind the existing `FaroSessionReplay` feature flag.
- No rrweb changes — this is purely a Grafana integration-timing fix.
- Tests and devstack validation (unminified build + CDP capture confirming the initial batch is gone) are in progress.
