### PR TITLE
Provisioning: Use GitHub PR merge refs for Git Sync previews

### DIFF
--- a/apps/provisioning/pkg/repository/git/branch_test.go
+++ b/apps/provisioning/pkg/repository/git/branch_test.go
@@ -23,6 +23,7 @@ func TestIsValidRef(t *testing.T) {
 		{"branch with underscore", "feature_x", true},
 		{"branch with dot", "v1.0", true},
 		{"release branch", "release/v2.10.3", true},
+		{"pull request merge ref", "refs/pull/123/merge", true},
 
 		// Valid commit SHAs.
 		{"short sha 7 chars", "abc1234", true},

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -886,7 +886,7 @@ func (r *gitRepository) Stage(ctx context.Context, opts repository.StageOptions)
 	return NewStagedGitRepository(ctx, r, opts)
 }
 
-// resolveRefToHash resolves a ref (branch name or commit hash) to a commit hash
+// resolveRefToHash resolves a ref (branch name, full ref, or commit hash) to a commit hash
 func (r *gitRepository) resolveRefToHash(ctx context.Context, ref string) (hash.Hash, error) {
 	ctx, _ = r.withGitContext(ctx, ref)
 
@@ -902,8 +902,9 @@ func (r *gitRepository) resolveRefToHash(ctx context.Context, ref string) (hash.
 		return refHash, nil
 	}
 
-	// Prefix ref with refs/heads/
-	ref = fmt.Sprintf("refs/heads/%s", ref)
+	if !strings.HasPrefix(ref, "refs/") {
+		ref = fmt.Sprintf("refs/heads/%s", ref)
+	}
 
 	// Not a valid hash, try to resolve as a branch reference
 	branchRef, err := r.client.GetRef(ctx, ref)

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -2794,11 +2794,12 @@ func TestGitRepository_EdgeCases(t *testing.T) {
 
 func TestGitRepository_ResolveRefToHash_EdgeCases(t *testing.T) {
 	tests := []struct {
-		name      string
-		setupMock func(*mocks.FakeClient)
-		ref       string
-		wantError bool
-		wantHash  string
+		name       string
+		setupMock  func(*mocks.FakeClient)
+		ref        string
+		wantError  bool
+		wantHash   string
+		wantGetRef string
 	}{
 		{
 			name: "valid short hash",
@@ -2816,8 +2817,21 @@ func TestGitRepository_ResolveRefToHash_EdgeCases(t *testing.T) {
 					Hash: hash.Hash{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
 				}, nil)
 			},
-			ref:       "invalid-hex-zzz",
-			wantError: false,
+			ref:        "invalid-hex-zzz",
+			wantError:  false,
+			wantGetRef: "refs/heads/invalid-hex-zzz",
+		},
+		{
+			name: "branch name is resolved as heads ref",
+			setupMock: func(mockClient *mocks.FakeClient) {
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/heads/feature",
+					Hash: hash.Hash{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22},
+				}, nil)
+			},
+			ref:        "feature",
+			wantError:  false,
+			wantGetRef: "refs/heads/feature",
 		},
 		{
 			name: "refs/heads/ prefix handling",
@@ -2827,8 +2841,9 @@ func TestGitRepository_ResolveRefToHash_EdgeCases(t *testing.T) {
 					Hash: hash.Hash{4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
 				}, nil)
 			},
-			ref:       "refs/heads/feature",
-			wantError: false,
+			ref:        "refs/heads/feature",
+			wantError:  false,
+			wantGetRef: "refs/heads/feature",
 		},
 		{
 			name: "refs/tags/ handling",
@@ -2838,8 +2853,21 @@ func TestGitRepository_ResolveRefToHash_EdgeCases(t *testing.T) {
 					Hash: hash.Hash{7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
 				}, nil)
 			},
-			ref:       "refs/tags/v1.0.0",
-			wantError: false,
+			ref:        "refs/tags/v1.0.0",
+			wantError:  false,
+			wantGetRef: "refs/tags/v1.0.0",
+		},
+		{
+			name: "refs/pull merge handling",
+			setupMock: func(mockClient *mocks.FakeClient) {
+				mockClient.GetRefReturns(nanogit.Ref{
+					Name: "refs/pull/123/merge",
+					Hash: hash.Hash{8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27},
+				}, nil)
+			},
+			ref:        "refs/pull/123/merge",
+			wantError:  false,
+			wantGetRef: "refs/pull/123/merge",
 		},
 	}
 
@@ -2868,6 +2896,11 @@ func TestGitRepository_ResolveRefToHash_EdgeCases(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, refHash)
+			}
+			if tt.wantGetRef != "" {
+				require.Equal(t, 1, mockClient.GetRefCallCount())
+				_, gotRef := mockClient.GetRefArgsForCall(0)
+				require.Equal(t, tt.wantGetRef, gotRef)
 			}
 		})
 	}

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -153,7 +153,7 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	progress.SetMessage(ctx, "listing pull request files")
 	// FIXME: this is leaky because it's supposed to be already a PullRequestRepo
 	base := cfg.GitHub.Branch
-	files, err := prRepo.CompareFiles(ctx, base, opts.Ref)
+	files, err := comparePullRequestFiles(ctx, prRepo, base, *opts, logger)
 	if err != nil {
 		logger.Error("failed to list pull request files", "error", err)
 		return fmt.Errorf("failed to list pull request files: %w", err)
@@ -180,6 +180,28 @@ func (c *PullRequestWorker) Process(ctx context.Context,
 	logger.Info("preview comment added")
 
 	return nil
+}
+
+func comparePullRequestFiles(ctx context.Context, repo PullRequestRepo, base string, opts provisioning.PullRequestJobOptions, logger logging.Logger) ([]repository.VersionedFileChange, error) {
+	mergeRef := pullRequestMergeRef(opts.PR)
+	if mergeRef == "" {
+		return repo.CompareFiles(ctx, base, opts.Ref)
+	}
+
+	files, err := repo.CompareFiles(ctx, base, mergeRef)
+	if err == nil || !errors.Is(err, repository.ErrRefNotFound) {
+		return files, err
+	}
+
+	logger.Info("pull request merge ref not found, falling back to head ref", "merge_ref", mergeRef, "head_ref", opts.Ref)
+	return repo.CompareFiles(ctx, base, opts.Ref)
+}
+
+func pullRequestMergeRef(pr int) string {
+	if pr <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("refs/pull/%d/merge", pr)
 }
 
 // Remove files we should not try to process

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker_test.go
@@ -53,6 +53,12 @@ func TestPullRequestWorker_IsSupported(t *testing.T) {
 	}
 }
 
+func TestPullRequestMergeRef(t *testing.T) {
+	require.Equal(t, "refs/pull/123/merge", pullRequestMergeRef(123))
+	require.Empty(t, pullRequestMergeRef(0))
+	require.Empty(t, pullRequestMergeRef(-1))
+}
+
 func TestPullRequestWorker_Process_NotPullRequestRepository(t *testing.T) {
 	evaluator := NewMockEvaluator(t)
 	commenter := NewMockCommenter(t)
@@ -200,7 +206,7 @@ func TestPullRequestWorker_Process(t *testing.T) {
 					},
 				})
 				progress.On("SetMessage", mock.Anything, "listing pull request files").Return()
-				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "test-ref").Return(nil, errors.New("failed to list files"))
+				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "refs/pull/123/merge").Return(nil, errors.New("failed to list files"))
 			},
 			expectedError: "failed to list pull request files: failed to list files",
 		},
@@ -221,7 +227,7 @@ func TestPullRequestWorker_Process(t *testing.T) {
 					},
 				})
 				progress.On("SetMessage", mock.Anything, "listing pull request files").Return()
-				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "test-ref").Return([]repository.VersionedFileChange{}, nil)
+				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "refs/pull/123/merge").Return([]repository.VersionedFileChange{}, nil)
 				progress.On("SetFinalMessage", mock.Anything, "no files to process").Return()
 			},
 			expectedError: "",
@@ -251,7 +257,7 @@ func TestPullRequestWorker_Process(t *testing.T) {
 					{Path: "another.yaml"}, // Supported file
 				}
 
-				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "test-ref").Return(files, nil)
+				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "refs/pull/123/merge").Return(files, nil)
 
 				// Only non-ignored files should be passed to the evaluator
 				expectedFiles := []repository.VersionedFileChange{
@@ -291,7 +297,7 @@ func TestPullRequestWorker_Process(t *testing.T) {
 					{Path: ".github/something"},    // Unsupported file
 				}
 
-				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "test-ref").Return(files, nil)
+				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "refs/pull/123/merge").Return(files, nil)
 
 				// Only supported files should be passed to the evaluator
 				expectedFiles := []repository.VersionedFileChange{
@@ -324,7 +330,7 @@ func TestPullRequestWorker_Process(t *testing.T) {
 				files := []repository.VersionedFileChange{
 					{Path: "test.yaml"},
 				}
-				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "test-ref").Return(files, nil)
+				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "refs/pull/123/merge").Return(files, nil)
 				evaluator.On("Evaluate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changeInfo{}, errors.New("evaluation failed"))
 			},
 			expectedError: "calculate changes: evaluation failed",
@@ -349,11 +355,38 @@ func TestPullRequestWorker_Process(t *testing.T) {
 				files := []repository.VersionedFileChange{
 					{Path: "test.yaml"},
 				}
-				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "test-ref").Return(files, nil)
+				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "refs/pull/123/merge").Return(files, nil)
 				evaluator.On("Evaluate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changeInfo{}, nil)
 				commenter.On("Comment", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("comment failed"))
 			},
 			expectedError: "comment pull request: comment failed",
