### PR TITLE
Provisioning: Add resource kind icons to job summary table

### DIFF
--- a/public/app/features/provisioning/Job/JobSummary.test.tsx
+++ b/public/app/features/provisioning/Job/JobSummary.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, within } from 'test/test-utils';
+
+import { type JobResourceSummary } from 'app/api/clients/provisioning/v0alpha1';
+
+import { JobSummary } from './JobSummary';
+
+function setup(summary: JobResourceSummary[]) {
+  return render(<JobSummary summary={summary} />);
+}
+
+function rowFor(label: string) {
+  return screen.getByRole('row', { name: new RegExp(label) });
+}
+
+describe('JobSummary', () => {
+  it('renders a row per resource kind with its name and an icon', () => {
+    setup([
+      { group: 'dashboard.grafana.app', kind: 'Dashboard', create: 2, update: 3, noop: 1 },
+      { group: 'folder.grafana.app', kind: 'Folder', delete: 1 },
+    ]);
+
+    const dashboardRow = rowFor('Dashboard');
+    expect(within(dashboardRow).getByText('Dashboard')).toBeInTheDocument();
+    // The kind icon is rendered alongside the name.
+    expect(dashboardRow.querySelector('svg')).toBeInTheDocument();
+
+    expect(rowFor('Folder')).toBeInTheDocument();
+  });
+
+  it('computes the total from the action counts', () => {
+    setup([{ group: 'dashboard.grafana.app', kind: 'Dashboard', create: 2, update: 3, noop: 1, error: 1 }]);
+
+    const row = rowFor('Dashboard');
+    const cells = within(row).getAllByRole('cell');
+    // Last column is Total: 2 (create) + 3 (update) + 1 (noop) + 1 (error) = 7.
+    expect(cells[cells.length - 1]).toHaveTextContent('7');
+  });
+
+  it('falls back to an Unknown label and a dash for rows missing a kind or counts', () => {
+    setup([{ group: '', kind: '' }]);
+
+    const row = rowFor('Unknown');
+    expect(within(row).getByText('Unknown')).toBeInTheDocument();
+    // The fallback icon still renders.
+    expect(row.querySelector('svg')).toBeInTheDocument();
+    // Empty count columns render a dash; total of an empty row is 0.
+    expect(within(row).getAllByText('-').length).toBeGreaterThan(0);
+    const cells = within(row).getAllByRole('cell');
+    expect(cells[cells.length - 1]).toHaveTextContent('0');
+  });
+});

--- a/public/app/features/provisioning/Job/JobSummary.tsx
+++ b/public/app/features/provisioning/Job/JobSummary.tsx
@@ -1,7 +1,10 @@
-import { InteractiveTable, Stack } from '@grafana/ui';
+import { t } from '@grafana/i18n';
+import { Icon, InteractiveTable, Stack } from '@grafana/ui';
 import { type JobResourceSummary } from 'app/api/clients/provisioning/v0alpha1';
 
