### PR TITLE
Navigation: Add page tab names as command palette search keywords (alerting notifications)

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -522,6 +522,7 @@ func (s *ServiceImpl) buildAlertNavLinks(c *contextmodel.ReqContext) *navtree.Na
 				Id:       "notification-config",
 				Url:      s.cfg.AppSubURL + "/alerting/notifications",
 				Icon:     "comment-alt-share",
+				Keywords: []string{"Contact points", "Notification policies", "Templates", "Time intervals"},
 			})
 		}
 	} else {


### PR DESCRIPTION
## What

Adds the **Notification configuration** page's tab names — *Contact points*, *Notification policies*, *Templates*, *Time intervals* — as `keywords` on the `notification-config` nav item (`buildAlertNavLinks` in `pkg/services/navtree/navtreeimpl/navtree.go`).

These keywords flow through `config.bootData.navTree` → `NavModelItem.keywords` → the command palette's `navTreeToActions`, where they are already matched against search input.

## Why

Page-level tabs are not part of the nav tree the command palette indexes (they're built dynamically per-feature at render time). So today you can't search for a tab like "Contact points" and find your way to it. Declaring the tab names as nav keywords is a low-cost way to make those sub-pages discoverable, without mapping every tab into its own palette action.

## Result / known limitation

Searching **"Contact points"** (or the other tab names) in the command palette now surfaces the **Notification configuration** result and routes to `/alerting/notifications`. 

However, **the matched keyword is not shown in the result**. The user sees a result titled "Notification configuration" without any explicit indication of *why* it matched their "contact points" query. It works, and it's still helpful, but it's not the ideal "you searched contact points, here's why this is a result" experience.

This is intentionally an MVP. **Requesting feedback from the grafana-frontend-navigation team** on:
- Whether surfacing the matched keyword in the palette result is worth doing.
- Whether this backend-keyword approach is the right pattern, or whether tab keywords should be contributed/owned frontend-side (and translated — these strings are currently plain English only).
- is it ok that this is English only for now? I couldn't figure out a way to translate this.

## Notes

- Only affects the V2 alerting nav (`alertingNavigationV2`, GA / on by default).
- Keywords are plain English; localized search won't match translated tab names yet.
- Scoped to one nav item as a proof of concept.