### PR TITLE
unified-storage: sort lastImportTime entries on the application side

### DIFF
--- a/pkg/extensions/enterprise_imports_test.go
+++ b/pkg/extensions/enterprise_imports_test.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/services/team/teamtest"
 	_ "github.com/grafana/grafana/pkg/services/user/usertest"
 	_ "github.com/grafana/grafana/pkg/storage/unified/resource/lease"
+	_ "github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 	_ "github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
 	_ "github.com/grafana/grafana/pkg/storage/unified/testing"
 	_ "github.com/grafana/grafana/pkg/tests/apis/provisioning/common"

--- a/pkg/storage/unified/resource/kv/last_import_time.go
+++ b/pkg/storage/unified/resource/kv/last_import_time.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -93,6 +94,12 @@ func (k *SqlKV) lastImportTimeKeys(ctx context.Context, opt ListOptions, yield f
 	shouldYield := true
 	defer func() { closeRows(rows, yield, shouldYield) }()
 
+	// Keys are composite strings (namespace~group~resource~unixTimestamp). The
+	// SQL ORDER BY sorts by the separate columns, which is not the same as
+	// byte-wise ordering of the assembled key: '~' (0x7E) sorts above letters
+	// and digits, so e.g. "ns1~..." precedes "ns~...". Other KV backends return
+	// keys in full-key byte order, so sort here to match that contract.
+	keys := make([]string, 0)
 	for rows.Next() {
 		var ns, group, resource string
 		var lastImportTime time.Time
@@ -100,14 +107,19 @@ func (k *SqlKV) lastImportTimeKeys(ctx context.Context, opt ListOptions, yield f
 			shouldYield = yield("", fmt.Errorf("error reading row: %w", err))
 			return
 		}
-
-		if shouldYield = yield(LastImportTimeKey(ns, group, resource, lastImportTime), nil); !shouldYield {
-			return
-		}
+		keys = append(keys, LastImportTimeKey(ns, group, resource, lastImportTime))
 	}
 
 	if err := rows.Err(); err != nil {
 		shouldYield = yield("", fmt.Errorf("failed to read rows: %w", err))
+		return
+	}
+
+	sort.Strings(keys)
+	for _, key := range keys {
+		if shouldYield = yield(key, nil); !shouldYield {
+			return
+		}
 	}
 }
 

--- a/pkg/storage/unified/resource/last_import_time_store_test.go
+++ b/pkg/storage/unified/resource/last_import_time_store_test.go
@@ -31,6 +31,14 @@ func testLastImportStore(t *testing.T, kv kv.KV, allowDuplicateNamespaceGroupRes
 	fnsr := NamespacedResource{Namespace: "namespace", Group: "folders", Resource: "folder"}
 	pnsr := NamespacedResource{Namespace: "namespace", Group: "playlists", Resource: "playlist"}
 
+	// Namespaces in a prefix relationship: "org" is a prefix of "org1". Sorting
+	// by the separate namespace/group/resource columns places "org" before
+	// "org1", but byte-wise ordering of the full composite key places
+	// "org1~..." before "org~..." because '~' (0x7E) sorts above '1' (0x31).
+	// All KV backends must agree on the byte-wise order.
+	onsr := NamespacedResource{Namespace: "org", Group: "dashboards", Resource: "dashboard"}
+	o1nsr := NamespacedResource{Namespace: "org1", Group: "dashboards", Resource: "dashboard"}
+
 	now := time.Now().Truncate(time.Second).UTC()
 
 	require.NoError(t, store.Save(t.Context(), ResourceLastImportTime{NamespacedResource: fnsr, LastImportTime: now.Add(-15 * time.Minute)}))
@@ -43,11 +51,18 @@ func testLastImportStore(t *testing.T, kv kv.KV, allowDuplicateNamespaceGroupRes
 
 	require.NoError(t, store.Save(t.Context(), ResourceLastImportTime{NamespacedResource: pnsr, LastImportTime: now.Add(-20 * time.Minute)}))
 
+	require.NoError(t, store.Save(t.Context(), ResourceLastImportTime{NamespacedResource: onsr, LastImportTime: now.Add(1 * time.Minute)}))
+	require.NoError(t, store.Save(t.Context(), ResourceLastImportTime{NamespacedResource: o1nsr, LastImportTime: now.Add(1 * time.Minute)}))
+
+	// Keys are returned in byte-wise order of the full composite key, so
+	// "org1~..." precedes "org~...".
 	// SQLKV only stores a single import time per namespace/group/resource.
 	expectedKeys := []string{
 		fmt.Sprintf("namespace~dashboards~dashboard~%d", now.Add(2*time.Minute).Unix()),
 		fmt.Sprintf("namespace~folders~folder~%d", now.Add(5*time.Minute).Unix()),
 		fmt.Sprintf("namespace~playlists~playlist~%d", now.Add(-20*time.Minute).Unix()),
+		fmt.Sprintf("org1~dashboards~dashboard~%d", now.Add(1*time.Minute).Unix()),
+		fmt.Sprintf("org~dashboards~dashboard~%d", now.Add(1*time.Minute).Unix()),
 	}
 	if allowDuplicateNamespaceGroupResource {
 		// Regular KV store keeps all previous import times, until they are deleted.
@@ -61,13 +76,18 @@ func testLastImportStore(t *testing.T, kv kv.KV, allowDuplicateNamespaceGroupRes
 			fmt.Sprintf("namespace~folders~folder~%d", now.Add(5*time.Minute).Unix()),
 
 			fmt.Sprintf("namespace~playlists~playlist~%d", now.Add(-20*time.Minute).Unix()),
+
+			fmt.Sprintf("org1~dashboards~dashboard~%d", now.Add(1*time.Minute).Unix()),
+			fmt.Sprintf("org~dashboards~dashboard~%d", now.Add(1*time.Minute).Unix()),
 		}
 	}
 	require.Equal(t, expectedKeys, collectKeys(t, store.kv.Keys(t.Context(), lastImportTimesSection, ListOptions{})))
 
 	expectedTimes := map[NamespacedResource]LastImportTimeKey{
-		dnsr: {Namespace: dnsr.Namespace, Group: dnsr.Group, Resource: dnsr.Resource, LastImportTime: now.Add(2 * time.Minute)},
-		fnsr: {Namespace: fnsr.Namespace, Group: fnsr.Group, Resource: fnsr.Resource, LastImportTime: now.Add(5 * time.Minute)},
+		dnsr:  {Namespace: dnsr.Namespace, Group: dnsr.Group, Resource: dnsr.Resource, LastImportTime: now.Add(2 * time.Minute)},
+		fnsr:  {Namespace: fnsr.Namespace, Group: fnsr.Group, Resource: fnsr.Resource, LastImportTime: now.Add(5 * time.Minute)},
+		onsr:  {Namespace: onsr.Namespace, Group: onsr.Group, Resource: onsr.Resource, LastImportTime: now.Add(1 * time.Minute)},
+		o1nsr: {Namespace: o1nsr.Namespace, Group: o1nsr.Group, Resource: o1nsr.Resource, LastImportTime: now.Add(1 * time.Minute)},
 	}
 
 	times, _, err := store.ListLastImportTimes(t.Context(), maxLastImportTimeAge)
@@ -82,6 +102,8 @@ func testLastImportStore(t *testing.T, kv kv.KV, allowDuplicateNamespaceGroupRes
 	expectedKeysAfterList := []string{
 		fmt.Sprintf("namespace~dashboards~dashboard~%d", now.Add(2*time.Minute).Unix()),
 		fmt.Sprintf("namespace~folders~folder~%d", now.Add(5*time.Minute).Unix()),
+		fmt.Sprintf("org1~dashboards~dashboard~%d", now.Add(1*time.Minute).Unix()),
+		fmt.Sprintf("org~dashboards~dashboard~%d", now.Add(1*time.Minute).Unix()),
 	}
 	require.Equal(t, expectedKeysAfterList, collectKeys(t, store.kv.Keys(t.Context(), lastImportTimesSection, ListOptions{})))
 }


### PR DESCRIPTION
Relying exclusively on the database sorting does not guarantee that they *keys* (built only in the application side in the case of SQLKV) are also sorted.

Specifically, this is a problem if a namespace (for example) is a prefix of another namespace: database sorting would sort "ns" before "ns1", but `ns~foo` sorts *after* `ns1~foo`, breaking the `Keys()` contract when `SortOrderAsc` is passed.