### PR TITLE
DataPro (migration): Migrate `core/history/remoteStorageConverter.ts`

### DIFF
--- a/public/app/core/history/RichHistoryRemoteStorage.test.ts
+++ b/public/app/core/history/RichHistoryRemoteStorage.test.ts
@@ -34,6 +34,21 @@ jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: () => dsMock,
 }));
 
+const datasources: Record<string, { uid: string; name: string }> = {
+  'name-of-ds1': { uid: 'ds1', name: 'name-of-ds1' },
+  'name-of-ds2': { uid: 'ds2', name: 'name-of-ds2' },
+};
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: (nameOrUid: string | { uid: string }) => {
+    if (typeof nameOrUid === 'string') {
+      return Promise.resolve(datasources[nameOrUid]);
+    }
+    return Promise.resolve(Object.values(datasources).find((ds) => ds.uid === nameOrUid.uid));
+  },
+}));
+
 const preferencesServiceMock = {
   patch: jest.fn(),
   load: jest.fn(),

--- a/public/app/core/history/RichHistoryRemoteStorage.ts
+++ b/public/app/core/history/RichHistoryRemoteStorage.ts
@@ -45,7 +45,7 @@ export default class RichHistoryRemoteStorage implements RichHistoryStorage {
       queries: newRichHistoryQuery.queries,
     });
     return {
-      richHistoryQuery: fromDTO(result),
+      richHistoryQuery: await fromDTO(result),
     };
   }
 
@@ -76,7 +76,7 @@ export default class RichHistoryRemoteStorage implements RichHistoryStorage {
     );
 
     const data = queryHistory.data;
-    const richHistory = (data.result.queryHistory || []).map(fromDTO);
+    const richHistory = await Promise.all((data.result.queryHistory || []).map(fromDTO));
     const total = data.result.totalCount || 0;
 
     return { richHistory, total };

--- a/public/app/core/history/remoteStorageConverter.test.ts
+++ b/public/app/core/history/remoteStorageConverter.test.ts
@@ -1,24 +1,18 @@
 import { type RichHistoryQuery } from 'app/types/explore';
 
-import { DatasourceSrv } from '../../features/plugins/datasource_srv';
-import { backendSrv } from '../services/backend_srv';
-
 import { type RichHistoryRemoteStorageDTO } from './RichHistoryRemoteStorage';
 import { fromDTO, toDTO } from './remoteStorageConverter';
 
-const dsMock = new DatasourceSrv();
-dsMock.init(
-  {
-    // @ts-ignore
-    'name-of-dev-test': { uid: 'dev-test', name: 'name-of-dev-test' },
-  },
-  ''
-);
+const devTest = { uid: 'dev-test', name: 'name-of-dev-test' };
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getBackendSrv: () => backendSrv,
-  getDataSourceSrv: () => dsMock,
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: (nameOrUid: string | { uid: string }) => {
+    if (typeof nameOrUid === 'string') {
+      return Promise.resolve(nameOrUid === devTest.name ? devTest : undefined);
+    }
+    return Promise.resolve(nameOrUid.uid === devTest.uid ? devTest : undefined);
+  },
 }));
 
 const validRichHistory: RichHistoryQuery = {
@@ -41,8 +35,8 @@ const validDTO: RichHistoryRemoteStorageDTO = {
 };
 
 describe('RemoteStorage converter', () => {
-  it('converts DTO to RichHistoryQuery', () => {
-    expect(fromDTO(validDTO)).toMatchObject(validRichHistory);
+  it('converts DTO to RichHistoryQuery', async () => {
+    expect(await fromDTO(validDTO)).toMatchObject(validRichHistory);
   });
   it('convert RichHistoryQuery to DTO', () => {
     expect(toDTO(validRichHistory)).toMatchObject(validDTO);

--- a/public/app/core/history/remoteStorageConverter.ts
+++ b/public/app/core/history/remoteStorageConverter.ts
@@ -1,10 +1,10 @@
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type RichHistoryQuery } from 'app/types/explore';
 
 import { type RichHistoryRemoteStorageDTO } from './RichHistoryRemoteStorage';
 
-export const fromDTO = (dto: RichHistoryRemoteStorageDTO): RichHistoryQuery => {
-  const datasource = getDataSourceSrv().getInstanceSettings({ uid: dto.datasourceUid });
+export const fromDTO = async (dto: RichHistoryRemoteStorageDTO): Promise<RichHistoryQuery> => {
+  const datasource = await getDataSourceInstanceSettings({ uid: dto.datasourceUid });
 
   return {
     id: dto.uid,


### PR DESCRIPTION
## Description
Migrate the Rich History remote storage converter off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstanceSettings()` from `@grafana/runtime/unstable`.

## Changes
* Replaced the `getDataSourceSrv().getInstanceSettings()` call in `remoteStorageConverter.ts` `fromDTO` (uid→name) with `getDataSourceInstanceSettings()`. As a result, `fromDTO` is now `async` and returns a Promise. `toDTO` does not resolve datasources and is unchanged.
* Updated the call sites in `RichHistoryRemoteStorage.ts`:
  * `addToRichHistory` - `fromDTO(result)` is now `await`ed.
  * `getRichHistory` - `(data.result.queryHistory || []).map(fromDTO)` is now `await Promise.all(...)`.
  * `updateComment` / `updateStarred` - `return fromDTO(dto.result)` is unchanged; these are already async methods returning `Promise<RichHistoryQuery>`, so returning the promise directly is type-correct.
* Updated `remoteStorageConverter.test.ts` and `RichHistoryRemoteStorage.test.ts` to mock `getDataSourceInstanceSettings` on `@grafana/runtime/unstable` (async) and to `await` `fromDTO`.

> Note: `buildQueryParams` in `RichHistoryRemoteStorage.ts` also uses `getDataSourceSrv()` (name→uid). That is a separate usage outside this converter's scope and is intentionally left unchanged; the `getDataSourceSrv` mock is retained in that test for it.

## Risks
* Low. Behaviour is unchanged — the same datasource metadata is resolved, just asynchronously. `getDataSourceInstanceSettings` falls back to the legacy service if its cache is empty. The public `RichHistoryStorage` method signatures were already async, so no interface changes.

## Demo
N/A - no user-facing changes.

## Testing Instructions
* `yarn jest public/app/core/history/remoteStorageConverter.test.ts public/app/core/history/RichHistoryRemoteStorage.test.ts` — all tests pass.
* Optionally, with query history backend enabled, confirm remote Rich History entries list with correct datasource names and that starring/commenting still works.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable