### PR TITLE
Search: reject cross-version SearchFieldDefinition divergence

### DIFF
--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -210,11 +211,17 @@ type SearchFieldsProvider interface {
 	// With a non-empty Version only that version's fields are returned.
 	// With an empty Version Fields returns every field declared by any
 	// version of (group, resource); a field declared in multiple versions
-	// appears once, with the preferred version's shape.
+	// appears once, with the preferred version's declaration.
 	//
-	// Two versions declaring a field with different shapes are not yet
-	// validated; a later check will reject mismatches. The returned slice
-	// is owned by the provider; do not mutate it.
+	// When the same field name is declared in multiple served versions of
+	// (group, resource), all declarations must agree on Type, Array, and
+	// Capabilities — the attributes that feed into the kind's bleve
+	// mapping. NewMapProvider rejects diverging declarations at
+	// construction time. Path, EmitZeroIfAbsent, CopyFromStandard, and
+	// Description may differ across versions: they are extractor- or
+	// presentation-side and the extractor applies them per-document with
+	// the document's own version's declaration. The returned slice is
+	// owned by the provider; do not mutate it.
 	Fields(gvr schema.GroupVersionResource) []SearchFieldDefinition
 
 	// PreferredVersion returns the served version that callers should use
@@ -268,6 +275,9 @@ func NewMapProvider(fields map[schema.GroupVersionResource][]SearchFieldDefiniti
 			panic("invalid SearchFieldDefinitions for " + gvr.String() + ": " + err.Error())
 		}
 	}
+	if err := validateCrossVersionConsistency(fields); err != nil {
+		panic("inconsistent SearchFieldDefinitions across versions: " + err.Error())
+	}
 	return &mapProvider{
 		fields:           fields,
 		preferredVersion: preferredVersions,
@@ -290,6 +300,137 @@ var stringOnlyCapabilities = []SearchCapability{
 	SearchCapabilityText,
 	SearchCapabilityPartial,
 	SearchCapabilityFacet,
+}
+
+// mappingAttributes is the bleve-mapping-affecting projection of a
+// SearchFieldDefinition used for cross-version equality. Only Type, Array,
+// and Capabilities count: those are what GetBleveMappings reads to produce
+// the kind's mapping, which is built once per (group, resource) from the
+// union across versions. Path, EmitZeroIfAbsent, and CopyFromStandard are
+// extractor-side concerns applied per-document with the document's own
+// version's declaration, so they may legitimately differ between versions.
+// Description is presentation-only.
+//
+// Capabilities are sorted, deduplicated, and joined into a single string so
+// the struct is directly comparable with ==.
+type mappingAttributes struct {
+	Type         SearchFieldType
+	Array        bool
+	Capabilities string
+}
+
+func mappingAttributesOf(sfd SearchFieldDefinition) mappingAttributes {
+	caps := slices.Clone(sfd.Capabilities)
+	slices.Sort(caps)
+	caps = slices.Compact(caps)
+	capStrs := make([]string, len(caps))
+	for i, c := range caps {
+		capStrs[i] = string(c)
+	}
+	return mappingAttributes{
+		Type:         sfd.Type,
+		Array:        sfd.Array,
+		Capabilities: strings.Join(capStrs, ","),
+	}
+}
+
+// diffMappingAttributes returns the names of the attributes that differ
+// between two projections, in a fixed order so error messages are
+// deterministic.
+func diffMappingAttributes(a, b mappingAttributes) []string {
+	var diffs []string
+	if a.Type != b.Type {
+		diffs = append(diffs, "type")
+	}
+	if a.Array != b.Array {
+		diffs = append(diffs, "array")
+	}
+	if a.Capabilities != b.Capabilities {
+		diffs = append(diffs, "capabilities")
+	}
+	return diffs
+}
+
+// validateCrossVersionConsistency rejects declarations where two served
+// versions of the same (group, resource) declare a field with the same
+// name but a different Type, Array flag, or Capabilities set. The bleve
+// mapping for a kind is built once per (group, resource) from the union
+// across versions: divergence on a mapping-affecting attribute would
+// silently pick one and lose the other, producing different query results
+// depending on which version's declaration the indexer happened to read
+// first.
+//
+// A field declared by only one version is fine: union without conflict.
+// Path, EmitZeroIfAbsent, CopyFromStandard, and Description may differ
+// across versions: they do not feed into the mapping and the extractor
+// applies them per-document with the document's own version's declaration.
+func validateCrossVersionConsistency(fields map[schema.GroupVersionResource][]SearchFieldDefinition) error {
+	type versionedField struct {
+		version    string
+		attributes mappingAttributes
+	}
+	perGroupResource := map[schema.GroupResource]map[string][]versionedField{}
+	for gvr, sfds := range fields {
+		gr := gvr.GroupResource()
+		if perGroupResource[gr] == nil {
+			perGroupResource[gr] = map[string][]versionedField{}
+		}
+		for _, sfd := range sfds {
+			perGroupResource[gr][sfd.Name] = append(perGroupResource[gr][sfd.Name], versionedField{
+				version:    gvr.Version,
+				attributes: mappingAttributesOf(sfd),
+			})
+		}
+	}
+	var violations []string
+	grs := make([]schema.GroupResource, 0, len(perGroupResource))
+	for gr := range perGroupResource {
+		grs = append(grs, gr)
+	}
+	slices.SortFunc(grs, func(a, b schema.GroupResource) int {
+		if c := strings.Compare(a.Group, b.Group); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Resource, b.Resource)
+	})
+	for _, gr := range grs {
+		names := perGroupResource[gr]
+		sortedNames := make([]string, 0, len(names))
+		for name := range names {
+			sortedNames = append(sortedNames, name)
+		}
+		slices.Sort(sortedNames)
+		for _, name := range sortedNames {
+			entries := names[name]
+			if len(entries) < 2 {
+				continue
+			}
+			slices.SortFunc(entries, func(a, b versionedField) int { return strings.Compare(a.version, b.version) })
+			// Compare every other version against the first sorted entry and
+			// collect the union of differing attributes. The first entry is
+			// just the reference point.
+			var diffs []string
+			for _, e := range entries[1:] {
+				for _, d := range diffMappingAttributes(entries[0].attributes, e.attributes) {
+					if !slices.Contains(diffs, d) {
+						diffs = append(diffs, d)
+					}
+				}
+			}
+			if len(diffs) == 0 {
+				continue
+			}
+			versions := make([]string, len(entries))
+			for i, e := range entries {
+				versions[i] = e.version
+			}
+			violations = append(violations, fmt.Sprintf("field %q on %s diverges across versions [%s] on %s", name, gr.String(), strings.Join(versions, ", "), strings.Join(diffs, ", ")))
+		}
+	}
+	if len(violations) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(violations, "; "))
 }
 
 // validateSearchFieldDefinitions returns a non-nil error when any declaration
