### PR TITLE
VizPanel: Set _UNSAFE_clearPreviousFieldValues to true always

### DIFF
--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -96,6 +96,7 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
     }),
     $behaviors: [],
     extendPanelContext: setDashboardPanelContext,
+    _UNSAFE_clearPreviousFieldValues: true,
   };
 
   // Set up Angular migration handler if migration data is present
@@ -118,8 +119,6 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
       compareWith: queryOptions.timeCompare,
     });
   }
-
-  vizPanelState._UNSAFE_clearPreviousFieldValues = Boolean(config.featureToggles.clearPreviousFieldValues);
 
   return new VizPanel(vizPanelState);
 }
@@ -163,6 +162,7 @@ export function buildLibraryPanel(panel: LibraryPanelKind, id?: number): VizPane
       defaults: {},
       overrides: [],
     },
+    _UNSAFE_clearPreviousFieldValues: true,
   };
 
   if (!config.publicDashboardAccessToken) {
@@ -170,8 +170,6 @@ export function buildLibraryPanel(panel: LibraryPanelKind, id?: number): VizPane
       $behaviors: [panelMenuBehavior],
     });
   }
-
-  vizPanelState._UNSAFE_clearPreviousFieldValues = Boolean(config.featureToggles.clearPreviousFieldValues);
 
   return new VizPanel(vizPanelState);
 }

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -494,6 +494,7 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
     $behaviors: [],
     extendPanelContext: setDashboardPanelContext,
     _UNSAFE_customMigrationHandler: getAngularPanelMigrationHandler(panel),
+    _UNSAFE_clearPreviousFieldValues: true,
   };
 
   if (panel.libraryPanel) {
@@ -533,8 +534,6 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
       ),
     });
   }
-
-  vizPanelState._UNSAFE_clearPreviousFieldValues = Boolean(config.featureToggles.clearPreviousFieldValues);
 
   const body = new VizPanel(vizPanelState);
 


### PR DESCRIPTION
This is the first step to deleting the feature toggle, which has been default enabled for about a month and will have been default enabled for 13.1. If we don't hear anything which makes us reverse course here, then we could consider removing `_UNSAFE_clearPreviousFieldValues` from scenes in a future version even, but this just allows us to kill off the flag.