### PR TITLE
Provisioning: Fix NPE when testing GHE repo on creation

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -236,6 +236,35 @@ func (r *Repository) Branch() string {
 	return ""
 }
 
+// SetBranch writes branch to the provider-specific spec field for git-based repositories,
+// mirroring Branch(). It is a no-op for non-git types or when the provider config is absent.
+func (r *Repository) SetBranch(branch string) {
+	switch r.Spec.Type {
+	case GitHubRepositoryType:
+		if r.Spec.GitHub != nil {
+			r.Spec.GitHub.Branch = branch
+		}
+	case GitHubEnterpriseRepositoryType:
+		if r.Spec.GitHubEnterprise != nil {
+			r.Spec.GitHubEnterprise.Branch = branch
+		}
+	case GitRepositoryType:
+		if r.Spec.Git != nil {
+			r.Spec.Git.Branch = branch
+		}
+	case BitbucketRepositoryType:
+		if r.Spec.Bitbucket != nil {
+			r.Spec.Bitbucket.Branch = branch
+		}
+	case GitLabRepositoryType:
+		if r.Spec.GitLab != nil {
+			r.Spec.GitLab.Branch = branch
+		}
+	default:
+		// do nothing
+	}
+}
+
 // URL returns the URL for git-based repositories
 // or an empty string for local repositories
 func (r *Repository) URL() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types_test.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types_test.go
@@ -137,3 +137,95 @@ func TestRepositoryType_IsGit(t *testing.T) {
 		})
 	}
 }
+
+func TestRepository_SetBranch(t *testing.T) {
+	t.Run("writes the provider-specific spec field and round-trips through Branch()", func(t *testing.T) {
+		tests := []struct {
+			name string
+			repo v0alpha1.Repository
+			// field returns the branch from the provider config the test set up, so we can assert
+			// SetBranch wrote the correct field (not just that Branch() happens to agree).
+			field func(r *v0alpha1.Repository) string
+		}{
+			{
+				name: "github",
+				repo: v0alpha1.Repository{Spec: v0alpha1.RepositorySpec{
+					Type:   v0alpha1.GitHubRepositoryType,
+					GitHub: &v0alpha1.GitHubRepositoryConfig{},
+				}},
+				field: func(r *v0alpha1.Repository) string { return r.Spec.GitHub.Branch },
+			},
+			{
+				name: "githubEnterprise",
+				repo: v0alpha1.Repository{Spec: v0alpha1.RepositorySpec{
+					Type:             v0alpha1.GitHubEnterpriseRepositoryType,
+					GitHubEnterprise: &v0alpha1.GitHubEnterpriseRepositoryConfig{},
+				}},
+				field: func(r *v0alpha1.Repository) string { return r.Spec.GitHubEnterprise.Branch },
+			},
+			{
+				name: "git",
+				repo: v0alpha1.Repository{Spec: v0alpha1.RepositorySpec{
+					Type: v0alpha1.GitRepositoryType,
+					Git:  &v0alpha1.GitRepositoryConfig{},
+				}},
+				field: func(r *v0alpha1.Repository) string { return r.Spec.Git.Branch },
+			},
+			{
+				name: "gitlab",
+				repo: v0alpha1.Repository{Spec: v0alpha1.RepositorySpec{
+					Type:   v0alpha1.GitLabRepositoryType,
+					GitLab: &v0alpha1.GitLabRepositoryConfig{},
+				}},
+				field: func(r *v0alpha1.Repository) string { return r.Spec.GitLab.Branch },
+			},
+			{
+				name: "bitbucket",
+				repo: v0alpha1.Repository{Spec: v0alpha1.RepositorySpec{
+					Type:      v0alpha1.BitbucketRepositoryType,
+					Bitbucket: &v0alpha1.BitbucketRepositoryConfig{},
+				}},
+				field: func(r *v0alpha1.Repository) string { return r.Spec.Bitbucket.Branch },
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				repo := tt.repo
+				repo.SetBranch("feature")
+				assert.Equal(t, "feature", tt.field(&repo), "should write the provider-specific spec field")
+				assert.Equal(t, "feature", repo.Branch(), "Branch() should reflect the value written by SetBranch")
+			})
+		}
+	})
+
+	t.Run("is a no-op and does not panic when the provider config is absent", func(t *testing.T) {
+		// Regression: SetBranch previously assumed Spec.GitHub and panicked for types whose config
+		// lives elsewhere (e.g. GitHub Enterprise) or is nil.
+		tests := []struct {
+			name string
+			repo v0alpha1.Repository
+		}{
+			{
+				name: "github type with nil GitHub config",
+				repo: v0alpha1.Repository{Spec: v0alpha1.RepositorySpec{Type: v0alpha1.GitHubRepositoryType}},
+			},
+			{
+				name: "githubEnterprise type with nil GitHubEnterprise config",
+				repo: v0alpha1.Repository{Spec: v0alpha1.RepositorySpec{Type: v0alpha1.GitHubEnterpriseRepositoryType}},
+			},
+			{
+				name: "local (non-git) type",
+				repo: v0alpha1.Repository{Spec: v0alpha1.RepositorySpec{Type: v0alpha1.LocalRepositoryType}},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				repo := tt.repo
+				assert.NotPanics(t, func() { repo.SetBranch("feature") })
+				assert.Equal(t, "", repo.Branch())
+			})
+		}
+	})
+}

--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -108,7 +108,7 @@ func (r *githubRepository) GetCurrentBranch() string {
 }
 
 func (r *githubRepository) SetBranch(branch string) {
-	r.config.Spec.GitHub.Branch = branch
+	r.config.SetBranch(branch)
 	r.GitRepository.SetBranch(branch)
 }
 


### PR DESCRIPTION
**What is this PR?**

Fixes a nil-pointer dereference (panic) when **testing a GitHub Enterprise repository on creation**, and makes a repository's branch consistent between its spec and the underlying git client.

**The NPE — what happens**

When a repository is tested with an empty branch, `githubRepository.Test()` resolves the repo's default branch and calls `SetBranch(...)`. The base implementation hard-coded the GitHub spec field:

```go
func (r *githubRepository) SetBranch(branch string) {
    r.config.Spec.GitHub.Branch = branch // panics for GHE: Spec.GitHub is nil
    r.GitRepository.SetBranch(branch)
}
```

A GitHub **Enterprise** repository stores its config under `Spec.GitHubEnterprise`, so `Spec.GitHub` is `nil` and the assignment dereferences a nil pointer.

**Repro**

1. Create (or hit the `test` connector for) a `githubEnterprise` repository **without an explicit branch**.
2. `Test()` sees an empty branch → resolves the default branch → calls `SetBranch(...)`.
3. 💥 nil pointer dereference.

**The source — why the existing GHE handling didn't save us**

GitHub Enterprise had its own `SetBranch` override that writes `Spec.GitHubEnterprise.Branch`. But Go struct embedding is **not** virtual dispatch: when the embedded base `Test()` calls `r.SetBranch(...)` internally, it invokes the *base* method, not the Enterprise override. So the Enterprise-specific write was bypassed and the base hit the nil `Spec.GitHub`. In other words, this is an OSS↔Enterprise logic leak — the OSS base assumed a GitHub-only spec, while Enterprise tried to patch that assumption from the outside (and couldn't, through embedding).

**Why we went with this approach**

A repository's branch can be read two different ways, and it isn't obvious which is authoritative:

- from the **spec** — `repo.Config().Branch()`: the declared/persisted branch, resolved per provider (`github` / `githubEnterprise` / `git` / `gitlab` / `bitbucket`); and
- from the **git repository itself** — the runtime branch the git client is pointed at (its default ref for operations).

Callers across the codebase reach for one or the other, and we **can't guarantee a caller knows which to use**. Worse, the two can silently drift — which is exactly what produced this bug for GHE (the spec field never got written, only the git client's branch did).

Rather than push that choice onto every call site, we keep the **spec and the git repository's branch in sync**, so reading either is always correct:

- Add a type-aware `Repository.SetBranch(branch)` that writes the correct provider-specific spec field — mirroring the existing `Branch()`/`URL()`/`Path()` accessors, so the per-provider switch lives in one place.
- `githubRepository.SetBranch` now calls `config.SetBranch(branch)` (type-aware, no nil deref for GHE) and still updates the git client's branch.

This fixes the NPE for GitHub Enterprise (and any non-`github` git provider), removes the OSS/Enterprise leak, and guarantees `Config().Branch()` and the git repo branch always agree.

**Tests**

- `TestRepository_SetBranch` — verifies `SetBranch` writes the correct provider field and round-trips through `Branch()` for every git provider, and is a safe no-op (no panic) for GitHub Enterprise / nil-config / `local` (the regression that caused the NPE).

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
