### PR TITLE
Timeseries: Add timezone to tooltip

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/types.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/types.ts
@@ -1,3 +1,5 @@
+import { type ReactNode } from 'react';
+
 import { type LineStyle } from '@grafana/schema';
 
 /** @alpha */
@@ -39,7 +41,7 @@ export interface VizTooltipItem {
   /** Display label for this row. */
   label: string;
   /** Formatted display value for this row. */
-  value: string;
+  value: string | ReactNode;
   /** CSS color string used for the color indicator. */
   color?: string;
   /** Shape of the color indicator. Defaults to `VizTooltipColorIndicator.series`. */

--- a/public/app/plugins/panel/barchart/BarChartPanel.tsx
+++ b/public/app/plugins/panel/barchart/BarChartPanel.tsx
@@ -210,6 +210,7 @@ export const BarChartPanel = (props: PanelProps<Options>) => {
                     adHocFilters={adHocFilters}
                     hideZeros={options.tooltip.hideZeros}
                     canExecuteActions={userCanExecuteActions}
+                    timeZone={timeZone}
                   />
                 );
               }}

--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -307,6 +307,7 @@ export const CandlestickPanel = ({
                       replaceVariables={replaceVariables}
                       dataLinks={dataLinks}
                       canExecuteActions={userCanExecuteActions}
+                      timeZone={timeZone}
                     />
                   );
                 }}

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -222,6 +222,7 @@ export const TimeSeriesPanel = ({
                       }
                       canExecuteActions={userCanExecuteActions}
                       compareDiffMs={compareDiffMs}
+                      timeZone={timeZone}
                     />
                   );
                 }}

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
@@ -5,11 +5,12 @@ import {
   type Field,
   FieldType,
   formattedValueToString,
+  getTimeZoneInfo,
   type InterpolateFunction,
   type LinkModel,
   usePluginContext,
 } from '@grafana/data';
-import { SortOrder, TooltipDisplayMode } from '@grafana/schema';
+import { SortOrder, type TimeZone, TooltipDisplayMode } from '@grafana/schema';
 import {
   type AdHocFilterModel,
   type FilterByGroupedLabelsModel,
@@ -23,6 +24,8 @@ import {
 } from '@grafana/ui';
 
 import { getFieldActions } from '../status-history/utils';
+
+import { TimeSeriesTooltipHeaderTime } from './TimeSeriesTooltipHeaderTime';
 
 // exemplar / annotation / time region hovering?
 // add annotation UI / alert dismiss UI?
@@ -53,6 +56,7 @@ export interface TimeSeriesTooltipProps {
   filterByGroupedLabels?: FilterByGroupedLabelsModel;
   canExecuteActions?: boolean;
   compareDiffMs?: number[];
+  timeZone?: TimeZone;
 }
 
 export const TimeSeriesTooltip = ({
@@ -72,6 +76,7 @@ export const TimeSeriesTooltip = ({
   canExecuteActions,
   compareDiffMs,
   filterByGroupedLabels,
+  timeZone,
 }: TimeSeriesTooltipProps) => {
   const pluginContext = usePluginContext();
 
@@ -121,9 +126,22 @@ export const TimeSeriesTooltip = ({
     }
   }
 
+  const getHeaderValue = () => {
+    if (xField.type === FieldType.time && timeZone !== undefined) {
+      const timezoneInfo = getTimeZoneInfo(timeZone, xVal);
+      if (timezoneInfo?.abbreviation !== undefined) {
+        return <TimeSeriesTooltipHeaderTime time={xDisp} timeZone={timezoneInfo.abbreviation} />;
+      } else {
+        return xDisp;
+      }
+    } else {
+      return xDisp;
+    }
+  };
+
   const headerItem: VizTooltipItem = {
     label: xField.type === FieldType.time ? '' : (xField.state?.displayName ?? xField.name),
-    value: xDisp,
+    value: getHeaderValue(),
   };
 
   return (

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltipHeaderTime.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltipHeaderTime.tsx
@@ -1,0 +1,26 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+export const TimeSeriesTooltipHeaderTime = ({ time, timeZone }: { time: string; timeZone: string }) => {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.wrapper}>
+      <div>{time}</div>
+      <div className={styles.timeZone}>{timeZone}</div>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    display: 'flex',
+    flexDirection: 'row',
+  }),
+  timeZone: css({
+    paddingLeft: theme.spacing(1),
+    fontWeight: 'bold',
+    color: theme.colors.text.secondary,
+  }),
+});

--- a/public/app/plugins/panel/trend/TrendPanel.tsx
+++ b/public/app/plugins/panel/trend/TrendPanel.tsx
@@ -104,6 +104,7 @@ export const TrendPanel = ({
                       dataLinks={dataLinks}
                       hideZeros={options.tooltip.hideZeros}
                       canExecuteActions={userCanExecuteActions}
+                      timeZone={timeZone}
                     />
                   );
                 }}


### PR DESCRIPTION
**What is this feature?**

This adds the timezone to the header of the timeseries tooltip, where the date is usually displayed. This allows the timezone being used to be communicated more clearly.

<img width="219" height="135" alt="Screenshot 2026-06-25 at 2 00 14 PM" src="https://github.com/user-attachments/assets/d45e70d3-9ade-4cd1-badf-fa3dbc06dfe3" />

**Which issue(s) does this PR fix?**:

Fixes #108310

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
