### PR TITLE
SplashScreenModal: What's new overlay appears in image renderer screenshots for service accounts

### DIFF
--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.test.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.test.tsx
@@ -1,0 +1,65 @@
+import { screen } from '@testing-library/react';
+import { render } from 'test/test-utils';
+
+import { contextSrv } from 'app/core/services/context_srv';
+
+import { SplashScreenModal } from './SplashScreenModal';
+
+jest.mock('./useShouldShowSplash', () => ({
+  useShouldShowSplash: jest.fn().mockReturnValue({
+    shouldShow: true,
+    dismiss: jest.fn(),
+    markEngaged: jest.fn(),
+  }),
+}));
+
+jest.mock('./splashContent', () => ({
+  getSplashScreenConfig: jest.fn().mockReturnValue({
+    version: '11.0.0',
+    features: [
+      {
+        id: 'feature-1',
+        icon: 'star',
+        badgeText: 'New',
+        accentColor: 'primary',
+        title: 'Test Feature',
+        subtitle: 'Test subtitle',
+        bullets: ['Bullet 1'],
+        heroImageUrl: '/test-image.png',
+      },
+    ],
+  }),
+}));
+
+jest.mock('./SplashScreenSlide', () => ({
+  SplashScreenSlide: () => <div data-testid="splash-slide" />,
+}));
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    ...jest.requireActual('app/core/services/context_srv').contextSrv,
+    user: { uid: 'u_regularuser' },
+    hasRole: jest.fn().mockReturnValue(true),
+    hasPermission: jest.fn().mockReturnValue(true),
+  },
+}));
+
+const mockContextSrv = jest.mocked(contextSrv);
+
+describe('SplashScreenModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockContextSrv.user.uid = 'u_regularuser';
+  });
+
+  it('renders for a regular user', () => {
+    render(<SplashScreenModal />);
+    expect(screen.getByLabelText("What's new in Grafana")).toBeInTheDocument();
+  });
+
+  it('does not render for a service account', () => {
+    mockContextSrv.user.uid = 'service-account:8';
+    render(<SplashScreenModal />);
+    expect(screen.queryByLabelText("What's new in Grafana")).not.toBeInTheDocument();
+  });
+});

--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.test.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.test.tsx
@@ -49,16 +49,10 @@ const mockContextSrv = jest.mocked(contextSrv);
 describe('SplashScreenModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockContextSrv.user.uid = 'u_regularuser';
   });
 
-  it('renders for a regular user', () => {
-    render(<SplashScreenModal />);
-    expect(screen.getByLabelText("What's new in Grafana")).toBeInTheDocument();
-  });
-
-  it('does not render for a service account', () => {
-    mockContextSrv.user.uid = 'service-account:8';
+  it('does not render for a render user', () => {
+    mockContextSrv.user.authenticatedBy = "render"
     render(<SplashScreenModal />);
     expect(screen.queryByLabelText("What's new in Grafana")).not.toBeInTheDocument();
   });

--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
@@ -43,7 +43,9 @@ export function SplashScreenModal() {
     [goToPrev, goToNext]
   );
 
-  if (!shouldShow) {
+  // Service accounts cannot log in to the UI to dismiss this modal, so it would
+  // permanently block dashboard screenshot rendering for those identities.
+  if (!shouldShow || contextSrv.user.uid.startsWith('service-account:')) {
     return null;
   }
 

--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
@@ -45,7 +45,7 @@ export function SplashScreenModal() {
 
   // Service accounts cannot log in to the UI to dismiss this modal, so it would
   // permanently block dashboard screenshot rendering for those identities.
-  if (!shouldShow || contextSrv.user.uid.startsWith('service-account:')) {
+  if (!shouldShow || contextSrv.user.authenticatedBy === 'render') {
     return null;
   }
 


### PR DESCRIPTION
## What is this PR doing?

Prevents the `SplashScreenModal` ("What's New" overlay) from rendering for Grafana service account sessions.

## Root cause

The splash checks for dismissal but service-accounts cannot dismiss as they cannot login and when using the renderer service to take a screenshot of dashboards (i.e. at the end of a load test run) the splash interferes with the screenshots.

## Fix

Added an early-return guard in `SplashScreenModal` that suppresses rendering when `contextSrv.user.uid` starts with `service-account:`. This prefix is set by the backend for all service account identities (confirmed via `GET /api/user`) and is a reliable signal that interactive dismissal is impossible. `contextSrv` was already imported in the component, so no new dependencies are introduced.

## Testing

Added unit tests covering:
  - Modal renders for a regular signed-in user
  - Modal is suppressed for a service account (`uid` prefixed with `service-account:`)

Fixes #127215
