### PR TITLE
Scopes: Remove useScopeSingleNodeEndpoint feature toggle from registry

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -449,11 +449,6 @@ export interface FeatureToggles {
   */
   scopeApi?: boolean;
   /**
-  * Use the single node endpoint for the scope api. This is used to fetch the scope parent node.
-  * @default true
-  */
-  useScopeSingleNodeEndpoint?: boolean;
-  /**
   * Makes the frontend use the 'names' param for fetching multiple scope nodes at once
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -882,15 +882,6 @@ var (
 			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:         "useScopeSingleNodeEndpoint",
-			Description:  "Use the single node endpoint for the scope api. This is used to fetch the scope parent node.",
-			Stage:        FeatureStagePublicPreview,
-			Owner:        grafanaOperatorExperienceSquad,
-			Expression:   "true",
-			Generate:     Generate{LegacyFrontend: true},
-			HideFromDocs: true,
-		},
-		{
 			Name:         "useMultipleScopeNodesEndpoint",
 			Description:  "Makes the frontend use the 'names' param for fetching multiple scope nodes at once",
 			Stage:        FeatureStagePublicPreview,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -101,7 +101,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-01-23,alertingSaveStatePeriodic,privatePreview,@grafana/alerting-squad,false,false,false
 2025-01-27,alertingSaveStateCompressed,preview,@grafana/alerting-squad,false,false,false
 2024-11-27,scopeApi,experimental,@grafana/grafana-app-platform-squad,false,false,false
-2025-07-31,useScopeSingleNodeEndpoint,preview,@grafana/grafana-operator-experience-squad,false,false,true
 2025-08-29,useMultipleScopeNodesEndpoint,preview,@grafana/grafana-operator-experience-squad,false,false,true
 2024-11-11,logQLScope,privatePreview,@grafana/data-sources-plugins,false,false,false
 2024-02-27,sqlExpressions,GA,@grafana/grafana-datasources-core-services,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5332,7 +5332,8 @@
       "metadata": {
         "name": "useScopeSingleNodeEndpoint",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-31T14:32:41Z"
+        "creationTimestamp": "2025-07-31T14:32:41Z",
+        "deletionTimestamp": "2026-06-24T02:41:49Z"
       },
       "spec": {
         "description": "Use the single node endpoint for the scope api. This is used to fetch the scope parent node.",


### PR DESCRIPTION
## Summary

Backend half of removing the `useScopeSingleNodeEndpoint` feature toggle. Deletes the registry entry in `pkg/services/featuremgmt/registry.go` and regenerates the dependent files via `make gen-feature-toggles`. `toggles_gen.json` keeps a `deletionTimestamp` tombstone, per the standard toggle-removal flow. No user-facing change — the toggle was Public Preview, default `true`.

The frontend reads were removed in #127122 (now merged), so this is ready to merge on its own.

Part of the multi-tenant frontend effort to remove legacy `config.featureToggles.X` toggles (grafana/grafana-frontend-platform#187).

## Test plan

- [ ] `make gen-feature-toggles` produces no further diff
- [ ] `go test ./pkg/services/featuremgmt/...` passes