### PR TITLE
feat(navigation): Add the Knowledge Graph Application page to the Observability section

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -63,6 +63,23 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 		}
 	}
 
+	// When the App Observability plugin is present it owns the "Application" entry in the
+	// Observability section, so hide the equivalent asserts "Applications" page. Operations
+	// is nested inside that node, so it is dropped along with it.
+	if enabledAccessibleAppPluginMap["grafana-app-observability-app"] != nil {
+		if obsSection := treeRoot.FindById(navtree.NavIDObservability); obsSection != nil {
+			assertsApplicationsURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/applications"
+			children := make([]*navtree.NavLink, 0, len(obsSection.Children))
+			for _, child := range obsSection.Children {
+				if child.Url == assertsApplicationsURL {
+					continue
+				}
+				children = append(children, child)
+			}
+			obsSection.Children = children
+		}
+	}
+
 	if len(appLinks) > 0 {
 		sort.SliceStable(appLinks, func(i, j int) bool {
 			return appLinks[i].Text < appLinks[j].Text

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -19,6 +19,7 @@ import (
 
 // The Knowledge Graph's version of the "Application" page.
 const assertsServicesPath = "/a/grafana-asserts-app/services"
+const appObservabilityAppID = "grafana-app-observability-app"
 
 func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel.ReqContext) error {
 	hasAccess := ac.HasAccess(s.accessControl, c)
@@ -68,7 +69,7 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 
 	// When the App Observability plugin is present it owns the "Application" entry
 	// in the Observability section, so hide the equivalent asserts "Application" page.
-	if treeRoot.FindById("plugin-page-grafana-app-observability-app") != nil {
+	if treeRoot.FindById("plugin-page-"+appObservabilityAppID) != nil {
 		if obsSection := treeRoot.FindById(navtree.NavIDObservability); obsSection != nil {
 			assertsApplicationsURL := s.cfg.AppSubURL + assertsServicesPath
 			children := make([]*navtree.NavLink, 0, len(obsSection.Children))
@@ -312,7 +313,7 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				// Place the asserts Application page in the same slot as the App Observability
 				// "Application" page, so it lands right after Frontend. Only one of the two is
 				// ever shown.
-				child.SortWeight = s.navigationAppConfig["grafana-app-observability-app"].SortWeight
+				child.SortWeight = s.navigationAppConfig[appObservabilityAppID].SortWeight
 			} else {
 				// keep current sorting of the pages, but above all the other apps
 				child.SortWeight = -100 + child.SortWeight
@@ -426,7 +427,7 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-sigil-app":                {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "AI", IsNew: true},
 		"grafana-asserts-app":              {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
 		"grafana-kowalski-app":             {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
-		"grafana-app-observability-app":    {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Application"},
+		appObservabilityAppID:              {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Application"},
 		"grafana-dbo11y-app":               {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Database", IsNew: true},
 		"grafana-k8s-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 6, Text: "Kubernetes"},
 		"grafana-csp-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 7, Icon: "cloud-provider"},

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -63,12 +63,11 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 		}
 	}
 
-	// When the App Observability plugin is present it owns the "Application" entry in the
-	// Observability section, so hide the equivalent asserts "Applications" page. Operations
-	// is nested inside that node, so it is dropped along with it.
+	// When the App Observability plugin is present it owns the "Application" entry
+	// in the Observability section, so hide the equivalent asserts "Application" page.
 	if enabledAccessibleAppPluginMap["grafana-app-observability-app"] != nil {
 		if obsSection := treeRoot.FindById(navtree.NavIDObservability); obsSection != nil {
-			assertsApplicationsURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/applications"
+			assertsApplicationsURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/services"
 			children := make([]*navtree.NavLink, 0, len(obsSection.Children))
 			for _, child := range obsSection.Children {
 				if child.Url == assertsApplicationsURL {
@@ -303,28 +302,12 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 	sectionChildren := []*navtree.NavLink{appLink}
 	// asserts pages expand to root Observability section instead of it's own node
 	if plugin.ID == "grafana-asserts-app" {
-		applicationsURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/applications"
-		operationsURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/operations"
-
-		// The Operations page is nested under the Applications page instead of being
-		// hoisted as a flat sibling like the other asserts pages.
-		var applicationsNode, operationsNode *navtree.NavLink
-		for _, child := range appLink.Children {
-			switch child.Url {
-			case applicationsURL:
-				applicationsNode = child
-			case operationsURL:
-				operationsNode = child
-			}
-		}
+		servicesURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/services"
 
 		sectionChildren = make([]*navtree.NavLink, 0, len(appLink.Children))
 		for _, child := range appLink.Children {
-			if child == operationsNode {
-				continue
-			}
-			if child.Url == applicationsURL {
-				// Place the asserts Applications page between Frontend (3) and Application (5)
+			if child.Url == servicesURL {
+				// Place the asserts Application page between Frontend (3) and Application Observability (5)
 				child.SortWeight = 4
 			} else {
 				// keep current sorting of the pages, but above all the other apps
@@ -332,11 +315,6 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 			}
 			child.Id = "standalone-plugin-page-" + strings.ReplaceAll(strings.ToLower(child.Text), " ", "-")
 			sectionChildren = append(sectionChildren, child)
-		}
-
-		if applicationsNode != nil && operationsNode != nil {
-			operationsNode.Id = "standalone-plugin-page-" + strings.ReplaceAll(strings.ToLower(operationsNode.Text), " ", "-")
-			applicationsNode.Children = append(applicationsNode.Children, operationsNode)
 		}
 	}
 

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -17,6 +17,9 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
+// The Knowledge Graph's version of the "Application" page.
+const assertsServicesPath = "/a/grafana-asserts-app/services"
+
 func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel.ReqContext) error {
 	hasAccess := ac.HasAccess(s.accessControl, c)
 	appLinks := []*navtree.NavLink{}
@@ -65,9 +68,9 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 
 	// When the App Observability plugin is present it owns the "Application" entry
 	// in the Observability section, so hide the equivalent asserts "Application" page.
-	if enabledAccessibleAppPluginMap["grafana-app-observability-app"] != nil {
+	if treeRoot.FindById("plugin-page-grafana-app-observability-app") != nil {
 		if obsSection := treeRoot.FindById(navtree.NavIDObservability); obsSection != nil {
-			assertsApplicationsURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/services"
+			assertsApplicationsURL := s.cfg.AppSubURL + assertsServicesPath
 			children := make([]*navtree.NavLink, 0, len(obsSection.Children))
 			for _, child := range obsSection.Children {
 				if child.Url == assertsApplicationsURL {
@@ -302,21 +305,21 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 	sectionChildren := []*navtree.NavLink{appLink}
 	// asserts pages expand to root Observability section instead of it's own node
 	if plugin.ID == "grafana-asserts-app" {
-		servicesURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/services"
+		servicesURL := s.cfg.AppSubURL + assertsServicesPath
 
-		sectionChildren = make([]*navtree.NavLink, 0, len(appLink.Children))
 		for _, child := range appLink.Children {
 			if child.Url == servicesURL {
-				// Place the asserts Application page in the same slot (4) as the App Observability
-				// "Application" page, right after Frontend (3). Only one of the two is ever shown.
-				child.SortWeight = 4
+				// Place the asserts Application page in the same slot as the App Observability
+				// "Application" page, so it lands right after Frontend. Only one of the two is
+				// ever shown.
+				child.SortWeight = s.navigationAppConfig["grafana-app-observability-app"].SortWeight
 			} else {
 				// keep current sorting of the pages, but above all the other apps
 				child.SortWeight = -100 + child.SortWeight
 			}
 			child.Id = "standalone-plugin-page-" + strings.ReplaceAll(strings.ToLower(child.Text), " ", "-")
-			sectionChildren = append(sectionChildren, child)
 		}
+		sectionChildren = appLink.Children
 	}
 
 	if sectionID == navtree.NavIDRoot {

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -288,9 +288,15 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 	if plugin.ID == "grafana-asserts-app" {
 		sectionChildren = appLink.Children
 
-		// keep current sorting if the pages, but above all the other apps
+		applicationsURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/applications"
 		for _, child := range sectionChildren {
-			child.SortWeight = -100 + child.SortWeight
+			if child.Url == applicationsURL {
+				// Place the asserts Applications page between Frontend (3) and Application (5)
+				child.SortWeight = 4
+			} else {
+				// keep current sorting of the pages, but above all the other apps
+				child.SortWeight = -100 + child.SortWeight
+			}
 			child.Id = "standalone-plugin-page-" + strings.ReplaceAll(strings.ToLower(child.Text), " ", "-")
 		}
 	}
@@ -399,10 +405,10 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-sigil-app":                {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "AI", IsNew: true},
 		"grafana-asserts-app":              {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
 		"grafana-kowalski-app":             {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
-		"grafana-app-observability-app":    {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Application"},
-		"grafana-dbo11y-app":               {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Database", IsNew: true},
-		"grafana-k8s-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 6, Text: "Kubernetes"},
-		"grafana-csp-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 7, Icon: "cloud-provider"},
+		"grafana-app-observability-app":    {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Application"},
+		"grafana-dbo11y-app":               {SectionID: navtree.NavIDObservability, SortWeight: 6, Text: "Database", IsNew: true},
+		"grafana-k8s-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 7, Text: "Kubernetes"},
+		"grafana-csp-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 8, Icon: "cloud-provider"},
 		"grafana-metricsdrilldown-app":     {SectionID: navtree.NavIDDrilldown, SortWeight: 1, Text: "Metrics"},
 		"grafana-lokiexplore-app":          {SectionID: navtree.NavIDDrilldown, SortWeight: 2, Text: "Logs"},
 		"grafana-exploretraces-app":        {SectionID: navtree.NavIDDrilldown, SortWeight: 3, Text: "Traces"},

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -286,10 +286,26 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 	sectionChildren := []*navtree.NavLink{appLink}
 	// asserts pages expand to root Observability section instead of it's own node
 	if plugin.ID == "grafana-asserts-app" {
-		sectionChildren = appLink.Children
-
 		applicationsURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/applications"
-		for _, child := range sectionChildren {
+		operationsURL := s.cfg.AppSubURL + "/a/grafana-asserts-app/operations"
+
+		// The Operations page is nested under the Applications page instead of being
+		// hoisted as a flat sibling like the other asserts pages.
+		var applicationsNode, operationsNode *navtree.NavLink
+		for _, child := range appLink.Children {
+			switch child.Url {
+			case applicationsURL:
+				applicationsNode = child
+			case operationsURL:
+				operationsNode = child
+			}
+		}
+
+		sectionChildren = make([]*navtree.NavLink, 0, len(appLink.Children))
+		for _, child := range appLink.Children {
+			if child == operationsNode {
+				continue
+			}
 			if child.Url == applicationsURL {
 				// Place the asserts Applications page between Frontend (3) and Application (5)
 				child.SortWeight = 4
@@ -298,6 +314,12 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				child.SortWeight = -100 + child.SortWeight
 			}
 			child.Id = "standalone-plugin-page-" + strings.ReplaceAll(strings.ToLower(child.Text), " ", "-")
+			sectionChildren = append(sectionChildren, child)
+		}
+
+		if applicationsNode != nil && operationsNode != nil {
+			operationsNode.Id = "standalone-plugin-page-" + strings.ReplaceAll(strings.ToLower(operationsNode.Text), " ", "-")
+			applicationsNode.Children = append(applicationsNode.Children, operationsNode)
 		}
 	}
 

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -307,7 +307,8 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 		sectionChildren = make([]*navtree.NavLink, 0, len(appLink.Children))
 		for _, child := range appLink.Children {
 			if child.Url == servicesURL {
-				// Place the asserts Application page between Frontend (3) and Application Observability (5)
+				// Place the asserts Application page in the same slot (4) as the App Observability
+				// "Application" page, right after Frontend (3). Only one of the two is ever shown.
 				child.SortWeight = 4
 			} else {
 				// keep current sorting of the pages, but above all the other apps
@@ -422,10 +423,10 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"grafana-sigil-app":                {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "AI", IsNew: true},
 		"grafana-asserts-app":              {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
 		"grafana-kowalski-app":             {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
-		"grafana-app-observability-app":    {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Application"},
-		"grafana-dbo11y-app":               {SectionID: navtree.NavIDObservability, SortWeight: 6, Text: "Database", IsNew: true},
-		"grafana-k8s-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 7, Text: "Kubernetes"},
-		"grafana-csp-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 8, Icon: "cloud-provider"},
+		"grafana-app-observability-app":    {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Application"},
+		"grafana-dbo11y-app":               {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Database", IsNew: true},
+		"grafana-k8s-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 6, Text: "Kubernetes"},
+		"grafana-csp-app":                  {SectionID: navtree.NavIDObservability, SortWeight: 7, Icon: "cloud-provider"},
 		"grafana-metricsdrilldown-app":     {SectionID: navtree.NavIDDrilldown, SortWeight: 1, Text: "Metrics"},
 		"grafana-lokiexplore-app":          {SectionID: navtree.NavIDDrilldown, SortWeight: 2, Text: "Logs"},
 		"grafana-exploretraces-app":        {SectionID: navtree.NavIDDrilldown, SortWeight: 3, Text: "Traces"},

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -464,29 +464,30 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 		},
 	}
 
-	pluginSettings := pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
-		assertsApp.ID:     {ID: 0, OrgID: 1, PluginID: assertsApp.ID, PluginVersion: "1.0.0", Enabled: true},
-		frontendApp.ID:    {ID: 0, OrgID: 1, PluginID: frontendApp.ID, PluginVersion: "1.0.0", Enabled: true},
-		applicationApp.ID: {ID: 0, OrgID: 1, PluginID: applicationApp.ID, PluginVersion: "1.0.0", Enabled: true},
-	}}
-
-	service := ServiceImpl{
-		log:            log.New("navtree"),
-		cfg:            setting.NewCfg(),
-		accessControl:  accesscontrolmock.New().WithPermissions(permissions),
-		pluginSettings: &pluginSettings,
-		features:       featuremgmt.WithFeatures(),
-		pluginStore: &pluginstore.FakePluginStore{
-			PluginList: []pluginstore.Plugin{assertsApp, frontendApp, applicationApp},
-		},
+	navigationAppConfig := map[string]NavigationAppConfig{
+		"grafana-asserts-app":           {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
+		"grafana-kowalski-app":          {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
+		"grafana-app-observability-app": {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Application"},
 	}
 
-	t.Run("asserts Applications page sits between Frontend and Application, other asserts pages stay on top", func(t *testing.T) {
-		service.navigationAppConfig = map[string]NavigationAppConfig{
-			"grafana-asserts-app":           {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
-			"grafana-kowalski-app":          {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
-			"grafana-app-observability-app": {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Application"},
+	newService := func(pluginList []pluginstore.Plugin) ServiceImpl {
+		settings := map[string]*pluginsettings.DTO{}
+		for _, p := range pluginList {
+			settings[p.ID] = &pluginsettings.DTO{ID: 0, OrgID: 1, PluginID: p.ID, PluginVersion: "1.0.0", Enabled: true}
 		}
+		return ServiceImpl{
+			log:                 log.New("navtree"),
+			cfg:                 setting.NewCfg(),
+			accessControl:       accesscontrolmock.New().WithPermissions(permissions),
+			pluginSettings:      &pluginsettings.FakePluginSettings{Plugins: settings},
+			features:            featuremgmt.WithFeatures(),
+			pluginStore:         &pluginstore.FakePluginStore{PluginList: pluginList},
+			navigationAppConfig: navigationAppConfig,
+		}
+	}
+
+	t.Run("without the App Observability plugin, the asserts Applications page sits between Frontend and Application with Operations nested", func(t *testing.T) {
+		service := newService([]pluginstore.Plugin{assertsApp, frontendApp})
 
 		treeRoot := navtree.NavTreeRoot{}
 		err := service.addAppLinks(&treeRoot, reqCtx)
@@ -496,23 +497,25 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 		monitoringNode := treeRoot.FindById(navtree.NavIDObservability)
 		require.NotNil(t, monitoringNode)
 		// Operations is nested under Applications, so it is not a flat sibling.
-		require.Len(t, monitoringNode.Children, 4)
+		require.Len(t, monitoringNode.Children, 3)
 
 		// Asserts "Entity graph" stays hoisted to the top, then Frontend, then the
-		// asserts "Applications" page (weight 4), then the Application plugin (weight 5).
+		// asserts "Applications" page (weight 4).
 		require.Equal(t, "Entity graph", monitoringNode.Children[0].Text)
 		require.Equal(t, "Frontend", monitoringNode.Children[1].Text)
 		require.Equal(t, "Applications", monitoringNode.Children[2].Text)
 		require.Equal(t, "standalone-plugin-page-applications", monitoringNode.Children[2].Id)
-		require.Equal(t, "Application", monitoringNode.Children[3].Text)
+
+		// Operations is nested as a child of the Applications page, not a flat sibling.
+		applicationsNode := monitoringNode.Children[2]
+		require.Len(t, applicationsNode.Children, 1)
+		require.Equal(t, "Operations", applicationsNode.Children[0].Text)
+		require.Equal(t, "standalone-plugin-page-operations", applicationsNode.Children[0].Id)
+		require.Equal(t, "/a/grafana-asserts-app/operations", applicationsNode.Children[0].Url)
 	})
 
-	t.Run("asserts Operations page is nested as a child of the Applications page", func(t *testing.T) {
-		service.navigationAppConfig = map[string]NavigationAppConfig{
-			"grafana-asserts-app":           {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
-			"grafana-kowalski-app":          {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
-			"grafana-app-observability-app": {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Application"},
-		}
+	t.Run("when the App Observability plugin is present, it replaces the asserts Applications page and Operations is hidden", func(t *testing.T) {
+		service := newService([]pluginstore.Plugin{assertsApp, frontendApp, applicationApp})
 
 		treeRoot := navtree.NavTreeRoot{}
 		err := service.addAppLinks(&treeRoot, reqCtx)
@@ -522,20 +525,22 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 		monitoringNode := treeRoot.FindById(navtree.NavIDObservability)
 		require.NotNil(t, monitoringNode)
 
-		var applicationsNode *navtree.NavLink
+		var hasAppObservability bool
 		for _, child := range monitoringNode.Children {
-			if child.Text == "Applications" {
-				applicationsNode = child
+			// The appo11y "Application" page is shown instead of the asserts "Applications" page.
+			if child.Text == "Application" && child.Url == "/a/grafana-app-observability-app/" {
+				hasAppObservability = true
 			}
-			// Operations must not appear as a flat sibling in the Observability section.
+			// The asserts "Applications" page must not be shown when appo11y is present.
+			require.NotEqual(t, "/a/grafana-asserts-app/applications", child.Url)
+			// Operations was nested under the asserts Applications page, so it is gone too.
 			require.NotEqual(t, "Operations", child.Text)
+			for _, grandchild := range child.Children {
+				require.NotEqual(t, "Operations", grandchild.Text)
+			}
 		}
 
-		require.NotNil(t, applicationsNode)
-		require.Len(t, applicationsNode.Children, 1)
-		require.Equal(t, "Operations", applicationsNode.Children[0].Text)
-		require.Equal(t, "standalone-plugin-page-operations", applicationsNode.Children[0].Id)
-		require.Equal(t, "/a/grafana-asserts-app/operations", applicationsNode.Children[0].Url)
+		require.True(t, hasAppObservability, "expected the appo11y Application page to be present")
 	})
 }
 

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -461,7 +461,7 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 	navigationAppConfig := map[string]NavigationAppConfig{
 		"grafana-asserts-app":           {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
 		"grafana-kowalski-app":          {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
-		"grafana-app-observability-app": {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Application"},
+		"grafana-app-observability-app": {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Application"},
 	}
 
 	newService := func(pluginList []pluginstore.Plugin) ServiceImpl {

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -376,6 +376,131 @@ func TestAddAppLinks(t *testing.T) {
 	})
 }
 
+func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}
+	permissions := []ac.Permission{
+		{Action: pluginaccesscontrol.ActionAppAccess, Scope: "*"},
+	}
+
+	assertsApp := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID:   "grafana-asserts-app",
+			Name: "Knowledge graph",
+			Type: plugins.TypeApp,
+			Includes: []*plugins.Includes{
+				{
+					Name:       "Knowledge graph",
+					Path:       "/a/grafana-asserts-app/",
+					Type:       "page",
+					AddToNav:   true,
+					DefaultNav: true,
+				},
+				{
+					Name:     "Entity graph",
+					Path:     "/a/grafana-asserts-app/entities",
+					Type:     "page",
+					AddToNav: true,
+				},
+				{
+					Name:     "Applications",
+					Path:     "/a/grafana-asserts-app/applications",
+					Type:     "page",
+					AddToNav: true,
+				},
+			},
+		},
+	}
+
+	frontendApp := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID:   "grafana-kowalski-app",
+			Name: "Frontend",
+			Type: plugins.TypeApp,
+			Includes: []*plugins.Includes{
+				{
+					Name:       "Frontend",
+					Path:       "/a/grafana-kowalski-app/",
+					Type:       "page",
+					AddToNav:   true,
+					DefaultNav: true,
+				},
+				{
+					Name:     "Overview",
+					Path:     "/a/grafana-kowalski-app/overview",
+					Type:     "page",
+					AddToNav: true,
+				},
+			},
+		},
+	}
+
+	applicationApp := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID:   "grafana-app-observability-app",
+			Name: "Application",
+			Type: plugins.TypeApp,
+			Includes: []*plugins.Includes{
+				{
+					Name:       "Application",
+					Path:       "/a/grafana-app-observability-app/",
+					Type:       "page",
+					AddToNav:   true,
+					DefaultNav: true,
+				},
+				{
+					Name:     "Services",
+					Path:     "/a/grafana-app-observability-app/services",
+					Type:     "page",
+					AddToNav: true,
+				},
+			},
+		},
+	}
+
+	pluginSettings := pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
+		assertsApp.ID:     {ID: 0, OrgID: 1, PluginID: assertsApp.ID, PluginVersion: "1.0.0", Enabled: true},
+		frontendApp.ID:    {ID: 0, OrgID: 1, PluginID: frontendApp.ID, PluginVersion: "1.0.0", Enabled: true},
+		applicationApp.ID: {ID: 0, OrgID: 1, PluginID: applicationApp.ID, PluginVersion: "1.0.0", Enabled: true},
+	}}
+
+	service := ServiceImpl{
+		log:            log.New("navtree"),
+		cfg:            setting.NewCfg(),
+		accessControl:  accesscontrolmock.New().WithPermissions(permissions),
+		pluginSettings: &pluginSettings,
+		features:       featuremgmt.WithFeatures(),
+		pluginStore: &pluginstore.FakePluginStore{
+			PluginList: []pluginstore.Plugin{assertsApp, frontendApp, applicationApp},
+		},
+	}
+
+	t.Run("asserts Applications page sits between Frontend and Application, other asserts pages stay on top", func(t *testing.T) {
+		service.navigationAppConfig = map[string]NavigationAppConfig{
+			"grafana-asserts-app":           {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
+			"grafana-kowalski-app":          {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
+			"grafana-app-observability-app": {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Application"},
+		}
+
+		treeRoot := navtree.NavTreeRoot{}
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+		treeRoot.Sort()
+
+		monitoringNode := treeRoot.FindById(navtree.NavIDObservability)
+		require.NotNil(t, monitoringNode)
+		require.Len(t, monitoringNode.Children, 4)
+
+		// Asserts "Entity graph" stays hoisted to the top, then Frontend, then the
+		// asserts "Applications" page (weight 4), then the Application plugin (weight 5).
+		require.Equal(t, "Entity graph", monitoringNode.Children[0].Text)
+		require.Equal(t, "Frontend", monitoringNode.Children[1].Text)
+		require.Equal(t, "Applications", monitoringNode.Children[2].Text)
+		require.Equal(t, "standalone-plugin-page-applications", monitoringNode.Children[2].Id)
+		require.Equal(t, "Application", monitoringNode.Children[3].Text)
+	})
+}
+
 func TestBuildDataConnectionsNavLink(t *testing.T) {
 	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
 	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -408,6 +408,12 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 					Type:     "page",
 					AddToNav: true,
 				},
+				{
+					Name:     "Operations",
+					Path:     "/a/grafana-asserts-app/operations",
+					Type:     "page",
+					AddToNav: true,
+				},
 			},
 		},
 	}
@@ -489,6 +495,7 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 
 		monitoringNode := treeRoot.FindById(navtree.NavIDObservability)
 		require.NotNil(t, monitoringNode)
+		// Operations is nested under Applications, so it is not a flat sibling.
 		require.Len(t, monitoringNode.Children, 4)
 
 		// Asserts "Entity graph" stays hoisted to the top, then Frontend, then the
@@ -498,6 +505,37 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 		require.Equal(t, "Applications", monitoringNode.Children[2].Text)
 		require.Equal(t, "standalone-plugin-page-applications", monitoringNode.Children[2].Id)
 		require.Equal(t, "Application", monitoringNode.Children[3].Text)
+	})
+
+	t.Run("asserts Operations page is nested as a child of the Applications page", func(t *testing.T) {
+		service.navigationAppConfig = map[string]NavigationAppConfig{
+			"grafana-asserts-app":           {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
+			"grafana-kowalski-app":          {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
+			"grafana-app-observability-app": {SectionID: navtree.NavIDObservability, SortWeight: 5, Text: "Application"},
+		}
+
+		treeRoot := navtree.NavTreeRoot{}
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+		treeRoot.Sort()
+
+		monitoringNode := treeRoot.FindById(navtree.NavIDObservability)
+		require.NotNil(t, monitoringNode)
+
+		var applicationsNode *navtree.NavLink
+		for _, child := range monitoringNode.Children {
+			if child.Text == "Applications" {
+				applicationsNode = child
+			}
+			// Operations must not appear as a flat sibling in the Observability section.
+			require.NotEqual(t, "Operations", child.Text)
+		}
+
+		require.NotNil(t, applicationsNode)
+		require.Len(t, applicationsNode.Children, 1)
+		require.Equal(t, "Operations", applicationsNode.Children[0].Text)
+		require.Equal(t, "standalone-plugin-page-operations", applicationsNode.Children[0].Id)
+		require.Equal(t, "/a/grafana-asserts-app/operations", applicationsNode.Children[0].Url)
 	})
 }
 

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -458,10 +458,24 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 		},
 	}
 
-	navigationAppConfig := map[string]NavigationAppConfig{
-		"grafana-asserts-app":           {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
-		"grafana-kowalski-app":          {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
-		"grafana-app-observability-app": {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Application"},
+	// Enabled and accessible, but none of its includes are added to the nav, so
+	// processAppPlugin returns no node. This still lands in
+	// enabledAccessibleAppPluginMap yet never adds an "Application" entry, so the
+	// asserts page must stay visible (exercises the tree lookup over the map).
+	applicationAppNoNav := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID:   "grafana-app-observability-app",
+			Name: "Application",
+			Type: plugins.TypeApp,
+			Includes: []*plugins.Includes{
+				{
+					Name:     "Application",
+					Path:     "/a/grafana-app-observability-app/",
+					Type:     "page",
+					AddToNav: false,
+				},
+			},
+		},
 	}
 
 	newService := func(pluginList []pluginstore.Plugin) ServiceImpl {
@@ -469,15 +483,18 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 		for _, p := range pluginList {
 			settings[p.ID] = &pluginsettings.DTO{ID: 0, OrgID: 1, PluginID: p.ID, PluginVersion: "1.0.0", Enabled: true}
 		}
-		return ServiceImpl{
-			log:                 log.New("navtree"),
-			cfg:                 setting.NewCfg(),
-			accessControl:       accesscontrolmock.New().WithPermissions(permissions),
-			pluginSettings:      &pluginsettings.FakePluginSettings{Plugins: settings},
-			features:            featuremgmt.WithFeatures(),
-			pluginStore:         &pluginstore.FakePluginStore{PluginList: pluginList},
-			navigationAppConfig: navigationAppConfig,
+		service := ServiceImpl{
+			log:            log.New("navtree"),
+			cfg:            setting.NewCfg(),
+			accessControl:  accesscontrolmock.New().WithPermissions(permissions),
+			pluginSettings: &pluginsettings.FakePluginSettings{Plugins: settings},
+			features:       featuremgmt.WithFeatures(),
+			pluginStore:    &pluginstore.FakePluginStore{PluginList: pluginList},
 		}
+		// Use the production nav defaults instead of a hand-rolled map so the test
+		// exercises the real section/weight config (asserts=2, Frontend=3, Application=4).
+		service.readNavigationSettings()
+		return service
 	}
 
 	t.Run("without the App Observability plugin, the asserts Application page sits between Frontend and App Observability", func(t *testing.T) {
@@ -522,6 +539,26 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 		}
 
 		require.True(t, hasAppObservability, "expected the appo11y Application page to be present")
+	})
+
+	t.Run("when the App Observability plugin is present but contributes no nav node, the asserts Application page stays visible", func(t *testing.T) {
+		service := newService([]pluginstore.Plugin{assertsApp, frontendApp, applicationAppNoNav})
+
+		treeRoot := navtree.NavTreeRoot{}
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+		treeRoot.Sort()
+
+		monitoringNode := treeRoot.FindById(navtree.NavIDObservability)
+		require.NotNil(t, monitoringNode)
+
+		var hasAssertsApplication bool
+		for _, child := range monitoringNode.Children {
+			if child.Url == "/a/grafana-asserts-app/services" {
+				hasAssertsApplication = true
+			}
+		}
+		require.True(t, hasAssertsApplication, "expected the asserts Application page to stay visible when appo11y contributes no nav node")
 	})
 }
 

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -403,14 +403,8 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 					AddToNav: true,
 				},
 				{
-					Name:     "Applications",
-					Path:     "/a/grafana-asserts-app/applications",
-					Type:     "page",
-					AddToNav: true,
-				},
-				{
-					Name:     "Operations",
-					Path:     "/a/grafana-asserts-app/operations",
+					Name:     "Application",
+					Path:     "/a/grafana-asserts-app/services",
 					Type:     "page",
 					AddToNav: true,
 				},
@@ -486,7 +480,7 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 		}
 	}
 
-	t.Run("without the App Observability plugin, the asserts Applications page sits between Frontend and Application with Operations nested", func(t *testing.T) {
+	t.Run("without the App Observability plugin, the asserts Application page sits between Frontend and App Observability", func(t *testing.T) {
 		service := newService([]pluginstore.Plugin{assertsApp, frontendApp})
 
 		treeRoot := navtree.NavTreeRoot{}
@@ -496,25 +490,17 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 
 		monitoringNode := treeRoot.FindById(navtree.NavIDObservability)
 		require.NotNil(t, monitoringNode)
-		// Operations is nested under Applications, so it is not a flat sibling.
 		require.Len(t, monitoringNode.Children, 3)
 
 		// Asserts "Entity graph" stays hoisted to the top, then Frontend, then the
-		// asserts "Applications" page (weight 4).
+		// asserts "Application" page (weight 4).
 		require.Equal(t, "Entity graph", monitoringNode.Children[0].Text)
 		require.Equal(t, "Frontend", monitoringNode.Children[1].Text)
-		require.Equal(t, "Applications", monitoringNode.Children[2].Text)
-		require.Equal(t, "standalone-plugin-page-applications", monitoringNode.Children[2].Id)
-
-		// Operations is nested as a child of the Applications page, not a flat sibling.
-		applicationsNode := monitoringNode.Children[2]
-		require.Len(t, applicationsNode.Children, 1)
-		require.Equal(t, "Operations", applicationsNode.Children[0].Text)
-		require.Equal(t, "standalone-plugin-page-operations", applicationsNode.Children[0].Id)
-		require.Equal(t, "/a/grafana-asserts-app/operations", applicationsNode.Children[0].Url)
+		require.Equal(t, "Application", monitoringNode.Children[2].Text)
+		require.Equal(t, "standalone-plugin-page-application", monitoringNode.Children[2].Id)
 	})
 
-	t.Run("when the App Observability plugin is present, it replaces the asserts Applications page and Operations is hidden", func(t *testing.T) {
+	t.Run("when the App Observability plugin is present, it replaces the asserts Application page", func(t *testing.T) {
 		service := newService([]pluginstore.Plugin{assertsApp, frontendApp, applicationApp})
 
 		treeRoot := navtree.NavTreeRoot{}
@@ -527,17 +513,12 @@ func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 
 		var hasAppObservability bool
 		for _, child := range monitoringNode.Children {
-			// The appo11y "Application" page is shown instead of the asserts "Applications" page.
+			// The appo11y "Application" page is shown instead of the asserts "Application" page.
 			if child.Text == "Application" && child.Url == "/a/grafana-app-observability-app/" {
 				hasAppObservability = true
 			}
-			// The asserts "Applications" page must not be shown when appo11y is present.
-			require.NotEqual(t, "/a/grafana-asserts-app/applications", child.Url)
-			// Operations was nested under the asserts Applications page, so it is gone too.
-			require.NotEqual(t, "Operations", child.Text)
-			for _, grandchild := range child.Children {
-				require.NotEqual(t, "Operations", grandchild.Text)
-			}
+			// The asserts "Application" page must not be shown when appo11y is present.
+			require.NotEqual(t, "/a/grafana-asserts-app/services", child.Url)
 		}
 
 		require.True(t, hasAppObservability, "expected the appo11y Application page to be present")


### PR DESCRIPTION
**What is this feature?**
- Adds the Knowledge graph's "Application" page to the Observability nav section, placed right after Frontend in the same slot the App Observability plugin's "Application" item uses (`/a/grafana-asserts-app/services`). The remaining asserts pages (e.g. Entity graph) stay hoisted above the other apps.
- When the legacy App Observability plugin is present it owns the "Application" entry, so we hide the equivalent asserts "Application" page. Only one "Application" item is ever shown.

**Why do we need this feature?**
- We're moving the entity catalog into AppO11y. On stacks where the legacy App Observability plugin isn't provisioned, the asserts app needs to provide the "Application" menu item in its place. Without this, that slot would either be empty or, where both plugins exist, render two duplicate "Application" entries.

**Who is this feature for?**
- Grafana Cloud users of Application Observability / Knowledge graph, primarily new stacks where the legacy application observability plugin is no longer provisioned.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
