### PR TITLE
Provisioning: support library panels in Git Sync backend

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -798,6 +798,21 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 
 	opts.StorageOptsRegister(dashv0.DashboardResourceInfo.GroupResource(), storageOpts)
 
+	// Library panels live inside folders, so the unified storage backend must accept the
+	// grafana.app/folder annotation. They are keyed by their own GroupResource, so they need
+	// a separate registration from dashboards; without it they default to
+	// EnableFolderSupport=false and any folder-scoped write (e.g. provisioning syncing a panel
+	// into a managed folder) is rejected with "folders are not supported". The folder is
+	// optional (panels may live at the root), so RequireFolder stays false.
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if b.libraryPanelsEnabled {
+		opts.StorageOptsRegister(dashv0.LibraryPanelResourceInfo.GroupResource(), apistore.StorageOptions{
+			Scheme:              opts.Scheme,
+			Index:               b.unified,
+			EnableFolderSupport: true,
+		})
+	}
+
 	// v0alpha1
 	if err := b.storageForVersion(apiGroupInfo, opts,
 		dashv0.DashboardResourceInfo,

--- a/pkg/tests/apis/provisioning/resourcekinds/testdata/kinds/librarypanel.json
+++ b/pkg/tests/apis/provisioning/resourcekinds/testdata/kinds/librarypanel.json
@@ -1,0 +1,18 @@
+{
+  "folderScoped": true,
+  "featureFlags": ["grafanaAPIServerWithExperimentalAPIs"],
+  "manifest": {
+    "apiVersion": "dashboard.grafana.app/v0alpha1",
+    "kind": "LibraryPanel",
+    "metadata": {
+      "name": "placeholder"
+    },
+    "spec": {
+      "title": "placeholder",
+      "type": "text",
+      "description": "provisioned library panel",
+      "options": {},
+      "fieldConfig": {}
+    }
+  }
+}


### PR DESCRIPTION
**What is this feature?**

Makes **library panels** (`dashboard.grafana.app/LibraryPanel`) provisionable through Git Sync, so they round-trip between Grafana and a repository the same way dashboards and folders do.

Core changes:
- `register.go` — register `apistore.StorageOptions{EnableFolderSupport: true}` for the LibraryPanel resource. Library panels are folder-scoped but were missing this registration (they are keyed by their own GroupResource, separate from dashboards), so unified storage rejected the folder annotation with `HTTP 422: "folders are not supported for librarypanels.dashboard.grafana.app"`. `RequireFolder` stays false since panels may live at the root.
- `pkg/apimachinery/identity` — add `IsProvisioningServiceIdentity`, a shared predicate for "is this the provisioning (Git Sync) service identity" (access-policy UID or provisioning-group audience), consolidating the check previously inlined in unified storage (`apistore.enforceManagerProperties`).
- `libraryelements/database.go` — allow the provisioning service identity to create/update library panels in repository-managed folders via that predicate; regular users stay blocked with `ErrLibraryElementProvisionedFolder` (needed for dual-write modes where writes still reach the legacy service).
- `setting.go` — declare library panels in the default `[provisioning] resources` set as **disabled** (`dashboard.grafana.app/LibraryPanel:folder:disabled`): surfaced but inert until enabled.
- Resource-kinds integration harness: new `librarypanel.json` descriptor exercising the full pipeline (export, sync, files CRUD, folder scope, delete/move jobs) via folder sync, with library panels served from unified storage (Mode5).

**Why do we need this feature?**

Library panels could not be exported to or synced from a Git repository, leaving a gap in Git Sync / provisioning coverage versus dashboards and folders. Two backend blockers prevented it: unified storage rejected the folder annotation on library panels (no `EnableFolderSupport`), and the legacy library-element write path refused any write into a repository-managed folder regardless of caller.

**Who is this feature for?**

Operators and teams using Git Sync (provisioning-as-code) who manage library panels alongside their dashboards and want them version-controlled and synced from a repository.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The harness serves library panels from unified storage (Mode5), since the legacy `library_element` table cannot store the manager/source annotations the round-trip requires. Rolling the **production** default to unified storage is a separate `deployment_tools` / `[unified_storage]` config step, not part of this PR — this PR is what makes that rollout work.
- Library panels are declared **`:disabled`** by default; enabling them by default is a later step in the onboarding journey.
- The `register.go` change touches the dashboard APIBuilder because the library panel resource is served there — worth a glance from that code owner. There is no config-driven path for `EnableFolderSupport`; every folder-scoped resource sets it in builder code.
- Frontend work (managed badges, save drawer, registry entry) is a separate PR per the FE/BE deploy-cadence split.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (Declared `:disabled` by default; library panel APIs are behind `grafanaAPIServerWithExperimentalAPIs`.)
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

**Testing**

- `go test -run TestIntegrationProvisioning_ResourceKinds_ ./pkg/tests/apis/provisioning/resourcekinds/` — passes for both playlist and library panel across all dimensions.
- `go test ./pkg/storage/unified/apistore/` — covers the consolidated manager-property enforcement.
- `go test -run TestIntegration_LibraryElement_ProvisionedFolder ./pkg/services/libraryelements/`
- `go test -run TestReadProvisioningResources ./pkg/setting/`
- `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)