### PR TITLE
perf(zanzana): cut per-request overhead in authz evaluation

### DIFF
--- a/pkg/services/authz/zanzana/server/admission.go
+++ b/pkg/services/authz/zanzana/server/admission.go
@@ -31,12 +31,12 @@ func (s *Server) acquireSlot(method, namespace string) (release func(), err erro
 		}
 	}
 
-	s.metrics.inflightRequests.WithLabelValues(method).Inc()
+	s.metrics.incInflight(method)
 
 	var once sync.Once
 	release = func() {
 		once.Do(func() {
-			s.metrics.inflightRequests.WithLabelValues(method).Dec()
+			s.metrics.decInflight(method)
 			if nl != nil {
 				nl.Release(1)
 			}

--- a/pkg/services/authz/zanzana/server/metrics.go
+++ b/pkg/services/authz/zanzana/server/metrics.go
@@ -19,39 +19,64 @@ type metrics struct {
 	inflightRequests *prometheus.GaugeVec
 	// rejectedRequests counts requests rejected by the concurrency limiter
 	rejectedRequests *prometheus.CounterVec
+
+	// Pre-resolved children for hot-path label values. WithLabelValues hashes the
+	// labels and takes the vec's internal lock on every call; resolving the known
+	// method/phase children once at construction turns each per-request observation
+	// into a plain map read (safe for concurrent reads; the maps are never written
+	// after construction).
+	requestDuration map[string]prometheus.Observer
+	inflight        map[string]prometheus.Gauge
+	batchPhase      map[string]prometheus.Observer
+}
+
+// requestMethods are the method label values resolved up front. Anything not
+// listed here falls back to WithLabelValues (cold paths only).
+var requestMethods = []string{
+	"Check", "BatchCheck", "List",
+	"Mutate", "WriteTuples", "Read", "ReadTuples", "Query", "Write",
+}
+
+// batchPhases are the batch-check phase label values resolved up front.
+var batchPhases = []string{
+	"group_resource", "folder_permission", "folder_subresource", "direct_resource",
 }
 
 func newZanzanaServerMetrics(reg prometheus.Registerer) *metrics {
-	return &metrics{
-		requestDurationSeconds: promauto.With(reg).NewHistogramVec(
-			prometheus.HistogramOpts{
-				Name:      "request_duration_seconds",
-				Help:      "Histogram for zanzana server request duration",
-				Namespace: metricsNamespace,
-				Subsystem: metricsSubSystem,
-				Buckets:   prometheus.ExponentialBuckets(0.00001, 4, 10),
-			},
-			[]string{"method"},
-		),
-		batchCheckPhaseDurationSeconds: promauto.With(reg).NewHistogramVec(
-			prometheus.HistogramOpts{
-				Name:      "batch_check_phase_duration_seconds",
-				Help:      "Histogram for batch check phase duration",
-				Namespace: metricsNamespace,
-				Subsystem: metricsSubSystem,
-				Buckets:   prometheus.ExponentialBuckets(0.00001, 4, 10),
-			},
-			[]string{"phase"},
-		),
-		inflightRequests: promauto.With(reg).NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name:      "inflight_requests",
-				Help:      "Current number of in-flight requests",
-				Namespace: metricsNamespace,
-				Subsystem: metricsSubSystem,
-			},
-			[]string{"method"},
-		),
+	requestDurationSeconds := promauto.With(reg).NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:      "request_duration_seconds",
+			Help:      "Histogram for zanzana server request duration",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Buckets:   prometheus.ExponentialBuckets(0.00001, 4, 10),
+		},
+		[]string{"method"},
+	)
+	batchCheckPhaseDurationSeconds := promauto.With(reg).NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:      "batch_check_phase_duration_seconds",
+			Help:      "Histogram for batch check phase duration",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Buckets:   prometheus.ExponentialBuckets(0.00001, 4, 10),
+		},
+		[]string{"phase"},
+	)
+	inflightRequests := promauto.With(reg).NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "inflight_requests",
+			Help:      "Current number of in-flight requests",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+		},
+		[]string{"method"},
+	)
+
+	m := &metrics{
+		requestDurationSeconds:         requestDurationSeconds,
+		batchCheckPhaseDurationSeconds: batchCheckPhaseDurationSeconds,
+		inflightRequests:               inflightRequests,
 		rejectedRequests: promauto.With(reg).NewCounterVec(
 			prometheus.CounterOpts{
 				Name:      "rejected_requests_total",
@@ -61,5 +86,54 @@ func newZanzanaServerMetrics(reg prometheus.Registerer) *metrics {
 			},
 			[]string{"method", "limiter"},
 		),
+		requestDuration: make(map[string]prometheus.Observer, len(requestMethods)),
+		inflight:        make(map[string]prometheus.Gauge, len(requestMethods)),
+		batchPhase:      make(map[string]prometheus.Observer, len(batchPhases)),
 	}
+
+	for _, method := range requestMethods {
+		m.requestDuration[method] = requestDurationSeconds.WithLabelValues(method)
+		m.inflight[method] = inflightRequests.WithLabelValues(method)
+	}
+	for _, phase := range batchPhases {
+		m.batchPhase[phase] = batchCheckPhaseDurationSeconds.WithLabelValues(phase)
+	}
+
+	return m
+}
+
+// observeRequestDuration records request duration, using a pre-resolved observer
+// for known methods and falling back to a label lookup for cold paths.
+func (m *metrics) observeRequestDuration(method string, seconds float64) {
+	if o, ok := m.requestDuration[method]; ok {
+		o.Observe(seconds)
+		return
+	}
+	m.requestDurationSeconds.WithLabelValues(method).Observe(seconds)
+}
+
+// observeBatchPhase records a batch-check phase duration via a pre-resolved observer.
+func (m *metrics) observeBatchPhase(phase string, seconds float64) {
+	if o, ok := m.batchPhase[phase]; ok {
+		o.Observe(seconds)
+		return
+	}
+	m.batchCheckPhaseDurationSeconds.WithLabelValues(phase).Observe(seconds)
+}
+
+// incInflight / decInflight adjust the in-flight gauge via a pre-resolved child.
+func (m *metrics) incInflight(method string) {
+	if g, ok := m.inflight[method]; ok {
+		g.Inc()
+		return
+	}
+	m.inflightRequests.WithLabelValues(method).Inc()
+}
+
+func (m *metrics) decInflight(method string) {
+	if g, ok := m.inflight[method]; ok {
+		g.Dec()
+		return
+	}
+	m.inflightRequests.WithLabelValues(method).Dec()
 }

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -268,20 +268,24 @@ func (s *Server) getContextuals(subject string, teams []string) (*openfgav1.Cont
 		)
 	}
 
-	seen := make(map[string]struct{})
-	var teamNames []string
-	for _, g := range teams {
-		if g == "" {
-			continue
+	// Only allocate the dedup map / sort when teams are present. The common
+	// end-user check has no teams, so this keeps that path allocation-free.
+	if len(teams) > 0 {
+		seen := make(map[string]struct{}, len(teams))
+		teamNames := make([]string, 0, len(teams))
+		for _, g := range teams {
+			if g == "" {
+				continue
+			}
+			if _, dup := seen[g]; !dup {
+				seen[g] = struct{}{}
+				teamNames = append(teamNames, g)
+			}
 		}
-		if _, dup := seen[g]; !dup {
-			seen[g] = struct{}{}
-			teamNames = append(teamNames, g)
+		sort.Strings(teamNames)
+		for _, n := range teamNames {
+			keys = append(keys, common.NewTypedTuple(common.TypeTeam, subject, common.RelationTeamMember, n))
 		}
-	}
-	sort.Strings(teamNames)
-	for _, n := range teamNames {
-		keys = append(keys, common.NewTypedTuple(common.TypeTeam, subject, common.RelationTeamMember, n))
 	}
 	if len(keys) == 0 {
 		return nil, nil

--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -50,20 +50,23 @@ func (s *Server) BatchCheck(ctx context.Context, r *authzv1.BatchCheckRequest) (
 	namespace := r.GetNamespace()
 	checkCount := len(r.GetChecks())
 
-	ctxLogger := s.logger.FromContext(ctx).New(
-		"subject", r.GetSubject(),
-		"namespace", namespace,
-		"check_count", checkCount,
-	)
-
 	defer func() {
 		duration := time.Since(start)
-		s.metrics.requestDurationSeconds.WithLabelValues("BatchCheck").Observe(duration.Seconds())
-		ctxLogger.Debug("BatchCheck execution time", "duration", duration.Milliseconds())
+		s.metrics.observeRequestDuration("BatchCheck", duration.Seconds())
+		s.logger.Debug("BatchCheck execution time",
+			"duration", duration.Milliseconds(),
+			"subject", r.GetSubject(),
+			"namespace", namespace,
+			"check_count", checkCount,
+		)
 
 		// Log slow batch checks for debugging (>1s is concerning)
 		if duration > time.Second {
-			ctxLogger.Debug("slow batch check detected", "duration_ms", duration.Milliseconds())
+			s.logger.Debug("slow batch check detected",
+				"duration_ms", duration.Milliseconds(),
+				"namespace", namespace,
+				"check_count", checkCount,
+			)
 		}
 	}()
 
@@ -181,7 +184,7 @@ func (s *Server) runPhase(ctx context.Context, phaseName string, namespace strin
 		span.SetStatus(codes.Error, err.Error())
 	}
 
-	s.metrics.batchCheckPhaseDurationSeconds.WithLabelValues(phaseName).Observe(duration.Seconds())
+	s.metrics.observeBatchPhase(phaseName, duration.Seconds())
 
 	// Log slow phases for debugging (>300ms is concerning)
 	if duration > 300*time.Millisecond {

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -27,17 +27,20 @@ func (s *Server) Check(ctx context.Context, r *authzv1.CheckRequest) (*authzv1.C
 	defer span.End()
 	span.SetAttributes(attribute.String("namespace", r.GetNamespace()))
 
-	ctxLogger := s.logger.FromContext(ctx).New(
-		"subject", r.GetSubject(),
-		"namespace", r.GetNamespace(),
-		"group", r.GetGroup(),
-		"resource", r.GetResource(),
-		"subresource", r.GetSubresource(),
-		"verb", r.GetVerb(),
-	)
 	defer func(t time.Time) {
-		s.metrics.requestDurationSeconds.WithLabelValues("Check").Observe(time.Since(t).Seconds())
-		ctxLogger.Debug("Check execution time", "duration", time.Since(t).Milliseconds())
+		elapsed := time.Since(t)
+		s.metrics.observeRequestDuration("Check", elapsed.Seconds())
+		// Avoid building a contextual logger per request; pass the fields directly
+		// so the logger is only materialized when debug logging is enabled.
+		s.logger.Debug("Check execution time",
+			"duration", elapsed.Milliseconds(),
+			"subject", r.GetSubject(),
+			"namespace", r.GetNamespace(),
+			"group", r.GetGroup(),
+			"resource", r.GetResource(),
+			"subresource", r.GetSubresource(),
+			"verb", r.GetVerb(),
+		)
 	}(time.Now())
 
 	if err := s.mtReconciler.EnsureNamespace(ctx, r.GetNamespace()); err != nil {

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -33,17 +33,18 @@ func (s *Server) List(ctx context.Context, r *authzv1.ListRequest) (*authzv1.Lis
 	defer span.End()
 	span.SetAttributes(attribute.String("namespace", r.GetNamespace()))
 
-	ctxLogger := s.logger.FromContext(ctx).New(
-		"subject", r.GetSubject(),
-		"namespace", r.GetNamespace(),
-		"group", r.GetGroup(),
-		"resource", r.GetResource(),
-		"subresource", r.GetSubresource(),
-		"verb", r.GetVerb(),
-	)
 	defer func(t time.Time) {
-		s.metrics.requestDurationSeconds.WithLabelValues("List").Observe(time.Since(t).Seconds())
-		ctxLogger.Debug("List execution time", "duration", time.Since(t).Milliseconds())
+		elapsed := time.Since(t)
+		s.metrics.observeRequestDuration("List", elapsed.Seconds())
+		s.logger.Debug("List execution time",
+			"duration", elapsed.Milliseconds(),
+			"subject", r.GetSubject(),
+			"namespace", r.GetNamespace(),
+			"group", r.GetGroup(),
+			"resource", r.GetResource(),
+			"subresource", r.GetSubresource(),
+			"verb", r.GetVerb(),
+		)
 	}(time.Now())
 
 	res, err := s.list(ctx, r)


### PR DESCRIPTION
## Summary

Reduce fixed per-request Go-side overhead on the Zanzana authz evaluation path (`Check` / `BatchCheck` / `List`). These costs are paid on every authz call regardless of outcome.

- **Logger**: drop the unconditional `s.logger.FromContext(ctx).New(...)` contextual-logger construction per request. Request fields are passed directly to the single `Debug` call, so no wrapper logger is materialized when debug logging is disabled.
- **Metrics**: pre-resolve the known `method` / `phase` prometheus children once at metrics construction (`observeRequestDuration` / `observeBatchPhase` / `incInflight` / `decInflight`) instead of calling `WithLabelValues` (label hash + vec lock) on every request. The `*Vec`s are retained, so cold paths and existing tests still work via fallback.
- **getContextuals**: only allocate the dedup map / sort when teams are present (no behavior change).

## Benchmark results

Isolated micro-benchmarks (the end-to-end `Check` path is dominated by OpenFGA at 5k–18k allocs/op, so these fixed costs are sub-0.5% there; the win is allocation/lock pressure under high QPS). `-count=8`, via `benchstat`:

```
                 │  before  │           after            │
                 │  sec/op  │  sec/op    vs base          │
RequestLog         1283.5n    845.1n     -34.15%  (p=0.000 n=8)
RequestMetric       59.89n    29.01n     -51.56%  (p=0.000 n=8)
Inflight(inc+dec)  106.75n    29.32n     -72.53%  (p=0.000 n=8)

RequestLog  allocs/op: 21 -> 14 (-33.3%)   B/op: 1888 -> 1312 (-30.5%)
```

Note: the `getContextuals` no-teams guard did **not** remove an allocation (the empty non-escaping map is already elided by the compiler); it's a small CPU/clarity win only.

## Behavior change

The per-request `Debug` timing lines no longer carry context-provider fields (e.g. trace IDs) that `FromContext(ctx)` injected; the explicit request fields (subject/namespace/group/...) are preserved inline. Error-path logging is unchanged.

## Test plan

- [x] `go build ./...` + `go vet` clean
- [x] `go test -short ./pkg/services/authz/zanzana/server/` passes
- [x] Existing `admission_test` / `server_contextuals_test` pass (metric values unaffected; pre-resolved children share the same underlying series)
- [ ] CI green