### PR TITLE
BrowseDashboards: Refresh Starred folders view when a folder is starred

### DIFF
--- a/packages/grafana-test-utils/src/fixtures/index.ts
+++ b/packages/grafana-test-utils/src/fixtures/index.ts
@@ -1,4 +1,4 @@
-import { setupMockStarredDashboards } from './starred';
+import { setupMockStarredDashboards, setupMockStarredFolders } from './starred';
 import { setupMockTeams } from './teams';
 
 /**
@@ -6,5 +6,6 @@ import { setupMockTeams } from './teams';
  */
 export const resetFixtures = () => {
   setupMockStarredDashboards();
+  setupMockStarredFolders();
   setupMockTeams();
 };

--- a/packages/grafana-test-utils/src/fixtures/starred.ts
+++ b/packages/grafana-test-utils/src/fixtures/starred.ts
@@ -12,3 +12,10 @@ export const setupMockStarredDashboards = () => {
 };
 
 export const mockStarredDashboardsMap = new Map<string, boolean>(initialStarredDashboards.map((uid) => [uid, true]));
+
+// No folders are starred by default
+export const setupMockStarredFolders = () => {
+  mockStarredFoldersMap.clear();
+};
+
+export const mockStarredFoldersMap = new Map<string, boolean>();

--- a/packages/grafana-test-utils/src/handlers/apis/collections.grafana.app/v1alpha1/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/apis/collections.grafana.app/v1alpha1/handlers.ts
@@ -1,6 +1,15 @@
 import { HttpResponse, http } from 'msw';
 
-import { mockStarredDashboardsMap } from '../../../../fixtures/starred';
+import { mockStarredDashboardsMap, mockStarredFoldersMap } from '../../../../fixtures/starred';
+
+// Maps a stars resource (keyed by `${group}/${kind}`) to the in-memory set backing it
+const STARRED_RESOURCE_MAPS = {
+  'dashboard.grafana.app/Dashboard': mockStarredDashboardsMap,
+  'folder.grafana.app/Folder': mockStarredFoldersMap,
+};
+
+const getStarsMapFor = (group: string, kind: string) =>
+  STARRED_RESOURCE_MAPS[`${group}/${kind}` as keyof typeof STARRED_RESOURCE_MAPS];
 
 const getStarsHandler = () =>
   http.get('/apis/collections.grafana.app/v1alpha1/namespaces/:namespace/stars', () => {
@@ -19,13 +28,10 @@ const getStarsHandler = () =>
             creationTimestamp: '2025-05-14T14:02:10Z',
           },
           spec: {
-            resource: [
-              {
-                group: 'dashboard.grafana.app',
-                kind: 'Dashboard',
-                names: Array.from(mockStarredDashboardsMap.keys()),
-              },
-            ],
+            resource: Object.entries(STARRED_RESOURCE_MAPS).map(([key, map]) => {
+              const [group, kind] = key.split('/');
+              return { group, kind, names: Array.from(map.keys()) };
+            }),
           },
           status: {},
         },
