### PR TITLE
Dynamic Dashboards: Fix hidden rows reserving empty space

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
@@ -1,9 +1,10 @@
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { render, userEvent } from 'test/test-utils';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { SceneTimeRange } from '@grafana/scenes';
 
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { DashboardScene } from '../DashboardScene';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
 
@@ -50,5 +51,36 @@ describe('RowItemRenderer', () => {
 
     await userEvent.click(toggle);
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('keeps a conditionally hidden row mounted but visually hidden so dnd indices stay contiguous', () => {
+    const conditionalRendering = new ConditionalRenderingGroup({
+      condition: 'and',
+      visibility: 'show',
+      conditions: [],
+      result: true,
+      renderHidden: false,
+    });
+    const row = new RowItem({
+      key: 'row-1',
+      title: 'My row',
+      layout: AutoGridLayoutManager.createEmpty(),
+      conditionalRendering,
+    });
+    const scene = new DashboardScene({
+      $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+      body: new RowsLayoutManager({ rows: [row] }),
+    });
+    const { container } = render(<scene.Component model={scene} />);
+
+    expect(screen.getByTestId(selectors.components.DashboardRow.wrapper(row.state.title!))).toBeInTheDocument();
+
+    act(() => {
+      conditionalRendering.setState({ result: false });
+    });
+
+    // The row header/content is gone, but a placeholder element stays in the DOM hidden via display: none
+    expect(screen.queryByTestId(selectors.components.DashboardRow.wrapper(row.state.title!))).not.toBeInTheDocument();
+    expect(container.querySelector('[data-rfd-draggable-id="row-1"]')).toHaveStyle({ display: 'none' });
   });
 });

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -67,12 +67,26 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
 
   const isDraggable = !isClone && isEditing;
 
-  if (isHidden) {
-    return null;
+  if (soloPanelContext) {
+    return isHidden ? null : <layout.Component model={layout} />;
   }
 
-  if (soloPanelContext) {
-    return <layout.Component model={layout} />;
+  if (isHidden) {
+    // Keep the Draggable mounted (but visually hidden) instead of unmounting the row.
+    // myIndex is derived from the full rows array, so removing the element from the DOM
+    // leaves a gap in @hello-pangea/dnd's index sequence and the Droppable reserves
+    // empty space where the row used to be.
+    return (
+      <Draggable key={key!} draggableId={key!} index={myIndex} isDragDisabled>
+        {(dragProvided) => (
+          <div
+            ref={dragProvided.innerRef}
+            {...dragProvided.draggableProps}
+            style={{ ...dragProvided.draggableProps.style, display: 'none' }}
+          />
+        )}
+      </Draggable>
+    );
   }
 
   const titleElement = (


### PR DESCRIPTION
A conditionally-hidden row returned null, unmounting its `Draggable`. Since each row's Draggable index is derived from the full rows array, removing the element left a gap in @hello-pangea/dnd's index sequence, causing the Droppable to reserve empty space where the row used to be.

The fix: Keep the Draggable mounted with `display: none` so indices stay contiguous and the hidden row takes no layout space.

|      | First row shown | Second row shown |  
|------|-----------------|------------------|
| Edit |     <img width="981" height="262" alt="Screenshot 2026-06-30 at 11 55 00" src="https://github.com/user-attachments/assets/86e77eb4-e07c-4228-ad8d-7f19b38dc471" />   |      <img width="983" height="269" alt="Screenshot 2026-06-30 at 11 55 09" src="https://github.com/user-attachments/assets/d57858da-5f8f-459e-b5fe-6a5331472582" />       |   
| View |      <img width="792" height="240" alt="Screenshot 2026-06-30 at 11 55 35" src="https://github.com/user-attachments/assets/d5292795-8f25-45db-affe-8f35cab1be80" />           |        <img width="769" height="219" alt="Screenshot 2026-06-30 at 11 55 26" src="https://github.com/user-attachments/assets/29c593bf-916b-4ea9-bf6e-2ba1c595e01d" />          |   

Fixes https://github.com/grafana/grafana/issues/127400

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
