### PR TITLE
Browse Dashboards: Fix counts in tabs and for delete/move dialogs

### DIFF
--- a/public/app/api/clients/folder/v1beta1/index.ts
+++ b/public/app/api/clients/folder/v1beta1/index.ts
@@ -93,7 +93,7 @@ export const folderAPIv1beta1 = generatedAPI
           const initialCounts: DescendantCount = {
             folders: folderUIDs.length,
             dashboards: dashboardUIDs.length,
-            library_elements: 0,
+            librarypanels: 0,
             alertrules: 0,
           };
 
@@ -113,7 +113,7 @@ export const folderAPIv1beta1 = generatedAPI
               acc.folders += counts.folders ?? 0;
               acc.dashboards += counts.dashboards ?? 0;
               acc.alertrules += counts.alertrules ?? 0;
-              acc.library_elements += counts.library_elements ?? 0;
+              acc.librarypanels += counts.librarypanels ?? 0;
               return acc;
             }, initialCounts);
 

--- a/public/app/api/clients/folder/v1beta1/utils.test.ts
+++ b/public/app/api/clients/folder/v1beta1/utils.test.ts
@@ -3,7 +3,7 @@ import { type ResourceStats } from '@grafana/api-clients/rtkq/folder/v1beta1';
 import { getParsedCounts } from './utils';
 
 describe('getParsedCounts', () => {
-  it('prefers the non-fallback entry and keeps the fallback only when no other entry exists', () => {
+  it('prefers non-zero non-fallback counts, otherwise uses a non-zero sql-fallback (and normalizes legacy resource names)', () => {
     let counts: ResourceStats[] = [
       { group: 'folder.grafana.app', resource: 'folders', count: 0 },
       { group: 'dashboard.grafana.app', resource: 'dashboards', count: 0 },

--- a/public/app/api/clients/folder/v1beta1/utils.test.ts
+++ b/public/app/api/clients/folder/v1beta1/utils.test.ts
@@ -1,0 +1,41 @@
+import { type ResourceStats } from '@grafana/api-clients/rtkq/folder/v1beta1';
+
+import { getParsedCounts } from './utils';
+
+describe('getParsedCounts', () => {
+  it('prefers the non-fallback entry and keeps the fallback only when no other entry exists', () => {
+    let counts: ResourceStats[] = [
+      { group: 'folder.grafana.app', resource: 'folders', count: 0 },
+      { group: 'dashboard.grafana.app', resource: 'dashboards', count: 0 },
+      { group: 'dashboard.grafana.app', resource: 'librarypanels', count: 0 },
+      { group: 'rules.alerting.grafana.app', resource: 'alertrules', count: 0 },
+      { group: 'sql-fallback', resource: 'alertrules', count: 1 },
+      { group: 'sql-fallback', resource: 'library_elements', count: 1 },
+    ];
+
+    expect(getParsedCounts(counts)).toEqual({
+      folders: 0,
+      dashboards: 0,
+      // also normalizes the library_elements to librarypanels
+      librarypanels: 1,
+      alertrules: 1,
+    });
+
+    counts = [
+      { group: 'folder.grafana.app', resource: 'folders', count: 2 },
+      { group: 'dashboard.grafana.app', resource: 'dashboards', count: 0 },
+      { group: 'dashboard.grafana.app', resource: 'librarypanels', count: 2 },
+      { group: 'rules.alerting.grafana.app', resource: 'alertrules', count: 2 },
+      { group: 'sql-fallback', resource: 'alertrules', count: 1 },
+      // we ignore this altogether in this case
+      { group: 'sql-fallback', resource: 'library_elements', count: 4 },
+    ];
+
+    expect(getParsedCounts(counts)).toEqual({
+      folders: 2,
+      dashboards: 0,
+      librarypanels: 2,
+      alertrules: 2,
+    });
+  });
+});

--- a/public/app/api/clients/folder/v1beta1/utils.test.ts
+++ b/public/app/api/clients/folder/v1beta1/utils.test.ts
@@ -37,5 +37,14 @@ describe('getParsedCounts', () => {
       librarypanels: 2,
       alertrules: 2,
     });
+
+    expect(
+      getParsedCounts([
+        { group: 'sql-fallback', resource: 'library_elements', count: 3 }, // FB first
+        { group: 'dashboard.grafana.app', resource: 'librarypanels', count: 0 }, // NF second
+      ])
+    ).toEqual({
+      librarypanels: 3,
+    });
   });
 });

--- a/public/app/api/clients/folder/v1beta1/utils.ts
+++ b/public/app/api/clients/folder/v1beta1/utils.ts
@@ -62,8 +62,11 @@ export const getParsedCounts = (counts: ResourceStats[]): Record<string, number>
     const name = normalizeResourceName(resource);
 
     if (result[name] === undefined) {
+      // By default, we just take the first value we see for given resource
       result[name] = count;
     } else if ((group !== 'sql-fallback' && count !== 0) || result[name] === 0) {
+      // non-sql-fallback values that are not 0 will override the sql-fallback values.
+      // Existing 0 values will get overridden by anything. 0 value is treated as a missing value.
       result[name] = count;
     }
   }

--- a/public/app/api/clients/folder/v1beta1/utils.ts
+++ b/public/app/api/clients/folder/v1beta1/utils.ts
@@ -36,27 +36,44 @@ export async function isProvisionedFolderCheck(
   }
 }
 
+// Maps legacy resource names emitted by the `sql-fallback` group onto the unified-storage
+// resource names so both code paths collapse into a single entry. The `sql-fallback` path
+// counts the legacy `library_element` table and reports it as `library_elements`, while
+// unified storage reports the same resource as `librarypanels`.
+const RESOURCE_NAME_ALIASES: Record<string, string> = {
+  library_elements: 'librarypanels',
+};
+
+const normalizeResourceName = (resource: string): string => RESOURCE_NAME_ALIASES[resource] ?? resource;
+
 /**
  * Normalizes a descendant counts response into a `{ resource: count }` map.
  *
  * The API may return two entries for the same resource — one from the resource's own group
- * (e.g. `dashboard.grafana.app`) and one from the `sql-fallback` group. The non-fallback
- * entry wins; the fallback is only kept when no other entry exists for that resource.
+ * (e.g. `dashboard.grafana.app`) and one from the `sql-fallback` group, sometimes under a
+ * different legacy resource name (see `RESOURCE_NAME_ALIASES`). The non-fallback entry is
+ * preferred, but a count of 0 is treated as "no data" and never beats a non-zero count,
+ * even one coming from the fallback group.
  */
 export const getParsedCounts = (counts: ResourceStats[]): Record<string, number> => {
   const result: Record<string, number> = {};
-  const isFromFallback: Record<string, boolean> = {};
+  const priorities: Record<string, number> = {};
+
+  // Higher priority wins. A non-zero count outranks a zero one, and within the same
+  // zero/non-zero tier a non-fallback entry outranks an sql-fallback entry.
+  const priorityOf = (count: number, fromFallback: boolean): number => {
+    if (count !== 0) {
+      return fromFallback ? 2 : 3;
+    }
+    return fromFallback ? 0 : 1;
+  };
 
   for (const { resource, count, group } of counts) {
-    const fromFallback = group === 'sql-fallback';
-    if (
-      // first time we see this resource count
-      !(resource in result) ||
-      // or we have count already, but that count is sql-fallback and now we have non fallback value
-      (isFromFallback[resource] && !fromFallback)
-    ) {
-      result[resource] = count;
-      isFromFallback[resource] = fromFallback;
+    const name = normalizeResourceName(resource);
+    const priority = priorityOf(count, group === 'sql-fallback');
+    if (!(name in result) || priority > priorities[name]) {
+      result[name] = count;
+      priorities[name] = priority;
     }
   }
 

--- a/public/app/api/clients/folder/v1beta1/utils.ts
+++ b/public/app/api/clients/folder/v1beta1/utils.ts
@@ -57,23 +57,14 @@ const normalizeResourceName = (resource: string): string => RESOURCE_NAME_ALIASE
  */
 export const getParsedCounts = (counts: ResourceStats[]): Record<string, number> => {
   const result: Record<string, number> = {};
-  const priorities: Record<string, number> = {};
-
-  // Higher priority wins. A non-zero count outranks a zero one, and within the same
-  // zero/non-zero tier a non-fallback entry outranks an sql-fallback entry.
-  const priorityOf = (count: number, fromFallback: boolean): number => {
-    if (count !== 0) {
-      return fromFallback ? 2 : 3;
-    }
-    return fromFallback ? 0 : 1;
-  };
 
   for (const { resource, count, group } of counts) {
     const name = normalizeResourceName(resource);
-    const priority = priorityOf(count, group === 'sql-fallback');
-    if (!(name in result) || priority > priorities[name]) {
+
+    if (result[name] === undefined) {
       result[name] = count;
-      priorities[name] = priority;
+    } else if ((group !== 'sql-fallback' && count !== 0) || result[name] === 0) {
+      result[name] = count;
     }
   }
 

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -223,7 +223,7 @@ describe('browseDashboardsAPI', () => {
       expect(result.data).toEqual({
         folders: 5,
         dashboards: 6,
-        library_elements: 7,
+        librarypanels: 7,
         alertrules: 9,
       });
     });
@@ -252,7 +252,7 @@ describe('browseDashboardsAPI', () => {
       expect(result.data).toEqual({
         folders: 3,
         dashboards: 3,
-        library_elements: 4,
+        librarypanels: 4,
         alertrules: 5,
       });
     });
@@ -272,7 +272,7 @@ describe('browseDashboardsAPI', () => {
       expect(result.data).toEqual({
         folders: 1,
         dashboards: 5,
-        library_elements: 0,
+        librarypanels: 0,
         alertrules: 0,
       });
       expect(result.data && Object.values(result.data).every(Number.isFinite)).toBe(true);

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -77,10 +77,10 @@ interface RestoreDashboardArgs {
 // We need to do this as the API will return different responses depending on the type of storage used and existing
 // resource types, even when we are using the old api/ endpoint.
 const normalizeDescendantCounts = (folderCounts: DescendantCountDTO): DescendantCount => ({
-  folders: folderCounts.folders ?? folderCounts.folder ?? 0,
-  dashboards: folderCounts.dashboards ?? folderCounts.dashboard ?? 0,
-  librarypanels: folderCounts.library_elements ?? folderCounts.librarypanel ?? 0,
-  alertrules: folderCounts.alertrules ?? folderCounts.alertrule ?? 0,
+  folders: folderCounts.folders || folderCounts.folder || 0,
+  dashboards: folderCounts.dashboards || folderCounts.dashboard || 0,
+  librarypanels: folderCounts.librarypanels || folderCounts.library_elements || folderCounts.librarypanel || 0,
+  alertrules: folderCounts.alertrules || folderCounts.alertrule || 0,
 });
 
 export interface ListFolderQueryArgs {

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -79,7 +79,7 @@ interface RestoreDashboardArgs {
 const normalizeDescendantCounts = (folderCounts: DescendantCountDTO): DescendantCount => ({
   folders: folderCounts.folders ?? folderCounts.folder ?? 0,
   dashboards: folderCounts.dashboards ?? folderCounts.dashboard ?? 0,
-  library_elements: folderCounts.library_elements ?? folderCounts.librarypanel ?? 0,
+  librarypanels: folderCounts.library_elements ?? folderCounts.librarypanel ?? 0,
   alertrules: folderCounts.alertrules ?? folderCounts.alertrule ?? 0,
 });
 
@@ -239,7 +239,7 @@ export const browseDashboardsAPI = createApi({
           const totalCounts: DescendantCount = {
             folders: folderUIDs.length,
             dashboards: dashboardUIDs.length,
-            library_elements: 0,
+            librarypanels: 0,
             alertrules: 0,
           };
 
@@ -248,7 +248,7 @@ export const browseDashboardsAPI = createApi({
             totalCounts.folders += normalizedCounts.folders;
             totalCounts.dashboards += normalizedCounts.dashboards;
             totalCounts.alertrules += normalizedCounts.alertrules;
-            totalCounts.library_elements += normalizedCounts.library_elements;
+            totalCounts.librarypanels += normalizedCounts.librarypanels;
           }
 
           return { data: totalCounts };

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.test.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.test.ts
@@ -16,27 +16,27 @@ describe('browse-dashboards utils', () => {
     const selection = { folder: { 'folder-a': true }, dashboard: {} };
 
     it('returns true when the only affected item is the selected folder itself', () => {
-      const affected = { folders: 1, dashboards: 0, library_elements: 0, alertrules: 0 };
+      const affected = { folders: 1, dashboards: 0, librarypanels: 0, alertrules: 0 };
       expect(getFolderIsEmpty(affected, selection)).toBe(true);
     });
 
     it('returns false when the selected folder contains a child folder', () => {
-      const affected = { folders: 2, dashboards: 0, library_elements: 0, alertrules: 0 };
+      const affected = { folders: 2, dashboards: 0, librarypanels: 0, alertrules: 0 };
       expect(getFolderIsEmpty(affected, selection)).toBe(false);
     });
 
     it('returns false when the selected folder contains a library panel', () => {
-      const affected = { folders: 1, dashboards: 0, library_elements: 1, alertrules: 0 };
+      const affected = { folders: 1, dashboards: 0, librarypanels: 1, alertrules: 0 };
       expect(getFolderIsEmpty(affected, selection)).toBe(false);
     });
 
     it('returns false when the selected folder contains an alert rule', () => {
-      const affected = { folders: 1, dashboards: 0, library_elements: 0, alertrules: 1 };
+      const affected = { folders: 1, dashboards: 0, librarypanels: 0, alertrules: 1 };
       expect(getFolderIsEmpty(affected, selection)).toBe(false);
     });
 
     it('subtracts selected dashboards so they are not counted as descendants', () => {
-      const affected = { folders: 1, dashboards: 1, library_elements: 0, alertrules: 0 };
+      const affected = { folders: 1, dashboards: 1, librarypanels: 0, alertrules: 0 };
       const selectionWithDashboard = {
         folder: { 'folder-a': true },
         dashboard: { 'dashboard-a': true },
@@ -45,7 +45,7 @@ describe('browse-dashboards utils', () => {
     });
 
     it('ignores falsy entries when counting selected items', () => {
-      const affected = { folders: 1, dashboards: 0, library_elements: 0, alertrules: 0 };
+      const affected = { folders: 1, dashboards: 0, librarypanels: 0, alertrules: 0 };
       const selectionWithDeselected = {
         folder: { 'folder-a': true, 'folder-b': false },
         dashboard: {},
@@ -54,7 +54,7 @@ describe('browse-dashboards utils', () => {
     });
 
     it('returns true when the affected counts are lower than the selection counts', () => {
-      const affected = { folders: 0, dashboards: 0, library_elements: 0, alertrules: 0 };
+      const affected = { folders: 0, dashboards: 0, librarypanels: 0, alertrules: 0 };
       expect(getFolderIsEmpty(affected, selection)).toBe(true);
     });
   });

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
@@ -25,7 +25,7 @@ export function getFolderIsEmpty(
     affectedItems.folders -
     selectedFolderCount +
     (affectedItems.dashboards - selectedDashboardCount) +
-    affectedItems.library_elements +
+    affectedItems.librarypanels +
     affectedItems.alertrules;
 
   return remaining <= 0;

--- a/public/app/features/browse-dashboards/hooks/useNavModel.ts
+++ b/public/app/features/browse-dashboards/hooks/useNavModel.ts
@@ -2,6 +2,7 @@ import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
 import { useGetFolderCountsQuery } from 'app/api/clients/folder/v1beta1';
+import { getParsedCounts } from 'app/api/clients/folder/v1beta1/utils';
 import {
   buildNavModel,
   getAlertingTabID,
@@ -25,8 +26,9 @@ export function useNavModel(folderDTO: FolderDTO | undefined, activeTab: 'dashbo
   // The counts are not critical to have so we are not dealing with the possible api error state here, we just won't
   // show the numbers in that case.
   if (folderCountsResult.isSuccess) {
-    panelsCount = folderCountsResult.data.counts.find((c) => c.resource === 'library_elements')?.count ?? 0;
-    rulesCount = folderCountsResult.data.counts.find((c) => c.resource === 'alertrules')?.count ?? 0;
+    const counts = getParsedCounts(folderCountsResult.data.counts);
+    panelsCount = counts.librarypanels ?? 0;
+    rulesCount = counts.alertrules ?? 0;
   }
 
   return useMemo(() => {

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -45,12 +45,17 @@ export type NewFolder = Pick<FolderDTO, 'title' | 'parentUid'>;
 export interface DescendantCountDTO {
   folders?: number;
   dashboards?: number;
-  library_elements?: number;
   alertrules?: number;
+  // There is this weird thing where legacy/sql-fallback values have different resource name for the panels. As the old
+  // API uses the same backend as new and just reshapes it, this will leak here.
+  library_elements?: number;
+  librarypanels?: number;
+
+  // Legacy keys that should not be actually returned anymore when unified storage is enabled but we keep it for now.
   folder?: number;
   dashboard?: number;
-  librarypanel?: number;
   alertrule?: number;
+  librarypanel?: number;
 }
 
 type DescendantResource = 'folders' | 'dashboards' | 'librarypanels' | 'alertrules';

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -53,6 +53,6 @@ export interface DescendantCountDTO {
   alertrule?: number;
 }
 
-type DescendantResource = 'folders' | 'dashboards' | 'library_elements' | 'alertrules';
+type DescendantResource = 'folders' | 'dashboards' | 'librarypanels' | 'alertrules';
 /** Summary of descendant counts by resource type, with keys matching the App Platform API response */
 export interface DescendantCount extends Record<DescendantResource, number> {}


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/127195

In case of response like
```
{
  "kind": "DescendantCounts",
  "apiVersion": "folder.grafana.app/v1",
  "counts": [
    {
      "group": "folder.grafana.app",
      "resource": "folders",
      "count": 0
    },
    {
      "group": "dashboard.grafana.app",
      "resource": "dashboards",
      "count": 0
    },
    {
      "group": "dashboard.grafana.app",
      "resource": "librarypanels",
      "count": 0
    },
    {
      "group": "rules.alerting.grafana.app",
      "resource": "alertrules",
      "count": 0
    },
    {
      "group": "sql-fallback",
      "resource": "alertrules",
      "count": 1
    },
    {
      "group": "sql-fallback",
      "resource": "library_elements",
      "count": 1
    }
  ]
}
```
from the API the front end code would in error take the 0 value from the unified storage instead of the non 0 fallback value. Also there was an issue with different names for `library_elements` and `librarypanels` which should be normalized.