+		},
+		{
+			name: "falls back to head ref when merge ref is missing",
+			opts: &provisioning.PullRequestJobOptions{
+				PR:  123,
+				Ref: "test-ref",
+			},
+			setupMocks: func(evaluator *MockEvaluator, commenter *MockCommenter, repo *mockPullRequestRepo, progress *jobs.MockJobProgressRecorder) {
+				repo.MockRepository.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-repo",
+					},
+					Spec: provisioning.RepositorySpec{
+						Title:  "test-repo",
+						GitHub: &provisioning.GitHubRepositoryConfig{Branch: "main"},
+					},
+				})
+				progress.On("SetMessage", mock.Anything, "listing pull request files").Return()
+				files := []repository.VersionedFileChange{
+					{Path: "test.yaml", Ref: "test-ref"},
+				}
+				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "refs/pull/123/merge").Return(nil, repository.ErrRefNotFound)
+				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "test-ref").Return(files, nil)
+				evaluator.On("Evaluate", mock.Anything, mock.Anything, mock.Anything, files, mock.Anything).Return(changeInfo{}, nil)
+				commenter.On("Comment", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedError: "",
 		},
 		{
 			name: "successful process",
@@ -373,10 +406,10 @@ func TestPullRequestWorker_Process(t *testing.T) {
 				})
 				progress.On("SetMessage", mock.Anything, "listing pull request files").Return()
 				files := []repository.VersionedFileChange{
-					{Path: "test.yaml"},
+					{Path: "test.yaml", Ref: "refs/pull/123/merge"},
 				}
-				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "test-ref").Return(files, nil)
-				evaluator.On("Evaluate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changeInfo{}, nil)
+				repo.MockPullRequestRepo.On("CompareFiles", mock.Anything, "main", "refs/pull/123/merge").Return(files, nil)
+				evaluator.On("Evaluate", mock.Anything, mock.Anything, mock.Anything, files, mock.Anything).Return(changeInfo{}, nil)
 				commenter.On("Comment", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			expectedError: "",

--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -23,6 +24,7 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	"github.com/grafana/nanogit/gittest"
 )
 
 // webhookBaseURL is the public base URL the webhook tests configure (matching
@@ -118,6 +120,43 @@ func waitForWebhook(t *testing.T, helper *common.GitTestHelper, repoName string,
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "webhook should be created")
 }
 
