### PR TITLE
Folders: grant default permissions on app platform folder create

### DIFF
--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -12,7 +12,7 @@ import {
   useMoveFoldersMutation as useMoveFoldersMutationLegacy,
 } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 
-import { AnnoKeyFolder } from '../../../../features/apiserver/types';
+import { AnnoKeyFolder, AnnoKeyGrantPermissions } from '../../../../features/apiserver/types';
 
 import {
   useGetFolderQueryFacade,
@@ -96,6 +96,28 @@ const setupUpdateFolderHandler = (onPatch?: jest.Mock) => {
             body && typeof body === 'object' && 'spec' in body
               ? (body.spec?.title ?? 'Updated Folder')
               : 'Updated Folder',
+        },
+      });
+    })
+  );
+};
+
+const setupCreateFolderHandler = (onCreate?: jest.Mock) => {
+  folderAPIVersionResolver.set('v1beta1');
+  server.use(
+    http.post('/apis/folder.grafana.app/v1beta1/namespaces/:namespace/folders', async ({ request }) => {
+      const body = await request.json();
+      onCreate?.(body);
+
+      return HttpResponse.json({
+        apiVersion: 'folder.grafana.app/v1beta1',
+        kind: 'Folder',
+        metadata: {
+          name: 'new-folder-uid',
+          generation: 1,
+        },
+        spec: {
+          title: body && typeof body === 'object' && 'spec' in body ? (body.spec?.title ?? 'test') : 'test',
         },
       });
     })
@@ -311,6 +333,49 @@ describe.each([
 
       expect(await screen.findByText('Folder created')).toBeInTheDocument();
       expect(dispatchMockFn).toHaveBeenCalled();
+    });
+
+    it('sets grant-permissions annotation when creating a root folder via the app platform API', async () => {
+      if (!toggle) {
+        return;
+      }
+
+      const createSpy = jest.fn();
+      setupCreateFolderHandler(createSpy);
+      const { user } = setupCreateFolder();
+
+      await user.click(screen.getByText(/Create Folder at root/));
+
+      await waitFor(() => expect(createSpy).toHaveBeenCalled());
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: { [AnnoKeyGrantPermissions]: 'default' },
+          }),
+        })
+      );
+    });
+
+    it('sets folder annotation when creating a nested folder via the app platform API', async () => {
+      if (!toggle) {
+        return;
+      }
+
+      const createSpy = jest.fn();
+      setupCreateFolderHandler(createSpy);
+      const { user } = setupCreateFolder();
+
+      await user.click(screen.getByText(/Create Folder in nested folder/));
+
+      await waitFor(() => expect(createSpy).toHaveBeenCalled());
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: { [AnnoKeyFolder]: folderA.item.uid },
+          }),
+        })
+      );
+      expect(createSpy.mock.calls[0][0].metadata.annotations[AnnoKeyGrantPermissions]).toBeUndefined();
     });
   });
 

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -35,6 +35,7 @@ import kbn from '../../../../core/utils/kbn';
 import {
   AnnoKeyCreatedBy,
   AnnoKeyFolder,
+  AnnoKeyGrantPermissions,
   AnnoKeyManagerKind,
   AnnoKeyUpdatedBy,
   AnnoKeyUpdatedTimestamp,
@@ -440,9 +441,10 @@ export function useCreateFolder() {
         metadata: {
           ...partialMetadata,
           generateName: 'f',
-          annotations: {
-            ...(folder.parentUid && { [AnnoKeyFolder]: folder.parentUid }),
-          },
+          annotations:
+            folder.parentUid && !isRootFolderUID(folder.parentUid)
+              ? { [AnnoKeyFolder]: folder.parentUid }
+              : { [AnnoKeyGrantPermissions]: 'default' },
         },
       },
     };


### PR DESCRIPTION
## Summary
- Set `grafana.app/grant-permissions: default` on root-level folder creates via the app platform API (`useCreateFolder`)
- Nested folder creates continue to set only `grafana.app/folder`
- Aligns folder create behavior with the legacy API path and dashboard create, so default RBAC permissions are written when `kubernetesAuthzResourcePermissionApis` is enabled

Fixes grafana/grafana#126964

## Test plan
- [x] `yarn jest public/app/api/clients/folder/v1beta1/hooks.test.ts` passes
- [ ] Manual: as an Editor, create a root folder and verify it appears in the browse list with Editor/Viewer permissions