### PR TITLE
Provisioning: backend groundwork for syncing library panels

### DIFF
--- a/pkg/apimachinery/identity/context.go
+++ b/pkg/apimachinery/identity/context.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/types"
 )
+
+// provisioningServiceAudience is the API group the provisioning (Git Sync) service token carries
+// as an audience in multi-tenant deployments. It mirrors the provisioning apiserver's group
+// ("provisioning.grafana.app"); it is duplicated here as a literal to keep apimachinery free of
+// dependencies on app packages.
+const provisioningServiceAudience = "provisioning.grafana.app"
 
 type ctxUserKey struct{}
 type metadataIdentityUIDKey struct{}
@@ -235,4 +242,18 @@ func IsServiceIdentity(ctx context.Context) bool {
 	}
 
 	return t == types.TypeAccessPolicy && (uid == serviceName || uid == serviceNameForProvisioning)
+}
+
+// IsProvisioningServiceIdentity reports whether auth is the provisioning (Git Sync) service
+// identity — identified either by its access-policy UID (single-tenant / OSS) or by carrying the
+// provisioning API group as a token audience (multi-tenant). Use it to grant the provisioning
+// service write paths that are otherwise closed to regular users. The unified storage backend
+// enforces the same rule on managed resources (pkg/storage/unified/apistore); this is the shared
+// predicate so legacy services that bypass that backend can apply it consistently.
+func IsProvisioningServiceIdentity(auth types.AuthInfo) bool {
+	if auth == nil {
+		return false
+	}
+	return auth.GetUID() == types.NewTypeID(types.TypeAccessPolicy, serviceNameForProvisioning) ||
+		slices.Contains(auth.GetAudience(), provisioningServiceAudience)
 }

--- a/pkg/apimachinery/identity/context_test.go
+++ b/pkg/apimachinery/identity/context_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/authz"
+	authtypes "github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -65,6 +66,60 @@ func TestWithProvisioningIdentity(t *testing.T) {
 		perms := requester.GetPermissions()
 		require.Contains(t, perms, "playlists:read")
 		require.Contains(t, perms, "playlists:write")
