### PR TITLE
Make traces LBAC docs live for public preview

### DIFF
--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
@@ -10,14 +10,11 @@ labels:
     - cloud
 title: Configure team LBAC for data sources for Tempo
 weight: 350
-_build:
-  list: false
-noindex: true
 ---
 
 # Configure team label-based access control for Tempo or Cloud Traces
 
-{{< docs/private-preview product="Label-based access control for traces" >}}
+{{< docs/public-preview product="Label-based access control for traces" >}}
 
 Team label-based access control (LBAC) for Cloud Traces or Tempo lets you restrict which spans teams can access by defining rules using trace attributes. LBAC provides fine-grained, team-based access control within a single tenant and mirrors the experience used for logs and metrics LBAC in Grafana Cloud.
 

--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
@@ -1,6 +1,6 @@
 ---
-title: "Configure Team LBAC for Tempo or Cloud Traces"
-description: "Use label-based access control (LBAC) to restrict Cloud Traces data by team and attribute rules."
+title: 'Configure Team LBAC for Tempo or Cloud Traces'
+description: 'Use label-based access control (LBAC) to restrict Cloud Traces data by team and attribute rules.'
 keywords:
   - tempo
   - datasource
@@ -17,7 +17,6 @@ weight: 350
 {{< docs/public-preview product="Label-based access control for traces" >}}
 
 Team label-based access control (LBAC) for Cloud Traces or Tempo lets you restrict which spans teams can access by defining rules using trace attributes. LBAC provides fine-grained, team-based access control within a single tenant and mirrors the experience used for logs and metrics LBAC in Grafana Cloud.
-
 
 {{< admonition type="note" >}}
 Unlike logs and metrics, which also support data source-level LBAC through cloud access policies, traces LBAC is currently available only at the team level.

--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
@@ -18,13 +18,16 @@ weight: 350
 
 Team label-based access control (LBAC) for Cloud Traces or Tempo lets you restrict which spans teams can access by defining rules using trace attributes. LBAC provides fine-grained, team-based access control within a single tenant and mirrors the experience used for logs and metrics LBAC in Grafana Cloud.
 
+
+{{< admonition type="note" >}}
 Unlike logs and metrics, which also support data source-level LBAC through cloud access policies, traces LBAC is currently available only at the team level.
+{{< /admonition >}}
 
 Grafana uses the term LBAC as an umbrella term for label-based access control for all data sources.
 Traces use **attributes**, not labels, for access control, but the Grafana UI surfaces this functionality as LBAC for consistency.
 
 This feature only applies to Grafana Cloud Traces, specifically, the Cloud-provisioned tracing data source.
-If you want to use this feature with a Tempo data source, contact Grafana Support to make sure that this is enabled in your organization.
+If you want to use this feature with a Tempo data source, contact Grafana Support to make sure that this is enabled in your organization. Data source LBAC is currently in private preview.
 
 ## How LBAC works
 

--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
@@ -27,7 +27,6 @@ Grafana uses the term LBAC as an umbrella term for label-based access control fo
 Traces use **attributes**, not labels, for access control, but the Grafana UI surfaces this functionality as LBAC for consistency.
 
 This feature only applies to Grafana Cloud Traces, specifically, the Cloud-provisioned tracing data source.
-If you want to use this feature with a Tempo data source, contact Grafana Support to make sure that this is enabled in your organization. Data source LBAC is currently in private preview.
 
 ## How LBAC works
 


### PR DESCRIPTION
**What is this feature?**

This PR changes the traces LBAC doc from private to public preview. It also makes the documentation public. 

Merge this PR whenever the traces LBAC enters public preview and not before. 

**Which issue(s) does this PR fix?**:



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
