### PR TITLE
Provisioning: add library panels to admin pages

### DIFF
--- a/pkg/tests/apis/provisioning/resourcekinds/testdata/kinds/librarypanel.json
+++ b/pkg/tests/apis/provisioning/resourcekinds/testdata/kinds/librarypanel.json
@@ -1,0 +1,18 @@
+{
+  "folderScoped": true,
+  "featureFlags": ["grafanaAPIServerWithExperimentalAPIs"],
+  "manifest": {
+    "apiVersion": "dashboard.grafana.app/v0alpha1",
+    "kind": "LibraryPanel",
+    "metadata": {
+      "name": "placeholder"
+    },
+    "spec": {
+      "title": "placeholder",
+      "type": "text",
+      "description": "provisioned library panel",
+      "options": {},
+      "fieldConfig": {}
+    }
+  }
+}

--- a/public/app/features/provisioning/types.ts
+++ b/public/app/features/provisioning/types.ts
@@ -92,11 +92,11 @@ export interface StatusInfo {
 }
 
 // Tree view types for combined Resources/Files view.
-// `Dashboard`/`Playlist` map to a provisioning resource kind (see resourceKinds.ts).
+// `Dashboard`/`Playlist`/`LibraryPanel` map to a provisioning resource kind (see resourceKinds.ts).
 // `Folder` usually does too, but getItemType also infers it from plain directory
 // paths that have no backing resource. `File` is the fallback for plain files
 // that don't map to a known kind.
-export type ItemType = 'Folder' | 'Dashboard' | 'Playlist' | 'File';
+export type ItemType = 'Folder' | 'Dashboard' | 'Playlist' | 'LibraryPanel' | 'File';
 export type SyncStatus = 'synced' | 'pending';
 
 export interface TreeItem {

--- a/public/app/features/provisioning/utils/resourceKinds.test.ts
+++ b/public/app/features/provisioning/utils/resourceKinds.test.ts
@@ -33,6 +33,12 @@ describe('resourceKinds registry', () => {
       resource: 'playlists',
       itemType: 'Playlist',
     });
+    expect(resourceKindInfos.librarypanel).toMatchObject({
+      group: 'dashboard.grafana.app',
+      kind: 'LibraryPanel',
+      resource: 'librarypanels',
+      itemType: 'LibraryPanel',
+    });
   });
 
   it('sources icons from the search package', () => {
@@ -46,6 +52,7 @@ describe('getKindInfoByResource', () => {
     expect(getKindInfoByResource('dashboards')).toBe(resourceKindInfos.dashboard);
     expect(getKindInfoByResource('folders')).toBe(resourceKindInfos.folder);
     expect(getKindInfoByResource('playlists')).toBe(resourceKindInfos.playlist);
+    expect(getKindInfoByResource('librarypanels')).toBe(resourceKindInfos.librarypanel);
   });
 
   it('returns undefined for unknown or missing resources', () => {
@@ -86,6 +93,12 @@ describe('getKindInfoByGroupKind', () => {
     expect(getKindInfoByGroupKind('folder.grafana.app', 'Folder')).toBe(resourceKindInfos.folder);
   });
 
+  it('disambiguates kinds that share an API group by the kind', () => {
+    // Dashboards and library panels both live in dashboard.grafana.app.
+    expect(getKindInfoByGroupKind('dashboard.grafana.app', 'LibraryPanel')).toBe(resourceKindInfos.librarypanel);
+    expect(getKindInfoByGroupKind('dashboard.grafana.app', 'Dashboard')).toBe(resourceKindInfos.dashboard);
+  });
+
   it('resolves on whichever identifier is present', () => {
     expect(getKindInfoByGroupKind(undefined, 'Playlist')).toBe(resourceKindInfos.playlist);
     expect(getKindInfoByGroupKind('playlist.grafana.app', undefined)).toBe(resourceKindInfos.playlist);
@@ -111,6 +124,10 @@ describe('getKindInfoByStat', () => {
     // The resource uniquely identifies the kind, so it wins over a group that
     // would otherwise resolve to a different kind.
     expect(getKindInfoByStat({ group: 'dashboard.grafana.app', resource: 'folders' })).toBe(resourceKindInfos.folder);
+    // Dashboards and library panels share dashboard.grafana.app; the resource tells them apart.
+    expect(getKindInfoByStat({ group: 'dashboard.grafana.app', resource: 'librarypanels' })).toBe(
+      resourceKindInfos.librarypanel
+    );
   });
 
   it('falls back to a group-only match when the resource is missing or unknown', () => {
@@ -153,6 +170,13 @@ describe('getRepositoryRoute', () => {
     expect(getRepositoryRoute(resourceKindInfos.playlist, makeRepo('instance'))).toBe('/playlists');
   });
 
+  it('routes library panels to their own collection page regardless of target', () => {
+    // Library panels live in folders but aren't browsable in the dashboards folder
+    // view, so they always resolve to /library-panels.
+    expect(getRepositoryRoute(resourceKindInfos.librarypanel, makeRepo('folder'))).toBe('/library-panels');
+    expect(getRepositoryRoute(resourceKindInfos.librarypanel, makeRepo('instance'))).toBe('/library-panels');
+  });
+
   it('falls back to the collection page when the repository name or spec is missing', () => {
     // No spec → not a folder target → collection page.
     expect(getRepositoryRoute(resourceKindInfos.dashboard, {})).toBe('/dashboards');
@@ -171,6 +195,7 @@ describe('getAvailableResourceKinds', () => {
       resourceKindInfos.folder,
       resourceKindInfos.dashboard,
       resourceKindInfos.playlist,
+      resourceKindInfos.librarypanel,
     ]);
   });
 

--- a/public/app/features/provisioning/utils/resourceKinds.ts
+++ b/public/app/features/provisioning/utils/resourceKinds.ts
@@ -81,6 +81,23 @@ export const resourceKindInfos = {
     listRoute: '/playlists',
     folderScoped: false,
   },
+  librarypanel: {
+    // Library panels share the dashboards API group but are keyed by their own
+    // GroupResource (librarypanels.dashboard.grafana.app).
+    group: DASHBOARD_API_GROUP,
+    kind: 'LibraryPanel',
+    resource: 'librarypanels',
+    itemType: 'LibraryPanel',
+    // getIconForKind doesn't know library panels, so use the library-panel icon directly.
+    icon: 'library-panel',
+    // No deep-link route for a single library panel exists; they're only viewable
+    // from the library panels collection page.
+    listRoute: '/library-panels',
+    // Library panels live inside folders on the backend, but the dashboards folder
+    // browse doesn't list them — they have their own collection page — so for
+    // routing they behave like a non-foldered kind and always resolve to listRoute.
+    folderScoped: false,
+  },
 } satisfies Record<string, ResourceKindInfo>;
 
 const allKindInfos: ResourceKindInfo[] = Object.values(resourceKindInfos);


### PR DESCRIPTION
> **Stacked on #127257** (routes `/api/library-elements` to the apiserver). Review/merge that first; this PR targets that branch and will retarget to `main` once it lands.

### What is this feature?

Makes **library panels** (`dashboard.grafana.app/LibraryPanel`) first-class in the provisioning admin pages. Frontend-only, plus the provisioning integration-test descriptor.

- **`resourceKinds.ts`** — new `librarypanel` entry: group `dashboard.grafana.app`, kind `LibraryPanel`, resource `librarypanels`, `library-panel` icon, `listRoute: /library-panels`. `folderScoped: false` — library panels live in folders on the backend, but the dashboards folder browse doesn't list them (they have their own collection page), so for routing they resolve to `/library-panels` like a non-foldered kind. No `getRoute` — there's no deep-link view route for a single library panel.
- **`types.ts`** — `'LibraryPanel'` added to the `ItemType` union.
- **`testdata/kinds/librarypanel.json`** — resourcekinds integration-test descriptor (the harness already serves every kind under test from unified storage / Mode 5).

Every provisioning admin consumer (resource tree, icons, resource stats, job summary, in-app routing, bulk actions, bootstrap wizard, availability gating) reads generically from the registry, so the single entry flows through automatically. **No library panel pages or components are touched.**

### Why do we need this feature?

The backend supports provisioning library panels via Git Sync, but the admin UI didn't recognize the kind — synced library panels rendered as generic files (no icon, routing, stats, or bulk actions). This closes that gap.

### Who is this feature for?

Git-Sync / provisioning-as-code users who manage library panels in their repositories.

### Which issue(s) does this PR fix?

<!-- Replace XXXXX with the issue number. -->

Fixes #

### Special notes for your reviewer

- The change is purely additive and gated on the settings endpoint's `availableResources`, so it has no effect until the backend reports library panels as a non-disabled provisioning resource.
- Builds on already-merged backend work: #127231 (provisioning identity) and #127235 (library panel folder support).
- Stacked on #127257 (apiserver routing) so the Library Panels page can show provisioned panels under unified storage; the FE change here doesn't depend on it to compile.

### Verification

- `yarn jest` provisioning `utils`/`Job`/`Repository`/`treeUtils` — pass (resourceKinds 27)
- `yarn typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)