-type SummaryCell<T extends keyof JobResourceSummary = keyof JobResourceSummary> = {
+import { getKindInfoByGroupKind } from '../utils/resourceKinds';
+
+type SummaryCell = {
   row: {
     original: JobResourceSummary;
   };
@@ -10,42 +13,51 @@ type SummaryCell<T extends keyof JobResourceSummary = keyof JobResourceSummary> 
 const getSummaryColumns = () => [
   {
     id: 'resource',
-    header: 'Resource',
-    cell: ({ row: { original: item } }: SummaryCell) => item.kind,
+    header: t('provisioning.job-summary.column-resource', 'Resource'),
+    cell: ({ row: { original: item } }: SummaryCell) => {
+      const info = getKindInfoByGroupKind(item.group, item.kind);
+      const kind = item.kind || t('provisioning.job-summary.unknown-kind', 'Unknown');
+      return (
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Icon name={info?.icon ?? 'question-circle'} />
+          <span>{kind}</span>
+        </Stack>
+      );
+    },
   },
   {
     id: 'created',
-    header: 'Created',
+    header: t('provisioning.job-summary.column-created', 'Created'),
     cell: ({ row: { original: item } }: SummaryCell) => item.create?.toString() || '-',
   },
   {
     id: 'deleted',
-    header: 'Deleted',
+    header: t('provisioning.job-summary.column-deleted', 'Deleted'),
     cell: ({ row: { original: item } }: SummaryCell) => item.delete?.toString() || '-',
   },
   {
     id: 'updated',
-    header: 'Updated',
+    header: t('provisioning.job-summary.column-updated', 'Updated'),
     cell: ({ row: { original: item } }: SummaryCell) => item.update?.toString() || '-',
   },
   {
     id: 'unchanged',
-    header: 'Unchanged',
+    header: t('provisioning.job-summary.column-unchanged', 'Unchanged'),
     cell: ({ row: { original: item } }: SummaryCell) => item.noop?.toString() || '-',
   },
   {
     id: 'warnings',
-    header: 'Warnings',
+    header: t('provisioning.job-summary.column-warnings', 'Warnings'),
     cell: ({ row: { original: item } }: SummaryCell) => item.warning?.toString() || '-',
   },
   {
     id: 'errors',
-    header: 'Errors',
+    header: t('provisioning.job-summary.column-errors', 'Errors'),
     cell: ({ row: { original: item } }: SummaryCell) => item.error?.toString() || '-',
   },
   {
     id: 'total',
-    header: 'Total',
+    header: t('provisioning.job-summary.column-total', 'Total'),
     cell: ({ row: { original: item } }: SummaryCell) => {
       const total = (item.create || 0) + (item.delete || 0) + (item.update || 0) + (item.noop || 0) + (item.error || 0);
       return total.toString();
@@ -63,7 +75,7 @@ export function JobSummary({ summary }: Props) {
       <InteractiveTable
         data={summary}
         columns={getSummaryColumns()}
-        getRowId={(item) => item.kind || ''}
+        getRowId={(item) => `${item.group ?? ''}/${item.kind ?? ''}`}
         pageSize={10}
       />
     </Stack>

--- a/public/app/features/provisioning/utils/resourceKinds.test.ts
+++ b/public/app/features/provisioning/utils/resourceKinds.test.ts
@@ -4,6 +4,7 @@ import { getIconForKind } from 'app/features/search/service/utils';
 import {
   resourceKindInfos,
   getAvailableResourceKinds,
+  getKindInfoByGroupKind,
   getKindInfoByItemType,
   getKindInfoByResource,
   getKindInfoByStatGroup,
@@ -75,6 +76,23 @@ describe('getKindInfoByStatGroup', () => {
 
   it('returns undefined for unknown groups', () => {
     expect(getKindInfoByStatGroup('alert.grafana.app')).toBeUndefined();
+  });
+});
+
+describe('getKindInfoByGroupKind', () => {
+  it('resolves a job summary row by group and kind', () => {
+    expect(getKindInfoByGroupKind('dashboard.grafana.app', 'Dashboard')).toBe(resourceKindInfos.dashboard);
+    expect(getKindInfoByGroupKind('folder.grafana.app', 'Folder')).toBe(resourceKindInfos.folder);
+  });
+
+  it('resolves on whichever identifier is present', () => {
+    expect(getKindInfoByGroupKind(undefined, 'Playlist')).toBe(resourceKindInfos.playlist);
+    expect(getKindInfoByGroupKind('playlist.grafana.app', undefined)).toBe(resourceKindInfos.playlist);
+  });
+
+  it('returns undefined when nothing matches or both identifiers are missing', () => {
+    expect(getKindInfoByGroupKind('alert.grafana.app', 'AlertRule')).toBeUndefined();
+    expect(getKindInfoByGroupKind(undefined, undefined)).toBeUndefined();
   });
 });
 

--- a/public/app/features/provisioning/utils/resourceKinds.ts
+++ b/public/app/features/provisioning/utils/resourceKinds.ts
@@ -122,6 +122,18 @@ export function getKindInfoByStatGroup(group?: string): ResourceKindInfo | undef
 }
 
 /**
+ * Look up a kind from a job summary row, which carries both the API group
+ * (`dashboard.grafana.app`) and the Kubernetes Kind (`Dashboard`). Matches on
+ * whichever identifiers are present so partially-populated summary rows still resolve.
+ */
+export function getKindInfoByGroupKind(group?: string, kind?: string): ResourceKindInfo | undefined {
+  if (!group && !kind) {
+    return undefined;
+  }
+  return allKindInfos.find((info) => (!group || info.group === group) && (!kind || info.kind === kind));
+}
+
+/**
  * Resolves which kinds the backend currently exposes for provisioning, gating on
  * the config-derived `availableResources` from the settings endpoint. Disabled
  * kinds (declared but not acted on) are excluded.

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13349,6 +13349,17 @@
         "error-fetching-active-job": "Error fetching active job"
       }
     },
+    "job-summary": {
+      "column-created": "Created",
+      "column-deleted": "Deleted",
+      "column-errors": "Errors",
+      "column-resource": "Resource",
+      "column-total": "Total",
+      "column-unchanged": "Unchanged",
+      "column-updated": "Updated",
+      "column-warnings": "Warnings",
+      "unknown-kind": "Unknown"
+    },
     "local": {
       "path-description": "Local file system path to the repository",
       "path-label": "Repository Path",


### PR DESCRIPTION

<img width="1782" height="460" alt="Screenshot 2026-06-25 at 12 12 19" src="https://github.com/user-attachments/assets/668d19f3-e86b-4288-8c9a-a0b6d11bc3b0" />


## Summary

Adds the per-kind icon next to the resource name in the Provisioning **Job Summary** table, so each row (Folder, Dashboard, LibraryPanel, …) is visually identifiable at a glance instead of being plain text.

The icon is resolved from the central `resourceKinds` registry using the summary row's `group`/`kind`, keeping the table consistent with the Resources tree view. Rows whose kind isn't in the registry fall back to a generic `question-circle` icon and an "Unknown" label (previously they rendered as a blank row).

## Changes

- `JobSummary.tsx`: render the kind icon in the Resource cell; fallback icon + "Unknown" label for unmapped rows; harden `getRowId` to avoid collisions on blank-kind rows; migrate column headers to i18n (`provisioning.job-summary.*`).
- `resourceKinds.ts`: add `getKindInfoByGroupKind(group, kind)` helper that resolves a summary row on whichever identifier is present.
- `resourceKinds.test.ts`: add coverage for the new helper.
- `grafana.json`: extracted i18n keys (`make i18n-extract`).

> Note: I considered also adding a **Group** column, but per review feedback the scope is intentionally limited to the icon improvement only.

## Testing

- `yarn jest public/app/features/provisioning/utils/resourceKinds` — 21/21 pass
- `yarn typecheck` — pass
- `yarn eslint` on changed files — clean

## Checklist

- [x] Tests added/updated
- [x] i18n strings extracted
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)