### PR TITLE
fix: storage service tracing with authz service

### DIFF
--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -10,6 +10,7 @@ import (
 	grpcAuth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -249,6 +250,7 @@ func newRemoteRBACClient(clientCfg *authzClientSettings, tracer trace.Tracer, re
 		),
 		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	}
 
 	// // if we serve the client as a load balancer


### PR DESCRIPTION
The multi-tenant setup had detached traces:
<img width="5118" height="5286" alt="image" src="https://github.com/user-attachments/assets/cba43424-aded-4dd3-9376-c80ca6707ca1" />

The remote authz gRPC client was created without an otel stats handler, so it never injected the traceparent header.
As a result every call to the authz service began a new, disconnected trace (verified locally with mt-tilt and on cloud). 

Adding `otelgrpc.NewClientHandler()` makes the client propagate trace context (the server already extracts it via `otelgrpc.NewServerHandler()`), so authz spans now attach to the calling request's trace.

<img width="5112" height="2644" alt="CleanShot 2026-06-26 at 11 14 47@2x" src="https://github.com/user-attachments/assets/f756a2e2-a46e-457f-8111-d4c84a55fa17" />
