### PR TITLE
Alerting: Keep app-owned rules immutable when the plugin check fails

### DIFF
--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -96,5 +96,5 @@ export {
   usePanelPluginVersion,
 } from './services/pluginMeta/hooks';
 export { getListedPanelPluginIds, getPanelPluginVersion, isPanelPluginInstalled } from './services/pluginMeta/panels';
-export { isAppPluginEnabled } from './services/pluginSettings/settings';
-export { useAppPluginEnabled } from './services/pluginSettings/hooks';
+export { isAppPluginEnabled, type AppPluginEnabledState } from './services/pluginSettings/settings';
+export { useAppPluginEnabled, useAppPluginEnabledState } from './services/pluginSettings/hooks';

--- a/packages/grafana-runtime/src/services/pluginSettings/hooks.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/hooks.ts
@@ -2,10 +2,9 @@ import { useAsync } from 'react-use';
 
 import { type PluginMeta } from '@grafana/data';
 
-import { isFetchError } from '../backendSrv';
-
 import { getPluginSettings } from './getPluginSettings';
-import { getAppPluginEnabled } from './settings';
+import { getAppPluginEnabled, getAppPluginEnabledState } from './settings';
+import { isNotFoundError } from './utils';
 
 /**
  * Hook that checks if an app plugin is installed and enabled.
@@ -15,6 +14,17 @@ import { getAppPluginEnabled } from './settings';
  */
 export function useAppPluginEnabled(pluginId: string) {
   const { loading, error, value } = useAsync(async () => getAppPluginEnabled(pluginId), [pluginId]);
+  return { loading, error, value };
+}
+
+/**
+ * Hook variant of {@link getAppPluginEnabledState} that distinguishes a definitive answer
+ * (`enabled` / `not-an-enabled-app`) from an indeterminate one (`unknown`, e.g. a failed request).
+ * @param pluginId - The ID of the app plugin.
+ * @returns loading, error and the resolved `AppPluginEnabledState` (undefined while loading).
+ */
+export function useAppPluginEnabledState(pluginId: string) {
+  const { loading, error, value } = useAsync(async () => getAppPluginEnabledState(pluginId), [pluginId]);
   return { loading, error, value };
 }
 
@@ -33,10 +43,8 @@ export function usePluginSettings(pluginId: string) {
     try {
       return await getPluginSettings(pluginId);
     } catch (err) {
-      // getLegacySettings wraps the raw fetch error as the `cause`. A 404 means the
-      // plugin is simply not installed — treat it as a normal absence, not an error.
-      const cause = err instanceof Error ? err.cause : err;
-      if (isFetchError(cause) && cause.status === 404) {
+      // A 404 means the plugin is simply not installed — treat it as a normal absence, not an error.
+      if (isNotFoundError(err)) {
         return undefined;
       }
       throw err;

--- a/packages/grafana-runtime/src/services/pluginSettings/settings.test.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/settings.test.ts
@@ -9,7 +9,7 @@ import { setLogger, initializeLoggersRegistry } from '../logging/registry';
 import { getPluginMetaFromCache, refetchPluginMeta } from '../pluginMeta/plugins';
 import { clockPanelMetaOnPrem, myOrgTestAppMeta } from '../pluginMeta/test-fixtures/v0alpha1Response';
 
-import { isAppPluginEnabled } from './settings';
+import { getAppPluginEnabledState, isAppPluginEnabled } from './settings';
 import { legacyClockPanelOnPrem, legacyMyOrgTestAppSettings } from './test-fixtures/legacy.settings';
 import { myOrgTestAppSettings } from './test-fixtures/v0alpha1Response';
 jest.mock('../pluginMeta/plugins', () => ({
@@ -216,6 +216,63 @@ describe('settings', () => {
 
         expect(enabled).toEqual(false);
         expect(backendSrv.get).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('getAppPluginEnabledState', () => {
+      it("returns 'enabled' for an installed, enabled app", async () => {
+        const state = await getAppPluginEnabledState(legacyMyOrgTestAppSettings.id);
+
+        expect(state).toBe('enabled');
+      });
+
+      it("returns 'not-an-enabled-app' for a disabled app", async () => {
+        backendSrv.get = jest.fn().mockResolvedValue({ ...legacyMyOrgTestAppSettings, enabled: false });
+
+        const state = await getAppPluginEnabledState(legacyMyOrgTestAppSettings.id);
+
+        expect(state).toBe('not-an-enabled-app');
+      });
+
+      it("returns 'not-an-enabled-app' for a non-app plugin", async () => {
+        backendSrv.get = jest.fn().mockResolvedValue(legacyClockPanelOnPrem);
+
+        const state = await getAppPluginEnabledState(legacyClockPanelOnPrem.id);
+
+        expect(state).toBe('not-an-enabled-app');
+      });
+
+      it("returns 'not-an-enabled-app' when the plugin is not installed (404)", async () => {
+        backendSrv.get = jest.fn().mockRejectedValue({ status: 404, data: { message: 'Plugin not found' } });
+
+        const state = await getAppPluginEnabledState('myorg-someplugin-app');
+
+        expect(state).toBe('not-an-enabled-app');
+      });
+
+      it("returns 'unknown' when the settings request fails with a server error", async () => {
+        backendSrv.get = jest.fn().mockRejectedValue({ status: 500, data: { message: 'Internal Server Error' } });
+
+        const state = await getAppPluginEnabledState('myorg-test-app');
+
+        expect(state).toBe('unknown');
+      });
+
+      it("returns 'unknown' when the settings request fails with an auth error", async () => {
+        backendSrv.get = jest.fn().mockRejectedValue({ status: 403, data: { message: 'Forbidden' } });
+
+        const state = await getAppPluginEnabledState('myorg-test-app');
+
+        expect(state).toBe('unknown');
+      });
+
+      it("returns 'not-an-enabled-app' for an empty plugin id without making a request", async () => {
+        backendSrv.get = jest.fn();
+
+        const state = await getAppPluginEnabledState('');
+
+        expect(state).toBe('not-an-enabled-app');
+        expect(backendSrv.get).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/grafana-runtime/src/services/pluginSettings/settings.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/settings.ts
@@ -2,7 +2,7 @@ import { PluginType } from '@grafana/data';
 
 import { getPluginSettings } from './getPluginSettings';
 import { logPluginSettingsError, logPluginSettingsWarning } from './logging';
-import { isAuthError } from './utils';
+import { isAuthError, isNotFoundError } from './utils';
 
 export async function getAppPluginEnabled(pluginId: string): Promise<boolean> {
   if (!pluginId) {
@@ -15,6 +15,49 @@ export async function getAppPluginEnabled(pluginId: string): Promise<boolean> {
   }
 
   return app.type === PluginType.app && Boolean(app.enabled);
+}
+
+/**
+ * The state of an app plugin from the caller's perspective:
+ * - `enabled`: the plugin is an installed, enabled app.
+ * - `not-an-enabled-app`: the plugin is a non-app type, a disabled app, or not installed (404) — a
+ *   definitive answer.
+ * - `unknown`: the settings request failed for a transient/indeterminate reason (auth / server /
+ *   network), so the state could not be determined.
+ */
+export type AppPluginEnabledState = 'enabled' | 'not-an-enabled-app' | 'unknown';
+
+/**
+ * Like {@link getAppPluginEnabled}, but distinguishes a definitive answer from an indeterminate one.
+ * Callers that gate destructive actions on plugin ownership should treat `unknown` as still managed
+ * rather than exposing those actions on a failed check.
+ */
+export async function getAppPluginEnabledState(pluginId: string): Promise<AppPluginEnabledState> {
+  if (!pluginId) {
+    return 'not-an-enabled-app';
+  }
+
+  try {
+    const app = await getPluginSettings(pluginId);
+    return app?.type === PluginType.app && Boolean(app.enabled) ? 'enabled' : 'not-an-enabled-app';
+  } catch (error) {
+    // getPluginSettings throws on a 404 (plugin not installed) as well as on transient failures
+    // (auth / server / network). A 404 is a definitive "not an installed app"; anything else means
+    // we could not determine the state.
+    if (isNotFoundError(error)) {
+      return 'not-an-enabled-app';
+    }
+    // Surface the indeterminate failure so a persistently failing check is visible, then report it
+    // as 'unknown' so callers keep treating the rule as managed rather than exposing it.
+    if (isAuthError(error)) {
+      logPluginSettingsWarning('getAppPluginEnabledState: could not determine plugin state, auth denied', {
+        pluginId,
+      });
+    } else {
+      logPluginSettingsError('getAppPluginEnabledState: could not determine plugin state', error, { pluginId });
+    }
+    return 'unknown';
+  }
 }
 
 /**

--- a/packages/grafana-runtime/src/services/pluginSettings/utils.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/utils.ts
@@ -1,4 +1,5 @@
 import { config } from '../../config';
+import { isFetchError } from '../backendSrv';
 
 export function getApiVersion(): string {
   return 'v0alpha1';
@@ -14,6 +15,16 @@ export function isAuthError(err: unknown): boolean {
   }
 
   return false;
+}
+
+/**
+ * Whether a plugin settings error means the plugin is simply not installed (a 404), as opposed to a
+ * transient/indeterminate failure (auth / server / network). `getLegacySettings` / `getAppPluginSettings`
+ * wrap the raw fetch error as the `cause`, so we unwrap one level before checking the status.
+ */
+export function isNotFoundError(err: unknown): boolean {
+  const cause = err instanceof Error ? err.cause : err;
+  return isFetchError(cause) && cause.status === 404;
 }
 
 export function getLegacyCacheKey(pluginId: string, _showErrorAlert = false) {

--- a/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx
@@ -2,8 +2,10 @@ import { render, screen, testWithFeatureToggles, userEvent, waitFor } from 'test
 import { byLabelText, byRole } from 'testing-library-selector';
 
 import { useAssistant } from '@grafana/assistant';
+import { type PluginMeta, PluginType } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { config, setPluginLinksHook } from '@grafana/runtime';
+import { invalidatePluginSettingsCache } from '@grafana/runtime/internal';
 import AlertRuleMenu from 'app/features/alerting/unified/components/rule-viewer/AlertRuleMenu';
 import { mockFolderApi, setupMswServer } from 'app/features/alerting/unified/mockApi';
 import {
@@ -17,7 +19,9 @@ import {
   mockPromRecordingRule,
   mockRulerGrafanaRecordingRule,
 } from 'app/features/alerting/unified/mocks';
-import { setFolderAccessControl } from 'app/features/alerting/unified/mocks/server/configure';
+import { addPlugin, failPlugin, setFolderAccessControl } from 'app/features/alerting/unified/mocks/server/configure';
+import { waitForServerRequest } from 'app/features/alerting/unified/mocks/server/events';
+import { flushMicrotasks } from 'app/features/alerting/unified/test/test-utils';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import * as miscUtils from 'app/features/alerting/unified/utils/misc';
 import { fromCombinedRule } from 'app/features/alerting/unified/utils/rule-id';
@@ -1678,5 +1682,244 @@ describe('AlertRuleMenu', () => {
         createShareLinkSpy.mockRestore();
       });
     });
+  });
+});
+
+/**
+ * Reproduces the exact case from the reported bug: alert rules owned by the Grafana Cloud
+ * Cost Management and Billing app, viewed on the rule-group detail page (which has only the
+ * Prometheus rule, no ruler rule). The rule is NOT provisioned (no `provenance`); its only
+ * immutability signal is the `__grafana_origin: plugin/<id>` label, gated by whether that app
+ * is an installed + enabled app (useAppPluginEnabled).
+ */
+describe('AlertRuleMenu — Grafana Cloud Cost Management app rules (reported bug)', () => {
+  // NOTE: confirm this id against a real Cloud instance — it's the value of the rule's
+  // `__grafana_origin` label (`plugin/<id>`). The behaviour under test does not depend on the
+  // exact string, only on whether the app resolves as installed + enabled.
+  const COST_MANAGEMENT_PLUGIN_ID = 'grafana-costmanagementui-app';
+
+  const costManagementApp = {
+    id: COST_MANAGEMENT_PLUGIN_ID,
+    name: 'Grafana Cloud Cost Management and Billing',
+    type: PluginType.app,
+    enabled: true,
+    info: {
+      author: { name: 'Grafana Labs', url: '' },
+      description: '',
+      links: [],
+      logos: { small: '', large: '' },
+      screenshots: [],
+      version: '',
+      updated: '',
+    },
+    module: '',
+    baseUrl: '',
+  } as PluginMeta;
+
+  const groupIdentifier = {
+    groupOrigin: 'grafana' as const,
+    namespace: { uid: 'namespace-uid' },
+    groupName: 'group-name',
+  };
+
+  // A firing, Grafana-managed alerting rule owned by the Cost Management app, with NO provenance.
+  // Mirrors a row like "Traces Usage: 50% of 20,000 GiB" from the screenshot.
+  const makeCostManagementPromRule = () =>
+    mockPromAlertingRule({
+      uid: 'cost-rule-uid',
+      folderUid: 'namespace-uid',
+      name: 'Traces Usage: 50% of 20,000 GiB',
+      state: PromAlertingRuleState.Firing,
+      labels: { __grafana_origin: `plugin/${COST_MANAGEMENT_PLUGIN_ID}` },
+      annotations: { summary: 'This alert is provisioned by the Grafana Cloud Cost Management and Billing app.' },
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    config.buildInfo = { ...config.buildInfo, edition: GrafanaEdition.Enterprise, env: 'production' };
+
+    // Assistant available -> "Analyze rule" shows (as in the screenshot).
+    mockUseAssistant.mockReturnValue({
+      isLoading: false,
+      isAvailable: true,
+      openAssistant: mockOpenAssistant,
+    } as unknown as ReturnType<typeof useAssistant>);
+
+    // Admin with FULL permissions, including delete — so that anything hidden is hidden because of
+    // plugin ownership, not lack of RBAC.
+    const fullFolderAccess = {
+      [AccessControlAction.AlertingRuleRead]: true,
+      [AccessControlAction.AlertingRuleUpdate]: true,
+      [AccessControlAction.AlertingRuleDelete]: true,
+      [AccessControlAction.AlertingRuleCreate]: true,
+      [AccessControlAction.FoldersRead]: true,
+    };
+    grantUserPermissions([
+      AccessControlAction.AlertingRuleRead,
+      AccessControlAction.AlertingRuleUpdate,
+      AccessControlAction.AlertingRuleDelete,
+      AccessControlAction.AlertingRuleCreate,
+      AccessControlAction.FoldersRead,
+      AccessControlAction.AlertingInstanceCreate,
+      AccessControlAction.AlertingSilenceCreate,
+      AccessControlAction.AlertingEnrichmentsRead,
+    ]);
+    setFolderAccessControl(fullFolderAccess);
+    mockFolderApi(server).folder(
+      'namespace-uid',
+      mockFolder({ uid: 'namespace-uid', title: 'Usage Alerts', accessControl: fullFolderAccess })
+    );
+
+    invalidatePluginSettingsCache(COST_MANAGEMENT_PLUGIN_ID);
+  });
+
+  // Enrichment menu item requires both feature toggles enabled.
+  testWithFeatureToggles({ enable: ['alertEnrichment', 'alertingEnrichmentPerRule'] });
+
+  it('matches the screenshot menu (no Edit/Delete) when the owning app is installed and enabled', async () => {
+    const settingsRequest = waitForServerRequest(addPlugin(costManagementApp)); // installed + enabled -> isPluginManaged = true
+
+    render(
+      <AlertRuleMenu
+        promRule={makeCostManagementPromRule()}
+        rulerRule={undefined}
+        identifier={{ ruleSourceName: 'grafana', uid: 'cost-rule-uid' }}
+        groupIdentifier={groupIdentifier}
+        handleSilence={handleSilence}
+        handleDelete={handleDelete}
+        handleDuplicateRule={handleDuplicateRule}
+        handleManageEnrichments={jest.fn()}
+      />
+    );
+
+    await openMenu();
+
+    // Present — exactly the actions visible in the reported screenshot.
+    expect(await ui.menuItems.manageEnrichments.find()).toBeInTheDocument();
+    expect(await ui.menuItems.silence.find()).toBeInTheDocument();
+    expect(await ui.menuItems.declareIncident.find()).toBeInTheDocument();
+    expect(await ui.menuItems.analyzeRule.find()).toBeInTheDocument();
+    expect(await ui.menuItems.copyLink.find()).toBeInTheDocument();
+    expect(await ui.menuItems.export.find()).toBeInTheDocument();
+
+    // Wait for the settings request to resolve so the 'enabled' -> managed branch is what hides these
+    // actions, not merely the immutable-while-loading default (which would mask a broken enabled path).
+    await settingsRequest;
+    await flushMicrotasks();
+
+    // Absent — these must stay hidden for an app-owned rule, despite full delete/edit permissions.
+    expect(ui.menuItems.delete.query()).not.toBeInTheDocument();
+    expect(ui.menuItems.pause.query()).not.toBeInTheDocument();
+    expect(ui.menuItems.resume.query()).not.toBeInTheDocument();
+    expect(ui.menuItems.duplicate.query()).not.toBeInTheDocument();
+  });
+
+  it('silencing does not unlock Delete for an app-owned rule (silencing is not causal)', async () => {
+    // Recreates the reported sequence: the owning app is installed + enabled, so the rule is
+    // immutable. The user silences it (their proxy for "unlock Delete") and Delete must STAY hidden.
+    // The silence click is cosmetic here — the real driver of visibility is the async plugin check,
+    // which has already resolved on the first menu open.
+    const settingsRequest = waitForServerRequest(addPlugin(costManagementApp));
+
+    render(
+      <AlertRuleMenu
+        promRule={makeCostManagementPromRule()}
+        rulerRule={undefined}
+        identifier={{ ruleSourceName: 'grafana', uid: 'cost-rule-uid' }}
+        groupIdentifier={groupIdentifier}
+        handleSilence={handleSilence}
+        handleDelete={handleDelete}
+        handleDuplicateRule={handleDuplicateRule}
+        handleManageEnrichments={jest.fn()}
+      />
+    );
+
+    await openMenu();
+    // Wait for the plugin check to resolve so we assert against the settled (enabled -> managed) state.
+    await settingsRequest;
+    await flushMicrotasks();
+    // Primary assertion: the app-owned rule offers Silence but no Delete (the screenshot state).
+    expect(await ui.menuItems.silence.find()).toBeInTheDocument();
+    expect(ui.menuItems.delete.query()).not.toBeInTheDocument();
+
+    // User silences the rule. (Secondary check — mirrors the existing handleSilence test.)
+    await user.click(await ui.menuItems.silence.find());
+    expect(handleSilence).toHaveBeenCalledTimes(1);
+
+    // Reopen the menu: Delete must still be hidden. Silencing did not "unlock" anything.
+    await waitFor(() => expect(ui.menu.query()).not.toBeInTheDocument());
+    await openMenu();
+    expect(await ui.menuItems.silence.find()).toBeInTheDocument();
+    expect(ui.menuItems.delete.query()).not.toBeInTheDocument();
+    expect(ui.menuItems.pause.query()).not.toBeInTheDocument();
+    expect(ui.menuItems.duplicate.query()).not.toBeInTheDocument();
+  });
+
+  it('exposes Delete/Pause/Duplicate when the owning app is installed but disabled (intended escape hatch)', async () => {
+    // A definitively-disabled app is the intended escape hatch: management actions become available
+    // so users are not locked out by an app they have turned off. This is NOT the reported bug —
+    // see the hook-level test for the genuine defect (an enabled app whose settings check fails).
+    addPlugin({ ...costManagementApp, enabled: false }); // installed but disabled -> isPluginManaged = false
+
+    render(
+      <AlertRuleMenu
+        promRule={makeCostManagementPromRule()}
+        rulerRule={undefined}
+        identifier={{ ruleSourceName: 'grafana', uid: 'cost-rule-uid' }}
+        groupIdentifier={groupIdentifier}
+        handleSilence={handleSilence}
+        handleDelete={handleDelete}
+        handleDuplicateRule={handleDuplicateRule}
+        handleManageEnrichments={jest.fn()}
+      />
+    );
+
+    await openMenu();
+
+    // Silence remains available (it is intentionally not gated by plugin ownership).
+    expect(await ui.menuItems.silence.find()).toBeInTheDocument();
+
+    // Disabled app -> escape hatch -> management actions are available.
+    expect(await ui.menuItems.delete.find()).toBeInTheDocument();
+    expect(await ui.menuItems.pause.find()).toBeInTheDocument();
+    expect(await ui.menuItems.duplicate.find()).toBeInTheDocument();
+  });
+
+  it('keeps Delete/Pause/Duplicate hidden when the owning app check fails (the reported bug)', async () => {
+    // The genuine defect: the owning app is installed + enabled, but its `GET /api/plugins/<id>/settings`
+    // request transiently fails (5xx / auth / network). That failure must NOT be read as "not an app"
+    // — otherwise an app-owned rule wrongly exposes management actions (the user's "Delete appears"
+    // report). An uncertain check keeps the rule managed; only a definitive not-an-enabled-app result
+    // (the disabled case above) releases it.
+    const settingsRequest = waitForServerRequest(failPlugin(COST_MANAGEMENT_PLUGIN_ID, 500));
+
+    render(
+      <AlertRuleMenu
+        promRule={makeCostManagementPromRule()}
+        rulerRule={undefined}
+        identifier={{ ruleSourceName: 'grafana', uid: 'cost-rule-uid' }}
+        groupIdentifier={groupIdentifier}
+        handleSilence={handleSilence}
+        handleDelete={handleDelete}
+        handleDuplicateRule={handleDuplicateRule}
+        handleManageEnrichments={jest.fn()}
+      />
+    );
+
+    await openMenu();
+
+    // Silence remains available (it is intentionally not gated by plugin ownership).
+    expect(await ui.menuItems.silence.find()).toBeInTheDocument();
+
+    // Wait for the failing plugin-settings request to be handled and its rejection to propagate, so
+    // we assert the SETTLED menu — while the check is in flight the rule is immutable regardless,
+    // which would mask the bug.
+    await settingsRequest;
+    await flushMicrotasks();
+
+    // Uncertain plugin state -> rule stays managed -> management actions stay hidden.
+    expect(ui.menuItems.delete.query()).not.toBeInTheDocument();
+    expect(ui.menuItems.pause.query()).not.toBeInTheDocument();
+    expect(ui.menuItems.duplicate.query()).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/hooks/useAbilities.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useAbilities.test.tsx
@@ -3,8 +3,9 @@ import { getWrapper, render, renderHook, screen, waitFor } from 'test/test-utils
 
 import { config } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
-import { setFolderAccessControl } from 'app/features/alerting/unified/mocks/server/configure';
+import { failPlugin, setFolderAccessControl } from 'app/features/alerting/unified/mocks/server/configure';
 import { MIMIR_DATASOURCE_UID } from 'app/features/alerting/unified/mocks/server/constants';
+import { waitForServerRequest } from 'app/features/alerting/unified/mocks/server/events';
 import {
   type AlertManagerDataSourceJsonData,
   AlertManagerImplementation,
@@ -12,9 +13,9 @@ import {
 import { AccessControlAction } from 'app/types/accessControl';
 import { type CombinedRule } from 'app/types/unified-alerting';
 
-import { getCloudRule, getGrafanaRule, grantUserPermissions, mockDataSource } from '../mocks';
+import { getCloudRule, getGrafanaRule, grantUserPermissions, mockDataSource, mockGrafanaRulerRule } from '../mocks';
 import { AlertmanagerProvider } from '../state/AlertmanagerContext';
-import { grantPermissionsHelper } from '../test/test-utils';
+import { flushMicrotasks, grantPermissionsHelper } from '../test/test-utils';
 import { setupDataSources } from '../testSetup/datasources';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 import * as misc from '../utils/misc';
@@ -241,6 +242,40 @@ describe('AlertRule abilities', () => {
 
     expect(updateSupported).toBe(true);
     expect(deleteSupported).toBe(true);
+  });
+
+  it('keeps a plugin-owned rule immutable when the plugin-enabled check fails (uncertain)', async () => {
+    // A rule owned by an app whose `GET /api/plugins/<id>/settings` transiently fails (5xx/auth/
+    // network). The failure must NOT be read as "not an app" — that would wrongly expose Edit/Delete
+    // on a genuinely app-owned rule. A definitively not-installed (404) or disabled app stays
+    // editable (the escape hatch above); an uncertain result keeps the rule managed.
+    // A real app id (not a built-in SupportedPlugin) so the settings request goes through the
+    // legacy /api/plugins/<id>/settings path that failPlugin intercepts and fails with a 500.
+    const pluginId = 'grafana-costmanagementui-app';
+    // Wait for the actual failing settings request rather than flushing a fixed number of microtasks
+    // — otherwise the assertion could pass on a still-loading hook (immutable while loading), which
+    // would mask the regression. The bug only surfaces once the failing check resolves.
+    const settingsRequest = waitForServerRequest(failPlugin(pluginId, 500));
+
+    // The origin label must live on the ruler rule's top-level labels — that is where
+    // getRulePluginOrigin reads it for the ruler ability path.
+    const rule = getGrafanaRule({
+      rulerRule: { ...mockGrafanaRulerRule(), labels: { __grafana_origin: `plugin/${pluginId}` } },
+    });
+
+    const { result } = renderHook(() => useAllAlertRuleAbilities(rule), { wrapper: wrapper() });
+
+    // The settings request has been handled; flush its rejection into the hook's state so we assert
+    // the fully SETTLED result.
+    await settingsRequest;
+    await flushMicrotasks();
+
+    // Uncertain plugin state -> rule stays managed -> Update/Delete are not supported.
+    const [updateSupported] = result.current[AlertRuleAction.Update];
+    const [deleteSupported] = result.current[AlertRuleAction.Delete];
+
+    expect(updateSupported).toBe(false);
+    expect(deleteSupported).toBe(false);
   });
 });
 

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { config, useAppPluginEnabled } from '@grafana/runtime';
+import { config, useAppPluginEnabledState } from '@grafana/runtime';
 import { contextSrv as ctx } from 'app/core/services/context_srv';
 import {
   PERMISSIONS_TIME_INTERVALS_MODIFY,
@@ -309,10 +309,8 @@ function useAllRulerRuleAbilities(
   const canSilence = useCanSilence(rule);
 
   const pluginOrigin = getRulePluginOrigin(rule);
-  // Check plugin installation - only fires when pluginOrigin is present (empty string returns false)
-  const { value: isPluginInstalled = false, loading: pluginCheckLoading } = useAppPluginEnabled(
-    pluginOrigin?.pluginId ?? ''
-  );
+  // Only fires when pluginOrigin is present (empty string returns 'not-an-enabled-app' immediately)
+  const { value: pluginState, loading: pluginCheckLoading } = useAppPluginEnabledState(pluginOrigin?.pluginId ?? '');
 
   const abilities = useMemo<Abilities<AlertRuleAction>>(() => {
     const isProvisioned = rule ? isProvisionedRule(rule) : false;
@@ -321,11 +319,12 @@ function useAllRulerRuleAbilities(
     const isFederated = false;
     const isGrafanaManagedAlertRule = rulerRuleType.grafana.rule(rule);
 
-    // Treat as plugin-provided only if:
-    // 1. Rule has origin label (pluginOrigin exists)
-    // 2. Plugin is currently installed (or still loading to be safe)
-    // If no pluginOrigin, short-circuit to false without checking plugin installation
-    const isPluginManaged = pluginOrigin ? pluginCheckLoading || isPluginInstalled : false;
+    // Treat as plugin-provided when the rule has an origin label and the owning app is not definitively
+    // a non-enabled app. We keep it managed while loading, when the app is enabled, and — crucially —
+    // when the check could not be determined ('unknown', e.g. a transient request failure), so a
+    // failed check can no longer wrongly expose Edit/Delete. Only a definitive 'not-an-enabled-app'
+    // (disabled / non-app / not installed) releases the rule as the intended escape hatch.
+    const isPluginManaged = pluginOrigin ? pluginCheckLoading || pluginState !== 'not-an-enabled-app' : false;
 
     // if a rule is either provisioned, federated or provided by a plugin rule, we don't allow it to be removed or edited
     const immutableRule = isProvisioned || isFederated || isPluginManaged;
@@ -367,7 +366,7 @@ function useAllRulerRuleAbilities(
     exportAllowed,
     pluginOrigin,
     pluginCheckLoading,
-    isPluginInstalled,
+    pluginState,
   ]);
 
   return abilities;
@@ -386,8 +385,8 @@ function useAllGrafanaPromRuleAbilities(rule: GrafanaPromRuleDTO | undefined): A
   const canSilenceInFolder = useCanSilenceInFolder(rule?.folderUid);
 
   const promPluginOrigin = getRulePluginOrigin(rule);
-  // Check plugin installation - only fires when promPluginOrigin is present (empty string returns false)
-  const { value: isPromPluginInstalled = false, loading: promPluginCheckLoading } = useAppPluginEnabled(
+  // Only fires when promPluginOrigin is present (empty string returns 'not-an-enabled-app' immediately)
+  const { value: promPluginState, loading: promPluginCheckLoading } = useAppPluginEnabledState(
     promPluginOrigin?.pluginId ?? ''
   );
 
@@ -399,9 +398,13 @@ function useAllGrafanaPromRuleAbilities(rule: GrafanaPromRuleDTO | undefined): A
     const isFederated = false;
     // All GrafanaPromRuleDTO rules are Grafana-managed by definition
     const isAlertingRule = prometheusRuleType.grafana.alertingRule(rule);
-    // Treat as plugin-provided only if both: has origin label AND plugin is currently installed
-    // During loading, default to immutable for safety
-    const isPluginProvided = Boolean(promPluginOrigin && (promPluginCheckLoading || isPromPluginInstalled));
+    // Treat as plugin-provided when the rule has an origin label and the owning app is not definitively
+    // a non-enabled app. Managed while loading, when enabled, and when the check is 'unknown' (e.g. a
+    // transient failure) so a failed check can't wrongly expose Edit/Delete; only a definitive
+    // 'not-an-enabled-app' (disabled / non-app / not installed) releases it as the intended escape hatch.
+    const isPluginProvided = Boolean(
+      promPluginOrigin && (promPluginCheckLoading || promPluginState !== 'not-an-enabled-app')
+    );
 
     // if a rule is either provisioned, federated or provided by a plugin rule, we don't allow it to be removed or edited
     const immutableRule = isProvisioned || isFederated || isPluginProvided;
@@ -442,7 +445,7 @@ function useAllGrafanaPromRuleAbilities(rule: GrafanaPromRuleDTO | undefined): A
     silenceSupported,
     promPluginOrigin,
     promPluginCheckLoading,
-    isPromPluginInstalled,
+    promPluginState,
   ]);
 
   return abilities;

--- a/public/app/features/alerting/unified/mocks/server/configure.ts
+++ b/public/app/features/alerting/unified/mocks/server/configure.ts
@@ -346,19 +346,21 @@ export const removePlugin = (pluginId: SupportedPlugin) => {
   server.use(getPluginMissingHandler(pluginId));
 };
 
-/** Make an additional plugin respond as installed and enabled */
+/** Make an additional plugin respond as installed and enabled. Returns the registered handler. */
 export const addPlugin = (pluginMeta: PluginMeta) => {
-  server.use(getSpecificPluginHandler(pluginMeta));
+  const handler = getSpecificPluginHandler(pluginMeta);
+  server.use(handler);
+  return handler;
 };
 
-/** Make a plugin settings request fail with a given HTTP status code (default 500) */
-export const failPlugin = (pluginId: SupportedPlugin, status = 500) => {
+/** Make a plugin settings request fail with a given HTTP status code (default 500). Returns the registered handler. */
+export const failPlugin = (pluginId: string, status = 500) => {
   invalidatePluginSettingsCache(pluginId);
-  server.use(
-    http.get(`/api/plugins/${pluginId}/settings`, () =>
-      HttpResponse.json({ message: 'Internal server error' }, { status })
-    )
+  const handler = http.get(`/api/plugins/${pluginId}/settings`, () =>
+    HttpResponse.json({ message: 'Internal server error' }, { status })
   );
+  server.use(handler);
+  return handler;
 };
 
 /** Get an error response for use in a API response, in the format:


### PR DESCRIPTION
**What is this feature?**
This PR fixes a bug for the alert rule menu where alert rules owned by an installed and enabled app could wrongly expose Delete, Edit, Pause, and Duplicate actions.

The root cause was that the plugin ownership check collapsed two different outcomes into one. A request to `GET /api/plugins/<id>/settings` that failed transiently (5xx, auth, or network) was read the same as "the plugin is not an enabled app". A failed check then released the rule as editable.

The fix introduces a tri-state result for the plugin check"
- `enabled`: installed and enabled app.
- `not-an-enabled-app`: a non-app type, a disabled app, or not installed (404). This is a definitive answer.
- `unknown`: the request failed for a transient or indeterminate reason, so the state could not be determined.

**Steps to reproduce**

- Have a Grafana-managed alert rule that is owned by an app (label __grafana_origin: plugin/) and has no provenance (created via the ruler API, not provisioning).
- The owning plugin resolves as not an installed + enabled app for the current user
- Open the rule-group detail page (/alerting/grafana/namespaces//groups//view) as an Admin and open the rule's "More" menu.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1826