### PR TITLE
CI: Include deb and rpm artifacts in GitHub releases

### DIFF
--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -33,7 +33,6 @@ jobs:
       release_branch: ${{ steps.output.outputs.release_branch }}
       dry_run: ${{ steps.output.outputs.dry_run }}
       latest: ${{ steps.output.outputs.latest }}
-      build_id: ${{ steps.output.outputs.build_id }}
     env:
       HEAD_REF: ${{ github.head_ref }}
       DRY_RUN: ${{ inputs.dry_run }}
@@ -42,30 +41,23 @@ jobs:
     runs-on: ubuntu-arm64-small
     steps:
     - if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') }}
-      # PR_BODY is read via env (not interpolated into the script) to avoid template injection. The
-      # automated public-release PR embeds "<!-- release-build-id: <id> -->"; manual PRs won't have it.
-      env:
-        PR_BODY: ${{ github.event.pull_request.body }}
       run: |
         {
         echo "VERSION=$(echo "${HEAD_REF}" | sed -e 's/release\/.*\//v/g')"
         echo "DRY_RUN=${{ contains(github.event.pull_request.labels.*.name, 'release/dry-run') }}"
         echo "LATEST=${{ contains(github.event.pull_request.labels.*.name, 'release/latest') && '1' || '0' }}"
-        echo "BUILD_ID=$(printf '%s' "$PR_BODY" | sed -nE 's/.*release-build-id: ([0-9]+).*/\1/p' | head -n1)"
         } >> "$GITHUB_ENV"
     - id: output
       run: |
         echo "dry_run: $DRY_RUN"
         echo "latest: $LATEST"
         echo "version: $VERSION"
-        echo "build_id: ${BUILD_ID:-}"
 
         {
           echo "release_branch=$(echo "$VERSION" | sed -s 's/^v/release-/g')"
           echo "dry_run=$DRY_RUN"
           echo "latest=$LATEST"
           echo "version=$VERSION"
-          echo "build_id=${BUILD_ID:-}"
         } >> "$GITHUB_OUTPUT"
   create_next_release_branch_grafana:
     name: Create next release branch (Grafana)
@@ -161,23 +153,22 @@ jobs:
       dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
       latest: ${{ needs.setup.outputs.latest }}
 
-  # Attach this build's deb/rpm to the GitHub release so the external apt/yum repo-sync can consume
-  # them. Only runs for the automated public-release path (build_id embedded in the PR body); the
-  # manual/private path keeps publishing apt/yum inline and carries no build_id, so this is skipped.
-  # Sources packages from dl.grafana.com (no GCS) and verifies each checksum against the gcom public
-  # packages API before uploading. RPMs are the signed ones served by dl.grafana.com.
+  # Attach this release's deb/rpm to the GitHub release so the external apt/yum repo-sync can consume
+  # them. Runs for every non-+security, non-dry-run public release. The gcom public packages API is the
+  # authoritative manifest (it holds exactly this version's build), so no build id is needed. Sources
+  # packages from dl.grafana.com (no GCS) and verifies each checksum against that API before uploading.
+  # RPMs are the signed ones served by dl.grafana.com.
   attach_release_packages:
     name: Attach Linux packages to the GitHub release
     needs:
       - setup
       - create_github_release
-    if: ${{ needs.setup.outputs.build_id != '' && needs.setup.outputs.dry_run != 'true' && !contains(needs.setup.outputs.version, '+security') }}
+    if: ${{ needs.setup.outputs.dry_run != 'true' && !contains(needs.setup.outputs.version, '+security') }}
     runs-on: ubuntu-arm64-small
     permissions:
       contents: write
     env:
       VERSION: ${{ needs.setup.outputs.version }}
-      BUILD_ID: ${{ needs.setup.outputs.build_id }}
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
     steps:
@@ -195,8 +186,8 @@ jobs:
             api="https://grafana.com/api/${product}/versions/${version}/packages"
             echo "Reading package manifest: ${api}"
             # The gcom public packages API is the authoritative manifest: each entry has url
-            # (dl.grafana.com) + sha256. Select only THIS build's deb/rpm — the new build_id-keyed
-            # filenames contain _<build_id>_, which also excludes any stale/old-format entries.
+            # (dl.grafana.com) + sha256. gcom holds exactly this version's build, so selecting by the
+            # .deb/.rpm extension yields the right set without needing a build id.
             manifest="$(curl -fsSL "$api")"
             count="$(printf '%s' "$manifest" | jq '(.items // .) | length')"
 
@@ -207,7 +198,7 @@ jobs:
               i=$((i + 1))
 
               case "$url" in
-                *_"${BUILD_ID}"_*.deb | *_"${BUILD_ID}"_*.rpm) ;;
+                *.deb | *.rpm) ;;
                 *) continue ;;
               esac
 
@@ -227,7 +218,7 @@ jobs:
           done
 
           if [ "${#files[@]}" -eq 0 ]; then
-            echo "::error::no deb/rpm found for build ${BUILD_ID} of ${version} in the gcom manifest"
+            echo "::error::no deb/rpm found for ${version} in the gcom packages manifest"
             exit 1
           fi
 

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -33,6 +33,7 @@ jobs:
       release_branch: ${{ steps.output.outputs.release_branch }}
       dry_run: ${{ steps.output.outputs.dry_run }}
       latest: ${{ steps.output.outputs.latest }}
+      build_id: ${{ steps.output.outputs.build_id }}
     env:
       HEAD_REF: ${{ github.head_ref }}
       DRY_RUN: ${{ inputs.dry_run }}
@@ -41,23 +42,30 @@ jobs:
     runs-on: ubuntu-arm64-small
     steps:
     - if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') }}
+      # PR_BODY is read via env (not interpolated into the script) to avoid template injection. The
+      # automated public-release PR embeds "<!-- release-build-id: <id> -->"; manual PRs won't have it.
+      env:
+        PR_BODY: ${{ github.event.pull_request.body }}
       run: |
         {
         echo "VERSION=$(echo "${HEAD_REF}" | sed -e 's/release\/.*\//v/g')"
         echo "DRY_RUN=${{ contains(github.event.pull_request.labels.*.name, 'release/dry-run') }}"
         echo "LATEST=${{ contains(github.event.pull_request.labels.*.name, 'release/latest') && '1' || '0' }}"
+        echo "BUILD_ID=$(printf '%s' "$PR_BODY" | sed -nE 's/.*release-build-id: ([0-9]+).*/\1/p' | head -n1)"
         } >> "$GITHUB_ENV"
     - id: output
       run: |
         echo "dry_run: $DRY_RUN"
         echo "latest: $LATEST"
         echo "version: $VERSION"
+        echo "build_id: ${BUILD_ID:-}"
 
         {
           echo "release_branch=$(echo "$VERSION" | sed -s 's/^v/release-/g')"
           echo "dry_run=$DRY_RUN"
           echo "latest=$LATEST"
           echo "version=$VERSION"
+          echo "build_id=${BUILD_ID:-}"
         } >> "$GITHUB_OUTPUT"
   create_next_release_branch_grafana:
     name: Create next release branch (Grafana)
@@ -152,6 +160,80 @@ jobs:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
       latest: ${{ needs.setup.outputs.latest }}
+
+  # Attach this build's deb/rpm to the GitHub release so the external apt/yum repo-sync can consume
+  # them. Only runs for the automated public-release path (build_id embedded in the PR body); the
+  # manual/private path keeps publishing apt/yum inline and carries no build_id, so this is skipped.
+  # Sources packages from dl.grafana.com (no GCS) and verifies each checksum against the gcom public
+  # packages API before uploading. RPMs are the signed ones served by dl.grafana.com.
+  attach_release_packages:
+    name: Attach Linux packages to the GitHub release
+    needs:
+      - setup
+      - create_github_release
+    if: ${{ needs.setup.outputs.build_id != '' && needs.setup.outputs.dry_run != 'true' && !contains(needs.setup.outputs.version, '+security') }}
+    runs-on: ubuntu-arm64-small
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.setup.outputs.version }}
+      BUILD_ID: ${{ needs.setup.outputs.build_id }}
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Download, verify checksums, and attach deb/rpm
+        run: |
+          set -euo pipefail
+
+          version="${VERSION#v}"   # gcom API + dl.grafana.com filenames use the bare version
+          tag="v${version}"        # the GitHub release tag
+
+          workdir="$(mktemp -d)"
+          files=()
+
+          for product in grafana grafana-enterprise; do
+            api="https://grafana.com/api/${product}/versions/${version}/packages"
+            echo "Reading package manifest: ${api}"
+            # The gcom public packages API is the authoritative manifest: each entry has url
+            # (dl.grafana.com) + sha256. Select only THIS build's deb/rpm — the new build_id-keyed
+            # filenames contain _<build_id>_, which also excludes any stale/old-format entries.
+            manifest="$(curl -fsSL "$api")"
+            count="$(printf '%s' "$manifest" | jq '(.items // .) | length')"
+
+            i=0
+            while [ "$i" -lt "$count" ]; do
+              url="$(printf '%s' "$manifest" | jq -r "(.items // .)[$i].url")"
+              sha="$(printf '%s' "$manifest" | jq -r "(.items // .)[$i].sha256" | tr -d '[:space:]')"
+              i=$((i + 1))
+
+              case "$url" in
+                *_"${BUILD_ID}"_*.deb | *_"${BUILD_ID}"_*.rpm) ;;
+                *) continue ;;
+              esac
+
+              fname="$(basename "$url")"
+              dest="${workdir}/${fname}"
+              echo "Downloading ${url}"
+              curl -fsSL -o "$dest" "$url"
+
+              actual="$(sha256sum "$dest" | awk '{print $1}')"
+              if [ "$actual" != "$sha" ]; then
+                echo "::error::checksum mismatch for ${fname}: expected '${sha}', got '${actual}'"
+                exit 1
+              fi
+              echo "verified ${fname}"
+              files+=("$dest")
+            done
+          done
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::no deb/rpm found for build ${BUILD_ID} of ${version} in the gcom manifest"
+            exit 1
+          fi
+
+          echo "Uploading ${#files[@]} package(s) to release ${tag}..."
+          gh release upload "$tag" "${files[@]}" --clobber --repo "$GH_REPO"
+
   post_on_slack:
     needs: setup
     runs-on: ubuntu-arm64-small

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -40,11 +40,6 @@ on:
         required: false
         type: string
         description: "Release date in format YYYY-MM-DD"
