### PR TITLE
DataPro (migration): Migrate `LogsContainer.tsx`

### DIFF
--- a/public/app/features/explore/Logs/LogsContainer.tsx
+++ b/public/app/features/explore/Logs/LogsContainer.tsx
@@ -21,7 +21,7 @@ import {
   hasQueryModificationSupport,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { PanelChrome } from '@grafana/ui';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
@@ -124,15 +124,7 @@ const LogsContainer = memo(function LogsContainer({
       }
       const mustCheck = !instances[query.refId] || instances[query.refId].uid !== query.datasource.uid;
       if (mustCheck) {
-        dsPromises.push(
-          new Promise((resolve) => {
-            getDataSourceSrv()
-              .get(query.datasource)
-              .then((ds) => {
-                resolve({ ds, refId: query.refId });
-              });
-          })
-        );
+        dsPromises.push(getDataSourceInstance(query.datasource).then((ds) => ({ ds, refId: query.refId })));
       }
     }
 


### PR DESCRIPTION
>[!NOTE]
> @grafana/observability-logs team, this file technically belongs to your team, but I didn't realize until after I migrated it 😆 

## Description
Migrate `LogsContainer` off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

## Changes
* Replaced `getDataSourceSrv().get()` with `getDataSourceInstance()` for mixed-mode datasource resolution.
* Removed the redundant `new Promise` wrapper, since `getDataSourceInstance()` already returns a promise.

## Risks
* Low. Only affects datasource resolution in Explore's mixed-mode Logs panel (log context, query modification/filter support). Behaviour is unchanged; `getDataSourceInstance` falls back to the legacy service if its cache is empty.

## Demo
N/A — no user-facing changes.

## Testing Instructions
* In Explore, select the `-- Mixed --` datasource and run log queries against two different log datasources.
* Verify log row context, "show context", and label/string filtering still work for each query.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable