### PR TITLE
Deps: Unpin production dependencies in `@grafana/runtime`

### DIFF
--- a/package.json
+++ b/package.json
@@ -425,6 +425,7 @@
     "slate-dev-environment@^0.2.2": "patch:slate-dev-environment@npm:0.2.5#.yarn/patches/slate-dev-environment-npm-0.2.5-9aeb7da7b5.patch",
     "react-split-pane@0.1.92": "patch:react-split-pane@npm:0.1.92#.yarn/patches/react-split-pane-npm-0.1.92-93dbf51dff.patch",
     "history@4.10.1": "patch:history@npm%3A4.10.1#./.yarn/patches/history-npm-4.10.1-ee217563ae.patch",
+    "history@^4.10.1": "patch:history@npm%3A4.10.1#./.yarn/patches/history-npm-4.10.1-ee217563ae.patch",
     "redux": "^5.0.0",
     "react-grid-layout": "patch:react-grid-layout@npm%3A1.4.4#~/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch",
     "@grafana/plugin-e2e/@grafana/e2e-selectors": "workspace:*",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -71,7 +71,7 @@
     "lru-cache": "^11.2.2",
     "react-loading-skeleton": "^3.5.0",
     "react-use": "^17.6.1",
-    "rxjs": "7.8.2"
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "16.0.1",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -63,7 +63,7 @@
     "@openfeature/ofrep-web-provider": "^0.4.1",
     "@openfeature/react-sdk": "^1.3.0",
     "@openfeature/web-sdk": "^1.8.0",
-    "@types/systemjs": "6.15.3",
+    "@types/systemjs": "^6.15.3",
     "fast-json-patch": "3.1.1",
     "history": "4.10.1",
     "immutable": "^5.1.5",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -69,7 +69,7 @@
     "immutable": "^5.1.5",
     "lodash": "^4.17.23",
     "lru-cache": "^11.2.2",
-    "react-loading-skeleton": "3.5.0",
+    "react-loading-skeleton": "^3.5.0",
     "react-use": "17.6.1",
     "rxjs": "7.8.2"
   },

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -65,7 +65,7 @@
     "@openfeature/web-sdk": "^1.8.0",
     "@types/systemjs": "^6.15.3",
     "fast-json-patch": "^3.1.1",
-    "history": "4.10.1",
+    "history": "^4.10.1",
     "immutable": "^5.1.5",
     "lodash": "^4.17.23",
     "lru-cache": "^11.2.2",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -70,7 +70,7 @@
     "lodash": "^4.17.23",
     "lru-cache": "^11.2.2",
     "react-loading-skeleton": "^3.5.0",
-    "react-use": "17.6.1",
+    "react-use": "^17.6.1",
     "rxjs": "7.8.2"
   },
   "devDependencies": {

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -64,7 +64,7 @@
     "@openfeature/react-sdk": "^1.3.0",
     "@openfeature/web-sdk": "^1.8.0",
     "@types/systemjs": "^6.15.3",
-    "fast-json-patch": "3.1.1",
+    "fast-json-patch": "^3.1.1",
     "history": "4.10.1",
     "immutable": "^5.1.5",
     "lodash": "^4.17.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2747,7 +2747,7 @@ __metadata:
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-loading-skeleton: "npm:^3.5.0"
-    react-use: "npm:17.6.1"
+    react-use: "npm:^17.6.1"
     rimraf: "npm:6.0.1"
     rollup: "npm:^4.60.1"
     rollup-plugin-esbuild: "npm:6.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2740,7 +2740,7 @@ __metadata:
     "@types/systemjs": "npm:^6.15.3"
     esbuild: "npm:0.25.8"
     fast-json-patch: "npm:^3.1.1"
-    history: "npm:4.10.1"
+    history: "npm:^4.10.1"
     immutable: "npm:^5.1.5"
     lodash: "npm:^4.17.23"
     lru-cache: "npm:^11.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2752,7 +2752,7 @@ __metadata:
     rollup: "npm:^4.60.1"
     rollup-plugin-esbuild: "npm:6.2.1"
     rollup-plugin-node-externals: "npm:^8.0.0"
-    rxjs: "npm:7.8.2"
+    rxjs: "npm:^7.8.2"
     typescript: "npm:6.0.2"
   peerDependencies:
     react: ^18.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,7 +2737,7 @@ __metadata:
     "@types/lodash": "npm:4.17.20"
     "@types/react": "npm:18.3.18"
     "@types/react-dom": "npm:18.3.5"
-    "@types/systemjs": "npm:6.15.3"
+    "@types/systemjs": "npm:^6.15.3"
     esbuild: "npm:0.25.8"
     fast-json-patch: "npm:3.1.1"
     history: "npm:4.10.1"
@@ -10442,7 +10442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/systemjs@npm:6.15.3":
+"@types/systemjs@npm:6.15.3, @types/systemjs@npm:^6.15.3":
   version: 6.15.3
   resolution: "@types/systemjs@npm:6.15.3"
   checksum: 10/c2e6d7b3d83282657074e0b2d5bfcd6e4923f02d659e7bd3bca215466aee1960a444243d0f97dd26e8843a45e2b34ee33ecac39efb4e419ce2dc8f8f7fb03472

--- a/yarn.lock
+++ b/yarn.lock
@@ -2739,7 +2739,7 @@ __metadata:
     "@types/react-dom": "npm:18.3.5"
     "@types/systemjs": "npm:^6.15.3"
     esbuild: "npm:0.25.8"
-    fast-json-patch: "npm:3.1.1"
+    fast-json-patch: "npm:^3.1.1"
     history: "npm:4.10.1"
     immutable: "npm:^5.1.5"
     lodash: "npm:^4.17.23"
@@ -17118,7 +17118,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-patch@npm:3.1.1, fast-json-patch@npm:^3.0.0-1":
+"fast-json-patch@npm:3.1.1, fast-json-patch@npm:^3.0.0-1, fast-json-patch@npm:^3.1.1":
   version: 3.1.1
   resolution: "fast-json-patch@npm:3.1.1"
   checksum: 10/3e56304e1c95ad1862a50e5b3f557a74c65c0ff2ba5b15caab983b43e70e86ddbc5bc887e9f7064f0aacfd0f0435a29ab2f000fe463379e72b906486345e6671

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,7 +2746,7 @@ __metadata:
     lru-cache: "npm:^11.2.2"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
-    react-loading-skeleton: "npm:3.5.0"
+    react-loading-skeleton: "npm:^3.5.0"
     react-use: "npm:17.6.1"
     rimraf: "npm:6.0.1"
     rollup: "npm:^4.60.1"


### PR DESCRIPTION
**What is this feature?**

Unpins all production dependencies in the `@grafana/runtime` package, using the `^` semver operator to allow consumers to bump minor + patch versions as needed (e.g., to resolve dependency vulnerabilities). Open to feedback on where specific dependencies should use `~` or remain pinned, if folks have specific context/knowledge around dependencies not respecting semver correctly.

Each commit was generated by manually updating the version specifier in `package.json`, then running `yarn && yarn dedupe && yarn typecheck`, before manually verifying the lockfile diff to ensure no actual version changes occurred (some doctoring was required to revert this when it happened).

**Why do we need this feature?**

Updated [internal policy](https://docs.google.com/document/d/19rr_cEdeIQmC34BO69SWl3ELJxpSBOwdVSJ1T7SERcY/edit?usp=sharing) (🔐) that specifies that published packages should NOT pin their dependencies, to prevent downstream consumers from being stuck with vulnerable transitive dependencies.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

cc #127460

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
