### PR TITLE
fix(annotations): avoid mutating annotation item query within repository

### DIFF
--- a/pkg/services/annotations/accesscontrol/accesscontrol.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol.go
@@ -26,6 +26,12 @@ var (
 	)
 )
 
+type Authorizer interface {
+	Authorize(ctx context.Context, query annotations.ItemQuery) (*AccessResources, error)
+}
+
+var _ Authorizer = (*AuthService)(nil)
+
 type AuthService struct {
 	db                        db.DB
 	features                  featuremgmt.FeatureToggles

--- a/pkg/services/annotations/annotationsapi/migration_repository_test.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/annotations/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationsimpl"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
@@ -80,6 +82,29 @@ func (f *fakeProxy) Update(context.Context, int64, int64, *annotations.Item) err
 func (f *fakeProxy) Delete(context.Context, int64, int64) error {
 	f.deleteCalls++
 	return f.deleteErr
+}
+
+type fakeReader struct {
+	items []*annotations.ItemDTO
+}
+
+var _ annotationsimpl.ReadStore = (*fakeReader)(nil)
+
+func (f *fakeReader) Type() string { return "fake" }
+func (f *fakeReader) Get(context.Context, annotations.ItemQuery, *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error) {
+	return f.items, nil
+}
+func (f *fakeReader) GetTags(context.Context, annotations.TagsQuery) (annotations.FindTagsResult, error) {
+	return annotations.FindTagsResult{}, nil
+}
+
+type fakeAuthorizer struct{}
+
+var _ accesscontrol.Authorizer = (*fakeAuthorizer)(nil)
+
+func (fakeAuthorizer) Authorize(context.Context, annotations.ItemQuery) (*accesscontrol.AccessResources, error) {
+	// Empty dashboards stops RepositoryImpl.Find after one pass.
+	return &accesscontrol.AccessResources{Dashboards: map[string]int64{}}, nil
 }
 
 func newTestRepo(t *testing.T, phase string, legacy *fakeLegacy, proxy *fakeProxy, userSvc user.Service) *migrationRepository {
@@ -197,6 +222,33 @@ func TestMigrationRepository_Find(t *testing.T) {
 		assert.Equal(t, []*annotations.ItemDTO{item(2, 20), item(1, 10)}, got)
 		assert.Len(t, proxy.listCalls, 1)
 		assert.Len(t, legacy.findCalls, 1)
+	})
+
+	t.Run("proxy-writes merges new and legacy, respecting the caller's limit", func(t *testing.T) {
+		legacyItems := []*annotations.ItemDTO{item(2, 20), item(3, 30)}
+		legacy := annotationsimpl.NewRepositoryImpl(
+			&fakeAuthorizer{},
+			nil,
+			&fakeReader{items: legacyItems},
+			nil,
+		)
+
+		proxy := &fakeProxy{listResult: []*annotations.ItemDTO{item(1, 10)}}
+		repo := &migrationRepository{
+			legacy:  legacy,
+			proxy:   proxy,
+			cfg:     &setting.Cfg{AnnotationAppPlatform: setting.AnnotationAppPlatformSettings{APIMigrationPhase: "proxy-writes"}},
+			userSvc: usertest.NewUserServiceFake(),
+			logger:  log.New("test"),
+		}
+
+		query := &annotations.ItemQuery{Limit: 3}
+		got, err := repo.Find(context.Background(), query)
+		require.NoError(t, err)
+
+		// New + legacy yields 3 candidates; the caller's limit of 3 must win the truncation.
+		require.Len(t, got, 3, "merge must respect the caller's limit, not a value mutated by legacy")
+		assert.Equal(t, int64(3), query.Limit, "the caller's query limit must be untouched")
 	})
 
 	t.Run("proxy-writes falls back to legacy when the new store errors", func(t *testing.T) {

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -20,11 +20,19 @@ import (
 )
 
 type RepositoryImpl struct {
-	db       db.DB
-	authZ    *accesscontrol.AuthService
+	authZ    accesscontrol.Authorizer
 	features featuremgmt.FeatureToggles
-	reader   readStore
-	writer   writeStore
+	reader   ReadStore
+	writer   WriteStore
+}
+
+func NewRepositoryImpl(authZ accesscontrol.Authorizer, features featuremgmt.FeatureToggles, reader ReadStore, writer WriteStore) *RepositoryImpl {
+	return &RepositoryImpl{
+		authZ:    authZ,
+		features: features,
+		reader:   reader,
+		writer:   writer,
+	}
 }
 
 func ProvideService(
@@ -43,7 +51,7 @@ func ProvideService(
 	xormStore := NewXormStore(cfg, log.New("annotations.sql"), db, tagService, reg)
 	write := xormStore
 
-	var read readStore
+	var read ReadStore
 	historianStore := loki.NewLokiHistorianStore(cfg.UnifiedAlerting.StateHistory, db, ruleStore, log.New("annotations.loki"), tracer, reg)
 	if historianStore != nil {
 		l.Debug("Using composite read store")
@@ -53,13 +61,12 @@ func ProvideService(
 		read = write
 	}
 
-	return &RepositoryImpl{
-		db:       db,
-		features: features,
-		authZ:    accesscontrol.NewAuthService(db, features, dashSvc, cfg),
-		reader:   read,
-		writer:   write,
-	}
+	return NewRepositoryImpl(
+		accesscontrol.NewAuthService(db, features, dashSvc, cfg),
+		features,
+		read,
+		write,
+	)
 }
 
 func (r *RepositoryImpl) Save(ctx context.Context, item *annotations.Item) error {
@@ -77,15 +84,17 @@ func (r *RepositoryImpl) Update(ctx context.Context, item *annotations.Item) err
 }
 
 func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
-	if query.Limit == 0 {
-		query.Limit = 100
+	// Create a copy of the query to avoid modifying the original
+	q := *query
+	if q.Limit == 0 {
+		q.Limit = 100
 	}
 
 	// Search without dashboard UID filter is expensive, so check without access control first
 	// nolint: staticcheck
-	if query.DashboardID == 0 && query.DashboardUID == "" {
+	if q.DashboardID == 0 && q.DashboardUID == "" {
 		// Return early if no annotations found, it's not necessary to perform expensive access control filtering
-		res, err := r.reader.Get(ctx, *query, &accesscontrol.AccessResources{
+		res, err := r.reader.Get(ctx, q, &accesscontrol.AccessResources{
 			SkipAccessControlFilter: true,
 		})
 		if err != nil || len(res) == 0 {
@@ -94,30 +103,30 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 		// If number of resources is less than limit, it makes sense to set query limit to this
 		// value, otherwise query will be iterating over all user's dashboards since original
 		// query limit is never reached.
-		query.Limit = int64(len(res))
+		q.Limit = int64(len(res))
 	}
 
-	results := make([]*annotations.ItemDTO, 0, query.Limit)
+	results := make([]*annotations.ItemDTO, 0, q.Limit)
 	// Page paginates dashboards (used in Authorize → SearchDashboards), not annotation rows (store uses Limit/Offset).
-	query.Page = 1
+	q.Page = 1
 
 	// Iterate over available annotations until query limit is reached
 	// or all available dashboards are checked
-	for len(results) < int(query.Limit) {
-		resources, err := r.authZ.Authorize(ctx, *query)
+	for len(results) < int(q.Limit) {
+		resources, err := r.authZ.Authorize(ctx, q)
 		if err != nil {
 			return nil, err
 		}
 
-		res, err := r.reader.Get(ctx, *query, resources)
+		res, err := r.reader.Get(ctx, q, resources)
 		if err != nil {
 			return nil, err
 		}
 
 		results = append(results, res...)
-		query.Page++ // next iteration fetches the next page of dashboards
+		q.Page++ // next iteration fetches the next page of dashboards
 		// All user's dashboards are fetched
-		if len(resources.Dashboards) < int(query.Limit) {
+		if len(resources.Dashboards) < int(q.Limit) {
 			break
 		}
 	}

--- a/pkg/services/annotations/annotationsimpl/cleanup.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup.go
@@ -11,7 +11,7 @@ import (
 
 // CleanupServiceImpl is responsible for cleaning old annotations.
 type CleanupServiceImpl struct {
-	store store
+	store Store
 }
 
 func ProvideCleanupService(db db.DB, cfg *setting.Cfg) *CleanupServiceImpl {

--- a/pkg/services/annotations/annotationsimpl/composite_store.go
+++ b/pkg/services/annotations/annotationsimpl/composite_store.go
@@ -16,10 +16,10 @@ import (
 // CompositeStore is a read store that combines two or more read stores, and queries all stores in parallel.
 type CompositeStore struct {
 	logger  log.Logger
-	readers []readStore
+	readers []ReadStore
 }
 
-func NewCompositeStore(logger log.Logger, readers ...readStore) *CompositeStore {
+func NewCompositeStore(logger log.Logger, readers ...ReadStore) *CompositeStore {
 	return &CompositeStore{
 		logger:  logger,
 		readers: readers,

--- a/pkg/services/annotations/annotationsimpl/composite_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/composite_store_test.go
@@ -28,7 +28,7 @@ func TestCompositeStore(t *testing.T) {
 		r2 := newFakeReader(withGetFn(getPanic))
 		store := &CompositeStore{
 			log.NewNopLogger(),
-			[]readStore{r1, r2},
+			[]ReadStore{r1, r2},
 		}
 
 		_, err := store.Get(context.Background(), annotations.ItemQuery{}, nil)
@@ -44,7 +44,7 @@ func TestCompositeStore(t *testing.T) {
 
 		store := &CompositeStore{
 			log.NewNopLogger(),
-			[]readStore{r1, r2},
+			[]ReadStore{r1, r2},
 		}
 
 		tc := []struct {
@@ -84,7 +84,7 @@ func TestCompositeStore(t *testing.T) {
 
 		store := &CompositeStore{
 			log.NewNopLogger(),
-			[]readStore{r1, r2},
+			[]ReadStore{r1, r2},
 		}
 
 		expected := []*annotations.ItemDTO{
@@ -113,7 +113,7 @@ func TestCompositeStore(t *testing.T) {
 
 		store := &CompositeStore{
 			log.NewNopLogger(),
-			[]readStore{r1, r2},
+			[]ReadStore{r1, r2},
 		}
 
 		expected := []*annotations.TagsDTO{
@@ -142,7 +142,7 @@ func TestCompositeStore(t *testing.T) {
 
 		store := &CompositeStore{
 			log.NewNopLogger(),
-			[]readStore{r1, r2},
+			[]ReadStore{r1, r2},
 		}
 
 		query := annotations.ItemQuery{}

--- a/pkg/services/annotations/annotationsimpl/store.go
+++ b/pkg/services/annotations/annotationsimpl/store.go
@@ -9,23 +9,23 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-type store interface {
-	readStore
-	writeStore
+type Store interface {
+	ReadStore
+	WriteStore
 }
 
-type commonStore interface {
+type CommonStore interface {
 	Type() string
 }
 
-type readStore interface {
-	commonStore
+type ReadStore interface {
+	CommonStore
 	Get(ctx context.Context, query annotations.ItemQuery, accessResources *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error)
 	GetTags(ctx context.Context, query annotations.TagsQuery) (annotations.FindTagsResult, error)
 }
 
-type writeStore interface {
-	commonStore
+type WriteStore interface {
+	CommonStore
 	Add(ctx context.Context, items *annotations.Item) error
 	AddMany(ctx context.Context, items []annotations.Item) error
 	Update(ctx context.Context, item *annotations.Item) error


### PR DESCRIPTION
This PR fixes an issue where the `*annotations.ItemQuery` was being modified in-place by the `Find` function of the `RepositoryImpl`, impacting downstream stores that rely on it. This was causing issues in the annotation migration repository as it passes this item query to multiple downstream repository calls and merges results, so the legacy repository mutating the query impacted the final result set (e.g. returning fewer items than expected because `Limit` was modified by the legacy repository).

This required a few changes:
* Operating on a de-referenced copy of the `*annotations.ItemQuery` within `Find`
* Exporting the annotation `Store` interfaces to facilitate testing of the `RepositoryImpl`
* Creating an `Authorizer` interface to facilitate testing of the `RepositoryImpl`