### PR TITLE
IAM: Let users read their own profile

### DIFF
--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -209,8 +209,7 @@ func (s *Service) k8sCtxWithIdentity(ctx context.Context) context.Context {
 	if id, ok := identity.OrgIDFrom(ctx); ok && id != 0 {
 		orgID = id
 	}
-	ctx, _ = identity.WithServiceIdentity(ctx, orgID)
-	return ctx
+	return identity.WithServiceIdentityContext(ctx, orgID)
 }
 
 // k8sCtxForSelfRead elevates ctx to the service identity when the caller is a

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -87,7 +87,7 @@ func (s *Service) GetByID(ctx context.Context, cmd *user.GetUserByIDQuery) (*use
 	defer span.End()
 
 	if s.isKubernetesUserServiceEnabled(ctx) && !s.shouldFallbackToLegacy(ctx) {
-		return s.k8sService.GetByID(s.k8sCtxWithIdentity(ctx), cmd)
+		return s.k8sService.GetByID(s.k8sCtxForSelfRead(ctx, cmd.ID, ""), cmd)
 	}
 
 	return s.legacyService.GetByID(ctx, cmd)
@@ -192,7 +192,7 @@ func (s *Service) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisableU
 
 func (s *Service) GetProfile(ctx context.Context, cmd *user.GetUserProfileQuery) (*user.UserProfileDTO, error) {
 	if s.isKubernetesUserServiceEnabled(ctx) && !s.shouldFallbackToLegacy(ctx) {
-		return s.k8sService.GetProfile(s.k8sCtxWithIdentity(ctx), cmd)
+		return s.k8sService.GetProfile(s.k8sCtxForSelfRead(ctx, cmd.UserID, cmd.UID), cmd)
 	}
 
 	return s.legacyService.GetProfile(ctx, cmd)
@@ -211,6 +211,32 @@ func (s *Service) k8sCtxWithIdentity(ctx context.Context) context.Context {
 	}
 	ctx, _ = identity.WithServiceIdentity(ctx, orgID)
 	return ctx
+}
+
+// k8sCtxForSelfRead elevates ctx to the service identity when the caller is a
+// user reading their own profile.
+func (s *Service) k8sCtxForSelfRead(ctx context.Context, targetID int64, targetUID string) context.Context {
+	requester, err := identity.GetRequester(ctx)
+	if err != nil || requester == nil || requester.GetIdentityType() != claims.TypeUser {
+		return s.k8sCtxWithIdentity(ctx)
+	}
+	if !isSelfUser(requester, targetID, targetUID) {
+		return s.k8sCtxWithIdentity(ctx)
+	}
+	return identity.WithServiceIdentityContext(ctx, requester.GetOrgID())
+}
+
+// isSelfUser reports whether targetID/targetUID identify the requester itself.
+func isSelfUser(requester identity.Requester, targetID int64, targetUID string) bool {
+	if targetUID != "" {
+		return targetUID == requester.GetRawIdentifier()
+	}
+	if targetID != 0 {
+		if internalID, err := requester.GetInternalID(); err == nil {
+			return internalID == targetID
+		}
+	}
+	return false
 }
 
 func (s *Service) GetUsageStats(ctx context.Context) map[string]any {

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	claims "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -322,6 +325,92 @@ func TestService_NoLegacyFallback(t *testing.T) {
 			require.ErrorIs(t, err, k8sErr)
 			require.Nil(t, got)
 		})
+	})
+}
+
+// ctxCapturingUserService records the context passed to GetProfile so tests can
+// assert which identity the k8s lookup runs as.
+type ctxCapturingUserService struct {
+	usertest.FakeUserService
+	gotCtx context.Context
+}
+
+func (f *ctxCapturingUserService) GetProfile(ctx context.Context, _ *user.GetUserProfileQuery) (*user.UserProfileDTO, error) {
+	f.gotCtx = ctx
+	return &user.UserProfileDTO{}, nil
+}
+
+func (f *ctxCapturingUserService) GetByID(ctx context.Context, _ *user.GetUserByIDQuery) (*user.User, error) {
+	f.gotCtx = ctx
+	return &user.User{}, nil
+}
+
+func TestService_GetProfile_SelfReadElevatesToServiceIdentity(t *testing.T) {
+	enableK8sUsersRedirect(t)
+
+	const selfUID = "u-self"
+	const selfID int64 = 5
+
+	caller := &identity.StaticRequester{Type: claims.TypeUser, UserUID: selfUID, UserID: selfID, OrgID: 2}
+
+	t.Run("reading own profile runs as the service identity", func(t *testing.T) {
+		k8s := &ctxCapturingUserService{}
+		s := newWrapperServiceForTest(k8s, &usertest.FakeUserService{})
+
+		ctx := identity.WithRequester(context.Background(), caller)
+		_, err := s.GetProfile(ctx, &user.GetUserProfileQuery{UserID: selfID, UID: selfUID})
+		require.NoError(t, err)
+		require.True(t, identity.IsServiceIdentity(k8s.gotCtx), "self-read should be elevated to the service identity")
+	})
+
+	t.Run("reading own profile by internal ID only is elevated", func(t *testing.T) {
+		k8s := &ctxCapturingUserService{}
+		s := newWrapperServiceForTest(k8s, &usertest.FakeUserService{})
+
+		ctx := identity.WithRequester(context.Background(), caller)
+		_, err := s.GetProfile(ctx, &user.GetUserProfileQuery{UserID: selfID})
+		require.NoError(t, err)
+		require.True(t, identity.IsServiceIdentity(k8s.gotCtx))
+	})
+
+	t.Run("reading another user's profile keeps the caller identity", func(t *testing.T) {
+		k8s := &ctxCapturingUserService{}
+		s := newWrapperServiceForTest(k8s, &usertest.FakeUserService{})
+
+		ctx := identity.WithRequester(context.Background(), caller)
+		_, err := s.GetProfile(ctx, &user.GetUserProfileQuery{UserID: 99, UID: "u-other"})
+		require.NoError(t, err)
+		require.False(t, identity.IsServiceIdentity(k8s.gotCtx), "reading another user must not be elevated")
+		got, err := identity.GetRequester(k8s.gotCtx)
+		require.NoError(t, err)
+		require.Equal(t, selfUID, got.GetRawIdentifier())
+	})
+}
+
+func TestService_GetByID_SelfReadElevatesToServiceIdentity(t *testing.T) {
+	enableK8sUsersRedirect(t)
+
+	const selfID int64 = 5
+	caller := &identity.StaticRequester{Type: claims.TypeUser, UserUID: "u-self", UserID: selfID, OrgID: 2}
+
+	t.Run("reading own user runs as the service identity", func(t *testing.T) {
+		k8s := &ctxCapturingUserService{}
+		s := newWrapperServiceForTest(k8s, &usertest.FakeUserService{})
+
+		ctx := identity.WithRequester(context.Background(), caller)
+		_, err := s.GetByID(ctx, &user.GetUserByIDQuery{ID: selfID})
+		require.NoError(t, err)
+		require.True(t, identity.IsServiceIdentity(k8s.gotCtx))
+	})
+
+	t.Run("reading another user keeps the caller identity", func(t *testing.T) {
+		k8s := &ctxCapturingUserService{}
+		s := newWrapperServiceForTest(k8s, &usertest.FakeUserService{})
+
+		ctx := identity.WithRequester(context.Background(), caller)
+		_, err := s.GetByID(ctx, &user.GetUserByIDQuery{ID: 99})
+		require.NoError(t, err)
+		require.False(t, identity.IsServiceIdentity(k8s.gotCtx))
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Allows any authenticated user to read their own profile and auth tokens without needing the broad `users:read` permission. The self read runs the underlying k8s lookup as the service account (which already holds `users:read`), scoped to the caller's own user. Reading anyone else still requires the existing permission.

Alternative implementation for https://github.com/grafana/grafana/pull/127054.

**Why do we need this feature?**

With `kubernetesUsersRedirect` enabled, `GET /api/user` and `GET /api/user/auth-tokens` returned HTTP 500 for non-admin users. These requests resolve the user via the IAM Users resource which requires the global `users:read` action that normal users don't have, so the API server returned forbidden and the handlers turned it into a 500. This broke the profile page for normal users.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
