### PR TITLE
DataPro (migration): Migrate `core/history/localStorageConverter.ts`

### DIFF
--- a/public/app/core/history/RichHistoryLocalStorage.test.ts
+++ b/public/app/core/history/RichHistoryLocalStorage.test.ts
@@ -29,6 +29,21 @@ jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: () => dsMock,
 }));
 
+const datasources: Record<string, { uid: string; name: string }> = {
+  'name-of-dev-test': { uid: 'dev-test', name: 'name-of-dev-test' },
+  'name-of-dev-test-2': { uid: 'dev-test-2', name: 'name-of-dev-test-2' },
+};
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: (nameOrUid: string | { uid: string }) => {
+    if (typeof nameOrUid === 'string') {
+      return Promise.resolve(datasources[nameOrUid]);
+    }
+    return Promise.resolve(Object.values(datasources).find((ds) => ds.uid === nameOrUid.uid));
+  },
+}));
+
 let loggerMock: MonitoringLogger;
 
 interface MockQuery extends DataQuery {

--- a/public/app/core/history/RichHistoryLocalStorage.ts
+++ b/public/app/core/history/RichHistoryLocalStorage.ts
@@ -43,7 +43,7 @@ export default class RichHistoryLocalStorage implements RichHistoryStorage {
    * Return history entries based on provided filters, perform migration and clean up entries not matching retention policy.
    */
   async getRichHistory(filters: RichHistorySearchFilters) {
-    const allQueries = getRichHistoryDTOs().map(fromDTO);
+    const allQueries = await Promise.all(getRichHistoryDTOs().map(fromDTO));
     const queries = filters.starred ? allQueries.filter((q) => q.starred === true) : allQueries;
 
     const timeFilter: [number, number] | undefined =
@@ -67,7 +67,7 @@ export default class RichHistoryLocalStorage implements RichHistoryStorage {
       ...newRichHistoryQuery,
     };
 
-    const newRichHistoryQueryDTO = toDTO(richHistoryQuery);
+    const newRichHistoryQueryDTO = await toDTO(richHistoryQuery);
     const currentRichHistoryDTOs = cleanUp(getRichHistoryDTOs());
 
     /* Compare queries of a new query and last saved queries. If they are the same, (except selected properties,
@@ -211,7 +211,7 @@ export default class RichHistoryLocalStorage implements RichHistoryStorage {
 function updateRichHistory(
   id: string,
   updateCallback: (richHistoryDTO: RichHistoryLocalStorageDTO) => void
-): RichHistoryQuery {
+): Promise<RichHistoryQuery> {
   const ts = parseInt(id, 10);
   const richHistoryDTOs: RichHistoryLocalStorageDTO[] = store.getObject(RICH_HISTORY_KEY, []);
   const richHistoryDTO = find(richHistoryDTOs, { ts });

--- a/public/app/core/history/localStorageConverter.test.ts
+++ b/public/app/core/history/localStorageConverter.test.ts
@@ -1,24 +1,18 @@
-import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { type RichHistoryQuery } from 'app/types/explore';
-
-import { backendSrv } from '../services/backend_srv';
 
 import { type RichHistoryLocalStorageDTO } from './RichHistoryLocalStorage';
 import { fromDTO, toDTO } from './localStorageConverter';
 
-const dsMock = new DatasourceSrv();
-dsMock.init(
-  {
-    // @ts-ignore
-    'name-of-dev-test': { uid: 'dev-test', name: 'name-of-dev-test' },
-  },
-  ''
-);
+const devTest = { uid: 'dev-test', name: 'name-of-dev-test' };
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getBackendSrv: () => backendSrv,
-  getDataSourceSrv: () => dsMock,
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: (nameOrUid: string | { uid: string }) => {
+    if (typeof nameOrUid === 'string') {
+      return Promise.resolve(nameOrUid === devTest.name ? devTest : undefined);
+    }
+    return Promise.resolve(nameOrUid.uid === devTest.uid ? devTest : undefined);
+  },
 }));
 
 const validRichHistory: RichHistoryQuery = {
@@ -40,24 +34,22 @@ const validDTO: RichHistoryLocalStorageDTO = {
 };
 
 describe('LocalStorage converted', () => {
-  it('converts RichHistoryQuery to local storage DTO', () => {
-    expect(toDTO(validRichHistory)).toMatchObject(validDTO);
+  it('converts RichHistoryQuery to local storage DTO', async () => {
+    expect(await toDTO(validRichHistory)).toMatchObject(validDTO);
   });
 
-  it('throws an error when data source for RichHistory does not exist to avoid saving invalid items', () => {
+  it('throws an error when data source for RichHistory does not exist to avoid saving invalid items', async () => {
     const invalidRichHistory = { ...validRichHistory, datasourceUid: 'invalid' };
-    expect(() => {
-      toDTO(invalidRichHistory);
-    }).toThrow();
+    await expect(toDTO(invalidRichHistory)).rejects.toThrow();
   });
 
-  it('converts DTO to RichHistoryQuery', () => {
-    expect(fromDTO(validDTO)).toMatchObject(validRichHistory);
+  it('converts DTO to RichHistoryQuery', async () => {
+    expect(await fromDTO(validDTO)).toMatchObject(validRichHistory);
   });
 
-  it('uses empty uid when datasource does not exist for a DTO to fail gracefully for queries from removed datasources', () => {
+  it('uses empty uid when datasource does not exist for a DTO to fail gracefully for queries from removed datasources', async () => {
     const invalidDto = { ...validDTO, datasourceName: 'removed' };
-    expect(fromDTO(invalidDto)).toMatchObject({
+    expect(await fromDTO(invalidDto)).toMatchObject({
       ...validRichHistory,
       datasourceName: 'removed',
       datasourceUid: '',

--- a/public/app/core/history/localStorageConverter.ts
+++ b/public/app/core/history/localStorageConverter.ts
@@ -1,10 +1,10 @@
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type RichHistoryQuery } from 'app/types/explore';
 
 import { type RichHistoryLocalStorageDTO } from './RichHistoryLocalStorage';
 
-export const fromDTO = (dto: RichHistoryLocalStorageDTO): RichHistoryQuery => {
-  const datasource = getDataSourceSrv().getInstanceSettings(dto.datasourceName);
+export const fromDTO = async (dto: RichHistoryLocalStorageDTO): Promise<RichHistoryQuery> => {
+  const datasource = await getDataSourceInstanceSettings(dto.datasourceName);
   return {
     id: dto.ts.toString(),
     createdAt: dto.ts,
@@ -16,8 +16,8 @@ export const fromDTO = (dto: RichHistoryLocalStorageDTO): RichHistoryQuery => {
   };
 };
 
-export const toDTO = (richHistoryQuery: RichHistoryQuery): RichHistoryLocalStorageDTO => {
-  const datasource = getDataSourceSrv().getInstanceSettings({ uid: richHistoryQuery.datasourceUid });
+export const toDTO = async (richHistoryQuery: RichHistoryQuery): Promise<RichHistoryLocalStorageDTO> => {
+  const datasource = await getDataSourceInstanceSettings({ uid: richHistoryQuery.datasourceUid });
 
   if (!datasource) {
     throw new Error('Datasource not found.');

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -500,11 +500,18 @@ async function handleHistory(
   Always write to local storage. If query history is enabled, we will use local storage for autocomplete only (and want to hide errors)
   If query history is disabled, we will use local storage for query history as well, and will want to show errors
   */
-    dispatch(addHistoryItem(true, datasource.uid, datasource.name, filteredQueries, config.queryHistoryEnabled));
-    if (config.queryHistoryEnabled) {
-      // write to remote if flag enabled
-      dispatch(addHistoryItem(false, datasource.uid, datasource.name, filteredQueries, false));
-    }
+    // Kick off both writes synchronously, then await them before refreshing below. Adding to
+    // history resolves the data source asynchronously, so a non-awaited write can land after
+    // loadRichHistory has already read stale storage.
+    const localWrite = dispatch(
+      addHistoryItem(true, datasource.uid, datasource.name, filteredQueries, config.queryHistoryEnabled)
+    );
+    // write to remote if flag enabled
+    const remoteWrite = config.queryHistoryEnabled
+      ? dispatch(addHistoryItem(false, datasource.uid, datasource.name, filteredQueries, false))
+      : undefined;
+    await localWrite;
+    await remoteWrite;
 
     // Because filtering happens in the backend we cannot add a new entry without checking if it matches currently
     // used filters. Instead, we refresh the query history list.


### PR DESCRIPTION
## Description
Migrate the Rich History local storage converter off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstanceSettings()` from `@grafana/runtime/unstable`.

## Changes
* Replaced both `getDataSourceSrv().getInstanceSettings()` calls in `localStorageConverter.ts` (name→uid in `fromDTO`, uid→name in `toDTO`) with `getDataSourceInstanceSettings()`. As a result, `fromDTO` and `toDTO` are now `async` and return Promises.
* Updated the three call sites in `RichHistoryLocalStorage.ts`:
  * `getRichHistory` - `getRichHistoryDTOs().map(fromDTO)` is now `await Promise.all(getRichHistoryDTOs().map(fromDTO))`.
  * `addToRichHistory` - `toDTO(richHistoryQuery)` is now `await`ed.
  * `updateRichHistory` - now returns `Promise<RichHistoryQuery>`; its callers (`updateStarred`/`updateComment`) were already async and return the promise unchanged.
* Updated `localStorageConverter.test.ts` and `RichHistoryLocalStorage.test.ts` to mock `getDataSourceInstanceSettings` on `@grafana/runtime/unstable` (async) and to `await` the converters.

> Note: `remoteStorageConverter.ts` defines its own `fromDTO`/`toDTO` and is a separate module — it is not part of this change.

## Risks
* Low. Behaviour is unchanged - the same datasource metadata is resolved, just asynchronously. `getDataSourceInstanceSettings` falls back to the legacy service if its cache is empty. The public `RichHistoryStorage` method signatures were already async, so no interface changes.

## Demo
N/A - no user-facing changes.

## Testing Instructions
* `yarn jest public/app/core/history/localStorageConverter.test.ts public/app/core/history/RichHistoryLocalStorage.test.ts` — all tests pass.
* Optionally, in Explore confirm Rich History entries still list with correct datasource names/uids and that starring/commenting still works.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable