### PR TITLE
Alerting: add backwards compatibility test for notification settings object in rules API

### DIFF
--- a/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
+++ b/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/grafana-app-sdk/resource"
@@ -815,6 +818,71 @@ func TestIntegrationNotificationSettings(t *testing.T) {
 		require.Equal(t, "empty", got.Spec.NotificationSettings.SimplifiedRouting.Receiver)
 
 		require.NoError(t, client.Delete(ctx, created.Name, v1.DeleteOptions{}))
+	})
+
+	t.Run("should default to SimplifiedRouting if type is unspecified using unstructured object", func(t *testing.T) {
+		rule := baseGen.Generate()
+		unstructuredRule := &unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"namespace": "default",
+					"annotations": map[string]string{
+						"grafana.app/folder": "test-folder",
+					},
+				},
+				"spec": map[string]any{
+					"title": rule.Title,
+					"expressions": map[string]any{
+						"A": map[string]any{
+							"queryType":     new(rule.Data[0].QueryType),
+							"datasourceUID": new(v0alpha1.AlertRuleDatasourceUID(rule.Data[0].DatasourceUID)),
+							"model":         rule.Data[0].Model,
+							"source":        new(true),
+							"relativeTimeRange": map[string]any{
+								"from": v0alpha1.AlertRulePromDurationWMillis("5m"),
+								"to":   v0alpha1.AlertRulePromDurationWMillis("0s"),
+							},
+						},
+					},
+					"trigger": map[string]any{
+						"interval": v0alpha1.AlertRulePromDuration(fmt.Sprintf("%ds", rule.IntervalSeconds)),
+					},
+					"noDataState":  common.ToK8sNoDataState(rule.NoDataState),
+					"execErrState": common.ToK8sExecErrState(rule.ExecErrState),
+					"notificationSettings": map[string]any{
+						"receiver": "empty",
+					},
+				},
+			},
+		}
+
+		unstructuredClient := helper.GetResourceClient(apis.ResourceClientArgs{
+			User:      helper.Org1.Admin,
+			Namespace: "default",
+			GVR: schema.GroupVersionResource{
+				Group:    "rules.alerting.grafana.app",
+				Version:  "v0alpha1",
+				Resource: "alertrules",
+			},
+		})
+
+		created, err := unstructuredClient.Resource.Create(ctx, unstructuredRule, v1.CreateOptions{})
+		require.NoError(t, err)
+
+		createdRule := new(v0alpha1.AlertRule)
+
+		runtime.DefaultUnstructuredConverter.FromUnstructured(created.Object, createdRule)
+
+		require.NoError(t, err)
+		require.NotNil(t, created)
+
+		got, err := client.Get(ctx, createdRule.Name, v1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, got.Spec.NotificationSettings)
+		require.NotNil(t, got.Spec.NotificationSettings.SimplifiedRouting)
+		require.Nil(t, got.Spec.NotificationSettings.NamedRoutingTree)
+		require.Equal(t, v0alpha1.AlertRuleNotificationSettingsTypeSimplifiedRouting, got.Spec.NotificationSettings.SimplifiedRouting.Type)
+		require.Equal(t, "empty", got.Spec.NotificationSettings.SimplifiedRouting.Receiver)
 	})
 
 	t.Run("should create and read rule with NamedRoutingTree notification settings", func(t *testing.T) {

--- a/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
+++ b/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
@@ -867,14 +867,14 @@ func TestIntegrationNotificationSettings(t *testing.T) {
 		})
 
 		created, err := unstructuredClient.Resource.Create(ctx, unstructuredRule, v1.CreateOptions{})
-		require.NoError(t, err)
-
-		createdRule := new(v0alpha1.AlertRule)
-
-		runtime.DefaultUnstructuredConverter.FromUnstructured(created.Object, createdRule)
 
 		require.NoError(t, err)
 		require.NotNil(t, created)
+
+		createdRule := new(v0alpha1.AlertRule)
+
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(created.Object, createdRule)
+		require.NoError(t, err)
 
 		got, err := client.Get(ctx, createdRule.Name, v1.GetOptions{})
 		require.NoError(t, err)

--- a/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
+++ b/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
@@ -806,6 +806,9 @@ func TestIntegrationNotificationSettings(t *testing.T) {
 		alertRule := newAlertRule(t, ns)
 
 		created, err := client.Create(ctx, alertRule, v1.CreateOptions{})
+		defer func() {
+			_ = client.Delete(ctx, created.GetName(), v1.DeleteOptions{})
+		}()
 		require.NoError(t, err)
 		require.NotNil(t, created)
 
@@ -867,6 +870,9 @@ func TestIntegrationNotificationSettings(t *testing.T) {
 		})
 
 		created, err := unstructuredClient.Resource.Create(ctx, unstructuredRule, v1.CreateOptions{})
+		defer func() {
+			_ = client.Delete(ctx, created.GetName(), v1.DeleteOptions{})
+		}()
 
 		require.NoError(t, err)
 		require.NotNil(t, created)
@@ -895,6 +901,9 @@ func TestIntegrationNotificationSettings(t *testing.T) {
 		alertRule := newAlertRule(t, ns)
 
 		created, err := client.Create(ctx, alertRule, v1.CreateOptions{})
+		defer func() {
+			_ = client.Delete(ctx, created.GetName(), v1.DeleteOptions{})
+		}()
 		require.NoError(t, err)
 		require.NotNil(t, created)
 
@@ -919,6 +928,9 @@ func TestIntegrationNotificationSettings(t *testing.T) {
 		alertRule := newAlertRule(t, ns)
 
 		created, err := client.Create(ctx, alertRule, v1.CreateOptions{})
+		defer func() {
+			_ = client.Delete(ctx, created.GetName(), v1.DeleteOptions{})
+		}()
 		require.NoError(t, err)
 		require.NotNil(t, created)
 
@@ -954,6 +966,9 @@ func TestIntegrationNotificationSettings(t *testing.T) {
 		alertRule := newAlertRule(t, ns)
 
 		created, err := client.Create(ctx, alertRule, v1.CreateOptions{})
+		defer func() {
+			_ = client.Delete(ctx, created.GetName(), v1.DeleteOptions{})
+		}()
 		require.NoError(t, err)
 		require.NotNil(t, created)
 
@@ -989,6 +1004,9 @@ func TestIntegrationNotificationSettings(t *testing.T) {
 		alertRule := newAlertRule(t, ns)
 
 		created, err := client.Create(ctx, alertRule, v1.CreateOptions{})
+		defer func() {
+			_ = client.Delete(ctx, created.GetName(), v1.DeleteOptions{})
+		}()
 		require.NoError(t, err)
 		require.NotNil(t, created)
 


### PR DESCRIPTION
**What is this feature?**

This PR adds test coverage for the defaulting behavior for the alert rule notification settings field. Specifically that we default to the SimplifiedRouting variant of that field when the discriminator field (`type`) is omitted.

**Why do we need this feature?**

To ensure future changes to the API don't break this behavior.