### PR TITLE
Deps: Unpin production dependencies in `@grafana/e2e-selectors`

### DIFF
--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -57,6 +57,6 @@
   },
   "dependencies": {
     "semver": "^7.7.0",
-    "typescript": "6.0.2"
+    "typescript": "^6.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,7 +2281,7 @@ __metadata:
     rollup-plugin-esbuild: "npm:6.2.1"
     rollup-plugin-node-externals: "npm:^8.0.0"
     semver: "npm:^7.7.0"
-    typescript: "npm:6.0.2"
+    typescript: "npm:^6.0.2"
   languageName: unknown
   linkType: soft
 
@@ -31836,7 +31836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:6.0.2":
+"typescript@npm:6.0.2, typescript@npm:^6.0.2":
   version: 6.0.2
   resolution: "typescript@npm:6.0.2"
   bin:
@@ -31866,7 +31866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^6.0.2#optional!builtin<compat/typescript>":
   version: 6.0.2
   resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
   bin:


### PR DESCRIPTION
**What is this feature?**

Unpins all production dependencies in the `@grafana/e2e-selectors` package, using the `^` semver operator to allow consumers to bump minor + patch versions as needed (e.g., to resolve dependency vulnerabilities). Open to feedback on where specific dependencies should use `~` or remain pinned, if folks have specific context/knowledge around dependencies not respecting semver correctly.

Each commit was generated by manually updating the version specifier in `package.json`, then running `yarn && yarn dedupe && yarn typecheck`, before manually verifying the lockfile diff to ensure no actual version changes occurred (some doctoring was required to revert this when it happened).

**Why do we need this feature?**

Updated [internal policy](https://docs.google.com/document/d/19rr_cEdeIQmC34BO69SWl3ELJxpSBOwdVSJ1T7SERcY/edit?usp=sharing) (🔐) that specifies that published packages should NOT pin their dependencies, to prevent downstream consumers from being stuck with vulnerable transitive dependencies.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

cc #127460

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
