### PR TITLE
Provisioning: Create feature flag for GithubEnterprise

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -17,6 +17,7 @@ declare module "@openfeature/core" {
     | "provisioningFolderMetadata"
     | "provisioning.readmes"
     | "provisioning.gitConventions"
+    | "provisioning.githubEnterprise"
     | "grafana.kubernetesAnnotationsClient"
     | "grafana.newPanelQueryErrorsUI"
     | "useKubernetesShortURLsAPI"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -85,6 +85,8 @@ export const FlagKeys = {
   PluginsUseMTPlugins: "plugins.useMTPlugins",
   /** Enable configurable commit message, branch name, and pull request title conventions for Git Sync */
   ProvisioningGitConventions: "provisioning.gitConventions",
+  /** Enable support for Github Enterprise */
+  ProvisioningGithubEnterprise: "provisioning.githubEnterprise",
   /** Render the README.md of a Git Sync provisioned folder inline below its dashboards list */
   ProvisioningReadmes: "provisioning.readmes",
   /** Allow setting folder metadata for provisioned folders */
@@ -507,6 +509,17 @@ export const useFlagPluginsUseMTPlugins = (options?: ReactFlagEvaluationOptions)
  */
 export const useFlagProvisioningGitConventions = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("provisioning.gitConventions", false, options).value;
+};
+
+/**
+ * Enable support for Github Enterprise
+ *
+ * **Details:**
+ * - flag key: `provisioning.githubEnterprise`
+ * - default value: `false`
+ */
+export const useFlagProvisioningGithubEnterprise = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("provisioning.githubEnterprise", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -288,6 +288,15 @@ var (
 			Generate:        Generate{Go: true, React: true},
 		},
 		{
+			Name:            "provisioning.githubEnterprise",
+			Description:     "Enable support for Github Enterprise",
+			Stage:           FeatureStageExperimental,
+			RequiresRestart: true,
+			Owner:           grafanaAppPlatformSquad,
+			Expression:      "false",
+			Generate:        Generate{React: true},
+		},
+		{
 			Name:            "grafanaAPIServerEnsureKubectlAccess",
 			Description:     "Start an additional https handler and write kubectl options",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -31,6 +31,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,provisioningExport,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,provisioning.readmes,preview,@grafana/grafana-app-platform-squad,false,false,true
 2026-06-09,provisioning.gitConventions,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2026-06-26,provisioning.githubEnterprise,experimental,@grafana/grafana-app-platform-squad,false,true,true
 2023-12-06,grafanaAPIServerEnsureKubectlAccess,experimental,@grafana/grafana-app-platform-squad,true,true,false
 2023-07-21,awsAsyncQueryCaching,GA,@grafana/data-sources-plugins,false,false,false
 2023-07-26,configurableSchedulerTick,experimental,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4254,6 +4254,24 @@
     },
     {
       "metadata": {
+        "name": "provisioning.githubEnterprise",
+        "resourceVersion": "1782489225893",
+        "creationTimestamp": "2026-06-26T13:53:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-06-26 15:53:45.893725 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enable support for Github Enterprise",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontend": true,
+        "requiresRestart": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "provisioning.readmes",
         "resourceVersion": "1781078230859",
         "creationTimestamp": "2026-05-22T09:03:04Z",


### PR DESCRIPTION
**What is this feature?**
Add feature flag for Github Enterprise to use for frontend components

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
