### PR TITLE
UI: Bump sidebar default + minimum width to 460px

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
@@ -7,7 +7,7 @@ import { useTheme2 } from '@grafana/ui';
 
 import { getComponentMetaFromComponentId, useExtensionSidebarContext } from './ExtensionSidebarProvider';
 
-export const DEFAULT_EXTENSION_SIDEBAR_WIDTH = 300;
+export const DEFAULT_EXTENSION_SIDEBAR_WIDTH = Math.max(300, Math.floor(window.innerWidth / 3));
 export const MIN_EXTENSION_SIDEBAR_WIDTH = 100;
 export const MAX_EXTENSION_SIDEBAR_WIDTH = Math.floor(window.innerWidth * (2 / 3));
 

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
@@ -7,9 +7,9 @@ import { useTheme2 } from '@grafana/ui';
 
 import { getComponentMetaFromComponentId, useExtensionSidebarContext } from './ExtensionSidebarProvider';
 
-export const MIN_EXTENSION_SIDEBAR_WIDTH = 300;
+export const MIN_EXTENSION_SIDEBAR_WIDTH = 460;
 export const MAX_EXTENSION_SIDEBAR_WIDTH = Math.floor(window.innerWidth * (2 / 3));
-export const DEFAULT_EXTENSION_SIDEBAR_WIDTH = Math.max(MIN_EXTENSION_SIDEBAR_WIDTH, Math.floor(window.innerWidth / 3));
+export const DEFAULT_EXTENSION_SIDEBAR_WIDTH = MIN_EXTENSION_SIDEBAR_WIDTH;
 
 type ExtensionSidebarComponentProps = {
   props?: Record<string, unknown>;

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
@@ -7,9 +7,9 @@ import { useTheme2 } from '@grafana/ui';
 
 import { getComponentMetaFromComponentId, useExtensionSidebarContext } from './ExtensionSidebarProvider';
 
-export const DEFAULT_EXTENSION_SIDEBAR_WIDTH = Math.max(300, Math.floor(window.innerWidth / 3));
-export const MIN_EXTENSION_SIDEBAR_WIDTH = 100;
+export const MIN_EXTENSION_SIDEBAR_WIDTH = 300;
 export const MAX_EXTENSION_SIDEBAR_WIDTH = Math.floor(window.innerWidth * (2 / 3));
+export const DEFAULT_EXTENSION_SIDEBAR_WIDTH = Math.max(MIN_EXTENSION_SIDEBAR_WIDTH, Math.floor(window.innerWidth / 3));
 
 type ExtensionSidebarComponentProps = {
   props?: Record<string, unknown>;

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -7,7 +7,11 @@ import { type ExtensionPointPluginMeta } from 'app/features/plugins/extensions/a
 import { getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
 import { CloseExtensionSidebarEvent, OpenExtensionSidebarEvent, ToggleExtensionSidebarEvent } from 'app/types/events';
 
-import { DEFAULT_EXTENSION_SIDEBAR_WIDTH, MAX_EXTENSION_SIDEBAR_WIDTH } from './ExtensionSidebar';
+import {
+  DEFAULT_EXTENSION_SIDEBAR_WIDTH,
+  MAX_EXTENSION_SIDEBAR_WIDTH,
+  MIN_EXTENSION_SIDEBAR_WIDTH,
+} from './ExtensionSidebar';
 
 export const EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarDocked';
 const EXTENSION_SIDEBAR_WIDTH_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarWidth';
@@ -241,7 +245,7 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
         setDockedComponentId: (componentId) => setDockedComponentWithProps(componentId, undefined),
         availableComponents,
         extensionSidebarWidth: Math.min(
-          extensionSidebarWidth ?? DEFAULT_EXTENSION_SIDEBAR_WIDTH,
+          Math.max(extensionSidebarWidth ?? DEFAULT_EXTENSION_SIDEBAR_WIDTH, MIN_EXTENSION_SIDEBAR_WIDTH),
           MAX_EXTENSION_SIDEBAR_WIDTH
         ),
         setExtensionSidebarWidth,


### PR DESCRIPTION
**What is this feature?**

Updates the default width of the sidebar to be 460px. Also, updates the minimum width to the same.

| Before | After |
|-|-|
| Default | |
| <img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/81c2ee80-870b-4df2-a467-cb2595c0b598" /> | <img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/4ddbd247-6125-4554-a9db-bd64c77c7623" /> |
| Minimum | |
| <img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/560b6020-c4fb-410f-b680-a9e10b35fb29" /> | <img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/4ddbd247-6125-4554-a9db-bd64c77c7623" /> |

**Why do we need this feature?**

Provides a larger surface area by default for the sidebar when it is opened -- one can assume that the user cares about the sidebar content if they've just opened it for the first time.

Provides a larger minimum, as anything smaller than this is unreasonably small for the content rendered in it (Assistant + Learning Paths): https://raintank-corp.slack.com/archives/C08GW7KDCJ0/p1782405826881849 (🔐).

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
