### PR TITLE
XYChart: cover all fieldValueColors cases

### DIFF
--- a/public/app/plugins/panel/xychart/__snapshots__/fieldValueColors.test.ts.snap
+++ b/public/app/plugins/panel/xychart/__snapshots__/fieldValueColors.test.ts.snap
@@ -14,6 +14,20 @@ exports[`fieldValueColors (golden baseline) RangeToText mapping 1`] = `
 }
 `;
 
+exports[`fieldValueColors (golden baseline) RangeToText with open-ended (from-only / to-only) and unbounded ranges 1`] = `
+{
+  "colors": [
+    "#5794f2ff",
+    null,
+    "#73bf69ff",
+  ],
+  "palette": [
+    "#73bf69ff",
+    "#5794f2ff",
+  ],
+}
+`;
+
 exports[`fieldValueColors (golden baseline) RegexToText is currently a no-op (documents pre-migration behavior) 1`] = `
 {
   "colors": [
@@ -21,6 +35,19 @@ exports[`fieldValueColors (golden baseline) RegexToText is currently a no-op (do
     null,
   ],
   "palette": [],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) SpecialValue Null matches both null and undefined (loose ==) 1`] = `
+{
+  "colors": [
+    "#b877d9ff",
+    "#b877d9ff",
+    null,
+  ],
+  "palette": [
+    "#b877d9ff",
+  ],
 }
 `;
 
@@ -38,6 +65,46 @@ exports[`fieldValueColors (golden baseline) SpecialValue mapping (NaN / Null) 1`
 }
 `;
 
+exports[`fieldValueColors (golden baseline) SpecialValue mapping (NullAndNaN / Empty) 1`] = `
+{
+  "colors": [
+    "#73bf69ff",
+    "#73bf69ff",
+    "#5794f2ff",
+    null,
+  ],
+  "palette": [
+    "#73bf69ff",
+    "#5794f2ff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) SpecialValue mapping (True / False) 1`] = `
+{
+  "colors": [
+    "#73bf69ff",
+    "#f2495cff",
+  ],
+  "palette": [
+    "#73bf69ff",
+    "#f2495cff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) SpecialValue mapping result without a color is skipped 1`] = `
+{
+  "colors": [
+    null,
+    "#b877d9ff",
+  ],
+  "palette": [
+    "#b877d9ff",
+  ],
+}
+`;
+
 exports[`fieldValueColors (golden baseline) ValueToText mapping 1`] = `
 {
   "colors": [
@@ -50,6 +117,32 @@ exports[`fieldValueColors (golden baseline) ValueToText mapping 1`] = `
     "#73bf69ff",
     "#fade2aff",
     "#f2495cff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) ValueToText mapping entries without a color are skipped 1`] = `
+{
+  "colors": [
+    null,
+    "#f2495cff",
+  ],
+  "palette": [
+    "#f2495cff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) ValueToText mapping on a string field (compares against quoted keys) 1`] = `
+{
+  "colors": [
+    "#73bf69ff",
+    "#fade2aff",
+    null,
+  ],
+  "palette": [
+    "#73bf69ff",
+    "#fade2aff",
   ],
 }
 `;
@@ -111,6 +204,25 @@ exports[`fieldValueColors (golden baseline) continuous gradient (needs min/max) 
     "#f35c56ff",
     "#f35359ff",
     "#f2495cff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) no color branch taken yields the empty defaults (getAll -> [], getOne -> -1) 1`] = `
+{
+  "colors": [],
+  "palette": [],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) single-step absolute thresholds (every value gets the base step) 1`] = `
+{
+  "colors": [
+    "#73bf69ff",
+    "#73bf69ff",
+  ],
+  "palette": [
+    "#73bf69ff",
   ],
 }
 `;

--- a/public/app/plugins/panel/xychart/fieldValueColors.test.ts
+++ b/public/app/plugins/panel/xychart/fieldValueColors.test.ts
@@ -110,4 +110,106 @@ describe('fieldValueColors (golden baseline)', () => {
     // empty palette, all values fall through to the -1 fallback (null here)
     expect(resolve(config, ['foobar', 'baz'], { type: FieldType.string })).toMatchSnapshot();
   });
+
+  it('ValueToText mapping on a string field (compares against quoted keys)', () => {
+    const config = {
+      mappings: [
+        {
+          type: MappingType.ValueToText,
+          options: {
+            a: { text: 'Apple', color: 'green' },
+            b: { text: 'Banana', color: 'yellow' },
+          },
+        },
+      ],
+    };
+    expect(resolve(config, ['a', 'b', 'c'], { type: FieldType.string })).toMatchSnapshot();
+  });
+
+  it('ValueToText mapping entries without a color are skipped', () => {
+    const config = {
+      mappings: [
+        {
+          type: MappingType.ValueToText,
+          options: {
+            '1': { text: 'one' }, // no color -> skipped, palette not advanced
+            '2': { text: 'two', color: 'red' },
+          },
+        },
+      ],
+    };
+    expect(resolve(config, [1, 2])).toMatchSnapshot();
+  });
+
+  it('RangeToText with open-ended (from-only / to-only) and unbounded ranges', () => {
+    const config = {
+      mappings: [
+        { type: MappingType.RangeToText, options: { from: 10, result: { color: 'green' } } }, // v >= 10
+        { type: MappingType.RangeToText, options: { to: 5, result: { color: 'blue' } } }, // v <= 5
+        { type: MappingType.RangeToText, options: { result: { color: 'red' } } }, // no bounds -> skipped
+      ],
+    };
+    expect(resolve(config, [3, 7, 20])).toMatchSnapshot();
+  });
+
+  it('SpecialValue mapping (NullAndNaN / Empty)', () => {
+    const config = {
+      mappings: [
+        {
+          type: MappingType.SpecialValue,
+          options: { match: SpecialValueMatch.NullAndNaN, result: { color: 'green' } },
+        },
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.Empty, result: { color: 'blue' } } },
+      ],
+    };
+    expect(resolve(config, [null, NaN, '', 5])).toMatchSnapshot();
+  });
+
+  it('SpecialValue mapping (True / False)', () => {
+    const config = {
+      mappings: [
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.True, result: { color: 'green' } } },
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.False, result: { color: 'red' } } },
+      ],
+    };
+    expect(resolve(config, [true, false], { type: FieldType.boolean })).toMatchSnapshot();
+  });
+
+  it('SpecialValue mapping result without a color is skipped', () => {
+    const config = {
+      mappings: [
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.NaN, result: {} } }, // no color -> skipped
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.Null, result: { color: 'purple' } } },
+      ],
+    };
+    expect(resolve(config, [NaN, null])).toMatchSnapshot();
+  });
+
+  it('SpecialValue Null matches both null and undefined (loose ==)', () => {
+    const config = {
+      mappings: [
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.Null, result: { color: 'purple' } } },
+      ],
+    };
+    expect(resolve(config, [null, undefined, 0])).toMatchSnapshot();
+  });
+
+  it('no color branch taken yields the empty defaults (getAll -> [], getOne -> -1)', () => {
+    // color field present but no mappings, no thresholds mode, no continuous mode:
+    // conds stays empty so getAll returns [] regardless of input length. discrete=false
+    // because getOne (-1) and getAll ([]) cannot agree here by construction.
+    const config = {};
+    expect(resolve(config, [1, 2, 3], { discrete: false })).toMatchSnapshot();
+  });
+
+  it('single-step absolute thresholds (every value gets the base step)', () => {
+    const config = {
+      color: { mode: FieldColorModeId.Thresholds },
+      thresholds: {
+        mode: ThresholdsMode.Absolute,
+        steps: [{ value: -Infinity, color: 'green' }],
+      },
+    };
+    expect(resolve(config, [1, 100])).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
**What is this feature?**

Expands unit coverage of `fieldValueColors` in the XY Chart panel (`scatter.ts`) to pin the resolved palette and per-value colors for every branch: ValueToText (number and string fields), color-less mapping entries (skipped), open-ended / unbounded RangeToText, all SpecialValue matches (NaN, Null, NullAndNaN, Empty, True, False), loose-equality null matching (null and undefined), the empty-branch quirk (`getAll -> []`), and single-step absolute thresholds.

Test-only — no production changes; existing snapshots are unchanged.

**Why do we need this feature?**

This is the introductory PR in a stack that makes the XY Chart color-by-value compiler tolerate a Content-Security-Policy without `unsafe-eval`. Locking current behavior in golden snapshots first lets the follow-up refactor prove it produces byte-identical output.

**Who is this feature for?**

Grafana dataviz maintainers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

PR 1 of a 3-PR stack (base for the CSP-fallback work). Pure test additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
