### PR TITLE
PublicDashboards: Migrate to async DataSource APIs

### DIFF
--- a/public/app/features/dashboard-scene/sharing/public-dashboards/utils.ts
+++ b/public/app/features/dashboard-scene/sharing/public-dashboards/utils.ts
@@ -1,7 +1,7 @@
 import { DataSourceWithBackend } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type VizPanel } from '@grafana/scenes';
 import { supportedDatasources } from 'app/features/dashboard/components/ShareModal/SharePublicDashboard/SupportedPubdashDatasources';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 import { type DashboardScene } from '../../scene/DashboardScene';
 import { getQueryRunnerFor } from '../../utils/utils';
@@ -13,7 +13,7 @@ export const getUnsupportedDashboardDatasources = async (types: string[]): Promi
     if (!supportedDatasources.has(type)) {
       unsupportedDS.add(type);
     } else {
-      const ds = await getDatasourceSrv().get(type);
+      const ds = await getDataSourceInstance(type);
       if (!(ds instanceof DataSourceWithBackend)) {
         unsupportedDS.add(type);
       }

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.test.tsx
@@ -1,5 +1,6 @@
-import { type DataSourceRef, type DataQuery, type TypedVariableModel } from '@grafana/data';
+import { type DataSourceApi, type DataSourceRef, type DataQuery, type TypedVariableModel } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { updateConfig } from 'app/core/config';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -17,22 +18,23 @@ const mockDS = mockDataSource({
   type: 'mock-ds-type',
 });
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => ({
-    get: () =>
-      Promise.resolve(
-        new DataSourceWithBackend({
-          ...mockDS,
-          meta: {
-            ...mockDS.meta,
-            alerting: true,
-            backend: true,
-          },
-        })
-      ),
-  }),
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
 }));
+
+beforeEach(() => {
+  jest.mocked(getDataSourceInstance).mockResolvedValue(
+    new DataSourceWithBackend({
+      ...mockDS,
+      meta: {
+        ...mockDS.meta,
+        alerting: true,
+        backend: true,
+      },
+    }) as unknown as DataSourceApi
+  );
+});
 
 describe('dashboardHasTemplateVariables', () => {
   it('false', () => {

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.ts
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.ts
@@ -1,7 +1,7 @@
 import { type TypedVariableModel } from '@grafana/data';
 import { config, DataSourceWithBackend, featureEnabled } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { getConfig } from 'app/core/config';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 import { type PanelModel } from '../../../state/PanelModel';
 import { shareDashboardType } from '../utils';
@@ -64,7 +64,7 @@ export const getUnsupportedDashboardDatasources = async (panels: PanelModel[]): 
         if (!supportedDatasources.has(dsType)) {
           unsupportedDS.add(dsType);
         } else {
-          const ds = await getDatasourceSrv().get(target.datasource);
+          const ds = await getDataSourceInstance(target.datasource);
           if (!(ds instanceof DataSourceWithBackend)) {
             unsupportedDS.add(dsType);
           }


### PR DESCRIPTION
**What is this feature?**

This PR migrates from the legacy sync API to a new async one, following the guide in https://github.com/grafana/grafana/issues/125083

**Why do we need this feature?**

Code maintenance.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/grafana/issues/127040

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
