### PR TITLE
Provisioning: resolve resource stats by plural resource, not just group

### DIFF
--- a/public/app/features/provisioning/Repository/RepositoryListItem.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryListItem.tsx
@@ -13,7 +13,7 @@ import { ReadOnlyBadge } from '../components/ReadOnlyBadge';
 import { PROVISIONING_URL } from '../constants';
 import { formatRepoUrl, getRepoHrefForProvider } from '../utils/git';
 import { getIsReadOnlyWorkflows } from '../utils/repository';
-import { getKindInfoByStatGroup, getRepositoryRoute } from '../utils/resourceKinds';
+import { getKindInfoByStat, getRepositoryRoute } from '../utils/resourceKinds';
 
 import { SyncRepository } from './SyncRepository';
 
@@ -79,7 +79,7 @@ export function RepositoryListItem({ repository }: Props) {
           {status?.stats?.length && (
             <Stack gap={1} direction="row" wrap>
               {status.stats.map((stat, index) => {
-                const info = getKindInfoByStatGroup(stat.group);
+                const info = getKindInfoByStat(stat);
                 const icon = info?.icon ?? 'file-alt';
                 const label = `${stat.count} ${stat.resource}`;
                 // Known kinds link to where the repository's resources live; unknown

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -23,7 +23,7 @@ import { QuotaLimitNote } from '../Shared/QuotaLimitNote';
 import { MissingFolderMetadataBanner } from '../components/Folders/MissingFolderMetadataBanner';
 import { hasMissingFolderMetadata } from '../utils/folderMetadata';
 import { isQuotaReachedOrExceeded } from '../utils/quota';
-import { getKindInfoByStatGroup, getRepositoryRoute } from '../utils/resourceKinds';
+import { getKindInfoByStat, getRepositoryRoute } from '../utils/resourceKinds';
 import { formatTimestamp } from '../utils/time';
 
 import { RepositoryHealthCard } from './RepositoryHealthCard';
@@ -54,7 +54,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
         id: 'Resource',
         header: 'Resource Type',
         cell: ({ row: { original } }: StatCell<'resource'>) => {
-          const info = getKindInfoByStatGroup(original.group);
+          const info = getKindInfoByStat(original);
           return (
             <Stack direction="row" gap={1} alignItems="center">
               <Icon name={info?.icon ?? 'file-alt'} />
@@ -76,7 +76,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
         id: 'actions',
         header: '',
         cell: ({ row: { original } }: StatCell) => {
-          const info = getKindInfoByStatGroup(original.group);
+          const info = getKindInfoByStat(original);
           // Unknown kinds have no destination, so no action.
           if (!info) {
             return null;

--- a/public/app/features/provisioning/Wizard/hooks/useResourceStats.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useResourceStats.ts
@@ -13,7 +13,7 @@ import {
 } from 'app/api/clients/provisioning/v0alpha1';
 import { ManagerKind } from 'app/features/apiserver/types';
 
-import { getKindInfoByStatGroup } from '../../utils/resourceKinds';
+import { getKindInfoByStat } from '../../utils/resourceKinds';
 
 export type UseResourceStatsOptions = {
   isHealthy?: boolean; // true only when healthy AND reconciled
@@ -28,7 +28,7 @@ function getManagedCount(managed?: ManagerStats[]) {
     if (manager.kind === ManagerKind.Repo) {
       // Loop through stats inside each manager and sum up the counts for known kinds
       manager.stats.forEach((stat) => {
-        if (getKindInfoByStatGroup(stat.group)) {
+        if (getKindInfoByStat(stat)) {
           totalCount += stat.count;
         }
       });
@@ -43,7 +43,7 @@ function getResourceCount(stats?: ResourceCount[], managed?: ManagerStats[]) {
 
   const addStat = (stat: ResourceCount) => {
     // Only count kinds the UI knows about (folders, dashboards, ...).
-    if (getKindInfoByStatGroup(stat.group)) {
+    if (getKindInfoByStat(stat)) {
       resourceCount += stat.count;
     }
   };

--- a/public/app/features/provisioning/utils/resourceKinds.test.ts
+++ b/public/app/features/provisioning/utils/resourceKinds.test.ts
@@ -6,6 +6,7 @@ import {
   getAvailableResourceKinds,
   getKindInfoByItemType,
   getKindInfoByResource,
+  getKindInfoByStat,
   getKindInfoByStatGroup,
   getRepositoryRoute,
   isResourceKindAvailable,
@@ -75,6 +76,33 @@ describe('getKindInfoByStatGroup', () => {
 
   it('returns undefined for unknown groups', () => {
     expect(getKindInfoByStatGroup('alert.grafana.app')).toBeUndefined();
+  });
+});
+
+describe('getKindInfoByStat', () => {
+  it('resolves by the plural resource name', () => {
+    expect(getKindInfoByStat({ group: 'dashboard.grafana.app', resource: 'dashboards' })).toBe(
+      resourceKindInfos.dashboard
+    );
+    expect(getKindInfoByStat({ group: 'playlist.grafana.app', resource: 'playlists' })).toBe(
+      resourceKindInfos.playlist
+    );
+  });
+
+  it('prefers the resource over the group when they point at different kinds', () => {
+    // The resource uniquely identifies the kind, so it wins over a group that
+    // would otherwise resolve to a different kind.
+    expect(getKindInfoByStat({ group: 'dashboard.grafana.app', resource: 'folders' })).toBe(resourceKindInfos.folder);
+  });
+
+  it('falls back to a group-only match when the resource is missing or unknown', () => {
+    expect(getKindInfoByStat({ group: 'folder.grafana.app' })).toBe(resourceKindInfos.folder);
+    expect(getKindInfoByStat({ group: 'folders' })).toBe(resourceKindInfos.folder);
+  });
+
+  it('returns undefined when neither resource nor group is known', () => {
+    expect(getKindInfoByStat({ group: 'alert.grafana.app', resource: 'rules' })).toBeUndefined();
+    expect(getKindInfoByStat({})).toBeUndefined();
   });
 });
 

--- a/public/app/features/provisioning/utils/resourceKinds.ts
+++ b/public/app/features/provisioning/utils/resourceKinds.ts
@@ -116,9 +116,26 @@ export function getKindInfoByItemType(itemType: ItemType): ResourceKindInfo | un
  * Look up a kind by a resource-stat group, accepting both the full API group
  * (`folder.grafana.app`) and the legacy short plural (`folders`) that the stats
  * endpoint can return interchangeably.
+ *
+ * Prefer `getKindInfoByStat` when a `resource` is available: several kinds can
+ * share an API group, so the group alone does not always identify the kind.
  */
 export function getKindInfoByStatGroup(group?: string): ResourceKindInfo | undefined {
   return allKindInfos.find((info) => info.group === group || info.resource === group);
+}
+
+/**
+ * Look up a kind from a resource-stat entry (`ResourceCount`), which carries both
+ * an API `group` and a plural `resource` name. The plural resource uniquely
+ * identifies the kind even when kinds share a group, so we match on it first and
+ * fall back to a group-only match for stats that omit the resource.
+ */
+export function getKindInfoByStat(stat: { group?: string; resource?: string }): ResourceKindInfo | undefined {
+  const byResource = allKindInfos.find((info) => info.resource === stat.resource);
+  if (byResource) {
+    return byResource;
+  }
+  return getKindInfoByStatGroup(stat.group);
 }
 
 /**


### PR DESCRIPTION

<img width="492" height="371" alt="Screenshot 2026-06-25 at 12 12 02" src="https://github.com/user-attachments/assets/60bc382c-376a-4825-aa03-b70c3ea9ae94" />


### What is this feature?

The provisioning resource-stats UI (repository list badges, the repository overview "Resource Type" table, and the wizard's resource counts) resolved each stat's kind from its **API group alone**. Several kinds can share an API group, so the group alone does not uniquely identify a kind.

This adds `getKindInfoByStat(stat)` to the central `resourceKinds.ts` registry, which:

- matches on the **plural `resource`** name first (which uniquely identifies a kind), and
- falls back to the existing `getKindInfoByStatGroup(stat.group)` for stats that omit the resource.

All resource-stats consumers (`RepositoryListItem`, `RepositoryOverview`, `useResourceStats`) now use it, so each kind renders its own label and icon even when two kinds share a group.

### Why do we need this feature?

When two provisioning kinds live in the same API group (e.g. dashboards and library panels both in `dashboard.grafana.app`), a group-only lookup collapses them onto a single kind — wrong icon, wrong label, and a duplicate stats row. Resolving by the unique plural resource fixes that. This is a standalone correctness fix; it's also a prerequisite for adding library panels to the provisioning admin UI.

### Special notes for your reviewer

- **Frontend-only**, extracted from #127230.
- Purely additive: `getKindInfoByStatGroup` stays for the group-only fallback; the new function wraps it.
- `resourceKinds.test.ts` covers resource resolution, resource-preferred-over-group, group-only fallback, and unknown → undefined.

### Verification

- `yarn jest public/app/features/provisioning/utils/resourceKinds.test.ts` — 22 passed
- `yarn typecheck` — clean
- `yarn eslint` on the 5 changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)