### PR TITLE
RBAC: account for org.users permissions when merging from zanzana

### DIFF
--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
@@ -270,18 +270,21 @@ func teamWildcardScope() string {
 	return ac.Scope("teams", "id", "*")
 }
 
-// isUserRBACAction matches user-management actions.
+// isUserRBACAction matches user-management actions, including the org.users:* family.
 func isUserRBACAction(action string) bool {
-	return strings.HasPrefix(action, "users:") || strings.HasPrefix(action, "users.")
+	return strings.HasPrefix(action, "users:") || strings.HasPrefix(action, "users.") ||
+		strings.HasPrefix(action, "org.users:")
 }
 
 // userScopeKind returns the legacy RBAC scope kind for a user-management action.
 // Most user actions are server-level and scoped to global.users (users:read/write/delete and
-// users.permissions:write all grant global.users:* in the fixed roles). users.permissions:read is
-// the exception: it gates org-level permission listing (fixed:org.users:reader) and is scoped to
-// the org-level users kind.
+// users.permissions:write all grant global.users:* in the fixed roles). The org-level
+// exceptions, scoped to the users kind, are users.permissions:read (fixed:org.users:reader)
+// and the org.users:* family (fixed:org.users:reader/writer).
 func userScopeKind(action string) string {
-	if action == ac.ActionUsersPermissionsRead {
+	// users.permissions:read and the org.users:* family are org-scoped (the users kind);
+	// the remaining user-management actions are server-level (global.users).
+	if action == ac.ActionUsersPermissionsRead || strings.HasPrefix(action, "org.users:") {
 		return "users"
 	}
 	return "global.users"

--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver_test.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver_test.go
@@ -886,6 +886,17 @@ func TestListPermissions_UserActions(t *testing.T) {
 		}, perms)
 	})
 
+	// The org.users:* family is org-scoped (users kind), like users.permissions:read.
+	for _, action := range []string{"org.users:read", "org.users:write", "org.users:remove"} {
+		t.Run(action+" All=true produces users:id:* wildcard", func(t *testing.T) {
+			perms, err := zanzanaResolve(&authzv1.ListResponse{All: true}, action, "")
+			require.NoError(t, err)
+			require.Equal(t, []ac.Permission{
+				{Action: action, Scope: "users:id:*"},
+			}, perms)
+		})
+	}
+
 	t.Run("items fall back to uid scope when scope resolver is nil", func(t *testing.T) {
 		perms, err := zanzanaResolve(&authzv1.ListResponse{Items: []string{"user-abc"}}, "users:read", "")
 		require.NoError(t, err)

--- a/pkg/services/authz/zanzana/common/translations.go
+++ b/pkg/services/authz/zanzana/common/translations.go
@@ -146,6 +146,12 @@ var resourceTranslations = map[string]resourceTranslation{
 			"users:delete":            newMapping(RelationDelete, ""),
 			"users.permissions:read":  newMapping(RelationGetPermissions, ""),
 			"users.permissions:write": newMapping(RelationSetPermissions, ""),
+			// The org.users:* family gates the same iam.grafana.app/users verbs as the
+			// global users:* family (see userManagementMappings in tuple_helpers.go).
+			// org.users:add is intentionally omitted, matching the write-side mapping.
+			"org.users:read":   newMapping(RelationGet, ""),
+			"org.users:write":  newMapping(RelationUpdate, ""),
+			"org.users:remove": newMapping(RelationDelete, ""),
 		},
 	},
 }


### PR DESCRIPTION
The org.users:* family (org.users:read/write/remove) gates the same iam.grafana.app/users verbs as the global users:* family on the write side (userManagementMappings in tuple_helpers.go), but the read/merge path did not list them, so org-level user-admin grants were never reflected back as legacy permissions.

Add org.users:read/write/remove to the KindUsers translation, match the org.users: prefix in isUserRBACAction, and scope the family to the org-level users kind in userScopeKind (users:id:*), matching roles.go and the docs. org.users:add is omitted, mirroring the write-side mapping.
