### PR TITLE
IAM: Cascade legacy team_member cleanup when deleting a team via unified storage

### DIFF
--- a/pkg/registry/apis/iam/legacy/delete_team_members_by_team.sql
+++ b/pkg/registry/apis/iam/legacy/delete_team_members_by_team.sql
@@ -1,0 +1,3 @@
+DELETE FROM {{ .Ident .TeamMemberTable }}
+WHERE org_id = {{ .Arg .Command.OrgID }}
+  AND team_id = {{ .Arg .Command.TeamID }}

--- a/pkg/registry/apis/iam/legacy/sql_test.go
+++ b/pkg/registry/apis/iam/legacy/sql_test.go
@@ -109,6 +109,12 @@ func TestIdentityQueries(t *testing.T) {
 		return &v
 	}
 
+	deleteTeamMembersByTeam := func(q *DeleteTeamMembersByTeamCommand) sqltemplate.SQLTemplate {
+		v := newDeleteTeamMembersByTeam(nodb, q)
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
 	createTeamMembersBulk := func(q *CreateTeamMembersBulkCommand) sqltemplate.SQLTemplate {
 		v := newCreateTeamMembersBulk(nodb, q)
 		v.SQLTemplate = mocks.NewTestingSQLTemplate()
@@ -416,6 +422,15 @@ func TestIdentityQueries(t *testing.T) {
 					Data: deleteTeamMembersBulk(&DeleteTeamMembersBulkCommand{
 						OrgID: 1,
 						UIDs:  []string{"team-member-1", "team-member-2", "team-member-3"},
+					}),
+				},
+			},
+			sqlDeleteTeamMembersByTeamQuery: {
+				{
+					Name: "delete_team_members_by_team",
+					Data: deleteTeamMembersByTeam(&DeleteTeamMembersByTeamCommand{
+						OrgID:  1,
+						TeamID: 1,
 					}),
 				},
 			},

--- a/pkg/registry/apis/iam/legacy/team.go
+++ b/pkg/registry/apis/iam/legacy/team.go
@@ -625,11 +625,24 @@ func (s *legacySQLStore) DeleteTeam(ctx context.Context, ns claims.NamespaceInfo
 	}
 	teamID := existing.ID
 
+	memberDeleteReq := newDeleteTeamMembersByTeam(sql, &DeleteTeamMembersByTeamCommand{
+		OrgID:  ns.OrgID,
+		TeamID: teamID,
+	})
+
 	return sql.DB.GetSqlxSession().WithTransaction(ctx, func(st *session.SessionTx) error {
 		if cmd.ExternalGroupReconciler != nil {
 			if err := cmd.ExternalGroupReconciler.DeleteAll(ctx, st, ns.OrgID, teamID); err != nil {
 				return fmt.Errorf("failed to delete team external groups: %w", err)
 			}
+		}
+
+		memberDeleteQuery, err := sqltemplate.Execute(sqlDeleteTeamMembersByTeamQuery, memberDeleteReq)
+		if err != nil {
+			return fmt.Errorf("error executing team members delete template: %w", err)
+		}
+		if _, err := st.Exec(ctx, memberDeleteQuery, memberDeleteReq.GetArgs()...); err != nil {
+			return fmt.Errorf("failed to delete team members: %w", err)
 		}
 
 		teamDeleteQuery, err := sqltemplate.Execute(sqlDeleteTeamTemplate, teamDeleteReq)

--- a/pkg/registry/apis/iam/legacy/team_binding.go
+++ b/pkg/registry/apis/iam/legacy/team_binding.go
@@ -402,6 +402,15 @@ type DeleteTeamMembersBulkCommand struct {
 	UIDs  []string
 }
 
+// DeleteTeamMembersByTeamCommand removes all team_member rows for a team in a
+// single SQL DELETE. Used by DeleteTeam to cascade member cleanup the way the
+// legacy team store does. OrgID scopes the DELETE so a TeamID can't reach
+// across orgs.
+type DeleteTeamMembersByTeamCommand struct {
+	OrgID  int64
+	TeamID int64
+}
+
 // CreateTeamMembersBulkCommand inserts multiple team_member rows in a single
 // multi-row INSERT. Each member must be fully populated (TeamID/TeamUID/UserID
 // already resolved, OrgID set, timestamps filled).
@@ -411,6 +420,7 @@ type CreateTeamMembersBulkCommand struct {
 
 var sqlDeleteTeamMemberQuery = mustTemplate("delete_team_member_query.sql")
 var sqlDeleteTeamMembersBulkQuery = mustTemplate("delete_team_members_bulk.sql")
+var sqlDeleteTeamMembersByTeamQuery = mustTemplate("delete_team_members_by_team.sql")
 var sqlCreateTeamMembersBulkQuery = mustTemplate("create_team_members_bulk.sql")
 
 type deleteTeamMembersBulkQuery struct {
@@ -425,6 +435,24 @@ func (r deleteTeamMembersBulkQuery) Validate() error {
 
 func newDeleteTeamMembersBulk(sql *legacysql.LegacyDatabaseHelper, cmd *DeleteTeamMembersBulkCommand) deleteTeamMembersBulkQuery {
 	return deleteTeamMembersBulkQuery{
+		SQLTemplate:     sqltemplate.New(sql.DialectForDriver()),
+		TeamMemberTable: sql.Table("team_member"),
+		Command:         cmd,
+	}
+}
+
+type deleteTeamMembersByTeamQuery struct {
+	sqltemplate.SQLTemplate
+	TeamMemberTable string
+	Command         *DeleteTeamMembersByTeamCommand
+}
+
+func (r deleteTeamMembersByTeamQuery) Validate() error {
+	return nil
+}
+
+func newDeleteTeamMembersByTeam(sql *legacysql.LegacyDatabaseHelper, cmd *DeleteTeamMembersByTeamCommand) deleteTeamMembersByTeamQuery {
+	return deleteTeamMembersByTeamQuery{
 		SQLTemplate:     sqltemplate.New(sql.DialectForDriver()),
 		TeamMemberTable: sql.Table("team_member"),
 		Command:         cmd,

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--delete_team_members_by_team-delete_team_members_by_team.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--delete_team_members_by_team-delete_team_members_by_team.sql
@@ -1,0 +1,3 @@
+DELETE FROM `grafana`.`team_member`
+WHERE org_id = 1
+  AND team_id = 1

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--delete_team_members_by_team-delete_team_members_by_team.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--delete_team_members_by_team-delete_team_members_by_team.sql
@@ -1,0 +1,3 @@
+DELETE FROM "grafana"."team_member"
+WHERE org_id = 1
+  AND team_id = 1

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--delete_team_members_by_team-delete_team_members_by_team.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--delete_team_members_by_team-delete_team_members_by_team.sql
@@ -1,0 +1,3 @@
+DELETE FROM "grafana"."team_member"
+WHERE org_id = 1
+  AND team_id = 1

--- a/pkg/tests/apis/iam/team/team_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_integration_test.go
@@ -25,7 +25,7 @@ import (
 func TestIntegrationTeams(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	modes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode5}
+	modes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode3, rest.Mode5}
 	for _, mode := range modes {
 		t.Run(fmt.Sprintf("Team CRUD operations with dual writer mode %d", mode), func(t *testing.T) {
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
@@ -47,8 +47,10 @@ func TestIntegrationTeams(t *testing.T) {
 			doTeamSpecMembersTests(t, helper)
 			doTeamSpecExternalGroupsOSSTests(t, helper)
 
-			if mode < 3 {
+			if mode < rest.Mode3 {
 				doTeamCRUDTestsUsingTheLegacyAPIs(t, helper, mode)
+			}
+			if mode < rest.Mode4 {
 				doTeamDeleteCascadesLegacyMembersTest(t, helper)
 			}
 		})
@@ -286,9 +288,9 @@ func doTeamCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 	})
 }
 
-// doTeamDeleteCascadesLegacyMembersTest guards F12: deleting a team must clean
-// up its legacy team_member rows. Only meaningful when legacy storage is
-// written (dual-write mode < 3), so the caller gates on mode.
+// doTeamDeleteCascadesLegacyMembersTest verifies that deleting a team cleans up
+// its legacy team_member rows. Only meaningful when legacy storage is written
+// (dual-write mode < 4), so the caller gates on mode.
 func doTeamDeleteCascadesLegacyMembersTest(t *testing.T, helper *apis.K8sTestHelper) {
 	t.Run("delete team cascades legacy team_member rows", func(t *testing.T) {
 		ctx := context.Background()
@@ -346,7 +348,7 @@ func doTeamDeleteCascadesLegacyMembersTest(t *testing.T, helper *apis.K8sTestHel
 
 		require.NoError(t, teamClient.Resource.Delete(ctx, teamUID, metav1.DeleteOptions{}))
 
-		require.Equal(t, 0, countMembers(), "team_member rows must be cleaned up after team delete (F12)")
+		require.Equal(t, 0, countMembers(), "team_member rows must be cleaned up after team delete")
 	})
 }
 

--- a/pkg/tests/apis/iam/team/team_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_integration_test.go
@@ -49,6 +49,7 @@ func TestIntegrationTeams(t *testing.T) {
 
 			if mode < 3 {
 				doTeamCRUDTestsUsingTheLegacyAPIs(t, helper, mode)
+				doTeamDeleteCascadesLegacyMembersTest(t, helper)
 			}
 		})
 	}
@@ -282,6 +283,70 @@ func doTeamCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 		// Cleanup
 		_, err = env.SQLStore.GetSqlxSession().Exec(ctx, "DELETE FROM team WHERE uid IN (?, ?)", "t000000001", "t000000002")
 		require.NoError(t, err)
+	})
+}
+
+// doTeamDeleteCascadesLegacyMembersTest guards F12: deleting a team must clean
+// up its legacy team_member rows. Only meaningful when legacy storage is
+// written (dual-write mode < 3), so the caller gates on mode.
+func doTeamDeleteCascadesLegacyMembersTest(t *testing.T, helper *apis.K8sTestHelper) {
+	t.Run("delete team cascades legacy team_member rows", func(t *testing.T) {
+		ctx := context.Background()
+		env := helper.GetEnv()
+
+		teamClient := helper.GetResourceClient(apis.ResourceClientArgs{
+			User:      helper.Org1.Admin,
+			Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+			GVR:       gvrTeams,
+		})
+
+		editorUID := helper.Org1.Editor.Identity.GetIdentifier()
+		viewerUID := helper.Org1.Viewer.Identity.GetIdentifier()
+
+		created, err := teamClient.Resource.Create(ctx, &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "iam.grafana.app/v0alpha1",
+			"kind":       "Team",
+			"metadata":   map[string]interface{}{"generateName": "team-del-cascade-"},
+			"spec": map[string]interface{}{
+				"title":       "Team del cascade",
+				"email":       "del-cascade@example.com",
+				"provisioned": false,
+				"externalUID": "",
+				"members": []map[string]interface{}{
+					{"kind": "User", "name": editorUID, "permission": "member", "external": false},
+					{"kind": "User", "name": viewerUID, "permission": "admin", "external": false},
+				},
+			},
+		}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		teamUID := created.GetName()
+
+		// Resolve the team's legacy int64 id before deletion. Orphaned
+		// team_member rows keep this team_id even though the team row is gone,
+		// so we must capture it now and count by id rather than joining back
+		// to the team table.
+		var teamID int64
+		rows, err := env.SQLStore.GetSqlxSession().Query(ctx, "SELECT id FROM team WHERE uid = ?", teamUID)
+		require.NoError(t, err)
+		require.True(t, rows.Next())
+		require.NoError(t, rows.Scan(&teamID))
+		require.NoError(t, rows.Close())
+
+		countMembers := func() int {
+			var n int
+			r, err := env.SQLStore.GetSqlxSession().Query(ctx, "SELECT COUNT(*) FROM team_member WHERE team_id = ?", teamID)
+			require.NoError(t, err)
+			require.True(t, r.Next())
+			require.NoError(t, r.Scan(&n))
+			require.NoError(t, r.Close())
+			return n
+		}
+
+		require.Equal(t, 2, countMembers(), "expected legacy team_member rows to exist before delete")
+
+		require.NoError(t, teamClient.Resource.Delete(ctx, teamUID, metav1.DeleteOptions{}))
+
+		require.Equal(t, 0, countMembers(), "team_member rows must be cleaned up after team delete (F12)")
 	})
 }
 


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes a regression where deleting a team left rows in the legacy `team_member` table when teams use unified storage (`kubernetesTeamsRedirect` +dual-write mode ≥ 1). The team row, its K8s teambindings, and `team_group` rows
were cleaned up, but the legacy `team_member` rows were not.

**Why do we need this feature?**
With the teams migration, `DELETE /api/teams/:id` routes through the K8s apiserver to the dual-write legacy store (`legacySQLStore.DeleteTeam`, `pkg/registry/apis/iam/legacy/team.go`). That function deletes the `team` row (`delete_team.sql`) and reconciles `team_group` away (`ExternalGroupReconciler.DeleteAll`), but never deletes the team's `team_member` rows.

The original legacy store always cascaded them in the same transaction:
```

// pkg/services/team/teamimpl/store.go
deletes := []string{
"DELETE FROM team_member WHERE org_id=? and team_id = ?",
"DELETE FROM team WHERE org_id=? and id = ?",
...
}

```

The new delete path didn't replicate that cascade. There is no `ON DELETE CASCADE` foreign key to rely on so the cleanup has to be added to the new path.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
Closes https://github.com/grafana/identity-access-team/issues/2187

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
