### PR TITLE
Hack 17 passkeys true passwordless

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -89,6 +89,8 @@ func (hs *HTTPServer) registerRoutes() {
 	if hs.Features.IsEnabledGlobally(featuremgmt.FlagGrafanaPasskeyAuthn) {
 		r.Post("/api/auth/passkey/login/begin", requestmeta.SetOwner(requestmeta.TeamAuth), quota(string(auth.QuotaTargetSrv)), routing.Wrap(hs.PasskeyLoginBegin))
 		r.Post("/api/auth/passkey/login/finish", requestmeta.SetOwner(requestmeta.TeamAuth), quota(string(auth.QuotaTargetSrv)), routing.Wrap(hs.PasskeyLoginFinish))
+		r.Post("/api/user/credential-enroll/begin", requestmeta.SetOwner(requestmeta.TeamAuth), routing.Wrap(hs.CredentialEnrollBegin))
+		r.Post("/api/user/credential-enroll/finish", requestmeta.SetOwner(requestmeta.TeamAuth), routing.Wrap(hs.CredentialEnrollFinish))
 	}
 
 	r.Get("/login", hs.LoginView)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -89,7 +89,10 @@ func (hs *HTTPServer) registerRoutes() {
 	if hs.Features.IsEnabledGlobally(featuremgmt.FlagGrafanaPasskeyAuthn) {
 		r.Post("/api/auth/passkey/login/begin", requestmeta.SetOwner(requestmeta.TeamAuth), quota(string(auth.QuotaTargetSrv)), routing.Wrap(hs.PasskeyLoginBegin))
 		r.Post("/api/auth/passkey/login/finish", requestmeta.SetOwner(requestmeta.TeamAuth), quota(string(auth.QuotaTargetSrv)), routing.Wrap(hs.PasskeyLoginFinish))
-		r.Post("/api/user/credential-enroll/begin", requestmeta.SetOwner(requestmeta.TeamAuth), routing.Wrap(hs.CredentialEnrollBegin))
+		// begin creates the passwordless user (and possibly its org), so it carries the same user/org
+		// quota gate as password signup (/api/user/signup) — otherwise this path would bypass the
+		// instance's account cap. finish only enrols a credential for the already-created user.
+		r.Post("/api/user/credential-enroll/begin", requestmeta.SetOwner(requestmeta.TeamAuth), quota(user.QuotaTargetSrv), quota(org.QuotaTargetSrv), routing.Wrap(hs.CredentialEnrollBegin))
 		r.Post("/api/user/credential-enroll/finish", requestmeta.SetOwner(requestmeta.TeamAuth), routing.Wrap(hs.CredentialEnrollFinish))
 	}
 

--- a/pkg/api/credential_enroll.go
+++ b/pkg/api/credential_enroll.go
@@ -1,13 +1,18 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/events"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/passkey"
+	tempuser "github.com/grafana/grafana/pkg/services/temp_user"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
@@ -62,10 +67,16 @@ func (hs *HTTPServer) CredentialEnrollBegin(c *contextmodel.ReqContext) response
 
 	usr, err := hs.userService.Create(c.Req.Context(), &createUserCmd)
 	if err != nil {
-		if errors.Is(err, user.ErrUserAlreadyExists) {
+		if !errors.Is(err, user.ErrUserAlreadyExists) {
+			return response.Error(http.StatusInternalServerError, "Failed to create user", err)
+		}
+		// The email may belong to an abandoned passwordless signup (a user row a previous begin created
+		// before its WebAuthn ceremony finished). Reuse that row if it is provably unusable; otherwise
+		// it is a real account and the email is taken.
+		usr, err = hs.reclaimAbandonedPasswordlessUser(c.Req.Context(), form.Email)
+		if err != nil {
 			return response.Error(http.StatusUnauthorized, "User with same email address already exists", nil)
 		}
-		return response.Error(http.StatusInternalServerError, "Failed to create user", err)
 	}
 
 	displayName := form.Name
@@ -101,22 +112,109 @@ func (hs *HTTPServer) CredentialEnrollFinish(c *contextmodel.ReqContext) respons
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
-	userID, _, err := hs.passkeyService.FinishEnrollment(c.Req.Context(), form.SessionID, form.Name, form.Response)
+	userID, source, err := hs.passkeyService.FinishEnrollment(c.Req.Context(), form.SessionID, form.Name, form.Response)
 	if err != nil {
 		if errors.Is(err, passkey.ErrChallengeExpired) {
 			return response.Error(http.StatusGone, "passkey.challenge-expired", err)
 		}
 		return response.Error(http.StatusBadRequest, "passkey enrollment failed", err)
 	}
-	// Source-specific post-steps (completing the signup/invite TempUser, applying invite org) are
-	// deferred; PW7 wires the invite branch.
 
 	usr, err := hs.userService.GetByID(c.Req.Context(), &user.GetUserByIDQuery{ID: userID})
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to load enrolled user", err)
 	}
+
+	resp := util.DynMap{"message": "Signed up", "code": "redirect-to-landing-page"}
+	// A self-service signup must finish the same way a password signup does (see SignUpStep2), so run
+	// the account-completion steps now that the passkey exists. Invite-initiated enrollment is a
+	// separate flow (PW7/PW9) and is not handled here.
+	if source == passkey.EnrollSourceSignup {
+		if rsp := hs.completePasskeySignup(c.Req.Context(), usr, resp); rsp != nil {
+			return rsp
+		}
+	}
+
 	if err := hs.loginUserWithUser(usr, c); err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to login user", err)
 	}
-	return response.JSON(http.StatusOK, util.DynMap{"message": "Signed up", "code": "redirect-to-landing-page"})
+	if source == passkey.EnrollSourceSignup {
+		metrics.MApiUserSignUpCompleted.Inc()
+	}
+	return response.JSON(http.StatusOK, resp)
+}
+
+// completePasskeySignup runs the post-account-creation steps that the password signup (SignUpStep2)
+// performs, so a passwordless signup behaves the same: it announces completion and adds the user to any
+// organisation that has a pending invite for their email (switching the response to land them on the
+// org picker). It returns a non-nil response only on failure.
+//
+// One SignUpStep2 step is intentionally omitted: marking the signup TempUser completed. That needs the
+// email verification code, which lives only in the begin request and is not carried to finish; a stale
+// SignUpStarted TempUser row is harmless.
+func (hs *HTTPServer) completePasskeySignup(ctx context.Context, usr *user.User, resp util.DynMap) response.Response {
+	if err := hs.bus.Publish(ctx, &events.SignUpCompleted{
+		Email: usr.Email,
+		Name:  usr.NameOrFallback(),
+	}); err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to publish event", err)
+	}
+
+	invites, err := hs.tempUserService.GetTempUsersQuery(ctx, &tempuser.GetTempUsersQuery{
+		Email:  usr.Email,
+		Status: tempuser.TmpUserInvitePending,
+	})
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to query database for invites", err)
+	}
+	for _, invite := range invites {
+		if ok, rsp := hs.applyUserInvite(ctx, usr, invite, false); !ok {
+			return rsp
+		}
+		resp["code"] = "redirect-to-select-org"
+	}
+	return nil
+}
+
+// reclaimAbandonedPasswordlessUser reuses an existing user row for a repeat passwordless signup, but
+// only when that row is provably unusable. CredentialEnrollBegin creates the user before the WebAuthn
+// ceremony runs, so a person who dismisses the OS prompt leaves behind a row with no password and no
+// passkey: it cannot log in by any means and it squats the email. Reclaiming it lets that person try
+// again. We reclaim ONLY when the row has no password, no passkey, and no external-auth (SSO/LDAP)
+// link; any of those marks a real account that must never be handed to a different signer, so we
+// refuse and the caller reports the email as taken.
+//
+// Residual edge: on an instance that links SSO accounts by email, an attacker could reclaim an
+// abandoned row and enrol a passkey before the real owner's first SSO login links to that same row.
+// That is only reachable with open signup and email verification turned off — the configuration the
+// docs already advise against.
+func (hs *HTTPServer) reclaimAbandonedPasswordlessUser(ctx context.Context, loginOrEmail string) (*user.User, error) {
+	usr, err := hs.userService.GetByLoginWithPassword(ctx, &user.GetUserByLoginQuery{LoginOrEmail: loginOrEmail})
+	if err != nil {
+		return nil, err
+	}
+	if usr == nil {
+		return nil, errors.New("user not found")
+	}
+	if usr.Password != "" {
+		return nil, errors.New("refusing to reclaim: user has a password")
+	}
+
+	creds, err := hs.passkeyStore.ListByUser(ctx, usr.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(creds) > 0 {
+		return nil, errors.New("refusing to reclaim: user already has a passkey")
+	}
+
+	// GetAuthInfo returns user.ErrUserNotFound when the user has no external-auth link. A nil error
+	// means a link exists, and any other error is unexpected — both block the reclaim.
+	if _, err := hs.authInfoService.GetAuthInfo(ctx, &login.GetAuthInfoQuery{UserId: usr.ID}); err == nil {
+		return nil, errors.New("refusing to reclaim: user is linked to an external auth provider")
+	} else if !errors.Is(err, user.ErrUserNotFound) {
+		return nil, err
+	}
+
+	return usr, nil
 }

--- a/pkg/api/credential_enroll.go
+++ b/pkg/api/credential_enroll.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/passkey"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+// credentialEnrollBeginRequest is the body for starting passwordless signup enrollment. It mirrors the
+// signup step-2 form minus the password: the account is created with no password and a passkey becomes
+// its only credential.
+type credentialEnrollBeginRequest struct {
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Username string `json:"username"`
+	OrgName  string `json:"orgName"`
+	Code     string `json:"code"`
+}
+
+// CredentialEnrollBegin creates a passwordless user from a signup and starts a WebAuthn registration
+// ceremony. It mirrors SignUpStep2's account creation but sets no password and, instead of completing
+// signup inline, returns the WebAuthn options + an enrollment-token sessionID that CredentialEnrollFinish
+// (PW6) consumes to persist the credential and log the user in. Anonymous endpoint.
+func (hs *HTTPServer) CredentialEnrollBegin(c *contextmodel.ReqContext) response.Response {
+	c.Req.Body = http.MaxBytesReader(c.Resp, c.Req.Body, maxPreAuthFormBodySize)
+
+	form := credentialEnrollBeginRequest{}
+	if err := web.Bind(c.Req, &form); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	if !hs.Cfg.AllowUserSignUp {
+		return response.Error(http.StatusUnauthorized, "User signup is disabled", nil)
+	}
+	// Guard before creating the user so a misconfigured instance doesn't leave a passwordless,
+	// passkey-less (locked-out) account behind.
+	if !hs.Cfg.Passkey.Enabled {
+		return response.Error(http.StatusBadRequest, "Passkey auth is not enabled", nil)
+	}
+
+	// No Password: the account is passwordless; a passkey will be its only credential.
+	createUserCmd := user.CreateUserCommand{
+		Email:   form.Email,
+		Login:   form.Username,
+		Name:    form.Name,
+		OrgName: form.OrgName,
+	}
+	// Email verification only applies when the operator enabled it (needs SMTP); the code is the
+	// proof-of-inbox trust anchor in that case. Mirrors SignUpStep2.
+	if hs.Cfg.VerifyEmailEnabled {
+		if ok, rsp := hs.verifyUserSignUpEmail(c.Req.Context(), form.Email, form.Code); !ok {
+			return rsp
+		}
+		createUserCmd.EmailVerified = true
+	}
+
+	usr, err := hs.userService.Create(c.Req.Context(), &createUserCmd)
+	if err != nil {
+		if errors.Is(err, user.ErrUserAlreadyExists) {
+			return response.Error(http.StatusUnauthorized, "User with same email address already exists", nil)
+		}
+		return response.Error(http.StatusInternalServerError, "Failed to create user", err)
+	}
+
+	displayName := form.Name
+	if displayName == "" {
+		displayName = form.Username
+	}
+	res, err := hs.passkeyService.BeginEnrollment(c.Req.Context(), passkey.RegisteringUser{
+		UserID:      usr.ID,
+		Name:        form.Username,
+		DisplayName: displayName,
+	}, passkey.EnrollSourceSignup)
+	if err != nil {
+		return mapPasskeyError(err)
+	}
+	return response.JSON(http.StatusOK, passkeyBeginResponse{SessionID: res.SessionID, Options: res.Options})
+}
+
+// credentialEnrollFinishRequest is the body posted to finish an anonymous enrollment: the sessionID
+// from begin, a user-chosen credential name, and the raw attestation the authenticator produced.
+type credentialEnrollFinishRequest struct {
+	SessionID string          `json:"sessionID"`
+	Name      string          `json:"name"`
+	Response  json.RawMessage `json:"response"`
+}
+
+// CredentialEnrollFinish verifies the attestation against the pending enrollment, persists the new
+// credential, and logs the user in — completing passwordless signup. Anonymous endpoint.
+func (hs *HTTPServer) CredentialEnrollFinish(c *contextmodel.ReqContext) response.Response {
+	c.Req.Body = http.MaxBytesReader(c.Resp, c.Req.Body, maxPreAuthFormBodySize)
+
+	form := credentialEnrollFinishRequest{}
+	if err := web.Bind(c.Req, &form); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+
+	userID, _, err := hs.passkeyService.FinishEnrollment(c.Req.Context(), form.SessionID, form.Name, form.Response)
+	if err != nil {
+		if errors.Is(err, passkey.ErrChallengeExpired) {
+			return response.Error(http.StatusGone, "passkey.challenge-expired", err)
+		}
+		return response.Error(http.StatusBadRequest, "passkey enrollment failed", err)
+	}
+	// Source-specific post-steps (completing the signup/invite TempUser, applying invite org) are
+	// deferred; PW7 wires the invite branch.
+
+	usr, err := hs.userService.GetByID(c.Req.Context(), &user.GetUserByIDQuery{ID: userID})
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "failed to load enrolled user", err)
+	}
+	if err := hs.loginUserWithUser(usr, c); err != nil {
+		return response.Error(http.StatusInternalServerError, "failed to login user", err)
+	}
+	return response.JSON(http.StatusOK, util.DynMap{"message": "Signed up", "code": "redirect-to-landing-page"})
+}

--- a/pkg/api/credential_enroll_test.go
+++ b/pkg/api/credential_enroll_test.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/passkey"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestCredentialEnrollBegin(t *testing.T) {
+	const path = "/api/user/credential-enroll/begin"
+
+	t.Run("creates a passwordless user and begins enrollment", func(t *testing.T) {
+		passkeySvc := &fakePasskeyService{beginEnrollResult: &passkey.BeginResult{
+			SessionID: "enroll-1",
+			Options:   json.RawMessage(`{"challenge":"abc"}`),
+		}}
+		var gotCmd *user.CreateUserCommand
+		userSvc := &usertest.FakeUserService{
+			CreateFn: func(_ context.Context, cmd *user.CreateUserCommand) (*user.User, error) {
+				gotCmd = cmd
+				return &user.User{ID: 7, Login: cmd.Login, Email: cmd.Email}, nil
+			},
+		}
+		cfg := setting.NewCfg()
+		cfg.AllowUserSignUp = true
+		cfg.Passkey.Enabled = true
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagGrafanaPasskeyAuthn)
+			hs.passkeyService = passkeySvc
+			hs.userService = userSvc
+			hs.Cfg = cfg
+		})
+
+		body := `{"email":"new@example.com","username":"newbie","name":"New Bie"}`
+		req := server.NewPostRequest(path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		// The account is created with NO password — a passkey will be its only credential.
+		require.NotNil(t, gotCmd)
+		require.Equal(t, "newbie", gotCmd.Login)
+		require.Empty(t, gotCmd.Password)
+		// Enrollment begins for the created user, tagged as a signup.
+		require.Equal(t, int64(7), passkeySvc.gotEnrollUser.UserID)
+		require.Equal(t, passkey.EnrollSourceSignup, passkeySvc.gotEnrollSource)
+
+		var resp passkeyBeginResponse
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+		require.Equal(t, "enroll-1", resp.SessionID)
+	})
+
+	t.Run("rejects when signup is disabled", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		cfg.AllowUserSignUp = false
+		cfg.Passkey.Enabled = true
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagGrafanaPasskeyAuthn)
+			hs.passkeyService = &fakePasskeyService{}
+			hs.userService = &usertest.FakeUserService{}
+			hs.Cfg = cfg
+		})
+
+		req := server.NewPostRequest(path, strings.NewReader(`{"email":"x@y.z","username":"x"}`))
+		req.Header.Set("Content-Type", "application/json")
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	})
+}
+
+func TestCredentialEnrollFinish(t *testing.T) {
+	const path = "/api/user/credential-enroll/finish"
+
+	t.Run("verifies attestation, persists credential, and logs the user in", func(t *testing.T) {
+		passkeySvc := &fakePasskeyService{finishEnrollUserID: 7, finishEnrollSource: passkey.EnrollSourceSignup}
+		userSvc := &usertest.FakeUserService{ExpectedUser: &user.User{ID: 7, Login: "newbie", Email: "new@example.com"}}
+		cfg := setting.NewCfg()
+		cfg.LoginCookieName = "grafana_session"
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagGrafanaPasskeyAuthn)
+			hs.passkeyService = passkeySvc
+			hs.userService = userSvc
+			hs.AuthTokenService = authtest.NewFakeUserAuthTokenService()
+			hs.log = log.New("credential-enroll-test")
+			hs.Cfg = cfg
+		})
+
+		body := `{"sessionID":"enroll-1","name":"My Laptop","response":{"id":"abc"}}`
+		req := server.NewPostRequest(path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Equal(t, "enroll-1", passkeySvc.gotFinishSessionID)
+		require.Equal(t, "My Laptop", passkeySvc.gotFinishName)
+		// The user is logged in: a session cookie is set.
+		require.NotEmpty(t, res.Cookies(), "expected a session cookie")
+	})
+
+	t.Run("expired challenge maps to 410", func(t *testing.T) {
+		passkeySvc := &fakePasskeyService{finishEnrollErr: passkey.ErrChallengeExpired}
+		cfg := setting.NewCfg()
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagGrafanaPasskeyAuthn)
+			hs.passkeyService = passkeySvc
+			hs.userService = &usertest.FakeUserService{}
+			hs.Cfg = cfg
+		})
+
+		body := `{"sessionID":"stale","response":{"id":"abc"}}`
+		req := server.NewPostRequest(path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.Equal(t, http.StatusGone, res.StatusCode)
+	})
+}

