### PR TITLE
Database: Fix PostgreSQL dialect incorrectly mapping DB_BigInt+IsAutoIncrement to SERIAL instead of BIGSERIAL

### DIFF
--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -266,6 +266,12 @@ func addDashboardMigration(mg *Migrator) {
 		Cols: []string{"dashboard_uid"},
 		Type: IndexType,
 	}))
+
+	mg.AddMigration("alter dashboard.id column to bigint", NewRawSQLMigration("").
+		Postgres("ALTER TABLE dashboard ALTER COLUMN id TYPE BIGINT;"))
+
+	mg.AddMigration("alter dashboard.id sequence to bigint", NewRawSQLMigration("").
+		Postgres(`DO $$ DECLARE seq_name TEXT; BEGIN seq_name := pg_get_serial_sequence('dashboard', 'id'); IF seq_name IS NOT NULL THEN EXECUTE format('ALTER SEQUENCE %s AS BIGINT', seq_name); END IF; END $$;`))
 }
 
 type FillDashbordUIDAndOrgIDMigration struct {

--- a/pkg/services/sqlstore/migrations/folder_mig.go
+++ b/pkg/services/sqlstore/migrations/folder_mig.go
@@ -91,6 +91,12 @@ func addFolderMigrations(mg *migrator.Migrator) {
 		Name: "IDX_folder_org_id_parent_uid",
 		Cols: []string{"org_id", "parent_uid"},
 	}))
+
+	mg.AddMigration("alter folder.id column to bigint", migrator.NewRawSQLMigration("").
+		Postgres("ALTER TABLE folder ALTER COLUMN id TYPE BIGINT;"))
+
+	mg.AddMigration("alter folder.id sequence to bigint", migrator.NewRawSQLMigration("").
+		Postgres(`DO $$ DECLARE seq_name TEXT; BEGIN seq_name := pg_get_serial_sequence('folder', 'id'); IF seq_name IS NOT NULL THEN EXECUTE format('ALTER SEQUENCE %s AS BIGINT', seq_name); END IF; END $$;`))
 }
 
 func folderv1() migrator.Table {

--- a/pkg/services/sqlstore/migrator/dialect_test.go
+++ b/pkg/services/sqlstore/migrator/dialect_test.go
@@ -6,6 +6,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPostgresDialectSQLType(t *testing.T) {
+	db := NewPostgresDialect()
+
+	tests := []struct {
+		name     string
+		col      *Column
+		expected string
+	}{
+		{
+			name:     "DB_BigInt with AutoIncrement should produce BIGSERIAL, not SERIAL",
+			col:      &Column{Type: DB_BigInt, IsAutoIncrement: true},
+			expected: DB_BigSerial,
+		},
+		{
+			name:     "DB_BigInt without AutoIncrement should produce BIGINT",
+			col:      &Column{Type: DB_BigInt, IsAutoIncrement: false},
+			expected: DB_BigInt,
+		},
+		{
+			name:     "DB_Int with AutoIncrement should still produce SERIAL",
+			col:      &Column{Type: DB_Int, IsAutoIncrement: true},
+			expected: DB_Serial,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := db.SQLType(tc.col)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestInsertQuery(t *testing.T) {
 	tests := []struct {
 		name                  string

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -89,6 +89,11 @@ func (db *PostgresDialect) SQLType(c *Column) string {
 		return DB_Uuid // do not add the length options
 	case DB_Blob, DB_TinyBlob, DB_MediumBlob, DB_LongBlob:
 		return DB_Bytea
+	case DB_BigInt:
+		if c.IsAutoIncrement {
+			return DB_BigSerial
+		}
+		res = t
 	case DB_Double:
 		return "DOUBLE PRECISION"
 	default:


### PR DESCRIPTION
**What is this feature?**

This is a bug fix. The PostgreSQL dialect's `SQLType` function falls through to a `default` case for `DB_BigInt` columns with `IsAutoIncrement: true`, returning `SERIAL` (32-bit int4) instead of `BIGSERIAL` (64-bit int8). This means every table in Grafana that declares its primary key as `DB_BigInt + IsAutoIncrement` — including `dashboard` and `folder` — is silently created with an INT4 column in PostgreSQL, despite the schema definition intending INT8.

**Why do we need this feature?**

On long-running PostgreSQL instances the `folder_id_seq` sequence can exhaust the INT4 maximum value of 2,147,483,647, at which point no new folders can be created and all dashboard provisioning fails. Separately, Grafana generates INT64 IDs at runtime that cannot be stored in the INT4 `dashboard.id` column, causing every provisioned dashboard save to fail with `pq: value "..." is out of range for type integer`.

This PR fixes the root cause in the dialect and adds PostgreSQL-only migrations to ALTER the `dashboard.id` and `folder.id` columns (and their backing sequences) from INT4 to BIGINT on existing installations.

**Who is this feature for?**

All users running Grafana backed by PostgreSQL, particularly long-running installations where INT4 sequences are approaching exhaustion or where dashboard provisioning has started failing with integer overflow errors.

**Which issue(s) does this PR fix?**

Fixes # _(no upstream issue filed yet — discovered via operational incident)_

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.