### PR TITLE
fix: Dynamically construct `jwk_set_url` by using kid as part of the URL

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1004,6 +1004,7 @@ email_claim =
 username_claim =
 email_attribute_path =
 username_attribute_path =
+# jwk_set_url may contain a {{kid}} placeholder that is replaced with the key id from the token header, e.g. https://public-keys.auth.elb.eu-west-1.amazonaws.com/{{kid}}
 jwk_set_url =
 jwk_set_bearer_token_file =
 jwk_set_file =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -948,6 +948,7 @@
 ;username_claim = sub
 ;email_attribute_path = jmespath.email
 ;username_attribute_path = jmespath.username
+# jwk_set_url may contain a {{kid}} placeholder that is replaced with the key id from the token header, e.g. https://public-keys.auth.elb.eu-west-1.amazonaws.com/{{kid}}
 ;jwk_set_url = https://foo.bar/.well-known/jwks.json
 ;jwk_set_bearer_token_file = /path/to/token/file
 ;jwk_set_file = /path/to/jwks.json

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/jwt/index.md
@@ -178,6 +178,16 @@ cache_ttl = 60m
 If the JWKS endpoint includes cache control headers and the value is less than the configured `cache_ttl`, then the cache control header value is used instead. If the `cache_ttl` is not set, the default of `60m` is used. `no-store` and `no-cache` cache control headers are ignored. To disable JWKS caching, set `cache_ttl = 0s`
 {{< /admonition >}}
 
+#### Use the key id to build the JWKS URL
+
+Some providers, such as AWS Application Load Balancer, host each key on its own URL derived from the token's key id (`kid`). To support these, `jwk_set_url` may include a `{{kid}}` placeholder that is replaced with the `kid` from the token header before the request is made.
+
+```ini
+jwk_set_url = https://public-keys.auth.elb.eu-west-1.amazonaws.com/{{kid}}
+```
+
+When the URL is templated, the token must carry a `kid` header, otherwise verification fails. Each resolved URL is cached independently.
+
 ### Verify token using a JSON Web Key Set loaded from JSON file
 
 Key set in the same format as in JWKS endpoint but located on disk.

--- a/pkg/services/auth/jwt/auth_test.go
+++ b/pkg/services/auth/jwt/auth_test.go
@@ -300,6 +300,50 @@ func TestIntegrationVerifyUsingJWKSetURL(t *testing.T) {
 		_, err := sc.authJWTSvc.Verify(sc.ctx, token)
 		require.Error(t, err)
 	})
+
+	t.Run("verifies a token using a {{kid}} templated URL", func(t *testing.T) {
+		var requestedPaths []string
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestedPaths = append(requestedPaths, r.URL.Path)
+			kid := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/"), "/jwks.json")
+			jwks := jose.JSONWebKeySet{}
+			for _, k := range jwksPublic.Keys {
+				if k.KeyID == kid {
+					jwks.Keys = append(jwks.Keys, k)
+				}
+			}
+			if err := json.NewEncoder(w).Encode(jwks); err != nil {
+				panic(err)
+			}
+		}))
+		t.Cleanup(ts.Close)
+
+		configure := func(t *testing.T, cfg *setting.Cfg) {
+			cfg.JWTAuth.JWKSetURL = ts.URL + "/{{kid}}/jwks.json"
+		}
+		runner := scenarioRunner(func(t *testing.T, sc scenarioContext) {
+			keySet := sc.authJWTSvc.keySet.(*keySetHTTP)
+			keySet.client = ts.Client()
+
+			token := sign(t, &jwKeys[1], jwt.Claims{Subject: subject}, nil)
+			verifiedClaims, err := sc.authJWTSvc.Verify(sc.ctx, token)
+			require.NoError(t, err)
+			assert.Equal(t, verifiedClaims["sub"], subject)
+			require.Contains(t, requestedPaths, "/key-id-01/jwks.json")
+		}, configure)
+		runner(t)
+	})
+
+	t.Run("rejects a token with no kid when URL is templated", func(t *testing.T) {
+		runner := scenarioRunner(func(t *testing.T, sc scenarioContext) {
+			token := sign(t, jwKeys[0].Key, jwt.Claims{Subject: subject}, nil)
+			_, err := sc.authJWTSvc.Verify(sc.ctx, token)
+			require.ErrorIs(t, err, ErrMissingKeyIDForTemplatedURL)
+		}, func(t *testing.T, cfg *setting.Cfg) {
+			cfg.JWTAuth.JWKSetURL = "https://example.com/{{kid}}/jwks.json"
+		})
+		runner(t)
+	})
 }
 
 // test that caCert and bearer token files have been read and configured and an error is thrown when the file does not exist or is empty

--- a/pkg/services/auth/jwt/key_sets.go
+++ b/pkg/services/auth/jwt/key_sets.go
@@ -32,6 +32,11 @@ var ErrKeySetConfigurationAmbiguous = errors.New("key set configuration is ambig
 var ErrJWTSetURLMustHaveHTTPSScheme = errors.New("jwt_set_url must have https scheme")
 var ErrFailedToDecodeKeyValue = errors.New("failed to base64-decode inline key value")
 var ErrPrivateKeyNotSupported = errors.New("private keys are not supported for JWT verification; configure the corresponding public key")
+var ErrMissingKeyIDForTemplatedURL = errors.New("jwk_set_url contains a {{kid}} placeholder but the token has no key id")
+
+// kidPlaceholder is replaced with the token's key id when present in jwk_set_url.
+// This allows fetching the JWKS from a per-key endpoint, e.g. AWS load balancer keys.
+const kidPlaceholder = "{{kid}}"
 
 type keySet interface {
 	Key(ctx context.Context, kid string) ([]jose.JSONWebKey, error)
@@ -43,6 +48,7 @@ type keySetJWKS struct {
 
 type keySetHTTP struct {
 	url             string
+	templated       bool
 	log             log.Logger
 	client          *http.Client
 	bearerTokenPath string
@@ -165,6 +171,7 @@ func (s *AuthService) newHTTPKeySet(urlStr string) (*keySetHTTP, error) {
 
 	return &keySetHTTP{
 		url:             urlStr,
+		templated:       strings.Contains(urlStr, kidPlaceholder),
 		log:             s.log,
 		bearerTokenPath: s.Cfg.JWTAuth.JWKSetBearerTokenFile,
 		client: &http.Client{
@@ -285,11 +292,21 @@ func getBearerToken(bearerTokenPath string) (string, error) {
 	return fmt.Sprintf("Bearer %s", t), nil
 }
 
-func (ks *keySetHTTP) getJWKS(ctx context.Context) (keySetJWKS, error) {
+func (ks *keySetHTTP) getJWKS(ctx context.Context, kid string) (keySetJWKS, error) {
 	var jwks keySetJWKS
 
+	reqURL := ks.url
+	cacheKey := ks.cacheKey
+	if ks.templated {
+		if kid == "" {
+			return jwks, ErrMissingKeyIDForTemplatedURL
+		}
+		reqURL = strings.ReplaceAll(ks.url, kidPlaceholder, url.PathEscape(kid))
+		cacheKey = fmt.Sprintf("auth-jwt:jwk-%s", reqURL)
+	}
+
 	if ks.cacheExpiration > 0 {
-		if val, err := ks.cache.Get(ctx, ks.cacheKey); err == nil {
+		if val, err := ks.cache.Get(ctx, cacheKey); err == nil {
 			err := json.Unmarshal(val, &jwks)
 			if err != nil {
 				ks.log.Warn("Failed to unmarshal key set from cache", "err", err)
@@ -299,9 +316,9 @@ func (ks *keySetHTTP) getJWKS(ctx context.Context) (keySetJWKS, error) {
 		}
 	}
 
-	ks.log.Debug("Getting key set from endpoint", "url", ks.url)
+	ks.log.Debug("Getting key set from endpoint", "url", reqURL)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ks.url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return jwks, err
 	}
@@ -335,9 +352,9 @@ func (ks *keySetHTTP) getJWKS(ctx context.Context) (keySetJWKS, error) {
 	if ks.cacheExpiration > 0 {
 		cacheExpiration := ks.getCacheExpiration(resp.Header.Get("cache-control"))
 
-		ks.log.Debug("Setting key set in cache", "url", ks.url,
+		ks.log.Debug("Setting key set in cache", "url", reqURL,
 			"cacheExpiration", cacheExpiration, "cacheControl", resp.Header.Get("cache-control"))
-		err = ks.cache.Set(ctx, ks.cacheKey, jsonBuf.Bytes(), cacheExpiration)
+		err = ks.cache.Set(ctx, cacheKey, jsonBuf.Bytes(), cacheExpiration)
 	}
 	return jwks, err
 }
@@ -368,7 +385,7 @@ func (ks *keySetHTTP) getCacheExpiration(cacheControl string) time.Duration {
 }
 
 func (ks keySetHTTP) Key(ctx context.Context, kid string) ([]jose.JSONWebKey, error) {
-	jwks, err := ks.getJWKS(ctx)
+	jwks, err := ks.getJWKS(ctx, kid)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

The JWT auth key set only supported a single, statically configured `jwk_set_url`. The HTTP key set (`keySetHTTP` in `pkg/services/auth/jwt/key_sets.go`) always fetched the JWKS from one fixed URL, ignoring the token's key id (`kid`).


## Root cause

The JWT auth key set only supported a single, statically configured `jwk_set_url`. The HTTP key set (`keySetHTTP` in `pkg/services/auth/jwt/key_sets.go`) always fetched the JWKS from one fixed URL, ignoring the token's key id (`kid`). Providers like AWS Application Load Balancer host each signing key at a different URL derived from the `kid`, so there was no way to configure JWT auth against them. The `kid` was already available at verification time (it is passed into `keySet.Key(ctx, kid)`), but it was never used to build the request URL.


## What changed

- `pkg/services/auth/jwt/key_sets.go`
 - Added a `{{kid}}` placeholder constant and a new sentinel error `ErrMissingKeyIDForTemplatedURL`.
 - Added a `templated` flag to `keySetHTTP`, set when the configured URL contains `{{kid}}`.
 - Changed `getJWKS` to take the `kid`. When the URL is templated it substitutes the `kid` (URL-path escaped to avoid injection) into the URL and uses a per-resolved-URL cache key, so different keys are cached independently. If a templated URL is configured but the token has no `kid`, it returns `ErrMissingKeyIDForTemplatedURL`. Non-templated URLs behave exactly as before.
 - Updated `Key` to pass the `kid` through to `getJWKS`.
- `conf/defaults.ini`, `conf/sample.ini`: documented the `{{kid}}` placeholder near `jwk_set_url`.
- `docs/sources/setup-grafana/configure-access/configure-authentication/jwt/index.md`: added a section explaining how to build the JWKS URL from the key id.
- `pkg/services/auth/jwt/auth_test.go`: added tests for the templated URL path (successful verification against a per-kid endpoint) and for the no-kid error case.

The change is backwards compatible: URLs without the placeholder keep their previous behavior and cache key.


## Issue

Fixes #109373

Issue: https://github.com/grafana/grafana/issues/109373


## Diffstat

```
conf/defaults.ini | 1 +
 conf/sample.ini | 1 +
 .../configure-authentication/jwt/index.md | 10 +++++
 pkg/services/auth/jwt/auth_test.go | 44 ++++++++++++++++++++++
 pkg/services/auth/jwt/key_sets.go | 31 +++++++++++----
 5 files changed, 80 insertions(+), 7 deletions(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.