### PR TITLE
Connections: migrate nav hooks to useDatasourcePluginMeta

### DIFF
--- a/public/app/features/connections/components/FeatureHighlightsTabPage.tsx
+++ b/public/app/features/connections/components/FeatureHighlightsTabPage.tsx
@@ -38,6 +38,7 @@ export function FeatureHighlightsTabPage({
   const info = useDataSourceInfo({
     dataSourcePluginName: pageNav.dataSourcePluginName,
     alertingSupported: dataSourceHeader.alertingSupported,
+    alertingLoading: dataSourceHeader.alertingLoading,
   });
 
   return (

--- a/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
+++ b/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
@@ -2,12 +2,13 @@ import { useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import { type NavModel, type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { useDatasourcePluginMeta } from '@grafana/runtime/internal';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { useDataSource, useDataSourceSettings } from 'app/features/datasources/state/hooks';
 import { getDataSourceLoadingNav, buildNavModel, getDataSourceNav } from 'app/features/datasources/state/navModel';
 import { useGetSingle } from 'app/features/plugins/admin/state/hooks';
 import { useSelector } from 'app/types/store';
+
+import { useIsAlertingSupported } from './useIsAlertingSupported';
 
 export function useDataSourceSettingsNav(pageIdParam?: string) {
   const { uid = '' } = useParams<{ uid: string }>();
@@ -18,10 +19,7 @@ export function useDataSourceSettingsNav(pageIdParam?: string) {
   const pageId = pageIdParam || params.get('page');
 
   const { plugin, loadError, loading } = useDataSourceSettings();
-  const { value: dataSourcePluginMeta } = useDatasourcePluginMeta(datasource.type);
-  const hasAlertingEnabled = Boolean(dataSourcePluginMeta?.alerting ?? false);
-  const isAlertManagerDatasource = dataSourcePluginMeta?.id === 'alertmanager';
-  const alertingSupported = hasAlertingEnabled || isAlertManagerDatasource;
+  const alertingSupported = useIsAlertingSupported(datasource.type);
 
   const navIndex = useSelector((state) => state.navIndex);
   const navIndexId = pageId ? `datasource-${pageId}-${uid}` : `datasource-settings-${uid}`;

--- a/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
+++ b/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
@@ -2,7 +2,7 @@ import { useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import { type NavModel, type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { useDatasourcePluginMeta } from '@grafana/runtime/internal';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { useDataSource, useDataSourceSettings } from 'app/features/datasources/state/hooks';
 import { getDataSourceLoadingNav, buildNavModel, getDataSourceNav } from 'app/features/datasources/state/navModel';
@@ -18,9 +18,9 @@ export function useDataSourceSettingsNav(pageIdParam?: string) {
   const pageId = pageIdParam || params.get('page');
 
   const { plugin, loadError, loading } = useDataSourceSettings();
-  const dsi = getDataSourceSrv()?.getInstanceSettings(uid);
-  const hasAlertingEnabled = Boolean(dsi?.meta?.alerting ?? false);
-  const isAlertManagerDatasource = dsi?.type === 'alertmanager';
+  const { value: dataSourcePluginMeta } = useDatasourcePluginMeta(datasource.type);
+  const hasAlertingEnabled = Boolean(dataSourcePluginMeta?.alerting ?? false);
+  const isAlertManagerDatasource = dataSourcePluginMeta?.id === 'alertmanager';
   const alertingSupported = hasAlertingEnabled || isAlertManagerDatasource;
 
   const navIndex = useSelector((state) => state.navIndex);

--- a/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
+++ b/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
@@ -19,7 +19,7 @@ export function useDataSourceSettingsNav(pageIdParam?: string) {
   const pageId = pageIdParam || params.get('page');
 
   const { plugin, loadError, loading } = useDataSourceSettings();
-  const alertingSupported = useIsAlertingSupported(datasource.type);
+  const { isSupported: alertingSupported, isLoading: alertingLoading } = useIsAlertingSupported(datasource.type);
 
   const navIndex = useSelector((state) => state.navIndex);
   const navIndexId = pageId ? `datasource-${pageId}-${uid}` : `datasource-settings-${uid}`;
@@ -86,6 +86,7 @@ export function useDataSourceSettingsNav(pageIdParam?: string) {
     pageNav: connectionsPageNav,
     dataSourceHeader: {
       alertingSupported,
+      alertingLoading,
     },
   };
 }

--- a/public/app/features/connections/hooks/useDataSourceTabNav.ts
+++ b/public/app/features/connections/hooks/useDataSourceTabNav.ts
@@ -2,7 +2,7 @@ import { useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import { type NavModel, type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { useDatasourcePluginMeta } from '@grafana/runtime/internal';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { useDataSource, useDataSourceMeta, useDataSourceSettings } from 'app/features/datasources/state/hooks';
 import { getDataSourceLoadingNav, buildNavModel, getDataSourceNav } from 'app/features/datasources/state/navModel';
@@ -19,9 +19,9 @@ export function useDataSourceTabNav(pageName: string, pageIdParam?: string) {
   const pageId = pageIdParam || params.get('page');
 
   const { plugin, loadError, loading } = useDataSourceSettings();
-  const dsi = getDataSourceSrv()?.getInstanceSettings(uid);
-  const hasAlertingEnabled = Boolean(dsi?.meta?.alerting ?? false);
-  const isAlertManagerDatasource = dsi?.type === 'alertmanager';
+  const { value: dataSourcePluginMeta } = useDatasourcePluginMeta(datasource.type);
+  const hasAlertingEnabled = Boolean(dataSourcePluginMeta?.alerting ?? false);
+  const isAlertManagerDatasource = dataSourcePluginMeta?.id === 'alertmanager';
   const alertingSupported = hasAlertingEnabled || isAlertManagerDatasource;
 
   const navIndex = useSelector((state) => state.navIndex);

--- a/public/app/features/connections/hooks/useDataSourceTabNav.ts
+++ b/public/app/features/connections/hooks/useDataSourceTabNav.ts
@@ -2,12 +2,13 @@ import { useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import { type NavModel, type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { useDatasourcePluginMeta } from '@grafana/runtime/internal';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { useDataSource, useDataSourceMeta, useDataSourceSettings } from 'app/features/datasources/state/hooks';
 import { getDataSourceLoadingNav, buildNavModel, getDataSourceNav } from 'app/features/datasources/state/navModel';
 import { useGetSingle } from 'app/features/plugins/admin/state/hooks';
 import { useSelector } from 'app/types/store';
+
+import { useIsAlertingSupported } from './useIsAlertingSupported';
 
 export function useDataSourceTabNav(pageName: string, pageIdParam?: string) {
   const { uid = '' } = useParams<{ uid: string }>();
@@ -19,10 +20,7 @@ export function useDataSourceTabNav(pageName: string, pageIdParam?: string) {
   const pageId = pageIdParam || params.get('page');
 
   const { plugin, loadError, loading } = useDataSourceSettings();
-  const { value: dataSourcePluginMeta } = useDatasourcePluginMeta(datasource.type);
-  const hasAlertingEnabled = Boolean(dataSourcePluginMeta?.alerting ?? false);
-  const isAlertManagerDatasource = dataSourcePluginMeta?.id === 'alertmanager';
-  const alertingSupported = hasAlertingEnabled || isAlertManagerDatasource;
+  const alertingSupported = useIsAlertingSupported(datasource.type);
 
   const navIndex = useSelector((state) => state.navIndex);
   const navIndexId = pageId ? `datasource-${pageId}-${uid}` : `datasource-${pageName}-${uid}`;

--- a/public/app/features/connections/hooks/useDataSourceTabNav.ts
+++ b/public/app/features/connections/hooks/useDataSourceTabNav.ts
@@ -20,7 +20,7 @@ export function useDataSourceTabNav(pageName: string, pageIdParam?: string) {
   const pageId = pageIdParam || params.get('page');
 
   const { plugin, loadError, loading } = useDataSourceSettings();
-  const alertingSupported = useIsAlertingSupported(datasource.type);
+  const { isSupported: alertingSupported, isLoading: alertingLoading } = useIsAlertingSupported(datasource.type);
 
   const navIndex = useSelector((state) => state.navIndex);
   const navIndexId = pageId ? `datasource-${pageId}-${uid}` : `datasource-${pageName}-${uid}`;
@@ -89,6 +89,7 @@ export function useDataSourceTabNav(pageName: string, pageIdParam?: string) {
     pageNav: connectionsPageNav,
     dataSourceHeader: {
       alertingSupported,
+      alertingLoading,
     },
   };
 }

--- a/public/app/features/connections/hooks/useIsAlertingSupported.test.ts
+++ b/public/app/features/connections/hooks/useIsAlertingSupported.test.ts
@@ -1,0 +1,67 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { PluginType } from '@grafana/data';
+import { setDatasourcePluginMetas } from '@grafana/runtime/internal';
+
+import { useIsAlertingSupported } from './useIsAlertingSupported';
+
+function getMockPluginMeta(id: string, alerting?: boolean) {
+  return {
+    id,
+    name: id,
+    type: PluginType.datasource,
+    alerting,
+    info: {
+      author: { name: '', url: '' },
+      description: '',
+      links: [],
+      logos: { large: '', small: '' },
+      screenshots: [],
+      updated: '',
+      version: '',
+    },
+    module: '',
+    baseUrl: '',
+  };
+}
+
+describe('useIsAlertingSupported', () => {
+  beforeEach(() => {
+    setDatasourcePluginMetas({
+      prometheus: getMockPluginMeta('prometheus', true),
+      testdata: getMockPluginMeta('testdata', false),
+      alertmanager: getMockPluginMeta('alertmanager'),
+    });
+  });
+
+  afterEach(() => {
+    setDatasourcePluginMetas({});
+  });
+
+  it('should be loading and not supported while the plugin meta is loading', async () => {
+    const { result } = renderHook(() => useIsAlertingSupported('prometheus'));
+    expect(result.current).toEqual({ isLoading: true, isSupported: false });
+    // let the async meta lookup settle to avoid state updates outside of act()
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  it('should be loading while the datasource type is not known yet', async () => {
+    const { result } = renderHook(() => useIsAlertingSupported(''));
+    await waitFor(() => expect(result.current).toEqual({ isLoading: true, isSupported: false }));
+  });
+
+  it('should be supported for a datasource with alerting enabled', async () => {
+    const { result } = renderHook(() => useIsAlertingSupported('prometheus'));
+    await waitFor(() => expect(result.current).toEqual({ isLoading: false, isSupported: true }));
+  });
+
+  it('should be supported for the alertmanager datasource', async () => {
+    const { result } = renderHook(() => useIsAlertingSupported('alertmanager'));
+    await waitFor(() => expect(result.current).toEqual({ isLoading: false, isSupported: true }));
+  });
+
+  it('should not be supported for a datasource without alerting support', async () => {
+    const { result } = renderHook(() => useIsAlertingSupported('testdata'));
+    await waitFor(() => expect(result.current).toEqual({ isLoading: false, isSupported: false }));
+  });
+});

--- a/public/app/features/connections/hooks/useIsAlertingSupported.ts
+++ b/public/app/features/connections/hooks/useIsAlertingSupported.ts
@@ -1,0 +1,6 @@
+import { useDatasourcePluginMeta } from '@grafana/runtime/internal';
+
+export function useIsAlertingSupported(datasourceType: string): boolean {
+  const { value: meta } = useDatasourcePluginMeta(datasourceType);
+  return Boolean(meta?.alerting) || meta?.id === 'alertmanager';
+}

--- a/public/app/features/connections/hooks/useIsAlertingSupported.ts
+++ b/public/app/features/connections/hooks/useIsAlertingSupported.ts
@@ -1,6 +1,22 @@
 import { useDatasourcePluginMeta } from '@grafana/runtime/internal';
 
-export function useIsAlertingSupported(datasourceType: string): boolean {
-  const { value: meta } = useDatasourcePluginMeta(datasourceType);
-  return Boolean(meta?.alerting) || meta?.id === 'alertmanager';
+export interface IsAlertingSupported {
+  isSupported: boolean;
+  isLoading: boolean;
+}
+
+/**
+ * Returns whether the datasource supports alerting. While isLoading is true
+ * the answer is not known yet (plugin meta still loading or datasource type
+ * not resolved) and isSupported should not be trusted — consumers should wait
+ * for isLoading to be false to avoid flashing incorrect UI.
+ */
+export function useIsAlertingSupported(datasourceType: string): IsAlertingSupported {
+  const { loading, value: meta } = useDatasourcePluginMeta(datasourceType);
+  const isLoading = !datasourceType || loading;
+
+  return {
+    isLoading,
+    isSupported: !isLoading && (Boolean(meta?.alerting) || meta?.id === 'alertmanager'),
+  };
 }

--- a/public/app/features/connections/tabs/ConnectData/DataSourceTabs.test.tsx
+++ b/public/app/features/connections/tabs/ConnectData/DataSourceTabs.test.tsx
@@ -75,6 +75,11 @@ const renderPage = (
   );
 };
 
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  useDatasourcePluginMeta: () => ({ loading: false, value: null }),
+}));
+
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
   return {

--- a/public/app/features/connections/tabs/ConnectData/DataSourceTabs.test.tsx
+++ b/public/app/features/connections/tabs/ConnectData/DataSourceTabs.test.tsx
@@ -4,6 +4,7 @@ import { render } from 'test/test-utils';
 
 import { LayoutModes, PluginType } from '@grafana/data';
 import { setPluginLinksHook, setPluginComponentsHook, setPluginFunctionsHook } from '@grafana/runtime';
+import { setDatasourcePluginMetas } from '@grafana/runtime/internal';
 import { contextSrv } from 'app/core/services/context_srv';
 import * as api from 'app/features/datasources/api';
 import { getMockDataSources } from 'app/features/datasources/mocks/dataSourcesMocks';
@@ -75,11 +76,6 @@ const renderPage = (
   );
 };
 
-jest.mock('@grafana/runtime/internal', () => ({
-  ...jest.requireActual('@grafana/runtime/internal'),
-  useDatasourcePluginMeta: () => ({ loading: false, value: null }),
-}));
-
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
   return {
@@ -110,25 +106,21 @@ jest.mock('@grafana/runtime', () => {
     getTemplateSrv: () => ({
       replace: (str: string) => str,
     }),
-    getDataSourceSrv: () => {
-      return {
-        getInstanceSettings: (uid: string) => {
-          return {
-            id: uid,
-            uid: uid,
-            type: PluginType.datasource,
-            name: uid,
-            meta: {
-              id: uid,
-              name: uid,
-              type: PluginType.datasource,
-              backend: true,
-              isBackend: true,
-            },
-          };
+    getDataSourceSrv: () => ({
+      getInstanceSettings: (uid: string) => ({
+        id: uid,
+        uid: uid,
+        type: PluginType.datasource,
+        name: uid,
+        meta: {
+          id: uid,
+          name: uid,
+          type: PluginType.datasource,
+          backend: true,
+          isBackend: true,
         },
-      };
-    },
+      }),
+    }),
   };
 });
 
@@ -162,13 +154,35 @@ describe('DataSourceEditTabs', () => {
     process.env.NODE_ENV = 'test';
     (api.getDataSources as jest.Mock) = jest.fn().mockResolvedValue(mockDatasources);
     (contextSrv.hasPermission as jest.Mock) = jest.fn().mockReturnValue(true);
+    setDatasourcePluginMetas({
+      [mockDatasources[0].type]: {
+        id: mockDatasources[0].type,
+        name: mockDatasources[0].type,
+        type: PluginType.datasource,
+        info: {
+          author: { name: '', url: '' },
+          description: '',
+          links: [],
+          logos: { large: '', small: '' },
+          screenshots: [],
+          updated: '',
+          version: '',
+        },
+        module: '',
+        baseUrl: '',
+      },
+    });
   });
 
-  it('should render Permissions and Insights tabs', () => {
+  afterEach(() => {
+    setDatasourcePluginMetas({});
+  });
+
+  it('should render Permissions and Insights tabs', async () => {
     const path = ROUTES.DataSourcesEdit.replace(':uid', mockDatasources[0].uid);
     renderPage(path);
 
-    const permissionsTab = screen.getByTestId('data-testid Tab Permissions');
+    const permissionsTab = await screen.findByTestId('data-testid Tab Permissions');
     expect(permissionsTab).toBeInTheDocument();
     expect(permissionsTab).toHaveTextContent('Permissions');
     expect(permissionsTab).toHaveAttribute('href', '/connections/datasources/edit/x/permissions');

--- a/public/app/features/datasources/components/DataSourceTabPage.tsx
+++ b/public/app/features/datasources/components/DataSourceTabPage.tsx
@@ -22,6 +22,7 @@ function DataSourceTabPage({ uid, pageId }: Props) {
   const info = useDataSourceInfo({
     dataSourcePluginName: pageNav.dataSourcePluginName,
     alertingSupported: dataSourceHeader.alertingSupported,
+    alertingLoading: dataSourceHeader.alertingLoading,
     failure: datasourceFailureByUID.get(uid),
   });
 

--- a/public/app/features/datasources/components/useDataSourceInfo.test.tsx
+++ b/public/app/features/datasources/components/useDataSourceInfo.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react';
+import { render, screen } from 'test/test-utils';
+
+import { useDataSourceInfo } from './useDataSourceInfo';
+
+describe('useDataSourceInfo', () => {
+  it('should return no info items when the plugin name is not available yet', () => {
+    const { result } = renderHook(() =>
+      useDataSourceInfo({
+        dataSourcePluginName: '',
+        alertingSupported: true,
+      })
+    );
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('should omit the alerting badge while alerting support is still loading', () => {
+    const { result } = renderHook(() =>
+      useDataSourceInfo({
+        dataSourcePluginName: 'Prometheus',
+        alertingSupported: false,
+        alertingLoading: true,
+      })
+    );
+
+    expect(result.current.map((item) => item.label)).not.toContain('Alerting');
+  });
+
+  it('should show a "Supported" badge when alerting is supported', () => {
+    const { result } = renderHook(() =>
+      useDataSourceInfo({
+        dataSourcePluginName: 'Prometheus',
+        alertingSupported: true,
+      })
+    );
+
+    const alertingItem = result.current.find((item) => item.label === 'Alerting');
+    render(<>{alertingItem?.value}</>);
+
+    expect(screen.getByText('Supported')).toBeInTheDocument();
+  });
+
+  it('should show a "Not supported" badge when alerting is not supported', () => {
+    const { result } = renderHook(() =>
+      useDataSourceInfo({
+        dataSourcePluginName: 'TestData',
+        alertingSupported: false,
+      })
+    );
+
+    const alertingItem = result.current.find((item) => item.label === 'Alerting');
+    render(<>{alertingItem?.value}</>);
+
+    expect(screen.getByText('Not supported')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/datasources/components/useDataSourceInfo.tsx
+++ b/public/app/features/datasources/components/useDataSourceInfo.tsx
@@ -9,6 +9,8 @@ import { DataSourceFailureBadge } from './DataSourceFailureBadge';
 type DataSourceInfo = {
   dataSourcePluginName: string;
   alertingSupported: boolean;
+  // while true, alertingSupported is not known yet and the badge is not rendered
+  alertingLoading?: boolean;
   failure?: DatasourceFailureDetails;
 };
 
@@ -26,19 +28,21 @@ export const useDataSourceInfo = (dataSourceInfo: DataSourceInfo): PageInfoItem[
     value: dataSourceInfo.dataSourcePluginName,
   });
 
-  info.push({
-    label: t('datasources.use-data-source-info.label.alerting', 'Alerting'),
-    value: (
-      <Badge
-        color={alertingEnabled ? 'green' : 'red'}
-        text={
-          alertingEnabled
-            ? t('datasources.use-data-source-info.badge-text-supported', 'Supported')
-            : t('datasources.use-data-source-info.badge-text-not-supported', 'Not supported')
-        }
-      ></Badge>
-    ),
-  });
+  if (!dataSourceInfo.alertingLoading) {
+    info.push({
+      label: t('datasources.use-data-source-info.label.alerting', 'Alerting'),
+      value: (
+        <Badge
+          color={alertingEnabled ? 'green' : 'red'}
+          text={
+            alertingEnabled
+              ? t('datasources.use-data-source-info.badge-text-supported', 'Supported')
+              : t('datasources.use-data-source-info.badge-text-not-supported', 'Not supported')
+          }
+        ></Badge>
+      ),
+    });
+  }
 
   if (isAdvisorEnabled()) {
     info.push({


### PR DESCRIPTION
## Summary

Migrates `useDataSourceSettingsNav` and `useDataSourceTabNav` off the deprecated synchronous `getDataSourceSrv().getInstanceSettings()` API to the new `useDatasourcePluginMeta` hook from `@grafana/runtime/internal`.

Part of #127035.

## Changes

Both hooks used `getDataSourceSrv()?.getInstanceSettings(uid)` solely to compute the alerting-support flag in the datasource page header, reading only `dsi.meta.alerting` and `dsi.type`. Since both fields are plugin metadata, the meta API is the right replacement per the migration guide's "use meta APIs where only plugin metadata is needed" guidance.

- `public/app/features/connections/hooks/useDataSourceSettingsNav.ts`
- `public/app/features/connections/hooks/useDataSourceTabNav.ts`

The `dsi.type === 'alertmanager'` check is now `dataSourcePluginMeta?.id === 'alertmanager'` (`meta.id` is the plugin identifier string; `meta.type` is the `PluginType` enum `'datasource'`).
