### PR TITLE
chore(mt-annotations): preserve legacy data field when proxying

### DIFF
--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -325,9 +325,9 @@ func (s *k8sRESTAdapter) Update(ctx context.Context,
 
 	// Preserve legacy data when the caller omits it, mirroring the legacy API's behavior.
 	// An absent annotation keeps the stored value, while a present annotation overwrites or clears it.
-	if _, ok := getLegacyData(resource); !ok {
-		if existingData, ok := getLegacyData(existing); ok {
-			setLegacyData(resource, existingData)
+	if _, ok := GetLegacyData(resource); !ok {
+		if existingData, ok := GetLegacyData(existing); ok {
+			SetLegacyData(resource, existingData)
 		}
 	}
 

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -72,7 +72,7 @@ func testGetLegacyID(t *testing.T, anno *annotationV0.Annotation) int64 {
 // testGetLegacyData is a test helper that extracts the legacy data blob from an annotation.
 func testGetLegacyData(t *testing.T, anno *annotationV0.Annotation) string {
 	t.Helper()
-	v, _ := getLegacyData(anno)
+	v, _ := GetLegacyData(anno)
 	return v
 }
 

--- a/pkg/registry/apps/annotation/legacy.go
+++ b/pkg/registry/apps/annotation/legacy.go
@@ -43,11 +43,11 @@ func SetLegacyID(obj metav1.Object, id int64) {
 	obj.SetLabels(labels)
 }
 
-// getLegacyData reads the grafana.app/legacyData annotation from the object.
+// GetLegacyData reads the grafana.app/legacyData annotation from the object.
 // The boolean reports whether the annotation was present, letting callers
 // distinguish an omitted value (preserve existing) from an explicit empty
 // value (clear) — mirroring the legacy API's omitted-vs-null data semantics.
-func getLegacyData(obj metav1.Object) (string, bool) {
+func GetLegacyData(obj metav1.Object) (string, bool) {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return "", false
@@ -56,10 +56,10 @@ func getLegacyData(obj metav1.Object) (string, bool) {
 	return v, ok
 }
 
-// setLegacyData writes the given data string to the grafana.app/legacyData
+// SetLegacyData writes the given data string to the grafana.app/legacyData
 // annotation on the object. An empty string is written verbatim so callers can
 // signal an explicit clear.
-func setLegacyData(obj metav1.Object, data string) {
+func SetLegacyData(obj metav1.Object, data string) {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string, 1)

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -183,7 +183,7 @@ func (s *PostgreSQLStore) Create(ctx context.Context, anno *annotationV0.Annotat
 	}
 
 	var legacyData *string
-	if d, ok := getLegacyData(anno); ok {
+	if d, ok := GetLegacyData(anno); ok {
 		legacyData = &d
 	}
 
@@ -212,7 +212,7 @@ func (s *PostgreSQLStore) Create(ctx context.Context, anno *annotationV0.Annotat
 // Update updates an existing annotation (only mutable fields: text, tags, scopes, legacy_data)
 func (s *PostgreSQLStore) Update(ctx context.Context, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
 	var legacyData *string
-	if d, ok := getLegacyData(anno); ok {
+	if d, ok := GetLegacyData(anno); ok {
 		legacyData = &d
 	}
 
@@ -456,7 +456,7 @@ func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
 
 	// Populate the legacy data annotation if the column has a value
 	if legacyData != nil {
-		setLegacyData(anno, *legacyData)
+		SetLegacyData(anno, *legacyData)
 	}
 
 	return anno

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	annotationpkg "github.com/grafana/grafana/pkg/registry/apps/annotation"
 	"github.com/grafana/grafana/pkg/services/annotations"
@@ -82,7 +83,11 @@ func (h *MigrationProxy) List(ctx context.Context, orgID int64, query *annotatio
 
 	dtos := make([]*annotations.ItemDTO, 0, len(annos))
 	for _, anno := range annos {
-		dto := annoToItemDTO(anno)
+		dto, err := annoToItemDTO(anno)
+		if err != nil {
+			h.logger.Warn("failed to convert annotation to DTO, dropping it", "err", err)
+			continue
+		}
 		if cb := anno.GetCreatedBy(); cb != "" {
 			if u, ok := userMap[cb]; ok {
 				applyUserToDTO(u, dto)
@@ -124,7 +129,11 @@ func Merge(newItems, legacyItems []*annotations.ItemDTO, limit int64) []*annotat
 
 // Create writes to new store and returns the assigned legacy ID.
 func (h *MigrationProxy) Create(ctx context.Context, orgID int64, item *annotations.Item) (int64, error) {
-	result, err := h.client.Create(ctx, orgID, itemToAnnotation(item))
+	anno, err := itemToAnnotation(item)
+	if err != nil {
+		return 0, err
+	}
+	result, err := h.client.Create(ctx, orgID, anno)
 	if err != nil {
 		return 0, err
 	}
@@ -138,7 +147,10 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	if err != nil {
 		return err
 	}
-	anno := itemToAnnotation(item)
+	anno, err := itemToAnnotation(item)
+	if err != nil {
+		return err
+	}
 	anno.SetName(existing.GetName())
 	anno.SetResourceVersion(existing.GetResourceVersion())
 	annotationpkg.SetLegacyID(anno, annotationID)
@@ -169,7 +181,10 @@ func (h *MigrationProxy) Get(ctx context.Context, orgID int64, annotationID int6
 		return nil, err
 	}
 
-	dto := annoToItemDTO(anno)
+	dto, err := annoToItemDTO(anno)
+	if err != nil {
+		return nil, err
+	}
 
 	createdBy := anno.GetCreatedBy()
 	if createdBy != "" {
@@ -190,7 +205,7 @@ func applyUserToDTO(u *user.User, dto *annotations.ItemDTO) {
 	dto.Email = u.Email
 }
 
-func annoToItemDTO(anno *annotationV0.Annotation) *annotations.ItemDTO {
+func annoToItemDTO(anno *annotationV0.Annotation) (*annotations.ItemDTO, error) {
 	dto := &annotations.ItemDTO{
 		ID:           annotationpkg.GetLegacyID(anno),
 		Text:         anno.Spec.Text,
@@ -207,11 +222,17 @@ func annoToItemDTO(anno *annotationV0.Annotation) *annotations.ItemDTO {
 	if ts := anno.GetCreationTimestamp(); !ts.IsZero() {
 		dto.Created = ts.UnixMilli()
 	}
-	return dto
+	if raw, ok := annotationpkg.GetLegacyData(anno); ok && raw != "" {
+		data, err := simplejson.NewJson([]byte(raw))
+		if err != nil {
+			return dto, fmt.Errorf("decoding legacy data: %w", err)
+		}
+		dto.Data = data
+	}
+	return dto, nil
 }
 
-// TODO: item.Data is not stored — consider adding a legacy_data field to the annotation schema to preserve it during migration.
-func itemToAnnotation(item *annotations.Item) *annotationV0.Annotation {
+func itemToAnnotation(item *annotations.Item) (*annotationV0.Annotation, error) {
 	spec := annotationV0.AnnotationSpec{
 		Text: item.Text,
 		Time: item.Epoch,
@@ -237,5 +258,14 @@ func itemToAnnotation(item *annotations.Item) *annotationV0.Annotation {
 		},
 		Spec: spec,
 	}
-	return anno
+
+	if item.Data != nil {
+		raw, err := item.Data.Encode()
+		if err != nil {
+			return anno, fmt.Errorf("encoding legacy data: %w", err)
+		}
+		annotationpkg.SetLegacyData(anno, string(raw))
+	}
+
+	return anno, nil
 }

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -21,6 +21,20 @@ import (
 // ErrNotFound is returned by proxy methods when the annotation is not in the new storage
 var ErrNotFound = errors.New("annotation not found in new store")
 
+// partialDecodeError signals that one or more optional fields could not be decoded
+// from an annotation. The annotation is still usable without those fields, so callers
+// can return the DTO (minus the affected fields) rather than dropping it.
+type partialDecodeError struct {
+	Fields []string
+	Err    error
+}
+
+func (e *partialDecodeError) Error() string {
+	return fmt.Sprintf("decoding fields %v: %v", e.Fields, e.Err)
+}
+
+func (e *partialDecodeError) Unwrap() error { return e.Err }
+
 // MigrationProxy routes annotation writes to the new API server.
 type MigrationProxy struct {
 	client *annotationAPIClient
@@ -85,8 +99,14 @@ func (h *MigrationProxy) List(ctx context.Context, orgID int64, query *annotatio
 	for _, anno := range annos {
 		dto, err := annoToItemDTO(anno)
 		if err != nil {
-			h.logger.Warn("failed to convert annotation to DTO, dropping it", "err", err)
-			continue
+			var decodeErr *partialDecodeError
+			if !errors.As(err, &decodeErr) {
+				h.logger.Warn("failed to convert annotation to DTO, dropping it",
+					"namespace", anno.GetNamespace(), "name", anno.GetName(), "err", err)
+				continue
+			}
+			h.logger.Warn("failed to decode fields on annotation, returning it without those fields",
+				"namespace", anno.GetNamespace(), "name", anno.GetName(), "fields", decodeErr.Fields, "err", decodeErr.Err)
 		}
 		if cb := anno.GetCreatedBy(); cb != "" {
 			if u, ok := userMap[cb]; ok {
@@ -183,7 +203,12 @@ func (h *MigrationProxy) Get(ctx context.Context, orgID int64, annotationID int6
 
 	dto, err := annoToItemDTO(anno)
 	if err != nil {
-		return nil, err
+		var decodeErr *partialDecodeError
+		if !errors.As(err, &decodeErr) {
+			return nil, err
+		}
+		h.logger.Warn("failed to decode fields on annotation, returning it without those fields",
+			"namespace", anno.GetNamespace(), "name", anno.GetName(), "fields", decodeErr.Fields, "err", decodeErr.Err)
 	}
 
 	createdBy := anno.GetCreatedBy()
@@ -225,7 +250,7 @@ func annoToItemDTO(anno *annotationV0.Annotation) (*annotations.ItemDTO, error) 
 	if raw, ok := annotationpkg.GetLegacyData(anno); ok && raw != "" {
 		data, err := simplejson.NewJson([]byte(raw))
 		if err != nil {
-			return dto, fmt.Errorf("decoding legacy data: %w", err)
+			return dto, &partialDecodeError{Fields: []string{"data"}, Err: err}
 		}
 		dto.Data = data
 	}

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	annotationpkg "github.com/grafana/grafana/pkg/registry/apps/annotation"
 	"github.com/grafana/grafana/pkg/services/annotations"
 )
 
@@ -63,4 +65,52 @@ func TestMerge(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestItemAnnotationConversion(t *testing.T) {
+	t.Run("present data round-trips through the legacyData annotation", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]any{"foo": "bar"})
+		anno, err := itemToAnnotation(&annotations.Item{Text: "hello", Data: data})
+		require.NoError(t, err)
+
+		stored, ok := annotationpkg.GetLegacyData(anno)
+		require.True(t, ok, "legacyData annotation should be set")
+		require.JSONEq(t, `{"foo":"bar"}`, stored)
+
+		dto, err := annoToItemDTO(anno)
+		require.NoError(t, err)
+		require.NotNil(t, dto.Data)
+		require.Equal(t, data.MustMap(), dto.Data.MustMap())
+	})
+
+	t.Run("nil data sets no annotation and reads back nil", func(t *testing.T) {
+		anno, err := itemToAnnotation(&annotations.Item{Text: "hello"})
+		require.NoError(t, err)
+
+		_, ok := annotationpkg.GetLegacyData(anno)
+		require.False(t, ok, "legacyData annotation should be absent when item has no data")
+
+		dto, err := annoToItemDTO(anno)
+		require.NoError(t, err)
+		require.Nil(t, dto.Data)
+	})
+
+	t.Run("empty legacyData annotation reads back nil", func(t *testing.T) {
+		anno, err := itemToAnnotation(&annotations.Item{Text: "hello"})
+		require.NoError(t, err)
+		annotationpkg.SetLegacyData(anno, "")
+
+		dto, err := annoToItemDTO(anno)
+		require.NoError(t, err)
+		require.Nil(t, dto.Data)
+	})
+
+	t.Run("malformed stored legacy data returns an error", func(t *testing.T) {
+		anno, err := itemToAnnotation(&annotations.Item{Text: "hello"})
+		require.NoError(t, err)
+		annotationpkg.SetLegacyData(anno, "{not json")
+
+		_, err = annoToItemDTO(anno)
+		require.Error(t, err)
+	})
 }

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -105,12 +105,21 @@ func TestItemAnnotationConversion(t *testing.T) {
 		require.Nil(t, dto.Data)
 	})
 
-	t.Run("malformed stored legacy data returns an error", func(t *testing.T) {
+	t.Run("malformed stored legacy data returns a partialDecodeError and a usable DTO", func(t *testing.T) {
 		anno, err := itemToAnnotation(&annotations.Item{Text: "hello"})
 		require.NoError(t, err)
 		annotationpkg.SetLegacyData(anno, "{not json")
 
-		_, err = annoToItemDTO(anno)
+		dto, err := annoToItemDTO(anno)
 		require.Error(t, err)
+
+		var decodeErr *partialDecodeError
+		require.ErrorAs(t, err, &decodeErr)
+		require.Equal(t, []string{"data"}, decodeErr.Fields)
+
+		// The annotation is still usable; only the Data field is dropped.
+		require.NotNil(t, dto)
+		require.Equal(t, "hello", dto.Text)
+		require.Nil(t, dto.Data)
 	})
 }


### PR DESCRIPTION
This PR follows up https://github.com/grafana/grafana/pull/126722, which added support for a `grafana.app/legacyData` annotation to k8s resource, and leverages it to preserve the legacy API `data` field when proxying to the new API during migration.

Closes: https://github.com/grafana/grafana-org/issues/952