### PR TITLE
navtree: Show Playlists nav link in anonymous mode

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -383,7 +383,9 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext) []*navt
 
 	dashboardChildNavs := []*navtree.NavLink{}
 
-	if c.IsSignedIn {
+	// Playlists are visible to anonymous users too, so the nav stays consistent
+	// with the playlist page and API which both serve anonymous Viewers.
+	if c.IsSignedIn || c.IsAnonymous {
 		showPlaylist := c.HasRole(org.RoleViewer)
 		//nolint:staticcheck // not yet migrated to OpenFeature
 		if s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagPlaylistsRBAC) {
@@ -394,7 +396,9 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext) []*navt
 				Text: "Playlists", SubTitle: "Groups of dashboards that are displayed in a sequence", Id: "dashboards/playlists", Url: s.cfg.AppSubURL + "/playlists", Icon: "presentation-play",
 			})
 		}
+	}
 
+	if c.IsSignedIn {
 		if s.cfg.SnapshotEnabled && hasAccess(ac.EvalPermission(dashboardsnapshots.ActionSnapshotsRead)) {
 			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
 				Text:     "Snapshots",

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -8,11 +8,16 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/navtree"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	starapi "github.com/grafana/grafana/pkg/services/star/api"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -137,5 +142,58 @@ func TestBuildStarredItemsNavLinks(t *testing.T) {
 		require.Equal(t, "A Dashboard", navLinks[0].Text)
 		require.Equal(t, "B Dashboard", navLinks[1].Text)
 		require.Equal(t, "C Dashboard", navLinks[2].Text)
+	})
+}
+
+func TestBuildDashboardNavLinks(t *testing.T) {
+	newService := func() ServiceImpl {
+		return ServiceImpl{
+			cfg:           setting.NewCfg(),
+			accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures()),
+			features:      featuremgmt.WithFeatures(),
+		}
+	}
+
+	hasPlaylistLink := func(navLinks []*navtree.NavLink) bool {
+		for _, link := range navLinks {
+			if link.Id == "dashboards/playlists" {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("Should show Playlists link for an anonymous Viewer", func(t *testing.T) {
+		httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+		reqCtx := &contextmodel.ReqContext{
+			SignedInUser: &user.SignedInUser{
+				IsAnonymous: true,
+				OrgRole:     org.RoleViewer,
+			},
+			IsSignedIn: false,
+			Context:    &web.Context{Req: httpReq},
+		}
+
+		service := newService()
+		navLinks := service.buildDashboardNavLinks(reqCtx)
+
+		require.True(t, hasPlaylistLink(navLinks), "expected anonymous Viewer to see the Playlists nav link")
+	})
+
+	t.Run("Should not show Playlists link for an unauthenticated user", func(t *testing.T) {
+		httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+		reqCtx := &contextmodel.ReqContext{
+			SignedInUser: &user.SignedInUser{
+				IsAnonymous: false,
+				OrgRole:     org.RoleViewer,
+			},
+			IsSignedIn: false,
+			Context:    &web.Context{Req: httpReq},
+		}
+
+		service := newService()
+		navLinks := service.buildDashboardNavLinks(reqCtx)
+
+		require.False(t, hasPlaylistLink(navLinks), "expected unauthenticated user to not see the Playlists nav link")
 	})
 }


### PR DESCRIPTION
**What is this feature?**

- The "Playlists" item now appears under the Dashboards navigation for anonymous users when anonymous access is enabled with a Viewer (or higher) role.
- Fully unauthenticated visitors (anonymous access disabled) still do not see the Playlists item.
- Snapshots, Library panels, Public dashboards, and Recently deleted remain visible to signed-in users only, with no change in behavior.
- Existing role and permission checks for Playlists are preserved, so access still respects the playlists permission when role-based access control is in effect.


**Why do we need this feature?**

- Previously the Playlists nav link was hidden for anonymous users even though the `/playlists` page and playlist API served them content. With the nav node missing, the page chrome incorrectly rendered a "Page not found"/404 state.

**Who is this feature for?**

Anonymous users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/126031

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
