### PR TITLE
Snapshots: Save snapshot selected settings in local storage

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.test.tsx
@@ -33,7 +33,7 @@ describe('ShareSnapshotTab', () => {
       tab.onExpireChange(ONE_HOUR);
 
       expect(tab.state.selectedExpireOption?.value).toBe(ONE_HOUR);
-      expect(getSnapshotShareConfiguration()).toEqual({ selectedExpireOption: ONE_HOUR });
+      expect(getSnapshotShareConfiguration()).toEqual({ expirationTime: ONE_HOUR });
     });
 
     it('persists the "Never" (0) option', () => {
@@ -42,11 +42,11 @@ describe('ShareSnapshotTab', () => {
       tab.onExpireChange(0);
 
       expect(tab.state.selectedExpireOption?.value).toBe(0);
-      expect(getSnapshotShareConfiguration()).toEqual({ selectedExpireOption: 0 });
+      expect(getSnapshotShareConfiguration()).toEqual({ expirationTime: 0 });
     });
 
     it('pre-populates the expire option from local storage when opened', () => {
-      updateSnapshotShareConfiguration({ selectedExpireOption: ONE_HOUR });
+      updateSnapshotShareConfiguration({ expirationTime: ONE_HOUR });
 
       const tab = buildSnapshotTab();
 
@@ -54,7 +54,7 @@ describe('ShareSnapshotTab', () => {
     });
 
     it('falls back to the default when the stored value is not a valid option', () => {
-      updateSnapshotShareConfiguration({ selectedExpireOption: 12345 });
+      updateSnapshotShareConfiguration({ expirationTime: 12345 });
 
       const tab = buildSnapshotTab();
 
@@ -75,7 +75,7 @@ describe('ShareSnapshotTab', () => {
 
       const stored = window.localStorage.getItem(SNAPSHOT_SHARE_CONFIGURATION);
       const parsed = JSON.parse(stored ?? '{}');
-      expect(validValues).toContain(parsed.selectedExpireOption);
+      expect(validValues).toContain(parsed.expirationTime);
     });
   });
 });

--- a/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.test.tsx
@@ -3,12 +3,7 @@ import { SceneTimeRange } from '@grafana/scenes';
 import { DashboardScene } from '../scene/DashboardScene';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 
-import {
-  getExpireOptions,
-  getSnapshotShareConfiguration,
-  ShareSnapshotTab,
-  updateSnapshotShareConfiguration,
-} from './ShareSnapshotTab';
+import { getExpireOptions, ShareSnapshotTab } from './ShareSnapshotTab';
 
 const SNAPSHOT_SHARE_CONFIGURATION = 'grafana.dashboard.snapshot.shareConfiguration';
 
@@ -33,7 +28,7 @@ describe('ShareSnapshotTab', () => {
       tab.onExpireChange(ONE_HOUR);
 
       expect(tab.state.selectedExpireOption?.value).toBe(ONE_HOUR);
-      expect(getSnapshotShareConfiguration()).toEqual({ expirationTime: ONE_HOUR });
+      expect(readStoredConfiguration()).toEqual({ expirationTime: ONE_HOUR });
     });
 
     it('persists the "Never" (0) option', () => {
@@ -42,11 +37,11 @@ describe('ShareSnapshotTab', () => {
       tab.onExpireChange(0);
 
       expect(tab.state.selectedExpireOption?.value).toBe(0);
-      expect(getSnapshotShareConfiguration()).toEqual({ expirationTime: 0 });
+      expect(readStoredConfiguration()).toEqual({ expirationTime: 0 });
     });
 
     it('pre-populates the expire option from local storage when opened', () => {
-      updateSnapshotShareConfiguration({ expirationTime: ONE_HOUR });
+      seedStoredConfiguration({ expirationTime: ONE_HOUR });
 
       const tab = buildSnapshotTab();
 
@@ -54,17 +49,17 @@ describe('ShareSnapshotTab', () => {
     });
 
     it('falls back to the default when the stored value is not a valid option', () => {
-      updateSnapshotShareConfiguration({ expirationTime: 12345 });
+      seedStoredConfiguration({ expirationTime: 12345 });
 
       const tab = buildSnapshotTab();
 
       expect(tab.state.selectedExpireOption.value).toBe(ONE_WEEK);
     });
-  });
 
-  describe('getSnapshotShareConfiguration', () => {
-    it('returns undefined when nothing is stored', () => {
-      expect(getSnapshotShareConfiguration()).toBeUndefined();
+    it('does not store anything until the user changes the option', () => {
+      buildSnapshotTab();
+
+      expect(readStoredConfiguration()).toBeUndefined();
     });
 
     it('only stores known expire option values', () => {
@@ -73,9 +68,7 @@ describe('ShareSnapshotTab', () => {
 
       tab.onExpireChange(ONE_HOUR);
 
-      const stored = window.localStorage.getItem(SNAPSHOT_SHARE_CONFIGURATION);
-      const parsed = JSON.parse(stored ?? '{}');
-      expect(validValues).toContain(parsed.expirationTime);
+      expect(validValues).toContain(readStoredConfiguration()?.expirationTime);
     });
   });
 });
@@ -90,4 +83,13 @@ function buildSnapshotTab() {
   });
 
   return new ShareSnapshotTab({ dashboardRef: scene.getRef() });
+}
+
+function readStoredConfiguration(): { expirationTime: number } | undefined {
+  const stored = window.localStorage.getItem(SNAPSHOT_SHARE_CONFIGURATION);
+  return stored ? JSON.parse(stored) : undefined;
+}
+
+function seedStoredConfiguration(config: { expirationTime: number }) {
+  window.localStorage.setItem(SNAPSHOT_SHARE_CONFIGURATION, JSON.stringify(config));
 }

--- a/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.test.tsx
@@ -1,0 +1,93 @@
+import { SceneTimeRange } from '@grafana/scenes';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+
+import {
+  getExpireOptions,
+  getSnapshotShareConfiguration,
+  ShareSnapshotTab,
+  updateSnapshotShareConfiguration,
+} from './ShareSnapshotTab';
+
+const SNAPSHOT_SHARE_CONFIGURATION = 'grafana.dashboard.snapshot.shareConfiguration';
+
+const ONE_HOUR = 60 * 60;
+const ONE_WEEK = 60 * 60 * 24 * 7;
+
+describe('ShareSnapshotTab', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe('expire option persistence', () => {
+    it('defaults to "1 Week" when nothing is stored', () => {
+      const tab = buildSnapshotTab();
+
+      expect(tab.state.selectedExpireOption.value).toBe(ONE_WEEK);
+    });
+
+    it('persists the selected expire option to local storage on change', () => {
+      const tab = buildSnapshotTab();
+
+      tab.onExpireChange(ONE_HOUR);
+
+      expect(tab.state.selectedExpireOption?.value).toBe(ONE_HOUR);
+      expect(getSnapshotShareConfiguration()).toEqual({ selectedExpireOption: ONE_HOUR });
+    });
+
+    it('persists the "Never" (0) option', () => {
+      const tab = buildSnapshotTab();
+
+      tab.onExpireChange(0);
+
+      expect(tab.state.selectedExpireOption?.value).toBe(0);
+      expect(getSnapshotShareConfiguration()).toEqual({ selectedExpireOption: 0 });
+    });
+
+    it('pre-populates the expire option from local storage when opened', () => {
+      updateSnapshotShareConfiguration({ selectedExpireOption: ONE_HOUR });
+
+      const tab = buildSnapshotTab();
+
+      expect(tab.state.selectedExpireOption.value).toBe(ONE_HOUR);
+    });
+
+    it('falls back to the default when the stored value is not a valid option', () => {
+      updateSnapshotShareConfiguration({ selectedExpireOption: 12345 });
+
+      const tab = buildSnapshotTab();
+
+      expect(tab.state.selectedExpireOption.value).toBe(ONE_WEEK);
+    });
+  });
+
+  describe('getSnapshotShareConfiguration', () => {
+    it('returns undefined when nothing is stored', () => {
+      expect(getSnapshotShareConfiguration()).toBeUndefined();
+    });
+
+    it('only stores known expire option values', () => {
+      const tab = buildSnapshotTab();
+      const validValues = getExpireOptions().map((o) => o.value);
+
+      tab.onExpireChange(ONE_HOUR);
+
+      const stored = window.localStorage.getItem(SNAPSHOT_SHARE_CONFIGURATION);
+      const parsed = JSON.parse(stored ?? '{}');
+      expect(validValues).toContain(parsed.selectedExpireOption);
+    });
+  });
+});
+
+function buildSnapshotTab() {
+  const scene = new DashboardScene({
+    title: 'my dashboard',
+    uid: 'dash-1',
+    meta: { canEdit: true },
+    $timeRange: new SceneTimeRange({}),
+    body: DefaultGridLayoutManager.fromVizPanels([]),
+  });
+
+  return new ShareSnapshotTab({ dashboardRef: scene.getRef() });
+}

--- a/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx
@@ -1,6 +1,6 @@
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 
-import { type SelectableValue } from '@grafana/data';
+import { store, type SelectableValue } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import {
@@ -54,7 +54,32 @@ export const getExpireOptions = () => {
   ];
 };
 
+const SNAPSHOT_SHARE_CONFIGURATION = 'grafana.dashboard.snapshot.shareConfiguration';
+
+type SnapshotShareConfiguration = {
+  selectedExpireOption: number;
+};
+
+// Returns the snapshot share configuration persisted in local storage, if any
+export function getSnapshotShareConfiguration(): SnapshotShareConfiguration | undefined {
+  if (store.exists(SNAPSHOT_SHARE_CONFIGURATION)) {
+    return store.getObject<SnapshotShareConfiguration>(SNAPSHOT_SHARE_CONFIGURATION);
+  }
+  return undefined;
+}
+
+export function updateSnapshotShareConfiguration(config: SnapshotShareConfiguration) {
+  store.setObject(SNAPSHOT_SHARE_CONFIGURATION, config);
+}
+
 const getDefaultExpireOption = () => {
+  const savedConfiguration = getSnapshotShareConfiguration();
+  if (savedConfiguration) {
+    const savedOption = getExpireOptions().find((o) => o.value === savedConfiguration.selectedExpireOption);
+    if (savedOption) {
+      return savedOption;
+    }
+  }
   return getExpireOptions()[2];
 };
 
@@ -114,6 +139,7 @@ export class ShareSnapshotTab extends SceneObjectBase<ShareSnapshotTabState> imp
     this.setState({
       selectedExpireOption: getExpireOptions().find((o) => o.value === option),
     });
+    updateSnapshotShareConfiguration({ selectedExpireOption: option });
   };
 
   private prepareSnapshot() {
@@ -150,12 +176,6 @@ export class ShareSnapshotTab extends SceneObjectBase<ShareSnapshotTabState> imp
   public onSnapshotCreate = async (external = false) => {
     const { selectedExpireOption } = this.state;
     const snapshot = this.prepareSnapshot();
-
-    // TODO
-    // snapshot.snapshot = {
-    //   originalUrl: window.location.href,
-    // };
-
     const cmdData = {
       dashboard: snapshot,
       name: snapshot.title,

--- a/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx
@@ -61,14 +61,14 @@ type SnapshotShareConfiguration = {
 };
 
 // Returns the snapshot share configuration persisted in local storage, if any
-export function getSnapshotShareConfiguration(): SnapshotShareConfiguration | undefined {
+function getSnapshotShareConfiguration(): SnapshotShareConfiguration | undefined {
   if (store.exists(SNAPSHOT_SHARE_CONFIGURATION)) {
     return store.getObject<SnapshotShareConfiguration>(SNAPSHOT_SHARE_CONFIGURATION);
   }
   return undefined;
 }
 
-export function updateSnapshotShareConfiguration(config: SnapshotShareConfiguration) {
+function updateSnapshotShareConfiguration(config: SnapshotShareConfiguration) {
   store.setObject(SNAPSHOT_SHARE_CONFIGURATION, config);
 }
 

--- a/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx
@@ -57,7 +57,7 @@ export const getExpireOptions = () => {
 const SNAPSHOT_SHARE_CONFIGURATION = 'grafana.dashboard.snapshot.shareConfiguration';
 
 type SnapshotShareConfiguration = {
-  selectedExpireOption: number;
+  expirationTime: number;
 };
 
 // Returns the snapshot share configuration persisted in local storage, if any
@@ -75,7 +75,7 @@ export function updateSnapshotShareConfiguration(config: SnapshotShareConfigurat
 const getDefaultExpireOption = () => {
   const savedConfiguration = getSnapshotShareConfiguration();
   if (savedConfiguration) {
-    const savedOption = getExpireOptions().find((o) => o.value === savedConfiguration.selectedExpireOption);
+    const savedOption = getExpireOptions().find((o) => o.value === savedConfiguration.expirationTime);
     if (savedOption) {
       return savedOption;
     }
@@ -139,7 +139,7 @@ export class ShareSnapshotTab extends SceneObjectBase<ShareSnapshotTabState> imp
     this.setState({
       selectedExpireOption: getExpireOptions().find((o) => o.value === option),
     });
-    updateSnapshotShareConfiguration({ selectedExpireOption: option });
+    updateSnapshotShareConfiguration({ expirationTime: option });
   };
 
   private prepareSnapshot() {


### PR DESCRIPTION
**What is this feature?**

Remember user last selected settings in local storage to pre-populate it next time. Same behavior we support for Share internally and Saved queries.
This is limited to the browser since it is saved in local storage.

<img width="551" height="397" alt="image" src="https://github.com/user-attachments/assets/f767c354-05d6-4917-b3eb-48e3353bab21" />

Fixes https://github.com/grafana/grafana/issues/121677

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
