### PR TITLE
Propagate traces through unified search distributor

### DIFF
--- a/pkg/server/ring.go
+++ b/pkg/server/ring.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
@@ -137,6 +138,7 @@ func newClientPool(clientCfg grpcclient.Config, log log.Logger, reg prometheus.R
 			return nil, err
 		}
 
+		opts = append(opts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
 		opts = append(opts, connectionBackoffOptions())
 
 		conn, err := grpc.NewClient(inst.Addr, opts...)


### PR DESCRIPTION
## What this fixes

This fixes missing OpenTelemetry context propagation for distributed search requests forwarded by the unified-storage search distributor.

Before this change, the distributor copied incoming gRPC metadata to the outgoing request, but the search ring client did not use the OTel gRPC client handler. That meant the outbound `distributor -> search-server` client span was missing, and the downstream search-server span was not parented to the distributor's active span.

Before:

```text
upstream gRPC client span
├── distributor gRPC server span
│   └── distributor.Search span
└── search-server gRPC server span   # wrong parent / sibling-like
```

After:

```text
upstream gRPC client span
└── distributor gRPC server span
    └── distributor.Search span
        └── distributor -> search-server gRPC client span
            └── search-server gRPC server span
```

This adds `otelgrpc.NewClientHandler()` to the search ring client's gRPC dial options, matching the other unified-storage gRPC client paths.
