### PR TITLE
Provisioning: extract provider-agnostic webhook handler

### DIFF
--- a/apps/provisioning/pkg/repository/github/webhook.go
+++ b/apps/provisioning/pkg/repository/github/webhook.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v82/github"
@@ -24,7 +25,6 @@ var subscribedEvents = []string{"pull_request", "push"} // same order as slices.
 type GithubWebhookRepository interface {
 	GithubRepository
 	repository.Hooks
-
 	repository.WebhookRepository
 }
 
@@ -32,14 +32,14 @@ var _ repository.WebhookRepository = (*githubWebhookRepository)(nil)
 
 type githubWebhookRepository struct {
 	GithubRepository
-	config            *provisioning.Repository
-	owner             string
-	repo              string
-	secret            common.RawSecureValue
-	gh                Client
-	webhookURL        string
-	incrementalPolicy repository.IncrementalSyncPolicy
-	replayCache       *replayCache
+	*repository.WebhookHandler
+	config      *provisioning.Repository
+	owner       string
+	repo        string
+	gh          Client
+	webhookURL  string
+	secret      common.RawSecureValue
+	replayCache *replayCache
 }
 
 func NewGithubWebhookRepository(
@@ -54,32 +54,33 @@ func NewGithubWebhookRepository(
 	if replay == nil {
 		replay = newReplayCache(defaultReplayCacheTTL)
 	}
-	return &githubWebhookRepository{
-		GithubRepository:  basic,
-		config:            basic.Config(),
-		owner:             basic.Owner(),
-		repo:              basic.Repo(),
-		gh:                basic.Client(),
-		webhookURL:        webhookURL,
-		secret:            secret,
-		incrementalPolicy: incrementalPolicy,
-		replayCache:       replay,
+	cfg := basic.Config()
+	slug := fmt.Sprintf("%s/%s", basic.Owner(), basic.Repo())
+	r := &githubWebhookRepository{
+		GithubRepository: basic,
+		config:           cfg,
+		owner:            basic.Owner(),
+		repo:             basic.Repo(),
+		gh:               basic.Client(),
+		webhookURL:       webhookURL,
+		secret:           secret,
+		replayCache:      replay,
 	}
+	r.WebhookHandler = repository.NewWebhookHandler(
+		r.processRequest, cfg.Status.Webhook, cfg.GetName(), slug,
+		cfg.Spec.GitHub.Branch, cfg.Spec.Sync.Enabled, incrementalPolicy,
+	)
+	return r
 }
 
-// Webhook implements Repository.
-func (r *githubWebhookRepository) Webhook(ctx context.Context, req *http.Request) (*provisioning.WebhookResponse, error) {
-	if r.config.Status.Webhook == nil {
-		return nil, fmt.Errorf("unexpected webhook request")
-	}
-
+func (r *githubWebhookRepository) processRequest(ctx context.Context, req *http.Request) (repository.WebhookEvent, error) {
 	if r.secret.IsZero() {
-		return nil, fmt.Errorf("missing webhook secret")
+		return repository.WebhookEvent{}, fmt.Errorf("missing webhook secret")
 	}
 
 	payload, err := github.ValidatePayload(req, []byte(r.secret))
 	if err != nil {
-		return nil, apierrors.NewUnauthorized("invalid signature")
+		return repository.WebhookEvent{}, apierrors.NewUnauthorized("invalid signature")
 	}
 
 	// Replay protection: key on the validated signature, not the
@@ -100,130 +101,65 @@ func (r *githubWebhookRepository) Webhook(ctx context.Context, req *http.Request
 	}
 	if r.replayCache.seenOrAdd(signature) {
 		logging.FromContext(ctx).Debug("dropping replayed webhook delivery", "delivery_id", github.DeliveryID(req))
-		return &provisioning.WebhookResponse{Code: http.StatusOK, Message: "ok"}, nil
+		return repository.WebhookEvent{Type: repository.WebhookEventReplay}, nil
 	}
 
-	return r.parseWebhook(ctx, github.WebHookType(req), payload)
-}
-
-// This method does not include context because it does delegate any more requests
-func (r *githubWebhookRepository) parseWebhook(ctx context.Context, messageType string, payload []byte) (*provisioning.WebhookResponse, error) {
-	event, err := github.ParseWebHook(messageType, payload)
+	event, err := github.ParseWebHook(github.WebHookType(req), payload)
 	if err != nil {
-		return nil, apierrors.NewBadRequest("invalid payload")
+		return repository.WebhookEvent{}, apierrors.NewBadRequest("invalid payload")
 	}
 
 	switch event := event.(type) {
 	case *github.PushEvent:
-		return r.parsePushEvent(ctx, event)
+		if event.GetRepo() == nil {
+			return repository.WebhookEvent{}, fmt.Errorf("missing repository in push event")
+		}
+		var deletedPaths []string
+		var totalChanges int
+		for _, change := range event.GetCommits() {
+			totalChanges += len(change.Added) + len(change.Modified) + len(change.Removed)
+			deletedPaths = append(deletedPaths, change.Removed...)
+		}
+		return repository.WebhookEvent{
+			Type:         repository.WebhookEventPush,
+			RepoSlug:     event.GetRepo().GetFullName(),
+			Branch:       strings.TrimPrefix(event.GetRef(), "refs/heads/"),
+			DeletedPaths: deletedPaths,
+			TotalChanges: totalChanges,
+		}, nil
 	case *github.PullRequestEvent:
-		return r.parsePullRequestEvent(event)
+		if event.GetRepo() == nil {
+			return repository.WebhookEvent{}, fmt.Errorf("missing repository in pull request event")
+		}
+		pr := event.GetPullRequest()
+		if pr == nil {
+			return repository.WebhookEvent{}, fmt.Errorf("expected PR in event")
+		}
+		return repository.WebhookEvent{
+			Type:      repository.WebhookEventPullRequest,
+			RepoSlug:  event.GetRepo().GetFullName(),
+			Branch:    pr.GetBase().GetRef(),
+			Action:    normalizeGitHubAction(event.GetAction()),
+			PRNumber:  pr.GetNumber(),
+			PRURL:     pr.GetHTMLURL(),
+			SourceRef: pr.GetHead().GetRef(),
+			Hash:      pr.GetHead().GetSHA(),
+		}, nil
 	case *github.PingEvent:
-		return &provisioning.WebhookResponse{
-			Code:    http.StatusOK,
-			Message: "ping received",
-		}, nil
+		return repository.WebhookEvent{Type: repository.WebhookEventPing}, nil
 	default:
-		return &provisioning.WebhookResponse{
-			Code:    http.StatusNotImplemented,
-			Message: fmt.Sprintf("unsupported messageType: %s", messageType),
+		return repository.WebhookEvent{
+			Type:    repository.WebhookEventUnsupported,
+			Message: fmt.Sprintf("unsupported messageType: %s", github.WebHookType(req)),
 		}, nil
 	}
 }
 
-func (r *githubWebhookRepository) parsePushEvent(ctx context.Context, event *github.PushEvent) (*provisioning.WebhookResponse, error) {
-	_, logger := r.logger(ctx, "")
-
-	if event.GetRepo() == nil {
-		return nil, fmt.Errorf("missing repository in push event")
+func normalizeGitHubAction(action string) repository.PullRequestAction {
+	if action == "synchronize" {
+		return repository.PullRequestActionUpdated
 	}
-	expected := fmt.Sprintf("%s/%s", r.owner, r.repo)
-	if event.GetRepo().GetFullName() != expected {
-		logger.Warn("webhook push event repository mismatch", "expected", expected, "got", event.GetRepo().GetFullName())
-		return nil, repository.ErrRepositoryMismatch
-	}
-
-	// No need to sync if not enabled
-	if !r.config.Spec.Sync.Enabled {
-		return &provisioning.WebhookResponse{Code: http.StatusOK}, nil
-	}
-
-	// Skip silently if the event is not for the main/master branch
-	// as we cannot configure the webhook to only publish events for the main branch
-	if event.GetRef() != fmt.Sprintf("refs/heads/%s", r.config.Spec.GitHub.Branch) {
-		return &provisioning.WebhookResponse{Code: http.StatusOK}, nil
-	}
-
-	var deletedPaths []string
-	var totalChanges int
-	for _, change := range event.GetCommits() {
-		totalChanges += len(change.Added) + len(change.Modified) + len(change.Removed)
-		deletedPaths = append(deletedPaths, change.Removed...)
-	}
-
-	incremental := r.incrementalPolicy.CanUseIncrementalSync(deletedPaths, totalChanges)
-
-	return &provisioning.WebhookResponse{
-		Code: http.StatusAccepted,
-		Job: &provisioning.JobSpec{
-			Repository: r.config.GetName(),
-			Action:     provisioning.JobActionPull,
-			Pull: &provisioning.SyncJobOptions{
-				Incremental: incremental,
-			},
-		},
-	}, nil
-}
-
-func (r *githubWebhookRepository) parsePullRequestEvent(event *github.PullRequestEvent) (*provisioning.WebhookResponse, error) {
-	if event.GetRepo() == nil {
-		return nil, fmt.Errorf("missing repository in pull request event")
-	}
-	cfg := r.config.Spec.GitHub
-	if cfg == nil {
-		return nil, fmt.Errorf("missing GitHub config")
-	}
-
-	expected := fmt.Sprintf("%s/%s", r.owner, r.repo)
-	if event.GetRepo().GetFullName() != expected {
-		slog.Warn("webhook pull request event repository mismatch", "expected", expected, "got", event.GetRepo().GetFullName())
-		return nil, repository.ErrRepositoryMismatch
-	}
-	pr := event.GetPullRequest()
-	if pr == nil {
-		return nil, fmt.Errorf("expected PR in event")
-	}
-
-	if pr.GetBase().GetRef() != r.config.Spec.GitHub.Branch {
-		return &provisioning.WebhookResponse{
-			Code:    http.StatusOK,
-			Message: fmt.Sprintf("ignoring pull request event as %s is not  the configured branch", pr.GetBase().GetRef()),
-		}, nil
-	}
-
-	action := event.GetAction()
-	if action != "opened" && action != "reopened" && action != "synchronize" {
-		return &provisioning.WebhookResponse{
-			Code:    http.StatusOK, // Nothing needed
-			Message: fmt.Sprintf("ignore pull request event: %s", action),
-		}, nil
-	}
-
-	// Queue an async job that will parse files
-	return &provisioning.WebhookResponse{
-		Code:    http.StatusAccepted, // Nothing needed
-		Message: fmt.Sprintf("pull request: %s", action),
-		Job: &provisioning.JobSpec{
-			Repository: r.config.GetName(),
-			Action:     provisioning.JobActionPullRequest,
-			PullRequest: &provisioning.PullRequestJobOptions{
-				URL:  pr.GetHTMLURL(),
-				PR:   pr.GetNumber(),
-				Ref:  pr.GetHead().GetRef(),
-				Hash: pr.GetHead().GetSHA(),
-			},
-		},
-	}, nil
+	return repository.PullRequestAction(action)
 }
 
 // CommentPullRequest adds a comment to a pull request.

--- a/apps/provisioning/pkg/repository/github/webhook_test.go
+++ b/apps/provisioning/pkg/repository/github/webhook_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -122,10 +121,17 @@ func TestParseWebhooks(t *testing.T) {
 					GenerateDashboardPreviews: true,
 				},
 			},
+			Status: provisioning.RepositoryStatus{
+				Webhook: &provisioning.WebhookStatus{},
+			},
 		},
-		owner: "grafana",
-		repo:  "git-ui-sync-demo",
+		owner:       "grafana",
+		repo:        "git-ui-sync-demo",
+		secret:      common.RawSecureValue("webhook-secret"),
+		replayCache: newReplayCache(time.Hour),
 	}
+	gh.WebhookHandler = repo.NewWebhookHandler(gh.processRequest, gh.config.Status.Webhook, gh.config.GetName(),
+		"grafana/git-ui-sync-demo", gh.config.Spec.GitHub.Branch, gh.config.Spec.Sync.Enabled, repo.IncrementalSyncPolicy{})
 
 	for _, tt := range tests {
 		name := fmt.Sprintf("webhook-%s-%s.json", tt.messageType, tt.name)
@@ -134,7 +140,7 @@ func TestParseWebhooks(t *testing.T) {
 			payload, err := os.ReadFile(path.Join("testdata", name))
 			require.NoError(t, err)
 
-			rsp, err := gh.parseWebhook(context.Background(), tt.messageType, payload)
+			rsp, err := gh.Webhook(t.Context(), signedWebhookRequest(t, tt.messageType, "webhook-secret", "", string(payload)))
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expected.Code, rsp.Code)
@@ -158,17 +164,23 @@ func TestParsePushEvent_LargeDiffForcesFullSync(t *testing.T) {
 					Branch: "main",
 				},
 			},
+			Status: provisioning.RepositoryStatus{
+				Webhook: &provisioning.WebhookStatus{},
+			},
 		},
-		owner:             "grafana",
-		repo:              "git-ui-sync-demo",
-		incrementalPolicy: repo.NewIncrementalSyncPolicy(false, 5),
+		owner:       "grafana",
+		repo:        "git-ui-sync-demo",
+		secret:      common.RawSecureValue("webhook-secret"),
+		replayCache: newReplayCache(time.Hour),
 	}
+	gh.WebhookHandler = repo.NewWebhookHandler(gh.processRequest, gh.config.Status.Webhook, gh.config.GetName(),
+		"grafana/git-ui-sync-demo", gh.config.Spec.GitHub.Branch, gh.config.Spec.Sync.Enabled, repo.NewIncrementalSyncPolicy(false, 5))
 
 	// nolint:gosec
 	payload, err := os.ReadFile(path.Join("testdata", "webhook-push-large_diff.json"))
 	require.NoError(t, err)
 
-	rsp, err := gh.parseWebhook(context.Background(), "push", payload)
+	rsp, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", "webhook-secret", "", string(payload)))
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusAccepted, rsp.Code)
@@ -196,27 +208,8 @@ func TestGitHubRepository_Webhook_ReplayProtection(t *testing.T) {
 
 	const defaultSecret = "webhook-secret"
 
-	// newSignedRequest signs payload with secret and sets the headers GitHub
-	// sends. deliveryID populates X-GitHub-Delivery; it is intentionally
-	// independent of the signature so tests can vary it freely.
-	newSignedRequest := func(payload, deliveryID, secret string) *http.Request {
-		req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
-		req.Header.Set("X-GitHub-Event", "push")
-		req.Header.Set("Content-Type", "application/json")
-		if deliveryID != "" {
-			req.Header.Set("X-GitHub-Delivery", deliveryID)
-		}
-
-		mac := hmac.New(sha256.New, []byte(secret))
-		mac.Write([]byte(payload))
-		signature := hex.EncodeToString(mac.Sum(nil))
-		req.Header.Set("X-Hub-Signature-256", "sha256="+signature)
-
-		return req
-	}
-
 	newRepo := func(cache *replayCache, secret string) *githubWebhookRepository {
-		return &githubWebhookRepository{
+		r := &githubWebhookRepository{
 			config: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-repo"},
 				Spec: provisioning.RepositorySpec{
@@ -232,12 +225,15 @@ func TestGitHubRepository_Webhook_ReplayProtection(t *testing.T) {
 			secret:      common.RawSecureValue(secret),
 			replayCache: cache,
 		}
+		r.WebhookHandler = repo.NewWebhookHandler(r.processRequest, r.config.Status.Webhook, r.config.GetName(),
+			"grafana/grafana", r.config.Spec.GitHub.Branch, r.config.Spec.Sync.Enabled, repo.IncrementalSyncPolicy{})
+		return r
 	}
 
 	t.Run("first delivery is accepted", func(t *testing.T) {
 		gh := newRepo(newReplayCache(time.Hour), defaultSecret)
 
-		rsp, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-1", defaultSecret))
+		rsp, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-1", pushPayload))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusAccepted, rsp.Code)
 	})
@@ -246,14 +242,14 @@ func TestGitHubRepository_Webhook_ReplayProtection(t *testing.T) {
 		gh := newRepo(newReplayCache(time.Hour), defaultSecret)
 
 		// First delivery succeeds with the normal accepted-job response.
-		first, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-dup", defaultSecret))
+		first, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-dup", pushPayload))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusAccepted, first.Code)
 
 		// Replaying the same signed request returns a generic 200 OK — same
 		// shape as other no-op paths so an attacker can't tell from the
 		// response whether the payload was previously processed.
-		dup, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-dup", defaultSecret))
+		dup, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-dup", pushPayload))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, dup.Code)
 		require.Equal(t, "ok", dup.Message)
@@ -266,10 +262,10 @@ func TestGitHubRepository_Webhook_ReplayProtection(t *testing.T) {
 		// delivery ID. Keying on the signature must still catch it.
 		gh := newRepo(newReplayCache(time.Hour), defaultSecret)
 
-		_, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-A", defaultSecret))
+		_, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-A", pushPayload))
 		require.NoError(t, err)
 
-		dup, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-B", defaultSecret))
+		dup, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-B", pushPayload))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, dup.Code, "same signed body under a different delivery id is still a replay")
 		require.Nil(t, dup.Job)
@@ -278,11 +274,11 @@ func TestGitHubRepository_Webhook_ReplayProtection(t *testing.T) {
 	t.Run("distinct payloads are independent", func(t *testing.T) {
 		gh := newRepo(newReplayCache(time.Hour), defaultSecret)
 
-		_, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-A", defaultSecret))
+		_, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-A", pushPayload))
 		require.NoError(t, err)
 
 		// A different body yields a different signature, so it is processed.
-		rsp, err := gh.Webhook(context.Background(), newSignedRequest(otherPayload, "delivery-B", defaultSecret))
+		rsp, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-B", otherPayload))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusAccepted, rsp.Code)
 	})
@@ -295,10 +291,10 @@ func TestGitHubRepository_Webhook_ReplayProtection(t *testing.T) {
 		repoA := newRepo(cache, "secret-a")
 		repoB := newRepo(cache, "secret-b")
 
-		_, err := repoA.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-A", "secret-a"))
+		_, err := repoA.Webhook(t.Context(), signedWebhookRequest(t, "push", "secret-a", "delivery-A", pushPayload))
 		require.NoError(t, err)
 
-		rsp, err := repoB.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-B", "secret-b"))
+		rsp, err := repoB.Webhook(t.Context(), signedWebhookRequest(t, "push", "secret-b", "delivery-B", pushPayload))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusAccepted, rsp.Code)
 	})
@@ -310,10 +306,10 @@ func TestGitHubRepository_Webhook_ReplayProtection(t *testing.T) {
 		first := newRepo(cache, defaultSecret)
 		second := newRepo(cache, defaultSecret)
 
-		_, err := first.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-1", defaultSecret))
+		_, err := first.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-1", pushPayload))
 		require.NoError(t, err)
 
-		dup, err := second.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-2", defaultSecret))
+		dup, err := second.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-2", pushPayload))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, dup.Code)
 		require.Equal(t, "ok", dup.Message)
@@ -324,12 +320,12 @@ func TestGitHubRepository_Webhook_ReplayProtection(t *testing.T) {
 		const ttl = 50 * time.Millisecond
 		gh := newRepo(newReplayCache(ttl), defaultSecret)
 
-		_, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-X", defaultSecret))
+		_, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-X", pushPayload))
 		require.NoError(t, err)
 
 		// Once the entry expires, the same signed request is processed again.
 		time.Sleep(ttl + 20*time.Millisecond)
-		rsp, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-X", defaultSecret))
+		rsp, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-X", pushPayload))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusAccepted, rsp.Code)
 	})
@@ -343,12 +339,12 @@ func TestGitHubRepository_Webhook_ReplayProtection(t *testing.T) {
 		req.Header.Set("X-GitHub-Delivery", "delivery-bad-sig")
 		req.Header.Set("X-Hub-Signature-256", "sha256=deadbeef")
 
-		_, err := gh.Webhook(context.Background(), req)
+		_, err := gh.Webhook(t.Context(), req)
 		require.Error(t, err)
 
 		// A subsequent valid request must still succeed — a failed signature
 		// must not poison the replay cache.
-		rsp, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-good", defaultSecret))
+		rsp, err := gh.Webhook(t.Context(), signedWebhookRequest(t, "push", defaultSecret, "delivery-good", pushPayload))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusAccepted, rsp.Code)
 	})
@@ -725,7 +721,7 @@ func TestGitHubRepository_Webhook(t *testing.T) {
 			},
 			expected: &provisioning.WebhookResponse{
 				Code:    http.StatusAccepted,
-				Message: "pull request: synchronize",
+				Message: "pull request: updated",
 				Job: &provisioning.JobSpec{
 					Repository: "test-repo",
 					Action:     provisioning.JobActionPullRequest,
@@ -872,48 +868,6 @@ func TestGitHubRepository_Webhook(t *testing.T) {
 				return req
 			},
 			expectedError: fmt.Errorf("missing repository in pull request event"),
-		},
-		{
-			name: "pull request event with missing GitHub config",
-			config: &provisioning.Repository{
-				Spec: provisioning.RepositorySpec{
-					// GitHub config is intentionally missing
-				},
-				Status: provisioning.RepositoryStatus{
-					Webhook: &provisioning.WebhookStatus{},
-				},
-			},
-			setupRequest: func() *http.Request {
-				payload := `{
-					"action": "opened",
-					"pull_request": {
-						"html_url": "https://github.com/grafana/grafana/pull/123",
-						"number": 123,
-						"head": {
-							"ref": "feature-branch",
-							"sha": "abcdef1234567890"
-						},
-						"base": {
-							"ref": "main"
-						}
-					},
-					"repository": {
-						"full_name": "grafana/grafana"
-					}
-				}`
-				req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
-				req.Header.Set("X-GitHub-Event", "pull_request")
-				req.Header.Set("Content-Type", "application/json")
-
-				// Create a valid signature
-				mac := hmac.New(sha256.New, []byte("webhook-secret"))
-				mac.Write([]byte(payload))
-				signature := hex.EncodeToString(mac.Sum(nil))
-				req.Header.Set("X-Hub-Signature-256", "sha256="+signature)
-
-				return req
-			},
-			expectedError: fmt.Errorf("missing GitHub config"),
 		},
 		{
 			name: "pull request event with repository mismatch",
@@ -1112,26 +1066,29 @@ func TestGitHubRepository_Webhook(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a GitHub repository with the test config. A fresh cache
 			// per subtest keeps replay state from leaking across cases.
-			repo := &githubWebhookRepository{
+			r := &githubWebhookRepository{
 				config:      tt.config,
 				owner:       "grafana",
 				repo:        "grafana",
 				secret:      common.RawSecureValue("webhook-secret"),
 				replayCache: newReplayCache(time.Hour),
 			}
+			r.WebhookHandler = repo.NewWebhookHandler(
+				r.processRequest, tt.config.Status.Webhook, tt.config.GetName(),
+				"grafana/grafana", tt.config.Spec.GitHub.Branch, tt.config.Spec.Sync.Enabled,
+				repo.IncrementalSyncPolicy{},
+			)
 
-			// Call the Webhook method
-			response, err := repo.Webhook(context.Background(), tt.setupRequest())
+			response, err := r.Webhook(t.Context(), tt.setupRequest())
 
 			// Check the error
 			if tt.expectedError != nil {
 				require.Error(t, err)
-				var statusErr *apierrors.StatusError
-				if errors.As(tt.expectedError, &statusErr) {
-					var actualStatusErr *apierrors.StatusError
-					require.True(t, errors.As(err, &actualStatusErr), "Expected StatusError but got different error type: %T", err)
-					require.Equal(t, statusErr.Status().Message, actualStatusErr.Status().Message)
-					require.Equal(t, statusErr.Status().Code, actualStatusErr.Status().Code)
+				if expected, ok := errors.AsType[*apierrors.StatusError](tt.expectedError); ok {
+					actual, ok := errors.AsType[*apierrors.StatusError](err)
+					require.True(t, ok, "Expected StatusError but got different error type: %T", err)
+					require.Equal(t, expected.Status().Message, actual.Status().Message)
+					require.Equal(t, expected.Status().Code, actual.Status().Code)
 				} else {
 					require.Equal(t, tt.expectedError.Error(), err.Error())
 				}
@@ -1211,7 +1168,7 @@ func TestGitHubRepository_CommentPullRequest(t *testing.T) {
 			}
 
 			// Call the CommentPullRequest method
-			err := repo.CommentPullRequest(context.Background(), tt.prNumber, tt.comment)
+			err := repo.CommentPullRequest(t.Context(), tt.prNumber, tt.comment)
 
 			// Check results
 			if tt.expectedError != nil {
@@ -1347,7 +1304,7 @@ func TestGitHubRepository_OnCreate(t *testing.T) {
 			}
 
 			// Call the OnCreate method
-			hookOps, err := repo.OnCreate(context.Background())
+			hookOps, err := repo.OnCreate(t.Context())
 
 			// Check results
 			if tt.expectedError != nil {
@@ -1845,7 +1802,7 @@ func TestGitHubRepository_OnUpdate(t *testing.T) {
 			}
 
 			// Call the OnUpdate method
-			hookOps, err := repo.OnUpdate(context.Background())
+			hookOps, err := repo.OnUpdate(t.Context())
 
 			// Check results
 			if tt.expectedError != nil {
@@ -2057,7 +2014,7 @@ func TestGitHubRepository_OnDelete(t *testing.T) {
 			}
 
 			// Call the OnDelete method
-			err := repo.OnDelete(context.Background())
+			err := repo.OnDelete(t.Context())
 
 			// Check results
 			if tt.expectedError != nil {
@@ -2095,7 +2052,7 @@ func TestGitHubRepository_RotateWebhookSecret(t *testing.T) {
 			},
 		}
 
-		ops, err := repo.RotateWebhookSecret(context.Background())
+		ops, err := repo.RotateWebhookSecret(t.Context())
 		require.NoError(t, err)
 		require.Len(t, ops, 2)
 		require.Equal(t, "replace", ops[0]["op"])
@@ -2122,7 +2079,7 @@ func TestGitHubRepository_RotateWebhookSecret(t *testing.T) {
 			},
 		}
 
-		ops, err := r.RotateWebhookSecret(context.Background())
+		ops, err := r.RotateWebhookSecret(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not found on remote")
 		require.Len(t, ops, 1)
@@ -2146,7 +2103,7 @@ func TestGitHubRepository_RotateWebhookSecret(t *testing.T) {
 			},
 		}
 
-		ops, err := repo.RotateWebhookSecret(context.Background())
+		ops, err := repo.RotateWebhookSecret(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "get webhook for rotation")
 		require.Nil(t, ops)
@@ -2169,7 +2126,7 @@ func TestGitHubRepository_RotateWebhookSecret(t *testing.T) {
 			},
 		}
 
-		ops, err := repo.RotateWebhookSecret(context.Background())
+		ops, err := repo.RotateWebhookSecret(t.Context())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "edit webhook during rotation")
 		require.Nil(t, ops)
@@ -2180,7 +2137,7 @@ func TestGitHubRepository_RotateWebhookSecret(t *testing.T) {
 			config: &provisioning.Repository{},
 		}
 
-		ops, err := repo.RotateWebhookSecret(context.Background())
+		ops, err := repo.RotateWebhookSecret(t.Context())
 		require.NoError(t, err)
 		require.Nil(t, ops)
 	})
@@ -2194,8 +2151,23 @@ func TestGitHubRepository_RotateWebhookSecret(t *testing.T) {
 			},
 		}
 
-		ops, err := repo.RotateWebhookSecret(context.Background())
+		ops, err := repo.RotateWebhookSecret(t.Context())
 		require.NoError(t, err)
 		require.Nil(t, ops)
 	})
+}
+
+func signedWebhookRequest(t *testing.T, eventType, secret, deliveryID, payload string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("X-GitHub-Event", eventType)
+	req.Header.Set("Content-Type", "application/json")
+	if deliveryID != "" {
+		req.Header.Set("X-GitHub-Delivery", deliveryID)
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	req.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	return req
 }

--- a/apps/provisioning/pkg/repository/webhook_handler.go
+++ b/apps/provisioning/pkg/repository/webhook_handler.go
@@ -1,0 +1,169 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+// WebhookEventType classifies a normalized inbound webhook delivery.
+type WebhookEventType int
+
+const (
+	WebhookEventUnsupported WebhookEventType = iota
+	WebhookEventPing
+	WebhookEventReplay
+	WebhookEventPush
+	WebhookEventPullRequest
+)
+
+type PullRequestAction string
+
+const (
+	PullRequestActionOpened   PullRequestAction = "opened"
+	PullRequestActionReopened PullRequestAction = "reopened"
+	PullRequestActionUpdated  PullRequestAction = "updated"
+)
+
+// ProcessRequestFunc returns a provider-agnostic WebhookEvent for an inbound
+// webhook request. It is the only provider-specific part of the inbound flow.
+type ProcessRequestFunc func(ctx context.Context, req *http.Request) (WebhookEvent, error)
+
+// WebhookHandler handles inbound webhook deliveries: it dispatches the
+// provider-normalized event into sync/pull-request job responses.
+type WebhookHandler struct {
+	processReqFunc    ProcessRequestFunc
+	status            *provisioning.WebhookStatus
+	repoName          string
+	repoSlug          string
+	branch            string
+	syncEnabled       bool
+	incrementalPolicy IncrementalSyncPolicy
+}
+
+// WebhookEvent is the provider-agnostic form of an inbound webhook delivery.
+// A provider's processRequest normalizes its native event into this shape.
+type WebhookEvent struct {
+	Type         WebhookEventType
+	RepoSlug     string
+	Branch       string
+	DeletedPaths []string
+	TotalChanges int
+	Action       PullRequestAction
+	PRNumber     int
+	PRURL        string
+	SourceRef    string
+	Hash         string
+	Message      string
+}
+
+func NewWebhookHandler(processReqFunc ProcessRequestFunc, status *provisioning.WebhookStatus, repoName, repoSlug, branch string, syncEnabled bool, incrementalPolicy IncrementalSyncPolicy) *WebhookHandler {
+	return &WebhookHandler{
+		processReqFunc:    processReqFunc,
+		status:            status,
+		repoName:          repoName,
+		repoSlug:          repoSlug,
+		branch:            branch,
+		syncEnabled:       syncEnabled,
+		incrementalPolicy: incrementalPolicy,
+	}
+}
+
+// Webhook dispatches an inbound webhook delivery into a sync/pull-request
+// job response. The provider supplies the event via processReqFunc.
+func (m *WebhookHandler) Webhook(ctx context.Context, req *http.Request) (*provisioning.WebhookResponse, error) {
+	if m.status == nil {
+		return nil, fmt.Errorf("unexpected webhook request")
+	}
+
+	ctx = logging.Context(ctx, logging.FromContext(ctx).With(slog.Group("repository", "slug", m.repoSlug, "ref", m.branch)))
+
+	event, err := m.processReqFunc(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch event.Type {
+	case WebhookEventPush:
+		if event.RepoSlug != m.repoSlug {
+			logging.FromContext(ctx).Warn("webhook push event repository mismatch", "expected", m.repoSlug, "got", event.RepoSlug)
+			return nil, ErrRepositoryMismatch
+		}
+		if !m.syncEnabled {
+			return &provisioning.WebhookResponse{Code: http.StatusOK}, nil
+		}
+		// Skip silently if the event is not for the configured branch, as the
+		// webhook cannot be configured to only publish events for one branch.
+		if event.Branch != m.branch {
+			return &provisioning.WebhookResponse{Code: http.StatusOK}, nil
+		}
+		return m.pushSyncResponse(event.DeletedPaths, event.TotalChanges), nil
+	case WebhookEventPullRequest:
+		if event.RepoSlug != m.repoSlug {
+			logging.FromContext(ctx).Warn("webhook pull request event repository mismatch", "expected", m.repoSlug, "got", event.RepoSlug)
+			return nil, ErrRepositoryMismatch
+		}
+		if event.Branch != m.branch {
+			return &provisioning.WebhookResponse{
+				Code:    http.StatusOK,
+				Message: fmt.Sprintf("ignoring pull request event as %s is not  the configured branch", event.Branch),
+			}, nil
+		}
+		if !watchedPullRequestAction(event.Action) {
+			return &provisioning.WebhookResponse{
+				Code:    http.StatusOK,
+				Message: fmt.Sprintf("ignore pull request event: %s", event.Action),
+			}, nil
+		}
+		return m.pullRequestResponse(event), nil
+	case WebhookEventPing:
+		return &provisioning.WebhookResponse{Code: http.StatusOK, Message: "ping received"}, nil
+	case WebhookEventReplay:
+		return &provisioning.WebhookResponse{Code: http.StatusOK, Message: "ok"}, nil
+	default:
+		return &provisioning.WebhookResponse{Code: http.StatusNotImplemented, Message: event.Message}, nil
+	}
+}
+
+func (m *WebhookHandler) pullRequestResponse(event WebhookEvent) *provisioning.WebhookResponse {
+	return &provisioning.WebhookResponse{
+		Code:    http.StatusAccepted,
+		Message: fmt.Sprintf("pull request: %s", event.Action),
+		Job: &provisioning.JobSpec{
+			Repository: m.repoName,
+			Action:     provisioning.JobActionPullRequest,
+			PullRequest: &provisioning.PullRequestJobOptions{
+				URL:  event.PRURL,
+				PR:   event.PRNumber,
+				Ref:  event.SourceRef,
+				Hash: event.Hash,
+			},
+		},
+	}
+}
+
+func (m *WebhookHandler) pushSyncResponse(deletedPaths []string, totalChanges int) *provisioning.WebhookResponse {
+	return &provisioning.WebhookResponse{
+		Code: http.StatusAccepted,
+		Job: &provisioning.JobSpec{
+			Repository: m.repoName,
+			Action:     provisioning.JobActionPull,
+			Pull: &provisioning.SyncJobOptions{
+				Incremental: m.incrementalPolicy.CanUseIncrementalSync(deletedPaths, totalChanges),
+			},
+		},
+	}
+}
+
+func watchedPullRequestAction(action PullRequestAction) bool {
+	switch action {
+	case PullRequestActionOpened, PullRequestActionReopened, PullRequestActionUpdated:
+		return true
+	default:
+		return false
+	}
+}

--- a/apps/provisioning/pkg/repository/webhook_test.go
+++ b/apps/provisioning/pkg/repository/webhook_test.go
@@ -1,0 +1,179 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+func TestWebhookHandler_Webhook(t *testing.T) {
+	tests := []struct {
+		name          string
+		noStatus      bool
+		syncDisabled  bool
+		event         WebhookEvent
+		processErr    error
+		expected      *provisioning.WebhookResponse
+		expectedError error
+	}{
+		{
+			name:          "missing webhook status",
+			noStatus:      true,
+			expectedError: fmt.Errorf("unexpected webhook request"),
+		},
+		{
+			name:          "verification failure",
+			processErr:    apierrors.NewUnauthorized("invalid signature"),
+			expectedError: apierrors.NewUnauthorized("invalid signature"),
+		},
+		{
+			name:          "parse failure",
+			processErr:    fmt.Errorf("invalid payload"),
+			expectedError: fmt.Errorf("invalid payload"),
+		},
+		{
+			name:          "push repository mismatch",
+			event:         WebhookEvent{Type: WebhookEventPush, RepoSlug: "other/repo", Branch: "main"},
+			expectedError: ErrRepositoryMismatch,
+		},
+		{
+			name:         "push sync disabled",
+			syncDisabled: true,
+			event:        WebhookEvent{Type: WebhookEventPush, RepoSlug: "grafana/grafana", Branch: "main"},
+			expected:     &provisioning.WebhookResponse{Code: http.StatusOK},
+		},
+		{
+			name:     "push other branch",
+			event:    WebhookEvent{Type: WebhookEventPush, RepoSlug: "grafana/grafana", Branch: "feature"},
+			expected: &provisioning.WebhookResponse{Code: http.StatusOK},
+		},
+		{
+			name:  "push accepted",
+			event: WebhookEvent{Type: WebhookEventPush, RepoSlug: "grafana/grafana", Branch: "main", TotalChanges: 1},
+			expected: &provisioning.WebhookResponse{
+				Code: http.StatusAccepted,
+				Job: &provisioning.JobSpec{
+					Repository: "test-repo",
+					Action:     provisioning.JobActionPull,
+					Pull:       &provisioning.SyncJobOptions{Incremental: true},
+				},
+			},
+		},
+		{
+			name:  "push large diff forces full sync",
+			event: WebhookEvent{Type: WebhookEventPush, RepoSlug: "grafana/grafana", Branch: "main", TotalChanges: 7},
+			expected: &provisioning.WebhookResponse{
+				Code: http.StatusAccepted,
+				Job: &provisioning.JobSpec{
+					Repository: "test-repo",
+					Action:     provisioning.JobActionPull,
+					Pull:       &provisioning.SyncJobOptions{Incremental: false},
+				},
+			},
+		},
+		{
+			name:          "pull request repository mismatch",
+			event:         WebhookEvent{Type: WebhookEventPullRequest, RepoSlug: "other/repo", Branch: "main"},
+			expectedError: ErrRepositoryMismatch,
+		},
+		{
+			name:  "pull request other branch",
+			event: WebhookEvent{Type: WebhookEventPullRequest, RepoSlug: "grafana/grafana", Branch: "develop"},
+			expected: &provisioning.WebhookResponse{
+				Code:    http.StatusOK,
+				Message: "ignoring pull request event as develop is not  the configured branch",
+			},
+		},
+		{
+			name:  "pull request ignored action",
+			event: WebhookEvent{Type: WebhookEventPullRequest, RepoSlug: "grafana/grafana", Branch: "main", Action: "closed"},
+			expected: &provisioning.WebhookResponse{
+				Code:    http.StatusOK,
+				Message: "ignore pull request event: closed",
+			},
+		},
+		{
+			name: "pull request accepted",
+			event: WebhookEvent{
+				Type:      WebhookEventPullRequest,
+				RepoSlug:  "grafana/grafana",
+				Branch:    "main",
+				Action:    PullRequestActionOpened,
+				PRNumber:  123,
+				PRURL:     "https://github.com/grafana/grafana/pull/123",
+				SourceRef: "feature-branch",
+				Hash:      "abcdef",
+			},
+			expected: &provisioning.WebhookResponse{
+				Code:    http.StatusAccepted,
+				Message: "pull request: opened",
+				Job: &provisioning.JobSpec{
+					Repository: "test-repo",
+					Action:     provisioning.JobActionPullRequest,
+					PullRequest: &provisioning.PullRequestJobOptions{
+						URL:  "https://github.com/grafana/grafana/pull/123",
+						PR:   123,
+						Ref:  "feature-branch",
+						Hash: "abcdef",
+					},
+				},
+			},
+		},
+		{
+			name:     "ping",
+			event:    WebhookEvent{Type: WebhookEventPing},
+			expected: &provisioning.WebhookResponse{Code: http.StatusOK, Message: "ping received"},
+		},
+		{
+			name:     "replay",
+			event:    WebhookEvent{Type: WebhookEventReplay},
+			expected: &provisioning.WebhookResponse{Code: http.StatusOK, Message: "ok"},
+		},
+		{
+			name:     "unsupported",
+			event:    WebhookEvent{Type: WebhookEventUnsupported, Message: "unsupported messageType: team"},
+			expected: &provisioning.WebhookResponse{Code: http.StatusNotImplemented, Message: "unsupported messageType: team"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var status *provisioning.WebhookStatus
+			if !tt.noStatus {
+				status = &provisioning.WebhookStatus{}
+			}
+			processReqFunc := func(context.Context, *http.Request) (WebhookEvent, error) {
+				return tt.event, tt.processErr
+			}
+
+			h := NewWebhookHandler(processReqFunc, status, "test-repo", "grafana/grafana", "main", !tt.syncDisabled, NewIncrementalSyncPolicy(false, 5))
+
+			rsp, err := h.Webhook(t.Context(), &http.Request{})
+
+			if tt.expectedError != nil {
+				require.Error(t, err)
+				if expected, ok := errors.AsType[*apierrors.StatusError](tt.expectedError); ok {
+					actual, ok := errors.AsType[*apierrors.StatusError](err)
+					require.True(t, ok, "expected StatusError, got %T", err)
+					require.Equal(t, expected.Status().Message, actual.Status().Message)
+					require.Equal(t, expected.Status().Code, actual.Status().Code)
+				} else {
+					require.Equal(t, tt.expectedError.Error(), err.Error())
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected.Code, rsp.Code)
+			require.Equal(t, tt.expected.Message, rsp.Message)
+			require.Equal(t, tt.expected.Job, rsp.Job)
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Extracts the inbound webhook dispatch from the GitHub repository into a provider-agnostic `WebhookHandler` in `apps/provisioning/pkg/repository`. The handler turns a normalized `WebhookEvent` into sync/pull-request job responses; each provider supplies only a `ProcessRequestFunc` that parses its native payload into that event. No behavior change — GitHub still satisfies the same `WebhookRepository` contract.

**Why do we need this feature?**

So other git providers (e.g. GitLab) can reuse the inbound dispatch logic instead of duplicating it.

**Which issue(s) does this PR fix?**:

- https://github.com/grafana/git-ui-sync-project/issues/17
