### PR TITLE
Fix/org delete dashboards fallback

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1872,7 +1872,41 @@ func (dr *DashboardServiceImpl) saveDashboardThroughK8s(ctx context.Context, cmd
 }
 
 func (dr *DashboardServiceImpl) deleteAllDashboardThroughK8s(ctx context.Context, orgID int64) error {
-	return dr.k8sclient.DeleteCollection(ctx, orgID, v1.ListOptions{})
+	err := dr.k8sclient.DeleteCollection(ctx, orgID, v1.ListOptions{})
+	if err == nil {
+		return nil
+	}
+
+	// Unified storage does not support the deletecollection verb and returns 405.
+	// Fall back to listing all dashboards and deleting them one by one.
+	if !apierrors.IsMethodNotSupported(err) {
+		return err
+	}
+
+	dr.log.Debug("DeleteCollection not supported, falling back to individual deletes", "orgID", orgID)
+
+	for continueToken := ""; ; {
+		list, listErr := dr.k8sclient.List(ctx, orgID, v1.ListOptions{
+			Limit:    listAllDashboardsLimit,
+			Continue: continueToken,
+		})
+		if listErr != nil {
+			return listErr
+		}
+
+		for _, item := range list.Items {
+			if delErr := dr.k8sclient.Delete(ctx, item.GetName(), orgID, v1.DeleteOptions{}); delErr != nil && !apierrors.IsNotFound(delErr) {
+				return delErr
+			}
+		}
+
+		continueToken = list.GetContinue()
+		if continueToken == "" {
+			break
+		}
+	}
+
+	return nil
 }
 
 func (dr *DashboardServiceImpl) deleteDashboardThroughK8s(ctx context.Context, cmd *dashboards.DeleteDashboardCommand, validateProvisionedDashboard bool) error {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1871,43 +1871,6 @@ func (dr *DashboardServiceImpl) saveDashboardThroughK8s(ctx context.Context, cmd
 	return dr.UnstructuredToLegacyDashboard(ctx, out, orgID)
 }
 
-func (dr *DashboardServiceImpl) deleteAllDashboardThroughK8s(ctx context.Context, orgID int64) error {
-	err := dr.k8sclient.DeleteCollection(ctx, orgID, v1.ListOptions{})
-	if err == nil {
-		return nil
-	}
-
-	// Unified storage does not support the deletecollection verb and returns 405.
-	// Fall back to listing all dashboards and deleting them one by one.
-	if !apierrors.IsMethodNotSupported(err) {
-		return err
-	}
-
-	dr.log.Debug("DeleteCollection not supported, falling back to individual deletes", "orgID", orgID)
-
-	for continueToken := ""; ; {
-		list, listErr := dr.k8sclient.List(ctx, orgID, v1.ListOptions{
-			Limit:    listAllDashboardsLimit,
-			Continue: continueToken,
-		})
-		if listErr != nil {
-			return listErr
-		}
-
-		for _, item := range list.Items {
-			if delErr := dr.k8sclient.Delete(ctx, item.GetName(), orgID, v1.DeleteOptions{}); delErr != nil && !apierrors.IsNotFound(delErr) {
-				return delErr
-			}
-		}
-
-		continueToken = list.GetContinue()
-		if continueToken == "" {
-			break
-		}
-	}
-
-	return nil
-}
 
 func (dr *DashboardServiceImpl) deleteDashboardThroughK8s(ctx context.Context, cmd *dashboards.DeleteDashboardCommand, validateProvisionedDashboard bool) error {
 	// get uid if not passed in
@@ -2461,6 +2424,44 @@ func (dr *DashboardServiceImpl) cleanupAfterDelete(ctx context.Context, orgID in
 
 		return dr.deleteResourcePermissions(sess, orgID, accesscontrol.GetResourceScopeUID("dashboards", uid))
 	})
+}
+
+func (dr *DashboardServiceImpl) deleteAllDashboardThroughK8s(ctx context.Context, orgID int64) error {
+	err := dr.k8sclient.DeleteCollection(ctx, orgID, v1.ListOptions{})
+	if err == nil {
+		return nil
+	}
+
+	// Unified storage does not support the deletecollection verb and returns 405.
+	// Fall back to listing all dashboards and deleting them one by one.
+	if !apierrors.IsMethodNotSupported(err) {
+		return err
+	}
+
+	dr.log.Debug("DeleteCollection not supported, falling back to individual deletes", "orgID", orgID)
+
+	for continueToken := ""; ; {
+		list, listErr := dr.k8sclient.List(ctx, orgID, v1.ListOptions{
+			Limit:    listAllDashboardsLimit,
+			Continue: continueToken,
+		})
+		if listErr != nil {
+			return listErr
+		}
+
+		for _, item := range list.Items {
+			if delErr := dr.k8sclient.Delete(ctx, item.GetName(), orgID, v1.DeleteOptions{}); delErr != nil && !apierrors.IsNotFound(delErr) {
+				return delErr
+			}
+		}
+
+		continueToken = list.GetContinue()
+		if continueToken == "" {
+			break
+		}
+	}
+
+	return nil
 }
 
 // FIXME: Remove me and handle nested deletions in the service with the DashboardPermissionsService

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	dashboardv0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
@@ -967,16 +969,83 @@ func TestDeleteDashboard(t *testing.T) {
 }
 
 func TestDeleteAllDashboards(t *testing.T) {
-	service := &DashboardServiceImpl{
-		cfg: setting.NewCfg(),
-	}
+	t.Run("DeleteCollection succeeds", func(t *testing.T) {
+		service := &DashboardServiceImpl{cfg: setting.NewCfg(), log: log.New("test")}
+		ctx, k8sCliMock := setupK8sDashboardTests(service)
+		k8sCliMock.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
-	ctx, k8sCliMock := setupK8sDashboardTests(service)
-	k8sCliMock.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		err := service.DeleteAllDashboards(ctx, 1)
+		require.NoError(t, err)
+		k8sCliMock.AssertExpectations(t)
+	})
 
-	err := service.DeleteAllDashboards(ctx, 1)
-	require.NoError(t, err)
-	k8sCliMock.AssertExpectations(t)
+	t.Run("DeleteCollection returns 405, falls back to individual deletes for empty org", func(t *testing.T) {
+		service := &DashboardServiceImpl{cfg: setting.NewCfg(), log: log.New("test")}
+		ctx, k8sCliMock := setupK8sDashboardTests(service)
+
+		methodNotSupported := apierrors.NewMethodNotSupported(schema.GroupResource{Resource: "dashboards"}, "delete collection")
+		k8sCliMock.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything).Return(methodNotSupported).Once()
+		k8sCliMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(&unstructured.UnstructuredList{}, nil).Once()
+
+		err := service.DeleteAllDashboards(ctx, 1)
+		require.NoError(t, err)
+		k8sCliMock.AssertExpectations(t)
+	})
+
+	t.Run("DeleteCollection returns 405, falls back and deletes each dashboard", func(t *testing.T) {
+		service := &DashboardServiceImpl{cfg: setting.NewCfg(), log: log.New("test")}
+		ctx, k8sCliMock := setupK8sDashboardTests(service)
+
+		methodNotSupported := apierrors.NewMethodNotSupported(schema.GroupResource{Resource: "dashboards"}, "delete collection")
+		k8sCliMock.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything).Return(methodNotSupported).Once()
+
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{
+				{Object: map[string]any{"metadata": map[string]any{"name": "dash-1"}}},
+				{Object: map[string]any{"metadata": map[string]any{"name": "dash-2"}}},
+			},
+		}
+		k8sCliMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(list, nil).Once()
+		k8sCliMock.On("Delete", mock.Anything, "dash-1", mock.Anything, mock.Anything).Return(nil).Once()
+		k8sCliMock.On("Delete", mock.Anything, "dash-2", mock.Anything, mock.Anything).Return(nil).Once()
+
+		err := service.DeleteAllDashboards(ctx, 1)
+		require.NoError(t, err)
+		k8sCliMock.AssertExpectations(t)
+	})
+
+	t.Run("DeleteCollection returns 405, individual delete ignores not-found errors", func(t *testing.T) {
+		service := &DashboardServiceImpl{cfg: setting.NewCfg(), log: log.New("test")}
+		ctx, k8sCliMock := setupK8sDashboardTests(service)
+
+		methodNotSupported := apierrors.NewMethodNotSupported(schema.GroupResource{Resource: "dashboards"}, "delete collection")
+		k8sCliMock.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything).Return(methodNotSupported).Once()
+
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{
+				{Object: map[string]any{"metadata": map[string]any{"name": "dash-1"}}},
+			},
+		}
+		k8sCliMock.On("List", mock.Anything, mock.Anything, mock.Anything).Return(list, nil).Once()
+		notFound := apierrors.NewNotFound(schema.GroupResource{Resource: "dashboards"}, "dash-1")
+		k8sCliMock.On("Delete", mock.Anything, "dash-1", mock.Anything, mock.Anything).Return(notFound).Once()
+
+		err := service.DeleteAllDashboards(ctx, 1)
+		require.NoError(t, err)
+		k8sCliMock.AssertExpectations(t)
+	})
+
+	t.Run("DeleteCollection returns non-405 error, propagates error", func(t *testing.T) {
+		service := &DashboardServiceImpl{cfg: setting.NewCfg(), log: log.New("test")}
+		ctx, k8sCliMock := setupK8sDashboardTests(service)
+
+		internalErr := apierrors.NewInternalError(fmt.Errorf("storage failure"))
+		k8sCliMock.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything).Return(internalErr).Once()
+
+		err := service.DeleteAllDashboards(ctx, 1)
+		require.Error(t, err)
+		k8sCliMock.AssertExpectations(t)
+	})
 }
 
 func TestSearchDashboards(t *testing.T) {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -68,7 +68,18 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
   const isDraggable = !isClone && isEditing;
 
   if (isHidden) {
-    return null;
+    // Keep the Draggable registered with its correct index to avoid gaps in the
+    // @hello-pangea/dnd index sequence. A gap (e.g. indices 0, 2) causes the
+    // Droppable to reserve visual space for the "missing" slot. Rendering an
+    // invisible, zero-height Draggable preserves contiguous indices without
+    // adding any visible space.
+    return (
+      <Draggable key={key!} draggableId={key!} index={myIndex} isDragDisabled={true}>
+        {(dragProvided) => (
+          <div ref={dragProvided.innerRef} {...dragProvided.draggableProps} style={{ display: 'none' }} />
+        )}
+      </Draggable>
+    );
   }
 
   if (soloPanelContext) {


### PR DESCRIPTION
**What is this feature?**
Bug fix for org deletion failing with HTTP 500 when unified storage is enabled.

**Why do we need this feature?**
When deleting an organization, Grafana calls `DeleteCollection` on `dashboard.grafana.app` to remove all dashboards for that org. Unified storage does not support the `deletecollection` verb and returns 405 Method Not Allowed, which bubbles up as a 500 error to the user. This makes it impossible to delete any organization when unified storage is in use.

**Who is this feature for?**
Grafana administrators running instances with unified storage enabled.

**Which issue(s) does this PR fix?**
Fixes #127386

**Special notes for your reviewer:**
- The fix is in `deleteAllDashboardThroughK8s` (`pkg/services/dashboards/service/dashboard_service.go`). If `DeleteCollection` returns a 405, the code now falls back to listing all dashboards in paginated batches and deleting them individually. Any other error still propagates as before. Not-found errors during individual deletes are silently ignored to handle races safely.
- Unit tests added for: successful `DeleteCollection`, 405 fallback with no dashboards, 405 fallback with dashboards, 405 fallback where individual delete returns 404, and non-405 error propagation.
- No feature toggle required — this is a bug fix on an existing code path.
- No documentation changes required.