### PR TITLE
Search: add bounded post-filter authz mode (part 2)

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -767,6 +767,10 @@ type Cfg struct {
 	SearchPostRankAuthzOverFetchFactor int
 	SearchPostRankAuthzMaxWindow       int
 	SearchPostRankAuthzMaxCandidates   int
+	// SearchPostRankAuthzFacetSampleSize bounds the candidate budget when
+	// aggregating facets on the post-filter path. Zero falls back to the
+	// default in search.PostRankAuthzConfig.effective().
+	SearchPostRankAuthzFacetSampleSize int
 
 	// Vector storage
 	EnableVectorBackend bool

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -185,6 +185,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.SearchPostRankAuthzOverFetchFactor = section.Key("search_post_rank_authz_over_fetch_factor").MustInt(0)
 	cfg.SearchPostRankAuthzMaxWindow = section.Key("search_post_rank_authz_max_window").MustInt(0)
 	cfg.SearchPostRankAuthzMaxCandidates = section.Key("search_post_rank_authz_max_candidates").MustInt(0)
+	cfg.SearchPostRankAuthzFacetSampleSize = section.Key("search_post_rank_authz_facet_sample_size").MustInt(0)
 	cfg.EnableVectorBackend = section.Key("vector_backend").MustBool(false)
 	cfg.VectorAllowedInternalCollections = section.Key("vector_allowed_internal_collections").Strings(",")
 	if len(cfg.VectorAllowedInternalCollections) == 0 {

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -162,6 +162,7 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 			assert.Equal(t, 0, cfg.SearchPostRankAuthzOverFetchFactor)
 			assert.Equal(t, 0, cfg.SearchPostRankAuthzMaxWindow)
 			assert.Equal(t, 0, cfg.SearchPostRankAuthzMaxCandidates)
+			assert.Equal(t, 0, cfg.SearchPostRankAuthzFacetSampleSize)
 		})
 
 		t.Run("reads configured values", func(t *testing.T) {
@@ -172,11 +173,13 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 			setSectionKey(cfg, "search_post_rank_authz_over_fetch_factor", "20")
 			setSectionKey(cfg, "search_post_rank_authz_max_window", "5000")
 			setSectionKey(cfg, "search_post_rank_authz_max_candidates", "12345")
+			setSectionKey(cfg, "search_post_rank_authz_facet_sample_size", "8000")
 			cfg.setUnifiedStorageConfig()
 			assert.True(t, cfg.SearchPostRankAuthz)
 			assert.Equal(t, 20, cfg.SearchPostRankAuthzOverFetchFactor)
 			assert.Equal(t, 5000, cfg.SearchPostRankAuthzMaxWindow)
 			assert.Equal(t, 12345, cfg.SearchPostRankAuthzMaxCandidates)
+			assert.Equal(t, 8000, cfg.SearchPostRankAuthzFacetSampleSize)
 		})
 	})
 

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -134,7 +134,7 @@ type IndexableDocument struct {
 	// When the resource is managed by an upstream repository
 	Manager *utils.ManagerProperties `json:"manager,omitempty"`
 
-	// indexed only field for faceting manager info
+	// keyword-indexed and stored field for faceting manager info
 	ManagedBy string `json:"managedBy,omitempty"`
 
 	// When the manager knows about file paths

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -116,9 +116,17 @@ type IndexFeature string
 // this feature before keeping a deleted document.
 const IndexFeatureDeletedMarker IndexFeature = "deleted-marker"
 
+// IndexFeatureStoredFacets means every facet-capable field is stored, so the
+// post-rank authorization path can aggregate facets app-side. Native bleve
+// faceting reads the index, not the stored values, so this is required only
+// where post-rank authorization runs — see RequiredIndexFeatures. Without it,
+// that path reports facet-capable but unstored fields as missing values.
+const IndexFeatureStoredFacets IndexFeature = "facets-are-stored"
+
 // currentIndexFeatures is recorded in every index this binary builds.
 var currentIndexFeatures = []IndexFeature{
 	IndexFeatureDeletedMarker,
+	IndexFeatureStoredFacets,
 }
 
 // requiredIndexFeatures is the subset an index must already have to be used. An
@@ -138,8 +146,14 @@ func CurrentIndexFeatures() []IndexFeature {
 }
 
 // RequiredIndexFeatures returns the features an index must have to be used.
-func RequiredIndexFeatures() []IndexFeature {
-	return slices.Sorted(slices.Values(requiredIndexFeatures))
+// postRankAuthz adds the features only that path depends on, so deployments
+// serving facets from bleve itself are not rebuilt for it.
+func RequiredIndexFeatures(postRankAuthz bool) []IndexFeature {
+	features := requiredIndexFeatures
+	if postRankAuthz {
+		features = append(slices.Clone(features), IndexFeatureStoredFacets)
+	}
+	return slices.Sorted(slices.Values(features))
 }
 
 // MissingIndexFeatures returns the required features the index does not have.
@@ -364,7 +378,7 @@ func newSearchServer(opts SearchOptions, storage StorageBackend, vectorBackend v
 		minBuildVersion:           opts.MinBuildVersion,
 		buildVersion:              opts.BuildVersion,
 		searchFields:              searchFields,
-		requiredFeatures:          RequiredIndexFeatures(),
+		requiredFeatures:          RequiredIndexFeatures(opts.PostRankAuthzEnabled),
 		injectFailuresPercent:     opts.InjectFailuresPercent,
 		indexModificationCacheTTL: opts.IndexModificationCacheTTL,
 

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -492,19 +492,16 @@ type hashableVersion struct {
 	Fields  []hashableField `json:"f"`
 }
 
-// searchFieldIndexMappingVersion changes when the server's interpretation of
-// capabilities changes the persisted index shape without changing declarations.
-// Bumping it shifts IndexAffectingHash and triggers a one-time index rebuild.
-const searchFieldIndexMappingVersion = 2
-
 // hashablePayload is the canonical hash input. Standard search fields
 // (shared by every kind) are mixed in alongside per-(group, resource)
-// versioned fields and the server mapping revision so either declaration or
-// mapping-semantic changes trigger a rebuild via the SearchFieldsHash check.
+// versioned fields so that changes to the standard set shift every kind's
+// hash and trigger a rebuild via the SearchFieldsHash check.
+//
+// Mapping changes that no declaration describes are carried by an IndexFeature
+// instead, so only the deployments that depend on them rebuild.
 type hashablePayload struct {
-	MappingVersion int               `json:"m"`
-	Standard       []hashableField   `json:"s"`
-	Versions       []hashableVersion `json:"v"`
+	Standard []hashableField   `json:"s"`
+	Versions []hashableVersion `json:"v"`
 }
 
 // canonicalHashableFields normalises a SearchFieldDefinition slice into
@@ -551,9 +548,8 @@ func (p *mapProvider) IndexAffectingHash(group, resource string) string {
 		})
 	}
 	payload := hashablePayload{
-		MappingVersion: searchFieldIndexMappingVersion,
-		Standard:       canonicalHashableFields(StandardSearchFieldDefinitions()),
-		Versions:       versionPayloads,
+		Standard: canonicalHashableFields(StandardSearchFieldDefinitions()),
+		Versions: versionPayloads,
 	}
 
 	// json.Marshal can only return a non-nil error for inputs it cannot

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -492,13 +492,19 @@ type hashableVersion struct {
 	Fields  []hashableField `json:"f"`
 }
 
+// searchFieldIndexMappingVersion changes when the server's interpretation of
+// capabilities changes the persisted index shape without changing declarations.
+// Bumping it shifts IndexAffectingHash and triggers a one-time index rebuild.
+const searchFieldIndexMappingVersion = 2
+
 // hashablePayload is the canonical hash input. Standard search fields
 // (shared by every kind) are mixed in alongside per-(group, resource)
-// versioned fields so that changes to the standard set shift every kind's
-// hash and trigger a rebuild via the SearchFieldsHash check.
+// versioned fields and the server mapping revision so either declaration or
+// mapping-semantic changes trigger a rebuild via the SearchFieldsHash check.
 type hashablePayload struct {
-	Standard []hashableField   `json:"s"`
-	Versions []hashableVersion `json:"v"`
+	MappingVersion int               `json:"m"`
+	Standard       []hashableField   `json:"s"`
+	Versions       []hashableVersion `json:"v"`
 }
 
 // canonicalHashableFields normalises a SearchFieldDefinition slice into
@@ -545,8 +551,9 @@ func (p *mapProvider) IndexAffectingHash(group, resource string) string {
 		})
 	}
 	payload := hashablePayload{
-		Standard: canonicalHashableFields(StandardSearchFieldDefinitions()),
-		Versions: versionPayloads,
+		MappingVersion: searchFieldIndexMappingVersion,
+		Standard:       canonicalHashableFields(StandardSearchFieldDefinitions()),
+		Versions:       versionPayloads,
 	}
 
 	// json.Marshal can only return a non-nil error for inputs it cannot

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -232,8 +232,9 @@ func TestMapProvider_IndexAffectingHash_GoldenHash(t *testing.T) {
 		},
 	}, nil)
 
-	// Standard tags declare facet capability so Bleve facets use their keyword-analyzed mapping.
-	const expected = "0f114ef8fa64163466eb9d3477163cfe964b5a626c37279d5e60a2586c18a064"
+	// Deliberate server mapping revision: facet capability now implies the
+	// canonical Bleve field is stored for app-side facet aggregation.
+	const expected = "122719d4168c4ba33d5f5e2fbb97afe0a933a2051a6cf7b55530c161baf7b421"
 	assert.Equal(t, expected, p.IndexAffectingHash(group, resource),
 		"canonical hash drifted. If json.Marshal output changed (Go release), update the literal; otherwise a code change shifted the canonical form.")
 }

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -232,9 +232,8 @@ func TestMapProvider_IndexAffectingHash_GoldenHash(t *testing.T) {
 		},
 	}, nil)
 
