### PR TITLE
Auth: align typed IAM relation sets with the OpenFGA model

### DIFF
--- a/pkg/services/authz/zanzana/common/info.go
+++ b/pkg/services/authz/zanzana/common/info.go
@@ -22,22 +22,22 @@ var typedResources = map[string]typeInfo{
 		folders.FolderResourceInfo.GroupResource().Group,
 		folders.FolderResourceInfo.GroupResource().Resource,
 		"",
-	): {Type: "folder", Relations: RelationsTyped},
+	): {Type: "folder", Relations: RelationsFolder},
 	FormatGroupResource(
 		iamv0alpha1.TeamResourceInfo.GroupResource().Group,
 		iamv0alpha1.TeamResourceInfo.GroupResource().Resource,
 		"",
-	): {Type: "team", Relations: RelationsTyped},
+	): {Type: "team", Relations: RelationsTeam},
 	FormatGroupResource(
 		iamv0alpha1.UserResourceInfo.GroupResource().Group,
 		iamv0alpha1.UserResourceInfo.GroupResource().Resource,
 		"",
-	): {Type: "user", Relations: RelationsTyped},
+	): {Type: "user", Relations: RelationsUser},
 	FormatGroupResource(
 		iamv0alpha1.ServiceAccountResourceInfo.GroupResource().Group,
 		iamv0alpha1.ServiceAccountResourceInfo.GroupResource().Resource,
 		"",
-	): {Type: "service-account", Relations: RelationsTyped},
+	): {Type: "service-account", Relations: RelationsServiceAccount},
 }
 
 func getTypeInfo(group, resource string) (typeInfo, bool) {

--- a/pkg/services/authz/zanzana/common/info_test.go
+++ b/pkg/services/authz/zanzana/common/info_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 )
@@ -25,6 +27,99 @@ func TestNewResourceInfoFromCheck_FolderCreateUnderParentUsesParentForPermission
 	require.Equal(t, parentUID, info.name)
 	require.Empty(t, info.folder)
 	require.Equal(t, NewTypedIdent(TypeFolder, parentUID), info.ResourceIdent())
+}
+
+// TestResourceInfoIsValidRelation_TypedResources locks the per-type relation sets to the
+// OpenFGA model. The List/Check/BatchCheck paths gate their per-object ListObjects/Check on
+// IsValidRelation, so an inaccurate set makes the server issue a relation OpenFGA rejects
+// (e.g. user#create). The `false` rows are the ones that matter.
+func TestResourceInfoIsValidRelation_TypedResources(t *testing.T) {
+	listReq := func(group, resource string) *authzv1.ListRequest {
+		return &authzv1.ListRequest{Group: group, Resource: resource}
+	}
+
+	type relCase struct {
+		relation string
+		valid    bool
+	}
+
+	tests := []struct {
+		name     string
+		group    string
+		resource string
+		cases    []relCase
+	}{
+		{
+			name:     "team",
+			group:    iamv0alpha1.TeamResourceInfo.GroupResource().Group,
+			resource: iamv0alpha1.TeamResourceInfo.GroupResource().Resource,
+			cases: []relCase{
+				{RelationGet, true},
+				{RelationCreate, true},
+				{RelationUpdate, true},
+				{RelationDelete, true},
+				{RelationGetPermissions, true},
+				{RelationSetPermissions, true},
+				{RelationSubresourceGet, true},
+				{RelationSubresourceCreate, true},
+				{RelationSubresourceGetPermissions, false},
+				{RelationSubresourceSetPermissions, false},
+			},
+		},
+		{
+			name:     "user",
+			group:    iamv0alpha1.UserResourceInfo.GroupResource().Group,
+			resource: iamv0alpha1.UserResourceInfo.GroupResource().Resource,
+			cases: []relCase{
+				{RelationGet, true},
+				{RelationCreate, false},
+				{RelationUpdate, true},
+				{RelationDelete, true},
+				{RelationGetPermissions, true},
+				{RelationSetPermissions, true},
+				{RelationSubresourceGet, true},
+				{RelationSubresourceGetPermissions, false},
+			},
+		},
+		{
+			name:     "service-account",
+			group:    iamv0alpha1.ServiceAccountResourceInfo.GroupResource().Group,
+			resource: iamv0alpha1.ServiceAccountResourceInfo.GroupResource().Resource,
+			cases: []relCase{
+				{RelationGet, true},
+				{RelationCreate, false},
+				{RelationUpdate, true},
+				{RelationDelete, true},
+				{RelationGetPermissions, false},
+				{RelationSetPermissions, false},
+				{RelationSubresourceGet, true},
+				{RelationSubresourceGetPermissions, false},
+			},
+		},
+		{
+			name:     "folder",
+			group:    folders.FolderResourceInfo.GroupResource().Group,
+			resource: folders.FolderResourceInfo.GroupResource().Resource,
+			cases: []relCase{
+				{RelationGet, true},
+				{RelationCreate, true},
+				{RelationGetPermissions, true},
+				{RelationSubresourceGetPermissions, true},
+				{RelationSubresourceSetPermissions, true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := NewResourceInfoFromList(listReq(tt.group, tt.resource))
+			require.Equal(t, tt.name, info.Type())
+			for _, c := range tt.cases {
+				assert.Equalf(t, c.valid, info.IsValidRelation(c.relation),
+					"%s: relation %q expected valid=%v", tt.name, c.relation, c.valid)
+			}
+		})
+	}
 }
 
 func TestNewResourceInfoFromCheck_FolderCreateAtRootUsesGeneral(t *testing.T) {

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -120,8 +120,9 @@ var RelationsSubresource = []string{
 	RelationSubresourceSetPermissions,
 }
 
-// RelationsTyped are relations that can be added to typed resources (folders, teams, users, etc).
-var RelationsTyped = append(
+// RelationsFolder are the relations valid on type "folder" (schema_folder.fga). Folders are the
+// one typed object with a full per-object relation set; the flat IAM types use the vars below.
+var RelationsFolder = append(
 	RelationsSubresource,
 	RelationGet,
 	RelationUpdate,
@@ -129,6 +130,44 @@ var RelationsTyped = append(
 	RelationDelete,
 	RelationGetPermissions,
 	RelationSetPermissions,
+)
+
+// RelationsSubresourceTyped are the subresource relations valid on the flat IAM types.
+// Unlike folders, these types have no resource_get_permissions / resource_set_permissions.
+var RelationsSubresourceTyped = []string{
+	RelationSubresourceGet,
+	RelationSubresourceUpdate,
+	RelationSubresourceCreate,
+	RelationSubresourceDelete,
+}
+
+// RelationsTeam are the relations valid on type "team". Teams keep a per-object `create`
+// (granted to admins), unlike user / service-account.
+var RelationsTeam = append(append([]string{}, RelationsSubresourceTyped...),
+	RelationGet,
+	RelationCreate,
+	RelationUpdate,
+	RelationDelete,
+	RelationGetPermissions,
+	RelationSetPermissions,
+)
+
+// RelationsUser are the relations valid on type "user": no per-object `create`
+// (governed by the group_resource), but get_permissions / set_permissions exist.
+var RelationsUser = append(append([]string{}, RelationsSubresourceTyped...),
+	RelationGet,
+	RelationUpdate,
+	RelationDelete,
+	RelationGetPermissions,
+	RelationSetPermissions,
+)
+
+// RelationsServiceAccount are the relations valid on type "service-account":
+// no per-object `create`, and no get_permissions / set_permissions.
+var RelationsServiceAccount = append(append([]string{}, RelationsSubresourceTyped...),
+	RelationGet,
+	RelationUpdate,
+	RelationDelete,
 )
 
 // VerbMapping is mapping a k8s verb to a zanzana relation.

--- a/pkg/services/authz/zanzana/server/server_batch_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check_test.go
@@ -319,6 +319,81 @@ func TestIntegrationServerBatchCheck(t *testing.T) {
 		assert.False(t, res.GetResults()["sa"].GetAllowed())
 	})
 
+	// Typed `create` batch checks. user / service-account have no per-object `create`, so an
+	// unresolved create item must resolve to denied rather than error the whole batch.
+	t.Run("create on user/service-account is denied, not errored", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("user-create", utils.VerbCreate, userGroup, userResource, "", "", "someuser"),
+			newItem("sa-create", utils.VerbCreate, serviceAccountGroup, serviceAccountResource, "", "", "some-sa"),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:1", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 2)
+		assert.False(t, res.GetResults()["user-create"].GetAllowed())
+		assert.False(t, res.GetResults()["sa-create"].GetAllowed())
+	})
+
+	t.Run("invalid create item does not poison other checks in the batch", func(t *testing.T) {
+		// The original symptom: one such create item used to error the entire batch, dropping
+		// unrelated valid results like the dashboard check below.
+		items := []*authzv1.BatchCheckItem{
+			newItem("dash", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"),       // user:1 has access
+			newItem("user-create", utils.VerbCreate, userGroup, userResource, "", "", "someuser"), // invalid per-object relation
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:1", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 2)
+		assert.True(t, res.GetResults()["dash"].GetAllowed())
+		assert.False(t, res.GetResults()["user-create"].GetAllowed())
+	})
+
+	t.Run("user:20 create on users is allowed via group_resource", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("user-create", utils.VerbCreate, userGroup, userResource, "", "", ""),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:20", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 1)
+		assert.True(t, res.GetResults()["user-create"].GetAllowed())
+	})
+
+	t.Run("user:21 (team admin) create on their team is allowed via per-object team create", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("team-create", utils.VerbCreate, teamGroup, teamResource, "", "", "admin-team"),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:21", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 1)
+		assert.True(t, res.GetResults()["team-create"].GetAllowed())
+	})
+
+	t.Run("subresource create on a user is allowed via resource_create", func(t *testing.T) {
+		// user has no base `create`, but the subresource branch is gated independently on
+		// resource_create, so a subresource create grant still resolves allowed.
+		items := []*authzv1.BatchCheckItem{
+			newItem("user-sub-create", utils.VerbCreate, userGroup, userResource, statusSubresource, "", "1"),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:22", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 1)
+		assert.True(t, res.GetResults()["user-sub-create"].GetAllowed())
+	})
+
+	t.Run("subresource get/set_permissions on user/team is denied, not errored", func(t *testing.T) {
+		// user/team have no subresource get/set_permissions in the model (folder-only).
+		// resolveTypedItems gates the subresource branch on the subresource relation, so these
+		// resolve to denied rather than erroring the batch on an undefined relation.
+		items := []*authzv1.BatchCheckItem{
+			newItem("user-sub-getperm", utils.VerbGetPermissions, userGroup, userResource, statusSubresource, "", "1"),
+			newItem("team-sub-setperm", utils.VerbSetPermissions, teamGroup, teamResource, statusSubresource, "", "1"),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:1", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 2)
+		assert.False(t, res.GetResults()["user-sub-getperm"].GetAllowed())
+		assert.False(t, res.GetResults()["team-sub-setperm"].GetAllowed())
+	})
+
 	t.Run("folder subresource access via set_edit", func(t *testing.T) {
 		// user:5 has set_edit on dashboards in folder 1, which grants get/update/create/delete
 		items := []*authzv1.BatchCheckItem{

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -120,17 +120,16 @@ func (s *Server) checkTyped(ctx context.Context, subject, relation string, resou
 	ctx, span := s.tracer.Start(ctx, "server.checkTyped")
 	defer span.End()
 
-	if !resource.IsValidRelation(relation) {
-		return &authzv1.CheckResponse{Allowed: false}, nil
-	}
-
 	var (
 		resourceIdent       = resource.ResourceIdent()
 		resourceCtx         = resource.Context()
 		subresourceRelation = common.SubresourceRelation(relation)
 	)
 
-	if resource.HasSubresource() {
+	// The subresource branch is gated on the subresource relation, independently of the base
+	// relation: a type may support e.g. resource_create without a per-object base create
+	// (user / service-account), so the base-relation guard below must not block it.
+	if resource.HasSubresource() && resource.IsValidRelation(subresourceRelation) {
 		// Check if subject has access as a subresource
 		res, err := s.openfgaCheck(ctx, store, subject, common.SubresourcePermissionRelation(subresourceRelation), resourceIdent, contextuals, resourceCtx)
 		if err != nil {
@@ -142,7 +141,7 @@ func (s *Server) checkTyped(ctx context.Context, subject, relation string, resou
 		}
 	}
 
-	if resourceIdent == "" {
+	if !resource.IsValidRelation(relation) || resourceIdent == "" {
 		return &authzv1.CheckResponse{Allowed: false}, nil
 	}
 

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -265,4 +265,67 @@ func TestIntegrationServerCheck(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 	})
+
+	// Typed `create` checks. user / service-account have no per-object `create`, so a named
+	// create check must resolve to denied rather than issue an invalid Check that errors.
+	t.Run("named create check on user without access is denied, not errored", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbCreate, userGroup, userResource, "", "", "someuser"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+
+	t.Run("named create check on service-account without access is denied, not errored", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbCreate, serviceAccountGroup, serviceAccountResource, "", "", "some-sa"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+
+	t.Run("user:20 create check on users is allowed via group_resource", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:20", utils.VerbCreate, userGroup, userResource, "", "", ""))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
+
+	t.Run("user:21 (team admin) create check on their team is allowed via per-object team create", func(t *testing.T) {
+		// teams keep a per-object `create` granted to admins, so this resolves allowed.
+		res, err := server.Check(newContextWithNamespace(), newReq("user:21", utils.VerbCreate, teamGroup, teamResource, "", "", "admin-team"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
+
+	// Subresource `create` must still resolve even though the base `create` relation does not
+	// exist on user / service-account: the base-relation guard must not block the subresource
+	// branch (the model defines resource_create for these types).
+	t.Run("user:22 subresource create on a user is allowed via resource_create", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:22", utils.VerbCreate, userGroup, userResource, statusSubresource, "", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
+
+	t.Run("user:23 subresource create on a service-account is allowed via resource_create", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:23", utils.VerbCreate, serviceAccountGroup, serviceAccountResource, statusSubresource, "", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
+
+	t.Run("user:1 subresource create without grant is denied, not errored", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbCreate, userGroup, userResource, statusSubresource, "", "1"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+
+	// user/team have no subresource get/set_permissions in the model (folder-only). A subresource
+	// permissions check on them must not issue can_resource_get_permissions (which OpenFGA would
+	// reject); the subresource branch is skipped and it resolves via the base relation instead.
+	t.Run("user subresource get_permissions is denied, not errored", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGetPermissions, userGroup, userResource, statusSubresource, "", "1"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+
+	t.Run("team subresource set_permissions is denied, not errored", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbSetPermissions, teamGroup, teamResource, statusSubresource, "", "1"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
 }

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -95,23 +95,16 @@ func (s *Server) listTyped(ctx context.Context, subject, relation string, resour
 	ctx, span := s.tracer.Start(ctx, "server.listTyped")
 	defer span.End()
 
-	if !resource.IsValidRelation(relation) {
-		return &authzv1.ListResponse{}, nil
-	}
-
 	var (
 		subresourceRelation = common.SubresourceRelation(relation)
 		resourceCtx         = resource.Context()
 	)
 
-	// Use optimized folder permission relations for permission management
-	listRelation := relation
-	if resource.Type() == common.TypeFolder {
-		listRelation = common.FolderPermissionRelation(relation)
-	}
-
+	// The subresource branch is gated on the subresource relation, independently of the base
+	// relation: a type may support e.g. resource_create without a per-object base create
+	// (user / service-account), so the base-relation guard below must not block it.
 	var items []string
-	if resource.HasSubresource() && common.IsSubresourceRelation(subresourceRelation) {
+	if resource.HasSubresource() && resource.IsValidRelation(subresourceRelation) {
 		// List requested subresources
 		res, err := s.listObjects(ctx, &openfgav1.ListObjectsRequest{
 			StoreId:              store.ID,
@@ -129,18 +122,26 @@ func (s *Server) listTyped(ctx context.Context, subject, relation string, resour
 		items = append(items, typedObjects(resource.Type(), res.GetObjects())...)
 	}
 
-	// List all resources user has access too
-	res, err := s.listObjects(ctx, &openfgav1.ListObjectsRequest{
-		StoreId:              store.ID,
-		AuthorizationModelId: store.ModelID,
-		Type:                 resource.Type(),
-		Relation:             listRelation,
-		User:                 subject,
-	}, contextuals)
-	if err != nil {
-		return nil, err
+	// List all resources the subject has direct access to via the base relation.
+	if resource.IsValidRelation(relation) {
+		// Use optimized folder permission relations for permission management
+		listRelation := relation
+		if resource.Type() == common.TypeFolder {
+			listRelation = common.FolderPermissionRelation(relation)
+		}
+
+		res, err := s.listObjects(ctx, &openfgav1.ListObjectsRequest{
+			StoreId:              store.ID,
+			AuthorizationModelId: store.ModelID,
+			Type:                 resource.Type(),
+			Relation:             listRelation,
+			User:                 subject,
+		}, contextuals)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, typedObjects(resource.Type(), res.GetObjects())...)
 	}
-	items = append(items, typedObjects(resource.Type(), res.GetObjects())...)
 
 	return &authzv1.ListResponse{
 		Items: items,

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -172,6 +172,79 @@ func TestIntegrationServerList(t *testing.T) {
 		assert.Contains(t, res.GetItems(), "1")
 	})
 
+	// Typed `create` listing. user / service-account have no per-object `create`, so listing
+	// them must return empty rather than issue an invalid ListObjects that OpenFGA rejects.
+	newCreateList := func(subject, group, resource string) *authzv1.ListRequest {
+		return &authzv1.ListRequest{
+			Namespace: namespace,
+			Verb:      utils.VerbCreate,
+			Subject:   subject,
+			Group:     group,
+			Resource:  resource,
+		}
+	}
+
+	t.Run("user:1 listing users with create returns empty, not error", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), newCreateList("user:1", userGroup, userResource))
+		require.NoError(t, err)
+		assert.False(t, res.GetAll())
+		assert.Empty(t, res.GetItems())
+	})
+
+	t.Run("user:1 listing service-accounts with create returns empty, not error", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), newCreateList("user:1", serviceAccountGroup, serviceAccountResource))
+		require.NoError(t, err)
+		assert.False(t, res.GetAll())
+		assert.Empty(t, res.GetItems())
+	})
+
+	t.Run("user:20 with group_resource users:create lists all", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), newCreateList("user:20", userGroup, userResource))
+		require.NoError(t, err)
+		assert.True(t, res.GetAll())
+	})
+
+	t.Run("user:21 (team admin) listing teams with create returns the admined team", func(t *testing.T) {
+		// teams keep a per-object `create`, so this lists the admined team rather than empty.
+		res, err := server.List(newContextWithNamespace(), newCreateList("user:21", teamGroup, teamResource))
+		require.NoError(t, err)
+		assert.False(t, res.GetAll())
+		assert.Contains(t, res.GetItems(), "admin-team")
+	})
+
+	t.Run("user:1 listing teams with create returns empty, not error", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), newCreateList("user:1", teamGroup, teamResource))
+		require.NoError(t, err)
+		assert.False(t, res.GetAll())
+		assert.Empty(t, res.GetItems())
+	})
+
+	t.Run("user:22 listing user subresource create returns the granted user", func(t *testing.T) {
+		// user / service-account have no base `create`, but subresource create must still list:
+		// the base-relation guard must not block the subresource branch.
+		req := newCreateList("user:22", userGroup, userResource)
+		req.Subresource = statusSubresource
+		res, err := server.List(newContextWithNamespace(), req)
+		require.NoError(t, err)
+		assert.Contains(t, res.GetItems(), "1")
+	})
+
+	t.Run("listing user subresource get_permissions is empty, not error", func(t *testing.T) {
+		// user has no subresource get_permissions in the model (folder-only); the subresource
+		// branch must be skipped rather than issue an undefined can_resource_get_permissions.
+		req := &authzv1.ListRequest{
+			Namespace:   namespace,
+			Verb:        utils.VerbGetPermissions,
+			Subject:     "user:1",
+			Group:       userGroup,
+			Resource:    userResource,
+			Subresource: statusSubresource,
+		}
+		res, err := server.List(newContextWithNamespace(), req)
+		require.NoError(t, err)
+		assert.Empty(t, res.GetItems())
+	})
+
 	t.Run("user:17 should be able to list all dashboards in folder 4 and all subfolders", func(t *testing.T) {
 		res, err := server.List(newContextWithNamespace(), newList("user:17", dashboardGroup, dashboardResource, ""))
 		require.NoError(t, err)
@@ -357,6 +430,79 @@ func TestIntegrationServerListStreaming(t *testing.T) {
 		assert.Len(t, res.GetFolders(), 0)
 
 		assert.Contains(t, res.GetItems(), "1")
+	})
+
+	// Typed `create` listing. user / service-account have no per-object `create`, so listing
+	// them must return empty rather than issue an invalid ListObjects that OpenFGA rejects.
+	newCreateList := func(subject, group, resource string) *authzv1.ListRequest {
+		return &authzv1.ListRequest{
+			Namespace: namespace,
+			Verb:      utils.VerbCreate,
+			Subject:   subject,
+			Group:     group,
+			Resource:  resource,
+		}
+	}
+
+	t.Run("user:1 listing users with create returns empty, not error", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), newCreateList("user:1", userGroup, userResource))
+		require.NoError(t, err)
+		assert.False(t, res.GetAll())
+		assert.Empty(t, res.GetItems())
+	})
+
+	t.Run("user:1 listing service-accounts with create returns empty, not error", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), newCreateList("user:1", serviceAccountGroup, serviceAccountResource))
+		require.NoError(t, err)
+		assert.False(t, res.GetAll())
+		assert.Empty(t, res.GetItems())
+	})
+
+	t.Run("user:20 with group_resource users:create lists all", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), newCreateList("user:20", userGroup, userResource))
+		require.NoError(t, err)
+		assert.True(t, res.GetAll())
+	})
+
+	t.Run("user:21 (team admin) listing teams with create returns the admined team", func(t *testing.T) {
+		// teams keep a per-object `create`, so this lists the admined team rather than empty.
+		res, err := server.List(newContextWithNamespace(), newCreateList("user:21", teamGroup, teamResource))
+		require.NoError(t, err)
+		assert.False(t, res.GetAll())
+		assert.Contains(t, res.GetItems(), "admin-team")
+	})
+
+	t.Run("user:1 listing teams with create returns empty, not error", func(t *testing.T) {
+		res, err := server.List(newContextWithNamespace(), newCreateList("user:1", teamGroup, teamResource))
+		require.NoError(t, err)
+		assert.False(t, res.GetAll())
+		assert.Empty(t, res.GetItems())
+	})
+
+	t.Run("user:22 listing user subresource create returns the granted user", func(t *testing.T) {
+		// user / service-account have no base `create`, but subresource create must still list:
+		// the base-relation guard must not block the subresource branch.
+		req := newCreateList("user:22", userGroup, userResource)
+		req.Subresource = statusSubresource
+		res, err := server.List(newContextWithNamespace(), req)
+		require.NoError(t, err)
+		assert.Contains(t, res.GetItems(), "1")
+	})
+
+	t.Run("listing user subresource get_permissions is empty, not error", func(t *testing.T) {
+		// user has no subresource get_permissions in the model (folder-only); the subresource
+		// branch must be skipped rather than issue an undefined can_resource_get_permissions.
+		req := &authzv1.ListRequest{
+			Namespace:   namespace,
+			Verb:        utils.VerbGetPermissions,
+			Subject:     "user:1",
+			Group:       userGroup,
+			Resource:    userResource,
+			Subresource: statusSubresource,
+		}
+		res, err := server.List(newContextWithNamespace(), req)
+		require.NoError(t, err)
+		assert.Empty(t, res.GetItems())
 	})
 
 	t.Run("user:17 should be able to list all dashboards in folder 4 and all subfolders", func(t *testing.T) {

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -73,6 +73,15 @@ func setup(t *testing.T, srv *Server) *Server {
 		common.NewFolderTuple("user:18", common.RelationCreate, "general"),
 		common.NewFolderResourceTuple("user:18", common.RelationCreate, dashboardGroup, dashboardResource, "", "general"),
 		common.NewGroupResourceTuple("user:19", common.RelationGetPermissions, userGroup, userResource, ""),
+		// user:20 can create users org-wide via the group_resource (the only place `create`
+		// is modeled for flat IAM types).
+		common.NewGroupResourceTuple("user:20", common.RelationCreate, userGroup, userResource, ""),
+		// user:21 is admin of team:admin-team, which grants per-object team `create` via `or admin`.
+		common.NewTypedTuple(common.TypeTeam, "user:21", common.RelationTeamAdmin, "admin-team"),
+		// user:22 / user:23 have a subresource `resource_create` grant on a user / service-account.
+		// These types have no per-object base `create`, but they do support subresource create.
+		common.NewTypedResourceTuple("user:22", common.RelationCreate, common.TypeUser, userGroup, userResource, statusSubresource, "1"),
+		common.NewTypedResourceTuple("user:23", common.RelationCreate, common.TypeServiceAccount, serviceAccountGroup, serviceAccountResource, statusSubresource, "1"),
 		common.NewResourceTuple("team:ctx-check#member", common.RelationGet, dashboardGroup, dashboardResource, "", "ctx-check-dashboard"),
 		common.NewResourceTuple("team:ctx-list#member", common.RelationGet, dashboardGroup, dashboardResource, "", "ctx-list-dashboard"),
 		common.NewResourceTuple("team:ctx-batch#member", common.RelationGet, dashboardGroup, dashboardResource, "", "ctx-batch-dashboard"),

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -49,8 +49,10 @@ const (
 
 var (
 	// RelationsFolder is used by reconciliation to list tuples for folder objects.
-	// It must include both verb relations (get/update/delete/...) and the permission-set relations (view/edit/admin)
-	RelationsFolder = append(append([]string{}, common.RelationsTyped...),
+	// NOTE: this is NOT common.RelationsFolder. It is a superset: common.RelationsFolder (the
+	// relations the authz path validates) PLUS the permission-set relations (view/edit/admin),
+	// which are stored on folder objects and so must be enumerated when syncing/deleting tuples.
+	RelationsFolder = append(append([]string{}, common.RelationsFolder...),
 		common.RelationSetView, common.RelationSetEdit, common.RelationSetAdmin,
 	)
 	// RelationsResouce is used by reconciliation to list tuples for resource objects.


### PR DESCRIPTION
## Summary

Flat IAM typed objects (`team`, `user`, `service-account`) were all assigned the folder relation set (`RelationsTyped`), which advertises relations that the OpenFGA model does **not** define on them:

- per-object `create` on `user` / `service-account` (it only exists on the `group_resource`),
- `get_permissions` / `set_permissions` on `service-account`,
- the subresource `*_permissions` relations on all three (folder-only).

`List`, `Check` and `BatchCheck` gate their per-object `ListObjects`/`Check` on `IsValidRelation`. Because the relation set lied, a request for one of these (e.g. `users:create`) issued an invalid relation that OpenFGA rejected with a hard error — failing the whole `List`/`Check`, and in `BatchCheck` **poisoning every other item in the batch**. That is the root cause behind wildcard permissions (e.g. `dashboards:*`, `folders:*`) being dropped during the Zanzana permission merge.

## Approach

Rather than special-casing `create` at each call site, give each type a relation set that mirrors the schema, so the existing `IsValidRelation` guards do the right thing everywhere:

- **`RelationsFolder`** (renamed from `RelationsTyped`) — the full per-object set; folder only.
- **`RelationsTeam`** — keeps per-object `create` (the model grants it to team admins via `or admin`) + `get/set_permissions`.
- **`RelationsUser`** — no `create`; keeps `get/set_permissions`.
- **`RelationsServiceAccount`** — no `create`, no `get/set_permissions`.
- **`RelationsSubresourceTyped`** — subresource relations without the folder-only `*_permissions`.

This fixes `List`, `BatchCheck` **and** the single-`Check` path uniformly, with no per-call-site special casing.

Additionally, `checkTyped`/`listTyped` previously validated the **base** relation before reaching the subresource branch, so removing base `create` from `user`/`service-account` would have wrongly denied their valid subresource `resource_create` grants. Those functions are restructured so the base-relation guard gates only the direct per-object check; the subresource branch runs first and is gated independently on the subresource relation — mirroring the already-correct `resolveTypedItems` in `BatchCheck`. (As a bonus this also stops typed subresource `*_permissions` requests from erroring on types that don't define them.)

## Relation to other PRs

- Alternative to #127229, which fixes the same user-visible bug by adding a `relation == create && type != folder` guard in `listTyped` and `resolveTypedItems`. That approach is surgical but (a) leaves the single-`Check` path unfixed, (b) encodes "which types support per-object create" as a `!= folder` special case in two spots, and (c) would force legitimate per-object `team` create listings (granted to admins) to empty. This PR fixes the root cause instead — the inaccurate relation set — so all three paths are consistent and `team` per-object create is preserved.
- Follows up #127200 (merged), which added resolver-side resilience to skip individual failing actions. This PR removes the reason those actions errored in the first place.

## Test plan

- [x] `common`: `TestResourceInfoIsValidRelation_TypedResources` — locks each type's valid/invalid relations to the model.
- [x] `server`: `TestIntegrationServerList` / `…Streaming` — `create` on `users`/`serviceaccounts` returns empty (not error); `group_resource` create still grants `All`; `team` admin per-object create still lists the admined team.
- [x] `server`: `TestIntegrationServerCheck` — named `create` checks on `user`/`service-account` are denied (not errored); the single-`Check` path the alternative PR leaves open.
- [x] `server`: `TestIntegrationServerBatchCheck` — `create` items are denied without poisoning sibling checks in the batch.
- [x] `server`: typed subresource `create` (`resource_create`) on `user`/`service-account` resolves allowed across `Check`/`List`/`BatchCheck` — i.e. the base-relation guard doesn't block the subresource branch.
- [x] All new tests verified to **fail** against the pre-fix code (relation set reverted to the folder superset), confirming they catch the regression.
- [x] Full `pkg/services/authz/zanzana/...` suite passes.
