### PR TITLE
Provisioning: Add Dashboard Previews to GitHub Enterprise

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -333,6 +333,23 @@ func (r *Repository) Path() string {
 	return ""
 }
 
+func (r *Repository) ShouldGenerateDashboardPreviews() bool {
+	switch r.Spec.Type {
+	case GitHubRepositoryType:
+		if r.Spec.GitHub != nil {
+			return r.Spec.GitHub.GenerateDashboardPreviews
+		}
+	case GitHubEnterpriseRepositoryType:
+		if r.Spec.GitHubEnterprise != nil {
+			return r.Spec.GitHubEnterprise.GenerateDashboardPreviews
+		}
+	default:
+		return false
+	}
+
+	return false
+}
+
 // ConnectionName returns the name of the connection referenced by this repository,
 // or an empty string if the repository does not use a connection.
 func (r *Repository) ConnectionName() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types_test.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types_test.go
@@ -229,3 +229,85 @@ func TestRepository_SetBranch(t *testing.T) {
 		}
 	})
 }
+
+func TestRepository_ShouldGenerateDashboardPreviews(t *testing.T) {
+	tests := []struct {
+		name string
+		repo v0alpha1.Repository
+		want bool
+	}{
+		{
+			name: "github with previews enabled",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type:   v0alpha1.GitHubRepositoryType,
+					GitHub: &v0alpha1.GitHubRepositoryConfig{GenerateDashboardPreviews: true},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "github with previews disabled",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type:   v0alpha1.GitHubRepositoryType,
+					GitHub: &v0alpha1.GitHubRepositoryConfig{GenerateDashboardPreviews: false},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "github type with nil github config",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type: v0alpha1.GitHubRepositoryType,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "githubEnterprise with previews enabled",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type:             v0alpha1.GitHubEnterpriseRepositoryType,
+					GitHubEnterprise: &v0alpha1.GitHubEnterpriseRepositoryConfig{GenerateDashboardPreviews: true},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "githubEnterprise with previews disabled",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type:             v0alpha1.GitHubEnterpriseRepositoryType,
+					GitHubEnterprise: &v0alpha1.GitHubEnterpriseRepositoryConfig{GenerateDashboardPreviews: false},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "githubEnterprise type with nil config",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type: v0alpha1.GitHubEnterpriseRepositoryType,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "non-github type returns false",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type: v0alpha1.GitLabRepositoryType,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.repo.ShouldGenerateDashboardPreviews())
+		})
+	}
+}

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -120,12 +120,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 	}
 
 	rendererAvailable := e.render.IsAvailable(ctx)
-	// GenerateDashboardPreviews lives on the type-specific config, which is nil
-	// for the other provider(s) — guard against a nil dereference (e.g. a GitHub
-	// Enterprise repo has Spec.GitHubEnterprise set, not Spec.GitHub).
-	generatePreviews := (cfg.Spec.GitHub != nil && cfg.Spec.GitHub.GenerateDashboardPreviews) ||
-		(cfg.Spec.GitHubEnterprise != nil && cfg.Spec.GitHubEnterprise.GenerateDashboardPreviews)
-	shouldRender := rendererAvailable && len(changes) == 1 && generatePreviews
+	shouldRender := rendererAvailable && len(changes) == 1 && cfg.ShouldGenerateDashboardPreviews()
 	info := changeInfo{
 		GrafanaBaseURL:       e.urls.Internal(ctx, cfg.Namespace),
 		RepositoryName:       cfg.Name,

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -63,6 +63,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "x",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -137,6 +138,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "org-2",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -216,6 +218,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "x",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -290,6 +293,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "x",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -367,6 +371,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "x",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -444,6 +449,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "x",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -516,6 +522,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "org-2",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -588,6 +595,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "x",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -837,6 +845,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "x",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -1184,6 +1193,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "x",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -1257,6 +1267,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "x",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},
@@ -1327,6 +1338,7 @@ func TestCalculateChanges(t *testing.T) {
 						Namespace: "x",
 					},
 					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
 							GenerateDashboardPreviews: true,
 						},


### PR DESCRIPTION
**What is this feature?**
Add Dashboard Previews support for GitHub Enterprise. Previously, this was only supported for GitHub. 

**Why do we need this feature?**
Bringing parity for Github Enterprise

**Who is this feature for?**
Enterprise

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/git-ui-sync-project/issues/1254

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
