### PR TITLE
ci: pin all GitHub Actions to full commit SHAs to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/alerting-swagger-gen.yml
+++ b/.github/workflows/alerting-swagger-gen.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 2
           persist-credentials: false

--- a/.github/workflows/alerting-update-module.yml
+++ b/.github/workflows/alerting-update-module.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Check if update branch exists
@@ -163,7 +163,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Send Slack Message
         if: steps.compare-commits.outputs.needs_update == 'true'
-        uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message/v2.0.4
+        uses: grafana/shared-workflows/actions/send-slack-message@2d985e9ff08e467946216a16a3a59fab5bb9e6cf # send-slack-message/v2.0.4
         with:
           method: 'chat.postMessage'
           # send to alerting-reviews channel

--- a/.github/workflows/analytics-events-report.yml
+++ b/.github/workflows/analytics-events-report.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       changed: ${{ steps.detect-changes.outputs.backend }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
     name: Validate Backend Configs
     runs-on: ubuntu-x64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Setup Go

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       changed: ${{ steps.detect-changes.outputs.backend }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Setup Go
@@ -89,7 +89,7 @@ jobs:
     steps:
       # Set up repository clone
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Get GitHub App token

--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -40,7 +40,7 @@ jobs:
           }' "$GITHUB_EVENT_PATH" > /tmp/pr_info.json
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: pr_info
           path: /tmp/pr_info.json

--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -35,7 +35,7 @@ jobs:
           permission_set: open_pr
 
       - name: Download PR info artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         id: download-pr-info
         with:
           github-token: ${{ github.token }}
@@ -61,7 +61,7 @@ jobs:
           echo "PR number: $PR_NUMBER"
 
       - name: Checkout Grafana
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 2

--- a/.github/workflows/build-docker-variants.yml
+++ b/.github/workflows/build-docker-variants.yml
@@ -99,9 +99,9 @@ jobs:
             artifact-name-prefix: artifacts-docker-distroless-slim
             tag-suffix: "-distroless-slim"
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.4
+      - uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/build-go-matrix.yml
+++ b/.github/workflows/build-go-matrix.yml
@@ -70,7 +70,7 @@ jobs:
             goos: windows
             goarch: arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Setup Go
@@ -121,7 +121,7 @@ jobs:
             goos: windows
             goarch: arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Get GitHub App token
@@ -151,9 +151,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
+      - uses: grafana/shared-workflows/actions/dockerhub-login@c6d954f7cd9c0022018982e01268de6cb75b913c # dockerhub-login/v1.0.2
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-go

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -41,7 +41,7 @@ jobs:
           github_app: grafana-writer
           permission_set: ${{ startsWith(github.ref_name, 'release-') && 'release-writer' || 'release-writer-main' }}
       - name: Checkout Grafana
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Update package.json versions
         uses: ./pkg/build/actions/bump-version
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -77,7 +77,7 @@ jobs:
           github_app: grafana-pr-automation
           permission_set: ${{ startsWith(github.ref_name, 'release-') && 'release' || 'main' }}
       - name: "Checkout Grafana repo"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5"
         with:
           ref: main
           sparse-checkout: |

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -44,7 +44,7 @@ jobs:
       changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
       main-sha: ${{ steps.get-main-sha.outputs.sha }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true
           fetch-depth: 0
@@ -174,7 +174,7 @@ jobs:
         codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: './pr'
           persist-credentials: false
@@ -217,7 +217,7 @@ jobs:
 
       - name: Checkout main branch
         if: steps.check-affected.outputs.affected == 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ needs.detect-changes.outputs.main-sha }}
           path: './main'
@@ -279,7 +279,7 @@ jobs:
       - name: Upload PR HTML coverage report
         if: steps.check-affected.outputs.affected == 'true'
         id: upload-coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: frontend-coverage-${{ steps.coverage-dir.outputs.slug }}
           path: ./pr/coverage/by-team/${{ steps.coverage-dir.outputs.path }}/html

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -11,8 +11,8 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: actions/checkout@v5
-      - uses: grafana/shared-workflows/actions/cleanup-branches@cleanup-branches/v0.2.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: grafana/shared-workflows/actions/cleanup-branches@c906affb19f070fde9dce56e0db8053c490946cc # cleanup-branches/v0.2.1
         with:
           dry-run: false
           max-date: "1 month ago"

