### PR TITLE
Alerting: mark rules view mode selector labels for i18n

### DIFF
--- a/public/app/features/alerting/unified/components/rules/Filter/RulesViewModeSelector.tsx
+++ b/public/app/features/alerting/unified/components/rules/Filter/RulesViewModeSelector.tsx
@@ -1,6 +1,7 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { type SelectableValue } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { RadioButtonGroup } from '@grafana/ui';
 
 import { trackRulesListViewChange } from '../../../Analytics';
@@ -11,11 +12,6 @@ import { useURLSearchParams } from '../../../hooks/useURLSearchParams';
 export type SupportedView = 'list' | 'grouped';
 
 type LegacySupportedView = 'list' | 'grouped' | 'state';
-
-const ViewOptions: Array<SelectableValue<SupportedView>> = [
-  { icon: 'folder', value: 'grouped', label: 'Grouped' },
-  { icon: 'list-ul', value: 'list', label: 'List' },
-];
 
 interface RulesViewModeSelectorV2Props {
   viewMode?: SupportedView;
@@ -30,7 +26,15 @@ interface RulesViewModeSelectorV2Props {
  * Use the complementary {@link useListViewMode} hook to get the current view mode and a handler for changing it.
  */
 function RulesViewModeSelectorV2({ viewMode, onViewModeChange }: RulesViewModeSelectorV2Props) {
-  return <RadioButtonGroup options={ViewOptions} value={viewMode} onChange={onViewModeChange} />;
+  const viewOptions = useMemo(
+    (): Array<SelectableValue<SupportedView>> => [
+      { icon: 'folder', value: 'grouped', label: t('alerting.rules-view-mode-selector.grouped', 'Grouped') },
+      { icon: 'list-ul', value: 'list', label: t('alerting.rules-view-mode-selector.list', 'List') },
+    ],
+    []
+  );
+
+  return <RadioButtonGroup options={viewOptions} value={viewMode} onChange={onViewModeChange} />;
 }
 
 export function useListViewMode() {
@@ -71,13 +75,16 @@ export function useListViewMode() {
   };
 }
 
-const LegacyViewOptions: Array<SelectableValue<LegacySupportedView>> = [
-  { label: 'Grouped', value: 'grouped' },
-  { label: 'List', value: 'list' },
-  { label: 'State', value: 'state' },
-];
-
 function RulesViewModeSelectorV1() {
+  const legacyViewOptions = useMemo(
+    (): Array<SelectableValue<LegacySupportedView>> => [
+      { label: t('alerting.rules-view-mode-selector.grouped', 'Grouped'), value: 'grouped' },
+      { label: t('alerting.rules-view-mode-selector.list', 'List'), value: 'list' },
+      { label: t('alerting.rules-view-mode-selector.state', 'State'), value: 'state' },
+    ],
+    []
+  );
+
   const [queryParams, updateQueryParams] = useURLSearchParams();
   const viewParam = queryParams.get('view');
 
@@ -87,7 +94,7 @@ function RulesViewModeSelectorV1() {
     updateQueryParams({ view });
   };
 
-  return <RadioButtonGroup options={LegacyViewOptions} value={currentView} onChange={handleViewChange} />;
+  return <RadioButtonGroup options={legacyViewOptions} value={currentView} onChange={handleViewChange} />;
 }
 
 function viewParamToLegacyView(viewParam: string | null): LegacySupportedView {

--- a/public/app/features/alerting/unified/components/rules/Filter/RulesViewModeSelector.tsx
+++ b/public/app/features/alerting/unified/components/rules/Filter/RulesViewModeSelector.tsx
@@ -28,8 +28,8 @@ interface RulesViewModeSelectorV2Props {
 function RulesViewModeSelectorV2({ viewMode, onViewModeChange }: RulesViewModeSelectorV2Props) {
   const viewOptions = useMemo(
     (): Array<SelectableValue<SupportedView>> => [
-      { icon: 'folder', value: 'grouped', label: t('alerting.rules-view-mode-selector.grouped', 'Grouped') },
-      { icon: 'list-ul', value: 'list', label: t('alerting.rules-view-mode-selector.list', 'List') },
+      { icon: 'folder', value: 'grouped', label: t('alerting.rules-view-mode-selector.view-options.grouped', 'Grouped') },
+      { icon: 'list-ul', value: 'list', label: t('alerting.rules-view-mode-selector.view-options.list', 'List') },
     ],
     []
   );
@@ -78,9 +78,9 @@ export function useListViewMode() {
 function RulesViewModeSelectorV1() {
   const legacyViewOptions = useMemo(
     (): Array<SelectableValue<LegacySupportedView>> => [
-      { label: t('alerting.rules-view-mode-selector.grouped', 'Grouped'), value: 'grouped' },
-      { label: t('alerting.rules-view-mode-selector.list', 'List'), value: 'list' },
-      { label: t('alerting.rules-view-mode-selector.state', 'State'), value: 'state' },
+      { label: t('alerting.rules-view-mode-selector.legacy-view-options.grouped', 'Grouped'), value: 'grouped' },
+      { label: t('alerting.rules-view-mode-selector.legacy-view-options.list', 'List'), value: 'list' },
+      { label: t('alerting.rules-view-mode-selector.legacy-view-options.state', 'State'), value: 'state' },
     ],
     []
   );

--- a/public/app/features/alerting/unified/components/rules/Filter/RulesViewModeSelector.tsx
+++ b/public/app/features/alerting/unified/components/rules/Filter/RulesViewModeSelector.tsx
@@ -28,8 +28,16 @@ interface RulesViewModeSelectorV2Props {
 function RulesViewModeSelectorV2({ viewMode, onViewModeChange }: RulesViewModeSelectorV2Props) {
   const viewOptions = useMemo(
     (): Array<SelectableValue<SupportedView>> => [
-      { icon: 'folder', value: 'grouped', label: t('alerting.rules-view-mode-selector.view-options.grouped', 'Grouped') },
-      { icon: 'list-ul', value: 'list', label: t('alerting.rules-view-mode-selector.view-options.list', 'List') },
+      {
+        icon: 'folder',
+        value: 'grouped',
+        label: t('alerting.rules-view-mode-selector.view-options.grouped', 'Grouped'),
+      },
+      {
+        icon: 'list-ul',
+        value: 'list',
+        label: t('alerting.rules-view-mode-selector.view-options.list', 'List'),
+      },
     ],
     []
   );
@@ -78,9 +86,18 @@ export function useListViewMode() {
 function RulesViewModeSelectorV1() {
   const legacyViewOptions = useMemo(
     (): Array<SelectableValue<LegacySupportedView>> => [
-      { label: t('alerting.rules-view-mode-selector.legacy-view-options.grouped', 'Grouped'), value: 'grouped' },
-      { label: t('alerting.rules-view-mode-selector.legacy-view-options.list', 'List'), value: 'list' },
-      { label: t('alerting.rules-view-mode-selector.legacy-view-options.state', 'State'), value: 'state' },
+      {
+        label: t('alerting.rules-view-mode-selector.legacy-view-options.grouped', 'Grouped'),
+        value: 'grouped',
+      },
+      {
+        label: t('alerting.rules-view-mode-selector.legacy-view-options.list', 'List'),
+        value: 'list',
+      },
+      {
+        label: t('alerting.rules-view-mode-selector.legacy-view-options.state', 'State'),
+        value: 'state',
+      },
     ],
     []
   );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3107,9 +3107,15 @@
       "view-as": "View as"
     },
     "rules-view-mode-selector": {
-      "grouped": "Grouped",
-      "list": "List",
-      "state": "State"
+      "legacy-view-options": {
+        "grouped": "Grouped",
+        "list": "List",
+        "state": "State"
+      },
+      "view-options": {
+        "grouped": "Grouped",
+        "list": "List"
+      }
     },
     "rules-filter-sidebar": {
       "clear-filters": "Clear filters"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3106,6 +3106,11 @@
       "title-search-help": "Search help",
       "view-as": "View as"
     },
+    "rules-view-mode-selector": {
+      "grouped": "Grouped",
+      "list": "List",
+      "state": "State"
+    },
     "rules-filter-sidebar": {
       "clear-filters": "Clear filters"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3106,6 +3106,15 @@
       "title-search-help": "Search help",
       "view-as": "View as"
     },
+    "rules-filter-sidebar": {
+      "clear-filters": "Clear filters"
+    },
+    "rules-group": {
+      "deleting": "Deleting",
+      "text-federated": "Federated",
+      "text-provisioned": "Provisioned",
+      "ungrouped": "Ungrouped"
+    },
     "rules-view-mode-selector": {
       "legacy-view-options": {
         "grouped": "Grouped",
@@ -3116,15 +3125,6 @@
         "grouped": "Grouped",
         "list": "List"
       }
-    },
-    "rules-filter-sidebar": {
-      "clear-filters": "Clear filters"
-    },
-    "rules-group": {
-      "deleting": "Deleting",
-      "text-federated": "Federated",
-      "text-provisioned": "Provisioned",
-      "ungrouped": "Ungrouped"
     },
     "saved-searches": {
       "actions-aria-label": "Actions",


### PR DESCRIPTION
## Summary

- Wrap grouped/list/state labels in the unified alerting rules view mode selector with `t()` for translation.
- Add matching `alerting.rules-view-mode-selector.*` keys to `public/locales/en-US/grafana.json`.

For #110215

## Test plan

- [ ] `yarn i18n-extract` (or CI i18n check) passes with the new keys
- [ ] Rules list view switcher still shows Grouped / List / State labels in en-US