### PR TITLE
Enable agent_review for DataPro in team notifications config

### DIFF
--- a/.github/team-notifications-config.json
+++ b/.github/team-notifications-config.json
@@ -90,7 +90,8 @@
         "pr_notify": true,
         "pr_weekly": true,
         "fr_notify": true,
-        "fr_weekly": true
+        "fr_weekly": true,
+        "agent_review": true
       }
     },
     {


### PR DESCRIPTION
Opts the DataPro squad into Oz agent PR reviews on external contributions by setting `agent_review: true` in its `enabled` block.

Pairs with the `team-datapro` review skill overlay in `grafana/community-triage` (separate PR) — the base feature/bugfix/docs review skills run regardless; the overlay adds DataPro-specific checks once the wiring workflow's pinned ref includes it.

## Test plan
- `jq empty .github/team-notifications-config.json` passes.
- Diff is scoped to DataPro's `enabled` block (2 lines).