### PR TITLE
SessionReplay: disable keepalive on the Faro FetchTransport when replay is enabled

### DIFF
--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -54,11 +54,24 @@ export class GrafanaJavascriptAgentBackend
       ignoreUrls.unshift(new RegExp(`.*${escapeRegex(options.customEndpoint)}.*`));
     }
 
+    const sessionReplayEnabled = getFeatureFlagClient().getBooleanValue(FlagKeys.FaroSessionReplay, false);
+
     const transports: BaseTransport[] = [new EchoSrvTransport({ ignoreUrls })];
 
     // If in cross origin iframe, default to writing to instance logging endpoint
     if (options.customEndpoint && !isCrossOriginIframe()) {
-      transports.push(new FetchTransport({ url: options.customEndpoint, apiKey: options.apiKey }));
+      transports.push(
+        new FetchTransport({
+          url: options.customEndpoint,
+          apiKey: options.apiKey,
+          // faro enables fetch keepalive per request whenever the body is under ~60KB, but the
+          // browser's ~64KB keepalive budget is shared across all in-flight requests, so faro's
+          // concurrent sends can collectively exceed it — leaving requests stuck "pending" and
+          // dropping session replay segments. When replay is enabled, force keepalive off for this
+          // transport; otherwise leave faro's default untouched.
+          ...(sessionReplayEnabled ? { requestOptions: { keepalive: false } } : {}),
+        })
+      );
     }
 
     // initialize GrafanaJavascriptAgent so it can set up its hooks and start collecting errors
@@ -98,7 +111,7 @@ export class GrafanaJavascriptAgentBackend
 
     const faro = initializeFaro(grafanaJavaScriptAgentOptions);
 
-    if (faro && getFeatureFlagClient().getBooleanValue(FlagKeys.FaroSessionReplay, false)) {
+    if (faro && sessionReplayEnabled) {
       this.initReplayAfterDomRendered(faro);
     }
   }


### PR DESCRIPTION
## What this PR does / why we need it

Session replay (and other Faro telemetry) is sent to the configured `custom_endpoint` via
Faro's `FetchTransport`. Faro enables fetch `keepalive` per request whenever the request body
is under ~60KB.

The browser, however, caps the *combined* body size of all in-flight `keepalive` requests at
~64KB per page, and Faro sends with concurrency — so several in-flight `keepalive` requests can
collectively exceed that budget. When that happens the `/collect` requests stall in a `pending`
state and recording segments are dropped, producing incomplete / broken-looking recordings.
This reproduces in production builds and not in development.

This PR overrides `keepalive` to `false` on that `FetchTransport`, but only when the session
replay feature flag is enabled. Sessions without replay are left completely unchanged (Faro's
default `keepalive` behaviour); only replay-enabled sessions — which generate the extra
in-flight traffic — opt out, so their sends complete reliably.
