### PR TITLE
Docs: fix broken OpenSearch data source links in Elasticsearch docs

### DIFF
--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -23,7 +23,7 @@ weight: 325
 [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html) is a search and analytics engine used for a variety of use cases. The built-in Elasticsearch data source lets you query and visualize logs or metrics stored in Elasticsearch, and annotate graphs with log events.
 
 {{< admonition type="note" >}}
-If you use Amazon OpenSearch Service (the successor to Amazon Elasticsearch Service), use the [OpenSearch data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/opensearch/) instead.
+If you use Amazon OpenSearch Service (the successor to Amazon Elasticsearch Service), use the [OpenSearch data source](https://grafana.com/docs/plugins/grafana-opensearch-datasource/latest/) instead.
 {{< /admonition >}}
 
 ## Key capabilities
@@ -86,5 +86,5 @@ Once you have configured the Elasticsearch data source, you can:
 
 ## Related data sources
 
-- [OpenSearch](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/opensearch/) - For Amazon OpenSearch Service.
+- [OpenSearch](https://grafana.com/docs/plugins/grafana-opensearch-datasource/latest/) - For Amazon OpenSearch Service.
 - [Loki](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/loki/) - Grafana's log aggregation system.


### PR DESCRIPTION
## Summary

Fixes two broken links in the Elasticsearch data source docs that point to a non-existent OpenSearch page under the core Grafana docs.

## Why

Both links target `/docs/grafana/<GRAFANA_VERSION>/datasources/opensearch/`, but OpenSearch is an external plugin and has no page under the core Grafana docs tree — that path returns a 404. The plugin's docs live in the plugin catalog at `https://grafana.com/docs/plugins/grafana-opensearch-datasource/latest/`, which is where these links now point.

The broken-links check flagged this on an unrelated docs PR that happened to touch the same file; this PR resolves it at the source so it no longer blocks edits to `_index.md`.

## Changes

- **[docs/sources/datasources/elasticsearch/_index.md](docs/sources/datasources/elasticsearch/_index.md)** — repoints the two OpenSearch links (the note admonition near the top and the "Related data sources" list) to the OpenSearch plugin catalog docs.
