### PR TITLE
Search: read search fields from app manifests

### DIFF
--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-github/v82 v82.0.0
 	github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana-plugin-sdk-go v0.292.1
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0

--- a/apps/advisor/go.sum
+++ b/apps/advisor/go.sum
@@ -500,8 +500,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-aws-sdk v1.4.4 h1:D9h1+fm0h77atG9vsSbaHv8WeAHt27R45wq+9/DYXlk=

--- a/apps/alerting/notifications/go.mod
+++ b/apps/alerting/notifications/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/alerting/notifications
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	k8s.io/apimachinery v0.36.1
 	k8s.io/apiserver v0.36.0

--- a/apps/alerting/notifications/go.sum
+++ b/apps/alerting/notifications/go.sum
@@ -94,8 +94,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=

--- a/apps/alerting/rules/go.mod
+++ b/apps/alerting/rules/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/getkin/kin-openapi v0.140.0
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/prometheus/common v0.68.1
 	github.com/stretchr/testify v1.11.1

--- a/apps/alerting/rules/go.sum
+++ b/apps/alerting/rules/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/annotation/go.mod
+++ b/apps/annotation/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/annotation
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/annotation/go.sum
+++ b/apps/annotation/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/collections/go.mod
+++ b/apps/collections/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/collections
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.36.1

--- a/apps/collections/go.sum
+++ b/apps/collections/go.sum
@@ -57,8 +57,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/apps/correlations/go.mod
+++ b/apps/correlations/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/correlations
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/correlations/go.sum
+++ b/apps/correlations/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/dashboard/go.mod
+++ b/apps/dashboard/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	cuelang.org/go v0.11.1
 	github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana-plugin-sdk-go v0.292.1
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6

--- a/apps/dashboard/go.sum
+++ b/apps/dashboard/go.sum
@@ -113,8 +113,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-plugin-sdk-go v0.292.1 h1:8wvKUqIOtbHC43WIr6kheIGdV6q4SMyWU9+jxcUA6mE=

--- a/apps/dashvalidator/go.mod
+++ b/apps/dashvalidator/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0
 	github.com/prometheus/prometheus v0.312.0

--- a/apps/dashvalidator/go.sum
+++ b/apps/dashvalidator/go.sum
@@ -580,8 +580,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-aws-sdk v1.4.4 h1:D9h1+fm0h77atG9vsSbaHv8WeAHt27R45wq+9/DYXlk=

--- a/apps/example/go.mod
+++ b/apps/example/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/example
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	k8s.io/apimachinery v0.36.1

