### PR TITLE
Deps: Unpin production dependencies in `@grafana/flamegraph`

### DIFF
--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -59,7 +59,7 @@
     "lodash": "^4.17.23",
     "react": "^18.3.1",
     "react-use": "^17.6.1",
-    "react-virtualized-auto-sizer": "1.0.26",
+    "react-virtualized-auto-sizer": "^1.0.26",
     "tinycolor2": "1.6.0"
   },
   "devDependencies": {

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -51,7 +51,7 @@
     "not IE 11"
   ],
   "dependencies": {
-    "@emotion/css": "11.13.5",
+    "@emotion/css": "^11.13.5",
     "@grafana/data": "13.2.0-pre",
     "@grafana/ui": "13.2.0-pre",
     "@leeoniya/ufuzzy": "1.0.19",

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -58,7 +58,7 @@
     "d3-scale": "^4.0.2",
     "lodash": "^4.17.23",
     "react": "^18.3.1",
-    "react-use": "17.6.1",
+    "react-use": "^17.6.1",
     "react-virtualized-auto-sizer": "1.0.26",
     "tinycolor2": "1.6.0"
   },

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -54,7 +54,7 @@
     "@emotion/css": "^11.13.5",
     "@grafana/data": "13.2.0-pre",
     "@grafana/ui": "13.2.0-pre",
-    "@leeoniya/ufuzzy": "1.0.19",
+    "@leeoniya/ufuzzy": "^1.0.19",
     "d3-scale": "^4.0.2",
     "lodash": "^4.17.23",
     "react": "18.3.1",

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -60,7 +60,7 @@
     "react": "^18.3.1",
     "react-use": "^17.6.1",
     "react-virtualized-auto-sizer": "^1.0.26",
-    "tinycolor2": "1.6.0"
+    "tinycolor2": "^1.6.0"
   },
   "devDependencies": {
     "@grafana/test-utils": "workspace:*",

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -57,7 +57,7 @@
     "@leeoniya/ufuzzy": "^1.0.19",
     "d3-scale": "^4.0.2",
     "lodash": "^4.17.23",
-    "react": "18.3.1",
+    "react": "^18.3.1",
     "react-use": "17.6.1",
     "react-virtualized-auto-sizer": "1.0.26",
     "tinycolor2": "1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,7 +2403,7 @@ __metadata:
     jest: "npm:^29.6.4"
     jest-canvas-mock: "npm:2.5.2"
     lodash: "npm:^4.17.23"
-    react: "npm:18.3.1"
+    react: "npm:^18.3.1"
     react-use: "npm:17.6.1"
     react-virtualized-auto-sizer: "npm:1.0.26"
     rollup: "npm:^4.60.1"
@@ -28078,7 +28078,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:18.3.1":
+"react@npm:18.3.1, react@npm:^18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2379,7 +2379,7 @@ __metadata:
     "@grafana/data": "npm:13.2.0-pre"
     "@grafana/test-utils": "workspace:*"
     "@grafana/ui": "npm:13.2.0-pre"
-    "@leeoniya/ufuzzy": "npm:1.0.19"
+    "@leeoniya/ufuzzy": "npm:^1.0.19"
     "@rollup/plugin-node-resolve": "npm:16.0.1"
     "@storybook/addon-webpack5-compiler-swc": "npm:^4.0.2"
     "@storybook/preset-scss": "npm:1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2410,7 +2410,7 @@ __metadata:
     rollup-plugin-esbuild: "npm:6.2.1"
     rollup-plugin-node-externals: "npm:^8.0.0"
     storybook: "npm:10.3.6"
-    tinycolor2: "npm:1.6.0"
+    tinycolor2: "npm:^1.6.0"
     typescript: "npm:6.0.2"
   peerDependencies:
     "@grafana/assistant": ^0.1.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2404,7 +2404,7 @@ __metadata:
     jest-canvas-mock: "npm:2.5.2"
     lodash: "npm:^4.17.23"
     react: "npm:^18.3.1"
-    react-use: "npm:17.6.1"
+    react-use: "npm:^17.6.1"
     react-virtualized-auto-sizer: "npm:1.0.26"
     rollup: "npm:^4.60.1"
     rollup-plugin-esbuild: "npm:6.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,7 +2375,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/flamegraph@workspace:packages/grafana-flamegraph"
   dependencies:
-    "@emotion/css": "npm:11.13.5"
+    "@emotion/css": "npm:^11.13.5"
     "@grafana/data": "npm:13.2.0-pre"
     "@grafana/test-utils": "workspace:*"
     "@grafana/ui": "npm:13.2.0-pre"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,7 +2405,7 @@ __metadata:
     lodash: "npm:^4.17.23"
     react: "npm:^18.3.1"
     react-use: "npm:^17.6.1"
-    react-virtualized-auto-sizer: "npm:1.0.26"
+    react-virtualized-auto-sizer: "npm:^1.0.26"
     rollup: "npm:^4.60.1"
     rollup-plugin-esbuild: "npm:6.2.1"
     rollup-plugin-node-externals: "npm:^8.0.0"
@@ -28035,7 +28035,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-virtualized-auto-sizer@npm:1.0.26, react-virtualized-auto-sizer@npm:^1.0.24, react-virtualized-auto-sizer@npm:^1.0.6":
+"react-virtualized-auto-sizer@npm:1.0.26, react-virtualized-auto-sizer@npm:^1.0.24, react-virtualized-auto-sizer@npm:^1.0.26, react-virtualized-auto-sizer@npm:^1.0.6":
   version: 1.0.26
   resolution: "react-virtualized-auto-sizer@npm:1.0.26"
   peerDependencies:


### PR DESCRIPTION
**What is this feature?**

Unpins all production dependencies in the `@grafana/flamegraph` package, using the `^` semver operator to allow consumers to bump minor + patch versions as needed (e.g., to resolve dependency vulnerabilities). Open to feedback on where specific dependencies should use `~` or remain pinned, if folks have specific context/knowledge around dependencies not respecting semver correctly.

Each commit was generated by manually updating the version specifier in `package.json`, then running `yarn && yarn dedupe && yarn typecheck`, before manually verifying the lockfile diff to ensure no actual version changes occurred (some doctoring was required to revert this when it happened).

**Why do we need this feature?**

Updated [internal policy](https://docs.google.com/document/d/19rr_cEdeIQmC34BO69SWl3ELJxpSBOwdVSJ1T7SERcY/edit?usp=sharing) (🔐) that specifies that published packages should NOT pin their dependencies, to prevent downstream consumers from being stuck with vulnerable transitive dependencies.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

cc #127460

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
