### PR TITLE
XYChart: layer value mappings over the color mode in fieldValueColors

### DIFF
--- a/public/app/plugins/panel/xychart/__snapshots__/fieldValueColors.test.ts.snap
+++ b/public/app/plugins/panel/xychart/__snapshots__/fieldValueColors.test.ts.snap
@@ -208,6 +208,21 @@ exports[`fieldValueColors (golden baseline) continuous gradient (needs min/max) 
 }
 `;
 
+exports[`fieldValueColors (golden baseline) mapping layered over multi-step thresholds 1`] = `
+{
+  "colors": [
+    "#b877d9ff",
+    "#73bf69ff",
+    "#f2495cff",
+  ],
+  "palette": [
+    "#b877d9ff",
+    "#73bf69ff",
+    "#f2495cff",
+  ],
+}
+`;
+
 exports[`fieldValueColors (golden baseline) no color branch taken yields the empty defaults (getAll -> [], getOne -> -1) 1`] = `
 {
   "colors": [],
@@ -222,6 +237,77 @@ exports[`fieldValueColors (golden baseline) single-step absolute thresholds (eve
     "#73bf69ff",
   ],
   "palette": [
+    "#73bf69ff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) unmatched mapping falls through to the threshold color 1`] = `
+{
+  "colors": [
+    "#73bf69ff",
+    "#73bf69ff",
+  ],
+  "palette": [
+    "#73bf69ff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) value mapping layered over a continuous gradient 1`] = `
+{
+  "colors": [
+    "#73bf69ff",
+    "#b877d9ff",
+    "#f2495cff",
+  ],
+  "palette": [
+    "#b877d9ff",
+    "#73bf69ff",
+    "#7cc165ff",
+    "#84c361ff",
+    "#8dc55dff",
+    "#95c659ff",
+    "#9ec855ff",
+    "#a6c952ff",
+    "#aeca4eff",
+    "#b5cb4bff",
+    "#bdcb48ff",
+    "#c4cb45ff",
+    "#caca43ff",
+    "#d0c941ff",
+    "#d6c73fff",
+    "#dbc53eff",
+    "#e0c23dff",
+    "#e4be3dff",
+    "#e8b93dff",
+    "#ebb43dff",
+    "#edae3eff",
+    "#efa83fff",
+    "#f1a141ff",
+    "#f29a43ff",
+    "#f39245ff",
+    "#f38a47ff",
+    "#f4814aff",
+    "#f4784dff",
+    "#f46f4fff",
+    "#f36652ff",
+    "#f35c56ff",
+    "#f35359ff",
+    "#f2495cff",
+  ],
+}
+`;
+
+exports[`fieldValueColors (golden baseline) value mapping layered over thresholds (matched -> mapping, else threshold) 1`] = `
+{
+  "colors": [
+    "#73bf69ff",
+    "#b877d9ff",
+    "#73bf69ff",
+  ],
+  "palette": [
+    "#b877d9ff",
     "#73bf69ff",
   ],
 }

--- a/public/app/plugins/panel/xychart/fieldValueColors.test.ts
+++ b/public/app/plugins/panel/xychart/fieldValueColors.test.ts
@@ -218,6 +218,53 @@ describe('fieldValueColors (golden baseline)', () => {
     };
     expect(resolve(config, [1, 100])).toMatchSnapshot();
   });
+
+  it('value mapping layered over thresholds (matched -> mapping, else threshold)', () => {
+    // mirrors the "Color by field (value mappings)" gdev panel: a single 700->purple mapping
+    // plus a green threshold. Unmatched values must fall through to green, not grey (-1).
+    const config = {
+      mappings: [{ type: MappingType.ValueToText, options: { '700': { color: 'purple' } } }],
+      thresholds: { mode: ThresholdsMode.Absolute, steps: [{ value: 0, color: 'green' }] },
+      color: { mode: FieldColorModeId.Thresholds },
+    };
+    expect(resolve(config, [100, 700, 900])).toMatchSnapshot();
+  });
+
+  it('mapping layered over multi-step thresholds', () => {
+    const config = {
+      mappings: [
+        { type: MappingType.SpecialValue, options: { match: SpecialValueMatch.Null, result: { color: 'purple' } } },
+      ],
+      thresholds: {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: 'green' },
+          { value: 50, color: 'red' },
+        ],
+      },
+      color: { mode: FieldColorModeId.Thresholds },
+    };
+    expect(resolve(config, [null, 10, 80])).toMatchSnapshot();
+  });
+
+  it('unmatched mapping falls through to the threshold color', () => {
+    // RegexToText is a no-op, so no value matches a mapping; all should resolve to the threshold
+    const config = {
+      mappings: [{ type: MappingType.RegexToText, options: { pattern: '/x/', result: { color: 'orange' } } }],
+      thresholds: { mode: ThresholdsMode.Absolute, steps: [{ value: 0, color: 'green' }] },
+      color: { mode: FieldColorModeId.Thresholds },
+    };
+    expect(resolve(config, [1, 2])).toMatchSnapshot();
+  });
+
+  it('value mapping layered over a continuous gradient', () => {
+    const config = {
+      mappings: [{ type: MappingType.ValueToText, options: { '50': { color: 'purple' } } }],
+      color: { mode: FieldColorModeId.ContinuousGrYlRd },
+    };
+    // discrete=false: the gradient path leaves getOne at -1, so it can't agree with getAll
+    expect(resolve(config, [0, 50, 100], { min: 0, max: 100, discrete: false })).toMatchSnapshot();
+  });
 });
 
 // Every branch of fieldValueColors, driven through both evaluators. The slow
@@ -358,6 +405,34 @@ const PARITY_CASES: Array<{
   {
     name: 'continuous gradient',
     config: { color: { mode: FieldColorModeId.ContinuousGrYlRd } },
+    values: [0, 50, 100],
+    min: 0,
+    max: 100,
+  },
+  {
+    name: 'mapping layered over thresholds',
+    config: {
+      mappings: [{ type: MappingType.ValueToText, options: { '700': { color: 'purple' } } }],
+      thresholds: { mode: ThresholdsMode.Absolute, steps: [{ value: 0, color: 'green' }] },
+      color: { mode: FieldColorModeId.Thresholds },
+    },
+    values: [100, 700, 900],
+  },
+  {
+    name: 'unmatched mapping falls through to thresholds',
+    config: {
+      mappings: [{ type: MappingType.RegexToText, options: { pattern: '/x/', result: { color: 'orange' } } }],
+      thresholds: { mode: ThresholdsMode.Absolute, steps: [{ value: 0, color: 'green' }] },
+      color: { mode: FieldColorModeId.Thresholds },
+    },
+    values: [1, 2],
+  },
+  {
+    name: 'mapping layered over continuous gradient',
+    config: {
+      mappings: [{ type: MappingType.ValueToText, options: { '50': { color: 'purple' } } }],
+      color: { mode: FieldColorModeId.ContinuousGrYlRd },
+    },
     values: [0, 50, 100],
     min: 0,
     max: 100,

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -596,85 +596,98 @@ interface ColorSpec {
   getAllOverride?: GetAllValues;
 }
 
-/** Build the value->color spec from a field config, or null when no color branch applies. */
-export function buildColorSpec(f: Field, theme: GrafanaTheme2): ColorSpec | null {
-  const index: unknown[] = [];
-  const rules: Array<{ rule: ColorRule; idx: number }> = [];
-
-  // if any mappings exist, use them regardless of other settings
-  if (f.config.mappings?.length ?? 0 > 0) {
-    let mappings = f.config.mappings!;
-
-    for (let i = 0; i < mappings.length; i++) {
-      let m = mappings[i];
-
-      if (m.type === MappingType.ValueToText) {
-        for (let k in m.options) {
-          let { color } = m.options[k];
-
-          if (color != null) {
-            let rhs = f.type === FieldType.string ? k : Number(k);
-            rules.push({ rule: { kind: 'eq', rhs }, idx: index.length });
-            index.push(getHex8Color(color, theme));
-          }
-        }
-      } else if (m.options.result.color != null) {
-        let { color } = m.options.result;
-
-        if (m.type === MappingType.RangeToText) {
-          let from = m.options.from != null ? Number(m.options.from) : undefined;
-          let to = m.options.to != null ? Number(m.options.to) : undefined;
-
-          if (from !== undefined || to !== undefined) {
-            rules.push({ rule: { kind: 'range', from, to }, idx: index.length });
-            index.push(getHex8Color(color, theme));
-          }
-        } else if (m.type === MappingType.SpecialValue) {
-          let spl = m.options.match;
-          let rule: ColorRule;
-
-          if (spl === SpecialValueMatch.NaN) {
-            rule = { kind: 'isNaN' };
-          } else if (spl === SpecialValueMatch.NullAndNaN) {
-            rule = { kind: 'nullOrNaN' };
-          } else if (spl === SpecialValueMatch.True) {
-            rule = { kind: 'eqStrict', rhs: true };
-          } else if (spl === SpecialValueMatch.False) {
-            rule = { kind: 'eqStrict', rhs: false };
-          } else if (spl === SpecialValueMatch.Empty) {
-            rule = { kind: 'eqStrict', rhs: '' };
-          } else {
-            // SpecialValueMatch.Null and any other match fall back to loose null
-            rule = { kind: 'isNullLoose' };
-          }
-
-          rules.push({ rule, idx: index.length });
-          index.push(getHex8Color(color, theme));
-        } else if (m.type === MappingType.RegexToText) {
-          // TODO
-        }
-      }
-    }
-
-    // the mappings branch always installs a -1 fallback, so even a config with
-    // no usable rule (e.g. RegexToText only) resolves to -1 rather than the
-    // empty defaults below
-    return { index, rules, fallback: -1 };
+/** Mapping layer: palette colors plus rules with indices local to `colors`. Null when the field has no mappings. */
+function buildMappingLayer(
+  f: Field,
+  theme: GrafanaTheme2
+): { colors: unknown[]; rules: Array<{ rule: ColorRule; idx: number }> } | null {
+  // operator precedence preserved intentionally: an empty mappings array falls through (no layer)
+  if (!(f.config.mappings?.length ?? 0 > 0)) {
+    return null;
   }
 
+  const colors: unknown[] = [];
+  const rules: Array<{ rule: ColorRule; idx: number }> = [];
+  let mappings = f.config.mappings!;
+
+  for (let i = 0; i < mappings.length; i++) {
+    let m = mappings[i];
+
+    if (m.type === MappingType.ValueToText) {
+      for (let k in m.options) {
+        let { color } = m.options[k];
+
+        if (color != null) {
+          let rhs = f.type === FieldType.string ? k : Number(k);
+          rules.push({ rule: { kind: 'eq', rhs }, idx: colors.length });
+          colors.push(getHex8Color(color, theme));
+        }
+      }
+    } else if (m.options.result.color != null) {
+      let { color } = m.options.result;
+
+      if (m.type === MappingType.RangeToText) {
+        let from = m.options.from != null ? Number(m.options.from) : undefined;
+        let to = m.options.to != null ? Number(m.options.to) : undefined;
+
+        if (from !== undefined || to !== undefined) {
+          rules.push({ rule: { kind: 'range', from, to }, idx: colors.length });
+          colors.push(getHex8Color(color, theme));
+        }
+      } else if (m.type === MappingType.SpecialValue) {
+        let spl = m.options.match;
+        let rule: ColorRule;
+
+        if (spl === SpecialValueMatch.NaN) {
+          rule = { kind: 'isNaN' };
+        } else if (spl === SpecialValueMatch.NullAndNaN) {
+          rule = { kind: 'nullOrNaN' };
+        } else if (spl === SpecialValueMatch.True) {
+          rule = { kind: 'eqStrict', rhs: true };
+        } else if (spl === SpecialValueMatch.False) {
+          rule = { kind: 'eqStrict', rhs: false };
+        } else if (spl === SpecialValueMatch.Empty) {
+          rule = { kind: 'eqStrict', rhs: '' };
+        } else {
+          // SpecialValueMatch.Null and any other match fall back to loose null
+          rule = { kind: 'isNullLoose' };
+        }
+
+        rules.push({ rule, idx: colors.length });
+        colors.push(getHex8Color(color, theme));
+      } else if (m.type === MappingType.RegexToText) {
+        // TODO
+      }
+    }
+  }
+
+  return { colors, rules };
+}
+
+/**
+ * Resolver for the field's color mode, or null for modes scatter does not resolve by value.
+ * This mirrors the scaleFunc layer of the display processor: it is both the standalone resolver
+ * and the fallback applied when no value mapping matches.
+ */
+type ColorModeBase =
+  | { kind: 'rules'; colors: unknown[]; rules: Array<{ rule: ColorRule; idx: number }>; fallback: number }
+  | { kind: 'gradient'; colors: unknown[]; toIdxs: GetAllValues };
+
+function buildColorModeBase(f: Field, theme: GrafanaTheme2): ColorModeBase | null {
   if (f.config.color?.mode === FieldColorModeId.Thresholds) {
     if (f.config.thresholds?.mode === ThresholdsMode.Absolute) {
       let steps = f.config.thresholds.steps;
       let lasti = steps.length - 1;
+      const rules: Array<{ rule: ColorRule; idx: number }> = [];
 
       for (let i = lasti; i > 0; i--) {
         rules.push({ rule: { kind: 'gte', rhs: Number(steps[i].value) }, idx: i });
       }
 
-      return { index: steps.map((s) => getHex8Color(s.color, theme)), rules, fallback: 0 };
+      return { kind: 'rules', colors: steps.map((s) => getHex8Color(s.color, theme)), rules, fallback: 0 };
     }
 
-    // TODO: percent thresholds — falls through to the empty defaults
+    // TODO: percent thresholds
     return null;
   }
 
@@ -689,14 +702,71 @@ export function buildColorSpec(f: Field, theme: GrafanaTheme2): ColorSpec | null
     }
 
     return {
-      index: gradient,
-      rules: [],
-      fallback: -1,
-      getAllOverride: (vals, min, max) => valuesToFills(vals as number[], gradient as string[], min!, max!),
+      kind: 'gradient',
+      colors: gradient,
+      toIdxs: (vals, min, max) => valuesToFills(vals as number[], gradient as string[], min!, max!),
     };
   }
 
   return null;
+}
+
+/**
+ * Build the value->color spec from a field config, or null when no color branch applies.
+ *
+ * Mappings are layered OVER the color mode, matching the display processor: a value that hits a
+ * mapping uses the mapping color, otherwise it falls through to the color-mode color (threshold
+ * step / gradient). Mappings are only exclusive (unmatched -> -1) when there is no color mode.
+ */
+export function buildColorSpec(f: Field, theme: GrafanaTheme2): ColorSpec | null {
+  const mapping = buildMappingLayer(f, theme);
+  const base = buildColorModeBase(f, theme);
+
+  // no mappings: pure color-mode resolution (or nothing)
+  if (mapping == null) {
+    if (base == null) {
+      return null;
+    }
+    if (base.kind === 'gradient') {
+      return { index: base.colors, rules: [], fallback: -1, getAllOverride: base.toIdxs };
+    }
+    return { index: base.colors, rules: base.rules, fallback: base.fallback };
+  }
+
+  // mappings but no color mode: mappings win, unmatched values fall back to -1 (grey), as before
+  if (base == null) {
+    return { index: mapping.colors, rules: mapping.rules, fallback: -1 };
+  }
+
+  // mappings layered over the color mode. The combined palette is [mapping colors, base colors];
+  // base indices are shifted by the mapping count so a matched mapping wins and everything else
+  // resolves through the color mode.
+  const offset = mapping.colors.length;
+  const index = [...mapping.colors, ...base.colors];
+
+  if (base.kind === 'gradient') {
+    const tests = mapping.rules.map(({ rule, idx }) => ({ test: rulePredicate(rule), idx }));
+    const getAllOverride: GetAllValues = (vals, min, max) => {
+      const baseIdxs = base.toIdxs(vals, min, max);
+      const out = Array(vals.length);
+      for (let i = 0; i < vals.length; i++) {
+        let mapped = -1;
+        for (let r = 0; r < tests.length; r++) {
+          if (tests[r].test(vals[i])) {
+            mapped = tests[r].idx;
+            break;
+          }
+        }
+        out[i] = mapped === -1 ? offset + baseIdxs[i] : mapped;
+      }
+      return out;
+    };
+    return { index, rules: [], fallback: -1, getAllOverride };
+  }
+
+  // base.kind === 'rules' (thresholds): merge into one rule list with the base indices offset
+  const rules = [...mapping.rules, ...base.rules.map(({ rule, idx }) => ({ rule, idx: offset + idx }))];
+  return { index, rules, fallback: offset + base.fallback };
 }
 
 /** Serialize a rule to its JS condition string, matching the historical compiled form exactly. */


### PR DESCRIPTION
**What is this feature?**

Fixes a coloring bug in the XY Chart: value mappings are now layered OVER the color mode instead of being exclusive.

`fieldValueColors` treated value mappings as exclusive — if any mapping existed, unmatched values resolved to `-1` (the grey `FALLBACK_COLOR`) instead of the color mode. So a panel with a value mapping plus a thresholds color scheme (e.g. the "Color by field (value mappings)" gdev panel: one `700 -> purple` mapping over a green threshold) drew every non-700 bubble grey instead of green.

The display processor layers mappings over the color mode's `scaleFunc`: a matched mapping wins, otherwise the value resolves through the color mode. This mirrors that by splitting the logic into a mapping layer and a color-mode base (thresholds / continuous gradient) and composing them. Mappings stay exclusive (unmatched -> grey) only when no color mode is configured, preserving existing behavior.

**Why do we need this feature?**

Color-by-field panels that combine value mappings with a thresholds/gradient color scheme rendered the wrong color (grey) for unmapped values.

**Who is this feature for?**

XY Chart users coloring points by field value with value mappings.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

PR 3 of 3 — stacked on #127330 (review/merge that first). Split out so this behavioral fix can be reviewed independently of the CSP-fallback refactor. Existing snapshots are unchanged; adds golden + fast/slow parity cases for mappings layered over single/multi-step thresholds, unmatched mappings falling through, and mappings over a continuous gradient. The `[100, 700, 900]` case now resolves `[green, purple, green]` (was all grey).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
