### PR TITLE
Unified Storage: Truncate title in vector embedding

### DIFF
--- a/pkg/storage/unified/search/vector/pgvector.go
+++ b/pkg/storage/unified/search/vector/pgvector.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	pgvector "github.com/pgvector/pgvector-go"
 	"go.opentelemetry.io/otel"
@@ -80,6 +81,21 @@ func fitEmbedding(v []float32, dim int) ([]float32, error) {
 	default:
 		return nil, fmt.Errorf("embedding has %d dims, column accepts at most %d", len(v), dim)
 	}
+}
+
+// truncateRunes caps s at max runes, never splitting a multi-byte character
+// (Postgres VARCHAR(n) counts characters, not bytes). When it has to cut, the
+// result ends in "..." to signal truncation and still fits within max. No-op
+// when s already fits.
+func truncateRunes(s string, max int) string {
+	if utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	const ellipsis = "..."
+	if max <= len(ellipsis) {
+		return string([]rune(s)[:max])
+	}
+	return string([]rune(s)[:max-len(ellipsis)]) + ellipsis
 }
 
 // Just dashboards for now
@@ -206,6 +222,7 @@ func (b *pgvectorBackend) upsertAll(ctx context.Context, tx db.Tx, vectors []Vec
 		if err != nil {
 			return fmt.Errorf("vector[%d]: %w", i, err)
 		}
+		vectors[i].Title = truncateRunes(vectors[i].Title, maxTitleLen)
 		req := &sqlVectorCollectionUpsertRequest{
 			SQLTemplate: sqltemplate.New(b.dialect),
 			Resource:    vectors[i].Resource,

--- a/pkg/storage/unified/search/vector/pgvector_test.go
+++ b/pkg/storage/unified/search/vector/pgvector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"unicode/utf8"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/require"
@@ -254,5 +255,26 @@ func TestFitEmbedding(t *testing.T) {
 	t.Run("dim of zero rejects any non-empty input", func(t *testing.T) {
 		_, err := fitEmbedding([]float32{1}, 0)
 		require.Error(t, err)
+	})
+}
+
+func TestTruncateRunes(t *testing.T) {
+	t.Run("short string is unchanged", func(t *testing.T) {
+		require.Equal(t, "hello", truncateRunes("hello", 1024))
+	})
+
+	t.Run("truncates and marks with ellipsis, staying within max", func(t *testing.T) {
+		got := truncateRunes("abcdefghij", 6)
+		require.Equal(t, "abc...", got)
+		require.Equal(t, 6, utf8.RuneCountInString(got))
+	})
+
+	t.Run("does not split a multi-byte rune", func(t *testing.T) {
+		// Each "é" / "—" is multi-byte; the kept prefix must stay valid
+		// UTF-8 and the whole result must fit within max runes.
+		got := truncateRunes("é—éxyz", 5)
+		require.Equal(t, "é—...", got)
+		require.True(t, utf8.ValidString(got))
+		require.Equal(t, 5, utf8.RuneCountInString(got))
 	})
 }

--- a/pkg/storage/unified/search/vector/store.go
+++ b/pkg/storage/unified/search/vector/store.go
@@ -15,6 +15,12 @@ import (
 // equivalent to running them on the un-padded native vectors.
 const EmbeddingDim = 1024
 
+// maxTitleLen is the width of the `title VARCHAR(1024)` column. Titles are
+// display-only (search results), so an over-long one (e.g. a verbose
+// "Dashboard — Panel" subresource title) is truncated to fit rather than
+// failing the whole transactional upsert.
+const maxTitleLen = 1024
+
 // VectorBackend is vector storage isolated per (namespace, model) so an HNSW
 // never mixes embeddings from different vector spaces.
 type VectorBackend interface {


### PR DESCRIPTION
Was running into errors bc some titles exceeded the columns max length (1024), so truncating them if they're too big.