### PR TITLE
Alerting: Fix alert_rule_state sequence overflow on PostgreSQL

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -178,4 +178,6 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	accesscontrol.AddManagedRoutesPermissions(mg)
 
 	addNatsDiscoveryMigrations(mg)
+
+	ualert.AddAlertRuleStateBigIntMigration(mg)
 }

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_state_table.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_state_table.go
@@ -27,3 +27,19 @@ func AddAlertRuleStateTable(mg *migrator.Migrator) {
 		migrator.NewAddIndexMigration(alertStateTable, alertStateTable.Indices[0]),
 	)
 }
+
+// AddAlertRuleStateBigIntMigration widens alert_rule_state.id to bigint on PostgreSQL.
+//
+// The migrator maps DB_BigInt with IsAutoIncrement to SERIAL (integer, max 2^31-1)
+// instead of BIGSERIAL (bigint), so the id column and its sequence are only 32-bit.
+// The periodic full-sync (DELETE + re-INSERT) burns through sequence values rapidly,
+// causing the sequence to overflow on busy installations. MySQL and SQLite already
+// store the column as a 64-bit integer, so this only affects PostgreSQL.
+func AddAlertRuleStateBigIntMigration(mg *migrator.Migrator) {
+	// Each statement is its own migration: a raw SQL migration runs as a single Exec,
+	// and PostgreSQL does not support multiple semicolon-separated statements in one Exec.
+	mg.AddMigration("alter alert_rule_state id column to bigint for postgres", migrator.NewRawSQLMigration("").
+		Postgres("ALTER TABLE alert_rule_state ALTER COLUMN id TYPE BIGINT;"))
+	mg.AddMigration("alter alert_rule_state id sequence to bigint for postgres", migrator.NewRawSQLMigration("").
+		Postgres("ALTER SEQUENCE alert_rule_state_id_seq AS BIGINT;"))
+}

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -30,6 +30,14 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("add column external_alertmanager_uid in ngalert_configuration", migrator.NewAddColumnMigration(migrator.Table{Name: "ngalert_configuration"}, &migrator.Column{
 		Name: "external_alertmanager_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: true,
 	}))
+
+	// Fix alert_rule_state.id column type on PostgreSQL. The migrator maps DB_BigInt with
+	// IsAutoIncrement to SERIAL (integer, max 2^31-1) instead of BIGSERIAL (bigint). The
+	// periodic full-sync (DELETE + re-INSERT) burns through sequence values rapidly, causing
+	// the sequence to overflow on busy installations.
+	mg.AddMigration("alter alert_rule_state id column and sequence to bigint for postgres", migrator.NewRawSQLMigration("").
+		Postgres("ALTER TABLE alert_rule_state ALTER COLUMN id TYPE BIGINT; ALTER SEQUENCE alert_rule_state_id_seq AS BIGINT;"))
+
 	// End of migration log, add new migrations above this line.
 }
 

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -31,17 +31,6 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 		Name: "external_alertmanager_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: true,
 	}))
 
-	// Fix alert_rule_state.id column type on PostgreSQL. The migrator maps DB_BigInt with
-	// IsAutoIncrement to SERIAL (integer, max 2^31-1) instead of BIGSERIAL (bigint). The
-	// periodic full-sync (DELETE + re-INSERT) burns through sequence values rapidly, causing
-	// the sequence to overflow on busy installations. Each statement must be its own
-	// migration because a raw SQL migration runs as a single Exec, and Postgres does not
-	// support multiple semicolon-separated statements in one Exec.
-	mg.AddMigration("alter alert_rule_state id column to bigint for postgres", migrator.NewRawSQLMigration("").
-		Postgres("ALTER TABLE alert_rule_state ALTER COLUMN id TYPE BIGINT;"))
-	mg.AddMigration("alter alert_rule_state id sequence to bigint for postgres", migrator.NewRawSQLMigration("").
-		Postgres("ALTER SEQUENCE alert_rule_state_id_seq AS BIGINT;"))
-
 	// End of migration log, add new migrations above this line.
 }
 

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -34,9 +34,13 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 	// Fix alert_rule_state.id column type on PostgreSQL. The migrator maps DB_BigInt with
 	// IsAutoIncrement to SERIAL (integer, max 2^31-1) instead of BIGSERIAL (bigint). The
 	// periodic full-sync (DELETE + re-INSERT) burns through sequence values rapidly, causing
-	// the sequence to overflow on busy installations.
-	mg.AddMigration("alter alert_rule_state id column and sequence to bigint for postgres", migrator.NewRawSQLMigration("").
-		Postgres("ALTER TABLE alert_rule_state ALTER COLUMN id TYPE BIGINT; ALTER SEQUENCE alert_rule_state_id_seq AS BIGINT;"))
+	// the sequence to overflow on busy installations. Each statement must be its own
+	// migration because a raw SQL migration runs as a single Exec, and Postgres does not
+	// support multiple semicolon-separated statements in one Exec.
+	mg.AddMigration("alter alert_rule_state id column to bigint for postgres", migrator.NewRawSQLMigration("").
+		Postgres("ALTER TABLE alert_rule_state ALTER COLUMN id TYPE BIGINT;"))
+	mg.AddMigration("alter alert_rule_state id sequence to bigint for postgres", migrator.NewRawSQLMigration("").
+		Postgres("ALTER SEQUENCE alert_rule_state_id_seq AS BIGINT;"))
 
 	// End of migration log, add new migrations above this line.
 }


### PR DESCRIPTION
**What is this feature?**

Adds a database migration that converts the `alert_rule_state.id` column and its sequence to `BIGINT` on PostgreSQL.

**Why do we need this feature?**

The migrator maps `DB_BigInt` + `IsAutoIncrement` to `SERIAL` (integer, max 2^31-1) instead of `BIGSERIAL` (bigint), capping the sequence at 2^31-1. The periodic full-sync (DELETE + re-INSERT) burns through sequence values rapidly, causing the sequence to overflow on busy installations.

The fix is appended as a new immutable migration (`ALTER TABLE ... TYPE BIGINT` + `ALTER SEQUENCE ... AS BIGINT`), so existing PostgreSQL databases are corrected in place rather than only fresh installs.

**Who is this feature for?**

Operators running Grafana Alerting on PostgreSQL, particularly busy installations affected by the periodic full-sync of alert rule state.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
