### PR TITLE
Codeowners: Assign grafana-openapi to navigation squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -777,7 +777,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-api-clients/src/clients/rtkq/shorturl/ @grafana/sharing-squad
 
 # @grafana/openapi
-/packages/grafana-openapi/ @grafana/grafana-search-navigate-organise @grafana/grafana-frontend-platform
+/packages/grafana-openapi/ @grafana/grafana-frontend-navigation @grafana/grafana-frontend-platform
 
 
 # root files, mostly frontend


### PR DESCRIPTION
## What

Fixes the owner of `/packages/grafana-openapi/` in `.github/CODEOWNERS`. It was assigned to `@grafana/grafana-search-navigate-organise`, which was renamed a while back. Replaced with`@grafana/grafana-frontend-navigation`