### PR TITLE
Graphite:  Add `carbonapi` compatibility fixes and integration tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -295,6 +295,8 @@
 /devenv/docker/blocks/collectd/ @grafana/observability-metrics
 /devenv/docker/blocks/etcd @grafana/grafana-app-platform-squad
 /devenv/docker/blocks/grafana/ @grafana/grafana-as-code
+/devenv/docker/blocks/carbonapi/ @grafana/data-sources-plugins
+/devenv/docker/blocks/carbonapi-booking/ @grafana/data-sources-plugins
 /devenv/docker/blocks/graphite/ @grafana/data-sources-plugins
 /devenv/docker/blocks/graphite1/ @grafana/data-sources-plugins
 /devenv/docker/blocks/influxdb/ @grafana/data-sources-plugins

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -352,3 +352,66 @@ jobs:
         if: always()
         run: |
           make devenv-down sources=postgres_tests
+
+  # Graphite datasource integration tests — run against multiple Graphite server versions.
+  # Tests in pkg/tsdb/graphite/graphite_integration_test.go are skipped when GRAPHITE_URL
+  # is absent, making them zero-cost for regular runs and opt-in for local dev.
+  graphite:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
+    name: Graphite integration (${{ matrix.graphite.name }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        graphite:
+          - name: graphite-1.0
+            image: graphiteapp/graphite-statsd:1.0.2-3
+            port: 80
+            url: http://localhost:8180
+          - name: graphite-1.1
+            image: graphiteapp/graphite-statsd:latest
+            port: 80
+            url: http://localhost:8180
+          - name: carbonapi
+            compose: devenv/docker/blocks/carbonapi/docker-compose.yaml
+            port: 8480
+            url: http://localhost:8480
+          # bookingcom/carbonapi does not publish Docker images; build from source.
+          # This exercises the backend-routing behaviour (strict query formatting,
+          # separate carbonzipper model) that caused the Booking.com regressions.
+          - name: bookingcom-carbonapi
+            build: source
+            url: http://localhost:8580
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Start Graphite (${{ matrix.graphite.name }})
+        if: ${{ matrix.graphite.image != '' && matrix.graphite.image != null }}
+        run: |
+          docker run -d --name graphite -p 8180:${{ matrix.graphite.port }} \
+            ${{ matrix.graphite.image }}
+          timeout 60 bash -c 'until curl -sf http://localhost:8180/; do sleep 2; done'
+
+      - name: Start carbonapi stack
+        if: ${{ matrix.graphite.compose != '' && matrix.graphite.compose != null }}
+        run: |
+          docker compose -f ${{ matrix.graphite.compose }} up -d
+          timeout 90 bash -c 'until curl -sf http://localhost:8480/; do sleep 3; done'
+
+      - name: Build and start bookingcom/carbonapi
+        if: ${{ matrix.graphite.build == 'source' }}
+        run: |
+          docker compose -f devenv/docker/blocks/carbonapi-booking/docker-compose.yaml up -d --build --wait --timeout 120
+
+      - name: Run integration tests
+        env:
+          GRAPHITE_URL: ${{ matrix.graphite.url }}
+        run: |
+          go test -run '^TestIntegrationGraphite' -timeout=3m -v ./pkg/tsdb/graphite/...

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -403,7 +403,42 @@ jobs:
         if: ${{ matrix.graphite.compose != '' && matrix.graphite.compose != null }}
         run: |
           docker compose -f ${{ matrix.graphite.compose }} up -d
-          timeout 90 bash -c 'until curl -sf http://localhost:8480/; do sleep 3; done'
+
+          # Wait for go-carbon's carbonserver HTTP to accept connections before
+          # carbonapi tries to connect to it on startup.
+          timeout 60 bash -c '
+            until curl -s -o /dev/null -w "%{http_code}" "http://localhost:8580/metrics/find?query=test&format=json" | grep -qE "^[0-9]{3}$"; do
+              sleep 2
+            done
+          '
+
+          # Seed the test metric directly over the carbon plaintext protocol.
+          # fake-carbonapi-data has a startup delay, so we seed early to give
+          # go-carbon's write loop maximum time to flush and index the file.
+          python3 -c "import socket,time; s=socket.socket(); s.connect(('localhost',2013)); s.sendall(b'grafanatest 42 '+str(int(time.time())).encode()+b'\n'); s.close()"
+          sleep 3
+
+          # Wait for carbonapi to be up (constantLine is evaluated locally, no backend needed).
+          timeout 90 bash -c '
+            until curl -sf "http://localhost:8480/render?target=constantLine(1)&format=json&from=-1min" > /dev/null; do
+              sleep 3
+            done
+          '
+
+          # Wait for go-carbon's index to contain the seeded metric, then wait for
+          # carbonapi to reflect it.  Query by name rather than wildcard — go-carbon
+          # returns 500 for query=* when top-level results are directory nodes only.
+          # Grep the body since carbonapi returns HTTP 200 with [] for unknown metrics.
+          timeout 90 bash -c '
+            until curl -sL "http://localhost:8580/metrics/find/?query=grafanatest&format=json" 2>/dev/null | grep -q "grafanatest"; do
+              sleep 2
+            done
+          '
+          timeout 90 bash -c '
+            until curl -s "http://localhost:8480/metrics/find?query=grafanatest&format=json" 2>/dev/null | grep -q "grafanatest"; do
+              sleep 2
+            done
+          '
 
       - name: Build and start bookingcom/carbonapi
         if: ${{ matrix.graphite.build == 'source' }}

--- a/Makefile
+++ b/Makefile
@@ -597,6 +597,22 @@ test-go-integration-redis: ## Run integration tests for redis cache.
 	REDIS_URL=localhost:6379 $(GO) test $(GO_TEST_FLAGS) -run IntegrationRedis -covermode=atomic -timeout=2m \
 		$(shell ./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -n$(SHARD) -m$(SHARDS) -d - -s)
 
+.PHONY: test-go-integration-graphite
+test-go-integration-graphite: ## Run integration tests for Graphite datasource. Requires a running Graphite server (make devenv sources=graphite).
+	@echo "test backend integration graphite tests"
+	$(GO) clean -testcache
+	GRAPHITE_URL=http://localhost:8180 $(GO) test $(GO_TEST_FLAGS) -run IntegrationGraphite -covermode=atomic -timeout=3m \
+		./pkg/tsdb/graphite/...
+
+.PHONY: test-go-integration-graphite-booking
+test-go-integration-graphite-booking: ## Run integration tests for Graphite datasource against bookingcom/carbonapi (built from source).
+	@echo "Building and starting bookingcom/carbonapi stack..."
+	docker compose -f devenv/docker/blocks/carbonapi-booking/docker-compose.yaml up -d --build --wait --timeout 120
+	@echo "Running integration tests..."
+	$(GO) clean -testcache
+	GRAPHITE_URL=http://localhost:8580 $(GO) test $(GO_TEST_FLAGS) -run IntegrationGraphite -covermode=atomic -timeout=3m \
+		./pkg/tsdb/graphite/...
+
 .PHONY: test-go-integration-memcached
 test-go-integration-memcached: ## Run integration tests for memcached cache.
 	@echo "test backend integration memcached tests"

--- a/devenv/docker/blocks/carbonapi-booking/Dockerfile.carbonapi
+++ b/devenv/docker/blocks/carbonapi-booking/Dockerfile.carbonapi
@@ -1,0 +1,13 @@
+FROM golang:alpine AS builder
+RUN apk add --no-cache git gcc musl-dev
+RUN git clone --depth=1 https://github.com/bookingcom/carbonapi /src
+WORKDIR /src
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /usr/local/bin/carbonapi ./cmd/carbonapi/
+
+FROM alpine:latest
+COPY --from=builder /usr/local/bin/carbonapi /usr/local/bin/carbonapi
+COPY carbonapi.yaml /etc/carbonapi/carbonapi.yaml
+COPY carbonzipper.yaml /etc/carbonapi/carbonzipper.yaml
+
+EXPOSE 8580
+CMD ["/usr/local/bin/carbonapi", "-config", "/etc/carbonapi/carbonapi.yaml"]

--- a/devenv/docker/blocks/carbonapi-booking/Dockerfile.go-carbon
+++ b/devenv/docker/blocks/carbonapi-booking/Dockerfile.go-carbon
@@ -1,0 +1,21 @@
+FROM golang:alpine AS builder
+RUN apk add --no-cache git gcc musl-dev
+RUN git clone --depth=1 https://github.com/go-graphite/go-carbon /src
+WORKDIR /src
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /usr/local/bin/go-carbon .
+
+FROM alpine:latest
+RUN apk add --no-cache python3
+
+COPY --from=builder /usr/local/bin/go-carbon /usr/local/bin/go-carbon
+COPY go-carbon.conf /etc/go-carbon/go-carbon.conf
+COPY storage-schemas.conf /etc/go-carbon/storage-schemas.conf
+
+# Pre-seed a whisper metric at image build time so the carbonserver's startup
+# filesystem scan finds it immediately.  Without this, go-carbon returns HTTP
+# 500 for find queries on an empty index, which carbonapi propagates as 422
+# (Unprocessable Entity) rather than treating it as "not found".
+COPY seed-whisper.py /tmp/seed-whisper.py
+RUN python3 /tmp/seed-whisper.py
+
+CMD ["/usr/local/bin/go-carbon", "-config", "/etc/go-carbon/go-carbon.conf"]

--- a/devenv/docker/blocks/carbonapi-booking/carbonapi.yaml
+++ b/devenv/docker/blocks/carbonapi-booking/carbonapi.yaml
@@ -1,0 +1,18 @@
+listen: ":8580"
+listenInternal: ":7580"
+graphiteVersionForGrafana: "1.1.0"
+# upstreams.backends must be non-empty — it is validated before zipperConfig is
+# read. The actual backend connection goes through the zipper config below.
+upstreams:
+  backends:
+    - "http://go-carbon:8080"
+cache:
+  type: "mem"
+  size_mb: 10
+  defaultTimeoutSec: 5
+expireDelaySec: 0
+loggerConfig:
+  outputPaths: ["stdout"]
+  level: "info"
+  encoding: "console"
+zipperConfig: "/etc/carbonapi/carbonzipper.yaml"

--- a/devenv/docker/blocks/carbonapi-booking/carbonzipper.yaml
+++ b/devenv/docker/blocks/carbonapi-booking/carbonzipper.yaml
@@ -1,0 +1,22 @@
+listen: ":7680"
+listenInternal: ":7681"
+maxProcs: 0
+buckets: 10
+timeouts:
+  global: "10s"
+  afterStarted: "10s"
+  connect: "200ms"
+# concurrencyLimit must be > 0. A zero value produces an unbuffered semaphore
+# channel that deadlocks all backend find/info requests in NewBackend.Proc().
+concurrencyLimit: 20
+keepAliveInterval: "30s"
+maxIdleConnsPerHost: 100
+expireDelaySec: 0
+# "go-carbon" resolves to the go-carbon container over the Docker bridge network.
+backends:
+  - "http://go-carbon:8080"
+graphite09compat: false
+loggerConfig:
+  outputPaths: ["stdout"]
+  level: "info"
+  encoding: "console"

--- a/devenv/docker/blocks/carbonapi-booking/docker-compose.yaml
+++ b/devenv/docker/blocks/carbonapi-booking/docker-compose.yaml
@@ -1,0 +1,28 @@
+services:
+  go-carbon:
+    build:
+      context: .
+      dockerfile: Dockerfile.go-carbon
+    # carbonserver (port 8080) is internal-only; no host port needed.
+    healthcheck:
+      # Verify the seed metric is visible — a bare find against an empty index
+      # returns HTTP 500, so we check for the known seed path specifically.
+      test: ["CMD-SHELL", "wget -qO- 'http://localhost:8080/metrics/find/?query=test.*&format=json' | grep -q integration"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  carbonapi:
+    build:
+      context: .
+      dockerfile: Dockerfile.carbonapi
+    ports:
+      - "8580:8580"
+    depends_on:
+      go-carbon:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8580/render?target=constantLine(1)&format=json&from=-1min"]
+      interval: 5s
+      timeout: 5s
+      retries: 20

--- a/devenv/docker/blocks/carbonapi-booking/go-carbon.conf
+++ b/devenv/docker/blocks/carbonapi-booking/go-carbon.conf
@@ -1,0 +1,46 @@
+[common]
+user = ""
+logfile = ""
+logLevel = "info"
+maxCPU = 1
+graphPrefix = ""
+metricEndpoint = ""
+metricInterval = "1m0s"
+
+[whisper]
+data-dir = "/var/lib/go-carbon/whisper"
+schemas-file = "/etc/go-carbon/storage-schemas.conf"
+workers = 1
+max-updates-per-second = 0
+sparse-create = false
+enabled = true
+
+[cache]
+max-size = 1000000
+write-strategy = "max"
+
+[udp]
+listen = ":2003"
+enabled = false
+
+[tcp]
+listen = ":2003"
+enabled = true
+
+[pickle]
+listen = ":2004"
+enabled = false
+
+[carbonserver]
+# Listen on all interfaces so carbonapi can reach it over the Docker network.
+listen = ":8080"
+enabled = true
+query-cache-enabled = false
+find-cache-enabled = false
+
+[dump]
+enabled = false
+
+[pprof]
+listen = "localhost:7007"
+enabled = false

--- a/devenv/docker/blocks/carbonapi-booking/seed-whisper.py
+++ b/devenv/docker/blocks/carbonapi-booking/seed-whisper.py
@@ -1,16 +1,20 @@
 """
-Create a minimal seed whisper file so go-carbon's carbonserver has at least
-one metric in its index on startup.  Without this, go-carbon returns HTTP 500
-for find queries on an empty index, which bookingcom/carbonapi propagates as
-HTTP 422 (Unprocessable Entity) rather than treating it as "not found".
+Pre-seed whisper files so go-carbon's carbonserver index is non-empty on startup.
+go-carbon returns HTTP 500 for find queries on an empty index, which
+bookingcom/carbonapi propagates as 422 rather than treating as "not found".
 """
 import struct, os
 
-os.makedirs("/var/lib/go-carbon/whisper/test", exist_ok=True)
-with open("/var/lib/go-carbon/whisper/test/integration.wsp", "wb") as f:
-    # Whisper header: aggregation=average(1), maxRetention=86400s, xff=0.5, archives=1
-    f.write(struct.pack(">LLfL", 1, 86400, 0.5, 1))
-    # Archive 0: data at byte 28 (16 header + 12 archive-info), 60s/pt, 1440 points
-    f.write(struct.pack(">LLL", 28, 60, 1440))
-    # 1440 empty data points (timestamp=0, value=0.0)
-    f.write(b"\x00" * (1440 * 12))
+def write_wsp(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        # Whisper header: aggregation=average(1), maxRetention=86400s, xff=0.5, archives=1
+        f.write(struct.pack(">LLfL", 1, 86400, 0.5, 1))
+        # Archive 0: offset=28, 60s/pt, 1440 points
+        f.write(struct.pack(">LLL", 28, 60, 1440))
+        f.write(b"\x00" * (1440 * 12))
+
+# test.integration is used by the go-carbon healthcheck (query=test.*)
+write_wsp("/var/lib/go-carbon/whisper/test/integration.wsp")
+# grafanatest is used by the integration test suite
+write_wsp("/var/lib/go-carbon/whisper/grafanatest.wsp")

--- a/devenv/docker/blocks/carbonapi-booking/seed-whisper.py
+++ b/devenv/docker/blocks/carbonapi-booking/seed-whisper.py
@@ -1,0 +1,16 @@
+"""
+Create a minimal seed whisper file so go-carbon's carbonserver has at least
+one metric in its index on startup.  Without this, go-carbon returns HTTP 500
+for find queries on an empty index, which bookingcom/carbonapi propagates as
+HTTP 422 (Unprocessable Entity) rather than treating it as "not found".
+"""
+import struct, os
+
+os.makedirs("/var/lib/go-carbon/whisper/test", exist_ok=True)
+with open("/var/lib/go-carbon/whisper/test/integration.wsp", "wb") as f:
+    # Whisper header: aggregation=average(1), maxRetention=86400s, xff=0.5, archives=1
+    f.write(struct.pack(">LLfL", 1, 86400, 0.5, 1))
+    # Archive 0: data at byte 28 (16 header + 12 archive-info), 60s/pt, 1440 points
+    f.write(struct.pack(">LLL", 28, 60, 1440))
+    # 1440 empty data points (timestamp=0, value=0.0)
+    f.write(b"\x00" * (1440 * 12))

--- a/devenv/docker/blocks/carbonapi-booking/storage-schemas.conf
+++ b/devenv/docker/blocks/carbonapi-booking/storage-schemas.conf
@@ -1,0 +1,3 @@
+[default]
+pattern = .*
+retentions = 60s:30d,1h:5y

--- a/devenv/docker/blocks/carbonapi/carbonapi.yaml
+++ b/devenv/docker/blocks/carbonapi/carbonapi.yaml
@@ -2,17 +2,9 @@
 # See https://github.com/go-graphite/carbonapi/blob/main/cmd/carbonapi/carbonapi.example.yaml
 
 listen: ":8080"
-listenInternal: ":7081"
 
-# Report as Graphite 1.1.0 so Grafana uses the correct query features
-graphiteVersionForGrafana: "1.1.0"
-
-# Use the go-carbon backend (via carbonzipper protocol over HTTP)
-# The go-carbon service exposes a carbonserver on port 8080 internally
-backends:
-  - "http://go-carbon:8080"
-
-# carbonzipper / backend configuration
+# Use the go-carbon backend (via carbonserver HTTP)
+# backends must be inside upstreams for upstream carbonapi (unlike bookingcom fork)
 upstreams:
   graphite09compat: false
   buckets: 10
@@ -20,14 +12,16 @@ upstreams:
   keepAliveInterval: "30s"
   maxIdleConnsPerHost: 100
   timeouts:
-    find: "2s"
+    find: "10s"
     render: "10s"
     connect: "200ms"
+  backends:
+    - "http://go-carbon:8080"
 
 # Caching — keep short for dev so tests see fresh data
 cache:
   type: "mem"
-  size: 100
+  size_mb: 100
   defaultTimeoutSec: 10
 
 # Logging

--- a/devenv/docker/blocks/carbonapi/carbonapi.yaml
+++ b/devenv/docker/blocks/carbonapi/carbonapi.yaml
@@ -1,0 +1,38 @@
+# carbonapi configuration for Grafana devenv
+# See https://github.com/go-graphite/carbonapi/blob/main/cmd/carbonapi/carbonapi.example.yaml
+
+listen: ":8080"
+listenInternal: ":7081"
+
+# Report as Graphite 1.1.0 so Grafana uses the correct query features
+graphiteVersionForGrafana: "1.1.0"
+
+# Use the go-carbon backend (via carbonzipper protocol over HTTP)
+# The go-carbon service exposes a carbonserver on port 8080 internally
+backends:
+  - "http://go-carbon:8080"
+
+# carbonzipper / backend configuration
+upstreams:
+  graphite09compat: false
+  buckets: 10
+  concurrencyLimitPerServer: 0
+  keepAliveInterval: "30s"
+  maxIdleConnsPerHost: 100
+  timeouts:
+    find: "2s"
+    render: "10s"
+    connect: "200ms"
+
+# Caching — keep short for dev so tests see fresh data
+cache:
+  type: "mem"
+  size: 100
+  defaultTimeoutSec: 10
+
+# Logging
+logger:
+  - logger: ""
+    file: "stderr"
+    level: "info"
+    encoding: "console"

--- a/devenv/docker/blocks/carbonapi/docker-compose.yaml
+++ b/devenv/docker/blocks/carbonapi/docker-compose.yaml
@@ -6,13 +6,10 @@ services:
     ports:
       - "2013:2003"   # carbon plaintext
       - "2014:2004"   # carbon pickle
+      - "8580:8080"   # carbonserver HTTP (exposed for CI health checks)
     volumes:
       - ./go-carbon.conf:/etc/go-carbon/go-carbon.conf
-    healthcheck:
-      test: ["CMD-SHELL", "echo 'test.metric 42' | nc -q1 localhost 2003 && echo ok"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
+      - ./storage-schemas.conf:/etc/go-carbon/storage-schemas.conf
 
   # carbonapi is the HTTP API layer (upstream of Booking's bookingcom/carbonapi fork).
   # It exposes the same /render, /metrics/find, /metrics/expand, /tags/* endpoints
@@ -27,8 +24,7 @@ services:
       - ./carbonapi.yaml:/etc/carbonapi/carbonapi.yaml
     command: ["-config", "/etc/carbonapi/carbonapi.yaml"]
     depends_on:
-      go-carbon:
-        condition: service_healthy
+      - go-carbon
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/render?target=constantLine(1)&format=json&from=-1min"]
       interval: 5s
@@ -39,8 +35,10 @@ services:
     image: grafana/fake-data-gen
     environment:
       FD_DATASOURCE: graphite
-      FD_PORT: 2013
+      FD_SERVER: go-carbon
+      FD_PORT: 2003
       FD_GRAPHITE_VERSION: 1.1
     depends_on:
-      go-carbon:
-        condition: service_healthy
+      - go-carbon
+    # Restart if connection to go-carbon fails on first attempt (TCP not ready yet).
+    restart: on-failure

--- a/devenv/docker/blocks/carbonapi/docker-compose.yaml
+++ b/devenv/docker/blocks/carbonapi/docker-compose.yaml
@@ -1,0 +1,46 @@
+services:
+  # go-carbon provides the carbon plaintext protocol receiver and whisper storage
+  # backend required by carbonapi.
+  go-carbon:
+    image: ghcr.io/go-graphite/go-carbon:latest
+    ports:
+      - "2013:2003"   # carbon plaintext
+      - "2014:2004"   # carbon pickle
+    volumes:
+      - ./go-carbon.conf:/etc/go-carbon/go-carbon.conf
+    healthcheck:
+      test: ["CMD-SHELL", "echo 'test.metric 42' | nc -q1 localhost 2003 && echo ok"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # carbonapi is the HTTP API layer (upstream of Booking's bookingcom/carbonapi fork).
+  # It exposes the same /render, /metrics/find, /metrics/expand, /tags/* endpoints
+  # as graphite-web, but with different behaviour around query formatting strictness.
+  #
+  # Port 8480 is used to avoid collision with existing graphite (8180) and graphite1 (8280) blocks.
+  carbonapi:
+    image: ghcr.io/go-graphite/carbonapi:latest
+    ports:
+      - "8480:8080"
+    volumes:
+      - ./carbonapi.yaml:/etc/carbonapi/carbonapi.yaml
+    command: ["-config", "/etc/carbonapi/carbonapi.yaml"]
+    depends_on:
+      go-carbon:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/render?target=constantLine(1)&format=json&from=-1min"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  fake-carbonapi-data:
+    image: grafana/fake-data-gen
+    environment:
+      FD_DATASOURCE: graphite
+      FD_PORT: 2013
+      FD_GRAPHITE_VERSION: 1.1
+    depends_on:
+      go-carbon:
+        condition: service_healthy

--- a/devenv/docker/blocks/carbonapi/go-carbon.conf
+++ b/devenv/docker/blocks/carbonapi/go-carbon.conf
@@ -1,0 +1,46 @@
+[common]
+logfile = ""
+logLevel = "info"
+maxCPU = 1
+graphPrefix = "carbon.agents.{host}"
+metricEndpoint = ""
+metricInterval = "1m0s"
+
+[whisper]
+data-dir = "/var/lib/graphite/whisper"
+schemas-file = "/etc/go-carbon/storage-schemas.conf"
+aggregation-file = ""
+workers = 1
+max-updates-per-second = 0
+max-creates-per-second = 0
+sparse-create = false
+enabled = true
+
+[cache]
+max-size = 1000000
+write-strategy = "max"
+
+[udp]
+listen = ":2003"
+enabled = false
+log-incomplete = false
+
+[tcp]
+listen = ":2003"
+enabled = true
+
+[pickle]
+listen = ":2004"
+enabled = true
+max-message-size = 67108864
+
+[carbonserver]
+listen = ":8080"
+enabled = false
+
+[dump]
+enabled = false
+
+[pprof]
+listen = "localhost:7007"
+enabled = false

--- a/devenv/docker/blocks/carbonapi/go-carbon.conf
+++ b/devenv/docker/blocks/carbonapi/go-carbon.conf
@@ -36,7 +36,13 @@ max-message-size = 67108864
 
 [carbonserver]
 listen = ":8080"
-enabled = false
+enabled = true
+# Rebuild the in-memory index every 3 seconds so metrics/find?query=* returns
+# 200 shortly after the first whisper file is created. Default is 5 minutes.
+# NOTE: the correct key is "scan-frequency" (not "filescaninterval").
+scan-frequency = "3s"
+# Index new metrics immediately when received (before the next scan cycle).
+realtime-index = 1
 
 [dump]
 enabled = false

--- a/devenv/docker/blocks/carbonapi/storage-schemas.conf
+++ b/devenv/docker/blocks/carbonapi/storage-schemas.conf
@@ -1,0 +1,3 @@
+[default]
+pattern = .*
+retentions = 10s:6h,1m:7d

--- a/pkg/tsdb/graphite/graphite_integration_test.go
+++ b/pkg/tsdb/graphite/graphite_integration_test.go
@@ -1,0 +1,235 @@
+package graphite
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// Integration tests for the Graphite backend datasource.
+//
+// These tests run against a real Graphite server (or compatible implementation such as
+// carbonapi) and are designed to catch compatibility regressions that mock-HTTP tests
+// cannot surface — encoding quirks, response format differences, and strictness around
+// query formatting that varies between Graphite versions.
+//
+// Usage:
+//
+//	# Start a Graphite server (e.g. via devenv)
+//	make devenv sources=graphite
+//
+//	# Run these tests
+//	GRAPHITE_URL=http://localhost:8180 go test -run '^TestIntegrationGraphite' ./pkg/tsdb/graphite/...
+//
+// Tests are skipped when GRAPHITE_URL is not set.
+
+func graphiteURL(t *testing.T) string {
+	t.Helper()
+	u, ok := os.LookupEnv("GRAPHITE_URL")
+	if !ok || u == "" {
+		t.Skip("GRAPHITE_URL not set — skipping Graphite integration tests")
+	}
+	return u
+}
+
+func newIntegrationService(t *testing.T) (*Service, *datasourceInfo) {
+	t.Helper()
+	url := graphiteURL(t)
+	svc := ProvideService(httpclient.NewProvider(), noop.NewTracerProvider().Tracer("graphite-integration"))
+	dsInfo := &datasourceInfo{
+		Id:         1,
+		URL:        url,
+		HTTPClient: &http.Client{Timeout: 10 * time.Second},
+	}
+	return svc, dsInfo
+}
+
+// TestIntegrationGraphiteHealthCheck verifies the Graphite server is reachable and
+// responds to a basic query (the same check the health check handler uses).
+func TestIntegrationGraphiteHealthCheck(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	svc, dsInfo := newIntegrationService(t)
+
+	req := &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+				ID:  1,
+				URL: dsInfo.URL,
+			},
+			OrgID: 1,
+		},
+		Queries: []backend.DataQuery{
+			{
+				RefID: "A",
+				TimeRange: backend.TimeRange{
+					From: time.Now().Add(-5 * time.Minute),
+					To:   time.Now(),
+				},
+				MaxDataPoints: 100,
+				JSON:          []byte(`{"target": "constantLine(100)"}`),
+			},
+		},
+	}
+
+	result, err := svc.RunQuery(context.Background(), req, dsInfo)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	resp, ok := result.Responses["A"]
+	require.True(t, ok)
+	assert.NoError(t, resp.Error)
+	assert.NotEmpty(t, resp.Frames)
+}
+
+// TestIntegrationGraphiteQuery verifies that a basic metric query returns valid data frames
+// with DisplayNameFromDS set to the metric name returned by Graphite (not the refId).
+//
+// This is a regression guard for issue #20454, where a naming convention change caused
+// DisplayNameFromDS to be set to the refId (#A) instead of the actual metric name.
+func TestIntegrationGraphiteQuery(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	svc, dsInfo := newIntegrationService(t)
+
+	req := &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+				ID:  1,
+				URL: dsInfo.URL,
+			},
+			OrgID: 1,
+		},
+		Queries: []backend.DataQuery{
+			{
+				RefID: "A",
+				TimeRange: backend.TimeRange{
+					From: time.Now().Add(-5 * time.Minute),
+					To:   time.Now(),
+				},
+				MaxDataPoints: 100,
+				JSON:          []byte(`{"target": "constantLine(42)"}`),
+			},
+		},
+	}
+
+	result, err := svc.RunQuery(context.Background(), req, dsInfo)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	resp, ok := result.Responses["A"]
+	require.True(t, ok)
+	require.NoError(t, resp.Error)
+	require.NotEmpty(t, resp.Frames)
+
+	frame := resp.Frames[0]
+	// Frame Name must be empty — it must NOT be the refId or the metric path.
+	assert.Equal(t, "", frame.Name, "frame Name should be empty, not the refId or metric path")
+
+	// DisplayNameFromDS must be the metric name returned by Graphite, not the refId.
+	require.Len(t, frame.Fields, 2)
+	valueField := frame.Fields[1]
+	require.NotNil(t, valueField.Config)
+	assert.NotEmpty(t, valueField.Config.DisplayNameFromDS, "DisplayNameFromDS should be set to the Graphite series name")
+	assert.NotEqual(t, "A", valueField.Config.DisplayNameFromDS, "DisplayNameFromDS must not be the refId")
+}
+
+// TestIntegrationGraphiteQueryTargetTrimming verifies that query targets with trailing
+// whitespace or newlines are trimmed before being sent to Graphite.
+//
+// This is a regression test for issue #17952, where trailing newlines in query targets
+// caused HTTP 400 errors from Booking's carbonapi (stricter than graphite-web).
+// The backend/alert query path does not wrap targets in aliasSub() as the frontend does,
+// so without trimming the raw whitespace reaches carbonapi verbatim.
+func TestIntegrationGraphiteQueryTargetTrimming(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	svc, dsInfo := newIntegrationService(t)
+
+	tests := []struct {
+		name      string
+		queryJSON string
+	}{
+		{
+			name:      "trailing newline",
+			queryJSON: "{\"target\": \"constantLine(1)\\n\"}",
+		},
+		{
+			name:      "leading and trailing whitespace",
+			queryJSON: `{"target": "  constantLine(1)  "}`,
+		},
+		{
+			name:      "targetFull with trailing newline",
+			queryJSON: "{\"target\": \"constantLine(1)\", \"targetFull\": \"constantLine(1)\\n\"}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &backend.QueryDataRequest{
+				PluginContext: backend.PluginContext{
+					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+						ID:  1,
+						URL: dsInfo.URL,
+					},
+					OrgID: 1,
+				},
+				Queries: []backend.DataQuery{
+					{
+						RefID: "A",
+						TimeRange: backend.TimeRange{
+							From: time.Now().Add(-5 * time.Minute),
+							To:   time.Now(),
+						},
+						MaxDataPoints: 100,
+						JSON:          []byte(tt.queryJSON),
+					},
+				},
+			}
+			result, err := svc.RunQuery(context.Background(), req, dsInfo)
+			require.NoError(t, err)
+			resp, ok := result.Responses["A"]
+			require.True(t, ok)
+			assert.NoError(t, resp.Error, "query with %s should not produce an error — check target trimming", tt.name)
+		})
+	}
+}
+
+// TestIntegrationGraphiteMetricsFind verifies that the /metrics/find resource endpoint
+// returns a valid response from the live Graphite server.
+func TestIntegrationGraphiteMetricsFind(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	url := graphiteURL(t)
+
+	svc := ProvideService(httpclient.NewProvider(), noop.NewTracerProvider().Tracer("graphite-integration"))
+	dsInfo := &datasourceInfo{
+		Id:         1,
+		URL:        url,
+		HTTPClient: &http.Client{Timeout: 10 * time.Second},
+	}
+
+	// Use a wildcard that should match at least the built-in carbon.* metrics
+	// available in graphite-statsd containers.
+	req, err := svc.createRequest(context.Background(), dsInfo, URLParams{
+		SubPath:     "metrics/find",
+		Method:      http.MethodPost,
+		Body:        nil,
+		Headers:     map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+		QueryParams: map[string][]string{"query": {"*"}},
+	})
+	require.NoError(t, err)
+
+	resp, err := dsInfo.HTTPClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		fmt.Sprintf("GET /metrics/find?query=* should return 200 from %s", url))
+}

--- a/pkg/tsdb/graphite/graphite_integration_test.go
+++ b/pkg/tsdb/graphite/graphite_integration_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
-
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 // Integration tests for the Graphite backend datasource.
@@ -58,7 +56,9 @@ func newIntegrationService(t *testing.T) (*Service, *datasourceInfo) {
 // TestIntegrationGraphiteHealthCheck verifies the Graphite server is reachable and
 // responds to a basic query (the same check the health check handler uses).
 func TestIntegrationGraphiteHealthCheck(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	svc, dsInfo := newIntegrationService(t)
 
 	req := &backend.QueryDataRequest{
@@ -97,7 +97,9 @@ func TestIntegrationGraphiteHealthCheck(t *testing.T) {
 // This is a regression guard for issue #20454, where a naming convention change caused
 // DisplayNameFromDS to be set to the refId (#A) instead of the actual metric name.
 func TestIntegrationGraphiteQuery(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	svc, dsInfo := newIntegrationService(t)
 
 	req := &backend.QueryDataRequest{
@@ -150,7 +152,9 @@ func TestIntegrationGraphiteQuery(t *testing.T) {
 // The backend/alert query path does not wrap targets in aliasSub() as the frontend does,
 // so without trimming the raw whitespace reaches carbonapi verbatim.
 func TestIntegrationGraphiteQueryTargetTrimming(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	svc, dsInfo := newIntegrationService(t)
 
 	tests := []struct {
@@ -205,7 +209,9 @@ func TestIntegrationGraphiteQueryTargetTrimming(t *testing.T) {
 // TestIntegrationGraphiteMetricsFind verifies that the /metrics/find resource endpoint
 // returns a valid response from the live Graphite server.
 func TestIntegrationGraphiteMetricsFind(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	url := graphiteURL(t)
 
 	svc := ProvideService(httpclient.NewProvider(), noop.NewTracerProvider().Tracer("graphite-integration"))
@@ -215,21 +221,21 @@ func TestIntegrationGraphiteMetricsFind(t *testing.T) {
 		HTTPClient: &http.Client{Timeout: 10 * time.Second},
 	}
 
-	// Use a wildcard that should match at least the built-in carbon.* metrics
-	// available in graphite-statsd containers.
+	// "grafanatest" is seeded by the CI setup; ensure it exists when running locally.
+	query := "grafanatest"
 	req, err := svc.createRequest(context.Background(), dsInfo, URLParams{
 		SubPath:     "metrics/find",
 		Method:      http.MethodPost,
 		Body:        nil,
 		Headers:     map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-		QueryParams: map[string][]string{"query": {"*"}},
+		QueryParams: map[string][]string{"query": {query}},
 	})
 	require.NoError(t, err)
 
 	resp, err := dsInfo.HTTPClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode,
-		fmt.Sprintf("GET /metrics/find?query=* should return 200 from %s", url))
+		fmt.Sprintf("POST /metrics/find?query=%s should return 200 from %s", query, url))
 }

--- a/pkg/tsdb/graphite/query.go
+++ b/pkg/tsdb/graphite/query.go
@@ -144,7 +144,7 @@ func (s *Service) processQuery(query backend.DataQuery) (string, *GraphiteQuery,
 		s.logger.Debug("Graphite", "empty query target", queryJSON)
 		return "", &queryJSON, false, nil
 	}
-	target := fixIntervalFormat(currTarget)
+	target := strings.TrimSpace(fixIntervalFormat(currTarget))
 
 	return target, nil, queryJSON.IsMetricTank, nil
 }

--- a/pkg/tsdb/graphite/query_test.go
+++ b/pkg/tsdb/graphite/query_test.go
@@ -842,7 +842,7 @@ func TestTargetSentToGraphite(t *testing.T) {
 			req := &backend.QueryDataRequest{
 				PluginContext: backend.PluginContext{
 					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{ID: 1, URL: server.URL},
-					OrgID: 1,
+					OrgID:                      1,
 				},
 				Queries: []backend.DataQuery{
 					{
@@ -869,23 +869,23 @@ func TestTargetSentToGraphite(t *testing.T) {
 //   - Frame Name is always empty — any change setting it to a refId would be caught here
 func TestDisplayNameFromDS(t *testing.T) {
 	tests := []struct {
-		name                    string
-		graphiteTarget          string
+		name                      string
+		graphiteTarget            string
 		expectedDisplayNameFromDS string
 	}{
 		{
-			name:                    "plain metric name flows to DisplayNameFromDS",
-			graphiteTarget:          "stats.counters.web.hits",
+			name:                      "plain metric name flows to DisplayNameFromDS",
+			graphiteTarget:            "stats.counters.web.hits",
 			expectedDisplayNameFromDS: "stats.counters.web.hits",
 		},
 		{
-			name:                    "alias-resolved name flows to DisplayNameFromDS",
-			graphiteTarget:          "Web Hits",
+			name:                      "alias-resolved name flows to DisplayNameFromDS",
+			graphiteTarget:            "Web Hits",
 			expectedDisplayNameFromDS: "Web Hits",
 		},
 		{
-			name:                    "aliasByNode-resolved name flows to DisplayNameFromDS",
-			graphiteTarget:          "hits",
+			name:                      "aliasByNode-resolved name flows to DisplayNameFromDS",
+			graphiteTarget:            "hits",
 			expectedDisplayNameFromDS: "hits",
 		},
 	}
@@ -905,7 +905,7 @@ func TestDisplayNameFromDS(t *testing.T) {
 			req := &backend.QueryDataRequest{
 				PluginContext: backend.PluginContext{
 					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{ID: 1, URL: server.URL},
-					OrgID: 1,
+					OrgID:                      1,
 				},
 				Queries: []backend.DataQuery{
 					{

--- a/pkg/tsdb/graphite/query_test.go
+++ b/pkg/tsdb/graphite/query_test.go
@@ -58,6 +58,58 @@ func TestProcessQuery(t *testing.T) {
 		assert.False(t, isMetricTank)
 	})
 
+	t.Run("Trims trailing newline from target", func(t *testing.T) {
+		queries := []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON:  []byte("{\"target\": \"stats.counters.web.hits\\n\"}"),
+			},
+		}
+		target, jsonModel, _, err := service.processQuery(queries[0])
+		assert.NoError(t, err)
+		assert.Nil(t, jsonModel)
+		assert.Equal(t, "stats.counters.web.hits", target)
+	})
+
+	t.Run("Trims leading and trailing whitespace from target", func(t *testing.T) {
+		queries := []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON:  []byte("{\"target\": \"  stats.counters.web.hits  \"}"),
+			},
+		}
+		target, jsonModel, _, err := service.processQuery(queries[0])
+		assert.NoError(t, err)
+		assert.Nil(t, jsonModel)
+		assert.Equal(t, "stats.counters.web.hits", target)
+	})
+
+	t.Run("Uses targetFull over target when both are set", func(t *testing.T) {
+		queries := []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON:  []byte(`{"target": "stats.counters.web.hits", "targetFull": "asPercent(stats.counters.web.hits, stats.counters.web.total)"}`),
+			},
+		}
+		target, jsonModel, _, err := service.processQuery(queries[0])
+		assert.NoError(t, err)
+		assert.Nil(t, jsonModel)
+		assert.Equal(t, "asPercent(stats.counters.web.hits, stats.counters.web.total)", target)
+	})
+
+	t.Run("Trims trailing newline from targetFull", func(t *testing.T) {
+		queries := []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON:  []byte("{\"target\": \"stats.counters.web.hits\", \"targetFull\": \"asPercent(stats.counters.web.hits, stats.counters.web.total)\\n\"}"),
+			},
+		}
+		target, jsonModel, _, err := service.processQuery(queries[0])
+		assert.NoError(t, err)
+		assert.Nil(t, jsonModel)
+		assert.Equal(t, "asPercent(stats.counters.web.hits, stats.counters.web.total)", target)
+	})
+
 	t.Run("Returns isMetricTank value", func(t *testing.T) {
 		queries := []backend.DataQuery{
 			{
@@ -743,6 +795,147 @@ func TestRunQueryE2E(t *testing.T) {
 					experimental.CheckGoldenJSONResponse(t, "testdata", fmt.Sprintf("%s-%s.golden", testName, refId), &resp, false)
 				}
 			}
+		})
+	}
+}
+
+// TestTargetSentToGraphite verifies the exact form body sent to the Graphite /render endpoint.
+// This is a regression test for issue #17952 where trailing newlines in query targets caused
+// HTTP 400 errors from Booking's carbonapi (which is stricter than graphite-web).
+func TestTargetSentToGraphite(t *testing.T) {
+	tests := []struct {
+		name           string
+		queryJSON      string
+		expectedTarget string
+	}{
+		{
+			name:           "trailing newline is trimmed before sending",
+			queryJSON:      "{\"target\": \"stats.counters.web.hits\\n\"}",
+			expectedTarget: "stats.counters.web.hits",
+		},
+		{
+			name:           "leading and trailing whitespace trimmed before sending",
+			queryJSON:      "{\"target\": \"  stats.counters.web.hits  \"}",
+			expectedTarget: "stats.counters.web.hits",
+		},
+		{
+			name:           "targetFull with trailing newline is trimmed before sending",
+			queryJSON:      "{\"target\": \"stats.counters.web.hits\", \"targetFull\": \"asPercent(stats.counters.web.hits, stats.counters.web.total)\\n\"}",
+			expectedTarget: "asPercent(stats.counters.web.hits, stats.counters.web.total)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var receivedTarget string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				err := r.ParseForm()
+				require.NoError(t, err)
+				receivedTarget = r.FormValue("target")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[]`))
+			}))
+			defer server.Close()
+
+			service := &Service{logger: backend.Logger}
+			dsInfo := &datasourceInfo{Id: 1, URL: server.URL, HTTPClient: &http.Client{}}
+			req := &backend.QueryDataRequest{
+				PluginContext: backend.PluginContext{
+					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{ID: 1, URL: server.URL},
+					OrgID: 1,
+				},
+				Queries: []backend.DataQuery{
+					{
+						RefID: "A",
+						TimeRange: backend.TimeRange{
+							From: time.Unix(1609459200, 0),
+							To:   time.Unix(1609459260, 0),
+						},
+						MaxDataPoints: 1000,
+						JSON:          []byte(tt.queryJSON),
+					},
+				},
+			}
+			_, err := service.RunQuery(context.Background(), req, dsInfo)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedTarget, receivedTarget)
+		})
+	}
+}
+
+// TestDisplayNameFromDS is a regression test for issue #20454 / grafana#117158.
+// It verifies that:
+//   - DisplayNameFromDS equals the series target returned by Graphite (including alias-resolved names)
+//   - Frame Name is always empty — any change setting it to a refId would be caught here
+func TestDisplayNameFromDS(t *testing.T) {
+	tests := []struct {
+		name                    string
+		graphiteTarget          string
+		expectedDisplayNameFromDS string
+	}{
+		{
+			name:                    "plain metric name flows to DisplayNameFromDS",
+			graphiteTarget:          "stats.counters.web.hits",
+			expectedDisplayNameFromDS: "stats.counters.web.hits",
+		},
+		{
+			name:                    "alias-resolved name flows to DisplayNameFromDS",
+			graphiteTarget:          "Web Hits",
+			expectedDisplayNameFromDS: "Web Hits",
+		},
+		{
+			name:                    "aliasByNode-resolved name flows to DisplayNameFromDS",
+			graphiteTarget:          "hits",
+			expectedDisplayNameFromDS: "hits",
+		},
+	}
+
+	service := &Service{logger: backend.Logger}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				resp := fmt.Sprintf(`[{"target": %q, "datapoints": [[100, 1609459200]]}]`, tt.graphiteTarget)
+				_, _ = w.Write([]byte(resp))
+			}))
+			defer server.Close()
+
+			dsInfo := &datasourceInfo{Id: 1, URL: server.URL, HTTPClient: &http.Client{}}
+			req := &backend.QueryDataRequest{
+				PluginContext: backend.PluginContext{
+					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{ID: 1, URL: server.URL},
+					OrgID: 1,
+				},
+				Queries: []backend.DataQuery{
+					{
+						RefID: "A",
+						TimeRange: backend.TimeRange{
+							From: time.Unix(1609459200, 0),
+							To:   time.Unix(1609459260, 0),
+						},
+						MaxDataPoints: 1000,
+						JSON:          []byte(`{"target": "ignored.because.graphite.returns.target"}`),
+					},
+				},
+			}
+			result, err := service.RunQuery(context.Background(), req, dsInfo)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			resp, ok := result.Responses["A"]
+			require.True(t, ok)
+			require.Len(t, resp.Frames, 1)
+
+			frame := resp.Frames[0]
+			// Frame Name must be empty — it is NOT the refId, not the metric path.
+			// This is the invariant broken by the naming convention change in #20454.
+			assert.Equal(t, "", frame.Name)
+
+			// DisplayNameFromDS must be the alias-resolved name Graphite returned.
+			valueField := frame.Fields[1]
+			require.NotNil(t, valueField.Config)
+			assert.Equal(t, tt.expectedDisplayNameFromDS, valueField.Config.DisplayNameFromDS)
 		})
 	}
 }

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -1286,6 +1286,45 @@ describe('graphiteDatasource', () => {
       expect(results.length).toBe(1);
     });
 
+    // Regression test for issue #17952: trailing newlines in query targets caused HTTP 400
+    // from Booking's carbonapi. The backend alert path does not wrap targets in aliasSub()
+    // as the frontend does, so raw whitespace reached carbonapi verbatim.
+    it('should trim trailing newline from target and targetFull', () => {
+      const originalTargetMap = {
+        A: 'stats.counters.web.hits\n',
+      };
+      const results = ctx.ds.backendBuildGraphiteQueries(
+        {
+          ...defaultQueryProperties,
+          targets: [{ target: 'stats.counters.web.hits\n', refId: 'A' }],
+        },
+        originalTargetMap
+      );
+      expect(results[0].target).toBe('stats.counters.web.hits');
+      expect(results[0].targetFull).toBe('stats.counters.web.hits');
+    });
+
+    it('should trim trailing newline from resolved cross-query target', () => {
+      // Series A has no trailing newline; only B's own target has one.
+      // The trim() must clean the final resolved value even when cross-references are involved.
+      const originalTargetMap = {
+        A: 'series1',
+        B: 'asPercent(#A, 100)\n',
+      };
+      const results = ctx.ds.backendBuildGraphiteQueries(
+        {
+          ...defaultQueryProperties,
+          targets: [
+            { target: 'series1', refId: 'A' },
+            { target: 'asPercent(#A, 100)\n', refId: 'B' },
+          ],
+        },
+        originalTargetMap
+      );
+      expect(results[1].target).toBe('asPercent(series1, 100)');
+      expect(results[1].targetFull).toBe('asPercent(series1, 100)');
+    });
+
     describe('when formatting targets', () => {
       it('does not attempt to glob for one variable', () => {
         const originalReplace = ctx.templateSrv.replace;
@@ -1680,6 +1719,70 @@ describe('graphiteDatasource', () => {
       expect(data[1].text).toBe('apps.backend.backend_02');
 
       config.featureToggles.graphiteBackendMode = false;
+    });
+
+    // Regression tests for missing backend-mode coverage.
+    // In backend mode, all variable query sub-paths use postResource() instead of
+    // direct HTTP fetch, but only the MetricName path had a test (added in #119498).
+    describe('backend mode variable query paths', () => {
+      beforeEach(() => {
+        config.featureToggles.graphiteBackendMode = true;
+      });
+
+      afterEach(() => {
+        config.featureToggles.graphiteBackendMode = false;
+      });
+
+      it('requestMetricFind uses postResource in backend mode', async () => {
+        postResourceMock.mockResolvedValue([
+          { text: 'backend_01', expandable: false },
+          { text: 'backend_02', expandable: true },
+        ]);
+
+        const data = await ctx.ds.metricFindQuery('apps.backend.*');
+
+        expect(postResourceMock).toHaveBeenCalledWith('metrics/find', expect.objectContaining({ query: 'apps.backend.*' }));
+        expect(data).toEqual([
+          { text: 'backend_01', expandable: false },
+          { text: 'backend_02', expandable: true },
+        ]);
+      });
+
+      it('requestMetricExpand uses postResource in backend mode', async () => {
+        postResourceMock.mockResolvedValue([
+          { text: 'apps.backend.backend_01', expandable: false },
+          { text: 'apps.backend.backend_02', expandable: false },
+        ]);
+
+        const data = await ctx.ds.metricFindQuery('expand(apps.backend.*)');
+
+        expect(postResourceMock).toHaveBeenCalledWith('metrics/expand', expect.objectContaining({ query: 'apps.backend.*' }));
+        expect(data).toEqual([
+          { text: 'apps.backend.backend_01', expandable: false },
+          { text: 'apps.backend.backend_02', expandable: false },
+        ]);
+      });
+
+      it('getTagsAutoComplete uses postResource in backend mode', async () => {
+        postResourceMock.mockResolvedValue(['server', 'region', 'env']);
+
+        const data = await ctx.ds.metricFindQuery('tags(server=backend_01)');
+
+        expect(postResourceMock).toHaveBeenCalledWith('tags/autoComplete/tags', expect.objectContaining({ tagPrefix: undefined }));
+        expect(data).toEqual([{ text: 'server' }, { text: 'region' }, { text: 'env' }]);
+      });
+
+      it('getTagValuesAutoComplete uses postResource in backend mode', async () => {
+        postResourceMock.mockResolvedValue(['backend_01', 'backend_02', 'backend_03']);
+
+        const data = await ctx.ds.metricFindQuery('tag_values(server)');
+
+        expect(postResourceMock).toHaveBeenCalledWith(
+          'tags/autoComplete/values',
+          expect.objectContaining({ tag: 'server' })
+        );
+        expect(data).toEqual([{ text: 'backend_01' }, { text: 'backend_02' }, { text: 'backend_03' }]);
+      });
     });
   });
 

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -1741,7 +1741,10 @@ describe('graphiteDatasource', () => {
 
         const data = await ctx.ds.metricFindQuery('apps.backend.*');
 
-        expect(postResourceMock).toHaveBeenCalledWith('metrics/find', expect.objectContaining({ query: 'apps.backend.*' }));
+        expect(postResourceMock).toHaveBeenCalledWith(
+          'metrics/find',
+          expect.objectContaining({ query: 'apps.backend.*' })
+        );
         expect(data).toEqual([
           { text: 'backend_01', expandable: false },
           { text: 'backend_02', expandable: true },
@@ -1756,7 +1759,10 @@ describe('graphiteDatasource', () => {
 
         const data = await ctx.ds.metricFindQuery('expand(apps.backend.*)');
 
-        expect(postResourceMock).toHaveBeenCalledWith('metrics/expand', expect.objectContaining({ query: 'apps.backend.*' }));
+        expect(postResourceMock).toHaveBeenCalledWith(
+          'metrics/expand',
+          expect.objectContaining({ query: 'apps.backend.*' })
+        );
         expect(data).toEqual([
           { text: 'apps.backend.backend_01', expandable: false },
           { text: 'apps.backend.backend_02', expandable: false },
@@ -1768,7 +1774,10 @@ describe('graphiteDatasource', () => {
 
         const data = await ctx.ds.metricFindQuery('tags(server=backend_01)');
 
-        expect(postResourceMock).toHaveBeenCalledWith('tags/autoComplete/tags', expect.objectContaining({ tagPrefix: undefined }));
+        expect(postResourceMock).toHaveBeenCalledWith(
+          'tags/autoComplete/tags',
+          expect.objectContaining({ tagPrefix: undefined })
+        );
         expect(data).toEqual([{ text: 'server' }, { text: 'region' }, { text: 'env' }]);
       });
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -311,8 +311,8 @@ export class GraphiteDatasource
         options.scopedVars
       );
 
-      targetClone.target = targetValue;
-      targetClone.targetFull = targetFullValue;
+      targetClone.target = targetValue.trim();
+      targetClone.targetFull = targetFullValue.trim();
       if (this.isMetricTank) {
         targetClone.isMetricTank = true;
       }


### PR DESCRIPTION
**What is this feature?**

Adds `carbonapi` compatibility fixes and integration test coverage for the Graphite data source.

- **Compatibility fix — trim query targets.** `carbonapi` (including the `bookingcom/carbonapi` fork) is stricter than `graphite-web` about query formatting and rejects targets with leading/trailing whitespace. Targets are now trimmed in both the backend (`pkg/tsdb/graphite/query.go`) and the frontend (`public/app/plugins/datasource/graphite/datasource.ts`).
- **Integration tests.** `pkg/tsdb/graphite/graphite_integration_test.go` runs against a live Graphite/carbonapi server and **self-skips when `GRAPHITE_URL` is unset**, so it is zero-cost for regular runs and opt-in for local dev.
- **CI job.** A new `graphite` job in `.github/workflows/pr-test-integration.yml` runs the suite against a matrix: `graphite-1.0`, `graphite-1.1`, `carbonapi`, and a source-built `bookingcom-carbonapi`.
- **devenv blocks.** New Docker blocks under `devenv/docker/blocks/carbonapi/` and `devenv/docker/blocks/carbonapi-booking/`, with Makefile healthcheck wiring and CODEOWNERS entries.

**Why do we need this feature?**

Some Graphite deployments route queries through `carbonapi` rather than `graphite-web`. Its stricter query parsing surfaced regressions that the existing test matrix did not catch. These changes fix the formatting incompatibility and add coverage that exercises multiple Graphite server implementations.

**Who is this feature for?**

Users running the Graphite data source against `carbonapi`-backed stores, and contributors maintaining the Graphite backend.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

This PR restores the work from #121758, which was closed unmerged with its branch deleted. The original commits could not be reopened in place (the signed-commits ruleset prevents restoring their unsigned head), so the three commits were recovered, **rebased onto current `main`**, re-signed, and pushed here. Two rebase conflicts were resolved during the rebase:

- `.github/workflows/pr-test-integration.yml`: kept only the new `graphite` job; the `required-backend-integration-tests` aggregator that appeared adjacent in the original diff has since been removed from `main`, so it was intentionally not resurrected.
- `.github/CODEOWNERS`: the `@grafana/partner-datasources` team was renamed to `@grafana/data-sources-plugins` on `main`; the new `carbonapi` blocks adopt the current team name to match the surrounding entries.

The `carbonapi` integration tests target the public `bookingcom/carbonapi` fork. Compatibility with upstream `go-graphite/carbonapi` remains the primary goal; this is a best-effort stopgap pending broader E2E coverage.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
