### PR TITLE
Deps: Unpin production dependencies in `@grafana/sql`

### DIFF
--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -48,7 +48,7 @@
     "@grafana/i18n": "13.2.0-pre",
     "@grafana/plugin-ui": "^0.13.1",
     "@grafana/ui": "13.2.0-pre",
-    "@react-awesome-query-builder/ui": "6.6.15",
+    "@react-awesome-query-builder/ui": "^6.6.15",
     "lodash": "4.18.1",
     "react-use": "17.6.1",
     "react-virtualized-auto-sizer": "1.0.26",

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -46,7 +46,7 @@
     "@grafana/data": "13.2.0-pre",
     "@grafana/e2e-selectors": "13.2.0-pre",
     "@grafana/i18n": "13.2.0-pre",
-    "@grafana/plugin-ui": "0.13.1",
+    "@grafana/plugin-ui": "^0.13.1",
     "@grafana/ui": "13.2.0-pre",
     "@react-awesome-query-builder/ui": "6.6.15",
     "lodash": "4.18.1",

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -49,7 +49,7 @@
     "@grafana/plugin-ui": "^0.13.1",
     "@grafana/ui": "13.2.0-pre",
     "@react-awesome-query-builder/ui": "^6.6.15",
-    "lodash": "4.18.1",
+    "lodash": "^4.18.1",
     "react-use": "17.6.1",
     "react-virtualized-auto-sizer": "1.0.26",
     "rxjs": "7.8.2",

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -41,7 +41,7 @@
     "postpack": "mv package.json.bak package.json"
   },
   "dependencies": {
-    "@emotion/css": "11.13.5",
+    "@emotion/css": "^11.13.5",
     "@grafana/assistant": "^0.1.24",
     "@grafana/data": "13.2.0-pre",
     "@grafana/e2e-selectors": "13.2.0-pre",

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.18.1",
     "react-use": "^17.6.1",
     "react-virtualized-auto-sizer": "^1.0.26",
-    "rxjs": "7.8.2",
+    "rxjs": "^7.8.2",
     "sql-formatter-plus": "1.3.6"
   },
   "devDependencies": {

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -51,7 +51,7 @@
     "@react-awesome-query-builder/ui": "^6.6.15",
     "lodash": "^4.18.1",
     "react-use": "^17.6.1",
-    "react-virtualized-auto-sizer": "1.0.26",
+    "react-virtualized-auto-sizer": "^1.0.26",
     "rxjs": "7.8.2",
     "sql-formatter-plus": "1.3.6"
   },

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -53,7 +53,7 @@
     "react-use": "^17.6.1",
     "react-virtualized-auto-sizer": "^1.0.26",
     "rxjs": "^7.8.2",
