### PR TITLE
Panel Query Editor: Pass section variables to query editor

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -42,12 +42,15 @@ jest.mock('@grafana/assistant', () => ({
   createAssistantContextItem: jest.fn(),
 }));
 
+const mockGet = jest.fn(() => Promise.resolve(mockDS));
+const mockGetInstanceSettings = jest.fn(() => mockDS);
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: () => ({
-    get: () => Promise.resolve(mockDS),
+    get: mockGet,
     getList: () => {},
-    getInstanceSettings: () => mockDS,
+    getInstanceSettings: mockGetInstanceSettings,
   }),
 }));
 
@@ -385,6 +388,23 @@ describe('QueryEditorRow', () => {
     onReplace: jest.fn(),
     index: 0,
     range: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+  });
+  it('forwards scopedVars when resolving a query datasource variable', async () => {
+    mockGetInstanceSettings.mockClear();
+    const data = {
+      state: LoadingState.Done,
+      series: [],
+      timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+    };
+    // A section-scoped (row/tab) datasource variable can only be resolved with the panel's scene
+    // scope, so QueryEditorRow must forward scopedVars to getInstanceSettings.
+    const scopedVars = { __sceneObject: { value: {} } };
+    const query = { refId: 'B', datasource: { uid: '${ds_var}', type: 'prometheus' } };
+    render(<QueryEditorRow {...props(data)} query={query} scopedVars={scopedVars} />);
+
+    await waitFor(() => {
+      expect(mockGetInstanceSettings).toHaveBeenCalledWith(query.datasource, scopedVars);
+    });
   });
   it('should display error message in corresponding panel', async () => {
     const data = {

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -14,6 +14,7 @@ import {
   LoadingState,
   type PanelData,
   type QueryResultMetaNotice,
+  type ScopedVars,
   type TimeRange,
   getDataSourceRef,
   PluginExtensionPoints,
@@ -75,6 +76,10 @@ export interface Props<TQuery extends DataQuery> {
   queryLibraryRef?: string;
   onCancelQueryLibraryEdit?: () => void;
   isOpen?: boolean;
+  /**
+   * Required to resolve section-scoped (row/tab) datasource variables
+   */
+  scopedVars?: ScopedVars;
 }
 
 interface State<TQuery extends DataQuery> {
@@ -115,7 +120,10 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
    */
   getInterpolatedDataSourceUID(): string | undefined {
     if (this.props.query.datasource) {
-      const instanceSettings = this.dataSourceSrv.getInstanceSettings(this.props.query.datasource);
+      const instanceSettings = this.dataSourceSrv.getInstanceSettings(
+        this.props.query.datasource,
+        this.props.scopedVars
+      );
       return instanceSettings?.rawRef?.uid ?? instanceSettings?.uid;
     }
 

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -8,12 +8,13 @@ import {
   type EventBusExtended,
   type HistoryItem,
   type PanelData,
+  type ScopedVars,
   getDataSourceRef,
   getNextRefId,
   isSystemOverrideWithRef,
 } from '@grafana/data';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
-import { type SceneObjectRef, type VizPanel } from '@grafana/scenes';
+import { SafeSerializableSceneObject, type SceneObjectRef, type VizPanel } from '@grafana/scenes';
 import { type DataSourceRef } from '@grafana/schema';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
@@ -248,7 +249,14 @@ export class QueryEditorRows extends PureComponent<Props> {
       queryLibraryRef,
       onCancelQueryLibraryEdit,
       isOpen,
+      panelRef,
     } = this.props;
+
+    // Scene scope for resolving section-scoped (row/tab) datasource variables, which live on a
+    // layout node rather than the dashboard root and so are not reachable from the global scene context.
+    const scopedVars: ScopedVars | undefined = panelRef
+      ? { __sceneObject: new SafeSerializableSceneObject(panelRef.resolve()) }
+      : undefined;
 
     return (
       <DragDropContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
@@ -257,7 +265,7 @@ export class QueryEditorRows extends PureComponent<Props> {
             return (
               <div data-testid="query-editor-rows" ref={provided.innerRef} {...provided.droppableProps}>
                 {queries.map((query, index) => {
-                  const dataSourceSettings = getDataSourceSettings(query, dsSettings);
+                  const dataSourceSettings = getDataSourceSettings(query, dsSettings, scopedVars);
                   const onChangeDataSourceSettings = dsSettings.meta.mixed
                     ? (settings: DataSourceInstanceSettings) => this.onDataSourceChange(settings, index)
                     : undefined;
@@ -270,6 +278,7 @@ export class QueryEditorRows extends PureComponent<Props> {
                       data={data}
                       query={query}
                       dataSource={dataSourceSettings}
+                      scopedVars={scopedVars}
                       onChangeDataSource={onChangeDataSourceSettings}
                       onChange={(query) => this.onChangeQuery(query, index)}
                       onReplace={(query) => this.onReplaceQuery(query, index)}
@@ -307,11 +316,12 @@ export class QueryEditorRows extends PureComponent<Props> {
 
 const getDataSourceSettings = (
   query: DataQuery,
-  groupSettings: DataSourceInstanceSettings
+  groupSettings: DataSourceInstanceSettings,
+  scopedVars?: ScopedVars
 ): DataSourceInstanceSettings => {
   if (!query.datasource) {
     return groupSettings;
   }
-  const querySettings = getDataSourceSrv().getInstanceSettings(query.datasource);
+  const querySettings = getDataSourceSrv().getInstanceSettings(query.datasource, scopedVars);
   return querySettings || groupSettings;
 };


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/126917 for `queryEditorNext=false` toggle

The root cause: QueryEditorRow resolved the query's datasource ref without forwarding the panel's scene scope, so section-scoped (tab/row) datasource variables — which live on a TabItem/RowItem node, not the dashboard root — couldn't be resolved and fell back to the default datasource.

**QueryEditorRow.tsx**
Added an optional scopedVars?: ScopedVars prop.
getInterpolatedDataSourceUID() now passes this.props.scopedVars to getInstanceSettings(...), so a ${tabDsVar} ref resolves through the panel's scene scope instead of the global (dashboard-root) context.
[QueryEditorRows.tsx](vscode-webview://0lcdep28ql662tf567svdlcse0relcoj1glnhsfhdue5j48oj62t/public/app/features/query/components/QueryEditorRows.tsx)

Builds scopedVars = { __sceneObject: new SafeSerializableSceneObject(panelRef.resolve()) } from the existing panelRef prop (the legacy QueriesTab already passes panelRef).
Threads it into both each <QueryEditorRow> and the module-level getDataSourceSettings() (which had the same gap at the panel-fallback resolution).
This mirrors how PR #126811 fixed the new editor (PanelEditNext) — the legacy editor (queryEditorNext defaults to false, so it's what most users hit) never received the same treatment. The fix also covers rows, which were broken the same way.

Backwards compatible: for non-scene callers (Explore, old dashboards) panelRef is undefined → scopedVars is undefined → behavior is unchanged.