### PR TITLE
Alerting: Render central history event timestamps in configured timezone

### DIFF
--- a/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom-v5-compat';
 import { useMeasure } from 'react-use';
 
 import { AlertLabels } from '@grafana/alerting/unstable';
-import { type GrafanaTheme2, type IconName, type TimeRange } from '@grafana/data';
+import { type GrafanaTheme2, type IconName, type TimeRange, type TimeZone, dateTimeFormat } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import {
   CustomVariable,
@@ -53,6 +53,7 @@ const PAGE_SIZE = 100;
  */
 interface HistoryEventsListProps {
   timeRange: TimeRange;
+  timeZone: TimeZone;
   valueInLabelFilter: VariableValue;
   valueInStateToFilter: VariableValue;
   valueInStateFromFilter: VariableValue;
@@ -61,6 +62,7 @@ interface HistoryEventsListProps {
 }
 export const HistoryEventsList = ({
   timeRange,
+  timeZone,
   valueInLabelFilter,
   valueInStateToFilter,
   valueInStateFromFilter,
@@ -133,6 +135,7 @@ export const HistoryEventsList = ({
         logRecords={historyRecords}
         addFilter={addFilter}
         timeRange={timeRange}
+        timeZone={timeZone}
         hideAlertRuleColumn={hideAlertRuleColumn}
       />
     </Stack>
@@ -149,9 +152,10 @@ interface HistoryLogEventsProps {
   logRecords: LogRecord[];
   addFilter: (key: string, value: string, type: FilterType) => void;
   timeRange: TimeRange;
+  timeZone: TimeZone;
   hideAlertRuleColumn?: boolean;
 }
-function HistoryLogEvents({ logRecords, addFilter, timeRange, hideAlertRuleColumn }: HistoryLogEventsProps) {
+function HistoryLogEvents({ logRecords, addFilter, timeRange, timeZone, hideAlertRuleColumn }: HistoryLogEventsProps) {
   const { page, pageItems, numberOfPages, onPageChange } = usePagination(logRecords, 1, PAGE_SIZE);
   const styles = useStyles2(getStyles);
 
@@ -172,6 +176,7 @@ function HistoryLogEvents({ logRecords, addFilter, timeRange, hideAlertRuleColum
               record={record}
               addFilter={addFilter}
               timeRange={timeRange}
+              timeZone={timeZone}
               hideAlertRuleColumn={hideAlertRuleColumn}
             />
           );
@@ -217,9 +222,10 @@ interface EventRowProps {
   record: LogRecord;
   addFilter: (key: string, value: string, type: FilterType) => void;
   timeRange: TimeRange;
+  timeZone: TimeZone;
   hideAlertRuleColumn?: boolean;
 }
-function EventRow({ record, addFilter, timeRange, hideAlertRuleColumn }: EventRowProps) {
+function EventRow({ record, addFilter, timeRange, timeZone, hideAlertRuleColumn }: EventRowProps) {
   const styles = useStyles2(getStyles);
   const [isCollapsed, setIsCollapsed] = useState(true);
   function onLabelClick([value, label]: [string | undefined, string | undefined]) {
@@ -242,7 +248,7 @@ function EventRow({ record, addFilter, timeRange, hideAlertRuleColumn }: EventRo
         />
         <Stack gap={0.5} direction={'row'} alignItems={'center'}>
           <div className={styles.timeCol}>
-            <Timestamp time={record.timestamp} />
+            <Timestamp time={record.timestamp} timeZone={timeZone} />
           </div>
           <div className={styles.transitionCol}>
             <EventTransition previous={record.line.previous} current={record.line.current} addFilter={addFilter} />
@@ -424,18 +430,11 @@ export function EventState({ state, showLabel = false, addFilter, type }: EventS
 
 interface TimestampProps {
   time: number; // epoch timestamp
+  timeZone: TimeZone;
 }
 
-const Timestamp = ({ time }: TimestampProps) => {
-  const dateTime = new Date(time);
-  const formattedDate = dateTime.toLocaleString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  });
+const Timestamp = ({ time, timeZone }: TimestampProps) => {
+  const formattedDate = dateTimeFormat(time, { format: 'MMMM D [at] HH:mm:ss', timeZone });
 
   return (
     <Text variant="body" weight="light">
@@ -566,7 +565,9 @@ function HistoryEventsListObjectRenderer({ model }: SceneComponentProps<HistoryE
   // This make sure the component is re-rendered when the variables change
   const { hideAlertRuleColumn } = model.useState();
 
-  const { value: timeRange } = sceneGraph.getTimeRange(model).useState(); // get time range from scene graph
+  const sceneTimeRange = sceneGraph.getTimeRange(model);
+  const { value: timeRange } = sceneTimeRange.useState(); // get time range from scene graph
+  const timeZone = sceneTimeRange.getTimeZone();
 
   const labelsFiltersVariable = sceneGraph.lookupVariable(LABELS_FILTER, model);
   const stateToFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_TO, model);
@@ -595,6 +596,7 @@ function HistoryEventsListObjectRenderer({ model }: SceneComponentProps<HistoryE
     return (
       <HistoryEventsList
         timeRange={timeRange}
+        timeZone={timeZone}
         valueInLabelFilter={labelsFiltersVariable.state.value}
         addFilter={addFilter}
         valueInStateToFilter={stateToFilterVariable.state.value}

--- a/public/app/features/alerting/unified/components/rules/central-state-history/HistoryEventsList.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/HistoryEventsList.test.tsx
@@ -28,6 +28,7 @@ describe('HistoryEventsList', () => {
         valueInStateFromFilter={StateFilterValues.all}
         addFilter={jest.fn()}
         timeRange={getDefaultTimeRange()}
+        timeZone={'browser'}
       />
     );
     await waitFor(() => {
@@ -43,6 +44,7 @@ describe('HistoryEventsList', () => {
         valueInStateFromFilter={StateFilterValues.all}
         addFilter={jest.fn()}
         timeRange={getDefaultTimeRange()}
+        timeZone={'browser'}
       />
     );
     await waitFor(() => {
@@ -65,6 +67,7 @@ describe('HistoryEventsList', () => {
         valueInStateToFilter={StateFilterValues.normal}
         addFilter={jest.fn()}
         timeRange={getDefaultTimeRange()}
+        timeZone={'browser'}
       />
     );
     await waitFor(() => {
@@ -84,6 +87,7 @@ describe('HistoryEventsList', () => {
         valueInStateFromFilter={StateFilterValues.all}
         addFilter={jest.fn()}
         timeRange={getDefaultTimeRange()}
+        timeZone={'browser'}
       />
     );
     await waitFor(() => {
@@ -105,6 +109,7 @@ describe('HistoryEventsList', () => {
         valueInStateToFilter={StateFilterValues.all}
         addFilter={jest.fn()}
         timeRange={getDefaultTimeRange()}
+        timeZone={'browser'}
       />
     );
     await waitFor(() => {
@@ -124,6 +129,7 @@ describe('HistoryEventsList', () => {
         valueInStateFromFilter={StateFilterValues.all}
         addFilter={jest.fn()}
         timeRange={getDefaultTimeRange()}
+        timeZone={'browser'}
       />
     );
     await waitFor(() => {
@@ -143,6 +149,7 @@ describe('HistoryEventsList', () => {
         valueInStateFromFilter={StateFilterValues.all}
         addFilter={jest.fn()}
         timeRange={getDefaultTimeRange()}
+        timeZone={'browser'}
       />
     );
     await waitFor(() => {
@@ -162,6 +169,7 @@ describe('HistoryEventsList', () => {
           valueInStateFromFilter={StateFilterValues.all}
           addFilter={jest.fn()}
           timeRange={getDefaultTimeRange()}
+          timeZone={'browser'}
         />
       );
 


### PR DESCRIPTION
## What this PR does

The **Alert Events** list in the central alert state history scene rendered timestamps in the browser's local timezone, ignoring the user's configured Grafana timezone. Every other timestamp in the same view — the timeseries chart above the list, and (when embedded in the IRM app) the surrounding escalation timeline — respects the configured timezone, so the list was the odd one out. On an account whose timezone is set to UTC but viewed from a browser in another zone, the list was off by the UTC offset.

The `Timestamp` component used `Date.prototype.toLocaleString(...)` with no `timeZone` option, which always formats in the runtime's local zone.

This change formats timestamps with `dateTimeFormat` from `@grafana/data`, using the timezone from the scene's time range (`sceneGraph.getTimeRange(model).getTimeZone()`). This matches the timeseries panel (which already uses the scene timezone) and the sibling `LogRecordViewer` component (which uses `dateTimeFormat`).

## How

- Read the scene timezone in `HistoryEventsListObjectRenderer` and thread it down the existing prop chain (`HistoryEventsList` → `HistoryLogEvents` → `EventRow` → `Timestamp`) alongside the `timeRange` that's already passed.
- `Timestamp` now uses `dateTimeFormat(time, { format: 'MMMM D [at] HH:mm:ss', timeZone })`. The format string preserves the existing display (`June 14 at 06:39:00`).

## Display format

The on-screen format is unchanged. The literal `[at]` in the moment format string reproduces the separator that `toLocaleString` produced for `en-US` date+time output.

## Testing

- Updated `HistoryEventsList.test.tsx` to pass the new required `timeZone` prop (`'browser'`, which renders in the runtime local zone — `Pacific/Easter` in CI — keeping the existing assertions intact).