-	// Deliberate server mapping revision: facet capability now implies the
-	// canonical Bleve field is stored for app-side facet aggregation.
-	const expected = "122719d4168c4ba33d5f5e2fbb97afe0a933a2051a6cf7b55530c161baf7b421"
+	// Standard tags declare facet capability so Bleve facets use their keyword-analyzed mapping.
+	const expected = "0f114ef8fa64163466eb9d3477163cfe964b5a626c37279d5e60a2586c18a064"
 	assert.Equal(t, expected, p.IndexAffectingHash(group, resource),
 		"canonical hash drifted. If json.Marshal output changed (Go release), update the literal; otherwise a code change shifted the canonical form.")
 }

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -640,9 +640,24 @@ func TestCombineBuildRequests(t *testing.T) {
 // features safe: requiring a feature this binary never records would rebuild
 // every index on every check, forever.
 func TestRequiredIndexFeaturesAreCurrent(t *testing.T) {
-	for _, required := range RequiredIndexFeatures() {
-		require.Contains(t, CurrentIndexFeatures(), required)
+	for _, postRankAuthz := range []bool{false, true} {
+		for _, required := range RequiredIndexFeatures(postRankAuthz) {
+			require.Contains(t, CurrentIndexFeatures(), required)
+		}
 	}
+}
+
+// TestRequiredIndexFeaturesStoredFacets covers the gating that keeps the stored
+// facet mapping from rebuilding indexes where post-rank authorization is off.
+func TestRequiredIndexFeaturesStoredFacets(t *testing.T) {
+	require.NotContains(t, RequiredIndexFeatures(false), IndexFeatureStoredFacets)
+	require.Contains(t, RequiredIndexFeatures(true), IndexFeatureStoredFacets)
+
+	// An index built before the stored facet mapping is reused with the option
+	// off, and rebuilt once it is on.
+	buildInfo := IndexBuildInfo{Features: []IndexFeature{IndexFeatureDeletedMarker}}
+	require.Empty(t, MissingIndexFeatures(buildInfo, RequiredIndexFeatures(false)))
+	require.Equal(t, []IndexFeature{IndexFeatureStoredFacets}, MissingIndexFeatures(buildInfo, RequiredIndexFeatures(true)))
 }
 
 func TestShouldRebuildIndex(t *testing.T) {

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -293,6 +293,11 @@ type SearchOptions struct {
 	// Percentage of search requests that should fail immediately (0-100). 0 = disabled, 100 = all requests fail.
 	InjectFailuresPercent int
 
+	// PostRankAuthzEnabled mirrors the index backend's post-rank authorization
+	// setting. It selects the index features this server requires, so an index
+	// that predates them is rebuilt before that path serves a query.
+	PostRankAuthzEnabled bool
+
 	// SearchFields holds the per-kind search-field wiring shared with the index
 	// backend. The search server reads the selectable fields and the definition
 	// hash from it and triggers a rebuild when either differs from the values

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2162,7 +2162,6 @@ func (b *bleveIndex) Search(
 	selectFields := slices.Clone(searchrequest.Fields)
 	if postRank {
 		b.ensureAuthzFields(searchrequest)
-		b.ensureFacetFields(searchrequest, req)
 	}
 	stats.AddRequestConversionTime(time.Since(conversionStarts))
 
@@ -2373,8 +2372,8 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 		// postFilter aggregates facets app-side over authorized hits (see
 		// facetAggregator); bleve's native facets would run over the unfiltered
 		// searcher and count unauthorized docs, so drop them here. The facet
-		// fields are added to the bleve load list in Search (ensureFacetFields),
-		// separate from the response column list.
+		// scan loads the stored facet fields on its own request copy
+		// (facetScanFields), separate from the response column list.
 		searchrequest.Facets = nil
 	}
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2106,9 +2106,9 @@ func (b *bleveIndex) Search(
 	// covers normal paginated search, federated queries, facet queries, and
 	// SearchBefore: bleve ranks, the runner authorizes app-side in rank order,
 	// and stops once the page is full (page-fill) or the sample budget is hit
-	// (facets). Pure count-only (Limit==0, no facets) stays on the in-searcher
-	// path for an exact total.
-	postRank := b.postRankAuthzEnabled && access != nil && (req.Limit > 0 || len(req.Facet) > 0)
+	// (facets). A count-only request (Limit==0, no facets) returns Bleve's
+	// unfiltered count with TotalHitsExact=false, avoiding a full authz scan.
+	postRank := b.postRankAuthzEnabled && access != nil && req.Limit >= 0
 
 	conversionStarts := time.Now()
 	// convert protobuf request to bleve request

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -88,8 +88,9 @@ type BleveOptions struct {
 	SearchFields *resource.SearchFieldsRegistry
 
 	// RequiredIndexFeatures overrides the index features an existing index must
-	// already have to be reused; nil means resource.RequiredIndexFeatures. Only
-	// tests set it. New indexes always record resource.CurrentIndexFeatures.
+	// already have to be reused; nil derives them from PostRankAuthzEnabled via
+	// resource.RequiredIndexFeatures. Only tests set it. New indexes always
+	// record resource.CurrentIndexFeatures.
 	RequiredIndexFeatures []resource.IndexFeature
 
 	// Snapshot configures remote index snapshot download at build time.
@@ -269,7 +270,7 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 
 	requiredFeatures := opts.RequiredIndexFeatures
 	if requiredFeatures == nil {
-		requiredFeatures = resource.RequiredIndexFeatures()
+		requiredFeatures = resource.RequiredIndexFeatures(opts.PostRankAuthzEnabled)
 	}
 
 	be := &bleveBackend{

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2292,6 +2292,12 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 		if !ok || !kf.facetable {
 			return nil, resource.NewBadRequestError(fmt.Sprintf("field %q does not support faceting", facet.Field))
 		}
+		// A negative limit is a slice bound on both paths: bleve trims its term
+		// list to the requested size without clamping, and so does the
+		// app-side aggregator. Reject it rather than panic in the handler.
+		if facet.Limit < 0 {
+			return nil, resource.NewBadRequestError(fmt.Sprintf("facet %q has a negative limit", name))
+		}
 		facets[name] = bleve.NewFacetRequest(kf.name, int(facet.Limit))
 	}
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2103,12 +2103,12 @@ func (b *bleveIndex) Search(
 	}
 
 	// postFilter is opt-in via the search_post_rank_authz config option. It
-	// covers normal paginated search and federated queries: bleve ranks, the
-	// runner authorizes app-side in rank order, and stops once the page is full.
-	// Count-only (Limit==0), facet, and SearchBefore requests stay on the
-	// in-searcher path (exact totals / exact facets).
-	postRank := b.postRankAuthzEnabled && access != nil &&
-		req.Limit > 0 && len(req.SearchBefore) == 0 && len(req.Facet) == 0
+	// covers normal paginated search, federated queries, facet queries, and
+	// SearchBefore: bleve ranks, the runner authorizes app-side in rank order,
+	// and stops once the page is full (page-fill) or the sample budget is hit
+	// (facets). Pure count-only (Limit==0, no facets) stays on the in-searcher
+	// path for an exact total.
+	postRank := b.postRankAuthzEnabled && access != nil && (req.Limit > 0 || len(req.Facet) > 0)
 
 	conversionStarts := time.Now()
 	// convert protobuf request to bleve request
@@ -2122,16 +2122,20 @@ func (b *bleveIndex) Search(
 		return nil, err
 	}
 
-	// A SearchAfter cursor carries one sort value per field in the sort order
-	// that produced it. The post-rank path appends a SortDocID tie-breaker, so
-	// its sort order is one longer than the in-searcher path's. A cursor
-	// created before the flag was enabled (or after it was turned off) has the
-	// wrong length for the current path. runPostFilterAuthz calls
+	// A SearchAfter/SearchBefore cursor carries one sort value per field in the
+	// sort order that produced it. The post-rank path appends a SortDocID
+	// tie-breaker, so its sort order is one longer than the in-searcher path's.
+	// A cursor created before the flag was enabled (or after it was turned off)
+	// has the wrong length for the current path. runPostFilterAuthz calls
 	// SearchInContext directly, so bleve doesn't validate the mismatch before
 	// the collector indexes into the shorter cursor. Guard it here: if the
 	// cursor doesn't match the post-rank sort order, fall back to the in-searcher
 	// path; if it still doesn't match, reject the request.
-	if postRank && len(req.SearchAfter) > 0 && len(req.SearchAfter) != len(searchrequest.Sort) {
+	cursorLen := len(req.SearchAfter)
+	if cursorLen == 0 {
+		cursorLen = len(req.SearchBefore)
+	}
+	if postRank && cursorLen > 0 && cursorLen != len(searchrequest.Sort) {
 		postRank = false
 		searchrequest, e = b.toBleveSearchRequest(ctx, req, access, postRank)
 		if e != nil {
@@ -2142,8 +2146,8 @@ func (b *bleveIndex) Search(
 			return nil, err
 		}
 	}
-	if len(req.SearchAfter) > 0 && len(req.SearchAfter) != len(searchrequest.Sort) {
-		response.Error = resource.NewBadRequestError("search_after cursor does not match the current sort order")
+	if cursorLen > 0 && cursorLen != len(searchrequest.Sort) {
+		response.Error = resource.NewBadRequestError("search cursor does not match the current sort order")
 		return response, nil
 	}
 
@@ -2156,6 +2160,7 @@ func (b *bleveIndex) Search(
 	selectFields := slices.Clone(searchrequest.Fields)
 	if postRank {
 		b.ensureAuthzFields(searchrequest)
+		b.ensureFacetFields(searchrequest, req)
 	}
 	stats.AddRequestConversionTime(time.Since(conversionStarts))
 
@@ -2308,13 +2313,19 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	}
 
 	// On the post-filter path bleve returns an unfiltered, bounded ranked window;
-	// authorization (and offset handling) happen afterward in bleveIndex.Search.
-	// The first window over-fetches via windowSize and pages with SearchAfter.
-	// From/offset are applied app-side (over authorized hits), so bleve starts at 0.
+	// authorization (and offset/facet aggregation) happen afterward in
+	// bleveIndex.Search. The first window over-fetches via windowSize (page-fill)
+	// or facetWindowSize (facets, one large window covering the sample budget)
+	// and pages with SearchAfter. From/offset are applied app-side (over
+	// authorized hits), so bleve starts at 0.
 	reqSize := size
 	reqFrom := offset
 	if postRankAuthz {
-		reqSize = b.postRankAuthz.windowSize(size)
+		if len(req.Facet) > 0 {
+			reqSize = b.postRankAuthz.facetWindowSize()
+		} else {
+			reqSize = b.postRankAuthz.windowSize(size)
+		}
 		reqFrom = 0
 	}
 
@@ -2356,6 +2367,15 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 		})
 	}
 
+	if postRankAuthz {
+		// postFilter aggregates facets app-side over authorized hits (see
+		// facetAggregator); bleve's native facets would run over the unfiltered
+		// searcher and count unauthorized docs, so drop them here. The facet
+		// fields are added to the bleve load list in Search (ensureFacetFields),
+		// separate from the response column list.
+		searchrequest.Facets = nil
+	}
+
 	// Add the sort fields
 	sorting := b.getSortFields(req)
 	searchrequest.SortBy(sorting)
@@ -2381,16 +2401,17 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	}
 
 	if postRankAuthz {
-		// Total-order tie-breaker for stable SearchAfter cursors. The doc ID
-		// {namespace}/{group}/{resource}/{name} is globally unique across a
-		// federated alias (dashboards + folders differ by the resource segment),
-		// so this guarantees no skips/dupes over the merged result set. (For
-		// non-federated queries the name tie-breaker above already gives a total
-		// order; the doc ID is still harmless and keeps the cursor shape uniform
-		// across federated and non-federated post-rank searches.)
+		// Total-order tie-breaker for stable SearchAfter/SearchBefore cursors.
+		// The doc ID {namespace}/{group}/{resource}/{name} is globally unique
+		// across a federated alias (dashboards + folders differ by the resource
+		// segment), so this guarantees no skips/dupes over the merged result set.
+		// (For non-federated queries the name tie-breaker above already gives a
+		// total order; the doc ID is still harmless and keeps the cursor shape
+		// uniform across federated and non-federated post-rank searches.)
 		searchrequest.Sort = append(searchrequest.Sort, &search.SortDocID{})
-		// The folder stored field (needed to authorize) is added to the bleve
-		// load list in Search, separate from the response column list.
+		// The folder and facet stored fields (needed to authorize / aggregate
+		// app-side) are added to the bleve load list in Search, separate from
+		// the response column list.
 	}
 
 	return searchrequest, nil

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2108,7 +2108,7 @@ func (b *bleveIndex) Search(
 	// and stops once the page is full (page-fill) or the sample budget is hit
 	// (facets). A count-only request (Limit==0, no facets) returns Bleve's
 	// unfiltered count with TotalHitsExact=false, avoiding a full authz scan.
-	postRank := b.postRankAuthzEnabled && access != nil && req.Limit >= 0
+	postRank := b.postRankAuthzEnabled && access != nil
 
 	conversionStarts := time.Now()
 	// convert protobuf request to bleve request

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -88,9 +88,8 @@ type BleveOptions struct {
 	SearchFields *resource.SearchFieldsRegistry
 
 	// RequiredIndexFeatures overrides the index features an existing index must
-	// already have to be reused; nil derives them from PostRankAuthzEnabled via
-	// resource.RequiredIndexFeatures. Only tests set it. New indexes always
-	// record resource.CurrentIndexFeatures.
+	// already have to be reused. Only tests set it. New indexes always record
+	// resource.CurrentIndexFeatures.
 	RequiredIndexFeatures []resource.IndexFeature
 
 	// Snapshot configures remote index snapshot download at build time.
@@ -2107,8 +2106,10 @@ func (b *bleveIndex) Search(
 	// covers normal paginated search, federated queries, facet queries, and
 	// SearchBefore: bleve ranks, the runner authorizes app-side in rank order,
 	// and stops once the page is full (page-fill) or the sample budget is hit
-	// (facets). A count-only request (Limit==0, no facets) returns Bleve's
-	// unfiltered count with TotalHitsExact=false, avoiding a full authz scan.
+	// (facets). A count-only request (Limit==0, no facets) authorizes up to
+	// MaxCandidates ranked hits: an exact authorized total when that exhausts
+	// the match set, otherwise Bleve's unfiltered count with
+	// TotalHitsExact=false.
 	postRank := b.postRankAuthzEnabled && access != nil
 
 	conversionStarts := time.Now()

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2109,6 +2109,9 @@ func (b *bleveIndex) Search(
 	// (facets). Pure count-only (Limit==0, no facets) stays on the in-searcher
 	// path for an exact total.
 	postRank := b.postRankAuthzEnabled && access != nil && (req.Limit > 0 || len(req.Facet) > 0)
+	if postRank && len(req.Facet) > 0 && !b.canAggregateFacetsPostRank(req.Facet) {
+		postRank = false
+	}
 
 	conversionStarts := time.Now()
 	// convert protobuf request to bleve request

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2109,9 +2109,6 @@ func (b *bleveIndex) Search(
 	// (facets). Pure count-only (Limit==0, no facets) stays on the in-searcher
 	// path for an exact total.
 	postRank := b.postRankAuthzEnabled && access != nil && (req.Limit > 0 || len(req.Facet) > 0)
-	if postRank && len(req.Facet) > 0 && !b.canAggregateFacetsPostRank(req.Facet) {
-		postRank = false
-	}
 
 	conversionStarts := time.Now()
 	// convert protobuf request to bleve request

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -21,6 +21,9 @@ type kindSearchFields struct {
 	// keywordFields maps a filter, sort or facet field name to the
 	// keyword-analyzed index field backing it.
 	keywordFields map[string]keywordField
+	// storedFacetFields maps a facet field name to the stored canonical field
+	// post-rank authorization loads for app-side aggregation.
+	storedFacetFields map[string]string
 	// textQueryKinds maps physical index field names to the query their analyzer
 	// needs.
 	textQueryKinds map[string]textQueryKind
@@ -31,9 +34,10 @@ type kindSearchFields struct {
 
 func newKindSearchFields(provider resource.SearchFieldsProvider, group, kindResource string, selectableFields []string) kindSearchFields {
 	return kindSearchFields{
-		keywordFields:  keywordFieldsForMapping(provider, group, kindResource, selectableFields),
-		textQueryKinds: textQueryKindsForMapping(provider, group, kindResource, selectableFields),
-		variants:       fieldVariantsOf(fieldDefinitionsForMapping(provider, group, kindResource)),
+		keywordFields:     keywordFieldsForMapping(provider, group, kindResource, selectableFields),
+		storedFacetFields: storedFacetFieldsForMapping(provider, group, kindResource),
+		textQueryKinds:    textQueryKindsForMapping(provider, group, kindResource, selectableFields),
+		variants:          fieldVariantsOf(fieldDefinitionsForMapping(provider, group, kindResource)),
 	}
 }
 
@@ -189,6 +193,37 @@ var keywordSubDocumentFields = []string{
 // referenceFieldPrefix is the keyword-analyzed reference sub-document. Its keys
 // are resource kinds, so they cannot be enumerated up front.
 const referenceFieldPrefix = "reference."
+
+// storedFacetFieldsForMapping returns the stored Bleve field that post-rank
+// authorization can load for each facet-capable API field. Facet capability
+// implies the canonical field is stored (see addCapabilityFieldMappings), so
+// every facetable field has a stored form the app-side aggregator can read.
+func storedFacetFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string) map[string]string {
+	fields := make(map[string]string)
+	add := func(def resource.SearchFieldDefinition, prefix string) {
+		if !def.HasCapability(resource.SearchCapabilityFacet) {
+			return
+		}
+
+		logicalName := prefix + def.Name
+		storedName := logicalName
+		if !def.HasCapability(resource.SearchCapabilityText) {
+			storedName = prefix + keywordVariantName(def.Name, false)
+		}
+		fields[logicalName] = storedName
+	}
+
+	for _, def := range resource.StandardSearchFieldDefinitions() {
+		add(def, "")
+	}
+	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
+		add(def, resource.SEARCH_FIELD_PREFIX)
+		if storedName, ok := fields[resource.SEARCH_FIELD_PREFIX+def.Name]; ok {
+			fields[def.Name] = storedName
+		}
+	}
+	return fields
+}
 
 // addCapabilityFieldMappings adds bleve field mappings to parent for a single
 // declared search field. The field is placed under parent using def.Name as

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -194,10 +194,10 @@ var keywordSubDocumentFields = []string{
 // are resource kinds, so they cannot be enumerated up front.
 const referenceFieldPrefix = "reference."
 
-// storedFacetFieldsForMapping returns the stored Bleve field that post-rank
-// authorization can load for each facet-capable API field. Facet capability
-// implies the canonical field is stored (see addCapabilityFieldMappings), so
-// every facetable field has a stored form the app-side aggregator can read.
+// storedFacetFieldsForMapping returns the stored keyword field that post-rank
+// authorization can load for each facet-capable API field. Facet terms come
+// from the keyword variant even when a field also declares text, so loading
+// this form preserves native Bleve facet casing and term boundaries.
 func storedFacetFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string) map[string]string {
 	fields := make(map[string]string)
 	add := func(def resource.SearchFieldDefinition, prefix string) {
@@ -206,11 +206,7 @@ func storedFacetFieldsForMapping(provider resource.SearchFieldsProvider, group, 
 		}
 
 		logicalName := prefix + def.Name
-		storedName := logicalName
-		if !def.HasCapability(resource.SearchCapabilityText) {
-			storedName = prefix + keywordVariantName(def.Name, false)
-		}
-		fields[logicalName] = storedName
+		fields[logicalName] = prefix + keywordVariantName(def.Name, def.HasCapability(resource.SearchCapabilityText))
 	}
 
 	for _, def := range resource.StandardSearchFieldDefinitions() {
@@ -287,9 +283,9 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 		m.IncludeTermVectors = false
 		m.SkipFreqNorm = true
 		m.DocValues = hasSort
-		// Canonical field for storage is the keyword variant only when no text
-		// mapping will also be created.
-		m.Store = (hasRetrieve || hasFacet) && !hasText
+		// Facets aggregate from the keyword variant after post-rank authz, even
+		// when the canonical text field is also stored for retrieval.
+		m.Store = hasFacet || (hasRetrieve && !hasText)
 		m.IncludeInAll = false
 		parent.AddFieldMappingsAt(keywordName, m)
 	}

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -236,8 +236,9 @@ func storedFacetFieldsForMapping(provider resource.SearchFieldsProvider, group, 
 //     (see keywordVariant). sort enables DocValues.
 //   - text                    → standard-analyzer text mapping at def.Name.
 //   - partial                 → ngram mapping at def.Name + "_ngram".
-//   - retrieve                → Store: true on the canonical field
-//     (def.Name if text is declared, else the keyword variant).
+//   - retrieve / facet        → Store: true on the canonical field
+//     (def.Name if text is declared, else the keyword variant). Facet implies
+//     stored: app-side post-rank facet aggregation reads the stored value.
 //
 // Special case: when a field has only [filter] (with or without retrieve) and
 // no text capability, the keyword variant is named def.Name directly, without
@@ -257,6 +258,7 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 	hasText := def.HasCapability(resource.SearchCapabilityText)
 	hasPartial := def.HasCapability(resource.SearchCapabilityPartial)
 	hasSort := def.HasCapability(resource.SearchCapabilitySort)
+	hasFacet := def.HasCapability(resource.SearchCapabilityFacet)
 	hasRetrieve := def.HasCapability(resource.SearchCapabilityRetrieve)
 	hasUnranked := def.HasCapability(resource.SearchCapabilityUnranked)
 
@@ -287,7 +289,7 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 		m.DocValues = hasSort
 		// Canonical field for storage is the keyword variant only when no text
 		// mapping will also be created.
-		m.Store = hasRetrieve && !hasText
+		m.Store = (hasRetrieve || hasFacet) && !hasText
 		m.IncludeInAll = false
 		parent.AddFieldMappingsAt(keywordName, m)
 	}
@@ -297,7 +299,7 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 		m.Analyzer = standard.Name
 		m.IncludeTermVectors = false
 		m.DocValues = false
-		m.Store = hasRetrieve
+		m.Store = hasRetrieve || hasFacet
 		m.IncludeInAll = false
 		m.SkipFreqNorm = hasUnranked
 		parent.AddFieldMappingsAt(def.Name, m)

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -272,6 +272,25 @@ func TestKeywordFieldsForMapping_StandardNameWins(t *testing.T) {
 	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS, fields[resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS].name)
 }
 
+func TestStoredFacetFieldsForMapping(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+		gvr: {
+			{Name: "summary", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFacet}},
+			{Name: "category", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFacet}},
+		},
+	}, nil)
+
+	fields := storedFacetFieldsForMapping(provider, gvr.Group, gvr.Resource)
+	assert.Equal(t, resource.SEARCH_FIELD_TAGS, fields[resource.SEARCH_FIELD_TAGS])
+	assert.Equal(t, resource.SEARCH_FIELD_MANAGED_BY, fields[resource.SEARCH_FIELD_MANAGED_BY])
+	assert.Equal(t, "fields.summary", fields["summary"])
+	assert.Equal(t, "fields.summary", fields["fields.summary"])
+	assert.Equal(t, "fields.category", fields["category"])
+	assert.Equal(t, "fields.category", fields["fields.category"])
+	assert.NotContains(t, fields, resource.SEARCH_FIELD_FOLDER)
+}
+
 func TestTextQueryKindsForMapping(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "example.grafana.app", Version: "v1", Resource: "widgets"}
 	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -123,6 +123,19 @@ func TestAddCapabilityFieldMappings_FilterAndText(t *testing.T) {
 	assert.False(t, kw.DocValues)
 }
 
+func TestAddCapabilityFieldMappings_TextFacetStoresKeywordVariant(t *testing.T) {
+	got := flatMappings(t, resource.SearchFieldDefinition{
+		Name: "summary",
+		Type: resource.SearchFieldTypeString,
+		Capabilities: []resource.SearchCapability{
+			resource.SearchCapabilityText,
+			resource.SearchCapabilityFacet,
+		},
+	})
+
+	assert.True(t, got["summary_keyword"].Store, "post-rank facets load native keyword terms")
+}
+
 func TestAddCapabilityFieldMappings_FullSet(t *testing.T) {
 	// A field that declares the full capability set produces the same shape
 	// as today's hardcoded standard "title" field: three mappings.
@@ -285,13 +298,53 @@ func TestStoredFacetFieldsForMapping(t *testing.T) {
 	fields := storedFacetFieldsForMapping(provider, gvr.Group, gvr.Resource)
 	assert.Equal(t, resource.SEARCH_FIELD_TAGS, fields[resource.SEARCH_FIELD_TAGS])
 	assert.Equal(t, resource.SEARCH_FIELD_MANAGED_BY, fields[resource.SEARCH_FIELD_MANAGED_BY])
-	assert.Equal(t, "fields.summary", fields["summary"])
-	assert.Equal(t, "fields.summary", fields["fields.summary"])
+	assert.Equal(t, "fields.summary_keyword", fields["summary"])
+	assert.Equal(t, "fields.summary_keyword", fields["fields.summary"])
 	assert.Equal(t, "fields.category", fields["category"])
 	assert.Equal(t, "fields.category", fields["fields.category"])
 	assert.Equal(t, "fields.facetOnly", fields["facetOnly"])
 	assert.NotContains(t, fields, resource.SEARCH_FIELD_FOLDER)
 	assert.NotContains(t, fields, "labels.region")
+}
+
+func TestPostRankFacetTermsMatchKeywordVariant(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
+	defs := []resource.SearchFieldDefinition{{
+		Name:         "summary",
+		Type:         resource.SearchFieldTypeString,
+		Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFacet},
+	}}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+		gvr: defs,
+	}, nil)
+	mappings, err := GetBleveMappings(provider, gvr.Group, gvr.Resource, nil)
+	require.NoError(t, err)
+	idx, err := bleve.NewMemOnly(mappings)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, idx.Close()) })
+
+	doc := &resource.IndexableDocument{Fields: map[string]any{"summary": "Mixed Case"}}
+	populateFieldVariants(doc, fieldVariantsOf(defs))
+	require.NoError(t, idx.Index("widget", doc))
+
+	req := bleve.NewSearchRequest(bleve.NewMatchAllQuery())
+	req.Fields = []string{"fields.summary_keyword"}
+	req.AddFacet("summary", bleve.NewFacetRequest("fields.summary_keyword", 10))
+	result, err := idx.Search(req)
+	require.NoError(t, err)
+	require.Len(t, result.Hits, 1)
+
+	agg := newFacetAggregator(map[string]*resourcepb.ResourceSearchRequest_Facet{
+		"summary": {Field: "summary", Limit: 10},
+	}, storedFacetFieldsForMapping(provider, gvr.Group, gvr.Resource))
+	agg.add(result.Hits[0])
+
+	nativeTerms := result.Facets["summary"].Terms.Terms()
+	require.Len(t, nativeTerms, 1)
+	postRankTerms := agg.build()["summary"].Terms
+	require.Equal(t, nativeTerms[0].Term, postRankTerms[0].Term)
+	require.Equal(t, int64(nativeTerms[0].Count), postRankTerms[0].Count)
+	assert.Equal(t, "mixed case", postRankTerms[0].Term)
 }
 
 func TestTextQueryKindsForMapping(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -323,7 +323,10 @@ func TestPostRankFacetTermsMatchKeywordVariant(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, idx.Close()) })
 
-	doc := &resource.IndexableDocument{Fields: map[string]any{"summary": "Mixed Case"}}
+	doc := &resource.IndexableDocument{
+		Key:    &resourcepb.ResourceKey{Group: gvr.Group, Resource: gvr.Resource},
+		Fields: map[string]any{"summary": "Mixed Case"},
+	}
 	populateFieldVariants(doc, fieldVariantsOf(defs))
 	require.NoError(t, idx.Index("widget", doc))
 

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -203,8 +203,8 @@ func TestAddCapabilityFieldMappings_SortWithoutFilter(t *testing.T) {
 }
 
 func TestAddCapabilityFieldMappings_FacetOnly(t *testing.T) {
-	// facet shares the keyword variant. Without retrieve, the field is
-	// indexed but not stored — same as the existing "managedBy" mapping.
+	// facet shares the keyword variant, and facet capability implies stored:
+	// app-side post-rank facet aggregation reads the stored value.
 	got := flatMappings(t, resource.SearchFieldDefinition{
 		Name:         "managedBy",
 		Type:         resource.SearchFieldTypeString,
@@ -213,7 +213,7 @@ func TestAddCapabilityFieldMappings_FacetOnly(t *testing.T) {
 	require.Equal(t, []string{"managedBy"}, slices.Sorted(maps.Keys(got)))
 	m := got["managedBy"]
 	assert.Equal(t, keyword.Name, m.Analyzer)
-	assert.False(t, m.Store)
+	assert.True(t, m.Store)
 }
 
 func TestKeywordFieldsForMapping(t *testing.T) {
@@ -278,6 +278,7 @@ func TestStoredFacetFieldsForMapping(t *testing.T) {
 		gvr: {
 			{Name: "summary", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFacet}},
 			{Name: "category", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFacet}},
+			{Name: "facetOnly", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFacet}},
 		},
 	}, nil)
 
@@ -288,7 +289,9 @@ func TestStoredFacetFieldsForMapping(t *testing.T) {
 	assert.Equal(t, "fields.summary", fields["fields.summary"])
 	assert.Equal(t, "fields.category", fields["category"])
 	assert.Equal(t, "fields.category", fields["fields.category"])
+	assert.Equal(t, "fields.facetOnly", fields["facetOnly"])
 	assert.NotContains(t, fields, resource.SEARCH_FIELD_FOLDER)
+	assert.NotContains(t, fields, "labels.region")
 }
 
 func TestTextQueryKindsForMapping(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -154,23 +154,6 @@ func (b *bleveIndex) ensureAuthzFields(searchrequest *bleve.SearchRequest) {
 	}
 }
 
-// ensureFacetFields makes Bleve load the stored facet fields so the post-rank
-// runner can aggregate them app-side. Facet capability implies the canonical
-// field is stored, so every facetable field has a stored form to load. Like
-// ensureAuthzFields this extends the Bleve load list only; it is not part of
-// the response column list.
-func (b *bleveIndex) ensureFacetFields(searchrequest *bleve.SearchRequest, req *resourcepb.ResourceSearchRequest) {
-	if slices.Contains(searchrequest.Fields, resource.SEARCH_FIELD_ALL_FIELDS) {
-		return
-	}
-	for _, facet := range req.Facet {
-		field := b.searchFields.storedFacetFields[facet.Field]
-		if !slices.Contains(searchrequest.Fields, field) {
-			searchrequest.Fields = append(searchrequest.Fields, field)
-		}
-	}
-}
-
 // authzResources builds the resource-type -> verb map used to authorize hits.
 // The primary resource uses the verb implied by req.Permission; federated
 // resources are read-only.
@@ -476,12 +459,16 @@ func (b *bleveIndex) aggregateFacetsFromTop(
 	initial.Fields = b.facetScanFields(facets)
 	windowReq := &initial
 
+	var firstRes *bleve.SearchResult
 	for {
 		res, err := index.SearchInContext(ctx, windowReq)
 		if err != nil {
 			return nil, 0, false, err
 		}
 		stats.AddSearchTime(res.Took)
+		if firstRes == nil {
+			firstRes = res
+		}
 
 		windowHits := res.Hits
 		candidateSeq := func(yield func(docInfo) bool) {
@@ -508,7 +495,9 @@ func (b *bleveIndex) aggregateFacetsFromTop(
 		}
 
 		if candidates >= maxCandidates {
-			return agg, authorized, false, nil
+			// Like the page scan: a budget that covered every match leaves
+			// nothing unsampled, so the facets are the complete authorized set.
+			return agg, authorized, candidates >= int64(firstRes.Total), nil
 		}
 		if len(res.Hits) < windowReq.Size || len(res.Hits) == 0 {
 			return agg, authorized, true, nil

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -241,6 +241,13 @@ func (b *bleveIndex) runPostFilterAuthz(
 	cfg := b.postRankAuthz
 	wantFacets := len(req.Facet) > 0
 
+	agg, aggregateFacetsInPageScan, facetAuthorized, facetExhausted, err := b.prepareFacetAggregation(
+		ctx, access, req, index, firstReq, resources, stats,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	extractFn := func(info docInfo) authz.BatchCheckItem {
 		return authz.BatchCheckItem{
 			Name:      info.name,
@@ -253,23 +260,6 @@ func (b *bleveIndex) runPostFilterAuthz(
 	}
 
 	page := make(search.DocumentMatchCollection, 0, limit)
-	var agg *facetAggregator
-	if wantFacets {
-		agg = newFacetAggregator(req.Facet, b.searchFields.storedFacetFields)
-	}
-	aggregateFacetsInPageScan := wantFacets
-	var facetAuthorized int64
-	var facetExhausted bool
-	if wantFacets && (len(req.SearchAfter) > 0 || len(req.SearchBefore) > 0) {
-		var err error
-		agg, facetAuthorized, facetExhausted, err = b.aggregateFacetsFromTop(
-			ctx, access, index, firstReq, resources, extractFn, req.Facet, stats,
-		)
-		if err != nil {
-			return nil, err
-		}
-		aggregateFacetsInPageScan = false
-	}
 
 	var candidates int64
 	var authorized int64
@@ -389,6 +379,40 @@ func (b *bleveIndex) runPostFilterAuthz(
 	}
 	return response, b.finalizePostFilter(ctx, response, page, selectFields, firstReq.Sort, req, firstRes,
 		authorized, exhausted, reverseSort, wantFacets, agg, stats)
+}
+
+func (b *bleveIndex) prepareFacetAggregation(
+	ctx context.Context,
+	access authlib.AccessClient,
+	req *resourcepb.ResourceSearchRequest,
+	index bleve.Index,
+	firstReq *bleve.SearchRequest,
+	resources map[string]string,
+	stats *resource.SearchStats,
+) (*facetAggregator, bool, int64, bool, error) {
+	if len(req.Facet) == 0 {
+		return nil, false, 0, false, nil
+	}
+
+	agg := newFacetAggregator(req.Facet, b.searchFields.storedFacetFields)
+	if len(req.SearchAfter) == 0 && len(req.SearchBefore) == 0 {
+		return agg, true, 0, false, nil
+	}
+
+	extractFn := func(info docInfo) authz.BatchCheckItem {
+		return authz.BatchCheckItem{
+			Name:      info.name,
+			Folder:    info.folder,
+			Verb:      info.verb,
+			Group:     info.group,
+			Resource:  info.resourceType,
+			Namespace: info.namespace,
+		}
+	}
+	agg, authorized, exhausted, err := b.aggregateFacetsFromTop(
+		ctx, access, index, firstReq, resources, extractFn, req.Facet, stats,
+	)
+	return agg, false, authorized, exhausted, err
 }
 
 func (b *bleveIndex) aggregateFacetsFromTop(

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -140,18 +140,11 @@ func (b *bleveIndex) ensureAuthzFields(searchrequest *bleve.SearchRequest) {
 	}
 }
 
-func (b *bleveIndex) canAggregateFacetsPostRank(facets map[string]*resourcepb.ResourceSearchRequest_Facet) bool {
-	for _, facet := range facets {
-		if _, ok := b.searchFields.storedFacetFields[facet.Field]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
 // ensureFacetFields makes Bleve load the stored facet fields so the post-rank
-// runner can aggregate them app-side. Like ensureAuthzFields this extends the
-// Bleve load list only; it is not part of the response column list.
+// runner can aggregate them app-side. Facet capability implies the canonical
+// field is stored, so every facetable field has a stored form to load. Like
+// ensureAuthzFields this extends the Bleve load list only; it is not part of
+// the response column list.
 func (b *bleveIndex) ensureFacetFields(searchrequest *bleve.SearchRequest, req *resourcepb.ResourceSearchRequest) {
 	if slices.Contains(searchrequest.Fields, resource.SEARCH_FIELD_ALL_FIELDS) {
 		return

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -708,7 +708,10 @@ func (a *facetAggregator) build() map[string]*resourcepb.ResourceSearchResponse_
 			}
 			return sorted[i].Term < sorted[j].Term
 		})
-		if limit == 0 {
+		// Zero means no term buckets, matching what bleve returns for size 0.
+		// Negative is rejected before the search runs; treating it the same way
+		// here keeps the slice bound below unreachable.
+		if limit <= 0 {
 			sorted = nil
 		} else if len(sorted) > limit {
 			sorted = sorted[:limit]

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -241,11 +241,17 @@ func (b *bleveIndex) runPostFilterAuthz(
 	cfg := b.postRankAuthz
 	wantFacets := len(req.Facet) > 0
 
-	agg, aggregateFacetsInPageScan, facetAuthorized, facetExhausted, err := b.prepareFacetAggregation(
+	agg, facetAuthorized, facetExhausted, err := b.prepareFacetAggregation(
 		ctx, access, req, index, firstReq, resources, stats,
 	)
 	if err != nil {
 		return nil, err
+	}
+	// Facets always use a separate scan starting at the top of the query. The
+	// page scan must retain its normal fetch window, otherwise the facet sample
+	// size can unnecessarily shorten pages for sparse-access users.
+	if wantFacets {
+		firstReq.Size = cfg.windowSize(limit)
 	}
 
 	extractFn := func(info docInfo) authz.BatchCheckItem {
@@ -265,12 +271,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 	var authorized int64
 	var exhausted bool
 	var firstRes *bleve.SearchResult
-	// Facet scans sample to FacetSampleSize; page-fill scans use the larger
-	// MaxCandidates budget so low authorized fractions can still fill the page.
 	maxCandidates := int64(cfg.MaxCandidates)
-	if aggregateFacetsInPageScan {
-		maxCandidates = int64(cfg.FacetSampleSize)
-	}
 
 	// SearchBefore is a reversed-sort SearchAfter (mirrors bleve's native
 	// SearchBefore): reverse the whole Sort once so the SortDocID tie-breaker
@@ -290,13 +291,13 @@ func (b *bleveIndex) runPostFilterAuthz(
 			stats.AddTotalHits(int(res.Total))
 		}
 
-		// Authorize this window's hits in rank order. Facet scans stop at the
-		// sample budget; page-fill scans keep going past MaxCandidates until at
-		// least one row is found, so sparse users don't get an empty first page.
+		// Authorize this window's hits in rank order. Page-fill scans keep going
+		// past MaxCandidates until at least one row is found, so sparse users
+		// don't get an empty first page.
 		windowHits := res.Hits
 		candidateSeq := func(yield func(docInfo) bool) {
 			for _, hit := range windowHits {
-				if candidates >= maxCandidates && (aggregateFacetsInPageScan || len(page) > 0) {
+				if candidates >= maxCandidates && len(page) > 0 {
 					return
 				}
 				info, ok := parseHitDocInfo(hit, resources)
@@ -316,16 +317,12 @@ func (b *bleveIndex) runPostFilterAuthz(
 				return nil, err
 			}
 			authorized++
-			if aggregateFacetsInPageScan {
-				agg.add(info.doc)
-			}
 			// Skip the first `offset` authorized hits, then fill the page.
 			if authorized > int64(offset) && len(page) < limit {
 				page = append(page, info.doc)
 			}
-			// Page-fill: stop as soon as the page is full (early-exit). Facet
-			// scans never early-exit — they walk the whole sample budget.
-			if !aggregateFacetsInPageScan && len(page) >= limit {
+			// Stop as soon as the page is full (early-exit).
+			if len(page) >= limit {
 				stop = true
 				break
 			}
@@ -333,12 +330,11 @@ func (b *bleveIndex) runPostFilterAuthz(
 		if stop {
 			break
 		}
-		// Candidate budget exhausted. For page-fill scans, only enforce the
-		// budget after the first authorized row; otherwise keep scanning so a
-		// sparse user does not get an empty first page just because the first
-		// authorized hit sorted beyond MaxCandidates. Facet scans always honor
-		// the FacetSampleSize budget.
-		if candidates >= maxCandidates && (aggregateFacetsInPageScan || len(page) > 0) {
+		// Candidate budget exhausted. Only enforce the budget after the first
+		// authorized row; otherwise keep scanning so a sparse user does not get
+		// an empty first page just because the first authorized hit sorted beyond
+		// MaxCandidates.
+		if candidates >= maxCandidates && len(page) > 0 {
 			break
 		}
 		// Window returned fewer hits than requested -> no more matches: every
@@ -356,16 +352,11 @@ func (b *bleveIndex) runPostFilterAuthz(
 		// Page on a shallow copy of the current request: only the cursor and
 		// the window Size change between windows; query, sort (already reversed
 		// once for SearchBefore), and fields are identical. Page-fill windows
-		// grow geometrically (capped at MaxWindow); facet windows stay fixed
-		// (they need a stable sample).
+		// grow geometrically (capped at MaxWindow).
 		next := *windowReq
 		next.SearchAfter = cursor
 		next.SearchBefore = nil
-		if aggregateFacetsInPageScan {
-			next.Size = cfg.facetWindowSize()
-		} else {
-			next.Size = cfg.growWindow(cfg.windowSize(limit), window+1)
-		}
+		next.Size = cfg.growWindow(cfg.windowSize(limit), window+1)
 		windowReq = &next
 	}
 
@@ -373,8 +364,10 @@ func (b *bleveIndex) runPostFilterAuthz(
 		attribute.Int64("search.candidates", candidates),
 		attribute.Int64("search.authorized", authorized),
 	)
-	if wantFacets && !aggregateFacetsInPageScan {
-		authorized = facetAuthorized
+	if wantFacets {
+		// The independent facet scan defines exactness, but a returned page may
+		// observe more authorized hits than a capped top sample.
+		authorized = max(authorized, facetAuthorized)
 		exhausted = facetExhausted
 	}
 	return response, b.finalizePostFilter(ctx, response, page, selectFields, firstReq.Sort, req, firstRes,
@@ -389,14 +382,9 @@ func (b *bleveIndex) prepareFacetAggregation(
 	firstReq *bleve.SearchRequest,
 	resources map[string]string,
 	stats *resource.SearchStats,
-) (*facetAggregator, bool, int64, bool, error) {
+) (*facetAggregator, int64, bool, error) {
 	if len(req.Facet) == 0 {
-		return nil, false, 0, false, nil
-	}
-
-	agg := newFacetAggregator(req.Facet, b.searchFields.storedFacetFields)
-	if len(req.SearchAfter) == 0 && len(req.SearchBefore) == 0 {
-		return agg, true, 0, false, nil
+		return nil, 0, false, nil
 	}
 
 	extractFn := func(info docInfo) authz.BatchCheckItem {
@@ -412,7 +400,7 @@ func (b *bleveIndex) prepareFacetAggregation(
 	agg, authorized, exhausted, err := b.aggregateFacetsFromTop(
 		ctx, access, index, firstReq, resources, extractFn, req.Facet, stats,
 	)
-	return agg, false, authorized, exhausted, err
+	return agg, authorized, exhausted, err
 }
 
 func (b *bleveIndex) aggregateFacetsFromTop(

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -140,17 +140,26 @@ func (b *bleveIndex) ensureAuthzFields(searchrequest *bleve.SearchRequest) {
 	}
 }
 
-// ensureFacetFields makes bleve load the facet stored fields so the post-rank
-// runner can aggregate them app-side (facetAggregator.add reads them from
-// doc.Fields). Like ensureAuthzFields this extends the bleve load list only; it
-// is NOT part of the response column list (selectFields).
+func (b *bleveIndex) canAggregateFacetsPostRank(facets map[string]*resourcepb.ResourceSearchRequest_Facet) bool {
+	for _, facet := range facets {
+		if _, ok := b.searchFields.storedFacetFields[facet.Field]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// ensureFacetFields makes Bleve load the stored facet fields so the post-rank
+// runner can aggregate them app-side. Like ensureAuthzFields this extends the
+// Bleve load list only; it is not part of the response column list.
 func (b *bleveIndex) ensureFacetFields(searchrequest *bleve.SearchRequest, req *resourcepb.ResourceSearchRequest) {
 	if slices.Contains(searchrequest.Fields, resource.SEARCH_FIELD_ALL_FIELDS) {
 		return
 	}
-	for _, f := range req.Facet {
-		if !slices.Contains(searchrequest.Fields, f.Field) {
-			searchrequest.Fields = append(searchrequest.Fields, f.Field)
+	for _, facet := range req.Facet {
+		field := b.searchFields.storedFacetFields[facet.Field]
+		if !slices.Contains(searchrequest.Fields, field) {
+			searchrequest.Fields = append(searchrequest.Fields, field)
 		}
 	}
 }
@@ -209,9 +218,10 @@ func parseHitDocInfo(doc *search.DocumentMatch, resources map[string]string) (do
 // authorizes hits in rank order, and stops once the page is filled (page-fill
 // queries) or the candidate budget is hit. TotalHits is the exact authorized
 // count when the scan exhausts the index from the top (small sets, no incoming
-// SearchAfter), else the unfiltered match count (page filled early / cap hit /
-// cursor pages — fast over exact). Facets are aggregated app-side over the
-// authorized sample. index may be a single bleve index or an IndexAlias
+// cursor), else the unfiltered match count (page filled early / cap hit /
+// cursor pages — fast over exact). Facets are aggregated app-side over an
+// authorized sample that always starts at the top of the full query. index may
+// be a single bleve index or an IndexAlias
 // (dashboards + folders); the globally-unique doc ID keeps the SortDocID
 // tie-breaker a total order across the merged set. SearchBefore is a
 // reversed-sort SearchAfter (see applySearchBefore).
@@ -252,7 +262,20 @@ func (b *bleveIndex) runPostFilterAuthz(
 	page := make(search.DocumentMatchCollection, 0, limit)
 	var agg *facetAggregator
 	if wantFacets {
-		agg = newFacetAggregator(req.Facet)
+		agg = newFacetAggregator(req.Facet, b.searchFields.storedFacetFields)
+	}
+	aggregateFacetsInPageScan := wantFacets
+	var facetAuthorized int64
+	var facetExhausted bool
+	if wantFacets && (len(req.SearchAfter) > 0 || len(req.SearchBefore) > 0) {
+		var err error
+		agg, facetAuthorized, facetExhausted, err = b.aggregateFacetsFromTop(
+			ctx, access, index, firstReq, resources, extractFn, req.Facet, stats,
+		)
+		if err != nil {
+			return nil, err
+		}
+		aggregateFacetsInPageScan = false
 	}
 
 	var candidates int64
@@ -262,7 +285,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 	// Facet scans sample to FacetSampleSize; page-fill scans use the larger
 	// MaxCandidates budget so low authorized fractions can still fill the page.
 	maxCandidates := int64(cfg.MaxCandidates)
-	if wantFacets {
+	if aggregateFacetsInPageScan {
 		maxCandidates = int64(cfg.FacetSampleSize)
 	}
 
@@ -284,13 +307,13 @@ func (b *bleveIndex) runPostFilterAuthz(
 			stats.AddTotalHits(int(res.Total))
 		}
 
-		// Authorize this window's hits in rank order. Facets always stop at the
+		// Authorize this window's hits in rank order. Facet scans stop at the
 		// sample budget; page-fill scans keep going past MaxCandidates until at
 		// least one row is found, so sparse users don't get an empty first page.
 		windowHits := res.Hits
 		candidateSeq := func(yield func(docInfo) bool) {
 			for _, hit := range windowHits {
-				if candidates >= maxCandidates && (wantFacets || len(page) > 0) {
+				if candidates >= maxCandidates && (aggregateFacetsInPageScan || len(page) > 0) {
 					return
 				}
 				info, ok := parseHitDocInfo(hit, resources)
@@ -310,7 +333,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 				return nil, err
 			}
 			authorized++
-			if wantFacets {
+			if aggregateFacetsInPageScan {
 				agg.add(info.doc)
 			}
 			// Skip the first `offset` authorized hits, then fill the page.
@@ -319,7 +342,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 			}
 			// Page-fill: stop as soon as the page is full (early-exit). Facet
 			// scans never early-exit — they walk the whole sample budget.
-			if !wantFacets && len(page) >= limit {
+			if !aggregateFacetsInPageScan && len(page) >= limit {
 				stop = true
 				break
 			}
@@ -332,7 +355,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 		// sparse user does not get an empty first page just because the first
 		// authorized hit sorted beyond MaxCandidates. Facet scans always honor
 		// the FacetSampleSize budget.
-		if candidates >= maxCandidates && (wantFacets || len(page) > 0) {
+		if candidates >= maxCandidates && (aggregateFacetsInPageScan || len(page) > 0) {
 			break
 		}
 		// Window returned fewer hits than requested -> no more matches: every
@@ -355,7 +378,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 		next := *windowReq
 		next.SearchAfter = cursor
 		next.SearchBefore = nil
-		if wantFacets {
+		if aggregateFacetsInPageScan {
 			next.Size = cfg.facetWindowSize()
 		} else {
 			next.Size = cfg.growWindow(cfg.windowSize(limit), window+1)
@@ -367,8 +390,82 @@ func (b *bleveIndex) runPostFilterAuthz(
 		attribute.Int64("search.candidates", candidates),
 		attribute.Int64("search.authorized", authorized),
 	)
+	if wantFacets && !aggregateFacetsInPageScan {
+		authorized = facetAuthorized
+		exhausted = facetExhausted
+	}
 	return response, b.finalizePostFilter(ctx, response, page, selectFields, firstReq.Sort, req, firstRes,
 		authorized, exhausted, reverseSort, wantFacets, agg, stats)
+}
+
+func (b *bleveIndex) aggregateFacetsFromTop(
+	ctx context.Context,
+	access authlib.AccessClient,
+	index bleve.Index,
+	firstReq *bleve.SearchRequest,
+	resources map[string]string,
+	extractFn func(docInfo) authz.BatchCheckItem,
+	facets map[string]*resourcepb.ResourceSearchRequest_Facet,
+	stats *resource.SearchStats,
+) (*facetAggregator, int64, bool, error) {
+	agg := newFacetAggregator(facets, b.searchFields.storedFacetFields)
+	cfg := b.postRankAuthz
+	maxCandidates := int64(cfg.FacetSampleSize)
+	var candidates int64
+	var authorized int64
+
+	initial := *firstReq
+	initial.SearchAfter = nil
+	initial.SearchBefore = nil
+	initial.Size = cfg.facetWindowSize()
+	windowReq := &initial
+
+	for {
+		res, err := index.SearchInContext(ctx, windowReq)
+		if err != nil {
+			return nil, 0, false, err
+		}
+		stats.AddSearchTime(res.Took)
+
+		windowHits := res.Hits
+		candidateSeq := func(yield func(docInfo) bool) {
+			for _, hit := range windowHits {
+				if candidates >= maxCandidates {
+					return
+				}
+				info, ok := parseHitDocInfo(hit, resources)
+				if !ok {
+					continue
+				}
+				candidates++
+				if !yield(info) {
+					return
+				}
+			}
+		}
+		for info, err := range authz.FilterAuthorized(ctx, access, candidateSeq, extractFn, authz.WithTracer(tracer)) {
+			if err != nil {
+				return nil, 0, false, err
+			}
+			authorized++
+			agg.add(info.doc)
+		}
+
+		if candidates >= maxCandidates {
+			return agg, authorized, false, nil
+		}
+		if len(res.Hits) < windowReq.Size || len(res.Hits) == 0 {
+			return agg, authorized, true, nil
+		}
+		cursor := hitSortFields(res.Hits[len(res.Hits)-1], windowReq.Sort)
+		if len(cursor) == 0 {
+			return agg, authorized, true, nil
+		}
+		next := *windowReq
+		next.SearchAfter = cursor
+		next.Size = cfg.facetWindowSize()
+		windowReq = &next
+	}
 }
 
 // applySearchBefore converts a SearchBefore request into a reversed-sort
@@ -386,11 +483,11 @@ func applySearchBefore(req *resourcepb.ResourceSearchRequest, firstReq *bleve.Se
 	return true
 }
 
-// finalizePostFilter sets TotalHits (exact authorized count when the scan
-// exhausted the index from the top, else the unfiltered match count), reverses
-// the page for SearchBefore, converts hits + facets into the response, and
-// reverses the page back to forward order for SearchBefore. See
-// runPostFilterAuthz for the TotalHits / facet-count semantics.
+// finalizePostFilter sets TotalHits, reverses the page for SearchBefore, and
+// converts hits + facets into the response. Facet requests report the
+// authorized facet-sample count so TotalHits and facet counts have the same
+// lower-bound semantics when capped. Non-facet requests retain the unfiltered
+// upper-bound fallback when their page scan does not produce an exact total.
 func (b *bleveIndex) finalizePostFilter(
 	ctx context.Context,
 	response *resourcepb.ResourceSearchResponse,
@@ -404,15 +501,13 @@ func (b *bleveIndex) finalizePostFilter(
 	agg *facetAggregator,
 	stats *resource.SearchStats,
 ) error {
-	// Exact authorized total only when the scan started from the top (no
-	// incoming SearchAfter/SearchBefore) and exhausted it. With a cursor the
-	// runner only authorizes hits returned after the cursor, so `authorized`
-	// on exhaustion is the tail count, not the whole-query total — fall back
-	// to the unfiltered firstRes.Total.
-	exact := exhausted && req.Limit > 0 && len(req.SearchAfter) == 0 && len(req.SearchBefore) == 0
-	if exact {
+	exact := exhausted
+	if wantFacets {
+		response.TotalHits = authorized
+	} else if exhausted && req.Limit > 0 && len(req.SearchAfter) == 0 && len(req.SearchBefore) == 0 {
 		response.TotalHits = authorized
 	} else {
+		exact = false
 		// Approximate: report the pre-authz match count (an over-count of the
 		// authorized total) instead of paying for a full scan.
 		response.TotalHits = int64(firstRes.Total)
@@ -450,44 +545,50 @@ func (b *bleveIndex) finalizePostFilter(
 // (<= FacetSampleSize candidates), not the full authorized set.
 type facetAggregator struct {
 	fields map[string]*resourcepb.ResourceSearchRequest_Facet
-	// field -> term -> count
+	// requested field -> stored Bleve field
+	storedFields map[string]string
+	// facet name -> term -> count
 	counts map[string]map[string]int64
-	// field -> number of authorized hits missing that field
+	// facet name -> number of authorized hits missing that field
 	missing map[string]int64
-	// field -> total authorized hits considered for that field
+	// facet name -> total authorized hits considered for that field
 	total map[string]int64
 }
 
-func newFacetAggregator(facets map[string]*resourcepb.ResourceSearchRequest_Facet) *facetAggregator {
+func newFacetAggregator(
+	facets map[string]*resourcepb.ResourceSearchRequest_Facet,
+	storedFields map[string]string,
+) *facetAggregator {
 	a := &facetAggregator{
-		fields:  facets,
-		counts:  make(map[string]map[string]int64, len(facets)),
-		missing: make(map[string]int64, len(facets)),
-		total:   make(map[string]int64, len(facets)),
+		fields:       facets,
+		storedFields: storedFields,
+		counts:       make(map[string]map[string]int64, len(facets)),
+		missing:      make(map[string]int64, len(facets)),
+		total:        make(map[string]int64, len(facets)),
 	}
-	for _, f := range facets {
-		a.counts[f.Field] = make(map[string]int64)
+	for name := range facets {
+		a.counts[name] = make(map[string]int64)
 	}
 	return a
 }
 
 func (a *facetAggregator) add(doc *search.DocumentMatch) {
-	for _, f := range a.fields {
-		v, ok := doc.Fields[f.Field]
+	for name, f := range a.fields {
+		v, ok := doc.Fields[a.storedFields[f.Field]]
 		if !ok || v == nil {
-			a.missing[f.Field]++
+			a.missing[name]++
 			continue
 		}
 		terms := facetTermValues(v)
 		if len(terms) == 0 {
-			a.missing[f.Field]++
+			a.missing[name]++
 			continue
 		}
 		// Total is the number of field values, not documents (matches bleve's
 		// TermsFacetBuilder: total counts every term visited).
-		a.total[f.Field] += int64(len(terms))
+		a.total[name] += int64(len(terms))
 		for _, term := range terms {
-			a.counts[f.Field][term]++
+			a.counts[name][term]++
 		}
 	}
 }
@@ -540,7 +641,7 @@ func facetTermValues(v any) []string {
 func (a *facetAggregator) build() map[string]*resourcepb.ResourceSearchResponse_Facet {
 	out := make(map[string]*resourcepb.ResourceSearchResponse_Facet, len(a.fields))
 	for k, f := range a.fields {
-		terms := a.counts[f.Field]
+		terms := a.counts[k]
 		limit := int(f.Limit)
 		sorted := make([]*resourcepb.ResourceSearchResponse_TermFacet, 0, len(terms))
 		for term, count := range terms {
@@ -555,13 +656,15 @@ func (a *facetAggregator) build() map[string]*resourcepb.ResourceSearchResponse_
 			}
 			return sorted[i].Term < sorted[j].Term
 		})
-		if limit > 0 && len(sorted) > limit {
+		if limit == 0 {
+			sorted = nil
+		} else if len(sorted) > limit {
 			sorted = sorted[:limit]
 		}
 		out[k] = &resourcepb.ResourceSearchResponse_Facet{
 			Field:   f.Field,
-			Total:   a.total[f.Field],
-			Missing: a.missing[f.Field],
+			Total:   a.total[k],
+			Missing: a.missing[k],
 			Terms:   sorted,
 		}
 	}

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -2,7 +2,9 @@ package search
 
 import (
 	"context"
+	"fmt"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -39,6 +41,11 @@ type PostRankAuthzConfig struct {
 	// short/empty page for sparse-access users (the in-searcher path is the
 	// exact alternative).
 	MaxCandidates int
+	// FacetSampleSize is the candidate budget when aggregating facets. Facet
+	// counts reflect a sample of up to this many ranked hits, not the full
+	// authorized set. Smaller than MaxCandidates since facets are a
+	// distribution that stabilizes with a modest sample.
+	FacetSampleSize int
 }
 
 // effective fills zero/negative fields with the defaults used by the post-filter
@@ -53,6 +60,9 @@ func (c PostRankAuthzConfig) effective() PostRankAuthzConfig {
 	if c.MaxCandidates <= 0 {
 		c.MaxCandidates = 50000
 	}
+	if c.FacetSampleSize <= 0 {
+		c.FacetSampleSize = 10000
+	}
 	return c
 }
 
@@ -61,6 +71,22 @@ func (c PostRankAuthzConfig) effective() PostRankAuthzConfig {
 // ranks the full match set and returns the top-N regardless of Size.
 func (c PostRankAuthzConfig) windowSize(limit int) int {
 	w := limit * c.OverFetchFactor
+	if w > c.MaxWindow {
+		w = c.MaxWindow
+	}
+	return w
+}
+
+// facetWindowSize returns the per-window bleve Size for facet queries: the
+// facet sample budget (FacetSampleSize) capped at MaxWindow. Facets need a
+// stable sample of up to FacetSampleSize candidates, so each window is as
+// large as the budget allows (capped by MaxWindow) to cover the sample in the
+// fewest bleve searches — each SearchAfter is a fresh search that re-walks the
+// match set, so fewer, larger windows means less total scoring work. With the
+// defaults (FacetSampleSize == MaxWindow == 10000) the whole sample is one
+// window.
+func (c PostRankAuthzConfig) facetWindowSize() int {
+	w := c.FacetSampleSize
 	if w > c.MaxWindow {
 		w = c.MaxWindow
 	}
@@ -114,6 +140,21 @@ func (b *bleveIndex) ensureAuthzFields(searchrequest *bleve.SearchRequest) {
 	}
 }
 
+// ensureFacetFields makes bleve load the facet stored fields so the post-rank
+// runner can aggregate them app-side (facetAggregator.add reads them from
+// doc.Fields). Like ensureAuthzFields this extends the bleve load list only; it
+// is NOT part of the response column list (selectFields).
+func (b *bleveIndex) ensureFacetFields(searchrequest *bleve.SearchRequest, req *resourcepb.ResourceSearchRequest) {
+	if slices.Contains(searchrequest.Fields, resource.SEARCH_FIELD_ALL_FIELDS) {
+		return
+	}
+	for _, f := range req.Facet {
+		if !slices.Contains(searchrequest.Fields, f.Field) {
+			searchrequest.Fields = append(searchrequest.Fields, f.Field)
+		}
+	}
+}
+
 // authzResources builds the resource-type -> verb map used to authorize hits.
 // The primary resource uses the verb implied by req.Permission; federated
 // resources are read-only.
@@ -163,15 +204,17 @@ func parseHitDocInfo(doc *search.DocumentMatch, resources map[string]string) (do
 	}, true
 }
 
-// runPostFilterAuthz implements postFilter mode for normal paginated search and
-// federated queries: bleve ranks without the authz wrapper, the runner fetches
-// bounded windows (paging via SearchAfter), authorizes hits in rank order, and
-// stops once the page is filled or the candidate budget is hit. TotalHits is the
-// exact authorized count when the scan exhausts the index (small sets), else the
-// unfiltered match count (page filled early / cap hit — fast over exact). index
-// may be a single bleve index or an IndexAlias (dashboards + folders); the
-// globally-unique doc ID keeps the SortDocID tie-breaker a total order across
-// the merged set.
+// runPostFilterAuthz implements postFilter mode: bleve ranks without the authz
+// wrapper, the runner fetches bounded windows (paging via SearchAfter),
+// authorizes hits in rank order, and stops once the page is filled (page-fill
+// queries) or the candidate budget is hit. TotalHits is the exact authorized
+// count when the scan exhausts the index from the top (small sets, no incoming
+// SearchAfter), else the unfiltered match count (page filled early / cap hit /
+// cursor pages — fast over exact). Facets are aggregated app-side over the
+// authorized sample. index may be a single bleve index or an IndexAlias
+// (dashboards + folders); the globally-unique doc ID keeps the SortDocID
+// tie-breaker a total order across the merged set. SearchBefore is a
+// reversed-sort SearchAfter (see applySearchBefore).
 func (b *bleveIndex) runPostFilterAuthz(
 	ctx context.Context,
 	access authlib.AccessClient,
@@ -193,6 +236,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 
 	resources := b.authzResources(req)
 	cfg := b.postRankAuthz
+	wantFacets := len(req.Facet) > 0
 
 	extractFn := func(info docInfo) authz.BatchCheckItem {
 		return authz.BatchCheckItem{
@@ -206,11 +250,27 @@ func (b *bleveIndex) runPostFilterAuthz(
 	}
 
 	page := make(search.DocumentMatchCollection, 0, limit)
+	var agg *facetAggregator
+	if wantFacets {
+		agg = newFacetAggregator(req.Facet)
+	}
+
 	var candidates int64
 	var authorized int64
 	var exhausted bool
 	var firstRes *bleve.SearchResult
+	// Facet scans sample to FacetSampleSize; page-fill scans use the larger
+	// MaxCandidates budget so low authorized fractions can still fill the page.
 	maxCandidates := int64(cfg.MaxCandidates)
+	if wantFacets {
+		maxCandidates = int64(cfg.FacetSampleSize)
+	}
+
+	// SearchBefore is a reversed-sort SearchAfter (mirrors bleve's native
+	// SearchBefore): reverse the whole Sort once so the SortDocID tie-breaker
+	// stays a total order in the reversed direction, walk away from the cursor,
+	// then reverse the page back to forward order in finalizePostFilter.
+	reverseSort := applySearchBefore(req, firstReq)
 
 	windowReq := firstReq
 	for window := 0; ; window++ {
@@ -224,14 +284,13 @@ func (b *bleveIndex) runPostFilterAuthz(
 			stats.AddTotalHits(int(res.Total))
 		}
 
-		// Authorize this window's hits in rank order. Keep scanning past the
-		// candidate budget until at least one row is found, so sparse users
-		// don't get an empty first page just because the first authorized hit
-		// sorted beyond MaxCandidates.
+		// Authorize this window's hits in rank order. Facets always stop at the
+		// sample budget; page-fill scans keep going past MaxCandidates until at
+		// least one row is found, so sparse users don't get an empty first page.
 		windowHits := res.Hits
 		candidateSeq := func(yield func(docInfo) bool) {
 			for _, hit := range windowHits {
-				if candidates >= maxCandidates && len(page) > 0 {
+				if candidates >= maxCandidates && (wantFacets || len(page) > 0) {
 					return
 				}
 				info, ok := parseHitDocInfo(hit, resources)
@@ -251,12 +310,16 @@ func (b *bleveIndex) runPostFilterAuthz(
 				return nil, err
 			}
 			authorized++
+			if wantFacets {
+				agg.add(info.doc)
+			}
 			// Skip the first `offset` authorized hits, then fill the page.
 			if authorized > int64(offset) && len(page) < limit {
 				page = append(page, info.doc)
 			}
-			// Stop as soon as the page is full (early-exit).
-			if len(page) >= limit {
+			// Page-fill: stop as soon as the page is full (early-exit). Facet
+			// scans never early-exit — they walk the whole sample budget.
+			if !wantFacets && len(page) >= limit {
 				stop = true
 				break
 			}
@@ -264,10 +327,12 @@ func (b *bleveIndex) runPostFilterAuthz(
 		if stop {
 			break
 		}
-		// Candidate budget exhausted. Only enforce it after the first
-		// authorized row; otherwise keep scanning so a sparse user does not get
-		// an empty first page.
-		if candidates >= maxCandidates && len(page) > 0 {
+		// Candidate budget exhausted. For page-fill scans, only enforce the
+		// budget after the first authorized row; otherwise keep scanning so a
+		// sparse user does not get an empty first page just because the first
+		// authorized hit sorted beyond MaxCandidates. Facet scans always honor
+		// the FacetSampleSize budget.
+		if candidates >= maxCandidates && (wantFacets || len(page) > 0) {
 			break
 		}
 		// Window returned fewer hits than requested -> no more matches: every
@@ -283,14 +348,18 @@ func (b *bleveIndex) runPostFilterAuthz(
 			break // no sort values -> cannot build a SearchAfter cursor
 		}
 		// Page on a shallow copy of the current request: only the cursor and
-		// the window Size change between windows; query, sort, and fields are
-		// identical. Grow the window geometrically (capped at MaxWindow) so a
-		// sparse-access or deep-offset scan reaches its first authorized hit in
-		// fewer, larger windows rather than many same-sized bleve searches.
+		// the window Size change between windows; query, sort (already reversed
+		// once for SearchBefore), and fields are identical. Page-fill windows
+		// grow geometrically (capped at MaxWindow); facet windows stay fixed
+		// (they need a stable sample).
 		next := *windowReq
 		next.SearchAfter = cursor
 		next.SearchBefore = nil
-		next.Size = cfg.growWindow(cfg.windowSize(limit), window+1)
+		if wantFacets {
+			next.Size = cfg.facetWindowSize()
+		} else {
+			next.Size = cfg.growWindow(cfg.windowSize(limit), window+1)
+		}
 		windowReq = &next
 	}
 
@@ -299,12 +368,29 @@ func (b *bleveIndex) runPostFilterAuthz(
 		attribute.Int64("search.authorized", authorized),
 	)
 	return response, b.finalizePostFilter(ctx, response, page, selectFields, firstReq.Sort, req, firstRes,
-		authorized, exhausted, stats)
+		authorized, exhausted, reverseSort, wantFacets, agg, stats)
+}
+
+// applySearchBefore converts a SearchBefore request into a reversed-sort
+// SearchAfter: the whole Sort is reversed once so the SortDocID tie-breaker
+// stays a total order in the reversed direction. Returns whether the request
+// was a SearchBefore (the page is reversed back to forward order in
+// finalizePostFilter).
+func applySearchBefore(req *resourcepb.ResourceSearchRequest, firstReq *bleve.SearchRequest) bool {
+	if len(req.SearchBefore) == 0 {
+		return false
+	}
+	firstReq.Sort.Reverse()
+	firstReq.SearchAfter = firstReq.SearchBefore
+	firstReq.SearchBefore = nil
+	return true
 }
 
 // finalizePostFilter sets TotalHits (exact authorized count when the scan
-// exhausted the index, else the unfiltered match count) and converts hits into
-// the response. See runPostFilterAuthz for the TotalHits semantics.
+// exhausted the index from the top, else the unfiltered match count), reverses
+// the page for SearchBefore, converts hits + facets into the response, and
+// reverses the page back to forward order for SearchBefore. See
+// runPostFilterAuthz for the TotalHits / facet-count semantics.
 func (b *bleveIndex) finalizePostFilter(
 	ctx context.Context,
 	response *resourcepb.ResourceSearchResponse,
@@ -314,15 +400,16 @@ func (b *bleveIndex) finalizePostFilter(
 	req *resourcepb.ResourceSearchRequest,
 	firstRes *bleve.SearchResult,
 	authorized int64,
-	exhausted bool,
+	exhausted, reverseSort, wantFacets bool,
+	agg *facetAggregator,
 	stats *resource.SearchStats,
 ) error {
 	// Exact authorized total only when the scan started from the top (no
-	// incoming SearchAfter) and exhausted it. With a SearchAfter cursor the
+	// incoming SearchAfter/SearchBefore) and exhausted it. With a cursor the
 	// runner only authorizes hits returned after the cursor, so `authorized`
 	// on exhaustion is the tail count, not the whole-query total — fall back
 	// to the unfiltered firstRes.Total.
-	exact := exhausted && req.Limit > 0 && len(req.SearchAfter) == 0
+	exact := exhausted && req.Limit > 0 && len(req.SearchAfter) == 0 && len(req.SearchBefore) == 0
 	if exact {
 		response.TotalHits = authorized
 	} else {
@@ -335,12 +422,148 @@ func (b *bleveIndex) finalizePostFilter(
 	response.MaxScore = firstRes.MaxScore
 	stats.AddReturnedDocuments(len(page))
 
+	if reverseSort {
+		// The scan collected the limit authorized hits closest to the cursor in
+		// reversed (descending) order; reverse to return them ascending, with
+		// the hit nearest the cursor last — matching bleve's SearchBefore.
+		for i, j := 0, len(page)-1; i < j; i, j = i+1, j-1 {
+			page[i], page[j] = page[j], page[i]
+		}
+	}
+
 	resultsConversionStart := time.Now()
 	results, err := b.hitsToTable(ctx, selectFields, page, sort, req.Explain)
 	if err != nil {
 		return err
 	}
 	response.Results = results
+	if wantFacets {
+		// Counts are the exact authorized term counts within the bounded sample;
+		// see facetAggregator.build for why we don't extrapolate.
+		response.Facet = agg.build()
+	}
 	stats.AddResultsConversionTime(time.Since(resultsConversionStart))
 	return nil
+}
+
+// facetAggregator computes facet counts app-side over the authorized sample
+// (<= FacetSampleSize candidates), not the full authorized set.
+type facetAggregator struct {
+	fields map[string]*resourcepb.ResourceSearchRequest_Facet
+	// field -> term -> count
+	counts map[string]map[string]int64
+	// field -> number of authorized hits missing that field
+	missing map[string]int64
+	// field -> total authorized hits considered for that field
+	total map[string]int64
+}
+
+func newFacetAggregator(facets map[string]*resourcepb.ResourceSearchRequest_Facet) *facetAggregator {
+	a := &facetAggregator{
+		fields:  facets,
+		counts:  make(map[string]map[string]int64, len(facets)),
+		missing: make(map[string]int64, len(facets)),
+		total:   make(map[string]int64, len(facets)),
+	}
+	for _, f := range facets {
+		a.counts[f.Field] = make(map[string]int64)
+	}
+	return a
+}
+
+func (a *facetAggregator) add(doc *search.DocumentMatch) {
+	for _, f := range a.fields {
+		v, ok := doc.Fields[f.Field]
+		if !ok || v == nil {
+			a.missing[f.Field]++
+			continue
+		}
+		terms := facetTermValues(v)
+		if len(terms) == 0 {
+			a.missing[f.Field]++
+			continue
+		}
+		// Total is the number of field values, not documents (matches bleve's
+		// TermsFacetBuilder: total counts every term visited).
+		a.total[f.Field] += int64(len(terms))
+		for _, term := range terms {
+			a.counts[f.Field][term]++
+		}
+	}
+}
+
+// facetTermValues extracts the individual facet terms from a stored field
+// value. Multi-value fields (e.g. tags) are stored as slices, so each element
+// is counted as its own term — matching bleve's native term facets. Empty
+// strings are dropped. Non-string scalars are formatted as a single term.
+func facetTermValues(v any) []string {
+	switch s := v.(type) {
+	case string:
+		if s == "" {
+			return nil
+		}
+		return []string{s}
+	case []string:
+		out := make([]string, 0, len(s))
+		for _, t := range s {
+			if t != "" {
+				out = append(out, t)
+			}
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(s))
+		for _, e := range s {
+			if str, ok := e.(string); ok && str != "" {
+				out = append(out, str)
+			}
+		}
+		return out
+	default:
+		t := fmt.Sprintf("%v", v)
+		if t == "" {
+			return nil
+		}
+		return []string{t}
+	}
+}
+
+// build assembles the response facets, keeping the top req.Facet[f].Limit terms
+// per field (by count desc, then term asc for determinism). Counts are the exact
+// number of authorized hits with that term within the bounded sample
+// (<= FacetSampleSize candidates). We deliberately do NOT extrapolate to the
+// full set: scaling by totalHits/candidates estimates the unfiltered term count,
+// not the authorized one, and over-counts badly for low-access-fraction users
+// (e.g. a tag on 2 authorized docs reported as 42). Exhausted scans are fully
+// exact; capped scans are a conservative lower bound — never more than what the
+// sample saw.
+func (a *facetAggregator) build() map[string]*resourcepb.ResourceSearchResponse_Facet {
+	out := make(map[string]*resourcepb.ResourceSearchResponse_Facet, len(a.fields))
+	for k, f := range a.fields {
+		terms := a.counts[f.Field]
+		limit := int(f.Limit)
+		sorted := make([]*resourcepb.ResourceSearchResponse_TermFacet, 0, len(terms))
+		for term, count := range terms {
+			sorted = append(sorted, &resourcepb.ResourceSearchResponse_TermFacet{
+				Term:  term,
+				Count: count,
+			})
+		}
+		sort.Slice(sorted, func(i, j int) bool {
+			if sorted[i].Count != sorted[j].Count {
+				return sorted[i].Count > sorted[j].Count
+			}
+			return sorted[i].Term < sorted[j].Term
+		})
+		if limit > 0 && len(sorted) > limit {
+			sorted = sorted[:limit]
+		}
+		out[k] = &resourcepb.ResourceSearchResponse_Facet{
+			Field:   f.Field,
+			Total:   a.total[f.Field],
+			Missing: a.missing[f.Field],
+			Terms:   sorted,
+		}
+	}
+	return out
 }

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -643,7 +643,7 @@ func (a *facetAggregator) add(doc *search.DocumentMatch) {
 			a.missing[name]++
 			continue
 		}
-		// Total is the number of field values, not documents (matches bleve's
+		// Total counts terms, not documents (matches bleve's
 		// TermsFacetBuilder: total counts every term visited).
 		a.total[name] += int64(len(terms))
 		for _, term := range terms {
@@ -656,6 +656,10 @@ func (a *facetAggregator) add(doc *search.DocumentMatch) {
 // value. Multi-value fields (e.g. tags) are stored as slices, so each element
 // is counted as its own term — matching bleve's native term facets. Empty
 // strings are dropped. Non-string scalars are formatted as a single term.
+//
+// A value repeated within one document yields one term: native facets read the
+// document's term set, where a duplicate leaves a single posting, so counting
+// the stored slice verbatim would report it twice.
 func facetTermValues(v any) []string {
 	switch s := v.(type) {
 	case string:
@@ -666,7 +670,7 @@ func facetTermValues(v any) []string {
 	case []string:
 		out := make([]string, 0, len(s))
 		for _, t := range s {
-			if t != "" {
+			if t != "" && !slices.Contains(out, t) {
 				out = append(out, t)
 			}
 		}
@@ -674,7 +678,7 @@ func facetTermValues(v any) []string {
 	case []any:
 		out := make([]string, 0, len(s))
 		for _, e := range s {
-			if str, ok := e.(string); ok && str != "" {
+			if str, ok := e.(string); ok && str != "" && !slices.Contains(out, str) {
 				out = append(out, str)
 			}
 		}

--- a/pkg/storage/unified/search/bleve_postrank_authz.go
+++ b/pkg/storage/unified/search/bleve_postrank_authz.go
@@ -93,6 +93,20 @@ func (c PostRankAuthzConfig) facetWindowSize() int {
 	return w
 }
 
+// countWindowSize returns the per-window bleve Size for count-only requests
+// (Limit == 0, no facets). There is no page to fill, so windowSize(0) would be
+// zero and bleve would return no hits to authorize at all. The scan instead
+// walks the ranked set in windows as large as the budget allows (capped by
+// MaxWindow) until it exhausts the match set — giving an exact authorized
+// total — or reaches MaxCandidates.
+func (c PostRankAuthzConfig) countWindowSize() int {
+	w := c.MaxCandidates
+	if w > c.MaxWindow {
+		w = c.MaxWindow
+	}
+	return w
+}
+
 // growWindow sizes each bleve window after the first. The first window uses
 // windowSize(limit); subsequent windows double so a sparse-access or
 // deep-offset scan covers ground in fewer, larger windows. Each bleve
@@ -209,7 +223,9 @@ func parseHitDocInfo(doc *search.DocumentMatch, resources map[string]string) (do
 // runPostFilterAuthz implements postFilter mode: bleve ranks without the authz
 // wrapper, the runner fetches bounded windows (paging via SearchAfter),
 // authorizes hits in rank order, and stops once the page is filled (page-fill
-// queries) or the candidate budget is hit. TotalHits is the exact authorized
+// queries) or the candidate budget is hit. Count-only queries (Limit == 0, no
+// facets) have no page and stop only on exhaustion or the budget. TotalHits is
+// the exact authorized
 // count when the scan exhausts the index from the top (small sets, no incoming
 // cursor), else the unfiltered match count (page filled early / cap hit /
 // cursor pages — fast over exact). Facets are aggregated app-side over an
@@ -240,6 +256,10 @@ func (b *bleveIndex) runPostFilterAuthz(
 	resources := b.authzResources(req)
 	cfg := b.postRankAuthz
 	wantFacets := len(req.Facet) > 0
+	// A count-only request returns no rows, so there is no page to fill: the
+	// scan authorizes ranked hits purely to total them and runs until the match
+	// set is exhausted or the candidate budget is reached.
+	countOnly := limit == 0 && !wantFacets
 
 	agg, facetAuthorized, facetExhausted, err := b.prepareFacetAggregation(
 		ctx, access, req, index, firstReq, resources, stats,
@@ -247,11 +267,20 @@ func (b *bleveIndex) runPostFilterAuthz(
 	if err != nil {
 		return nil, err
 	}
-	// Facets always use a separate scan starting at the top of the query. The
-	// page scan must retain its normal fetch window, otherwise the facet sample
-	// size can unnecessarily shorten pages for sparse-access users.
-	if wantFacets {
-		firstReq.Size = cfg.windowSize(limit)
+
+	baseWindow := cfg.windowSize(limit)
+	switch {
+	case countOnly:
+		baseWindow = cfg.countWindowSize()
+		// No rows are returned, so load only what authorization reads.
+		firstReq.Fields = []string{resource.SEARCH_FIELD_FOLDER}
+		firstReq.Size = baseWindow
+	case wantFacets:
+		// Facets always use a separate scan starting at the top of the query.
+		// The page scan must retain its normal fetch window, otherwise the
+		// facet sample size can unnecessarily shorten pages for sparse-access
+		// users.
+		firstReq.Size = baseWindow
 	}
 
 	extractFn := func(info docInfo) authz.BatchCheckItem {
@@ -293,11 +322,12 @@ func (b *bleveIndex) runPostFilterAuthz(
 
 		// Authorize this window's hits in rank order. Page-fill scans keep going
 		// past MaxCandidates until at least one row is found, so sparse users
-		// don't get an empty first page.
+		// don't get an empty first page. Count-only scans have no page, so the
+		// budget applies on its own.
 		windowHits := res.Hits
 		candidateSeq := func(yield func(docInfo) bool) {
 			for _, hit := range windowHits {
-				if candidates >= maxCandidates && len(page) > 0 {
+				if candidates >= maxCandidates && (countOnly || len(page) > 0) {
 					return
 				}
 				info, ok := parseHitDocInfo(hit, resources)
@@ -322,7 +352,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 				page = append(page, info.doc)
 			}
 			// Stop as soon as the page is full (early-exit).
-			if len(page) >= limit {
+			if !countOnly && len(page) >= limit {
 				stop = true
 				break
 			}
@@ -330,11 +360,15 @@ func (b *bleveIndex) runPostFilterAuthz(
 		if stop {
 			break
 		}
-		// Candidate budget exhausted. Only enforce the budget after the first
-		// authorized row; otherwise keep scanning so a sparse user does not get
-		// an empty first page just because the first authorized hit sorted beyond
-		// MaxCandidates.
-		if candidates >= maxCandidates && len(page) > 0 {
+		// Candidate budget exhausted. On page-fill scans only enforce the budget
+		// after the first authorized row; otherwise keep scanning so a sparse
+		// user does not get an empty first page just because the first
+		// authorized hit sorted beyond MaxCandidates.
+		if candidates >= maxCandidates && (countOnly || len(page) > 0) {
+			// A budget that covered every match leaves nothing unseen, so the
+			// authorized count is still exact. candidates never exceeds the
+			// number of hits walked, so this can only under-claim.
+			exhausted = candidates >= int64(firstRes.Total)
 			break
 		}
 		// Window returned fewer hits than requested -> no more matches: every
@@ -356,7 +390,7 @@ func (b *bleveIndex) runPostFilterAuthz(
 		next := *windowReq
 		next.SearchAfter = cursor
 		next.SearchBefore = nil
-		next.Size = cfg.growWindow(cfg.windowSize(limit), window+1)
+		next.Size = cfg.growWindow(baseWindow, window+1)
 		windowReq = &next
 	}
 
@@ -403,6 +437,22 @@ func (b *bleveIndex) prepareFacetAggregation(
 	return agg, authorized, exhausted, err
 }
 
+// facetScanFields is the stored-field projection the facet scan needs: the
+// folder to authorize a hit and the stored facet fields to count its terms.
+// The response columns come from the page scan, so loading them here would
+// fetch stored data for up to FacetSampleSize hits that is never returned.
+func (b *bleveIndex) facetScanFields(facets map[string]*resourcepb.ResourceSearchRequest_Facet) []string {
+	fields := make([]string, 0, len(facets)+1)
+	for _, facet := range facets {
+		field := b.searchFields.storedFacetFields[facet.Field]
+		if field != "" && !slices.Contains(fields, field) {
+			fields = append(fields, field)
+		}
+	}
+	slices.Sort(fields)
+	return append(fields, resource.SEARCH_FIELD_FOLDER)
+}
+
 func (b *bleveIndex) aggregateFacetsFromTop(
 	ctx context.Context,
 	access authlib.AccessClient,
@@ -423,6 +473,7 @@ func (b *bleveIndex) aggregateFacetsFromTop(
 	initial.SearchAfter = nil
 	initial.SearchBefore = nil
 	initial.Size = cfg.facetWindowSize()
+	initial.Fields = b.facetScanFields(facets)
 	windowReq := &initial
 
 	for {
@@ -509,7 +560,10 @@ func (b *bleveIndex) finalizePostFilter(
 	exact := exhausted
 	if wantFacets {
 		response.TotalHits = authorized
-	} else if exhausted && req.Limit > 0 && len(req.SearchAfter) == 0 && len(req.SearchBefore) == 0 {
+	} else if exhausted && len(req.SearchAfter) == 0 && len(req.SearchBefore) == 0 {
+		// The scan saw every match from the top, so the authorized count is
+		// exact. Count-only requests (Limit == 0) reach this too: they scan
+		// solely to total, and only fall through when the budget cuts them off.
 		response.TotalHits = authorized
 	} else {
 		exact = false

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -1911,6 +1911,35 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		require.Equal(t, legacyRes.Facet, res.Facet)
 	})
 
+	t.Run("repeated tag values match the in-searcher path", func(t *testing.T) {
+		// Native facets read indexed terms while app-side aggregation walks the
+		// stored slice, so a value repeated inside one document is where the two
+		// can disagree.
+		legacyIndex := newTestDashboardsIndex(t, threshold, 2, noop)
+		postRankIndex := newTestDashboardsIndexPostRank(t, 2)
+		docs := []*resource.BulkIndexItem{
+			newDocWithTags("doc-0", "allowed", []string{"prod", "prod"}),
+			newDocWithTags("doc-1", "allowed", []string{"prod", "latency"}),
+			newDocWithTags("doc-2", "denied", []string{"prod", "prod"}),
+		}
+		indexDocs(t, legacyIndex, docs)
+		indexDocs(t, postRankIndex, docs)
+		q := listQuery(10)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 10},
+		}
+
+		legacyNames, legacyRes := searchNames(t, legacyIndex, &countingAccessClient{
+			allowedFolders: map[string]bool{"allowed": true},
+		}, q)
+		names, res := searchNames(t, postRankIndex, &countingAccessClient{
+			allowedFolders: map[string]bool{"allowed": true},
+		}, q)
+
+		require.Equal(t, legacyNames, names)
+		require.Equal(t, legacyRes.Facet, res.Facet)
+	})
+
 	t.Run("managedBy facets match the in-searcher path", func(t *testing.T) {
 		// managedBy is facet-capable and stored (facet implies stored), so the
 		// post-rank path aggregates it app-side like any other facet field.
@@ -2858,7 +2887,7 @@ func TestSearchSeparatesDeletedFromLiveDocuments(t *testing.T) {
 func TestSearchPostRankAuthzSeparatesDeletedFromLiveDocuments(t *testing.T) {
 	index := newTestDashboardsIndexPostRank(t, 3)
 
-	doc := func(name string, deleted *bool) *resource.BulkIndexItem {
+	doc := func(name, folder string, deleted *bool, tags ...string) *resource.BulkIndexItem {
 		return &resource.BulkIndexItem{
 			Action: resource.ActionIndex,
 			Doc: &resource.IndexableDocument{
@@ -2869,28 +2898,79 @@ func TestSearchPostRankAuthzSeparatesDeletedFromLiveDocuments(t *testing.T) {
 					Name:      name,
 				},
 				Title:     name,
-				Folder:    "folder-a",
+				Folder:    folder,
+				Tags:      tags,
 				IsDeleted: deleted,
 			},
 		}
 	}
+	// The trashed document sits in an authorized folder, so anything that lets
+	// it through is the deleted scope failing, not authorization.
 	indexDocs(t, index, []*resource.BulkIndexItem{
-		doc("no-marker", nil),
-		doc("live", new(false)),
-		doc("trashed", new(true)),
+		doc("no-marker", "allowed", nil, "shared"),
+		doc("live", "allowed", new(false), "shared", "live-only"),
+		doc("denied", "denied", new(false), "shared", "denied-only"),
+		doc("trashed", "allowed", new(true), "shared", "trash-only"),
 	})
 
-	ac := &countingAccessClient{allowAll: true}
+	newAC := func() *countingAccessClient {
+		return &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+	}
+	tagFacet := func(q *resourcepb.ResourceSearchRequest) *resourcepb.ResourceSearchRequest {
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 10},
+		}
+		return q
+	}
 
-	names, res := searchNames(t, index, ac, listQuery(100))
-	require.ElementsMatch(t, []string{"no-marker", "live"}, names)
-	require.Equal(t, int64(2), res.TotalHits)
+	t.Run("live search excludes deleted and unauthorized documents", func(t *testing.T) {
+		names, res := searchNames(t, index, newAC(), listQuery(100))
+		require.ElementsMatch(t, []string{"no-marker", "live"}, names)
+		require.Equal(t, int64(2), res.TotalHits)
+	})
 
-	q := listQuery(100)
-	q.IsDeleted = true
-	names, res = searchNames(t, index, ac, q)
-	require.Equal(t, []string{"trashed"}, names)
-	require.Equal(t, int64(1), res.TotalHits)
+	t.Run("trash search returns only deleted documents", func(t *testing.T) {
+		q := listQuery(100)
+		q.IsDeleted = true
+		names, res := searchNames(t, index, newAC(), q)
+		require.Equal(t, []string{"trashed"}, names)
+		require.Equal(t, int64(1), res.TotalHits)
+	})
+
+	t.Run("live facet counts exclude deleted documents", func(t *testing.T) {
+		names, res := searchNames(t, index, newAC(), tagFacet(listQuery(100)))
+		require.ElementsMatch(t, []string{"no-marker", "live"}, names)
+		require.Equal(t, map[string]int64{"shared": 2, "live-only": 1}, facetTermCounts(res.Facet["tags"]))
+		require.Equal(t, int64(3), res.Facet["tags"].Total)
+	})
+
+	t.Run("trash facet counts exclude live documents", func(t *testing.T) {
+		q := tagFacet(listQuery(100))
+		q.IsDeleted = true
+		names, res := searchNames(t, index, newAC(), q)
+		require.Equal(t, []string{"trashed"}, names)
+		require.Equal(t, map[string]int64{"shared": 1, "trash-only": 1}, facetTermCounts(res.Facet["tags"]))
+	})
+
+	t.Run("count-only totals exclude deleted documents", func(t *testing.T) {
+		ac := newAC()
+		_, res := searchNames(t, index, ac, listQuery(0))
+		require.Equal(t, int64(2), res.TotalHits)
+		require.True(t, res.TotalHitsExact)
+		require.Equal(t, 3, ac.checked, "the deleted document is not even a candidate")
+	})
+}
+
+// facetTermCounts flattens a facet response into term -> count for comparison.
+func facetTermCounts(f *resourcepb.ResourceSearchResponse_Facet) map[string]int64 {
+	if f == nil {
+		return nil
+	}
+	counts := make(map[string]int64, len(f.Terms))
+	for _, term := range f.Terms {
+		counts[term.Term] = term.Count
+	}
+	return counts
 }
 
 // checkSearchQueryUnordered asserts on the set of names, where order is not under

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -1765,6 +1765,41 @@ func TestSearchPostRankAuthz(t *testing.T) {
 
 	// --- Facets on the postFilter path (aggregated app-side over authorized hits) ---
 
+	t.Run("facets use a top sample without shortening sparse pages", func(t *testing.T) {
+		// The top facet sample contains no authorized docs, but the page scan
+		// must continue with its independent MaxCandidates budget to fill the
+		// requested page from later ranked hits.
+		cfg := search.PostRankAuthzConfig{
+			OverFetchFactor: 1,
+			MaxWindow:       20,
+			MaxCandidates:   100,
+			FacetSampleSize: 10,
+		}
+		index := newTestDashboardsIndexPostRankWithConfig(t, 2, cfg)
+		docs := make([]*resource.BulkIndexItem, 0, 30)
+		for i := 0; i < 30; i++ {
+			folder := "denied"
+			if i >= 20 {
+				folder = "allowed"
+			}
+			docs = append(docs, newDocWithTags(fmt.Sprintf("doc-%02d", i), folder, []string{"visible"}))
+		}
+		indexDocs(t, index, docs)
+
+		q := listQuery(3)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 10},
+		}
+		names, res := searchNames(t, index, &countingAccessClient{
+			allowedFolders: map[string]bool{"allowed": true},
+		}, q)
+
+		require.Equal(t, []string{"doc-20", "doc-21", "doc-22"}, names)
+		require.Empty(t, res.Facet["tags"].Terms, "facets remain tied to the top sample")
+		require.Equal(t, int64(3), res.TotalHits, "returned authorized rows raise the sampled total")
+		require.False(t, res.TotalHitsExact, "the top facet sample was capped")
+	})
+
 	t.Run("exhausted tag facets match the in-searcher path", func(t *testing.T) {
 		legacyIndex := newTestDashboardsIndex(t, threshold, 2, noop)
 		postRankIndex := newTestDashboardsIndexPostRank(t, 2)

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -1774,7 +1774,9 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		require.Equal(t, legacyRes.Facet, res.Facet)
 	})
 
-	t.Run("non-stored facets stay on the in-searcher path", func(t *testing.T) {
+	t.Run("managedBy facets match the in-searcher path", func(t *testing.T) {
+		// managedBy is facet-capable and stored (facet implies stored), so the
+		// post-rank path aggregates it app-side like any other facet field.
 		legacyIndex := newTestDashboardsIndex(t, threshold, 2, noop)
 		postRankIndex := newTestDashboardsIndexPostRank(t, 2)
 		docs := []*resource.BulkIndexItem{
@@ -1799,6 +1801,12 @@ func TestSearchPostRankAuthz(t *testing.T) {
 
 		require.Equal(t, legacyNames, names)
 		require.Equal(t, legacyRes.Facet, res.Facet)
+		// The denied doc's manager must not leak into the authorized facet.
+		f := res.Facet["managedBy"]
+		require.Equal(t, int64(2), f.Total)
+		for _, term := range f.Terms {
+			require.NotEqual(t, "repo:secret", term.Term)
+		}
 	})
 
 	t.Run("zero facet limit matches the in-searcher path", func(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -1230,6 +1230,12 @@ func newDoc(name, folder string) *resource.BulkIndexItem {
 	}
 }
 
+func newDocWithTags(name, folder string, tags []string) *resource.BulkIndexItem {
+	d := newDoc(name, folder)
+	d.Doc.Tags = tags
+	return d
+}
+
 func listQuery(limit int64) *resourcepb.ResourceSearchRequest {
 	return &resourcepb.ResourceSearchRequest{
 		Options: &resourcepb.ListOptions{
@@ -1739,6 +1745,307 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		res := searchResponse(t, index, ac, q)
 		require.NotNil(t, res.Error)
 	})
+
+	// --- Facets on the postFilter path (aggregated app-side over authorized hits) ---
+
+	t.Run("facets aggregated app-side over authorized hits", func(t *testing.T) {
+		index := newTestDashboardsIndexPostRank(t, 2)
+		indexDocs(t, index, []*resource.BulkIndexItem{
+			newDoc("doc-0", "allowed"),
+			newDoc("doc-1", "denied"),
+			newDoc("doc-2", "allowed"),
+		})
+		ac := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+		q := listQuery(10)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"folder": {Field: "folder", Limit: 10},
+		}
+		names, res := searchNames(t, index, ac, q)
+		require.ElementsMatch(t, []string{"doc-0", "doc-2"}, names)
+		f := res.Facet["folder"]
+		require.NotNil(t, f, "facet counts should be aggregated app-side")
+		// Only authorized hits contribute: both authorized docs are in the
+		// "allowed" folder; "denied" must not appear.
+		require.Equal(t, int64(2), f.Total)
+		require.Equal(t, int64(0), f.Missing)
+		require.Len(t, f.Terms, 1)
+		require.Equal(t, "allowed", f.Terms[0].Term)
+		require.Equal(t, int64(2), f.Terms[0].Count)
+	})
+
+	t.Run("facets split multi-value tag fields into individual terms", func(t *testing.T) {
+		index := newTestDashboardsIndexPostRank(t, 2)
+		indexDocs(t, index, []*resource.BulkIndexItem{
+			newDocWithTags("doc-0", "allowed", []string{"prod", "latency"}),
+			newDocWithTags("doc-1", "denied", []string{"prod", "secrets"}),
+			newDocWithTags("doc-2", "allowed", []string{"prod"}),
+			newDocWithTags("doc-3", "allowed", nil), // no tags -> missing
+		})
+		ac := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+		q := listQuery(10)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 100},
+		}
+		_, res := searchNames(t, index, ac, q)
+		f := res.Facet["tags"]
+		require.NotNil(t, f)
+		// Authorized docs: doc-0 (prod, latency), doc-2 (prod), doc-3 (none).
+		// Each tag element is its own term: prod=2, latency=1. Total = 3 values.
+		// doc-3 has no tags -> missing=1. The denied doc-1's "secrets" tag must
+		// not appear, and tags must never be stringified as "[prod latency]".
+		require.Equal(t, int64(3), f.Total)
+		require.Equal(t, int64(1), f.Missing)
+		terms := map[string]int64{}
+		for _, term := range f.Terms {
+			terms[term.Term] = term.Count
+			require.NotContains(t, term.Term, "[", "tag must not be stringified as an array")
+		}
+		require.Equal(t, map[string]int64{"prod": 2, "latency": 1}, terms)
+		require.NotContains(t, terms, "secrets", "unauthorized doc's tag must not be counted")
+	})
+
+	t.Run("facets report exact sample counts when the scan is capped (no extrapolation)", func(t *testing.T) {
+		// FacetSampleSize below the dataset size forces a capped scan. Counts
+		// are the exact authorized term counts within the bounded sample, NOT
+		// extrapolated: scaling by TotalHits/candidates would estimate the
+		// unfiltered count and over-count for low-access-fraction users.
+		index := newTestDashboardsIndexPostRankWithConfig(t, 2, search.PostRankAuthzConfig{
+			FacetSampleSize: 20,
+		})
+		docs := make([]*resource.BulkIndexItem, 0, 100)
+		for i := 0; i < 100; i++ {
+			docs = append(docs, newDoc(fmt.Sprintf("doc-%03d", i), "allowed"))
+		}
+		indexDocs(t, index, docs)
+
+		ac := &countingAccessClient{allowAll: true}
+		q := listQuery(10)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"folder": {Field: "folder", Limit: 10},
+		}
+		_, res := searchNames(t, index, ac, q)
+		f := res.Facet["folder"]
+		require.NotNil(t, f)
+		// 20 candidates sampled (FacetSampleSize cap); all 20 are "allowed".
+		// Counts reflect only the sample, not the full 100-doc set.
+		require.Equal(t, int64(20), f.Total, "Total is the sample count, not extrapolated")
+		require.Len(t, f.Terms, 1)
+		require.Equal(t, "allowed", f.Terms[0].Term)
+		require.Equal(t, int64(20), f.Terms[0].Count, "term count is the sample count, not extrapolated")
+	})
+
+	t.Run("facets do not over-count for low-access-fraction users", func(t *testing.T) {
+		// Reproduces the reported UI bug: a tag appears on a few authorized docs
+		// but extrapolation (totalHits/candidates) reported a scaled-up count.
+		// The exact sample count must match what the tag-filtered search
+		// actually delivers, not the unfiltered total.
+		index := newTestDashboardsIndexPostRankWithConfig(t, 2, search.PostRankAuthzConfig{
+			FacetSampleSize: 100, MaxCandidates: 100,
+		})
+		docs := make([]*resource.BulkIndexItem, 0, 200)
+		for i := 0; i < 200; i++ {
+			folder := "denied"
+			if i < 4 { // 4 allowed of 200 -> 2% authorized fraction
+				folder = "allowed"
+			}
+			docs = append(docs, newDocWithTags(fmt.Sprintf("doc-%03d", i), folder, []string{"graceful-simply"}))
+		}
+		indexDocs(t, index, docs)
+		ac := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+
+		q := listQuery(0) // facets-only: no page to fill, sample the facets
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 10},
+		}
+		_, res := searchNames(t, index, ac, q)
+		f := res.Facet["tags"]
+		require.NotNil(t, f)
+		require.Equal(t, "graceful-simply", f.Terms[0].Term)
+		// Only the 4 allowed docs are authorized; the facet counts those, not
+		// the 200 unfiltered matches.
+		require.Equal(t, int64(4), f.Terms[0].Count, "facet count is the authorized count, not extrapolated to the unfiltered total")
+	})
+
+	t.Run("app-side facet term list respects Limit", func(t *testing.T) {
+		index := newTestDashboardsIndexPostRank(t, 2)
+		// Folders with descending counts so the top-2 are well defined.
+		folders := []struct {
+			name  string
+			count int
+		}{
+			{"f1", 4}, {"f2", 3}, {"f3", 2}, {"f4", 1},
+		}
+		docs := make([]*resource.BulkIndexItem, 0, 10)
+		for _, f := range folders {
+			for i := 0; i < f.count; i++ {
+				docs = append(docs, newDoc(fmt.Sprintf("%s-%d", f.name, i), f.name))
+			}
+		}
+		indexDocs(t, index, docs)
+
+		ac := &countingAccessClient{allowAll: true}
+		q := listQuery(100)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"folder": {Field: "folder", Limit: 2},
+		}
+		_, res := searchNames(t, index, ac, q)
+		f := res.Facet["folder"]
+		require.NotNil(t, f)
+		require.Len(t, f.Terms, 2, "term list must be truncated to the requested Limit")
+		require.Equal(t, "f1", f.Terms[0].Term)
+		require.Equal(t, int64(4), f.Terms[0].Count)
+		require.Equal(t, "f2", f.Terms[1].Term)
+		require.Equal(t, int64(3), f.Terms[1].Count)
+		require.Equal(t, int64(10), f.Total)
+	})
+
+	t.Run("facet fields are not leaked into response columns", func(t *testing.T) {
+		// The post-rank path loads facet stored fields to aggregate app-side,
+		// but they must not become response columns (mirrors the folder authz
+		// field leak guard).
+		index := newTestDashboardsIndexPostRank(t, 2)
+		indexDocs(t, index, []*resource.BulkIndexItem{
+			newDocWithTags("doc-0", "allowed", []string{"prod"}),
+			newDoc("doc-1", "allowed"),
+		})
+		ac := &countingAccessClient{allowAll: true}
+		q := listQuery(10)
+		q.Fields = []string{"title"}
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 10},
+		}
+		_, res := searchNames(t, index, ac, q)
+		cols := columnNames(res)
+		require.Equal(t, []string{"title"}, cols, "only the requested field should be returned, not the facet field")
+	})
+
+	// --- SearchBefore (reverse cursor) on the postFilter path ---
+
+	// backwardNames runs a SearchBefore query with the given cursor and returns
+	// the names in the returned (forward-ordered) page, plus the response.
+	backwardNames := func(t *testing.T, index resource.ResourceIndex, ac authlib.AccessClient, cursor []string, limit int64) ([]string, *resourcepb.ResourceSearchResponse) {
+		t.Helper()
+		q := listQuery(limit)
+		q.SearchBefore = cursor
+		return searchNames(t, index, ac, q)
+	}
+
+	t.Run("SearchBefore returns the previous page in forward order", func(t *testing.T) {
+		index := newTestDashboardsIndexPostRank(t, 2)
+		docs := make([]*resource.BulkIndexItem, 0, 30)
+		for i := 0; i < 30; i++ {
+			docs = append(docs, newDoc(fmt.Sprintf("doc-%02d", i), "allowed"))
+		}
+		indexDocs(t, index, docs)
+
+		ac := &countingAccessClient{allowAll: true}
+		// Establish a forward cursor at doc-14 (the 15th hit).
+		_, fwd := searchNames(t, index, ac, listQuery(15))
+		rows := fwd.Results.GetRows()
+		require.Len(t, rows, 15)
+		cursor := rows[len(rows)-1].SortFields // doc-14
+		require.Equal(t, "doc-14", rows[len(rows)-1].Key.Name)
+
+		// The 5 hits immediately before doc-14, in forward order.
+		names, res := backwardNames(t, index, ac, cursor, 5)
+		require.Equal(t, []string{"doc-09", "doc-10", "doc-11", "doc-12", "doc-13"}, names)
+		require.Equal(t, int64(30), res.TotalHits, "TotalHits stays the unfiltered match count")
+	})
+
+	t.Run("SearchBefore pages backwards contiguously with no dupes or skips", func(t *testing.T) {
+		index := newTestDashboardsIndexPostRank(t, 2)
+		docs := make([]*resource.BulkIndexItem, 0, 30)
+		for i := 0; i < 30; i++ {
+			docs = append(docs, newDoc(fmt.Sprintf("doc-%02d", i), "allowed"))
+		}
+		indexDocs(t, index, docs)
+
+		ac := &countingAccessClient{allowAll: true}
+		// Start from doc-14.
+		_, fwd := searchNames(t, index, ac, listQuery(15))
+		cursor := fwd.Results.GetRows()[len(fwd.Results.GetRows())-1].SortFields
+
+		// Walk backwards in pages of 5; each page's first row is the next cursor.
+		var got []string
+		pages := [][]string{
+			{"doc-09", "doc-10", "doc-11", "doc-12", "doc-13"},
+			{"doc-04", "doc-05", "doc-06", "doc-07", "doc-08"},
+			{"doc-00", "doc-01", "doc-02", "doc-03"}, // start of index reached
+		}
+		for p, want := range pages {
+			require.Less(t, p, 100)
+			names, res := backwardNames(t, index, ac, cursor, 5)
+			require.Equal(t, want, names, "page %d backwards", p)
+			got = append(got, names...)
+			rows := res.Results.GetRows()
+			if len(rows) == 0 {
+				break
+			}
+			cursor = rows[0].SortFields // smallest sort key -> next SearchBefore cursor
+			if len(rows) < 5 {
+				break // shorter page => reached the start
+			}
+		}
+		// Backward walk covers doc-00..doc-13 exactly once, in forward order
+		// within each page and decreasing ranges across pages.
+		wantAll := []string{
+			"doc-09", "doc-10", "doc-11", "doc-12", "doc-13",
+			"doc-04", "doc-05", "doc-06", "doc-07", "doc-08",
+			"doc-00", "doc-01", "doc-02", "doc-03",
+		}
+		require.Equal(t, wantAll, got)
+	})
+
+	t.Run("SearchBefore respects authorization", func(t *testing.T) {
+		index := newTestDashboardsIndexPostRank(t, 2)
+		// Even-indexed docs authorized; titles equal names so order is stable.
+		docs := make([]*resource.BulkIndexItem, 0, 20)
+		for i := 0; i < 20; i++ {
+			folder := "denied"
+			if i%2 == 0 {
+				folder = "allowed"
+			}
+			docs = append(docs, newDoc(fmt.Sprintf("doc-%02d", i), folder))
+		}
+		indexDocs(t, index, docs)
+
+		ac := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+		// Forward cursor at doc-18 (authorized). Forward search over authorized
+		// hits returns the even docs; the last returned is doc-18.
+		_, fwd := searchNames(t, index, ac, listQuery(20))
+		rows := fwd.Results.GetRows()
+		require.Equal(t, "doc-18", rows[len(rows)-1].Key.Name)
+		cursor := rows[len(rows)-1].SortFields
+
+		// The 3 authorized hits immediately before doc-18 (in forward order):
+		// doc-12, doc-14, doc-16.
+		names, _ := backwardNames(t, index, ac, cursor, 3)
+		require.Equal(t, []string{"doc-12", "doc-14", "doc-16"}, names)
+	})
+
+	t.Run("stale SearchBefore cursor falls back to in-searcher path", func(t *testing.T) {
+		// A SearchBefore cursor created before the flag was enabled has one
+		// fewer sort value (no SortDocID tie-breaker). The post-rank path must
+		// fall back to the in-searcher path instead of feeding bleve a
+		// mismatched cursor.
+		index := newTestDashboardsIndexPostRank(t, 2)
+		indexDocs(t, index, []*resource.BulkIndexItem{
+			newDoc("doc-a", "allowed"),
+			newDoc("doc-b", "allowed"),
+			newDoc("doc-c", "allowed"),
+		})
+		ac := &countingAccessClient{allowAll: true}
+		// Pre-flag cursor shape: [title, name], no _id tie-breaker (len 2). The
+		// post-rank sort order is [title, name, _id] (len 3); this cursor
+		// mismatches post-rank and falls back to the in-searcher path, whose
+		// sort is [title, name] (len 2) — a match.
+		q := listQuery(10)
+		q.SearchBefore = []string{"doc-c", "doc-c"}
+		names, res := searchNames(t, index, ac, q)
+		require.Nil(t, res.Error)
+		// Falls back to in-searcher SearchBefore: the hits before ("doc-c","doc-c").
+		require.Equal(t, []string{"doc-a", "doc-b"}, names)
+	})
 }
 
 // newTestFoldersIndexPostRank builds a folders index with the post-rank-authz
@@ -1878,6 +2185,14 @@ func TestSearchPostRankAuthzFederated(t *testing.T) {
 		return all
 	}
 
+	federatedRowLabels := func(rows []*resourcepb.ResourceTableRow) [][2]string {
+		out := make([][2]string, 0, len(rows))
+		for _, row := range rows {
+			out = append(out, [2]string{row.Key.Resource, row.Key.Name})
+		}
+		return out
+	}
+
 	t.Run("returns dashboards + folders merged in sort order", func(t *testing.T) {
 		dash := newTestDashboardsIndexPostRank(t, 2)
 		folder := newTestFoldersIndexPostRank(t, 2, search.PostRankAuthzConfig{})
@@ -2006,6 +2321,83 @@ func TestSearchPostRankAuthzFederated(t *testing.T) {
 		ac := search.NewStubAccessClient(map[string]bool{"dashboards": true, "folders": true})
 		got := pageAllFederated(t, dash, folder, ac, 5)
 		require.Equal(t, want, got, "duplicate titles must page deterministically by _id across the alias")
+	})
+
+	t.Run("facets aggregated app-side over authorized federated hits", func(t *testing.T) {
+		dash := newTestDashboardsIndexPostRank(t, 2)
+		folder := newTestFoldersIndexPostRank(t, 2, search.PostRankAuthzConfig{})
+		indexDashboards(t, dash, []*resource.BulkIndexItem{
+			newDash("d-aaa", "aaa", "any"), // no region label -> missing
+		})
+		indexDashboards(t, folder, []*resource.BulkIndexItem{
+			newFolder("f-zzz", "zzz", map[string]string{"region": "west"}),
+			newFolder("f-mmm", "mmm", map[string]string{"region": "east"}),
+		})
+
+		ac := search.NewStubAccessClient(map[string]bool{"dashboards": true, "folders": true})
+		q := federatedQuery(100)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"region": {Field: "labels.region", Limit: 100},
+		}
+		_, res := searchFederated(t, dash, folder, ac, q)
+
+		f, ok := res.Facet["region"]
+		require.True(t, ok, "facet should be aggregated app-side")
+		require.NotNil(t, f)
+		// 2 authorized hits have a region label (west, east); the dashboard has
+		// none -> missing. Total is the number of field values, not docs.
+		require.Equal(t, int64(2), f.Total)
+		require.Equal(t, int64(1), f.Missing)
+		terms := map[string]int64{}
+		for _, term := range f.Terms {
+			terms[term.Term] = term.Count
+		}
+		require.Equal(t, map[string]int64{"west": 1, "east": 1}, terms)
+	})
+
+	t.Run("SearchBefore returns the previous federated page in forward order", func(t *testing.T) {
+		// Use a tiny MaxWindow so the backward scan crosses window boundaries.
+		cfg := search.PostRankAuthzConfig{MaxWindow: 6}
+		dash := newTestDashboardsIndexPostRankWithConfig(t, 2, cfg)
+		folder := newTestFoldersIndexPostRank(t, 2, cfg)
+		// 6 dashboards (t-00,t-02,...,t-10) and 6 folders (t-01,t-03,...,t-11),
+		// interleaved by title so the merged sort alternates resources.
+		docs := make([]*resource.BulkIndexItem, 0, 6)
+		for i := 0; i < 6; i++ {
+			docs = append(docs, newDash(fmt.Sprintf("d-%02d", i), fmt.Sprintf("t-%02d", i*2), "allowed"))
+		}
+		indexDashboards(t, dash, docs)
+		fdocs := make([]*resource.BulkIndexItem, 0, 6)
+		for i := 0; i < 6; i++ {
+			fdocs = append(fdocs, newFolder(fmt.Sprintf("f-%02d", i), fmt.Sprintf("t-%02d", i*2+1), nil))
+		}
+		indexDashboards(t, folder, fdocs)
+
+		// Merged forward title order: t-00(d-00), t-01(f-00), t-02(d-01), ...
+		merged := make([][2]string, 0, 12)
+		for i := 0; i < 12; i++ {
+			if i%2 == 0 {
+				merged = append(merged, [2]string{"dashboards", fmt.Sprintf("d-%02d", i/2)})
+			} else {
+				merged = append(merged, [2]string{"folders", fmt.Sprintf("f-%02d", i/2)})
+			}
+		}
+
+		ac := search.NewStubAccessClient(map[string]bool{"dashboards": true, "folders": true})
+		// Forward page of 8 -> merged[0..7]; cursor = merged[7] (t-07, f-03).
+		_, fwd := searchFederated(t, dash, folder, ac, federatedQuery(8))
+		fwdRows := fwd.Results.GetRows()
+		require.Len(t, fwdRows, 8)
+		require.Equal(t, merged[:8], federatedRowLabels(fwdRows))
+		cursor := fwdRows[len(fwdRows)-1].SortFields
+
+		// SearchBefore limit=5 -> the 5 merged hits before the cursor, forward
+		// order: merged[2..6] = t-02..t-06.
+		q := federatedQuery(5)
+		q.SearchBefore = cursor
+		got, res := searchFederated(t, dash, folder, ac, q)
+		require.Equal(t, merged[2:7], got, "SearchBefore must return the previous federated page in forward order")
+		require.Equal(t, int64(12), res.TotalHits, "TotalHits stays the unfiltered merged match count")
 	})
 }
 

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -2152,6 +2152,34 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		require.False(t, res.TotalHitsExact, "the facet sample stopped at its cap")
 	})
 
+	t.Run("facet sample stays exact when the budget covers every match", func(t *testing.T) {
+		// The sample consumes its whole budget, but that budget spans the entire
+		// match set, so no authorized document went uncounted.
+		cfg := search.PostRankAuthzConfig{MaxWindow: 10, FacetSampleSize: 20, MaxCandidates: 100}
+		index := newTestDashboardsIndexPostRankWithConfig(t, 2, cfg)
+		docs := make([]*resource.BulkIndexItem, 0, 20)
+		for i := 0; i < 20; i++ {
+			folder := "denied"
+			if i%2 == 0 {
+				folder = "allowed"
+			}
+			docs = append(docs, newDocWithTags(fmt.Sprintf("doc-%02d", i), folder, []string{"shared"}))
+		}
+		indexDocs(t, index, docs)
+
+		q := listQuery(5)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 10},
+		}
+		_, res := searchNames(t, index, &countingAccessClient{
+			allowedFolders: map[string]bool{"allowed": true},
+		}, q)
+
+		require.Equal(t, int64(10), res.TotalHits)
+		require.True(t, res.TotalHitsExact, "the sample budget covered every match")
+		require.Equal(t, map[string]int64{"shared": 10}, facetTermCounts(res.Facet["tags"]))
+	})
+
 	t.Run("exhausted facet-only query reports an exact authorized total", func(t *testing.T) {
 		index := newTestDashboardsIndexPostRank(t, 2)
 		indexDocs(t, index, []*resource.BulkIndexItem{

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -1473,6 +1473,22 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		require.Empty(t, names)
 	})
 
+	t.Run("count-only request returns an unfiltered approximate total", func(t *testing.T) {
+		index := newTestDashboardsIndexPostRank(t, 2)
+		indexDocs(t, index, []*resource.BulkIndexItem{
+			newDoc("doc-0", "allowed"),
+			newDoc("doc-1", "denied"),
+		})
+
+		ac := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+		names, res := searchNames(t, index, ac, listQuery(0))
+
+		require.Empty(t, names)
+		require.Equal(t, int64(2), res.TotalHits, "the count includes unauthorized matches")
+		require.False(t, res.TotalHitsExact)
+		require.Zero(t, ac.checked, "count-only does not authorize individual documents")
+	})
+
 	t.Run("limit larger than total returns everything authorized", func(t *testing.T) {
 		index := newTestDashboardsIndexPostRank(t, 2)
 		indexDocs(t, index, []*resource.BulkIndexItem{

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -1748,29 +1748,103 @@ func TestSearchPostRankAuthz(t *testing.T) {
 
 	// --- Facets on the postFilter path (aggregated app-side over authorized hits) ---
 
-	t.Run("facets aggregated app-side over authorized hits", func(t *testing.T) {
-		index := newTestDashboardsIndexPostRank(t, 2)
-		indexDocs(t, index, []*resource.BulkIndexItem{
-			newDoc("doc-0", "allowed"),
-			newDoc("doc-1", "denied"),
-			newDoc("doc-2", "allowed"),
-		})
-		ac := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+	t.Run("exhausted tag facets match the in-searcher path", func(t *testing.T) {
+		legacyIndex := newTestDashboardsIndex(t, threshold, 2, noop)
+		postRankIndex := newTestDashboardsIndexPostRank(t, 2)
+		docs := []*resource.BulkIndexItem{
+			newDocWithTags("doc-0", "allowed", []string{"prod east", "latency"}),
+			newDocWithTags("doc-1", "denied", []string{"secret"}),
+			newDocWithTags("doc-2", "allowed", []string{"prod east"}),
+		}
+		indexDocs(t, legacyIndex, docs)
+		indexDocs(t, postRankIndex, docs)
 		q := listQuery(10)
 		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
-			"folder": {Field: "folder", Limit: 10},
+			"tags": {Field: "tags", Limit: 10},
 		}
-		names, res := searchNames(t, index, ac, q)
+
+		legacyNames, legacyRes := searchNames(t, legacyIndex, &countingAccessClient{
+			allowedFolders: map[string]bool{"allowed": true},
+		}, q)
+		names, res := searchNames(t, postRankIndex, &countingAccessClient{
+			allowedFolders: map[string]bool{"allowed": true},
+		}, q)
+		require.Equal(t, legacyNames, names)
 		require.ElementsMatch(t, []string{"doc-0", "doc-2"}, names)
-		f := res.Facet["folder"]
-		require.NotNil(t, f, "facet counts should be aggregated app-side")
-		// Only authorized hits contribute: both authorized docs are in the
-		// "allowed" folder; "denied" must not appear.
-		require.Equal(t, int64(2), f.Total)
-		require.Equal(t, int64(0), f.Missing)
-		require.Len(t, f.Terms, 1)
-		require.Equal(t, "allowed", f.Terms[0].Term)
-		require.Equal(t, int64(2), f.Terms[0].Count)
+		require.Equal(t, legacyRes.Facet, res.Facet)
+	})
+
+	t.Run("non-stored facets stay on the in-searcher path", func(t *testing.T) {
+		legacyIndex := newTestDashboardsIndex(t, threshold, 2, noop)
+		postRankIndex := newTestDashboardsIndexPostRank(t, 2)
+		docs := []*resource.BulkIndexItem{
+			newDoc("doc-0", "allowed"),
+			newDoc("doc-1", "allowed"),
+			newDoc("doc-2", "denied"),
+		}
+		docs[0].Doc.ManagedBy = "repo:one"
+		docs[1].Doc.ManagedBy = "repo:two"
+		docs[2].Doc.ManagedBy = "repo:secret"
+		indexDocs(t, legacyIndex, docs)
+		indexDocs(t, postRankIndex, docs)
+		q := listQuery(10)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"managedBy": {Field: "managedBy", Limit: 10},
+		}
+
+		legacyAC := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+		postRankAC := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+		legacyNames, legacyRes := searchNames(t, legacyIndex, legacyAC, q)
+		names, res := searchNames(t, postRankIndex, postRankAC, q)
+
+		require.Equal(t, legacyNames, names)
+		require.Equal(t, legacyRes.Facet, res.Facet)
+	})
+
+	t.Run("zero facet limit matches the in-searcher path", func(t *testing.T) {
+		legacyIndex := newTestDashboardsIndex(t, threshold, 2, noop)
+		postRankIndex := newTestDashboardsIndexPostRank(t, 2)
+		docs := []*resource.BulkIndexItem{
+			newDocWithTags("doc-0", "allowed", []string{"prod", "latency"}),
+			newDocWithTags("doc-1", "allowed", nil),
+		}
+		indexDocs(t, legacyIndex, docs)
+		indexDocs(t, postRankIndex, docs)
+		q := listQuery(10)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 0},
+		}
+
+		_, legacyRes := searchNames(t, legacyIndex, &countingAccessClient{allowAll: true}, q)
+		_, res := searchNames(t, postRankIndex, &countingAccessClient{allowAll: true}, q)
+		require.Equal(t, legacyRes.Facet, res.Facet)
+		require.Empty(t, res.Facet["tags"].Terms)
+		require.Equal(t, int64(2), res.Facet["tags"].Total)
+		require.Equal(t, int64(1), res.Facet["tags"].Missing)
+	})
+
+	t.Run("facet aliases targeting the same field do not double-count", func(t *testing.T) {
+		index := newTestDashboardsIndexPostRank(t, 2)
+		indexDocs(t, index, []*resource.BulkIndexItem{
+			newDocWithTags("doc-0", "allowed", []string{"prod", "latency"}),
+			newDocWithTags("doc-1", "allowed", []string{"prod"}),
+		})
+		q := listQuery(10)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"primary":   {Field: "tags", Limit: 10},
+			"secondary": {Field: "tags", Limit: 10},
+		}
+
+		_, res := searchNames(t, index, &countingAccessClient{allowAll: true}, q)
+		require.Equal(t, res.Facet["primary"], res.Facet["secondary"])
+		for _, name := range []string{"primary", "secondary"} {
+			facet := res.Facet[name]
+			require.Equal(t, int64(3), facet.Total)
+			require.Equal(t, []*resourcepb.ResourceSearchResponse_TermFacet{
+				{Term: "prod", Count: 2},
+				{Term: "latency", Count: 1},
+			}, facet.Terms)
+		}
 	})
 
 	t.Run("facets split multi-value tag fields into individual terms", func(t *testing.T) {
@@ -1804,6 +1878,42 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		require.NotContains(t, terms, "secrets", "unauthorized doc's tag must not be counted")
 	})
 
+	t.Run("facets are independent of forward and backward cursors", func(t *testing.T) {
+		index := newTestDashboardsIndexPostRank(t, 2)
+		docs := make([]*resource.BulkIndexItem, 0, 10)
+		for i := 0; i < 10; i++ {
+			tag := "even"
+			if i%2 != 0 {
+				tag = "odd"
+			}
+			docs = append(docs, newDocWithTags(fmt.Sprintf("doc-%02d", i), "allowed", []string{tag}))
+		}
+		indexDocs(t, index, docs)
+		ac := &countingAccessClient{allowAll: true}
+		facets := map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 10},
+		}
+
+		baselineQuery := listQuery(4)
+		baselineQuery.Facet = facets
+		_, baseline := searchNames(t, index, ac, baselineQuery)
+
+		afterQuery := listQuery(3)
+		afterQuery.Facet = facets
+		afterQuery.SearchAfter = baseline.Results.GetRows()[3].SortFields
+		afterNames, after := searchNames(t, index, ac, afterQuery)
+		require.Equal(t, []string{"doc-04", "doc-05", "doc-06"}, afterNames)
+		require.Equal(t, baseline.Facet, after.Facet)
+
+		_, cursorPage := searchNames(t, index, ac, listQuery(7))
+		beforeQuery := listQuery(3)
+		beforeQuery.Facet = facets
+		beforeQuery.SearchBefore = cursorPage.Results.GetRows()[6].SortFields
+		beforeNames, before := searchNames(t, index, ac, beforeQuery)
+		require.Equal(t, []string{"doc-03", "doc-04", "doc-05"}, beforeNames)
+		require.Equal(t, baseline.Facet, before.Facet)
+	})
+
 	t.Run("facets report exact sample counts when the scan is capped (no extrapolation)", func(t *testing.T) {
 		// FacetSampleSize below the dataset size forces a capped scan. Counts
 		// are the exact authorized term counts within the bounded sample, NOT
@@ -1814,23 +1924,23 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		})
 		docs := make([]*resource.BulkIndexItem, 0, 100)
 		for i := 0; i < 100; i++ {
-			docs = append(docs, newDoc(fmt.Sprintf("doc-%03d", i), "allowed"))
+			docs = append(docs, newDocWithTags(fmt.Sprintf("doc-%03d", i), "allowed", []string{"sampled"}))
 		}
 		indexDocs(t, index, docs)
 
 		ac := &countingAccessClient{allowAll: true}
 		q := listQuery(10)
 		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
-			"folder": {Field: "folder", Limit: 10},
+			"tags": {Field: "tags", Limit: 10},
 		}
 		_, res := searchNames(t, index, ac, q)
-		f := res.Facet["folder"]
+		f := res.Facet["tags"]
 		require.NotNil(t, f)
 		// 20 candidates sampled (FacetSampleSize cap); all 20 are "allowed".
 		// Counts reflect only the sample, not the full 100-doc set.
 		require.Equal(t, int64(20), f.Total, "Total is the sample count, not extrapolated")
 		require.Len(t, f.Terms, 1)
-		require.Equal(t, "allowed", f.Terms[0].Term)
+		require.Equal(t, "sampled", f.Terms[0].Term)
 		require.Equal(t, int64(20), f.Terms[0].Count, "term count is the sample count, not extrapolated")
 	})
 
@@ -1864,21 +1974,43 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		// Only the 4 allowed docs are authorized; the facet counts those, not
 		// the 200 unfiltered matches.
 		require.Equal(t, int64(4), f.Terms[0].Count, "facet count is the authorized count, not extrapolated to the unfiltered total")
+		require.Equal(t, int64(4), res.TotalHits, "total and facet counts use the same authorized sample")
+		require.False(t, res.TotalHitsExact, "the facet sample stopped at its cap")
+	})
+
+	t.Run("exhausted facet-only query reports an exact authorized total", func(t *testing.T) {
+		index := newTestDashboardsIndexPostRank(t, 2)
+		indexDocs(t, index, []*resource.BulkIndexItem{
+			newDocWithTags("doc-0", "allowed", []string{"prod"}),
+			newDocWithTags("doc-1", "denied", []string{"secret"}),
+			newDocWithTags("doc-2", "allowed", []string{"latency"}),
+		})
+		q := listQuery(0)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 10},
+		}
+
+		_, res := searchNames(t, index, &countingAccessClient{
+			allowedFolders: map[string]bool{"allowed": true},
+		}, q)
+		require.Equal(t, int64(2), res.TotalHits)
+		require.True(t, res.TotalHitsExact)
+		require.Equal(t, int64(2), res.Facet["tags"].Total)
 	})
 
 	t.Run("app-side facet term list respects Limit", func(t *testing.T) {
 		index := newTestDashboardsIndexPostRank(t, 2)
-		// Folders with descending counts so the top-2 are well defined.
-		folders := []struct {
+		// Tags with descending counts so the top-2 are well defined.
+		tags := []struct {
 			name  string
 			count int
 		}{
 			{"f1", 4}, {"f2", 3}, {"f3", 2}, {"f4", 1},
 		}
 		docs := make([]*resource.BulkIndexItem, 0, 10)
-		for _, f := range folders {
-			for i := 0; i < f.count; i++ {
-				docs = append(docs, newDoc(fmt.Sprintf("%s-%d", f.name, i), f.name))
+		for _, tag := range tags {
+			for i := 0; i < tag.count; i++ {
+				docs = append(docs, newDocWithTags(fmt.Sprintf("%s-%d", tag.name, i), "allowed", []string{tag.name}))
 			}
 		}
 		indexDocs(t, index, docs)
@@ -1886,10 +2018,10 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		ac := &countingAccessClient{allowAll: true}
 		q := listQuery(100)
 		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
-			"folder": {Field: "folder", Limit: 2},
+			"tags": {Field: "tags", Limit: 2},
 		}
 		_, res := searchNames(t, index, ac, q)
-		f := res.Facet["folder"]
+		f := res.Facet["tags"]
 		require.NotNil(t, f)
 		require.Len(t, f.Terms, 2, "term list must be truncated to the requested Limit")
 		require.Equal(t, "f1", f.Terms[0].Term)
@@ -2326,26 +2458,26 @@ func TestSearchPostRankAuthzFederated(t *testing.T) {
 	t.Run("facets aggregated app-side over authorized federated hits", func(t *testing.T) {
 		dash := newTestDashboardsIndexPostRank(t, 2)
 		folder := newTestFoldersIndexPostRank(t, 2, search.PostRankAuthzConfig{})
-		indexDashboards(t, dash, []*resource.BulkIndexItem{
-			newDash("d-aaa", "aaa", "any"), // no region label -> missing
-		})
-		indexDashboards(t, folder, []*resource.BulkIndexItem{
-			newFolder("f-zzz", "zzz", map[string]string{"region": "west"}),
-			newFolder("f-mmm", "mmm", map[string]string{"region": "east"}),
-		})
+		dashboardDoc := newDash("d-aaa", "aaa", "any") // no tags -> missing
+		westFolder := newFolder("f-zzz", "zzz", nil)
+		westFolder.Doc.Tags = []string{"west"}
+		eastFolder := newFolder("f-mmm", "mmm", nil)
+		eastFolder.Doc.Tags = []string{"east"}
+		indexDashboards(t, dash, []*resource.BulkIndexItem{dashboardDoc})
+		indexDashboards(t, folder, []*resource.BulkIndexItem{westFolder, eastFolder})
 
 		ac := search.NewStubAccessClient(map[string]bool{"dashboards": true, "folders": true})
 		q := federatedQuery(100)
 		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
-			"region": {Field: "labels.region", Limit: 100},
+			"tags": {Field: "tags", Limit: 100},
 		}
 		_, res := searchFederated(t, dash, folder, ac, q)
 
-		f, ok := res.Facet["region"]
+		f, ok := res.Facet["tags"]
 		require.True(t, ok, "facet should be aggregated app-side")
 		require.NotNil(t, f)
-		// 2 authorized hits have a region label (west, east); the dashboard has
-		// none -> missing. Total is the number of field values, not docs.
+		// 2 authorized hits have tags (west, east); the dashboard has none.
+		// Total is the number of field values, not docs.
 		require.Equal(t, int64(2), f.Total)
 		require.Equal(t, int64(1), f.Missing)
 		terms := map[string]int64{}

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -1473,20 +1473,65 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		require.Empty(t, names)
 	})
 
-	t.Run("count-only request returns an unfiltered approximate total", func(t *testing.T) {
+	t.Run("count-only request returns an exact authorized total", func(t *testing.T) {
 		index := newTestDashboardsIndexPostRank(t, 2)
 		indexDocs(t, index, []*resource.BulkIndexItem{
 			newDoc("doc-0", "allowed"),
 			newDoc("doc-1", "denied"),
+			newDoc("doc-2", "allowed"),
 		})
 
 		ac := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
 		names, res := searchNames(t, index, ac, listQuery(0))
 
-		require.Empty(t, names)
-		require.Equal(t, int64(2), res.TotalHits, "the count includes unauthorized matches")
+		require.Empty(t, names, "a count-only request returns no rows")
+		require.Equal(t, int64(2), res.TotalHits, "unauthorized matches are excluded")
+		require.True(t, res.TotalHitsExact, "the scan exhausted the match set")
+		require.Equal(t, 3, ac.checked, "every match is authorized once")
+	})
+
+	t.Run("count-only request approximates once the budget is hit", func(t *testing.T) {
+		cfg := search.PostRankAuthzConfig{MaxWindow: 20, MaxCandidates: 40}
+		index := newTestDashboardsIndexPostRankWithConfig(t, 2, cfg)
+		docs := make([]*resource.BulkIndexItem, 0, 200)
+		for i := 0; i < 200; i++ {
+			folder := "denied"
+			if i%2 == 0 {
+				folder = "allowed"
+			}
+			docs = append(docs, newDoc(fmt.Sprintf("doc-%03d", i), folder))
+		}
+		indexDocs(t, index, docs)
+
+		ac := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+		_, res := searchNames(t, index, ac, listQuery(0))
+
+		require.Equal(t, int64(200), res.TotalHits, "a capped count falls back to the unfiltered match count")
 		require.False(t, res.TotalHitsExact)
-		require.Zero(t, ac.checked, "count-only does not authorize individual documents")
+		require.Equal(t, 40, ac.checked, "the scan stops at MaxCandidates")
+	})
+
+	t.Run("count-only request stays exact when the budget covers every match", func(t *testing.T) {
+		// The scan consumes its whole budget, but that budget spans the entire
+		// match set, so nothing is left unseen.
+		cfg := search.PostRankAuthzConfig{MaxWindow: 10, MaxCandidates: 20}
+		index := newTestDashboardsIndexPostRankWithConfig(t, 2, cfg)
+		docs := make([]*resource.BulkIndexItem, 0, 20)
+		for i := 0; i < 20; i++ {
+			folder := "denied"
+			if i%2 == 0 {
+				folder = "allowed"
+			}
+			docs = append(docs, newDoc(fmt.Sprintf("doc-%02d", i), folder))
+		}
+		indexDocs(t, index, docs)
+
+		ac := &countingAccessClient{allowedFolders: map[string]bool{"allowed": true}}
+		_, res := searchNames(t, index, ac, listQuery(0))
+
+		require.Equal(t, int64(10), res.TotalHits)
+		require.True(t, res.TotalHitsExact, "the budget covered every match")
+		require.Equal(t, 20, ac.checked)
 	})
 
 	t.Run("limit larger than total returns everything authorized", func(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -1311,6 +1311,7 @@ func pageAll(t *testing.T, index resource.ResourceIndex, ac authlib.AccessClient
 	return all
 }
 
+//nolint:gocyclo // The subtests share post-rank fixtures and helpers.
 func TestSearchPostRankAuthz(t *testing.T) {
 	t.Run("stops checking once the page is full", func(t *testing.T) {
 		index := newTestDashboardsIndexPostRank(t, 2)

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -1800,6 +1800,46 @@ func TestSearchPostRankAuthz(t *testing.T) {
 		require.False(t, res.TotalHitsExact, "the top facet sample was capped")
 	})
 
+	t.Run("cursor facets retain page authorized total", func(t *testing.T) {
+		// The top facet sample contains no authorized docs, while the page after
+		// the cursor does. The response total must include the latter.
+		cfg := search.PostRankAuthzConfig{
+			OverFetchFactor: 1,
+			MaxWindow:       20,
+			MaxCandidates:   100,
+			FacetSampleSize: 10,
+		}
+		index := newTestDashboardsIndexPostRankWithConfig(t, 2, cfg)
+		docs := make([]*resource.BulkIndexItem, 0, 30)
+		for i := 0; i < 30; i++ {
+			folder := "denied"
+			if i >= 20 {
+				folder = "allowed"
+			}
+			docs = append(docs, newDocWithTags(fmt.Sprintf("doc-%02d", i), folder, []string{"visible"}))
+		}
+		indexDocs(t, index, docs)
+
+		// Use the native post-rank cursor shape after doc-19.
+		_, cursorRes := searchNames(t, index, &countingAccessClient{allowAll: true}, listQuery(20))
+		rows := cursorRes.Results.GetRows()
+		require.Len(t, rows, 20)
+
+		q := listQuery(3)
+		q.SearchAfter = slices.Clone(rows[len(rows)-1].SortFields)
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: "tags", Limit: 10},
+		}
+		names, res := searchNames(t, index, &countingAccessClient{
+			allowedFolders: map[string]bool{"allowed": true},
+		}, q)
+
+		require.Equal(t, []string{"doc-20", "doc-21", "doc-22"}, names)
+		require.Empty(t, res.Facet["tags"].Terms, "facets remain tied to the denied top sample")
+		require.Equal(t, int64(3), res.TotalHits, "page authorization must raise the sampled total")
+		require.False(t, res.TotalHitsExact, "the top facet sample was capped")
+	})
+
 	t.Run("exhausted tag facets match the in-searcher path", func(t *testing.T) {
 		legacyIndex := newTestDashboardsIndex(t, threshold, 2, noop)
 		postRankIndex := newTestDashboardsIndexPostRank(t, 2)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -934,6 +934,23 @@ func TestBleveSearchRequestDefaultSortIncludesNameTieBreaker(t *testing.T) {
 		require.NotNil(t, errResult)
 		assert.Contains(t, errResult.Message, `field "labels.region" does not support faceting`)
 	})
+
+	// Both the bleve term trimmer and the post-rank aggregator use the limit as
+	// a slice bound, so a negative one has to be turned away before either runs.
+	t.Run("rejects a negative facet limit", func(t *testing.T) {
+		for _, postRankAuthz := range []bool{false, true} {
+			searchReq, errResult := idx.toBleveSearchRequest(t.Context(), &resourcepb.ResourceSearchRequest{
+				Options: &resourcepb.ListOptions{},
+				Limit:   10,
+				Facet: map[string]*resourcepb.ResourceSearchRequest_Facet{
+					"tagValues": {Field: resource.SEARCH_FIELD_TAGS, Limit: -1},
+				},
+			}, nil, postRankAuthz)
+			require.Nil(t, searchReq)
+			require.NotNil(t, errResult)
+			assert.Contains(t, errResult.Message, `facet "tagValues" has a negative limit`)
+		}
+	})
 }
 
 var _ authlib.AccessClient = (*StubAccessClient)(nil)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1151,6 +1151,22 @@ func withRequiredIndexFeatures(features ...resource.IndexFeature) setupOption {
 	}
 }
 
+func withPostRankAuthzEnabled() setupOption {
+	return func(options *BleveOptions) {
+		options.PostRankAuthzEnabled = true
+	}
+}
+
+// TestRequiredIndexFeaturesFollowPostRankAuthz covers the gate that keeps the
+// stored facet mapping from rebuilding indexes that serve facets from bleve.
+func TestRequiredIndexFeaturesFollowPostRankAuthz(t *testing.T) {
+	nativeFacets, _ := setupBleveBackend(t)
+	require.NotContains(t, nativeFacets.requiredFeatures, resource.IndexFeatureStoredFacets)
+
+	postRank, _ := setupBleveBackend(t, withPostRankAuthzEnabled())
+	require.Contains(t, postRank.requiredFeatures, resource.IndexFeatureStoredFacets)
+}
+
 // TestBuildIndexReuseChecksRequiredFeatures covers an on-disk index built before
 // a mapping change: a binary requiring an index feature the index lacks rebuilds
 // rather than serve wrong answers, and reuses the index when it requires none.

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -119,6 +119,7 @@ func NewSearchOptions(
 				OverFetchFactor: cfg.SearchPostRankAuthzOverFetchFactor,
 				MaxWindow:       cfg.SearchPostRankAuthzMaxWindow,
 				MaxCandidates:   cfg.SearchPostRankAuthzMaxCandidates,
+				FacetSampleSize: cfg.SearchPostRankAuthzFacetSampleSize,
 			},
 		}, indexMetrics)
 

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -140,6 +140,7 @@ func NewSearchOptions(
 			IndexMinUpdateInterval:    cfg.IndexMinUpdateInterval,
 			IndexModificationCacheTTL: cfg.IndexModificationCacheTTL,
 			InjectFailuresPercent:     cfg.SearchInjectFailuresPercent,
+			PostRankAuthzEnabled:      cfg.SearchPostRankAuthz,
 
 			IndexSnapshotEnabled:            cfg.IndexSnapshotEnabled,
 			IndexSnapshotBucketURL:          cfg.IndexSnapshotBucketURL,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
@@ -347,6 +347,7 @@
           {
             "type": "text",
             "analyzer": "keyword",
+            "store": true,
             "index": true,
             "skip_freq_norm": true
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -94,6 +94,7 @@
           {
             "type": "text",
             "analyzer": "keyword",
+            "store": true,
             "index": true,
             "skip_freq_norm": true
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
@@ -122,6 +122,7 @@
           {
             "type": "text",
             "analyzer": "keyword",
+            "store": true,
             "index": true,
             "skip_freq_norm": true
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
@@ -143,6 +143,7 @@
           {
             "type": "text",
             "analyzer": "keyword",
+            "store": true,
             "index": true,
             "skip_freq_norm": true
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -94,6 +94,7 @@
           {
             "type": "text",
             "analyzer": "keyword",
+            "store": true,
             "index": true,
             "skip_freq_norm": true
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team.json
@@ -158,6 +158,7 @@
           {
             "type": "text",
             "analyzer": "keyword",
+            "store": true,
             "index": true,
             "skip_freq_norm": true
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
@@ -144,6 +144,7 @@
           {
             "type": "text",
             "analyzer": "keyword",
+            "store": true,
             "index": true,
             "skip_freq_norm": true
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -170,6 +170,7 @@
           {
             "type": "text",
             "analyzer": "keyword",
+            "store": true,
             "index": true,
             "skip_freq_norm": true
           }


### PR DESCRIPTION
## Summary

This is **part 2** of the post-filter (post-rank) authorization work for bleve search. **Part 1** (#127642, merged) added the opt-in `search_post_rank_authz` config option and the post-rank path for normal paginated search and federated (dashboards + folders) queries. This PR extends that path to cover **facet queries**, **SearchBefore (backward) paging**, and **count-only requests**, so the flag is a single on/off switch for every query shape.

- Part 1: #127642 — post-rank authz for paginated search and federation (merged)
- Part 2: this PR — facets, SearchBefore, count-only, and gate relaxation on top of #127642

The in-searcher path authorizes _while bleve is still searching_, which can force it to check a very large number of candidates before returning a small page. The post-rank path lets bleve rank first, then authorizes the ranked hits in application code, in rank order. Page scans stop when the page fills or the `MaxCandidates` budget is reached after at least one authorized row; zero-result scans may continue beyond that budget (known limitation below). Facet scans always stop at their sample budget. No unauthorized document can ever appear in results — both paths call the same `authz.FilterAuthorized` (BatchCheck) with the same resource→verb map.

## What this PR adds on top of #127642

### Facets (app-side, over an authorized sample)

`#127642` left facets on the in-searcher path (bleve's native facets over the filtered searcher). This PR routes facets through the post-rank path:

- Facets are aggregated app-side over an authorized sample bounded by a new `FacetSampleSize` config tunable (`search_post_rank_authz_facet_sample_size`, default 10,000). bleve's native facets are dropped on the post-rank path — they would run over the unfiltered searcher and count unauthorized docs.
- Facet fields are loaded into the bleve request via `ensureFacetFields`, kept **out of the response column list** (mirrors the folder authz-field leak guard from #127642). The facet scan loads only the folder and the stored facet fields, not the response columns.
- Facet capability now implies that the canonical bleve field is stored, so app-side aggregation can read every declared facet field. Indexes built with that mapping record a `stored-facets` index feature, which is **required only when `search_post_rank_authz` is enabled** — environments on native facets do not rebuild for this experimental path. Once the flag becomes the default the feature moves to the global required set.
- Facets are scoped to the full query, not the current page. Requests with `SearchAfter` or `SearchBefore` run a separate facet scan from the top so cursors do not change facet counts.
- Multi-value fields (e.g. `tags`) are split into individual terms, matching bleve's `TermsFacetBuilder` semantics — a stored `["prod","latency"]` is counted as `prod` + `latency`, not a stringified `"[prod latency]"`. `Total` counts field values, not documents.
- Counts are the **exact authorized term counts within the sample** — no extrapolation. Extrapolating by `totalHits/candidates` estimates the _unfiltered_ term count, not the _authorized_ one, and over-counts badly for low-access-fraction users (a tag on 2 authorized docs was reported as 42). Exhausted scans are fully exact; capped scans return a conservative lower bound — never more than the sample saw. Facet responses report the authorized sample count in `TotalHits`; `TotalHitsExact` is true only when the facet scan exhausts the query.
- Facet scans use one large fixed window (`facetWindowSize = FacetSampleSize` capped at `MaxWindow`) so the whole sample is covered in the fewest bleve searches (one, with the defaults).

### SearchBefore (backward paging)

`SearchBefore` is transformed into a reversed-sort `SearchAfter` (mirroring bleve's native `SearchBefore` handling), walked with the existing forward bounded scan, then reversed back to forward order before returning. The `SortDocID` tie-breaker stays a total order in the reversed direction, so federated dashboard+folder `SearchBefore` cursors are deterministic with no skips or dupes.

### Count-only requests (`Limit == 0`, no facets)

Count-only requests now run on the post-rank path too, rather than being the one shape that falls back to the in-searcher scan. There is no page to fill, so the scan authorizes ranked hits purely to total them:

- It walks the ranked set in `countWindowSize` windows (`MaxCandidates` capped at `MaxWindow`) and enforces the `MaxCandidates` budget on its own — the page-fill escape hatch that keeps scanning until the first authorized row does not apply, because there is no page.
- If the scan exhausts the match set, `TotalHits` is the **exact** authorized total with `TotalHitsExact = true`, identical to what the in-searcher path returns. A budget that happens to cover the entire match set stays exact as well.
- Only when the budget cuts the scan short does it fall back to bleve's unfiltered count with `TotalHitsExact = false` — the same bound the page-fill path already reports.
- No extrapolation. The scanned candidates are the top-ranked N rather than a random sample, so scaling the authorized ratio to the full match set is biased whenever access correlates with sort order, and the wire response has no way to distinguish a point estimate from a bound.
- The scan loads only the folder field, since no rows are returned.

### Gate relaxation

The post-rank gate is now the flag itself: every query shape — paginated search, federation, facets, `SearchBefore`, and count-only — goes through the post-rank path when `search_post_rank_authz` is on. The stale-cursor guard from #127642 now covers `SearchBefore` cursors too: a cursor whose length doesn't match the post-rank sort order falls back to the in-searcher path; if it matches neither sort order, the request is rejected with a 400.

## What this PR preserves from #127642

All of part 1's refinements are kept unchanged for non-facet queries: the plain-bool `PostRankAuthzEnabled` config (not a closure), the `over_fetch_factor` / `max_window` / `max_candidates` tunables, the `selectFields` response-column separation (authz/aggregation fields never leak into results), the geometric `growWindow` for page-fill windows, and the `TotalHits` tail-count fix (exact authorized total only when the scan started from the top with no incoming cursor and exhausted the index; otherwise the unfiltered match count). Facet queries use the authorized-sample `TotalHits` semantics described above.

## Config (`[unified_storage]`)

```ini
search_post_rank_authz = false                              # master switch (default off)
# search_post_rank_authz_over_fetch_factor = 0              # default 5   — first window Size = limit * factor
# search_post_rank_authz_max_window = 0                     # default 10000 — per-window Size ceiling + geometric growth cap
# search_post_rank_authz_max_candidates = 0                 # default 50000 — page-fill and count-only candidate budget
# search_post_rank_authz_facet_sample_size = 0              # default 10000 — facet sample budget (NEW in this PR)
```

Zero values keep the built-in defaults. As in #127642, these tunables are intentionally **not** advertised in `conf/defaults.ini` while the design settles — they remain configurable via `custom.ini` / `GF_UNIFIED_STORAGE_*` env vars.

## Important behavior changes (relative to #127642)

- Facet queries now run on the post-rank path when the flag is on: counts are exact authorized term counts within a bounded sample (no extrapolation); capped scans return a conservative lower bound.
- Facet-capable fields are now stored in bleve. Indexes record a `stored-facets` feature that is required only when `search_post_rank_authz` is enabled, so rebuilds are scheduled only where the flag is on.
- Facets remain scoped to the full query and are independent of `SearchAfter` / `SearchBefore` cursors.
- `SearchBefore` runs on the post-rank path when the flag is on, paging backwards contiguously with no dupes/skips across federated aliases.
- Count-only (`Limit == 0`, no facets) runs on the post-rank path: an exact authorized total when the scan exhausts the match set within the candidate budget, otherwise bleve's unfiltered count with `TotalHitsExact = false`.
- A stale `SearchBefore` cursor (created before the flag was enabled) falls back to the in-searcher path instead of feeding bleve a mismatched cursor.

## Out of scope (planned follow-ups)

- **Absolute scan cap for the zero-access / deep-offset case.** #127642 documented this as a known limitation; this PR does not add it either. The geometric window growth reduces the cost, but a hard absolute ceiling remains a follow-up.
- **Concurrent `BatchCheck`.** Not introduced here.

## Test plan

- `go test ./pkg/storage/unified/search/ -run TestSearchPostRankAuthz`
- `go test ./pkg/storage/unified/search/ -run TestSearchPostRankAuthzFederated`
- `go test ./pkg/storage/unified/search/`
- `go test ./pkg/setting/`
- `go build ./pkg/storage/unified/... ./pkg/setting/...`
- `golangci-lint run pkg/storage/unified/search/... pkg/setting/... --new-from-rev=origin/main`

New coverage includes: app-side facets; stored facet mappings and the conditional index feature; multi-value tag splitting; facet aliases and zero limits; cursor-independent facets; capped-sample counts (no extrapolation); low-access-fraction over-count guard; facet `Limit` truncation; facet-field column-leak guard; count-only totals when the scan exhausts, when the budget caps it, and when the budget lands exactly on the match count; `SearchBefore` forward order, contiguous backward paging, authorization, and stale-cursor fallback; federated facets and federated `SearchBefore`.
