### PR TITLE
Zanzana: Add create relation for users and service accounts

### DIFF
--- a/pkg/services/authz/zanzana/schema/schema_core.fga
+++ b/pkg/services/authz/zanzana/schema/schema_core.fga
@@ -3,6 +3,7 @@ module core
 type user
   relations
     define get: [user, service-account, team#member, role#assignee]
+    define create: [user, service-account, team#member, role#assignee]
     define update: [user, service-account, team#member, role#assignee]
     define delete: [user, service-account, team#member, role#assignee]
 
@@ -12,6 +13,7 @@ type user
 type service-account
   relations
     define get: [user, service-account, team#member, role#assignee]
+    define create: [user, service-account, team#member, role#assignee]
     define update: [user, service-account, team#member, role#assignee]
     define delete: [user, service-account, team#member, role#assignee]
 


### PR DESCRIPTION
Follow-up to #127321.

Adds the `create` relation to the `user` and `service-account` core types in the Zanzana schema so authorization checks for `create` on these resources don't fail.