### PR TITLE
TraceView: Isolate aggregation.* tags in a Summary attributes accordion

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -97,6 +97,7 @@ export function TraceView(props: Props) {
     detailReferencesToggle,
     detailReferenceItemToggle,
     detailTagsToggle,
+    detailSummaryAttributesToggle,
     detailWarningsToggle,
     detailStackTracesToggle,
   } = useDetailState(props.dataFrames[0]);
@@ -248,6 +249,7 @@ export function TraceView(props: Props) {
             detailReferenceItemToggle={detailReferenceItemToggle}
             detailProcessToggle={detailProcessToggle}
             detailTagsToggle={detailTagsToggle}
+            detailSummaryAttributesToggle={detailSummaryAttributesToggle}
             detailToggle={toggleDetail}
             addHoverIndentGuideId={addHoverIndentGuideId}
             removeHoverIndentGuideId={removeHoverIndentGuideId}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/DetailState.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/DetailState.tsx
@@ -22,6 +22,7 @@ import { type TraceSpanReference } from '../../types/trace';
 export default class DetailState {
   isTagsOpen: boolean;
   isProcessOpen: boolean;
+  isSummaryAttributesOpen: boolean;
   logs: { isOpen: boolean; openedItems: Set<TraceLog> };
   references: { isOpen: boolean; openedItems: Set<TraceSpanReference> };
   isWarningsOpen: boolean;
@@ -32,6 +33,7 @@ export default class DetailState {
     const {
       isTagsOpen,
       isProcessOpen,
+      isSummaryAttributesOpen,
       isReferencesOpen,
       isWarningsOpen,
       isStackTracesOpen,
@@ -40,6 +42,7 @@ export default class DetailState {
     }: DetailState | Record<string, undefined> = oldState || {};
     this.isTagsOpen = Boolean(isTagsOpen);
     this.isProcessOpen = Boolean(isProcessOpen);
+    this.isSummaryAttributesOpen = Boolean(isSummaryAttributesOpen);
     this.isReferencesOpen = Boolean(isReferencesOpen);
     this.isWarningsOpen = Boolean(isWarningsOpen);
     this.isStackTracesOpen = Boolean(isStackTracesOpen);
@@ -62,6 +65,12 @@ export default class DetailState {
   toggleProcess() {
     const next = new DetailState(this);
     next.isProcessOpen = !this.isProcessOpen;
+    return next;
+  }
+
+  toggleSummaryAttributes() {
+    const next = new DetailState(this);
+    next.isSummaryAttributesOpen = !this.isSummaryAttributesOpen;
     return next;
   }
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
@@ -80,6 +80,7 @@ describe('<SpanDetail>', () => {
     logsToggle: jest.fn(),
     processToggle: jest.fn(),
     tagsToggle: jest.fn(),
+    summaryAttributesToggle: jest.fn(),
     warningsToggle: jest.fn(),
     referencesToggle: jest.fn(),
     createFocusSpanLink: jest.fn().mockReturnValue({}),
@@ -181,6 +182,7 @@ describe('<SpanDetail>', () => {
     props.processToggle.mockReset();
     props.logsToggle.mockReset();
     props.logItemToggle.mockReset();
+    props.summaryAttributesToggle.mockReset();
 
     setPluginLinksHook(() => ({
       isLoading: false,
@@ -364,6 +366,48 @@ describe('<SpanDetail>', () => {
       expect(screen.queryByText('(summary)')).not.toBeInTheDocument();
       expect(screen.queryByText('End Time:')).not.toBeInTheDocument();
       expect(screen.queryByText('(inherited from slowest span)')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('summary attribute tags', () => {
+    const summarySpanWithTags = {
+      ...span,
+      aggregation: { isSummary: true, isPreservedOutlier: false, spanCount: 3 },
+      tags: [
+        { key: 'http.method', value: 'POST' },
+        { key: 'aggregation.is_summary', value: 'true' },
+        { key: 'aggregation.span_count', value: '3' },
+      ],
+    };
+    // All accordions collapsed so each renders its abbreviated key preview.
+    const summaryTagsProps = { ...props, span: summarySpanWithTags, detailState: new DetailState() };
+
+    beforeEach(() => {
+      jest.mocked(formatDuration).mockImplementation((duration: number) => `${duration}us`);
+    });
+
+    it('renders a dedicated Summary attributes accordion for summary spans', () => {
+      render(<SpanDetail {...(summaryTagsProps as unknown as SpanDetailProps)} />);
+      expect(screen.getByRole('switch', { name: /Summary attributes/ })).toBeInTheDocument();
+    });
+
+    it('moves aggregation.* tags out of Span attributes into Summary attributes', () => {
+      render(<SpanDetail {...(summaryTagsProps as unknown as SpanDetailProps)} />);
+      // The aggregation key is shown once (in the Summary attributes preview), not duplicated
+      // under Span attributes.
+      expect(screen.getAllByText('aggregation.span_count')).toHaveLength(1);
+      expect(screen.getByText('http.method')).toBeInTheDocument();
+    });
+
+    it('toggles the Summary attributes accordion', async () => {
+      render(<SpanDetail {...(summaryTagsProps as unknown as SpanDetailProps)} />);
+      await userEvent.click(screen.getByRole('switch', { name: /Summary attributes/ }));
+      expect(props.summaryAttributesToggle).toHaveBeenLastCalledWith(span.spanID);
+    });
+
+    it('does not render a Summary attributes accordion for non-summary spans', () => {
+      render(<SpanDetail {...({ ...props, detailState: new DetailState() } as unknown as SpanDetailProps)} />);
+      expect(screen.queryByRole('switch', { name: /Summary attributes/ })).not.toBeInTheDocument();
     });
   });
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -44,7 +44,7 @@ import { type SpanLinkFunc } from '../../types/links';
 import { type TraceProcess, type TraceSpan, type TraceSpanReference } from '../../types/trace';
 import { formatDuration } from '../../utils/date';
 import { getServiceDisplayName } from '../../utils/service-name';
-import { getSummaryCountBadgeStyle, getSummaryDurationStats } from '../../utils/summary-span';
+import { getSummaryCountBadgeStyle, getSummaryDurationStats, partitionAggregationTags } from '../../utils/summary-span';
 
 import AccordionCategorizedKeyValues from './AccordionCategorizedKeyValues';
 import AccordionKeyValues from './AccordionKeyValues';
@@ -269,6 +269,7 @@ export type SpanDetailProps = {
   traceToProfilesOptions?: TraceToProfilesOptions;
   timeZone: TimeZone;
   tagsToggle: (spanID: string) => void;
+  summaryAttributesToggle: (spanID: string) => void;
   traceStartTime: number;
   traceDuration: number;
   traceName: string;
@@ -297,6 +298,7 @@ export default function SpanDetail(props: SpanDetailProps) {
     processToggle,
     span,
     tagsToggle,
+    summaryAttributesToggle,
     traceStartTime,
     traceDuration,
     traceName,
@@ -318,6 +320,7 @@ export default function SpanDetail(props: SpanDetailProps) {
   const {
     isTagsOpen,
     isProcessOpen,
+    isSummaryAttributesOpen,
     logs: logsState,
     isWarningsOpen,
     references: referencesState,
@@ -347,6 +350,11 @@ export default function SpanDetail(props: SpanDetailProps) {
   // single figure and surface the group's end time.
   const isSummarySpan = span.aggregation?.isSummary === true;
   const summaryDurationStats = isSummarySpan && span.aggregation ? getSummaryDurationStats(span.aggregation) : null;
+  // On summary spans, present the raw `aggregation.*` tags in their own accordion rather
+  // than mixed into the regular span attributes.
+  const { aggregationTags, otherTags } = isSummarySpan
+    ? partitionAggregationTags(tags)
+    : { aggregationTags: [], otherTags: tags };
   const durationValue = summaryDurationStats
     ? summaryDurationStats.map((stat) => `${stat.value} (${stat.labelLower})`).join(' | ')
     : formatDuration(duration);
@@ -451,9 +459,21 @@ export default function SpanDetail(props: SpanDetailProps) {
 
   const listOfContentCards = [];
 
+  if (isSummarySpan && aggregationTags.length > 0) {
+    listOfContentCards.push(
+      <AccordionKeyValues
+        data={aggregationTags}
+        label={t('explore.span-detail.label-summary-attributes', 'Summary attributes')}
+        isOpen={isSummaryAttributesOpen}
+        linksGetter={resourceLinksGetter}
+        onToggle={() => summaryAttributesToggle(spanID)}
+      />
+    );
+  }
+
   listOfContentCards.push(
     <AccordionCategorizedKeyValues
-      data={tags}
+      data={otherTags}
       sectionType="span"
       label={t('explore.span-detail.label-span-attributes', 'Span attributes')}
       isOpen={isTagsOpen}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
@@ -99,6 +99,7 @@ export type SpanDetailRowProps = {
   traceToProfilesOptions?: TraceToProfilesOptions;
   timeZone: TimeZone;
   tagsToggle: (spanID: string) => void;
+  summaryAttributesToggle: (spanID: string) => void;
   traceStartTime: number;
   traceDuration: number;
   traceName: string;
@@ -134,6 +135,7 @@ const UnthemedSpanDetailRow = React.memo<SpanDetailRowProps>((props) => {
     traceToProfilesOptions,
     timeZone,
     tagsToggle,
+    summaryAttributesToggle,
     traceStartTime,
     traceDuration,
     traceName,
@@ -186,6 +188,7 @@ const UnthemedSpanDetailRow = React.memo<SpanDetailRowProps>((props) => {
               traceToProfilesOptions={traceToProfilesOptions}
               timeZone={timeZone}
               tagsToggle={tagsToggle}
+              summaryAttributesToggle={summaryAttributesToggle}
               traceStartTime={traceStartTime}
               traceDuration={traceDuration}
               traceName={traceName}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -91,6 +91,7 @@ type TVirtualizedTraceViewOwnProps = {
   detailReferenceItemToggle: (spanID: string, reference: TraceSpanReference) => void;
   detailProcessToggle: (spanID: string) => void;
   detailTagsToggle: (spanID: string) => void;
+  detailSummaryAttributesToggle: (spanID: string) => void;
   detailToggle: (spanID: string) => void;
   setSpanNameColumnWidth: (width: number) => void;
   hoverIndentGuideIds: Set<string>;
@@ -534,6 +535,7 @@ class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTraceViewP
       detailStackTracesToggle,
       detailStates,
       detailTagsToggle,
+      detailSummaryAttributesToggle,
       detailToggle,
       spanNameColumnWidth,
       trace,
@@ -579,6 +581,7 @@ class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTraceViewP
           traceToProfilesOptions={traceToProfilesOptions}
           timeZone={timeZone}
           tagsToggle={detailTagsToggle}
+          summaryAttributesToggle={detailSummaryAttributesToggle}
           traceStartTime={trace.startTime}
           traceDuration={trace.duration}
           traceName={trace.traceName}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
@@ -96,6 +96,7 @@ export type TProps = {
   detailReferenceItemToggle: (spanID: string, reference: TraceSpanReference) => void;
   detailProcessToggle: (spanID: string) => void;
   detailTagsToggle: (spanID: string) => void;
+  detailSummaryAttributesToggle: (spanID: string) => void;
   detailToggle: (spanID: string) => void;
   addHoverIndentGuideId: (spanID: string) => void;
   removeHoverIndentGuideId: (spanID: string) => void;

--- a/public/app/features/explore/TraceView/components/constants/aggregation.ts
+++ b/public/app/features/explore/TraceView/components/constants/aggregation.ts
@@ -1,0 +1,5 @@
+// Prefix for the `aggregation.*` tags that the span pruning processor writes onto
+// summary and preserved-outlier spans. Kept in its own lightweight module so both the
+// trace transform (model) and UI utilities can share it without pulling in heavy
+// dependencies across layers.
+export const AGGREGATION_PREFIX = 'aggregation.';

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -17,6 +17,7 @@ import { isEqual as _isEqual } from 'lodash';
 // @ts-ignore
 import { type TraceKeyValuePair } from '@grafana/data';
 
+import { AGGREGATION_PREFIX } from '../constants/aggregation';
 import { getTraceSpanIdsAsTree } from '../selectors/trace';
 import {
   type TraceResponse,
@@ -35,8 +36,6 @@ import { getTraceName } from './trace-viewer';
 function asTagArray(tags: unknown): TraceKeyValuePair[] {
   return Array.isArray(tags) ? tags : [];
 }
-
-const AGGREGATION_PREFIX = 'aggregation.';
 
 /**
  * Detect a pruned (summary / preserved-outlier) span from its `aggregation.*` tags and

--- a/public/app/features/explore/TraceView/components/utils/summary-span.test.ts
+++ b/public/app/features/explore/TraceView/components/utils/summary-span.test.ts
@@ -1,0 +1,32 @@
+import { type TraceKeyValuePair } from '@grafana/data';
+
+import { partitionAggregationTags } from './summary-span';
+
+describe('partitionAggregationTags', () => {
+  it('splits aggregation.* tags from the rest, preserving order', () => {
+    const tags: TraceKeyValuePair[] = [
+      { key: 'http.method', value: 'POST' },
+      { key: 'aggregation.is_summary', value: 'true' },
+      { key: 'http.status_code', value: '200' },
+      { key: 'aggregation.span_count', value: '3' },
+    ];
+
+    const { aggregationTags, otherTags } = partitionAggregationTags(tags);
+
+    expect(aggregationTags.map((t) => t.key)).toEqual(['aggregation.is_summary', 'aggregation.span_count']);
+    expect(otherTags.map((t) => t.key)).toEqual(['http.method', 'http.status_code']);
+  });
+
+  it('returns an empty aggregation list when no aggregation.* tags are present', () => {
+    const tags: TraceKeyValuePair[] = [{ key: 'http.method', value: 'POST' }];
+
+    const { aggregationTags, otherTags } = partitionAggregationTags(tags);
+
+    expect(aggregationTags).toEqual([]);
+    expect(otherTags).toEqual(tags);
+  });
+
+  it('handles an empty tag list', () => {
+    expect(partitionAggregationTags([])).toEqual({ aggregationTags: [], otherTags: [] });
+  });
+});

--- a/public/app/features/explore/TraceView/components/utils/summary-span.ts
+++ b/public/app/features/explore/TraceView/components/utils/summary-span.ts
@@ -1,11 +1,33 @@
 import { css } from '@emotion/css';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, type TraceKeyValuePair } from '@grafana/data';
 import { t } from '@grafana/i18n';
 
+import { AGGREGATION_PREFIX } from '../constants/aggregation';
 import { type SpanAggregation } from '../types/trace';
 
 import { formatDuration } from './date';
+
+/**
+ * Split a span's tags into the raw `aggregation.*` tags written by span pruning and
+ * everything else, preserving original order within each group. Lets SpanDetail keep
+ * `aggregation.*` tags out of the regular attribute list and present them separately.
+ */
+export function partitionAggregationTags(tags: TraceKeyValuePair[]): {
+  aggregationTags: TraceKeyValuePair[];
+  otherTags: TraceKeyValuePair[];
+} {
+  const aggregationTags: TraceKeyValuePair[] = [];
+  const otherTags: TraceKeyValuePair[] = [];
+  for (const tag of tags) {
+    if (typeof tag.key === 'string' && tag.key.startsWith(AGGREGATION_PREFIX)) {
+      aggregationTags.push(tag);
+    } else {
+      otherTags.push(tag);
+    }
+  }
+  return { aggregationTags, otherTags };
+}
 
 /**
  * Pill badge that shows a summary span's aggregated span_count. Shared by the

--- a/public/app/features/explore/TraceView/useDetailState.ts
+++ b/public/app/features/explore/TraceView/useDetailState.ts
@@ -86,11 +86,15 @@ export function useDetailState(frame: DataFrame) {
       (spanID: string) => makeDetailSubsectionToggle('tags', detailStates, setDetailStates)(spanID),
       [detailStates]
     ),
+    detailSummaryAttributesToggle: useCallback(
+      (spanID: string) => makeDetailSubsectionToggle('summaryAttributes', detailStates, setDetailStates)(spanID),
+      [detailStates]
+    ),
   };
 }
 
 function makeDetailSubsectionToggle(
-  subSection: 'tags' | 'process' | 'logs' | 'warnings' | 'references' | 'stackTraces',
+  subSection: 'tags' | 'process' | 'summaryAttributes' | 'logs' | 'warnings' | 'references' | 'stackTraces',
   detailStates: Map<string, DetailState>,
   setDetailStates: (detailStates: Map<string, DetailState>) => void
 ) {
@@ -104,14 +108,20 @@ function makeDetailSubsectionToggle(
       detailState = old.toggleTags();
     } else if (subSection === 'process') {
       detailState = old.toggleProcess();
+    } else if (subSection === 'summaryAttributes') {
+      detailState = old.toggleSummaryAttributes();
     } else if (subSection === 'warnings') {
       detailState = old.toggleWarnings();
     } else if (subSection === 'references') {
       detailState = old.toggleReferences();
     } else if (subSection === 'stackTraces') {
       detailState = old.toggleStackTraces();
-    } else {
+    } else if (subSection === 'logs') {
       detailState = old.toggleLogs();
+    } else {
+      // Exhaustive: every subsection is handled above. Bail rather than fall through to a
+      // default toggle if a new subsection is added without its own branch.
+      return;
     }
     const newDetailStates = new Map(detailStates);
     newDetailStates.set(spanID, detailState);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8841,6 +8841,7 @@
       "label-resource-attributes": "Resource attributes",
       "label-span-attributes": "Span attributes",
       "label-stack-trace": "Stack trace",
+      "label-summary-attributes": "Summary attributes",
       "label-warnings": "Warnings",
       "overview-items": {
         "label": {


### PR DESCRIPTION
## What

SpanDetail follow-up for the span-pruning Trace View updates (grafana/grafana-adaptivetraces-app#1054). Progressive disclosure for the raw `aggregation.*` tags on pruned summary spans:

- On a summary span, the `aggregation.*` tags are split out of the **Span attributes** list into a dedicated, separately-collapsible **Summary attributes** accordion (collapsed by default).
- The regular attribute list is no longer cluttered by the processor's bookkeeping tags, while the raw values stay one click away.
- Non-summary spans are unaffected (no aggregation metadata, no accordion, no filtering).

> [!IMPORTANT]
> **Review only the [top-of-stack diff](https://github.com/grafana/grafana/compare/feat/1053-summary-aware-spandetail...feat/1054-summary-attributes-accordion).** Stacked on #127307, which is stacked on #127111; base retargets as the stack merges down.
>
> **Reading guide:** the logic lives in `summary-span.ts` (partition) and `SpanDetail/index.tsx` (accordion); the rest is mechanical toggle plumbing, tests, and i18n.

### Demo
[Attached demo + annotated screenshot](https://github.com/grafana/grafana/pull/127309#issuecomment-4812438399) (combines #127307 and #127309)

## How

- New `partitionAggregationTags` helper in `utils/summary-span.ts`, splitting tags on `AGGREGATION_PREFIX`, extracted to a small `components/constants/aggregation.ts` module shared by the model and UI so the helper doesn't pull in the heavy `transform-trace-data` module. Unit-tested.
- A `summaryAttributes` detail-state toggle threaded through `DetailState` -> `useDetailState` -> `TraceView` -> `VirtualizedTraceView` -> `SpanDetailRow` -> `SpanDetail`, mirroring the existing `tags` toggle so open/closed state persists across virtualized re-renders.

## Tests

- `summary-span.test.ts` - `partitionAggregationTags` (split, order preservation, empty cases).
- `SpanDetail/index.test.tsx` - accordion present for summary spans, `aggregation.*` moved out of Span attributes, toggle wiring, absent for non-summary spans.
- Full TraceView suite (613 tests) green; typecheck + lint + prettier clean.


## How to test locally

Summary spans only appear when spans carry pruned-span `aggregation.*` tags (produced by Adaptive Traces); the local demo sources (TNS / `gdev-tempo`) do not emit these, so point local dev at real data.

**Against real data (full UI):**
1. Provision a Tempo datasource against a stack that has Adaptive Traces pruned spans (e.g. our ops Tempo stack), then run the backend (`make run`) and frontend (`yarn start`). Tempo is now an externalized datasource, auto-discovered from `data/plugins/` at startup, so there is no separate plugin build step.
2. In Explore, query a trace containing summary spans (e.g. TraceQL `{ span.aggregation.is_summary = true }`).
3. Open the trace and click a `(summary)` span. Confirm a separate **Summary attributes** accordion (collapsed by default) holds the `aggregation.*` tags, and that those tags no longer appear in the main **Span attributes** section. Non-summary spans are unchanged (no accordion).

> Datasource: `grafanacloud-ops-traces` (uid `grafanacloud-traces`, id `557179`, type Tempo), region `ops-eu-south-0`, on `ops.grafana-ops.net`.
> 
> Working Explore deep link (opens that datasource with { span.aggregation.is_summary = true }, last 3h:
> https://ops.grafana-ops.net/goto/sbf2c4?orgId=stacks-27821

**Without a datasource (logic/rendering only):**
`yarn jest public/app/features/explore/TraceView/ --watchAll=false` covers `partitionAggregationTags` and the accordion behavior via `pruned-spans.fixture.ts`.
