### PR TITLE
Dashboards: Show a disabled resize hint on auto-grid panels in edit mode

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.test.tsx
@@ -1,0 +1,58 @@
+import { act } from '@testing-library/react';
+import { render, screen } from 'test/test-utils';
+
+import { getPanelPlugin } from '@grafana/data/test';
+import { setPluginImportUtils } from '@grafana/runtime';
+import { VizPanel } from '@grafana/scenes';
+
+import { activateFullSceneTree } from '../../utils/test-utils';
+import { DashboardScene } from '../DashboardScene';
+
+import { AutoGridItem } from './AutoGridItem';
+import { AutoGridLayout } from './AutoGridLayout';
+import { AutoGridLayoutManager } from './AutoGridLayoutManager';
+
+setPluginImportUtils({
+  importPanelPlugin: () => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: () => undefined,
+});
+
+const RESIZE_DISABLED_LABEL = 'Panels cannot be resized in auto layout';
+
+function buildTestScene({ isEditing }: { isEditing: boolean }) {
+  const panel = new VizPanel({ title: 'Panel 1', key: 'panel-1', pluginId: 'table' });
+  const gridItem = new AutoGridItem({ key: 'grid-item-1', body: panel });
+  const manager = new AutoGridLayoutManager({
+    key: 'test-AutoGridLayoutManager',
+    layout: new AutoGridLayout({ children: [gridItem] }),
+  });
+  const dashboard = new DashboardScene({ body: manager, isEditing });
+
+  activateFullSceneTree(dashboard);
+
+  return { dashboard, gridItem };
+}
+
+async function renderItem(isEditing: boolean) {
+  const { gridItem } = buildTestScene({ isEditing });
+  render(<gridItem.Component model={gridItem} />);
+  // The VizPanel loads its plugin asynchronously; flush so the resulting state
+  // update settles inside act() and does not trigger console warnings.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe('AutoGridItemRenderer', () => {
+  it('shows the resize-disabled hint while editing', async () => {
+    await renderItem(true);
+
+    expect(screen.getByLabelText(RESIZE_DISABLED_LABEL)).toBeInTheDocument();
+  });
+
+  it('does not show the resize-disabled hint when not editing', async () => {
+    await renderItem(false);
+
+    expect(screen.queryByLabelText(RESIZE_DISABLED_LABEL)).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
@@ -2,8 +2,9 @@ import { css, cx } from '@emotion/css';
 import { memo, useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { LazyLoader, sceneGraph, type SceneComponentProps, type VizPanel } from '@grafana/scenes';
-import { useElementSelection, useStyles2 } from '@grafana/ui';
+import { Icon, Tooltip, useElementSelection, useStyles2 } from '@grafana/ui';
 
 import { type ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { useIsConditionallyHidden } from '../../conditional-rendering/hooks/useIsConditionallyHidden';
@@ -53,6 +54,21 @@ export function AutoGridItemRenderer({ model }: SceneComponentProps<AutoGridItem
           const [isConditionallyHidden, conditionalRenderingClass, conditionalRenderingOverlay, renderHidden] =
             useIsConditionallyHidden(conditionalRendering);
 
+          const resizeDisabledLabel = t(
+            'dashboard.auto-grid-item.resize-disabled-tooltip',
+            'Panels cannot be resized in auto layout'
+          );
+          const resizeDisabledHint = isEditing ? (
+            <Tooltip content={resizeDisabledLabel} placement="top">
+              <Icon
+                name="expand-arrows"
+                size="sm"
+                className={styles.resizeDisabledHint}
+                aria-label={resizeDisabledLabel}
+              />
+            </Tooltip>
+          ) : null;
+
           return isConditionallyHidden && !isEditing && !renderHidden ? null : (
             <div
               {...(addDndContainer
@@ -77,6 +93,7 @@ export function AutoGridItemRenderer({ model }: SceneComponentProps<AutoGridItem
                   >
                     <item.Component model={item} />
                     {conditionalRenderingOverlay}
+                    {resizeDisabledHint}
                   </LazyLoader>
                 ) : (
                   <div
@@ -90,6 +107,7 @@ export function AutoGridItemRenderer({ model }: SceneComponentProps<AutoGridItem
                   >
                     <item.Component model={item} />
                     {conditionalRenderingOverlay}
+                    {resizeDisabledHint}
                   </div>
                 )
               }
@@ -170,5 +188,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   hidden: css({
     display: 'none',
+  }),
+  resizeDisabledHint: css({
+    position: 'absolute',
+    bottom: theme.spacing(0.5),
+    right: theme.spacing(0.5),
+    color: theme.colors.text.secondary,
+    cursor: 'not-allowed',
+    zIndex: 1,
   }),
 });

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5295,6 +5295,9 @@
         "min-width-error": "A number between 50 and 2000 is required"
       }
     },
+    "auto-grid-item": {
+      "resize-disabled-tooltip": "Panels cannot be resized in auto layout"
+    },
     "canvas-actions": {
       "add": {
         "paste": {


### PR DESCRIPTION
**What this PR does / why we need it**:

In the auto-grid layout, panels cannot be resized, but there is no indication of this where users expect to resize a panel — the bottom-right corner that hosts the resize handle in the custom grid layout. This adds a disabled icon with a tooltip "Panels cannot be resized in auto layout" in that corner while the dashboard is being edited, so users understand why dragging there does nothing.

**Which issue(s) this PR fixes**:

Fixes #127273

**Implementation notes**:

- `AutoGridItemRenderer.tsx` renders the hint (a `Tooltip` wrapping an `Icon`) in the bottom-right corner of each panel, gated on `isEditing`.
- Adds the `dashboard.auto-grid-item.resize-disabled-tooltip` i18n string.
- Unit tests in `AutoGridItemRenderer.test.tsx` cover that the hint shows while editing and is hidden otherwise.

**Open questions for reviewers (happy to adjust):**

- **Icon** — I used `expand-arrows` (muted) as it mirrors a resize affordance, but it could read as "resizable". A `lock`-style icon may communicate "disabled" more clearly. What does the team prefer?
- **Visibility** — currently shown on every panel while editing. It could instead be revealed on panel hover (closer to other panel controls). Let me know which you'd like.

**Special notes for your reviewer**:

Frontend-only change.
