### PR TITLE
CI: Make Levitate workflow non-blocking in policy-bot

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -235,6 +235,7 @@ approval_rules:
           conclusions:
             - skipped
             - success
+            - failure
           workflows:
             - .github/workflows/detect-breaking-changes-levitate.yml
   - name: Workflow .github/workflows/documentation-ci.yml succeeded or skipped

--- a/Makefile
+++ b/Makefile
@@ -845,3 +845,5 @@ GENERATE_POLICY_BOT_CONFIG_SHA := sha256:d05ff5c7d4247da155c85f8c6f1f9f7c6d013d1
 	sed -i.bak '/name: Workflow \.github\/workflows\/govulncheck\.yml/,/workflows:/{s/- success/- success\n            - failure/;}' .policy.yml; rm -f .policy.yml.bak
 # Make check-frontend-test-coverage non-blocking - accept failure so it doesn't prevent merge
 	sed -i.bak '/name: Workflow \.github\/workflows\/check-frontend-test-coverage\.yml/,/workflows:/{s/- success/- success\n            - failure/;}' .policy.yml; rm -f .policy.yml.bak
+# Make detect-breaking-changes-levitate non-blocking - accept failure so it doesn't prevent merge
+	sed -i.bak '/name: Workflow \.github\/workflows\/detect-breaking-changes-levitate\.yml/,/workflows:/{s/- success/- success\n            - failure/;}' .policy.yml; rm -f .policy.yml.bak


### PR DESCRIPTION
**What is this feature?**

Do not block policy-bot CI approval on the Levitate workflow failing, as it is designed to do that.

**Why do we need this feature?**

Levitate workflow fails on breaking changes being detected to warn developers, but is meant to be non-blocking.

Blocking: #126582

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

Similar to #125445

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
