### PR TITLE
revert(setting): re-enable HTTP/2 negotiation in remote settings client

### DIFF
--- a/pkg/services/setting/service.go
+++ b/pkg/services/setting/service.go
@@ -178,8 +178,6 @@ type Config struct {
 	// being closed. Defaults to DefaultIdleConnTimeout. Set to a negative value to use the
 	// client-go default.
 	IdleConnTimeout time.Duration
-	// EnableHTTP2 allows HTTP/2 for the client connection. It is disabled by default.
-	EnableHTTP2 bool
 }
 
 // Setting represents the parsed spec of a Setting resource.
@@ -565,13 +563,6 @@ func getRestClient(config Config, log logging.Logger, m clientMetrics) (*rest.RE
 	// Add a default scheme to handle K8s API error responses
 	scheme := runtime.NewScheme()
 
-	// When HTTP/2 is disabled we restrict ALPN to HTTP/1.1 unconditionally.
-	// ALPN only applies to TLS; plain HTTP already uses HTTP/1.1.
-	tlsClientConfig := config.TLSClientConfig
-	if !config.EnableHTTP2 {
-		tlsClientConfig.NextProtos = []string{"http/1.1"}
-	}
-
 	// Create the rate limiter explicitly so we can wrap it with instrumentation
 	rateLimiter := &instrumentedRateLimiter{
 		RateLimiter: flowcontrol.NewTokenBucketRateLimiter(qps, burst),
@@ -580,7 +571,7 @@ func getRestClient(config Config, log logging.Logger, m clientMetrics) (*rest.RE
 
 	restConfig := &rest.Config{
 		Host:            config.URL,
-		TLSClientConfig: tlsClientConfig,
+		TLSClientConfig: config.TLSClientConfig,
 		WrapTransport:   wrapTransport,
 		RateLimiter:     rateLimiter,
 		UserAgent:       userAgent,

--- a/pkg/services/setting/service_test.go
+++ b/pkg/services/setting/service_test.go
@@ -22,7 +22,6 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 )
 
@@ -662,73 +661,6 @@ func TestNew(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, client)
 		assert.True(t, wrapTransportCalled)
-	})
-}
-
-func TestNew_HTTPProtocol(t *testing.T) {
-	settings := []Setting{{Section: "server", Key: "port", Value: "3000"}}
-
-	newHTTP2Server := func(t *testing.T, negotiatedProto *atomic.Int32) *httptest.Server {
-		t.Helper()
-		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			negotiatedProto.Store(int32(r.ProtoMajor))
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(generateSettingsJSON(settings, "")))
-		}))
-		// Offer HTTP/2 via ALPN so the client's protocol preference decides the outcome.
-		server.EnableHTTP2 = true
-		server.StartTLS()
-		t.Cleanup(server.Close)
-		return server
-	}
-
-	newClient := func(t *testing.T, tlsConfig rest.TLSClientConfig, url string, enableHTTP2 bool) Service {
-		t.Helper()
-		client, err := New(Config{
-			URL:             url,
-			WrapTransport:   func(rt http.RoundTripper) http.RoundTripper { return rt },
-			TLSClientConfig: tlsConfig,
-			CacheTTL:        -1,
-			EnableHTTP2:     enableHTTP2,
-		})
-		require.NoError(t, err)
-		return client
-	}
-
-	insecure := rest.TLSClientConfig{Insecure: true}
-	ctx := request.WithNamespace(context.Background(), "test-namespace")
-
-	t.Run("should negotiate HTTP/1.1 when HTTP/2 is not enabled", func(t *testing.T) {
-		var proto atomic.Int32
-		server := newHTTP2Server(t, &proto)
-
-		_, err := newClient(t, insecure, server.URL, false).List(ctx, metav1.LabelSelector{})
-
-		require.NoError(t, err)
-		assert.Equal(t, int32(1), proto.Load(), "client should negotiate HTTP/1.1 by default")
-	})
-
-	t.Run("should negotiate HTTP/1.1 when HTTP/2 is disabled but caller sets h2 in NextProtos", func(t *testing.T) {
-		var proto atomic.Int32
-		server := newHTTP2Server(t, &proto)
-
-		// EnableHTTP2 is the source of truth: a caller-supplied h2 preference must
-		// not re-admit HTTP/2 while the flag is off.
-		tlsConfig := rest.TLSClientConfig{Insecure: true, NextProtos: []string{"h2", "http/1.1"}}
-		_, err := newClient(t, tlsConfig, server.URL, false).List(ctx, metav1.LabelSelector{})
-
-		require.NoError(t, err)
-		assert.Equal(t, int32(1), proto.Load(), "EnableHTTP2=false should force HTTP/1.1 regardless of NextProtos")
-	})
-
-	t.Run("should negotiate HTTP/2 when EnableHTTP2 is set", func(t *testing.T) {
-		var proto atomic.Int32
-		server := newHTTP2Server(t, &proto)
-
-		_, err := newClient(t, insecure, server.URL, true).List(ctx, metav1.LabelSelector{})
-
-		require.NoError(t, err)
-		assert.Equal(t, int32(2), proto.Load(), "client should negotiate HTTP/2 when EnableHTTP2 is set")
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Backs out the change that forced the remote settings client to negotiate HTTP/1.1 by removing the EnableHTTP2 config flag and the unconditional ALPN restriction, restoring default protocol negotiation. The idle-connection bounding introduced in the same original change is intentionally retained, as it is unrelated to protocol selection.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
