### PR TITLE
Docs: Graffonet clarification

### DIFF
--- a/contribute/feature-toggles.md
+++ b/contribute/feature-toggles.md
@@ -159,12 +159,12 @@ If using non-boolean flags (a unique feature of the new feature flag system), ex
 
 For advanced, non-React contexts (utilities, class methods, callbacks), you can use the OpenFeature client directly.
 
-However, because this is seperate from the React render loop there are important caveats you must be aware of:
+However, because this is separate from the React render loop there are important caveats you must be aware of:
 
 - Flag values are loaded asynchronously, so you cannot call `getBooleanValue()` just at the top-level of a module. You must wait until `app.ts` has initialised until you call a flag otherwise you will only get the default value
 - Flag values can change over the lifetime of the session, so do not store or cache the result. Always evaluate flags just in time when you use them, preferably in the if statement, for example.
 
-It is strongly preferred to use the React hooks instead of getting the client.
+It's strongly preferred to use the React hooks instead of getting the client.
 
 ```ts
 import { getFeatureFlagClient, FlagKeys } from '@grafana/runtime/internal';

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -120,7 +120,7 @@ Backporting is the process of copying the pull request into the version branch o
 
 Backporting should be a rare exception, reserved only for critical bug fixes, and must be initiated by a Grafana Labs employee. We generally avoid automatic backports, as these changes carry some risk: they typically receive less manual testing than changes included in regular point releases.
 
-If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, seperate backport PRs will automatically be creataed.
+If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, separate backport PRs will automatically be created.
 
 #### Required labels
 

--- a/docs/sources/as-code/observability-as-code/_index.md
+++ b/docs/sources/as-code/observability-as-code/_index.md
@@ -85,4 +85,4 @@ If you're already using established [Infrastructure as code](ref:infra-as-code) 
   - Manage dashboards, folders, and data sources via Kubernetes Custom Resources.
   - Integrate with GitOps workflows for seamless version control and deployment.
 - [Crossplane](https://github.com/grafana/crossplane-provider-grafana) lets you manage Grafana resources using Kubernetes manifests with the Grafana Crossplane provider.
-- [Grafonnet (deprecated)](https://github.com/grafana/grafonnet) is a Jsonnet library for generating Grafana dashboard JSON definitions programmatically.
+- [Grafonnet](https://github.com/grafana/grafonnet) is a Jsonnet library for generating Grafana dashboard JSON definitions programmatically. **Grafonnet is not officially supported by Grafana. Instead, use the [Foundation SDK](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/foundation-sdk/)** to create dashboards as code.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -187,7 +187,7 @@ On this screen, you'll sync the external resources you specified in the previous
 
 To set up synchronization:
 
-1. Select wether you want to store synced resources in a **new folder or at root level** in Grafana. For more information on these options, refer to [Sync targets](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts#sync-targets/). The UI provides information about the available resources you can sync.
+1. Select whether you want to store synced resources in a **new folder or at root level** in Grafana. For more information on these options, refer to [Sync targets](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts#sync-targets/). The UI provides information about the available resources you can sync.
 1. Enter a **Display name** for your repository connection. All the synced resources from this Git Sync connection will appear under the this name in the Grafana UI.
 1. Click **Synchronize with external storage** to continue.
 1. You can repeat this process for up to 10 connections.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
@@ -109,12 +109,12 @@ spec:
     url: '<GIT_REPO_URL>'
     branch: '<BRANCH>'
     path: grafana/
-# GitHub App connection only:
+  # GitHub App connection only:
   connection:
     name: '<GITHUB_CONNECTION_NAME>'
 # GitHub Personal Access Token only:
 secure:
-  token: { create: "GIT_PAT" }
+  token: { create: 'GIT_PAT' }
 
 # GitLab Personal Access Token only:
 spec:
@@ -123,7 +123,7 @@ spec:
     url: '<GIT_REPO_URL>'
     branch: '<BRANCH>'
 secure:
-  token: { create: "GIT_PAT" }
+  token: { create: 'GIT_PAT' }
 
 # Bitbucket Personal Access Token only:
 spec:
@@ -133,7 +133,7 @@ spec:
     branch: '<BRANCH>'
     tokenUser: tokenuser
 secure:
-  token: { create: "GIT_PAT" }
+  token: { create: 'GIT_PAT' }
 
 # Pure Git only:
 spec:
@@ -141,10 +141,10 @@ spec:
   git:
     url: '<GIT_REPO_URL>'
     branch: '<BRANCH>'
-    path: "grafana/"
+    path: 'grafana/'
     tokenUser: tokenuser
 secure:
-  token: { create: "GIT_PAT" }
+  token: { create: 'GIT_PAT' }
 ```
 
 Replace the placeholders with your values:


### PR DESCRIPTION
Replaces https://github.com/grafana/grafana/pull/127212.

[@nijuse](https://github.com/nijuse), I had to open a new PR for this. While Graffonet is not deprecated, we don't support it either, so I made the updates accordingly. 

Thanks do much for reaching out and fixing the other typos!
