### PR TITLE
[release-12.3.9] CI: Backport upstream-run-id dispatch (#127405)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -143,6 +143,10 @@ jobs:
             // pro/nightly build from main where the stamped commit is already the HEAD.
             if (workflow === 'release-build-enterprise.yml') {
               inputs["grafana-public-commit"] = PUBLIC_COMMIT;
+              // Supply run ID separately in case we ever change what BUILD_ID is.
+              // upstream-run-id is used with the github actions API and `gh run watch` to ensure coupled workflows
+              // fail together.
+              inputs["upstream-run-id"] = String(BUILD_ID);
             }
 
             await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
Backports the `release-build.yml` change from #127405 to `release-12.3.9`: the downstream dispatch to `release-build-enterprise.yml` now passes `upstream-run-id`, gating the enterprise `write-release-metadata` sentinel. create-release-tag.yml dropped (absent here). actionlint validated.