### PR TITLE
TestData: Fix series label duplication when expression is added

### DIFF
--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -184,6 +184,22 @@ describe('Check field state calculations (displayName and id)', () => {
     expect(title).toEqual('Series A Field 1');
   });
 
+  it('should not duplicate field name when it equals frame name across multiple frames', () => {
+    const title = checkScenario({
+      frames: [
+        toDataFrame({
+          name: 'A-series',
+          fields: [{ name: 'A-series' }],
+        }),
+        toDataFrame({
+          name: '',
+          fields: [{ name: 'B' }],
+        }),
+      ],
+    });
+    expect(title).toEqual('A-series');
+  });
+
   it('should add field name count to name if it exists more than once and is equal to TIME_SERIES_VALUE_FIELD_NAME', () => {
     const title = checkScenario({
       frames: [

--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -200,6 +200,82 @@ describe('Check field state calculations (displayName and id)', () => {
     expect(title).toEqual('A-series');
   });
 
+  it('should not duplicate field name when it equals frame name in single frame', () => {
+    const title = checkScenario({
+      frames: [
+        toDataFrame({
+          name: 'MyMetric',
+          fields: [{ name: 'MyMetric' }],
+        }),
+      ],
+    });
+    expect(title).toEqual('MyMetric');
+  });
+
+  it('should not duplicate when all frames have same field name matching their frame name', () => {
+    const title = checkScenario({
+      frames: [
+        toDataFrame({
+          name: 'A-series',
+          fields: [{ name: 'A-series' }],
+        }),
+        toDataFrame({
+          name: 'A-series',
+          fields: [{ name: 'A-series' }],
+        }),
+      ],
+    });
+    expect(title).toEqual('A-series');
+  });
+
+  it('should not duplicate field name matching frame name even with labels', () => {
+    const title = checkScenario({
+      frames: [
+        toDataFrame({
+          name: 'cpu',
+          fields: [{ name: 'cpu', labels: { host: 'server1' } }],
+        }),
+        toDataFrame({
+          name: '',
+          fields: [{ name: 'cpu', labels: { host: 'server2' } }],
+        }),
+      ],
+    });
+    expect(title).toEqual('cpu {host="server1"}');
+  });
+
+  it('should still show field name when it differs from frame name', () => {
+    const title = checkScenario({
+      frames: [
+        toDataFrame({
+          name: 'Series A',
+          fields: [{ name: 'Field 1' }],
+        }),
+        toDataFrame({
+          name: 'Series B',
+          fields: [{ name: 'Field 1' }],
+        }),
+      ],
+    });
+    expect(title).toEqual('Series A Field 1');
+  });
+
+  it('should show frame name when field name is empty', () => {
+    const title = checkScenario({
+      frames: [
+        toDataFrame({
+          name: 'Series A',
+          fields: [{ name: '' }],
+        }),
+        toDataFrame({
+          name: 'Series B',
+          fields: [{ name: '' }],
+        }),
+      ],
+    });
+    expect(title).toEqual('Series A');
+  });
+
   it('should add field name count to name if it exists more than once and is equal to TIME_SERIES_VALUE_FIELD_NAME', () => {
     const title = checkScenario({
       frames: [

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -131,7 +131,7 @@ function calculateFieldDisplayName(
     frameNameAdded = true;
   }
 
-  if (field.name && field.name !== TIME_SERIES_VALUE_FIELD_NAME) {
+  if (field.name && field.name !== TIME_SERIES_VALUE_FIELD_NAME && (!frameNameAdded || field.name !== frame?.name)) {
     parts.push(field.name);
   }
 


### PR DESCRIPTION
## What this PR does

Fixes #125691

When an expression is added to a panel using the TestData datasource, the series label/alias duplicates (e.g., "A-series A-series"). This happens because `calculateFieldDisplayName` in `fieldState.ts` unconditionally adds the field name after the frame name, even when they are identical.

## Root cause

TestData backend sets both `frame.name` and `field.name` to `"{refId}-series"`. When an expression is added, `frameNamesDiffer` becomes `true` (expression frame has empty name), so the frame name is prepended -- then the identical field name is also appended, causing duplication.

## Fix

In `packages/grafana-data/src/field/fieldState.ts`, added a guard to skip adding the field name when it is identical to the frame name already added:

```typescript
if (field.name && field.name !== TIME_SERIES_VALUE_FIELD_NAME && (!frameNameAdded || field.name !== frame?.name)) {
```

## Test

Added test case verifying that when a frame has `name='A-series'` and `field.name='A-series'`, the display name is just `"A-series"` (not `"A-series A-series"`).
