### PR TITLE
datasource: propagate the apiserver request context to the health check

### DIFF
--- a/pkg/registry/apis/datasource/sub_health.go
+++ b/pkg/registry/apis/datasource/sub_health.go
@@ -78,7 +78,7 @@ func (r *subHealthREST) Connect(ctx context.Context, name string, opts runtime.O
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer m.Record()
 
-		_, reqSpan := tracing.Start(req.Context(), "datasource.health.request",
+		_, reqSpan := tracing.Start(ctx, "datasource.health.request",
 			attribute.String("namespace", namespace),
 			attribute.String("plugin_id", r.builder.pluginJSON.ID),
 			attribute.String("datasource_uid", name),
@@ -102,7 +102,7 @@ func (r *subHealthREST) Connect(ctx context.Context, name string, opts runtime.O
 			return
 		}
 
-		healthCtx := config.WithGrafanaConfig(req.Context(), pluginCtx.GrafanaConfig)
+		healthCtx := config.WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
 		healthCtx = contextualMiddlewares(healthCtx)
 
 		checkHealthCtx, checkHealthSpan := tracing.Start(healthCtx, "datasource.health.pluginClient.CheckHealth")

--- a/pkg/registry/apis/datasource/sub_health_test.go
+++ b/pkg/registry/apis/datasource/sub_health_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/config"
@@ -391,6 +392,36 @@ func TestSubHealthREST_HandlerMapsResponse(t *testing.T) {
 		require.Equal(t, pluginCtx.GrafanaConfig, capturedRequest.PluginContext.GrafanaConfig)
 		require.Equal(t, "test-ds", capturedRequest.PluginContext.DataSourceInstanceSettings.UID)
 		require.Equal(t, "Test Datasource", capturedRequest.PluginContext.DataSourceInstanceSettings.Name)
+	})
+
+	t.Run("CheckHealth context carries the request namespace", func(t *testing.T) {
+		var gotNamespace string
+		shr := subHealthREST{
+			builder: &DataSourceAPIBuilder{
+				client: mockHealthClient{
+					checkHealthFunc: func(ctx context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+						gotNamespace = request.NamespaceValue(ctx)
+						return &backend.CheckHealthResult{Status: backend.HealthStatusOk, Message: "ok"}, nil
+					},
+				},
+				datasources:     &mockHealthDatasourceProvider{instanceSettings: &backend.DataSourceInstanceSettings{}},
+				contextProvider: &mockHealthContextProvider{pluginCtx: backend.PluginContext{GrafanaConfig: config.NewGrafanaCfg(map[string]string{})}},
+			},
+		}
+
+		// The apiserver puts the request namespace in the Connect context. It must reach the
+		// plugin CheckHealth call so the multi-tenant middleware can resolve stack settings;
+		// the inner req.Context() does not carry it (httptest requests use context.Background).
+		ctx := request.WithNamespace(context.Background(), "stacks-10782")
+		responder := &mockHealthResponder{}
+		handler, err := shr.Connect(ctx, "dsname", nil, responder)
+		require.NoError(t, err)
+
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+		require.NoError(t, responder.err)
+		require.Equal(t, "stacks-10782", gotNamespace,
+			"the namespace from the apiserver request context must reach the plugin CheckHealth call")
 	})
 
 	t.Run("handler succeeds with full request URL", func(t *testing.T) {


### PR DESCRIPTION
## What

The datasource `health` subresource built the context for the plugin `CheckHealth` call from the connect handler's `req.Context()` instead of the apiserver request context (`ctx`) passed to `Connect`. As a result, request-scoped values set by the apiserver — notably the request namespace (`request.NamespaceValue(ctx)`) — were not available to the plugin client and any context-based handler middlewares on the health path.

The `query` subresource does not have this problem: it threads the `Connect` `ctx` all the way through to the plugin client. This change makes `health` consistent with `query` by deriving the request span and the `CheckHealth` context from `ctx`.

This is a regression introduced [here](https://github.com/grafana/grafana/pull/125365/changes#diff-89d8484e8d06f23f154d82117c4f091c60651cde0f534b948ead38a926387419L80).

## Why

`req.Context()` inside the connect handler does not carry the apiserver's request info, so `request.NamespaceValue(ctx)` returned an empty namespace during health checks even though the same request had the namespace available at the apiserver/authorization layer. Handlers and middlewares that depend on values from the request context therefore behaved differently for health checks than for queries.

## Change

```go
// before
healthCtx := config.WithGrafanaConfig(req.Context(), pluginCtx.GrafanaConfig)
// after
healthCtx := config.WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
```

(The request span is likewise started from `ctx`.)
