### PR TITLE
`iam`: Add metrics and tracing to the resource permission authorizer

### DIFF
--- a/pkg/registry/apis/iam/authorizer/metrics.go
+++ b/pkg/registry/apis/iam/authorizer/metrics.go
@@ -1,0 +1,61 @@
+package authorizer
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+const (
+	metricsNamespace = "iam"
+	metricsSubsystem = "apiserver"
+)
+
+var (
+	registerMetricsOnce sync.Once
+
+	// parentFetchDuration tracks the latency of parent (folder) lookups performed during
+	// resource permission authorization. These run per-item when filtering lists, so this is
+	// the key signal for the N+1 cost of folder resolution.
+	// Labels: resource (group.resource of the target), status (Kubernetes status reason,
+	// e.g. Success/NotFound/Forbidden, matching the storage wrapper's status vocabulary).
+	parentFetchDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "resource_permissions_parent_fetch_duration_seconds",
+		Help:      "Latency of parent (folder) lookups performed during resource permission authorization, by resource and status",
+		Buckets:   prometheus.DefBuckets, // 5ms to 10s
+	}, []string{"resource", "status"})
+)
+
+// RegisterMetrics registers the IAM authorizer metrics with the given registerer.
+func RegisterMetrics(reg prometheus.Registerer) {
+	registerMetricsOnce.Do(func() {
+		if err := reg.Register(parentFetchDuration); err != nil {
+			log.New("iam.authorizer").Warn("failed to register iam authorizer metrics", "error", err)
+		}
+	})
+}
+
+func observeParentFetch(gr schema.GroupResource, dur time.Duration, err error) {
+	parentFetchDuration.WithLabelValues(gr.String(), statusFromError(err)).Observe(dur.Seconds())
+}
+
+// statusFromError maps an error to a metric status label using Kubernetes status
+// reasons (e.g. Success, NotFound, Forbidden). Intentionally mirrors the storage
+// wrapper's classifier so both IAM histograms share one status vocabulary.
+func statusFromError(err error) string {
+	if err == nil {
+		return metav1.StatusSuccess
+	}
+	if reason := apierrors.ReasonForError(err); reason != metav1.StatusReasonUnknown {
+		return string(reason)
+	}
+	return metav1.StatusFailure
+}

--- a/pkg/registry/apis/iam/authorizer/parent_provider.go
+++ b/pkg/registry/apis/iam/authorizer/parent_provider.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/grafana/authlib/authn"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,7 +137,12 @@ func (p *ParentProviderImpl) getClient(ctx context.Context, gr schema.GroupResou
 	return client, nil
 }
 
-func (p *ParentProviderImpl) GetParent(ctx context.Context, gr schema.GroupResource, namespace, name string) (string, error) {
+func (p *ParentProviderImpl) GetParent(ctx context.Context, gr schema.GroupResource, namespace, name string) (parent string, err error) {
+	start := time.Now()
+	defer func() {
+		observeParentFetch(gr, time.Since(start), err)
+	}()
+
 	client, err := p.getClient(ctx, gr)
 	if err != nil {
 		return "", err

--- a/pkg/registry/apis/iam/authorizer/resource_permissions.go
+++ b/pkg/registry/apis/iam/authorizer/resource_permissions.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"strconv"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -15,8 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
 )
-
-// TODO: Logs, Metrics, Traces?
 
 // ParentProvider interface for fetching parent information of resources
 type ParentProvider interface {
@@ -31,6 +32,7 @@ type ResourcePermissionsAuthorizer struct {
 	accessClient   types.AccessClient
 	parentProvider ParentProvider
 	logger         log.Logger
+	tracer         trace.Tracer
 }
 
 var _ storewrapper.ResourceStorageAuthorizer = (*ResourcePermissionsAuthorizer)(nil)
@@ -38,11 +40,13 @@ var _ storewrapper.ResourceStorageAuthorizer = (*ResourcePermissionsAuthorizer)(
 func NewResourcePermissionsAuthorizer(
 	accessClient types.AccessClient,
 	parentProvider ParentProvider,
+	tracer trace.Tracer,
 ) *ResourcePermissionsAuthorizer {
 	return &ResourcePermissionsAuthorizer{
 		accessClient:   accessClient,
 		parentProvider: parentProvider,
 		logger:         log.New("iam.authorizer.resource-permissions"),
+		tracer:         tracer,
 	}
 }
 
@@ -74,6 +78,10 @@ func (r *ResourcePermissionsAuthorizer) hasUsersPermissionsRead(ctx context.Cont
 // getTarget(i) supplies the resource identity for item i; when ok is false that item is excluded.
 // If the caller has users.permissions:read, returns all items without per-resource checks.
 func CanViewTargets[T any](r *ResourcePermissionsAuthorizer, ctx context.Context, authInfo types.AuthInfo, items []T, getTarget func(i int) (namespace, apiGroup, resource, name string, ok bool)) ([]T, error) {
+	ctx, span := r.tracer.Start(ctx, "resource-permissions.can-view-targets")
+	defer span.End()
+	span.SetAttributes(attribute.Int("items_count", len(items)))
+
 	if authInfo == nil {
 		return nil, storewrapper.ErrUnauthenticated
 	}
@@ -84,14 +92,19 @@ func CanViewTargets[T any](r *ResourcePermissionsAuthorizer, ctx context.Context
 	// if caller has users.permissions:read, allow all items
 	if ns, _, _, _, ok := getTarget(0); ok {
 		if allowAll, err := r.hasUsersPermissionsRead(ctx, authInfo, ns); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "error checking users.permissions:read")
 			return nil, err
 		} else if allowAll {
+			span.SetAttributes(attribute.Bool("has_users_permissions_read", true))
 			return items, nil
 		}
 	}
 	accessPolicy := isAccessPolicy(authInfo)
 
 	// build checks - use item index as correlation ID so results map back without a side table
+	parentCalls := 0
+	failedParentCalls := 0
 	checks := make([]types.BatchCheckItem, 0, n)
 	var namespace string
 	for i := range n {
@@ -110,8 +123,10 @@ func CanViewTargets[T any](r *ResourcePermissionsAuthorizer, ctx context.Context
 		// Access Policies have global scope, so no parent check needed
 		if !accessPolicy && r.parentProvider.HasParent(targetGR) {
 			var err error
+			parentCalls++
 			parent, err = r.parentProvider.GetParent(ctx, targetGR, ns, name)
 			if err != nil {
+				failedParentCalls++
 				r.logger.Debug("can view targets: error fetching parent, denying this item",
 					"error", fmt.Sprintf("%v", err), "namespace", ns, "group", apiGroup, "resource", resource, "name", name)
 				continue
@@ -126,6 +141,8 @@ func CanViewTargets[T any](r *ResourcePermissionsAuthorizer, ctx context.Context
 			Folder:        parent,
 		})
 	}
+	span.SetAttributes(attribute.Int("get_parent_calls", parentCalls))
+	span.SetAttributes(attribute.Int("failed_get_parent_calls", failedParentCalls))
 
 	allowed := make([]bool, n)
 	for start := 0; start < len(checks); start += types.MaxBatchCheckItems {
@@ -138,6 +155,8 @@ func CanViewTargets[T any](r *ResourcePermissionsAuthorizer, ctx context.Context
 			Checks:    checks[start:end],
 		})
 		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "error batch checking permissions")
 			return nil, err
 		}
 		for id, result := range res.Results {
@@ -153,11 +172,16 @@ func CanViewTargets[T any](r *ResourcePermissionsAuthorizer, ctx context.Context
 			filtered = append(filtered, item)
 		}
 	}
+	span.SetAttributes(attribute.Int("filtered_items_count", len(filtered)))
 	return filtered, nil
 }
 
 // AfterGet implements ResourceStorageAuthorizer.
 func (r *ResourcePermissionsAuthorizer) AfterGet(ctx context.Context, obj runtime.Object) error {
+	// Annotate the surrounding storewrapper span rather than opening a child:
+	// this is a single-object path and error recording is handled by the wrapper.
+	span := trace.SpanFromContext(ctx)
+
 	authInfo, ok := types.AuthInfoFrom(ctx)
 	if !ok {
 		return storewrapper.ErrUnauthenticated
@@ -168,17 +192,20 @@ func (r *ResourcePermissionsAuthorizer) AfterGet(ctx context.Context, obj runtim
 		if ok, err := r.hasUsersPermissionsRead(ctx, authInfo, o.Namespace); err != nil {
 			return err
 		} else if ok {
+			span.SetAttributes(attribute.Bool("has_users_permissions_read", true))
 			return nil
 		}
 
 		target := o.Spec.Resource
 		targetGR := schema.GroupResource{Group: target.ApiGroup, Resource: target.Resource}
+		span.SetAttributes(attribute.String("target_resource", targetGR.String()))
 
 		parent := ""
 		// Fetch the parent of the resource
 		// Access Policies have global scope, so no parent check needed
 		if !isAccessPolicy(authInfo) && r.parentProvider.HasParent(targetGR) {
 			p, err := r.parentProvider.GetParent(ctx, targetGR, o.Namespace, target.Name)
+			span.SetAttributes(attribute.Int("get_parent_calls", 1))
 			if err != nil {
 				r.logger.Error("after get: error fetching parent", "error", err.Error(),
 					"namespace", o.Namespace,
@@ -202,6 +229,7 @@ func (r *ResourcePermissionsAuthorizer) AfterGet(ctx context.Context, obj runtim
 		if err != nil {
 			return err
 		}
+		span.SetAttributes(attribute.Bool("allowed", res.Allowed))
 		if !res.Allowed {
 			return k8serrors.NewNotFound(targetGR, target.Name)
 		}
@@ -212,6 +240,10 @@ func (r *ResourcePermissionsAuthorizer) AfterGet(ctx context.Context, obj runtim
 }
 
 func (r *ResourcePermissionsAuthorizer) beforeWrite(ctx context.Context, obj runtime.Object) error {
+	// Annotate the surrounding storewrapper span rather than opening a child:
+	// this is a single-object path and error recording is handled by the wrapper.
+	span := trace.SpanFromContext(ctx)
+
 	authInfo, ok := types.AuthInfoFrom(ctx)
 	if !ok {
 		return storewrapper.ErrUnauthenticated
@@ -220,12 +252,14 @@ func (r *ResourcePermissionsAuthorizer) beforeWrite(ctx context.Context, obj run
 	case *iamv0.ResourcePermission:
 		target := o.Spec.Resource
 		targetGR := schema.GroupResource{Group: target.ApiGroup, Resource: target.Resource}
+		span.SetAttributes(attribute.String("target_resource", targetGR.String()))
 
 		parent := ""
 		// Fetch the parent of the resource
 		// Access Policies have global scope, so no parent check needed
 		if !isAccessPolicy(authInfo) && r.parentProvider.HasParent(targetGR) {
 			p, err := r.parentProvider.GetParent(ctx, targetGR, o.Namespace, target.Name)
+			span.SetAttributes(attribute.Int("get_parent_calls", 1))
 			if err != nil {
 				r.logger.Error("before write: error fetching parent", "error", err.Error(),
 					"namespace", o.Namespace,
@@ -249,6 +283,7 @@ func (r *ResourcePermissionsAuthorizer) beforeWrite(ctx context.Context, obj run
 		if err != nil {
 			return err
 		}
+		span.SetAttributes(attribute.Bool("allowed", res.Allowed))
 		if !res.Allowed {
 			return k8serrors.NewForbidden(targetGR, target.Name, fmt.Errorf("user cannot set permissions on this resource"))
 		}

--- a/pkg/registry/apis/iam/authorizer/resource_permissions_test.go
+++ b/pkg/registry/apis/iam/authorizer/resource_permissions_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/authlib/types"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
 func newResourcePermission(apiGroup, resource, name string) *iamv0.ResourcePermission {
@@ -70,7 +71,7 @@ func TestResourcePermissions_AfterGet(t *testing.T) {
 
 			accessClient := &fakeAccessClient{checkFunc: checkFunc}
 			fakeParentProvider := &fakeParentProvider{hasParent: true, getParentFunc: getParentFunc}
-			resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider)
+			resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider, tracing.NewNoopTracerService())
 			ctx := types.WithAuthInfo(context.Background(), user)
 
 			err := resPermAuthz.AfterGet(ctx, fold1)
@@ -103,7 +104,7 @@ func TestResourcePermissions_AfterGet_WithUsersPermissionsRead(t *testing.T) {
 	}
 	accessClient := &fakeAccessClient{checkFunc: checkFunc}
 	fakeParentProvider := &fakeParentProvider{hasParent: true, getParentFunc: getParentFunc}
-	resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider)
+	resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider, tracing.NewNoopTracerService())
 	ctx := types.WithAuthInfo(context.Background(), user)
 
 	err := resPermAuthz.AfterGet(ctx, fold1)
@@ -154,7 +155,7 @@ func TestResourcePermissions_FilterList(t *testing.T) {
 
 	accessClient := &fakeAccessClient{checkFunc: checkFunc, batchCheckFunc: batchCheckFunc}
 	fakeParentProvider := &fakeParentProvider{hasParent: true, getParentFunc: getParentFunc}
-	resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider)
+	resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider, tracing.NewNoopTracerService())
 	ctx := types.WithAuthInfo(context.Background(), user)
 
 	obj, err := resPermAuthz.FilterList(ctx, list)
@@ -191,7 +192,7 @@ func TestResourcePermissions_FilterList_WithUsersPermissionsRead(t *testing.T) {
 	}
 	accessClient := &fakeAccessClient{checkFunc: checkFunc}
 	fakeParentProvider := &fakeParentProvider{hasParent: true, getParentFunc: getParentFunc}
-	resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider)
+	resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider, tracing.NewNoopTracerService())
 	ctx := types.WithAuthInfo(context.Background(), user)
 
 	obj, err := resPermAuthz.FilterList(ctx, list)
@@ -247,7 +248,7 @@ func TestResourcePermissions_beforeWrite(t *testing.T) {
 
 			accessClient := &fakeAccessClient{checkFunc: checkFunc}
 			fakeParentProvider := &fakeParentProvider{hasParent: true, getParentFunc: getParentFunc}
-			resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider)
+			resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider, tracing.NewNoopTracerService())
 			ctx := types.WithAuthInfo(context.Background(), user)
 
 			err := resPermAuthz.beforeWrite(ctx, fold1)

--- a/pkg/registry/apis/iam/metrics.go
+++ b/pkg/registry/apis/iam/metrics.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	iamauthorizer "github.com/grafana/grafana/pkg/registry/apis/iam/authorizer"
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -67,7 +68,7 @@ var (
 		Subsystem: metricsSubSystem,
 		Name:      "storage_wrapper_duration_seconds",
 		Help:      "Latency of IAM storage wrapper operations split by layer (authz vs inner store), operation, resource, and status",
-		Buckets:   prometheus.ExponentialBuckets(0.001, 2, 10), // 1ms to ~1s
+		Buckets:   prometheus.DefBuckets,
 	}, []string{"layer", "op", "resource", "status"})
 )
 
@@ -86,6 +87,8 @@ func registerMetrics(reg prometheus.Registerer) {
 				log.New("iam.apis").Warn("failed to register iam apiserver metrics", "error", err)
 			}
 		}
+
+		iamauthorizer.RegisterMetrics(reg)
 	})
 }
 

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -127,7 +127,7 @@ func RegisterAPIService(
 
 	var resourcePermsSearchAuthorizer *iamauthorizer.ResourcePermissionsAuthorizer
 	if resourcePermsSearchBackend != nil {
-		resourcePermsSearchAuthorizer = iamauthorizer.NewResourcePermissionsAuthorizer(accessClient, resourceParentProvider)
+		resourcePermsSearchAuthorizer = iamauthorizer.NewResourcePermissionsAuthorizer(accessClient, resourceParentProvider, tracing)
 	}
 
 	builder := &IdentityAccessManagementAPIBuilder{
@@ -763,7 +763,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateResourcePermissionsAPIGroup(
 	authzWrapper := storewrapper.New(
 		regStoreDW,
 		iamv0.ResourcePermissionInfo.GroupResource(),
-		iamauthorizer.NewResourcePermissionsAuthorizer(b.accessClient, b.resourceParentProvider),
+		iamauthorizer.NewResourcePermissionsAuthorizer(b.accessClient, b.resourceParentProvider, b.tracing),
 		storewrapper.WithObserver(storageObserver{}),
 	)
 


### PR DESCRIPTION
**Why**:
I suspect fetching resource parents to properly authorize resource permissions is going to be the bottleneck.
This PR adds insights that will help us decide whether we need to make this more performant.