### PR TITLE
MT annotations: add advisory check for retention_ttl

### DIFF
--- a/apps/advisor/pkg/app/checks/configchecks/annotations_config_step.go
+++ b/apps/advisor/pkg/app/checks/configchecks/annotations_config_step.go
@@ -1,0 +1,67 @@
+package configchecks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	advisor "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
+	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+const annotationsRetentionTTLItem = "annotations.retention_ttl"
+
+// defaultRetentionTTL mirrors the default shipped in defaults.ini.
+const defaultRetentionTTL = 2160 * time.Hour
+
+type annotationsConfigStep struct {
+	appPlatformSection *setting.DynamicSection
+}
+
+func (s *annotationsConfigStep) Title() string {
+	return "Annotations config check"
+}
+
+func (s *annotationsConfigStep) Description() string {
+	return "Checks if the annotations configuration is set correctly."
+}
+
+func (s *annotationsConfigStep) Resolution() string {
+	return "Follow the documentation for each element."
+}
+
+func (s *annotationsConfigStep) ID() string {
+	return "annotations_config"
+}
+
+func (s *annotationsConfigStep) Run(ctx context.Context, log logging.Logger, _ *advisor.CheckSpec, it any) ([]advisor.CheckReportFailure, error) {
+	itemPath, ok := it.(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid item type %T", it)
+	}
+	if itemPath != annotationsRetentionTTLItem {
+		// Only interested in the annotations retention TTL item
+		return nil, nil
+	}
+
+	// alert if retention_ttl is set as the default value
+	if s.appPlatformSection.Key("retention_ttl").MustDuration(defaultRetentionTTL) == defaultRetentionTTL {
+		return []advisor.CheckReportFailure{checks.NewCheckReportFailure(
+			advisor.CheckReportFailureSeverityLow,
+			s.ID(),
+			"retention_ttl",
+			itemPath,
+			[]advisor.CheckErrorLink{
+				{
+					Message: "Evaluate default value",
+					// TODO: This is a placeholder. Update this to the correct path once available.
+					Url: "https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#annotations",
+				},
+			},
+		)}, nil
+	}
+
+	return nil, nil
+}

--- a/apps/advisor/pkg/app/checks/configchecks/annotations_config_step_test.go
+++ b/apps/advisor/pkg/app/checks/configchecks/annotations_config_step_test.go
@@ -1,0 +1,109 @@
+package configchecks
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	advisor "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
+	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnotationsConfigStepRetentionTuned(t *testing.T) {
+	// Explicitly set to a non-default value - no advisory.
+	step := newAnnotationsStep(t, "720h")
+
+	checkReportFailures, err := step.Run(context.Background(), logging.DefaultLogger, nil, annotationsRetentionTTLItem)
+	require.NoError(t, err)
+	require.Len(t, checkReportFailures, 0)
+}
+
+func TestAnnotationsConfigStepRetentionAtDefault(t *testing.T) {
+	// Left at the shipped default (2160h) - advisory fires.
+	step := newAnnotationsStep(t, "2160h")
+
+	checkReportFailures, err := step.Run(context.Background(), logging.DefaultLogger, nil, annotationsRetentionTTLItem)
+	require.NoError(t, err)
+	requireRetentionAdvisory(t, checkReportFailures)
+}
+
+func TestAnnotationsConfigStepRetentionUnset(t *testing.T) {
+	// Unset reads back as the default in the merged config - advisory fires.
+	step := newAnnotationsStep(t, "")
+
+	checkReportFailures, err := step.Run(context.Background(), logging.DefaultLogger, nil, annotationsRetentionTTLItem)
+	require.NoError(t, err)
+	requireRetentionAdvisory(t, checkReportFailures)
+}
+
+func TestAnnotationsConfigStepOtherItem(t *testing.T) {
+	// Items other than the retention TTL are ignored by this step.
+	step := newAnnotationsStep(t, "")
+
+	checkReportFailures, err := step.Run(context.Background(), logging.DefaultLogger, nil, "security.secret_key")
+	require.NoError(t, err)
+	require.Len(t, checkReportFailures, 0)
+}
+
+func TestConfigCheckGatesAnnotationsStepWhenDisabled(t *testing.T) {
+	// When the app platform annotations API is disabled, the step and item are not registered.
+	cfg := setting.NewCfg()
+	cfg.SectionWithEnvOverrides("annotations.app_platform").Key("enabled").SetValue("false")
+	c := New(cfg)
+
+	require.False(t, hasAnnotationsStep(c.Steps()))
+
+	items, err := c.Items(context.Background())
+	require.NoError(t, err)
+	require.NotContains(t, items, annotationsRetentionTTLItem)
+}
+
+func TestConfigCheckIncludesAnnotationsStepWhenEnabled(t *testing.T) {
+	// When the app platform annotations API is enabled, the step and item are registered.
+	cfg := setting.NewCfg()
+	cfg.SectionWithEnvOverrides("annotations.app_platform").Key("enabled").SetValue("true")
+	c := New(cfg)
+
+	require.True(t, hasAnnotationsStep(c.Steps()))
+
+	items, err := c.Items(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, items, annotationsRetentionTTLItem)
+}
+
+func newAnnotationsStep(t *testing.T, retention string) *annotationsConfigStep {
+	t.Helper()
+	cfg := setting.NewCfg()
+	section := cfg.SectionWithEnvOverrides("annotations.app_platform")
+	if retention != "" {
+		section.Key("retention_ttl").SetValue(retention)
+	}
+	return &annotationsConfigStep{appPlatformSection: section}
+}
+
+// requireRetentionAdvisory asserts that exactly one retention advisory and its contents.
+func requireRetentionAdvisory(t *testing.T, checkReportFailures []advisor.CheckReportFailure) {
+	t.Helper()
+	require.Len(t, checkReportFailures, 1)
+	failure := checkReportFailures[0]
+	require.Equal(t, advisor.CheckReportFailureSeverityLow, failure.Severity)
+	require.Equal(t, "annotations_config", failure.StepID)
+	require.Equal(t, "retention_ttl", failure.Item)
+	require.Equal(t, annotationsRetentionTTLItem, failure.ItemID)
+	require.Equal(t, []advisor.CheckErrorLink{
+		{
+			Message: "Evaluate default value",
+			Url:     "https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#annotations",
+		},
+	}, failure.Links)
+}
+
+func hasAnnotationsStep(steps []checks.Step) bool {
+	return slices.ContainsFunc(steps, func(s checks.Step) bool {
+		_, ok := s.(*annotationsConfigStep)
+		return ok
+	})
+}

--- a/apps/advisor/pkg/app/checks/configchecks/check.go
+++ b/apps/advisor/pkg/app/checks/configchecks/check.go
@@ -28,7 +28,11 @@ func (c *check) Name() string {
 }
 
 func (c *check) Items(ctx context.Context) ([]any, error) {
-	return []any{"security.secret_key"}, nil
+	items := []any{"security.secret_key"}
+	if c.annotationsAppPlatformEnabled() {
+		items = append(items, annotationsRetentionTTLItem)
+	}
+	return items, nil
 }
 
 func (c *check) Item(ctx context.Context, id string) (any, error) {
@@ -40,9 +44,21 @@ func (c *check) Init(ctx context.Context) error {
 }
 
 func (c *check) Steps() []checks.Step {
-	return []checks.Step{
+	steps := []checks.Step{
 		&securityConfigStep{
 			securitySection: c.cfg.SectionWithEnvOverrides("security"),
 		},
 	}
+	// Only register the annotations step when the App Platform annotations API is
+	// enabled, otherwise it would show up as an empty "no action needed" entry.
+	if c.annotationsAppPlatformEnabled() {
+		steps = append(steps, &annotationsConfigStep{
+			appPlatformSection: c.cfg.SectionWithEnvOverrides("annotations.app_platform"),
+		})
+	}
+	return steps
+}
+
+func (c *check) annotationsAppPlatformEnabled() bool {
+	return c.cfg.SectionWithEnvOverrides("annotations.app_platform").Key("enabled").MustBool(false)
 }


### PR DESCRIPTION
Implements [grafana/grafana-org/issues/939](https://github.com/grafana/grafana-org/issues/939)

When `[annotations.app_platform].enabled = true` and `retention_ttl = 2160h`
<img width="1496" height="903" alt="Screenshot 2026-06-30 at 5 29 07 PM" src="https://github.com/user-attachments/assets/df48f19c-53b7-474e-950c-abc72db7d94e" />
