### PR TITLE
DataPro (migration): Migrate `RecentQueriesList.tsx`

### DIFF
--- a/public/app/features/explore/RecentQueries/RecentQueriesList.test.tsx
+++ b/public/app/features/explore/RecentQueries/RecentQueriesList.test.tsx
@@ -57,13 +57,11 @@ jest.mock('@grafana/data', () => {
   };
 });
 
-// Mock getDataSourceSrv for datasource resolution
-const mockGet = jest.fn();
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => ({
-    get: mockGet,
-  }),
+// Mock getDataSourceInstance so datasource resolution
+const mockGetDataSourceInstance = jest.fn();
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: (uid: string) => mockGetDataSourceInstance(uid),
 }));
 
 function makeQuery(id: string, dsUid: string, dsName: string, createdAt: number): RichHistoryQuery {
@@ -107,7 +105,7 @@ describe('RecentQueriesList', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGet.mockImplementation((uid: string) => {
+    mockGetDataSourceInstance.mockImplementation((uid: string) => {
       if (uid === 'ds-prom') {
         return Promise.resolve(makeDsApi('ds-prom', '/img/prometheus.svg'));
       }
@@ -123,14 +121,14 @@ describe('RecentQueriesList', () => {
       render(<RecentQueriesList {...defaultProps} isLoading={true} />);
       expect(screen.getByText(/loading/i)).toBeInTheDocument();
       // Let useAsync settle to avoid act() warnings
-      await waitFor(() => expect(mockGet).not.toHaveBeenCalled());
+      await waitFor(() => expect(mockGetDataSourceInstance).not.toHaveBeenCalled());
     });
 
     it('does not show query rows when loading', async () => {
       render(<RecentQueriesList {...defaultProps} isLoading={true} queries={allQueries} />);
       expect(screen.queryByTestId('recent-query-row')).not.toBeInTheDocument();
       // Let useAsync settle
-      await waitFor(() => expect(mockGet).toHaveBeenCalled());
+      await waitFor(() => expect(mockGetDataSourceInstance).toHaveBeenCalled());
     });
   });
 
@@ -139,13 +137,13 @@ describe('RecentQueriesList', () => {
       render(<RecentQueriesList {...defaultProps} queries={[]} />);
       expect(screen.getByText(/no recent queries found/i)).toBeInTheDocument();
       // Let useAsync settle (empty queries = no DS calls)
-      await waitFor(() => expect(mockGet).not.toHaveBeenCalled());
+      await waitFor(() => expect(mockGetDataSourceInstance).not.toHaveBeenCalled());
     });
 
     it('does not show empty state when loading', async () => {
       render(<RecentQueriesList {...defaultProps} queries={[]} isLoading={true} />);
       expect(screen.queryByText(/no recent queries found/i)).not.toBeInTheDocument();
-      await waitFor(() => expect(mockGet).not.toHaveBeenCalled());
+      await waitFor(() => expect(mockGetDataSourceInstance).not.toHaveBeenCalled());
     });
   });
 
@@ -187,7 +185,7 @@ describe('RecentQueriesList', () => {
 
   describe('datasource resolution failure', () => {
     it('renders rows with fallback when datasource resolution fails', async () => {
-      mockGet.mockRejectedValue(new Error('not found'));
+      mockGetDataSourceInstance.mockRejectedValue(new Error('not found'));
       const queries = [makeQuery('q1', 'ds-missing', 'Missing DS', jan3)];
       render(<RecentQueriesList {...defaultProps} queries={queries} />);
       // Wait for DS resolution attempt to complete

--- a/public/app/features/explore/RecentQueries/RecentQueriesList.tsx
+++ b/public/app/features/explore/RecentQueries/RecentQueriesList.tsx
@@ -4,7 +4,7 @@ import { useAsync } from 'react-use';
 
 import { type DataSourceApi, type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { EmptyState, ScrollContainer, Spinner, Text, useStyles2 } from '@grafana/ui';
 import { createQueryText, mapQueriesToHeadings } from 'app/core/utils/richHistory';
 import { type SortOrder } from 'app/core/utils/richHistoryTypes';
@@ -50,7 +50,7 @@ export const RecentQueriesList = memo(function RecentQueriesList({
     const entries = await Promise.all(
       uniqueDsUids.map(async (uid) => {
         try {
-          const dsApi = await getDataSourceSrv().get(uid);
+          const dsApi = await getDataSourceInstance(uid);
           return [uid, dsApi] as const;
         } catch {
           return [uid, undefined] as const;


### PR DESCRIPTION
## Description
Migrate `RecentQueriesList` off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

## Changes
* Replaced `getDataSourceSrv().get(uid)` with `getDataSourceInstance(uid)` in the `useAsync` resolver that maps datasource UIDs to their API instances.
* Updated `RecentQueriesList.test.tsx` to mock `getDataSourceInstance` instead of `getDataSourceSrv().get`, so resolution is fed through the new async API and avoids the cache-miss fallback warning (`jest-fail-on-console`).

## Risks
* Low. Only affects the Recent Queries list (datasource logos and per-query display text). The resolved instance is still the full `DataSourceApi`, so `getQueryDisplayText` behaviour is unchanged; the new API falls back to the legacy service if its cache is empty.

## Demo
N/A — no user-facing changes.

## Testing Instructions
* Open Explore → Query history / Recent queries with queries from multiple datasources.
* Confirm each row shows the correct datasource logo and query display text, and that resolution failures still render rows with a sensible fallback.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable