### PR TITLE
DataPro (migration): Migrate `core/utils/explore.ts`

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -1,5 +1,6 @@
 import {
   type DataSourceApi,
+  type DataSourceRef,
   dateTime,
   type ExploreUrlState,
   type GrafanaConfig,
@@ -69,6 +70,11 @@ const getDataSourceSrvMock = jest.fn().mockReturnValue(datasourceSrv);
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: () => getDataSourceSrvMock(),
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: (ref?: DataSourceRef | string) => datasourceSrv.get(ref),
 }));
 
 // Avoids errors caused by circular dependencies

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -24,7 +24,7 @@ import {
   urlUtil,
   generateUUID,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { RefreshPicker } from '@grafana/ui';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { type QueryOptions, type QueryTransaction } from 'app/types/explore';
@@ -74,7 +74,7 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
         .map(async (q) => {
           // if the query defines a datasource, use that one, otherwise use the one from the panel, which should always be defined.
           // this will rejects if the datasource is not found, or return the default one if dsRef is not provided.
-          const queryDs = await getDataSourceSrv().get(q.datasource || dsRef);
+          const queryDs = await getDataSourceInstance(q.datasource || dsRef);
 
           return {
             // interpolate the query using its datasource `interpolateVariablesInQueries` method if defined, othewise return the query as-is.
@@ -186,13 +186,13 @@ export async function generateEmptyQuery(
     // otherwise use last queries' datasource
     datasourceRef = queries[queries.length - 1].datasource;
   } else {
-    datasourceInstance = await getDataSourceSrv().get();
+    datasourceInstance = await getDataSourceInstance();
     defaultQuery = datasourceInstance.getDefaultQuery?.(CoreApp.Explore);
     datasourceRef = datasourceInstance.getRef();
   }
 
   if (!datasourceInstance) {
-    datasourceInstance = await getDataSourceSrv().get(datasourceRef);
+    datasourceInstance = await getDataSourceInstance(datasourceRef);
     defaultQuery = datasourceInstance.getDefaultQuery?.(CoreApp.Explore);
   }
 
@@ -230,7 +230,7 @@ export async function ensureQueries(
       let validDS = true;
       if (query.datasource) {
         try {
-          await getDataSourceSrv().get(query.datasource.uid);
+          await getDataSourceInstance(query.datasource.uid);
         } catch {
           console.error(`One of the queries has a datasource that is no longer available and was removed.`);
           validDS = false;
@@ -249,7 +249,7 @@ export async function ensureQueries(
   }
   try {
     // if a datasource override get its ref, otherwise get the default datasource
-    const emptyQueryRef = newQueryDataSourceOverride ?? (await getDataSourceSrv().get()).getRef();
+    const emptyQueryRef = newQueryDataSourceOverride ?? (await getDataSourceInstance()).getRef();
     const emptyQuery = await generateEmptyQuery(queries ?? [], undefined, emptyQueryRef);
     return [emptyQuery];
   } catch {

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -109,6 +109,17 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: (ref?: DataSourceRef | string) => {
+    if (!ref) {
+      return datasources[0];
+    }
+
+    return datasources.find((ds) => (typeof ref === 'string' ? ds.uid === ref : ds.uid === ref.uid)) || datasources[0];
+  },
+}));
+
 function setupQueryResponse(state: StoreState) {
   const leftDatasourceInstance = assertIsDefined(state.explore.panes.left!.datasourceInstance);
 


### PR DESCRIPTION
## Description
Migrate `core/utils/explore.ts` off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

## Changes
* Replaced all five `getDataSourceSrv().get(...)` calls with `getDataSourceInstance(...)`:
  * `getExploreUrl` - resolves each query's datasource before interpolation.
  * `generateEmptyQuery` - resolves the default datasource and the datasource for a given ref.
  * `ensureQueries` - validates a query's datasource and resolves the default datasource ref.
* All call sites were already `await`ed, so these are 1:1 replacements. `getDataSourceInstance` preserves the existing semantics: returns the same `DataSourceApi`, returns the default datasource when no ref is given, and throws when a datasource cannot be resolved (the `ensureQueries` try/catch behaviour is unchanged).
* Updated `explore.test.ts` to mock `getDataSourceInstance` on `@grafana/runtime/unstable`, delegating to the existing `DatasourceSrvMock`.

## Risks
* Low. Behavior is unchanged - the same datasource instances are resolved, just via the new API. `getDataSourceInstance` falls back to the legacy service if its cache is empty. No function signatures changed (all were already async).

## Demo
N/A - no user-facing changes.

## Testing Instructions
* `yarn jest public/app/core/utils/explore.test.ts` — all tests pass.
* Optionally, in a dashboard panel use the "Explore" menu action and confirm the Explore URL opens with the correct datasource and queries; in Explore, switch datasources and confirm new/empty queries initialise correctly.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable