### PR TITLE
Provisioning: make informer watch transport swappable (NATS stub)

### DIFF
--- a/apps/provisioning/pkg/informer/clientwrap.go
+++ b/apps/provisioning/pkg/informer/clientwrap.go
@@ -1,0 +1,44 @@
+// Package informer swaps the watch transport of the generated provisioning
+// informers while keeping their LIST-seeded cache.
+//
+// The generated SharedInformerFactory builds each informer's ListWatch from the
+// typed clientset: ListFunc calls client...List and WatchFunc calls
+// client...Watch. WrapClient decorates that clientset so every typed Watch is
+// served by a custom WatchFunc, while List and all other calls are delegated to
+// the real client. Passing the wrapped client to the stock factory therefore
+// reroutes the informers' delta source without touching how their caches are
+// seeded, listers, or event-handler wiring.
+//
+// The per-resource wrappers live in one file each (repository.go, job.go,
+// connection.go, historicjob.go), mirroring the generated typed clientset.
+package informer
+
+import (
+	versioned "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
+	typedv0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
+)
+
+// WrapClient returns a clientset whose typed Watch calls are served by fn while
+// List and every other call delegate to real. A nil fn returns real unchanged.
+func WrapClient(real versioned.Interface, fn WatchFunc) versioned.Interface {
+	if fn == nil {
+		return real
+	}
+	return &clientset{Interface: real, fn: fn}
+}
+
+type clientset struct {
+	versioned.Interface
+	fn WatchFunc
+}
+
+func (c *clientset) ProvisioningV0alpha1() typedv0alpha1.ProvisioningV0alpha1Interface {
+	return &provisioningV0alpha1{ProvisioningV0alpha1Interface: c.Interface.ProvisioningV0alpha1(), fn: c.fn}
+}
+
+// provisioningV0alpha1 decorates the group client. Each resource getter (in its
+// own file) returns a typed wrapper that overrides Watch with fn.
+type provisioningV0alpha1 struct {
+	typedv0alpha1.ProvisioningV0alpha1Interface
+	fn WatchFunc
+}

--- a/apps/provisioning/pkg/informer/clientwrap_test.go
+++ b/apps/provisioning/pkg/informer/clientwrap_test.go
@@ -1,0 +1,101 @@
+package informer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+
+	provisioningapis "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/fake"
+)
+
+func TestWrapClient_RoutesWatchThroughWatchFunc(t *testing.T) {
+	const ns = "stacks-1"
+	sentinel := watch.NewFake()
+	t.Cleanup(sentinel.Stop)
+
+	var gotGVR schema.GroupVersionResource
+	var gotNS string
+	var calls int
+	fn := func(_ context.Context, gvr schema.GroupVersionResource, namespace string, _ metav1.ListOptions) (watch.Interface, error) {
+		calls++
+		gotGVR, gotNS = gvr, namespace
+		return sentinel, nil
+	}
+
+	wrapped := WrapClient(fake.NewClientset(), fn)
+	prov := wrapped.ProvisioningV0alpha1()
+
+	cases := []struct {
+		name string
+		gvr  schema.GroupVersionResource
+		call func() (watch.Interface, error)
+	}{
+		{"repositories", provisioningapis.RepositoryResourceInfo.GroupVersionResource(), func() (watch.Interface, error) {
+			return prov.Repositories(ns).Watch(context.Background(), metav1.ListOptions{})
+		}},
+		{"jobs", provisioningapis.JobResourceInfo.GroupVersionResource(), func() (watch.Interface, error) {
+			return prov.Jobs(ns).Watch(context.Background(), metav1.ListOptions{})
+		}},
+		{"connections", provisioningapis.ConnectionResourceInfo.GroupVersionResource(), func() (watch.Interface, error) {
+			return prov.Connections(ns).Watch(context.Background(), metav1.ListOptions{})
+		}},
+		{"historicjobs", provisioningapis.HistoricJobResourceInfo.GroupVersionResource(), func() (watch.Interface, error) {
+			return prov.HistoricJobs(ns).Watch(context.Background(), metav1.ListOptions{})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls = 0
+			w, err := tc.call()
+			require.NoError(t, err)
+			assert.Equal(t, 1, calls, "watch func should be invoked exactly once")
+			assert.Equal(t, tc.gvr, gotGVR)
+			assert.Equal(t, ns, gotNS)
+			assert.Equal(t, sentinel, w, "the watch func's watch.Interface should be returned")
+		})
+	}
+}
+
+func TestWrapClient_DelegatesListToReal(t *testing.T) {
+	var watchCalled bool
+	fn := func(context.Context, schema.GroupVersionResource, string, metav1.ListOptions) (watch.Interface, error) {
+		watchCalled = true
+		return nil, nil
+	}
+
+	wrapped := WrapClient(fake.NewClientset(), fn)
+
+	// List must reach the (fake) real client, not the watch func.
+	list, err := wrapped.ProvisioningV0alpha1().Repositories("stacks-1").List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	assert.Empty(t, list.Items)
+	assert.False(t, watchCalled, "List must not invoke the watch func")
+}
+
+func TestWrapClient_NilWatchFuncReturnsReal(t *testing.T) {
+	real := fake.NewClientset()
+	assert.Equal(t, real, WrapClient(real, nil))
+}
+
+func TestNewNATSInformerFactory_DropIn(t *testing.T) {
+	f := NewNATSInformerFactory(fake.NewClientset(), time.Minute)
+	require.NotNil(t, f)
+	// The generated accessors and typed listers must still be available.
+	assert.NotNil(t, f.Provisioning().V0alpha1().Repositories().Lister())
+	assert.NotNil(t, f.Provisioning().V0alpha1().Jobs().Lister())
+}
+
+func TestNewInformerFactory(t *testing.T) {
+	f := NewInformerFactory(fake.NewClientset(), time.Minute)
+	require.NotNil(t, f)
+	assert.NotNil(t, f.Provisioning().V0alpha1().Repositories().Lister())
+}

--- a/apps/provisioning/pkg/informer/connection.go
+++ b/apps/provisioning/pkg/informer/connection.go
@@ -1,0 +1,25 @@
+package informer
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	provisioningapis "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	typedv0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
+)
+
+func (p *provisioningV0alpha1) Connections(namespace string) typedv0alpha1.ConnectionInterface {
+	return &connections{ConnectionInterface: p.ProvisioningV0alpha1Interface.Connections(namespace), fn: p.fn, namespace: namespace}
+}
+
+type connections struct {
+	typedv0alpha1.ConnectionInterface
+	fn        WatchFunc
+	namespace string
+}
+
+func (c *connections) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return c.fn(ctx, provisioningapis.ConnectionResourceInfo.GroupVersionResource(), c.namespace, opts)
+}

--- a/apps/provisioning/pkg/informer/factory.go
+++ b/apps/provisioning/pkg/informer/factory.go
@@ -1,0 +1,26 @@
+package informer
+
+import (
+	"time"
+
+	versioned "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
+	informers "github.com/grafana/grafana/apps/provisioning/pkg/generated/informers/externalversions"
+)
+
+// NewInformerFactory builds the standard provisioning SharedInformerFactory,
+// backed by the apiserver LIST+WATCH. It is exactly
+// informers.NewSharedInformerFactory and exists so callers can pick between the
+// apiserver and NATS variants from a single package.
+func NewInformerFactory(client versioned.Interface, resync time.Duration) informers.SharedInformerFactory {
+	return informers.NewSharedInformerFactory(client, resync)
+}
+
+// NewNATSInformerFactory builds a provisioning SharedInformerFactory whose
+// informers keep their LIST-seeded cache (and their listers and event-handler
+// wiring) but take their watch deltas from a NATS-based watch instead of the
+// apiserver watch. The NATS watch transport is not implemented yet, so the
+// informers' Watch currently fails with ErrNotImplemented while LIST still
+// seeds the cache.
+func NewNATSInformerFactory(client versioned.Interface, resync time.Duration) informers.SharedInformerFactory {
+	return informers.NewSharedInformerFactory(WrapClient(client, NotImplemented), resync)
+}

--- a/apps/provisioning/pkg/informer/historicjob.go
+++ b/apps/provisioning/pkg/informer/historicjob.go
@@ -1,0 +1,25 @@
+package informer
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	provisioningapis "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	typedv0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
+)
+
+func (p *provisioningV0alpha1) HistoricJobs(namespace string) typedv0alpha1.HistoricJobInterface {
+	return &historicJobs{HistoricJobInterface: p.ProvisioningV0alpha1Interface.HistoricJobs(namespace), fn: p.fn, namespace: namespace}
+}
+
+type historicJobs struct {
+	typedv0alpha1.HistoricJobInterface
+	fn        WatchFunc
+	namespace string
+}
+
+func (h *historicJobs) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return h.fn(ctx, provisioningapis.HistoricJobResourceInfo.GroupVersionResource(), h.namespace, opts)
+}

--- a/apps/provisioning/pkg/informer/job.go
+++ b/apps/provisioning/pkg/informer/job.go
@@ -1,0 +1,25 @@
+package informer
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	provisioningapis "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	typedv0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
+)
+
+func (p *provisioningV0alpha1) Jobs(namespace string) typedv0alpha1.JobInterface {
+	return &jobs{JobInterface: p.ProvisioningV0alpha1Interface.Jobs(namespace), fn: p.fn, namespace: namespace}
+}
+
+type jobs struct {
+	typedv0alpha1.JobInterface
+	fn        WatchFunc
+	namespace string
+}
+
+func (j *jobs) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return j.fn(ctx, provisioningapis.JobResourceInfo.GroupVersionResource(), j.namespace, opts)
+}

--- a/apps/provisioning/pkg/informer/repository.go
+++ b/apps/provisioning/pkg/informer/repository.go
@@ -1,0 +1,25 @@
+package informer
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	provisioningapis "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	typedv0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
+)
+
+func (p *provisioningV0alpha1) Repositories(namespace string) typedv0alpha1.RepositoryInterface {
+	return &repositories{RepositoryInterface: p.ProvisioningV0alpha1Interface.Repositories(namespace), fn: p.fn, namespace: namespace}
+}
+
+type repositories struct {
+	typedv0alpha1.RepositoryInterface
+	fn        WatchFunc
+	namespace string
+}
+
+func (r *repositories) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return r.fn(ctx, provisioningapis.RepositoryResourceInfo.GroupVersionResource(), r.namespace, opts)
+}

--- a/apps/provisioning/pkg/informer/watchfunc.go
+++ b/apps/provisioning/pkg/informer/watchfunc.go
@@ -1,0 +1,25 @@
+package informer
+
+import (
+	"context"
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// WatchFunc produces the delta source (a watch.Interface) for a single resource
+// type and namespace. It is the injection point used to replace an informer's
+// watch transport without changing how its cache is seeded by LIST.
+type WatchFunc func(ctx context.Context, gvr schema.GroupVersionResource, namespace string, opts metav1.ListOptions) (watch.Interface, error)
+
+// ErrNotImplemented is returned by NotImplemented.
+var ErrNotImplemented = errors.New("informer watch: not implemented")
+
+// NotImplemented is a placeholder WatchFunc that always fails. It lets callers
+// wire up the watch-swap mechanism before a real transport (e.g. a NATS-based
+// watch) exists.
+func NotImplemented(context.Context, schema.GroupVersionResource, string, metav1.ListOptions) (watch.Interface, error) {
+	return nil, ErrNotImplemented
+}

--- a/apps/provisioning/pkg/informer/watchfunc_test.go
+++ b/apps/provisioning/pkg/informer/watchfunc_test.go
@@ -1,0 +1,21 @@
+package informer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestNotImplemented(t *testing.T) {
+	w, err := NotImplemented(context.Background(), schema.GroupVersionResource{Resource: "things"}, "ns", metav1.ListOptions{})
+	assert.Nil(t, w)
+	require.ErrorIs(t, err, ErrNotImplemented)
+}
+
+// NotImplemented must satisfy the WatchFunc type so it can be passed wherever a
+// WatchFunc is expected.
+var _ WatchFunc = NotImplemented

--- a/pkg/operators/provisioning/connection_operator.go
+++ b/pkg/operators/provisioning/connection_operator.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	appcontroller "github.com/grafana/grafana/apps/provisioning/pkg/controller"
-	informer "github.com/grafana/grafana/apps/provisioning/pkg/generated/informers/externalversions"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller"
 	"github.com/grafana/grafana/pkg/server"
 )
@@ -33,10 +32,7 @@ func RunConnectionController(ctx context.Context, deps server.OperatorDependenci
 		return fmt.Errorf("failed to create provisioning client: %w", err)
 	}
 
-	informerFactory := informer.NewSharedInformerFactoryWithOptions(
-		provisioningClient,
-		controllerCfg.ResyncInterval(),
-	)
+	informerFactory := newInformerFactory(provisioningClient, controllerCfg.ResyncInterval())
 
 	statusPatcher := appcontroller.NewConnectionStatusPatcher(provisioningClient.ProvisioningV0alpha1())
 	connInformer := informerFactory.Provisioning().V0alpha1().Connections()

--- a/pkg/operators/provisioning/informer_watch.go
+++ b/pkg/operators/provisioning/informer_watch.go
@@ -1,0 +1,27 @@
+package provisioning
+
+import (
+	"time"
+
+	versioned "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
+	informers "github.com/grafana/grafana/apps/provisioning/pkg/generated/informers/externalversions"
+	"github.com/grafana/grafana/apps/provisioning/pkg/informer"
+)
+
+// natsWatchEnabled routes the provisioning operators' informers through the
+// informer package's watch swap (currently a not-implemented placeholder)
+// instead of the apiserver watch, while keeping the LIST-seeded cache. Internal
+// switch, defaults to false.
+//
+// TODO: implement the NATS-based watch (informer.NewNATSInformerFactory) and
+// enable this; until then it stays false and the apiserver watch is used.
+var natsWatchEnabled = false
+
+// newInformerFactory builds the provisioning informer factory for the operators,
+// honouring natsWatchEnabled.
+func newInformerFactory(client versioned.Interface, resync time.Duration) informers.SharedInformerFactory {
+	if natsWatchEnabled {
+		return informer.NewNATSInformerFactory(client, resync)
+	}
+	return informer.NewInformerFactory(client, resync)
+}

--- a/pkg/operators/provisioning/jobqueue_operator.go
+++ b/pkg/operators/provisioning/jobqueue_operator.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana-app-sdk/logging"
 	folderv1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/controller"
-	informer "github.com/grafana/grafana/apps/provisioning/pkg/generated/informers/externalversions"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/server"
 	"github.com/grafana/grafana/pkg/setting"
@@ -41,10 +40,7 @@ func RunJobQueueController(ctx context.Context, deps server.OperatorDependencies
 	}
 
 	// Jobs informer and controller for insert notifications
-	jobInformerFactory := informer.NewSharedInformerFactoryWithOptions(
-		provisioningClient,
-		controllerCfg.ResyncInterval(),
-	)
+	jobInformerFactory := newInformerFactory(provisioningClient, controllerCfg.ResyncInterval())
 	jobInformer := jobInformerFactory.Provisioning().V0alpha1().Jobs()
 	jobController := controller.NewJobController()
 	if _, err := jobInformer.Informer().AddEventHandler(jobController.EventHandler()); err != nil {

--- a/pkg/operators/provisioning/jobs_operator.go
+++ b/pkg/operators/provisioning/jobs_operator.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana-app-sdk/logging"
 	folderv1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/controller"
-	informer "github.com/grafana/grafana/apps/provisioning/pkg/generated/informers/externalversions"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/server"
 	"github.com/grafana/grafana/pkg/setting"
@@ -41,19 +40,13 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 	}
 
 	// Jobs informer and controller (resync ~60s like in register.go)
-	jobInformerFactory := informer.NewSharedInformerFactoryWithOptions(
-		provisioningClient,
-		controllerCfg.ResyncInterval(),
-	)
+	jobInformerFactory := newInformerFactory(provisioningClient, controllerCfg.ResyncInterval())
 	jobInformer := jobInformerFactory.Provisioning().V0alpha1().Jobs()
 
 	var startHistoryInformers func()
 	if controllerCfg.historyExpiration > 0 {
 		// History jobs informer and controller (separate factory with resync == expiration)
-		historyInformerFactory := informer.NewSharedInformerFactoryWithOptions(
-			provisioningClient,
-			controllerCfg.historyExpiration,
-		)
+		historyInformerFactory := newInformerFactory(provisioningClient, controllerCfg.historyExpiration)
 		historyJobInformer := historyInformerFactory.Provisioning().V0alpha1().HistoricJobs()
 		historyJobController := controller.NewHistoryJobController(
 			provisioningClient.ProvisioningV0alpha1(),

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -17,8 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 	"github.com/grafana/grafana/pkg/server"
-
-	informer "github.com/grafana/grafana/apps/provisioning/pkg/generated/informers/externalversions"
 )
 
 func RunRepoController(ctx context.Context, deps server.OperatorDependencies) error {
@@ -37,10 +35,7 @@ func RunRepoController(ctx context.Context, deps server.OperatorDependencies) er
 		return fmt.Errorf("failed to create provisioning client: %w", err)
 	}
 
-	informerFactory := informer.NewSharedInformerFactoryWithOptions(
-		provisioningClient,
-		controllerCfg.ResyncInterval(),
-	)
+	informerFactory := newInformerFactory(provisioningClient, controllerCfg.ResyncInterval())
 
 	unified, err := controllerCfg.UnifiedStorageClient()
 	if err != nil {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -34,6 +34,7 @@ import (
 	clientset "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
 	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
 	informers "github.com/grafana/grafana/apps/provisioning/pkg/generated/informers/externalversions"
+	informer "github.com/grafana/grafana/apps/provisioning/pkg/informer"
 	appjobs "github.com/grafana/grafana/apps/provisioning/pkg/jobs"
 	"github.com/grafana/grafana/apps/provisioning/pkg/loki"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
@@ -145,6 +146,25 @@ type APIBuilder struct {
 	incrementalPolicy             repository.IncrementalSyncPolicy
 	folderAPIVersion              string
 	webhookSecretRotationInterval time.Duration
+
+	// natsWatchEnabled routes the provisioning informers' watch through the
+	// informer package's watch swap (currently a not-implemented placeholder)
+	// instead of the apiserver watch, while keeping the LIST-seeded cache.
+	// Internal switch, defaults to false.
+	//
+	// TODO: implement the NATS-based watch (informer.NewNATSInformerFactory) and
+	// enable this; until then it stays false and the apiserver watch is used.
+	natsWatchEnabled bool
+}
+
+// newInformerFactory builds the provisioning informer factory. When
+// natsWatchEnabled is set, the informers keep their LIST-seeded caches but their
+// watch is served by the informer package instead of the apiserver watch.
+func (b *APIBuilder) newInformerFactory(c clientset.Interface, resync time.Duration) informers.SharedInformerFactory {
+	if b.natsWatchEnabled {
+		return informer.NewNATSInformerFactory(c, resync)
+	}
+	return informer.NewInformerFactory(c, resync)
 }
 
 // NewAPIBuilder creates an API builder for the provisioning API.
@@ -932,7 +952,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 
 			// Informer with resync interval used for health check and reconciliation
 			informerFactoryResyncInterval := 60 * time.Second
-			sharedInformerFactory := informers.NewSharedInformerFactory(c, informerFactoryResyncInterval)
+			sharedInformerFactory := b.newInformerFactory(c, informerFactoryResyncInterval)
 			repoInformer := sharedInformerFactory.Provisioning().V0alpha1().Repositories()
 			jobInformer := sharedInformerFactory.Provisioning().V0alpha1().Jobs()
 			connInformer := sharedInformerFactory.Provisioning().V0alpha1().Connections()
@@ -1145,7 +1165,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				// Create HistoryJobController for cleanup of old job history entries
 				// Separate informer factory for HistoryJob cleanup with resync interval
 				historyJobExpiration := 10 * time.Minute
-				historyJobInformerFactory := informers.NewSharedInformerFactory(c, historyJobExpiration)
+				historyJobInformerFactory := b.newInformerFactory(c, historyJobExpiration)
 				historyJobInformer := historyJobInformerFactory.Provisioning().V0alpha1().HistoricJobs()
 				go historyJobInformer.Informer().Run(postStartHookCtx.Done())
 				historyJobController := appcontroller.NewHistoryJobController(


### PR DESCRIPTION
## Why

The provisioning informers (`Repository`, `Job`, `Connection`, `HistoricJob`) deliver real-time changes via the Kubernetes **watch** — the "messaging" half of an informer — while **LIST** seeds the local cache. We want to be able to replace that watch transport (with a NATS-based watch) **without giving up the LIST-seeded cache**, the listers, or the controllers' event-handler wiring.

#127528 was the prerequisite: it decoupled the controllers from the informers, so they now consume `Lister()` + `EventHandler()` and no longer care *how* deltas arrive. That makes the watch source a pure wiring concern.

This PR lands **only the swap mechanism**, with a `NotImplemented` placeholder watch, gated off by default. The real NATS watch — and the publisher/contract side — follow in separate PRs. Landing the seam first keeps each of those changes small and focused.

## What

- New package `apps/provisioning/pkg/informer` (one file per resource, mirroring the generated clientset):
  - `WrapClient(real, fn)` — decorates the typed clientset, overriding only `Watch` on `Repositories`/`Jobs`/`Connections`/`HistoricJobs` (each forwarding its GVR from `…ResourceInfo.GroupVersionResource()`); `List` and everything else delegate to the real client.
  - `WatchFunc` + `NotImplemented`/`ErrNotImplemented` — the injection contract and its placeholder.
  - `NewInformerFactory(client, resync)` — the standard apiserver LIST+WATCH factory.
  - `NewNATSInformerFactory(client, resync)` — the same factory fed the wrapped client (currently the `NotImplemented` stub).
- Callers select between the two behind a plain internal `bool` defaulting to `false` (no feature toggle yet; `TODO` to enable once NATS lands):
  - `register.go` — `APIBuilder.natsWatchEnabled` + a `newInformerFactory` helper used by the main and HistoricJob factory sites.
  - The 4 operators (`repo`/`jobs`/`jobqueue`/`connection`) — a package-level `natsWatchEnabled` + shared `newInformerFactory`.

## How

A `SharedIndexInformer` is fed by a `ListerWatcher`: `List` seeds the cache, `Watch` streams deltas. The generated factory builds that `ListWatch` from the typed clientset — `ListFunc` calls `client….List`, `WatchFunc` calls `client….Watch`:

```go
// generated informer (repository.go) — the seam:
WatchFunc: func(opts v1.ListOptions) (watch.Interface, error) {
    return client.ProvisioningV0alpha1().Repositories(namespace).Watch(context.Background(), opts)
},
```

So passing the factory a clientset whose `Watch` is overridden (and `List`/everything else delegated) reroutes **only** the delta source — the generated factory, informers, and typed listers are untouched, and the cache stays LIST-seeded:

```go
func NewNATSInformerFactory(client versioned.Interface, resync time.Duration) informers.SharedInformerFactory {
    return informers.NewSharedInformerFactory(WrapClient(client, NotImplemented), resync)
}
```

The wiring just picks a constructor:

```go
if b.natsWatchEnabled {
    return informer.NewNATSInformerFactory(c, resync)
}
return informer.NewInformerFactory(c, resync)
```

## Testing

- `go test ./apps/provisioning/pkg/informer/` — per-resource `Watch` routes through the `WatchFunc` with the correct GVR/namespace; `List` delegates to the real client; `NotImplemented` returns `ErrNotImplemented`; both factory constructors are drop-ins with working typed listers.
- `go build` + `go vet` of `pkg/registry/apis/provisioning`, `pkg/operators/provisioning`, and the new package — clean. `gofmt` clean.
- `golangci-lint` couldn't run locally (go1.25-built binary vs the repo's go1.26.4) — CI covers it.

## Behavior change

Pure mechanism, **gated off by default** (`natsWatchEnabled = false` in `register.go` and all four operators) — no functional change. With the switch on, the informers' `Watch` fails with `not implemented` while `List` still seeds the cache, which is how a later PR swaps in the real NATS watch.

**Follow-ups:** the NATS-backed `watch.Interface` + decoder, the publisher (`BroadcasterConsumer` → NATS) and contract (subjects/payload), periodic-relist self-heal, and metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)