### PR TITLE
[release-13.1.1] CI: only run notify-pr in grafana/grafana

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -962,6 +962,9 @@ jobs:
             --field version_type="canary"
 
   notify-pr:
+    # Only run in grafana/grafana itself. In the security mirror (a private repo) this job would
+    # both leak that a build is happening and fail (nothing depends on it, but it fails the run).
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-x64-small
     permissions:
       contents: read


### PR DESCRIPTION
`release-build.yml` also runs in the **grafana-security-mirror** (private). There, the `notify-pr` job leaks that a build is happening and **fails** — nothing depends on it, but it sets the run conclusion to failure. Guard it on `github.repository == 'grafana/grafana'` so it only runs in the public repo. actionlint clean.