+func createGiteaPullRequest(t *testing.T, ctx context.Context, remote *gittest.RemoteRepository, base, head, title string) int {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{
+		"base":  base,
+		"head":  head,
+		"title": title,
+	})
+	require.NoError(t, err, "failed to marshal pull request")
+
+	repoURL, err := url.Parse(remote.URL)
+	require.NoError(t, err, "failed to parse remote URL")
+	apiURL := fmt.Sprintf("%s://%s/api/v1/repos/%s/%s/pulls", repoURL.Scheme, repoURL.Host, remote.Owner, remote.Name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
+	require.NoError(t, err, "failed to create pull request request")
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(remote.User.Username, remote.User.Password)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "failed to create pull request")
+	defer func() {
+		require.NoError(t, resp.Body.Close())
+	}()
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "pull request should be created")
+
+	var created struct {
+		Number int `json:"number"`
+		Index  int `json:"index"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created), "failed to decode pull request")
+	if created.Number != 0 {
+		return created.Number
+	}
+	require.NotZero(t, created.Index, "pull request response should include number or index")
+	return created.Index
+}
+
 func TestIntegrationProvisioning_GithubRepoNoWebhookWhenDisabled(t *testing.T) {
 	helper := sharedGitHelper(t)
 	ctx := context.Background()
@@ -158,15 +197,17 @@ func TestIntegrationProvisioning_GithubRepoWebhookCreated(t *testing.T) {
 	waitForWebhook(t, helper, repoName, 456)
 }
 
-// TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment verifies the
+// TestIntegrationProvisioning_GithubPullRequestWebhookFallsBackToHeadRefForComment verifies the
 // end-to-end PR webhook path without a real GitHub PR: a pushed gittest feature
-// branch supplies the diff, the webhook payload supplies PR metadata, and the
-// mocked GitHub comments endpoint captures the PR worker's generated comment.
-func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing.T) {
+// branch supplies the webhook head metadata, Gitea creates a real PR without a
+// refs/pull/<PR>/merge ref (see go-gitea/gitea#13134), and the mocked GitHub
+// comments endpoint captures the PR worker's generated comment after it falls
+// back to the head ref.
+func TestIntegrationProvisioning_GithubPullRequestWebhookFallsBackToHeadRefForComment(t *testing.T) {
 	helper := sharedGitHelper(t)
 	ctx := context.Background()
 
-	const repoName = "github-pr-comment"
+	const repoName = "github-pr-merge-ref"
 	const dashboardPath = "dashboard.json"
 	webhookURL := expectedWebhookURL(webhookBaseURL, helper.Namespace, repoName)
 
@@ -198,8 +239,8 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	))
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient(mockOpts...)
 
-	_, local := helper.CreateGithubRepo(t, repoName, map[string][]byte{
-		dashboardPath: common.DashboardJSON("gh-pr-comment-dash", "GitHub PR Comment Dashboard", 1),
+	remote, local := helper.CreateGithubRepo(t, repoName, map[string][]byte{
+		dashboardPath: common.DashboardJSON("gh-pr-merge-ref-dash", "GitHub PR Merge Ref Dashboard", 1),
 	}, webhookBaseURL, "write")
 	waitForWebhook(t, helper, repoName, 654)
 	helper.SyncAndWait(t, repoName)
@@ -209,12 +250,12 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	// produces the [original] link in the comment; SyncAndWait only waits for
 	// job success, not resource visibility, so without this barrier the Get can
 	// race the sync write and drop the [original] link.
-	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, ctx, "gh-pr-comment-dash", repoName, dashboardPath)
+	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, ctx, "gh-pr-merge-ref-dash", repoName, dashboardPath)
 
-	const branchName = "feature-pr-comment"
+	const branchName = "feature-pr-merge-ref"
 	_, err := local.Git("checkout", "-b", branchName)
 	require.NoError(t, err, "failed to create feature branch")
-	err = local.UpdateFile(dashboardPath, string(common.DashboardJSON("gh-pr-comment-dash", "GitHub PR Comment Dashboard Updated", 2)))
+	err = local.UpdateFile(dashboardPath, string(common.DashboardJSON("gh-pr-merge-ref-dash", "GitHub PR Feature Branch Dashboard", 2)))
 	require.NoError(t, err, "failed to update dashboard")
 	_, err = local.Git("add", dashboardPath)
 	require.NoError(t, err, "failed to add dashboard")
@@ -225,14 +266,16 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	_, err = local.Git("push", "-u", "origin", branchName)
 	require.NoError(t, err, "failed to push feature branch")
 
-	prURL := fmt.Sprintf("https://github.example.com/git/%s/pull/123", repoName)
+	prNumber := createGiteaPullRequest(t, ctx, remote, "main", branchName, "Update dashboard")
+
+	prURL := fmt.Sprintf("https://github.example.com/git/%s/pull/%d", repoName, prNumber)
 	payload, err := json.Marshal(map[string]any{
 		"action": "opened",
 		"repository": map[string]any{
 			"full_name": fmt.Sprintf("git/%s", repoName),
 		},
 		"pull_request": map[string]any{
-			"number":   123,
+			"number":   prNumber,
 			"html_url": prURL,
 			"base": map[string]any{
 				"ref": "main",
@@ -310,7 +353,7 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	require.NotEqualf(t, -1, originalEnd, "comment should close original link:\n%s", comment)
 	originalURL, err := url.Parse(originalRemainder[:originalEnd])
 	require.NoError(t, err, "comment should contain a valid original URL")
-	require.Equal(t, "/d/gh-pr-comment-dash/github-pr-comment-dashboard-updated", originalURL.Path)
+	require.Equal(t, "/d/gh-pr-merge-ref-dash/github-pr-feature-branch-dashboard", originalURL.Path)
 
 	previewMarker := "[preview]("
 	previewStart := strings.Index(comment, previewMarker)


### PR DESCRIPTION
**What is this feature?**

Git Sync pull request previews now try to compare against GitHub's synthetic PR merge ref, `refs/pull/<PR>/merge`, before falling back to the pull request head branch when that merge ref is unavailable.

**Why do we need this feature?**

In busy monorepos, many open pull requests can lag behind the default branch. Comparing Git Sync previews against the plain feature branch can make Grafana report or comment on PRs because they are behind the default branch, rather than because the PR's effective merged result changes Grafana-managed resources.

Using GitHub's merge ref lets Grafana preview the same effective tree GitHub presents for a pull request after applying the feature branch on top of the base branch.

**Who is this feature for?**

Teams using Git Sync with GitHub pull requests, especially teams keeping Grafana dashboards in active monorepos with many concurrent PRs.

**Which issue(s) does this PR fix?**:

Fixes #127532

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Validation notes:
- Added coverage for preferring GitHub's PR merge ref and falling back to the PR head ref when the merge ref is unavailable.
- Added integration coverage for the signed PR webhook flow through comment creation. The local Gitea test backend does not expose `refs/pull/<PR>/merge`, so the integration test verifies the fallback behavior end to end.