### PR TITLE
Docs: Expand RBAC basic role management examples

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles/index.md
@@ -73,6 +73,21 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/#basic-role-assignments
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/rbac-fixed-basic-role-definitions/#basic-role-assignments
+  rbac-for-app-plugins:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/rbac-for-app-plugins/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/rbac-for-app-plugins/
+  assign-rbac-roles:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/assign-rbac-roles/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/assign-rbac-roles/
+  service-accounts:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/service-accounts/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/service-accounts/
 ---
 
 # Manage RBAC roles
@@ -121,6 +136,20 @@ For a reference of basic and fixed role assignments, refer to [RBAC role definit
 ## Update role permissions
 
 If the default basic role permissions don't meet your requirements you can change them.
+
+Basic roles are mutable. You can add or remove individual permissions on the `Viewer`, `Editor`, `Admin`, and `Grafana Admin` roles without creating a custom role. Each permission is a combination of an `action` and a `scope`. For example, you can remove access to a specific app plugin from all viewers by removing the relevant permissions from the `basic:viewer` role.
+
+Before you change basic role permissions, decide which roles to modify and how the change affects your users and teams. For planning guidance, refer to [Plan your RBAC rollout strategy](ref:plan-rbac-rollout-strategy).
+
+{{< admonition type="caution" >}}
+Changes that you make to a basic role apply to every [organization](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/organization-management/) in the Grafana instance. For example, if you add the `fixed:users:writer` role's permissions to the `Viewer` basic role, all viewers in every organization in the instance can create users.
+
+Basic role changes are scoped to a single Grafana instance. On Grafana Cloud, each stack is a separate instance, so you must apply the change to each stack individually.
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
+If you only need to change access for specific users or teams rather than for every viewer, editor, or admin, leave the basic roles unchanged. Instead, assign the `No Basic Role` organization role and grant fixed or custom roles to those users or teams. For more information, refer to [Assign RBAC roles](ref:assign-rbac-roles).
+{{< /admonition >}}
 
 You can change basic roles' permissions [via the configuration file](#update-basic-role-permissions-in-the-configuration-file) or [using the RBAC API](#update-basic-role-permissions-using-the-rbac-api).
 
@@ -194,7 +223,98 @@ Make sure to **increment** the role version for the changes to be accounted for.
 
 ### Update basic role permissions using the RBAC API
 
-Refer to the [RBAC HTTP API](ref:api-rbac-update-a-role) for more details.
+Use the RBAC HTTP API when you want to change basic role permissions programmatically, for example from a script or a CI pipeline. The API uses two endpoints:
+
+- `GET /api/access-control/roles/{roleUID}` returns a basic role and all of its permissions. Refer to [Get a role](ref:api-rbac-get-a-role).
+- `PUT /api/access-control/roles/{roleUID}` replaces the role's permissions with the set that you send. Refer to [Update a role](ref:api-rbac-update-a-role).
+
+Basic role UIDs follow the pattern `basic_<role>`, where `<role>` is `viewer`, `editor`, `admin`, or `grafana_admin`.
+
+Because `PUT` replaces the entire permission set, fetch the current role first, modify its permissions, increment its `version`, and then send the result back. Each request authenticates with a [service account token](ref:service-accounts) that has the `Role writer` role, or with basic authentication as a `Grafana Admin`.
+
+{{< admonition type="note" >}}
+Send `global: true` in the request body when you update a global basic role, and set `version` to a value higher than the current version. Grafana rejects updates that don't increase the version.
+{{< /admonition >}}
+
+#### Example: Modify the Grafana Admin role using the API
+
+The following example makes the same change as the [configuration file example](#example-modify-the-grafana-admin-role) using the API instead. It removes the permissions to list, grant, and revoke roles to teams, and adds permissions to read and write Grafana folders.
+
+The script fetches the `basic:grafana_admin` role, removes and adds permissions with `jq`, increments the version, and updates the role:
+
+```bash
+# Fetch the role, modify its permissions, and increment its version
+curl -H "Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>" \
+  -X GET '<GRAFANA_URL>/api/access-control/roles/basic_grafana_admin' | \
+  jq 'del(.created) | del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
+  jq 'del(.permissions[] | select(.action == "teams.roles:read")) | del(.permissions[] | select(.action == "teams.roles:add")) | del(.permissions[] | select(.action == "teams.roles:remove"))' | \
+  jq '.permissions += [{"action": "folders:read", "scope": "folders:*"}, {"action": "folders:write", "scope": "folders:*"}]' > basic_grafana_admin.json
+
+# Update the role with the modified permissions
+curl -H "Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>" -H "Content-Type: application/json" \
+  -X PUT -d @basic_grafana_admin.json \
+  '<GRAFANA_URL>/api/access-control/roles/basic_grafana_admin'
+```
+
+Replace the following placeholders:
+
+- _`<SERVICE_ACCOUNT_TOKEN>`_: A service account token with permission to read and write roles, for example `glsa_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`. To use basic authentication instead, replace the `Authorization` header with `-u admin:<PASSWORD>`.
+- _`<GRAFANA_URL>`_: The base URL of your Grafana instance, for example `https://<YOUR_STACK_NAME>.grafana.net` on Grafana Cloud or `http://localhost:3000` for a local instance.
+
+The `jq` filters first strip the read-only `created` and `updated` timestamps and increment the role `version`, then remove the unwanted permissions, and finally append the new ones. The `PUT` request sends the resulting role definition back to Grafana.
+
+#### Example: Remove Grafana Assistant access from Viewers
+
+By default, viewers can access all app plugins that their organization role allows, including Grafana Assistant. To prevent viewers from accessing Grafana Assistant, remove the following permissions from the `basic:viewer` role:
+
+| Action                               | Scope                              |
+| ------------------------------------ | ---------------------------------- |
+| `grafana-assistant-app.chats:access` |                                    |
+| `plugins.app:access`                 | `plugins:id:grafana-assistant-app` |
+
+You can remove these permissions with the configuration file or with the API.
+
+Use the `role > from` list and `permission > state` option of your provisioning file to remove the permissions:
+
+```yaml
+apiVersion: 2
+
+roles:
+  - name: 'basic:viewer'
+    global: true
+    version: 9
+    from:
+      - name: 'basic:viewer'
+        global: true
+    permissions:
+      - action: 'grafana-assistant-app.chats:access'
+        state: 'absent'
+      - action: 'plugins.app:access'
+        scope: 'plugins:id:grafana-assistant-app'
+        state: 'absent'
+```
+
+Alternatively, use the RBAC HTTP API. The following script fetches the `basic:viewer` role, removes the two Grafana Assistant permissions, increments the version, and updates the role:
+
+```bash
+# Fetch the role, remove the Grafana Assistant permissions, and increment its version
+curl -H "Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>" \
+  -X GET '<GRAFANA_URL>/api/access-control/roles/basic_viewer' | \
+  jq 'del(.created) | del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
+  jq 'del(.permissions[] | select(.action == "grafana-assistant-app.chats:access")) | del(.permissions[] | select(.action == "plugins.app:access" and .scope == "plugins:id:grafana-assistant-app"))' > basic_viewer.json
+
+# Update the role with the modified permissions
+curl -H "Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>" -H "Content-Type: application/json" \
+  -X PUT -d @basic_viewer.json \
+  '<GRAFANA_URL>/api/access-control/roles/basic_viewer'
+```
+
+Replace the following placeholders:
+
+- _`<SERVICE_ACCOUNT_TOKEN>`_: A service account token with permission to read and write roles.
+- _`<GRAFANA_URL>`_: The base URL of your Grafana instance.
+
+To find the IDs of other app plugins, refer to [RBAC for app plugins](ref:rbac-for-app-plugins). That page also explains how to grant fine-grained app plugin access to specific users and teams without changing the basic roles.
 
 ## Reset basic roles to their default
 

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-terraform-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-terraform-provisioning/index.md
@@ -46,6 +46,21 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/service-accounts/#to-add-a-token-to-a-service-account
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/account-management/authentication-and-permissions/service-accounts/#to-add-a-token-to-a-service-account
+  plan-rbac-rollout-strategy:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/plan-rbac-rollout-strategy/
+  manage-rbac-roles:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/manage-rbac-roles/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/manage-rbac-roles/
+  custom-role-actions-scopes:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/custom-role-actions-scopes/
 ---
 
 # Provisioning RBAC with Terraform
@@ -56,13 +71,17 @@ Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/g
 
 You can create, change or remove [Custom roles](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role) and create or remove [role assignments](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role_assignment), by using [Terraform's Grafana provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs).
 
+Before you provision roles and assignments, decide which roles to create and how to assign them to users and teams. For planning guidance, refer to [Plan your RBAC rollout strategy](ref:plan-rbac-rollout-strategy).
+
 ## Before you begin
 
 - Ensure you have the grafana/grafana [Terraform provider](https://registry.terraform.io/providers/grafana/grafana/) 1.29.0 or higher.
 
 - Ensure you are using Grafana 9.2 or higher.
 
-## Create a Service Account Token for provisioning
+- Decide how to authenticate the provider. We recommend a [service account token](ref:service-accounts) for self-managed Grafana and Grafana Cloud. For more information, refer to [Create a service account token for provisioning](#create-a-service-account-token-for-provisioning).
+
+## Create a service account token for provisioning
 
 We recommend using service account tokens for provisioning. [Service accounts](ref:service-accounts) support fine grained permissions, which allows you to easily authenticate and use the minimum set of permissions needed to provision your RBAC infrastructure.
 
@@ -74,33 +93,47 @@ To create a service account token for provisioning, complete the following steps
    - Alternatively, you can assign "Admin" basic role to the service account.
 1. [Create a new service account token](ref:service-accounts-to-add-a-token-to-a-service-account) for use in Terraform.
 
-Alternatively, you can use basic authentication. To view all the supported authentication formats, see [here](https://registry.terraform.io/providers/grafana/grafana/latest/docs#authentication).
+Alternatively, you can use basic authentication. To view all the supported authentication formats, refer to the [provider authentication documentation](https://registry.terraform.io/providers/grafana/grafana/latest/docs#authentication).
 
 ## Configure the Terraform provider
 
 RBAC support is included as part of the [Grafana Terraform provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs).
 
-The following is an example you can use to configure the Terraform provider.
+The following example configures the provider. To keep your service account token out of source control, set the credentials with the `GRAFANA_URL` and `GRAFANA_AUTH` environment variables instead of hardcoding them in the configuration:
 
 ```terraform
 terraform {
-    required_providers {
-        grafana = {
-            source = "grafana/grafana"
-            version = ">= 1.29.0"
-        }
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = ">= 1.29.0"
     }
+  }
 }
 
-provider "grafana" {
-    url = <YOUR_GRAFANA_URL>
-    auth = <YOUR_GRAFANA_SERVICE_ACCOUNT_TOKEN>
-}
+# Reads credentials from the GRAFANA_URL and GRAFANA_AUTH environment variables
+provider "grafana" {}
 ```
+
+Export the environment variables before you run Terraform:
+
+```bash
+export GRAFANA_URL="<GRAFANA_URL>"
+export GRAFANA_AUTH="<SERVICE_ACCOUNT_TOKEN>"
+```
+
+Replace the following placeholders:
+
+- _`<GRAFANA_URL>`_: The base URL of your Grafana instance, for example `https://<YOUR_STACK_NAME>.grafana.net` on Grafana Cloud or `http://localhost:3000` for a local instance.
+- _`<SERVICE_ACCOUNT_TOKEN>`_: A service account token with permission to manage the roles and assignments that you provision, for example `glsa_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`.
+
+Alternatively, set the `url` and `auth` attributes directly in the `provider` block. To view all the supported authentication formats, refer to the [provider authentication documentation](https://registry.terraform.io/providers/grafana/grafana/latest/docs#authentication).
 
 ## Provision basic roles
 
 Basic roles (`None`, `Viewer`, `Editor`, `Admin`, and `Grafana Admin`) correspond to a user's or service account's organization role. A basic role's permissions are derived from the organization role, so you manage basic roles by setting the organization role rather than by creating an RBAC role assignment. The `grafana_role_assignment` resource only assigns fixed and custom roles.
+
+To change which permissions a basic role grants, rather than who has the role, edit the basic role's permissions instead. For more information, refer to [Manage RBAC roles](ref:manage-rbac-roles).
 
 {{< admonition type="note" >}}
 Assigning a basic role such as `basic_admin` with `grafana_role_assignment` fails with the error `this endpoint cannot be used to assign basic, managed or external services roles`.
@@ -158,37 +191,42 @@ The following example shows how to provision a custom role with some permissions
 
 ```terraform
 resource "grafana_role" "my_new_role" {
-  name  = "my_new_role"
-  description = "My test role"
-  version = 1
-  uid = "newroleuid"
-  global = false
+  name        = "custom:users:manager"
+  description = "Manage organization users and teams"
+  uid         = "customusersmanager"
+  version     = 1
+  global      = false
 
+  # Manage organization users
+  permissions {
+    action = "org.users:read"
+    scope  = "users:*"
+  }
   permissions {
     action = "org.users:add"
-    scope = "users:*"
+    scope  = "users:*"
   }
   permissions {
     action = "org.users:write"
-    scope = "users:*"
+    scope  = "users:*"
+  }
+
+  # Manage teams
+  permissions {
+    action = "teams:create"
   }
   permissions {
-    action = "org.users:read"
-    scope = "users:*"
+    action = "teams:read"
+    scope  = "teams:*"
   }
   permissions {
-	  action = "teams:create"
-  }
-  permissions {
-	  action = "teams:read"
-	  scope = "teams:*"
-  }
-  permissions {
-	  action = "teams:write"
-	  scope = "teams:*"
+    action = "teams:write"
+    scope  = "teams:*"
   }
 }
 ```
+
+For a reference of the available actions and scopes that you can grant in a custom role, refer to [RBAC actions and scopes](ref:custom-role-actions-scopes).
 
 2. Run the command `terraform apply`.
 3. Go to Grafana's UI and check that the new role appears in the role picker:
@@ -238,8 +276,9 @@ Note that instead of using a provisioned role, you can also look up the `uid` of
 You can use the [API endpoint for listing roles](ref:api-rbac-create-and-manage-custom-roles) to look up role `uid`s.
 Similarly, you can look up and use `id`s of users, teams and service accounts that have not been provisioned to assign roles to them.
 
-## Useful Links
+## Useful links
 
-[RBAC setup with Grafana provisioning](ref:rbac-grafana-provisioning)
-
-[Grafana Cloud Terraform provisioning](/docs/grafana-cloud/developer-resources/infrastructure-as-code/terraform/)
+- [Plan your RBAC rollout strategy](ref:plan-rbac-rollout-strategy)
+- [Manage RBAC roles](ref:manage-rbac-roles)
+- [RBAC setup with Grafana provisioning](ref:rbac-grafana-provisioning)
+- [Grafana Cloud Terraform provisioning](/docs/grafana-cloud/developer-resources/infrastructure-as-code/terraform/)


### PR DESCRIPTION
## Summary

The "Update basic role permissions using the RBAC API" section of the Manage RBAC roles page was a single sentence with no example, and the Terraform provisioning examples were minimal. Neither page linked to the RBAC rollout strategy doc. This PR fleshes both out with complete, tested examples grounded in a real use case (preventing Viewers from accessing the Grafana Assistant app plugin).

### `manage-rbac-roles/index.md`
- Rewrote the RBAC HTTP API section into a full walkthrough: documents `GET`/`PUT /api/access-control/roles/{roleUID}`, the `basic_<role>` UID pattern, and the fetch → modify → increment-`version` → `PUT` flow.
- Added two worked `curl` examples: modifying the Grafana Admin role (remove team-role delegation, add folder read/write) and removing Grafana Assistant access from Viewers (`grafana-assistant-app.chats:access` + `plugins.app:access` scoped to `plugins:id:grafana-assistant-app`), shown in both provisioning-YAML (`state: absent`) and HTTP API form.
- Added caveats (changes affect all orgs in the instance; per-instance/per-Cloud-stack; the "No Basic Role + fixed/custom roles" alternative) as admonitions.
- Linked the RBAC rollout strategy doc, Assign RBAC roles, and RBAC for app plugins.

### `rbac-terraform-provisioning/index.md`
- Linked the strategy doc from the intro, "Before you begin", and "Useful links".
- Switched provider auth to the idiomatic `GRAFANA_URL`/`GRAFANA_AUTH` env-var pattern.
- Enhanced the custom-role example with comments, a realistic permission set, and an actions/scopes reference link. Fixed two title-case headings and a "see here" wording.

## Test plan

- [x] `yarn prettier --write` on both files (no formatting changes needed).
- [x] Verified the RBAC HTTP API examples against a local Grafana on `localhost:3000`: `GET`/`PUT /api/access-control/roles/basic_viewer` and `basic_grafana_admin` returned `200`; re-fetch confirmed permissions added/removed and version incremented; service-account-token auth confirmed.
- [ ] Docs preview render review.