### PR TITLE
FeatureToggles: Add grafana.customDashboardTemplates feature flag

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -24,6 +24,7 @@ declare module "@openfeature/core" {
     | "sqlExpressionsCodeMirror"
     | "newSavedQueriesExperience"
     | "grafana.orgDashboardTemplates"
+    | "grafana.customDashboardTemplates"
     | "dashboardTemplatesAssistantButton"
     | "suggestedDashboardsAssistantButton"
     | "newLogsPanel"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -39,6 +39,8 @@ export const FlagKeys = {
   FlameGraphWithCallTree: "flameGraphWithCallTree",
   /** Enables global and folder-scoped dashboard variables via dashboard.grafana.app */
   GlobalDashboardVariables: "globalDashboardVariables",
+  /** Enables custom dashboard templates for enterprise */
+  GrafanaCustomDashboardTemplates: "grafana.customDashboardTemplates",
   /** Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button) */
   GrafanaEnableScopesFirstMode: "grafana.enableScopesFirstMode",
   /** Enables usage of the new annotations API client */
@@ -254,6 +256,17 @@ export const useFlagFlameGraphWithCallTree = (options?: ReactFlagEvaluationOptio
  */
 export const useFlagGlobalDashboardVariables = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("globalDashboardVariables", false, options).value;
+};
+
+/**
+ * Enables custom dashboard templates for enterprise
+ *
+ * **Details:**
+ * - flag key: `grafana.customDashboardTemplates`
+ * - default value: `false`
+ */
+export const useFlagGrafanaCustomDashboardTemplates = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.customDashboardTemplates", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1113,6 +1113,14 @@ var (
 			Expression:  "false",
 		},
 		{
+			Name:        "grafana.customDashboardTemplates",
+			Description: "Enables custom dashboard templates for enterprise",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaSharingSquad,
+			Generate:    Generate{Go: true, React: true},
+			Expression:  "false",
+		},
+		{
 			Name:        "dashboardTemplatesAssistantButton",
 			Description: "Enables the Assistant button in the dashboard templates card",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -128,6 +128,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,dashboardValidatorApp,experimental,@grafana/sharing-squad,false,false,false
 2025-10-28,dashboardTemplates,preview,@grafana/sharing-squad,false,false,false
 2026-05-22,grafana.orgDashboardTemplates,experimental,@grafana/sharing-squad,false,false,false
+2026-06-24,grafana.customDashboardTemplates,experimental,@grafana/sharing-squad,false,false,false
 2026-05-22,dashboardTemplatesAssistantButton,experimental,@grafana/sharing-squad,false,false,true
 2026-05-22,suggestedDashboardsAssistantButton,experimental,@grafana/sharing-squad,false,false,true
 2024-05-24,alertingListViewV2,GA,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -343,6 +343,10 @@ const (
 	// Enables org-defined dashboard templates for enterprise
 	FlagGrafanaOrgDashboardTemplates = "grafana.orgDashboardTemplates"
 
+	// FlagGrafanaCustomDashboardTemplates
+	// Enables custom dashboard templates for enterprise
+	FlagGrafanaCustomDashboardTemplates = "grafana.customDashboardTemplates"
+
 	// FlagAlertingNavigationV2
 	// Enables the new Alerting navigation structure with improved menu grouping
 	FlagAlertingNavigationV2 = "alertingNavigationV2"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2346,6 +2346,19 @@
     },
     {
       "metadata": {
+        "name": "grafana.customDashboardTemplates",
+        "resourceVersion": "1782324923384",
+        "creationTimestamp": "2026-06-24T18:15:23Z"
+      },
+      "spec": {
+        "description": "Enables custom dashboard templates for enterprise",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.dedicatedGrafanaComProxyAPIToken",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2026-05-22T09:03:04Z"


### PR DESCRIPTION
## What is this feature?

Adds a new experimental feature flag `grafana.customDashboardTemplates` (Go + React generated) and regenerates the toggle artifacts. **Additive only** — the existing `grafana.orgDashboardTemplates` flag is left in place.

## Why do we need this feature?

This is the **backend portion** split out of the dashboard-templates frontend PR (#125228). It introduces the flag the new frontend wiring consumes (`FlagKeys.GrafanaCustomDashboardTemplates`).

Originally this was a rename of `orgDashboardTemplates`, but `main` already has frontend callers of the old flag (e.g. `DashboardScenePageStateManager.ts`, `SaveDashboard.tsx`). A rename regenerates the OpenFeature TS without the old symbols and breaks `main`'s typecheck. Adding the flag instead keeps everything building; the old flag is removed in a follow-up cleanup once all callers have migrated and deployed.

## Who is this feature for?

Grafana Sharing squad / dashboards.

## Which issue(s) does this PR fix?

N/A — backend split of the templates feature.

## Special notes for your reviewer

- Purely additive: 6 files, `+40/-0`. No existing symbol removed; `make gen-feature-toggles` is clean and `go build` passes.
- **Frontend PR #125228** migrates callers from `orgDashboardTemplates` → `customDashboardTemplates` and depends on this PR for the new symbols.
- The enterprise RBAC authorizer PR (grafana-enterprise#12436) also depends on the `featuremgmt.FlagGrafanaCustomDashboardTemplates` constant added here.
- Follow-up: a small cleanup PR will remove `grafana.orgDashboardTemplates` once it has no remaining callers.