--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       # Checks-out your repository, which is validated in the next step
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: GitHub CODEOWNERS Validator

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -40,7 +40,7 @@ jobs:
           github_app: grafana-pr-automation
 
       - name: Run commands
-        uses: grafana/grafana-github-actions/commands@main
+        uses: grafana/grafana-github-actions/commands@3c62d35c5a66e730186a338e45aeb8fa784e2d56 # main
         with:
           metricsWriteAPIKey: ""
           token: ${{ steps.get-github-app-token.outputs.token }}

--- a/.github/workflows/community-release.yml
+++ b/.github/workflows/community-release.yml
@@ -34,14 +34,14 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
           # Secrets placed in the ci/repo/grafana/grafana/community_release path in Vault
           repo_secrets: |
             GRAFANABOT_FORUM_KEY=community_release:GRAFANABOT_FORUM_KEY
 
       - name: Run community-release (manually invoked)
-        uses: grafana/grafana-github-actions-go/community-release@main
+        uses: grafana/grafana-github-actions-go/community-release@f49c00e5c4585f724717bdbb003c3560a3c1d849 # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ inputs.version }}

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -27,7 +27,7 @@ jobs:
       next_version: ${{ steps.versions.outputs.next_version }}
       release_branch: ${{ steps.versions.outputs.release_branch }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       # Derive everything from main's current version. main sits at the next minor's
@@ -67,7 +67,7 @@ jobs:
         with:
           github_app: grafana-writer
           permission_set: release-writer-main
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ steps.get-writer-app-token.outputs.token }}
           persist-credentials: false
@@ -124,7 +124,7 @@ jobs:
         with:
           github_app: grafana-writer
           permission_set: release-writer-main
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ steps.get-writer-app-token.outputs.token }}
           persist-credentials: false

--- a/.github/workflows/create-security-branch.yml
+++ b/.github/workflows/create-security-branch.yml
@@ -87,7 +87,7 @@ jobs:
           permission_set: ${{ steps.app-config.outputs.permission_set }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
           repository: ${{ inputs.repository }}

--- a/.github/workflows/create-security-patch-from-security-mirror.yml
+++ b/.github/workflows/create-security-patch-from-security-mirror.yml
@@ -51,7 +51,7 @@ jobs:
       # labels list extra branches to copy the patch into.
       - name: Resolve VUL ID and backport targets
         id: labels
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -75,7 +75,7 @@ jobs:
       # (success, not failure — a missing label isn't an error, just nothing to do yet).
       - name: Comment when VUL ID is missing
         if: ${{ steps.labels.outputs.vul_id == '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             await github.rest.issues.createComment({
@@ -128,7 +128,7 @@ jobs:
       # visible, self-contained notification with its own run link.
       - name: Comment dispatch status
         if: ${{ steps.labels.outputs.vul_id != '' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           VUL_ID: ${{ steps.labels.outputs.vul_id }}
           BACKPORT_REFS: ${{ steps.labels.outputs.backport_refs }}

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
@@ -65,7 +65,7 @@ jobs:
           echo "deploy-name=pr_${PR_NUMBER}_${SANITIZED_BRANCH:0:30}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Storybook
-        uses: grafana/shared-workflows/actions/push-to-gcs@main
+        uses: grafana/shared-workflows/actions/push-to-gcs@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
           environment: prod
           bucket: ${{ env.BUCKET_NAME }}

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       changed-frontend-packages: ${{ steps.detect-changes.outputs.frontend-packages }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           ref: ${{ inputs.version }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Log in to GCS
         id: login-to-gcs
-        uses: grafana/shared-workflows/actions/login-to-gcs@main
+        uses: grafana/shared-workflows/actions/login-to-gcs@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
           environment: prod
           service_account: github-gf-storybook-deploy@grafanalabs-workload-identity.iam.gserviceaccount.com
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload new storybook
         id: upload-new-storybook
-        uses: grafana/shared-workflows/actions/push-to-gcs@main
+        uses: grafana/shared-workflows/actions/push-to-gcs@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
           environment: prod
           bucket: ${{ env.BUCKET_NAME }}

--- a/.github/workflows/detect-breaking-changes-levitate.yml
+++ b/.github/workflows/detect-breaking-changes-levitate.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: './pr'
           persist-credentials: false
@@ -53,7 +53,7 @@ jobs:
         run: zip -r ./pr_built_packages.zip ./packages/**/*.tgz
 
       - name: Upload build output as artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: buildPr
           path: './pr/pr_built_packages.zip'
@@ -69,12 +69,12 @@ jobs:
 
     steps:
       # We need to check out the PR's branch to get actions from the same branch, so if they change in a PR this action can pick up those changes
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: './pr'
           persist-credentials: false
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: './base'
           ref: ${{ github.event.pull_request.base.ref }}
@@ -100,7 +100,7 @@ jobs:
         run: zip -r ./base_built_packages.zip ./packages/**/*.tgz
 
       - name: Upload build output as artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: buildBase
           path: './base/base_built_packages.zip'
@@ -116,7 +116,7 @@ jobs:
       id-token: 'write'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
@@ -127,12 +127,12 @@ jobs:
         uses: ./.github/actions/yarn-install
 
       - name: Get built packages from pr
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: buildPr
 
       - name: Get built packages from base
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: buildBase
 
@@ -175,7 +175,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Upload check output as artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: levitate
           path: levitate/
@@ -197,17 +197,17 @@ jobs:
         with:
           github_app: grafana-pr-automation
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
       - name: 'Download artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: levitate
 
       - name: Parsing levitate result
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         id: levitate-run
         with:
           script: |
@@ -218,7 +218,7 @@ jobs:
       # Check if label exists
       - name: Check if "levitate breaking change" label exists
         id: does-label-exist
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
@@ -312,7 +312,7 @@ jobs:
       # Add the label
       - name: Add "levitate breaking change" label
         if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
         with:
@@ -328,7 +328,7 @@ jobs:
       # Remove label (no more breaking changes)
       - name: Remove "levitate breaking change" label
         if: steps.levitate-run.outputs.exit_code == 0 && steps.does-label-exist.outputs.result == 1
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
         with:
@@ -346,7 +346,7 @@ jobs:
       # Related issue: https://github.com/renovatebot/renovate/issues/1908
       - name: Add "grafana/grafana-frontend-platform" as a reviewer
         if: steps.levitate-run.outputs.exit_code == 1
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         # FIXME: GATB doesn't seem to grant us necessary pull_requests write permissions
         continue-on-error: true
         env:
@@ -365,7 +365,7 @@ jobs:
       # Remove reviewers (no more breaking changes)
       - name: Remove "grafana/grafana-frontend-platform" from the list of reviewers
         if: steps.levitate-run.outputs.exit_code == 0
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         # FIXME: GATB doesn't seem to grant us necessary pull_requests write permissions
         continue-on-error: true
         env:

--- a/.github/workflows/documentation-ci.yml
+++ b/.github/workflows/documentation-ci.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: grafana/vale:latest # zizmor: ignore[unpinned-images]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - uses: grafana/writers-toolkit/vale-action@vale-action/v2 # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/feature-toggles-ci.yml
+++ b/.github/workflows/feature-toggles-ci.yml
@@ -17,7 +17,7 @@ jobs:
       changedbackend: ${{ steps.detect-changes.outputs.backend }}
       changeddocs: ${{ steps.detect-changes.outputs.docs }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -20,7 +20,7 @@ jobs:
       changed-frontend-packages: ${{ steps.detect-changes.outputs.frontend-packages }}
       changed-frontend-dependencies: ${{ steps.detect-changes.outputs.frontend-dependencies }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -42,7 +42,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-x64
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node.js
@@ -61,7 +61,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-x64
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node.js
@@ -92,7 +92,7 @@ jobs:
     env:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node.js
@@ -112,7 +112,7 @@ jobs:
     env:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node
@@ -142,7 +142,7 @@ jobs:
     env:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node
@@ -169,7 +169,7 @@ jobs:
     name: Verify API clients
     runs-on: ubuntu-x64
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node
@@ -200,7 +200,7 @@ jobs:
     name: Verify OpenAPI specs
     runs-on: ubuntu-x64
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node.js
@@ -236,7 +236,7 @@ jobs:
     name: Verify API clients (enterprise)
     runs-on: ubuntu-x64
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node
@@ -275,7 +275,7 @@ jobs:
     runs-on: ubuntu-x64
     steps:
     - name: Checkout build commit
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-x64
     steps:
     - name: Checkout build commit
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
         path: './pr'
@@ -320,7 +320,7 @@ jobs:
         pr_count=$(sed -n 's/.*Found \([0-9]*\) circular.*/\1/p' /tmp/pr-circular-clean.txt)
         echo "$pr_count"
     - name: Checkout main branch
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
         repository: 'grafana/grafana'
@@ -365,7 +365,7 @@ jobs:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false && needs.detect-changes.outputs.changed == 'true'
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Get GitHub App token
@@ -393,7 +393,7 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node.js

--- a/.github/workflows/frontend-perf-tests.yaml
+++ b/.github/workflows/frontend-perf-tests.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
@@ -29,7 +29,7 @@ jobs:
             FSPERF_PASSWORD=frontend_perf_tests:fsperf_password
 
       - name: Authenticate Docker
-        uses: grafana/shared-workflows/actions/login-to-gar@main
+        uses: grafana/shared-workflows/actions/login-to-gar@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         id: login-to-gar
         with:
           registry: 'us-docker.pkg.dev'

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       changed: ${{ steps.detect-changes.outputs.backend }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -39,7 +39,7 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     runs-on: ubuntu-arm64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Setup Go
@@ -61,7 +61,7 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     runs-on: ubuntu-x64-xlarge
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Setup Go

--- a/.github/workflows/i18n-crowdin-create-tasks.yml
+++ b/.github/workflows/i18n-crowdin-create-tasks.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - name: 'Get vault secrets'
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
             # Vault secret paths:
             # - ci/repo/grafana/grafana/grafana-frontend-crowdin-token
             repo_secrets: |
                 CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
       - name: Create tasks in Crowdin
-        uses: grafana/grafana-github-actions/crowdin-create-tasks@main
+        uses: grafana/grafana-github-actions/crowdin-create-tasks@3c62d35c5a66e730186a338e45aeb8fa784e2d56 # main
         with:
           crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 5

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Get GitHub App token
@@ -29,14 +29,14 @@ jobs:
           github_app: grafana-pr-approver
       - name: 'Get vault secrets'
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
             # Vault secret paths:
             # - ci/repo/grafana/grafana/grafana-frontend-crowdin-token
             repo_secrets: |
                 CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
       - name: Download from Crowdin
-        uses: grafana/grafana-github-actions/crowdin-download@main
+        uses: grafana/grafana-github-actions/crowdin-download@3c62d35c5a66e730186a338e45aeb8fa784e2d56 # main
         with:
           crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 5

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -20,19 +20,19 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: 'Get vault secrets'
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
             # Vault secret paths:
             # - ci/repo/grafana/grafana/grafana-frontend-crowdin-token
             repo_secrets: |
                 CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
       - name: Upload to Crowdin
-        uses: grafana/grafana-github-actions/crowdin-upload@main
+        uses: grafana/grafana-github-actions/crowdin-upload@3c62d35c5a66e730186a338e45aeb8fa784e2d56 # main
         with:
           crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 5

--- a/.github/workflows/i18n-verify.yml
+++ b/.github/workflows/i18n-verify.yml
@@ -14,4 +14,4 @@ jobs:
   verify-i18n:
     # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
-    uses: grafana/grafana-github-actions/.github/workflows/verify-i18n.yml@main
+    uses: grafana/grafana-github-actions/.github/workflows/verify-i18n.yml@3c62d35c5a66e730186a338e45aeb8fa784e2d56 # main

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -40,7 +40,7 @@ jobs:
           github_app: grafana-pr-automation
 
       - name: Run Commands
-        uses: grafana/grafana-github-actions/commands@main
+        uses: grafana/grafana-github-actions/commands@3c62d35c5a66e730186a338e45aeb8fa784e2d56 # main
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
           configPath: "issue-opened"

--- a/.github/workflows/lint-build-docs.yml
+++ b/.github/workflows/lint-build-docs.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/migrate-prs.yml
+++ b/.github/workflows/migrate-prs.yml
@@ -46,7 +46,7 @@ jobs:
           github_app: grafana-pr-automation
           permission_set: ${{ startsWith(github.ref_name, 'release-') && 'pr-writer-release' || 'pr-writer-main' }}
       - name: Migrate PRs
-        uses: grafana/grafana-github-actions-go/migrate-open-prs@main
+        uses: grafana/grafana-github-actions-go/migrate-open-prs@f49c00e5c4585f724717bdbb003c3560a3c1d849 # main
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
           ownerRepo: ${{ inputs.ownerRepo }}

--- a/.github/workflows/policybot.yml
+++ b/.github/workflows/policybot.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - run: make .policy.yml

--- a/.github/workflows/pr-build-grafana.yml
+++ b/.github/workflows/pr-build-grafana.yml
@@ -23,7 +23,7 @@ jobs:
       changed: ${{ steps.detect-changes.outputs.frontend == 'true' || steps.detect-changes.outputs.backend == 'true' }}
       frontend: ${{ steps.detect-changes.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -44,7 +44,7 @@ jobs:
     outputs:
       version: ${{ steps.output.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Set up version
@@ -61,7 +61,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node
@@ -82,7 +82,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/build-go
@@ -105,7 +105,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/build-targz
@@ -130,8 +130,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
-      - uses: actions/checkout@v6
+      - uses: grafana/shared-workflows/actions/dockerhub-login@c6d954f7cd9c0022018982e01268de6cb75b913c # dockerhub-login/v1.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -177,7 +177,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-x64
     steps:
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
+      - uses: grafana/shared-workflows/actions/login-to-gar@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         id: login-to-gar
         with:
           registry: 'us-docker.pkg.dev'
@@ -218,11 +218,11 @@ jobs:
       statuses: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
+      - uses: grafana/shared-workflows/actions/login-to-gar@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         id: login-to-gar
         with:
           registry: 'us-docker.pkg.dev'
@@ -233,7 +233,7 @@ jobs:
 
       - name: Get vault secrets
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
           repo_secrets: |
             METICULOUS_API_TOKEN=meticulous-ui:api-token

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Run PR Checks
-        uses: grafana/grafana-github-actions/pr-checks@main
+        uses: grafana/grafana-github-actions/pr-checks@3c62d35c5a66e730186a338e45aeb8fa784e2d56 # main
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           configPath: pr-checks

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-arm64-small
     steps:
       - name: Run PR Commands
-        uses: grafana/grafana-github-actions/commands@main
+        uses: grafana/grafana-github-actions/commands@3c62d35c5a66e730186a338e45aeb8fa784e2d56 # main
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           configPath: pr-commands

--- a/.github/workflows/pr-dependabot-update-go-workspace.yml
+++ b/.github/workflows/pr-dependabot-update-go-workspace.yml
@@ -29,7 +29,7 @@ jobs:
         github_app: grafana-go-workspace-bot
 
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       run-e2e-tests: ${{ steps.detect-changes.outputs.e2e == 'true' || github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -45,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -65,7 +65,7 @@ jobs:
         run: make build-go
 
       - name: Upload backend build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: grafana-backend
           path: bin/
@@ -81,7 +81,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -109,7 +109,7 @@ jobs:
         run: make build-js
 
       - name: Upload frontend build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: grafana-frontend
           path: |
@@ -131,13 +131,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+      - uses: grafana/shared-workflows/actions/dockerhub-login@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
+      - uses: grafana/shared-workflows/actions/login-to-gar@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         if: github.event.pull_request.head.repo.fork == false
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -170,7 +170,7 @@ jobs:
         shardTotal: [8]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -185,14 +185,14 @@ jobs:
 
       # Download the grafana artifacts and stitch them together into a standalone prod-ish Grafana distribution
       - name: Download backend artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: grafana-backend
           path: grafana-server/bin
       - name: Fix binary permissions
         run: chmod +x grafana-server/bin/grafana*
       - name: Download frontend artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: grafana-frontend
           path: grafana-server/public
@@ -266,14 +266,14 @@ jobs:
           echo "View combined logs and HTML report in the 'All Playwright tests complete' job once all tests finish."
           exit 1
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: grafana-server-log-${{ matrix.shard }}
           path: grafana-server/grafana.log
           retention-days: 7
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success() || failure()
         with:
           name: playwright-blob-${{ matrix.shard }}
@@ -293,7 +293,7 @@ jobs:
     steps:
       - name: Download blob reports from GitHub Actions Artifacts
         if: needs.run-playwright-tests.result != 'skipped'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: blobs
           pattern: playwright-blob-*
@@ -317,7 +317,7 @@ jobs:
       - name: Upload HTML report
         if: needs.run-playwright-tests.result != 'skipped'
         id: upload-html
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-html
           path: playwright-report
@@ -368,7 +368,7 @@ jobs:
     steps:
       - name: Download blob reports from GitHub Actions Artifacts
         if: needs.run-playwright-tests.result != 'skipped'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: blobs
           pattern: playwright-blob-*
@@ -406,12 +406,12 @@ jobs:
     runs-on: ubuntu-x64-small
     steps:
       - id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
           repo_secrets: |
             GRAFANA_MISC_STATS_API_KEY=grafana-misc-stats:api_key
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Setup Node.js

--- a/.github/workflows/pr-endpoint-feature-toggle.yml
+++ b/.github/workflows/pr-endpoint-feature-toggle.yml
@@ -16,7 +16,7 @@ jobs:
       backend-strict: ${{ steps.changed-files.outputs.backend_strict_any_changed }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true
           fetch-depth: 0
@@ -79,7 +79,7 @@ jobs:
 
       - name: Checkout code
         if: steps.label-check.outputs.skip != 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           sparse-checkout: .github/workflows/scripts
@@ -98,7 +98,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Check job results

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
       changed: ${{ steps.detect-changes.outputs.frontend }}
       devenv-changed: ${{ steps.detect-changes.outputs.devenv }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-x64-small
     name: Generate golden files
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Go
@@ -51,7 +51,7 @@ jobs:
       run: make generate-golden-files
       working-directory: apps/dashboard
     - name: Upload golden files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: golden-files
         retention-days: 1
@@ -79,11 +79,11 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
         total: [16]
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Download golden files
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: golden-files
         path: apps/dashboard/pkg/migration
@@ -114,7 +114,7 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
         total: [16]
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Get GitHub App token
@@ -127,7 +127,7 @@ jobs:
       with:
         token: ${{ steps.get-github-app-token.outputs.token }}
     - name: Download golden files
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: golden-files
         path: apps/dashboard/pkg/migration
@@ -150,7 +150,7 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node.js
@@ -168,7 +168,7 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node.js
@@ -198,7 +198,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Check test suites
@@ -218,7 +218,7 @@ jobs:
   #   permissions:
   #     contents: read
   #   steps:
-  #   - uses: actions/checkout@v5
+  #   - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
   #     with:
   #       persist-credentials: false
   #   - name: Setup Docker

--- a/.github/workflows/pr-go-workspace-check.yml
+++ b/.github/workflows/pr-go-workspace-check.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       changed: ${{ steps.detect-changes.outputs.backend }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
 
@@ -87,7 +87,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
 

--- a/.github/workflows/pr-k8s-codegen-check.yml
+++ b/.github/workflows/pr-k8s-codegen-check.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
 

--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true
           fetch-depth: 0

--- a/.github/workflows/pr-patch-check.yml
+++ b/.github/workflows/pr-patch-check.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           github_app: grafana-releases-oss
       - name: "Dispatch job"
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ steps.get-github-app-token.outputs.token }}
           script: |
@@ -72,7 +72,7 @@ jobs:
       - name: "Wait for success"
         # Only run metadata reads (status/conclusion) — never fetch logs or artifacts,
         # since the security-patch-actions workflow output must not be exposed.
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ steps.get-github-app-token.outputs.token }}
           script: |

--- a/.github/workflows/pr-test-docker.yml
+++ b/.github/workflows/pr-test-docker.yml
@@ -45,7 +45,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: docker/setup-docker-action@3fb92d6d9c634363128c8cce4bc3b2826526370a # v4
@@ -53,7 +53,7 @@ jobs:
         run: docker buildx create --use
       - name: Login to DockerHub
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-        uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.4
+        uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
       - name: Build alpine (full source)
         run: make build-docker-full DOCKER_BUILD_ARGS=--load
 
@@ -68,7 +68,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node
@@ -90,7 +90,7 @@ jobs:
     outputs:
       version: ${{ steps.build.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - id: build
@@ -114,7 +114,7 @@ jobs:
     outputs:
       version: ${{ needs.build-backend.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/build-targz

--- a/.github/workflows/pr-test-integration-pgvector.yml
+++ b/.github/workflows/pr-test-integration-pgvector.yml
@@ -39,7 +39,7 @@ jobs:
       PGVECTOR_TEST_DB: host=127.0.0.1 port=5433 dbname=grafana_vectors user=grafana password=password sslmode=disable
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Start pgvector via docker compose

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       changed: ${{ steps.detect-changes.outputs.backend }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -71,7 +71,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Setup Go
@@ -107,7 +107,7 @@ jobs:
       MYSQL_HOST: 127.0.0.1
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Start MySQL via docker compose
@@ -159,7 +159,7 @@ jobs:
       POSTGRES_HOST: 127.0.0.1
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Start Postgres via docker compose
@@ -205,7 +205,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Get GitHub App token
@@ -253,7 +253,7 @@ jobs:
       MYSQL_HOST: 127.0.0.1
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Start MySQL via docker compose
@@ -317,7 +317,7 @@ jobs:
       POSTGRES_HOST: 127.0.0.1
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Start Postgres via docker compose

--- a/.github/workflows/pr-unified-storage-compatibility.yml
+++ b/.github/workflows/pr-unified-storage-compatibility.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true
           fetch-depth: 0

--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -52,7 +52,7 @@ jobs:
           path: ./artifact
       - name: Log in to GCS
         id: login-to-gcs
-        uses: grafana/shared-workflows/actions/login-to-gcs@main
+        uses: grafana/shared-workflows/actions/login-to-gcs@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
           environment: ${{ inputs.environment }}
           service_account: ${{ inputs.service-account }}
@@ -77,7 +77,7 @@ jobs:
           fi
       - name: Upload artifacts
         if: steps.coalesce.outputs.has-artifacts == 'true'
-        uses: grafana/shared-workflows/actions/push-to-gcs@main
+        uses: grafana/shared-workflows/actions/push-to-gcs@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
           bucket: ${{ inputs.bucket }}
           environment: ${{ inputs.environment }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Set up version (Release Branches)
@@ -104,7 +104,7 @@ jobs:
         with:
           github_app: grafana-releases-oss
           permission_set: ${{ github.ref_name == 'main' && 'dispatch-downstream-main' || 'dispatch-downstream-release' }} # different branches require different permission sets
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           REF: ${{ github.ref_name }}
           VERSION: ${{ needs.setup.outputs.version }}
@@ -160,7 +160,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node
@@ -220,7 +220,7 @@ jobs:
             os: darwin
             arch: arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/build-go
@@ -288,7 +288,7 @@ jobs:
             os: darwin
             arch: arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/build-targz
@@ -374,7 +374,7 @@ jobs:
             rpm: true
             allow-failure: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -444,8 +444,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
-      - uses: actions/checkout@v6
+      - uses: grafana/shared-workflows/actions/dockerhub-login@c6d954f7cd9c0022018982e01268de6cb75b913c # dockerhub-login/v1.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -567,8 +567,8 @@ jobs:
           - name: windows-arm64
             arch: arm64
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
-      - uses: actions/checkout@v6
+      - uses: grafana/shared-workflows/actions/dockerhub-login@c6d954f7cd9c0022018982e01268de6cb75b913c # dockerhub-login/v1.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -890,7 +890,7 @@ jobs:
       statuses: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -917,7 +917,7 @@ jobs:
 
       - name: Get vault secrets
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
           repo_secrets: |
             METICULOUS_API_TOKEN=meticulous-ui:api-token

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -64,7 +64,7 @@ jobs:
           echo "github.ref: $GITHUB_REF"
 
       - name: Checkout workflow ref
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           fetch-depth: 100
@@ -90,7 +90,7 @@ jobs:
         shell: bash
 
       - name: Checkout build commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           ref: ${{ inputs.grafana_commit }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -133,14 +133,14 @@ jobs:
             echo "WORK_BRANCH=release/${RUN_NUMBER}/${VERSION}"
           } >> "$GITHUB_ENV"
       - name: Checkout Grafana target branch #checkout the target branch to base the release branch on
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ steps.get-writer-app-token.outputs.token }} # used only for fetching; commits go via kminehart API
           ref: ${{ env.RELEASE_BRANCH }}
           fetch-tags: true
           fetch-depth: 0
       - name: Checkout Grafana (main)
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ github.token }}
           ref: main
@@ -154,7 +154,7 @@ jobs:
       # workspace (the release-branch checkout). That subtree may lag main and miss the action,
       # failing the step. Mirror cache-build:false behavior (no GOCACHE; modules via actions/cache).
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: .grafana-main/go.mod
           cache: false

--- a/.github/workflows/release-verify-packages.yml
+++ b/.github/workflows/release-verify-packages.yml
@@ -29,7 +29,7 @@ jobs:
     name: Verify deb
     runs-on: ubuntu-x64-large
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -137,7 +137,7 @@ jobs:
     name: Verify rpm
     runs-on: ubuntu-x64-large
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -238,7 +238,7 @@ jobs:
     name: Verify docker
     runs-on: ubuntu-x64-large
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -325,7 +325,7 @@ jobs:
     name: Verify docker-ubuntu
     runs-on: ubuntu-x64-large
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -21,7 +21,7 @@ jobs:
     name: Verify ${{ inputs.targz-artifact-name }}
     runs-on: ubuntu-x64-large
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/relyance-scan.yml
+++ b/.github/workflows/relyance-scan.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/report-frontend-coverage-to-bench.yaml
+++ b/.github/workflows/report-frontend-coverage-to-bench.yaml
@@ -36,7 +36,7 @@ jobs:
         codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: main
           persist-credentials: false
@@ -77,7 +77,7 @@ jobs:
 
       - name: Get Vault secrets
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a56a2305a3382563f57731863d97d17f9aadcde6 # main
         with:
           repo_secrets: |
             PROMETHEUS_URL=frontend_perf_tests:prometheus_push_url

--- a/.github/workflows/run-schema-v2-e2e.yml
+++ b/.github/workflows/run-schema-v2-e2e.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Setup Go

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Run Shellcheck

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           operations-per-run: 750

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       changed: ${{ steps.detect-changes.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
           - tritanopia_dark
     name: "Run Storybook a11y tests (${{ matrix.STORYBOOK_THEME }} theme)"
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         persist-credentials: false
     - name: Setup Node

--- a/.github/workflows/swagger-gen.yml
+++ b/.github/workflows/swagger-gen.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       changed: ${{ steps.detect-changes.outputs.backend }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
     steps:
       # Set up repository clone
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
       - name: Get GitHub App token

--- a/.github/workflows/sync-mirror-event.yml
+++ b/.github/workflows/sync-mirror-event.yml
@@ -31,7 +31,7 @@ jobs:
           github_app: grafana-releases-oss
           permission_set: ${{ github.ref_name == 'main' && 'main' || 'release' }} # different branches require different permission sets
 
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         if: github.repository == 'grafana/grafana'
         with:
           github-token: ${{ steps.get-github-app-token.outputs.token }}

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: echo "fetch_depth=$(( ${{ github.event.pull_request.commits }} + 2 ))" >> "$GITHUB_OUTPUT"
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           fetch-depth: ${{ steps.fetch_depth.outputs.fetch_depth }}

--- a/.github/workflows/update-schema-types.yml
+++ b/.github/workflows/update-schema-types.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
## Summary

**66 workflow files** reference GitHub Actions pinned to **mutable version tags and branch references** (`@v4`–`@v7`, `@main`, versioned tags like `cleanup-branches/v0.2.1`). This includes Grafana's own shared actions (`grafana/shared-workflows`, `grafana/grafana-github-actions`) all referenced via `@main`.

The release and deploy workflows have access to DockerHub credentials, Google Artifact Registry, GCS buckets, Vault secrets, and Slack bot tokens — making a compromised upstream action extremely high impact.

## Actions pinned (26 unique refs across 66 files)

| Action | Mutable ref | Fixed |
|--------|-------------|-------|
| `actions/checkout` | `@v5`, `@v6` | SHA-pinned |
| `actions/upload-artifact` | `@v4`, `@v5`, `@v7` | SHA-pinned |
| `grafana/shared-workflows/actions/get-vault-secrets` | `@main` ⚠️ | SHA-pinned |
| `grafana/shared-workflows/actions/dockerhub-login` | `@main` ⚠️ | SHA-pinned |
| `grafana/shared-workflows/actions/login-to-gar` | `@main` ⚠️ | SHA-pinned |
| `grafana/grafana-github-actions/commands` | `@main` ⚠️ | SHA-pinned |
| `grafana/grafana-github-actions-go/community-release` | `@main` ⚠️ | SHA-pinned |
| ... and 19 more | | |

## Vulnerability class

Supply-chain attack via mutable Action tag/branch references (CWE-829). See [GitHub Security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).