### PR TITLE
Provisioning: add library panels to the admin only registry

### DIFF
--- a/pkg/tests/apis/provisioning/resourcekinds/testdata/kinds/librarypanel.json
+++ b/pkg/tests/apis/provisioning/resourcekinds/testdata/kinds/librarypanel.json
@@ -1,0 +1,18 @@
+{
+  "folderScoped": true,
+  "featureFlags": ["grafanaAPIServerWithExperimentalAPIs"],
+  "manifest": {
+    "apiVersion": "dashboard.grafana.app/v0alpha1",
+    "kind": "LibraryPanel",
+    "metadata": {
+      "name": "placeholder"
+    },
+    "spec": {
+      "title": "placeholder",
+      "type": "text",
+      "description": "provisioned library panel",
+      "options": {},
+      "fieldConfig": {}
+    }
+  }
+}

--- a/public/app/features/provisioning/types.ts
+++ b/public/app/features/provisioning/types.ts
@@ -92,11 +92,11 @@ export interface StatusInfo {
 }
 
 // Tree view types for combined Resources/Files view.
-// `Dashboard`/`Playlist` map to a provisioning resource kind (see resourceKinds.ts).
+// `Dashboard`/`Playlist`/`LibraryPanel` map to a provisioning resource kind (see resourceKinds.ts).
 // `Folder` usually does too, but getItemType also infers it from plain directory
 // paths that have no backing resource. `File` is the fallback for plain files
 // that don't map to a known kind.