@@ -327,8 +468,10 @@ func (p *mapProvider) Fields(gvr schema.GroupVersionResource) []SearchFieldDefin
 	}
 	// Empty version: return the union across every registered version of
 	// (gvr.Group, gvr.Resource), deduplicated by Name. Preferred version
-	// goes first so its shape wins on collisions; other versions are
-	// iterated in sorted order for determinism.
+	// goes first, other versions are iterated in sorted order, so the
+	// returned slice is deterministic. Cross-version consistency on Type,
+	// Array, and Capabilities is enforced by NewMapProvider, so the dedup
+	// never has to choose between conflicting mappings for the same name.
 	var out []SearchFieldDefinition
 	seen := map[string]bool{}
 	appendNew := func(sfds []SearchFieldDefinition) {

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -69,14 +69,15 @@ func TestMapProvider_FieldsUnionAcrossVersions(t *testing.T) {
 	v1 := schema.GroupVersionResource{Group: gr.Group, Version: "v1", Resource: gr.Resource}
 	v2 := schema.GroupVersionResource{Group: gr.Group, Version: "v2", Resource: gr.Resource}
 
+	shared := SearchFieldDefinition{Name: "shared", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}}
 	p := NewMapProvider(
 		map[schema.GroupVersionResource][]SearchFieldDefinition{
 			v1: {
-				{Name: "shared", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}},
+				shared,
 				{Name: "only_v1", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}},
 			},
 			v2: {
-				{Name: "shared", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityText}},
+				shared,
 				{Name: "only_v2", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}},
 			},
 		},
@@ -87,21 +88,14 @@ func TestMapProvider_FieldsUnionAcrossVersions(t *testing.T) {
 	assert.Len(t, p.Fields(v1), 2)
 	assert.Len(t, p.Fields(v2), 2)
 
-	// Empty-version lookup returns the union deduped by Name.
+	// Empty-version lookup returns the union deduped by Name. A field
+	// declared identically in both versions appears once.
 	union := p.Fields(schema.GroupVersionResource{Group: gr.Group, Resource: gr.Resource})
 	names := make([]string, 0, len(union))
 	for _, sfd := range union {
 		names = append(names, sfd.Name)
 	}
 	assert.ElementsMatch(t, []string{"shared", "only_v1", "only_v2"}, names)
-
-	// Preferred version (v1) wins on Name collisions: the shape of `shared`
-	// comes from v1, not v2.
-	for _, sfd := range union {
-		if sfd.Name == "shared" {
-			assert.Equal(t, []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}, sfd.Capabilities)
-		}
-	}
 }
 
 func TestMapProvider_IndexAffectingHash(t *testing.T) {
@@ -345,5 +339,142 @@ func TestValidateSearchFieldDefinitions(t *testing.T) {
 			{Name: "tag", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFacet}},
 		})
 		require.NoError(t, err)
+	})
+}
+
+func TestValidateCrossVersionConsistency(t *testing.T) {
+	gr := schema.GroupResource{Group: "example.test", Resource: "widgets"}
+	v1 := schema.GroupVersionResource{Group: gr.Group, Version: "v1", Resource: gr.Resource}
+	v2 := schema.GroupVersionResource{Group: gr.Group, Version: "v2", Resource: gr.Resource}
+
+	t.Run("identical declaration across versions is allowed", func(t *testing.T) {
+		shared := SearchFieldDefinition{Name: "label", Path: "spec.label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}}
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {shared},
+			v2: {shared},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("capability order does not count as divergence", func(t *testing.T) {
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}}},
+			v2: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityRetrieve, SearchCapabilityFilter}}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("description differing across versions is allowed", func(t *testing.T) {
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}, Description: "old"}},
+			v2: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}, Description: "renamed for clarity"}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("path differing across versions is allowed", func(t *testing.T) {
+		// Path is an extractor-side concern: each version's document is
+		// extracted with that version's declaration, so v1 can read from
+		// spec.foo while v2 reads from spec.bar without conflicting on the
+		// shared bleve mapping.
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "label", Path: "spec.foo", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+			v2: {{Name: "label", Path: "spec.bar", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("path real vs computed across versions is allowed", func(t *testing.T) {
+		// One version backs the field with a JSON path, the other leaves
+		// Path empty so a custom builder fills it in. The bleve mapping is
+		// the same either way.
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "label", Path: "spec.foo", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+			v2: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("emitZeroIfAbsent differing across versions is allowed", func(t *testing.T) {
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "count", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter}, EmitZeroIfAbsent: true}},
+			v2: {{Name: "count", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("copyFromStandard differing across versions is allowed", func(t *testing.T) {
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "created", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityRetrieve}, CopyFromStandard: StandardFieldCreated}},
+			v2: {{Name: "created", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityRetrieve}}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("duplicate capability within one declaration does not count as divergence", func(t *testing.T) {
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityFilter, SearchCapabilityRetrieve}}},
+			v2: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("field declared in only one version is allowed", func(t *testing.T) {
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "only_v1", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+			v2: {{Name: "only_v2", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("diverging capabilities are rejected", func(t *testing.T) {
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}}},
+			v2: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityText}}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `field "label"`)
+		assert.Contains(t, err.Error(), gr.String())
+		assert.Contains(t, err.Error(), "v1")
+		assert.Contains(t, err.Error(), "v2")
+		assert.Contains(t, err.Error(), "capabilities")
+	})
+
+	t.Run("diverging type is rejected", func(t *testing.T) {
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "count", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+			v2: {{Name: "count", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "type")
+	})
+
+	t.Run("diverging array flag is rejected", func(t *testing.T) {
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1: {{Name: "tags", Type: SearchFieldTypeString, Array: true, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+			v2: {{Name: "tags", Type: SearchFieldTypeString, Array: false, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "array")
+	})
+
+	t.Run("unrelated (group, resource) does not interfere", func(t *testing.T) {
+		other := schema.GroupVersionResource{Group: "other.test", Version: "v1", Resource: "things"}
+		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
+			v1:    {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+			other: {{Name: "label", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("NewMapProvider panics on cross-version divergence", func(t *testing.T) {
+		assert.PanicsWithValue(t,
+			`inconsistent SearchFieldDefinitions across versions: field "label" on widgets.example.test diverges across versions [v1, v2] on capabilities`,
+			func() {
+				NewMapProvider(map[schema.GroupVersionResource][]SearchFieldDefinition{
+					v1: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
+					v2: {{Name: "label", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityText}}},
+				}, nil)
+			})
 	})
 }


### PR DESCRIPTION
When a kind is served at more than one version, the bleve mapping is built once from the union of `SearchFieldDefinition`s across every version. If two versions declared the same field name with a different `Type`, `Array` flag, or `Capabilities` set, the dedup would silently keep one and drop the other. `NewMapProvider` now rejects that at construction with an error naming the field, the GroupResource, the conflicting versions, and the diverging attributes.

`Path`, `EmitZeroIfAbsent`, `CopyFromStandard`, and `Description` may still differ across versions — each version's document is extracted with that version's own declaration, so they do not feed into the shared mapping. No in-tree kind hits this today; no wire change, no rebuild trigger, no consumer changes.
