### PR TITLE
DataPro (migration): Migrate `useExplorePageTitle.ts`

### DIFF
--- a/public/app/features/explore/hooks/useExplorePageTitle.test.tsx
+++ b/public/app/features/explore/hooks/useExplorePageTitle.test.tsx
@@ -2,13 +2,23 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { TestProvider } from 'test/helpers/TestProvider';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
-import { setDataSourceSrv } from '@grafana/runtime';
-import { type DataSourceRef } from '@grafana/schema';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { AppChromeService } from 'app/core/components/AppChrome/AppChromeService';
 
 import { makeDatasourceSetup } from '../spec/helper/setup';
 
 import { useExplorePageTitle } from './useExplorePageTitle';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
+}));
+
+const getDataSourceInstanceMock = jest.mocked(getDataSourceInstance);
+
+afterEach(() => {
+  getDataSourceInstanceMock.mockReset();
+});
 
 describe('useExplorePageTitle', () => {
   it('changes the document title of the explore page to include the datasource in use', async () => {
@@ -17,29 +27,17 @@ describe('useExplorePageTitle', () => {
       makeDatasourceSetup({ name: 'elastic', uid: 'elastic-uid' }),
     ];
 
-    setDataSourceSrv({
-      registerRuntimeDataSource: jest.fn(),
-      get(datasource?: string | DataSourceRef | null) {
-        let ds;
-        if (!datasource) {
-          ds = datasources[0]?.api;
-        } else {
-          ds = datasources.find((ds) =>
-            typeof datasource === 'string'
-              ? ds.api.name === datasource || ds.api.uid === datasource
-              : ds.api.uid === datasource?.uid
-          )?.api;
-        }
+    getDataSourceInstanceMock.mockImplementation(async (datasource) => {
+      const ds =
+        typeof datasource === 'string'
+          ? datasources.find((ds) => ds.api.name === datasource || ds.api.uid === datasource)?.api
+          : datasources.find((ds) => ds.api.uid === datasource?.uid)?.api;
 
-        if (ds) {
-          return Promise.resolve(ds);
-        }
+      if (ds) {
+        return ds;
+      }
 
-        return Promise.reject();
-      },
-      getInstanceSettings: jest.fn(),
-      getList: jest.fn(),
-      reload: jest.fn(),
+      throw new Error(`Datasource ${datasource} not found`);
     });
 
     const chromeMock: AppChromeService = jest.mocked(new AppChromeService());
@@ -72,29 +70,17 @@ describe('useExplorePageTitle', () => {
       makeDatasourceSetup({ name: 'elastic', uid: 'elastic-uid' }),
     ];
 
-    setDataSourceSrv({
-      registerRuntimeDataSource: jest.fn(),
-      get(datasource?: string | DataSourceRef | null) {
-        let ds;
-        if (!datasource) {
-          ds = datasources[0]?.api;
-        } else {
-          ds = datasources.find((ds) =>
-            typeof datasource === 'string'
-              ? ds.api.name === datasource || ds.api.uid === datasource
-              : ds.api.uid === datasource?.uid
-          )?.api;
-        }
+    getDataSourceInstanceMock.mockImplementation(async (datasource) => {
+      const ds =
+        typeof datasource === 'string'
+          ? datasources.find((ds) => ds.api.name === datasource || ds.api.uid === datasource)?.api
+          : datasources.find((ds) => ds.api.uid === datasource?.uid)?.api;
 
-        if (ds) {
-          return Promise.resolve(ds);
-        }
+      if (ds) {
+        return ds;
+      }
 
-        return Promise.reject();
-      },
-      getInstanceSettings: jest.fn(),
-      getList: jest.fn(),
-      reload: jest.fn(),
+      throw new Error(`Datasource ${datasource} not found`);
     });
 
     const chromeMock: AppChromeService = jest.mocked(new AppChromeService());

--- a/public/app/features/explore/hooks/useExplorePageTitle.ts
+++ b/public/app/features/explore/hooks/useExplorePageTitle.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { Branding } from 'app/core/components/Branding/Branding';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useNavModel } from 'app/core/hooks/useNavModel';
@@ -40,7 +40,7 @@ export function useExplorePageTitle(params: ExploreQueryParams) {
           return Promise.reject();
         }
 
-        return getDataSourceSrv().get(pane.datasource);
+        return getDataSourceInstance(pane.datasource);
       })
     )
       .then((results) => results.filter(isFulfilled).map((result) => result.value))


### PR DESCRIPTION
## Description
Migrate `useExplorePageTitle` off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

## Changes
* Replaced `getDataSourceSrv().get()` with `getDataSourceInstance()` when resolving the datasources used to build the Explore page/tab title. The call already sat inside `Promise.allSettled`, so no other restructuring was needed.
* Updated the unit test to feed data through the new async API (`jest.mock('@grafana/runtime/unstable')`) instead of `setDataSourceSrv`. This avoids the legacy-fallback console warning the new API emits on a cache miss.

## Risks
* Low. Only affects the document title and breadcrumb shown on the Explore page. Behaviour is unchanged; `getDataSourceInstance` falls back to the legacy service if its cache is empty.

## Demo
N/A - no user-facing changes.

## Testing Instructions
* Open Explore with a datasource selected and confirm the browser tab title and breadcrumb show the datasource name.
* In split view with two different datasources, confirm both names appear (`A | B`).

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable