### PR TITLE
DataPro (migration): Migrate `expressions/ExpressionDatasource.ts`

### DIFF
--- a/public/app/features/expressions/ExpressionDatasource.test.ts
+++ b/public/app/features/expressions/ExpressionDatasource.test.ts
@@ -12,12 +12,14 @@ const mockGetDatasource = jest.fn();
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => backendSrv,
-  getDataSourceSrv: () => ({
-    get: mockGetDatasource,
-  }),
   getTemplateSrv: () => ({
     replace: (val: string) => (val ? val.replace('$input', '10').replace('$window', '10s') : val),
   }),
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: (...args: unknown[]) => mockGetDatasource(...args),
 }));
 
 describe('ExpressionDatasourceApi', () => {

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -16,11 +16,11 @@ import {
   DataSourceWithBackend,
   type FetchResponse,
   getBackendSrv,
-  getDataSourceSrv,
   getTemplateSrv,
   toDataQueryResponse,
 } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import icnDatasourceSvg from 'img/icn-datasource.svg';
 
@@ -50,7 +50,7 @@ export class ExpressionDatasourceApi extends DataSourceWithBackend<ExpressionQue
 
   query(request: DataQueryRequest<ExpressionQuery>): Observable<DataQueryResponse> {
     let targets = request.targets.map(async (query: ExpressionQuery): Promise<ExpressionQuery> => {
-      const ds = await getDataSourceSrv().get(query.datasource, request.scopedVars);
+      const ds = await getDataSourceInstance(query.datasource, request.scopedVars);
 
       if (!ds.interpolateVariablesInQueries) {
         return query;


### PR DESCRIPTION
## Description
Migrate `ExpressionDatasourceApi.query()` off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

## Changes
- Replaced `getDataSourceSrv().get(query.datasource, request.scopedVars)` with `getDataSourceInstance(query.datasource, request.scopedVars)` when resolving each target query's datasource for variable interpolation. The call was already `await`ed, so no restructuring was needed.
- Updated `ExpressionDatasource.test.ts` to mock `getDataSourceInstance` from `@grafana/runtime/unstable` instead of `getDataSourceSrv().get`.

## Risks
- Low. Only affects resolving the inner datasource for each expression target before interpolating its variables. Behaviour is unchanged; `getDataSourceInstance` falls back to the legacy service if its cache is empty.

## Demo
N/A - no user-facing changes.

## Testing Instructions
- In Explore or a dashboard, build an expression query (e.g. Math/Reduce) referencing another datasource that uses template variables, and confirm the query still runs and variables interpolate correctly.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable