### PR TITLE
QueryField: Refactor to use standard Portal/floating-ui

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -677,7 +677,7 @@
   },
   "packages/grafana-ui/src/components/Typeahead/Typeahead.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
-      "count": 2
+      "count": 1
     }
   },
   "packages/grafana-ui/src/components/VizLegend/types.ts": {

--- a/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
@@ -13,6 +13,7 @@ import { DataLinkBuiltInVars, type GrafanaTheme2, VariableOrigin, type VariableS
 import { SlatePrism } from '../../slate-plugins/slate-prism';
 import { useStyles2 } from '../../themes/ThemeContext';
 import { getFocusStyles } from '../../themes/mixins';
+import { SelectionReference } from '../../utils/SelectionReference';
 import { getPositioningMiddleware } from '../../utils/floating';
 import { SCHEMA, makeValue } from '../../utils/slate';
 import { getInputStyles } from '../Input/Input';
@@ -20,7 +21,6 @@ import { Portal } from '../Portal/Portal';
 import { ScrollContainer } from '../ScrollContainer/ScrollContainer';
 
 import { DataLinkSuggestions } from './DataLinkSuggestions';
-import { SelectionReference } from './SelectionReference';
 
 const modulo = (a: number, n: number) => a - n * Math.floor(a / n);
 

--- a/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryFn } from '@storybook/react-webpack5';
-import { useId, useState } from 'react';
+import { useId } from 'react';
 
 import { type TypeaheadInput, type TypeaheadOutput } from '../../types/completion';
 import { Field } from '../Forms/Field';
@@ -73,19 +73,13 @@ const METRICS = [
 // and the portal is created and torn down cleanly when the field mounts/unmounts.
 export const WithSuggestions: StoryFn<typeof QueryField> = (args: Omit<QueryFieldProps, 'theme'>) => {
   const id = useId();
-  const [show, setShow] = useState(false);
 
   return (
-    <>
-      <button onClick={() => setShow(!show)}>{show ? 'Hide' : 'Show'} QueryField</button>
-      {!show && (
-        <Field
-          label={<Label id={id}>Type to see suggestions (e.g. &quot;ra&quot;, &quot;http&quot;, &quot;go&quot;)</Label>}
-        >
-          <QueryField {...args} aria-labelledby={id} />
-        </Field>
-      )}
-    </>
+    <Field
+      label={<Label id={id}>Type to see suggestions (e.g. &quot;ra&quot;, &quot;http&quot;, &quot;go&quot;)</Label>}
+    >
+      <QueryField {...args} aria-labelledby={id} />
+    </Field>
   );
 };
 

--- a/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryFn } from '@storybook/react-webpack5';
-import { useId } from 'react';
+import { useId, useState } from 'react';
 
-import { type TypeaheadInput } from '../../types/completion';
+import { type TypeaheadInput, type TypeaheadOutput } from '../../types/completion';
 import { Field } from '../Forms/Field';
 import { Label } from '../Forms/Label';
 
@@ -52,6 +52,58 @@ Basic.args = {
   }),
   query: 'Query text',
   placeholder: 'Placeholder text',
+  disabled: false,
+};
+
+// A static set of suggestions to mimic what a real datasource would return from onTypeahead.
+// The SuggestionsPlugin filters and sorts these based on what's typed before rendering the Typeahead.
+const FUNCTIONS = ['rate', 'sum', 'avg', 'min', 'max', 'count', 'histogram_quantile', 'increase', 'irate'];
+const METRICS = [
+  'go_goroutines',
+  'go_memstats_alloc_bytes',
+  'http_request_duration_seconds',
+  'http_requests_total',
+  'process_cpu_seconds_total',
+  'up',
+];
+
+// Exercises the full SuggestionsPlugin -> Typeahead path: typing in the field calls onTypeahead,
+// and a non-empty `suggestions` result opens the Typeahead portal anchored to the caret.
+// Use it to manually verify suggestions render, keyboard navigation (Arrow/Enter/Tab/Escape) works,
+// and the portal is created and torn down cleanly when the field mounts/unmounts.
+export const WithSuggestions: StoryFn<typeof QueryField> = (args: Omit<QueryFieldProps, 'theme'>) => {
+  const id = useId();
+  const [show, setShow] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setShow(!show)}>{show ? 'Hide' : 'Show'} QueryField</button>
+      {!show && (
+        <Field
+          label={<Label id={id}>Type to see suggestions (e.g. &quot;ra&quot;, &quot;http&quot;, &quot;go&quot;)</Label>}
+        >
+          <QueryField {...args} aria-labelledby={id} />
+        </Field>
+      )}
+    </>
+  );
+};
+
+WithSuggestions.args = {
+  onTypeahead: async (_input: TypeaheadInput): Promise<TypeaheadOutput> => ({
+    suggestions: [
+      {
+        label: 'Functions',
+        items: FUNCTIONS.map((label) => ({ label, kind: 'function' })),
+      },
+      {
+        label: 'Metrics',
+        items: METRICS.map((label) => ({ label })),
+      },
+    ],
+  }),
+  query: '',
+  placeholder: 'Start typing to trigger the typeahead…',
   disabled: false,
 };
 

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
@@ -226,7 +226,11 @@ class Portal extends PureComponent<React.PropsWithChildren<PortalProps>, {}> {
   }
 
   componentWillUnmount() {
-    document.body.removeChild(this.node);
+    try {
+      this.node.remove();
+    } catch (err) {
+      console.error('Failed to remove typeahead portal node from DOM', err);
+    }
   }
 
   render() {

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
@@ -1,14 +1,17 @@
 import { css } from '@emotion/css';
+import { autoUpdate, offset, useFloating } from '@floating-ui/react';
 import { isEqual } from 'lodash';
-import { createRef, PureComponent } from 'react';
+import { createRef, PureComponent, useEffect, type PropsWithChildren } from 'react';
 import * as React from 'react';
-import ReactDOM from 'react-dom';
 import { FixedSizeList } from 'react-window';
 
 import { type GrafanaTheme2, ThemeContext } from '@grafana/data';
 
 import { type CompletionItem, type CompletionItemGroup, CompletionItemKind } from '../../types/completion';
+import { SelectionReference } from '../../utils/SelectionReference';
+import { getPositioningMiddleware } from '../../utils/floating';
 import { flattenGroupItems, calculateLongestLabel, calculateListSizes } from '../../utils/typeahead';
+import { Portal } from '../Portal/Portal';
 
 import { TypeaheadInfo } from './TypeaheadInfo';
 import { TypeaheadItem } from './TypeaheadItem';
@@ -52,8 +55,6 @@ export class Typeahead extends PureComponent<Props, State> {
       this.props.menuRef(this);
     }
 
-    document.addEventListener('selectionchange', this.handleSelectionChange);
-
     const allItems = flattenGroupItems(this.props.groupedItems);
     const longestLabel = calculateLongestLabel(allItems);
     const { listWidth, listHeight, itemHeight } = calculateListSizes(this.context, allItems, longestLabel);
@@ -63,14 +64,6 @@ export class Typeahead extends PureComponent<Props, State> {
       itemHeight,
       allItems,
     });
-  };
-
-  componentWillUnmount = () => {
-    document.removeEventListener('selectionchange', this.handleSelectionChange);
-  };
-
-  handleSelectionChange = () => {
-    this.forceUpdate();
   };
 
   componentDidUpdate = (prevProps: Readonly<Props>, prevState: Readonly<State>) => {
@@ -132,32 +125,8 @@ export class Typeahead extends PureComponent<Props, State> {
     }
   };
 
-  get menuPosition(): string {
-    // Exit for unit tests
-    if (!window.getSelection) {
-      return '';
-    }
-
-    const selection = window.getSelection();
-    const node = selection && selection.anchorNode;
-
-    // Align menu overlay to editor node
-    if (node && node.parentElement) {
-      // Read from DOM
-      const rect = node.parentElement.getBoundingClientRect();
-      const scrollX = window.scrollX;
-      const scrollY = window.scrollY;
-
-      return `position: absolute; display: flex; top: ${rect.top + scrollY + rect.height + 6}px; left: ${
-        rect.left + scrollX - 2
-      }px`;
-    }
-
-    return '';
-  }
-
   render() {
-    const { prefix, isOpen = false, origin } = this.props;
+    const { prefix, isOpen = false } = this.props;
     const { allItems, listWidth, listHeight, itemHeight, hoveredItem, typeaheadIndex } = this.state;
     const styles = getStyles(this.context);
 
@@ -165,7 +134,7 @@ export class Typeahead extends PureComponent<Props, State> {
     const documentationItem = allItems[hoveredItem ? hoveredItem : typeaheadIndex || 0];
 
     return (
-      <Portal origin={origin} isOpen={isOpen} style={this.menuPosition}>
+      <TypeaheadPortal isOpen={isOpen}>
         <ul role="menu" className={styles.typeahead} data-testid="typeahead">
           <FixedSizeList
             ref={this.listRef}
@@ -201,48 +170,55 @@ export class Typeahead extends PureComponent<Props, State> {
         </ul>
 
         {showDocumentation && <TypeaheadInfo height={listHeight} item={documentationItem} />}
-      </Portal>
+      </TypeaheadPortal>
     );
   }
 }
 
-interface PortalProps {
-  index?: number;
-  isOpen: boolean;
-  origin: string;
-  style: string;
-}
+/**
+ * Positions the typeahead menu next to the caret in the Slate editor and renders it into the
+ * shared overlay portal. Uses floating-ui with a selection-anchored virtual reference, the same
+ * pattern used by other caret-anchored menus (e.g. DataLinkInput).
+ */
+function TypeaheadPortal({ isOpen, children }: PropsWithChildren<{ isOpen: boolean }>) {
+  const { refs, floatingStyles, update } = useFloating({
+    open: isOpen,
+    placement: 'bottom-start',
+    strategy: 'fixed',
+    // Mirror the previous manual offsets: 6px below the caret line, nudged 2px to the left.
+    middleware: [offset({ mainAxis: 6, crossAxis: -2 }), ...getPositioningMiddleware('bottom-start')],
+    whileElementsMounted: autoUpdate,
+  });
 
-class Portal extends PureComponent<React.PropsWithChildren<PortalProps>, {}> {
-  node: HTMLElement;
+  // Anchor positioning to the current text selection (the caret). Set once; the virtual element
+  // reads the live selection rect on every reposition.
+  useEffect(() => {
+    refs.setReference(new SelectionReference());
+  }, [refs]);
 
-  constructor(props: React.PropsWithChildren<PortalProps>) {
-    super(props);
-    const { index = 0, origin = 'query' } = props;
-    this.node = document.createElement('div');
-    this.node.classList.add(`slate-typeahead-${origin}-${index}`);
-  }
-
-  componentDidMount() {
-    this.node.setAttribute('style', this.props.style);
-    document.body.appendChild(this.node);
-  }
-
-  componentWillUnmount() {
-    this.node.remove();
-  }
-
-  render() {
-    if (this.props.isOpen) {
-      this.node.setAttribute('style', this.props.style);
-      this.node.classList.add(`slate-typeahead--open`);
-      return ReactDOM.createPortal(this.props.children, this.node);
-    } else {
-      this.node.classList.remove(`slate-typeahead--open`);
+  // The caret moves as the user types or navigates, so reposition on selection changes while open.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
     }
+    document.addEventListener('selectionchange', update);
+    return () => document.removeEventListener('selectionchange', update);
+  }, [isOpen, update]);
 
+  if (!isOpen) {
     return null;
   }
+
+  // The `slate-typeahead--open` class is a behavioural hook: keybindingSrv queries for it so the
+  // global Esc handler defers to the typeahead while suggestions are open.
+  return (
+    <Portal>
+      {/* display: flex lays the suggestion list and the documentation panel out side by side. */}
+      <div ref={refs.setFloating} style={{ ...floatingStyles, display: 'flex' }} className="slate-typeahead--open">
+        {children}
+      </div>
+    </Portal>
+  );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
@@ -218,19 +218,18 @@ class Portal extends PureComponent<React.PropsWithChildren<PortalProps>, {}> {
 
   constructor(props: React.PropsWithChildren<PortalProps>) {
     super(props);
-    const { index = 0, origin = 'query', style } = props;
+    const { index = 0, origin = 'query' } = props;
     this.node = document.createElement('div');
-    this.node.setAttribute('style', style);
     this.node.classList.add(`slate-typeahead-${origin}-${index}`);
+  }
+
+  componentDidMount() {
+    this.node.setAttribute('style', this.props.style);
     document.body.appendChild(this.node);
   }
 
   componentWillUnmount() {
-    try {
-      this.node.remove();
-    } catch (err) {
-      console.error('Failed to remove typeahead portal node from DOM', err);
-    }
+    this.node.remove();
   }
 
   render() {

--- a/packages/grafana-ui/src/utils/SelectionReference.ts
+++ b/packages/grafana-ui/src/utils/SelectionReference.ts
@@ -1,5 +1,10 @@
 import { type VirtualElement } from '@popperjs/core/lib/types';
 
+/**
+ * A floating-ui/popper virtual reference element anchored to the current text selection (caret).
+ * Used to position floating menus (suggestions, typeahead) relative to where the user is typing
+ * inside a contenteditable Slate editor.
+ */
 export class SelectionReference implements VirtualElement {
   getBoundingClientRect() {
     const selection = window.getSelection();


### PR DESCRIPTION
Alternate to https://github.com/grafana/grafana/pull/127336, refactors the Typeahead component to use the standard `<Portal />` component and floating-ui for positioning.

Avoids the bugs in the previously implementation by using the same standard utilities that everything else uses.