### PR TITLE
Chore: Use Stack component from @grafana/ui package

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPolicyDrawer.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPolicyDrawer.tsx
@@ -2,9 +2,8 @@ import { Fragment, useMemo, useState } from 'react';
 
 import { AlertLabel, type RouteMatchResult, type RouteWithID } from '@grafana/alerting';
 import { Trans } from '@grafana/i18n';
-import { Button, Divider, Drawer, Text, TextLink } from '@grafana/ui';
+import { Button, Divider, Drawer, Stack, Text, TextLink } from '@grafana/ui';
 
-import { Stack } from '../../../../../../plugins/datasource/parca/QueryEditor/Stack';
 import { ROOT_ROUTE_NAME } from '../../../utils/k8s/constants';
 import { createRelativeUrl } from '../../../utils/url';
 

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
@@ -1,10 +1,9 @@
 import { groupBy } from 'lodash';
 
 import { t } from '@grafana/i18n';
-import { Alert, Box, LoadingPlaceholder, withErrorBoundary } from '@grafana/ui';
+import { Alert, Box, LoadingPlaceholder, Stack, withErrorBoundary } from '@grafana/ui';
 import { stringifyErrorLike } from 'app/features/alerting/unified/utils/misc';
 
-import { Stack } from '../../../../../../plugins/datasource/parca/QueryEditor/Stack';
 import { type Labels } from '../../../../../../types/unified-alerting-dto';
 import { type AlertManagerDataSource } from '../../../utils/datasource';
 

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewGrafanaManaged.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewGrafanaManaged.tsx
@@ -1,10 +1,9 @@
 import { groupBy } from 'lodash';
 
 import { t } from '@grafana/i18n';
-import { Alert, Box, LoadingPlaceholder, withErrorBoundary } from '@grafana/ui';
+import { Alert, Box, LoadingPlaceholder, Stack, withErrorBoundary } from '@grafana/ui';
 import { stringifyErrorLike } from 'app/features/alerting/unified/utils/misc';
 
-import { Stack } from '../../../../../../plugins/datasource/parca/QueryEditor/Stack';
 import { type Labels } from '../../../../../../types/unified-alerting-dto';
 import { type AlertManagerDataSource } from '../../../utils/datasource';
 

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRoute.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRoute.tsx
@@ -3,9 +3,8 @@ import { css } from '@emotion/css';
 import { AlertLabels, type RouteMatchResult, type RouteWithID } from '@grafana/alerting';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { Text, useStyles2 } from '@grafana/ui';
+import { Stack, Text, useStyles2 } from '@grafana/ui';
 
-import { Stack } from '../../../../../../plugins/datasource/parca/QueryEditor/Stack';
 import { arrayLabelsToObject } from '../../../utils/labels';
 import { Spacer } from '../../Spacer';
 


### PR DESCRIPTION
**What is this feature?**

Initially implemented in here https://github.com/grafana/grafana/pull/68839 
But I think it was a mistake or simply we didn't have a Stakc component back then. Either way Stack component in parca datasource shouldn't be used in alerting. Hence we're going to remove parca datasource from core soon. 

