### PR TITLE
Provisioning: fix flaky sync integration tests

### DIFF
--- a/pkg/tests/apis/provisioning/jobs/pullrequestjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pullrequestjob_auth_test.go
@@ -18,13 +18,17 @@ func TestIntegrationProvisioning_PullRequestJobRejected(t *testing.T) {
 
 	const repo = "pr-job-rejected-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1,
+		Name:       repo,
+		SyncTarget: "folder",
+		Copies:     map[string]string{},
+		// The namespace-wide count assertion in CreateLocalRepo flakes when a
+		// prior test leaks resources into this shared server; scope the check
+		// to this repo's own managed resources instead.
+		SkipResourceAssertions: true,
 	}
 	helper.CreateLocalRepo(t, testRepo)
+	helper.RequireRepoFolderCount(t, repo, 1)
+	helper.RequireRepoDashboardCount(t, repo, 0)
 
 	body := common.AsJSON(provisioning.JobSpec{
 		Action: provisioning.JobActionPullRequest,

--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -27,10 +27,14 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	helper := sharedHelper(t)
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:            repoName,
-		SyncTarget:      "folder",
-		ExpectedFolders: 1,
+		Name:       repoName,
+		SyncTarget: "folder",
+		// The namespace-wide count assertion in CreateLocalRepo flakes when a
+		// prior test leaks resources into this shared server; scope the check
+		// to this repo's own managed folder instead.
+		SkipResourceAssertions: true,
 	})
+	helper.RequireRepoFolderCount(t, repoName, 1)
 
 	ctx := t.Context()
 

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -291,7 +291,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		err = os.WriteFile(filepath.Join(repoPath, "new_a", "dashboard_new1.json"), newDash1Content, 0o600)
 		require.NoError(t, err, "should be able to write new_a/dashboard_new1.json")
 
-		newDash2Content := strings.Replace(string(helper.LoadFile("../testdata/timeline-demo.json")), `"uid": "mIJjFy8Kz"`, `"uid": "quota-nested-extra"`, 1)
+		newDash2Content := strings.Replace(string(helper.LoadFile("../testdata/timeline-demo.json")), `"name": "mIJjFy8Kz"`, `"name": "quota-nested-extra"`, 1)
 		err = os.MkdirAll(filepath.Join(repoPath, "new_b"), 0o750)
 		require.NoError(t, err)
 		err = os.WriteFile(filepath.Join(repoPath, "new_b", "dashboard_new2.json"), []byte(newDash2Content), 0o600)


### PR DESCRIPTION
## What

Fix three flaky provisioning integration tests (all **test-only**, no production change).

### Count-assertion flake
`TestIntegrationProvisioning_PullRequestJobRejected` and `TestIntegrationFolderManagerConsistency` failed intermittently with:

```
should have the expected dashboards and folders after sync
```

`CreateLocalRepo`'s `countNonOrphanedResources` counts every unmanaged / other-managed resource across the **shared** test server. Resources leaked (or index-flapped) by earlier tests inflate that namespace-wide total, so the assertion never converges. The repo-scoped helpers `RequireRepoFolderCount` / `RequireRepoDashboardCount` already count only resources whose `grafana.app/managerId` matches the repo under test and are immune to cross-test leakage — this is the behaviour the original fix (#126699) said it implemented but the code diverged from.

Fix: set `SkipResourceAssertions: true` on the two tests and assert with the repo-scoped helpers instead. A global switch of `CreateLocalRepo` was deliberately avoided — 219 callers, and export tests (e.g. `jobs/exportjob_test.go`) rely on the total count of pre-seeded unmanaged resources.

### Latent quota twin
`quota/sync_quota_test.go:294` carried the same no-op `strings.Replace` bug that flakes `TestIntegrationProvisioning_MoveResources`: it targeted a non-existent `"uid"` field, but the v2 testdata dashboards identify by `metadata.name`, so the replace did nothing and the two dashboards were not actually distinct. Retargeted to `"name"`.

> **Note:** `TestIntegrationProvisioning_MoveResources` has the identical no-op-replace root cause but is intentionally **not** included in this PR.

## Files
- `pkg/tests/apis/provisioning/jobs/pullrequestjob_auth_test.go`
- `pkg/tests/apis/provisioning/managed_test.go`
- `pkg/tests/apis/provisioning/quota/sync_quota_test.go`

## Testing
Test-only changes. Integration tests not run locally (require the full provisioning server harness); CI covers them. `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)