### PR TITLE
Alerting: Save interval/maxDataPoints when options tooltip closes

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
@@ -75,7 +75,12 @@ describe('QueryOptions', () => {
     const button = screen.getByRole('button', { name: /toggle query options/i });
     await user.click(button);
 
+    expect(button).toHaveAttribute('aria-expanded', 'true');
     expect(document.activeElement).toBe(button);
+
+    await user.keyboard('{Escape}');
+
+    expect(document.activeElement).not.toBe(button);
   });
 
   it('displays time range, max data points and min interval values', () => {

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
@@ -80,6 +80,7 @@ describe('QueryOptions', () => {
 
     await user.keyboard('{Escape}');
 
+    expect(button).toHaveAttribute('aria-expanded', 'false');
     expect(document.activeElement).not.toBe(button);
   });
 
@@ -99,7 +100,9 @@ describe('QueryOptions', () => {
     expect(screen.getByText(/Min. Interval = 15s/)).toBeInTheDocument();
   });
 
-  it('does not render time range picker when onChangeTimeRange is not provided', () => {
+  it('does not render time range picker when onChangeTimeRange is not provided', async () => {
+    const user = userEvent.setup();
+
     render(
       <TestProvider>
         <QueryOptions
@@ -112,6 +115,9 @@ describe('QueryOptions', () => {
     );
 
     const button = screen.getByRole('button', { name: /toggle query options/i });
-    expect(button).toBeInTheDocument();
+    await user.click(button);
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.queryByLabelText(/time range/i)).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, userEvent } from 'test/test-utils';
+
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import { QueryOptions } from './QueryOptions';
+
+import type { AlertQuery } from 'app/types/unified-alerting-dto';
+
+const mockQuery = {
+  refId: 'A',
+  relativeTimeRange: { from: 600, to: 0 },
+} as AlertQuery;
+
+const defaultOptions = {
+  maxDataPoints: 1000,
+  minInterval: '15s',
+};
+
+describe('QueryOptions', () => {
+  it('renders the options button with correct aria attributes', () => {
+    render(
+      <TestProvider>
+        <QueryOptions
+          query={mockQuery}
+          queryOptions={defaultOptions}
+          onChangeQueryOptions={jest.fn()}
+          index={0}
+        />
+      </TestProvider>
+    );
+
+    const button = screen.getByRole('button', { name: /toggle query options/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('toggles aria-expanded when options button is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TestProvider>
+        <QueryOptions
+          query={mockQuery}
+          queryOptions={defaultOptions}
+          onChangeQueryOptions={jest.fn()}
+          index={0}
+        />
+      </TestProvider>
+    );
+
+    const button = screen.getByRole('button', { name: /toggle query options/i });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('blurs the active element when toggletip closes', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TestProvider>
+        <QueryOptions
+          query={mockQuery}
+          queryOptions={defaultOptions}
+          onChangeQueryOptions={jest.fn()}
+          index={0}
+        />
+      </TestProvider>
+    );
+
+    const button = screen.getByRole('button', { name: /toggle query options/i });
+    await user.click(button);
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it('displays time range, max data points and min interval values', () => {
+    render(
+      <TestProvider>
+        <QueryOptions
+          query={mockQuery}
+          queryOptions={defaultOptions}
+          onChangeQueryOptions={jest.fn()}
+          index={0}
+        />
+      </TestProvider>
+    );
+
+    expect(screen.getByText(/MD = 1000/)).toBeInTheDocument();
+    expect(screen.getByText(/Min. Interval = 15s/)).toBeInTheDocument();
+  });
+
+  it('does not render time range picker when onChangeTimeRange is not provided', () => {
+    render(
+      <TestProvider>
+        <QueryOptions
+          query={mockQuery}
+          queryOptions={defaultOptions}
+          onChangeQueryOptions={jest.fn()}
+          index={0}
+        />
+      </TestProvider>
+    );
+
+    const button = screen.getByRole('button', { name: /toggle query options/i });
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -50,6 +50,12 @@ export const QueryOptions = ({
         }
         closeButton={true}
         placement="bottom-start"
+        onClose={() => {
+          const activeEl = document.activeElement;
+          if (activeEl instanceof HTMLElement) {
+            activeEl.blur();
+          }
+        }}
       >
         <button type="button" className={styles.actionLink} onClick={() => setShowOptions(!showOptions)}>
           <Trans i18nKey="alerting.query-options.button-options">Options</Trans>{' '}

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -57,7 +57,13 @@ export const QueryOptions = ({
           }
         }}
       >
-        <button type="button" className={styles.actionLink} onClick={() => setShowOptions(!showOptions)}>
+        <button
+          type="button"
+          className={styles.actionLink}
+          aria-label={t('alerting.query-options.aria-toggle-options', 'Toggle query options')}
+          aria-expanded={showOptions}
+          onClick={() => setShowOptions(!showOptions)}
+        >
           <Trans i18nKey="alerting.query-options.button-options">Options</Trans>{' '}
           {showOptions ? <Icon name="angle-right" /> : <Icon name="angle-down" />}
         </button>

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -51,6 +51,7 @@ export const QueryOptions = ({
         closeButton={true}
         placement="bottom-start"
         onClose={() => {
+          setShowOptions(false);
           const activeEl = document.activeElement;
           if (activeEl instanceof HTMLElement) {
             activeEl.blur();


### PR DESCRIPTION
## What this PR does

Fixes #111664

When the options tooltip on the alert rule editor closes via outside click, the `onBlur` handler on the input never fires because the input is removed from the DOM first. This causes the typed interval/maxDataPoints values to be lost.

## Fix

Added an `onClose` handler to the `Toggletip` in `QueryOptions.tsx` that programmatically blurs the currently focused element. This triggers the input's `onBlur` handler, saving the value before the tooltip content is unmounted.

```tsx
onClose={() => {
  const activeEl = document.activeElement;
  if (activeEl instanceof HTMLElement) {
    activeEl.blur();
  }
}}
```

This is a minimal, safe fix — it only affects the behavior when the tooltip closes, and `blur()` on an already-blurred element is a no-op.
