### PR TITLE
fix(annotations): grafana.app/legacyID label selector

### DIFF
--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -447,10 +447,7 @@ func parseLabelSelector(ls labels.Selector) (labelFilters, error) {
 	if ls == nil {
 		return f, nil
 	}
-	requirements, selectable := ls.Requirements()
-	if !selectable {
-		return f, fmt.Errorf("label selector cannot match anything")
-	}
+	requirements, _ := ls.Requirements()
 	for _, r := range requirements {
 		if r.Operator() != selection.Equals && r.Operator() != selection.DoubleEquals {
 			return f, fmt.Errorf("unsupported operator %s for %s (only = or == supported)", r.Operator(), r.Key())

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -411,7 +411,7 @@ func parseFieldSelector(fs fields.Selector) (fieldFilters, error) {
 	}
 	for _, r := range fs.Requirements() {
 		if r.Operator != selection.Equals && r.Operator != selection.DoubleEquals {
-			return f, fmt.Errorf("unsupported operator %s for %s (only = supported)", r.Operator, r.Field)
+			return f, fmt.Errorf("unsupported operator %s for %s (only = or == supported)", r.Operator, r.Field)
 		}
 		switch r.Field {
 		case "spec.dashboardUID":
@@ -453,7 +453,7 @@ func parseLabelSelector(ls labels.Selector) (labelFilters, error) {
 	}
 	for _, r := range requirements {
 		if r.Operator() != selection.Equals && r.Operator() != selection.DoubleEquals {
-			return f, fmt.Errorf("unsupported operator %s for %s (only = supported)", r.Operator(), r.Key())
+			return f, fmt.Errorf("unsupported operator %s for %s (only = or == supported)", r.Operator(), r.Key())
 		}
 		switch r.Key() {
 		case LabelKeyLegacyID:

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -144,6 +145,9 @@ func (s *k8sRESTAdapter) List(ctx context.Context, options *internalversion.List
 
 	opts := ListOptions{}
 	if err := parseFieldSelector(options.FieldSelector, &opts); err != nil {
+		return nil, apierrors.NewBadRequest(err.Error())
+	}
+	if err := parseLabelSelector(options.LabelSelector, &opts); err != nil {
 		return nil, apierrors.NewBadRequest(err.Error())
 	}
 
@@ -405,14 +409,36 @@ func parseFieldSelector(fs fields.Selector, opts *ListOptions) error {
 				return fmt.Errorf("invalid timeEnd value %q: %w", r.Value, err)
 			}
 			opts.To = v
-		case "metadata.legacyID":
-			v, err := strconv.ParseInt(r.Value, 10, 64)
+		default:
+			return fmt.Errorf("unsupported field selector: %s", r.Field)
+		}
+	}
+	return nil
+}
+
+// parseLabelSelector translates K8s label selectors into Store ListOptions.
+func parseLabelSelector(ls labels.Selector, opts *ListOptions) error {
+	if ls == nil {
+		return nil
+	}
+	requirements, _ := ls.Requirements()
+	for _, r := range requirements {
+		if r.Operator() != selection.Equals && r.Operator() != selection.DoubleEquals {
+			return fmt.Errorf("unsupported operator %s for %s (only = supported)", r.Operator(), r.Key())
+		}
+		switch r.Key() {
+		case LabelKeyLegacyID:
+			value, ok := r.Values().PopAny()
+			if !ok {
+				return fmt.Errorf("missing value for label selector %s", r.Key())
+			}
+			v, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
-				return fmt.Errorf("invalid legacyID value %q: %w", r.Value, err)
+				return fmt.Errorf("invalid legacyID value %q: %w", value, err)
 			}
 			opts.LegacyID = v
 		default:
-			return fmt.Errorf("unsupported field selector: %s", r.Field)
+			return fmt.Errorf("unsupported label selector: %s", r.Key())
 		}
 	}
 	return nil

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -143,12 +143,23 @@ func (s *k8sRESTAdapter) List(ctx context.Context, options *internalversion.List
 	start := time.Now()
 	defer func() { observe(ctx, s.logger, s.metrics.RequestDuration, "list", start, err) }()
 
-	opts := ListOptions{}
-	if err := parseFieldSelector(options.FieldSelector, &opts); err != nil {
+	ff, err := parseFieldSelector(options.FieldSelector)
+	if err != nil {
 		return nil, apierrors.NewBadRequest(err.Error())
 	}
-	if err := parseLabelSelector(options.LabelSelector, &opts); err != nil {
+	lf, err := parseLabelSelector(options.LabelSelector)
+	if err != nil {
 		return nil, apierrors.NewBadRequest(err.Error())
+	}
+
+	opts := ListOptions{
+		// from field selector
+		DashboardUID: ff.DashboardUID,
+		PanelID:      ff.PanelID,
+		From:         ff.From,
+		To:           ff.To,
+		// from label selector
+		LegacyID: lf.LegacyID,
 	}
 
 	opts.Limit = 100
@@ -379,69 +390,87 @@ func (s *k8sRESTAdapter) Delete(ctx context.Context, name string, deleteValidati
 	return nil, false, nil
 }
 
-// parseFieldSelector translates K8s field selectors into Store ListOptions.
-func parseFieldSelector(fs fields.Selector, opts *ListOptions) error {
+// fieldFilters holds the filters derived from a K8s field selector.
+type fieldFilters struct {
+	DashboardUID string
+	PanelID      int64
+	From         int64
+	To           int64
+}
+
+// labelFilters holds the filters derived from a K8s label selector.
+type labelFilters struct {
+	LegacyID int64
+}
+
+// parseFieldSelector translates K8s field selectors into field filters.
+func parseFieldSelector(fs fields.Selector) (fieldFilters, error) {
+	var f fieldFilters
 	if fs == nil {
-		return nil
+		return f, nil
 	}
 	for _, r := range fs.Requirements() {
 		if r.Operator != selection.Equals && r.Operator != selection.DoubleEquals {
-			return fmt.Errorf("unsupported operator %s for %s (only = supported)", r.Operator, r.Field)
+			return f, fmt.Errorf("unsupported operator %s for %s (only = supported)", r.Operator, r.Field)
 		}
 		switch r.Field {
 		case "spec.dashboardUID":
-			opts.DashboardUID = r.Value
+			f.DashboardUID = r.Value
 		case "spec.panelID":
 			v, err := strconv.ParseInt(r.Value, 10, 64)
 			if err != nil {
-				return fmt.Errorf("invalid panelID value %q: %w", r.Value, err)
+				return f, fmt.Errorf("invalid panelID value %q: %w", r.Value, err)
 			}
-			opts.PanelID = v
+			f.PanelID = v
 		case "spec.time":
 			v, err := strconv.ParseInt(r.Value, 10, 64)
 			if err != nil {
-				return fmt.Errorf("invalid time value %q: %w", r.Value, err)
+				return f, fmt.Errorf("invalid time value %q: %w", r.Value, err)
 			}
-			opts.From = v
+			f.From = v
 		case "spec.timeEnd":
 			v, err := strconv.ParseInt(r.Value, 10, 64)
 			if err != nil {
-				return fmt.Errorf("invalid timeEnd value %q: %w", r.Value, err)
+				return f, fmt.Errorf("invalid timeEnd value %q: %w", r.Value, err)
 			}
-			opts.To = v
+			f.To = v
 		default:
-			return fmt.Errorf("unsupported field selector: %s", r.Field)
+			return f, fmt.Errorf("unsupported field selector: %s", r.Field)
 		}
 	}
-	return nil
+	return f, nil
 }
 
-// parseLabelSelector translates K8s label selectors into Store ListOptions.
-func parseLabelSelector(ls labels.Selector, opts *ListOptions) error {
+// parseLabelSelector translates K8s label selectors into label filters.
+func parseLabelSelector(ls labels.Selector) (labelFilters, error) {
+	var f labelFilters
 	if ls == nil {
-		return nil
+		return f, nil
 	}
-	requirements, _ := ls.Requirements()
+	requirements, selectable := ls.Requirements()
+	if !selectable {
+		return f, fmt.Errorf("label selector cannot match anything")
+	}
 	for _, r := range requirements {
 		if r.Operator() != selection.Equals && r.Operator() != selection.DoubleEquals {
-			return fmt.Errorf("unsupported operator %s for %s (only = supported)", r.Operator(), r.Key())
+			return f, fmt.Errorf("unsupported operator %s for %s (only = supported)", r.Operator(), r.Key())
 		}
 		switch r.Key() {
 		case LabelKeyLegacyID:
 			value, ok := r.Values().PopAny()
 			if !ok {
-				return fmt.Errorf("missing value for label selector %s", r.Key())
+				return f, fmt.Errorf("missing value for label selector %s", r.Key())
 			}
 			v, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
-				return fmt.Errorf("invalid legacyID value %q: %w", value, err)
+				return f, fmt.Errorf("invalid legacyID value %q: %w", value, err)
 			}
-			opts.LegacyID = v
+			f.LegacyID = v
 		default:
-			return fmt.Errorf("unsupported label selector: %s", r.Key())
+			return f, fmt.Errorf("unsupported label selector: %s", r.Key())
 		}
 	}
-	return nil
+	return f, nil
 }
 
 func (s *k8sRESTAdapter) validateAnnotation(anno *annotationV0.Annotation) error {

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -14,7 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 	registryrest "k8s.io/apiserver/pkg/registry/rest"
@@ -423,21 +423,21 @@ func TestK8sAdapter_List(t *testing.T) {
 		return adapter, ctx
 	}
 
-	t.Run("field selector filters by legacy ID", func(t *testing.T) {
+	t.Run("label selector filters by legacy ID", func(t *testing.T) {
 		adapter, ctx := setup(t)
 		result, err := adapter.List(ctx, &internalversion.ListOptions{
-			FieldSelector: fields.ParseSelectorOrDie("metadata.legacyID=100"),
+			LabelSelector: labels.SelectorFromSet(labels.Set{LabelKeyLegacyID: "200"}),
 		})
 		require.NoError(t, err)
 		list := result.(*annotationV0.AnnotationList)
 		require.Len(t, list.Items, 1)
-		assert.Equal(t, "anno-a", list.Items[0].Name)
+		assert.Equal(t, "anno-b", list.Items[0].Name)
 	})
 
-	t.Run("non-matching legacy ID returns empty", func(t *testing.T) {
+	t.Run("non-matching legacy ID label returns empty", func(t *testing.T) {
 		adapter, ctx := setup(t)
 		result, err := adapter.List(ctx, &internalversion.ListOptions{
-			FieldSelector: fields.ParseSelectorOrDie("metadata.legacyID=999"),
+			LabelSelector: labels.SelectorFromSet(labels.Set{LabelKeyLegacyID: "999"}),
 		})
 		require.NoError(t, err)
 		list := result.(*annotationV0.AnnotationList)

--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	annotationpkg "github.com/grafana/grafana/pkg/registry/apps/annotation"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -103,7 +104,7 @@ func (s *annotationAPIClient) Delete(ctx context.Context, orgID int64, name stri
 // every partition. Carrying the annotation time to the call sites would let us prune them.
 func (s *annotationAPIClient) GetByLegacyID(ctx context.Context, orgID int64, annotationID int64) (*annotationV0.Annotation, error) {
 	list, err := s.k8sClient.List(ctx, orgID, v1.ListOptions{
-		FieldSelector: fmt.Sprintf("metadata.legacyID=%d", annotationID),
+		LabelSelector: fmt.Sprintf("%s=%d", annotationpkg.LabelKeyLegacyID, annotationID),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR switches the migration proxy to resolve annotations by a label selector on `grafana.app/legacyID` instead of a `metadata.legacyID` field selector. The app-platform apiserver only accepts registered field selectors and was rejecting `metadata.legacyID` since it was not registered as a selectable field. This pattern also makes more sense in general since `grafana.app/legacyID` is surfaced as a k8s label, so naturally label selectors should be used for filtering.