### PR TITLE
DataPro (migration): Migrate `RichHistoryStarredTab.tsx`

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
@@ -4,7 +4,8 @@ import { useAsync } from 'react-use';
 
 import { type DataSourceApi, type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { useStyles2, Select, MultiSelect, FilterInput, Button } from '@grafana/ui';
 import { createDatasourcesList } from 'app/core/utils/richHistory';
 import { SortOrder, type RichHistorySearchFilters, type RichHistorySettings } from 'app/core/utils/richHistoryTypes';
@@ -111,8 +112,7 @@ export function RichHistoryStarredTab(props: RichHistoryStarredTabProps) {
         : listOfDatasources.map((ds) => ds.uid);
     const dsGetProm = await datasourcesToGet.map(async (dsf) => {
       try {
-        // this get works off datasource names
-        return getDataSourceSrv().get(dsf);
+        return await getDataSourceInstance(dsf);
       } catch (e) {
         return Promise.resolve();
       }


### PR DESCRIPTION
## Description
Migrate `RichHistoryStarredTab` off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

## Changes
* Replaced `getDataSourceSrv().get()` with `getDataSourceInstance()` for resolving the datasource instances used to render starred query cards.
* Added `await` so the surrounding `try/catch` correctly handles not-found datasources, which the downstream type-guard filter already expects.

## Risks
* Low. Only affects datasource resolution for the Query History "Starred" tab. Behaviour is unchanged; `getDataSourceInstance` falls back to the legacy service if its cache is empty.

## Demo
N/A — no user-facing changes.

## Testing Instructions
* In Explore, open Query History and switch to the **Starred** tab.
* Star a query, then verify starred cards render with the correct datasource name/icon, and that filtering by data source still works.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable