### PR TITLE
Developer Guide: Add note about requiring signed commits

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -6,7 +6,7 @@ This guide helps you get started developing Grafana.
 
 Make sure you have the following dependencies installed before setting up your developer environment:
 
-- [Git](https://git-scm.com/)
+- [Git](https://git-scm.com/) (The Grafana organization requires signed commits. See the [Github docs](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) on how to set this up, if it is not already.)
 - [Go](https://golang.org/dl/) (see [go.mod](../go.mod#L3) for minimum required version)
 - [Node.js (Long Term Support)](https://nodejs.org), with [corepack enabled](https://nodejs.org/api/corepack.html#enabling-the-feature). See [.nvmrc](../.nvmrc) for supported version. We recommend that you use a version manager such as [nvm](https://github.com/nvm-sh/nvm), [fnm](https://github.com/Schniz/fnm), or similar.
 - [GCC](https://gcc.gnu.org/) (optional, not recommended; enables CGO for smaller, dynamically linked binaries)


### PR DESCRIPTION
Grafana as an organization is requiring signed commits to its repos. Add a note in the developer guide for new contributors who may want to know how to configure this.