--- a/apps/example/go.sum
+++ b/apps/example/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/apps/folder/go.mod
+++ b/apps/folder/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/folder
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/folder/go.sum
+++ b/apps/folder/go.sum
@@ -57,8 +57,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/apps/iam/go.mod
+++ b/apps/iam/go.mod
@@ -44,7 +44,7 @@ replace (
 
 require (
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/iam/go.sum
+++ b/apps/iam/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/live/go.mod
+++ b/apps/live/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/live
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/live/go.sum
+++ b/apps/live/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/logsdrilldown/go.mod
+++ b/apps/logsdrilldown/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/logsdrilldown
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/logsdrilldown/go.sum
+++ b/apps/logsdrilldown/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/playlist/go.mod
+++ b/apps/playlist/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/playlist
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
 	k8s.io/klog/v2 v2.140.0

--- a/apps/playlist/go.sum
+++ b/apps/playlist/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/plugins/go.mod
+++ b/apps/plugins/go.mod
@@ -15,7 +15,7 @@ replace github.com/grafana/grafana/pkg/plugins => ../../pkg/plugins
 require (
 	github.com/emicklei/go-restful/v3 v3.13.0
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0
 	github.com/grafana/grafana/pkg/apiserver v0.0.0

--- a/apps/plugins/go.sum
+++ b/apps/plugins/go.sum
@@ -433,8 +433,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-aws-sdk v1.4.4 h1:D9h1+fm0h77atG9vsSbaHv8WeAHt27R45wq+9/DYXlk=

--- a/apps/preferences/go.mod
+++ b/apps/preferences/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/preferences
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/preferences/go.sum
+++ b/apps/preferences/go.sum
@@ -57,8 +57,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-github/v82 v82.0.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/apps/dashboard v0.0.0-20260424050122-76eba5631b44
 	github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6

--- a/apps/provisioning/go.sum
+++ b/apps/provisioning/go.sum
@@ -101,8 +101,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/apps/dashboard v0.0.0-20260424050122-76eba5631b44 h1:/aHFQcMfdIWkNMGMAdx3URhRc9sulLVfhOKTw3xvQ8Y=

--- a/apps/quotas/go.mod
+++ b/apps/quotas/go.mod
@@ -44,7 +44,7 @@ replace (
 
 require (
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/pkg/storage/unified/resourcepb v0.0.0
 	github.com/stretchr/testify v1.11.1

--- a/apps/quotas/go.sum
+++ b/apps/quotas/go.sum
@@ -603,8 +603,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-aws-sdk v1.4.4 h1:D9h1+fm0h77atG9vsSbaHv8WeAHt27R45wq+9/DYXlk=

--- a/apps/sdk.mk
+++ b/apps/sdk.mk
@@ -1,4 +1,4 @@
-APP_SDK_VERSION = v0.56.2
+APP_SDK_VERSION = v0.56.3
 APP_SDK_DIR     = $(shell go env GOPATH)/bin/app-sdk-$(APP_SDK_VERSION)
 APP_SDK_BIN     = $(APP_SDK_DIR)/grafana-app-sdk
 

--- a/apps/secret/go.mod
+++ b/apps/secret/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/secret
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1

--- a/apps/secret/go.sum
+++ b/apps/secret/go.sum
@@ -61,8 +61,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/apps/shorturl/go.mod
+++ b/apps/shorturl/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/shorturl
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.2
+	github.com/grafana/grafana-app-sdk v0.56.3
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	github.com/stretchr/testify v1.11.1

--- a/apps/shorturl/go.sum
+++ b/apps/shorturl/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/grafana/gofpdf v0.0.0-20250307124105-3b9c5d35577f // @grafana/sharing-squad
 	github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b // @grafana/grafana-operator-experience-squad
 	github.com/grafana/grafana-api-golang-client v0.27.0 // @grafana/alerting-backend
-	github.com/grafana/grafana-app-sdk v0.56.2 // @grafana/grafana-app-platform-squad
+	github.com/grafana/grafana-app-sdk v0.56.3 // @grafana/grafana-app-platform-squad
 	github.com/grafana/grafana-app-sdk/logging v0.56.2 // @grafana/grafana-app-platform-squad
 	github.com/grafana/grafana-aws-sdk v1.4.4 // @grafana/data-sources-plugins
 	github.com/grafana/grafana-azure-sdk-go/v2 v2.4.1 // @grafana/data-sources-plugins

--- a/go.sum
+++ b/go.sum
@@ -1620,8 +1620,8 @@ github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b h1:5qp8/5YPt/Z2
 github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/grafana-api-golang-client v0.27.0 h1:zIwMXcbCB4n588i3O2N6HfNcQogCNTd/vPkEXTr7zX8=
 github.com/grafana/grafana-api-golang-client v0.27.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
-github.com/grafana/grafana-app-sdk v0.56.2 h1:bPPlqSluP8HNjLBKgNphe+6xpEpz2domri9Bje/G1lc=
-github.com/grafana/grafana-app-sdk v0.56.2/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
+github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-aws-sdk v1.4.4 h1:D9h1+fm0h77atG9vsSbaHv8WeAHt27R45wq+9/DYXlk=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1046,6 +1046,7 @@ github.com/grafana/authlib/types v0.0.0-20260414201248-d766c8627a66/go.mod h1:j+
 github.com/grafana/authlib/types v0.0.0-20260511070317-cdec9a89f585/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2 h1:qhugDMdQ4Vp68H0tp/0iN17DM2ehRo1rLEdOFe/gB8I=
 github.com/grafana/cloudflare-go v0.0.0-20230110200409-c627cf6792f2/go.mod h1:w/aiO1POVIeXUQyl0VQSZjl5OAGDTL5aX+4v0RA1tcw=
+github.com/grafana/codejen v0.0.4-0.20250428224353-8764ced07770/go.mod h1:HVKowlidslFhPxKtj5oRrWS+d1u0zl7xC8aeWm7dEUU=
 github.com/grafana/cog v0.1.7/go.mod h1:COrMoYqkPLqUOycJ7619qR0O7QPGOsoBzDtPILtaC4I=
 github.com/grafana/cog v0.1.11/go.mod h1:vXehXG9c/mp0CwqfQLWbT/0VEEIw+IEXe5LGhZspcqQ=
 github.com/grafana/cog v0.1.12/go.mod h1:vXehXG9c/mp0CwqfQLWbT/0VEEIw+IEXe5LGhZspcqQ=
@@ -1350,8 +1351,10 @@ github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmt
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
+github.com/oasdiff/yaml v0.0.9/go.mod h1:8lvhgJG4xiKPj3HN5lDow4jZHPlx1i7dIwzkdAo6oAM=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.12/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0 h1:LiZB1h0GIcudcDci2bxbqI6DXV8bF8POAnArqvRrIyw=
 github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0/go.mod h1:F/7q8/HZz+TXjlsoZQQKVYvXTZaFH4QRa3y+j1p7MS0=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
@@ -2073,6 +2076,7 @@ golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVo
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8/go.mod h1:CQ1k9gNrJ50XIzaKCRR2hssIjF07kZFEiieALBM/ARQ=
 golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/exp v0.0.0-20240823005443-9b4947da3948/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -1,0 +1,134 @@
+package resource
+
+import (
+	"maps"
+	"strings"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// NewManifestBackedProvider builds a SearchFieldsProvider from the search
+// fields declared in the given app manifests. It walks every version's kinds,
+// converts each declared field into a SearchFieldDefinition, and returns the
+// same map-backed provider NewMapProvider produces, so the per-field and
+// cross-version consistency checks apply here too.
+//
+// CopyFromStandard has no manifest counterpart and is never set from a
+// manifest. A kind that needs it keeps a builder-side provider instead.
+func NewManifestBackedProvider(manifests []app.Manifest) SearchFieldsProvider {
+	fields := map[schema.GroupVersionResource][]SearchFieldDefinition{}
+	preferred := map[schema.GroupResource]string{}
+
+	for _, m := range manifests {
+		if m.ManifestData == nil {
+			continue
+		}
+		group := m.ManifestData.Group
+		for _, version := range m.ManifestData.Versions {
+			for _, kind := range version.Kinds {
+				if len(kind.SearchFields) == 0 {
+					continue
+				}
+				gvr := schema.GroupVersionResource{
+					Group:    group,
+					Version:  version.Name,
+					Resource: manifestResourceName(kind),
+				}
+				fields[gvr] = manifestSearchFieldsToDefinitions(kind.SearchFields)
+
+				gr := gvr.GroupResource()
+				if pv := m.ManifestData.PreferredVersion; pv != "" {
+					preferred[gr] = pv
+				} else {
+					// No explicit preference: the last version that declares the
+					// kind wins, matching the manifest's "latest version" default.
+					preferred[gr] = version.Name
+				}
+			}
+		}
+	}
+	return NewMapProvider(fields, preferred)
+}
+
+// manifestResourceName returns the lower-cased resource (plural) name for a
+// kind, defaulting to the kind name plus "s" when the manifest omits the
+// plural, which mirrors the app-sdk default.
+func manifestResourceName(kind app.ManifestVersionKind) string {
+	plural := kind.Plural
+	if plural == "" {
+		plural = kind.Kind + "s"
+	}
+	return strings.ToLower(plural)
+}
+
+// manifestSearchFieldsToDefinitions converts the manifest's search field
+// declarations into SearchFieldDefinitions. The manifest carries plain
+// strings for Type and Capabilities; the values match the SearchFieldType and
+// SearchCapability constants one-to-one.
+func manifestSearchFieldsToDefinitions(in []app.ManifestVersionKindSearchField) []SearchFieldDefinition {
+	out := make([]SearchFieldDefinition, len(in))
+	for i, f := range in {
+		caps := make([]SearchCapability, len(f.Capabilities))
+		for j, c := range f.Capabilities {
+			caps[j] = SearchCapability(c)
+		}
+		out[i] = SearchFieldDefinition{
+			Name:             f.Name,
+			Path:             f.Path,
+			Type:             SearchFieldType(f.Type),
+			Array:            f.Array,
+			Capabilities:     caps,
+			EmitZeroIfAbsent: f.EmitZeroIfAbsent,
+			Description:      f.Description,
+		}
+	}
+	return out
+}
+
+// manifestDeclaredKindKeys returns the lower-cased "group/resource" keys of
+// every kind that declares at least one search field in any version. The key
+// format matches SearchFieldProvidersForBuilders so the two maps merge.
+func manifestDeclaredKindKeys(manifests []app.Manifest) map[string]bool {
+	keys := map[string]bool{}
+	for _, m := range manifests {
+		if m.ManifestData == nil {
+			continue
+		}
+		for _, version := range m.ManifestData.Versions {
+			for _, kind := range version.Kinds {
+				if len(kind.SearchFields) == 0 {
+					continue
+				}
+				keys[strings.ToLower(m.ManifestData.Group+"/"+manifestResourceName(kind))] = true
+			}
+		}
+	}
+	return keys
+}
+
+// SearchFieldProviders returns the per-("group/resource") provider map that
+// drives bleve mappings. A kind's search fields come from its manifest when the
+// manifest declares any; otherwise the builder-supplied provider is used. Keys
+// are lower-cased "group/resource", matching SearchFieldProvidersForBuilders.
+//
+// Until kinds migrate their search fields into CUE, no manifest declares any,
+// so this returns exactly the builder providers and boot behaviour is
+// unchanged.
+func SearchFieldProviders(manifests []app.Manifest, builderProviders map[string]SearchFieldsProvider) map[string]SearchFieldsProvider {
+	out := make(map[string]SearchFieldsProvider, len(builderProviders))
+	maps.Copy(out, builderProviders)
+
+	declared := manifestDeclaredKindKeys(manifests)
+	if len(declared) == 0 {
+		return out
+	}
+
+	// A single manifest-backed provider covers every declared kind; each map
+	// entry queries it for its own (group, resource).
+	manifestProvider := NewManifestBackedProvider(manifests)
+	for key := range declared {
+		out[key] = manifestProvider
+	}
+	return out
+}

--- a/pkg/storage/unified/resource/search_field_manifest_test.go
+++ b/pkg/storage/unified/resource/search_field_manifest_test.go
@@ -1,0 +1,136 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func manifestWithSearchFields() app.Manifest {
+	return app.Manifest{ManifestData: &app.ManifestData{
+		Group:            "widgets.example.test",
+		PreferredVersion: "v2",
+		Versions: []app.ManifestVersion{
+			{
+				Name: "v1",
+				Kinds: []app.ManifestVersionKind{{
+					Kind:   "Widget",
+					Plural: "widgets",
+					SearchFields: []app.ManifestVersionKindSearchField{
+						{Name: "color", Path: "spec.color", Type: "string", Capabilities: []string{"filter", "sort"}},
+					},
+				}},
+			},
+			{
+				Name: "v2",
+				Kinds: []app.ManifestVersionKind{{
+					Kind:   "Widget",
+					Plural: "widgets",
+					SearchFields: []app.ManifestVersionKindSearchField{
+						{Name: "color", Path: "spec.settings.color", Type: "string", Capabilities: []string{"filter", "sort"}},
+						{Name: "size", Path: "spec.size", Type: "int64", Array: true, EmitZeroIfAbsent: true, Capabilities: []string{"filter"}},
+					},
+				}},
+			},
+		},
+	}}
+}
+
+func TestNewManifestBackedProvider(t *testing.T) {
+	p := NewManifestBackedProvider([]app.Manifest{manifestWithSearchFields()})
+
+	v2 := schema.GroupVersionResource{Group: "widgets.example.test", Version: "v2", Resource: "widgets"}
+	got := p.Fields(v2)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, SearchFieldDefinition{
+		Name:         "color",
+		Path:         "spec.settings.color",
+		Type:         SearchFieldTypeString,
+		Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilitySort},
+	}, got[0])
+	assert.Equal(t, SearchFieldDefinition{
+		Name:             "size",
+		Path:             "spec.size",
+		Type:             SearchFieldTypeInt64,
+		Array:            true,
+		EmitZeroIfAbsent: true,
+		Capabilities:     []SearchCapability{SearchCapabilityFilter},
+	}, got[1])
+
+	// Path may differ per version; v1 declares the same field at a different path.
+	v1 := schema.GroupVersionResource{Group: "widgets.example.test", Version: "v1", Resource: "widgets"}
+	v1Fields := p.Fields(v1)
+	require.Len(t, v1Fields, 1)
+	assert.Equal(t, "spec.color", v1Fields[0].Path)
+
+	// The manifest's explicit preferredVersion is honoured.
+	assert.Equal(t, "v2", p.PreferredVersion("widgets.example.test", "widgets"))
+}
+
+func TestNewManifestBackedProvider_DefaultsPluralAndPreferredVersion(t *testing.T) {
+	// No plural and no explicit preferredVersion: resource defaults to kind+"s"
+	// (lower-cased) and the last declaring version is preferred.
+	p := NewManifestBackedProvider([]app.Manifest{{ManifestData: &app.ManifestData{
+		Group: "widgets.example.test",
+		Versions: []app.ManifestVersion{
+			{Name: "v1", Kinds: []app.ManifestVersionKind{{
+				Kind:         "Gadget",
+				SearchFields: []app.ManifestVersionKindSearchField{{Name: "name", Path: "spec.name", Type: "string", Capabilities: []string{"filter"}}},
+			}}},
+			{Name: "v2", Kinds: []app.ManifestVersionKind{{
+				Kind:         "Gadget",
+				SearchFields: []app.ManifestVersionKindSearchField{{Name: "name", Path: "spec.name", Type: "string", Capabilities: []string{"filter"}}},
+			}}},
+		},
+	}}})
+
+	gvr := schema.GroupVersionResource{Group: "widgets.example.test", Version: "v1", Resource: "gadgets"}
+	require.Len(t, p.Fields(gvr), 1)
+	assert.Equal(t, "v2", p.PreferredVersion("widgets.example.test", "gadgets"))
+}
+
+// stubProvider is a SearchFieldsProvider used only to assert identity in the
+// merge test; its methods are never exercised for their return values.
+type stubProvider struct{ SearchFieldsProvider }
+
+func TestSearchFieldProviders_ManifestWinsBuilderFallback(t *testing.T) {
+	widgetBuilder := &stubProvider{}
+	gadgetBuilder := &stubProvider{}
+	builderProviders := map[string]SearchFieldsProvider{
+		"widgets.example.test/widgets": widgetBuilder, // manifest also declares this one
+		"widgets.example.test/gadgets": gadgetBuilder, // builder-only, manifest declares nothing
+	}
+
+	got := SearchFieldProviders([]app.Manifest{manifestWithSearchFields()}, builderProviders)
+
+	// Widget is declared in the manifest, so its provider is replaced.
+	require.NotSame(t, widgetBuilder, got["widgets.example.test/widgets"])
+	require.NotNil(t, got["widgets.example.test/widgets"])
+
+	// Gadget is not in the manifest, so it keeps the builder provider.
+	assert.Same(t, gadgetBuilder, got["widgets.example.test/gadgets"])
+}
+
+func TestSearchFieldProviders_NoManifestDeclarationsIsNoOp(t *testing.T) {
+	widgetBuilder := &stubProvider{}
+	builderProviders := map[string]SearchFieldsProvider{
+		"widgets.example.test/widgets": widgetBuilder,
+	}
+
+	// A manifest that declares no search fields must not change anything.
+	manifestNoFields := app.Manifest{ManifestData: &app.ManifestData{
+		Group: "widgets.example.test",
+		Versions: []app.ManifestVersion{{
+			Name:  "v1",
+			Kinds: []app.ManifestVersionKind{{Kind: "Widget", Plural: "widgets"}},
+		}},
+	}}
+
+	got := SearchFieldProviders([]app.Manifest{manifestNoFields}, builderProviders)
+	assert.Same(t, widgetBuilder, got["widgets.example.test/widgets"])
+	assert.Len(t, got, 1)
+}

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -97,7 +97,10 @@ func NewSearchOptions(
 				return resource.SearchOptions{}, err
 			}
 			searchFieldsHashes = resource.SearchFieldsHashesForBuilders(builders)
-			searchFieldsProviders = resource.SearchFieldProvidersForBuilders(builders)
+			// Prefer search fields declared in manifests, falling back to the
+			// builder-supplied provider for kinds that don't declare any in CUE.
+			builderProviders := resource.SearchFieldProvidersForBuilders(builders)
+			searchFieldsProviders = resource.SearchFieldProviders(resource.AppManifests(), builderProviders)
 		}
 
 		bleve, err := NewBleveBackend(BleveOptions{


### PR DESCRIPTION
This bumps grafana-app-sdk to v0.56.3 (which adds searchFields to the app manifest schema) and starts reading those declarations when building the search index.

NewManifestBackedProvider reads searchFields from the app manifests and returns the same provider type the builders already use. Provider construction now prefers a kind's manifest declaration and falls back to the builder-supplied provider for kinds that don't declare any. No in-tree kind declares searchFields in CUE yet, so this is behaviour-preserving: every kind still gets exactly the fields its builder produces today, with no index rebuild.

The logging submodule stays at v0.56.2; the new SDK version is compatible with it.

Part of grafana/search-and-storage-team#827.
