### PR TITLE
BrowseDashboards: Show dashboard description tooltip when it's available

### DIFF
--- a/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
@@ -5,7 +5,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { config } from '@grafana/runtime';
 import { getFolderFixtures } from '@grafana/test-utils/unstable';
 
-import { sharedWithMeFolder } from '../fixtures/dashboardsTreeItem.fixture';
+import { sharedWithMeFolder, wellFormedDashboard } from '../fixtures/dashboardsTreeItem.fixture';
 import { SelectionState } from '../types';
 
 import { DashboardsTree } from './DashboardsTree';
@@ -195,6 +195,50 @@ describe('browse-dashboards DashboardsTree', () => {
     await user.click(folderButton);
 
     expect(handler).toHaveBeenCalledWith(folder.item.uid, true);
+  });
+
+  it('renders a description tooltip indicator when the item has a description', () => {
+    const dashboardWithDescription = wellFormedDashboard(10, undefined, { description: 'A helpful description' });
+
+    render(
+      <DashboardsTree
+        permissions={mockPermissions}
+        items={[dashboardWithDescription]}
+        isSelected={isSelected}
+        width={WIDTH}
+        height={HEIGHT}
+        onFolderClick={noop}
+        onTagClick={noop}
+        onItemSelectionChange={noop}
+        onAllSelectionChange={noop}
+        isItemLoaded={allItemsAreLoaded}
+        requestLoadMore={requestLoadMore}
+      />
+    );
+
+    expect(screen.getByLabelText('Description')).toBeInTheDocument();
+  });
+
+  it('does not render a description tooltip indicator when the item has no description', () => {
+    const dashboardWithoutDescription = wellFormedDashboard(11);
+
+    render(
+      <DashboardsTree
+        permissions={mockPermissions}
+        items={[dashboardWithoutDescription]}
+        isSelected={isSelected}
+        width={WIDTH}
+        height={HEIGHT}
+        onFolderClick={noop}
+        onTagClick={noop}
+        onItemSelectionChange={noop}
+        onAllSelectionChange={noop}
+        isItemLoaded={allItemsAreLoaded}
+        requestLoadMore={requestLoadMore}
+      />
+    );
+
+    expect(screen.queryByLabelText('Description')).not.toBeInTheDocument();
   });
 
   it('renders empty folder indicators', () => {

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -113,7 +113,7 @@ export function NameCell({ row: { original: data }, onFolderClick, treeID }: Nam
         <FolderRepo folder={item} />
 
         {item.description && (
-          <Tooltip content={item.description} placement="top" interactive={false}>
+          <Tooltip content={item.description} placement="top" interactive>
             <span className={styles.description}>
               <Icon
                 name="info-circle"

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -4,8 +4,9 @@ import Skeleton from 'react-loading-skeleton';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Avatar, Icon, IconButton, Link, Spinner, Text, Tooltip, useStyles2 } from '@grafana/ui';
+import { Avatar, Icon, IconButton, Link, Spinner, Text, useStyles2 } from '@grafana/ui';
 import { getSvgSize } from '@grafana/ui/internal';
+import { DescriptionTooltip } from 'app/features/search/components/DescriptionTooltip';
 import { getIconForItem } from 'app/features/search/service/utils';
 
 import { Indent } from '../../../core/components/Indent/Indent';
@@ -112,17 +113,7 @@ export function NameCell({ row: { original: data }, onFolderClick, treeID }: Nam
 
         <FolderRepo folder={item} />
 
-        {item.description && (
-          <Tooltip content={item.description} placement="top" interactive>
-            <span className={styles.description}>
-              <Icon
-                name="info-circle"
-                size="sm"
-                aria-label={t('browse-dashboards.name-cell.description-tooltip', 'Description')}
-              />
-            </span>
-          </Tooltip>
-        )}
+        <DescriptionTooltip description={item.description} />
 
         {ownerReference && (
           <div className={styles.ownerReference}>
@@ -156,12 +147,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       gap: theme.spacing(1),
       overflow: 'hidden',
-    }),
-    description: css({
-      display: 'inline-flex',
-      alignItems: 'center',
-      color: theme.colors.text.secondary,
-      flex: '0 0 auto',
     }),
     link: css({
       '&:hover': {

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -4,7 +4,7 @@ import Skeleton from 'react-loading-skeleton';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Avatar, Icon, IconButton, Link, Spinner, Text, useStyles2 } from '@grafana/ui';
+import { Avatar, Icon, IconButton, Link, Spinner, Text, Tooltip, useStyles2 } from '@grafana/ui';
 import { getSvgSize } from '@grafana/ui/internal';
 import { getIconForItem } from 'app/features/search/service/utils';
 
@@ -112,6 +112,18 @@ export function NameCell({ row: { original: data }, onFolderClick, treeID }: Nam
 
         <FolderRepo folder={item} />
 
+        {item.description && (
+          <Tooltip content={item.description} placement="top" interactive={false}>
+            <span className={styles.description}>
+              <Icon
+                name="info-circle"
+                size="sm"
+                aria-label={t('browse-dashboards.name-cell.description-tooltip', 'Description')}
+              />
+            </span>
+          </Tooltip>
+        )}
+
         {ownerReference && (
           <div className={styles.ownerReference}>
             {ownerReference.avatarUrl && <Avatar src={ownerReference.avatarUrl} alt={ownerReference.title} />}
@@ -144,6 +156,12 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       gap: theme.spacing(1),
       overflow: 'hidden',
+    }),
+    description: css({
+      display: 'inline-flex',
+      alignItems: 'center',
+      color: theme.colors.text.secondary,
+      flex: '0 0 auto',
     }),
     link: css({
       '&:hover': {

--- a/public/app/features/search/components/DescriptionTooltip.tsx
+++ b/public/app/features/search/components/DescriptionTooltip.tsx
@@ -1,0 +1,34 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
+
+interface DescriptionTooltipProps {
+  description?: string;
+}
+
+export function DescriptionTooltip({ description }: DescriptionTooltipProps) {
+  const styles = useStyles2(getStyles);
+
+  if (!description) {
+    return null;
+  }
+
+  return (
+    <Tooltip content={description} placement="top" interactive>
+      <span className={styles.icon}>
+        <Icon name="info-circle" size="sm" aria-label={t('search.description-tooltip.label', 'Description')} />
+      </span>
+    </Tooltip>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  icon: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.colors.text.secondary,
+    flex: '0 0 auto',
+  }),
+});

--- a/public/app/features/search/page/components/SearchResultsTable.test.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.test.tsx
@@ -130,6 +130,71 @@ describe('SearchResultsTable', () => {
       expect(screen.getByText('foo')).toBeInTheDocument();
       expect(screen.getByText('bar')).toBeInTheDocument();
     });
+
+    it('does not render a description tooltip indicator when there is no description', async () => {
+      render(
+        <SearchResultsTable
+          keyboardEvents={mockKeyboardEvents}
+          response={mockSearchResult}
+          onTagSelected={mockOnTagSelected}
+          selection={mockSelection}
+          selectionToggle={mockSelectionToggle}
+          clearSelection={mockClearSelection}
+          height={1000}
+          width={1000}
+        />
+      );
+      await screen.findByRole('table');
+
+      expect(screen.queryByLabelText('Description')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when an item has a description', () => {
+    const searchData = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'kind', type: FieldType.string, config: {}, values: [DashboardSearchItemType.DashDB] },
+        { name: 'uid', type: FieldType.string, config: {}, values: ['my-dashboard-1'] },
+        { name: 'name', type: FieldType.string, config: {}, values: ['My dashboard 1'] },
+        { name: 'description', type: FieldType.string, config: {}, values: ['A helpful description'] },
+        { name: 'panel_type', type: FieldType.string, config: {}, values: [''] },
+        { name: 'url', type: FieldType.string, config: {}, values: ['/my-dashboard-1'] },
+        { name: 'tags', type: FieldType.other, config: {}, values: [['foo', 'bar']] },
+        { name: 'ds_uid', type: FieldType.other, config: {}, values: [''] },
+        { name: 'location', type: FieldType.string, config: {}, values: ['/my-dashboard-1'] },
+      ],
+    });
+    const dataFrames = applyFieldOverrides({
+      data: [searchData],
+      fieldConfig: { defaults: {}, overrides: [] },
+      replaceVariables: (value) => value,
+      theme: createTheme(),
+    });
+    const mockSearchResult: QueryResponse = {
+      isItemLoaded: jest.fn().mockReturnValue(true),
+      loadMoreItems: jest.fn(),
+      totalRows: searchData.length,
+      view: new DataFrameView<DashboardQueryResult>(dataFrames[0]),
+    };
+
+    it('renders a description tooltip indicator', async () => {
+      render(
+        <SearchResultsTable
+          keyboardEvents={mockKeyboardEvents}
+          response={mockSearchResult}
+          onTagSelected={mockOnTagSelected}
+          selection={mockSelection}
+          selectionToggle={mockSelectionToggle}
+          clearSelection={mockClearSelection}
+          height={1000}
+          width={1000}
+        />
+      );
+      await screen.findByRole('table');
+
+      expect(screen.getByLabelText('Description')).toBeInTheDocument();
+    });
   });
 
   describe('when there is panel data', () => {

--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -338,6 +338,10 @@ const getColumnStyles = (theme: GrafanaTheme2) => {
       userSelect: 'text',
       whiteSpace: 'nowrap',
     }),
+    nameCell: css({
+      // Gap between name and description tooltip
+      gap: theme.spacing(0.5),
+    }),
     typeCell: css({
       gap: theme.spacing(0.5),
     }),

--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -338,12 +338,8 @@ const getColumnStyles = (theme: GrafanaTheme2) => {
       userSelect: 'text',
       whiteSpace: 'nowrap',
     }),
-    descriptionTooltip: css({
-      display: 'inline-flex',
-      alignItems: 'center',
-      color: theme.colors.text.secondary,
-      flex: '0 0 auto',
-      marginLeft: theme.spacing(1),
+    nameCell: css({
+      gap: theme.spacing(1),
     }),
     typeCell: css({
       gap: theme.spacing(0.5),

--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -338,6 +338,13 @@ const getColumnStyles = (theme: GrafanaTheme2) => {
       userSelect: 'text',
       whiteSpace: 'nowrap',
     }),
+    descriptionTooltip: css({
+      display: 'inline-flex',
+      alignItems: 'center',
+      color: theme.colors.text.secondary,
+      flex: '0 0 auto',
+      marginLeft: theme.spacing(1),
+    }),
     typeCell: css({
       gap: theme.spacing(0.5),
     }),

--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -338,9 +338,6 @@ const getColumnStyles = (theme: GrafanaTheme2) => {
       userSelect: 'text',
       whiteSpace: 'nowrap',
     }),
-    nameCell: css({
-      gap: theme.spacing(1),
-    }),
     typeCell: css({
       gap: theme.spacing(0.5),
     }),

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -119,6 +119,7 @@ export const generateColumns = (
       let classNames = cx(styles.nameCellStyle);
       let name = access.name.values[p.row.index];
       const isDeleted = access.isDeleted?.values[p.row.index];
+      const description = access.description?.values[p.row.index];
 
       if (!name?.length) {
         const loading = p.row.index >= response.view.dataFrame.length;
@@ -126,10 +127,11 @@ export const generateColumns = (
         classNames += ' ' + styles.missingTitleText;
       }
       const { key, ...cellProps } = p.cellProps;
+      const isLoaded = response.isItemLoaded(p.row.index);
 
       return (
         <div key={key} className={styles.cell} {...cellProps}>
-          {!response.isItemLoaded(p.row.index) ? (
+          {!isLoaded ? (
             <Skeleton width={200} />
           ) : isDeleted || !p.userProps.href ? (
             <span className={classNames}>{name}</span>
@@ -138,6 +140,17 @@ export const generateColumns = (
               {name}
             </a>
           )}
+          {isLoaded && description ? (
+            <Tooltip content={description} placement="top" interactive>
+              <span className={styles.descriptionTooltip}>
+                <Icon
+                  name="info-circle"
+                  size="sm"
+                  aria-label={t('search.results-table.description-tooltip', 'Description')}
+                />
+              </span>
+            </Tooltip>
+          ) : null}
         </div>
       );
     },

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -131,7 +131,7 @@ export const generateColumns = (
       const isLoaded = response.isItemLoaded(p.row.index);
 
       return (
-        <div key={key} className={cx(styles.cell, styles.nameCell)} {...cellProps}>
+        <div key={key} className={cx(styles.cell, isLoaded && description && styles.nameCell)} {...cellProps}>
           {!isLoaded ? (
             <Skeleton width={200} />
           ) : isDeleted || !p.userProps.href ? (

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -19,6 +19,7 @@ import { formatDate, formatDuration } from 'app/core/internationalization/dates'
 import { PluginIconName } from 'app/features/plugins/admin/types';
 import { ShowModalReactEvent } from 'app/types/events';
 
+import { DescriptionTooltip } from '../../components/DescriptionTooltip';
 import { type QueryResponse, type SearchResultMeta } from '../../service/types';
 import { DELETED_BY_UNKNOWN, formatDeletedByDisplayValue, getIconForKind } from '../../service/utils';
 import { type SelectionChecker, type SelectionToggle } from '../selection';
@@ -130,7 +131,7 @@ export const generateColumns = (
       const isLoaded = response.isItemLoaded(p.row.index);
 
       return (
-        <div key={key} className={styles.cell} {...cellProps}>
+        <div key={key} className={cx(styles.cell, styles.nameCell)} {...cellProps}>
           {!isLoaded ? (
             <Skeleton width={200} />
           ) : isDeleted || !p.userProps.href ? (
@@ -140,17 +141,7 @@ export const generateColumns = (
               {name}
             </a>
           )}
-          {isLoaded && description ? (
-            <Tooltip content={description} placement="top" interactive>
-              <span className={styles.descriptionTooltip}>
-                <Icon
-                  name="info-circle"
-                  size="sm"
-                  aria-label={t('search.results-table.description-tooltip', 'Description')}
-                />
-              </span>
-            </Tooltip>
-          ) : null}
+          {isLoaded ? <DescriptionTooltip description={description} /> : null}
         </div>
       );
     },

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -50,6 +50,7 @@ export interface DashboardQueryResult {
   url: string; // link to value (unique)
   panel_type: string;
   tags: string[];
+  description?: string;
   location: string; // url that can be split
   ds_uid: string[];
   isDeleted?: boolean;

--- a/public/app/features/search/service/unified.test.ts
+++ b/public/app/features/search/service/unified.test.ts
@@ -195,6 +195,41 @@ describe('toDashboardResults', () => {
     expect(results.meta?.custom?.sortBy).toBe('errors_today');
   });
 
+  it('always includes a description field even when the first hit has no description', () => {
+    const mockHits: SearchHit[] = [
+      {
+        resource: 'dashboards',
+        name: 'no-description',
+        title: 'No description',
+        folder: 'General',
+        tags: [],
+        field: {},
+        url: '/d/no-description',
+      },
+      {
+        resource: 'dashboards',
+        name: 'has-description',
+        title: 'Has description',
+        description: 'A helpful description',
+        folder: 'General',
+        tags: [],
+        field: {},
+        url: '/d/has-description',
+      },
+    ];
+
+    const mockResponse: SearchAPIResponse = {
+      totalHits: 2,
+      hits: mockHits,
+      facets: {},
+    };
+    const results = toDashboardResults(mockResponse, '');
+
+    const descriptionField = results.fields.find((f) => f.name === 'description');
+    expect(descriptionField).toBeDefined();
+    expect(descriptionField!.values).toEqual(['', 'A helpful description']);
+  });
+
   describe('respects appSubUrl in search result URLs', () => {
     const originalAppSubUrl = config.appSubUrl;
 

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -41,6 +41,7 @@ export type SearchHit = {
   resource: string; // dashboards | folders
   name: string;
   title: string;
+  description?: string;
   folder: string;
   tags: string[];
 
@@ -431,6 +432,10 @@ export function toDashboardResults(rsp: SearchAPIResponse, sort: string): DataFr
       // Sort tags so we aren't reliant on the backend having done this for us
       // Sorting order can be different between APIs/search implementations
       tags: (hit.tags || []).sort(),
+      // The backend omits description when empty. arrayToDataFrame derives the frame's
+      // fields from the first row's keys, so without an explicit value here the column
+      // would be missing whenever the first hit has no description.
+      description: hit.description ?? '',
       folder,
       location,
       name: hit.title, // 🤯 FIXME hit.name is k8s name, eg grafana dashboards UID

--- a/public/app/features/search/service/utils.test.ts
+++ b/public/app/features/search/service/utils.test.ts
@@ -3,6 +3,7 @@ import { type DashboardDataDTO } from 'app/types/dashboard';
 
 import { AnnoKeyUpdatedBy, type Resource, type ResourceList } from '../../apiserver/types';
 
+import { type DashboardQueryResult } from './types';
 import { type SearchHit } from './unified';
 import {
   appendFrame,
@@ -10,6 +11,7 @@ import {
   DELETED_BY_UNKNOWN,
   filterSearchResults,
   formatDeletedByDisplayValue,
+  queryResultToViewItem,
   resourceToSearchResult,
 } from './utils';
 
@@ -191,6 +193,36 @@ describe('resourceToSearchResult', () => {
     const [hit] = resourceToSearchResult(list, displayMap);
 
     expect(hit.field.deletedBy).toBe(DELETED_BY_REMOVED);
+  });
+});
+
+describe('queryResultToViewItem', () => {
+  function makeQueryResult(partial?: Partial<DashboardQueryResult>): DashboardQueryResult {
+    return {
+      kind: 'dashboard',
+      name: 'A dashboard',
+      uid: 'abc',
+      url: '/d/abc',
+      panel_type: '',
+      tags: [],
+      location: '',
+      ds_uid: [],
+      score: 0,
+      explain: {},
+      ...partial,
+    };
+  }
+
+  it('carries the description through to the view item', () => {
+    const viewItem = queryResultToViewItem(makeQueryResult({ description: 'A helpful description' }));
+
+    expect(viewItem.description).toBe('A helpful description');
+  });
+
+  it('leaves description undefined when not present', () => {
+    const viewItem = queryResultToViewItem(makeQueryResult());
+
+    expect(viewItem.description).toBeUndefined();
   });
 });
 

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -140,6 +140,7 @@ export function queryResultToViewItem(
     kind: parseKindString(item.kind),
     uid: item.uid,
     title: item.name,
+    description: item.description,
     url: item.url,
     tags: item.tags ?? [],
     managedBy: managedByStr,

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -36,6 +36,7 @@ export interface DashboardViewItem {
   kind: DashboardViewItemKind;
   uid: string;
   title: string;
+  description?: string;
   url?: string;
   tags?: string[];
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4399,7 +4399,6 @@
     },
     "my-team-folders": "My team folders",
     "name-cell": {
-      "description-tooltip": "Description",
       "no-items": "No items"
     },
     "new-folder": {
@@ -14467,6 +14466,9 @@
       "new-folder": "New folder",
       "new-template-dashboard": "Use template"
     },
+    "description-tooltip": {
+      "label": "Description"
+    },
     "generate-columns": {
       "score": "Score"
     },
@@ -14478,7 +14480,6 @@
       "deleted-by-unknown-tooltip": "Failed to look up the account that deleted this dashboard",
       "deleted-less-than-1-min": "< 1 min",
       "deleted-remaining-header": "Time remaining",
-      "description-tooltip": "Description",
       "location-header": "Location",
       "name-header": "Name",
       "tags-header": "Tags",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4399,6 +4399,7 @@
     },
     "my-team-folders": "My team folders",
     "name-cell": {
+      "description-tooltip": "Description",
       "no-items": "No items"
     },
     "new-folder": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14478,6 +14478,7 @@
       "deleted-by-unknown-tooltip": "Failed to look up the account that deleted this dashboard",
       "deleted-less-than-1-min": "< 1 min",
       "deleted-remaining-header": "Time remaining",
+      "description-tooltip": "Description",
       "location-header": "Location",
       "name-header": "Name",
       "tags-header": "Tags",


### PR DESCRIPTION
**What is this feature?**

Add a hover tooltip next to dashboards that have a description, surfacing the description that search already returns so users can read it without opening the dashboard.

https://github.com/user-attachments/assets/44ac581a-8af0-42d3-a841-0f1edbd70fa0. 

Search view / Folder view:  
<img width="1419" height="401" alt="image" src="https://github.com/user-attachments/assets/cde92189-bf4f-48be-be34-2888036e9236" />



**Why do we need this feature?**

Descriptions were already available from search but never displayed in the browse view, so users had to open a dashboard just to see what it was for. This makes that context visible at a glance.

**Who is this feature for?**

Anyone browsing dashboards by folder in Grafana, including users relying on assistive technology.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/127220

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
