### PR TITLE
GrafanaUI: Focus confirm input instead of disabled button in ConfirmContent

### DIFF
--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx
@@ -64,14 +64,21 @@ export const ConfirmContent = ({
   const [isDisabled, setIsDisabled] = useState(disabled);
   const styles = useStyles2(getStyles);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const onConfirmationTextChange = (event: React.FormEvent<HTMLInputElement>) => {
     setIsDisabled(confirmPromptText?.toLowerCase().localeCompare(event.currentTarget.value.toLowerCase()) !== 0);
   };
 
   useEffect(() => {
-    buttonRef.current?.focus();
-  }, []);
+    // With a type-to-confirm prompt the confirm button starts disabled, so land focus
+    // on the input the user must type into rather than the unusable button.
+    if (confirmPromptText && !disabled) {
+      inputRef.current?.focus();
+    } else {
+      buttonRef.current?.focus();
+    }
+  }, [confirmPromptText, disabled]);
 
   useEffect(() => {
     setIsDisabled(disabled ? true : Boolean(confirmPromptText));
@@ -111,6 +118,7 @@ export const ConfirmContent = ({
             <Stack alignItems="flex-start">
               <Field disabled={disabled}>
                 <Input
+                  ref={inputRef}
                   placeholder={placeholder}
                   onChange={onConfirmationTextChange}
                   data-testid={selectors.pages.ConfirmModal.input}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contributor guidelines in the CONTRIBUTING.md file.
2. Ensure you include and run the appropriate tests as part of your Pull Request.
3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.
6. Name your PR as "<FeatureArea>: Describe your change", e.g. "Alerting: Prevent race condition".

-->

### What is this feature?

`ConfirmContent` focuses its confirm button on mount. When a type-to-confirm prompt (`confirmPromptText`) is set, that button starts **disabled** — so focus lands on an unusable control. This change focuses the **text input** the user must type into instead, falling back to the confirm button when there is no prompt (existing behavior is preserved for all non-prompt callers).

### Why do we need this feature?

When a confirmation requires typing a word (e.g. "Delete") before the action enables, the user expects the cursor to be in the input ready to type. Focusing the disabled button forced consumers to add their own focus workarounds.

### Who is this feature for?

Any consumer of `ConfirmContent` / `ConfirmModal` that uses the type-to-confirm flow, and the users interacting with those confirmations (including keyboard users).

### Which issue(s) does this PR fix?

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

N/A

### Special notes for your reviewer

- Behavior is unchanged for callers without `confirmPromptText` (still focuses the confirm button).
- The input-focus path is guarded on `!disabled`, so a hard-disabled control still falls back to the button.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/5cceba59-8d05-4eca-b900-8ffd6c381c42" /> | <video src="https://github.com/user-attachments/assets/ca530039-f0d0-4403-94e9-860be3ec34b1" /> | 







Please check that:

- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.