### PR TITLE
MegaMenu: Instrument the Configurable Nav A/B experiment

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -2,7 +2,7 @@ import { act, getWrapper, render, screen, userEvent, waitFor, within } from 'tes
 
 import { type NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { setBackendSrv } from '@grafana/runtime';
+import { reportExperimentView, reportInteraction, setBackendSrv } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
 import {
   customGetUserPreferencesHandler,
@@ -21,10 +21,19 @@ import { AppChromeService } from '../AppChromeService';
 
 import { MegaMenu } from './MegaMenu';
 import { customisableNavTree, nestedNavTree } from './__mocks__/fixtures';
+import { NAV_EXPERIMENT_GROUP, NAV_EXPERIMENT_ID, resetNavExperimentStateForTests } from './navExperiment';
 
 // The org switcher fetches user orgs on mount when signed in, which is irrelevant here.
 jest.mock('../OrganizationSwitcher/OrganizationSwitcher', () => ({
   OrganizationSwitcher: () => null,
+}));
+
+// Spy on the analytics reporters so we can assert the experiment exposure and the variant/org
+// stamped onto the KPI interactions, while keeping the rest of @grafana/runtime real.
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+  reportExperimentView: jest.fn(),
 }));
 
 // The searcher resolves starred UIDs to nav rows but has no MSW path, so stub it.
@@ -71,6 +80,8 @@ describe('MegaMenu', () => {
     // populates the Starred section deterministically (the stars query runs regardless of sign-in).
     setMockStarredDashboards([STARRED_DASHBOARD.uid]);
     setupSearcher();
+    // The exposure guard and cached variant live in module scope, so reset them per test.
+    resetNavExperimentStateForTests();
   });
 
   afterEach(async () => {
@@ -124,11 +135,13 @@ describe('MegaMenu', () => {
       contextSrv.isSignedIn = true;
       // The preferences query skips when the user isn't signed in.
       contextSrv.user.isSignedIn = true;
+      contextSrv.user.orgId = 42;
     });
 
     afterEach(() => {
       contextSrv.isSignedIn = false;
       contextSrv.user.isSignedIn = false;
+      contextSrv.user.orgId = 0;
     });
 
     it('shows a loading skeleton until preferences have loaded, instead of the un-customised menu', async () => {
@@ -141,6 +154,53 @@ describe('MegaMenu', () => {
       expect(list).toHaveAttribute('aria-busy', 'true');
       // The real items aren't rendered yet (so there's no reflow once preferences arrive)
       expect(screen.queryByRole('link', { name: 'Explore' })).not.toBeInTheDocument();
+    });
+
+    describe('experiment instrumentation', () => {
+      it('fires the exposure event once with the treatment variant', async () => {
+        renderMegaMenu();
+
+        await screen.findByRole('link', { name: 'Explore' });
+        expect(reportExperimentView).toHaveBeenCalledTimes(1);
+        expect(reportExperimentView).toHaveBeenCalledWith(NAV_EXPERIMENT_ID, NAV_EXPERIMENT_GROUP, 'treatment');
+      });
+
+      it('fires the exposure event with the control variant when the flag is off', async () => {
+        setTestFlags({ [CUSTOMISE_FLAG]: false });
+        renderMegaMenu();
+
+        await screen.findByRole('link', { name: 'Explore' });
+        expect(reportExperimentView).toHaveBeenCalledTimes(1);
+        expect(reportExperimentView).toHaveBeenCalledWith(NAV_EXPERIMENT_ID, NAV_EXPERIMENT_GROUP, 'control');
+      });
+
+      it('stamps the variant and org onto the nav click interaction', async () => {
+        const { user } = renderMegaMenu();
+
+        await user.click(await screen.findByRole('link', { name: 'Explore' }));
+
+        expect(reportInteraction).toHaveBeenCalledWith(
+          'grafana_navigation_item_clicked',
+          expect.objectContaining({ experiment_nav_customization: 'treatment', org_id: 42 })
+        );
+      });
+
+      it('stamps the variant and org onto the pin interaction', async () => {
+        const { user } = renderMegaMenu();
+
+        await screen.findByRole('link', { name: 'Dashboards' });
+        const pinButton = screen
+          .getAllByRole('button', { hidden: true })
+          .find((button) => button.getAttribute('aria-label') === 'Pin Dashboards');
+        await user.click(pinButton!);
+
+        await waitFor(() =>
+          expect(reportInteraction).toHaveBeenCalledWith(
+            'grafana_nav_item_pinned',
+            expect.objectContaining({ path: '/dashboards', experiment_nav_customization: 'treatment', org_id: 42 })
+          )
+        );
+      });
     });
 
     describe('pinned items', () => {

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -2,7 +2,7 @@ import { act, getWrapper, render, screen, userEvent, waitFor, within } from 'tes
 
 import { type NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { reportExperimentView, reportInteraction, setBackendSrv } from '@grafana/runtime';
+import { setBackendSrv } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
 import {
   customGetUserPreferencesHandler,
@@ -21,19 +21,10 @@ import { AppChromeService } from '../AppChromeService';
 
 import { MegaMenu } from './MegaMenu';
 import { customisableNavTree, nestedNavTree } from './__mocks__/fixtures';
-import { NAV_EXPERIMENT_GROUP, NAV_EXPERIMENT_ID, resetNavExperimentStateForTests } from './navExperiment';
 
 // The org switcher fetches user orgs on mount when signed in, which is irrelevant here.
 jest.mock('../OrganizationSwitcher/OrganizationSwitcher', () => ({
   OrganizationSwitcher: () => null,
-}));
-
-// Spy on the analytics reporters so we can assert the experiment exposure and the variant/org
-// stamped onto the KPI interactions, while keeping the rest of @grafana/runtime real.
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  reportInteraction: jest.fn(),
-  reportExperimentView: jest.fn(),
 }));
 
 // The searcher resolves starred UIDs to nav rows but has no MSW path, so stub it.
@@ -80,8 +71,6 @@ describe('MegaMenu', () => {
     // populates the Starred section deterministically (the stars query runs regardless of sign-in).
     setMockStarredDashboards([STARRED_DASHBOARD.uid]);
     setupSearcher();
-    // The exposure guard and cached variant live in module scope, so reset them per test.
-    resetNavExperimentStateForTests();
   });
 
   afterEach(async () => {
@@ -135,13 +124,11 @@ describe('MegaMenu', () => {
       contextSrv.isSignedIn = true;
       // The preferences query skips when the user isn't signed in.
       contextSrv.user.isSignedIn = true;
-      contextSrv.user.orgId = 42;
     });
 
     afterEach(() => {
       contextSrv.isSignedIn = false;
       contextSrv.user.isSignedIn = false;
-      contextSrv.user.orgId = 0;
     });
 
     it('shows a loading skeleton until preferences have loaded, instead of the un-customised menu', async () => {
@@ -154,53 +141,6 @@ describe('MegaMenu', () => {
       expect(list).toHaveAttribute('aria-busy', 'true');
       // The real items aren't rendered yet (so there's no reflow once preferences arrive)
       expect(screen.queryByRole('link', { name: 'Explore' })).not.toBeInTheDocument();
-    });
-
-    describe('experiment instrumentation', () => {
-      it('fires the exposure event once with the treatment variant', async () => {
-        renderMegaMenu();
-
-        await screen.findByRole('link', { name: 'Explore' });
-        expect(reportExperimentView).toHaveBeenCalledTimes(1);
-        expect(reportExperimentView).toHaveBeenCalledWith(NAV_EXPERIMENT_ID, NAV_EXPERIMENT_GROUP, 'treatment');
-      });
-
-      it('fires the exposure event with the control variant when the flag is off', async () => {
-        setTestFlags({ [CUSTOMISE_FLAG]: false });
-        renderMegaMenu();
-
-        await screen.findByRole('link', { name: 'Explore' });
-        expect(reportExperimentView).toHaveBeenCalledTimes(1);
-        expect(reportExperimentView).toHaveBeenCalledWith(NAV_EXPERIMENT_ID, NAV_EXPERIMENT_GROUP, 'control');
-      });
-
-      it('stamps the variant and org onto the nav click interaction', async () => {
-        const { user } = renderMegaMenu();
-
-        await user.click(await screen.findByRole('link', { name: 'Explore' }));
-
-        expect(reportInteraction).toHaveBeenCalledWith(
-          'grafana_navigation_item_clicked',
-          expect.objectContaining({ experiment_nav_customization: 'treatment', org_id: 42 })
-        );
-      });
-
-      it('stamps the variant and org onto the pin interaction', async () => {
-        const { user } = renderMegaMenu();
-
-        await screen.findByRole('link', { name: 'Dashboards' });
-        const pinButton = screen
-          .getAllByRole('button', { hidden: true })
-          .find((button) => button.getAttribute('aria-label') === 'Pin Dashboards');
-        await user.click(pinButton!);
-
-        await waitFor(() =>
-          expect(reportInteraction).toHaveBeenCalledWith(
-            'grafana_nav_item_pinned',
-            expect.objectContaining({ path: '/dashboards', experiment_nav_customization: 'treatment', org_id: 42 })
-          )
-        );
-      });
     });
 
     describe('pinned items', () => {

--- a/public/app/core/components/AppChrome/MegaMenu/hooks.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/hooks.ts
@@ -20,6 +20,7 @@ import { useDispatch, useSelector } from 'app/types/store';
 
 import { contextSrv } from '../../../services/context_srv';
 
+import { getNavExperimentPayload, reportNavExperimentViewOnce, setNavExperimentVariant } from './navExperiment';
 import {
   enrichWithInteractionTracking,
   expandPinnedUrls,
@@ -93,7 +94,21 @@ export const useNavCustomization = () => {
     [newPrefsEnabled, patchPreferences, patchPreferencesK8s, notifyApp]
   );
 
-  const canCustomise = useBooleanFlagValue('grafana.customizableMegaMenu', false) && contextSrv.isSignedIn;
+  const customizableMegaMenu = useBooleanFlagValue('grafana.customizableMegaMenu', false);
+  const canCustomise = customizableMegaMenu && contextSrv.isSignedIn;
+
+  // A/B experiment instrumentation: with a boolean flag, "treatment" = flag on, "control" = flag
+  // off. Cache the variant so the KPI interactions can be stamped with it, and fire the exposure
+  // (denominator) event once per page load for the experiment population (signed-in users).
+  const variant = customizableMegaMenu ? 'treatment' : 'control';
+  useEffect(() => {
+    if (!contextSrv.isSignedIn) {
+      return;
+    }
+    setNavExperimentVariant(variant);
+    reportNavExperimentViewOnce(variant);
+  }, [variant]);
+
   // Pins come from preferences, so render a skeleton until they've loaded on first visit — otherwise
   // the menu renders un-pinned and then reflows (pins jump to the top). Cached after the first load.
   const isLoading = canCustomise && pinnedLoading;
@@ -193,13 +208,19 @@ export const useNavCustomization = () => {
       const effective = expandPinnedUrls(pinnedUrls, baseItems);
       leaves.forEach((leaf) => (isUnpin ? effective.delete(leaf) : effective.add(leaf)));
       const next = normalizePinnedUrls(effective, baseItems);
-      reportInteraction(isUnpin ? 'grafana_nav_item_unpinned' : 'grafana_nav_item_pinned', { path: url });
+      reportInteraction(isUnpin ? 'grafana_nav_item_unpinned' : 'grafana_nav_item_pinned', {
+        path: url,
+        ...getNavExperimentPayload(),
+      });
       persistPinned(next);
     } else {
       // Legacy bookmarks behaviour (flag off): single-url toggle + redux Bookmarks section update.
       const isSaved = isPinned(url);
       const newItems = isSaved ? pinnedUrls.filter((i) => url !== i) : [...pinnedUrls, url];
-      reportInteraction(isSaved ? 'grafana_nav_item_unpinned' : 'grafana_nav_item_pinned', { path: url });
+      reportInteraction(isSaved ? 'grafana_nav_item_unpinned' : 'grafana_nav_item_pinned', {
+        path: url,
+        ...getNavExperimentPayload(),
+      });
       persistBookmarkUrls(newItems, () => {
         setPinnedUrls(newItems);
         dispatch(setBookmark({ item, isSaved: !isSaved }));

--- a/public/app/core/components/AppChrome/MegaMenu/hooks.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/hooks.ts
@@ -70,6 +70,22 @@ export const useNavCustomization = () => {
   const { pinnedItems, isLoading: pinnedLoading } = usePinnedItems();
   const notifyApp = useAppNotification();
 
+  const customizableMegaMenu = useBooleanFlagValue('grafana.customizableMegaMenu', false);
+  const canCustomise = customizableMegaMenu && contextSrv.isSignedIn;
+
+  // A/B experiment instrumentation: with a boolean flag, "treatment" = flag on, "control" = flag
+  // off. Cache the variant so the KPI interactions can be stamped with it, and fire the exposure
+  // (denominator) event once per page load for the experiment population (signed-in users). Kept up
+  // here with the other hooks so a future early return can't make the effect conditional.
+  const variant = customizableMegaMenu ? 'treatment' : 'control';
+  useEffect(() => {
+    if (!contextSrv.isSignedIn) {
+      return;
+    }
+    setNavExperimentVariant(variant);
+    reportNavExperimentViewOnce(variant);
+  }, [variant]);
+
   // Persist the bookmark urls via the app-platform preferences API when the new-preferences flag is
   // on, otherwise the legacy endpoint.
   // TODO drop the legacy branch once newPrefsEnabled is fully rolled out.
@@ -93,21 +109,6 @@ export const useNavCustomization = () => {
     },
     [newPrefsEnabled, patchPreferences, patchPreferencesK8s, notifyApp]
   );
-
-  const customizableMegaMenu = useBooleanFlagValue('grafana.customizableMegaMenu', false);
-  const canCustomise = customizableMegaMenu && contextSrv.isSignedIn;
-
-  // A/B experiment instrumentation: with a boolean flag, "treatment" = flag on, "control" = flag
-  // off. Cache the variant so the KPI interactions can be stamped with it, and fire the exposure
-  // (denominator) event once per page load for the experiment population (signed-in users).
-  const variant = customizableMegaMenu ? 'treatment' : 'control';
-  useEffect(() => {
-    if (!contextSrv.isSignedIn) {
-      return;
-    }
-    setNavExperimentVariant(variant);
-    reportNavExperimentViewOnce(variant);
-  }, [variant]);
 
   // Pins come from preferences, so render a skeleton until they've loaded on first visit — otherwise
   // the menu renders un-pinned and then reflows (pins jump to the top). Cached after the first load.

--- a/public/app/core/components/AppChrome/MegaMenu/navExperiment.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/navExperiment.ts
@@ -1,0 +1,55 @@
+import { reportExperimentView } from '@grafana/runtime';
+
+import { contextSrv } from '../../../services/context_srv';
+
+/**
+ * Instrumentation for the Configurable Nav A/B experiment (behind `grafana.customizableMegaMenu`).
+ *
+ * The assigned variant is cached in module scope so the KPI interactions (nav clicks, pin/unpin)
+ * can be stamped with it without threading the value through `enrichWithInteractionTracking` (which
+ * is recursive and called in several places). The exposure (denominator) event is fired once per
+ * page load via {@link reportNavExperimentViewOnce}.
+ */
+export const NAV_EXPERIMENT_ID = 'navCustomization';
+export const NAV_EXPERIMENT_GROUP = 'rollout';
+
+export type NavExperimentVariant = 'treatment' | 'control';
+
+let currentVariant: NavExperimentVariant | undefined;
+let hasExposed = false;
+
+export function setNavExperimentVariant(variant: NavExperimentVariant) {
+  currentVariant = variant;
+}
+
+/**
+ * Extra properties stamped onto the existing KPI interactions so they can be attributed to the
+ * experiment variant (and filtered to the eligible cohort by `org_id` at analysis time).
+ */
+export function getNavExperimentPayload(): Record<string, unknown> {
+  if (!currentVariant) {
+    return {};
+  }
+  return {
+    experiment_nav_customization: currentVariant,
+    org_id: contextSrv.user.orgId,
+  };
+}
+
+/**
+ * Fire the exposure event once per page load. Guarded by a module-scope boolean so opening the menu
+ * repeatedly doesn't re-emit it (which would inflate the denominator).
+ */
+export function reportNavExperimentViewOnce(variant: NavExperimentVariant) {
+  if (hasExposed) {
+    return;
+  }
+  hasExposed = true;
+  reportExperimentView(NAV_EXPERIMENT_ID, NAV_EXPERIMENT_GROUP, variant);
+}
+
+/** Test-only: reset the module-scope exposure guard and cached variant between tests. */
+export function resetNavExperimentStateForTests() {
+  currentVariant = undefined;
+  hasExposed = false;
+}

--- a/public/app/core/components/AppChrome/MegaMenu/navExperiment.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/navExperiment.ts
@@ -47,9 +47,3 @@ export function reportNavExperimentViewOnce(variant: NavExperimentVariant) {
   hasExposed = true;
   reportExperimentView(NAV_EXPERIMENT_ID, NAV_EXPERIMENT_GROUP, variant);
 }
-
-/** Test-only: reset the module-scope exposure guard and cached variant between tests. */
-export function resetNavExperimentStateForTests() {
-  currentVariant = undefined;
-  hasExposed = false;
-}

--- a/public/app/core/components/AppChrome/MegaMenu/navExperiment.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/navExperiment.ts
@@ -8,8 +8,8 @@ import { reportExperimentView } from '@grafana/runtime';
  * is recursive and called in several places). The exposure (denominator) event is fired once per
  * page load via {@link reportNavExperimentViewOnce}.
  */
-export const NAV_EXPERIMENT_ID = 'navCustomization';
-export const NAV_EXPERIMENT_GROUP = 'rollout';
+const NAV_EXPERIMENT_ID = 'navCustomization';
+const NAV_EXPERIMENT_GROUP = 'rollout';
 
 export type NavExperimentVariant = 'treatment' | 'control';
 

--- a/public/app/core/components/AppChrome/MegaMenu/navExperiment.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/navExperiment.ts
@@ -1,7 +1,5 @@
 import { reportExperimentView } from '@grafana/runtime';
 
-import { contextSrv } from '../../../services/context_srv';
-
 /**
  * Instrumentation for the Configurable Nav A/B experiment (behind `grafana.customizableMegaMenu`).
  *
@@ -24,7 +22,9 @@ export function setNavExperimentVariant(variant: NavExperimentVariant) {
 
 /**
  * Extra properties stamped onto the existing KPI interactions so they can be attributed to the
- * experiment variant (and filtered to the eligible cohort by `org_id` at analysis time).
+ * experiment variant. The org/tenant identifiers needed to filter to the eligible cohort at
+ * analysis time are already attached to every event by the analytics backends, so they aren't
+ * duplicated here.
  */
 export function getNavExperimentPayload(): Record<string, unknown> {
   if (!currentVariant) {
@@ -32,7 +32,6 @@ export function getNavExperimentPayload(): Record<string, unknown> {
   }
   return {
     experiment_nav_customization: currentVariant,
-    org_id: contextSrv.user.orgId,
   };
 }
 

--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -13,6 +13,7 @@ import { getFooterLinks } from '../../Footer/Footer';
 import { HelpModal } from '../../help/HelpModal';
 
 import { DOCK_MENU_BUTTON_ID, MEGA_MENU_HEADER_TOGGLE_ID } from './MegaMenuHeader';
+import { getNavExperimentPayload } from './navExperiment';
 
 const emitOpenShortcutsModal = () => {
   appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
@@ -64,6 +65,7 @@ export const enrichWithInteractionTracking = (
       menuIsDocked: megaMenuDockedState,
       itemIsBookmarked: newItem?.parentItem?.id === 'bookmarks',
       isNew,
+      ...getNavExperimentPayload(),
     });
     onClick?.();
   };


### PR DESCRIPTION
**What is this feature?**

- Records an exposure event the first time the navigation menu loads for a signed-in user, so we can measure how many people were placed into the experiment.
- Tags the variant ("treatment" when the new customizable navigation is on, "control" when it is off) along with the organization id onto the existing navigation-click and pin/unpin events.
- The exposure event fires only once per page load, even if the menu is opened repeatedly, to keep the participant count accurate.
- All behavior is gated on the existing customizable mega menu feature flag; users without it on are recorded as "control".


Note: This is base on top of feature PR https://github.com/grafana/grafana/pull/127166



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
