### PR TITLE
FS: Pass baggage headers into OpenFeature evaluation context

### DIFF
--- a/pkg/services/frontend/context_middleware.go
+++ b/pkg/services/frontend/context_middleware.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -26,7 +27,7 @@ func (s *frontendService) contextMiddleware() web.Middleware {
 			ctx := r.Context()
 
 			span := trace.SpanFromContext(ctx)
-			ctx = setRequestContext(ctx, w, r)
+			ctx = setRequestContext(ctx, w, r, s.baggageEvalContextKeys)
 
 			// Preserve the original span so the setRequestContext span doesn't get propagated as a parent of the rest of the request
 			ctx = trace.ContextWithSpan(ctx, span)
@@ -36,7 +37,7 @@ func (s *frontendService) contextMiddleware() web.Middleware {
 	}
 }
 
-func setRequestContext(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+func setRequestContext(ctx context.Context, w http.ResponseWriter, r *http.Request, baggageEvalContextKeys []string) context.Context {
 	ctx, span := tracing.Start(ctx, "setRequestContext")
 	defer span.End()
 
@@ -75,15 +76,16 @@ func setRequestContext(ctx context.Context, w http.ResponseWriter, r *http.Reque
 		reqContext.Logger = reqContext.Logger.New("user_agent", userAgent)
 	}
 
-	// Parse namespace from W3C baggage header
-	var namespace string
+	// Parse the W3C baggage header once. It carries the namespace plus any
+	// additional members configured for the evaluation context below.
+	var bag baggage.Baggage
 	if baggageHeader := r.Header.Get("baggage"); baggageHeader != "" {
-		if bag, err := baggage.Parse(baggageHeader); err == nil {
-			if member := bag.Member("namespace"); member.Value() != "" {
-				namespace = member.Value()
-			}
+		if parsed, err := baggage.Parse(baggageHeader); err == nil {
+			bag = parsed
 		}
 	}
+
+	namespace := bag.Member("namespace").Value()
 	if namespace != "" {
 		ctx = request.WithNamespace(ctx, namespace)
 	}
@@ -94,11 +96,32 @@ func setRequestContext(ctx context.Context, w http.ResponseWriter, r *http.Reque
 	if namespace != "" {
 		openFeatureNamespace = namespace
 	}
-	evalCtx := openfeature.NewEvaluationContext(openFeatureNamespace, map[string]any{
+	attributes := map[string]any{
 		"namespace": openFeatureNamespace,
 		"hostname":  hostname,
-	})
+	}
+
+	// Copy configured baggage members into the evaluation context. The members
+	// can't be hardcoded here because they may be specific to a particular
+	// deployment, so the set of keys is driven by configuration.
+	for _, key := range baggageEvalContextKeys {
+		if value := bag.Member(key).Value(); value != "" {
+			attributes[key] = value
+		}
+	}
+
+	evalCtx := openfeature.NewEvaluationContext(openFeatureNamespace, attributes)
 	ctx = openfeature.MergeTransactionContext(ctx, evalCtx)
 
 	return ctx
+}
+
+// readBaggageEvalContextKeys returns the list of W3C baggage member keys whose
+// values are copied into the per-request OpenFeature evaluation context.
+//
+// [frontend_service]
+// baggage_eval_context_keys = key1 key2
+func readBaggageEvalContextKeys(cfg *setting.Cfg) []string {
+	sec := cfg.SectionWithEnvOverrides("frontend_service")
+	return sec.Key("baggage_eval_context_keys").Strings(" ")
 }

--- a/pkg/services/frontend/context_middleware_test.go
+++ b/pkg/services/frontend/context_middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	gokitlog "github.com/go-kit/log"
+	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
@@ -49,7 +50,7 @@ func TestSetRequestContext(t *testing.T) {
 		req.Header.Set("baggage", "namespace=stacks-123")
 		rec := httptest.NewRecorder()
 
-		ctx := setRequestContext(req.Context(), rec, req)
+		ctx := setRequestContext(req.Context(), rec, req, nil)
 
 		namespace, ok := request.NamespaceFrom(ctx)
 		assert.True(t, ok, "Namespace should be present in context")
@@ -61,7 +62,7 @@ func TestSetRequestContext(t *testing.T) {
 		req.Header.Set("baggage", "trace-id=abc123,namespace=tenant-456,user-id=xyz")
 		rec := httptest.NewRecorder()
 
-		ctx := setRequestContext(req.Context(), rec, req)
+		ctx := setRequestContext(req.Context(), rec, req, nil)
 
 		namespace, ok := request.NamespaceFrom(ctx)
 		assert.True(t, ok, "Namespace should be present in context")
@@ -72,7 +73,7 @@ func TestSetRequestContext(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
 
-		ctx := setRequestContext(req.Context(), rec, req)
+		ctx := setRequestContext(req.Context(), rec, req, nil)
 
 		namespace, ok := request.NamespaceFrom(ctx)
 		assert.False(t, ok, "Namespace should not be present in context")
@@ -84,7 +85,7 @@ func TestSetRequestContext(t *testing.T) {
 		req.Header.Set("baggage", "invalid-baggage-format;;;")
 		rec := httptest.NewRecorder()
 
-		ctx := setRequestContext(req.Context(), rec, req)
+		ctx := setRequestContext(req.Context(), rec, req, nil)
 
 		namespace, ok := request.NamespaceFrom(ctx)
 		assert.False(t, ok, "Namespace should not be present in context")
@@ -96,11 +97,67 @@ func TestSetRequestContext(t *testing.T) {
 		req.Header.Set("baggage", "other-key=other-value")
 		rec := httptest.NewRecorder()
 
-		ctx := setRequestContext(req.Context(), rec, req)
+		ctx := setRequestContext(req.Context(), rec, req, nil)
 
 		namespace, ok := request.NamespaceFrom(ctx)
 		assert.False(t, ok, "Namespace should not be present in context")
 		assert.Empty(t, namespace, "Namespace should be empty when namespace member not in baggage")
+	})
+}
+
+func TestSetRequestContextBaggageEvalContext(t *testing.T) {
+	t.Run("copies configured baggage members into the evaluation context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("baggage", "namespace=tenant-1,org_id=42,region=eu,ignored=nope")
+		rec := httptest.NewRecorder()
+
+		ctx := setRequestContext(req.Context(), rec, req, []string{"org_id", "region"})
+
+		attrs := openfeature.TransactionContext(ctx).Attributes()
+		assert.Equal(t, "tenant-1", attrs["namespace"])
+		assert.Equal(t, "42", attrs["org_id"])
+		assert.Equal(t, "eu", attrs["region"])
+		assert.NotContains(t, attrs, "ignored", "members not in the configured list should not be copied")
+	})
+
+	t.Run("omits configured members that are absent from the baggage header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("baggage", "namespace=tenant-1")
+		rec := httptest.NewRecorder()
+
+		ctx := setRequestContext(req.Context(), rec, req, []string{"org_id"})
+
+		attrs := openfeature.TransactionContext(ctx).Attributes()
+		assert.NotContains(t, attrs, "org_id", "absent baggage members should not be added")
+	})
+
+	t.Run("keeps default namespace and hostname when no keys are configured", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Host = "example.com"
+		rec := httptest.NewRecorder()
+
+		ctx := setRequestContext(req.Context(), rec, req, nil)
+
+		attrs := openfeature.TransactionContext(ctx).Attributes()
+		assert.Equal(t, "default", attrs["namespace"])
+		assert.Equal(t, "example.com", attrs["hostname"])
+	})
+}
+
+func TestReadBaggageEvalContextKeys(t *testing.T) {
+	t.Run("returns configured keys", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		sec, err := cfg.Raw.NewSection("frontend_service")
+		assert.NoError(t, err)
+		_, err = sec.NewKey("baggage_eval_context_keys", "org_id region")
+		assert.NoError(t, err)
+
+		assert.Equal(t, []string{"org_id", "region"}, readBaggageEvalContextKeys(cfg))
+	})
+
+	t.Run("returns empty list when not configured", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		assert.Empty(t, readBaggageEvalContextKeys(cfg))
 	})
 }
 

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -60,6 +60,10 @@ type frontendService struct {
 	index           *IndexProvider
 	settingsService settingservice.Service // nil if not configured
 	pluginsCDN      *pluginscdn.Service
+
+	// baggageEvalContextKeys are the W3C baggage member keys copied into the
+	// per-request OpenFeature evaluation context.
+	baggageEvalContextKeys []string
 }
 
 func ProvideFrontendService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, promGatherer prometheus.Gatherer, promRegister prometheus.Registerer, license licensing.Licensing, hooksService *hooks.HooksService) (*frontendService, error) {
@@ -95,6 +99,8 @@ func ProvideFrontendService(cfg *setting.Cfg, features featuremgmt.FeatureToggle
 		index:           index,
 		settingsService: settingsService,
 		pluginsCDN:      pluginsCDN,
+
+		baggageEvalContextKeys: readBaggageEvalContextKeys(cfg),
 	}
 	s.BasicService = services.NewBasicService(s.start, s.running, s.stop)
 	return s, nil


### PR DESCRIPTION
**What is this feature?**

Adds the capability to the frontend service to parse values from the [baggage header](https://www.w3.org/TR/baggage/) and put them into the OpenFeature evaluation context.

Service upstream from frontend service currently sends the `namespace` property through baggage, e.g.

```http
GET /d/abc123/my-dashboard HTTP/1.1
Host: foo.example.net
User-Agent: Mozilla/5.0
Accept: text/html
baggage: namespace=stacks-124345
```

Our use of this at the moment is fairly limited (just for the settings service), but this extends the same mechanism so we can add more properties for OpenFeature evaluation without needing to perform additional API requests.

To avoid clients just sending _any_ baggage values ending up in the OpenFeature eval context, we also introduce configuration to specify a list of allowed baggage values to make it into the eval context.

**Why do we need this feature?**

So we can properly target feature flag rollouts for the frontend service.