### PR TITLE
Frontend: enable gzip request compression for Faro when session replay is enabled

### DIFF
--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -65,12 +65,17 @@ export class GrafanaJavascriptAgentBackend
         new FetchTransport({
           url: options.customEndpoint,
           apiKey: options.apiKey,
-          // faro enables fetch keepalive per request whenever the body is under ~60KB, but the
-          // browser's ~64KB keepalive budget is shared across all in-flight requests, so faro's
-          // concurrent sends can collectively exceed it — leaving requests stuck "pending" and
-          // dropping session replay segments. When replay is enabled, force keepalive off for this
-          // transport; otherwise leave faro's default untouched.
-          ...(sessionReplayEnabled ? { requestOptions: { keepalive: false } } : {}),
+          // When session replay is enabled, opt this transport out of fetch keepalive and turn
+          // on gzip request compression:
+          //  - keepalive: faro enables it per request when the body is under ~60KB, but the
+          //    browser's ~64KB budget is shared across all in-flight requests, so faro's
+          //    concurrent sends can collectively exceed it — leaving requests stuck "pending"
+          //    and dropping session replay segments.
+          //  - requestCompression: gzip-compresses request bodies via the browser's
+          //    CompressionStream (session replay produces the large payloads that benefit most),
+          //    falling back to uncompressed when CompressionStream is unavailable.
+          // When session replay is off, both are omitted so faro's defaults are left untouched.
+          ...(sessionReplayEnabled ? { requestOptions: { keepalive: false }, requestCompression: true } : {}),
         })
       );
     }


### PR DESCRIPTION
## What this PR does / why we need it

When the session replay feature flag (`faroSessionReplay`) is enabled, this turns on
`requestCompression` for Faro's `FetchTransport`, so session replay request bodies are
gzip-compressed via the browser's native `CompressionStream` (falling back to uncompressed
when `CompressionStream` is unavailable). It is folded into the existing
session-replay-gated transport options (keepalive), since both are driven by the same
condition. When session replay is off, faro's defaults are left untouched.

Session replay produces the large payloads, so compressing them reduces upload bandwidth and
eases pressure on the browser's shared in-flight request/keepalive budget.

`requestCompression` was introduced in `@grafana/faro-web-sdk`
[v2.8.0](https://github.com/grafana/faro-web-sdk/releases/tag/v2.8.0)
([grafana/faro-web-sdk#2028](https://github.com/grafana/faro-web-sdk/pull/2028)). Grafana
already depends on faro `^2.8.2` on `main`, so this is a small enable — no dependency or
lockfile change.

## Test plan

- [ ] CI passes (typecheck / lint / build)
- [ ] With session replay enabled, `/collect` requests are gzip-compressed
      (`Content-Encoding: gzip`) and the collector accepts them; without session replay they are not
