### PR TITLE
Zanzana: Remove create relation from team

### DIFF
--- a/pkg/services/authz/zanzana/common/info_test.go
+++ b/pkg/services/authz/zanzana/common/info_test.go
@@ -55,7 +55,8 @@ func TestResourceInfoIsValidRelation_TypedResources(t *testing.T) {
 			resource: iamv0alpha1.TeamResourceInfo.GroupResource().Resource,
 			cases: []relCase{
 				{RelationGet, true},
-				{RelationCreate, true},
+				// teams have no per-object create; creation is governed by the group_resource.
+				{RelationCreate, false},
 				{RelationUpdate, true},
 				{RelationDelete, true},
 				{RelationGetPermissions, true},

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -141,11 +141,11 @@ var RelationsSubresourceTyped = []string{
 	RelationSubresourceDelete,
 }
 
-// RelationsTeam are the relations valid on type "team". Teams keep a per-object `create`
-// (granted to admins), unlike user / service-account.
+// RelationsTeam are the relations valid on type "team". Like user / service-account, teams
+// have no per-object `create`: creation is governed by the group_resource (the team does not
+// exist yet, so a `create` tuple can't target a specific team object).
 var RelationsTeam = append(append([]string{}, RelationsSubresourceTyped...),
 	RelationGet,
-	RelationCreate,
 	RelationUpdate,
 	RelationDelete,
 	RelationGetPermissions,

--- a/pkg/services/authz/zanzana/schema/schema_core.fga
+++ b/pkg/services/authz/zanzana/schema/schema_core.fga
@@ -36,7 +36,6 @@ type team
     define member: [user, service-account] or admin
 
     define get: [user, service-account, team#member, role#assignee] or member
-    define create: [user, service-account, team#member, role#assignee] or admin
     define update: [user, service-account, team#member, role#assignee] or admin
     define delete: [user, service-account, team#member, role#assignee] or admin
 

--- a/pkg/services/authz/zanzana/server/server_batch_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check_test.go
@@ -357,14 +357,14 @@ func TestIntegrationServerBatchCheck(t *testing.T) {
 		assert.True(t, res.GetResults()["user-create"].GetAllowed())
 	})
 
-	t.Run("user:21 (team admin) create on their team is allowed via per-object team create", func(t *testing.T) {
+	t.Run("user:21 (team admin) create on their team is denied: team create is group_resource only", func(t *testing.T) {
 		items := []*authzv1.BatchCheckItem{
 			newItem("team-create", utils.VerbCreate, teamGroup, teamResource, "", "", "admin-team"),
 		}
 		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:21", items))
 		require.NoError(t, err)
 		require.Len(t, res.GetResults(), 1)
-		assert.True(t, res.GetResults()["team-create"].GetAllowed())
+		assert.False(t, res.GetResults()["team-create"].GetAllowed())
 	})
 
 	t.Run("subresource create on a user is allowed via resource_create", func(t *testing.T) {

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -286,11 +286,11 @@ func TestIntegrationServerCheck(t *testing.T) {
 		assert.True(t, res.GetAllowed())
 	})
 
-	t.Run("user:21 (team admin) create check on their team is allowed via per-object team create", func(t *testing.T) {
-		// teams keep a per-object `create` granted to admins, so this resolves allowed.
+	t.Run("user:21 (team admin) create check on their team is denied: team create is group_resource only", func(t *testing.T) {
+		// teams have no per-object `create`; being admin of a team does not grant creating it.
 		res, err := server.Check(newContextWithNamespace(), newReq("user:21", utils.VerbCreate, teamGroup, teamResource, "", "", "admin-team"))
 		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
+		assert.False(t, res.GetAllowed())
 	})
 
 	// Subresource `create` must still resolve even though the base `create` relation does not

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -204,12 +204,12 @@ func TestIntegrationServerList(t *testing.T) {
 		assert.True(t, res.GetAll())
 	})
 
-	t.Run("user:21 (team admin) listing teams with create returns the admined team", func(t *testing.T) {
-		// teams keep a per-object `create`, so this lists the admined team rather than empty.
+	t.Run("user:21 (team admin) listing teams with create returns empty: team create is group_resource only", func(t *testing.T) {
+		// teams have no per-object `create`; admin of a team does not make it "creatable".
 		res, err := server.List(newContextWithNamespace(), newCreateList("user:21", teamGroup, teamResource))
 		require.NoError(t, err)
 		assert.False(t, res.GetAll())
-		assert.Contains(t, res.GetItems(), "admin-team")
+		assert.NotContains(t, res.GetItems(), "admin-team")
 	})
 
 	t.Run("user:1 listing teams with create returns empty, not error", func(t *testing.T) {
@@ -464,12 +464,12 @@ func TestIntegrationServerListStreaming(t *testing.T) {
 		assert.True(t, res.GetAll())
 	})
 
-	t.Run("user:21 (team admin) listing teams with create returns the admined team", func(t *testing.T) {
-		// teams keep a per-object `create`, so this lists the admined team rather than empty.
+	t.Run("user:21 (team admin) listing teams with create returns empty: team create is group_resource only", func(t *testing.T) {
+		// teams have no per-object `create`; admin of a team does not make it "creatable".
 		res, err := server.List(newContextWithNamespace(), newCreateList("user:21", teamGroup, teamResource))
 		require.NoError(t, err)
 		assert.False(t, res.GetAll())
-		assert.Contains(t, res.GetItems(), "admin-team")
+		assert.NotContains(t, res.GetItems(), "admin-team")
 	})
 
 	t.Run("user:1 listing teams with create returns empty, not error", func(t *testing.T) {

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -76,7 +76,8 @@ func setup(t *testing.T, srv *Server) *Server {
 		// user:20 can create users org-wide via the group_resource (the only place `create`
 		// is modeled for flat IAM types).
 		common.NewGroupResourceTuple("user:20", common.RelationCreate, userGroup, userResource, ""),
-		// user:21 is admin of team:admin-team, which grants per-object team `create` via `or admin`.
+		// user:21 is admin of team:admin-team. Team admin does NOT grant per-object `create`:
+		// team creation is governed by the group_resource, like users / service accounts.
 		common.NewTypedTuple(common.TypeTeam, "user:21", common.RelationTeamAdmin, "admin-team"),
 		// user:22 / user:23 have a subresource `resource_create` grant on a user / service-account.
 		// These types have no per-object base `create`, but they do support subresource create.


### PR DESCRIPTION
## Summary

Removes the per-object `create` relation from the `team` type in the Zanzana OpenFGA schema, and from `RelationsTeam` so the `IsValidRelation` guards stay consistent across `Check` / `List` / `BatchCheck`.

Like `user` and `service-account`, `team` shouldn't have a per-object `create`: creation targets a team id that doesn't exist yet, so a `create` tuple can't point at a specific `team:<id>` object. Team creation is authorized at the namespace level via the `group_resource` — `teams:create` translates to a `group_resource:iam.grafana.app/teams` tuple, never a per-object tuple.

## Why the `or admin` graft didn't justify it

The only thing that granted per-object team `create` was the `or admin` graft, and "a team admin can create the team they already administer" is meaningless — the team already exists.

Unlike folders — where admin→create legitimately means "create a child **inside** this folder" via `create from parent` — teams are not containers, so the folder precedent doesn't apply. The old modeling also produced a misleading `ListObjects` result: "teams you can create" resolved to "teams you admin".

## Changes

- `schema_core.fga`: drop `create` from `team`.
- `common/tuple.go`: drop `RelationCreate` from `RelationsTeam` (+ updated doc comment).
- Tests updated to the corrected semantics: team admin `create` is now **denied** (Check/BatchCheck) and **not listed** (List); creation flows only through the `group_resource`. The `user:21` admin tuple is retained as a negative case (admin ≠ create).