### PR TITLE
[release-13.1.1] CI: Backport upstream-run-id dispatch (#127405)

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -47,6 +47,42 @@ jobs:
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
         run: |
+          set -euo pipefail
+
+          # Idempotent re-runs (e.g. auto-promotion retries): if the tag ref already exists AND points
+          # at the requested commit, this is a no-op. If it exists but points elsewhere, fail loudly —
+          # don't silently accept a tag on the wrong commit.
+          ref_err=$(mktemp)
+          if existing=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" 2>"$ref_err"); then
+            rm -f "$ref_err"
+            obj_sha=$(printf '%s' "$existing" | jq -r '.object.sha')
+            obj_type=$(printf '%s' "$existing" | jq -r '.object.type')
+            # This workflow publishes an ANNOTATED tag. Only a matching annotated tag is a valid no-op;
+            # a lightweight tag (or any other ref type) is an anomaly we surface rather than accept.
+            if [ "$obj_type" != "tag" ]; then
+              echo "::error::Tag ${TAG} already exists as a non-annotated ref (type ${obj_type}); expected an annotated tag." >&2
+              exit 1
+            fi
+            # Annotated tag: dereference the tag object to the commit it points at.
+            target=$(gh api "repos/${REPO}/git/tags/${obj_sha}" --jq '.object.sha')
+            # Resolve the requested commit to its canonical 40-char SHA so a short SHA input still matches.
+            want=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}" --jq '.sha')
+            if [ "$target" = "$want" ]; then
+              echo "Annotated tag ${TAG} already exists at ${want}; nothing to do."
+              exit 0
+            fi
+            echo "::error::Tag ${TAG} already exists but points at ${target}, not ${want}." >&2
+            exit 1
+          elif ! grep -q "HTTP 404" "$ref_err"; then
+            # Only a 404 means "tag absent, go create it". Any other error (5xx, auth, rate limit) must
+            # fail loudly — otherwise we'd fall through to creation and fail on an already-existing ref,
+            # leaking an orphan tag object and hiding the real problem.
+            echo "::error::Failed to query tag ${TAG}: $(cat "$ref_err")" >&2
+            rm -f "$ref_err"
+            exit 1
+          fi
+          rm -f "$ref_err"
+
           tag_sha=$(gh api "repos/${REPO}/git/tags" \
             --method POST \
             -f "tag=${TAG}" \

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -143,6 +143,10 @@ jobs:
             // pro/nightly build from main where the stamped commit is already the HEAD.
             if (workflow === 'release-build-enterprise.yml') {
               inputs["grafana-public-commit"] = PUBLIC_COMMIT;
+              // Supply run ID separately in case we ever change what BUILD_ID is.
+              // upstream-run-id is used with the github actions API and `gh run watch` to ensure coupled workflows
+              // fail together.
+              inputs["upstream-run-id"] = String(BUILD_ID);
             }
 
             await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
Backports #127405 to `release-13.1.1`: the `release-build.yml` downstream dispatch now passes `upstream-run-id` to the enterprise build. This gates the enterprise `write-release-metadata` sentinel (paired with grafana-enterprise#12494), which the automated scheduled public-release process needs to discover a complete RC. Also includes create-release-tag idempotency from the same commit.