-      build_id:
-        required: false
-        type: string
-        default: ""
-        description: "The prerelease build id (grafana-security-mirror run id) for this release. When set, it is embedded in the PR body so release-comms can attach this build's deb/rpm to the GitHub release. Set by the automated public-release (auto-promote) path; empty otherwise."
 
 permissions:
   contents: read
@@ -110,7 +105,6 @@ jobs:
       LATEST: ${{ inputs.latest }}
       DRY_RUN: ${{ inputs.dry_run }}
       RUN_NUMBER: ${{ github.run_number }}
-      BUILD_ID: ${{ inputs.build_id }}
     steps:
       - name: Get GitHub App token
         id: get-github-app-token
@@ -281,14 +275,6 @@ jobs:
           if [ "$LATEST" = "true" ]; then
             LATEST_FLAG=(-l "release/latest")
           fi
-
-          BODY="These code changes must be merged after a release is complete"
-          # When this PR comes from the automated public-release path, embed the build id so release-comms
-          # can attach this exact build's deb/rpm (from dl.grafana.com) to the GitHub release on merge.
-          if [ -n "$BUILD_ID" ]; then
-            BODY="$(printf '%s\n\n<!-- release-build-id: %s -->' "$BODY" "$BUILD_ID")"
-          fi
-
           gh pr create \
             "${LATEST_FLAG[@]}" \
             -l "no-changelog" \
@@ -296,4 +282,4 @@ jobs:
             -B "${RELEASE_BRANCH}" \
             -H "${WORK_BRANCH}" \
             --title "Release: $VERSION" \
-            --body "$BODY"
+            --body "These code changes must be merged after a release is complete"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: string
         description: "Release date in format YYYY-MM-DD"
+      build_id:
+        required: false
+        type: string
+        default: ""
+        description: "The prerelease build id (grafana-security-mirror run id) for this release. When set, it is embedded in the PR body so release-comms can attach this build's deb/rpm to the GitHub release. Set by the automated public-release (auto-promote) path; empty otherwise."
 
 permissions:
   contents: read
@@ -105,6 +110,7 @@ jobs:
       LATEST: ${{ inputs.latest }}
       DRY_RUN: ${{ inputs.dry_run }}
       RUN_NUMBER: ${{ github.run_number }}
+      BUILD_ID: ${{ inputs.build_id }}
     steps:
       - name: Get GitHub App token
         id: get-github-app-token
@@ -275,6 +281,14 @@ jobs:
           if [ "$LATEST" = "true" ]; then
             LATEST_FLAG=(-l "release/latest")
           fi
+
+          BODY="These code changes must be merged after a release is complete"
+          # When this PR comes from the automated public-release path, embed the build id so release-comms
+          # can attach this exact build's deb/rpm (from dl.grafana.com) to the GitHub release on merge.
+          if [ -n "$BUILD_ID" ]; then
+            BODY="$(printf '%s\n\n<!-- release-build-id: %s -->' "$BODY" "$BUILD_ID")"
+          fi
+
           gh pr create \
             "${LATEST_FLAG[@]}" \
             -l "no-changelog" \
@@ -282,4 +296,4 @@ jobs:
             -B "${RELEASE_BRANCH}" \
             -H "${WORK_BRANCH}" \
             --title "Release: $VERSION" \
-            --body "These code changes must be merged after a release is complete"
+            --body "$BODY"


### PR DESCRIPTION
There's an external process to sync deb and rpm packages from GitHub releases to our apt/yum repositories. When the `release-pr` is merged and after the GitHub release is created the `release-comms.yml` workflow downloads the `rpm` and `deb` installer from grafana.com and adds them to the GitHub release.