### PR TITLE
[IAM] Honor grace period when marking tokens for rotation upon Lookups

### DIFF
--- a/pkg/models/usertoken/user_token.go
+++ b/pkg/models/usertoken/user_token.go
@@ -41,12 +41,18 @@ type UserToken struct {
 const UrgentRotateTime = 1 * time.Minute
 
 func (t *UserToken) NeedsRotation(rotationInterval time.Duration) bool {
+	return t.NeedsRotationAt(time.Now(), rotationInterval)
+}
+
+// NeedsRotationAt is NeedsRotation evaluated against the given time rather than the
+// wall clock, so callers (and tests) can reason about rotation deterministically.
+func (t *UserToken) NeedsRotationAt(now time.Time, rotationInterval time.Duration) bool {
 	rotatedAt := time.Unix(t.RotatedAt, 0)
 	if !t.AuthTokenSeen {
-		return rotatedAt.Before(time.Now().Add(-UrgentRotateTime))
+		return rotatedAt.Before(now.Add(-UrgentRotateTime))
 	}
 
-	return rotatedAt.Before(time.Now().Add(-rotationInterval))
+	return rotatedAt.Before(now.Add(-rotationInterval))
 }
 
 const rotationLeeway = 5 * time.Second

--- a/pkg/services/auth/authimpl/auth_token.go
+++ b/pkg/services/auth/authimpl/auth_token.go
@@ -224,10 +224,14 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 
 			graceEnabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagAuthTokenRotationGracePeriod, false, openfeature.TransactionContext(ctx))
 			if graceEnabled {
+				// The token has been rotated very recently, so we don't want to rotate it again.
+				// We accomplish this by restoring its rotation time and marking it back as seen.
 				model.AuthTokenSeen = origAuthTokenSeen
 				model.RotatedAt = origRotatedAt
 			}
 		} else {
+			// The token was last rotated more than UrgentRotateTime time ago. We keep the modified rotated_at and
+			// mark it as unseen so that it will be considered as needing urgent rotation during authentication.
 			ctxLogger.Debug("Prev seen token", "tokenID", model.Id, "userID", model.UserId, "clientIP", model.ClientIp, "userAgent", model.UserAgent, "authToken", model.AuthToken)
 		}
 	}

--- a/pkg/services/auth/authimpl/auth_token.go
+++ b/pkg/services/auth/authimpl/auth_token.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/singleflight"
@@ -198,6 +199,9 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 
 	// Current incoming token is the previous auth token in the DB and the auth_token_seen is true
 	if model.AuthToken != hashedToken && model.PrevAuthToken == hashedToken && model.AuthTokenSeen {
+		origAuthTokenSeen := model.AuthTokenSeen
+		origRotatedAt := model.RotatedAt
+
 		model.AuthTokenSeen = false
 		model.RotatedAt = getTime().Add(-usertoken.UrgentRotateTime).Unix()
 
@@ -217,6 +221,12 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 
 		if affectedRows == 0 {
 			ctxLogger.Debug("Prev seen token unchanged", "tokenID", model.Id, "userID", model.UserId, "clientIP", model.ClientIp, "userAgent", model.UserAgent, "authToken", model.AuthToken)
+
+			graceEnabled := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagAuthTokenRotationGracePeriod, false, openfeature.TransactionContext(ctx))
+			if graceEnabled {
+				model.AuthTokenSeen = origAuthTokenSeen
+				model.RotatedAt = origRotatedAt
+			}
 		} else {
 			ctxLogger.Debug("Prev seen token", "tokenID", model.Id, "userID", model.UserId, "clientIP", model.ClientIp, "userAgent", model.UserAgent, "authToken", model.AuthToken)
 		}

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -6,9 +6,12 @@ import (
 	"errors"
 	"net"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -21,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -532,9 +536,13 @@ func TestIntegrationUserAuthToken(t *testing.T) {
 			require.ErrorIs(t, err, auth.ErrUserTokenNotFound)
 		})
 
-		t.Run("should not rotate token when last rotation happened recently", func(t *testing.T) {
+		// rotateOnceForReplay creates a token and rotates it once so there is a
+		// distinct previous/current pair. On return getTime sits at the moment
+		// of rotation, so a follow-up rotation is still within SkipRotationTime.
+		rotateOnceForReplay := func(t *testing.T) (*auth.UserToken, *auth.UserToken) {
+			t.Helper()
 			advanceTime(SkipRotationTime + 1*time.Second)
-			prevToken, err := ctx.tokenService.CreateToken(context.Background(), &auth.CreateTokenCommand{
+			initial, err := ctx.tokenService.CreateToken(context.Background(), &auth.CreateTokenCommand{
 				User:      usr,
 				ClientIP:  nil,
 				UserAgent: "",
@@ -542,16 +550,79 @@ func TestIntegrationUserAuthToken(t *testing.T) {
 			require.NoError(t, err)
 
 			advanceTime(SkipRotationTime + 1*time.Second)
-			rotatedToken, err := ctx.tokenService.RotateToken(context.Background(), auth.RotateCommand{UnHashedToken: prevToken.UnhashedToken})
+			current, err := ctx.tokenService.RotateToken(context.Background(), auth.RotateCommand{UnHashedToken: initial.UnhashedToken})
 			require.NoError(t, err)
-			assert.True(t, rotatedToken.UnhashedToken != prevToken.UnhashedToken)
-			assert.True(t, rotatedToken.PrevAuthToken == hashToken("", prevToken.UnhashedToken))
+			require.NotEqual(t, initial.UnhashedToken, current.UnhashedToken)
+			return initial, current
+		}
 
-			// Should not rotate because it already rotated less than 5s ago
-			skippedToken, err := ctx.tokenService.RotateToken(context.Background(), auth.RotateCommand{UnHashedToken: rotatedToken.UnhashedToken})
+		t.Run("should not rotate token when current token is replayed within SkipRotationTime", func(t *testing.T) {
+			_, current := rotateOnceForReplay(t)
+
+			skipped, err := ctx.tokenService.RotateToken(context.Background(), auth.RotateCommand{UnHashedToken: current.UnhashedToken})
 			require.NoError(t, err)
-			assert.True(t, skippedToken.UnhashedToken == rotatedToken.UnhashedToken)
-			assert.True(t, skippedToken.PrevAuthToken == hashToken("", prevToken.UnhashedToken))
+			assert.Equal(t, current.UnhashedToken, skipped.UnhashedToken, "rotation within SkipRotationTime should be skipped, returning the same token")
+		})
+
+		t.Run("should not rotate token when previous token is replayed and current is unseen", func(t *testing.T) {
+			initial, current := rotateOnceForReplay(t)
+
+			before, err := ctx.getAuthTokenByID(current.Id)
+			require.NoError(t, err)
+			require.False(t, before.AuthTokenSeen)
+
+			skipped, err := ctx.tokenService.RotateToken(context.Background(), auth.RotateCommand{UnHashedToken: initial.UnhashedToken})
+			require.NoError(t, err)
+
+			after, err := ctx.getAuthTokenByID(current.Id)
+			require.NoError(t, err)
+			assert.Equal(t, before.AuthToken, after.AuthToken, "current auth token should not change")
+			assert.Equal(t, before.PrevAuthToken, after.PrevAuthToken, "previous auth token should not change")
+			assert.Equal(t, before.RotatedAt, after.RotatedAt, "rotated_at should not change when rotation is skipped")
+			assert.Equal(t, initial.UnhashedToken, skipped.UnhashedToken, "skipped rotation should return the replayed token")
+		})
+
+		t.Run("does not rotate when previous token is replayed and current is seen and grace period is enabled", func(t *testing.T) {
+			setupOpenFeatureFlag(t, featuremgmt.FlagAuthTokenRotationGracePeriod, true)
+
+			initial, current := rotateOnceForReplay(t)
+
+			// Mark new token as seen.
+			_, err := ctx.tokenService.LookupToken(context.Background(), current.UnhashedToken)
+			require.NoError(t, err)
+
+			before, err := ctx.getAuthTokenByID(current.Id)
+			require.NoError(t, err)
+			require.True(t, before.AuthTokenSeen)
+
+			skipped, err := ctx.tokenService.RotateToken(context.Background(), auth.RotateCommand{UnHashedToken: initial.UnhashedToken})
+			require.NoError(t, err)
+
+			after, err := ctx.getAuthTokenByID(current.Id)
+			require.NoError(t, err)
+			assert.Equal(t, before.AuthToken, after.AuthToken, "current auth token should not change")
+			assert.Equal(t, before.PrevAuthToken, after.PrevAuthToken, "previous auth token should not change")
+			assert.Equal(t, before.RotatedAt, after.RotatedAt, "rotated_at should not change when rotation is skipped")
+			assert.Equal(t, initial.UnhashedToken, skipped.UnhashedToken, "skipped rotation should return the replayed token")
+		})
+
+		t.Run("re-rotates when previous token is replayed and current is seen and grace period is disabled", func(t *testing.T) {
+			initial, current := rotateOnceForReplay(t)
+
+			_, err := ctx.tokenService.LookupToken(context.Background(), current.UnhashedToken)
+			require.NoError(t, err)
+
+			before, err := ctx.getAuthTokenByID(current.Id)
+			require.NoError(t, err)
+			require.True(t, before.AuthTokenSeen)
+
+			rotated, err := ctx.tokenService.RotateToken(context.Background(), auth.RotateCommand{UnHashedToken: initial.UnhashedToken})
+			require.NoError(t, err)
+
+			after, err := ctx.getAuthTokenByID(current.Id)
+			require.NoError(t, err)
+			assert.NotEqual(t, before.AuthToken, after.AuthToken, "current auth token should be rotated (legacy behaviour)")
+			assert.NotEqual(t, initial.UnhashedToken, rotated.UnhashedToken, "a new token should be minted (legacy behaviour)")
 		})
 
 		t.Run("should return error when token is revoked", func(t *testing.T) {
@@ -697,6 +768,26 @@ func TestIntegrationUserAuthToken(t *testing.T) {
 		utMap := utJSON.MustMap()
 
 		require.True(t, reflect.DeepEqual(utMap, uatMap))
+	})
+}
+
+var openfeatureTestMutex sync.Mutex
+
+func setupOpenFeatureFlag(t *testing.T, flag string, value bool) {
+	t.Helper()
+	openfeatureTestMutex.Lock()
+
+	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
+		flag: setting.NewInMemoryFlag(flag, value),
+	})
+	require.NoError(t, err)
+
+	err = openfeature.SetProviderAndWait(provider)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+		openfeatureTestMutex.Unlock()
 	})
 }
 

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -699,6 +700,89 @@ func TestIntegrationUserAuthToken(t *testing.T) {
 			assert.Len(t, revokedTokens, 1)
 
 			getTime = time.Now
+		})
+	})
+
+	t.Run("LookupToken with a recently rotated previous token", func(t *testing.T) {
+		// setup creates a token, rotates it (so the initial token becomes the previous
+		// token) and marks the new current token as seen, all within UrgentRotateTime of
+		// the rotation. On return getTime sits at the moment of rotation.
+		setup := func(t *testing.T, c *testContext) (prevUnhashed string, id, rotatedAt int64) {
+			t.Helper()
+			getTime = func() time.Time { return now }
+			initial, err := c.tokenService.CreateToken(context.Background(), &auth.CreateTokenCommand{
+				User:      usr,
+				ClientIP:  net.ParseIP("192.168.10.11"),
+				UserAgent: "agent",
+			})
+			require.NoError(t, err)
+
+			// Advance past SkipRotationTime so RotateToken actually rotates instead of skipping
+			getTime = func() time.Time { return now.Add(SkipRotationTime + time.Second) }
+			current, err := c.tokenService.RotateToken(context.Background(), auth.RotateCommand{UnHashedToken: initial.UnhashedToken})
+			require.NoError(t, err)
+
+			// Mark the new token as seen
+			_, err = c.tokenService.LookupToken(context.Background(), current.UnhashedToken)
+			require.NoError(t, err)
+
+			return initial.UnhashedToken, current.Id, now.Add(SkipRotationTime + time.Second).Unix()
+		}
+
+		t.Run("is not flagged for rotation when grace period is enabled", func(t *testing.T) {
+			c := createTestContext(t)
+			setupOpenFeatureFlag(t, featuremgmt.FlagAuthTokenRotationGracePeriod, true)
+			rotationInterval := time.Duration(c.cfg.TokenRotationIntervalMinutes) * time.Minute
+			prevUnhashed, id, rotatedAt := setup(t, c)
+
+			got, err := c.tokenService.LookupToken(context.Background(), prevUnhashed)
+			require.NoError(t, err)
+
+			// Evaluated less than UrgentRotateTime time after the rotation, the token must not need rotation.
+			evalAt := time.Unix(rotatedAt, 0).Add(usertoken.UrgentRotateTime / 2)
+			assert.False(t, got.NeedsRotationAt(evalAt, rotationInterval), "token within grace period must not need rotation")
+			assert.True(t, got.AuthTokenSeen)
+			assert.Equal(t, rotatedAt, got.RotatedAt)
+
+			model, err := c.getAuthTokenByID(id)
+			require.NoError(t, err)
+			assert.True(t, model.AuthTokenSeen)
+			assert.Equal(t, rotatedAt, model.RotatedAt)
+		})
+
+		t.Run("is flagged for urgent rotation when grace period is disabled", func(t *testing.T) {
+			c := createTestContext(t)
+			rotationInterval := time.Duration(c.cfg.TokenRotationIntervalMinutes) * time.Minute
+			prevUnhashed, id, rotatedAt := setup(t, c)
+
+			got, err := c.tokenService.LookupToken(context.Background(), prevUnhashed)
+			require.NoError(t, err)
+
+			// Legacy behaviour: the returned token is backdated and unseen, so it needs
+			// urgent rotation, even though the DB record was never changed.
+			evalAt := time.Unix(rotatedAt, 0).Add(usertoken.UrgentRotateTime / 2)
+			assert.True(t, got.NeedsRotationAt(evalAt, rotationInterval), "legacy behaviour flags the token for urgent rotation")
+			assert.False(t, got.AuthTokenSeen)
+			assert.Less(t, got.RotatedAt, rotatedAt)
+
+			model, err := c.getAuthTokenByID(id)
+			require.NoError(t, err)
+			assert.True(t, model.AuthTokenSeen)
+			assert.Equal(t, rotatedAt, model.RotatedAt)
+		})
+
+		t.Run("still triggers re-rotation past the grace period when enabled", func(t *testing.T) {
+			c := createTestContext(t)
+			setupOpenFeatureFlag(t, featuremgmt.FlagAuthTokenRotationGracePeriod, true)
+			rotationInterval := time.Duration(c.cfg.TokenRotationIntervalMinutes) * time.Minute
+			prevUnhashed, _, rotatedAt := setup(t, c)
+
+			getTime = func() time.Time { return time.Unix(rotatedAt, 0).Add(2 * usertoken.UrgentRotateTime) }
+			got, err := c.tokenService.LookupToken(context.Background(), prevUnhashed)
+			require.NoError(t, err)
+
+			assert.False(t, got.AuthTokenSeen)
+			assert.True(t, got.NeedsRotationAt(getTime().Add(time.Second), rotationInterval))
 		})
 	})
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3139,6 +3139,15 @@ var (
 			Expression:  "false",
 			Generate:    Generate{React: true},
 		},
+		{
+			Name:         "auth.tokenRotationGracePeriod",
+			Description:  "Keeps a recently rotated previous session token valid instead of forcing an urgent re-rotation, which should prevent multi-tab race-condition logouts",
+			Stage:        FeatureStageExperimental,
+			Owner:        identityAccessTeam,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{Go: true},
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -365,3 +365,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-22,table.protoRowParser,experimental,@grafana/dataviz-squad,false,false,true
 2026-06-23,dataviz.experimentalColorSchemes,experimental,@grafana/dataviz-squad,false,false,true
 2026-06-25,grafana.customizableMegaMenu,experimental,@grafana/grafana-frontend-navigation,false,false,true
+2026-06-26,auth.tokenRotationGracePeriod,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -961,4 +961,8 @@ const (
 	// FlagSplunkUseLegacyResultsApi
 	// Makes the Splunk data source use the deprecated REST API v1 search result endpoints instead of v2
 	FlagSplunkUseLegacyResultsApi = "splunk.useLegacyResultsApi"
+
+	// FlagAuthTokenRotationGracePeriod
+	// Keeps a recently rotated previous session token valid instead of forcing an urgent re-rotation, which should prevent multi-tab race-condition logouts
+	FlagAuthTokenRotationGracePeriod = "auth.tokenRotationGracePeriod"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -993,6 +993,23 @@
     },
     {
       "metadata": {
+        "name": "auth.tokenRotationGracePeriod",
+        "resourceVersion": "1782472850879",
+        "creationTimestamp": "2026-06-26T10:33:47Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-06-26 11:20:50.87964 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Keeps a recently rotated previous session token valid instead of forcing an urgent re-rotation, which should prevent multi-tab race-condition logouts",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "authZGRPCServer",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2024-06-13T09:41:35Z"


### PR DESCRIPTION
Tries to fix the issue described in https://github.com/grafana/grafana/pull/127023#issuecomment-4794700234 by applying a partial fix of what https://github.com/grafana/grafana/pull/127023 contained.

The idea is that when tokens are looked up, every time a request is authenticated, if the token being used has been rotated recently and the newer token has already been used but this request is still carrying the old token, it should still be valid within a grace period. IIUC, the logic for this seems to be there but there's a bug preventing the grace-period from being honored.

The bug in that specific scenario is that we end up modifying the token in-memory (not in the DB), by adding extra time to its rotation time and marking it as unseen [here](https://github.com/grafana/grafana/blob/273c94ec5f7666566d268d543dc7479e55ad13a0/pkg/services/auth/authimpl/auth_token.go#L201-L202), to check if we need to mark it for urgent rotation or not. If we don't need to mark it for urgent rotation, we keep the record unmodified in the DB, but we don't restore the in-memory version (should be done [here](https://github.com/grafana/grafana/blob/273c94ec5f7666566d268d543dc7479e55ad13a0/pkg/services/auth/authimpl/auth_token.go#L218)), which ultimately makes it be considered for urgent rotation anyway [here](https://github.com/grafana/grafana/blob/1008a7ff81d3e52d469547aa4acd691fbed4363d/pkg/services/authn/clients/session.go#L62-L69). 

The proposed fix is gated behind the `auth.tokenRotationGracePeriod` feature flag which is turned off by default.

---

The PR also adds some extra token-rotation unit tests for the 5s `SkipTokenRotation` grace-period introduced in https://github.com/grafana/grafana/pull/106075 because I noticed the tests I added in that PR were testing the wrong thing 🫤 