-    "sql-formatter-plus": "1.3.6"
+    "sql-formatter-plus": "^1.3.6"
   },
   "devDependencies": {
     "@rollup/plugin-dynamic-import-vars": "2.1.5",

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -50,7 +50,7 @@
     "@grafana/ui": "13.2.0-pre",
     "@react-awesome-query-builder/ui": "^6.6.15",
     "lodash": "^4.18.1",
-    "react-use": "17.6.1",
+    "react-use": "^17.6.1",
     "react-virtualized-auto-sizer": "1.0.26",
     "rxjs": "7.8.2",
     "sql-formatter-plus": "1.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,7 +2857,7 @@ __metadata:
     "@types/systemjs": "npm:6.15.3"
     i18next-cli: "npm:^1.48.0"
     jest: "npm:^29.6.4"
-    lodash: "npm:4.18.1"
+    lodash: "npm:^4.18.1"
     react-use: "npm:17.6.1"
     react-virtualized-auto-sizer: "npm:1.0.26"
     rollup: "npm:^4.60.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2590,7 +2590,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/plugin-ui@npm:0.13.1, @grafana/plugin-ui@npm:^0.13.0, @grafana/plugin-ui@npm:^0.13.1":
+"@grafana/plugin-ui@npm:^0.13.0, @grafana/plugin-ui@npm:^0.13.1":
   version: 0.13.1
   resolution: "@grafana/plugin-ui@npm:0.13.1"
   dependencies:
@@ -2839,7 +2839,7 @@ __metadata:
     "@grafana/data": "npm:13.2.0-pre"
     "@grafana/e2e-selectors": "npm:13.2.0-pre"
     "@grafana/i18n": "npm:13.2.0-pre"
-    "@grafana/plugin-ui": "npm:0.13.1"
+    "@grafana/plugin-ui": "npm:^0.13.1"
     "@grafana/ui": "npm:13.2.0-pre"
     "@react-awesome-query-builder/ui": "npm:6.6.15"
     "@rollup/plugin-dynamic-import-vars": "npm:2.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2841,7 +2841,7 @@ __metadata:
     "@grafana/i18n": "npm:13.2.0-pre"
     "@grafana/plugin-ui": "npm:^0.13.1"
     "@grafana/ui": "npm:13.2.0-pre"
-    "@react-awesome-query-builder/ui": "npm:6.6.15"
+    "@react-awesome-query-builder/ui": "npm:^6.6.15"
     "@rollup/plugin-dynamic-import-vars": "npm:2.1.5"
     "@rollup/plugin-image": "npm:3.0.3"
     "@rollup/plugin-json": "npm:6.1.0"
@@ -6904,7 +6904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-awesome-query-builder/ui@npm:6.6.15, @react-awesome-query-builder/ui@npm:^6.6.4":
+"@react-awesome-query-builder/ui@npm:6.6.15, @react-awesome-query-builder/ui@npm:^6.6.15, @react-awesome-query-builder/ui@npm:^6.6.4":
   version: 6.6.15
   resolution: "@react-awesome-query-builder/ui@npm:6.6.15"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2859,7 +2859,7 @@ __metadata:
     jest: "npm:^29.6.4"
     lodash: "npm:^4.18.1"
     react-use: "npm:^17.6.1"
-    react-virtualized-auto-sizer: "npm:1.0.26"
+    react-virtualized-auto-sizer: "npm:^1.0.26"
     rollup: "npm:^4.60.1"
     rxjs: "npm:7.8.2"
     sql-formatter-plus: "npm:1.3.6"
@@ -28035,7 +28035,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-virtualized-auto-sizer@npm:1.0.26, react-virtualized-auto-sizer@npm:^1.0.24, react-virtualized-auto-sizer@npm:^1.0.6":
+"react-virtualized-auto-sizer@npm:1.0.26, react-virtualized-auto-sizer@npm:^1.0.24, react-virtualized-auto-sizer@npm:^1.0.26, react-virtualized-auto-sizer@npm:^1.0.6":
   version: 1.0.26
   resolution: "react-virtualized-auto-sizer@npm:1.0.26"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,7 +2834,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/sql@workspace:packages/grafana-sql"
   dependencies:
-    "@emotion/css": "npm:11.13.5"
+    "@emotion/css": "npm:^11.13.5"
     "@grafana/assistant": "npm:^0.1.24"
     "@grafana/data": "npm:13.2.0-pre"
     "@grafana/e2e-selectors": "npm:13.2.0-pre"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,7 +2862,7 @@ __metadata:
     react-virtualized-auto-sizer: "npm:^1.0.26"
     rollup: "npm:^4.60.1"
     rxjs: "npm:^7.8.2"
-    sql-formatter-plus: "npm:1.3.6"
+    sql-formatter-plus: "npm:^1.3.6"
     typescript: "npm:6.0.2"
   peerDependencies:
     "@grafana/data": ">=10.4.0"
@@ -30055,7 +30055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sql-formatter-plus@npm:1.3.6, sql-formatter-plus@npm:^1.3.6":
+"sql-formatter-plus@npm:^1.3.6":
   version: 1.3.6
   resolution: "sql-formatter-plus@npm:1.3.6"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2858,7 +2858,7 @@ __metadata:
     i18next-cli: "npm:^1.48.0"
     jest: "npm:^29.6.4"
     lodash: "npm:^4.18.1"
-    react-use: "npm:17.6.1"
+    react-use: "npm:^17.6.1"
     react-virtualized-auto-sizer: "npm:1.0.26"
     rollup: "npm:^4.60.1"
     rxjs: "npm:7.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2861,7 +2861,7 @@ __metadata:
     react-use: "npm:^17.6.1"
     react-virtualized-auto-sizer: "npm:^1.0.26"
     rollup: "npm:^4.60.1"
-    rxjs: "npm:7.8.2"
+    rxjs: "npm:^7.8.2"
     sql-formatter-plus: "npm:1.3.6"
     typescript: "npm:6.0.2"
   peerDependencies:


### PR DESCRIPTION
**What is this feature?**

Unpins all production dependencies in the `@grafana/sql` package, using the `^` semver operator to allow consumers to bump minor + patch versions as needed (e.g., to resolve dependency vulnerabilities). Open to feedback on where specific dependencies should use `~` or remain pinned, if folks have specific context/knowledge around dependencies not respecting semver correctly.

Each commit was generated by manually updating the version specifier in `package.json`, then running `yarn && yarn dedupe && yarn typecheck`, before manually verifying the lockfile diff to ensure no actual version changes occurred (some doctoring was required to revert this when it happened).

**Why do we need this feature?**

Updated [internal policy](https://docs.google.com/document/d/19rr_cEdeIQmC34BO69SWl3ELJxpSBOwdVSJ1T7SERcY/edit?usp=sharing) (🔐) that specifies that published packages should NOT pin their dependencies, to prevent downstream consumers from being stuck with vulnerable transitive dependencies.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

cc #127460

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
