### PR TITLE
UPlot: Fix canvas test flake

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.canvas.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.canvas.test.tsx
@@ -63,6 +63,7 @@ describe('TableNG SparklineCell threshold wiring (canvas)', () => {
   let prepareConfigSpy: jest.SpyInstance;
 
   const assertCanvasOutput = async () => {
+    await waitFor(() => uPlotInstance?.status === 1);
     await waitFor(() => expect(document.querySelector('.u-over')).toBeInTheDocument());
     expect(removeCanvasTransforms(uPlotInstance!.ctx.__getEvents())).toMatchCanvasSnapshot([], { width, height });
   };

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.canvas.test.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.canvas.test.tsx
@@ -220,9 +220,13 @@ describe('HeatmapPanel (canvas)', () => {
 
   const assertUPlotReady = async () => {
     expect(screen.getByTestId(selectors.components.VizLayout.container)).toBeVisible();
-    await waitFor(() =>
-      expect(screen.getByTestId(selectors.components.VizLayout.container).querySelector('.u-over')).toBeVisible()
-    );
+
+    await waitFor(() => uPlotInstance?.status === 1);
+    await waitFor(() => {
+      return expect(
+        screen.getByTestId(selectors.components.VizLayout.container).querySelector('.u-over')
+      ).toBeVisible();
+    });
   };
 
   const assertCanvasOutput = async (snapshotSize: { width: number; height: number } = { width, height }) => {

--- a/public/app/plugins/panel/xychart/XYChartPanel.canvas.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel.canvas.test.tsx
@@ -275,6 +275,7 @@ describe('XYChartPanel2', () => {
 
   const assertUPlotReady = async () => {
     expect(screen.getByTestId(selectors.components.VizLayout.container)).toBeVisible();
+    await waitFor(() => uPlotInstance?.status === 1);
     await waitFor(() =>
       expect(screen.getByTestId(selectors.components.VizLayout.container).querySelector('.u-over')).toBeVisible()
     );


### PR DESCRIPTION
**What is this feature?**
Only checking for the existence of uPlot’s `.u-over` DOM element as indication of plot readiness is not sufficient as the annotation draw microtask can still be ongoing when the test snapshot is taken.

**Why do we need this feature?**
Fix test flake

**Special notes for your reviewer:**
Couldn't figure out why this just started to flake (and the local flake rate was about half of executions), but since uPlot does draw work after greedily creating the u-over element the fix makes sense, was able to run the heatmap test 100x without any more flake, so LGTM.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
