### PR TITLE
Provisioning: Fix multi-org usage stats

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -61,7 +61,6 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/usage"
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
-	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
@@ -107,11 +106,8 @@ type APIBuilder struct {
 	allowImageRendering bool
 	minSyncInterval     time.Duration
 
-	features   featuremgmt.FeatureToggles
-	usageStats usagestats.Service
-	// usageNamespaceLister enumerates the namespaces to collect usage stats for
-	// (one per org). Nil on the multi-tenant standalone path, where the collector
-	// falls back to the default namespace.
+	features             featuremgmt.FeatureToggles
+	usageStats           usagestats.Service
 	usageNamespaceLister usage.NamespaceLister
 
 	tracer              tracing.Tracer
@@ -316,30 +312,6 @@ func createJobHistoryConfigFromSettings(cfg *setting.Cfg) *JobHistoryConfig {
 	return &JobHistoryConfig{}
 }
 
-// listOrgNamespaces returns a function that lists the namespaces for the orgs of given instance.
-func listOrgNamespaces(orgSvc org.Service, namespacer request.NamespaceMapper) func(ctx context.Context) ([]string, error) {
-	return func(ctx context.Context) ([]string, error) {
-		orgs, err := orgSvc.Search(ctx, &org.SearchOrgsQuery{})
-		if err != nil {
-			return nil, err
-		}
-
-		// Deduplicate the namespaces.
-		seen := make(map[string]struct{}, len(orgs))
-		out := make([]string, 0, len(orgs))
-		for _, o := range orgs {
-			ns := namespacer(o.ID)
-			if _, ok := seen[ns]; ok {
-				continue
-			}
-			seen[ns] = struct{}{}
-			out = append(out, ns)
-		}
-
-		return out, nil
-	}
-}
-
 // RegisterAPIService returns an API builder, from [NewAPIBuilder]. It is called by Wire.
 // This function happily uses services core to Grafana, and does not need to be multi-tenancy-compatible.
 func RegisterAPIService(
@@ -420,7 +392,7 @@ func RegisterAPIService(
 		return nil, err
 	}
 	builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
-	builder.usageNamespaceLister = listOrgNamespaces(orgSvc, request.GetNamespaceMapper(cfg))
+	builder.usageNamespaceLister = usage.UsageNamespaceLister(cfg, orgSvc)
 	apiregistration.RegisterAPI(builder)
 
 	// Register v1beta1
@@ -461,7 +433,7 @@ func RegisterAPIService(
 		return nil, err
 	}
 	v1beta1Builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
-	v1beta1Builder.usageNamespaceLister = listOrgNamespaces(orgSvc, request.GetNamespaceMapper(cfg))
+	v1beta1Builder.usageNamespaceLister = usage.UsageNamespaceLister(cfg, orgSvc)
 	apiregistration.RegisterAPI(v1beta1Builder)
 
 	// Return the preferred (v0alpha1) builder since it runs controllers/workers

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -61,7 +61,9 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/usage"
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -107,6 +109,10 @@ type APIBuilder struct {
 
 	features   featuremgmt.FeatureToggles
 	usageStats usagestats.Service
+	// usageNamespaceLister enumerates the namespaces to collect usage stats for
+	// (one per org). Nil on the multi-tenant standalone path, where the collector
+	// falls back to the default namespace.
+	usageNamespaceLister usage.NamespaceLister
 
 	tracer              tracing.Tracer
 	repoStore           grafanarest.Storage
@@ -310,6 +316,30 @@ func createJobHistoryConfigFromSettings(cfg *setting.Cfg) *JobHistoryConfig {
 	return &JobHistoryConfig{}
 }
 
+// listOrgNamespaces returns a function that lists the namespaces for the orgs of given instance.
+func listOrgNamespaces(orgSvc org.Service, namespacer request.NamespaceMapper) func(ctx context.Context) ([]string, error) {
+	return func(ctx context.Context) ([]string, error) {
+		orgs, err := orgSvc.Search(ctx, &org.SearchOrgsQuery{})
+		if err != nil {
+			return nil, err
+		}
+
+		// Deduplicate the namespaces.
+		seen := make(map[string]struct{}, len(orgs))
+		out := make([]string, 0, len(orgs))
+		for _, o := range orgs {
+			ns := namespacer(o.ID)
+			if _, ok := seen[ns]; ok {
+				continue
+			}
+			seen[ns] = struct{}{}
+			out = append(out, ns)
+		}
+
+		return out, nil
+	}
+}
+
 // RegisterAPIService returns an API builder, from [NewAPIBuilder]. It is called by Wire.
 // This function happily uses services core to Grafana, and does not need to be multi-tenancy-compatible.
 func RegisterAPIService(
@@ -323,6 +353,7 @@ func RegisterAPIService(
 	access authlib.AccessClient,
 	storageStatus dualwrite.Service,
 	usageStats usagestats.Service,
+	orgSvc org.Service,
 	tracer tracing.Tracer,
 	extraBuilders []ExtraBuilder,
 	extraWorkers []jobs.Worker,
@@ -389,6 +420,7 @@ func RegisterAPIService(
 		return nil, err
 	}
 	builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
+	builder.usageNamespaceLister = listOrgNamespaces(orgSvc, request.GetNamespaceMapper(cfg))
 	apiregistration.RegisterAPI(builder)
 
 	// Register v1beta1
@@ -429,6 +461,7 @@ func RegisterAPIService(
 		return nil, err
 	}
 	v1beta1Builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
+	v1beta1Builder.usageNamespaceLister = listOrgNamespaces(orgSvc, request.GetNamespaceMapper(cfg))
 	apiregistration.RegisterAPI(v1beta1Builder)
 
 	// Return the preferred (v0alpha1) builder since it runs controllers/workers
@@ -960,7 +993,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			go jobInformer.Informer().Run(postStartHookCtx.Done())
 			go connInformer.Informer().Run(postStartHookCtx.Done())
 
-			usageMetricCollector := usage.MetricCollector(b.tracer, b.repoLister.List, b.unified)
+			usageMetricCollector := usage.MetricCollector(b.tracer, b.usageNamespaceLister, b.repoLister.List, b.unified)
 			b.usageStats.RegisterMetricsFunc(usageMetricCollector)
 
 			metrics := jobs.RegisterJobMetrics(b.registry)

--- a/pkg/registry/apis/provisioning/usage/namespace.go
+++ b/pkg/registry/apis/provisioning/usage/namespace.go
@@ -2,7 +2,9 @@ package usage
 
 import (
 	"context"
+	"strconv"
 
+	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
@@ -10,13 +12,13 @@ import (
 
 // UsageNamespaceLister returns the NamespaceLister the usage-stats collector uses to
 // decide which namespaces to count. On-prem (no StackID) it enumerates one namespace
-// per org so counts are aggregated across every org; on a cloud stack it keeps the
-// original single-tenant behaviour of only counting the "default" namespace.
+// per org so counts are aggregated across every org; on a cloud stack it just lists the single namespace
+// accessible to the stack.
 func UsageNamespaceLister(cfg *setting.Cfg, orgSvc org.Service) NamespaceLister {
 	if cfg.StackID == "" {
 		return orgNamespaceLister(request.GetNamespaceMapper(cfg), orgSvc)
 	}
-	return defaultNamespaceLister()
+	return stackNamespaceLister(cfg.StackID)
 }
 
 // orgNamespaceLister lists one namespace per org in the instance, deduplicated.
@@ -45,10 +47,16 @@ func orgNamespaceLister(namespacer request.NamespaceMapper, orgSvc org.Service) 
 	}
 }
 
-// defaultNamespaceLister always reports just the "default" namespace -- the
-// single-tenant behaviour used when per-org enumeration is not wanted.
-func defaultNamespaceLister() NamespaceLister {
+// stackNamespaceLister always reports just the given namespace, which is the
+// only namespace accessible to the given stack.
+func stackNamespaceLister(stackID string) NamespaceLister {
 	return func(ctx context.Context) ([]string, error) {
-		return []string{"default"}, nil
+		stackId, err := strconv.ParseInt(stackID, 10, 64)
+		if err != nil {
+			stackId = 0
+		}
+
+		cloudNamespace := claims.CloudNamespaceFormatter(stackId)
+		return []string{cloudNamespace}, nil
 	}
 }

--- a/pkg/registry/apis/provisioning/usage/namespace.go
+++ b/pkg/registry/apis/provisioning/usage/namespace.go
@@ -1,0 +1,54 @@
+package usage
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// UsageNamespaceLister returns the NamespaceLister the usage-stats collector uses to
+// decide which namespaces to count. On-prem (no StackID) it enumerates one namespace
+// per org so counts are aggregated across every org; on a cloud stack it keeps the
+// original single-tenant behaviour of only counting the "default" namespace.
+func UsageNamespaceLister(cfg *setting.Cfg, orgSvc org.Service) NamespaceLister {
+	if cfg.StackID == "" {
+		return orgNamespaceLister(request.GetNamespaceMapper(cfg), orgSvc)
+	}
+	return defaultNamespaceLister()
+}
+
+// orgNamespaceLister lists one namespace per org in the instance, deduplicated.
+// Deduplication matters because a namespace mapper can map several orgs to the same
+// namespace (e.g. the cloud mapper), which would otherwise be counted once per org.
+func orgNamespaceLister(namespacer request.NamespaceMapper, orgSvc org.Service) NamespaceLister {
+	return func(ctx context.Context) ([]string, error) {
+		orgs, err := orgSvc.Search(ctx, &org.SearchOrgsQuery{})
+		if err != nil {
+			return nil, err
+		}
+
+		// Deduplicate the namespaces.
+		seen := make(map[string]struct{}, len(orgs))
+		out := make([]string, 0, len(orgs))
+		for _, o := range orgs {
+			ns := namespacer(o.ID)
+			if _, ok := seen[ns]; ok {
+				continue
+			}
+			seen[ns] = struct{}{}
+			out = append(out, ns)
+		}
+
+		return out, nil
+	}
+}
+
+// defaultNamespaceLister always reports just the "default" namespace -- the
+// single-tenant behaviour used when per-org enumeration is not wanted.
+func defaultNamespaceLister() NamespaceLister {
+	return func(ctx context.Context) ([]string, error) {
+		return []string{"default"}, nil
+	}
+}

--- a/pkg/registry/apis/provisioning/usage/namespace_test.go
+++ b/pkg/registry/apis/provisioning/usage/namespace_test.go
@@ -1,0 +1,83 @@
+package usage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgtest"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestUsageNamespaceLister(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("cloud stack uses the default namespace and ignores orgs", func(t *testing.T) {
+		// StackID set => cloud. The orgs must not be consulted.
+		orgSvc := &orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 1}, {ID: 2}}}
+		lister := UsageNamespaceLister(&setting.Cfg{StackID: "123"}, orgSvc)
+
+		nss, err := lister(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"default"}, nss)
+	})
+
+	t.Run("on-prem enumerates one namespace per org", func(t *testing.T) {
+		orgSvc := &orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 1}, {ID: 2}}}
+		lister := UsageNamespaceLister(&setting.Cfg{}, orgSvc)
+
+		nss, err := lister(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"default", "org-2"}, nss)
+	})
+}
+
+func TestOrgNamespaceLister(t *testing.T) {
+	ctx := context.Background()
+	// On-prem mapper: org 1 -> "default", org N -> "org-N".
+	onPremMapper := request.GetNamespaceMapper(&setting.Cfg{})
+
+	t.Run("maps every org to its namespace", func(t *testing.T) {
+		orgSvc := &orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 1}, {ID: 2}, {ID: 3}}}
+
+		nss, err := orgNamespaceLister(onPremMapper, orgSvc)(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"default", "org-2", "org-3"}, nss)
+	})
+
+	t.Run("deduplicates namespaces", func(t *testing.T) {
+		// A mapper that collapses every org to the same namespace (as cloud does).
+		collapse := func(int64) string { return "stack-7" }
+		orgSvc := &orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 1}, {ID: 2}, {ID: 3}}}
+
+		nss, err := orgNamespaceLister(collapse, orgSvc)(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"stack-7"}, nss)
+	})
+
+	t.Run("returns empty when there are no orgs", func(t *testing.T) {
+		orgSvc := &orgtest.FakeOrgService{ExpectedOrgs: nil}
+
+		nss, err := orgNamespaceLister(onPremMapper, orgSvc)(ctx)
+		require.NoError(t, err)
+		require.Empty(t, nss)
+	})
+
+	t.Run("propagates the org service error", func(t *testing.T) {
+		orgSvc := &orgtest.FakeOrgService{ExpectedError: errors.New("boom")}
+
+		nss, err := orgNamespaceLister(onPremMapper, orgSvc)(ctx)
+		require.Error(t, err)
+		require.Nil(t, nss)
+	})
+}
+
+func TestDefaultNamespaceLister(t *testing.T) {
+	nss, err := defaultNamespaceLister()(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"default"}, nss)
+}

