### PR TITLE
Extension sidebar: Float over page on mobile instead of shrinking it

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.test.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.test.tsx
@@ -7,17 +7,52 @@ import { render, screen, waitFor, act, getWrapper } from 'test/test-utils';
 import { config, setBackendSrv } from '@grafana/runtime';
 import { getCustomSearchHandler } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
+import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 
 import { backendSrv } from '../../services/backend_srv';
 import { Page } from '../Page/Page';
 
-import { AppChrome } from './AppChrome';
+import { AppChrome, EXTENSION_SIDEBAR_FLOATING_TESTID } from './AppChrome';
+import {
+  type ExtensionSidebarContextType,
+  useExtensionSidebarContext,
+} from './ExtensionSidebar/ExtensionSidebarProvider';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   usePluginLinks: jest.fn().mockReturnValue({ links: [] }),
 }));
+
+jest.mock('app/core/hooks/useMediaQueryMinWidth');
+
+jest.mock('./ExtensionSidebar/ExtensionSidebar', () => ({
+  ...jest.requireActual('./ExtensionSidebar/ExtensionSidebar'),
+  ExtensionSidebar: () => <div data-testid="ext-sidebar-stub" />,
+}));
+
+jest.mock('./ExtensionSidebar/ExtensionSidebarProvider', () => ({
+  ...jest.requireActual('./ExtensionSidebar/ExtensionSidebarProvider'),
+  useExtensionSidebarContext: jest.fn(),
+}));
+
+const mockUseMediaQueryMinWidth = jest.mocked(useMediaQueryMinWidth);
+const mockUseExtensionSidebarContext = jest.mocked(useExtensionSidebarContext);
+
+const closedSidebarContext: ExtensionSidebarContextType = {
+  isOpen: false,
+  dockedComponentId: undefined,
+  setDockedComponentId: jest.fn(),
+  availableComponents: new Map(),
+  extensionSidebarWidth: 300,
+  setExtensionSidebarWidth: jest.fn(),
+};
+
+const openSidebarContext: ExtensionSidebarContextType = {
+  ...closedSidebarContext,
+  isOpen: true,
+  dockedComponentId: 'p/c/v',
+};
 
 setBackendSrv(backendSrv);
 setupMockServer();
