### PR TITLE
`Access-Control`: Write datasource action-sets on permission grant

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -461,6 +461,17 @@ func (s *Service) mapPermission(permission string) ([]string, error) {
 		}
 	}
 
+	// Write action set token for datasources. Granular actions are also written until
+	// FlagIamOnlyStoreDatasourceActionSets is enabled (after the backfill migration has run).
+	if s.options.Resource == datasources.ScopeRoot {
+		actions = append(actions, s.options.GetActionSetName(permission))
+
+		onlyActionSets, _ := openfeature.NewDefaultClient().BooleanValue(context.Background(), featuremgmt.FlagIamOnlyStoreDatasourceActionSets, false, openfeature.EvaluationContext{})
+		if onlyActionSets {
+			return actions, nil
+		}
+	}
+
 	// New resources with no legacy granular data go straight to action-set-only.
 	if s.options.Resource == accesscontrol.AlertingRoutesResource {
 		return []string{s.options.GetActionSetName(permission)}, nil
@@ -709,7 +720,8 @@ func isActionSetEnabledResource(action string) bool {
 	return strings.HasPrefix(action, dashboards.ScopeDashboardsRoot) ||
 		strings.HasPrefix(action, folder.ScopeFoldersRoot) ||
 		strings.HasPrefix(action, accesscontrol.AlertingRoutesKind) ||
-		strings.HasPrefix(action, serviceaccounts.ScopeServiceAccountRoot)
+		strings.HasPrefix(action, serviceaccounts.ScopeServiceAccountRoot) ||
+		strings.HasPrefix(action, datasources.ScopeRoot)
 }
 
 // scopeResource returns the resource prefix used for Resource fields in commands/queries.

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -862,4 +863,60 @@ func setupTestEnvironmentWithCfg(t *testing.T, ops Options, features featuremgmt
 	require.NoError(t, err)
 
 	return service, userSvc, teamSvc, cfg
+}
+
+func TestMapPermission_Datasource(t *testing.T) {
+	dsOpts := Options{
+		Resource: datasources.ScopeRoot,
+		PermissionsToActions: map[string][]string{
+			"Query": {datasources.ActionRead, datasources.ActionQuery},
+			"Edit":  {datasources.ActionRead, datasources.ActionQuery, datasources.ActionWrite, datasources.ActionDelete},
+			"Admin": {datasources.ActionRead, datasources.ActionQuery, datasources.ActionWrite, datasources.ActionDelete, datasources.ActionPermissionsRead, datasources.ActionPermissionsWrite},
+		},
+	}
+
+	t.Run("flag off: Edit emits action set token AND granular actions", func(t *testing.T) {
+		svc := &Service{options: dsOpts}
+		actions, err := svc.mapPermission("Edit")
+		require.NoError(t, err)
+		assert.Contains(t, actions, dsOpts.GetActionSetName("Edit")) // datasources:edit
+		assert.Contains(t, actions, datasources.ActionWrite)
+		assert.Contains(t, actions, datasources.ActionDelete)
+	})
+
+	t.Run("flag off: Query token collides with the granular query action", func(t *testing.T) {
+		svc := &Service{options: dsOpts}
+		actions, err := svc.mapPermission("Query")
+		require.NoError(t, err)
+		// GetActionSetName("Query") == datasources:query == datasources.ActionQuery
+		assert.Equal(t, dsOpts.GetActionSetName("Query"), datasources.ActionQuery)
+		assert.Contains(t, actions, datasources.ActionRead)
+		assert.Contains(t, actions, datasources.ActionQuery)
+	})
+
+	t.Run("flag on: emits only action set token", func(t *testing.T) {
+		openfeatureTestMutex.Lock()
+		defer func() {
+			_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+			openfeatureTestMutex.Unlock()
+		}()
+
+		provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
+			featuremgmt.FlagIamOnlyStoreDatasourceActionSets: setting.NewInMemoryFlag(featuremgmt.FlagIamOnlyStoreDatasourceActionSets, true),
+		})
+		require.NoError(t, err)
+		require.NoError(t, openfeature.SetProviderAndWait(provider))
+
+		svc := &Service{options: dsOpts}
+		actions, err := svc.mapPermission("Edit")
+		require.NoError(t, err)
+		require.Len(t, actions, 1)
+		assert.Equal(t, dsOpts.GetActionSetName("Edit"), actions[0])
+	})
+}
+
+func TestIsActionSetEnabledResource_Datasource(t *testing.T) {
+	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":query"))
+	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":edit"))
+	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":admin"))
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2280,6 +2280,15 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "iam.onlyStoreDatasourceActionSets",
+			Description:  "When storing datasource resource permissions, only store action sets and not the full list of underlying permissions",
+			Stage:        FeatureStageExperimental,
+			Generate:     Generate{LegacyGo: true},
+			HideFromDocs: true,
+			Owner:        identityAccessTeam,
+			Expression:   "false",
+		},
+		{
 			Name:         "excludeRedundantManagedPermissions",
 			Description:  "Exclude redundant individual dashboard/folder permissions from managed roles at query time",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -265,6 +265,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-10-17,pluginStoreServiceLoading,experimental,@grafana/grafana-catalog,false,false,false
 2025-10-20,onlyStoreActionSets,GA,@grafana/identity-access-team,false,false,false
 2026-05-22,onlyStoreServiceAccountActionSets,experimental,@grafana/identity-access-team,false,false,false
+2026-06-26,iam.onlyStoreDatasourceActionSets,experimental,@grafana/identity-access-team,false,false,false
 2026-05-22,excludeRedundantManagedPermissions,experimental,@grafana/identity-access-team,false,false,false
 2025-12-16,pluginInsights,experimental,@grafana/grafana-catalog,false,false,true
 2025-10-29,panelTimeSettings,preview,@grafana/dashboards-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -714,6 +714,10 @@ const (
 	// When storing service account resource permissions, only store action sets and not the full list of underlying permissions
 	FlagOnlyStoreServiceAccountActionSets = "onlyStoreServiceAccountActionSets"
 
+	// FlagIamOnlyStoreDatasourceActionSets
+	// When storing datasource resource permissions, only store action sets and not the full list of underlying permissions
+	FlagIamOnlyStoreDatasourceActionSets = "iam.onlyStoreDatasourceActionSets"
+
 	// FlagExcludeRedundantManagedPermissions
 	// Exclude redundant individual dashboard/folder permissions from managed roles at query time
 	FlagExcludeRedundantManagedPermissions = "excludeRedundantManagedPermissions"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2858,6 +2858,23 @@
     },
     {
       "metadata": {
+        "name": "iam.onlyStoreDatasourceActionSets",
+        "resourceVersion": "1782461544304",
+        "creationTimestamp": "2026-06-26T07:57:19Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-06-26 08:12:24.304094 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "When storing datasource resource permissions, only store action sets and not the full list of underlying permissions",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "improvedExternalSessionHandling",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2024-09-17T10:54:39Z"


### PR DESCRIPTION
**What**

When setting datasource resource permissions, also store the action set (e.g. `datasources:query`, `datasources:edit`, `datasources:admin`) alongside the granular actions so managed roles and the K8s ResourcePermission API can resolve permissions by action set.

Dual-write is gated by iam.onlyStoreDatasourceActionSets: when off (default), both the actionSet and granular actions are stored; when on, only the actionSet is written. Treat datasources as an action-set-enabled resource so GetPermissions and RBAC expansion resolve stored tokens correctly.

Adds FlagIamOnlyStoreDatasourceActionSets (experimental, disabled by default).

**Why**
In order to manage datasource resource permissions through the new k8s apis we need action-sets to be stored. 

Issue: https://github.com/grafana/identity-access-team/issues/1994