### PR TITLE
unified-storage: fix storage_backend list trash sort logic

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1573,7 +1573,7 @@ func applyLiveHistoryFilter(filteredKeys []DataKey, req *resourcepb.ListRequest)
 	return filteredKeys
 }
 
-// applyPagination filters keys based on pagination parameters (descending order only)
+// applyPagination filters keys based on pagination parameters
 func applyPagination(keys []DataKey, lastSeenRV int64, sortAscending bool) []DataKey {
 	if lastSeenRV == 0 {
 		return keys

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1574,14 +1574,18 @@ func applyLiveHistoryFilter(filteredKeys []DataKey, req *resourcepb.ListRequest)
 }
 
 // applyPagination filters keys based on pagination parameters (descending order only)
-func applyPagination(keys []DataKey, lastSeenRV int64) []DataKey {
+func applyPagination(keys []DataKey, lastSeenRV int64, sortAscending bool) []DataKey {
 	if lastSeenRV == 0 {
 		return keys
 	}
 
 	pagedKeys := make([]DataKey, 0, len(keys))
 	for _, key := range keys {
-		if key.ResourceVersion < lastSeenRV {
+		if sortAscending {
+			if key.ResourceVersion > lastSeenRV {
+				pagedKeys = append(pagedKeys, key)
+			}
+		} else if key.ResourceVersion < lastSeenRV {
 			pagedKeys = append(pagedKeys, key)
 		}
 	}
@@ -1843,12 +1847,14 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 
 	// Parse continue token if provided
 	lastSeenRV := int64(0)
+	tokenSortAscending := false
 	if req.NextPageToken != "" {
 		token, err := GetContinueToken(req.NextPageToken)
 		if err != nil {
 			return 0, fmt.Errorf("invalid continue token: %w", err)
 		}
 		lastSeenRV = ToSnowflakeRV(token.ResourceVersion)
+		tokenSortAscending = token.SortAscending
 	}
 
 	// Generate a new resource version for the list
@@ -1856,7 +1862,11 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 
 	// Handle trash differently from regular history
 	if req.Source == resourcepb.ListRequest_TRASH {
-		return k.processTrashEntries(ctx, req, fn, listRV, lastSeenRV)
+		sortAscending := req.GetVersionMatchV2() == resourcepb.ResourceVersionMatchV2_NotOlderThan
+		if req.NextPageToken != "" {
+			sortAscending = tokenSortAscending
+		}
+		return k.processTrashEntries(ctx, req, fn, listRV, lastSeenRV, sortAscending)
 	}
 
 	// Get all history entries by iterating through datastore keys
@@ -1889,10 +1899,11 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 	// Apply "live" history logic: ignore events before the last delete
 	filteredKeys = applyLiveHistoryFilter(filteredKeys, req)
 
-	// Pagination: filter out items up to and including lastSeenRV
-	pagedKeys := applyPagination(filteredKeys, lastSeenRV)
+	// Pagination: filter out items up to and including lastSeenRV. Regular
+	// history is served descending (keys fetched SortOrderDesc above).
+	pagedKeys := applyPagination(filteredKeys, lastSeenRV, false)
 
-	iter := newKvHistoryIterator(ctx, k.dataStore, pagedKeys, listRV, false)
+	iter := newKvHistoryIterator(ctx, k.dataStore, pagedKeys, listRV, false, false)
 	defer iter.stop()
 
 	if err := fn(iter); err != nil {
@@ -1906,16 +1917,18 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 // It streams through keys in ascending order, tracking name groups. For each name,
 // if the latest event is a delete, it's a trash candidate.
 //
-// The results are sorted by RV desc: the sorting in this case matters as it's
+// Candidates are sorted by RV in the requested direction (sortAscending): this is
 // the only convenient place to sort results by RV using the datastore before
-// doing a BatchGet to fetch the resources. Existing user-facing features (such as
-// Restore Dashboards) currently rely on this behaviour.
+// doing a BatchGet to fetch the resources. The Restore Dashboards UI lists trash
+// without a version match (descending), while paginating callers that resume from
+// a watermark request NotOlderThan (ascending) so they make forward progress.
 func (k *kvStorageBackend) processTrashEntries(
 	ctx context.Context,
 	req *resourcepb.ListRequest,
 	fn func(ListIterator) error,
 	listRV int64,
 	lastSeenRV int64,
+	sortAscending bool,
 ) (int64, error) {
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.processTrashEntries")
 	defer span.End()
@@ -1963,16 +1976,17 @@ func (k *kvStorageBackend) processTrashEntries(
 	// Process the final name group
 	processNameGroup()
 
-	// Sort candidates by resource version descending so the most recently
-	// deleted items come first.
 	slices.SortFunc(candidates, func(a, b DataKey) int {
+		if sortAscending {
+			return cmp.Compare(a.ResourceVersion, b.ResourceVersion)
+		}
 		return cmp.Compare(b.ResourceVersion, a.ResourceVersion)
 	})
 
 	// Apply RV-based pagination: skip candidates already seen on previous pages.
-	candidates = applyPagination(candidates, lastSeenRV)
+	candidates = applyPagination(candidates, lastSeenRV, sortAscending)
 
-	iter := newKvHistoryIterator(ctx, k.dataStore, candidates, listRV, true)
+	iter := newKvHistoryIterator(ctx, k.dataStore, candidates, listRV, true, sortAscending)
 	defer iter.stop()
 
 	if err := fn(iter); err != nil {
@@ -1996,11 +2010,12 @@ func matchesTrashVersionFilter(req *resourcepb.ListRequest, key DataKey) bool {
 }
 
 // newKvHistoryIterator builds a kvHistoryIterator over dataStore.BatchGet(keys).
-func newKvHistoryIterator(ctx context.Context, ds *dataStore, keys []DataKey, listRV int64, skipProvisioned bool) *kvHistoryIterator {
+func newKvHistoryIterator(ctx context.Context, ds *dataStore, keys []DataKey, listRV int64, skipProvisioned bool, sortAscending bool) *kvHistoryIterator {
 	next, stopFn := iter.Pull2(ds.BatchGet(ctx, keys))
 	return &kvHistoryIterator{
 		listRV:          listRV,
 		skipProvisioned: skipProvisioned,
+		sortAscending:   sortAscending,
 		next:            next,
 		stopFn:          stopFn,
 	}
@@ -2009,6 +2024,7 @@ func newKvHistoryIterator(ctx context.Context, ds *dataStore, keys []DataKey, li
 type kvHistoryIterator struct {
 	listRV          int64
 	skipProvisioned bool
+	sortAscending   bool
 
 	next   func() (DataObj, error, bool)
 	stopFn func()
@@ -2080,6 +2096,7 @@ func (i *kvHistoryIterator) ContinueToken() string {
 	token := ContinueToken{
 		Name:            i.currentDataObj.Key.Name,
 		ResourceVersion: i.currentDataObj.Key.ResourceVersion,
+		SortAscending:   i.sortAscending,
 	}
 	return token.String()
 }

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -1838,6 +1838,109 @@ func TestKvStorageBackend_ListTrash_Success(t *testing.T) {
 	require.Equal(t, rvA, items[2].resourceVersion)
 }
 
+// TestKvStorageBackend_ListTrash_SortOrder verifies that trash listing honors
+// the sort convention: NotOlderThan yields ascending order (so watermark-based
+// callers advance forward), while the default match stays descending (which the
+// Restore Dashboards UI relies on). It also checks that ascending pagination
+// resumes forward via the continue token.
+func TestKvStorageBackend_ListTrash_SortOrder(t *testing.T) {
+	backend := setupTestStorageBackend(t)
+	ctx := context.Background()
+
+	createAndDelete := func(name string) int64 {
+		obj, err := createTestObjectWithName(name, appsNamespace, "data-"+name)
+		require.NoError(t, err)
+		meta, err := utils.MetaAccessor(obj)
+		require.NoError(t, err)
+
+		key := &resourcepb.ResourceKey{Namespace: "default", Group: "apps", Resource: "resources", Name: name}
+		addRV, err := backend.WriteEvent(ctx, WriteEvent{
+			Type: resourcepb.WatchEvent_ADDED, Key: key,
+			Value: objectToJSONBytes(t, obj), Object: meta,
+		})
+		require.NoError(t, err)
+		delRV, err := backend.WriteEvent(ctx, WriteEvent{
+			Type: resourcepb.WatchEvent_DELETED, Key: key,
+			Value: objectToJSONBytes(t, obj), Object: meta, ObjectOld: meta, PreviousRV: addRV,
+		})
+		require.NoError(t, err)
+		return delRV
+	}
+
+	rvA := createAndDelete("resource-a")
+	rvB := createAndDelete("resource-b")
+	rvC := createAndDelete("resource-c")
+	require.Less(t, rvA, rvB)
+	require.Less(t, rvB, rvC)
+
+	// collect lists (name, rv) and the continue token of the last consumed item,
+	// stopping after at most `limit` items.
+	collect := func(req *resourcepb.ListRequest, limit int) ([]string, []int64, string) {
+		var names []string
+		var rvs []int64
+		var token string
+		_, err := backend.ListHistory(ctx, req, func(iter ListIterator) error {
+			for iter.Next() {
+				if err := iter.Error(); err != nil {
+					return err
+				}
+				names = append(names, iter.Name())
+				rvs = append(rvs, iter.ResourceVersion())
+				token = iter.ContinueToken()
+				if limit > 0 && len(names) >= limit {
+					break
+				}
+			}
+			return iter.Error()
+		})
+		require.NoError(t, err)
+		return names, rvs, token
+	}
+
+	baseReq := func() *resourcepb.ListRequest {
+		return &resourcepb.ListRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{Namespace: "default", Group: "apps", Resource: "resources"},
+			},
+			Source: resourcepb.ListRequest_TRASH,
+			Limit:  10,
+		}
+	}
+
+	t.Run("NotOlderThan sorts ascending", func(t *testing.T) {
+		req := baseReq()
+		req.VersionMatchV2 = resourcepb.ResourceVersionMatchV2_NotOlderThan
+		names, rvs, _ := collect(req, 0)
+		require.Equal(t, []string{"resource-a", "resource-b", "resource-c"}, names)
+		require.Equal(t, []int64{rvA, rvB, rvC}, rvs)
+	})
+
+	t.Run("default match stays descending", func(t *testing.T) {
+		names, _, _ := collect(baseReq(), 0)
+		require.Equal(t, []string{"resource-c", "resource-b", "resource-a"}, names)
+	})
+
+	t.Run("ascending pagination resumes forward", func(t *testing.T) {
+		req := baseReq()
+		req.VersionMatchV2 = resourcepb.ResourceVersionMatchV2_NotOlderThan
+		req.Limit = 1
+		names, _, token := collect(req, 1)
+		require.Equal(t, []string{"resource-a"}, names)
+		require.NotEmpty(t, token)
+
+		// Direction must be pinned in the token so the next page stays ascending.
+		decoded, err := GetContinueToken(token)
+		require.NoError(t, err)
+		require.True(t, decoded.SortAscending)
+
+		next := baseReq()
+		next.VersionMatchV2 = resourcepb.ResourceVersionMatchV2_NotOlderThan
+		next.NextPageToken = token
+		names2, _, _ := collect(next, 0)
+		require.Equal(t, []string{"resource-b", "resource-c"}, names2)
+	})
+}
+
 func TestKvStorageBackend_GetResourceStats_Success(t *testing.T) {
 	backend := setupTestStorageBackend(t)
 	ctx := context.Background()


### PR DESCRIPTION
fixes https://github.com/grafana/search-and-storage-team/issues/848

list trash in storage_backend has different sorting logic than in sql/backend. This is causing issues with the dashboard service cleanup job, because we always return trash list in descending order and the dashboard services saves the RV of the last processed item. The current logic makes the dashboard service re-process every item in the list every time it runs.

This PR brings the same logic into storage_backend: if client requests a `NotOlderThan` parameter, we flip to ascending sort.