### PR TITLE
Provisioning: fix flaky GithubPullRequestWebhookPostsComment test

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -377,17 +377,23 @@ func (h *ProvisioningTestHelper) AwaitJobSuccess(t *testing.T, ctx context.Conte
 	job = h.AwaitJob(t, ctx, job)
 	lastErrors := MustNestedStringSlice(job.Object, "status", "errors")
 	lastState := MustNestedString(job.Object, "status", "state")
+	// A worker that returns an error records it in status.message, not
+	// status.errors, so surface it explicitly — otherwise a failed job only
+	// reports state=error with no reason.
+	lastMessage := MustNestedString(job.Object, "status", "message")
 
 	repo := job.GetLabels()[jobs.LabelRepository]
 
 	// Debug state if job failed
 	if len(lastErrors) > 0 || lastState != string(provisioning.JobStateSuccess) {
+		t.Logf("job '%s' did not succeed: state=%q message=%q errors=%v",
+			job.GetName(), lastState, lastMessage, lastErrors)
 		h.DebugState(t, repo, fmt.Sprintf("JOB FAILED: %s", job.GetName()))
 	}
 
 	require.Empty(t, lastErrors, "historic job '%s' has errors: %v", job.GetName(), lastErrors)
 	require.Equal(t, string(provisioning.JobStateSuccess), lastState,
-		"historic job '%s' was not successful", job.GetName())
+		"historic job '%s' was not successful (message: %q)", job.GetName(), lastMessage)
 }
 
 func (h *ProvisioningTestHelper) AwaitJob(t *testing.T, ctx context.Context, job *unstructured.Unstructured) *unstructured.Unstructured {

--- a/pkg/tests/apis/provisioning/git/webhook/helper_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/helper_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
 )
 
 var env = common.NewSharedGitEnv(
@@ -14,7 +15,9 @@ var env = common.NewSharedGitEnv(
 
 func sharedGitHelper(t *testing.T) *common.GitTestHelper {
 	t.Helper()
-	return env.GetCleanHelper(t)
+	helper := env.GetCleanHelper(t)
+	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
+	return helper
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -25,6 +25,12 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
+// webhookBaseURL is the public base URL the webhook tests configure (matching
+// WithProvisioningPublicRootURL in the shared env). It is both passed to
+// CreateGithubRepo as the repository's spec.webhook.baseUrl and used to predict
+// the webhook URL the reconciler builds, so the mock and the server agree.
+const webhookBaseURL = "https://grafana.example.com"
+
 // githubHealthCheckMocks returns ghmock handlers that satisfy the GitHub
 // branch protection health check (returns 403 — gracefully skipped).
 func githubHealthCheckMocks() []ghmock.MockBackendOption {
@@ -45,70 +51,44 @@ func githubHealthCheckMocks() []ghmock.MockBackendOption {
 	}
 }
 
-// webhookCreationMocks returns ghmock handlers for webhook creation.
-//
-// The handlers are stateful: the created hook is remembered and served back by
-// the list and get-by-id endpoints. This mirrors real GitHub, where GetHook
-// returns the existing hook so the reconciler's OnUpdate path is a no-op. If
-// get-by-id is left unmocked it 404s, which the reconciler reads as
-// ErrFileNotFound and "recreates" the webhook on every reconcile — rotating the
-// webhook secret each time and racing any concurrent job that decrypts it
-// (yielding intermittent "decrypt webhookSecret: not found").
-func webhookCreationMocks(hookID int64) []ghmock.MockBackendOption {
-	var mu sync.Mutex
-	var created *github.Hook
-
-	return []ghmock.MockBackendOption{
-		ghmock.WithRequestMatchHandler(
-			ghmock.GetReposHooksByOwnerByRepo,
-			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				mu.Lock()
-				hooks := []*github.Hook{}
-				if created != nil {
-					hooks = append(hooks, created)
-				}
-				mu.Unlock()
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(hooks)
-			}),
-		),
-		ghmock.WithRequestMatchHandler(
-			ghmock.PostReposHooksByOwnerByRepo,
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var hook github.Hook
-				if err := json.NewDecoder(r.Body).Decode(&hook); err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
-					return
-				}
-				h := &github.Hook{
-					ID:     github.Ptr(hookID),
-					URL:    hook.GetConfig().URL,
-					Config: hook.Config,
-					Events: hook.Events,
-					Active: hook.Active,
-				}
-				mu.Lock()
-				created = h
-				mu.Unlock()
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(h)
-			}),
-		),
-		ghmock.WithRequestMatchHandler(
-			ghmock.GetReposHooksByOwnerByRepoByHookId,
-			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				mu.Lock()
-				h := created
-				mu.Unlock()
-				if h == nil {
-					w.WriteHeader(http.StatusNotFound)
-					return
-				}
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(h)
-			}),
-		),
+// webhookCreationMocks returns ghmock handlers backing a single immutable
+// webhook, served by the create, list, and get-by-id endpoints — mirroring real
+// GitHub. get-by-id must return the same URL and events the reconciler expects
+// so its OnUpdate path is a no-op. If get-by-id is left unmocked it 404s, which
+// the reconciler reads as ErrFileNotFound and so "recreates" the webhook on
+// every reconcile, rotating the webhook secret each time and racing any
+// concurrent job that decrypts it (yielding intermittent "decrypt webhookSecret:
+// not found"). The hook is built once and only read, so no synchronization is
+// needed.
+func webhookCreationMocks(hookID int64, webhookURL string) []ghmock.MockBackendOption {
+	hook := &github.Hook{
+		ID:     github.Ptr(hookID),
+		Active: github.Ptr(true),
+		Events: []string{"pull_request", "push"}, // == subscribedEvents
+		Config: &github.HookConfig{URL: github.Ptr(webhookURL)},
 	}
+	encode := func(v any) http.HandlerFunc {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(v)
+		}
+	}
+	return []ghmock.MockBackendOption{
+		ghmock.WithRequestMatchHandler(ghmock.GetReposHooksByOwnerByRepo, encode([]*github.Hook{hook})),
+		ghmock.WithRequestMatchHandler(ghmock.PostReposHooksByOwnerByRepo, encode(hook)),
+		ghmock.WithRequestMatchHandler(ghmock.GetReposHooksByOwnerByRepoByHookId, encode(hook)),
+	}
+}
+
+// expectedWebhookURL mirrors the server-side webhook URL builder
+// (buildWebhookURL) so a test can predict the URL the reconciler will compare
+// against. The repository's spec.webhook.baseUrl (set via CreateGithubRepo's
+// webhookBaseURL) is the base; the GVR comes from the same resource info the
+// server uses, so only the path template is duplicated.
+func expectedWebhookURL(baseURL, namespace, repoName string) string {
+	gvr := provisioning.RepositoryResourceInfo.GroupVersionResource()
+	return fmt.Sprintf("%s/apis/%s/%s/namespaces/%s/%s/%s/webhook",
+		strings.TrimRight(baseURL, "/"), gvr.Group, gvr.Version, namespace, gvr.Resource, repoName)
 }
 
 // waitForWebhook polls until Status.Webhook is populated with the expected ID.
@@ -152,13 +132,15 @@ func TestIntegrationProvisioning_GithubRepoNoWebhookWhenDisabled(t *testing.T) {
 func TestIntegrationProvisioning_GithubRepoWebhookCreated(t *testing.T) {
 	helper := sharedGitHelper(t)
 
-	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(456)...)
+	const repoName = "github-with-webhook"
+	webhookURL := expectedWebhookURL(webhookBaseURL, helper.Namespace, repoName)
+
+	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(456, webhookURL)...)
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient(mockOpts...)
 
-	const repoName = "github-with-webhook"
 	helper.CreateGithubRepo(t, repoName, map[string][]byte{
 		"dashboard.json": common.DashboardJSON("gh-webhook-dash", "GitHub Webhook Dashboard", 1),
-	}, "https://grafana.example.com", "write")
+	}, webhookBaseURL, "write")
 
 	waitForWebhook(t, helper, repoName, 456)
 }
@@ -171,9 +153,13 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	helper := sharedGitHelper(t)
 	ctx := context.Background()
 
+	const repoName = "github-pr-comment"
+	const dashboardPath = "dashboard.json"
+	webhookURL := expectedWebhookURL(webhookBaseURL, helper.Namespace, repoName)
+
 	var commentsMu sync.Mutex
 	var comments []string