-export type ItemType = 'Folder' | 'Dashboard' | 'Playlist' | 'File';
+export type ItemType = 'Folder' | 'Dashboard' | 'Playlist' | 'LibraryPanel' | 'File';
 export type SyncStatus = 'synced' | 'pending';
 
 export interface TreeItem {

--- a/public/app/features/provisioning/utils/resourceKinds.test.ts
+++ b/public/app/features/provisioning/utils/resourceKinds.test.ts
@@ -33,6 +33,12 @@ describe('resourceKinds registry', () => {
       resource: 'playlists',
       itemType: 'Playlist',
     });
+    expect(resourceKindInfos.librarypanel).toMatchObject({
+      group: 'dashboard.grafana.app',
+      kind: 'LibraryPanel',
+      resource: 'librarypanels',
+      itemType: 'LibraryPanel',
+    });
   });
 
   it('sources icons from the search package', () => {
@@ -46,6 +52,7 @@ describe('getKindInfoByResource', () => {
     expect(getKindInfoByResource('dashboards')).toBe(resourceKindInfos.dashboard);
     expect(getKindInfoByResource('folders')).toBe(resourceKindInfos.folder);
     expect(getKindInfoByResource('playlists')).toBe(resourceKindInfos.playlist);
+    expect(getKindInfoByResource('librarypanels')).toBe(resourceKindInfos.librarypanel);
   });
 
   it('returns undefined for unknown or missing resources', () => {
@@ -86,6 +93,12 @@ describe('getKindInfoByGroupKind', () => {
     expect(getKindInfoByGroupKind('folder.grafana.app', 'Folder')).toBe(resourceKindInfos.folder);
   });
 
+  it('disambiguates kinds that share an API group by the kind', () => {
+    // Dashboards and library panels both live in dashboard.grafana.app.
+    expect(getKindInfoByGroupKind('dashboard.grafana.app', 'LibraryPanel')).toBe(resourceKindInfos.librarypanel);
+    expect(getKindInfoByGroupKind('dashboard.grafana.app', 'Dashboard')).toBe(resourceKindInfos.dashboard);
+  });
+
   it('resolves on whichever identifier is present', () => {
     expect(getKindInfoByGroupKind(undefined, 'Playlist')).toBe(resourceKindInfos.playlist);
     expect(getKindInfoByGroupKind('playlist.grafana.app', undefined)).toBe(resourceKindInfos.playlist);
@@ -111,6 +124,10 @@ describe('getKindInfoByStat', () => {
     // The resource uniquely identifies the kind, so it wins over a group that
     // would otherwise resolve to a different kind.
     expect(getKindInfoByStat({ group: 'dashboard.grafana.app', resource: 'folders' })).toBe(resourceKindInfos.folder);
+    // Dashboards and library panels share dashboard.grafana.app; the resource tells them apart.
+    expect(getKindInfoByStat({ group: 'dashboard.grafana.app', resource: 'librarypanels' })).toBe(
+      resourceKindInfos.librarypanel
+    );
   });
 
   it('falls back to a group-only match when the resource is missing or unknown', () => {
@@ -153,6 +170,13 @@ describe('getRepositoryRoute', () => {
     expect(getRepositoryRoute(resourceKindInfos.playlist, makeRepo('instance'))).toBe('/playlists');
   });
 
+  it('routes library panels to their own collection page regardless of target', () => {
+    // Library panels live in folders but aren't browsable in the dashboards folder
+    // view, so they always resolve to /library-panels.
+    expect(getRepositoryRoute(resourceKindInfos.librarypanel, makeRepo('folder'))).toBe('/library-panels');
+    expect(getRepositoryRoute(resourceKindInfos.librarypanel, makeRepo('instance'))).toBe('/library-panels');
+  });
+
   it('falls back to the collection page when the repository name or spec is missing', () => {
     // No spec → not a folder target → collection page.
     expect(getRepositoryRoute(resourceKindInfos.dashboard, {})).toBe('/dashboards');
@@ -171,6 +195,7 @@ describe('getAvailableResourceKinds', () => {
       resourceKindInfos.folder,
       resourceKindInfos.dashboard,
       resourceKindInfos.playlist,
+      resourceKindInfos.librarypanel,
     ]);
   });
 

--- a/public/app/features/provisioning/utils/resourceKinds.ts
+++ b/public/app/features/provisioning/utils/resourceKinds.ts
@@ -81,6 +81,23 @@ export const resourceKindInfos = {
     listRoute: '/playlists',
     folderScoped: false,
   },
+  librarypanel: {
+    // Library panels share the dashboards API group but are keyed by their own
+    // GroupResource (librarypanels.dashboard.grafana.app).
+    group: DASHBOARD_API_GROUP,
+    kind: 'LibraryPanel',
+    resource: 'librarypanels',
+    itemType: 'LibraryPanel',
+    // getIconForKind doesn't know library panels, so use the library-panel icon directly.
+    icon: 'library-panel',
+    // No deep-link route for a single library panel exists; they're only viewable
+    // from the library panels collection page.
+    listRoute: '/library-panels',
+    // Library panels live inside folders on the backend, but the dashboards folder
+    // browse doesn't list them — they have their own collection page — so for
+    // routing they behave like a non-foldered kind and always resolve to listRoute.
+    folderScoped: false,
+  },
 } satisfies Record<string, ResourceKindInfo>;
 
 const allKindInfos: ResourceKindInfo[] = Object.values(resourceKindInfos);


### PR DESCRIPTION

<img width="1084" height="794" alt="Screenshot 2026-06-25 at 12 24 23" src="https://github.com/user-attachments/assets/2065c818-71b5-4537-8ae5-b505bb697bec" />
<img width="1905" height="765" alt="Screenshot 2026-06-25 at 12 12 35" src="https://github.com/user-attachments/assets/cb65630f-ecbc-4c0c-8050-a91a2aae6ec5" />
<img width="1897" height="969" alt="Screenshot 2026-06-25 at 12 12 29" src="https://github.com/user-attachments/assets/8dcfe1b6-6acd-4e88-ae63-2d93594b602c" />
<img width="1782" height="460" alt="Screenshot 2026-06-25 at 12 12 19" src="https://github.com/user-attachments/assets/81c042e3-77c5-432e-8362-5020d678fb65" />
<img width="492" height="371" alt="Screenshot 2026-06-25 at 12 12 02" src="https://github.com/user-attachments/assets/0879cdfb-9ff7-4861-8eed-e37c142d075e" />





## Summary

Adds library panels as a recognized resource kind in the provisioning admin UI, and the matching integration-harness descriptor. This is **frontend-only** (plus a backend test fixture) — it deliberately does **not** include the legacy `/api/library-elements` → apiserver routing, so we can confirm this slice passes CI on its own.

## Changes

- **`resourceKinds.ts`** — new `librarypanel` entry in the central registry (`dashboard.grafana.app/LibraryPanel`, `librarypanels`, `library-panel` icon, routes to `/library-panels` via `folderScoped: false`). Every generic consumer (tree view, stats, icons, routing, bulk actions) picks it up from this one entry.
- **`types.ts`** — `'LibraryPanel'` added to the `ItemType` union.
- **`resourceKinds.test.ts`** — coverage for the new kind (registry identifiers, group+kind/resource lookups, routing).
- **`testdata/kinds/librarypanel.json`** — descriptor for the generic resourcekinds integration harness.

## Why no API routing

The harness provisions each kind through the **apiserver in Mode5** via the files endpoint — it never touches the legacy `/api/library-elements` handlers, and the `EnableFolderSupport` backend support it relies on is already in main (#127235). So this registry + descriptor slice stands alone. The legacy-endpoint routing lives in a separate stacked PR.

## Behavior

Purely additive — the kind is gated on `availableResources`, so it only surfaces where the backend reports library panels as a non-disabled provisioning resource (requires `kubernetesLibraryPanels` + Mode5). No library panel pages/components touched.

## Testing

- `yarn jest resourceKinds.test.ts` — 27 passed
- `yarn typecheck` — clean
- `yarn eslint` on changed files — clean

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (n/a)
- [x] No breaking changes

🤖 Generated with Claude Code