### PR TITLE
Auth: fix group_resource-only typed create in List and BatchCheck

### DIFF
--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -199,20 +199,6 @@ func IsGroupResourceRelation(relation string) bool {
 	return isValidRelation(relation, RelationsGroupResource)
 }
 
-// IsGroupResourceOnlyTypedRelation reports relations stored only on group_resource for
-// typed IAM objects (team, user, service-account) that cannot be listed per-instance.
-func IsGroupResourceOnlyTypedRelation(typ, relation string) bool {
-	if relation != RelationCreate {
-		return false
-	}
-	switch typ {
-	case TypeTeam, TypeUser, TypeServiceAccount:
-		return true
-	default:
-		return false
-	}
-}
-
 func IsSubresourceRelation(relation string) bool {
 	return isValidRelation(relation, RelationsSubresource)
 }

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -199,6 +199,20 @@ func IsGroupResourceRelation(relation string) bool {
 	return isValidRelation(relation, RelationsGroupResource)
 }
 
+// IsGroupResourceOnlyTypedRelation reports relations stored only on group_resource for
+// typed IAM objects (team, user, service-account) that cannot be listed per-instance.
+func IsGroupResourceOnlyTypedRelation(typ, relation string) bool {
+	if relation != RelationCreate {
+		return false
+	}
+	switch typ {
+	case TypeTeam, TypeUser, TypeServiceAccount:
+		return true
+	default:
+		return false
+	}
+}
+
 func IsSubresourceRelation(relation string) bool {
 	return isValidRelation(relation, RelationsSubresource)
 }

--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -706,6 +706,14 @@ func (s *Server) resolveTypedItems(
 		sample := groupItems[0]
 		allowed := make(map[string]bool)
 
+		// Flat typed objects (team, user, service-account) only carry `create` on the
+		// group_resource, never per object, so there is nothing to list here and the
+		// per-object ListObjects relation does not exist. Leaving these items unresolved
+		// denies them. Folders keep their folder-scoped create.
+		if key.relation == common.RelationCreate && key.typ != common.TypeFolder {
+			continue
+		}
+
 		subresourceRelation := common.SubresourceRelation(key.relation)
 		if sample.resource.HasSubresource() && sample.resource.IsValidRelation(subresourceRelation) {
 			if err := s.collectAllowedObjects(ctx, allowed, &openfgav1.ListObjectsRequest{

--- a/pkg/services/authz/zanzana/server/server_batch_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check_test.go
@@ -158,6 +158,29 @@ func TestIntegrationServerBatchCheck(t *testing.T) {
 		assert.True(t, res.GetResults()["check1"].GetAllowed())
 	})
 
+	t.Run("user without teams:create is denied, not errored", func(t *testing.T) {
+		// team has no per-object `create` relation in the model (it only exists on the
+		// group_resource), so an unresolved teams:create item must resolve to denied
+		// rather than erroring the whole batch on an invalid ListObjects relation.
+		items := []*authzv1.BatchCheckItem{
+			newItem("check1", utils.VerbCreate, teamGroup, teamResource, "", "", ""),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:1", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 1)
+		assert.False(t, res.GetResults()["check1"].GetAllowed())
+	})
+
+	t.Run("user with group_resource teams:create is allowed", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("check1", utils.VerbCreate, teamGroup, teamResource, "", "", ""),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:20", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 1)
+		assert.True(t, res.GetResults()["check1"].GetAllowed())
+	})
+
 	t.Run("subresource permissions check", func(t *testing.T) {
 		items := []*authzv1.BatchCheckItem{
 			newItem("check1", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"), // has access

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -84,6 +84,10 @@ func (s *Server) list(ctx context.Context, r *authzv1.ListRequest) (*authzv1.Lis
 		return &authzv1.ListResponse{All: true}, nil
 	}
 
+	if !resource.IsGeneric() && common.IsGroupResourceOnlyTypedRelation(resource.Type(), relation) {
+		return &authzv1.ListResponse{}, nil
+	}
+
 	if resource.IsGeneric() {
 		return s.listGeneric(ctx, r.GetSubject(), relation, resource, contextuals, store)
 	}

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -84,10 +84,6 @@ func (s *Server) list(ctx context.Context, r *authzv1.ListRequest) (*authzv1.Lis
 		return &authzv1.ListResponse{All: true}, nil
 	}
 
-	if !resource.IsGeneric() && common.IsGroupResourceOnlyTypedRelation(resource.Type(), relation) {
-		return &authzv1.ListResponse{}, nil
-	}
-
 	if resource.IsGeneric() {
 		return s.listGeneric(ctx, r.GetSubject(), relation, resource, contextuals, store)
 	}
@@ -100,6 +96,13 @@ func (s *Server) listTyped(ctx context.Context, subject, relation string, resour
 	defer span.End()
 
 	if !resource.IsValidRelation(relation) {
+		return &authzv1.ListResponse{}, nil
+	}
+
+	// Flat typed objects (team, user, service-account) only carry `create` on the
+	// group_resource, never per object, so once the group-level check has failed there
+	// is nothing to list. Folders are the exception, keeping their folder-scoped create.
+	if relation == common.RelationCreate && resource.Type() != common.TypeFolder {
 		return &authzv1.ListResponse{}, nil
 	}
 

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -172,6 +172,31 @@ func TestIntegrationServerList(t *testing.T) {
 		assert.Contains(t, res.GetItems(), "1")
 	})
 
+	t.Run("user without teams:create lists teams create as empty", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), &authzv1.ListRequest{
+			Namespace: namespace,
+			Verb:      utils.VerbCreate,
+			Subject:   "user:1",
+			Group:     teamGroup,
+			Resource:  teamResource,
+		})
+		require.NoError(t, err)
+		assert.False(t, res.GetAll())
+		assert.Empty(t, res.GetItems())
+	})
+
+	t.Run("user with group_resource teams:create lists all", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), &authzv1.ListRequest{
+			Namespace: namespace,
+			Verb:      utils.VerbCreate,
+			Subject:   "user:20",
+			Group:     teamGroup,
+			Resource:  teamResource,
+		})
+		require.NoError(t, err)
+		assert.True(t, res.GetAll())
+	})
+
 	t.Run("user:17 should be able to list all dashboards in folder 4 and all subfolders", func(t *testing.T) {
 		res, err := server.List(newContextWithNamespace(), newList("user:17", dashboardGroup, dashboardResource, ""))
 		require.NoError(t, err)
@@ -357,6 +382,31 @@ func TestIntegrationServerListStreaming(t *testing.T) {
 		assert.Len(t, res.GetFolders(), 0)
 
 		assert.Contains(t, res.GetItems(), "1")
+	})
+
+	t.Run("user without teams:create lists teams create as empty", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), &authzv1.ListRequest{
+			Namespace: namespace,
+			Verb:      utils.VerbCreate,
+			Subject:   "user:1",
+			Group:     teamGroup,
+			Resource:  teamResource,
+		})
+		require.NoError(t, err)
+		assert.False(t, res.GetAll())
+		assert.Empty(t, res.GetItems())
+	})
+
+	t.Run("user with group_resource teams:create lists all", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), &authzv1.ListRequest{
+			Namespace: namespace,
+			Verb:      utils.VerbCreate,
+			Subject:   "user:20",
+			Group:     teamGroup,
+			Resource:  teamResource,
+		})
+		require.NoError(t, err)
+		assert.True(t, res.GetAll())
 	})
 
 	t.Run("user:17 should be able to list all dashboards in folder 4 and all subfolders", func(t *testing.T) {

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -77,6 +77,7 @@ func setup(t *testing.T, srv *Server) *Server {
 		common.NewResourceTuple("team:ctx-list#member", common.RelationGet, dashboardGroup, dashboardResource, "", "ctx-list-dashboard"),
 		common.NewResourceTuple("team:ctx-batch#member", common.RelationGet, dashboardGroup, dashboardResource, "", "ctx-batch-dashboard"),
 		common.NewResourceTuple("team:ctx-1000#member", common.RelationGet, dashboardGroup, dashboardResource, "", "ctx-1000-dashboard"),
+		common.NewGroupResourceTuple("user:20", common.RelationCreate, teamGroup, teamResource, ""),
 	}
 
 	return setupOpenFGADatabase(t, srv, tuples)


### PR DESCRIPTION
## Summary

Flat typed IAM objects (`team`, `user`, `service-account`) only store the `create` relation on `group_resource` in the OpenFGA model — not on individual typed objects. When a subject lacks org-wide create, List and BatchCheck were still attempting per-object `ListObjects` with an invalid relation (e.g. `team#create`), causing OpenFGA errors.

- **List**: return an empty list from `listTyped` once the group-level check has failed
- **BatchCheck**: skip the invalid per-object list in the direct-resource phase so unresolved items resolve to denied instead of failing the whole batch

This fixes the root cause behind wildcard permissions (e.g. `dashboards:*`, `folders:*`) being dropped during Zanzana permission merge. #127200 (merged) added resolver-side resilience to skip individual failing actions; this PR fixes the server behavior so those actions no longer error in the first place.

## Test plan

- [x] `TestIntegrationServerList` — user without `teams:create` gets empty list; user with group_resource create gets `All: true`
- [x] `TestIntegrationServerListStreaming` — same cases for streaming List
- [x] `TestIntegrationServerBatchCheck` — user without `teams:create` is denied (not errored); user with group_resource create is allowed
- [x] Full `TestIntegrationServerBatchCheck` suite passes