@@ -61,6 +96,8 @@ const setup = (children: ReactNode) => {
 describe('AppChrome', () => {
   beforeEach(() => {
     server.use(getCustomSearchHandler([]));
+    mockUseMediaQueryMinWidth.mockReturnValue(false);
+    mockUseExtensionSidebarContext.mockReturnValue(closedSidebarContext);
   });
 
   afterEach(() => {
@@ -106,6 +143,28 @@ describe('AppChrome', () => {
     });
     waitFor(() => {
       expect(screen.queryByRole('link', { name: 'Skip to main content' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('extension sidebar mobile floating', () => {
+    beforeEach(() => {
+      mockUseExtensionSidebarContext.mockReturnValue(openSidebarContext);
+    });
+
+    it('renders the sidebar as a full-width floating overlay on small screens', async () => {
+      mockUseMediaQueryMinWidth.mockReturnValue(false);
+      setup(<Page navId="child1">Children</Page>);
+
+      await screen.findByTestId('ext-sidebar-stub');
+      expect(screen.getByTestId(EXTENSION_SIDEBAR_FLOATING_TESTID)).toBeInTheDocument();
+    });
+
+    it('renders the sidebar docked, not floating, on larger screens', async () => {
+      mockUseMediaQueryMinWidth.mockReturnValue(true);
+      setup(<Page navId="child1">Children</Page>);
+
+      await screen.findByTestId('ext-sidebar-stub');
+      expect(screen.queryByTestId(EXTENSION_SIDEBAR_FLOATING_TESTID)).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -30,6 +30,8 @@ import { ReturnToPrevious } from './ReturnToPrevious/ReturnToPrevious';
 import { SingleTopBar } from './TopBar/SingleTopBar';
 import { getChromeHeaderLevelHeight, useChromeHeaderLevels } from './TopBar/useChromeHeaderHeight';
 
+export const EXTENSION_SIDEBAR_FLOATING_TESTID = 'extension-sidebar-floating';
+
 export interface Props extends PropsWithChildren<{}> {}
 
 export function AppChrome({ children }: Props) {
@@ -53,6 +55,7 @@ export function AppChrome({ children }: Props) {
   const styles = useStyles2(getStyles, headerLevels, getChromeHeaderLevelHeight(), visualRefreshEnabled);
   const contentSizeStyles = useStyles2(getContentSizeStyles, extensionSidebarWidth);
   const dragStyles = useStyles2(getDragStyles);
+  const isSmallScreen = !useMediaQueryMinWidth('sm');
 
   useResponsiveDockedMegaMenu(chrome);
   useMegaMenuFocusHelper(state.megaMenuOpen, state.megaMenuDocked);
@@ -143,26 +146,32 @@ export function AppChrome({ children }: Props) {
               [styles.pageContainerMenuDocked]: menuDockedAndOpen || isScopesDashboardsOpen,
               [styles.pageContainerMenuDockedScopes]: menuDockedAndOpen && isScopesDashboardsOpen,
               [styles.pageContainerWithSidebar]: !state.chromeless && isExtensionSidebarOpen,
-              [contentSizeStyles.contentWidth]: !state.chromeless && isExtensionSidebarOpen,
+              [contentSizeStyles.contentWidth]: !state.chromeless && isExtensionSidebarOpen && !isSmallScreen,
             })}
             id="pageContent"
             tabIndex={-1}
           >
             {children}
           </main>
-          {!state.chromeless && isExtensionSidebarOpen && (
-            <Resizable
-              className={styles.sidebarContainer}
-              defaultSize={{ width: extensionSidebarWidth }}
-              enable={{ left: true }}
-              onResize={(_evt, _direction, ref) => setExtensionSidebarWidth(ref.getBoundingClientRect().width)}
-              handleClasses={{ left: dragStyles.dragHandleBaseVertical }}
-              minWidth={MIN_EXTENSION_SIDEBAR_WIDTH}
-              maxWidth={MAX_EXTENSION_SIDEBAR_WIDTH}
-            >
-              <ExtensionSidebar />
-            </Resizable>
-          )}
+          {!state.chromeless &&
+            isExtensionSidebarOpen &&
+            (isSmallScreen ? (
+              <div className={styles.sidebarContainerFloating} data-testid={EXTENSION_SIDEBAR_FLOATING_TESTID}>
+                <ExtensionSidebar />
+              </div>
+            ) : (
+              <Resizable
+                className={styles.sidebarContainer}
+                defaultSize={{ width: extensionSidebarWidth }}
+                enable={{ left: true }}
+                onResize={(_evt, _direction, ref) => setExtensionSidebarWidth(ref.getBoundingClientRect().width)}
+                handleClasses={{ left: dragStyles.dragHandleBaseVertical }}
+                minWidth={MIN_EXTENSION_SIDEBAR_WIDTH}
+                maxWidth={MAX_EXTENSION_SIDEBAR_WIDTH}
+              >
+                <ExtensionSidebar />
+              </Resizable>
+            ))}
         </div>
       </div>
       {!state.chromeless && !state.megaMenuDocked && <AppChromeMenu />}
@@ -298,6 +307,14 @@ const getStyles = (theme: GrafanaTheme2, headerLevels: number, headerHeight: num
       bottom: 0,
       zIndex: theme.zIndex.navbarFixed + 1,
       right: 0,
+    }),
+    sidebarContainerFloating: css({
+      position: 'fixed',
+      top: headerLevels * headerHeight,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      zIndex: theme.zIndex.navbarFixed + 1,
     }),
   };
 };

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBarActions.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBarActions.tsx
@@ -5,6 +5,7 @@ import { Components } from '@grafana/e2e-selectors';
 import { type ScopesContextValue } from '@grafana/runtime';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { Stack, useStyles2 } from '@grafana/ui';
+import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { ScopesSelector } from 'app/features/scopes/selector/ScopesSelector';
 
 import { useExtensionSidebarContext } from '../ExtensionSidebar/ExtensionSidebarProvider';
@@ -22,11 +23,12 @@ export function SingleTopBarActions({ actions, breadcrumbActions, scopes }: Prop
   const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
   const { isOpen: isExtensionSidebarOpen, extensionSidebarWidth } = useExtensionSidebarContext();
   const styles = useStyles2(getStyles, extensionSidebarWidth, visualRefreshEnabled);
+  const isSmallScreen = !useMediaQueryMinWidth('sm');
 
   return (
     <div
       data-testid={Components.NavToolbar.container}
-      className={cx(styles.actionsBar, isExtensionSidebarOpen && styles.constrained)}
+      className={cx(styles.actionsBar, isExtensionSidebarOpen && !isSmallScreen && styles.constrained)}
     >
       <Stack alignItems="center" justifyContent="flex-start" flex={1} wrap="nowrap" minWidth={0}>
         {scopes?.state.enabled ? <ScopesSelector /> : undefined}


### PR DESCRIPTION
**What is this feature?**

On small screens (below the `sm` / 544px breakpoint) the extension sidebar (Assistant / Pathfinder) now floats as a full-width overlay on top of the page instead of docking beside it and shrinking the page content. Desktop behavior is unchanged — the sidebar stays docked and resizable.

**Why do we need this feature?**

When docked, the sidebar shrinks the page to `calc(100% - sidebarWidth)` — roughly 114px on a 414px phone — leaving the page content unusable while the sidebar is open.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/121018
