### PR TITLE
DataPro (migration): Migrate `correlations/Forms/QueryEditorField.tsx`

### DIFF
--- a/public/app/features/correlations/Forms/QueryEditorField.test.tsx
+++ b/public/app/features/correlations/Forms/QueryEditorField.test.tsx
@@ -3,10 +3,14 @@ import { type ReactNode } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 
-import { setDataSourceSrv } from '@grafana/runtime';
-import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 
 import { QueryEditorField } from './QueryEditorField';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
+}));
 
 const Wrapper = ({ children }: { children: ReactNode }) => {
   const methods = useForm({ defaultValues: { query: {} } });
@@ -25,17 +29,14 @@ const renderWithContext = (
   children: ReactNode,
   getHandler: (name: string) => Promise<MockDataSourceApi> = defaultGetHandler
 ) => {
-  const dsServer = setupDataSources();
-  dsServer.get = getHandler;
-
-  setDataSourceSrv(dsServer);
+  jest.mocked(getDataSourceInstance).mockImplementation((ref) => getHandler(ref as string));
 
   render(<Wrapper>{children}</Wrapper>);
 };
 
 describe('QueryEditorField', () => {
-  afterAll(() => {
-    jest.restoreAllMocks();
+  afterEach(() => {
+    jest.mocked(getDataSourceInstance).mockReset();
   });
 
   it('should render the query editor', async () => {

--- a/public/app/features/correlations/Forms/QueryEditorField.tsx
+++ b/public/app/features/correlations/Forms/QueryEditorField.tsx
@@ -3,7 +3,7 @@ import { useAsync } from 'react-use';
 
 import { CoreApp } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { Field, LoadingPlaceholder, Alert, TextLink } from '@grafana/ui';
 
 interface Props {
@@ -22,7 +22,7 @@ export const QueryEditorField = ({ dsUid, invalid, error, name }: Props) => {
     if (!dsUid) {
       return;
     }
-    return getDataSourceSrv().get(dsUid);
+    return getDataSourceInstance(dsUid);
   }, [dsUid]);
 
   const QueryEditor = datasource?.components?.QueryEditor;


### PR DESCRIPTION
## Description
Migrate `QueryEditorField` in the Correlations forms off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

## Changes
- Replaced the `getDataSourceSrv().get(dsUid)` call that resolves the target datasource for the correlation query editor with `getDataSourceInstance(dsUid)`. The call already lived inside a `useAsync`, so no restructuring was needed - `getDataSourceInstance` keeps the same throw-on-not-found contract, and the rejection is still surfaced via the hook's `error`.
- Updated `QueryEditorField.test.tsx` to mock `getDataSourceInstance` from `@grafana/runtime/unstable` instead of feeding data through `setDataSourceSrv`. The previous setup would otherwise trigger the new API's legacy fallback path and log a console warning that fails the suite.

## Risks
- Low. Only affects loading the target datasource's query editor in the Correlations add/edit forms. Behaviour is unchanged; `getDataSourceInstance` falls back to the legacy service if its cache is empty.

## Demo
N/A - no user-facing changes.

## Testing Instructions
- Go to Administration → Plugins and data → Correlations, add or edit a correlation, and confirm the target data source's query editor still loads (and the loading / error / "no data source" / "no query editor" states still render correctly).

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable