### PR TITLE
Alerting: set default notification settings type in alert rule mutator

### DIFF
--- a/apps/alerting/rules/pkg/app/alertrule/mutator.go
+++ b/apps/alerting/rules/pkg/app/alertrule/mutator.go
@@ -39,6 +39,12 @@ func NewMutator(cfg config.RuntimeConfig) *simple.Mutator {
 				return nil, err
 			}
 
+			// For backwards compatibility with the old notification settings object we need to set the default to SimplifiedRouting here
+			// we need to do this here because cog doesn't thread the default enum value for the discriminator all the way through
+			if ns := r.Spec.NotificationSettings; ns != nil && ns.SimplifiedRouting != nil && ns.SimplifiedRouting.Type == "" {
+				ns.SimplifiedRouting.Type = v1.AlertRuleNotificationSettingsTypeSimplifiedRouting
+			}
+
 			return &app.MutatingResponse{UpdatedObject: r}, nil
 		},
 	}

--- a/apps/alerting/rules/pkg/app/app_test.go
+++ b/apps/alerting/rules/pkg/app/app_test.go
@@ -133,6 +133,32 @@ func TestAlertRuleValidation_OpenAPISchemaValidation(t *testing.T) {
 	})
 }
 
+func TestAlertRuleMutation_DefaultsNotificationSettingsType(t *testing.T) {
+	r := baseAlertRule()
+	r.Spec.NotificationSettings = &v1.AlertRuleNotificationSettings{
+		SimplifiedRouting: &v1.AlertRuleSimplifiedRouting{
+			Receiver: "notif-ok",
+			// omit type
+		},
+	}
+
+	validator, err := validation.NewBuilder[*v1.AlertRule]().
+		WithOpenAPIValidation(*manifestdata.LocalManifest().ManifestData, schema.GroupKind{Group: "rules.alerting.grafana.app", Kind: "AlertRule"}).
+		Build()
+	require.NoError(t, err)
+
+	err = validator.Validate(context.Background(), &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r})
+	// this should fail because the mutator hasn't added the default type yet
+	require.Error(t, err, "empty notification settings type should fail schema validation before mutation")
+
+	resp, err := alertrule.NewMutator(makeDefaultRuntimeConfig()).Mutate(context.Background(), &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: r})
+	require.NoError(t, err)
+	mutated := resp.UpdatedObject.(*v1.AlertRule)
+	require.Equal(t, v1.AlertRuleNotificationSettingsTypeSimplifiedRouting, mutated.Spec.NotificationSettings.SimplifiedRouting.Type)
+
+	require.NoError(t, validator.Validate(context.Background(), &appsdk.AdmissionRequest{Action: resource.AdmissionActionCreate, Object: mutated}))
+}
+
 func TestAlertRuleValidation_SuccessWithNamedRoutingTree(t *testing.T) {
 	r := baseAlertRule()
 	r.Spec.NotificationSettings = &v1.AlertRuleNotificationSettings{


### PR DESCRIPTION
**What is this feature?**

This PR sets the default notification settings type field in the alert rule mutator. We have logic in place to set the discriminator when `type` is omitted which was sufficient before we wired up openapi validation because we only use the type to determine which variant of the object we should unmarshal into. We need this now because the openapi validator validates every field in the spec where our custom validation doesn't.