### PR TITLE
fix(setting): force HTTP/1.1 and bound idle connections

### DIFF
--- a/pkg/services/setting/service.go
+++ b/pkg/services/setting/service.go
@@ -55,6 +55,9 @@ const DefaultBurst = 300
 const DefaultCacheTTL = 5 * time.Second
 const DefaultCacheMaxEntries = 1000
 
+// DefaultIdleConnTimeout caps how long idle keep-alive connections are pooled.
+const DefaultIdleConnTimeout = 30 * time.Second
+
 const (
 	ApiGroup   = "setting.grafana.app"
 	apiVersion = "v1beta1"
@@ -171,6 +174,12 @@ type Config struct {
 	CacheTTL time.Duration
 	// CacheMaxEntries sets the max LRU cache entries. Defaults to DefaultCacheMaxEntries (1000).
 	CacheMaxEntries int
+	// IdleConnTimeout caps how long idle keep-alive connections are pooled before
+	// being closed. Defaults to DefaultIdleConnTimeout. Set to a negative value to use the
+	// client-go default.
+	IdleConnTimeout time.Duration
+	// EnableHTTP2 allows HTTP/2 for the client connection. It is disabled by default.
+	EnableHTTP2 bool
 }
 
 // Setting represents the parsed spec of a Setting resource.
@@ -526,9 +535,17 @@ func getRestClient(config Config, log logging.Logger, m clientMetrics) (*rest.RE
 		}
 	}
 
+	idleConnTimeout := DefaultIdleConnTimeout
+	if config.IdleConnTimeout != 0 {
+		idleConnTimeout = config.IdleConnTimeout
+	}
+
 	// Wrap with tracing middleware to propagate trace context to all outbound requests
 	tracingMiddleware := httpclientprovider.TracingMiddleware(logging.NewNopLogger(), tracer)
 	wrapTransport := func(rt http.RoundTripper) http.RoundTripper {
+		if baseTransport, ok := rt.(*http.Transport); ok && idleConnTimeout > 0 {
+			baseTransport.IdleConnTimeout = idleConnTimeout
+		}
 		tracingRT := tracingMiddleware.CreateMiddleware(httpclient.Options{}, rt)
 		return authTransport(tracingRT)
 	}
@@ -548,6 +565,13 @@ func getRestClient(config Config, log logging.Logger, m clientMetrics) (*rest.RE
 	// Add a default scheme to handle K8s API error responses
 	scheme := runtime.NewScheme()
 
+	// When HTTP/2 is disabled we restrict ALPN to HTTP/1.1 unconditionally.
+	// ALPN only applies to TLS; plain HTTP already uses HTTP/1.1.
+	tlsClientConfig := config.TLSClientConfig
+	if !config.EnableHTTP2 {
+		tlsClientConfig.NextProtos = []string{"http/1.1"}
+	}
+
 	// Create the rate limiter explicitly so we can wrap it with instrumentation
 	rateLimiter := &instrumentedRateLimiter{
 		RateLimiter: flowcontrol.NewTokenBucketRateLimiter(qps, burst),
@@ -556,7 +580,7 @@ func getRestClient(config Config, log logging.Logger, m clientMetrics) (*rest.RE
 
 	restConfig := &rest.Config{
 		Host:            config.URL,
-		TLSClientConfig: config.TLSClientConfig,
+		TLSClientConfig: tlsClientConfig,
 		WrapTransport:   wrapTransport,
 		RateLimiter:     rateLimiter,
 		UserAgent:       userAgent,

--- a/pkg/services/setting/service_test.go
+++ b/pkg/services/setting/service_test.go
@@ -22,6 +22,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 )
 
@@ -661,6 +662,73 @@ func TestNew(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, client)
 		assert.True(t, wrapTransportCalled)
+	})
+}
+
+func TestNew_HTTPProtocol(t *testing.T) {
+	settings := []Setting{{Section: "server", Key: "port", Value: "3000"}}
+
+	newHTTP2Server := func(t *testing.T, negotiatedProto *atomic.Int32) *httptest.Server {
+		t.Helper()
+		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			negotiatedProto.Store(int32(r.ProtoMajor))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(generateSettingsJSON(settings, "")))
+		}))
+		// Offer HTTP/2 via ALPN so the client's protocol preference decides the outcome.
+		server.EnableHTTP2 = true
+		server.StartTLS()
+		t.Cleanup(server.Close)
+		return server
+	}
+
+	newClient := func(t *testing.T, tlsConfig rest.TLSClientConfig, url string, enableHTTP2 bool) Service {
+		t.Helper()
+		client, err := New(Config{
+			URL:             url,
+			WrapTransport:   func(rt http.RoundTripper) http.RoundTripper { return rt },
+			TLSClientConfig: tlsConfig,
+			CacheTTL:        -1,
+			EnableHTTP2:     enableHTTP2,
+		})
+		require.NoError(t, err)
+		return client
+	}
+
+	insecure := rest.TLSClientConfig{Insecure: true}
+	ctx := request.WithNamespace(context.Background(), "test-namespace")
+
+	t.Run("should negotiate HTTP/1.1 when HTTP/2 is not enabled", func(t *testing.T) {
+		var proto atomic.Int32
+		server := newHTTP2Server(t, &proto)
+
+		_, err := newClient(t, insecure, server.URL, false).List(ctx, metav1.LabelSelector{})
+
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), proto.Load(), "client should negotiate HTTP/1.1 by default")
+	})
+
+	t.Run("should negotiate HTTP/1.1 when HTTP/2 is disabled but caller sets h2 in NextProtos", func(t *testing.T) {
+		var proto atomic.Int32
+		server := newHTTP2Server(t, &proto)
+
+		// EnableHTTP2 is the source of truth: a caller-supplied h2 preference must
+		// not re-admit HTTP/2 while the flag is off.
+		tlsConfig := rest.TLSClientConfig{Insecure: true, NextProtos: []string{"h2", "http/1.1"}}
+		_, err := newClient(t, tlsConfig, server.URL, false).List(ctx, metav1.LabelSelector{})
+
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), proto.Load(), "EnableHTTP2=false should force HTTP/1.1 regardless of NextProtos")
+	})
+
+	t.Run("should negotiate HTTP/2 when EnableHTTP2 is set", func(t *testing.T) {
+		var proto atomic.Int32
+		server := newHTTP2Server(t, &proto)
+
+		_, err := newClient(t, insecure, server.URL, true).List(ctx, metav1.LabelSelector{})
+
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), proto.Load(), "client should negotiate HTTP/2 when EnableHTTP2 is set")
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Two new configuration options on the remote settings service client (`pkg/services/setting`): the client now negotiates HTTP/1.1 by default (with an opt-in `EnableHTTP2` field) and applies a bounded transport idle-connection timeout (default 30s, configurable via `IdleConnTimeout`). Together these cause pooled connections to be recycled regularly so the client re-resolves DNS, rather than staying pinned to a single backend IP.

**Why do we need this feature?**

In production (Kubernetes), the client held long-lived keep-alive and HTTP/2-multiplexed connections that pinned to the first resolved backend IP. HTTP/2 multiplexes all requests onto a single connection that is never torn down while it stays healthy, and even HTTP/1.1 keep-alive connections survive well beyond DNS record changes. As a result, newly added backend endpoints (new pod IPs) were not detected in a timely manner: the client kept reusing its existing connection and continued sending all traffic to the original pod instead of spreading load across the new endpoints. Forcing HTTP/1.1 plus a low idle timeout bounds how long a connection persists, so DNS is re-resolved promptly and new endpoints are picked up.

**Who is this feature for?**

Operators running Grafana (and the settings service) in dynamic environments such as Kubernetes, where backend endpoints change during rollouts and scaling. The defaults fix the new-endpoint detection delay for all callers of this client transparently, while the new fields let advanced callers re-enable HTTP/2 or tune the idle timeout for their deployment.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
