### PR TITLE
fix(rbac): coalesce concurrent permission cache misses

### DIFF
--- a/pkg/infra/localcache/cache.go
+++ b/pkg/infra/localcache/cache.go
@@ -49,6 +49,33 @@ func (s *CacheService) ExclusiveSet(key string, getValue func() (any, error), du
 	return nil
 }
 
+// GetOrExclusiveSet returns the value cached under key. On a miss it acquires the
+// per-key lock and re-checks the cache before computing, so a value produced by a
+// concurrent caller that finished while we waited on the lock is reused instead of
+// recomputed. Unlike ExclusiveSet it returns the resolved value, so callers don't
+// have to capture it through getValue's closure.
+func (s *CacheService) GetOrExclusiveSet(key string, getValue func() (any, error), dur time.Duration) (any, error) {
+	if v, ok := s.Get(key); ok {
+		return v, nil
+	}
+
+	unlock := s.Lock(key)
+	defer unlock()
+
+	// Another caller may have populated the cache while we waited on the lock.
+	if v, ok := s.Get(key); ok {
+		return v, nil
+	}
+
+	v, err := getValue()
+	if err != nil {
+		return nil, err
+	}
+
+	s.Set(key, v, dur)
+	return v, nil
+}
+
 func (s *CacheService) ExclusiveDelete(key string) {
 	unlock := s.Lock(key)
 	defer unlock()

--- a/pkg/infra/localcache/cache_test.go
+++ b/pkg/infra/localcache/cache_test.go
@@ -1,13 +1,17 @@
 package localcache
 
 import (
+	"errors"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+var errTest = errors.New("test error")
 
 // TestExclusiveSet simulates a real-world scenario of concurrent goroutines
 // trying to read and write to the same cache key. Using standard Set and
@@ -67,5 +71,69 @@ func TestExclusiveSet(t *testing.T) {
 
 	// At the end of this process, no one is holding the lock to the `key`,
 	// so this mapping should be empty.
+	require.Empty(t, cache.locks)
+}
+
+// TestGetOrExclusiveSet verifies that concurrent callers racing on a cold key
+// only compute the value once: the winner runs getValue, the rest reuse the
+// cached result via the post-lock re-check rather than recomputing.
+func TestGetOrExclusiveSet(t *testing.T) {
+	cache := New(time.Minute, time.Minute)
+
+	const (
+		numWorkers = 20
+		key        = "test-key"
+		want       = 42
+	)
+
+	var calls atomic.Int64
+	getValue := func() (any, error) {
+		calls.Add(1)
+		// Hold the lock long enough that the other workers pile up behind it.
+		time.Sleep(20 * time.Millisecond)
+		return want, nil
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([]any, numWorkers)
+	errs := make([]error, numWorkers)
+	for i := range numWorkers {
+		wg.Go(func() {
+			<-start
+			results[i], errs[i] = cache.GetOrExclusiveSet(key, getValue, time.Minute)
+		})
+	}
+
+	close(start)
+	wg.Wait()
+
+	require.Equal(t, int64(1), calls.Load(), "getValue should run exactly once across concurrent callers")
+	for i := range numWorkers {
+		require.NoError(t, errs[i])
+		require.Equal(t, want, results[i])
+	}
+
+	cached, ok := cache.Get(key)
+	require.True(t, ok, "value should be cached")
+	require.Equal(t, want, cached)
+
+	// No one holds the lock anymore, so the locks map should be empty.
+	require.Empty(t, cache.locks)
+}
+
+// TestGetOrExclusiveSet_Error verifies that a failing getValue is not cached and
+// the error is propagated to the caller.
+func TestGetOrExclusiveSet_Error(t *testing.T) {
+	cache := New(time.Minute, time.Minute)
+
+	wantErr := errTest
+	_, err := cache.GetOrExclusiveSet("test-key", func() (any, error) {
+		return nil, wantErr
+	}, time.Minute)
+
+	require.ErrorIs(t, err, wantErr)
+	_, ok := cache.Get("test-key")
+	require.False(t, ok, "failed value should not be cached")
 	require.Empty(t, cache.locks)
 }

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -436,11 +436,23 @@ func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermi
 		return permissions, nil
 	}
 
-	if err := s.cache.ExclusiveSet(key, getValue, cacheTTL); err != nil {
+	// ReloadCache forces a fresh computation, so bypass the read-coalescing
+	// re-check and always recompute under the lock.
+	if options.ReloadCache {
+		if err := s.cache.ExclusiveSet(key, getValue, cacheTTL); err != nil {
+			return nil, err
+		}
+		return permissions, nil
+	}
+
+	// Coalesce concurrent misses for the same key: callers that block on the lock
+	// reuse the value the winner computed instead of each re-running getPermissionsFn.
+	value, err := s.cache.GetOrExclusiveSet(key, getValue, cacheTTL)
+	if err != nil {
 		return nil, err
 	}
 
-	return permissions, nil
+	return value.([]accesscontrol.Permission), nil
 }
 
 func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -3,7 +3,10 @@ package acimpl
 import (
 	"context"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,6 +59,64 @@ func setupTestEnv(t testing.TB, registerRoles bool) *Service {
 	}
 
 	return ac
+}
+
+func TestService_getCachedPermissions_CoalescesConcurrentMisses(t *testing.T) {
+	s := &Service{cache: localcache.ProvideService()}
+
+	var calls atomic.Int64
+	fn := func(_ context.Context) ([]accesscontrol.Permission, error) {
+		calls.Add(1)
+		// Hold the computation long enough for the other workers to block on the lock.
+		time.Sleep(20 * time.Millisecond)
+		return []accesscontrol.Permission{{Action: "test:action"}}, nil
+	}
+
+	const numWorkers = 20
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([][]accesscontrol.Permission, numWorkers)
+	errs := make([]error, numWorkers)
+	for i := range numWorkers {
+		wg.Go(func() {
+			<-start
+			results[i], errs[i] = s.getCachedPermissions(context.Background(), "test-key", fn, accesscontrol.Options{})
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	require.Equal(t, int64(1), calls.Load(), "getPermissionsFn should run once for concurrent cache misses")
+	for i := range numWorkers {
+		require.NoError(t, errs[i])
+		require.Len(t, results[i], 1)
+		require.Equal(t, "test:action", results[i][0].Action)
+	}
+}
+
+func TestService_getCachedPermissions_ReloadCacheRecomputes(t *testing.T) {
+	s := &Service{cache: localcache.ProvideService()}
+	ctx := context.Background()
+
+	var calls atomic.Int64
+	fn := func(_ context.Context) ([]accesscontrol.Permission, error) {
+		calls.Add(1)
+		return []accesscontrol.Permission{{Action: "test:action"}}, nil
+	}
+
+	_, err := s.getCachedPermissions(ctx, "test-key", fn, accesscontrol.Options{})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), calls.Load())
+
+	// A subsequent read is served from cache without recomputing.
+	_, err = s.getCachedPermissions(ctx, "test-key", fn, accesscontrol.Options{})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), calls.Load())
+
+	// ReloadCache forces a fresh computation.
+	_, err = s.getCachedPermissions(ctx, "test-key", fn, accesscontrol.Options{ReloadCache: true})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), calls.Load())
 }
 
 func TestIntegrationUsageMetrics(t *testing.T) {


### PR DESCRIPTION
## What

Adds `localcache.GetOrExclusiveSet`, a read-coalescing cache primitive, and routes the non-reload path of `getCachedPermissions` through it.

## Why

A trace of `GET /api/users/search` showed ~2.4s of the 2.55s request spent in request-time RBAC permission resolution. The root cause is in `localcache.CacheService.ExclusiveSet`: it acquires a per-key lock and then **always** calls `getValue()` — it never re-checks the cache after winning the lock.

So when several concurrent requests for the same user miss the cache:
- they **serialize** on the per-key lock, and
- each one **recomputes** the identical value (re-running the expensive Zanzana resolution — ~30 sequential `List` calls), even though the first caller already stored the result.

In the trace this showed up as a ~1.95s lock-wait followed by a redundant ~30 `authlib.zanzana.client.List` calls.

## How

`GetOrExclusiveSet` re-checks the cache after acquiring the lock and returns the resolved value, so later callers reuse the value the winner computed instead of recomputing:

- `pkg/infra/localcache/cache.go` — new `GetOrExclusiveSet`. `ExclusiveSet`/`ExclusiveDelete`/`Lock` are untouched.
- `pkg/services/accesscontrol/acimpl/service.go` — `getCachedPermissions` routes the **non-reload** miss path through `GetOrExclusiveSet`. `ReloadCache` keeps its existing force-recompute behavior via `ExclusiveSet`.

## Tests

- `TestGetOrExclusiveSet` / `TestGetOrExclusiveSet_Error` (localcache, `-race`): N concurrent callers on a cold key compute exactly once.
- `TestService_getCachedPermissions_CoalescesConcurrentMisses` / `..._ReloadCacheRecomputes`.

`go test -race`, `go vet`, and `golangci-lint` all pass on the changed packages.