### PR TITLE
Deps: Unpin production dependencies in `@grafana/alerting`

### DIFF
--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -91,7 +91,7 @@
     "react-dom": "^18.0.0"
   },
   "dependencies": {
-    "@emotion/css": "11.13.5",
+    "@emotion/css": "^11.13.5",
     "@faker-js/faker": "^9.8.0",
     "@grafana/api-clients": "13.2.0-pre",
     "@grafana/i18n": "13.2.0-pre",

--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -95,7 +95,7 @@
     "@faker-js/faker": "^9.8.0",
     "@grafana/api-clients": "13.2.0-pre",
     "@grafana/i18n": "13.2.0-pre",
-    "@reduxjs/toolkit": "2.10.1",
+    "@reduxjs/toolkit": "^2.10.1",
     "fishery": "^2.3.1",
     "lodash": "^4.17.21",
     "tinycolor2": "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,7 +2120,7 @@ __metadata:
     "@grafana/api-clients": "npm:13.2.0-pre"
     "@grafana/i18n": "npm:13.2.0-pre"
     "@grafana/test-utils": "workspace:*"
-    "@reduxjs/toolkit": "npm:2.10.1"
+    "@reduxjs/toolkit": "npm:^2.10.1"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"
     "@testing-library/user-event": "npm:^14.6.1"
@@ -7025,7 +7025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reduxjs/toolkit@npm:2.10.1":
+"@reduxjs/toolkit@npm:2.10.1, @reduxjs/toolkit@npm:^2.10.1":
   version: 2.10.1
   resolution: "@reduxjs/toolkit@npm:2.10.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,7 +2115,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/alerting@workspace:packages/grafana-alerting"
   dependencies:
-    "@emotion/css": "npm:11.13.5"
+    "@emotion/css": "npm:^11.13.5"
     "@faker-js/faker": "npm:^9.8.0"
     "@grafana/api-clients": "npm:13.2.0-pre"
     "@grafana/i18n": "npm:13.2.0-pre"


### PR DESCRIPTION
**What is this feature?**

Unpins all production dependencies in the `@grafana/alerting` package, using the `^` semver operator to allow consumers to bump minor + patch versions as needed (e.g., to resolve dependency vulnerabilities). Open to feedback on where specific dependencies should use `~` or remain pinned, if folks have specific context/knowledge around dependencies not respecting semver correctly.

Each commit was generated by manually updating the version specifier in `package.json`, then running `yarn && yarn dedupe && yarn typecheck`, before manually verifying the lockfile diff to ensure no actual version changes occurred (some doctoring was required to revert this when it happened).

**Why do we need this feature?**

Updated [internal policy](https://docs.google.com/document/d/19rr_cEdeIQmC34BO69SWl3ELJxpSBOwdVSJ1T7SERcY/edit?usp=sharing) (🔐) that specifies that published packages should NOT pin their dependencies, to prevent downstream consumers from being stuck with vulnerable transitive dependencies.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

cc #127460

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