-	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(654)...)
+	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(654, webhookURL)...)
 	mockOpts = append(mockOpts, ghmock.WithRequestMatchHandler(
 		ghmock.PostReposIssuesCommentsByOwnerByRepoByIssueNumber,
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -199,11 +185,9 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	))
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient(mockOpts...)
 
-	const repoName = "github-pr-comment"
-	const dashboardPath = "dashboard.json"
 	_, local := helper.CreateGithubRepo(t, repoName, map[string][]byte{
 		dashboardPath: common.DashboardJSON("gh-pr-comment-dash", "GitHub PR Comment Dashboard", 1),
-	}, "https://grafana.example.com", "write")
+	}, webhookBaseURL, "write")
 	waitForWebhook(t, helper, repoName, 654)
 	helper.SyncAndWait(t, repoName)
 
@@ -333,13 +317,15 @@ func TestIntegrationProvisioning_GithubRepoWebhookRecreatedWhenMissing(t *testin
 	helper := sharedGitHelper(t)
 	ctx := context.Background()
 
-	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(789)...)
+	const repoName = "github-webhook-restart"
+	webhookURL := expectedWebhookURL(webhookBaseURL, helper.Namespace, repoName)
+
+	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(789, webhookURL)...)
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient(mockOpts...)
 
-	const repoName = "github-webhook-restart"
 	helper.CreateGithubRepo(t, repoName, map[string][]byte{
 		"dashboard.json": common.DashboardJSON("restart-dash", "Restart Dashboard", 1),
-	}, "https://grafana.example.com", "write")
+	}, webhookBaseURL, "write")
 
 	waitForWebhook(t, helper, repoName, 789)
 
@@ -374,13 +360,15 @@ func TestIntegrationProvisioning_WebhookLastRotatedSetOnCreation(t *testing.T) {
 	helper := sharedGitHelper(t)
 	ctx := context.Background()
 
-	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(100)...)
+	const repoName = "github-last-rotated"
+	webhookURL := expectedWebhookURL(webhookBaseURL, helper.Namespace, repoName)
+
+	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(100, webhookURL)...)
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient(mockOpts...)
 
-	const repoName = "github-last-rotated"
 	helper.CreateGithubRepo(t, repoName, map[string][]byte{
 		"dashboard.json": common.DashboardJSON("rotated-dash", "Rotated Dashboard", 1),
-	}, "https://grafana.example.com", "write")
+	}, webhookBaseURL, "write")
 
 	// Wait for webhook, then check LastRotated.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -400,38 +388,29 @@ func TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired(t *testing.T) {
 	helper := sharedGitHelper(t)
 	ctx := context.Background()
 
-	// Mock: health check + webhook creation + webhook get/edit for rotation.
-	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(200)...)
+	const repoName = "github-rotation-test"
+	webhookURL := expectedWebhookURL(webhookBaseURL, helper.Namespace, repoName)
+
+	// Mock: health check + webhook create/list/get-by-id + webhook edit for rotation.
+	mockOpts := append(githubHealthCheckMocks(), webhookCreationMocks(200, webhookURL)...)
 	mockOpts = append(mockOpts,
-		ghmock.WithRequestMatchHandler(
-			ghmock.GetReposHooksByOwnerByRepoByHookId,
-			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(&github.Hook{
-					ID:     github.Ptr(int64(200)),
-					URL:    github.Ptr("https://grafana.example.com/hook"),
-					Events: []string{"pull_request", "push"},
-				})
-			}),
-		),
 		ghmock.WithRequestMatchHandler(
 			ghmock.PatchReposHooksByOwnerByRepoByHookId,
 			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(&github.Hook{
 					ID:     github.Ptr(int64(200)),
-					URL:    github.Ptr("https://grafana.example.com/hook"),
 					Events: []string{"pull_request", "push"},
+					Config: &github.HookConfig{URL: github.Ptr(webhookURL)},
 				})
 			}),
 		),
 	)
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient(mockOpts...)
 
-	const repoName = "github-rotation-test"
 	helper.CreateGithubRepo(t, repoName, map[string][]byte{
 		"dashboard.json": common.DashboardJSON("rotation-dash", "Rotation Dashboard", 1),
-	}, "https://grafana.example.com", "write")
+	}, webhookBaseURL, "write")
 
 	waitForWebhook(t, helper, repoName, 200)
 

--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -52,14 +52,21 @@ func githubHealthCheckMocks() []ghmock.MockBackendOption {
 }
 
 // webhookCreationMocks returns ghmock handlers backing a single immutable
-// webhook, served by the create, list, and get-by-id endpoints — mirroring real
-// GitHub. get-by-id must return the same URL and events the reconciler expects
-// so its OnUpdate path is a no-op. If get-by-id is left unmocked it 404s, which
-// the reconciler reads as ErrFileNotFound and so "recreates" the webhook on
-// every reconcile, rotating the webhook secret each time and racing any
-// concurrent job that decrypts it (yielding intermittent "decrypt webhookSecret:
-// not found"). The hook is built once and only read, so no synchronization is
-// needed.
+// webhook, served by the create, list, get-by-id, and delete endpoints —
+// mirroring real GitHub. The hook is built once and only read, so no
+// synchronization is needed.
+//
+// get-by-id must return the same URL and events the reconciler expects so its
+// OnUpdate path is a no-op. If get-by-id is left unmocked it 404s, which the
+// reconciler reads as ErrFileNotFound and so "recreates" the webhook on every
+// reconcile, rotating the webhook secret each time and racing any concurrent job
+// that decrypts it (yielding intermittent "decrypt webhookSecret: not found").
+//
+// delete must also be registered: once get-by-id registers the
+// /repos/.../hooks/{id} path, a DELETE to that same path (from the deletion
+// finalizer's OnDelete) would otherwise match the path but not the method and
+// return 405, which is not tolerated like the unmatched-route 404 — leaving the
+// repository's finalizer stuck and CleanupAllResources timing out.
 func webhookCreationMocks(hookID int64, webhookURL string) []ghmock.MockBackendOption {
 	hook := &github.Hook{
 		ID:     github.Ptr(hookID),
@@ -77,6 +84,12 @@ func webhookCreationMocks(hookID int64, webhookURL string) []ghmock.MockBackendO
 		ghmock.WithRequestMatchHandler(ghmock.GetReposHooksByOwnerByRepo, encode([]*github.Hook{hook})),
 		ghmock.WithRequestMatchHandler(ghmock.PostReposHooksByOwnerByRepo, encode(hook)),
 		ghmock.WithRequestMatchHandler(ghmock.GetReposHooksByOwnerByRepoByHookId, encode(hook)),
+		ghmock.WithRequestMatchHandler(
+			ghmock.DeleteReposHooksByOwnerByRepoByHookId,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			}),
+		),
 	}
 }
 

--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -46,13 +46,30 @@ func githubHealthCheckMocks() []ghmock.MockBackendOption {
 }
 
 // webhookCreationMocks returns ghmock handlers for webhook creation.
+//
+// The handlers are stateful: the created hook is remembered and served back by
+// the list and get-by-id endpoints. This mirrors real GitHub, where GetHook
+// returns the existing hook so the reconciler's OnUpdate path is a no-op. If
+// get-by-id is left unmocked it 404s, which the reconciler reads as
+// ErrFileNotFound and "recreates" the webhook on every reconcile — rotating the
+// webhook secret each time and racing any concurrent job that decrypts it
+// (yielding intermittent "decrypt webhookSecret: not found").
 func webhookCreationMocks(hookID int64) []ghmock.MockBackendOption {
+	var mu sync.Mutex
+	var created *github.Hook
+
 	return []ghmock.MockBackendOption{
 		ghmock.WithRequestMatchHandler(
 			ghmock.GetReposHooksByOwnerByRepo,
 			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				mu.Lock()
+				hooks := []*github.Hook{}
+				if created != nil {
+					hooks = append(hooks, created)
+				}
+				mu.Unlock()
 				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode([]*github.Hook{})
+				_ = json.NewEncoder(w).Encode(hooks)
 			}),
 		),
 		ghmock.WithRequestMatchHandler(
@@ -63,14 +80,32 @@ func webhookCreationMocks(hookID int64) []ghmock.MockBackendOption {
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
 				}
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(&github.Hook{
+				h := &github.Hook{
 					ID:     github.Ptr(hookID),
 					URL:    hook.GetConfig().URL,
 					Config: hook.Config,
 					Events: hook.Events,
 					Active: hook.Active,
-				})
+				}
+				mu.Lock()
+				created = h
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(h)
+			}),
+		),
+		ghmock.WithRequestMatchHandler(
+			ghmock.GetReposHooksByOwnerByRepoByHookId,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				mu.Lock()
+				h := created
+				mu.Unlock()
+				if h == nil {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(h)
 			}),
 		),
 	}


### PR DESCRIPTION
## What

Fixes the flaky `TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment`. It intermittently failed with the PR job in `state=error` and message `decrypt webhookSecret: not found`.

## Root cause

An **incomplete GitHub webhook mock**, not a product bug.

The test stubbed webhook *create* and *list* but not *get-by-id* (`GetReposHooksByOwnerByRepoByHookId`). The resulting sequence:

1. `OnCreate` registers the webhook and writes `/secure/webhookSecret`.
2. That `/secure` write bumps the repository `generation`, so the next reconcile runs `OnUpdate` → `updateWebhook` → `GetWebhook(id)`.
3. With get-by-id unmocked, the call 404s → mapped to `ErrFileNotFound` → the reconciler "recreates" the webhook and **rotates its secret**, writing `/secure/webhookSecret` again → generation bumps again → loop.
4. The webhook `SecureValue` is replaced on essentially every reconcile. A concurrent pull-request job building the repository (`GetRepository` → build → `secure.WebhookSecret()`) occasionally decrypts a just-replaced name and fails with `decrypt webhookSecret: not found`. The error surfaces in `GetRepository`, before the worker runs, marking the historic job errored.

Real GitHub returns `200` on get-by-id, so `updateWebhook` is a no-op there — the churn only happens under the incomplete mock. (The same churn is what the existing `RecreatedWhenMissing` / `WebhookSecretRotatedWhenExpired` tests already work around with status-patch retries.)

## Fix

Make `webhookCreationMocks` model a single immutable webhook served by **create + list + get-by-id + delete**, mirroring real GitHub:

- **get-by-id** returns the same URL and events the reconciler expects, so `updateWebhook` sees no change (`mustUpdate=false`) and stops rotating the secret. The expected URL is computed by `expectedWebhookURL`, which mirrors the server-side `buildWebhookURL` (same `RepositoryResourceInfo` GVR; base = the repo's `spec.webhook.baseUrl`), so mock and server always agree.
- **delete** must also be registered. Once get-by-id registers the `/repos/.../hooks/{id}` path, a `DELETE` to that same path (from the deletion finalizer's `OnDelete`) would otherwise match the path but not the method and return **405** — which, unlike the unmatched-route **404**, is not tolerated by `deleteWebhook`. That left the repository's finalizer stuck and `CleanupAllResources` timing out. The DELETE handler returns `204`.

Supporting changes:

- **Surface `status.message` in `AwaitJobSuccess`** so a failed job reports its actual error instead of only `state=error`. This is what made the root cause diagnosable (the worker error lands in `status.message`, not `status.errors`).
- **Default the shared GitHub client to an empty mock** between tests in the webhook package, so background reconciles of one test's repos never fall through to a real GitHub client.

## Testing

Test-only change (3 files). Suggested verification:

```bash
cd pkg/tests/apis/provisioning/git/webhook
go test -tags enterprise -race -run TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment -count=50 .
go test -tags enterprise -race ./pkg/tests/apis/provisioning/git/webhook/...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
