### PR TITLE
Conditional rendering fixed

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -68,7 +68,18 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
   const isDraggable = !isClone && isEditing;
 
   if (isHidden) {
-    return null;
+    // Keep the Draggable registered with its correct index to avoid gaps in the
+    // @hello-pangea/dnd index sequence. A gap (e.g. indices 0, 2) causes the
+    // Droppable to reserve visual space for the "missing" slot. Rendering an
+    // invisible, zero-height Draggable preserves contiguous indices without
+    // adding any visible space.
+    return (
+      <Draggable key={key!} draggableId={key!} index={myIndex} isDragDisabled={true}>
+        {(dragProvided) => (
+          <div ref={dragProvided.innerRef} {...dragProvided.draggableProps} style={{ display: 'none' }} />
+        )}
+      </Draggable>
+    );
   }
 
   if (soloPanelContext) {


### PR DESCRIPTION
**What is this fix?**
When a row has a "show/hide" conditional rendering rule and the hide 
condition is met, the space where the row was remains visually reserved 
instead of collapsing.

**Root cause:**
`RowItemRenderer` returned `null` before rendering the `<Draggable>` 
component when a row was hidden. This removed the row's Draggable from 
the `@hello-pangea/dnd` context entirely, leaving a gap in the index 
sequence (e.g. indices 0, 2 instead of 0, 1, 2). The Droppable 
reserves visual space for the missing index slot, producing the empty 
space.

**Fix:**
Instead of returning `null` before the Draggable, hidden rows now 
render a zero-height `<Draggable>` with `style={{ display: 'none' }}`. 
This keeps indices contiguous so the Droppable has no gap to fill, 
while `display: none` ensures no visual space is taken.

**Which issue(s) does this PR fix?**
Fixes #127400

**Special notes for your reviewer:**
- No new feature toggle needed — this fixes existing conditional 
  rendering behavior.
- To reproduce: create a dashboard with a Rows layout, add a row with 
  a "hide when variable = X" condition, switch the variable to X and 
  observe the empty space disappears after this fix.