### PR TITLE
unified-storage: fix title_ngram query analyzer

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2261,7 +2261,11 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 					q := bleve.NewMatchQuery(removeSmallTerms(req.Query)) // removeSmallTerms should be part of the analyzer
 					q.SetBoost(float64(field.Boost))
 					q.SetField(field.Name)
-					q.Analyzer = standard.Name               // analyze the text
+					if field.Name == resource.SEARCH_FIELD_TITLE_NGRAM {
+						q.Analyzer = TITLE_ANALYZER
+					} else {
+						q.Analyzer = standard.Name // analyze the text
+					}
 					q.Operator = query.MatchQueryOperatorAnd // all terms must match
 					disjoin.AddQuery(q)
 

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -275,6 +275,32 @@ func TestCanSearchByTitle(t *testing.T) {
 	})
 }
 
+// TestSearchHyphenatedTitleSubstring reproduces the regression vs. the legacy
+// SQL search, which matched titles with a plain substring `title LIKE '%q%'`.
+// A search-as-you-type query that truncates the final hyphen-separated token
+// (e.g. "alpha-beta-ga") should still match "alpha-beta-gamma", the way the
+// legacy substring match did.
+func TestSearchHyphenatedTitleSubstring(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+
+	index := newTestDashboardsIndex(t, threshold, 2, noop)
+	indexDocumentsWithTitles(t, index, key, map[string]string{
+		"name1": "alpha-beta-gamma",
+		"name2": "unrelated",
+	})
+
+	// Truncated final token (2 chars). Legacy LIKE '%alpha-beta-ga%' matched.
+	checkSearchQuery(t, index, newTestQuery("alpha-beta-ga"), []string{"name1"})
+	// Truncated final token (3 chars, hits the ngram index).
+	checkSearchQuery(t, index, newTestQuery("alpha-beta-gam"), []string{"name1"})
+	// Whole leading tokens.
+	checkSearchQuery(t, index, newTestQuery("alpha-beta"), []string{"name1"})
+}
+
 // TestTitleNgramFieldSearch queries exclusively against the title_ngram field
 // (via explicit QueryFields) to prove partial/prefix matching works without
 // relying on the title field mapping.

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
@@ -3,17 +3,6 @@
   "hits": [
     {
       "resource": "dashboards",
-      "name": "timeseries-stacking2",
-      "title": "TimeSeries \u0026 BarChart Stacking",
-      "tags": [
-        "gdev",
-        "panel-tests",
-        "graph-ng"
-      ],
-      "score": 0.131
-    },
-    {
-      "resource": "dashboards",
       "name": "timeseries-stacking",
       "title": "Panel Tests - TimeSeries - stacking",
       "tags": [
@@ -21,8 +10,19 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.123
+      "score": 0.63
+    },
+    {
+      "resource": "dashboards",
+      "name": "timeseries-stacking2",
+      "title": "TimeSeries \u0026 BarChart Stacking",
+      "tags": [
+        "gdev",
+        "panel-tests",
+        "graph-ng"
+      ],
+      "score": 0.6
     }
   ],
-  "maxScore": 0.131
+  "maxScore": 0.63
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.168
+      "score": 0.663
     }
   ],
-  "maxScore": 0.168
+  "maxScore": 0.663
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.059
+      "score": 0.214
     }
   ],
-  "maxScore": 0.059
+  "maxScore": 0.214
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
@@ -10,7 +10,7 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.115,
+      "score": 0.112,
       "explain": {
         "children": [
           {
@@ -33,11 +33,11 @@
                               },
                               {
                                 "message": "queryNorm",
-                                "value": 0.026
+                                "value": 0.025
                               }
                             ],
                             "message": "queryWeight(fields.panel_title:orange^5.000000), product of:",
-                            "value": 0.32
+                            "value": 0.313
                           },
                           {
                             "children": [
@@ -60,20 +60,20 @@
                                 "value": 2.485
                               }
                             ],
-                            "message": "fieldWeight(fields.panel_title:orange in <docID>), as per bm25 model, product of:",
+                            "message": "fieldWeight(fields.panel_title:orange in \u003cdocID\u003e), as per bm25 model, product of:",
                             "value": 1.108
                           }
                         ],
-                        "message": "weight(fields.panel_title:orange^5.000000 in <docID>), product of:",
-                        "value": 0.355
+                        "message": "weight(fields.panel_title:orange^5.000000 in \u003cdocID\u003e), product of:",
+                        "value": 0.346
                       }
                     ],
                     "message": "sum of:",
-                    "value": 0.355
+                    "value": 0.346
                   }
                 ],
                 "message": "sum of:",
-                "value": 0.355
+                "value": 0.346
               },
               {
                 "message": "coord(1/4)",
@@ -82,7 +82,7 @@
             ],
             "message": "product of:",
             "partial_match": true,
-            "value": 0.089
+            "value": 0.087
           },
           {
             "children": [
@@ -98,11 +98,11 @@
                           },
                           {
                             "message": "queryNorm",
-                            "value": 0.026
+                            "value": 0.025
                           }
                         ],
                         "message": "ConstantScore()^1.000000, product of:",
-                        "value": 0.026
+                        "value": 0.025
                       },
                       {
                         "message": "ConstantScore()",
@@ -110,21 +110,21 @@
                       }
                     ],
                     "message": "weight(^1.000000), product of:",
-                    "value": 0.026
+                    "value": 0.025
                   }
                 ],
                 "message": "sum of:",
-                "value": 0.026
+                "value": 0.025
               }
             ],
             "message": "sum of:",
-            "value": 0.026
+            "value": 0.025
           }
         ],
         "message": "sum of:",
-        "value": 0.115
+        "value": 0.112
       }
     }
   ],
-  "maxScore": 0.115
+  "maxScore": 0.112
 }


### PR DESCRIPTION
This fixes a bug when searching for partial title matches with hyphens: searching for `alpha-beta-ga` does not match `alpha-beta-gamma`, but both `alpha-beta` and `alpha-beta-gam` do

We index the `title_ngram` field in the bleve document with a custom analyzer which tokenizes the title n-grams by **[whitespace only](https://github.com/grafana/grafana/blob/841709183cd24c8310062372f81a2c2c81dd1aeb/pkg/storage/unified/search/custom_analyzers.go#L37)**. But at query time, we tokenize the query term using the standard bleve analyzer, which tokenizes by whitespace and most other punctuation (including hyphens).

in the example of the test in this PR, this results in bleve trying to find an n-gram that matches `alpha` AND `beta` AND `ga`. Nothing matches because our n-gram minimum length is 3. 

This PR fixes this by running the same analyzer on the query that we use to analyze the `title_ngram` field.