@@ -54,15 +60,15 @@ const successResponse = {
 
 const addStarHandler = () =>
   http.put<UpdateOrDeleteStarsParams>(UPDATE_STARS_URL, ({ params }) => {
-    const { id } = params;
-    mockStarredDashboardsMap.set(id, true);
+    const { id, group, kind } = params;
+    getStarsMapFor(group, kind).set(id, true);
     return HttpResponse.json(successResponse);
   });
 
 const removeStarHandler = () =>
   http.delete<UpdateOrDeleteStarsParams>(UPDATE_STARS_URL, ({ params }) => {
-    const { id } = params;
-    mockStarredDashboardsMap.delete(id);
+    const { id, group, kind } = params;
+    getStarsMapFor(group, kind).delete(id);
     return HttpResponse.json(successResponse);
   });
 

--- a/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
+
+import { selectors } from '@grafana/e2e-selectors';
+import { setBackendSrv } from '@grafana/runtime';
+import { setupMockServer } from '@grafana/test-utils/server';
+import { getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
+import { type CombinedFolder } from 'app/api/clients/folder/v1beta1/hooks';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { STARRED_FOLDERS_UID } from 'app/features/search/constants';
+import { useSelector } from 'app/types/store';
+
+import { FolderDetailsActions } from './FolderDetailsActions';
+
+const [, { folderA }] = getFolderFixtures();
+const folderToStar = folderA.item;
+
+setBackendSrv(backendSrv);
+setupMockServer();
+
+// Renders the starred-folders collection straight from the browse-dashboards store, mirroring what
+// the browse list shows. Lets the test assert on rendered output instead of redux internals.
+const StarredFoldersList = () => {
+  const collection = useSelector((state) => state.browseDashboards.childrenByParentUID[STARRED_FOLDERS_UID]);
+  return (
+    <ul>
+      {collection?.items.map((item) => (
+        <li key={item.uid}>{item.title}</li>
+      ))}
+    </ul>
+  );
+};
+
+describe('FolderDetailsActions', () => {
+  // starredFoldersEnabled() gates the star button on these feature toggles plus the OpenFeature flag
+  testWithFeatureToggles({ enable: ['starsFromAPIServer', 'foldersAppPlatformAPI'] });
+
+  beforeEach(() => {
+    setTestFlags({ 'grafana.starredFolders': true });
+  });
+
+  afterEach(() => {
+    setTestFlags({});
+  });
+
+  it('refetches the starred folders list when a folder is starred', async () => {
+    const { user } = render(
+      <>
+        <FolderDetailsActions folderDTO={folderToStar as unknown as CombinedFolder} />
+        <StarredFoldersList />
+      </>
+    );
+
+    // The folder isn't in the starred-folders list yet
+    expect(screen.queryByText(folderToStar.title)).not.toBeInTheDocument();
+
+    const starButton = await screen.findByTestId(selectors.components.NavToolbar.markAsFavorite);
+    await waitFor(() => expect(starButton).not.toBeDisabled());
+    await user.click(starButton);
+
+    // Starring triggers a refetch that adds the folder to the rendered list
+    expect(await screen.findByText(folderToStar.title)).toBeInTheDocument();
+  });
+});

--- a/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.tsx
+++ b/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.tsx
@@ -10,11 +10,15 @@ import { type CombinedFolder, useGetFolderQueryFacade } from 'app/api/clients/fo
 import { OwnerReference } from 'app/core/components/OwnerReferences/OwnerReference';
 import { contextSrv } from 'app/core/services/context_srv';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
+import { STARRED_FOLDERS_UID } from 'app/features/search/constants';
 import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
 import { useGetTeamByUidQuery } from 'app/features/teams/hooks';
 import { AccessControlAction } from 'app/types/accessControl';
+import { useDispatch } from 'app/types/store';
 
+import { PAGE_SIZE } from '../../api/constants';
 import { getFolderPermissions } from '../../permissions';
+import { refetchChildren } from '../../state/actions';
 import { starredFoldersEnabled } from '../../utils/dashboards';
 import CreateNewButton from '../CreateNewButton';
 import { FolderActionsButton } from '../FolderActionsButton';
@@ -24,6 +28,13 @@ export const FolderDetailsActions = ({ folderDTO }: { folderDTO?: CombinedFolder
   const { data: rootFolderDTO } = useGetFolderQueryFacade(folderDTO ? undefined : 'general');
   const { isReadOnlyRepo, repoType } = useGetResourceRepositoryView({ folderName: folderDTO?.uid });
   const { canCreateDashboards, canCreateFolders } = getFolderPermissions(folderDTO ?? rootFolderDTO);
+  const dispatch = useDispatch();
+
+  // Stars and the browse-dashboards "Starred folders" row use independent caches, so refetch the
+  // virtual folder's children when a folder is starred/unstarred to keep the browse list in sync.
+  const handleStarChange = () => {
+    dispatch(refetchChildren({ parentUID: STARRED_FOLDERS_UID, pageSize: PAGE_SIZE }));
+  };
 
   const handleButtonClickToRecentlyDeleted = () => {
     reportInteraction('grafana_browse_dashboards_page_button_to_recently_deleted', {
@@ -36,7 +47,13 @@ export const FolderDetailsActions = ({ folderDTO }: { folderDTO?: CombinedFolder
   return (
     <Stack alignItems="center">
       {starredFoldersEnabled() && folderDTO && (
-        <StarToolbarButton group="folder.grafana.app" kind="Folder" id={folderDTO.uid} title={folderDTO.title} />
+        <StarToolbarButton
+          group="folder.grafana.app"
+          kind="Folder"
+          id={folderDTO.uid}
+          title={folderDTO.title}
+          onStarChange={handleStarChange}
+        />
       )}
       {canReadTeams && config.featureToggles.teamFolders && folderDTO && 'ownerReferences' in folderDTO && (
         <FolderOwners ownerReferences={folderDTO.ownerReferences} />


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md
2. Ensure you include and run the appropriate tests as part of your Pull Request.
-->

### What is this feature?

When you star a folder from the folder detail page and then navigate (without a full reload) back to the dashboards list, the newly-starred folder now shows up immediately under the **Starred folders** special folder. Previously it only appeared after a hard refresh.

The folder star button now refetches the `Starred folders` virtual folder's children whenever a folder is starred or unstarred, keeping the browse list in sync.

### Why do we need this feature?

Stars are mutated through the collections RTK Query API (which only invalidates the `Stars` tag), but the **Starred folders** browse row isn't driven by RTK Query — its contents live in the bespoke `browseDashboards` Redux slice, populated by the `refetchChildren` / `fetchNextChildrenPage` thunks. Nothing told that slice to refetch after a star changed, and because it persists across client-side navigation, the list stayed stale until a full page reload re-bootstrapped everything.

This wires the existing `onStarChange` callback on `StarToolbarButton` to dispatch `refetchChildren` for the starred-folders virtual folder — the same pattern already used to keep the slice fresh after folder/dashboard moves, deletes, and team-folder changes.

### Who is this feature for?

Anyone using the customisable mega menu / starred folders feature (`grafana.starredFolders`).

### Special notes for your reviewer

- Frontend-only change, scoped to a single file.
- Folders can only be starred from one place (`FolderDetailsActions`), so that's the only wiring needed.
- Tests to follow in a separate change.