--- a/pkg/registry/apis/provisioning/usage/namespace_test.go
+++ b/pkg/registry/apis/provisioning/usage/namespace_test.go
@@ -23,7 +23,7 @@ func TestUsageNamespaceLister(t *testing.T) {
 
 		nss, err := lister(ctx)
 		require.NoError(t, err)
-		require.Equal(t, []string{"default"}, nss)
+		require.Equal(t, []string{"stacks-123"}, nss)
 	})
 
 	t.Run("on-prem enumerates one namespace per org", func(t *testing.T) {
@@ -76,8 +76,8 @@ func TestOrgNamespaceLister(t *testing.T) {
 	})
 }
 
-func TestDefaultNamespaceLister(t *testing.T) {
-	nss, err := defaultNamespaceLister()(context.Background())
+func TestStackNamespaceLister(t *testing.T) {
+	nss, err := stackNamespaceLister("123")(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, []string{"default"}, nss)
+	require.Equal(t, []string{"stacks-123"}, nss)
 }

--- a/pkg/registry/apis/provisioning/usage/usage.go
+++ b/pkg/registry/apis/provisioning/usage/usage.go
@@ -54,32 +54,46 @@ func MetricCollector(tracer tracing.Tracer, namespaces NamespaceLister, reposito
 		managedCounts := make(map[string]int)
 		repoCounts := make(map[string]int)
 		for _, ns := range nss {
-			var nsCtx context.Context
-			nsCtx, _, err = identity.WithProvisioningIdentity(ctx, ns)
-			if err != nil {
-				return m, err
-			}
-			nsCtx = request.WithNamespace(nsCtx, ns)
+			nsSpanCtx, nsSpan := tracer.Start(ctx, "Provisioning.Usage.collectProvisioningStats.countManagedObjects")
 
+			var nsCtx context.Context
+			nsCtx, _, err = identity.WithProvisioningIdentity(nsSpanCtx, ns)
+			if err != nil {
+				nsSpan.RecordError(err)
+				nsSpan.SetStatus(codes.Error, fmt.Sprintf("failed to create provisioning identity: %v", err))
+				return m, fmt.Errorf("create provisioning identity: %w", err)
+			}
+
+			nsCtx = request.WithNamespace(nsCtx, ns)
 			var count *resourcepb.CountManagedObjectsResponse
 			count, err = unified.CountManagedObjects(nsCtx, &resourcepb.CountManagedObjectsRequest{
 				Namespace: ns,
 			})
 			if err != nil {
-				return m, fmt.Errorf("count managed objects: %w", err)
+				nsSpan.RecordError(err)
+				nsSpan.SetStatus(codes.Error, fmt.Sprintf("failed to count managed objects on namespace %s: %v", ns, err))
+				return m, fmt.Errorf("count managed objects on namespace %s: %w", ns, err)
 			}
 			for _, v := range count.Items {
 				managedCounts[v.Kind] += int(v.Count)
 			}
+			nsSpan.SetAttributes(attribute.Int("totalManagedObjectsCount", len(count.Items)))
 
 			var repos []provisioning.Repository
 			repos, err = repositoryLister(nsCtx)
 			if err != nil {
-				return m, fmt.Errorf("list repositories: %w", err)
+				nsSpan.RecordError(err)
+				nsSpan.SetStatus(codes.Error, fmt.Sprintf("failed to list repositories on namespace %s: %v", ns, err))
+				return m, fmt.Errorf("list repositories on namespace %s: %w", ns, err)
 			}
+
 			for _, repo := range repos {
 				repoCounts[string(repo.Spec.Type)]++
 			}
+
+			nsSpan.SetAttributes(attribute.Int("totalRepositoriesCount", len(repos)))
+			nsSpan.SetStatus(codes.Ok, "")
+			nsSpan.End()
 		}
 
 		span.SetAttributes(attribute.Int("namespaceCount", len(nss)))

--- a/pkg/registry/apis/provisioning/usage/usage.go
+++ b/pkg/registry/apis/provisioning/usage/usage.go
@@ -16,66 +16,78 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
-func MetricCollector(tracer tracing.Tracer, repositoryLister func(ctx context.Context) ([]provisioning.Repository, error), unified resource.ResourceClient) usagestats.MetricsFunc {
-	return func(ctx context.Context) (metrics map[string]any, err error) {
+// NamespaceLister returns the set of namespaces to collect provisioning usage
+// stats for. In a single-tenant deployment this is one namespace per org.
+type NamespaceLister func(ctx context.Context) ([]string, error)
+
+func MetricCollector(tracer tracing.Tracer, namespaces NamespaceLister, repositoryLister func(ctx context.Context) ([]provisioning.Repository, error), unified resource.ResourceClient) usagestats.MetricsFunc {
+	return func(ctx context.Context) (m map[string]any, err error) {
 		ctx, span := tracer.Start(ctx, "Provisioning.Usage.collectProvisioningStats")
 		defer func() {
-			span.SetStatus(codes.Error, fmt.Sprintf("failed to fetch provisioning usage stats: %v", err))
+			if err != nil {
+				span.SetStatus(codes.Error, fmt.Sprintf("failed to fetch provisioning usage stats: %v", err))
+			} else {
+				span.SetStatus(codes.Ok, "")
+			}
 			span.End()
 		}()
 
-		m := map[string]any{}
+		m = map[string]any{}
 		if unified == nil {
-			// FIXME: does this case make any sense? no unified storage -> no game
+			// No unified storage means there is nothing to count.
 			span.SetStatus(codes.Ok, "unified storage is not available")
 			return m, nil
 		}
 
-		// FIXME: hardcoded to "default" for now -- it works for single tenant deployments
-		// we could discover the set of valid namespaces, but that would count everything for
-		// each instance in cloud.
-		ns := "default"
-		ctx, _, err = identity.WithProvisioningIdentity(ctx, ns)
-		if err != nil {
-			return nil, err
-		}
-		ctx = request.WithNamespace(ctx, ns)
-
-		// FIXME: hardcoded to "default" for now -- it works for single tenant deployments
-		// we could discover the set of valid namespaces, but that would count everything for
-		// each instance in cloud.
-		//
-		// We could get namespaces from the list of repos below, but that could be zero
-		// while we still have resources managed by terraform, etc
-		count, err := unified.CountManagedObjects(ctx, &resourcepb.CountManagedObjectsRequest{
-			Namespace: ns,
-		})
-		if err != nil {
-			return m, fmt.Errorf("count managed objects: %w", err)
-		}
-		counts := make(map[string]int, 10)
-		for _, v := range count.Items {
-			counts[v.Kind] = counts[v.Kind] + int(v.Count)
+		// Resolve the namespaces to collect for (one per org). When no lister is
+		// wired -- the multi-tenant standalone path -- fall back to the default
+		// namespace, which preserves single-tenant behaviour.
+		nss := []string{"default"}
+		if namespaces != nil {
+			nss, err = namespaces(ctx)
+			if err != nil {
+				return m, fmt.Errorf("list namespaces: %w", err)
+			}
 		}
 
-		span.SetAttributes(attribute.Int("totalManagedObjectsCount", len(count.Items)))
-		for k, v := range counts {
+		// Counts are aggregated across all namespaces into the same stat keys.
+		managedCounts := make(map[string]int)
+		repoCounts := make(map[string]int)
+		for _, ns := range nss {
+			var nsCtx context.Context
+			nsCtx, _, err = identity.WithProvisioningIdentity(ctx, ns)
+			if err != nil {
+				return m, err
+			}
+			nsCtx = request.WithNamespace(nsCtx, ns)
+
+			var count *resourcepb.CountManagedObjectsResponse
+			count, err = unified.CountManagedObjects(nsCtx, &resourcepb.CountManagedObjectsRequest{
+				Namespace: ns,
+			})
+			if err != nil {
+				return m, fmt.Errorf("count managed objects: %w", err)
+			}
+			for _, v := range count.Items {
+				managedCounts[v.Kind] += int(v.Count)
+			}
+
+			var repos []provisioning.Repository
+			repos, err = repositoryLister(nsCtx)
+			if err != nil {
+				return m, fmt.Errorf("list repositories: %w", err)
+			}
+			for _, repo := range repos {
+				repoCounts[string(repo.Spec.Type)]++
+			}
+		}
+
+		span.SetAttributes(attribute.Int("namespaceCount", len(nss)))
+		for k, v := range managedCounts {
 			m[fmt.Sprintf("stats.managed_by.%s.count", k)] = v
 		}
-
-		// Inspect all configs
-		repos, err := repositoryLister(ctx)
-		if err != nil {
-			return m, fmt.Errorf("list repositories: %w", err)
-		}
-		clear(counts)
-		for _, repo := range repos {
-			counts[string(repo.Spec.Type)] = counts[string(repo.Spec.Type)] + 1
-		}
-
-		span.SetAttributes(attribute.Int("repositoryCount", len(repos)))
-		// Count how many items of each repository type
-		for k, v := range counts {
+		// Count how many items of each repository type.
+		for k, v := range repoCounts {
 			m[fmt.Sprintf("stats.repository.%s.count", k)] = v
 		}
 

--- a/pkg/registry/apis/provisioning/usage/usage_test.go
+++ b/pkg/registry/apis/provisioning/usage/usage_test.go
@@ -1,0 +1,119 @@
+package usage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// managedKind is the manager kind reported by CountManagedObjects (e.g. "repo"),
+// which is what the collector keys stats.managed_by.<kind>.count on.
+const managedKind = "repo"
+
+func managedCount(kind string, count int64) *resourcepb.CountManagedObjectsResponse {
+	return &resourcepb.CountManagedObjectsResponse{
+		Items: []*resourcepb.CountManagedObjectsResponse_ResourceCount{
+			{Kind: kind, Count: count},
+		},
+	}
+}
+
+// no unified storage -> nothing to count, no error.
+func TestMetricCollector_NoUnifiedStorage(t *testing.T) {
+	fn := MetricCollector(tracing.NewNoopTracerService(), nil, nil, nil)
+
+	m, err := fn(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, m)
+}
+
+// nil namespace lister falls back to the "default" namespace (single-tenant behaviour).
+func TestMetricCollector_FallbackDefaultNamespace(t *testing.T) {
+	unified := resource.NewMockResourceClient(t)
+	unified.EXPECT().
+		CountManagedObjects(mock.Anything, mock.MatchedBy(func(req *resourcepb.CountManagedObjectsRequest) bool {
+			return req.Namespace == "default"
+		})).
+		Return(managedCount(managedKind, 2), nil).
+		Once()
+
+	repoLister := func(ctx context.Context) ([]provisioning.Repository, error) {
+		// The collector must scope the context to the namespace it is counting.
+		require.Equal(t, "default", request.NamespaceValue(ctx))
+		return []provisioning.Repository{
+			{Spec: provisioning.RepositorySpec{Type: provisioning.GitHubRepositoryType}},
+		}, nil
+	}
+
+	fn := MetricCollector(tracing.NewNoopTracerService(), nil, repoLister, unified)
+
+	m, err := fn(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 2, m["stats.managed_by."+managedKind+".count"])
+	require.Equal(t, 1, m["stats.repository."+string(provisioning.GitHubRepositoryType)+".count"])
+}
+
+// counts from every namespace are summed into the same stat keys.
+func TestMetricCollector_AggregatesAcrossNamespaces(t *testing.T) {
+	unified := resource.NewMockResourceClient(t)
+	unified.EXPECT().
+		CountManagedObjects(mock.Anything, mock.MatchedBy(func(req *resourcepb.CountManagedObjectsRequest) bool {
+			return req.Namespace == "default"
+		})).
+		Return(managedCount(managedKind, 3), nil).
+		Once()
+	unified.EXPECT().
+		CountManagedObjects(mock.Anything, mock.MatchedBy(func(req *resourcepb.CountManagedObjectsRequest) bool {
+			return req.Namespace == "org-2"
+		})).
+		Return(managedCount(managedKind, 2), nil).
+		Once()
+
+	repoLister := func(ctx context.Context) ([]provisioning.Repository, error) {
+		github := provisioning.Repository{Spec: provisioning.RepositorySpec{Type: provisioning.GitHubRepositoryType}}
+		switch request.NamespaceValue(ctx) {
+		case "default":
+			return []provisioning.Repository{github}, nil
+		case "org-2":
+			return []provisioning.Repository{github, github}, nil
+		default:
+			return nil, nil
+		}
+	}
+	namespaces := func(ctx context.Context) ([]string, error) {
+		return []string{"default", "org-2"}, nil
+	}
+
+	fn := MetricCollector(tracing.NewNoopTracerService(), namespaces, repoLister, unified)
+
+	m, err := fn(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 5, m["stats.managed_by."+managedKind+".count"])                               // 3 + 2
+	require.Equal(t, 3, m["stats.repository."+string(provisioning.GitHubRepositoryType)+".count"]) // 1 + 2
+}
+
+// an error from any namespace fails the whole collection (fail-fast).
+func TestMetricCollector_ErrorFailFast(t *testing.T) {
+	unified := resource.NewMockResourceClient(t)
+	unified.EXPECT().
+		CountManagedObjects(mock.Anything, mock.Anything).
+		Return(nil, errors.New("boom")).
+		Once()
+	namespaces := func(ctx context.Context) ([]string, error) {
+		return []string{"default"}, nil
+	}
+
+	fn := MetricCollector(tracing.NewNoopTracerService(), namespaces, nil, unified)
+
+	_, err := fn(context.Background())
+	require.Error(t, err)
+}

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -995,7 +995,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 		return nil, err
 	}
 	quotaGetter := extras.ProvideQuotaGetter(cfg)
-	provisioningAPIBuilder, err := provisioning2.RegisterAPIService(cfg, featureToggles, apiserverService, registerer, resourceClient, eventualRestConfigProvider, accessClient, dualwriteService, usageStats, tracingService, v11, v12, repositoryFactory, connectionFactory, quotaGetter)
+	provisioningAPIBuilder, err := provisioning2.RegisterAPIService(cfg, featureToggles, apiserverService, registerer, resourceClient, eventualRestConfigProvider, accessClient, dualwriteService, usageStats, orgService, tracingService, v11, v12, repositoryFactory, connectionFactory, quotaGetter)
 	if err != nil {
 		return nil, err
 	}
@@ -1735,7 +1735,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	quotaGetter := extras.ProvideQuotaGetter(cfg)
-	provisioningAPIBuilder, err := provisioning2.RegisterAPIService(cfg, featureToggles, apiserverService, registerer, resourceClient, eventualRestConfigProvider, accessClient, dualwriteService, usageStats, tracingService, v11, v12, repositoryFactory, connectionFactory, quotaGetter)
+	provisioningAPIBuilder, err := provisioning2.RegisterAPIService(cfg, featureToggles, apiserverService, registerer, resourceClient, eventualRestConfigProvider, accessClient, dualwriteService, usageStats, orgService, tracingService, v11, v12, repositoryFactory, connectionFactory, quotaGetter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -125,7 +125,8 @@ type ProvisioningTestHelper struct {
 
 // WithNamespace returns a new ProvisioningTestHelper scoped to the specified namespace and user.
 // This is useful for multi-org testing where you need separate helpers for different organizations.
-func (h *ProvisioningTestHelper) WithNamespace(namespace string, user apis.User) *ProvisioningTestHelper {
+func (h *ProvisioningTestHelper) WithNamespace(t *testing.T, namespace string, user apis.User) *ProvisioningTestHelper {
+	t.Helper()
 	gv := &schema.GroupVersion{Group: "provisioning.grafana.app", Version: "v0alpha1"}
 
 	return &ProvisioningTestHelper{
@@ -178,9 +179,9 @@ func (h *ProvisioningTestHelper) WithNamespace(namespace string, user apis.User)
 			Namespace: namespace,
 			GVR:       dashboardsV2beta1.DashboardResourceInfo.GroupVersionResource(),
 		}),
-		AdminREST:  user.RESTClient(nil, gv),
-		EditorREST: user.RESTClient(nil, gv),
-		ViewerREST: user.RESTClient(nil, gv),
+		AdminREST:  user.RESTClient(t, gv),
+		EditorREST: user.RESTClient(t, gv),
+		ViewerREST: user.RESTClient(t, gv),
 	}
 }
 
@@ -1168,7 +1169,7 @@ func (h *ProvisioningTestHelper) WaitForHealthyRepository(t *testing.T, name str
 			return
 		}
 		errType := MustNestedString(repoStatus.Object, "status", "health", "error")
-		assert.Empty(collect, errType, "repository %s has health error: %s", name, errType)
+		assert.Empty(collect, errType, "repository %s has health error: %s - %v", name, errType, repoStatus.Object)
 		msgs := MustNestedStringSlice(repoStatus.Object, "status", "health", "message")
 		assert.Empty(collect, msgs, "repository %s has health messages: %v", name, msgs)
 		status, found := mustNestedBool(repoStatus.Object, "status", "health", "healthy")

--- a/pkg/tests/apis/provisioning/orgs/namespace_isolation_test.go
+++ b/pkg/tests/apis/provisioning/orgs/namespace_isolation_test.go
@@ -34,8 +34,8 @@ func TestCrossNamespaceIsolation_FolderSync(t *testing.T) {
 	helper := sharedHelper(t)
 
 	// Create scoped helpers for each organization
-	orgAHelper := helper.WithNamespace(helper.Namespacer(helper.Org1.OrgID), helper.Org1.Admin)
-	orgBHelper := helper.WithNamespace(helper.Namespacer(helper.OrgB.OrgID), helper.OrgB.Admin)
+	orgAHelper := helper.WithNamespace(t, helper.Namespacer(helper.Org1.OrgID), helper.Org1.Admin)
+	orgBHelper := helper.WithNamespace(t, helper.Namespacer(helper.OrgB.OrgID), helper.OrgB.Admin)
 
 	// Clean up resources after test
 	defer orgAHelper.Cleanup(t)

--- a/pkg/tests/apis/provisioning/orgs/usagestats_test.go
+++ b/pkg/tests/apis/provisioning/orgs/usagestats_test.go
@@ -29,8 +29,8 @@ func TestIntegrationProvisioning_MultiOrgUsageStats(t *testing.T) {
 	defaultNS := helper.Namespacer(helper.Org1.OrgID) // "default"
 	orgBNS := helper.Namespacer(helper.OrgB.OrgID)    // "org-<id>"
 
-	orgAHelper := helper.WithNamespace(defaultNS, helper.Org1.Admin)
-	orgBHelper := helper.WithNamespace(orgBNS, helper.OrgB.Admin)
+	orgAHelper := helper.WithNamespace(t, defaultNS, helper.Org1.Admin)
+	orgBHelper := helper.WithNamespace(t, orgBNS, helper.OrgB.Admin)
 	defer orgAHelper.Cleanup(t)
 	defer orgBHelper.Cleanup(t)
 
@@ -38,13 +38,13 @@ func TestIntegrationProvisioning_MultiOrgUsageStats(t *testing.T) {
 	// LocalPath dirs keep the two repositories fully isolated on disk.
 	orgAHelper.CreateLocalRepo(t, common.TestRepo{
 		Name:                   "org-a-usage-repo",
-		LocalPath:              t.TempDir(),
+		LocalPath:              helper.ProvisioningPath,
 		Copies:                 map[string]string{"../testdata/all-panels.json": "dashboard.json"},
 		SkipResourceAssertions: true,
 	})
 	orgBHelper.CreateLocalRepo(t, common.TestRepo{
 		Name:                   "org-b-usage-repo",
-		LocalPath:              t.TempDir(),
+		LocalPath:              helper.ProvisioningPath,
 		Copies:                 map[string]string{"../testdata/all-panels.json": "dashboard.json"},
 		SkipResourceAssertions: true,
 	})
@@ -61,13 +61,6 @@ func TestIntegrationProvisioning_MultiOrgUsageStats(t *testing.T) {
 		// Aggregated across both orgs: one local repo each => 2 total. Before the
 		// multi-org fix only the "default" namespace was counted, so this was 1.
 		assert.Equal(collect, 2.0, m["stats.repository.local.count"], "repos summed across orgs")
-
-		// Per-org breakdown proves both namespaces were enumerated, not just "default".
-		perOrg, ok := m["stats.repository.local.org.count"].(map[string]any)
-		if assert.True(collect, ok, "per-org repo breakdown should be present") {
-			assert.Equal(collect, 1.0, perOrg[defaultNS], "org-1 should report 1 local repo")
-			assert.Equal(collect, 1.0, perOrg[orgBNS], "org-2 should report 1 local repo")
-		}
 
 		// Managed objects are counted across orgs too (>= the 2 synced dashboards).
 		managed, _ := m["stats.managed_by.repo.count"].(float64)

--- a/pkg/tests/apis/provisioning/orgs/usagestats_test.go
+++ b/pkg/tests/apis/provisioning/orgs/usagestats_test.go
@@ -1,0 +1,76 @@
+package orgs
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/infra/usagestats"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioning_MultiOrgUsageStats verifies that the provisioning
+// usage-stats collector enumerates every org's namespace (not just "default")
+// and aggregates repository and managed-object counts across all of them.
+//
+// It creates one synced local repository (with a dashboard) in two different
+// organizations and asserts that the anonymous usage report
+// (/api/admin/usage-report-preview) reflects both orgs.
+func TestIntegrationProvisioning_MultiOrgUsageStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	helper := sharedHelper(t)
+
+	defaultNS := helper.Namespacer(helper.Org1.OrgID) // "default"
+	orgBNS := helper.Namespacer(helper.OrgB.OrgID)    // "org-<id>"
+
+	orgAHelper := helper.WithNamespace(defaultNS, helper.Org1.Admin)
+	orgBHelper := helper.WithNamespace(orgBNS, helper.OrgB.Admin)
+	defer orgAHelper.Cleanup(t)
+	defer orgBHelper.Cleanup(t)
+
+	// One synced local repo (with a single dashboard) in each org. Distinct
+	// LocalPath dirs keep the two repositories fully isolated on disk.
+	orgAHelper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   "org-a-usage-repo",
+		LocalPath:              t.TempDir(),
+		Copies:                 map[string]string{"../testdata/all-panels.json": "dashboard.json"},
+		SkipResourceAssertions: true,
+	})
+	orgBHelper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   "org-b-usage-repo",
+		LocalPath:              t.TempDir(),
+		Copies:                 map[string]string{"../testdata/all-panels.json": "dashboard.json"},
+		SkipResourceAssertions: true,
+	})
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		report := apis.DoRequest(helper.K8sTestHelper, apis.RequestParams{
+			Method: http.MethodGet,
+			Path:   "/api/admin/usage-report-preview",
+			User:   helper.Org1.Admin,
+		}, &usagestats.Report{})
+
+		m := report.Result.Metrics
+
+		// Aggregated across both orgs: one local repo each => 2 total. Before the
+		// multi-org fix only the "default" namespace was counted, so this was 1.
+		assert.Equal(collect, 2.0, m["stats.repository.local.count"], "repos summed across orgs")
+
+		// Per-org breakdown proves both namespaces were enumerated, not just "default".
+		perOrg, ok := m["stats.repository.local.org.count"].(map[string]any)
+		if assert.True(collect, ok, "per-org repo breakdown should be present") {
+			assert.Equal(collect, 1.0, perOrg[defaultNS], "org-1 should report 1 local repo")
+			assert.Equal(collect, 1.0, perOrg[orgBNS], "org-2 should report 1 local repo")
+		}
+
+		// Managed objects are counted across orgs too (>= the 2 synced dashboards).
+		managed, _ := m["stats.managed_by.repo.count"].(float64)
+		assert.GreaterOrEqual(collect, managed, 2.0, "repo-managed objects summed across orgs")
+	}, time.Second*30, time.Millisecond*250, "expected multi-org provisioning usage stats")
+}

--- a/pkg/tests/apis/provisioning/orgs/usagestats_test.go
+++ b/pkg/tests/apis/provisioning/orgs/usagestats_test.go
@@ -38,13 +38,13 @@ func TestIntegrationProvisioning_MultiOrgUsageStats(t *testing.T) {
 	// LocalPath dirs keep the two repositories fully isolated on disk.
 	orgAHelper.CreateLocalRepo(t, common.TestRepo{
 		Name:                   "org-a-usage-repo",
-		LocalPath:              helper.ProvisioningPath,
+		LocalPath:              helper.ProvisioningPath + "/org-a-usage-repo",
 		Copies:                 map[string]string{"../testdata/all-panels.json": "dashboard.json"},
 		SkipResourceAssertions: true,
 	})
 	orgBHelper.CreateLocalRepo(t, common.TestRepo{
 		Name:                   "org-b-usage-repo",
-		LocalPath:              helper.ProvisioningPath,
+		LocalPath:              helper.ProvisioningPath + "/org-b-usage-repo",
 		Copies:                 map[string]string{"../testdata/all-panels.json": "dashboard.json"},
 		SkipResourceAssertions: true,
 	})


### PR DESCRIPTION
**What is this feature?**

Makes the provisioning (git sync) usage-stats collector multi-org aware. Previously it was hardcoded to the `default` namespace; it now enumerates every org's namespace (deduplicated) and aggregates repository and managed-object counts across all of them.

- `usage.MetricCollector` takes a `NamespaceLister`, iterates the namespaces, and aggregates into the existing `stats.repository.<type>.count` / `stats.managed_by.<kind>.count` keys.
- `RegisterAPIService` builds the namespace lister from `org.Service` + `request.GetNamespaceMapper(cfg)` (deduplicated — in cloud the mapper collapses every org to a single stack namespace) and attaches it to the preferred builder. The multi-tenant-safe `NewAPIBuilder` contract is left untouched: the lister is injected as a closure and falls back to the `default` namespace when absent.

Counterpart https://github.com/grafana/grafana-enterprise/pull/12493

**Why do we need this feature?**

In multi-org single-tenant deployments the collector only counted org 1 (`default`), so provisioning repositories and managed resources in every other org were silently missing from the anonymous usage report and support bundles. The limitation was previously `FIXME`-marked in the collector.

**Who is this feature for?**

Grafana operators running provisioning across multiple organizations, and Grafana Labs usage telemetry — both now get accurate cross-org counts.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/git-ui-sync-project/issues/1069

**Special notes for your reviewer:**

- Backend-only. These stats are not rendered in any UI page — they flow to the anonymous usage report (`/api/admin/usage-report-preview`), support bundles, and Grafana Labs telemetry. The Admin → Stats page uses a separate path (`statsimpl`) that is already multi-org aware.
- No new feature toggle: this fixes behavior within the existing `provisioning` flag.
- `pkg/server/wire_gen.go` is regenerated (`make gen-go`) to inject `org.Service` into `RegisterAPIService`.
- Tests: unit tests for the collector (`pkg/registry/apis/provisioning/usage/usage_test.go`) and a multi-org integration test (`pkg/tests/apis/provisioning/orgs/usagestats_test.go`) that creates a synced repo in two orgs and asserts the usage report aggregates both.

Please check that:
- [x] It works as expected from a user's perspective (verified via unit + integration tests and `/api/admin/usage-report-preview`).
- [ ] N/A — pre-GA: this change is within the existing `provisioning` feature toggle.
- [ ] N/A — docs: internal telemetry only, no user-facing documentation.
