### PR TITLE
feat(navtree): support hierarchical assistant app nav

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -218,6 +218,10 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 		}
 	}
 
+	if navConfig, ok := s.navigationAppConfig[plugin.ID]; ok && navConfig.HierarchicalNavigation {
+		nestPluginNavLinksByURL(appLink)
+	}
+
 	// Apps without any nav children are not part of navtree
 	if len(appLink.Children) == 0 {
 		return nil
@@ -254,6 +258,49 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 	}
 
 	return nil
+}
+
+func nestPluginNavLinksByURL(appLink *navtree.NavLink) {
+	nested := map[*navtree.NavLink]struct{}{}
+	for _, child := range appLink.Children {
+		parent := findClosestNavParentByURL(appLink.Children, child)
+		if parent == nil || parent == child || parent.Url == appLink.Url {
+			continue
+		}
+
+		parent.Children = append(parent.Children, child)
+		nested[child] = struct{}{}
+	}
+
+	if len(nested) == 0 {
+		return
+	}
+
+	children := make([]*navtree.NavLink, 0, len(appLink.Children)-len(nested))
+	for _, child := range appLink.Children {
+		if _, ok := nested[child]; !ok {
+			children = append(children, child)
+		}
+	}
+	appLink.Children = children
+}
+
+func findClosestNavParentByURL(children []*navtree.NavLink, child *navtree.NavLink) *navtree.NavLink {
+	var parent *navtree.NavLink
+	for _, candidate := range children {
+		if candidate == child || candidate.Url == "" || !isNavURLParent(candidate.Url, child.Url) {
+			continue
+		}
+
+		if parent == nil || len(candidate.Url) > len(parent.Url) {
+			parent = candidate
+		}
+	}
+	return parent
+}
+
+func isNavURLParent(parentURL string, childURL string) bool {
+	return childURL != parentURL && strings.HasPrefix(childURL, parentURL+"/")
 }
 
 func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *navtree.NavTreeRoot, plugin pluginstore.Plugin, appLink *navtree.NavLink) {
@@ -417,7 +464,7 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-labelmanagement-app":      {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 5, Text: "Label management"},
 		"grafana-incident-app":             {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 6, Text: "Incident"},
 		"grafana-oncall-app":               {SectionID: navtree.NavIDAlertsAndIncidents, SortWeight: 7, Text: "OnCall"},
-		"grafana-assistant-app":            {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAssistant, Text: "Assistant", SubTitle: "AI-powered assistant for Grafana", Icon: "ai-sparkle"},
+		"grafana-assistant-app":            {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAssistant, Text: "Assistant", SubTitle: "AI-powered assistant for Grafana", Icon: "ai-sparkle", HierarchicalNavigation: true},
 		"grafana-ml-app":                   {SectionID: navtree.NavIDRoot, SortWeight: navtree.WeightAIAndML, Text: "Machine Learning", SubTitle: "Explore AI and machine learning features", Icon: "gf-ml-alt"},
 		"grafana-cloud-link-app":           {SectionID: navtree.NavIDCfgPlugins, SortWeight: 3},
 		"grafana-adaptive-metrics-app":     {SectionID: navtree.NavIDAdaptiveTelemetry, SortWeight: 1},

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -153,6 +153,115 @@ func TestAddAppLinks(t *testing.T) {
 		require.Equal(t, "Page2", app1Node.Children[0].Text)
 	})
 
