### PR TITLE
Preferences: Allow non-user identities to list namespace preferences

### DIFF
--- a/pkg/registry/apis/preferences/store.go
+++ b/pkg/registry/apis/preferences/store.go
@@ -66,35 +66,8 @@ func (s *preferencesStorage) ListPreferences(ctx context.Context, options *inter
 		Items: make([]preferences.Preferences, 0, len(groups)+2),
 	}
 
-	// Append user+team preferences
 	addPreferencesToResult := func(owner utils.OwnerReference) error {
-		switch owner.Owner {
-		case utils.NamespaceResourceOwner:
-			// OK
-		case utils.UserResourceOwner:
-			if !isUser || user.GetIdentifier() != owner.Identifier {
-				return nil
-			}
-		case utils.TeamResourceOwner:
-			if !isUser || !slices.Contains(groups, owner.Identifier) {
-				return nil
-			}
-		default:
-			return nil // skip
-		}
-
-		rsp, err := s.Get(ctx, owner.AsName(), &metav1.GetOptions{})
-		if k8serrors.IsNotFound(err) {
-			return nil // don't add it to the list
-		}
-		if rsp != nil {
-			obj, ok := rsp.(*preferences.Preferences)
-			if !ok {
-				return fmt.Errorf("expected preferences, found %T", rsp)
-			}
-			result.Items = append(result.Items, *obj)
-		}
-		return err
+		return s.appendOwnerPreferences(ctx, user, isUser, owner, result)
 	}
 
 	// Try getting an explicit preferences
@@ -143,4 +116,36 @@ func (s *preferencesStorage) ListPreferences(ctx context.Context, options *inter
 	}
 
 	return result, nil
+}
+
+// appendOwnerPreferences fetches the preferences for a single owner and, if the
+// caller is allowed to see them and they exist, appends them to result.
+func (s *preferencesStorage) appendOwnerPreferences(ctx context.Context, user identity.Requester, isUser bool, owner utils.OwnerReference, result *preferences.PreferencesList) error {
+	switch owner.Owner {
+	case utils.NamespaceResourceOwner:
+		// OK
+	case utils.UserResourceOwner:
+		if !isUser || user.GetIdentifier() != owner.Identifier {
+			return nil
+		}
+	case utils.TeamResourceOwner:
+		if !isUser || !slices.Contains(user.GetGroups(), owner.Identifier) {
+			return nil
+		}
+	default:
+		return nil // skip
+	}
+
+	rsp, err := s.Get(ctx, owner.AsName(), &metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil // don't add it to the list
+	}
+	if rsp != nil {
+		obj, ok := rsp.(*preferences.Preferences)
+		if !ok {
+			return fmt.Errorf("expected preferences, found %T", rsp)
+		}
+		result.Items = append(result.Items, *obj)
+	}
+	return err
 }

--- a/pkg/registry/apis/preferences/store.go
+++ b/pkg/registry/apis/preferences/store.go
@@ -43,10 +43,10 @@ func (s *preferencesStorage) ListPreferences(ctx context.Context, options *inter
 	if err != nil {
 		return nil, err
 	}
-	if user.GetIdentityType() != authlib.TypeUser {
-		return nil, fmt.Errorf("only users may list preferences")
-	}
-	if user.GetIdentifier() == "" {
+	// Non-user identities (e.g. the image renderer) may list preferences, but
+	// they only receive the namespace (org) preferences -- never user or team ones.
+	isUser := user.GetIdentityType() == authlib.TypeUser
+	if isUser && user.GetIdentifier() == "" {
 		return nil, fmt.Errorf("user identifier is required")
 	}
 	if options == nil {
@@ -72,11 +72,11 @@ func (s *preferencesStorage) ListPreferences(ctx context.Context, options *inter
 		case utils.NamespaceResourceOwner:
 			// OK
 		case utils.UserResourceOwner:
-			if user.GetIdentifier() != owner.Identifier {
+			if !isUser || user.GetIdentifier() != owner.Identifier {
 				return nil
 			}
 		case utils.TeamResourceOwner:
-			if !slices.Contains(groups, owner.Identifier) {
+			if !isUser || !slices.Contains(groups, owner.Identifier) {
 				return nil
 			}
 		default:
@@ -119,19 +119,21 @@ func (s *preferencesStorage) ListPreferences(ctx context.Context, options *inter
 		return result, nil
 	}
 
-	// Add the explicit user values
-	if err = addPreferencesToResult(utils.UserOwner(user.GetIdentifier())); err != nil {
-		return nil, err
-	}
-
-	// predictable order
-	slices.Sort(groups)
-	for i, group := range groups {
-		if i >= PreferencesTeamLimit {
-			break // only process the first PreferencesTeamLimit -- to keep it bounded
-		}
-		if err = addPreferencesToResult(utils.TeamOwner(group)); err != nil {
+	if isUser {
+		// Add the explicit user values
+		if err = addPreferencesToResult(utils.UserOwner(user.GetIdentifier())); err != nil {
 			return nil, err
+		}
+
+		// predictable order
+		slices.Sort(groups)
+		for i, group := range groups {
+			if i >= PreferencesTeamLimit {
+				break // only process the first PreferencesTeamLimit -- to keep it bounded
+			}
+			if err = addPreferencesToResult(utils.TeamOwner(group)); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/registry/apis/preferences/store_test.go
+++ b/pkg/registry/apis/preferences/store_test.go
@@ -221,14 +221,21 @@ func TestListPreferences_Errors(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("non-user identity is rejected", func(t *testing.T) {
-		store := &preferencesStorage{Storage: &fakeStorage{}}
+	t.Run("non-user identity only receives namespace preferences", func(t *testing.T) {
+		fake := &fakeStorage{items: map[string]*preferences.Preferences{
+			"user-sa-1": newPref("user-sa-1"),
+			"team-a":    newPref("team-a"),
+			"namespace": newPref("namespace"),
+		}}
+		store := &preferencesStorage{Storage: fake}
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Type:    claims.TypeServiceAccount,
 			UserUID: "sa-1",
+			Groups:  []string{"a"},
 		})
-		_, err := store.ListPreferences(ctx, nil)
-		require.ErrorContains(t, err, "only users may list preferences")
+		list, err := store.ListPreferences(ctx, nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{"namespace"}, names(list))
 	})
 
 	t.Run("user without identifier is rejected", func(t *testing.T) {


### PR DESCRIPTION
#### What

Previously, `preferencesStorage.ListPreferences` rejected any caller that was not a user identity with the error only users may list preferences. This broke preference listing when called on behalf of non-user identities such as the image renderer, which needs to resolve preferences to render dashboards correctly.

This change allows non-user identities to list preferences, but restricts them to only the namespace (org) preferences — they never receive user or team preferences.

#### Why

The image renderer (and other non-user service identities) request the frontend index, which in turn lists preferences. With the old behaviour these requests failed outright. Non-user identities have no meaningful "user" or "team" scope, so returning the namespace-level preferences is both safe and sufficient.

This is to match the previous behaviour from the index handler which would only return default/org preferences.

#### How

- Replaced the hard rejection with an `isUser` flag derived from the identity type. The empty-identifier check now only applies to user identities.
- In `addPreferencesToResult`, the user- and team-owner cases now bail out for non-users, so even an explicit `metadata.name` field selector targeting a user/team owner returns nothing for a non-user caller.
- Wrapped the user + team preference gathering in `if isUser`, so non-users skip straight to appending only the namespace preferences.