### PR TITLE
Alerting: always set promote header when importing Alertmanager config

### DIFF
--- a/public/app/features/alerting/unified/api/convertToGMAApi.ts
+++ b/public/app/features/alerting/unified/api/convertToGMAApi.ts
@@ -84,6 +84,7 @@ export const convertToGMAApi = alertingApi.injectEndpoints({
           'X-Grafana-Alerting-Config-Identifier': configIdentifier,
           // TODO: Remove this header once the backend no longer requires it
           'X-Grafana-Alerting-Merge-Matchers': `__grafana_managed_route__=${configIdentifier}`,
+          'X-Grafana-Alerting-Promote': 'true',
           ...(forceReplace ? { 'X-Grafana-Alerting-Config-Force-Replace': 'true' } : {}),
         },
       }),


### PR DESCRIPTION
## Summary

- Sets `X-Grafana-Alerting-Promote: true` on all `POST /api/convert/api/v1/alerts` requests from the import wizard.
- This promotes the imported Alertmanager config into the main Grafana config immediately, making it editable via regular APIs.

## Test plan

- [ ] Import Alertmanager config via the import wizard (YAML file or datasource source)
- [ ] Verify the promoted config is editable in the Grafana Alertmanager UI