### PR TITLE
GrafanaUI: Convert Typeahead to a function component

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -675,11 +675,6 @@
       "count": 1
     }
   },
-  "packages/grafana-ui/src/components/Typeahead/Typeahead.tsx": {
-    "react-prefer-function-component/react-prefer-function-component": {
-      "count": 1
-    }
-  },
   "packages/grafana-ui/src/components/VizLegend/types.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
@@ -1,8 +1,6 @@
 import { css } from '@emotion/css';
 import { autoUpdate, offset, useFloating } from '@floating-ui/react';
-import { isEqual } from 'lodash';
-import { createRef, PureComponent, useEffect, type PropsWithChildren } from 'react';
-import * as React from 'react';
+import { useContext, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
 import { FixedSizeList } from 'react-window';
 
 import { type GrafanaTheme2, ThemeContext } from '@grafana/data';
@@ -22,157 +20,140 @@ interface Props {
   origin: string;
   groupedItems: CompletionItemGroup[];
   prefix?: string;
-  menuRef?: (el: Typeahead) => void;
+  menuRef?: (el: TypeaheadMenu) => void;
   onSelectSuggestion?: (suggestion: CompletionItem) => void;
   isOpen?: boolean;
 }
 
-export interface State {
-  allItems: CompletionItem[];
-  listWidth: number;
-  listHeight: number;
-  itemHeight: number;
-  hoveredItem: number | null;
-  typeaheadIndex: number | null;
+/** Imperative handle exposed via the `menuRef` prop so the keyboard plugin can drive the menu. */
+export interface TypeaheadMenu {
+  moveMenuIndex: (moveAmount: number) => void;
+  insertSuggestion: () => void;
 }
 
-export class Typeahead extends PureComponent<Props, State> {
-  static contextType = ThemeContext;
-  context!: React.ContextType<typeof ThemeContext>;
-  listRef = createRef<FixedSizeList>();
+function deriveListState(groupedItems: CompletionItemGroup[], theme: GrafanaTheme2) {
+  const allItems = flattenGroupItems(groupedItems);
+  const longestLabel = calculateLongestLabel(allItems);
+  const { listWidth, listHeight, itemHeight } = calculateListSizes(theme, allItems, longestLabel);
+  return { allItems, listWidth, listHeight, itemHeight };
+}
 
-  state: State = {
-    hoveredItem: null,
-    typeaheadIndex: null,
-    allItems: [],
-    listWidth: -1,
-    listHeight: -1,
-    itemHeight: -1,
-  };
+export function Typeahead({ prefix, isOpen = false, groupedItems, menuRef, onSelectSuggestion }: Props) {
+  const theme = useContext(ThemeContext);
+  const listRef = useRef<FixedSizeList>(null);
 
-  componentDidMount = () => {
-    if (this.props.menuRef) {
-      this.props.menuRef(this);
-    }
+  const [hoveredItem, setHoveredItem] = useState<number | null>(null);
+  const [typeaheadIndex, setTypeaheadIndex] = useState<number | null>(null);
 
-    const allItems = flattenGroupItems(this.props.groupedItems);
-    const longestLabel = calculateLongestLabel(allItems);
-    const { listWidth, listHeight, itemHeight } = calculateListSizes(this.context, allItems, longestLabel);
-    this.setState({
-      listWidth,
-      listHeight,
-      itemHeight,
-      allItems,
-    });
-  };
+  // The flattened items and list dimensions are purely derived from the grouped items, so memoize
+  // them. The reference dep is enough to skip recomputes on hover/selection re-renders (those don't
+  // change `groupedItems`), which is what the original isEqual guard was protecting against.
+  const { allItems, listWidth, listHeight, itemHeight } = useMemo(
+    () => deriveListState(groupedItems, theme),
+    [groupedItems, theme]
+  );
 
-  componentDidUpdate = (prevProps: Readonly<Props>, prevState: Readonly<State>) => {
-    if (
-      this.state.typeaheadIndex !== null &&
-      prevState.typeaheadIndex !== this.state.typeaheadIndex &&
-      this.listRef &&
-      this.listRef.current
-    ) {
-      if (this.state.typeaheadIndex === 1) {
-        this.listRef.current.scrollToItem(0); // special case for handling the first group label
-        return;
-      }
-      this.listRef.current.scrollToItem(this.state.typeaheadIndex);
-    }
+  // Reset the highlighted suggestion whenever the items change. Assigning state during render is the
+  // React-recommended way to adjust state in response to a changed prop: it re-renders immediately
+  // instead of committing the stale selection first, which an effect would not avoid.
+  const [prevGroupedItems, setPrevGroupedItems] = useState(groupedItems);
+  if (groupedItems !== prevGroupedItems) {
+    setPrevGroupedItems(groupedItems);
+    setTypeaheadIndex(null);
+  }
 
-    if (isEqual(prevProps.groupedItems, this.props.groupedItems) === false) {
-      const allItems = flattenGroupItems(this.props.groupedItems);
-      const longestLabel = calculateLongestLabel(allItems);
-      const { listWidth, listHeight, itemHeight } = calculateListSizes(this.context, allItems, longestLabel);
-      this.setState({ listWidth, listHeight, itemHeight, allItems, typeaheadIndex: null });
-    }
-  };
+  // The menu handle is stable, but the keyboard plugin invokes it outside of render, so the methods
+  // read the latest props/state through a ref and functional state updates.
+  const latest = useRef({ allItems, typeaheadIndex, onSelectSuggestion });
+  latest.current = { allItems, typeaheadIndex, onSelectSuggestion };
 
-  onMouseEnter = (index: number) => {
-    this.setState({
-      hoveredItem: index,
-    });
-  };
+  const menu = useMemo<TypeaheadMenu>(
+    () => ({
+      moveMenuIndex: (moveAmount: number) => {
+        const itemCount = latest.current.allItems.length;
+        if (!itemCount) {
+          return;
+        }
+        setTypeaheadIndex((current) => {
+          // Select next suggestion
+          let newTypeaheadIndex = modulo((current || 0) + moveAmount, itemCount);
 
-  onMouseLeave = () => {
-    this.setState({
-      hoveredItem: null,
-    });
-  };
+          if (latest.current.allItems[newTypeaheadIndex].kind === CompletionItemKind.GroupTitle) {
+            newTypeaheadIndex = modulo(newTypeaheadIndex + moveAmount, itemCount);
+          }
 
-  moveMenuIndex = (moveAmount: number) => {
-    const itemCount = this.state.allItems.length;
-    if (itemCount) {
-      // Select next suggestion
-      const typeaheadIndex = this.state.typeaheadIndex || 0;
-      let newTypeaheadIndex = modulo(typeaheadIndex + moveAmount, itemCount);
+          return newTypeaheadIndex;
+        });
+      },
+      insertSuggestion: () => {
+        const { onSelectSuggestion, allItems, typeaheadIndex } = latest.current;
+        if (onSelectSuggestion && typeaheadIndex !== null) {
+          onSelectSuggestion(allItems[typeaheadIndex]);
+        }
+      },
+    }),
+    []
+  );
 
-      if (this.state.allItems[newTypeaheadIndex].kind === CompletionItemKind.GroupTitle) {
-        newTypeaheadIndex = modulo(newTypeaheadIndex + moveAmount, itemCount);
-      }
+  useEffect(() => {
+    menuRef?.(menu);
+  }, [menuRef, menu]);
 
-      this.setState({
-        typeaheadIndex: newTypeaheadIndex,
-      });
-
+  useEffect(() => {
+    if (typeaheadIndex === null || !listRef.current) {
       return;
     }
-  };
-
-  insertSuggestion = () => {
-    if (this.props.onSelectSuggestion && this.state.typeaheadIndex !== null) {
-      this.props.onSelectSuggestion(this.state.allItems[this.state.typeaheadIndex]);
+    if (typeaheadIndex === 1) {
+      listRef.current.scrollToItem(0); // special case for handling the first group label
+      return;
     }
-  };
+    listRef.current.scrollToItem(typeaheadIndex);
+  }, [typeaheadIndex]);
 
-  render() {
-    const { prefix, isOpen = false } = this.props;
-    const { allItems, listWidth, listHeight, itemHeight, hoveredItem, typeaheadIndex } = this.state;
-    const styles = getStyles(this.context);
+  const styles = getStyles(theme);
 
-    const showDocumentation = hoveredItem || typeaheadIndex;
-    const documentationItem = allItems[hoveredItem ? hoveredItem : typeaheadIndex || 0];
+  const showDocumentation = hoveredItem || typeaheadIndex;
+  const documentationItem = allItems[hoveredItem ? hoveredItem : typeaheadIndex || 0];
 
-    return (
-      <TypeaheadPortal isOpen={isOpen}>
-        <ul role="menu" className={styles.typeahead} data-testid="typeahead">
-          <FixedSizeList
-            ref={this.listRef}
-            itemCount={allItems.length}
-            itemSize={itemHeight}
-            itemKey={(index) => {
-              const item = allItems && allItems[index];
-              const key = item ? `${index}-${item.label}` : `${index}`;
-              return key;
-            }}
-            width={listWidth}
-            height={listHeight}
-          >
-            {({ index, style }) => {
-              const item = allItems && allItems[index];
-              if (!item) {
-                return null;
-              }
+  return (
+    <TypeaheadPortal isOpen={isOpen}>
+      <ul role="menu" className={styles.typeahead} data-testid="typeahead">
+        <FixedSizeList
+          ref={listRef}
+          itemCount={allItems.length}
+          itemSize={itemHeight}
+          itemKey={(index) => {
+            const item = allItems && allItems[index];
+            const key = item ? `${index}-${item.label}` : `${index}`;
+            return key;
+          }}
+          width={listWidth}
+          height={listHeight}
+        >
+          {({ index, style }) => {
+            const item = allItems && allItems[index];
+            if (!item) {
+              return null;
+            }
 
-              return (
-                <TypeaheadItem
-                  onClickItem={() => (this.props.onSelectSuggestion ? this.props.onSelectSuggestion(item) : {})}
-                  isSelected={typeaheadIndex === null ? false : allItems[typeaheadIndex] === item}
-                  item={item}
-                  prefix={prefix}
-                  style={style}
-                  onMouseEnter={() => this.onMouseEnter(index)}
-                  onMouseLeave={this.onMouseLeave}
-                />
-              );
-            }}
-          </FixedSizeList>
-        </ul>
+            return (
+              <TypeaheadItem
+                onClickItem={() => (onSelectSuggestion ? onSelectSuggestion(item) : {})}
+                isSelected={typeaheadIndex === null ? false : allItems[typeaheadIndex] === item}
+                item={item}
+                prefix={prefix}
+                style={style}
+                onMouseEnter={() => setHoveredItem(index)}
+                onMouseLeave={() => setHoveredItem(null)}
+              />
+            );
+          }}
+        </FixedSizeList>
+      </ul>
 
-        {showDocumentation && <TypeaheadInfo height={listHeight} item={documentationItem} />}
-      </TypeaheadPortal>
-    );
-  }
+      {showDocumentation && <TypeaheadInfo height={listHeight} item={documentationItem} />}
+    </TypeaheadPortal>
+  );
 }
 
 /**

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
@@ -1,10 +1,11 @@
 import { css } from '@emotion/css';
 import { autoUpdate, offset, useFloating } from '@floating-ui/react';
-import { useContext, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
+import { useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
 import { FixedSizeList } from 'react-window';
 
-import { type GrafanaTheme2, ThemeContext } from '@grafana/data';
+import { type GrafanaTheme2 } from '@grafana/data';
 
+import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 import { type CompletionItem, type CompletionItemGroup, CompletionItemKind } from '../../types/completion';
 import { SelectionReference } from '../../utils/SelectionReference';
 import { getPositioningMiddleware } from '../../utils/floating';
@@ -31,27 +32,23 @@ export interface TypeaheadMenu {
   insertSuggestion: () => void;
 }
 
-function deriveListState(groupedItems: CompletionItemGroup[], theme: GrafanaTheme2) {
-  const allItems = flattenGroupItems(groupedItems);
-  const longestLabel = calculateLongestLabel(allItems);
-  const { listWidth, listHeight, itemHeight } = calculateListSizes(theme, allItems, longestLabel);
-  return { allItems, listWidth, listHeight, itemHeight };
+function useTypeaheadList(groupedItems: CompletionItemGroup[]) {
+  const theme = useTheme2();
+
+  return useMemo(() => {
+    const allItems = flattenGroupItems(groupedItems);
+    const longestLabel = calculateLongestLabel(allItems);
+    const { listWidth, listHeight, itemHeight } = calculateListSizes(theme, allItems, longestLabel);
+    return { allItems, listWidth, listHeight, itemHeight };
+  }, [groupedItems, theme]);
 }
 
 export function Typeahead({ prefix, isOpen = false, groupedItems, menuRef, onSelectSuggestion }: Props) {
-  const theme = useContext(ThemeContext);
   const listRef = useRef<FixedSizeList>(null);
 
   const [hoveredItem, setHoveredItem] = useState<number | null>(null);
   const [typeaheadIndex, setTypeaheadIndex] = useState<number | null>(null);
-
-  // The flattened items and list dimensions are purely derived from the grouped items, so memoize
-  // them. The reference dep is enough to skip recomputes on hover/selection re-renders (those don't
-  // change `groupedItems`), which is what the original isEqual guard was protecting against.
-  const { allItems, listWidth, listHeight, itemHeight } = useMemo(
-    () => deriveListState(groupedItems, theme),
-    [groupedItems, theme]
-  );
+  const { allItems, listWidth, listHeight, itemHeight } = useTypeaheadList(groupedItems);
 
   // Reset the highlighted suggestion whenever the items change. Assigning state during render is the
   // React-recommended way to adjust state in response to a changed prop: it re-renders immediately
@@ -110,7 +107,7 @@ export function Typeahead({ prefix, isOpen = false, groupedItems, menuRef, onSel
     listRef.current.scrollToItem(typeaheadIndex);
   }, [typeaheadIndex]);
 
-  const styles = getStyles(theme);
+  const styles = useStyles2(getStyles);
 
   const showDocumentation = hoveredItem || typeaheadIndex;
   const documentationItem = allItems[hoveredItem ? hoveredItem : typeaheadIndex || 0];

--- a/packages/grafana-ui/src/slate-plugins/suggestions.tsx
+++ b/packages/grafana-ui/src/slate-plugins/suggestions.tsx
@@ -1,7 +1,7 @@
 import { debounce, sortBy } from 'lodash';
 import { type Editor, type Plugin as SlatePlugin } from 'slate-react';
 
-import { Typeahead } from '../components/Typeahead/Typeahead';
+import { Typeahead, type TypeaheadMenu } from '../components/Typeahead/Typeahead';
 import {
   type CompletionItem,
   type SuggestionsState,
@@ -32,7 +32,7 @@ export function SuggestionsPlugin({
   onWillApplySuggestion?: (suggestion: string, state: SuggestionsState) => string;
   portalOrigin: string;
 }): SlatePlugin {
-  let typeaheadRef: Typeahead;
+  let typeaheadRef: TypeaheadMenu;
   let state: SuggestionsState = {
     groupedItems: [],
     typeaheadPrefix: '',
@@ -206,7 +206,7 @@ export function SuggestionsPlugin({
         <>
           {children}
           <Typeahead
-            menuRef={(menu: Typeahead) => (typeaheadRef = menu)}
+            menuRef={(menu) => (typeaheadRef = menu)}
             origin={portalOrigin}
             prefix={state.typeaheadPrefix}
             isOpen={!!state.groupedItems.length}


### PR DESCRIPTION
**What is this feature?**

Refactors the `grafana-ui` `Typeahead` component from a class component to a function component using hooks (`useState`, `useMemo`, `useRef`, `useEffect`, `useContext`), and updates its only consumer, the Slate `SuggestionsPlugin`, to use the new exported `TypeaheadMenu` imperative-handle type. The imperative `moveMenuIndex`/`insertSuggestion` methods are still exposed via the existing `menuRef` callback prop, the derived item list and dimensions are now memoized, and the selection reset on changed items uses the documented render-phase state-adjustment pattern. The obsolete `react-prefer-function-component` ESLint suppression was pruned automatically.

**Why do we need this feature?**

Class components are legacy; moving to a function component keeps the code consistent with the rest of the codebase and removes a lint suppression.

**Who is this feature for?**

Grafana frontend developers; there is no user-facing behaviour change.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

`Typeahead` is not exported from the package's public barrel, so the `TypeaheadMenu` type change is internal-only and not a public API break.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
