### PR TITLE
IAM: Resolve team member UID under a service identity so team admins can manage members

### DIFF
--- a/pkg/services/team/teamk8s/team.go
+++ b/pkg/services/team/teamk8s/team.go
@@ -119,7 +119,12 @@ func (s *TeamK8sService) resolveUserUID(ctx context.Context, namespace string, u
 	selector := labels.SelectorFromSet(labels.Set{
 		utils.LabelKeyDeprecatedInternalID: strconv.FormatInt(userID, 10),
 	})
-	result, err := client.List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	// Resolve the user with a service identity: the caller is already authorized
+	// for the team membership operation (e.g. teams.permissions:write) but may
+	// lack users:list (e.g. a team admin), which would otherwise fail the lookup.
+	// Mirrors the legacy SQL lookup, which needed no users:list.
+	svcCtx := identity.WithServiceIdentityForSingleNamespaceContext(ctx, namespace)
+	result, err := client.List(svcCtx, metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/services/team/teamk8s/team_test.go
+++ b/pkg/services/team/teamk8s/team_test.go
@@ -1446,14 +1446,15 @@ func TestTeamK8sService_GetTeamIDsByUser(t *testing.T) {
 
 func TestTeamK8sService_IsTeamMember(t *testing.T) {
 	tests := []struct {
-		name           string
-		orgID          int64
-		teamID         int64
-		userID         int64
-		serverResponse func(w http.ResponseWriter, r *http.Request)
-		nilProvider    bool
-		expectErr      bool
-		expectMember   bool
+		name                   string
+		orgID                  int64
+		teamID                 int64
+		userID                 int64
+		serverResponse         func(w http.ResponseWriter, r *http.Request)
+		nilProvider            bool
+		enforceServiceIdentity bool
+		expectErr              bool
+		expectMember           bool
 	}{
 		{
 			name:           "returns true when user is a team member",
@@ -1554,6 +1555,15 @@ func TestTeamK8sService_IsTeamMember(t *testing.T) {
 			expectMember: false,
 		},
 		{
+			name:                   "resolves member under a service identity while team read stays as caller",
+			orgID:                  1,
+			teamID:                 10,
+			userID:                 42,
+			serverResponse:         membershipServerHandler(t),
+			enforceServiceIdentity: true,
+			expectMember:           true,
+		},
+		{
 			name:        "returns error when config provider not initialized",
 			orgID:       1,
 			teamID:      10,
@@ -1571,7 +1581,11 @@ func TestTeamK8sService_IsTeamMember(t *testing.T) {
 			} else {
 				ts := httptest.NewServer(http.HandlerFunc(tt.serverResponse))
 				defer ts.Close()
-				provider := &mockDirectRestConfigProvider{restConfig: &clientrest.Config{Host: ts.URL}}
+				cfg := &clientrest.Config{Host: ts.URL}
+				if tt.enforceServiceIdentity {
+					cfg.Transport = serviceIdentityRBAC{base: http.DefaultTransport}
+				}
+				provider := &mockDirectRestConfigProvider{restConfig: cfg}
 				svc = NewTeamK8sService(log.NewNopLogger(), nil, provider, tracing.InitializeTracerForTest())
 			}
 
@@ -2505,4 +2519,13 @@ func (m *mockDirectRestConfigProvider) IsReady() bool {
 func contextWithReqContext() context.Context {
 	reqCtx := &contextmodel.ReqContext{}
 	return context.WithValue(context.Background(), ctxkey.Key{}, reqCtx)
+}
+
+type serviceIdentityRBAC struct{ base http.RoundTripper }
+
+func (g serviceIdentityRBAC) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Path, "/users") != identity.IsServiceIdentity(req.Context()) {
+		return &http.Response{StatusCode: http.StatusForbidden, Body: http.NoBody, Header: make(http.Header)}, nil
+	}
+	return g.base.RoundTrip(req)
 }


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes a regression where **team admins** (an org Viewer who is Admin of a specific team) could not add, remove, or change the role of members on their own team when teams use unified storage (`kubernetesTeamsRedirect` + dual-write mode ≥ 1). The operation failed with HTTP 500. 

**Why do we need this feature?**
The K8s-backed team service translates the legacy `int64` user ID to a K8s user UID by listing the `users` resource (`resolveUserUID`). That list was made with the **caller's** identity, and listing users requires `users:list` — which team admins don't hold — so the apiserver returned 403 and the team operation surfaced a 500:
```
team.k8s "failed to resolve user UID" err="users.iam.grafana.app is forbidden:
User cannot list resource \"users\" in API group \"iam.grafana.app\" ... unauthorized request"
```

This is a regression vs legacy/Mode0, where these operations succeed (legacy resolves the user via a SQL lookup that needs no `users:list`).

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Closes https://github.com/grafana/identity-access-team/issues/2177

