### PR TITLE
Provisioning: Fix flaky PR comment webhook test

### DIFF
--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -172,6 +172,13 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	waitForWebhook(t, helper, repoName, 654)
 	helper.SyncAndWait(t, repoName)
 
+	// Ensure the synced dashboard is queryable before opening the PR. The PR
+	// worker's DryRun does a Get-by-name to populate Existing, which is what
+	// produces the [original] link in the comment; SyncAndWait only waits for
+	// job success, not resource visibility, so without this barrier the Get can
+	// race the sync write and drop the [original] link.
+	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, ctx, "gh-pr-comment-dash", repoName, dashboardPath)
+
 	const branchName = "feature-pr-comment"
 	_, err := local.Git("checkout", "-b", branchName)
 	require.NoError(t, err, "failed to create feature branch")


### PR DESCRIPTION
## What this PR does

Fixes intermittent failures of `TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment` (`pkg/tests/apis/provisioning/git/webhook/webhook_test.go`).

## Root cause

The test exercises the *update-an-existing-dashboard* PR path and asserts the generated PR comment contains both an `[original](...)` and a `[preview](...)` link. The failure surfaced as:

```
webhook_test.go:268: Should not be: -1
  Messages: comment should contain original link
```

i.e. the comment had `[preview](...)` but no `[original](...)`.

The single-dashboard comment template only renders `[original]` when `GrafanaURL` is set. The evaluator sets `GrafanaURL` only when the dashboard already exists in Grafana — `changes.go`:

```go
if info.Parsed.Existing != nil {
    info.GrafanaURL = ... // [original] link
}
```

`Existing` is populated by a Get-by-name in `ParsedResource.DryRun` (`parser.go`), and the error is intentionally swallowed. `SyncAndWait` waits only for the sync **job** to succeed, not for the written dashboard to be queryable. So the PR worker's `Get` could race the sync write, leaving `Existing` nil and dropping the `[original]` link.

Product behaviour is correct (a genuinely-absent dashboard legitimately has no `[original]` link) — the new test just skipped the established "wait until the synced resource is gettable" guard.

## Fix (test-only)

Add a `RequireRepoManagedDashboard` barrier after the initial `SyncAndWait`, so the dashboard is gettable by name before the PR is opened. Mirrors the existing pattern in `managed_dashboard_commit_message_test.go`.

```go
common.RequireRepoManagedDashboard(t, helper.DashboardsV1, ctx, "gh-pr-comment-dash", repoName, dashboardPath)
```

No production code changes.

## Verification

```
go test -tags enterprise ./pkg/tests/apis/provisioning/git/webhook/ \
  -run TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment -count=10
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)