--- a/pkg/api/credential_enroll_test.go
+++ b/pkg/api/credential_enroll_test.go
@@ -9,10 +9,18 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/login/authinfotest"
 	"github.com/grafana/grafana/pkg/services/passkey"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
+	tempuser "github.com/grafana/grafana/pkg/services/temp_user"
+	"github.com/grafana/grafana/pkg/services/temp_user/tempusertest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
@@ -64,6 +72,124 @@ func TestCredentialEnrollBegin(t *testing.T) {
 		require.Equal(t, "enroll-1", resp.SessionID)
 	})
 
+	t.Run("reuses an abandoned passwordless account on retry", func(t *testing.T) {
+		// A previous begin created this user but the ceremony was abandoned: no password, no passkey,
+		// no external link. A retry must reuse the row and continue, not fail with "already exists".
+		passkeySvc := &fakePasskeyService{beginEnrollResult: &passkey.BeginResult{
+			SessionID: "enroll-2",
+			Options:   json.RawMessage(`{"challenge":"abc"}`),
+		}}
+		orphan := &user.User{ID: 9, Login: "newbie", Email: "new@example.com"}
+		userSvc := &usertest.FakeUserService{
+			CreateFn: func(context.Context, *user.CreateUserCommand) (*user.User, error) {
+				return nil, user.ErrUserAlreadyExists
+			},
+			GetByLoginFn: func(context.Context, *user.GetUserByLoginQuery) (*user.User, error) {
+				return orphan, nil
+			},
+		}
+		cfg := setting.NewCfg()
+		cfg.AllowUserSignUp = true
+		cfg.Passkey.Enabled = true
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagGrafanaPasskeyAuthn)
+			hs.passkeyService = passkeySvc
+			hs.userService = userSvc
+			hs.passkeyStore = &fakePasskeyStore{}                                               // no passkey
+			hs.authInfoService = &authinfotest.FakeService{ExpectedError: user.ErrUserNotFound} // no link
+			hs.Cfg = cfg
+		})
+
+		body := `{"email":"new@example.com","username":"newbie","name":"New Bie"}`
+		req := server.NewPostRequest(path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		// Enrollment proceeds for the reclaimed row, not a freshly created user.
+		require.Equal(t, int64(9), passkeySvc.gotEnrollUser.UserID)
+	})
+
+	t.Run("refuses to reclaim a usable account", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			orphan   *user.User
+			store    *fakePasskeyStore
+			authInfo *authinfotest.FakeService
+		}{
+			{
+				name:     "has a password",
+				orphan:   &user.User{ID: 9, Login: "newbie", Email: "new@example.com", Password: "hashed"},
+				store:    &fakePasskeyStore{},
+				authInfo: &authinfotest.FakeService{ExpectedError: user.ErrUserNotFound},
+			},
+			{
+				name:     "already has a passkey",
+				orphan:   &user.User{ID: 9, Login: "newbie", Email: "new@example.com"},
+				store:    &fakePasskeyStore{listResult: []*passkey.Credential{{ID: 1}}},
+				authInfo: &authinfotest.FakeService{ExpectedError: user.ErrUserNotFound},
+			},
+			{
+				name:     "linked to an external auth provider",
+				orphan:   &user.User{ID: 9, Login: "newbie", Email: "new@example.com"},
+				store:    &fakePasskeyStore{},
+				authInfo: &authinfotest.FakeService{ExpectedUserAuth: &login.UserAuth{}},
+			},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				userSvc := &usertest.FakeUserService{
+					CreateFn: func(context.Context, *user.CreateUserCommand) (*user.User, error) {
+						return nil, user.ErrUserAlreadyExists
+					},
+					GetByLoginFn: func(context.Context, *user.GetUserByLoginQuery) (*user.User, error) {
+						return tc.orphan, nil
+					},
+				}
+				cfg := setting.NewCfg()
+				cfg.AllowUserSignUp = true
+				cfg.Passkey.Enabled = true
+				server := SetupAPITestServer(t, func(hs *HTTPServer) {
+					hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagGrafanaPasskeyAuthn)
+					hs.passkeyService = &fakePasskeyService{}
+					hs.userService = userSvc
+					hs.passkeyStore = tc.store
+					hs.authInfoService = tc.authInfo
+					hs.Cfg = cfg
+				})
+
+				req := server.NewPostRequest(path, strings.NewReader(`{"email":"new@example.com","username":"newbie"}`))
+				req.Header.Set("Content-Type", "application/json")
+				res, err := server.Send(req)
+				require.NoError(t, err)
+				defer func() { require.NoError(t, res.Body.Close()) }()
+				require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+			})
+		}
+	})
+
+	t.Run("is gated by the user quota", func(t *testing.T) {
+		// begin creates the user, so it must honour the same account cap as password signup.
+		cfg := setting.NewCfg()
+		cfg.AllowUserSignUp = true
+		cfg.Passkey.Enabled = true
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagGrafanaPasskeyAuthn)
+			hs.passkeyService = &fakePasskeyService{}
+			hs.userService = &usertest.FakeUserService{}
+			hs.QuotaService = quotatest.New(true, nil) // quota reached
+			hs.Cfg = cfg
+		})
+
+		req := server.NewPostRequest(path, strings.NewReader(`{"email":"new@example.com","username":"newbie"}`))
+		req.Header.Set("Content-Type", "application/json")
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.Equal(t, http.StatusForbidden, res.StatusCode)
+	})
+
 	t.Run("rejects when signup is disabled", func(t *testing.T) {
 		cfg := setting.NewCfg()
 		cfg.AllowUserSignUp = false
@@ -87,15 +213,34 @@ func TestCredentialEnrollBegin(t *testing.T) {
 func TestCredentialEnrollFinish(t *testing.T) {
 	const path = "/api/user/credential-enroll/finish"
 
-	t.Run("verifies attestation, persists credential, and logs the user in", func(t *testing.T) {
+	t.Run("verifies attestation, persists credential, logs in, and completes the signup", func(t *testing.T) {
 		passkeySvc := &fakePasskeyService{finishEnrollUserID: 7, finishEnrollSource: passkey.EnrollSourceSignup}
 		userSvc := &usertest.FakeUserService{ExpectedUser: &user.User{ID: 7, Login: "newbie", Email: "new@example.com"}}
+
+		// Capture the signup-completed event and the pending-invite lookup so we can assert the same
+		// account-completion steps SignUpStep2 performs also run for a passwordless signup.
+		eventBus := bus.ProvideBus(tracing.InitializeTracerForTest())
+		var completedEmail string
+		eventBus.AddEventListener(func(_ context.Context, e *events.SignUpCompleted) error {
+			completedEmail = e.Email
+			return nil
+		})
+		var invitesEmail string
+		tempUserSvc := &tempusertest.FakeTempUserService{
+			GetTempUsersQueryFN: func(_ context.Context, q *tempuser.GetTempUsersQuery) ([]*tempuser.TempUserDTO, error) {
+				invitesEmail = q.Email
+				return nil, nil
+			},
+		}
+
 		cfg := setting.NewCfg()
 		cfg.LoginCookieName = "grafana_session"
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
 			hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagGrafanaPasskeyAuthn)
 			hs.passkeyService = passkeySvc
 			hs.userService = userSvc
+			hs.bus = eventBus
+			hs.tempUserService = tempUserSvc
 			hs.AuthTokenService = authtest.NewFakeUserAuthTokenService()
 			hs.log = log.New("credential-enroll-test")
 			hs.Cfg = cfg
@@ -113,6 +258,9 @@ func TestCredentialEnrollFinish(t *testing.T) {
 		require.Equal(t, "My Laptop", passkeySvc.gotFinishName)
 		// The user is logged in: a session cookie is set.
 		require.NotEmpty(t, res.Cookies(), "expected a session cookie")
+		// Signup completion ran: the event fired and pending invites were checked for this email.
+		require.Equal(t, "new@example.com", completedEmail)
+		require.Equal(t, "new@example.com", invitesEmail)
 	})
 
 	t.Run("expired challenge maps to 410", func(t *testing.T) {

--- a/pkg/api/passkey_test.go
+++ b/pkg/api/passkey_test.go
@@ -32,6 +32,17 @@ type fakePasskeyService struct {
 	beginRegErr    error
 	gotRegUser     passkey.RegisteringUser
 
+	beginEnrollResult *passkey.BeginResult
+	beginEnrollErr    error
+	gotEnrollUser     passkey.RegisteringUser
+	gotEnrollSource   passkey.EnrollSource
+
+	finishEnrollUserID int64
+	finishEnrollSource passkey.EnrollSource
+	finishEnrollErr    error
+	gotFinishSessionID string
+	gotFinishName      string
+
 	finishRegCred *passkey.Credential
 	finishRegErr  error
 }
@@ -47,6 +58,16 @@ func (f *fakePasskeyService) FinishLogin(context.Context, string, []byte) (int64
 func (f *fakePasskeyService) BeginRegistration(_ context.Context, u passkey.RegisteringUser) (*passkey.BeginResult, error) {
 	f.gotRegUser = u
 	return f.beginRegResult, f.beginRegErr
+}
+
+func (f *fakePasskeyService) BeginEnrollment(_ context.Context, u passkey.RegisteringUser, src passkey.EnrollSource) (*passkey.BeginResult, error) {
+	f.gotEnrollUser, f.gotEnrollSource = u, src
+	return f.beginEnrollResult, f.beginEnrollErr
+}
+
+func (f *fakePasskeyService) FinishEnrollment(_ context.Context, sessionID, name string, _ []byte) (int64, passkey.EnrollSource, error) {
+	f.gotFinishSessionID, f.gotFinishName = sessionID, name
+	return f.finishEnrollUserID, f.finishEnrollSource, f.finishEnrollErr
 }
 
 func (f *fakePasskeyService) FinishRegistration(context.Context, string, passkey.RegisteringUser, string, []byte) (*passkey.Credential, error) {

--- a/pkg/services/authn/authnimpl/passkey_login_integration_test.go
+++ b/pkg/services/authn/authnimpl/passkey_login_integration_test.go
@@ -46,6 +46,14 @@ func (s *recordingPasskeyService) BeginRegistration(context.Context, passkey.Reg
 	return nil, nil
 }
 
+func (s *recordingPasskeyService) BeginEnrollment(context.Context, passkey.RegisteringUser, passkey.EnrollSource) (*passkey.BeginResult, error) {
+	return nil, nil
+}
+
+func (s *recordingPasskeyService) FinishEnrollment(context.Context, string, string, []byte) (int64, passkey.EnrollSource, error) {
+	return 0, "", nil
+}
+
 func (s *recordingPasskeyService) FinishRegistration(context.Context, string, passkey.RegisteringUser, string, []byte) (*passkey.Credential, error) {
 	return nil, nil
 }

--- a/pkg/services/authn/clients/passkey_test.go
+++ b/pkg/services/authn/clients/passkey_test.go
@@ -42,6 +42,14 @@ func (f *fakePasskeyService) BeginRegistration(context.Context, passkey.Register
 	return nil, nil
 }
 
+func (f *fakePasskeyService) BeginEnrollment(context.Context, passkey.RegisteringUser, passkey.EnrollSource) (*passkey.BeginResult, error) {
+	return nil, nil
+}
+
+func (f *fakePasskeyService) FinishEnrollment(context.Context, string, string, []byte) (int64, passkey.EnrollSource, error) {
+	return 0, "", nil
+}
+
 func (f *fakePasskeyService) FinishRegistration(context.Context, string, passkey.RegisteringUser, string, []byte) (*passkey.Credential, error) {
 	return nil, nil
 }

--- a/pkg/services/passkey/passkeyimpl/enrollment_store.go
+++ b/pkg/services/passkey/passkeyimpl/enrollment_store.go
@@ -1,0 +1,77 @@
+package passkeyimpl
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+const (
+	enrollKeyPrefix = "passkey-enroll:"
+	enrollTTL       = 5 * time.Minute
+)
+
+// enrollSource records which anonymous flow created the pending enrollment, so finish can run the
+// right post-step (complete signup / apply invite org / finish bootstrap).
+type enrollSource string
+
+const (
+	enrollSourceSignup    enrollSource = "signup"
+	enrollSourceInvite    enrollSource = "invite"
+	enrollSourceBootstrap enrollSource = "bootstrap"
+)
+
+// enrollmentSession is the state carried between an anonymous enroll begin and finish: the user the
+// credential will belong to (resolved from a TempUser code or bootstrap token at begin), the flow it
+// came from, and the opaque WebAuthn SessionData (serialized by the caller; opaque to this store).
+type enrollmentSession struct {
+	UserID          int64        `json:"userID"`
+	Source          enrollSource `json:"source"`
+	WebAuthnSession []byte       `json:"webAuthnSession"`
+}
+
+// enrollmentStore holds the short-lived, single-use state for an anonymous passkey enrollment between
+// its begin and finish steps, keyed by an opaque session id. It is backed by remotecache (via the
+// cacheStorage interface from challenge_store.go) so begin and finish work across replicas in HA.
+// Unlike the challenge store it also carries the enrolling user id, because anonymous finish has no
+// session to derive it from.
+type enrollmentStore struct {
+	cache cacheStorage
+	log   log.Logger
+}
+
+func newEnrollmentStore(cache cacheStorage) *enrollmentStore {
+	return &enrollmentStore{cache: cache, log: log.New("passkey.enrollment")}
+}
+
+// set json-encodes the pending enrollment under sessionID with a fixed non-zero TTL (remotecache
+// treats 0 as 24h).
+func (s *enrollmentStore) set(ctx context.Context, sessionID string, sess enrollmentSession) error {
+	data, err := json.Marshal(sess)
+	if err != nil {
+		return err
+	}
+	return s.cache.Set(ctx, enrollKeyPrefix+sessionID, data, enrollTTL)
+}
+
+// take returns the pending enrollment for sessionID and deletes it, so each is used at most once. It
+// returns remotecache.ErrCacheItemNotFound when the id is unknown, already used, or expired. The
+// delete is best-effort: remotecache has no atomic get-and-delete, so a rare concurrent double-read is
+// possible; the TTL bounds it.
+func (s *enrollmentStore) take(ctx context.Context, sessionID string) (enrollmentSession, error) {
+	key := enrollKeyPrefix + sessionID
+	data, err := s.cache.Get(ctx, key)
+	if err != nil {
+		return enrollmentSession{}, err
+	}
+	if err := s.cache.Delete(ctx, key); err != nil {
+		s.log.Warn("failed to delete used passkey enrollment session", "err", err)
+	}
+	var sess enrollmentSession
+	if err := json.Unmarshal(data, &sess); err != nil {
+		return enrollmentSession{}, err
+	}
+	return sess, nil
+}

--- a/pkg/services/passkey/passkeyimpl/enrollment_store.go
+++ b/pkg/services/passkey/passkeyimpl/enrollment_store.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/passkey"
 )
 
 const (
@@ -13,23 +14,13 @@ const (
 	enrollTTL       = 5 * time.Minute
 )
 
-// enrollSource records which anonymous flow created the pending enrollment, so finish can run the
-// right post-step (complete signup / apply invite org / finish bootstrap).
-type enrollSource string
-
-const (
-	enrollSourceSignup    enrollSource = "signup"
-	enrollSourceInvite    enrollSource = "invite"
-	enrollSourceBootstrap enrollSource = "bootstrap"
-)
-
 // enrollmentSession is the state carried between an anonymous enroll begin and finish: the user the
 // credential will belong to (resolved from a TempUser code or bootstrap token at begin), the flow it
 // came from, and the opaque WebAuthn SessionData (serialized by the caller; opaque to this store).
 type enrollmentSession struct {
-	UserID          int64        `json:"userID"`
-	Source          enrollSource `json:"source"`
-	WebAuthnSession []byte       `json:"webAuthnSession"`
+	UserID          int64                `json:"userID"`
+	Source          passkey.EnrollSource `json:"source"`
+	WebAuthnSession []byte               `json:"webAuthnSession"`
 }
 
 // enrollmentStore holds the short-lived, single-use state for an anonymous passkey enrollment between

--- a/pkg/services/passkey/passkeyimpl/enrollment_store_test.go
+++ b/pkg/services/passkey/passkeyimpl/enrollment_store_test.go
@@ -8,11 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/remotecache"
+	"github.com/grafana/grafana/pkg/services/passkey"
 )
 
 func TestEnrollmentStore(t *testing.T) {
 	ctx := context.Background()
-	sess := enrollmentSession{UserID: 42, Source: enrollSourceSignup, WebAuthnSession: []byte("webauthn-session")}
+	sess := enrollmentSession{UserID: 42, Source: passkey.EnrollSourceSignup, WebAuthnSession: []byte("webauthn-session")}
 
 	t.Run("set then take returns the stored session", func(t *testing.T) {
 		store := newEnrollmentStore(newFakeCache())

--- a/pkg/services/passkey/passkeyimpl/enrollment_store_test.go
+++ b/pkg/services/passkey/passkeyimpl/enrollment_store_test.go
@@ -1,0 +1,49 @@
+package passkeyimpl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/remotecache"
+)
+
+func TestEnrollmentStore(t *testing.T) {
+	ctx := context.Background()
+	sess := enrollmentSession{UserID: 42, Source: enrollSourceSignup, WebAuthnSession: []byte("webauthn-session")}
+
+	t.Run("set then take returns the stored session", func(t *testing.T) {
+		store := newEnrollmentStore(newFakeCache())
+		require.NoError(t, store.set(ctx, "sess-1", sess))
+
+		got, err := store.take(ctx, "sess-1")
+		require.NoError(t, err)
+		require.Equal(t, sess, got)
+	})
+
+	t.Run("take is single-use: a second take reports not found", func(t *testing.T) {
+		store := newEnrollmentStore(newFakeCache())
+		require.NoError(t, store.set(ctx, "sess-1", sess))
+
+		_, err := store.take(ctx, "sess-1")
+		require.NoError(t, err)
+
+		_, err = store.take(ctx, "sess-1")
+		require.ErrorIs(t, err, remotecache.ErrCacheItemNotFound)
+	})
+
+	t.Run("take on an unknown session id reports not found", func(t *testing.T) {
+		store := newEnrollmentStore(newFakeCache())
+		_, err := store.take(ctx, "nope")
+		require.ErrorIs(t, err, remotecache.ErrCacheItemNotFound)
+	})
+
+	t.Run("set uses a non-zero 5 minute TTL", func(t *testing.T) {
+		fake := newFakeCache()
+		store := newEnrollmentStore(fake)
+		require.NoError(t, store.set(ctx, "sess-1", sess))
+		require.Equal(t, 5*time.Minute, fake.expires[enrollKeyPrefix+"sess-1"])
+	})
+}

--- a/pkg/services/passkey/passkeyimpl/service.go
+++ b/pkg/services/passkey/passkeyimpl/service.go
@@ -30,12 +30,13 @@ var _ passkey.Service = (*Service)(nil)
 var errDisabled = errors.New("passkey auth is not enabled")
 
 type Service struct {
-	wa      *wan.WebAuthn
-	store   passkey.Store
-	cache   *challengeStore
-	cfg     setting.PasskeySettings
-	metrics *metrics
-	log     log.Logger
+	wa         *wan.WebAuthn
+	store      passkey.Store
+	cache      *challengeStore
+	enrollment *enrollmentStore
+	cfg        setting.PasskeySettings
+	metrics    *metrics
+	log        log.Logger
 }
 
 func ProvideService(cfg *setting.Cfg, store passkey.Store, remoteCache *remotecache.RemoteCache, reg prometheus.Registerer) (*Service, error) {
@@ -47,11 +48,12 @@ func ProvideService(cfg *setting.Cfg, store passkey.Store, remoteCache *remoteca
 // webauthn.New (which requires a valid RP config) so the server still boots with the feature off.
 func newService(settings setting.PasskeySettings, store passkey.Store, cache cacheStorage, reg prometheus.Registerer) (*Service, error) {
 	s := &Service{
-		store:   store,
-		cache:   newChallengeStore(cache),
-		cfg:     settings,
-		metrics: newMetrics(reg),
-		log:     log.New("passkey.service"),
+		store:      store,
+		cache:      newChallengeStore(cache),
+		enrollment: newEnrollmentStore(cache),
+		cfg:        settings,
+		metrics:    newMetrics(reg),
+		log:        log.New("passkey.service"),
 	}
 
 	if settings.Enabled {
@@ -181,6 +183,27 @@ func (s *Service) BeginRegistration(ctx context.Context, ru passkey.RegisteringU
 	return res, nil
 }
 
+// BeginEnrollment starts a registration ceremony for a user created by an anonymous flow (signup,
+// invite, bootstrap) and stores the pending state — including the user id and source — in the
+// enrollment store so the anonymous finish can persist the credential without a session.
+func (s *Service) BeginEnrollment(ctx context.Context, ru passkey.RegisteringUser, source passkey.EnrollSource) (*passkey.BeginResult, error) {
+	if s.wa == nil {
+		return nil, errDisabled
+	}
+	// A freshly-created user has no credentials yet, so there is nothing to exclude.
+	user := newWebAuthnUser(ru.UserID, ru.Name, ru.DisplayName, nil)
+	creation, session, err := s.wa.BeginRegistration(user)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin passkey enrollment: %w", err)
+	}
+	res, err := s.persistEnrollment(ctx, ru.UserID, source, session, creation.Response)
+	if err != nil {
+		return nil, err
+	}
+	s.metrics.registrationBegin.Inc()
+	return res, nil
+}
+
 func (s *Service) FinishRegistration(ctx context.Context, sessionID string, ru passkey.RegisteringUser, name string, responseBody []byte) (*passkey.Credential, error) {
 	if s.wa == nil {
 		return nil, errDisabled
@@ -218,6 +241,56 @@ func (s *Service) FinishRegistration(ctx context.Context, sessionID string, ru p
 	return stored, nil
 }
 
+// FinishEnrollment verifies an attestation against a pending anonymous enrollment (signup/invite/
+// bootstrap) and persists the credential for the user recorded at begin. It mirrors FinishRegistration
+// but reads the user id + source from the enrollment store instead of an authenticated session.
+func (s *Service) FinishEnrollment(ctx context.Context, sessionID, name string, responseBody []byte) (int64, passkey.EnrollSource, error) {
+	if s.wa == nil {
+		return 0, "", errDisabled
+	}
+	sess, err := s.enrollment.take(ctx, sessionID)
+	if err != nil {
+		if errors.Is(err, remotecache.ErrCacheItemNotFound) {
+			return 0, "", passkey.ErrChallengeExpired
+		}
+		return 0, "", err
+	}
+
+	var wanSession wan.SessionData
+	if err := json.Unmarshal(sess.WebAuthnSession, &wanSession); err != nil {
+		return 0, "", err
+	}
+
+	existing, err := s.store.ListByUser(ctx, sess.UserID)
+	if err != nil {
+		return 0, "", err
+	}
+	// Name/display name don't matter at finish — only the user handle (encodeUserHandle(UserID)) must
+	// match the one bound into the session at begin.
+	user := newWebAuthnUser(sess.UserID, "", "", existing)
+
+	parsed, err := protocol.ParseCredentialCreationResponseBytes(responseBody)
+	if err != nil {
+		s.metrics.registrationFinish.WithLabelValues(resultFailure).Inc()
+		return 0, "", err
+	}
+
+	credential, err := s.wa.CreateCredential(user, wanSession, parsed)
+	if err != nil {
+		s.metrics.registrationFinish.WithLabelValues(resultFailure).Inc()
+		return 0, "", err
+	}
+
+	stored := toStoreCredential(sess.UserID, name, credential)
+	if err := s.store.Create(ctx, stored); err != nil {
+		s.metrics.registrationFinish.WithLabelValues(resultFailure).Inc()
+		return 0, "", err
+	}
+
+	s.metrics.registrationFinish.WithLabelValues(resultSuccess).Inc()
+	return sess.UserID, sess.Source, nil
+}
+
 // persistSession stores the ceremony's SessionData under a fresh opaque id and returns it together
 // with the begin options (raw JSON) the client needs for navigator.credentials.*.
 func (s *Service) persistSession(ctx context.Context, session *wan.SessionData, options any) (*passkey.BeginResult, error) {
@@ -231,6 +304,27 @@ func (s *Service) persistSession(ctx context.Context, session *wan.SessionData, 
 	}
 	if err := s.cache.set(ctx, sessionID, data); err != nil {
 		return nil, fmt.Errorf("failed to store passkey challenge: %w", err)
+	}
+	opts, err := json.Marshal(options)
+	if err != nil {
+		return nil, err
+	}
+	return &passkey.BeginResult{SessionID: sessionID, Options: opts}, nil
+}
+
+// persistEnrollment mirrors persistSession but stores into the enrollment store, carrying the user id
+// and source so the anonymous finish knows whose credential to create and which post-step to run.
+func (s *Service) persistEnrollment(ctx context.Context, userID int64, source passkey.EnrollSource, session *wan.SessionData, options any) (*passkey.BeginResult, error) {
+	data, err := json.Marshal(session)
+	if err != nil {
+		return nil, err
+	}
+	sessionID, err := util.GetRandomString(sessionIDLength)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.enrollment.set(ctx, sessionID, enrollmentSession{UserID: userID, Source: source, WebAuthnSession: data}); err != nil {
+		return nil, fmt.Errorf("failed to store passkey enrollment: %w", err)
 	}
 	opts, err := json.Marshal(options)
 	if err != nil {

--- a/pkg/services/passkey/passkeyimpl/service_test.go
+++ b/pkg/services/passkey/passkeyimpl/service_test.go
@@ -112,6 +112,37 @@ func TestSessionRoundTrip(t *testing.T) {
 	require.Equal(t, original.UserVerification, loaded.UserVerification)
 }
 
+func TestBeginEnrollment(t *testing.T) {
+	ctx := context.Background()
+	cache := newFakeCache()
+	svc, err := newService(validSettings(), nil, cache, nil)
+	require.NoError(t, err)
+
+	res, err := svc.BeginEnrollment(ctx, passkey.RegisteringUser{UserID: 7, Name: "newbie", DisplayName: "New Bie"}, passkey.EnrollSourceSignup)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.SessionID)
+	require.True(t, json.Valid(res.Options), "begin options must be valid JSON for the client")
+
+	// The pending enrollment is stored in the enrollment namespace, carrying the user id + source so
+	// the anonymous finish (which has no session) knows whose credential to persist.
+	raw, ok := cache.data[enrollKeyPrefix+res.SessionID]
+	require.True(t, ok, "enrollment session should be stored")
+	var sess enrollmentSession
+	require.NoError(t, json.Unmarshal(raw, &sess))
+	require.Equal(t, int64(7), sess.UserID)
+	require.Equal(t, passkey.EnrollSourceSignup, sess.Source)
+	require.NotEmpty(t, sess.WebAuthnSession)
+}
+
+func TestFinishEnrollmentUnknownMapsToExpired(t *testing.T) {
+	ctx := context.Background()
+	svc, err := newService(validSettings(), nil, newFakeCache(), nil)
+	require.NoError(t, err)
+
+	_, _, err = svc.FinishEnrollment(ctx, "never-stored", "my passkey", []byte(`{}`))
+	require.ErrorIs(t, err, passkey.ErrChallengeExpired)
+}
+
 func TestLoadSessionUnknownMapsToExpired(t *testing.T) {
 	ctx := context.Background()
 	svc, err := newService(validSettings(), nil, newFakeCache(), nil)

--- a/pkg/services/passkey/service.go
+++ b/pkg/services/passkey/service.go
@@ -23,6 +23,16 @@ type RegisteringUser struct {
 	DisplayName string
 }
 
+// EnrollSource records which anonymous flow started a passkey enrollment, so the finish step can run
+// the right post-step (complete signup, apply an invite's org membership, finish bootstrap).
+type EnrollSource string
+
+const (
+	EnrollSourceSignup    EnrollSource = "signup"
+	EnrollSourceInvite    EnrollSource = "invite"
+	EnrollSourceBootstrap EnrollSource = "bootstrap"
+)
+
 // BeginResult carries the public-key options the browser hands to navigator.credentials.*, plus the
 // opaque sessionID that ties the begin and finish halves of one ceremony together. Options is raw
 // JSON produced by go-webauthn and passed through to the client untouched.
@@ -45,6 +55,17 @@ type Service interface {
 
 	// BeginRegistration starts enrolling a new passkey for an already-authenticated user.
 	BeginRegistration(ctx context.Context, user RegisteringUser) (*BeginResult, error)
+
+	// BeginEnrollment starts enrolling the first passkey for a user via an anonymous flow (signup,
+	// invite, bootstrap) where there is no session. The pending state carries the user's id and the
+	// source so the anonymous finish can persist the credential and run the right post-step.
+	BeginEnrollment(ctx context.Context, user RegisteringUser, source EnrollSource) (*BeginResult, error)
+
+	// FinishEnrollment verifies the attestation in responseBody against the pending enrollment for
+	// sessionID, persists the credential under name, and returns the enrolled user's id and the source
+	// flow so the caller can run the right post-step. Returns ErrChallengeExpired for an unknown/expired
+	// sessionID.
+	FinishEnrollment(ctx context.Context, sessionID, name string, responseBody []byte) (userID int64, source EnrollSource, err error)
 
 	// FinishRegistration verifies the attestation in responseBody against the stored challenge and
 	// persists the new credential under name. It returns ErrChallengeExpired for an expired sessionID.

--- a/public/app/core/components/Login/passkeyLogin.test.tsx
+++ b/public/app/core/components/Login/passkeyLogin.test.tsx
@@ -79,6 +79,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete config.passkey;
+  config.disableLoginForm = false;
 });
 
 describe('usePasskeyAutofill', () => {
@@ -105,6 +106,16 @@ describe('usePasskeyAutofill', () => {
 
   it('does not start a ceremony when passkeys are disabled', () => {
     config.passkey = { enabled: false };
+    mockSupportsAutofill.mockResolvedValue(true);
+
+    render(<Harness />);
+
+    expect(mockSupportsAutofill).not.toHaveBeenCalled();
+    expect(mockStartAuthentication).not.toHaveBeenCalled();
+  });
+
+  it('does not start a ceremony in passwordless mode (no username field to attach to)', () => {
+    config.disableLoginForm = true;
     mockSupportsAutofill.mockResolvedValue(true);
 
     render(<Harness />);
@@ -166,6 +177,17 @@ describe('usePasskeyButtonMode', () => {
     render(<ModeHarness />);
 
     await waitFor(() => expect(screen.getByTestId('mode')).toHaveTextContent('hidden'));
+  });
+
+  it('stays visible in passwordless mode even when autofill is supported', async () => {
+    // The login form (and the username field autofill attaches to) is hidden in passwordless mode, so
+    // the explicit button must remain the entry point rather than hiding behind autofill.
+    config.disableLoginForm = true;
+    mockSupportsAutofill.mockResolvedValue(true);
+
+    render(<ModeHarness />);
+
+    await waitFor(() => expect(screen.getByTestId('mode')).toHaveTextContent('secondary'));
   });
 
   it('is secondary even when the device has no platform authenticator (cross-device flow)', async () => {

--- a/public/app/core/components/Login/passkeyLogin.ts
+++ b/public/app/core/components/Login/passkeyLogin.ts
@@ -82,7 +82,14 @@ export function usePasskeyAutofill(): void {
   useEffect(() => {
     mounted.current = true;
 
-    if (!config.passkey?.enabled || typeof window === 'undefined' || !('PublicKeyCredential' in window)) {
+    // In passwordless mode the login form (and its autocomplete="webauthn" username field) is hidden,
+    // so there is no field for Conditional UI to attach to — the explicit button is the entry point.
+    if (
+      config.disableLoginForm ||
+      !config.passkey?.enabled ||
+      typeof window === 'undefined' ||
+      !('PublicKeyCredential' in window)
+    ) {
       return;
     }
 
@@ -137,7 +144,11 @@ export function usePasskeyButtonMode(): PasskeyButtonMode {
       // When the browser supports Conditional UI, the username field's autofill already offers the
       // passkey (including "from another device"), so the explicit button would be a redundant second
       // prompt. Hide it and let autofill be the single entry point.
-      if (await browserSupportsWebAuthnAutofill()) {
+      //
+      // Exception: in passwordless mode the login form — and therefore the username field autofill
+      // attaches to — is hidden, so autofill has nowhere to surface. Keep the explicit button as the
+      // entry point (its click runs the same discoverable login, no username field required).
+      if (!config.disableLoginForm && (await browserSupportsWebAuthnAutofill())) {
         if (!cancelled) {
           setMode('hidden');
         }

--- a/public/app/core/components/Signup/SignupPage.test.tsx
+++ b/public/app/core/components/Signup/SignupPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, fireEvent, screen, waitFor, userEvent } from 'test/test-utils';
 
+import { config } from '@grafana/runtime';
 import { getRouteComponentProps } from 'app/core/navigation/mocks/routeProps';
 
 import { SignupPage } from './SignupPage';
@@ -105,5 +106,34 @@ describe('Signup Page', () => {
       })
     );
     expect(window.location.assign).toHaveBeenCalledWith('/');
+  });
+});
+
+describe('Signup Page - passwordless', () => {
+  beforeEach(() => {
+    config.disableLoginForm = true;
+    config.passkey = { enabled: true };
+    Object.defineProperty(window, 'PublicKeyCredential', { value: function () {}, configurable: true });
+  });
+  afterEach(() => {
+    config.disableLoginForm = false;
+    delete config.passkey;
+    delete (window as { PublicKeyCredential?: unknown }).PublicKeyCredential;
+  });
+
+  it('hides the password fields and shows the passkey button', () => {
+    render(<SignupPage {...props} />);
+
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Confirm password')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create your passkey' })).toBeInTheDocument();
+  });
+
+  it('warns and disables submit when the browser lacks WebAuthn support', () => {
+    delete (window as { PublicKeyCredential?: unknown }).PublicKeyCredential;
+    render(<SignupPage {...props} />);
+
+    expect(screen.getByRole('button', { name: 'Create your passkey' })).toBeDisabled();
+    expect(screen.getByText(/does not support passkeys/i)).toBeInTheDocument();
   });
 });

--- a/public/app/core/components/Signup/SignupPage.test.tsx
+++ b/public/app/core/components/Signup/SignupPage.test.tsx
@@ -1,9 +1,18 @@
+import { startRegistration } from '@simplewebauthn/browser';
 import { render, fireEvent, screen, waitFor, userEvent } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
 import { getRouteComponentProps } from 'app/core/navigation/mocks/routeProps';
 
+import { PASSKEY_HINT_KEY } from '../Login/passkeyLogin';
+
 import { SignupPage } from './SignupPage';
+
+jest.mock('@simplewebauthn/browser', () => ({
+  ...jest.requireActual('@simplewebauthn/browser'),
+  startRegistration: jest.fn(),
+}));
+const mockStartRegistration = startRegistration as jest.MockedFunction<typeof startRegistration>;
 
 const postMock = jest.fn();
 jest.mock('@grafana/runtime', () => ({
@@ -135,5 +144,26 @@ describe('Signup Page - passwordless', () => {
 
     expect(screen.getByRole('button', { name: 'Create your passkey' })).toBeDisabled();
     expect(screen.getByText(/does not support passkeys/i)).toBeInTheDocument();
+  });
+
+  it('writes the passkey hint after a successful signup so the next login shows the primary label', async () => {
+    localStorage.clear();
+    mockStartRegistration.mockResolvedValueOnce({ id: 'cred-1', response: {} } as never);
+    postMock
+      .mockResolvedValueOnce({ sessionID: 'sess-1', options: {} }) // credential-enroll/begin
+      .mockResolvedValueOnce({ message: 'Signed up' }); // credential-enroll/finish
+
+    render(<SignupPage {...props} />);
+
+    await userEvent.type(screen.getByRole('textbox', { name: 'Your name' }), 'test-user');
+    await userEvent.type(screen.getByRole('textbox', { name: 'Email' }), 'test@gmail.com');
+    fireEvent.click(screen.getByRole('button', { name: 'Create your passkey' }));
+
+    await waitFor(() => expect(localStorage.getItem(PASSKEY_HINT_KEY)).toBe('true'));
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/user/credential-enroll/finish',
+      expect.objectContaining({ sessionID: 'sess-1' }),
+      { showErrorAlert: false }
+    );
   });
 });

--- a/public/app/core/components/Signup/SignupPage.tsx
+++ b/public/app/core/components/Signup/SignupPage.tsx
@@ -2,6 +2,7 @@ import { type PublicKeyCredentialCreationOptionsJSON, startRegistration } from '
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import { store } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
 import { Alert, Button, Field, Input, LinkButton, Stack } from '@grafana/ui';
@@ -11,7 +12,7 @@ import { type GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { w3cStandardEmailValidator } from 'app/features/admin/utils';
 
 import { InnerBox, LoginLayout } from '../Login/LoginLayout';
-import { isWebAuthnAbort } from '../Login/passkeyLogin';
+import { isWebAuthnAbort, PASSKEY_HINT_KEY } from '../Login/passkeyLogin';
 import { PasswordField } from '../PasswordField/PasswordField';
 
 interface SignupDTO {
@@ -88,6 +89,10 @@ export const SignupPage = ({ queryParams }: Props) => {
         { sessionID: begin.sessionID, name: t('sign-up.passkey.default-name', 'Passkey'), response },
         { showErrorAlert: false }
       );
+      // Mark this browser as passkey-enrolled so the login page shows the primary "Sign in with a
+      // passkey" label next time, not the "from another device" fallback — same hint the login and
+      // profile-enroll flows write.
+      store.set(PASSKEY_HINT_KEY, true);
       window.location.assign(getConfig().appSubUrl + '/');
     } catch (err) {
       // The user dismissed the OS prompt: let them retry without losing the form.

--- a/public/app/core/components/Signup/SignupPage.tsx
+++ b/public/app/core/components/Signup/SignupPage.tsx
@@ -1,14 +1,17 @@
+import { type PublicKeyCredentialCreationOptionsJSON, startRegistration } from '@simplewebauthn/browser';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
-import { getBackendSrv } from '@grafana/runtime';
-import { Field, Input, Button, LinkButton, Stack } from '@grafana/ui';
+import { getBackendSrv, isFetchError } from '@grafana/runtime';
+import { Alert, Button, Field, Input, LinkButton, Stack } from '@grafana/ui';
 import { getConfig } from 'app/core/config';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { type GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { w3cStandardEmailValidator } from 'app/features/admin/utils';
 
 import { InnerBox, LoginLayout } from '../Login/LoginLayout';
+import { isWebAuthnAbort } from '../Login/passkeyLogin';
 import { PasswordField } from '../PasswordField/PasswordField';
 
 interface SignupDTO {
@@ -16,9 +19,14 @@ interface SignupDTO {
   email: string;
   username: string;
   orgName?: string;
-  password: string;
+  password?: string;
   code: string;
   confirm?: string;
+}
+
+interface CredentialEnrollBeginResponse {
+  sessionID: string;
+  options: PublicKeyCredentialCreationOptionsJSON;
 }
 
 interface QueryParams {
@@ -28,8 +36,28 @@ interface QueryParams {
 
 interface Props extends GrafanaRouteComponentProps<{}, QueryParams> {}
 
+// Passwordless mode: the instance has hidden the password login form and enabled passkeys, so signup
+// enrols a passkey instead of setting a password. Matches the login page's own gate (disableLoginForm).
+function isPasswordless(): boolean {
+  return getConfig().disableLoginForm && Boolean(getConfig().passkey?.enabled);
+}
+
+function toErrorMessage(err: unknown): string {
+  if (isFetchError(err)) {
+    if (err.status === 410 || err.data?.messageId === 'passkey.challenge-expired') {
+      return t('sign-up.passkey.error-expired', 'That took too long. Please try again.');
+    }
+    return err.data?.message ?? t('sign-up.passkey.error-unknown', 'Could not create your passkey. Please try again.');
+  }
+  return t('sign-up.passkey.error-unknown', 'Could not create your passkey. Please try again.');
+}
+
 export const SignupPage = ({ queryParams }: Props) => {
   const notifyApp = useAppNotification();
+  const passwordless = isPasswordless();
+  const webAuthnSupported = typeof window !== 'undefined' && 'PublicKeyCredential' in window;
+  const [submitError, setSubmitError] = useState<string>();
+  const [submitting, setSubmitting] = useState(false);
   const {
     handleSubmit,
     formState: { errors },
@@ -37,11 +65,49 @@ export const SignupPage = ({ queryParams }: Props) => {
     getValues,
   } = useForm<SignupDTO>({ defaultValues: { email: queryParams.email, code: queryParams.code } });
 
+  // enrollPasskey creates the passwordless user and enrols a passkey via the credential-enroll
+  // ceremony, then reloads — finish sets the session cookie, so we land authenticated.
+  const enrollPasskey = async (formData: SignupDTO) => {
+    setSubmitError(undefined);
+    setSubmitting(true);
+    try {
+      const begin = await getBackendSrv().post<CredentialEnrollBeginResponse>(
+        '/api/user/credential-enroll/begin',
+        {
+          email: formData.email,
+          username: formData.email,
+          name: formData.name,
+          orgName: formData.orgName,
+          code: formData.code,
+        },
+        { showErrorAlert: false }
+      );
+      const response = await startRegistration({ optionsJSON: begin.options });
+      await getBackendSrv().post(
+        '/api/user/credential-enroll/finish',
+        { sessionID: begin.sessionID, name: t('sign-up.passkey.default-name', 'Passkey'), response },
+        { showErrorAlert: false }
+      );
+      window.location.assign(getConfig().appSubUrl + '/');
+    } catch (err) {
+      // The user dismissed the OS prompt: let them retry without losing the form.
+      if (!isWebAuthnAbort(err)) {
+        setSubmitError(toErrorMessage(err));
+      }
+      setSubmitting(false);
+    }
+  };
+
   const onSubmit = async (formData: SignupDTO) => {
     if (formData.name === '') {
       delete formData.name;
     }
     delete formData.confirm;
+
+    if (passwordless) {
+      await enrollPasskey(formData);
+      return;
+    }
 
     const response = await getBackendSrv()
       .post('/api/user/signup/step2', {
@@ -97,36 +163,55 @@ export const SignupPage = ({ queryParams }: Props) => {
               <Input id="verification-code" {...register('code')} />
             </Field>
           )}
-          <Field
-            label={t('sign-up.password-label', 'Password')}
-            invalid={!!errors.password}
-            error={errors?.password?.message}
-          >
-            <PasswordField
-              id="new-password"
-              autoFocus
-              autoComplete="new-password"
-              {...register('password', { required: 'Password is required' })}
+          {!passwordless && (
+            <>
+              <Field
+                label={t('sign-up.password-label', 'Password')}
+                invalid={!!errors.password}
+                error={errors?.password?.message}
+              >
+                <PasswordField
+                  id="new-password"
+                  autoFocus
+                  autoComplete="new-password"
+                  {...register('password', { required: 'Password is required' })}
+                />
+              </Field>
+              <Field
+                label={t('sign-up.confirm-password-label', 'Confirm password')}
+                invalid={!!errors.confirm}
+                error={errors?.confirm?.message}
+              >
+                <PasswordField
+                  id="confirm-new-password"
+                  autoComplete="new-password"
+                  {...register('confirm', {
+                    required: 'Confirmed password is required',
+                    validate: (v) => v === getValues().password || 'Passwords must match!',
+                  })}
+                />
+              </Field>
+            </>
+          )}
+
+          {submitError && <Alert severity="error" title={submitError} />}
+          {passwordless && !webAuthnSupported && (
+            <Alert
+              severity="warning"
+              title={t(
+                'sign-up.passkey.unsupported',
+                'This browser does not support passkeys. Use a browser that supports them to sign up.'
+              )}
             />
-          </Field>
-          <Field
-            label={t('sign-up.confirm-password-label', 'Confirm password')}
-            invalid={!!errors.confirm}
-            error={errors?.confirm?.message}
-          >
-            <PasswordField
-              id="confirm-new-password"
-              autoComplete="new-password"
-              {...register('confirm', {
-                required: 'Confirmed password is required',
-                validate: (v) => v === getValues().password || 'Passwords must match!',
-              })}
-            />
-          </Field>
+          )}
 
           <Stack>
-            <Button type="submit">
-              <Trans i18nKey="sign-up.submit-button">Submit</Trans>
+            <Button type="submit" disabled={submitting || (passwordless && !webAuthnSupported)}>
+              {passwordless ? (
+                <Trans i18nKey="sign-up.passkey.submit-button">Create your passkey</Trans>
+              ) : (
+                <Trans i18nKey="sign-up.submit-button">Submit</Trans>
+              )}
             </Button>
             <LinkButton fill="text" href={getConfig().appSubUrl + '/login'}>
               <Trans i18nKey="sign-up.back-button">Back to login</Trans>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10991,7 +10991,8 @@
         "unknown": "Could not sign in with passkey. Please try again."
       },
       "sign-in": "Sign in with a passkey",
-      "signing-in": "Signing in…"
+      "signing-in": "Signing in…",
+      "use-another-device": "Use a passkey from another device"
     },
     "services": {
       "sing-in-with-prefix": "Sign in with {{serviceName}}"
@@ -14799,6 +14800,13 @@
     "confirm-password-label": "Confirm password",
     "email-label": "Email",
     "org-name-label": "Org. name",
+    "passkey": {
+      "default-name": "Passkey",
+      "error-expired": "That took too long. Please try again.",
+      "error-unknown": "Could not create your passkey. Please try again.",
+      "submit-button": "Create your passkey",
+      "unsupported": "This browser does not support passkeys. Use a browser that supports them to sign up."
+    },
     "password-label": "Password",
     "submit-button": "Submit",
     "user-name-label": "Your name",


### PR DESCRIPTION
On top https://github.com/grafana/grafana/pull/127025
Makes Grafana login fully passwordless: when passkeys are on and the password form is hidden, a passkey is the only way to sign in — including at signup, where new users create a passkey instead of a password. No new toggle:

```
[auth]
disable_login_form = true
[auth.passkey]
enabled = true
```
Changes

- Anonymous enrollment (/api/user/credential-enroll/begin + /finish): a signed-out signup creates the user and enrolls their first passkey; cross-replica safe via shared cache.
- Signup page: password fields replaced with a "Create your passkey" button.
- Login page: passkey button stays as the entry point when the password form is hidden.

Hardening

- Abandoned signups (no password, no passkey) are reused on retry — only when provably unusable, never a real account.
- Enroll finish runs the same completion as password signup (event + pending invites).
- Enroll-begin is quota-gated, so it can't bypass the account cap.

Out of scope

Invite/admin enrollment and lost-passkey recovery.