### PR TITLE
Chore: Remove tempo from commands and use it as string

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -125,14 +125,6 @@
   },
   {
     "type": "label",
-    "name": "datasource/Tempo",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/457"
-    }
-  },
-  {
-    "type": "label",
     "name": "datasource/grafana-pyroscope",
     "action": "addToProject",
     "addToProject": {

--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -189,15 +189,6 @@
   {
     "type": "changedfiles",
     "matches": [
-      "public/app/plugins/datasource/tempo/**/*",
-      "pkg/tsdb/tempo/**/*"
-    ],
-    "action": "updateLabel",
-    "addLabel": "datasource/Tempo"
-  },
-  {
-    "type": "changedfiles",
-    "matches": [
       "public/app/features/variables/**/*",
       "public/app/features/templating/**/*"
     ],

--- a/pkg/services/pluginsintegration/coreplugin/coreplugins.go
+++ b/pkg/services/pluginsintegration/coreplugin/coreplugins.go
@@ -42,7 +42,6 @@ const (
 	InfluxDB        = "influxdb"
 	Loki            = "loki"
 	Prometheus      = "prometheus"
-	Tempo           = "tempo"
 	TestData        = "grafana-testdata-datasource"
 	TestDataAlias   = "testdata"
 	PostgreSQL      = "grafana-postgresql-datasource"

--- a/pkg/services/pluginsintegration/pipeline/pipeline.go
+++ b/pkg/services/pluginsintegration/pipeline/pipeline.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/signature"
 	"github.com/grafana/grafana/pkg/plugins/pluginassets"
 	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
-	"github.com/grafana/grafana/pkg/services/pluginsintegration/coreplugin"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/provisionedplugins"
 )
@@ -45,7 +44,7 @@ func ProvideDiscoveryStage(cfg *config.PluginManagementCfg, pr registry.Service)
 
 func ProvideBootstrapStage(cfg *config.PluginManagementCfg, sc plugins.SignatureCalculator, ap pluginassets.Provider, cdn *pluginscdn.Service) *bootstrap.Bootstrap {
 	disableAlertingForTempoDecorateFunc := func(ctx context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
-		if p.ID == coreplugin.Tempo && !cfg.Features.TempoAlertingEnabled {
+		if p.ID == "tempo" && !cfg.Features.TempoAlertingEnabled {
 			p.Alerting = false
 		}
 		return p, nil


### PR DESCRIPTION
- Remove tempo label addToProject action
- Remove tempo from pr commands
- use `"tempo"` instead of having a contant for it

Related PR https://github.com/grafana/grafana/pull/127056 