### PR TITLE
DataPro (migration): Migrate `explore/state/correlations.ts`

### DIFF
--- a/public/app/features/explore/state/correlations.ts
+++ b/public/app/features/explore/state/correlations.ts
@@ -5,7 +5,8 @@ import {
   generatedAPI as correlationsAPIv0alpha1,
 } from '@grafana/api-clients/rtkq/correlations/v0alpha1';
 import { type DataLinkTransformationConfig } from '@grafana/data';
-import { type CorrelationData, getDataSourceSrv, reportInteraction, config } from '@grafana/runtime';
+import { type CorrelationData, reportInteraction, config } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { getMessageFromError } from 'app/core/utils/errors';
@@ -71,8 +72,8 @@ export function saveCurrentCorrelation(
       : targetPane.datasourceInstance?.getRef();
 
     const [sourceDatasource, targetDatasource] = await Promise.all([
-      getDataSourceSrv().get(sourceDatasourceRef),
-      getDataSourceSrv().get(targetDataSourceRef),
+      getDataSourceInstance(sourceDatasourceRef),
+      getDataSourceInstance(targetDataSourceRef),
     ]);
 
     if (sourceDatasource?.uid && targetDatasource?.uid && targetPane.correlationEditorHelperData?.resultField) {


### PR DESCRIPTION
## Description
Migrate the Explore correlations state off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

## Changes
* Replaced the two `getDataSourceSrv().get()` calls used to resolve the source and target datasources when saving a correlation with `getDataSourceInstance()`. They already ran inside `Promise.all`, so no restructuring was needed.

## Risks
* Low. Only affects datasource resolution in the Explore correlation editor's save flow. Behaviour is unchanged; `getDataSourceInstance` falls back to the legacy service if its cache is empty.

## Demo
N/A - no user-facing changes.

## Testing Instructions
* In Explore, open the correlation editor in split view, select a source and target query, and save a correlation.
* Verify the correlation is created successfully and the panes reload as before (test with `kubernetesCorrelations` both on and off).

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable