### PR TITLE
chore(setting): track remote settings cache eviction rate

### DIFF
--- a/pkg/services/setting/service.go
+++ b/pkg/services/setting/service.go
@@ -84,6 +84,8 @@ type clientMetrics struct {
 	rateLimiterThrottleTotal prometheus.Counter
 	cacheHitTotal            prometheus.Counter
 	cacheMissTotal           prometheus.Counter
+	cacheEvictionTotal       prometheus.Counter
+	cacheSize                prometheus.Gauge
 }
 
 // Service retrieves configuration settings from a remote settings service.
@@ -340,7 +342,9 @@ func (s *remoteSettingService) List(ctx context.Context, labelSelector metav1.La
 	}
 
 	if s.cache != nil {
-		s.cache.Add(cacheKey, allSettings)
+		if evicted := s.cache.Add(cacheKey, allSettings); evicted {
+			s.metrics.cacheEvictionTotal.Inc()
+		}
 	}
 
 	return allSettings, nil
@@ -683,6 +687,20 @@ func initMetrics(serviceName string) clientMetrics {
 			Help:        "Total number of List cache misses",
 			ConstLabels: constLabels,
 		}),
+		cacheEvictionTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   "settings",
+			Subsystem:   "service",
+			Name:        "list_settings_cache_eviction_total",
+			Help:        "Total number of List cache entries evicted due to capacity (CacheMaxEntries) being exceeded; use to tune cache size",
+			ConstLabels: constLabels,
+		}),
+		cacheSize: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace:   "settings",
+			Subsystem:   "service",
+			Name:        "list_settings_cache_size",
+			Help:        "Current number of entries in the List cache; compare against CacheMaxEntries to tune cache size",
+			ConstLabels: constLabels,
+		}),
 	}
 	return metrics
 }
@@ -693,6 +711,8 @@ func (s *remoteSettingService) Describe(descs chan<- *prometheus.Desc) {
 	s.metrics.rateLimiterThrottleTotal.Describe(descs)
 	s.metrics.cacheHitTotal.Describe(descs)
 	s.metrics.cacheMissTotal.Describe(descs)
+	s.metrics.cacheEvictionTotal.Describe(descs)
+	s.metrics.cacheSize.Describe(descs)
 }
 
 func (s *remoteSettingService) Collect(metrics chan<- prometheus.Metric) {
@@ -701,4 +721,9 @@ func (s *remoteSettingService) Collect(metrics chan<- prometheus.Metric) {
 	s.metrics.rateLimiterThrottleTotal.Collect(metrics)
 	s.metrics.cacheHitTotal.Collect(metrics)
 	s.metrics.cacheMissTotal.Collect(metrics)
+	s.metrics.cacheEvictionTotal.Collect(metrics)
+	if s.cache != nil {
+		s.metrics.cacheSize.Set(float64(s.cache.Len()))
+	}
+	s.metrics.cacheSize.Collect(metrics)
 }


### PR DESCRIPTION
**What is this feature?**

Adds two Prometheus metrics to the remote settings service's List cache: `settings_service_list_settings_cache_eviction_total`, a counter of capacity-driven evictions (entries dropped because `CacheMaxEntries` was exceeded, excluding TTL expiry), and `settings_service_list_settings_cache_size`, a gauge reporting the live cache entry count at scrape time.

**Why do we need this feature?**

To support tuning of the cache. Alongside the existing hit and miss counters, these metrics let operators distinguish capacity pressure from natural TTL churn and decide whether `CacheMaxEntries` should be raised: a rising eviction count with the size gauge pinned at `CacheMaxEntries` indicates the cache is too small, while a size that stays well below the limit means added capacity would not improve the hit rate.
