### PR TITLE
datasources: query: removed unnecessary backward compatibility code

### DIFF
--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -81,14 +81,6 @@ var PathRewriters = []filters.PathRewriter{
 			return matches[1] + "/name" // connector requires a name
 		},
 	},
-	{
-		// Rewrite the deprecated query path
-		// NOTE, this should be removed after the enterprise changes are running in hosted grafana
-		Pattern: regexp.MustCompile(`(/apis/.*.datasource.grafana.app/v0alpha1/namespaces/.*/connections/.*/query$)`),
-		ReplaceFunc: func(matches []string) string {
-			return strings.Replace(matches[0], "connections", "datasources", 1)
-		},
-	},
 }
 
 func GetDefaultBuildHandlerChainFunc(builders []APIGroupBuilder, reg prometheus.Registerer) BuildHandlerChainFunc {

--- a/pkg/services/apiserver/builder/helper_test.go
+++ b/pkg/services/apiserver/builder/helper_test.go
@@ -123,10 +123,6 @@ func TestRedirection(t *testing.T) {
 			name:   "datasource query",
 			url:    "/apis/datasource.grafana.app/v0alpha1/namespaces/default/query",
 			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query",
-		}, {
-			name:   "datasource query (using connections)",
-			url:    "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/connections/xxx/query",
-			expect: "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/xxx/query",
 		},
 	}
 

--- a/pkg/tests/apis/datasource/testdata_test.go
+++ b/pkg/tests/apis/datasource/testdata_test.go
@@ -312,31 +312,6 @@ func TestIntegrationTestDatasource(t *testing.T) {
 			checkCSVResult(qdr.Responses["A"])
 			checkCSVResult(qdr.Responses["B"])
 		})
-
-		// Use the deprecated connections path
-		// NOTE: remove after this is deployed to hosted grafana
-		t.Run("deprecated connections path", func(t *testing.T) {
-			var statusCode int
-			result := adminClient.Post().
-				Namespace("default").
-				Resource("connections"). // <<<<< should rewrite to datasources
-				Name("test").            // datasource UID
-				SubResource("query").
-				SetHeader("Content-type", "application/json").
-				Body(body).
-				Do(ctx).
-				StatusCode(&statusCode)
-
-			require.Equal(t, int(http.StatusOK), statusCode) // query success
-			raw, _ := result.Raw()
-			require.NotNil(t, raw)
-
-			qdr := &backend.QueryDataResponse{}
-			err = json.Unmarshal(raw, qdr)
-
-			checkCSVResult(qdr.Responses["A"])
-			checkCSVResult(qdr.Responses["B"])
-		})
 	})
 
 	t.Run("resources", func(t *testing.T) {


### PR DESCRIPTION
in the datasource pods, we are switching from the `.../connections/...` URL paths to `.../datasources/...` URL paths.

they already support both, and now the query-service only uses the new `..../datasources/....` path, so we can remove the handling of `..../connections/....` .