+	})
+}
+
+// fakeAuthInfo drives GetUID and GetAudience independently. It embeds StaticRequester to satisfy
+// the rest of the authtypes.AuthInfo interface; StaticRequester.GetAudience returns an org-scoped
+// value, so it cannot exercise the token-audience branch on its own.
+type fakeAuthInfo struct {
+	*identity.StaticRequester
+	uid      string
+	audience []string
+}
+
+func (f fakeAuthInfo) GetUID() string        { return f.uid }
+func (f fakeAuthInfo) GetAudience() []string { return f.audience }
+
+func TestIsProvisioningServiceIdentity(t *testing.T) {
+	t.Run("nil is not the provisioning identity", func(t *testing.T) {
+		require.False(t, identity.IsProvisioningServiceIdentity(nil))
+	})
+
+	t.Run("matches by access-policy:provisioning UID", func(t *testing.T) {
+		r := &identity.StaticRequester{Type: authtypes.TypeAccessPolicy, UserUID: "provisioning"}
+		require.Equal(t, "access-policy:provisioning", r.GetUID())
+		require.True(t, identity.IsProvisioningServiceIdentity(r))
+	})
+
+	t.Run("matches by provisioning group audience", func(t *testing.T) {
+		// UID is unrelated, so only the audience branch can satisfy the check.
+		auth := fakeAuthInfo{
+			StaticRequester: &identity.StaticRequester{},
+			uid:             "user:42",
+			audience:        []string{"org:1", "provisioning.grafana.app"},
+		}
+		require.True(t, identity.IsProvisioningServiceIdentity(auth))
+	})
+
+	t.Run("the generic service identity does not match", func(t *testing.T) {
+		r := &identity.StaticRequester{Type: authtypes.TypeAccessPolicy, UserUID: "service"}
+		require.False(t, identity.IsProvisioningServiceIdentity(r))
+	})
+
+	t.Run("an unrelated identity does not match", func(t *testing.T) {
+		auth := fakeAuthInfo{
+			StaticRequester: &identity.StaticRequester{},
+			uid:             "user:42",
+			audience:        []string{"org:1"},
+		}
+		require.False(t, identity.IsProvisioningServiceIdentity(auth))
+	})
+
+	t.Run("the requester from WithProvisioningIdentity matches", func(t *testing.T) {
+		_, requester, err := identity.WithProvisioningIdentity(context.Background(), "default")
+		require.NoError(t, err)
+		require.True(t, identity.IsProvisioningServiceIdentity(requester))
 	})
 }
 

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -133,7 +133,7 @@ func (l *LibraryElementService) CreateElement(c context.Context, signedInUser id
 		if err != nil {
 			return model.LibraryElementDTO{}, err
 		}
-		if f.ManagedBy == utils.ManagerKindRepo {
+		if f.ManagedBy == utils.ManagerKindRepo && !identity.IsProvisioningServiceIdentity(signedInUser) {
 			return model.LibraryElementDTO{}, model.ErrLibraryElementProvisionedFolder
 		}
 	}
@@ -613,7 +613,7 @@ func (l *LibraryElementService) PatchLibraryElement(c context.Context, signedInU
 		if err != nil {
 			return model.LibraryElementDTO{}, err
 		}
-		if f.ManagedBy == utils.ManagerKindRepo {
+		if f.ManagedBy == utils.ManagerKindRepo && !identity.IsProvisioningServiceIdentity(signedInUser) {
 			return model.LibraryElementDTO{}, model.ErrLibraryElementProvisionedFolder
 		}
 

--- a/pkg/services/libraryelements/libraryelements_provisioned_folder_test.go
+++ b/pkg/services/libraryelements/libraryelements_provisioned_folder_test.go
@@ -1,0 +1,128 @@
+package libraryelements
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/libraryelements/model"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// Repository-managed (provisioned) folders reject library element writes from
+// regular users so manual edits cannot drift from the synced source of truth.
+// The provisioning service identity must be exempt so Git Sync can create and
+// update the panels it manages inside those folders.
+func TestIntegration_LibraryElement_ProvisionedFolder(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	const provisionedFolderUID = "uid_for_ProvisionedFolder"
+
+	provisionedFolder := func() *folder.Folder {
+		return &folder.Folder{
+			ID:        2, // nolint:staticcheck
+			OrgID:     1,
+			UID:       provisionedFolderUID,
+			Title:     "ProvisionedFolder",
+			ManagedBy: utils.ManagerKindRepo,
+		}
+	}
+
+	rawModel := func(t *testing.T) json.RawMessage {
+		t.Helper()
+		b, err := json.Marshal(map[string]any{"type": "text", "title": "Provisioned Library Panel"})
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("CreateElement", func(t *testing.T) {
+		t.Run("a regular user cannot create a library panel in a provisioned folder", func(t *testing.T) {
+			sc := setupTestScenario(t)
+			sc.folderSvc.ExpectedFolder = provisionedFolder()
+			folderUID := provisionedFolderUID
+
+			_, err := sc.service.CreateElement(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, model.CreateLibraryElementCommand{
+				FolderUID: &folderUID,
+				Name:      "Regular User Panel",
+				Kind:      int64(model.PanelElement),
+				Model:     rawModel(t),
+			})
+			require.ErrorIs(t, err, model.ErrLibraryElementProvisionedFolder)
+		})
+
+		t.Run("the provisioning identity can create a library panel in a provisioned folder", func(t *testing.T) {
+			sc := setupTestScenario(t)
+			sc.folderSvc.ExpectedFolder = provisionedFolder()
+			folderUID := provisionedFolderUID
+
+			ctx, provisioner, err := identity.WithProvisioningIdentity(sc.reqContext.Req.Context(), "default")
+			require.NoError(t, err)
+
+			result, err := sc.service.CreateElement(ctx, provisioner, model.CreateLibraryElementCommand{
+				FolderUID: &folderUID,
+				Name:      "Provisioned Panel",
+				Kind:      int64(model.PanelElement),
+				Model:     rawModel(t),
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, result.UID)
+		})
+	})
+
+	t.Run("PatchLibraryElement", func(t *testing.T) {
+		t.Run("a regular user cannot move a library panel into a provisioned folder", func(t *testing.T) {
+			sc := setupTestScenario(t)
+			created := createPanelInScenarioFolder(t, sc)
+
+			sc.folderSvc.ExpectedFolder = provisionedFolder()
+			folderUID := provisionedFolderUID
+
+			_, err := sc.service.PatchLibraryElement(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, model.PatchLibraryElementCommand{
+				FolderUID: &folderUID,
+				Kind:      int64(model.PanelElement),
+				Version:   created.Version,
+			}, created.UID)
+			require.ErrorIs(t, err, model.ErrLibraryElementProvisionedFolder)
+		})
+
+		t.Run("the provisioning identity can move a library panel into a provisioned folder", func(t *testing.T) {
+			sc := setupTestScenario(t)
+			created := createPanelInScenarioFolder(t, sc)
+
+			sc.folderSvc.ExpectedFolder = provisionedFolder()
+			folderUID := provisionedFolderUID
+
+			ctx, provisioner, err := identity.WithProvisioningIdentity(sc.reqContext.Req.Context(), "default")
+			require.NoError(t, err)
+
+			result, err := sc.service.PatchLibraryElement(ctx, provisioner, model.PatchLibraryElementCommand{
+				FolderUID: &folderUID,
+				Kind:      int64(model.PanelElement),
+				Version:   created.Version,
+			}, created.UID)
+			require.NoError(t, err)
+			require.Equal(t, created.UID, result.UID)
+		})
+	})
+}
+
+// createPanelInScenarioFolder creates a library panel in the scenario's regular
+// (non-provisioned) folder so subsequent patch operations have an element to
+// move.
+func createPanelInScenarioFolder(t *testing.T, sc scenarioContext) model.LibraryElementDTO {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{"type": "text", "title": "Existing Library Panel"})
+	require.NoError(t, err)
+	created, err := sc.service.CreateElement(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, model.CreateLibraryElementCommand{
+		FolderUID: &sc.folder.UID,
+		Name:      "Existing Library Panel",
+		Kind:      int64(model.PanelElement),
+		Model:     b,
+	})
+	require.NoError(t, err)
+	return created
+}

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"slices"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +18,6 @@ import (
 
 	authtypes "github.com/grafana/authlib/types"
 
-	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -192,7 +190,7 @@ func enforceManagerProperties(auth authtypes.AuthInfo, obj utils.GrafanaMetaAcce
 		return nil // not managed
 
 	case utils.ManagerKindRepo:
-		if auth.GetUID() == "access-policy:provisioning" || slices.Contains(auth.GetAudience(), provisioning.GROUP) {
+		if identity.IsProvisioningServiceIdentity(auth) {
 			return nil // OK!
 		}
 		// This can fallback to writing the value with a provisioning client

--- a/pkg/tests/apis/provisioning/resourcekinds/export_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/export_test.go
@@ -38,7 +38,7 @@ func TestIntegrationProvisioning_ResourceKinds_Export(t *testing.T) {
 			repo := rk.name + "-export-repo"
 			helper.CreateLocalRepo(t, common.TestRepo{
 				Name:                   repo,
-				SyncTarget:             "instance", // export is only supported for instance sync
+				SyncTarget:             "folder",
 				Workflows:              []string{"write"},
 				SkipResourceAssertions: true,
 			})
@@ -85,7 +85,7 @@ func TestIntegrationProvisioning_ResourceKinds_SelectiveExport(t *testing.T) {
 			repo := rk.name + "-selective-export-repo"
 			helper.CreateLocalRepo(t, common.TestRepo{
 				Name:                   repo,
-				SyncTarget:             "instance",
+				SyncTarget:             "folder",
 				Workflows:              []string{"write"},
 				SkipResourceAssertions: true,
 			})

--- a/pkg/tests/apis/provisioning/resourcekinds/files_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/files_test.go
@@ -39,7 +39,7 @@ func TestIntegrationProvisioning_ResourceKinds_FilesEndpoint(t *testing.T) {
 			name := rk.name + "-files"
 			helper.CreateLocalRepo(t, common.TestRepo{
 				Name:                   repo,
-				SyncTarget:             "instance",
+				SyncTarget:             "folder",
 				Workflows:              []string{"write"},
 				SkipResourceAssertions: true,
 			})

--- a/pkg/tests/apis/provisioning/resourcekinds/folder_scope_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/folder_scope_test.go
@@ -2,6 +2,7 @@ package resourcekinds
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,7 +37,7 @@ func TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope(t *testin
 			subPath := "team-a/" + rk.name + ".json"
 			helper.CreateLocalRepo(t, common.TestRepo{
 				Name:                   repo,
-				SyncTarget:             "instance",
+				SyncTarget:             "folder",
 				Workflows:              []string{"write"},
 				SkipResourceAssertions: true,
 			})
@@ -51,8 +52,9 @@ func TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope(t *testin
 				Message:    "create " + rk.name,
 				Body:       string(common.ResourceToJSON(t, rk.newResource(t, name, "Folderscope "+rk.kind))),
 			})
+			createBody, _ := io.ReadAll(createResp.Body)
 			require.NoError(t, createResp.Body.Close())
-			require.Equalf(t, 200, createResp.StatusCode, "%s create in a subdirectory should succeed", rk.name)
+			require.Equalf(t, 200, createResp.StatusCode, "%s create in a subdirectory should succeed; body: %s", rk.name, createBody)
 			require.Contains(t, repositoryFilePaths(t, ctx, helper, repo), subPath, "the file should exist in the repository subdirectory")
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {

--- a/pkg/tests/apis/provisioning/resourcekinds/harness_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/harness_test.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/restmapper"
 
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
@@ -125,6 +127,15 @@ func (rk resourceKind) token() string {
 	return rk.group + "/" + rk.kind
 }
 
+// unifiedStorageKey is the [unified_storage] config key (<resource>.<group>) for this kind. The
+// plural resource is derived from the kind name; the descriptors under test follow the regular
+// lowercase-plural convention (Dashboard->dashboards, LibraryPanel->librarypanels). If a derived
+// key is wrong the kind silently falls back to its default storage, so the dimension tests fail
+// loudly rather than passing on the wrong backend.
+func (rk resourceKind) unifiedStorageKey() string {
+	return strings.ToLower(rk.kind) + "s." + rk.group
+}
+
 // instance returns a deterministic (name, title) pair for the i-th resource of this kind.
 func (rk resourceKind) instance(i int) (name, title string) {
 	return fmt.Sprintf("%s-%d", rk.name, i), fmt.Sprintf("%s %d", rk.kind, i)
@@ -195,6 +206,17 @@ func harnessOptions(kinds []resourceKind) []common.GrafanaOption {
 			// Setting [provisioning] resources replaces the default set.
 			opts.ProvisioningResources = tokens
 			opts.EnableFeatureToggles = append(opts.EnableFeatureToggles, flags...)
+			// Serve every kind under test from unified storage (Mode5). Provisioning round-trips
+			// the manager/source annotations through that backend; legacy stores backing some
+			// kinds (e.g. library panels via library_element) have nowhere to persist them.
+			if opts.UnifiedStorageConfig == nil {
+				opts.UnifiedStorageConfig = map[string]setting.UnifiedStorageConfig{}
+			}
+			for _, rk := range kinds {
+				opts.UnifiedStorageConfig[rk.unifiedStorageKey()] = setting.UnifiedStorageConfig{
+					DualWriterMode: grafanarest.Mode5,
+				}
+			}
 		},
 	}
 }

--- a/pkg/tests/apis/provisioning/resourcekinds/jobs_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/jobs_test.go
@@ -29,7 +29,7 @@ func TestIntegrationProvisioning_ResourceKinds_DeleteJob(t *testing.T) {
 			repo := rk.name + "-delete-job-repo"
 			helper.CreateLocalRepo(t, common.TestRepo{
 				Name:                   repo,
-				SyncTarget:             "instance",
+				SyncTarget:             "folder",
 				Workflows:              []string{"write"},
 				SkipResourceAssertions: true,
 			})
@@ -79,7 +79,7 @@ func TestIntegrationProvisioning_ResourceKinds_MoveJob(t *testing.T) {
 			repo := rk.name + "-move-job-repo"
 			helper.CreateLocalRepo(t, common.TestRepo{
 				Name:                   repo,
-				SyncTarget:             "instance",
+				SyncTarget:             "folder",
 				Workflows:              []string{"write"},
 				SkipResourceAssertions: true,
 			})

--- a/pkg/tests/apis/provisioning/resourcekinds/sync_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/sync_test.go
@@ -30,7 +30,7 @@ func TestIntegrationProvisioning_ResourceKinds_Sync(t *testing.T) {
 			repo := rk.name + "-sync-repo"
 			helper.CreateLocalRepo(t, common.TestRepo{
 				Name:                   repo,
-				SyncTarget:             "instance",
+				SyncTarget:             "folder",
 				SkipResourceAssertions: true,
 			})
 


### PR DESCRIPTION
## Summary

Backend groundwork that lets the provisioning (Git Sync) service write **folder-scoped resources** — specifically library panels — and lets the resource-kinds integration harness exercise that round-trip. Split out from #127228; this is the reusable infrastructure, deliberately **without** the change that actually serves library panels (the `dashboard` APIBuilder `EnableFolderSupport` registration) or the library-panel resource-kinds descriptor — those stay for a follow-up PR.

Three independent pieces, each useful on its own:

### 1. Shared provisioning-service identity predicate (refactor)
`pkg/apimachinery/identity` gains `IsProvisioningServiceIdentity` — a single predicate for "is this the provisioning service?", matching either the access-policy UID (single-tenant / OSS) or the provisioning API group carried as a token audience (multi-tenant). `pkg/storage/unified/apistore/managed.go` now calls it instead of inlining the `access-policy:provisioning` / audience check, dropping its local `slices` and `provisioning` v0alpha1 imports. Kept in apimachinery as a literal so the package stays free of app dependencies.

### 2. Library-element provisioned-folder guard
`pkg/services/libraryelements/database.go` exempts the provisioning service identity from the repository-managed-folder write block on `CreateElement` / `PatchLibraryElement`, so Git Sync can create and move the panels it manages. Regular users stay blocked with `ErrLibraryElementProvisionedFolder` — this matters for dual-write modes where writes still reach the legacy library-element service.

### 3. Resource-kinds harness storage config
The integration harness now serves every kind under test from unified storage (Mode5) and syncs via the folder target, so the manager/source annotations a provisioning round-trip depends on can actually be persisted (the legacy `library_element` table has nowhere to store them).

## Why

Two backend blockers stopped folder-scoped resources like library panels from round-tripping through Git Sync: the managed-folder check was duplicated and inconsistent across the unified-storage backend and the legacy library-element write path, and the test harness couldn't persist the annotations a round-trip needs. This PR removes both, independent of when library panels are switched on.

## Testing

- `go vet` clean on all affected packages
- `go test -run TestIsProvisioningServiceIdentity ./pkg/apimachinery/identity/` ✅ (covers nil, UID match, audience match, generic service identity, unrelated identity, and `WithProvisioningIdentity`)
- `go test ./pkg/storage/unified/apistore/` ✅
- `go test -run TestIntegration_LibraryElement_ProvisionedFolder ./pkg/services/libraryelements/` ✅ (regular user blocked, provisioning identity allowed, on both create and move)
- `go test -run TestIntegrationProvisioning_ResourceKinds_ ./pkg/tests/apis/provisioning/resourcekinds/` ✅ (playlist across all dimensions on the new folder-sync / Mode5 harness)

## Notes for reviewers

- No API behavior changes for end users — the identity change is a pure consolidation, and the libraryelements change only widens an existing block for the provisioning service.
- The follow-up PR adds the `dashboard` APIBuilder registration and the `librarypanel.json` resource-kinds descriptor that turn this groundwork into a working library-panel sync.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes
- [ ] Docs (n/a — internal backend groundwork)

🤖 Generated with [Claude Code](https://claude.com/claude-code)