### PR TITLE
DataPro (migration): Migrate `RichHistoryQueriesTab.tsx`

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
@@ -4,7 +4,8 @@ import { useAsync } from 'react-use';
 
 import { type DataSourceApi, type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { Button, FilterInput, MultiSelect, RangeSlider, Select, useStyles2 } from '@grafana/ui';
 import { mapNumbertoTimeInSlider, mapQueriesToHeadings } from 'app/core/utils/richHistory';
 import { SortOrder, type RichHistorySearchFilters, type RichHistorySettings } from 'app/core/utils/richHistoryTypes';
@@ -150,8 +151,7 @@ export function RichHistoryQueriesTab(props: RichHistoryQueriesTabProps) {
     const datasourcesToGet = listOfDatasources.map((ds) => ds.uid);
     const dsGetProm = datasourcesToGet.map(async (dsf) => {
       try {
-        // this get works off datasource names
-        return getDataSourceSrv().get(dsf);
+        return await getDataSourceInstance(dsf);
       } catch (e) {
         return Promise.resolve();
       }


### PR DESCRIPTION
## Description
Migrate `RichHistoryQueriesTab` off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

## Changes
* Replaced `getDataSourceSrv().get()` with `getDataSourceInstance()` for resolving the datasource instances used to render rich history query cards.
* Added `await` so the surrounding `try/catch` correctly handles not-found datasources, which the downstream type-guard filter already expects.

## Risks
* Low. Only affects datasource resolution for the Query History "Queries" tab. Behaviour is unchanged; `getDataSourceInstance` falls back to the legacy service if its cache is empty.

## Demo
N/A - no user-facing changes.

## Testing Instructions
* In Explore, open Query History and switch to the **Queries** tab.
* Verify query cards render with the correct datasource name/icon, and that filtering by data source still works.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable