### PR TITLE
IAM: Return 403 instead of 500 when a user lookup is forbidden

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -34,6 +34,7 @@ import (
 	"net/http"
 
 	"go.opentelemetry.io/otel"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
@@ -613,6 +614,8 @@ func middlewareUserUIDResolver(userService user.Service, paramName string) web.H
 		} else {
 			if errors.Is(err, user.ErrUserNotFound) {
 				c.JsonApiErr(http.StatusNotFound, "User not found", nil)
+			} else if k8serrors.IsForbidden(err) {
+				c.JsonApiErr(http.StatusForbidden, "Access denied to user", err)
 			} else {
 				c.JsonApiErr(http.StatusInternalServerError, "Failed to resolve user", err)
 			}

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -76,6 +78,9 @@ func (hs *HTTPServer) getUserUserProfile(c *contextmodel.ReqContext, userID int6
 		if errors.Is(err, user.ErrUserNotFound) {
 			return response.Error(http.StatusNotFound, user.ErrUserNotFound.Error(), nil)
 		}
+		if k8serrors.IsForbidden(err) {
+			return response.Error(http.StatusForbidden, "Access denied to user", err)
+		}
 		return response.Error(http.StatusInternalServerError, "Failed to get user", err)
 	}
 
@@ -117,6 +122,9 @@ func (hs *HTTPServer) GetUserByLoginOrEmail(c *contextmodel.ReqContext) response
 	if err != nil {
 		if errors.Is(err, user.ErrUserNotFound) {
 			return response.Error(http.StatusNotFound, user.ErrUserNotFound.Error(), nil)
+		}
+		if k8serrors.IsForbidden(err) {
+			return response.Error(http.StatusForbidden, "Access denied to user", err)
 		}
 		return response.Error(http.StatusInternalServerError, "Failed to get user", err)
 	}

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,6 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
@@ -442,6 +445,96 @@ func Test_GetUserByID(t *testing.T) {
 
 			assert.Equal(t, tc.expectedIsGrafanaAdminSynced, resp.IsGrafanaAdminExternallySynced)
 			assert.Equal(t, tc.expectedIsExternallySynced, resp.IsExternallySynced)
+		})
+	}
+}
+
+func forbiddenUserErr() error {
+	return apierrors.NewForbidden(
+		schema.GroupResource{Group: "iam.grafana.app", Resource: "users"},
+		"u123", errors.New("unauthorized request"),
+	)
+}
+
+func Test_GetUserByID_ErrorMapping(t *testing.T) {
+	testcases := []struct {
+		name         string
+		err          error
+		expectedCode int
+	}{
+		{name: "forbidden maps to 403", err: forbiddenUserErr(), expectedCode: http.StatusForbidden},
+		{name: "user not found maps to 404", err: user.ErrUserNotFound, expectedCode: http.StatusNotFound},
+		{name: "other errors map to 500", err: errors.New("error"), expectedCode: http.StatusInternalServerError},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			hs := &HTTPServer{
+				Cfg:         setting.NewCfg(),
+				userService: &usertest.FakeUserService{ExpectedError: tc.err},
+			}
+
+			sc := setupScenarioContext(t, "/api/users/1")
+			sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+				sc.context = c
+				return hs.GetUserByID(c)
+			})
+			sc.m.Get("/api/users/:id", sc.defaultHandler)
+			sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
+
+			require.Equal(t, tc.expectedCode, sc.resp.Code)
+		})
+	}
+}
+
+func Test_GetUserByLoginOrEmail_ErrorMapping(t *testing.T) {
+	testcases := []struct {
+		name         string
+		err          error
+		expectedCode int
+	}{
+		{name: "forbidden maps to 403", err: forbiddenUserErr(), expectedCode: http.StatusForbidden},
+		{name: "user not found maps to 404", err: user.ErrUserNotFound, expectedCode: http.StatusNotFound},
+		{name: "other errors map to 500", err: errors.New("error"), expectedCode: http.StatusInternalServerError},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			hs := &HTTPServer{
+				Cfg:         setting.NewCfg(),
+				userService: &usertest.FakeUserService{ExpectedError: tc.err},
+			}
+
+			sc := setupScenarioContext(t, "/api/users/lookup")
+			sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+				sc.context = c
+				return hs.GetUserByLoginOrEmail(c)
+			})
+			sc.m.Get("/api/users/lookup", sc.defaultHandler)
+			sc.fakeReqWithParams("GET", sc.url, map[string]string{"loginOrEmail": "admin@test.com"}).exec()
+
+			require.Equal(t, tc.expectedCode, sc.resp.Code)
+		})
+	}
+}
+
+func TestMiddlewareUserUIDResolver_ErrorMapping(t *testing.T) {
+	testcases := []struct {
+		name         string
+		err          error
+		expectedCode int
+	}{
+		{name: "forbidden maps to 403", err: forbiddenUserErr(), expectedCode: http.StatusForbidden},
+		{name: "user not found maps to 404", err: user.ErrUserNotFound, expectedCode: http.StatusNotFound},
+		{name: "other errors map to 500", err: errors.New("error"), expectedCode: http.StatusInternalServerError},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			userService := &usertest.FakeUserService{ExpectedError: tc.err}
+
+			sc := setupScenarioContext(t, "/api/users/u123")
+			sc.m.Get("/api/users/:id", middlewareUserUIDResolver(userService, ":id"))
+			sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
+
+			require.Equal(t, tc.expectedCode, sc.resp.Code)
 		})
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Maps the k8s forbidden error to a 403 instead of a generic 500 in the user read endpoints, so callers without access get a proper `access denied` response.

**Why do we need this feature?**

When `kubernetesUsersRedirect` is enabled, the k8s user service runs as the end-user identity, so the iam apiserver legitimately returns forbidden when the caller lacks access. Those errors were falling through to the catch-all and surfacing as 500 `Failed to get user` or `Failed to resolve user`. It was confusing for clients and indistinguishable from a real server error.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
