### PR TITLE
DataPro (migration): Migrate `expressions/components/SqlExpressions/hooks/useSQLSchemas.ts`

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
@@ -85,6 +85,11 @@ jest.mock('@grafana/runtime', () => ({
   reportInteraction: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn().mockResolvedValue({ uid: 'mock-ds-uid', type: 'mock-ds-type' }),
+}));
+
 describe('SqlExpr', () => {
   const SqlEditorMock = jest.mocked(SqlEditor);
   const SQLEditorMock = jest.mocked(SQLEditor);

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.ts
@@ -3,7 +3,8 @@ import { useDeepCompareEffect } from 'react-use';
 
 import { getAPINamespace } from '@grafana/api-clients';
 import { type AdHocVariableFilter, getDefaultTimeRange, type ScopedVars, type TimeRange } from '@grafana/data';
-import { config, getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 
@@ -84,7 +85,7 @@ export function useSQLSchemas({ queries, enabled, timeRange, scopedVars, filters
         return;
       }
 
-      const defaultDs = getDataSourceSrv().getInstanceSettings(null);
+      const defaultDs = await getDataSourceInstanceSettings(null);
       const resolvedQueries = nonDashboardQueries.map((query) => {
         if (!query.datasource && defaultDs) {
           return { ...query, datasource: { uid: defaultDs.uid, type: defaultDs.type } };


### PR DESCRIPTION
## Description
Migrate the `useSQLSchemas` hook off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstanceSettings()` from `@grafana/runtime/unstable`.

## Changes
- Replaced `getDataSourceSrv().getInstanceSettings(null)` with `await getDataSourceInstanceSettings(null)` when resolving the default datasource for queries that don't specify one. The call already lives in the `async` `fetchSchemas`, so only an `await` was added.

## Risks
- Low. Only affects resolving the default datasource for SQL-expression schema lookups. Behaviour is unchanged; `getDataSourceInstanceSettings` falls back to the legacy service if its cache is empty.

## Demo
N/A - no user-facing changes.

## Testing Instructions
- With the SQL expressions feature enabled, add a SQL expression that references a query without an explicit datasource and confirm schema/autocomplete still resolves against the default datasource.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable