### PR TITLE
CI: Use docker compose test block for MySQL integration tests

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -105,26 +105,23 @@ jobs:
     env:
       GRAFANA_TEST_DB: mysql
       MYSQL_HOST: 127.0.0.1
-    services:
-      mysql:
-        image: mysql:8.0.43
-        env:
-          MYSQL_ROOT_PASSWORD: rootpass
-          MYSQL_DATABASE: grafana_tests
-          MYSQL_USER: grafana
-          MYSQL_PASSWORD: password
-        options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=5s --health-retries=3
-        ports:
-          - 3306:3306
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+      - name: Start MySQL via docker compose
+        run: make devenv sources=mysql_tests mysql_version=8.0.43
       - name: Setup Go
         uses: ./.github/actions/setup-go
-      - name: Setup MySQL devenv
-        run: mysql -h 127.0.0.1 -P 3306 -u root -prootpass < devenv/docker/blocks/mysql_tests/setup.sql
+      - name: Wait for MySQL
+        run: |
+          for _ in $(seq 1 60); do
+            mysql -h 127.0.0.1 -P 3306 -uroot -prootpass -e 'SELECT 1' >/dev/null 2>&1 && exit 0
+            sleep 1
+          done
+          echo "MySQL did not become ready in time" >&2
+          exit 1
       - name: Run tests
         env:
           SHARD: ${{ matrix.shard }}
@@ -135,6 +132,9 @@ jobs:
           CGO_ENABLED=0 go test -run='^$' "${PACKAGES[@]}"
           echo "Running tests now"
           CGO_ENABLED=0 go test -p=1 -timeout=12m -run '^TestIntegration' "${PACKAGES[@]}"
+      - name: Cleanup MySQL
+        if: always()
+        run: make devenv-down sources=mysql_tests
 
   postgres:
     # Run this workflow only for PRs from forks
@@ -251,22 +251,13 @@ jobs:
     env:
       GRAFANA_TEST_DB: mysql
       MYSQL_HOST: 127.0.0.1
-    services:
-      mysql:
-        image: mysql:8.0.43
-        env:
-          MYSQL_ROOT_PASSWORD: rootpass
-          MYSQL_DATABASE: grafana_tests
-          MYSQL_USER: grafana
-          MYSQL_PASSWORD: password
-        options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=5s --health-retries=3
-        ports:
-          - 3306:3306
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+      - name: Start MySQL via docker compose
+        run: make devenv sources=mysql_tests mysql_version=8.0.43
       - name: Get GitHub App token
         id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
@@ -280,8 +271,14 @@ jobs:
       # modules are visible when the Go cache key is computed.
       - name: Setup Go
         uses: ./.github/actions/setup-go
-      - name: Setup MySQL devenv
-        run: mysql -h 127.0.0.1 -P 3306 -u root -prootpass < devenv/docker/blocks/mysql_tests/setup.sql
+      - name: Wait for MySQL
+        run: |
+          for _ in $(seq 1 60); do
+            mysql -h 127.0.0.1 -P 3306 -uroot -prootpass -e 'SELECT 1' >/dev/null 2>&1 && exit 0
+            sleep 1
+          done
+          echo "MySQL did not become ready in time" >&2
+          exit 1
       - name: Run tests
         env:
           SHARD: ${{ matrix.shard }}
@@ -292,6 +289,9 @@ jobs:
           CGO_ENABLED=0 go test -tags=enterprise -run='^$' "${PACKAGES[@]}"
           echo "Running tests now"
           CGO_ENABLED=0 go test -p=1 -tags=enterprise -timeout=12m -run '^TestIntegration' "${PACKAGES[@]}"
+      - name: Cleanup MySQL
+        if: always()
+        run: make devenv-down sources=mysql_tests
 
   postgres-enterprise:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)

--- a/devenv/docker/blocks/mysql_tests/docker-compose.yaml
+++ b/devenv/docker/blocks/mysql_tests/docker-compose.yaml
@@ -4,6 +4,15 @@
       args:
         - mysql_version=${mysql_version}
     platform: linux/amd64
+    # Durability-relaxing flags safe for ephemeral test databases: skip redo-log
+    # fsyncs, the doublewrite buffer, and binary logging to cut write overhead.
+    command:
+      [
+        "mysqld",
+        "--innodb-flush-log-at-trx-commit=0",
+        "--innodb-doublewrite=0",
+        "--skip-log-bin",
+      ]
     environment:
       MYSQL_ROOT_PASSWORD: rootpass
       MYSQL_DATABASE: grafana_tests


### PR DESCRIPTION
Aligns the MySQL tests to use the devenv blocks like Postgres does, which also allows it to use `tmpfs` and other tweaks in the command to improve performance.

This seems to be saving around 1m of total test time, but the integration tests have a lot of variation.

Comparing one shard of MySQL tests (2/16)

After:
```
ok  	github.com/grafana/grafana/pkg/api/pluginproxy	1.685s
ok  	github.com/grafana/grafana/pkg/extensions/apiserver/registry/provisioning/gitlab	3.968s
ok  	github.com/grafana/grafana/pkg/extensions/cachingmt/cache/wrappers	8.452s
ok  	github.com/grafana/grafana/pkg/infra/usagestats/statscollector	0.715s
ok  	github.com/grafana/grafana/pkg/services/anonymous/anonimpl/anonstore	0.965s
ok  	github.com/grafana/grafana/pkg/services/ngalert/api	33.083s
ok  	github.com/grafana/grafana/pkg/services/query	5.056s
ok  	github.com/grafana/grafana/pkg/services/store	6.037s
ok  	github.com/grafana/grafana/pkg/storage/unified/testing	163.513s
ok  	github.com/grafana/grafana/pkg/tests/apis	3.046s
ok  	github.com/grafana/grafana/pkg/tests/apis/dashboard	37.152s
ok  	github.com/grafana/grafana/pkg/tests/apis/provisioning/connection	31.658s
ok  	github.com/grafana/grafana/pkg/tests/apis/provisioning/repository	62.487s
```

Before:
```
ok  	github.com/grafana/grafana/pkg/api/pluginproxy	3.193s
ok  	github.com/grafana/grafana/pkg/extensions/apiserver/registry/provisioning/gitlab	4.601s
ok  	github.com/grafana/grafana/pkg/extensions/cachingmt/cache/wrappers	8.448s
ok  	github.com/grafana/grafana/pkg/infra/usagestats/statscollector	1.428s
ok  	github.com/grafana/grafana/pkg/services/anonymous/anonimpl/anonstore	1.899s
ok  	github.com/grafana/grafana/pkg/services/ngalert/api	69.180s
ok  	github.com/grafana/grafana/pkg/services/query	10.209s
ok  	github.com/grafana/grafana/pkg/services/store	12.416s
ok  	github.com/grafana/grafana/pkg/storage/unified/testing	224.087s
ok  	github.com/grafana/grafana/pkg/tests/apis	3.463s
ok  	github.com/grafana/grafana/pkg/tests/apis/dashboard	45.010s
ok  	github.com/grafana/grafana/pkg/tests/apis/provisioning/connection	32.510s
ok  	github.com/grafana/grafana/pkg/tests/apis/provisioning/repository	62.856s
```