### PR TITLE
LibraryElements: route all /api/library-elements endpoints to the apiserver

### DIFF
--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -6,10 +6,14 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net/http"
+	"slices"
+	"sort"
+	"strings"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
@@ -30,6 +34,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/errhttp"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -63,6 +68,12 @@ func (l *LibraryElementService) registerAPIEndpoints() {
 // 404: notFoundError
 // 500: internalServerError
 func (l *LibraryElementService) createHandler(c *contextmodel.ReqContext) response.Response {
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if l.features.IsEnabled(c.Req.Context(), featuremgmt.FlagKubernetesLibraryPanels) {
+		l.k8sHandler.createK8sLibraryElement(c)
+		return nil // already handled in the k8s handler
+	}
+
 	cmd := model.CreateLibraryElementCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
@@ -123,6 +134,12 @@ func (l *LibraryElementService) createHandler(c *contextmodel.ReqContext) respon
 // 404: notFoundError
 // 500: internalServerError
 func (l *LibraryElementService) deleteHandler(c *contextmodel.ReqContext) response.Response {
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if l.features.IsEnabled(c.Req.Context(), featuremgmt.FlagKubernetesLibraryPanels) {
+		l.k8sHandler.deleteK8sLibraryElement(c)
+		return nil // already handled in the k8s handler
+	}
+
 	id, err := l.DeleteLibraryElement(c.Req.Context(), c.SignedInUser, web.Params(c.Req)[":uid"])
 	if err != nil {
 		return l.toLibraryElementError(err, "Failed to delete library element")
@@ -188,6 +205,12 @@ func (l *LibraryElementService) getHandler(c *contextmodel.ReqContext) response.
 // 401: unauthorisedError
 // 500: internalServerError
 func (l *LibraryElementService) getAllHandler(c *contextmodel.ReqContext) response.Response {
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if l.features.IsEnabled(c.Req.Context(), featuremgmt.FlagKubernetesLibraryPanels) {
+		l.k8sHandler.getK8sAllLibraryElements(c)
+		return nil // already handled in the k8s handler
+	}
+
 	query := model.SearchLibraryElementsQuery{
 		PerPage:          c.QueryInt("perPage"),
 		Page:             c.QueryInt("page"),
@@ -230,6 +253,12 @@ func (l *LibraryElementService) getAllHandler(c *contextmodel.ReqContext) respon
 // 412: preconditionFailedError
 // 500: internalServerError
 func (l *LibraryElementService) patchHandler(c *contextmodel.ReqContext) response.Response {
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if l.features.IsEnabled(c.Req.Context(), featuremgmt.FlagKubernetesLibraryPanels) {
+		l.k8sHandler.patchK8sLibraryElement(c)
+		return nil // already handled in the k8s handler
+	}
+
 	cmd := model.PatchLibraryElementCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
@@ -290,6 +319,12 @@ func (l *LibraryElementService) patchHandler(c *contextmodel.ReqContext) respons
 // 404: notFoundError
 // 500: internalServerError
 func (l *LibraryElementService) getConnectionsHandler(c *contextmodel.ReqContext) response.Response {
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if l.features.IsEnabled(c.Req.Context(), featuremgmt.FlagKubernetesLibraryPanels) {
+		l.k8sHandler.getK8sLibraryElementConnections(c)
+		return nil // already handled in the k8s handler
+	}
+
 	libraryPanelUID := web.Params(c.Req)[":uid"]
 
 	// make sure the library element exists
@@ -358,6 +393,12 @@ func (l *LibraryElementService) getConnectionsHandler(c *contextmodel.ReqContext
 // 404: notFoundError
 // 500: internalServerError
 func (l *LibraryElementService) getByNameHandler(c *contextmodel.ReqContext) response.Response {
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if l.features.IsEnabled(c.Req.Context(), featuremgmt.FlagKubernetesLibraryPanels) {
+		l.k8sHandler.getK8sLibraryElementByName(c)
+		return nil // already handled in the k8s handler
+	}
+
 	elements, err := l.getLibraryElementsByName(c.Req.Context(), c.SignedInUser, web.Params(c.Req)[":name"])
 	if err != nil {
 		return l.toLibraryElementError(err, "Failed to get library element")
@@ -607,6 +648,305 @@ func (lk8s *libraryElementsK8sHandler) getK8sLibraryElement(c *contextmodel.ReqC
 	c.JSON(http.StatusOK, model.LibraryElementResponse{Result: *dto})
 }
 
+func (lk8s *libraryElementsK8sHandler) getK8sAllLibraryElements(c *contextmodel.ReqContext) {
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return
+	}
+	// The apiserver enforces read access per the signed-in user's client, so we do not
+	// re-implement permission filtering here.
+	out, err := client.List(c.Req.Context(), v1.ListOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+
+	searchString := strings.ToLower(c.Query("searchString"))
+	typeFilter := parseCommaSeparated(c.Query("typeFilter"))
+	folderFilterUIDs := parseCommaSeparated(c.Query("folderFilterUIDs"))
+	excludeUID := c.Query("excludeUid")
+
+	elements := make([]model.LibraryElementDTO, 0, len(out.Items))
+	for _, item := range out.Items {
+		dto, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, item)
+		if err != nil {
+			c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+			return
+		}
+
+		if excludeUID != "" && dto.UID == excludeUID {
+			continue
+		}
+		if searchString != "" && !strings.Contains(strings.ToLower(dto.Name), searchString) {
+			continue
+		}
+		if len(typeFilter) > 0 && !slices.Contains(typeFilter, dto.Type) {
+			continue
+		}
+		if len(folderFilterUIDs) > 0 && !slices.Contains(folderFilterUIDs, dto.FolderUID) {
+			continue
+		}
+
+		elements = append(elements, *dto)
+	}
+
+	descending := c.Query("sortDirection") == "alpha-desc"
+	sort.Slice(elements, func(i, j int) bool {
+		if descending {
+			return elements[i].Name > elements[j].Name
+		}
+		return elements[i].Name < elements[j].Name
+	})
+
+	totalCount := int64(len(elements))
+
+	perPage := c.QueryInt("perPage")
+	if perPage <= 0 {
+		perPage = 100
+	}
+	page := c.QueryInt("page")
+	if page <= 0 {
+		page = 1
+	}
+
+	start := (page - 1) * perPage
+	if start > len(elements) {
+		start = len(elements)
+	}
+	end := start + perPage
+	if end > len(elements) {
+		end = len(elements)
+	}
+
+	c.JSON(http.StatusOK, model.LibraryElementSearchResponse{Result: model.LibraryElementSearchResult{
+		TotalCount: totalCount,
+		Elements:   elements[start:end],
+		Page:       page,
+		PerPage:    perPage,
+	}})
+}
+
+func (lk8s *libraryElementsK8sHandler) getK8sLibraryElementByName(c *contextmodel.ReqContext) {
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return
+	}
+	out, err := client.List(c.Req.Context(), v1.ListOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+
+	name := web.Params(c.Req)[":name"]
+	elements := make([]model.LibraryElementDTO, 0)
+	for _, item := range out.Items {
+		dto, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, item)
+		if err != nil {
+			c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+			return
+		}
+		if dto.Name == name {
+			elements = append(elements, *dto)
+		}
+	}
+
+	c.JSON(http.StatusOK, model.LibraryElementArrayResponse{Result: elements})
+}
+
+func (lk8s *libraryElementsK8sHandler) getK8sLibraryElementConnections(c *contextmodel.ReqContext) {
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return
+	}
+	libraryPanelUID := web.Params(c.Req)[":uid"]
+	out, err := client.Get(c.Req.Context(), libraryPanelUID, v1.GetOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+	element, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, *out)
+	if err != nil {
+		c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+		return
+	}
+
+	dashboards, err := lk8s.dashboardsService.GetDashboardsByLibraryPanelUID(c.Req.Context(), libraryPanelUID, c.GetOrgID())
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+
+	connections := make([]model.LibraryElementConnectionDTO, 0)
+	for _, dashboard := range dashboards {
+		// Unlike the legacy handler, we do not re-check per-folder view permissions here:
+		// the apiserver Get above already enforced read access on the panel, and the
+		// folder permission check lives on the service (l.requireViewPermissionsOnFolderUID),
+		// which is not reachable from the k8s handler without a circular dependency.
+
+		// connections are not an individual resource and therefore do not have an id
+		// instead, return something that will be consistent and somewhat unique for the connection.
+		hash := fnv.New64a()
+		_, err := fmt.Fprintf(hash, "%d:%s:%d:%d", element.ID, dashboard.UID, c.GetOrgID(), element.Meta.Created.Unix())
+		if err != nil {
+			c.JsonApiErr(http.StatusInternalServerError, "Failed to generate connection id", err)
+			return
+		}
+		// ensure it is positive and smaller than 9007199254740991, otherwise we will lose prescision
+		// in javascript, which has the safest number as 9007199254740991, compared to 9223372036854775807 in go
+		connectionID := int64(hash.Sum64() & ((1 << 52) - 1))
+
+		connections = append(connections, model.LibraryElementConnectionDTO{
+			ID:            connectionID,
+			Kind:          int64(model.PanelElement),
+			ElementID:     element.ID,
+			ConnectionID:  dashboard.ID, // nolint:staticcheck
+			ConnectionUID: dashboard.UID,
+			// returns the creation information of the library element, not the connection
+			CreatedBy: model.LibraryElementDTOMetaUser{
+				Id:        element.Meta.CreatedBy.Id,
+				Name:      element.Meta.CreatedBy.Name,
+				AvatarUrl: element.Meta.CreatedBy.AvatarUrl,
+			},
+			Created: element.Meta.Created,
+		})
+	}
+
+	c.JSON(http.StatusOK, model.LibraryElementConnectionsResponse{Result: connections})
+}
+
+func (lk8s *libraryElementsK8sHandler) createK8sLibraryElement(c *contextmodel.ReqContext) {
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return
+	}
+	cmd := model.CreateLibraryElementCommand{}
+	if err := web.Bind(c.Req, &cmd); err != nil {
+		c.JsonApiErr(http.StatusBadRequest, "bad request data", err)
+		return
+	}
+
+	spec, err := legacyModelToLibraryPanelSpec(cmd.Name, cmd.Model)
+	if err != nil {
+		c.JsonApiErr(http.StatusBadRequest, "conversion error", err)
+		return
+	}
+	obj := &dashboardV0.LibraryPanel{Spec: spec}
+	// The apiserver requires either a name or generateName; the legacy create allowed
+	// an empty UID and generated one, so mirror that here (as the playlist handler does).
+	if cmd.UID == "" {
+		cmd.UID = util.GenerateShortUID()
+	}
+	obj.SetName(cmd.UID)
+	if cmd.FolderUID != nil {
+		meta, err := utils.MetaAccessor(obj)
+		if err != nil {
+			c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+			return
+		}
+		meta.SetFolder(*cmd.FolderUID)
+	}
+
+	unstructuredObj, err := toUnstructured(obj)
+	if err != nil {
+		c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+		return
+	}
+
+	out, err := client.Create(c.Req.Context(), unstructuredObj, v1.CreateOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+
+	dto, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, *out)
+	if err != nil {
+		c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+		return
+	}
+	c.JSON(http.StatusOK, model.LibraryElementResponse{Result: *dto})
+}
+
+func (lk8s *libraryElementsK8sHandler) patchK8sLibraryElement(c *contextmodel.ReqContext) {
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return
+	}
+	uid := web.Params(c.Req)[":uid"]
+	cmd := model.PatchLibraryElementCommand{}
+	if err := web.Bind(c.Req, &cmd); err != nil {
+		c.JsonApiErr(http.StatusBadRequest, "bad request data", err)
+		return
+	}
+
+	existing, err := client.Get(c.Req.Context(), uid, v1.GetOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+
+	// Start from the existing object and apply the patch fields that are present.
+	updated := existing.DeepCopy()
+	if len(cmd.Model) > 0 || cmd.Name != "" {
+		// reconstruct the name to use for the spec.Title from the patch (or fall back to existing)
+		name := cmd.Name
+		if name == "" {
+			if meta, mErr := utils.MetaAccessor(existing); mErr == nil {
+				name = meta.FindTitle("")
+			}
+		}
+		spec, err := legacyModelToLibraryPanelSpec(name, cmd.Model)
+		if err != nil {
+			c.JsonApiErr(http.StatusBadRequest, "conversion error", err)
+			return
+		}
+		specMap, err := specToUnstructuredMap(spec)
+		if err != nil {
+			c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+			return
+		}
+		updated.Object["spec"] = specMap
+	}
+
+	updated.SetName(uid)
+	updated.SetResourceVersion(existing.GetResourceVersion())
+	if cmd.FolderUID != nil {
+		meta, err := utils.MetaAccessor(updated)
+		if err != nil {
+			c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+			return
+		}
+		meta.SetFolder(*cmd.FolderUID)
+	}
+
+	out, err := client.Update(c.Req.Context(), updated, v1.UpdateOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+
+	dto, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, *out)
+	if err != nil {
+		c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+		return
+	}
+	c.JSON(http.StatusOK, model.LibraryElementResponse{Result: *dto})
+}
+
+func (lk8s *libraryElementsK8sHandler) deleteK8sLibraryElement(c *contextmodel.ReqContext) {
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return
+	}
+	uid := web.Params(c.Req)[":uid"]
+	err := client.Delete(c.Req.Context(), uid, v1.DeleteOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+	// The k8s delete does not return the legacy numeric ID, so it is left as 0.
+	c.JSON(http.StatusOK, model.DeleteLibraryElementResponse{Message: "Library element deleted"})
+}
+
 func (lk8s *libraryElementsK8sHandler) unstructuredToLegacyLibraryPanelDTO(c *contextmodel.ReqContext, item unstructured.Unstructured) (*model.LibraryElementDTO, error) {
 	spec, exists := item.Object["spec"].(map[string]interface{})
 	if !exists {
@@ -746,6 +1086,41 @@ func (lk8s *libraryElementsK8sHandler) getClient(c *contextmodel.ReqContext) (dy
 		return nil, false
 	}
 	return dyn.Resource(lk8s.gvr).Namespace(lk8s.namespacer(c.OrgID)), true
+}
+
+// parseCommaSeparated splits a comma separated query value into trimmed, non-empty values.
+func parseCommaSeparated(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	values := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	return values
+}
+
+// toUnstructured converts a typed LibraryPanel into the unstructured form expected by the
+// dynamic client, preserving metadata (name, folder annotation) set on the object.
+func toUnstructured(obj *dashboardV0.LibraryPanel) (*unstructured.Unstructured, error) {
+	out, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert library panel to unstructured: %w", err)
+	}
+	return &unstructured.Unstructured{Object: out}, nil
+}
+
+// specToUnstructuredMap converts a LibraryPanelSpec into a map suitable for embedding in an
+// unstructured object's "spec" field.
+func specToUnstructuredMap(spec dashboardV0.LibraryPanelSpec) (map[string]any, error) {
+	out, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert library panel spec to unstructured: %w", err)
+	}
+	return out, nil
 }
 
 func (lk8s *libraryElementsK8sHandler) writeError(c *contextmodel.ReqContext, err error) {

--- a/pkg/services/libraryelements/conversions.go
+++ b/pkg/services/libraryelements/conversions.go
@@ -60,3 +60,27 @@ func toRawMessage(raw runtime.Object) (json.RawMessage, error) {
 	}
 	return nil, fmt.Errorf("unsupported library panel type: %T", raw)
 }
+
+// legacyModelToLibraryPanelSpec is the inverse of the legacyModel reconstruction in
+// unstructuredToLegacyLibraryPanelDTO. It builds a LibraryPanelSpec from the legacy
+// library panel JSON model and the library panel name.
+//
+// Note on titles: the legacy model's "title" is the panel title as shown in a dashboard
+// (spec.PanelTitle), while the library panel's own name is spec.Title. The model JSON's
+// own "title" field would otherwise unmarshal into spec.Title (same json tag), so we
+// explicitly move it to PanelTitle and set Title from the supplied name afterwards.
+func legacyModelToLibraryPanelSpec(name string, modelJSON json.RawMessage) (v0alpha1.LibraryPanelSpec, error) {
+	var spec v0alpha1.LibraryPanelSpec
+	if len(modelJSON) > 0 {
+		if err := json.Unmarshal(modelJSON, &spec); err != nil {
+			return spec, fmt.Errorf("failed to unmarshal library panel model: %w", err)
+		}
+	}
+
+	// The model's "title" is the in-dashboard panel title, not the library panel name.
+	spec.PanelTitle = spec.Title
+	// The library panel name is authoritative for spec.Title.
+	spec.Title = name
+
+	return spec, nil
+}

--- a/pkg/services/libraryelements/conversions_test.go
+++ b/pkg/services/libraryelements/conversions_test.go
@@ -101,3 +101,34 @@ func TestConversionsCommands(t *testing.T) {
 		})
 	}
 }
+
+func TestLegacyModelToLibraryPanelSpec(t *testing.T) {
+	// The legacy model JSON's "title" is the in-dashboard panel title (PanelTitle),
+	// while the supplied name is the library panel name (Title).
+	modelJSON := json.RawMessage(`{
+		"type": "timeseries",
+		"pluginVersion": "1.2.3",
+		"title": "panel title",
+		"description": "descr",
+		"options": {"hello": "options"},
+		"fieldConfig": {"hello": "fieldConfig"},
+		"datasource": {"type": "ttt", "uid": "uid", "apiVersion": "v0alpha1"},
+		"gridPos": {"w": 1, "h": 2, "x": 3, "y": 4},
+		"transparent": true
+	}`)
+
+	spec, err := legacyModelToLibraryPanelSpec("library panel name", modelJSON)
+	require.NoError(t, err)
+
+	require.Equal(t, "library panel name", spec.Title)
+	require.Equal(t, "panel title", spec.PanelTitle)
+	require.Equal(t, "timeseries", spec.Type)
+	require.Equal(t, "1.2.3", spec.PluginVersion)
+	require.Equal(t, "descr", spec.Description)
+	require.True(t, spec.Transparent)
+	require.Equal(t, map[string]any{"hello": "options"}, spec.Options.Object)
+	require.Equal(t, map[string]any{"hello": "fieldConfig"}, spec.FieldConfig.Object)
+	require.NotNil(t, spec.Datasource)
+	require.Equal(t, "ttt", spec.Datasource.Type)
+	require.Equal(t, v0alpha1.GridPos{W: 1, H: 2, X: 3, Y: 4}, spec.GridPos)
+}


### PR DESCRIPTION
### What is this feature?

Routes **all** legacy `/api/library-elements` HTTP handlers to the dashboard apiserver (k8s) when the `kubernetesLibraryPanels` feature toggle is enabled. Previously only **GET-by-UID** was routed; **list, getByName, connections, create, patch and delete** still read/wrote the legacy `library_element` SQL table.

Implemented in `pkg/services/libraryelements/` following the existing playlist k8s-handler pattern (`pkg/api/playlist.go`):

- **Reads** — `getK8sAllLibraryElements` (list + `searchString`/`typeFilter`/`folderFilterUIDs`/`excludeUid` filtering, name sort, pagination), `getK8sLibraryElementByName`, `getK8sLibraryElementConnections`.
- **Writes** — `createK8sLibraryElement`, `patchK8sLibraryElement`, `deleteK8sLibraryElement` via the dynamic client.
- **New conversion** — `legacyModelToLibraryPanelSpec` in `conversions.go`, the faithful inverse of the existing `unstructuredToLegacyLibraryPanelDTO` read conversion (handles the `title`→`panelTitle` / library-panel-name→`title` distinction). Unit-tested in `conversions_test.go`.

The legacy path is **untouched when the toggle is off** — every handler keeps its existing behavior and only short-circuits to the k8s handler behind the same `//nolint:staticcheck` flag gate the existing `getHandler` uses.

### Why do we need this feature?

With library panels served from unified storage (the storage mode that makes Git Sync / provisioning round-trip work), the legacy `library_element` table doesn't receive them — so the Library Panels page (which calls the list endpoint) was empty and writes bypassed unified storage. Routing all endpoints to the apiserver makes the page and CRUD work consistently against unified storage.

### Who is this feature for?

Operators running with `kubernetesLibraryPanels` enabled / library panels on unified storage, and Git Sync provisioning users.

### Which issue(s) does this PR fix?

Part of grafana/git-ui-sync-project#281 (the Search and create/patch/update items).

### Special notes for your reviewer

- **Owning squad heads-up** — this is the routing work tracked in git-ui-sync-project#281 (Get already routed; this adds Search/list, getByName, connections, and create/patch/update). Worth a look from whoever's driving that ticket.
- **Connections folder permissions** — the legacy `getConnectionsHandler` re-checks per-folder view permissions and filters out connections in folders the user can't view. The k8s handler skips that filter (the helper lives on the service, not the handler, and pulling it in would create a circular dependency); the apiserver `Get` already enforces read access on the panel itself. Flagging in case the per-folder filter must be preserved — easy to wire through if so.
- **Write round-trip needs integration verification** — `create`/`patch` build the unstructured `LibraryPanel` from the legacy command (UID generated client-side when empty, mirroring playlist; resourceVersion carried from the existing object on patch). Unit-tested the conversion; the full HTTP→apiserver→unified round-trip should be exercised in an integration/e2e environment with the toggle on before this is taken out of draft.
- **Delete** returns no legacy numeric ID (k8s delete doesn't surface one), so the response `id` is `0`.

### Verification

- `go build` / `go vet` / `gofmt` — clean
- `go test ./pkg/services/libraryelements/` — pass (legacy tests run with the toggle off)
- Added `conversions_test.go` coverage for `legacyModelToLibraryPanelSpec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)