### PR TITLE
localcache: refactor ExclusiveSet to ExclusiveGetOrSet to prevent con…

### DIFF
--- a/pkg/infra/localcache/cache.go
+++ b/pkg/infra/localcache/cache.go
@@ -36,17 +36,39 @@ func New(defaultExpiration, cleanupInterval time.Duration) *CacheService {
 	}
 }
 
-func (s *CacheService) ExclusiveSet(key string, getValue func() (any, error), dur time.Duration) error {
+// ExclusiveSet locks the entry associated with the given key, calls getValue
+// to fetch it, stores it in the cache (overwriting any existing value), and returns it.
+func (s *CacheService) ExclusiveSet(key string, getValue func() (any, error), dur time.Duration) (any, error) {
 	unlock := s.Lock(key)
 	defer unlock()
 
 	v, err := getValue()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.Set(key, v, dur)
-	return nil
+	return v, nil
+}
+
+// ExclusiveGetOrSet locks the entry associated with the given key. If the value is
+// already in the cache, it returns it immediately. Otherwise, it calls getValue
+// to fetch it, stores it in the cache, and returns it.
+func (s *CacheService) ExclusiveGetOrSet(key string, getValue func() (any, error), dur time.Duration) (any, error) {
+	unlock := s.Lock(key)
+	defer unlock()
+
+	if v, ok := s.Get(key); ok {
+		return v, nil
+	}
+
+	v, err := getValue()
+	if err != nil {
+		return nil, err
+	}
+
+	s.Set(key, v, dur)
+	return v, nil
 }
 
 func (s *CacheService) ExclusiveDelete(key string) {

--- a/pkg/infra/localcache/cache_test.go
+++ b/pkg/infra/localcache/cache_test.go
@@ -3,6 +3,7 @@ package localcache
 import (
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,7 +41,8 @@ func TestExclusiveSet(t *testing.T) {
 		wg.Go(func() {
 			<-start
 			if _, ok := cache.Get(key); !ok {
-				require.NoError(t, cache.ExclusiveSet(key, read, time.Minute))
+				_, err := cache.ExclusiveGetOrSet(key, read, time.Minute)
+				require.NoError(t, err)
 			}
 		})
 
@@ -58,7 +60,8 @@ func TestExclusiveSet(t *testing.T) {
 	// which would delete the cache entry.
 	_, ok := cache.Get(key)
 	if !ok {
-		require.NoError(t, cache.ExclusiveSet(key, read, time.Minute))
+		_, err := cache.ExclusiveGetOrSet(key, read, time.Minute)
+		require.NoError(t, err)
 	}
 
 	cached, ok := cache.Get(key)
@@ -68,4 +71,53 @@ func TestExclusiveSet(t *testing.T) {
 	// At the end of this process, no one is holding the lock to the `key`,
 	// so this mapping should be empty.
 	require.Empty(t, cache.locks)
+}
+
+func TestExclusiveGetOrSetCoalescing(t *testing.T) {
+	var calls int32
+	barrier := make(chan struct{})
+	getValue := func() (any, error) {
+		atomic.AddInt32(&calls, 1)
+		<-barrier // block until all requests are queued up
+		return "hello", nil
+	}
+
+	cache := New(time.Minute, time.Minute)
+	const numReqs = 5
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	results := make([]any, numReqs)
+	errs := make([]error, numReqs)
+
+	for i := 0; i < numReqs; i++ {
+		idx := i
+		wg.Go(func() {
+			<-start
+			val, err := cache.ExclusiveGetOrSet("coalesce-key", getValue, time.Minute)
+			results[idx] = val
+			errs[idx] = err
+		})
+	}
+
+	close(start)
+
+	// Sleep briefly to ensure all goroutines enter ExclusiveGetOrSet and block.
+	// The first goroutine will call getValue and block on barrier.
+	// The other 4 goroutines will block on cache.Lock("coalesce-key").
+	time.Sleep(50 * time.Millisecond)
+
+	// Release the barrier so the first goroutine sets the value and unlocks
+	close(barrier)
+
+	wg.Wait()
+
+	// Assert getValue was called exactly once
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+	// Assert all callers got the correct result without error
+	for i := 0; i < numReqs; i++ {
+		require.NoError(t, errs[i])
+		require.Equal(t, "hello", results[i])
+	}
 }

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -424,10 +424,8 @@ func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermi
 	span.AddEvent("cache miss")
 	metrics.MAccessPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).Inc()
 
-	var permissions []accesscontrol.Permission
 	getValue := func() (any, error) {
-		var err error
-		permissions, err = getPermissionsFn(ctx)
+		permissions, err := getPermissionsFn(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -436,8 +434,21 @@ func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermi
 		return permissions, nil
 	}
 
-	if err := s.cache.ExclusiveSet(key, getValue, cacheTTL); err != nil {
+	var permissionsVal any
+	var err error
+	if options.ReloadCache {
+		permissionsVal, err = s.cache.ExclusiveSet(key, getValue, cacheTTL)
+	} else {
+		permissionsVal, err = s.cache.ExclusiveGetOrSet(key, getValue, cacheTTL)
+	}
+
+	if err != nil {
 		return nil, err
+	}
+
+	permissions, ok := permissionsVal.([]accesscontrol.Permission)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type in permissions cache: %T", permissionsVal)
 	}
 
 	return permissions, nil


### PR DESCRIPTION
**What is this feature?**

This PR introduces an `ExclusiveGetOrSet` method to the internal `localcache` service and integrates it into the Access Control service. When a cache miss occurs under concurrency, the first thread locks and fetches the value. Subsequent threads waiting on the same lock will return the newly cached value immediately instead of sequentially performing redundant backend/database fetches.

**Why do we need this feature?**

Currently, multiple concurrent requests checking access control permissions for the same user will all miss the cache at once, queue up behind the cache lock, and then sequentially execute identical database lookups. This leads to stampedes/double-fetches on the database and CPU overhead.

**Who is this feature for?**

This is an internal optimization to improve Grafana performance and database scalability under concurrent user loads.

**Which issue(s) does this PR fix?**:

Fixes # (Performance hardening / optimization)

**Special notes for your reviewer:**

- Refactored the signature of `CacheService.ExclusiveSet` to return `(any, error)` to match `ExclusiveGetOrSet` for API symmetry.
- Updated Access Control to call `ExclusiveSet` only when `ReloadCache: true` is explicitly requested, and `ExclusiveGetOrSet` otherwise.
- Added concurrent coalescing unit tests in `cache_test.go` and verified all access control tests pass successfully.