### PR TITLE
unified-storage: log sql/backend methods usage

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -768,6 +768,12 @@ type Cfg struct {
 
 	EnableSQLKVBackend                bool
 	EnableSQLKVCompatibilityMode      bool
+	// LogSQLBackendCalls, when true, logs every call that reaches an exported
+	// method of the legacy SQL backend. Temporary smoke-test instrumentation
+	// used to confirm no production traffic still reaches sql/backend before
+	// removing the sqlkv backwards-compatibility layer.
+	// TODO: remove this when sql/backend backwards compatibility is no longer needed.
+	LogSQLBackendCalls                bool
 	EnableKVLeases                    bool
 	EnableGarbageCollection           bool
 	GarbageCollectionDryRun           bool

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -766,8 +766,8 @@ type Cfg struct {
 	EnforcedQuotaResources        []string
 	QuotasErrorMessageSupportInfo string
 
-	EnableSQLKVBackend                bool
-	EnableSQLKVCompatibilityMode      bool
+	EnableSQLKVBackend           bool
+	EnableSQLKVCompatibilityMode bool
 	// LogSQLBackendCalls, when true, logs every call that reaches an exported
 	// method of the legacy SQL backend. Temporary smoke-test instrumentation
 	// used to confirm no production traffic still reaches sql/backend before

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -253,6 +253,10 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.EnableSQLKVBackend = section.Key("enable_sqlkv_backend").MustBool(false)
 	// enable sqlkv backwards compatibility mode with sql/backend
 	cfg.EnableSQLKVCompatibilityMode = section.Key("enable_sqlkv_compatibility_mode").MustBool(true)
+	// log every call reaching an exported method of the legacy sql/backend
+	// (temporary smoke-test instrumentation; default off)
+	// TODO: remove this when sql/backend backwards compatibility is no longer needed.
+	cfg.LogSQLBackendCalls = section.Key("log_sql_backend_calls").MustBool(false)
 	// enable per-resource leases in the KV backend; only effective when the
 	// SQL RV manager is not in use.
 	cfg.EnableKVLeases = section.Key("enable_kv_leases").MustBool(false)

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -148,6 +148,8 @@ func NewStorageBackend(
 			DisablePruner:           cfg.DisablePruner,
 			DashboardVersionsToKeep: cfg.DashboardVersionsToKeep,
 			BatchTransactionTimeout: cfg.ResourceVersionBatchTransactionTimeout,
+			// TODO: remove this when sql/backend backwards compatibility is no longer needed.
+			LogCalls:                cfg.LogSQLBackendCalls,
 		})
 	}
 
