### PR TITLE
docs: note node version shadowing gotcha for cloud agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 
 ### Prerequisites
 
-- **Node.js v24.x** (see `.nvmrc` for exact version). Use `nvm install` / `nvm use` to match.
+- **Node.js v24.x** (see `.nvmrc` for exact version). Use `nvm install` / `nvm use` to match. Note: in the cloud VM a `node` shim (v22) is first on `PATH` for non-login shells, so a bare `node` may report v22; login shells (e.g. `bash -l`, and the tmux login shells used to run services) resolve v24 via nvm. Run services from a login shell or prepend the nvm bin (`/home/ubuntu/.nvm/versions/node/v24.11.0/bin`) to `PATH`.
 - **Go 1.26.4** (see `go.mod`). Pre-installed in the VM.
 - **Yarn 4.11.0** via corepack (bundled in `.yarn/releases/`). Run `corepack enable` if `yarn` is not found.
 - **GCC** required for CGo/SQLite compilation of the backend.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Documents a non-obvious environment gotcha discovered while setting up the Cursor Cloud dev environment: in the cloud VM a `node` shim (v22) is first on `PATH` for non-login shells, so a bare `node` may report v22, while login shells resolve v24 via nvm.

This is a docs-only change to `AGENTS.md` under the existing `## Cursor Cloud specific instructions` section.

## Environment verification

- Backend: `make run` → HTTP 200 on `localhost:3000`
- Frontend: `yarn start` → compiled successfully, no TypeScript errors
- Lint: `make lint-go GO_LINT_FILES=./pkg/services/featuremgmt/...` → 0 issues
- Tests: `go test ./pkg/services/featuremgmt/...` and `yarn jest` (grafana-data) → pass
- Hello-world: logged in (admin/admin) and created/saved a dashboard

[Saved Hello World Dashboard](https://cursor.com/agents/bc-ade93b1c-1889-41d4-ae54-537aa9f4ecb1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgrafana_dashboard_saved.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ade93b1c-1889-41d4-ae54-537aa9f4ecb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ade93b1c-1889-41d4-ae54-537aa9f4ecb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

