### PR TITLE
Shortcuts : Change kiosk mode key and category scope from dashboard to global

### DIFF
--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -93,6 +93,10 @@ export const useShortcuts = () => {
         description: t('help-modal.shortcuts-description.show-all-shortcuts', 'Show all keyboard shortcuts'),
       },
       { keys: ['c', 't'], description: t('help-modal.shortcuts-description.change-theme', 'Change theme') },
+      {
+        keys: ['d', 'k'],
+        description: t('help-modal.shortcuts-description.toggle-kiosk', 'Toggle kiosk mode (hides top nav)'),
+      },
     ];
 
     // Add assistant shortcut only if assistant is available
@@ -164,10 +168,6 @@ export const useShortcuts = () => {
           {
             keys: ['d', 'v'],
             description: t('help-modal.shortcuts-description.toggle-active-mode', 'Toggle in-active / view mode'),
-          },
-          {
-            keys: ['d', 'k'],
-            description: t('help-modal.shortcuts-description.toggle-kiosk', 'Toggle kiosk mode (hides top nav)'),
           },
           {
             keys: ['d', '⇧ + e'],

--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -83,6 +83,10 @@ export const useShortcuts = () => {
       { keys: ['g', 'e'], description: t('help-modal.shortcuts-description.go-to-explore', 'Go to Explore') },
       { keys: ['g', 'p'], description: t('help-modal.shortcuts-description.go-to-profile', 'Go to Profile') },
       { keys: ['g', 'a'], description: t('help-modal.shortcuts-description.open-alerting', 'Go to Alerting') },
+      {
+        keys: ['g', 'k'],
+        description: t('help-modal.shortcuts-description.toggle-kiosk', 'Toggle kiosk mode (hides top nav)'),
+      },
       { keys: [`${modKey} + k`], description: t('help-modal.shortcuts-description.open-search', 'Open search') },
       {
         keys: ['esc'],
@@ -93,10 +97,6 @@ export const useShortcuts = () => {
         description: t('help-modal.shortcuts-description.show-all-shortcuts', 'Show all keyboard shortcuts'),
       },
       { keys: ['c', 't'], description: t('help-modal.shortcuts-description.change-theme', 'Change theme') },
-      {
-        keys: ['d', 'k'],
-        description: t('help-modal.shortcuts-description.toggle-kiosk', 'Toggle kiosk mode (hides top nav)'),
-      },
     ];
 
     // Add assistant shortcut only if assistant is available

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -68,6 +68,9 @@ export class KeybindingSrv {
       // 'change pseudo locale'
       this.bind('c p l', () => togglePseudoLocale());
     }
+    this.bind('d k', () => {
+      this.chromeService.onToggleKioskMode();
+    });
   }
 
   bindGlobalEsc() {
@@ -396,10 +399,6 @@ export class KeybindingSrv {
 
     this.bind('d s', () => {
       this.showDashEditView();
-    });
-
-    this.bind('d k', () => {
-      this.chromeService.onToggleKioskMode();
     });
 
     //Autofit panels

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -68,7 +68,7 @@ export class KeybindingSrv {
       // 'change pseudo locale'
       this.bind('c p l', () => togglePseudoLocale());
     }
-    this.bind('d k', () => {
+    this.bind('g k', () => {
       this.chromeService.onToggleKioskMode();
     });
   }


### PR DESCRIPTION

### Problem

The kiosk mode shortcut (`d + k`) is no longer working after upgrading to the latest Grafana version. This happened because the kiosk mode option was moved from its previous location to the profile section, causing the existing shortcut listener to stop functioning.

### Solution

* Moved the kiosk mode keyboard shortcut listener to the global section so it remains accessible regardless of the current UI location.
* Updated the kiosk mode shortcut from `d + k` to `g + k` to align with the new shortcut handling flow and avoid conflicts.

### Impact

Users can now access kiosk mode using the new global shortcut (`g + k`) in the upgraded Grafana version.


Issue ID : https://github.com/grafana/grafana/issues/96944

