### PR TITLE
DataPro (migration): Migrate `Explore.tsx`

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -20,7 +20,8 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
+import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import {
   type AdHocFilterItem,
@@ -202,7 +203,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
     if (!query) {
       return false;
     }
-    const ds = await getDataSourceSrv().get(query.datasource);
+    const ds = await getDataSourceInstance(query.datasource);
     if (hasToggleableQueryFiltersSupport(ds) && ds.queryHasFilter(query, { key, value: value.toString() })) {
       return true;
     }
@@ -270,7 +271,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
       if (datasource == null) {
         return query;
       }
-      const ds = await getDataSourceSrv().get(datasource);
+      const ds = await getDataSourceInstance(datasource);
       const toggleableFilters = ['ADD_FILTER', 'ADD_FILTER_OUT'];
       if (hasToggleableQueryFiltersSupport(ds) && toggleableFilters.includes(modification.type)) {
         return ds.toggleQueryFilter(query, {
@@ -322,14 +323,14 @@ export class Explore extends PureComponent<Props, ExploreState> {
        * More data source may struggle with this setting: https://github.com/grafana/grafana/issues/112075
        * We're making it enabled for tempo only and will try to make it optional for other data sources in the future.
        */
-      const dsType = getDataSourceSrv().getInstanceSettings({ uid: options?.datasourceUid })?.type;
+      const dsType = (await getDataSourceInstanceSettings({ uid: options?.datasourceUid }))?.type;
       if (dsType === 'tempo' || options?.queries?.every((q) => q.datasource?.type === 'tempo')) {
         compact = true;
       }
 
       this.props.splitOpen(options ? { ...options, compact } : options);
       if (options && this.props.datasourceInstance) {
-        const target = (await getDataSourceSrv().get(options.datasourceUid)).type;
+        const target = (await getDataSourceInstanceSettings(options.datasourceUid))?.type;
         const source =
           this.props.datasourceInstance.uid === MIXED_DATASOURCE_NAME
             ? get(this.props.queries, '0.datasource.type')


### PR DESCRIPTION
## Description
Migrate `Explore.tsx` off the deprecated synchronous `getDataSourceSrv()` API to the new async datasource APIs from `@grafana/runtime/unstable`.

## Changes
* Replaced `getDataSourceSrv().get()` with `getDataSourceInstance()` in `isFilterLabelActive` and `onModifyQueries` (both need the full datasource instance).
* Replaced the two `.type` reads in `onSplitOpen` with `getDataSourceInstanceSettings()`; switched the `target` lookup from `.get()` to settings so we no longer load the full plugin instance just to read `.type`.
* Removed the now-unused `getDataSourceSrv` import (kept `reportInteraction` on `@grafana/runtime`).

## Risks
* Low. Affects Explore's Logs Details filtering (filter for/out, query modification) and the split-view open flow (tempo compact mode + split-view tracking). Behaviour is unchanged; the new APIs fall back to the legacy service if their cache is empty.
* `target` in split-view tracking is now `string | undefined` (settings may be undefined), which `reportInteraction` accepts.

## Demo
N/A — no user-facing changes.

## Testing Instructions
* In Explore, run a log query and use Logs Details to filter for/out a label; confirm the query updates.
* Open a panel in split view from a Tempo datasource and confirm it opens in compact mode; verify the `grafana_explore_split_view_opened` interaction still reports correct `source`/`target`.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable