### PR TITLE
Provisioning: fix flaky TestIntegrationProvisioning_MoveResources

### DIFF
--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -322,9 +322,9 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		// and updated/content-updated.json). Two files mapping to the same dashboard UID
 		// are written in parallel by the full sync below and would race into an
 		// optimistic-lock conflict ("the object has been modified").
-		timelineContent := strings.Replace(string(helper.LoadFile("testdata/timeline-demo.json")), `"uid": "mIJjFy8Kz"`, `"uid": "move-dir-timeline"`, 1)
+		timelineContent := strings.Replace(string(helper.LoadFile("testdata/timeline-demo.json")), `"name": "mIJjFy8Kz"`, `"name": "move-dir-timeline"`, 1)
 		helper.WriteToProvisioningPath(t, "source-dir/timeline-demo.json", []byte(timelineContent))
-		textOptionsContent := strings.Replace(string(helper.LoadFile("testdata/text-options.json")), `"uid": "WZ7AhQiVz"`, `"uid": "move-dir-text"`, 1)
+		textOptionsContent := strings.Replace(string(helper.LoadFile("testdata/text-options.json")), `"name": "WZ7AhQiVz"`, `"name": "move-dir-text"`, 1)
 		helper.WriteToProvisioningPath(t, "source-dir/text-options.json", []byte(textOptionsContent))
 
 		// Sync to ensure files are recognized


### PR DESCRIPTION
## Summary

`TestIntegrationProvisioning_MoveResources` flakes with an optimistic-lock conflict during sync:

```
sync job "move-test-repo-sync" ... ended in error state; errors: [writing resource from file
source-dir/timeline-demo.json: Operation cannot be fulfilled on dashboards.dashboard.grafana.app
"mIJjFy8Kz": the object has been modified; please apply your changes to the latest version and try again]
```

([example failure](https://github.com/grafana/grafana/actions/runs/28363689218/job/84024225227))

### Root cause

The `move directory ... should return MethodNotAllowed` subtest does a full sync of `source-dir/timeline-demo.json` and `source-dir/text-options.json`. Those files share dashboard UIDs with files written by earlier subtests in the same repo:

- `source-dir/timeline-demo.json` (UID `mIJjFy8Kz`) ↔ `deep/nested/timeline.json` (same UID)
- `source-dir/text-options.json` (UID `WZ7AhQiVz`) ↔ `updated/content-updated.json` (same UID)

Sync writes resources in parallel, so two files mapping to the same dashboard UID race into an optimistic-lock conflict.

PR #126779 attempted to fix this by rewriting the UIDs to be unique, but targeted a `"uid"` field that does not exist in these `dashboard.grafana.app/v2` testdata files — their identity lives in `metadata.name`. The `strings.Replace` matched nothing and was a silent no-op, so the colliding UIDs remained (visible in the failure dump, which still shows `mIJjFy8Kz`/`WZ7AhQiVz`).

## Changes

- Target `metadata.name` instead of the non-existent `"uid"` field, so the `source-dir/*` files get unique UIDs (`move-dir-timeline`, `move-dir-text`) and no longer collide during the parallel sync.

## Testing

- `go vet ./pkg/tests/apis/provisioning/` — clean
- `go test -run TestIntegrationProvisioning_MoveResources ./pkg/tests/apis/provisioning/ -count=5` — passes 5/5 (plus an initial single run)

## Checklist

- [x] Tests pass
- [x] No production code changed (test-only fix)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)