### PR TITLE
GrafanaUI: Fix exceptions coming from unmounting Typeahead/QueryField

### DIFF
--- a/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryFn } from '@storybook/react-webpack5';
-import { useId, useState } from 'react';
+import { useId } from 'react';
 
 import { type TypeaheadInput, type TypeaheadOutput } from '../../types/completion';
 import { Field } from '../Forms/Field';
@@ -73,19 +73,13 @@ const METRICS = [
 // and the portal is created and torn down cleanly when the field mounts/unmounts.
 export const WithSuggestions: StoryFn<typeof QueryField> = (args: Omit<QueryFieldProps, 'theme'>) => {
   const id = useId();
-  const [show, setShow] = useState(false);
 
   return (
-    <>
-      <button onClick={() => setShow(!show)}>{show ? 'Hide' : 'Show'} QueryField</button>
-      {!show && (
-        <Field
-          label={<Label id={id}>Type to see suggestions (e.g. &quot;ra&quot;, &quot;http&quot;, &quot;go&quot;)</Label>}
-        >
-          <QueryField {...args} aria-labelledby={id} />
-        </Field>
-      )}
-    </>
+    <Field
+      label={<Label id={id}>Type to see suggestions (e.g. &quot;ra&quot;, &quot;http&quot;, &quot;go&quot;)</Label>}
+    >
+      <QueryField {...args} aria-labelledby={id} />
+    </Field>
   );
 };
 

--- a/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryFn } from '@storybook/react-webpack5';
-import { useId } from 'react';
+import { useId, useState } from 'react';
 
-import { type TypeaheadInput } from '../../types/completion';
+import { type TypeaheadInput, type TypeaheadOutput } from '../../types/completion';
 import { Field } from '../Forms/Field';
 import { Label } from '../Forms/Label';
 
@@ -52,6 +52,58 @@ Basic.args = {
   }),
   query: 'Query text',
   placeholder: 'Placeholder text',
+  disabled: false,
+};
+
+// A static set of suggestions to mimic what a real datasource would return from onTypeahead.
+// The SuggestionsPlugin filters and sorts these based on what's typed before rendering the Typeahead.
+const FUNCTIONS = ['rate', 'sum', 'avg', 'min', 'max', 'count', 'histogram_quantile', 'increase', 'irate'];
+const METRICS = [
+  'go_goroutines',
+  'go_memstats_alloc_bytes',
+  'http_request_duration_seconds',
+  'http_requests_total',
+  'process_cpu_seconds_total',
+  'up',
+];
+
+// Exercises the full SuggestionsPlugin -> Typeahead path: typing in the field calls onTypeahead,
+// and a non-empty `suggestions` result opens the Typeahead portal anchored to the caret.
+// Use it to manually verify suggestions render, keyboard navigation (Arrow/Enter/Tab/Escape) works,
+// and the portal is created and torn down cleanly when the field mounts/unmounts.
+export const WithSuggestions: StoryFn<typeof QueryField> = (args: Omit<QueryFieldProps, 'theme'>) => {
+  const id = useId();
+  const [show, setShow] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setShow(!show)}>{show ? 'Hide' : 'Show'} QueryField</button>
+      {!show && (
+        <Field
+          label={<Label id={id}>Type to see suggestions (e.g. &quot;ra&quot;, &quot;http&quot;, &quot;go&quot;)</Label>}
+        >
+          <QueryField {...args} aria-labelledby={id} />
+        </Field>
+      )}
+    </>
+  );
+};
+
+WithSuggestions.args = {
+  onTypeahead: async (_input: TypeaheadInput): Promise<TypeaheadOutput> => ({
+    suggestions: [
+      {
+        label: 'Functions',
+        items: FUNCTIONS.map((label) => ({ label, kind: 'function' })),
+      },
+      {
+        label: 'Metrics',
+        items: METRICS.map((label) => ({ label })),
+      },
+    ],
+  }),
+  query: '',
+  placeholder: 'Start typing to trigger the typeahead…',
   disabled: false,
 };
 

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
@@ -226,7 +226,11 @@ class Portal extends PureComponent<React.PropsWithChildren<PortalProps>, {}> {
   }
 
   componentWillUnmount() {
-    document.body.removeChild(this.node);
+    try {
+      this.node.remove();
+    } catch (err) {
+      console.error('Failed to remove typeahead portal node from DOM', err);
+    }
   }
 
   render() {

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
@@ -218,19 +218,18 @@ class Portal extends PureComponent<React.PropsWithChildren<PortalProps>, {}> {
 
   constructor(props: React.PropsWithChildren<PortalProps>) {
     super(props);
-    const { index = 0, origin = 'query', style } = props;
+    const { index = 0, origin = 'query' } = props;
     this.node = document.createElement('div');
-    this.node.setAttribute('style', style);
     this.node.classList.add(`slate-typeahead-${origin}-${index}`);
+  }
+
+  componentDidMount() {
+    this.node.setAttribute('style', this.props.style);
     document.body.appendChild(this.node);
   }
 
   componentWillUnmount() {
-    try {
-      this.node.remove();
-    } catch (err) {
-      console.error('Failed to remove typeahead portal node from DOM', err);
-    }
+    this.node.remove();
   }
 
   render() {


### PR DESCRIPTION
We're seeing exceptions in production coming from the Typeahead component, surfaced by the React 19 upgrade:

```
Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at Portal.componentWillUnmount (Typeahead.tsx:229)
```

The crash comes from the separate `<Portal />` implementation in Typeahead - it manually appends a container `<div />` to `document.body` in its constructor and removes it on unmount with `document.body.removeChild()`.

React 19 seems to be stricter about this, where react can run `componentWillUnmount` multiple times for the same instance, leading to this crash. I don't super understand myself, and haven't been able to reproduce the issue locally, but claude tells me the crux of this is that the assumption that 1 constructor = 1 componentWillUnmount is no longer true:
- mount    → constructor + componentDidMount: (node appended)
- unmount  → componentWillUnmount: removeChild → node detached
- remount  → componentDidMount: ← SAME instance, constructor does NOT re-run, not not re-attached
- unmount  → componentWillUnmount: removeChild → 💥 node already detached

Changes:
- `Typeahead.tsx` -  replace `document.body.removeChild(this.node)` with `this.node.remove()` to remove the node from whatever parent it has, and is a safe no-op if it has none, so it won't throw regardless of React's unmount ordering.
- `Typeahead.tsx` - move `document.body.appendChild(this.node)` to `componentDidMount`, so the node is correctly re-mounted after its unmounted
- `QueryField.story.tsx` - add a story to test Typeahead and suggestions