### PR TITLE
OrganizationSwitcher: Reload page after switching active organization

### DIFF
--- a/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.test.tsx
+++ b/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.test.tsx
@@ -3,7 +3,6 @@ import { TestProvider } from 'test/helpers/TestProvider';
 import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 
 import { OrgRole } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { ContextSrv, setContextSrv } from 'app/core/services/context_srv';
 import { getUserOrganizations, setUserOrganization } from 'app/features/org/state/actions';
 import { type StoreState } from 'app/types/store';
@@ -33,7 +32,7 @@ const renderWithProvider = ({ initialState }: { initialState?: Partial<StoreStat
 
 describe('OrganisationSwitcher', () => {
   const originalLocation = window.location;
-  let assignMock: jest.Mock;
+  let reloadMock: jest.Mock;
 
   beforeEach(() => {
     mockDispatch.mockReset();
@@ -46,11 +45,11 @@ describe('OrganisationSwitcher', () => {
         }) as unknown as MediaQueryList
     );
 
-    assignMock = jest.fn();
+    reloadMock = jest.fn();
     Object.defineProperty(window, 'location', {
       configurable: true,
       writable: true,
-      value: { ...originalLocation, assign: assignMock },
+      value: { ...originalLocation, reload: reloadMock },
     });
   });
 
@@ -122,9 +121,8 @@ describe('OrganisationSwitcher', () => {
     expect(getUserOrganizations).not.toHaveBeenCalled();
   });
 
-  it('dispatches setUserOrganization and navigates after the request resolves', async () => {
+  it('dispatches setUserOrganization and reloads after the request resolves', async () => {
     mockDispatch.mockResolvedValueOnce(undefined);
-    config.appSubUrl = '/grafana';
 
     renderWithProvider({
       initialState: {
@@ -142,12 +140,11 @@ describe('OrganisationSwitcher', () => {
 
     expect(setUserOrganization).toHaveBeenCalledWith(2);
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'setUserOrganization', orgId: 2 });
-    expect(assignMock).toHaveBeenCalledWith('/grafana/?orgId=2');
+    expect(reloadMock).toHaveBeenCalled();
   });
 
-  it('does not navigate when setUserOrganization rejects', async () => {
+  it('does not reload when setUserOrganization rejects', async () => {
     mockDispatch.mockRejectedValueOnce(new Error('boom'));
-    config.appSubUrl = '/grafana';
 
     renderWithProvider({
       initialState: {
@@ -164,6 +161,6 @@ describe('OrganisationSwitcher', () => {
     await selectOptionInTest(screen.getByRole('combobox', { name: 'Change organization' }), 'test2');
 
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'setUserOrganization', orgId: 2 });
-    expect(assignMock).not.toHaveBeenCalled();
+    expect(reloadMock).not.toHaveBeenCalled();
   });
 });

--- a/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.tsx
+++ b/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
 import type { SelectableValue } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { Text } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getUserOrganizations, setUserOrganization } from 'app/features/org/state/actions';
@@ -20,13 +19,14 @@ export function OrganizationSwitcher() {
       return;
     }
     try {
-      // Await so /api/user/using/:orgId completes before navigation
+      // Await so /api/user/using/:orgId persists the active org before we reload
       await dispatch(setUserOrganization(option.value.orgId));
     } catch {
       // backendSrv shows the error toast; abort so we don't reload into the wrong org
       return;
     }
-    window.location.assign(`${config.appSubUrl}/?orgId=${option.value.orgId}`);
+    // Hard reload so cached state (Redux, RTK Query, scenes) from the previous org is cleared
+    window.location.reload();
   };
   useEffect(() => {
     if (


### PR DESCRIPTION
## What this PR does

Restores the full page reload after switching the active organization via the
OrganizationSwitcher, so the UI reflects the newly selected org without a manual
browser refresh.

## Why

In #120967 the switch flow replaced `window.location.reload()` with
`window.location.assign('/?orgId=N')`. The active org is persisted server-side by
the awaited `POST /api/user/using/:orgId`, but cached client state (Redux store,
RTK Query, scenes) from the previous org is no longer cleared on switch. Users see
stale dashboards, logs, and metrics until they manually refresh the browser.

This is a regression in 13.1.0; switching worked correctly in 13.0.2.

## Change

After the switch request resolves, call `window.location.reload()` instead of
navigating to `/?orgId=N`. Since the POST already persists the active org, the
reload renders the current page in the new org and clears all in-memory state.
This matches the established pattern in `SharedPreferences`, which persists a
preference then reloads to apply it. The now-unused `config`/`appSubUrl` usage is
removed.

## Which issue(s) this PR fixes

- https://github.com/grafana/grafana/issues/127148

## Testing

- Updated `OrganizationSwitcher.test.tsx` to assert `window.location.reload` is
  called on success and not called when the dispatch rejects.
- `yarn jest OrganizationSwitcher` passes (6/6); eslint and prettier clean.

Manual: with a user in 2+ orgs, switch org from the app chrome switcher and
confirm the page reloads and shows the new org's data without a manual refresh.