+	t.Run("Should keep plugin nav items flat by default", func(t *testing.T) {
+		nestedApp := pluginstore.Plugin{
+			JSONData: plugins.JSONData{
+				ID:   "nested-app",
+				Name: "Nested app",
+				Type: plugins.TypeApp,
+				Includes: []*plugins.Includes{
+					{
+						Name:     "Settings",
+						Path:     "/a/nested-app/settings",
+						Type:     "page",
+						AddToNav: true,
+					},
+					{
+						Name:     "Features",
+						Path:     "/a/nested-app/settings/features",
+						Type:     "page",
+						AddToNav: true,
+					},
+				},
+			},
+		}
+		nestedService := service
+		nestedService.navigationAppConfig = map[string]NavigationAppConfig{}
+		nestedService.pluginStore = &pluginstore.FakePluginStore{PluginList: []pluginstore.Plugin{nestedApp}}
+		nestedService.pluginSettings = &pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
+			nestedApp.ID: {OrgID: 1, PluginID: nestedApp.ID, Enabled: true},
+		}}
+
+		treeRoot := navtree.NavTreeRoot{}
+		err := nestedService.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+
+		appNode := treeRoot.FindById("plugin-page-nested-app")
+		require.NotNil(t, appNode)
+		require.Len(t, appNode.Children, 2)
+		require.Empty(t, appNode.Children[0].Children)
+		require.Empty(t, appNode.Children[1].Children)
+	})
+
+	t.Run("Should nest plugin nav items by URL for apps that opt in to hierarchical navigation", func(t *testing.T) {
+		assistantApp := pluginstore.Plugin{
+			JSONData: plugins.JSONData{
+				ID:   "grafana-assistant-app",
+				Name: "Assistant",
+				Type: plugins.TypeApp,
+				Includes: []*plugins.Includes{
+					{
+						Name:     "Settings",
+						Path:     "/a/grafana-assistant-app/settings",
+						Type:     "page",
+						AddToNav: true,
+					},
+					{
+						Name:     "Features",
+						Path:     "/a/grafana-assistant-app/settings/features",
+						Type:     "page",
+						AddToNav: true,
+					},
+					{
+						Name:     "Skills",
+						Path:     "/a/grafana-assistant-app/settings/features/skills",
+						Type:     "page",
+						AddToNav: true,
+					},
+					{
+						Name:     "Memories",
+						Path:     "/a/grafana-assistant-app/settings/features/memories",
+						Type:     "page",
+						AddToNav: true,
+					},
+					{
+						Name:     "Automations",
+						Path:     "/a/grafana-assistant-app/settings/automations",
+						Type:     "page",
+						AddToNav: true,
+					},
+				},
+			},
+		}
+		assistantService := service
+		assistantService.navigationAppConfig = map[string]NavigationAppConfig{
+			assistantApp.ID: {SectionID: navtree.NavIDRoot, HierarchicalNavigation: true},
+		}
+		assistantService.pluginStore = &pluginstore.FakePluginStore{PluginList: []pluginstore.Plugin{assistantApp}}
+		assistantService.pluginSettings = &pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
+			assistantApp.ID: {OrgID: 1, PluginID: assistantApp.ID, Enabled: true},
+		}}
+
+		treeRoot := navtree.NavTreeRoot{}
+		err := assistantService.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+
+		assistantNode := treeRoot.FindById("plugin-page-grafana-assistant-app")
+		require.NotNil(t, assistantNode)
+		require.Len(t, assistantNode.Children, 1)
+
+		settingsNode := assistantNode.Children[0]
+		require.Equal(t, "Settings", settingsNode.Text)
+		require.Len(t, settingsNode.Children, 2)
+		require.Equal(t, "Features", settingsNode.Children[0].Text)
+		require.Equal(t, "Automations", settingsNode.Children[1].Text)
+
+		featuresNode := settingsNode.Children[0]
+		require.Len(t, featuresNode.Children, 2)
+		require.Equal(t, "Skills", featuresNode.Children[0].Text)
+		require.Equal(t, "Memories", featuresNode.Children[1].Text)
+	})
+
 	// This can be done by using `[navigation.app_sections]` in the INI config
 	t.Run("Should move apps that have root nav id configured to the root", func(t *testing.T) {
 		service.navigationAppConfig = map[string]NavigationAppConfig{

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -54,12 +54,13 @@ type ServiceImpl struct {
 }
 
 type NavigationAppConfig struct {
-	SectionID  string
-	SortWeight int64
-	Text       string
-	Icon       string
-	SubTitle   string
-	IsNew      bool
+	SectionID              string
+	SortWeight             int64
+	Text                   string
+	Icon                   string
+	SubTitle               string
+	IsNew                  bool
+	HierarchicalNavigation bool
 }
 
 func ProvideService(cfg *setting.Cfg, accessControl ac.AccessControl, pluginStore pluginstore.Store, pluginSettings pluginsettings.Service, starClient starapi.K8sClients,


### PR DESCRIPTION
## What

Adds opt-in hierarchical navigation for app plugin nav links and enables it for the Grafana Assistant app.

## Why

Assistant settings pages can expose nested routes in plugin.json without every route appearing at the same nav level.