### PR TITLE
DataPro (migration): Migrate `explore/state/utils.ts`

### DIFF
--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -21,7 +21,7 @@ import {
   type URLRange,
   type URLRangeValue,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery, type DataSourceJsonData, type DataSourceRef, type TimeZone } from '@grafana/schema';
 import { getLocalRichHistoryStorage } from 'app/core/history/richHistoryStorageProvider';
 import { SortOrder } from 'app/core/utils/richHistoryTypes';
@@ -295,7 +295,7 @@ export async function getCorrelationsData(state: StoreState, exploreId: string) 
   const isCorrelationEditorMode = state.explore.correlationEditorDetails?.editorMode || false;
   const isLeftPane = Object.keys(state.explore.panes)[0] === exploreId;
   const showCorrelationEditorLinks = isCorrelationEditorMode && isLeftPane;
-  const defaultCorrelationEditorDatasource = showCorrelationEditorLinks ? await getDataSourceSrv().get() : undefined;
+  const defaultCorrelationEditorDatasource = showCorrelationEditorLinks ? await getDataSourceInstance() : undefined;
   const interpolateCorrelationHelperVars =
     isCorrelationEditorMode && !isLeftPane && correlationEditorHelperData !== undefined;
 


### PR DESCRIPTION
## Description
Migrate `getCorrelationsData` in the Explore state utils off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

## Changes
* Replaced the `getDataSourceSrv().get()` call that resolves the default datasource for correlation editor links with `getDataSourceInstance()`. The call was already `await`ed, so no restructuring was needed.

> Note: this file also uses `getDatasourceSrv()` from `app/features/plugins/datasource_srv` (a different, local service) — that is intentionally left unchanged as it's not part of this migration.

## Risks
* Low. Only affects resolving the default datasource when building correlation data in the Explore correlations editor. Behaviour is unchanged; `getDataSourceInstance` falls back to the legacy service if its cache is empty.

## Demo
N/A - no user-facing changes.

## Testing Instructions
* In Explore, enable the correlations editor and confirm correlation links/transformations still build correctly on the left pane.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable