### PR TITLE
IAM: Remove legacy fallback from GetByID/UID

### DIFF
--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -86,18 +86,10 @@ func (s *Service) GetByID(ctx context.Context, cmd *user.GetUserByIDQuery) (*use
 	))
 	defer span.End()
 
-	ctxLogger := s.logger.FromContext(ctx)
-
 	if s.isKubernetesUserServiceEnabled(ctx) && !s.shouldFallbackToLegacy(ctx) {
-		result, err := s.k8sService.GetByID(s.k8sCtxWithIdentity(ctx), cmd)
-		if err == nil {
-			span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
-			return result, nil
-		}
-		ctxLogger.Warn("k8s GetByID failed, falling back to legacy", "userID", cmd.ID, "err", err)
+		return s.k8sService.GetByID(s.k8sCtxWithIdentity(ctx), cmd)
 	}
 
-	span.SetAttributes(attribute.Bool("fallback_to_legacy", true))
 	return s.legacyService.GetByID(ctx, cmd)
 }
 
@@ -107,18 +99,10 @@ func (s *Service) GetByUID(ctx context.Context, cmd *user.GetUserByUIDQuery) (*u
 	))
 	defer span.End()
 
-	ctxLogger := s.logger.FromContext(ctx)
-
 	if s.isKubernetesUserServiceEnabled(ctx) && !s.shouldFallbackToLegacy(ctx) {
-		result, err := s.k8sService.GetByUID(s.k8sCtxWithIdentity(ctx), cmd)
-		if err == nil {
-			span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
-			return result, nil
-		}
-		ctxLogger.Warn("k8s GetByUID failed, falling back to legacy", "userUID", cmd.UID, "err", err)
+		return s.k8sService.GetByUID(s.k8sCtxWithIdentity(ctx), cmd)
 	}
 
-	span.SetAttributes(attribute.Bool("fallback_to_legacy", true))
 	return s.legacyService.GetByUID(ctx, cmd)
 }
 

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -13,10 +15,12 @@ import (
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
 	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -267,6 +271,82 @@ func TestMetrics(t *testing.T) {
 		assert.Len(t, stats, 2, stats)
 		assert.Equal(t, int64(1), stats["stats.user.role_none.count"])
 		assert.Equal(t, 1, stats["stats.password_policy.count"])
+	})
+}
+
+func TestService_NoLegacyFallback(t *testing.T) {
+	enableK8sUsersRedirect(t)
+
+	k8sErr := errors.New("k8s boom")
+	legacyUser := &user.User{ID: 1, Login: "from-legacy"}
+
+	t.Run("GetByID", func(t *testing.T) {
+		t.Run("k8s hit is returned without consulting legacy", func(t *testing.T) {
+			s := newWrapperServiceForTest(
+				&usertest.FakeUserService{ExpectedUser: &user.User{ID: 2, Login: "from-k8s"}},
+				&usertest.FakeUserService{ExpectedUser: legacyUser},
+			)
+			got, err := s.GetByID(context.Background(), &user.GetUserByIDQuery{ID: 5})
+			require.NoError(t, err)
+			require.Equal(t, "from-k8s", got.Login)
+		})
+
+		t.Run("k8s error is surfaced, no fallback to legacy", func(t *testing.T) {
+			s := newWrapperServiceForTest(
+				&usertest.FakeUserService{ExpectedError: k8sErr},
+				&usertest.FakeUserService{ExpectedUser: legacyUser},
+			)
+			got, err := s.GetByID(context.Background(), &user.GetUserByIDQuery{ID: 5})
+			require.ErrorIs(t, err, k8sErr)
+			require.Nil(t, got)
+		})
+	})
+
+	t.Run("GetByUID", func(t *testing.T) {
+		t.Run("k8s hit is returned without consulting legacy", func(t *testing.T) {
+			s := newWrapperServiceForTest(
+				&usertest.FakeUserService{ExpectedUser: &user.User{ID: 2, Login: "from-k8s"}},
+				&usertest.FakeUserService{ExpectedUser: legacyUser},
+			)
+			got, err := s.GetByUID(context.Background(), &user.GetUserByUIDQuery{UID: "uid"})
+			require.NoError(t, err)
+			require.Equal(t, "from-k8s", got.Login)
+		})
+
+		t.Run("k8s error is surfaced, no fallback to legacy", func(t *testing.T) {
+			s := newWrapperServiceForTest(
+				&usertest.FakeUserService{ExpectedError: k8sErr},
+				&usertest.FakeUserService{ExpectedUser: legacyUser},
+			)
+			got, err := s.GetByUID(context.Background(), &user.GetUserByUIDQuery{UID: "uid"})
+			require.ErrorIs(t, err, k8sErr)
+			require.Nil(t, got)
+		})
+	})
+}
+
+func newWrapperServiceForTest(k8sService, legacyService user.Service) *Service {
+	return &Service{
+		legacyService:     legacyService,
+		k8sService:        k8sService,
+		openFeatureClient: openfeature.NewDefaultClient(),
+		logger:            log.New("test"),
+		tracer:            tracing.InitializeTracerForTest(),
+		cfg:               setting.NewCfg(),
+	}
+}
+
+func enableK8sUsersRedirect(t *testing.T) {
+	t.Helper()
+	flag, err := setting.ParseFlag(featuremgmt.FlagKubernetesUsersRedirect, "true")
+	require.NoError(t, err)
+	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagKubernetesUsersRedirect: flag,
+	})
+	require.NoError(t, err)
+	require.NoError(t, openfeature.SetProviderAndWait(provider))
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(memprovider.NewInMemoryProvider(nil))
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes the error-based legacy fallback from the k8s user-service wrapper's `GetByID` and `GetByUID`. When `kubernetesUsersRedirect` is enabled, both now return the k8s result/error directly instead of silently retrying against the legacy SQL store on any error.

**Why do we need this feature?**

The error-based fallback was masking real failures in the k8s path: any error from unified storage was swallowed and quietly served from the legacy store, so genuine bugs and authorization problems never surfaced. Removing it makes the k8s redirect the single source of truth and lets failures be observed instead of hidden.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
