### PR TITLE
TraceView: Differentiate summary spans in the overview minimap

### DIFF
--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/CanvasSpanGraph.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/CanvasSpanGraph.tsx
@@ -37,7 +37,13 @@ const getStyles = (theme: GrafanaTheme2) => {
 };
 
 type CanvasSpanGraphProps = {
-  items: Array<{ valueWidth: number; valueOffset: number; serviceName: string; isSummary?: boolean; spanCount?: number }>;
+  items: Array<{
+    valueWidth: number;
+    valueOffset: number;
+    serviceName: string;
+    isSummary?: boolean;
+    spanCount?: number;
+  }>;
   valueWidth: number;
 };
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/CanvasSpanGraph.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/CanvasSpanGraph.tsx
@@ -37,7 +37,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 };
 
 type CanvasSpanGraphProps = {
-  items: Array<{ valueWidth: number; valueOffset: number; serviceName: string; isSummary?: boolean }>;
+  items: Array<{ valueWidth: number; valueOffset: number; serviceName: string; isSummary?: boolean; spanCount?: number }>;
   valueWidth: number;
 };
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/CanvasSpanGraph.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/CanvasSpanGraph.tsx
@@ -37,7 +37,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 };
 
 type CanvasSpanGraphProps = {
-  items: Array<{ valueWidth: number; valueOffset: number; serviceName: string }>;
+  items: Array<{ valueWidth: number; valueOffset: number; serviceName: string; isSummary?: boolean }>;
   valueWidth: number;
 };
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/CanvasSpanGraph.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/CanvasSpanGraph.tsx
@@ -21,7 +21,7 @@ import { useStyles2, useTheme2 } from '@grafana/ui';
 import { autoColor } from '../../Theme';
 import { getRgbColorByKey } from '../../utils/color-generator';
 
-import renderIntoCanvas from './render-into-canvas';
+import renderIntoCanvas, { type SpanGraphItem } from './render-into-canvas';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
@@ -37,13 +37,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 };
 
 type CanvasSpanGraphProps = {
-  items: Array<{
-    valueWidth: number;
-    valueOffset: number;
-    serviceName: string;
-    isSummary?: boolean;
-    spanCount?: number;
-  }>;
+  items: SpanGraphItem[];
   valueWidth: number;
 };
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/index.test.tsx
@@ -71,4 +71,9 @@ describe('getItem()', () => {
   it('flags normal spans as not summary', () => {
     expect(getItem(base as unknown as TraceSpan).isSummary).toBe(false);
   });
+
+  it('threads span_count for summary spans (drives proportional minimap weight)', () => {
+    const span = { ...base, aggregation: { isSummary: true, spanCount: 24 } } as unknown as TraceSpan;
+    expect(getItem(span).spanCount).toBe(24);
+  });
 });

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/index.test.tsx
@@ -16,9 +16,10 @@ import { getAllByTestId, render, screen } from '@testing-library/react';
 
 import traceGenerator from '../../demo/trace-generators';
 import transformTraceData from '../../model/transform-trace-data';
+import { type TraceSpan } from '../../types/trace';
 import { polyfill as polyfillAnimationFrame } from '../../utils/test/requestAnimationFrame';
 
-import SpanGraph, { type SpanGraphProps, TIMELINE_TICK_INTERVAL } from './index';
+import SpanGraph, { getItem, type SpanGraphProps, TIMELINE_TICK_INTERVAL } from './index';
 
 describe('<SpanGraph>', () => {
   polyfillAnimationFrame(window);
@@ -56,5 +57,18 @@ describe('<SpanGraph>', () => {
   it('renders <TickLabels /> with the correct numnber of ticks', async () => {
     const tickLabelsDiv = screen.getByTestId('TickLabels');
     expect(getAllByTestId(tickLabelsDiv, 'tick').length).toBe(TIMELINE_TICK_INTERVAL + 1);
+  });
+});
+
+describe('getItem()', () => {
+  const base = { relativeStartTime: 0, duration: 100, process: { serviceName: 'svc' } };
+
+  it('flags summary spans', () => {
+    const span = { ...base, aggregation: { isSummary: true } } as unknown as TraceSpan;
+    expect(getItem(span).isSummary).toBe(true);
+  });
+
+  it('flags normal spans as not summary', () => {
+    expect(getItem(base as unknown as TraceSpan).isSummary).toBe(false);
   });
 });

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/index.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/index.tsx
@@ -51,13 +51,16 @@ type SpanItem = {
   valueOffset: number;
   valueWidth: number;
   serviceName: string;
+  isSummary: boolean;
 };
 
-function getItem(span: TraceSpan): SpanItem {
+// exported for tests
+export function getItem(span: TraceSpan): SpanItem {
   return {
     valueOffset: span.relativeStartTime,
     valueWidth: span.duration,
     serviceName: getServiceColorKey(span.process),
+    isSummary: span.aggregation?.isSummary === true,
   };
 }
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/index.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/index.tsx
@@ -52,6 +52,10 @@ type SpanItem = {
   valueWidth: number;
   serviceName: string;
   isSummary: boolean;
+  // Number of spans this summary represents; drives its proportional weight in
+  // the minimap so the pruned trace keeps the unpruned density shape. 0 for
+  // normal spans.
+  spanCount: number;
 };
 
 // exported for tests
@@ -61,6 +65,7 @@ export function getItem(span: TraceSpan): SpanItem {
     valueWidth: span.duration,
     serviceName: getServiceColorKey(span.process),
     isSummary: span.aggregation?.isSummary === true,
+    spanCount: span.aggregation?.spanCount ?? 0,
   };
 }
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/index.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/index.tsx
@@ -27,6 +27,7 @@ import { getServiceColorKey } from '../../utils/service-name';
 import CanvasSpanGraph from './CanvasSpanGraph';
 import TickLabels from './TickLabels';
 import ViewingLayer from './ViewingLayer';
+import { type SpanGraphItem } from './render-into-canvas';
 
 const getStyles = () => {
   return {
@@ -47,19 +48,8 @@ export type SpanGraphProps = {
   updateNextViewRangeTime: (nextUpdate: ViewRangeTimeUpdate) => void;
 };
 
-type SpanItem = {
-  valueOffset: number;
-  valueWidth: number;
-  serviceName: string;
-  isSummary: boolean;
-  // Number of spans this summary represents; drives its proportional weight in
-  // the minimap so the pruned trace keeps the unpruned density shape. 0 for
-  // normal spans.
-  spanCount: number;
-};
-
 // exported for tests
-export function getItem(span: TraceSpan): SpanItem {
+export function getItem(span: TraceSpan): SpanGraphItem {
   return {
     valueOffset: span.relativeStartTime,
     valueWidth: span.duration,
@@ -69,7 +59,7 @@ export function getItem(span: TraceSpan): SpanItem {
   };
 }
 
-function getItems(trace: Trace): SpanItem[] {
+function getItems(trace: Trace): SpanGraphItem[] {
   return trace.spans.map(getItem);
 }
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.test.ts
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.test.ts
@@ -61,7 +61,11 @@ describe('renderIntoCanvas()', () => {
     // a gradient (vs a solid rgba string) was used for summary spans.
     createLinearGradient() {
       const stops: Array<{ offset: number; color: string }> = [];
-      return { __isGradient: true, stops, addColorStop: (offset: number, color: string) => stops.push({ offset, color }) };
+      return {
+        __isGradient: true,
+        stops,
+        addColorStop: (offset: number, color: string) => stops.push({ offset, color }),
+      };
     }
   }
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.test.ts
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.test.ts
@@ -38,8 +38,8 @@ describe('renderIntoCanvas()', () => {
   const basicItem = { valueWidth: 100, valueOffset: 50, serviceName: 'some-name' };
 
   class CanvasContext {
-    fillStyle: undefined;
-    fillRectAccumulator: Array<{ fillStyle: undefined; height: number; width: number; x: number; y: number }> = [];
+    fillStyle: unknown;
+    fillRectAccumulator: Array<{ fillStyle: unknown; height: number; width: number; x: number; y: number }> = [];
 
     constructor() {
       this.fillStyle = undefined;
@@ -55,6 +55,13 @@ describe('renderIntoCanvas()', () => {
         x,
         y,
       });
+    }
+
+    // Minimal CanvasGradient stub: records its color stops so tests can assert
+    // a gradient (vs a solid rgba string) was used for summary spans.
+    createLinearGradient() {
+      const stops: Array<{ offset: number; color: string }> = [];
+      return { __isGradient: true, stops, addColorStop: (offset: number, color: string) => stops.push({ offset, color }) };
     }
   }
 
@@ -155,6 +162,48 @@ describe('renderIntoCanvas()', () => {
       expect(canvas.getContext.mock.calls).toEqual([['2d', { alpha: false }]]);
       expect(canvas.contexts.length).toBe(1);
       expect(canvas.contexts[0].fillRectAccumulator).toEqual(expectedDrawings);
+    });
+  });
+
+  describe('summary spans', () => {
+    it('draws summary spans taller than normal spans (fixed elevated weight)', () => {
+      const items = [
+        { valueWidth: 100, valueOffset: 0, serviceName: 'svc-normal' },
+        { valueWidth: 100, valueOffset: 0, serviceName: 'svc-summary', isSummary: true },
+      ];
+      const canvas = new Canvas();
+      renderIntoCanvas(canvas as unknown as HTMLCanvasElement, items, 4000, getColorFactory(), BG_COLOR);
+      // index 0 is the background fill; 1 = normal span, 2 = summary span
+      const [, normalRect, summaryRect] = canvas.contexts[0].fillRectAccumulator;
+      expect(summaryRect.height).toBeGreaterThan(normalRect.height);
+    });
+
+    it('gives every summary span the same height regardless of order', () => {
+      const items = [
+        { valueWidth: 100, valueOffset: 0, serviceName: 'a', isSummary: true },
+        { valueWidth: 100, valueOffset: 0, serviceName: 'b' },
+        { valueWidth: 100, valueOffset: 0, serviceName: 'c', isSummary: true },
+      ];
+      const canvas = new Canvas();
+      renderIntoCanvas(canvas as unknown as HTMLCanvasElement, items, 4000, getColorFactory(), BG_COLOR);
+      const [, first, , third] = canvas.contexts[0].fillRectAccumulator;
+      expect(first.height).toBe(third.height);
+    });
+
+    it('fills summary spans with a gradient and normal spans with a solid color', () => {
+      const items = [
+        { valueWidth: 100, valueOffset: 0, serviceName: 'svc-normal' },
+        { valueWidth: 100, valueOffset: 0, serviceName: 'svc-summary', isSummary: true },
+      ];
+      const canvas = new Canvas();
+      renderIntoCanvas(canvas as unknown as HTMLCanvasElement, items, 4000, getColorFactory(), BG_COLOR);
+      const [, normalRect, summaryRect] = canvas.contexts[0].fillRectAccumulator;
+      expect(typeof normalRect.fillStyle).toBe('string');
+      // gradient object with light tint -> base -> dark shade stops
+      expect(summaryRect.fillStyle).toMatchObject({
+        __isGradient: true,
+        stops: [{ offset: 0 }, { offset: 0.38 }, { offset: 1 }],
+      });
     });
   });
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.test.ts
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.test.ts
@@ -170,28 +170,29 @@ describe('renderIntoCanvas()', () => {
   });
 
   describe('summary spans', () => {
-    it('draws summary spans taller than normal spans (fixed elevated weight)', () => {
+    it('draws a summary as a block proportional to its span_count (shape preservation)', () => {
       const items = [
         { valueWidth: 100, valueOffset: 0, serviceName: 'svc-normal' },
-        { valueWidth: 100, valueOffset: 0, serviceName: 'svc-summary', isSummary: true },
+        { valueWidth: 100, valueOffset: 0, serviceName: 'svc-summary', isSummary: true, spanCount: 10 },
       ];
       const canvas = new Canvas();
       renderIntoCanvas(canvas as unknown as HTMLCanvasElement, items, 4000, getColorFactory(), BG_COLOR);
       // index 0 is the background fill; 1 = normal span, 2 = summary span
       const [, normalRect, summaryRect] = canvas.contexts[0].fillRectAccumulator;
-      expect(summaryRect.height).toBeGreaterThan(normalRect.height);
+      // the summary fills ~span_count times a normal span's vertical footprint,
+      // restoring the density the collapsed spans would have occupied
+      expect(Math.round(summaryRect.height / normalRect.height)).toBe(10);
     });
 
-    it('gives every summary span the same height regardless of order', () => {
+    it('scales summary height with span_count (larger count is taller)', () => {
       const items = [
-        { valueWidth: 100, valueOffset: 0, serviceName: 'a', isSummary: true },
-        { valueWidth: 100, valueOffset: 0, serviceName: 'b' },
-        { valueWidth: 100, valueOffset: 0, serviceName: 'c', isSummary: true },
+        { valueWidth: 100, valueOffset: 0, serviceName: 'a', isSummary: true, spanCount: 5 },
+        { valueWidth: 100, valueOffset: 0, serviceName: 'b', isSummary: true, spanCount: 20 },
       ];
       const canvas = new Canvas();
       renderIntoCanvas(canvas as unknown as HTMLCanvasElement, items, 4000, getColorFactory(), BG_COLOR);
-      const [, first, , third] = canvas.contexts[0].fillRectAccumulator;
-      expect(first.height).toBe(third.height);
+      const [, small, large] = canvas.contexts[0].fillRectAccumulator;
+      expect(large.height).toBeGreaterThan(small.height);
     });
 
     it('fills summary spans with a gradient and normal spans with a solid color', () => {

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.test.ts
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.test.ts
@@ -212,6 +212,38 @@ describe('renderIntoCanvas()', () => {
     });
   });
 
+  describe('fill color caching', () => {
+    it('computes each service fill color once, regardless of item count or summary/normal mix', () => {
+      // Large, mostly-normal trace with only three services repeated: this is the
+      // hot path (unpruned traces) that motivates caching per service instead of
+      // recomputing the fill for every span.
+      const items = _range(300).map((i) => ({
+        valueWidth: 100,
+        valueOffset: i,
+        serviceName: `svc-${i % 3}`,
+        isSummary: i % 50 === 0,
+      }));
+      const canvas = new Canvas();
+      const getFillColor = getColorFactory();
+      renderIntoCanvas(canvas as unknown as HTMLCanvasElement, items, 4000, getFillColor, BG_COLOR);
+      expect(getFillColor.inputOutput.map((io) => io.input)).toEqual(['svc-0', 'svc-1', 'svc-2']);
+    });
+
+    it('reuses one identical solid fill string for every normal span of a service', () => {
+      const items = [
+        { valueWidth: 100, valueOffset: 0, serviceName: 'svc-a' },
+        { valueWidth: 100, valueOffset: 1, serviceName: 'svc-a' },
+        { valueWidth: 100, valueOffset: 2, serviceName: 'svc-a' },
+      ];
+      const canvas = new Canvas();
+      renderIntoCanvas(canvas as unknown as HTMLCanvasElement, items, 4000, getColorFactory(), BG_COLOR);
+      // index 0 is the background fill; the rest are the span rects.
+      const [, ...rects] = canvas.contexts[0].fillRectAccumulator;
+      expect(typeof rects[0].fillStyle).toBe('string');
+      expect(new Set(rects.map((r) => r.fillStyle)).size).toBe(1);
+    });
+  });
+
   describe('when there are many items', () => {
     it('sets the height when there are many items', () => {
       const canvas = new Canvas();

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type TNil from '../../types/TNil';
-
 // exported for tests
 export const ITEM_ALPHA = 0.8;
 export const MIN_ITEM_HEIGHT = 2;
@@ -21,42 +19,77 @@ export const MAX_TOTAL_HEIGHT = 200;
 export const MIN_ITEM_WIDTH = 10;
 export const MIN_TOTAL_HEIGHT = 60;
 export const MAX_ITEM_HEIGHT = 6;
+// Summary spans carry a fixed elevated vertical weight so pruning (N spans -> 1
+// summary) does not collapse the minimap's density shape. Fixed, NOT proportional
+// to span_count, to avoid wild density swings between summaries. Tunable / pending
+// design (Figma "Overview - shape preservation"). See grafana-adaptivetraces-app#1031.
+export const SUMMARY_WEIGHT = 3;
+export const MAX_SUMMARY_ITEM_HEIGHT = MAX_ITEM_HEIGHT * SUMMARY_WEIGHT;
+
+type SpanGraphItem = { valueWidth: number; valueOffset: number; serviceName: string; isSummary?: boolean };
+
+// Light-to-dark gradient within the service hue, matching the waterfall summary
+// bar (which uses CSS color-mix; canvas has no color-mix so we mix in JS).
+const TINT = 0.3; // toward white at the left
+const SHADE = 0.55; // toward black at the right
+const rgba = ([r, g, b]: [number, number, number]) => `rgba(${r},${g},${b},${ITEM_ALPHA})`;
+const tint = ([r, g, b]: [number, number, number]) => rgba([r + (255 - r) * TINT, g + (255 - g) * TINT, b + (255 - b) * TINT]);
+const shade = ([r, g, b]: [number, number, number]) => rgba([r * (1 - SHADE), g * (1 - SHADE), b * (1 - SHADE)]);
 
 export default function renderIntoCanvas(
   canvas: HTMLCanvasElement,
-  items: Array<{ valueWidth: number; valueOffset: number; serviceName: string }>,
+  items: SpanGraphItem[],
   totalValueWidth: number,
   getFillColor: (serviceName: string) => [number, number, number],
   bgColor: string
 ) {
-  const fillCache: Map<string, string | TNil> = new Map();
-  const cHeight = items.length < MIN_TOTAL_HEIGHT ? MIN_TOTAL_HEIGHT : Math.min(items.length, MAX_TOTAL_HEIGHT);
+  const colorCache: Map<string, [number, number, number]> = new Map();
+  const weightOf = (item: SpanGraphItem) => (item.isSummary ? SUMMARY_WEIGHT : 1);
+  const totalWeight = items.reduce((sum, item) => sum + weightOf(item), 0);
+  const cHeight = totalWeight < MIN_TOTAL_HEIGHT ? MIN_TOTAL_HEIGHT : Math.min(totalWeight, MAX_TOTAL_HEIGHT);
   const cWidth = window.innerWidth * 2;
   // eslint-disable-next-line no-param-reassign
   canvas.width = cWidth;
   // eslint-disable-next-line no-param-reassign
   canvas.height = cHeight;
-  const itemHeight = Math.min(MAX_ITEM_HEIGHT, Math.max(MIN_ITEM_HEIGHT, cHeight / items.length));
-  const itemYChange = cHeight / items.length;
+  // Pixels per unit of weight. A normal span occupies one unit; a summary span
+  // occupies SUMMARY_WEIGHT units (taller bar + larger vertical step). With no
+  // summary spans, weight === index and this matches the previous layout exactly.
+  const step = cHeight / totalWeight;
 
   const ctx = canvas.getContext('2d', { alpha: false });
   if (ctx) {
     ctx.fillStyle = bgColor;
     ctx.fillRect(0, 0, cWidth, cHeight);
+    let cumulativeWeight = 0;
     for (let i = 0; i < items.length; i++) {
-      const { valueWidth, valueOffset, serviceName } = items[i];
+      const { valueWidth, valueOffset, serviceName, isSummary } = items[i];
       const x = (valueOffset / totalValueWidth) * cWidth;
       let width = (valueWidth / totalValueWidth) * cWidth;
       if (width < MIN_ITEM_WIDTH) {
         width = MIN_ITEM_WIDTH;
       }
-      let fillStyle = fillCache.get(serviceName);
-      if (!fillStyle) {
-        fillStyle = `rgba(${getFillColor(serviceName).concat(ITEM_ALPHA).join()})`;
-        fillCache.set(serviceName, fillStyle);
+      const weight = isSummary ? SUMMARY_WEIGHT : 1;
+      const maxHeight = isSummary ? MAX_SUMMARY_ITEM_HEIGHT : MAX_ITEM_HEIGHT;
+      const itemHeight = Math.min(maxHeight, Math.max(MIN_ITEM_HEIGHT, step * weight));
+      const y = step * cumulativeWeight;
+
+      let rgb = colorCache.get(serviceName);
+      if (!rgb) {
+        rgb = getFillColor(serviceName);
+        colorCache.set(serviceName, rgb);
       }
-      ctx.fillStyle = fillStyle;
-      ctx.fillRect(x, i * itemYChange, width, itemHeight);
+      if (isSummary) {
+        const gradient = ctx.createLinearGradient(x, 0, x + width, 0);
+        gradient.addColorStop(0, tint(rgb));
+        gradient.addColorStop(0.38, rgba(rgb));
+        gradient.addColorStop(1, shade(rgb));
+        ctx.fillStyle = gradient;
+      } else {
+        ctx.fillStyle = rgba(rgb);
+      }
+      ctx.fillRect(x, y, width, itemHeight);
+      cumulativeWeight += weight;
     }
   }
 }

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
@@ -19,14 +19,14 @@ export const MAX_TOTAL_HEIGHT = 200;
 export const MIN_ITEM_WIDTH = 10;
 export const MIN_TOTAL_HEIGHT = 60;
 export const MAX_ITEM_HEIGHT = 6;
-// Summary spans carry a fixed elevated vertical weight so pruning (N spans -> 1
-// summary) does not collapse the minimap's density shape. Fixed, NOT proportional
-// to span_count, to avoid wild density swings between summaries. Tunable / pending
-// design (Figma "Overview - shape preservation"). See grafana-adaptivetraces-app#1031.
-const SUMMARY_WEIGHT = 3;
-const MAX_SUMMARY_ITEM_HEIGHT = MAX_ITEM_HEIGHT * SUMMARY_WEIGHT;
 
-type SpanGraphItem = { valueWidth: number; valueOffset: number; serviceName: string; isSummary?: boolean };
+type SpanGraphItem = {
+  valueWidth: number;
+  valueOffset: number;
+  serviceName: string;
+  isSummary?: boolean;
+  spanCount?: number;
+};
 
 // Light-to-dark gradient within the service hue, matching the waterfall summary
 // bar (which uses CSS color-mix; canvas has no color-mix so we mix in JS).
@@ -45,7 +45,13 @@ export default function renderIntoCanvas(
   bgColor: string
 ) {
   const colorCache: Map<string, [number, number, number]> = new Map();
-  const weightOf = (item: SpanGraphItem) => (item.isSummary ? SUMMARY_WEIGHT : 1);
+  // A summary span weighs as much as the spans it represents (span_count), so the
+  // pruned trace keeps the unpruned density shape: total weight equals the original
+  // span count, and the summary occupies the vertical extent its spans would have.
+  // Fixed weight would only signal "a summary is here" and flatten that shape, which
+  // is what #1031's "shape preservation" mockup explicitly restores. A normal span
+  // weighs 1; a summary with no span_count falls back to 1.
+  const weightOf = (item: SpanGraphItem) => (item.isSummary ? Math.max(item.spanCount ?? 0, 1) : 1);
   const totalWeight = items.reduce((sum, item) => sum + weightOf(item), 0);
   const cHeight = totalWeight < MIN_TOTAL_HEIGHT ? MIN_TOTAL_HEIGHT : Math.min(totalWeight, MAX_TOTAL_HEIGHT);
   const cWidth = window.innerWidth * 2;
@@ -53,9 +59,8 @@ export default function renderIntoCanvas(
   canvas.width = cWidth;
   // eslint-disable-next-line no-param-reassign
   canvas.height = cHeight;
-  // Pixels per unit of weight. A normal span occupies one unit; a summary span
-  // occupies SUMMARY_WEIGHT units (taller bar + larger vertical step). With no
-  // summary spans, weight === index and this matches the previous layout exactly.
+  // Pixels per unit of weight. With no summary spans, weight === index and this
+  // matches the previous layout exactly.
   const step = cHeight / totalWeight;
 
   const ctx = canvas.getContext('2d', { alpha: false });
@@ -70,9 +75,12 @@ export default function renderIntoCanvas(
       if (width < MIN_ITEM_WIDTH) {
         width = MIN_ITEM_WIDTH;
       }
-      const weight = isSummary ? SUMMARY_WEIGHT : 1;
-      const maxHeight = isSummary ? MAX_SUMMARY_ITEM_HEIGHT : MAX_ITEM_HEIGHT;
-      const itemHeight = Math.min(maxHeight, Math.max(MIN_ITEM_HEIGHT, step * weight));
+      const weight = weightOf(items[i]);
+      // Summary fills its whole proportional slot (the vertical extent its spans
+      // would have occupied); normal spans keep the clamped thin-bar height.
+      const itemHeight = isSummary
+        ? Math.max(MIN_ITEM_HEIGHT, step * weight)
+        : Math.min(MAX_ITEM_HEIGHT, Math.max(MIN_ITEM_HEIGHT, step * weight));
       const y = step * cumulativeWeight;
 
       let rgb = colorCache.get(serviceName);

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
@@ -60,8 +60,9 @@ export default function renderIntoCanvas(
   // eslint-disable-next-line no-param-reassign
   canvas.height = cHeight;
   // Pixels per unit of weight. With no summary spans, weight === index and this
-  // matches the previous layout exactly.
-  const step = cHeight / totalWeight;
+  // matches the previous layout exactly. Guard the empty-trace case (totalWeight 0)
+  // so step stays finite; the draw loop below does nothing when there are no items.
+  const step = totalWeight > 0 ? cHeight / totalWeight : 0;
 
   const ctx = canvas.getContext('2d', { alpha: false });
   if (ctx) {

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
@@ -46,11 +46,11 @@ export default function renderIntoCanvas(
 ) {
   const colorCache: Map<string, [number, number, number]> = new Map();
   // A summary span weighs as much as the spans it represents (span_count), so the
-  // pruned trace keeps the unpruned density shape: total weight equals the original
-  // span count, and the summary occupies the vertical extent its spans would have.
-  // Fixed weight would only signal "a summary is here" and flatten that shape, which
-  // is what #1031's "shape preservation" mockup explicitly restores. A normal span
-  // weighs 1; a summary with no span_count falls back to 1.
+  // aggregated region keeps its vertical density extent instead of collapsing to one
+  // thin bar: total weight equals the original span count, and the summary occupies
+  // the vertical extent its spans would have. A fixed weight would only signal "a
+  // summary is here" and flatten that extent. A normal span weighs 1; a summary with
+  // no span_count falls back to 1.
   const weightOf = (item: SpanGraphItem) => (item.isSummary ? Math.max(item.spanCount ?? 0, 1) : 1);
   const totalWeight = items.reduce((sum, item) => sum + weightOf(item), 0);
   const cHeight = totalWeight < MIN_TOTAL_HEIGHT ? MIN_TOTAL_HEIGHT : Math.min(totalWeight, MAX_TOTAL_HEIGHT);

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
@@ -23,8 +23,8 @@ export const MAX_ITEM_HEIGHT = 6;
 // summary) does not collapse the minimap's density shape. Fixed, NOT proportional
 // to span_count, to avoid wild density swings between summaries. Tunable / pending
 // design (Figma "Overview - shape preservation"). See grafana-adaptivetraces-app#1031.
-export const SUMMARY_WEIGHT = 3;
-export const MAX_SUMMARY_ITEM_HEIGHT = MAX_ITEM_HEIGHT * SUMMARY_WEIGHT;
+const SUMMARY_WEIGHT = 3;
+const MAX_SUMMARY_ITEM_HEIGHT = MAX_ITEM_HEIGHT * SUMMARY_WEIGHT;
 
 type SpanGraphItem = { valueWidth: number; valueOffset: number; serviceName: string; isSummary?: boolean };
 
@@ -33,7 +33,8 @@ type SpanGraphItem = { valueWidth: number; valueOffset: number; serviceName: str
 const TINT = 0.3; // toward white at the left
 const SHADE = 0.55; // toward black at the right
 const rgba = ([r, g, b]: [number, number, number]) => `rgba(${r},${g},${b},${ITEM_ALPHA})`;
-const tint = ([r, g, b]: [number, number, number]) => rgba([r + (255 - r) * TINT, g + (255 - g) * TINT, b + (255 - b) * TINT]);
+const tint = ([r, g, b]: [number, number, number]) =>
+  rgba([r + (255 - r) * TINT, g + (255 - g) * TINT, b + (255 - b) * TINT]);
 const shade = ([r, g, b]: [number, number, number]) => rgba([r * (1 - SHADE), g * (1 - SHADE), b * (1 - SHADE)]);
 
 export default function renderIntoCanvas(

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
@@ -58,7 +58,13 @@ export default function renderIntoCanvas(
   // summary is here" and flatten that extent. A normal span weighs 1; a summary with
   // no span_count falls back to 1.
   const weightOf = (item: SpanGraphItem) => (item.isSummary ? Math.max(item.spanCount ?? 0, 1) : 1);
-  const totalWeight = items.reduce((sum, item) => sum + weightOf(item), 0);
+  // Plain loop rather than reduce: on large unpruned traces (all normal spans)
+  // this runs once per span, so the closure + call overhead of reduce is worth
+  // avoiding.
+  let totalWeight = 0;
+  for (let i = 0; i < items.length; i++) {
+    totalWeight += weightOf(items[i]);
+  }
   const cHeight = totalWeight < MIN_TOTAL_HEIGHT ? MIN_TOTAL_HEIGHT : Math.min(totalWeight, MAX_TOTAL_HEIGHT);
   const cWidth = window.innerWidth * 2;
   // eslint-disable-next-line no-param-reassign
@@ -69,6 +75,9 @@ export default function renderIntoCanvas(
   // matches the previous layout exactly. Guard the empty-trace case (totalWeight 0)
   // so step stays finite; the draw loop below does nothing when there are no items.
   const step = totalWeight > 0 ? cHeight / totalWeight : 0;
+  // A normal span always weighs 1, so its clamped height is invariant across the
+  // loop; hoist it out instead of recomputing per span (the hot path).
+  const normalItemHeight = Math.min(MAX_ITEM_HEIGHT, Math.max(MIN_ITEM_HEIGHT, step));
 
   const ctx = canvas.getContext('2d', { alpha: false });
   if (ctx) {
@@ -82,12 +91,6 @@ export default function renderIntoCanvas(
       if (width < MIN_ITEM_WIDTH) {
         width = MIN_ITEM_WIDTH;
       }
-      const weight = weightOf(items[i]);
-      // Summary fills its whole proportional slot (the vertical extent its spans
-      // would have occupied); normal spans keep the clamped thin-bar height.
-      const itemHeight = isSummary
-        ? Math.max(MIN_ITEM_HEIGHT, step * weight)
-        : Math.min(MAX_ITEM_HEIGHT, Math.max(MIN_ITEM_HEIGHT, step * weight));
       const y = step * cumulativeWeight;
 
       let rgb = colorCache.get(serviceName);
@@ -96,11 +99,16 @@ export default function renderIntoCanvas(
         colorCache.set(serviceName, rgb);
       }
       if (isSummary) {
+        // Summary fills its whole proportional slot (the vertical extent its spans
+        // would have occupied).
+        const weight = weightOf(items[i]);
         const gradient = ctx.createLinearGradient(x, 0, x + width, 0);
         gradient.addColorStop(0, tint(rgb));
         gradient.addColorStop(0.38, rgba(rgb));
         gradient.addColorStop(1, shade(rgb));
         ctx.fillStyle = gradient;
+        ctx.fillRect(x, y, width, Math.max(MIN_ITEM_HEIGHT, step * weight));
+        cumulativeWeight += weight;
       } else {
         let fill = fillCache.get(serviceName);
         if (fill === undefined) {
@@ -108,9 +116,9 @@ export default function renderIntoCanvas(
           fillCache.set(serviceName, fill);
         }
         ctx.fillStyle = fill;
+        ctx.fillRect(x, y, width, normalItemHeight);
+        cumulativeWeight += 1;
       }
-      ctx.fillRect(x, y, width, itemHeight);
-      cumulativeWeight += weight;
     }
   }
 }

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
@@ -20,11 +20,13 @@ export const MIN_ITEM_WIDTH = 10;
 export const MIN_TOTAL_HEIGHT = 60;
 export const MAX_ITEM_HEIGHT = 6;
 
-type SpanGraphItem = {
+export type SpanGraphItem = {
   valueWidth: number;
   valueOffset: number;
   serviceName: string;
   isSummary?: boolean;
+  // Number of spans a summary represents; drives its proportional vertical
+  // weight in the minimap so the pruned trace keeps the unpruned density shape.
   spanCount?: number;
 };
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/render-into-canvas.tsx
@@ -47,6 +47,10 @@ export default function renderIntoCanvas(
   bgColor: string
 ) {
   const colorCache: Map<string, [number, number, number]> = new Map();
+  // Solid normal-span fill string, built once per service. Rebuilding it per item
+  // (a template-literal alloc on every span) is a measurable cost on large,
+  // unpruned traces where every span takes this path.
+  const fillCache: Map<string, string> = new Map();
   // A summary span weighs as much as the spans it represents (span_count), so the
   // aggregated region keeps its vertical density extent instead of collapsing to one
   // thin bar: total weight equals the original span count, and the summary occupies
@@ -98,7 +102,12 @@ export default function renderIntoCanvas(
         gradient.addColorStop(1, shade(rgb));
         ctx.fillStyle = gradient;
       } else {
-        ctx.fillStyle = rgba(rgb);
+        let fill = fillCache.get(serviceName);
+        if (fill === undefined) {
+          fill = rgba(rgb);
+          fillCache.set(serviceName, fill);
+        }
+        ctx.fillStyle = fill;
       }
       ctx.fillRect(x, y, width, itemHeight);
       cumulativeWeight += weight;

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.test.ts
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.test.ts
@@ -303,7 +303,7 @@ describe('transformTraceData() pruned span detection', () => {
     expect(agg.durationMinNs).toBe(4_000_000);
   });
 
-  // The Number.isNaN guard drops a non-numeric value rather than writing NaN into a number field.
+  // The Number.isFinite guard drops a non-numeric value rather than writing NaN into a number field.
   // The span is still detected as a summary (is_summary is unaffected) and sibling numeric values
   // are still extracted.
   it('drops a non-numeric aggregation value instead of storing NaN', () => {
@@ -317,13 +317,17 @@ describe('transformTraceData() pruned span detection', () => {
     expect(agg.durationMinNs).toBe(4_000_000);
   });
 
-  // Number() coerces null/boolean/empty-string to a misleading 0 or 1, which a bare NaN check
-  // would let through; the type guard must reject these. (Copilot review, 2026-06-11)
+  // Number() coerces null/boolean/empty-string to a misleading 0 or 1, and "Infinity" / an
+  // out-of-range exponent to a non-finite Infinity, which a bare NaN check would let through; the
+  // finite guard must reject all of these. A non-finite spanCount would make the minimap's total
+  // weight infinite and its step/height math collapse to 0/NaN. (Copilot reviews, 2026-06-11, 2026-07-14)
   it.each([
     ['null', null],
     ['boolean false', false],
     ['boolean true', true],
     ['empty string', ''],
+    ['Infinity string', 'Infinity'],
+    ['out-of-range exponent string', '1e400'],
   ])('drops a %s span_count instead of coercing it to 0/1', (_label, bad) => {
     const fixture = structuredClone(summaryDefaultsOnly);
     const tags = fixture.spans.find((s) => s.spanID === 'summ00000000a101')!.tags!;

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -74,12 +74,14 @@ function extractSpanAggregation(tags: TraceKeyValuePair[]): SpanAggregation | un
   ] as const;
   for (const [key, field] of numericFields) {
     if (byKey.has(key)) {
-      // Accept real numbers and numeric strings only. Number() would coerce null/boolean/[]/''
-      // to a misleading 0 or 1, so restrict the input before coercing rather than relying on a
-      // NaN check alone (the tag value type is `any`).
+      // Accept real numbers and finite numeric strings only. Number() would coerce null/boolean/[]/''
+      // to a misleading 0 or 1, so restrict the input before coercing rather than relying on the
+      // finite check alone (the tag value type is `any`). Number.isFinite (not just !isNaN) also
+      // rejects Infinity from "Infinity" or an out-of-range exponent, which would otherwise make the
+      // minimap's total weight infinite and collapse its step/height math to 0/NaN.
       const raw = byKey.get(key);
       const value = typeof raw === 'number' ? raw : typeof raw === 'string' && raw.trim() !== '' ? Number(raw) : NaN;
-      if (!Number.isNaN(value)) {
+      if (Number.isFinite(value)) {
         aggregation[field] = value;
       }
     }


### PR DESCRIPTION
Makes pruned **summary spans** visually distinct in the trace **overview minimap** (`SpanGraph`)

- Closes grafana/grafana-adaptivetraces-app#1031
- Builds on the model layer from #126019

## What this does

The minimap is canvas-drawn (`render-into-canvas.tsx`), so this is a canvas change, not CSS.

- **Density-extent preservation (the issue's "shape preservation"):** a summary span is weighted by its **`span_count`** (proportional) and drawn as a **single full-height gradient block** over its slot. Total canvas weight then equals the original (pre-pruning) span count, so the aggregated region keeps its **vertical share of the minimap** instead of collapsing to one thin bar. To be precise: it restores the region's vertical *density extent*; it is **not** a reconstruction of the individual spans - the block is uniform across the summary's wall-clock window and does not recreate the original per-span horizontal silhouette/texture. This matches the "shape preservation" mockup (a smooth block, not redrawn bars).
- **Gradient fill:** summary blocks use a light-to-dark gradient within the service hue (`createLinearGradient`, tint/shade mixed in JS since canvas has no CSS `color-mix`), matching the waterfall treatment in #127111.
- `isSummary` + `span_count` are threaded through `getItem` into the canvas items.

## Blast radius / risk

This is **not** a per-span change gated to summary bars (unlike the waterfall in #127111, where each row is independent). The minimap's vertical layout is **global**, so the risk profile splits in two:

- **Traces with no summary spans: byte-identical to today.** Every weight is 1, so `totalWeight`, `cHeight`, `step`, item heights and `y` all reduce to the previous math. Verified: the pre-existing canvas render tests are unchanged and still pass. Zero behavior change for non-pruned traces.
- **Traces containing summary spans: the whole minimap canvas re-flows** (intentional - this is the density-extent preservation described above). `weightOf` feeds `totalWeight` -> `cHeight` -> `step`, which set every span's `y` and the normal spans' heights. So introducing summary weight shifts **normal** spans too; the effect is not limited to summary bars. "Normal spans render exactly as before" does **not** hold when a summary is present.
- **Bounded:** slot heights sum exactly to `cHeight` (no overflow), the intrinsic canvas height stays clamped at 200 and the displayed minimap height is unchanged (fixed 60px CSS), and a summary with no `span_count` falls back to weight 1.

## Why proportional, not fixed weight

#1031's Scope paragraph says "fixed elevated weight, *not* proportional to span_count". We deviate, deliberately:

- The issue's **title + Problem statement** are about preserving density: pruning "loses **N-1 bars worth of visual density**". Restoring that lost vertical density is proportional weight by definition.
- The **"shape preservation" mockup** renders the aggregated region as a tall density-restoring block, not a small fixed bump.
- The "chaotic swings" worry dissolves: with `weight = span_count`, the aggregated region's vertical weight matches the original by construction, so its density no longer collapses (it is drawn as one block, not the original per-span texture).
- The "fixed" wording appears to be the **waterfall** row-height concept (summary row = normal row height) mis-applied to the minimap.

Full rationale: grafana/grafana-adaptivetraces-app#1031 (comment).

### Demo
[Attached demo + validation summary](https://github.com/grafana/grafana/pull/127218#issuecomment-4806505730)

## Testing

- Suite of SpanGraph unit tests (existing + new): summary footprint proportional to `span_count`, larger count is taller, gradient-vs-solid fill, `span_count` threading, and unchanged rendering for no-summary traces. typecheck + lint + knip clean.

### How to test locally

Summary spans only appear when spans carry pruned-span `aggregation.*` tags (produced by Adaptive Traces); the local demo sources (TNS / `gdev-tempo`) do not emit these, so point local dev at real data.

**Against real data (full UI):**
1. Provision a Tempo datasource against a stack that has Adaptive Traces pruned spans (e.g. our ops Tempo stack), then run the backend (`make run`) and frontend (`yarn start`). Tempo is now an externalized datasource, auto-discovered from `data/plugins/` at startup, so there is no separate plugin build step.
2. In Explore, query a trace containing summary spans (e.g. TraceQL `{ span.aggregation.is_summary = true }`).
3. Open the trace and click a `(summary)` span to expand SpanDetail. Confirm the header shows the `(summary)` label and count badge, Duration shows `min | median | max`, an End Time item is present, and Resource attributes are annotated `(inherited from slowest span)`.

> Datasource: `grafanacloud-ops-traces` (uid `grafanacloud-traces`, id `557179`, type Tempo), region `ops-eu-south-0`, on `ops.grafana-ops.net`.
> 
> Working Explore deep link (opens that datasource with { span.aggregation.is_summary = true }, last 3h:
> https://ops.grafana-ops.net/goto/sbf2c4?orgId=stacks-27821

**Without a datasource (logic/rendering only):**
`yarn jest public/app/features/explore/TraceView/ --watchAll=false` covers the summary-span minimap cases via `pruned-spans.fixture.ts`.

## Slices

- Slice 1 (model): #126019 (merged)
- Slice 2 (waterfall): #127111
- Slice 3 (minimap): this PR
