### PR TITLE
Provisioning: add "View repository" link next to provisioned badges

### DIFF
--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -45,7 +45,7 @@ export const FolderRepo = memo(function FolderRepo({ folder, enableRepositoryLin
 
   return (
     // badge with text and icon only has different height, we will need to adjust the layout using stretch
-    <Stack direction="row" alignItems="center">
+    <Stack direction="row" alignItems="stretch">
       {isReadOnlyRepo && <ReadOnlyBadge repoType={repoType} />}
       <ManagedBadge managerKind={ManagerKind.Repo} name={repository?.title || repository?.name} />
       {enableRepositoryLink && <ViewRepositoryButton repositoryName={repository?.name} />}

--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -4,6 +4,7 @@ import { Stack } from '@grafana/ui';
 import { ManagerKind } from 'app/features/apiserver/types';
 import { ManagedBadge } from 'app/features/provisioning/components/ManagedBadge';
 import { ReadOnlyBadge } from 'app/features/provisioning/components/ReadOnlyBadge';
+import { ViewRepositoryButton } from 'app/features/provisioning/components/ViewRepositoryButton';
 import {
   RepoViewStatus,
   useGetResourceRepositoryView,
@@ -15,9 +16,11 @@ import { type FolderDTO } from 'app/types/folders';
 
 export interface Props {
   folder?: FolderDTO | DashboardViewItem;
+  /** When true, render a "View repository" link next to the badge. Opt-in so the folder picker dropdown stays non-interactive. */
+  enableRepositoryLink?: boolean;
 }
 
-export const FolderRepo = memo(function FolderRepo({ folder }: Props) {
+export const FolderRepo = memo(function FolderRepo({ folder, enableRepositoryLink = false }: Props) {
   // Check if we can skip early without needing the useIsProvisionedInstance query
   // This reduces RTK Query subscriptions and prevents re-render loops on API errors
   const canSkipEarly = getCanSkipEarly(folder);
@@ -45,6 +48,7 @@ export const FolderRepo = memo(function FolderRepo({ folder }: Props) {
     <Stack direction="row" alignItems="stretch">
       {isReadOnlyRepo && <ReadOnlyBadge repoType={repoType} />}
       <ManagedBadge managerKind={ManagerKind.Repo} name={repository?.title || repository?.name} />
+      {enableRepositoryLink && <ViewRepositoryButton repositoryName={repository?.name} />}
     </Stack>
   );
 });

--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -45,7 +45,7 @@ export const FolderRepo = memo(function FolderRepo({ folder, enableRepositoryLin
 
   return (
     // badge with text and icon only has different height, we will need to adjust the layout using stretch
-    <Stack direction="row" alignItems="stretch">
+    <Stack direction="row" alignItems="center">
       {isReadOnlyRepo && <ReadOnlyBadge repoType={repoType} />}
       <ManagedBadge managerKind={ManagerKind.Repo} name={repository?.title || repository?.name} />
       {enableRepositoryLink && <ViewRepositoryButton repositoryName={repository?.name} />}

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -154,7 +154,7 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
             onClick={() => setShowRenameDrawer(true)}
           />
         )}
-        <FolderRepo folder={folder} />
+        <FolderRepo folder={folder} enableRepositoryLink />
       </Stack>
     );
   };

--- a/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.tsx
+++ b/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.tsx
@@ -27,7 +27,7 @@ export const ManagedDashboardNavBarBadge = ({ dashboard }: { dashboard: Dashboar
   const isOrphaned = kind === ManagerKind.Repo && isError && isFetchError(error) && error.status === 404;
 
   return (
-    <Stack direction="row" alignItems="stretch">
+    <Stack direction="row" alignItems="center">
       <ManagedBadge managerKind={kind} name={repoData?.spec?.title || id} isOrphaned={isOrphaned} />
       <ViewRepositoryButton repositoryName={kind === ManagerKind.Repo ? id : undefined} isOrphaned={isOrphaned} />
     </Stack>

--- a/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.tsx
+++ b/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.tsx
@@ -27,7 +27,7 @@ export const ManagedDashboardNavBarBadge = ({ dashboard }: { dashboard: Dashboar
   const isOrphaned = kind === ManagerKind.Repo && isError && isFetchError(error) && error.status === 404;
 
   return (
-    <Stack direction="row" alignItems="center" gap={0.5}>
+    <Stack direction="row" alignItems="stretch">
       <ManagedBadge managerKind={kind} name={repoData?.spec?.title || id} isOrphaned={isOrphaned} />
       <ViewRepositoryButton repositoryName={kind === ManagerKind.Repo ? id : undefined} isOrphaned={isOrphaned} />
     </Stack>

--- a/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.tsx
+++ b/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.tsx
@@ -1,9 +1,11 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 
 import { config, isFetchError } from '@grafana/runtime';
+import { Stack } from '@grafana/ui';
 import { useGetRepositoryQuery } from 'app/api/clients/provisioning/v0alpha1';
 import { ManagerKind } from 'app/features/apiserver/types';
 import { ManagedBadge } from 'app/features/provisioning/components/ManagedBadge';
+import { ViewRepositoryButton } from 'app/features/provisioning/components/ViewRepositoryButton';
 
 import { type DashboardScene } from './DashboardScene';
 
@@ -24,5 +26,10 @@ export const ManagedDashboardNavBarBadge = ({ dashboard }: { dashboard: Dashboar
   // Repository-managed dashboard where the repo no longer exists
   const isOrphaned = kind === ManagerKind.Repo && isError && isFetchError(error) && error.status === 404;
 
-  return <ManagedBadge managerKind={kind} name={repoData?.spec?.title || id} isOrphaned={isOrphaned} />;
+  return (
+    <Stack direction="row" alignItems="center" gap={0.5}>
+      <ManagedBadge managerKind={kind} name={repoData?.spec?.title || id} isOrphaned={isOrphaned} />
+      <ViewRepositoryButton repositoryName={kind === ManagerKind.Repo ? id : undefined} isOrphaned={isOrphaned} />
+    </Stack>
+  );
 };

--- a/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.tsx
+++ b/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.tsx
@@ -27,7 +27,7 @@ export const ManagedDashboardNavBarBadge = ({ dashboard }: { dashboard: Dashboar
   const isOrphaned = kind === ManagerKind.Repo && isError && isFetchError(error) && error.status === 404;
 
   return (
-    <Stack direction="row" alignItems="center">
+    <Stack direction="row" alignItems="stretch">
       <ManagedBadge managerKind={kind} name={repoData?.spec?.title || id} isOrphaned={isOrphaned} />
       <ViewRepositoryButton repositoryName={kind === ManagerKind.Repo ? id : undefined} isOrphaned={isOrphaned} />
     </Stack>

--- a/public/app/features/provisioning/components/ViewRepositoryButton.test.tsx
+++ b/public/app/features/provisioning/components/ViewRepositoryButton.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from 'test/test-utils';
+
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { ViewRepositoryButton } from './ViewRepositoryButton';
+
+describe('ViewRepositoryButton', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(contextSrv, 'hasPermission')
+      .mockImplementation((action: string) => action === AccessControlAction.ProvisioningRepositoriesRead);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders a link to the repository view when permitted and repositoryName is set', () => {
+    render(<ViewRepositoryButton repositoryName="my-repo" />);
+
+    const link = screen.getByRole('link', { name: 'View repository' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/admin/provisioning/my-repo');
+  });
+
+  it('encodes the repository name in the URL', () => {
+    render(<ViewRepositoryButton repositoryName="my repo/with special" />);
+
+    const link = screen.getByRole('link', { name: 'View repository' });
+    expect(link).toHaveAttribute('href', '/admin/provisioning/my%20repo%2Fwith%20special');
+  });
+
+  it('renders nothing without provisioning.repositories:read permission', () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
+
+    render(<ViewRepositoryButton repositoryName="my-repo" />);
+
+    expect(screen.queryByRole('link', { name: 'View repository' })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the resource is orphaned', () => {
+    render(<ViewRepositoryButton repositoryName="my-repo" isOrphaned />);
+
+    expect(screen.queryByRole('link', { name: 'View repository' })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing without a repositoryName', () => {
+    render(<ViewRepositoryButton />);
+
+    expect(screen.queryByRole('link', { name: 'View repository' })).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/provisioning/components/ViewRepositoryButton.test.tsx
+++ b/public/app/features/provisioning/components/ViewRepositoryButton.test.tsx
@@ -1,18 +1,23 @@
 import { render, screen } from 'test/test-utils';
 
+import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { ViewRepositoryButton } from './ViewRepositoryButton';
 
 describe('ViewRepositoryButton', () => {
+  const originalProvisioningToggle = config.featureToggles.provisioning;
+
   beforeEach(() => {
+    config.featureToggles.provisioning = true;
     jest
       .spyOn(contextSrv, 'hasPermission')
       .mockImplementation((action: string) => action === AccessControlAction.ProvisioningRepositoriesRead);
   });
 
   afterEach(() => {
+    config.featureToggles.provisioning = originalProvisioningToggle;
     jest.restoreAllMocks();
   });
 
@@ -29,6 +34,14 @@ describe('ViewRepositoryButton', () => {
 
     const link = screen.getByRole('link', { name: 'View repository' });
     expect(link).toHaveAttribute('href', '/admin/provisioning/my%20repo%2Fwith%20special');
+  });
+
+  it('renders nothing when the provisioning feature toggle is off', () => {
+    config.featureToggles.provisioning = false;
+
+    render(<ViewRepositoryButton repositoryName="my-repo" />);
+
+    expect(screen.queryByRole('link', { name: 'View repository' })).not.toBeInTheDocument();
   });
 
   it('renders nothing without provisioning.repositories:read permission', () => {

--- a/public/app/features/provisioning/components/ViewRepositoryButton.tsx
+++ b/public/app/features/provisioning/components/ViewRepositoryButton.tsx
@@ -1,0 +1,38 @@
+import { t } from '@grafana/i18n';
+import { LinkButton } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { PROVISIONING_URL } from '../constants';
+
+interface ViewRepositoryButtonProps {
+  /** Name of the managing repository (the `:name` segment of the repository view URL). */
+  repositoryName?: string;
+  /** Repository-managed resource whose backing repository no longer exists. */
+  isOrphaned?: boolean;
+}
+
+/**
+ * Compact icon link to the repository view (`/admin/provisioning/:name`). Self-gates: renders
+ * nothing unless the resource has a repository name, is not orphaned, and the user has
+ * `provisioning.repositories:read`. Rendered as a real anchor so middle-click / open-in-new-tab work.
+ */
+export function ViewRepositoryButton({ repositoryName, isOrphaned = false }: ViewRepositoryButtonProps) {
+  if (!repositoryName || isOrphaned || !contextSrv.hasPermission(AccessControlAction.ProvisioningRepositoriesRead)) {
+    return null;
+  }
+
+  const label = t('provisioning.view-repository-button.label', 'View repository');
+
+  return (
+    <LinkButton
+      href={`${PROVISIONING_URL}/${encodeURIComponent(repositoryName)}`}
+      variant="secondary"
+      fill="outline"
+      size="sm"
+      icon="code-branch"
+      tooltip={label}
+      aria-label={label}
+    />
+  );
+}

--- a/public/app/features/provisioning/components/ViewRepositoryButton.tsx
+++ b/public/app/features/provisioning/components/ViewRepositoryButton.tsx
@@ -1,4 +1,5 @@
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { LinkButton } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -15,10 +16,17 @@ interface ViewRepositoryButtonProps {
 /**
  * Compact icon link to the repository view (`/admin/provisioning/:name`). Self-gates: renders
  * nothing unless the resource has a repository name, is not orphaned, and the user has
- * `provisioning.repositories:read`. Rendered as a real anchor so middle-click / open-in-new-tab work.
+ * `provisioning.repositories:read`. It also requires the `provisioning` feature toggle, since the
+ * target repository route only exists when provisioning is enabled. Rendered as a real anchor so
+ * middle-click / open-in-new-tab work.
  */
 export function ViewRepositoryButton({ repositoryName, isOrphaned = false }: ViewRepositoryButtonProps) {
-  if (!repositoryName || isOrphaned || !contextSrv.hasPermission(AccessControlAction.ProvisioningRepositoriesRead)) {
+  if (
+    !config.featureToggles.provisioning ||
+    !repositoryName ||
+    isOrphaned ||
+    !contextSrv.hasPermission(AccessControlAction.ProvisioningRepositoriesRead)
+  ) {
     return null;
   }
 

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -194,6 +194,9 @@ export enum AccessControlAction {
   // Saved Queries
   QueriesRead = 'queries:read',
   QueriesWrite = 'queries:write',
+
+  // Provisioning
+  ProvisioningRepositoriesRead = 'provisioning.repositories:read',
 }
 
 export interface Role extends RoleDto {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13760,6 +13760,9 @@
       "hidden-characters": "This field contains hidden characters that may have been introduced by copying and pasting. Please retype or clean the value and try again.",
       "url-with-credentials": "Repository URL must not include a username or password. Remove credentials from the URL and use the token field instead."
     },
+    "view-repository-button": {
+      "label": "View repository"
+    },
     "warning-title-default": "Warning",
     "watch-stream": {
       "error-description": "Real-time updates could not be started. Refresh the page to see the latest data.",


### PR DESCRIPTION
**What is this feature?**

- Adds a small "View repository" link, shown next to the "Provisioned" badge on provisioned dashboards (page header) and on provisioned root folders (browse page header).
- Clicking it takes the user to that resource's managing repository page.
- The link only appears when the user has permission to read provisioning repositories; users without access continue to see just the badge.
- The link is hidden for resources whose backing repository no longer exists (orphaned) and for non-repository-managed resources.
<img width="1166" height="307" alt="image" src="https://github.com/user-attachments/assets/7623a484-360f-4f07-9c1b-d0203b435d17" />


**Why do we need this feature?**

- Previously there was no direct way to get from a provisioned dashboard or folder to the repository managing it; users had to navigate to the provisioning admin area manually. This adds a discoverable, one-click path.

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1224

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
