### PR TITLE
Zanzana: Remove create relation from user and service-account

### DIFF
--- a/pkg/services/authz/zanzana/schema/schema_core.fga
+++ b/pkg/services/authz/zanzana/schema/schema_core.fga
@@ -3,7 +3,6 @@ module core
 type user
   relations
     define get: [user, service-account, team#member, role#assignee]
-    define create: [user, service-account, team#member, role#assignee]
     define update: [user, service-account, team#member, role#assignee]
     define delete: [user, service-account, team#member, role#assignee]
 
@@ -13,7 +12,6 @@ type user
 type service-account
   relations
     define get: [user, service-account, team#member, role#assignee]
-    define create: [user, service-account, team#member, role#assignee]
     define update: [user, service-account, team#member, role#assignee]
     define delete: [user, service-account, team#member, role#assignee]
 


### PR DESCRIPTION
## Summary

Removes the per-object `create` relation from the `user` and `service-account` core types in the Zanzana OpenFGA schema (`schema_core.fga`).

Per-object `create` on these types doesn't make sense: creation targets a resource id that doesn't exist yet, so a `create` tuple can't point at a specific `user:<id>` / `service-account:<id>` object. Creation is instead authorized at the namespace level via the `group_resource` — `users:create` translates to a `group_resource:iam.grafana.app/users` tuple (`newUnscopedMapping` in `translations.go`), never a per-object tuple.

## Why it's safe

- The Go relation sets `RelationsUser` / `RelationsServiceAccount` already exclude `create` (from #127353).
- The `IsValidRelation` guards in `Check` / `List` / `BatchCheck` mean OpenFGA is never asked to check per-object `create` on these types, so removing it from the schema can't cause the invalid-relation errors that #127450 was guarding against.
- Existing tests already encode the intended behavior (`server_check_test.go`): a named `create` check on user/service-account resolves to **denied** (not an error), and `create` is allowed via `group_resource`.

This effectively reverts #127450, which re-added these relations unnecessarily.