@@ -290,6 +292,11 @@ type BackendOptions struct {
 	// BatchTransactionTimeout bounds one batched WithTx in the resource version
 	// manager. Zero selects the rvmanager default.
 	BatchTransactionTimeout time.Duration
+
+	// LogCalls enables temporary smoke-test logging of every call that reaches
+	// an exported method of the SQL backend.
+	// TODO: remove after confirming sql/backend receives no production traffic.
+	LogCalls bool
 }
 
 func NewBackend(opts BackendOptions) (Backend, error) {
@@ -332,6 +339,7 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		batchTxnTimeout:         opts.BatchTransactionTimeout,
 		garbageCollection:       garbageCollection,
 		gcGate:                  opts.GCGate,
+		logCalls:                opts.LogCalls,
 	}
 	if err := backend.Init(ctx); err != nil {
 		return nil, err
@@ -409,6 +417,23 @@ type backend struct {
 	// Fields to control the cleanup of "lastImportTime" rows (used to find indexes to rebuild)
 	lastImportTimeMaxAge       time.Duration
 	lastImportTimeDeletionTime atomic.Pointer[time.Time]
+
+	// logCalls enables temporary smoke-test logging in logCall.
+	// TODO: remove after confirming sql/backend receives no production traffic.
+	logCalls bool
+}
+
+// logCall is temporary smoke-test instrumentation: it records every call that
+// reaches an exported method of the legacy SQL backend. Used to confirm that no
+// production traffic is still routed to sql/backend before removing the sqlkv
+// backwards-compatibility layer. Remove once that verification is complete.
+//
+// TODO: remove after confirming sql/backend receives no production traffic.
+func (b *backend) logCall(method string) {
+	if !b.logCalls {
+		return
+	}
+	b.log.Warn("SMOKETEST sql/backend method called", "method", method)
 }
 
 func (b *backend) Init(ctx context.Context) error {
@@ -701,6 +726,7 @@ func (b *backend) Stop(_ context.Context) error {
 
 // GetResourceStats implements Backend.
 func (b *backend) GetResourceStats(ctx context.Context, nsr resource.NamespacedResource, minCount int) ([]resource.ResourceStats, error) {
+	b.logCall("GetResourceStats")
 	ctx, span := tracer.Start(ctx, "sql.backend.GetResourceStats", trace.WithAttributes(
 		attribute.String("namespace", nsr.Namespace),
 		attribute.String("group", nsr.Group),
@@ -751,6 +777,7 @@ func toMicrosecondRV(rv int64) int64 {
 }
 
 func (b *backend) WriteEvent(ctx context.Context, event resource.WriteEvent) (int64, error) {
+	b.logCall("WriteEvent")
 	if b.disableStorageServices {
 		return 0, fmt.Errorf("storage backend is not enabled")
 	}
@@ -995,6 +1022,7 @@ func (b *backend) checkConflict(res db.Result, key *resourcepb.ResourceKey, rv i
 }
 
 func (b *backend) ReadResource(ctx context.Context, req *resourcepb.ReadRequest) *resource.BackendReadResponse {
+	b.logCall("ReadResource")
 	_, span := tracer.Start(ctx, "sql.backend.ReadResource")
 	defer span.End()
 
@@ -1038,6 +1066,7 @@ func (b *backend) ReadResource(ctx context.Context, req *resourcepb.ReadRequest)
 }
 
 func (b *backend) ListIterator(ctx context.Context, req *resourcepb.ListRequest, cb func(resource.ListIterator) error) (int64, error) {
+	b.logCall("ListIterator")
 	ctx, span := tracer.Start(ctx, "sql.backend.ListIterator")
 	defer span.End()
 
@@ -1062,6 +1091,7 @@ func (b *backend) ListIterator(ctx context.Context, req *resourcepb.ListRequest,
 }
 
 func (b *backend) ListHistory(ctx context.Context, req *resourcepb.ListRequest, cb func(resource.ListIterator) error) (int64, error) {
+	b.logCall("ListHistory")
 	ctx, span := tracer.Start(ctx, "sql.backend.ListHistory")
 	defer span.End()
 
@@ -1116,6 +1146,7 @@ func (b *backend) listLatest(ctx context.Context, req *resourcepb.ListRequest, c
 // ListModifiedSince will return all resources that have changed since the given resource version.
 // If a resource has changes, only the latest change will be returned.
 func (b *backend) ListModifiedSince(ctx context.Context, key resource.NamespacedResource, sinceRv int64, _ *time.Time) (int64, iter.Seq2[*resource.ModifiedResource, error]) {
+	b.logCall("ListModifiedSince")
 	sinceRv = toMicrosecondRV(sinceRv)
 
 	// Validate key before doing latest RV check
@@ -1371,6 +1402,7 @@ func (b *backend) getHistory(ctx context.Context, req *resourcepb.ListRequest, c
 }
 
 func (b *backend) WatchWriteEvents(ctx context.Context) (<-chan *resource.WrittenEvent, error) {
+	b.logCall("WatchWriteEvents")
 	if b.disableStorageServices {
 		return nil, fmt.Errorf("watcher is not enabled")
 	}
@@ -1469,6 +1501,7 @@ func (b *backend) lastImportTimeDB(ctx context.Context) db.ContextExecer {
 }
 
 func (b *backend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
+	b.logCall("GetResourceLastImportTimes")
 	ctx, span := tracer.Start(ctx, "sql.backend.GetResourceLastImportTimes")
 	defer span.End()
 

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -149,7 +149,7 @@ func NewStorageBackend(
 			DashboardVersionsToKeep: cfg.DashboardVersionsToKeep,
 			BatchTransactionTimeout: cfg.ResourceVersionBatchTransactionTimeout,
 			// TODO: remove this when sql/backend backwards compatibility is no longer needed.
-			LogCalls:                cfg.LogSQLBackendCalls,
+			LogCalls: cfg.LogSQLBackendCalls,
 		})
 	}
 

--- a/pkg/storage/unified/sql/backend_blob.go
+++ b/pkg/storage/unified/sql/backend_blob.go
@@ -23,10 +23,12 @@ var (
 )
 
 func (b *backend) SupportsSignedURLs() bool {
+	b.logCall("SupportsSignedURLs")
 	return false
 }
 
 func (b *backend) PutResourceBlob(ctx context.Context, req *resourcepb.PutBlobRequest) (*resourcepb.PutBlobResponse, error) {
+	b.logCall("PutResourceBlob")
 	ctx, span := tracer.Start(ctx, "sql.backend.PutResourceBlob")
 	defer span.End()
 
@@ -83,6 +85,7 @@ func (b *backend) PutResourceBlob(ctx context.Context, req *resourcepb.PutBlobRe
 }
 
 func (b *backend) GetResourceBlob(ctx context.Context, key *resourcepb.ResourceKey, info *utils.BlobInfo, mustProxy bool) (*resourcepb.GetBlobResponse, error) {
+	b.logCall("GetResourceBlob")
 	ctx, span := tracer.Start(ctx, "sql.backend.GetResourceBlob")
 	defer span.End()
 

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -153,6 +153,7 @@ func buildKeyPath(key *resourcepb.ResourceKey, rv int64, action resourcepb.BulkR
 }
 
 func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings, iter resource.BulkRequestIterator) *resourcepb.BulkResponse {
+	b.logCall("ProcessBulk")
 	if b.disableStorageServices {
 		return &resourcepb.BulkResponse{
 			Error: resource.AsErrorResult(errors.New("storage backend is not enabled")),

--- a/pkg/storage/unified/sql/backend_stats.go
+++ b/pkg/storage/unified/sql/backend_stats.go
@@ -22,6 +22,7 @@ var _ resource.StatsGetter = &backend{}
 // GetStats implements resource.ResourceIndexServer.
 // This will use the SQL index to count values
 func (b *backend) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
+	b.logCall("GetStats")
 	ctx, span := tracer.Start(ctx, "sql.backend.GetStats")
 	defer span.End()
 


### PR DESCRIPTION
This is to smoke test its usage so we're 100% positive we can flip over to storage_backend