### PR TITLE
Auth: skip failing Zanzana list actions when merging user permissions

### DIFF
--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
@@ -384,7 +384,11 @@ func (r *ZanzanaPermissionResolver) listAllWithPrefix(ctx context.Context, names
 		if strings.HasPrefix(entry.Action, prefix) {
 			perms, err := r.listPermissions(ctx, namespace, subject, teams, entry.Group, entry.Resource, entry.Verb, entry.Action, scope)
 			if err != nil {
-				return nil, err
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return nil, err
+				}
+				zLogger.Warn("failed to list zanzana permissions for action, skipping", "action", entry.Action, "error", err)
+				continue
 			}
 			permissions = append(permissions, perms...)
 		}

--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver_test.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver_test.go
@@ -2,6 +2,7 @@ package acimpl
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 	"sync"
@@ -12,10 +13,47 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 )
+
+type verbErroringZanzanaClient struct {
+	fakeZanzanaClient
+	failVerb string
+	allResp  *authzv1.ListResponse
+}
+
+func (c *verbErroringZanzanaClient) List(_ context.Context, req *authzv1.ListRequest) (*authzv1.ListResponse, error) {
+	if req.GetVerb() == c.failVerb {
+		return nil, errors.New("failed to perform list request")
+	}
+	return c.allResp, nil
+}
+
+func TestResolveCurrentUserPermissions_SkipsFailingAction(t *testing.T) {
+	client := &verbErroringZanzanaClient{
+		failVerb: utils.VerbCreate,
+		allResp:  &authzv1.ListResponse{All: true},
+	}
+	r := NewZanzanaPermissionResolver(client, &usertest.FakeUserService{}, nil, false)
+
+	usr := &identity.StaticRequester{
+		Type:    claims.TypeUser,
+		UserID:  1,
+		UserUID: "u1",
+		OrgID:   1,
+	}
+
+	perms, err := r.ResolveCurrentUserPermissions(context.Background(), usr)
+	require.NoError(t, err)
+
+	require.Contains(t, permScopes(perms, "dashboards:read"), ac.Scope("dashboards", "*"))
+	require.Contains(t, permScopes(perms, "folders:read"), ac.Scope("folders", "*"))
+	require.Empty(t, permScopes(perms, "dashboards:create"))
+	require.Empty(t, permScopes(perms, "folders:create"))
+}
 
 // capturingZanzanaClient records every ListRequest it receives so tests can
 // assert on the group / resource / verb / subject sent to Zanzana.


### PR DESCRIPTION
## Summary

- When resolving user permissions from Zanzana, skip individual actions whose List call fails instead of aborting the whole lookup
- Fixes merged wildcard grants (e.g. `dashboards:*`, `folders:*`) being dropped when an unrelated action like `teams:create` fails
- Adds a unit test covering the skip behavior
