### PR TITLE
fix: duplicate legends in testdata source + mathexp

### DIFF
--- a/pkg/expr/converter.go
+++ b/pkg/expr/converter.go
@@ -357,11 +357,23 @@ func checkIfSeriesNeedToBeFixed(frames []*data.Frame, datasourceType string) fun
 		}
 		if good {
 			return func(series mathexp.Series, valueField *data.Field) {
+				name := selector(valueField)
 				series.SetLabels(data.Labels{
-					nameLabelName: selector(valueField),
+					nameLabelName: name,
 				})
+				setSyntheticNameDisplayName(series, name)
 			}
 		}
 	}
 	return nil
+}
+
+func setSyntheticNameDisplayName(series mathexp.Series, name string) {
+	field := series.AsDataFrame().Fields[1]
+	if field.Config == nil {
+		field.Config = &data.FieldConfig{}
+	}
+	if field.Config.DisplayName == "" && field.Config.DisplayNameFromDS == "" {
+		field.Config.DisplayNameFromDS = name
+	}
 }

--- a/pkg/expr/converter_test.go
+++ b/pkg/expr/converter_test.go
@@ -28,6 +28,26 @@ func TestConvertDataFramesToResults(t *testing.T) {
 
 	t.Run("should add name label if no labels and specific data source", func(t *testing.T) {
 		supported := []string{datasources.DS_GRAPHITE, datasources.DS_TESTDATA}
+
+		t.Run("sets display name from synthetic name label", func(t *testing.T) {
+			frames := []*data.Frame{
+				data.NewFrame("",
+					data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
+					data.NewField("A-series", nil, []*float64{new(2.0)})),
+			}
+
+			resultType, res, err := converter.Convert(context.Background(), datasources.DS_TESTDATA, frames)
+			require.NoError(t, err)
+			assert.Equal(t, "single frame series", resultType)
+			require.Len(t, res.Values, 1)
+
+			series, ok := res.Values[0].(mathexp.Series)
+			require.True(t, ok)
+			valueField := series.AsDataFrame().Fields[1]
+			require.Equal(t, data.Labels{nameLabelName: "A-series"}, valueField.Labels)
+			require.NotNil(t, valueField.Config)
+			require.Equal(t, "A-series", valueField.Config.DisplayNameFromDS)
+		})
 		t.Run("when only field name is specified", func(t *testing.T) {
 			t.Run("use value field names if one frame - many series", func(t *testing.T) {
 				supported := []string{datasources.DS_GRAPHITE, datasources.DS_TESTDATA}


### PR DESCRIPTION
I'm open to other ideas for how to fix this, but the issue has the reproduction steps which I've copied below:

1. add new panel
2. choose grafana-testdata-datasource
3. leave on random walk or change to CSV Metric Values or any other scenario
4. Add expression, choose math
5. type "1" as the expression
6. verify that the series name/label/alias is now "A-series A-series"
7. change Alias to "2026" or something else and see that it stays duplicated.

Fixes #125691
