### PR TITLE
Docs: Added back v1 resource information

### DIFF
--- a/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -49,7 +49,7 @@ There are currently three dashboard JSON schema models:
 
 - [V2 Resource](#v2-resource-model): The current schema, supporting new features such as advanced layouts and conditional rendering. It models all dashboard elements as Kubernetes kinds, following Kubernetes conventions for declaring dashboard components.
 - [V1 Resource](#v1-resource-model): The Classic dashboard schema formatted as a Kubernetes-style resource. Its `spec` property contains the Classic model of the schema. It was the default format for API communication between Grafana v12.2.0 and v13.0.0 and has been used for exporting, importing, and sharing dashboards.
-- [Classic](#classic-model): A non-Kubernetes resource that was the default before Grafana v13.0. It's been widely used for exporting, importing, and sharing dashboards in the Grafana dashboards collection at [grafana.com/dashboards](https://grafana.com/grafana/dashboards/). Dashboards created using this model can be exported using either this model or V2.
+- [Classic](#classic-model): A non-Kubernetes resource that was the default before Grafana v12.2. It's been widely used for exporting, importing, and sharing dashboards in the Grafana dashboards collection at [grafana.com/dashboards](https://grafana.com/grafana/dashboards/). Dashboards created using this model can be exported using either this model or V2.
 
 {{< admonition type="note" >}}
 [Observability as Code](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/) works with both versions of the JSON model, but it's fully compatible with version 2.

--- a/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -49,7 +49,7 @@ There are currently three dashboard JSON schema models:
 
 - [V2 Resource](#v2-resource-model): The current schema, supporting new features such as advanced layouts and conditional rendering. It models all dashboard elements as Kubernetes kinds, following Kubernetes conventions for declaring dashboard components.
 - [V1 Resource](#v1-resource-model): The Classic dashboard schema formatted as a Kubernetes-style resource. Its `spec` property contains the Classic model of the schema. It was the default format for API communication between Grafana v12.2.0 and v13.0.0 and has been used for exporting, importing, and sharing dashboards.
-- [Classic](#classic-model): A non-Kubernetes resource that was the default before Grafana v12.2. It's been widely used for exporting, importing, and sharing dashboards in the Grafana dashboards collection at [grafana.com/dashboards](https://grafana.com/grafana/dashboards/). Dashboards created using this model can be exported using either this model or V2.
+- [Classic](#classic-model): A non-Kubernetes resource that was the default before Grafana v12.2.0. It's been widely used for exporting, importing, and sharing dashboards in the Grafana dashboards collection at [grafana.com/dashboards](https://grafana.com/grafana/dashboards/). Dashboards created using this model can be exported using either this model or V2.
 
 {{< admonition type="note" >}}
 [Observability as Code](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/) works with both versions of the JSON model, but it's fully compatible with version 2.

--- a/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -77,14 +77,14 @@ You can also reach the Swagger schema documentation from your Grafana Cloud inst
 The V1 Resource schema model formats the [Classic JSON model](#classic-model) schema as a Kubernetes-style resource.
 The `spec` property of the schema contains the Classic-style model of the schema.
 
-For the detailed V1 Resource model schema, refer to the [Swagger documentation](https://play.grafana.org/swagger?api=dashboard.grafana.app-v1beta1).
+For the detailed V1 Resource model schema, refer to the [Swagger documentation](https://play.grafana.org/swagger?api=dashboard.grafana.app-v1).
 You can also reach the Swagger schema documentation from your Grafana Cloud instance at: https://grafana.com/launch/swagger.
 
 The following code snippet shows the fields included in the V1 Resource model:
 
 ```json
 {
-  "apiVersion": "dashboard.grafana.app/v1beta1",
+  "apiVersion": "dashboard.grafana.app/v1",
   "kind": "Dashboard",
   "metadata": {
     "name": "isnt5ss",

--- a/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -26,6 +26,7 @@ keywords:
   - json
   - model
   - schema v2
+  - v1 resource
   - v2 resource
   - classic
 labels:
@@ -47,6 +48,7 @@ Grafana dashboards are represented as JSON objects that store metadata, panels, 
 There are currently three dashboard JSON schema models:
 
 - [V2 Resource](#v2-resource-model): The current schema, supporting new features such as advanced layouts and conditional rendering. It models all dashboard elements as Kubernetes kinds, following Kubernetes conventions for declaring dashboard components.
+- [V1 Resource](#v1-resource-model): The Classic dashboard schema formatted as a Kubernetes-style resource. Its `spec` property contains the Classic model of the schema. It was the default format for API communication between Grafana v12.2.0 and v13.0.0 and has been used for exporting, importing, and sharing dashboards.
 - [Classic](#classic-model): A non-Kubernetes resource that was the default before Grafana v13.0. It's been widely used for exporting, importing, and sharing dashboards in the Grafana dashboards collection at [grafana.com/dashboards](https://grafana.com/grafana/dashboards/). Dashboards created using this model can be exported using either this model or V2.
 
 {{< admonition type="note" >}}
@@ -70,7 +72,79 @@ To access the JSON representation of a dashboard:
 For the detailed V2 Resource model schema, refer to the [Swagger documentation](https://play.grafana.org/swagger?api=dashboard.grafana.app-v2beta1).
 You can also reach the Swagger schema documentation from your Grafana Cloud instance at: https://grafana.com/launch/swagger.
 
-<!-- how does this work? -->
+## V1 Resource model
+
+The V1 Resource schema model formats the [Classic JSON model](#classic-model) schema as a Kubernetes-style resource.
+The `spec` property of the schema contains the Classic-style model of the schema.
+
+For the detailed V1 Resource model schema, refer to the [Swagger documentation](https://play.grafana.org/swagger?api=dashboard.grafana.app-v1beta1).
+You can also reach the Swagger schema documentation from your Grafana Cloud instance at: https://grafana.com/launch/swagger.
+
+The following code snippet shows the fields included in the V1 Resource model:
+
+```json
+{
+  "apiVersion": "dashboard.grafana.app/v1beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "isnt5ss",
+    "namespace": "stacks-521104",
+    "uid": "92674c0e-0360-4bb4-99ab-fb150581376d",
+    "resourceVersion": "1764705030717045",
+    "generation": 1,
+    "creationTimestamp": "2025-12-02T19:50:30Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "1329"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "user:u000000002",
+      "grafana.app/folder": "",
+      "grafana.app/saved-from-ui": "Grafana Cloud (instant)"
+    }
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 1329,
+    "links": [],
+    "panels": [],
+    "preload": false,
+    "schemaVersion": 42,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "Africa/Abidjan",
+    "title": "Graphite suggestions",
+    "uid": "isnt5ss",
+    "version": 1,
+    "weekStart": ""
+  },
+  "status": {}
+}
+```
 
 ## Classic model
 


### PR DESCRIPTION
LLMs, including those used by Grafana Assistant, are seeing V1 schema dashboards but not finding any information about them. This PR is meant to address that gap by adding V1 resource model information back to the docs with the context of when V1 was relevant.