### PR TITLE
Scopes: Remove useMultipleScopeNodesEndpoint toggle from registry

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -454,11 +454,6 @@ export interface FeatureToggles {
   */
   scopeApi?: boolean;
   /**
-  * Makes the frontend use the 'names' param for fetching multiple scope nodes at once
-  * @default true
-  */
-  useMultipleScopeNodesEndpoint?: boolean;
-  /**
   * In-development feature that will allow injection of labels into loki queries.
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -900,15 +900,6 @@ var (
 			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:         "useMultipleScopeNodesEndpoint",
-			Description:  "Makes the frontend use the 'names' param for fetching multiple scope nodes at once",
-			Stage:        FeatureStagePublicPreview,
-			Owner:        grafanaOperatorExperienceSquad,
-			Expression:   "true",
-			Generate:     Generate{LegacyFrontend: true},
-			HideFromDocs: true,
-		},
-		{
 			Name:         "logQLScope",
 			Description:  "In-development feature that will allow injection of labels into loki queries.",
 			Stage:        FeatureStagePrivatePreview,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -103,7 +103,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-01-23,alertingSaveStatePeriodic,privatePreview,@grafana/alerting-squad,false,false,false
 2025-01-27,alertingSaveStateCompressed,preview,@grafana/alerting-squad,false,false,false
 2024-11-27,scopeApi,experimental,@grafana/grafana-app-platform-squad,false,false,false
-2025-08-29,useMultipleScopeNodesEndpoint,preview,@grafana/grafana-operator-experience-squad,false,false,true
 2024-11-11,logQLScope,privatePreview,@grafana/data-sources-plugins,false,false,false
 2024-02-27,sqlExpressions,GA,@grafana/grafana-datasources-core-services,false,false,false
 2025-07-23,sqlExpressionsColumnAutoComplete,experimental,@grafana/datapro,false,false,true


### PR DESCRIPTION
## Summary

Backend half of removing the `useMultipleScopeNodesEndpoint` feature toggle. Deletes the registry entry in `pkg/services/featuremgmt/registry.go` and regenerates the dependent files via `make gen-feature-toggles`. `toggles_gen.json` already carried a `deletionTimestamp` tombstone for this toggle, so only the registry entry, the generated TS field, and the CSV row change. No user-facing change — the toggle was Public Preview, default `true`.

The frontend reads were removed in #127123 (now merged), so this is ready to merge on its own.

Part of the multi-tenant frontend effort to remove legacy `config.featureToggles.X` toggles (grafana/grafana-frontend-platform#187).

## Test plan

- [ ] `make gen-feature-toggles` produces no further diff
- [ ] `go test ./pkg/services/featuremgmt/...` passes