### PR TITLE
DataPro (migration): Migrate correlations enrich path off `getDataSourceSrv`

### DIFF
--- a/public/app/features/correlations/CorrelationsPageAppPlatform.test.tsx
+++ b/public/app/features/correlations/CorrelationsPageAppPlatform.test.tsx
@@ -154,6 +154,21 @@ jest.mock('@grafana/runtime', () => {
   };
 });
 
+// Delegate the new async datasource APIs to the legacy srv configured per-test via setDataSourceSrv,
+// so the cache-miss legacy fallback (which logs a warning that fails on console) is never hit.
+jest.mock('@grafana/runtime/unstable', () => {
+  const actualRuntime = jest.requireActual('@grafana/runtime');
+  const actualUnstable = jest.requireActual('@grafana/runtime/unstable');
+
+  return {
+    ...actualUnstable,
+    getDataSourceInstanceSettings: (ref: Parameters<typeof actualUnstable.getDataSourceInstanceSettings>[0]) =>
+      Promise.resolve(actualRuntime.getDataSourceSrv().getInstanceSettings(ref)),
+    getDataSourceInstance: (ref: Parameters<typeof actualUnstable.getDataSourceInstance>[0]) =>
+      actualRuntime.getDataSourceSrv().get(ref),
+  };
+});
+
 jest.mock('app/core/copy/appNotification', () => {
   return {
     ...jest.requireActual('app/core/copy/appNotification'),

--- a/public/app/features/correlations/CorrelationsPageLegacy.test.tsx
+++ b/public/app/features/correlations/CorrelationsPageLegacy.test.tsx
@@ -205,6 +205,21 @@ jest.mock('@grafana/runtime', () => {
   };
 });
 
+// Delegate the new async datasource APIs to the legacy srv configured per-test via setDataSourceSrv,
+// so the cache-miss legacy fallback (which logs a warning that fails on console) is never hit.
+jest.mock('@grafana/runtime/unstable', () => {
+  const actualRuntime = jest.requireActual('@grafana/runtime');
+  const actualUnstable = jest.requireActual('@grafana/runtime/unstable');
+
+  return {
+    ...actualUnstable,
+    getDataSourceInstanceSettings: (ref: Parameters<typeof actualUnstable.getDataSourceInstanceSettings>[0]) =>
+      Promise.resolve(actualRuntime.getDataSourceSrv().getInstanceSettings(ref)),
+    getDataSourceInstance: (ref: Parameters<typeof actualUnstable.getDataSourceInstance>[0]) =>
+      actualRuntime.getDataSourceSrv().get(ref),
+  };
+});
+
 beforeAll(() => {
   mockBoundingClientRect();
   mocks.contextSrv.hasPermission.mockImplementation(() => true);

--- a/public/app/features/correlations/useCorrelations.ts
+++ b/public/app/features/correlations/useCorrelations.ts
@@ -1,8 +1,8 @@
 import { useAsyncFn } from 'react-use';
 import { lastValueFrom } from 'rxjs';
 
-import { getDataSourceSrv, type FetchResponse, type CorrelationData, type CorrelationsData } from '@grafana/runtime';
-import { getLogger } from '@grafana/runtime/unstable';
+import { type FetchResponse, type CorrelationData, type CorrelationsData } from '@grafana/runtime';
+import { getDataSourceInstanceSettings, getLogger } from '@grafana/runtime/unstable';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
 import {
@@ -23,10 +23,13 @@ export interface CorrelationsResponse {
   totalCount: number;
 }
 
-export const toEnrichedCorrelationData = ({ sourceUID, ...correlation }: Correlation): CorrelationData | undefined => {
-  const sourceDatasource = getDataSourceSrv().getInstanceSettings(sourceUID);
+export const toEnrichedCorrelationData = async ({
+  sourceUID,
+  ...correlation
+}: Correlation): Promise<CorrelationData | undefined> => {
+  const sourceDatasource = await getDataSourceInstanceSettings(sourceUID);
   const targetDatasource =
-    correlation.type === 'query' ? getDataSourceSrv().getInstanceSettings(correlation.targetUID) : undefined;
+    correlation.type === 'query' ? await getDataSourceInstanceSettings(correlation.targetUID) : undefined;
 
   // According to #72258 we will remove logic to handle orgId=0/null as global correlations.
   // This logging is to check if there are any customers who did not migrate existing correlations.
@@ -69,10 +72,15 @@ export const toEnrichedCorrelationData = ({ sourceUID, ...correlation }: Correla
 
 const validSourceFilter = (correlation: CorrelationData | undefined): correlation is CorrelationData => !!correlation;
 
-export const toEnrichedCorrelationsData = (correlationsResponse: CorrelationsResponse): CorrelationsData => {
+export const toEnrichedCorrelationsData = async (
+  correlationsResponse: CorrelationsResponse
+): Promise<CorrelationsData> => {
+  const correlations = (await Promise.all(correlationsResponse.correlations.map(toEnrichedCorrelationData))).filter(
+    validSourceFilter
+  );
   return {
     ...correlationsResponse,
-    correlations: correlationsResponse.correlations.map(toEnrichedCorrelationData).filter(validSourceFilter),
+    correlations,
   };
 };
 
@@ -110,8 +118,8 @@ export const useCorrelations = () => {
     async ({ sourceUID, ...correlation }) => {
       return backend
         .post<CreateCorrelationResponse>(`/api/datasources/uid/${sourceUID}/correlations`, correlation)
-        .then((response) => {
-          const enrichedCorrelation = toEnrichedCorrelationData(response.result);
+        .then(async (response) => {
+          const enrichedCorrelation = await toEnrichedCorrelationData(response.result);
           if (enrichedCorrelation !== undefined) {
             return enrichedCorrelation;
           } else {
@@ -132,8 +140,8 @@ export const useCorrelations = () => {
     ({ sourceUID, uid, ...correlation }) =>
       backend
         .patch<UpdateCorrelationResponse>(`/api/datasources/uid/${sourceUID}/correlations/${uid}`, correlation)
-        .then((response) => {
-          const enrichedCorrelation = toEnrichedCorrelationData(response.result);
+        .then(async (response) => {
+          const enrichedCorrelation = await toEnrichedCorrelationData(response.result);
           if (enrichedCorrelation !== undefined) {
             return enrichedCorrelation;
           } else {

--- a/public/app/features/correlations/useCorrelationsK8s.test.ts
+++ b/public/app/features/correlations/useCorrelationsK8s.test.ts
@@ -5,17 +5,16 @@ import { type DataSourceRef } from '@grafana/schema/dist/esm/index';
 
 import { toEnrichedCorrelationDataK8s, useCorrelationsK8s } from './useCorrelationsK8s';
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: jest.fn().mockReturnValue({
-    getInstanceSettings: (ref: DataSourceRef) => {
-      if (ref.uid !== 'notFoundUid') {
-        return typeof ref === 'string' ? { uid: ref, type: ref } : ref;
-      } else {
-        return undefined;
-      }
-    },
-  }),
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: (ref: DataSourceRef | string) => {
+    const uid = typeof ref === 'string' ? ref : ref.uid;
+    if (uid !== 'notFoundUid') {
+      return Promise.resolve(typeof ref === 'string' ? { uid: ref, type: ref } : ref);
+    } else {
+      return Promise.resolve(undefined);
+    }
+  },
 }));
 
 jest.mock('@grafana/api-clients/rtkq/correlations/v0alpha1', () => ({
@@ -31,8 +30,8 @@ describe('useCorrelationsK8s', () => {
   });
 
   describe('toEnrichedCorrelationDataK8s', () => {
-    it('returns undefined if the source datasource is not found', () => {
-      const correlation = toEnrichedCorrelationDataK8s({
+    it('returns undefined if the source datasource is not found', async () => {
+      const correlation = await toEnrichedCorrelationDataK8s({
         apiVersion: 'testApiVer',
         kind: 'testKind',
         metadata: {
@@ -49,8 +48,8 @@ describe('useCorrelationsK8s', () => {
 
       expect(correlation).toBe(undefined);
     });
-    it('returns undefined if its a query correlation and the targetDS is not found', () => {
-      const correlation = toEnrichedCorrelationDataK8s({
+    it('returns undefined if its a query correlation and the targetDS is not found', async () => {
+      const correlation = await toEnrichedCorrelationDataK8s({
         apiVersion: 'testApiVer',
         kind: 'testKind',
         metadata: {
@@ -68,8 +67,8 @@ describe('useCorrelationsK8s', () => {
 
       expect(correlation).toBe(undefined);
     });
-    it('returns an external correlation', () => {
-      const correlation = toEnrichedCorrelationDataK8s({
+    it('returns an external correlation', async () => {
+      const correlation = await toEnrichedCorrelationDataK8s({
         apiVersion: 'testApiVer',
         kind: 'testKind',
         metadata: {
@@ -94,8 +93,8 @@ describe('useCorrelationsK8s', () => {
         uid: 'testUid',
       });
     });
-    it('returns a query correlation', () => {
-      const correlation = toEnrichedCorrelationDataK8s({
+    it('returns a query correlation', async () => {
+      const correlation = await toEnrichedCorrelationDataK8s({
         apiVersion: 'testApiVer',
         kind: 'testKind',
         metadata: {
@@ -123,8 +122,8 @@ describe('useCorrelationsK8s', () => {
         uid: 'testUid',
       });
     });
-    it('marks a correlation with a manager as provisioned', () => {
-      const correlation = toEnrichedCorrelationDataK8s({
+    it('marks a correlation with a manager as provisioned', async () => {
+      const correlation = await toEnrichedCorrelationDataK8s({
         apiVersion: 'testApiVer',
         kind: 'testKind',
         metadata: { name: 'testUid', annotations: { 'grafana.app/managedBy': 'something' } },
@@ -151,8 +150,8 @@ describe('useCorrelationsK8s', () => {
       });
     });
 
-    it('marks a correlation with a manager that allows edits as not provisioned', () => {
-      const correlation = toEnrichedCorrelationDataK8s({
+    it('marks a correlation with a manager that allows edits as not provisioned', async () => {
+      const correlation = await toEnrichedCorrelationDataK8s({
         apiVersion: 'testApiVer',
         kind: 'testKind',
         metadata: {

--- a/public/app/features/correlations/useCorrelationsK8s.test.ts
+++ b/public/app/features/correlations/useCorrelationsK8s.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react';
 
 import { useListCorrelationQuery } from '@grafana/api-clients/rtkq/correlations/v0alpha1';
+import { SupportedTransformationType } from '@grafana/data';
 import { type DataSourceRef } from '@grafana/schema/dist/esm/index';
 
 import { toEnrichedCorrelationDataK8s, useCorrelationsK8s } from './useCorrelationsK8s';
@@ -122,6 +123,37 @@ describe('useCorrelationsK8s', () => {
         uid: 'testUid',
       });
     });
+    it('maps non-regex transformations to logfmt and defaults a missing target url', async () => {
+      const correlation = await toEnrichedCorrelationDataK8s({
+        apiVersion: 'testApiVer',
+        kind: 'testKind',
+        metadata: {
+          name: 'testUid',
+        },
+        spec: {
+          label: 'testLabel',
+          description: 'testDesc',
+          source: { group: 'notFoundGroup', name: 'foundUid' },
+          type: 'external',
+          config: { field: 'testField', target: {}, transformations: [{ type: 'logfmt' }] },
+        },
+      });
+
+      expect(correlation).toStrictEqual({
+        config: {
+          field: 'testField',
+          target: { url: '' },
+          transformations: [{ type: SupportedTransformationType.Logfmt }],
+        },
+        description: 'testDesc',
+        label: 'testLabel',
+        provisioned: false,
+        source: { type: 'foundUid', uid: 'foundUid' },
+        type: 'external',
+        uid: 'testUid',
+      });
+    });
+
     it('marks a correlation with a manager as provisioned', async () => {
       const correlation = await toEnrichedCorrelationDataK8s({
         apiVersion: 'testApiVer',
@@ -189,5 +221,11 @@ describe('useCorrelationsK8s', () => {
     useListCorrelationMock.mockReturnValue({ data: [] });
     renderHook(() => useCorrelationsK8s(10, 5));
     expect(useListCorrelationMock).toHaveBeenCalledWith({ limit: 50 });
+  });
+
+  it('returns a formatted error when the list query fails', async () => {
+    useListCorrelationMock.mockReturnValue({ error: { status: 500 } });
+    const { result } = renderHook(() => useCorrelationsK8s(10, 1));
+    expect(result.current.error).toBeDefined();
   });
 });

--- a/public/app/features/correlations/useCorrelationsK8s.ts
+++ b/public/app/features/correlations/useCorrelationsK8s.ts
@@ -1,21 +1,18 @@
+import { useEffect, useState } from 'react';
+
 import { handleRequestError } from '@grafana/api-clients';
 import {
   type Correlation as CorrelationK8s,
   useListCorrelationQuery,
 } from '@grafana/api-clients/rtkq/correlations/v0alpha1';
 import { SupportedTransformationType } from '@grafana/data';
-import {
-  type CorrelationData,
-  type CorrelationExternal,
-  type CorrelationQuery,
-  getDataSourceSrv,
-} from '@grafana/runtime';
+import { type CorrelationData, type CorrelationExternal, type CorrelationQuery } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { toEnrichedCorrelationData } from './useCorrelations';
 
-export const toEnrichedCorrelationDataK8s = (item: CorrelationK8s): CorrelationData | undefined => {
-  const dsSrv = getDataSourceSrv();
-  const sourceDS = dsSrv.getInstanceSettings({ type: item.spec.source.group, uid: item.spec.source.name });
+export const toEnrichedCorrelationDataK8s = async (item: CorrelationK8s): Promise<CorrelationData | undefined> => {
+  const sourceDS = await getDataSourceInstanceSettings({ type: item.spec.source.group, uid: item.spec.source.name });
   if (sourceDS !== undefined) {
     // if a resource has a manager set, it must explicitly allow edits
     const isManaged = item.metadata.annotations?.['grafana.app/managedBy'] !== undefined;
@@ -51,7 +48,10 @@ export const toEnrichedCorrelationDataK8s = (item: CorrelationK8s): CorrelationD
       };
       return toEnrichedCorrelationData(extCorr);
     } else {
-      const targetDs = dsSrv.getInstanceSettings({ type: item.spec.target?.group, uid: item.spec.target?.name });
+      const targetDs = await getDataSourceInstanceSettings({
+        type: item.spec.target?.group,
+        uid: item.spec.target?.name,
+      });
       if (targetDs !== undefined) {
         const queryCorr: CorrelationQuery = {
           ...baseCor,
@@ -82,21 +82,41 @@ export const useCorrelationsK8s = (limit = 100, page: number) => {
   }
 
   const { currentData, isLoading, error } = useListCorrelationQuery({ limit: pagedLimit });
-  const startIdx = limit * (page - 1);
-  const pagedData = currentData?.items.slice(startIdx, startIdx + limit) ?? [];
-  const enrichedCorrelations =
-    currentData !== undefined
-      ? pagedData
-          .filter((i) => i.metadata.name !== undefined)
-          .map((item) => toEnrichedCorrelationDataK8s(item))
-          .filter((i) => i !== undefined)
-      : [];
+
+  const [enrichedCorrelations, setEnrichedCorrelations] = useState<CorrelationData[]>([]);
+  const [isEnriching, setIsEnriching] = useState(false);
+
+  useEffect(() => {
+    if (currentData === undefined) {
+      setEnrichedCorrelations([]);
+      return;
+    }
+
+    let cancelled = false;
+    setIsEnriching(true);
+
+    const startIdx = limit * (page - 1);
+    const pagedData = currentData.items.slice(startIdx, startIdx + limit);
+
+    Promise.all(
+      pagedData.filter((i) => i.metadata.name !== undefined).map((item) => toEnrichedCorrelationDataK8s(item))
+    ).then((enriched) => {
+      if (!cancelled) {
+        setEnrichedCorrelations(enriched.filter((i) => i !== undefined));
+        setIsEnriching(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentData, limit, page]);
 
   const fmtedError = error ? handleRequestError(error) : undefined;
 
   return {
     currentData: enrichedCorrelations,
-    isLoading,
+    isLoading: isLoading || isEnriching,
     error: fmtedError,
     remainingItems: currentData?.metadata.remainingItemCount || 0,
     doesContinue: currentData?.metadata.continue !== undefined,

--- a/public/app/features/correlations/utils.test.ts
+++ b/public/app/features/correlations/utils.test.ts
@@ -17,15 +17,13 @@ import { type Correlation } from './types';
 import { attachCorrelationsToDataFrames, generateDefaultLabel, generatePartialEditSpec } from './utils';
 import * as utils from './utils';
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: jest.fn().mockReturnValue({
-    get: jest.fn().mockResolvedValue({
-      name: 'getTest',
-      getRef: () => {
-        return { type: 'testTypeFromLookup', uid: 'testUidFromLookup' };
-      },
-    }),
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn().mockResolvedValue({
+    name: 'getTest',
+    getRef: () => {
+      return { type: 'testTypeFromLookup', uid: 'testUidFromLookup' };
+    },
   }),
 }));
 

--- a/public/app/features/correlations/utils.ts
+++ b/public/app/features/correlations/utils.ts
@@ -6,7 +6,8 @@ import {
   type CorrelationSpec,
 } from '@grafana/api-clients/rtkq/correlations/v0alpha1';
 import { type DataFrame, DataLinkConfigOrigin } from '@grafana/data';
-import { config, type CorrelationData, type CorrelationsData, getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
+import { config, type CorrelationData, type CorrelationsData, getBackendSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery, type DataSourceRef } from '@grafana/schema';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { type ExploreItemState } from 'app/types/explore';
@@ -134,7 +135,7 @@ export const createCorrelation = async (
 
 const getDSInstanceForPane = async (pane: ExploreItemState) => {
   if (pane.datasourceInstance?.meta.mixed) {
-    return await getDataSourceSrv().get(pane.queries[0].datasource);
+    return await getDataSourceInstance(pane.queries[0].datasource);
   } else {
     return pane.datasourceInstance;
   }
@@ -182,11 +183,10 @@ export const generatePartialEditSpec = (data: EditFormDTO, correlation: Correlat
 };
 
 export const generateAddSpec = async (data: FormDTO): Promise<CorrelationSpec> => {
-  const dsSrv = getDataSourceSrv();
-  const sourceDs = await dsSrv.get(data.sourceUID);
+  const sourceDs = await getDataSourceInstance(data.sourceUID);
   let targetDs;
   if ('targetUID' in data && data.targetUID !== undefined) {
-    targetDs = await dsSrv.get(data.targetUID!);
+    targetDs = await getDataSourceInstance(data.targetUID!);
   }
 
   return {
@@ -224,8 +224,7 @@ export const getCorrelationsFromStorage = async (
             array.findIndex((ref2) => ref2?.uid === ref?.uid && ref2?.type === ref?.type) === index
         );
     } else {
-      const dataSourceSrv = getDataSourceSrv();
-      const instanceDS = await dataSourceSrv.get(instanceUid);
+      const instanceDS = await getDataSourceInstance(instanceUid);
       const instanceDSRef = instanceDS.getRef();
       queryDSRefList = [instanceDSRef];
     }
@@ -246,9 +245,9 @@ export const getCorrelationsFromStorage = async (
       })
     );
     // this is just for retrieving in explore, so pagination features are not needed
-    const enrichedCorr = (data?.items ?? [])
-      .map((item) => toEnrichedCorrelationDataK8s(item))
-      .filter((i) => i !== undefined);
+    const enrichedCorr = (
+      await Promise.all((data?.items ?? []).map((item) => toEnrichedCorrelationDataK8s(item)))
+    ).filter((i) => i !== undefined);
     correlations = {
       correlations: enrichedCorr,
       page: 0,


### PR DESCRIPTION
## Description
Migrate the Correlations feature's datasource-enrichment path off the deprecated synchronous `getDataSourceSrv()` APIs to the new async `getDataSourceInstanceSettings()` and `getDataSourceInstance()` from `@grafana/runtime/unstable`.

This consolidates **DPRO-158** (`useCorrelations.ts`), **DPRO-159** (`useCorrelationsK8s.ts`), and **DPRO-160** (`utils.ts`) into a single PR. They cannot be split: the exported helper `toEnrichedCorrelationData` lives in `useCorrelations.ts` and is shared by the other two files. Migrating its `getInstanceSettings` calls forces it `async`, which cascades through all three at once — splitting would mean a broken intermediate compile or a throwaway sync/async shim.

## Changes
- **`useCorrelations.ts`** - `toEnrichedCorrelationData` and `toEnrichedCorrelationsData` are now `async`; the latter resolves its mapped items via `Promise.all`. The `create`/`update` mutations `await` the enrichment. `getInstanceSettings` → `getDataSourceInstanceSettings`.
- **`useCorrelationsK8s.ts`** - `toEnrichedCorrelationDataK8s` is now `async` (its own two `getInstanceSettings` calls migrated too). The `useCorrelationsK8s` hook computed enriched data synchronously during render; it now resolves it in a `useEffect` with cancellation, stores it in state, and folds an `isEnriching` flag into the returned `isLoading` so consumers keep showing the loading state until enrichment completes.
- **`utils.ts`** - the K8s `.map(toEnrichedCorrelationDataK8s)` is wrapped in `Promise.all`; the file's own `getDataSourceSrv().get()` calls (`getDSInstanceForPane`, `generateAddSpec`, `getCorrelationsFromStorage`) → `getDataSourceInstance()`.
- **Tests** - `useCorrelationsK8s.test.ts` mocks `@grafana/runtime/unstable` and awaits the now-async helper. The page tests (`CorrelationsPageLegacy`, `CorrelationsPageAppPlatform`) delegate the new async APIs to the legacy srv each test already configures via `setDataSourceSrv`, avoiding the cache-miss legacy-fallback console warning. `utils.test.ts` mirrors its existing `.get` mock onto `getDataSourceInstance`.

## Risks
- Low–medium. Behaviour is preserved; the new APIs fall back to the legacy service if their cache is empty. The one behavioural nuance is the K8s list hook: enrichment is now async, so enriched rows appear a tick after the query resolves. This is covered by `isLoading` (now `isLoading || isEnriching`) so no empty-state flash, and the effect guards against setting state after unmount.

## Demo
N/A - no user-facing changes.

## Testing Instructions
- Administration → Plugins and data → Correlations: list, add, edit, and delete correlations and confirm source/target datasources still resolve and render. Exercise both the legacy and the App Platform (`kubernetesCorrelations`) paths.
- In Explore, confirm correlation links/transformations still build on data frames.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable