### PR TITLE
Provisioning: add provider logo to repository page title

### DIFF
--- a/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
@@ -11,6 +11,7 @@ import { Page } from 'app/core/components/Page/Page';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { isNotFoundError } from 'app/features/alerting/unified/api/util';
 
+import { RepoIcon } from '../Shared/RepoIcon';
 import { PROVISIONING_URL } from '../constants';
 
 import { RepositoryActions } from './RepositoryActions';
@@ -61,6 +62,12 @@ export default function RepositoryStatusPage() {
         text: data?.spec?.title ?? t('provisioning.repository-status-page.title', 'Repository Status'),
         subTitle: data?.spec?.description,
       }}
+      renderTitle={(title) => (
+        <Stack alignItems="center" gap={1}>
+          <RepoIcon type={data?.spec?.type} />
+          <h1>{title}</h1>
+        </Stack>
+      )}
       actions={data && <RepositoryActions repository={data} />}
     >
       <Page.Contents isLoading={query.isLoading}>

--- a/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
@@ -63,9 +63,9 @@ export default function RepositoryStatusPage() {
         subTitle: data?.spec?.description,
       }}
       renderTitle={(title) => (
-        <Stack alignItems="center" gap={1}>
+        <Stack alignItems="center">
           <RepoIcon type={data?.spec?.type} />
-          <h1>{title}</h1>
+          <Text element="h1">{title}</Text>
         </Stack>
       )}
       actions={data && <RepositoryActions repository={data} />}


### PR DESCRIPTION
Shows the provider logo/icon next to the repository title on the repository status page.


https://github.com/user-attachments/assets/01f4abe5-fd76-4a4d-82c1-1f9228d77e73

