### PR TITLE
Deps: Unpin production dependencies in `@grafana/o11y-ds-frontend`

### DIFF
--- a/packages/grafana-o11y-ds-frontend/package.json
+++ b/packages/grafana-o11y-ds-frontend/package.json
@@ -40,7 +40,7 @@
     "postpack": "mv package.json.bak package.json"
   },
   "dependencies": {
-    "@emotion/css": "11.13.5",
+    "@emotion/css": "^11.13.5",
     "@grafana/data": "13.2.0-pre",
     "@grafana/e2e-selectors": "13.2.0-pre",
     "@grafana/plugin-ui": "^0.13.1",

--- a/packages/grafana-o11y-ds-frontend/package.json
+++ b/packages/grafana-o11y-ds-frontend/package.json
@@ -47,7 +47,7 @@
     "@grafana/runtime": "13.2.0-pre",
     "@grafana/ui": "13.2.0-pre",
     "react-use": "^17.6.1",
-    "rxjs": "7.8.2"
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
     "@rollup/plugin-dynamic-import-vars": "2.1.5",

--- a/packages/grafana-o11y-ds-frontend/package.json
+++ b/packages/grafana-o11y-ds-frontend/package.json
@@ -46,7 +46,7 @@
     "@grafana/plugin-ui": "^0.13.1",
     "@grafana/runtime": "13.2.0-pre",
     "@grafana/ui": "13.2.0-pre",
-    "react-use": "17.6.1",
+    "react-use": "^17.6.1",
     "rxjs": "7.8.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2504,7 +2504,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/o11y-ds-frontend@workspace:packages/grafana-o11y-ds-frontend"
   dependencies:
-    "@emotion/css": "npm:11.13.5"
+    "@emotion/css": "npm:^11.13.5"
     "@grafana/data": "npm:13.2.0-pre"
     "@grafana/e2e-selectors": "npm:13.2.0-pre"
     "@grafana/plugin-ui": "npm:^0.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,7 +2525,7 @@ __metadata:
     react: "npm:18.3.1"
     react-use: "npm:^17.6.1"
     rollup: "npm:^4.60.1"
-    rxjs: "npm:7.8.2"
+    rxjs: "npm:^7.8.2"
     typescript: "npm:6.0.2"
   peerDependencies:
     react: ^18.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2523,7 +2523,7 @@ __metadata:
     "@types/systemjs": "npm:6.15.3"
     jest: "npm:^29.6.4"
     react: "npm:18.3.1"
-    react-use: "npm:17.6.1"
+    react-use: "npm:^17.6.1"
     rollup: "npm:^4.60.1"
     rxjs: "npm:7.8.2"
     typescript: "npm:6.0.2"


### PR DESCRIPTION
**What is this feature?**

Unpins all production dependencies in the `@grafana/o11y-ds-frontend` package, using the `^` semver operator to allow consumers to bump minor + patch versions as needed (e.g., to resolve dependency vulnerabilities). Open to feedback on where specific dependencies should use `~` or remain pinned, if folks have specific context/knowledge around dependencies not respecting semver correctly.

Each commit was generated by manually updating the version specifier in `package.json`, then running `yarn && yarn dedupe && yarn typecheck`, before manually verifying the lockfile diff to ensure no actual version changes occurred (some doctoring was required to revert this when it happened).

**Why do we need this feature?**

Updated [internal policy](https://docs.google.com/document/d/19rr_cEdeIQmC34BO69SWl3ELJxpSBOwdVSJ1T7SERcY/edit?usp=sharing) (🔐) that specifies that published packages should NOT pin their dependencies, to prevent downstream consumers from being stuck with vulnerable transitive dependencies.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

cc #127460

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
