### PR TITLE
Set up Cursor Cloud dev environment for Grafana

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 ### Prerequisites
 
 - **Node.js v24.x** (see `.nvmrc` for exact version). Use `nvm install` / `nvm use` to match.
+- **Node PATH gotcha**: the VM injects a `node` shim at `/exec-daemon/node` (v22) that sits ahead of nvm's node in `PATH`. To make the correct nvm node (v24) win, the nvm bin dir is prepended to `PATH` in `~/.bashrc` during setup. If `node --version` shows v22 in a new shell, run `nvm use` (or re-source `~/.bashrc`) before building/testing.
 - **Go 1.26.4** (see `go.mod`). Pre-installed in the VM.
 - **Yarn 4.11.0** via corepack (bundled in `.yarn/releases/`). Run `corepack enable` if `yarn` is not found.
 - **GCC** required for CGo/SQLite compilation of the backend.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cursor Cloud development environment for Grafana (Go backend + TypeScript/React frontend). No product code changes — this only adds one non-obvious environment gotcha to `AGENTS.md`.

## What was done

- Installed Node.js v24.11.0 via nvm (matching `.nvmrc`) and enabled corepack (Yarn 4.15.0).
- Installed frontend deps with `yarn install --immutable` (build scripts disabled via `enableScripts: false`).
- Built and ran the backend with `make run` (air hot-reload) — serves on `localhost:3000`, default `admin`/`admin`.
- Ran the frontend dev server with `yarn start` (webpack) — compiled successfully.
- Verified lint/test harnesses with targeted runs.
- Documented the `/exec-daemon/node` PATH precedence gotcha in `AGENTS.md`.

## Hello-world verification

Logged in as admin and created + saved a "Hello World Dashboard" with a live time-series panel using the built-in Grafana data source.

[grafana_create_dashboard_demo.mp4](https://cursor.com/agents/bc-429d5bcd-1b63-40e9-be42-2459d092e724/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgrafana_create_dashboard_demo.mp4)

[Saved Hello World Dashboard](https://cursor.com/agents/bc-429d5bcd-1b63-40e9-be42-2459d092e724/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgrafana_saved_dashboard.webp)

## Testing

- ✅ `go test ./pkg/util/`
- ✅ `yarn jest --no-watch packages/grafana-data/src/utils/csv.test.ts`
- ✅ `yarn eslint packages/grafana-data/src/utils/csv.ts`
- ✅ `make run` (backend up, `/api/health` returns DB ok, v13.2.0-local)
- ✅ `yarn start` (frontend compiled successfully)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-429d5bcd-1b63-40e9-be42-2459d092e724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-429d5bcd-1b63-40e9-be42-2459d092e724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

