### PR TITLE
Alerting: Fix N+1 query when listing rules with ha_single_node_evaluation

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -3568,10 +3568,8 @@ func TestNewDBRuleMutator(t *testing.T) {
 	})
 }
 
-// TestRouteGetRuleStatuses_DBMode_BatchesStateLoad verifies that listing rules with the
-// DB rule mutator (HA single-node eval mode) loads all of the org's alert states in a
-// single GetAll call instead of one GetStatesForRuleUID per rule (the N+1 in #124004),
-// while still producing correct per-rule state.
+// TestRouteGetRuleStatuses_DBMode_BatchesStateLoad verifies that the DB rule mutator loads all
+// of the org's alert states in one GetAll instead of one query per rule (the N+1 in #124004).
 func TestRouteGetRuleStatuses_DBMode_BatchesStateLoad(t *testing.T) {
 	timeNow = func() time.Time { return time.Date(2022, 3, 10, 14, 0, 0, 0, time.UTC) }
 	orgID := int64(1)
@@ -3636,9 +3634,7 @@ func TestRouteGetRuleStatuses_DBMode_BatchesStateLoad(t *testing.T) {
 	})
 }
 
-// sleepingInstanceReader is a state.InstanceReader that returns pre-generated instances and
-// sleeps a fixed delay per call to simulate DB round-trip latency. It counts calls so a
-// benchmark can report DB round trips per op.
+// sleepingInstanceReader is a state.InstanceReader that simulates DB latency and counts calls.
 type sleepingInstanceReader struct {
 	instances []*ngmodels.AlertInstance
 	delay     time.Duration
@@ -3663,9 +3659,8 @@ func (r *sleepingInstanceReader) ListAlertInstances(_ context.Context, cmd *ngmo
 	return out, nil
 }
 
-// BenchmarkRouteGetRuleStatuses_DBMode probes the N+1 in the HA single-node DB path by
-// injecting a per-query latency and reporting the number of store round trips per op.
-// Before the fix db_calls/op scales with rule count; after it is 1.
+// BenchmarkRouteGetRuleStatuses_DBMode measures the HA single-node DB path, reporting store
+// round trips per op (scales with rule count before the fix).
 func BenchmarkRouteGetRuleStatuses_DBMode(b *testing.B) {
 	timeNow = func() time.Time { return time.Date(2022, 3, 10, 14, 0, 0, 0, time.UTC) }
 	orgID := int64(1)
@@ -3674,8 +3669,7 @@ func BenchmarkRouteGetRuleStatuses_DBMode(b *testing.B) {
 
 	for _, ruleCount := range []int{10, 100, 500, 1000, 5000} {
 		b.Run(fmt.Sprintf("rules=%d", ruleCount), func(b *testing.B) {
-			// fakes.NewRuleStore requires *testing.T; build the store directly since the
-			// methods exercised here don't use the embedded testing handle.
+			// fakes.NewRuleStore requires *testing.T; build the store directly.
 			ruleStore := &fakes.RuleStore{
 				Rules:   map[int64][]*ngmodels.AlertRule{},
 				Folders: map[int64][]*folder.Folder{},
@@ -3695,7 +3689,7 @@ func BenchmarkRouteGetRuleStatuses_DBMode(b *testing.B) {
 
 			var calls int64
 			reader := &sleepingInstanceReader{instances: instances, delay: perQueryLatency, calls: &calls}
-			storeReader := state.NewStoreStateReader(reader, log.NewNopLogger())
+			storeReader := state.NewStoreStateReader(reader, log.NewNopLogger(), 0, nil)
 
 			api := NewPrometheusSrv(
 				log.NewNopLogger(),
@@ -3723,11 +3717,8 @@ func BenchmarkRouteGetRuleStatuses_DBMode(b *testing.B) {
 	}
 }
 
-// BenchmarkRouteGetRuleStatuses_Cardinality fixes the rule count and varies the number of
-// alert INSTANCES per rule, at a realistic low DB round-trip latency. It isolates the
-// cost driven by instance cardinality (loading + converting all instances to compute
-// per-rule totals) from the per-rule N+1 round-trip cost. Compare loader on/off to see
-// how much the batch fix helps once instance volume dominates.
+// BenchmarkRouteGetRuleStatuses_Cardinality varies instances per rule at a fixed rule count to
+// isolate the cost driven by instance cardinality from the per-rule N+1 round-trip cost.
 func BenchmarkRouteGetRuleStatuses_Cardinality(b *testing.B) {
 	timeNow = func() time.Time { return time.Date(2022, 3, 10, 14, 0, 0, 0, time.UTC) }
 	orgID := int64(1)
@@ -3759,7 +3750,7 @@ func BenchmarkRouteGetRuleStatuses_Cardinality(b *testing.B) {
 
 			var calls int64
 			reader := &sleepingInstanceReader{instances: instances, delay: perQueryLatency, calls: &calls}
-			storeReader := state.NewStoreStateReader(reader, log.NewNopLogger())
+			storeReader := state.NewStoreStateReader(reader, log.NewNopLogger(), 0, nil)
 
 			api := NewPrometheusSrv(
 				log.NewNopLogger(), storeReader, NewDBRuleMutator(storeReader),
@@ -3789,10 +3780,8 @@ func (nopStatusReader) Status(_ context.Context, _ ngmodels.AlertRuleKey) (ngmod
 	return ngmodels.RuleStatus{Health: "ok"}, true
 }
 
-// BenchmarkRouteGetRuleStatuses_PrimaryVsSecondary compares serving the rules-list endpoint
-// from in-memory state (the evaluating "primary" pod) versus from the DB via StoreStateReader
-// (a non-primary pod, ha_single_node_evaluation), at high instance cardinality. This validates
-// whether routing the read to the primary sidesteps the cost.
+// BenchmarkRouteGetRuleStatuses_PrimaryVsSecondary compares serving the rules list from
+// in-memory state (evaluating pod) versus from the DB via StoreStateReader (non-primary pod).
 func BenchmarkRouteGetRuleStatuses_PrimaryVsSecondary(b *testing.B) {
 	timeNow = func() time.Time { return time.Date(2022, 3, 10, 14, 0, 0, 0, time.UTC) }
 	orgID := int64(1)
@@ -3838,7 +3827,7 @@ func BenchmarkRouteGetRuleStatuses_PrimaryVsSecondary(b *testing.B) {
 		}
 	}
 	var calls int64
-	storeReader := state.NewStoreStateReader(&sleepingInstanceReader{instances: dbInstances, delay: perQueryLatency, calls: &calls}, log.NewNopLogger())
+	storeReader := state.NewStoreStateReader(&sleepingInstanceReader{instances: dbInstances, delay: perQueryLatency, calls: &calls}, log.NewNopLogger(), 0, nil)
 	secondaryAPI := NewPrometheusSrv(
 		log.NewNopLogger(), storeReader, NewDBRuleMutator(storeReader),
 		ruleStore, &fakeRuleAccessControlService{}, fakes.NewFakeProvisioningStore(),
@@ -3860,8 +3849,7 @@ func BenchmarkRouteGetRuleStatuses_PrimaryVsSecondary(b *testing.B) {
 	})
 }
 
-// countingAlertInstanceManager wraps AlertInstanceManager and counts calls to
-// GetStatesForRuleUID (callCount) and GetAll (getAllCount). Both counters are optional.
+// countingAlertInstanceManager wraps AlertInstanceManager and counts calls; both counters are optional.
 type countingAlertInstanceManager struct {
 	inner       state.AlertInstanceManager
 	callCount   *int

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -3723,6 +3723,143 @@ func BenchmarkRouteGetRuleStatuses_DBMode(b *testing.B) {
 	}
 }
 
+// BenchmarkRouteGetRuleStatuses_Cardinality fixes the rule count and varies the number of
+// alert INSTANCES per rule, at a realistic low DB round-trip latency. It isolates the
+// cost driven by instance cardinality (loading + converting all instances to compute
+// per-rule totals) from the per-rule N+1 round-trip cost. Compare loader on/off to see
+// how much the batch fix helps once instance volume dominates.
+func BenchmarkRouteGetRuleStatuses_Cardinality(b *testing.B) {
+	timeNow = func() time.Time { return time.Date(2022, 3, 10, 14, 0, 0, 0, time.UTC) }
+	orgID := int64(1)
+	queryPermissions := map[int64]map[string][]string{1: {datasources.ActionQuery: {datasources.ScopeAll}}}
+	const perQueryLatency = 300 * time.Microsecond // matches the measured prod MySQL RTT (~0.3ms)
+	const ruleCount = 500
+
+	for _, instancesPerRule := range []int{1, 20, 100, 500} {
+		b.Run(fmt.Sprintf("rules=%d/instances_per_rule=%d", ruleCount, instancesPerRule), func(b *testing.B) {
+			ruleStore := &fakes.RuleStore{
+				Rules:   map[int64][]*ngmodels.AlertRule{},
+				Folders: map[int64][]*folder.Folder{},
+				History: map[string][]*ngmodels.AlertRuleVersion{},
+				Hook:    func(any) error { return nil },
+			}
+			gen := ngmodels.RuleGen
+			groupKey := ngmodels.GenerateGroupKey(orgID)
+			rules := gen.With(gen.WithOrgID(orgID), gen.WithGroupKey(groupKey), gen.WithUniqueGroupIndex()).GenerateManyRef(ruleCount)
+			ruleStore.PutRule(context.Background(), rules...)
+
+			m := ngmodels.AlertInstanceMutators{}
+			instances := make([]*ngmodels.AlertInstance, 0, ruleCount*instancesPerRule)
+			for _, r := range rules {
+				for j := 0; j < instancesPerRule; j++ {
+					instances = append(instances, ngmodels.AlertInstanceGen(
+						m.WithOrgID(orgID), m.WithRuleUID(r.UID), m.WithLabelsHash(fmt.Sprintf("%s-%d", r.UID, j))))
+				}
+			}
+
+			var calls int64
+			reader := &sleepingInstanceReader{instances: instances, delay: perQueryLatency, calls: &calls}
+			storeReader := state.NewStoreStateReader(reader, log.NewNopLogger())
+
+			api := NewPrometheusSrv(
+				log.NewNopLogger(), storeReader, NewDBRuleMutator(storeReader),
+				ruleStore, &fakeRuleAccessControlService{}, fakes.NewFakeProvisioningStore(),
+			)
+			req, err := http.NewRequest("GET", "/api/v1/rules", nil)
+			require.NoError(b, err)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				c := &contextmodel.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &user.SignedInUser{OrgID: orgID, Permissions: queryPermissions}}
+				resp := api.RouteGetRuleStatuses(c)
+				if resp.Status() != http.StatusOK {
+					b.Fatalf("unexpected status %d", resp.Status())
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(atomic.LoadInt64(&calls))/float64(b.N), "db_calls/op")
+			b.ReportMetric(float64(ruleCount*instancesPerRule), "instances")
+		})
+	}
+}
+
+type nopStatusReader struct{}
+
+func (nopStatusReader) Status(_ context.Context, _ ngmodels.AlertRuleKey) (ngmodels.RuleStatus, bool) {
+	return ngmodels.RuleStatus{Health: "ok"}, true
+}
+
+// BenchmarkRouteGetRuleStatuses_PrimaryVsSecondary compares serving the rules-list endpoint
+// from in-memory state (the evaluating "primary" pod) versus from the DB via StoreStateReader
+// (a non-primary pod, ha_single_node_evaluation), at high instance cardinality. This validates
+// whether routing the read to the primary sidesteps the cost.
+func BenchmarkRouteGetRuleStatuses_PrimaryVsSecondary(b *testing.B) {
+	timeNow = func() time.Time { return time.Date(2022, 3, 10, 14, 0, 0, 0, time.UTC) }
+	orgID := int64(1)
+	queryPermissions := map[int64]map[string][]string{1: {datasources.ActionQuery: {datasources.ScopeAll}}}
+	const ruleCount = 500
+	const instancesPerRule = 200 // 100k instances total, approximating a high-cardinality page
+	const perQueryLatency = 300 * time.Microsecond
+
+	ruleStore := &fakes.RuleStore{
+		Rules:   map[int64][]*ngmodels.AlertRule{},
+		Folders: map[int64][]*folder.Folder{},
+		History: map[string][]*ngmodels.AlertRuleVersion{},
+		Hook:    func(any) error { return nil },
+	}
+	gen := ngmodels.RuleGen
+	groupKey := ngmodels.GenerateGroupKey(orgID)
+	rules := gen.With(gen.WithOrgID(orgID), gen.WithGroupKey(groupKey), gen.WithUniqueGroupIndex()).GenerateManyRef(ruleCount)
+	ruleStore.PutRule(context.Background(), rules...)
+
+	req, err := http.NewRequest("GET", "/api/v1/rules", nil)
+	require.NoError(b, err)
+	newCtx := func() *contextmodel.ReqContext {
+		return &contextmodel.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &user.SignedInUser{OrgID: orgID, Permissions: queryPermissions}}
+	}
+
+	// PRIMARY: in-memory state manager holding all instances (what the evaluating pod has).
+	inMem := &fakeAlertInstanceManager{states: map[int64]map[string][]*state.State{}}
+	for _, r := range rules {
+		inMem.GenerateAlertInstances(orgID, r.UID, instancesPerRule)
+	}
+	primaryAPI := NewPrometheusSrv(
+		log.NewNopLogger(), inMem, NewInMemoryRuleMutator(nopStatusReader{}, inMem),
+		ruleStore, &fakeRuleAccessControlService{}, fakes.NewFakeProvisioningStore(),
+	)
+
+	// SECONDARY: StoreStateReader over the DB (per-query latency), same instance volume.
+	m := ngmodels.AlertInstanceMutators{}
+	dbInstances := make([]*ngmodels.AlertInstance, 0, ruleCount*instancesPerRule)
+	for _, r := range rules {
+		for j := 0; j < instancesPerRule; j++ {
+			dbInstances = append(dbInstances, ngmodels.AlertInstanceGen(
+				m.WithOrgID(orgID), m.WithRuleUID(r.UID), m.WithLabelsHash(fmt.Sprintf("%s-%d", r.UID, j))))
+		}
+	}
+	var calls int64
+	storeReader := state.NewStoreStateReader(&sleepingInstanceReader{instances: dbInstances, delay: perQueryLatency, calls: &calls}, log.NewNopLogger())
+	secondaryAPI := NewPrometheusSrv(
+		log.NewNopLogger(), storeReader, NewDBRuleMutator(storeReader),
+		ruleStore, &fakeRuleAccessControlService{}, fakes.NewFakeProvisioningStore(),
+	)
+
+	b.Run("primary_in_memory", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if r := primaryAPI.RouteGetRuleStatuses(newCtx()); r.Status() != http.StatusOK {
+				b.Fatalf("status %d", r.Status())
+			}
+		}
+	})
+	b.Run("secondary_db_storestatereader", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if r := secondaryAPI.RouteGetRuleStatuses(newCtx()); r.Status() != http.StatusOK {
+				b.Fatalf("status %d", r.Status())
+			}
+		}
+	})
+}
+
 // countingAlertInstanceManager wraps AlertInstanceManager and counts calls to
 // GetStatesForRuleUID (callCount) and GetAll (getAllCount). Both counters are optional.
 type countingAlertInstanceManager struct {

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"slices"
 	"sort"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3567,18 +3568,180 @@ func TestNewDBRuleMutator(t *testing.T) {
 	})
 }
 
-// countingAlertInstanceManager wraps AlertInstanceManager and counts GetStatesForRuleUID calls.
+// TestRouteGetRuleStatuses_DBMode_BatchesStateLoad verifies that listing rules with the
+// DB rule mutator (HA single-node eval mode) loads all of the org's alert states in a
+// single GetAll call instead of one GetStatesForRuleUID per rule (the N+1 in #124004),
+// while still producing correct per-rule state.
+func TestRouteGetRuleStatuses_DBMode_BatchesStateLoad(t *testing.T) {
+	timeNow = func() time.Time { return time.Date(2022, 3, 10, 14, 0, 0, 0, time.UTC) }
+	orgID := int64(1)
+	queryPermissions := map[int64]map[string][]string{1: {datasources.ActionQuery: {datasources.ScopeAll}}}
+
+	newReqContext := func() *contextmodel.ReqContext {
+		req, err := http.NewRequest("GET", "/api/v1/rules", nil)
+		require.NoError(t, err)
+		return &contextmodel.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &user.SignedInUser{OrgID: orgID, Permissions: queryPermissions}}
+	}
+
+	setup := func(t *testing.T) (PrometheusSrv, *int, *int, ngmodels.RulesGroup) {
+		ruleStore := fakes.NewRuleStore(t)
+		fakeAIM := NewFakeAlertInstanceManager(t)
+		gen := ngmodels.RuleGen
+		groupKey := ngmodels.GenerateGroupKey(orgID)
+		rules := gen.With(gen.WithOrgID(orgID), gen.WithGroupKey(groupKey), gen.WithUniqueGroupIndex()).GenerateManyRef(20)
+		ruleStore.PutRule(context.Background(), rules...)
+		for _, r := range rules {
+			fakeAIM.GenerateAlertInstances(orgID, r.UID, 1, withAlertingState())
+		}
+
+		callCount, getAllCount := 0, 0
+		counting := &countingAlertInstanceManager{inner: fakeAIM, callCount: &callCount, getAllCount: &getAllCount}
+
+		api := NewPrometheusSrv(
+			log.NewNopLogger(),
+			counting,
+			NewDBRuleMutator(counting),
+			ruleStore,
+			&fakeRuleAccessControlService{},
+			fakes.NewFakeProvisioningStore(),
+		)
+		return *api, &callCount, &getAllCount, rules
+	}
+
+	t.Run("loads state once for the whole org, not per rule", func(t *testing.T) {
+		api, callCount, getAllCount, rules := setup(t)
+
+		resp := api.RouteGetRuleStatuses(newReqContext())
+		require.Equal(t, http.StatusOK, resp.Status())
+
+		assert.Equal(t, 1, *getAllCount, "GetAll should be called exactly once per request")
+		assert.Equal(t, 0, *callCount, "GetStatesForRuleUID should not be called (batched via GetAll)")
+
+		result := &apimodels.RuleResponse{}
+		require.NoError(t, json.Unmarshal(resp.Body(), result))
+		require.Len(t, result.Data.RuleGroups, 1)
+		require.Len(t, result.Data.RuleGroups[0].Rules, len(rules))
+		for _, r := range result.Data.RuleGroups[0].Rules {
+			assert.Equal(t, "firing", r.State, "each rule should reflect its firing state from the batched load")
+		}
+	})
+
+	t.Run("reloads state on every request (no cross-request caching)", func(t *testing.T) {
+		api, _, getAllCount, _ := setup(t)
+
+		require.Equal(t, http.StatusOK, api.RouteGetRuleStatuses(newReqContext()).Status())
+		require.Equal(t, http.StatusOK, api.RouteGetRuleStatuses(newReqContext()).Status())
+
+		assert.Equal(t, 2, *getAllCount, "each request must load fresh state; states must not be cached across requests")
+	})
+}
+
+// sleepingInstanceReader is a state.InstanceReader that returns pre-generated instances and
+// sleeps a fixed delay per call to simulate DB round-trip latency. It counts calls so a
+// benchmark can report DB round trips per op.
+type sleepingInstanceReader struct {
+	instances []*ngmodels.AlertInstance
+	delay     time.Duration
+	calls     *int64
+}
+
+func (r *sleepingInstanceReader) ListAlertInstances(_ context.Context, cmd *ngmodels.ListAlertInstancesQuery) ([]*ngmodels.AlertInstance, error) {
+	atomic.AddInt64(r.calls, 1)
+	if r.delay > 0 {
+		time.Sleep(r.delay)
+	}
+	out := make([]*ngmodels.AlertInstance, 0, len(r.instances))
+	for _, in := range r.instances {
+		if in.RuleOrgID != cmd.RuleOrgID {
+			continue
+		}
+		if cmd.RuleUID != "" && in.RuleUID != cmd.RuleUID {
+			continue
+		}
+		out = append(out, in)
+	}
+	return out, nil
+}
+
+// BenchmarkRouteGetRuleStatuses_DBMode probes the N+1 in the HA single-node DB path by
+// injecting a per-query latency and reporting the number of store round trips per op.
+// Before the fix db_calls/op scales with rule count; after it is 1.
+func BenchmarkRouteGetRuleStatuses_DBMode(b *testing.B) {
+	timeNow = func() time.Time { return time.Date(2022, 3, 10, 14, 0, 0, 0, time.UTC) }
+	orgID := int64(1)
+	queryPermissions := map[int64]map[string][]string{1: {datasources.ActionQuery: {datasources.ScopeAll}}}
+	const perQueryLatency = 1 * time.Millisecond
+
+	for _, ruleCount := range []int{10, 100, 500, 1000, 5000} {
+		b.Run(fmt.Sprintf("rules=%d", ruleCount), func(b *testing.B) {
+			// fakes.NewRuleStore requires *testing.T; build the store directly since the
+			// methods exercised here don't use the embedded testing handle.
+			ruleStore := &fakes.RuleStore{
+				Rules:   map[int64][]*ngmodels.AlertRule{},
+				Folders: map[int64][]*folder.Folder{},
+				History: map[string][]*ngmodels.AlertRuleVersion{},
+				Hook:    func(any) error { return nil },
+			}
+			gen := ngmodels.RuleGen
+			groupKey := ngmodels.GenerateGroupKey(orgID)
+			rules := gen.With(gen.WithOrgID(orgID), gen.WithGroupKey(groupKey), gen.WithUniqueGroupIndex()).GenerateManyRef(ruleCount)
+			ruleStore.PutRule(context.Background(), rules...)
+
+			m := ngmodels.AlertInstanceMutators{}
+			instances := make([]*ngmodels.AlertInstance, 0, ruleCount)
+			for _, r := range rules {
+				instances = append(instances, ngmodels.AlertInstanceGen(m.WithOrgID(orgID), m.WithRuleUID(r.UID)))
+			}
+
+			var calls int64
+			reader := &sleepingInstanceReader{instances: instances, delay: perQueryLatency, calls: &calls}
+			storeReader := state.NewStoreStateReader(reader, log.NewNopLogger())
+
+			api := NewPrometheusSrv(
+				log.NewNopLogger(),
+				storeReader,
+				NewDBRuleMutator(storeReader),
+				ruleStore,
+				&fakeRuleAccessControlService{},
+				fakes.NewFakeProvisioningStore(),
+			)
+
+			req, err := http.NewRequest("GET", "/api/v1/rules", nil)
+			require.NoError(b, err)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				c := &contextmodel.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &user.SignedInUser{OrgID: orgID, Permissions: queryPermissions}}
+				resp := api.RouteGetRuleStatuses(c)
+				if resp.Status() != http.StatusOK {
+					b.Fatalf("unexpected status %d", resp.Status())
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(atomic.LoadInt64(&calls))/float64(b.N), "db_calls/op")
+		})
+	}
+}
+
+// countingAlertInstanceManager wraps AlertInstanceManager and counts calls to
+// GetStatesForRuleUID (callCount) and GetAll (getAllCount). Both counters are optional.
 type countingAlertInstanceManager struct {
-	inner     state.AlertInstanceManager
-	callCount *int
+	inner       state.AlertInstanceManager
+	callCount   *int
+	getAllCount *int
 }
 
 func (c *countingAlertInstanceManager) GetAll(ctx context.Context, orgID int64) []*state.State {
+	if c.getAllCount != nil {
+		*c.getAllCount++
+	}
 	return c.inner.GetAll(ctx, orgID)
 }
 
 func (c *countingAlertInstanceManager) GetStatesForRuleUID(ctx context.Context, orgID int64, alertRuleUID string) []*state.State {
-	*c.callCount++
+	if c.callCount != nil {
+		*c.callCount++
+	}
 	return c.inner.GetStatesForRuleUID(ctx, orgID, alertRuleUID)
 }
 

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -296,9 +296,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *contextmodel.ReqContext) respon
 
 	ctx, span := tracer.Start(c.Req.Context(), "api.prometheus.RouteGetRuleStatuses")
 	defer span.End()
-	// Attach a request-scoped batch state loader so the rule mutator loads all of the org's
-	// alert states in a single query instead of one per rule (N+1). Only NewDBRuleMutator
-	// reads it; NewInMemoryRuleMutator ignores it.
+	// Attach a request-scoped batch state loader to avoid an N+1 state query (see statesForRule).
 	ctx = withBatchStateLoader(ctx)
 	// Propagate the new context so child spans can attach to it.
 	c.Req = c.Req.WithContext(ctx)
@@ -387,14 +385,16 @@ func NewInMemoryRuleMutator(statusReader StatusReader, manager state.AlertInstan
 
 type batchStateLoaderKey struct{}
 
-// batchStateLoader loads all of an org's alert states once per request and serves per-rule
-// lookups from memory, avoiding an N+1 query against the store when listing many rules.
-// It is scoped to a single request (see withBatchStateLoader), so the states it serves are
-// always freshly loaded and never shared across requests.
+// batchStateLoader pins one org-wide state snapshot per request so per-rule lookups avoid an
+// N+1 query and all rules in a response see the same snapshot.
 type batchStateLoader struct {
-	mu     sync.Mutex
-	loaded bool
-	byUID  map[string][]*state.State
+	mu    sync.Mutex
+	byUID map[string][]*state.State
+}
+
+// statesByRuleUIDReader is implemented by managers that expose a pre-indexed state snapshot.
+type statesByRuleUIDReader interface {
+	StatesByRuleUID(ctx context.Context, orgID int64) map[string][]*state.State
 }
 
 // withBatchStateLoader attaches an empty per-request batch loader to ctx.
@@ -402,10 +402,8 @@ func withBatchStateLoader(ctx context.Context) context.Context {
 	return context.WithValue(ctx, batchStateLoaderKey{}, &batchStateLoader{})
 }
 
-// statesForRule returns the alert states for a single rule. When a request-scoped
-// batchStateLoader is present on ctx, it loads all of the org's states once (a single
-// GetAll) and serves subsequent rules from memory. Without a loader it falls back to a
-// per-rule query, preserving behaviour for callers that don't set one up.
+// statesForRule returns a rule's states from the request's pinned org snapshot, falling back
+// to a per-rule query when no batch loader is on ctx.
 func statesForRule(ctx context.Context, manager state.AlertInstanceManager, orgID int64, ruleUID string) []*state.State {
 	l, ok := ctx.Value(batchStateLoaderKey{}).(*batchStateLoader)
 	if !ok {
@@ -414,20 +412,21 @@ func statesForRule(ctx context.Context, manager state.AlertInstanceManager, orgI
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if !l.loaded {
-		l.byUID = make(map[string][]*state.State)
-		for _, s := range manager.GetAll(ctx, orgID) {
-			l.byUID[s.AlertRuleUID] = append(l.byUID[s.AlertRuleUID], s)
+	if l.byUID == nil {
+		if r, ok := manager.(statesByRuleUIDReader); ok {
+			l.byUID = r.StatesByRuleUID(ctx, orgID)
+		} else {
+			l.byUID = make(map[string][]*state.State)
+			for _, s := range manager.GetAll(ctx, orgID) {
+				l.byUID[s.AlertRuleUID] = append(l.byUID[s.AlertRuleUID], s)
+			}
 		}
-		l.loaded = true
 	}
 	return l.byUID[ruleUID]
 }
 
-// NewDBRuleMutator creates a RuleMutator that reads alert state once and derives both status
-// and alert state from the result. Used in HA single-node eval mode, where we don't have
-// in-memory data to get rule state. When listing rules it uses a request-scoped batch loader
-// (see statesForRule) to avoid an N+1 query.
+// NewDBRuleMutator creates a RuleMutator that derives both status and alert state from stored
+// state. Used in HA single-node eval mode, where we don't have in-memory data to get rule state.
 func NewDBRuleMutator(manager state.AlertInstanceManager) RuleMutator {
 	return func(ctx context.Context, source *ngmodels.AlertRule, toMutate *apimodels.AlertingRule, stateFilterSet map[eval.State]struct{}, matchers labels.Matchers, labelOptions []ngmodels.LabelOption, limitAlerts int64) (map[string]int64, map[string]int64) {
 		states := statesForRule(ctx, manager, source.OrgID, source.UID)

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/prometheus/alertmanager/pkg/labels"
@@ -295,6 +296,10 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *contextmodel.ReqContext) respon
 
 	ctx, span := tracer.Start(c.Req.Context(), "api.prometheus.RouteGetRuleStatuses")
 	defer span.End()
+	// Attach a request-scoped batch state loader so the rule mutator loads all of the org's
+	// alert states in a single query instead of one per rule (N+1). Only NewDBRuleMutator
+	// reads it; NewInMemoryRuleMutator ignores it.
+	ctx = withBatchStateLoader(ctx)
 	// Propagate the new context so child spans can attach to it.
 	c.Req = c.Req.WithContext(ctx)
 	orgID := c.GetOrgID()
@@ -380,12 +385,52 @@ func NewInMemoryRuleMutator(statusReader StatusReader, manager state.AlertInstan
 	}
 }
 
-// NewDBRuleMutator creates a RuleMutator that performs a single GetStatesForRuleUID
-// call and derives both status and alert state from the result. Used in HA single-node eval
-// mode, where we don't have in-memory data to get rule state.
+type batchStateLoaderKey struct{}
+
+// batchStateLoader loads all of an org's alert states once per request and serves per-rule
+// lookups from memory, avoiding an N+1 query against the store when listing many rules.
+// It is scoped to a single request (see withBatchStateLoader), so the states it serves are
+// always freshly loaded and never shared across requests.
+type batchStateLoader struct {
+	mu     sync.Mutex
+	loaded bool
+	byUID  map[string][]*state.State
+}
+
+// withBatchStateLoader attaches an empty per-request batch loader to ctx.
+func withBatchStateLoader(ctx context.Context) context.Context {
+	return context.WithValue(ctx, batchStateLoaderKey{}, &batchStateLoader{})
+}
+
+// statesForRule returns the alert states for a single rule. When a request-scoped
+// batchStateLoader is present on ctx, it loads all of the org's states once (a single
+// GetAll) and serves subsequent rules from memory. Without a loader it falls back to a
+// per-rule query, preserving behaviour for callers that don't set one up.
+func statesForRule(ctx context.Context, manager state.AlertInstanceManager, orgID int64, ruleUID string) []*state.State {
+	l, ok := ctx.Value(batchStateLoaderKey{}).(*batchStateLoader)
+	if !ok {
+		return manager.GetStatesForRuleUID(ctx, orgID, ruleUID)
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.loaded {
+		l.byUID = make(map[string][]*state.State)
+		for _, s := range manager.GetAll(ctx, orgID) {
+			l.byUID[s.AlertRuleUID] = append(l.byUID[s.AlertRuleUID], s)
+		}
+		l.loaded = true
+	}
+	return l.byUID[ruleUID]
+}
+
+// NewDBRuleMutator creates a RuleMutator that reads alert state once and derives both status
+// and alert state from the result. Used in HA single-node eval mode, where we don't have
+// in-memory data to get rule state. When listing rules it uses a request-scoped batch loader
+// (see statesForRule) to avoid an N+1 query.
 func NewDBRuleMutator(manager state.AlertInstanceManager) RuleMutator {
 	return func(ctx context.Context, source *ngmodels.AlertRule, toMutate *apimodels.AlertingRule, stateFilterSet map[eval.State]struct{}, matchers labels.Matchers, labelOptions []ngmodels.LabelOption, limitAlerts int64) (map[string]int64, map[string]int64) {
-		states := manager.GetStatesForRuleUID(ctx, source.OrgID, source.UID)
+		states := statesForRule(ctx, manager, source.OrgID, source.UID)
 
 		status := state.StatesToRuleStatus(states)
 		if len(states) == 0 {

--- a/pkg/services/ngalert/metrics/state.go
+++ b/pkg/services/ngalert/metrics/state.go
@@ -6,9 +6,11 @@ import (
 )
 
 type State struct {
-	StateUpdateDuration   prometheus.Histogram
-	StateFullSyncDuration prometheus.Histogram
-	r                     prometheus.Registerer
+	StateUpdateDuration            prometheus.Histogram
+	StateFullSyncDuration          prometheus.Histogram
+	StateCacheRefreshFailuresTotal prometheus.Counter
+	StateCacheLastRefreshSuccess   prometheus.Gauge
+	r                              prometheus.Registerer
 }
 
 // Registerer exposes the Prometheus register directly. The state package needs this as, it uses a collector to fetch the current alerts by state in the system.
@@ -35,6 +37,22 @@ func NewStateMetrics(r prometheus.Registerer) *State {
 				Name:      "state_full_sync_duration_seconds",
 				Help:      "The duration of fully synchronizing the state with the database.",
 				Buckets:   []float64{0.01, 0.1, 1, 2, 5, 10, 60},
+			},
+		),
+		StateCacheRefreshFailuresTotal: promauto.With(r).NewCounter(
+			prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "state_cache_refresh_failures_total",
+				Help:      "The total number of failed loads of the cached alert state.",
+			},
+		),
+		StateCacheLastRefreshSuccess: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "state_cache_last_refresh_success_timestamp_seconds",
+				Help:      "Unix timestamp of the last fully successful background refresh of the cached alert state.",
 			},
 		),
 	}

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -193,7 +193,10 @@ type AlertNG struct {
 	clientGenerator resource.ClientGenerator
 
 	evaluationCoordinator EvaluationCoordinator
-	schedCfg              schedule.SchedulerCfg
+	// storeStateReader serves API rule statuses from the DB in ha_single_node_evaluation mode.
+	// It maintains a background-refreshed in-memory cache; started in Run when set.
+	storeStateReader *state.StoreStateReader
+	schedCfg         schedule.SchedulerCfg
 }
 
 // newRuleSequenceStore returns a RuleSequenceStore backed by the k8s API if a
@@ -467,7 +470,10 @@ func (ng *AlertNG) init() error {
 
 		// Use StoreStateReader to serve rule statuses / alert instances from the database,
 		// because non-primary nodes have no in-memory state
-		storeStateReader := state.NewStoreStateReader(ng.InstanceStore, ng.Log)
+		// Refresh the cached state roughly every base evaluation interval so API reads are
+		// fast and staleness is bounded to ~one eval cycle.
+		storeStateReader := state.NewStoreStateReader(ng.InstanceStore, ng.Log, ng.Cfg.UnifiedAlerting.BaseInterval)
+		ng.storeStateReader = storeStateReader
 		apiStateManager = storeStateReader
 		ruleMutator = apiprometheus.NewDBRuleMutator(storeStateReader)
 	} else {
@@ -765,6 +771,12 @@ func (ng *AlertNG) Run(ctx context.Context) error {
 		}
 		return nil
 	})
+
+	if ng.storeStateReader != nil {
+		children.Go(func() error {
+			return ng.storeStateReader.Run(subCtx)
+		})
+	}
 
 	children.Go(func() error {
 		return ng.MultiOrgAlertmanager.Run(subCtx)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -193,8 +193,8 @@ type AlertNG struct {
 	clientGenerator resource.ClientGenerator
 
 	evaluationCoordinator EvaluationCoordinator
-	// storeStateReader serves API rule statuses from the DB in ha_single_node_evaluation mode.
-	// It maintains a background-refreshed in-memory cache; started in Run when set.
+	// storeStateReader serves API rule statuses from a cached DB snapshot in
+	// ha_single_node_evaluation mode; started in Run when set.
 	storeStateReader *state.StoreStateReader
 	schedCfg         schedule.SchedulerCfg
 }
@@ -470,9 +470,8 @@ func (ng *AlertNG) init() error {
 
 		// Use StoreStateReader to serve rule statuses / alert instances from the database,
 		// because non-primary nodes have no in-memory state
-		// Refresh the cached state roughly every base evaluation interval so API reads are
-		// fast and staleness is bounded to ~one eval cycle.
-		storeStateReader := state.NewStoreStateReader(ng.InstanceStore, ng.Log, ng.Cfg.UnifiedAlerting.BaseInterval)
+		// Refreshed in the background every base interval to bound staleness.
+		storeStateReader := state.NewStoreStateReader(ng.InstanceStore, ng.Log, ng.Cfg.UnifiedAlerting.BaseInterval, ng.Metrics.GetStateMetrics())
 		ng.storeStateReader = storeStateReader
 		apiStateManager = storeStateReader
 		ruleMutator = apiprometheus.NewDBRuleMutator(storeStateReader)

--- a/pkg/services/ngalert/state/store_state_reader.go
+++ b/pkg/services/ngalert/state/store_state_reader.go
@@ -4,43 +4,53 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-// defaultStateCacheRefresh is how often the background refresh reloads cached org state
-// when no interval is provided.
+// defaultStateCacheRefresh is the fallback background refresh interval.
 const defaultStateCacheRefresh = time.Minute
 
-// orgStates is an immutable snapshot of one org's alert states, indexed by rule UID.
-// It is replaced atomically; callers must never mutate it.
+// stateCacheIdleEviction is how long an org may go unread before its cached state is evicted.
+const stateCacheIdleEviction = 15 * time.Minute
+
+// orgStates is an immutable per-org snapshot of alert states, indexed by rule UID.
 type orgStates struct {
 	all   []*State
 	byUID map[string][]*State
 }
 
-// StoreStateReader reads alert instances from the store and returns them as a slice of State.
-//
-// Deserializing alert-instance state from the database is expensive (protobuf decode +
-// reflection + GC). Under ha_single_node_evaluation the API serves rule statuses from the
-// database on every request, so listing rules would re-deserialize the entire org's state
-// on each call. To avoid that, StoreStateReader keeps an in-memory, per-org snapshot of
-// already-deserialized state and refreshes it in the background on a fixed interval. Reads
-// are served from the snapshot (fast); staleness is bounded by the refresh interval.
+// orgEntry holds an org's snapshot and when it was last read.
+type orgEntry struct {
+	snap       atomic.Pointer[orgStates]
+	lastAccess atomic.Int64 // unix nanos
+}
+
+func (e *orgEntry) touch() {
+	e.lastAccess.Store(time.Now().UnixNano())
+}
+
+// StoreStateReader serves alert state from the store via per-org in-memory snapshots that are
+// refreshed in the background, so reads avoid re-deserializing state on every request.
+// Staleness is bounded by the refresh interval.
 type StoreStateReader struct {
 	reader  InstanceReader
 	log     log.Logger
 	refresh time.Duration
+	metrics *metrics.State
 
-	cache sync.Map           // orgID(int64) -> *orgStates
+	cache sync.Map           // orgID(int64) -> *orgEntry
 	group singleflight.Group // dedupes concurrent cold loads per org
 }
 
-func NewStoreStateReader(reader InstanceReader, log log.Logger, refresh time.Duration) *StoreStateReader {
+// NewStoreStateReader creates a StoreStateReader. metrics may be nil.
+func NewStoreStateReader(reader InstanceReader, log log.Logger, refresh time.Duration, metrics *metrics.State) *StoreStateReader {
 	if refresh <= 0 {
 		refresh = defaultStateCacheRefresh
 	}
@@ -48,60 +58,84 @@ func NewStoreStateReader(reader InstanceReader, log log.Logger, refresh time.Dur
 		reader:  reader,
 		log:     log,
 		refresh: refresh,
+		metrics: metrics,
 	}
 }
 
-// Run periodically refreshes the cached state for every org that has been queried, until
-// ctx is cancelled. It must be started once by the owning service (see AlertNG.Run).
+// Run refreshes the cached state of queried orgs until ctx is cancelled.
 func (m *StoreStateReader) Run(ctx context.Context) error {
 	t := time.NewTicker(m.refresh)
 	defer t.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil
 		case <-t.C:
 			m.refreshAll(ctx)
 		}
 	}
 }
 
-// refreshAll reloads, in the background, the state of every org already in the cache.
+// refreshAll reloads every recently read org and evicts idle ones.
 func (m *StoreStateReader) refreshAll(ctx context.Context) {
-	m.cache.Range(func(k, _ any) bool {
+	ok := true
+	m.cache.Range(func(k, v any) bool {
 		orgID := k.(int64)
+		entry := v.(*orgEntry)
+		if time.Since(time.Unix(0, entry.lastAccess.Load())) > stateCacheIdleEviction {
+			m.cache.Delete(orgID)
+			return true
+		}
 		snap, err := m.loadOrg(ctx, orgID)
 		if err != nil {
+			ok = false
+			m.countRefreshFailure()
 			m.log.Error("Failed to refresh cached alert state", "orgID", orgID, "error", err)
-			return true // keep the previous snapshot; try again next tick
+			return true
 		}
-		m.cache.Store(orgID, snap)
+		entry.snap.Store(snap)
 		return true
 	})
+	if ok && m.metrics != nil {
+		m.metrics.StateCacheLastRefreshSuccess.SetToCurrentTime()
+	}
 }
 
-// snapshot returns the cached snapshot for an org, loading it once on a cold miss.
-// Concurrent cold misses for the same org are coalesced so only one DB load happens.
+func (m *StoreStateReader) countRefreshFailure() {
+	if m.metrics != nil {
+		m.metrics.StateCacheRefreshFailuresTotal.Inc()
+	}
+}
+
+// snapshot returns the org's cached snapshot, cold-loading it once (singleflight-deduped).
 func (m *StoreStateReader) snapshot(ctx context.Context, orgID int64) *orgStates {
 	if v, ok := m.cache.Load(orgID); ok {
-		return v.(*orgStates)
+		entry := v.(*orgEntry)
+		entry.touch()
+		return entry.snap.Load()
 	}
 	v, err, _ := m.group.Do(strconv.FormatInt(orgID, 10), func() (any, error) {
-		if v, ok := m.cache.Load(orgID); ok { // another caller populated it
+		if v, ok := m.cache.Load(orgID); ok {
 			return v, nil
 		}
 		snap, err := m.loadOrg(ctx, orgID)
 		if err != nil {
 			return nil, err
 		}
-		m.cache.Store(orgID, snap)
-		return snap, nil
+		entry := &orgEntry{}
+		entry.snap.Store(snap)
+		entry.touch()
+		m.cache.Store(orgID, entry)
+		return entry, nil
 	})
 	if err != nil {
+		m.countRefreshFailure()
 		m.log.Error("Failed to load alert state from DB", "orgID", orgID, "error", err)
 		return &orgStates{byUID: map[string][]*State{}}
 	}
-	return v.(*orgStates)
+	entry := v.(*orgEntry)
+	entry.touch()
+	return entry.snap.Load()
 }
 
 // loadOrg reads and deserializes all of an org's alert state from the database.
@@ -126,6 +160,11 @@ func (m *StoreStateReader) GetAll(ctx context.Context, orgID int64) []*State {
 
 func (m *StoreStateReader) GetStatesForRuleUID(ctx context.Context, orgID int64, alertRuleUID string) []*State {
 	return m.snapshot(ctx, orgID).byUID[alertRuleUID]
+}
+
+// StatesByRuleUID returns the org's states indexed by rule UID. Callers must not modify it.
+func (m *StoreStateReader) StatesByRuleUID(ctx context.Context, orgID int64) map[string][]*State {
+	return m.snapshot(ctx, orgID).byUID
 }
 
 func (m *StoreStateReader) Status(ctx context.Context, key models.AlertRuleKey) (models.RuleStatus, bool) {

--- a/pkg/services/ngalert/state/store_state_reader.go
+++ b/pkg/services/ngalert/state/store_state_reader.go
@@ -2,45 +2,130 @@ package state
 
 import (
 	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-// StoreStateReader reads alert instances from the store and returns them as slice of State.
-type StoreStateReader struct {
-	reader InstanceReader
-	log    log.Logger
+// defaultStateCacheRefresh is how often the background refresh reloads cached org state
+// when no interval is provided.
+const defaultStateCacheRefresh = time.Minute
+
+// orgStates is an immutable snapshot of one org's alert states, indexed by rule UID.
+// It is replaced atomically; callers must never mutate it.
+type orgStates struct {
+	all   []*State
+	byUID map[string][]*State
 }
 
-func NewStoreStateReader(reader InstanceReader, log log.Logger) *StoreStateReader {
-	return &StoreStateReader{
-		reader: reader,
-		log:    log,
+// StoreStateReader reads alert instances from the store and returns them as a slice of State.
+//
+// Deserializing alert-instance state from the database is expensive (protobuf decode +
+// reflection + GC). Under ha_single_node_evaluation the API serves rule statuses from the
+// database on every request, so listing rules would re-deserialize the entire org's state
+// on each call. To avoid that, StoreStateReader keeps an in-memory, per-org snapshot of
+// already-deserialized state and refreshes it in the background on a fixed interval. Reads
+// are served from the snapshot (fast); staleness is bounded by the refresh interval.
+type StoreStateReader struct {
+	reader  InstanceReader
+	log     log.Logger
+	refresh time.Duration
+
+	cache sync.Map           // orgID(int64) -> *orgStates
+	group singleflight.Group // dedupes concurrent cold loads per org
+}
+
+func NewStoreStateReader(reader InstanceReader, log log.Logger, refresh time.Duration) *StoreStateReader {
+	if refresh <= 0 {
+		refresh = defaultStateCacheRefresh
 	}
+	return &StoreStateReader{
+		reader:  reader,
+		log:     log,
+		refresh: refresh,
+	}
+}
+
+// Run periodically refreshes the cached state for every org that has been queried, until
+// ctx is cancelled. It must be started once by the owning service (see AlertNG.Run).
+func (m *StoreStateReader) Run(ctx context.Context) error {
+	t := time.NewTicker(m.refresh)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			m.refreshAll(ctx)
+		}
+	}
+}
+
+// refreshAll reloads, in the background, the state of every org already in the cache.
+func (m *StoreStateReader) refreshAll(ctx context.Context) {
+	m.cache.Range(func(k, _ any) bool {
+		orgID := k.(int64)
+		snap, err := m.loadOrg(ctx, orgID)
+		if err != nil {
+			m.log.Error("Failed to refresh cached alert state", "orgID", orgID, "error", err)
+			return true // keep the previous snapshot; try again next tick
+		}
+		m.cache.Store(orgID, snap)
+		return true
+	})
+}
+
+// snapshot returns the cached snapshot for an org, loading it once on a cold miss.
+// Concurrent cold misses for the same org are coalesced so only one DB load happens.
+func (m *StoreStateReader) snapshot(ctx context.Context, orgID int64) *orgStates {
+	if v, ok := m.cache.Load(orgID); ok {
+		return v.(*orgStates)
+	}
+	v, err, _ := m.group.Do(strconv.FormatInt(orgID, 10), func() (any, error) {
+		if v, ok := m.cache.Load(orgID); ok { // another caller populated it
+			return v, nil
+		}
+		snap, err := m.loadOrg(ctx, orgID)
+		if err != nil {
+			return nil, err
+		}
+		m.cache.Store(orgID, snap)
+		return snap, nil
+	})
+	if err != nil {
+		m.log.Error("Failed to load alert state from DB", "orgID", orgID, "error", err)
+		return &orgStates{byUID: map[string][]*State{}}
+	}
+	return v.(*orgStates)
+}
+
+// loadOrg reads and deserializes all of an org's alert state from the database.
+func (m *StoreStateReader) loadOrg(ctx context.Context, orgID int64) (*orgStates, error) {
+	instances, err := m.reader.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
+		RuleOrgID: orgID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	states := m.convertToStates(instances)
+	byUID := make(map[string][]*State, len(states))
+	for _, s := range states {
+		byUID[s.AlertRuleUID] = append(byUID[s.AlertRuleUID], s)
+	}
+	return &orgStates{all: states, byUID: byUID}, nil
 }
 
 func (m *StoreStateReader) GetAll(ctx context.Context, orgID int64) []*State {
-	instances, err := m.reader.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
-		RuleOrgID: orgID,
-	})
-	if err != nil {
-		m.log.Error("Failed to list alert instances from DB", "orgID", orgID, "error", err)
-		return nil
-	}
-	return m.convertToStates(instances)
+	return m.snapshot(ctx, orgID).all
 }
 
 func (m *StoreStateReader) GetStatesForRuleUID(ctx context.Context, orgID int64, alertRuleUID string) []*State {
-	instances, err := m.reader.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
-		RuleOrgID: orgID,
-		RuleUID:   alertRuleUID,
-	})
-	if err != nil {
-		m.log.Error("Failed to list alert instances from DB", "orgID", orgID, "ruleUID", alertRuleUID, "error", err)
-		return nil
-	}
-	return m.convertToStates(instances)
+	return m.snapshot(ctx, orgID).byUID[alertRuleUID]
 }
 
 func (m *StoreStateReader) Status(ctx context.Context, key models.AlertRuleKey) (models.RuleStatus, bool) {

--- a/pkg/services/ngalert/state/store_state_reader_test.go
+++ b/pkg/services/ngalert/state/store_state_reader_test.go
@@ -75,7 +75,7 @@ func TestStoreStateReader_GetAll(t *testing.T) {
 				})).Return(tc.instances, nil).Once()
 			}
 
-			manager := NewStoreStateReader(mockReader, log.NewNopLogger(), 0)
+			manager := NewStoreStateReader(mockReader, log.NewNopLogger(), 0, nil)
 			states := manager.GetAll(context.Background(), orgID)
 
 			if tc.expectNilOnError {
@@ -152,7 +152,7 @@ func TestStoreStateReader_GetStatesForRuleUID(t *testing.T) {
 				})).Return(tc.instances, nil).Once()
 			}
 
-			manager := NewStoreStateReader(mockReader, log.NewNopLogger(), 0)
+			manager := NewStoreStateReader(mockReader, log.NewNopLogger(), 0, nil)
 			states := manager.GetStatesForRuleUID(context.Background(), orgID, ruleUID)
 
 			if tc.expectNilOnError {
@@ -217,7 +217,7 @@ func TestStoreStateReader_Status(t *testing.T) {
 				return q.RuleOrgID == orgID
 			})).Return(tc.instances, tc.dbError).Once()
 
-			reader := NewStoreStateReader(mockReader, log.NewNopLogger(), 0)
+			reader := NewStoreStateReader(mockReader, log.NewNopLogger(), 0, nil)
 			status, exists := reader.Status(context.Background(), key)
 
 			require.Equal(t, tc.expectExists, exists)
@@ -246,7 +246,7 @@ func TestStoreStateReader_CachesAndRefreshes(t *testing.T) {
 		return q.RuleOrgID == orgID && q.RuleUID == ""
 	})).Return(inst(models.InstanceStateFiring), nil)
 
-	m := NewStoreStateReader(mockReader, log.NewNopLogger(), time.Hour)
+	m := NewStoreStateReader(mockReader, log.NewNopLogger(), time.Hour, nil)
 
 	// Repeated reads are served from cache: only one DB load happens.
 	for i := 0; i < 5; i++ {
@@ -261,5 +261,28 @@ func TestStoreStateReader_CachesAndRefreshes(t *testing.T) {
 
 	// Subsequent reads still come from cache (no extra DB call).
 	require.Len(t, m.GetStatesForRuleUID(context.Background(), orgID, ruleUID), 1)
+	mockReader.AssertNumberOfCalls(t, "ListAlertInstances", 2)
+}
+
+func TestStoreStateReader_EvictsIdleOrgs(t *testing.T) {
+	orgID := int64(1)
+	mockReader := &mockInstanceReader{}
+	mockReader.On("ListAlertInstances", mock.Anything, mock.Anything).Return([]*models.AlertInstance{}, nil)
+
+	m := NewStoreStateReader(mockReader, log.NewNopLogger(), time.Hour, nil)
+	m.GetAll(context.Background(), orgID)
+	mockReader.AssertNumberOfCalls(t, "ListAlertInstances", 1)
+
+	// An org not read within the idle threshold is evicted without reloading.
+	v, ok := m.cache.Load(orgID)
+	require.True(t, ok)
+	v.(*orgEntry).lastAccess.Store(time.Now().Add(-2 * stateCacheIdleEviction).UnixNano())
+	m.refreshAll(context.Background())
+	mockReader.AssertNumberOfCalls(t, "ListAlertInstances", 1)
+	_, ok = m.cache.Load(orgID)
+	require.False(t, ok)
+
+	// The next read cold-loads again.
+	m.GetAll(context.Background(), orgID)
 	mockReader.AssertNumberOfCalls(t, "ListAlertInstances", 2)
 }

--- a/pkg/services/ngalert/state/store_state_reader_test.go
+++ b/pkg/services/ngalert/state/store_state_reader_test.go
@@ -75,7 +75,7 @@ func TestStoreStateReader_GetAll(t *testing.T) {
 				})).Return(tc.instances, nil).Once()
 			}
 
-			manager := NewStoreStateReader(mockReader, log.NewNopLogger())
+			manager := NewStoreStateReader(mockReader, log.NewNopLogger(), 0)
 			states := manager.GetAll(context.Background(), orgID)
 
 			if tc.expectNilOnError {
@@ -144,15 +144,15 @@ func TestStoreStateReader_GetStatesForRuleUID(t *testing.T) {
 			mockReader := &mockInstanceReader{}
 			if tc.dbError != nil {
 				mockReader.On("ListAlertInstances", mock.Anything, mock.MatchedBy(func(q *models.ListAlertInstancesQuery) bool {
-					return q.RuleOrgID == orgID && q.RuleUID == ruleUID
+					return q.RuleOrgID == orgID
 				})).Return([]*models.AlertInstance(nil), tc.dbError).Once()
 			} else {
 				mockReader.On("ListAlertInstances", mock.Anything, mock.MatchedBy(func(q *models.ListAlertInstancesQuery) bool {
-					return q.RuleOrgID == orgID && q.RuleUID == ruleUID
+					return q.RuleOrgID == orgID
 				})).Return(tc.instances, nil).Once()
 			}
 
-			manager := NewStoreStateReader(mockReader, log.NewNopLogger())
+			manager := NewStoreStateReader(mockReader, log.NewNopLogger(), 0)
 			states := manager.GetStatesForRuleUID(context.Background(), orgID, ruleUID)
 
 			if tc.expectNilOnError {
@@ -214,10 +214,10 @@ func TestStoreStateReader_Status(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockReader := &mockInstanceReader{}
 			mockReader.On("ListAlertInstances", mock.Anything, mock.MatchedBy(func(q *models.ListAlertInstancesQuery) bool {
-				return q.RuleOrgID == orgID && q.RuleUID == ruleUID
+				return q.RuleOrgID == orgID
 			})).Return(tc.instances, tc.dbError).Once()
 
-			reader := NewStoreStateReader(mockReader, log.NewNopLogger())
+			reader := NewStoreStateReader(mockReader, log.NewNopLogger(), 0)
 			status, exists := reader.Status(context.Background(), key)
 
 			require.Equal(t, tc.expectExists, exists)
@@ -226,4 +226,40 @@ func TestStoreStateReader_Status(t *testing.T) {
 			mockReader.AssertExpectations(t)
 		})
 	}
+}
+
+func TestStoreStateReader_CachesAndRefreshes(t *testing.T) {
+	orgID := int64(1)
+	ruleUID := "rule-1"
+	inst := func(s models.InstanceStateType) []*models.AlertInstance {
+		return []*models.AlertInstance{{
+			AlertInstanceKey: models.AlertInstanceKey{RuleOrgID: orgID, RuleUID: ruleUID, LabelsHash: "h"},
+			Labels:           models.InstanceLabels{"alertname": "t"},
+			CurrentState:     s,
+			LastEvalTime:     time.Now(),
+		}}
+	}
+
+	mockReader := &mockInstanceReader{}
+	// The cache always loads org-scoped state in bulk (no per-rule query).
+	call := mockReader.On("ListAlertInstances", mock.Anything, mock.MatchedBy(func(q *models.ListAlertInstancesQuery) bool {
+		return q.RuleOrgID == orgID && q.RuleUID == ""
+	})).Return(inst(models.InstanceStateFiring), nil)
+
+	m := NewStoreStateReader(mockReader, log.NewNopLogger(), time.Hour)
+
+	// Repeated reads are served from cache: only one DB load happens.
+	for i := 0; i < 5; i++ {
+		require.Len(t, m.GetStatesForRuleUID(context.Background(), orgID, ruleUID), 1)
+	}
+	mockReader.AssertNumberOfCalls(t, "ListAlertInstances", 1)
+
+	// A background refresh reloads from the DB and atomically updates the snapshot.
+	call.Return(inst(models.InstanceStateNormal), nil)
+	m.refreshAll(context.Background())
+	mockReader.AssertNumberOfCalls(t, "ListAlertInstances", 2)
+
+	// Subsequent reads still come from cache (no extra DB call).
+	require.Len(t, m.GetStatesForRuleUID(context.Background(), orgID, ruleUID), 1)
+	mockReader.AssertNumberOfCalls(t, "ListAlertInstances", 2)
 }


### PR DESCRIPTION
**What is this feature?**

Speeds up the Grafana rules API (`/api/prometheus/grafana/api/v1/rules`) under `ha_single_node_evaluation` by caching deserialized alert state in `StoreStateReader` and refreshing it in the background.

**Why do we need this feature?**

With `ha_single_node_evaluation`, the API serves rule statuses from the DB via `StoreStateReader` on every request (on all nodes). Listing rules therefore re-reads and re-deserializes the entire org's alert-instance state on each call.

Reproduced on a DB (Grafana 13.0.2, 2,053 rules, 1,495 dashboards, 1,458 compressed state blobs): `GET .../v1/rules?limit_alerts=0&group_limit=40` takes **~48s**.

CPU profile of that request:
- `ProtoInstanceDBStore.ListAlertInstances` — **51%** cumulative
- `protobuf.Unmarshal` ~22%, xorm reflection (`reflect.Append/Set`) ~30%, GC ~40%
- **~0% in DB round-trips**

So the cost is CPU-bound **deserialization of state**, repeated per request, and not query count or round-trips. A shared/distributed cache can't help (reading serialized state still deserializes on read), and disabling ha_single_node_evaluation isn't an option because recording rules would then double-write.

This PR caches the already-deserialized per-org state in memory and refreshes it on a background ticker (every base evaluation interval). Reads are served from the snapshot:
- Warm reads (steady state / UI polling): ~48s → sub-second.
- Cold miss (first load, post-restart): one bulk load populates the cache (singleflight-deduped to prevent stampedes).
- Staleness is bound to the refresh interval (no stale-forever).

**Who is this feature for?**

Operators running Grafana Alerting in HA with `ha_single_node_evaluation` enabled, especially with large numbers of alert rules.

**Which issue(s) does this PR fix?**:
Fixes #124004

**Special notes for your reviewer:**

Root cause and fix are backed by a local reproduction on a real production DB and a CPU profile (above): the rules API re-deserializes all org alert states per request; this PR serves it from a background-refreshed in-memory snapshot.

- `GetStatesForRuleUID` now bulk-loads the org once and indexes by rule UID in memory (no per-rule query).
- The background refresh loop (`StoreStateReader.Run(ctx)`) is wired into `AlertNG.Run` via the existing errgroup and stops on context cancel. The refresh interval defaults to `UnifiedAlerting.BaseInterval`.
- Staleness is bound to one refresh interval (addresses the correctness concern with an unbounded cache).
- Unit test `TestStoreStateReader_CachesAndRefreshes` verifies that N reads trigger a single DB load and that a refresh atomically updates the snapshot.
- Only the cold-cache path remains expensive; reducing rule/instance cardinality shrinks that further but isn't required for steady-state.

With the background-refreshed cache, warm reads make no DB calls at all: `db_calls/op` drops to the per-op share of the single cold load (e.g. 0.045 at 5000 rules), rendered by benchstat in fractional units below.

```sh
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/api
cpu: Apple M3 Pro
                                          │   before.txt    │              after.txt              │
                                          │     sec/op      │    sec/op     vs base               │
RouteGetRuleStatuses_DBMode/rules=10-12     11890.63µ ± 12%   82.07µ ±  6%  -99.31% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=100-12    123853.3µ ±  2%   759.4µ ±  6%  -99.39% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=500-12     630.728m ±  7%   3.722m ±  5%  -99.41% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=1000-12   1270.743m ±  6%   7.549m ±  4%  -99.41% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=5000-12    7429.55m ±  6%   43.02m ± 12%  -99.42% (p=0.002 n=6)
geomean                                        387.8m         2.374m        -99.39%

                                          │    before.txt     │              after.txt               │
                                          │    db_calls/op    │ db_calls/op   vs base                │
RouteGetRuleStatuses_DBMode/rules=10-12     10000000.00µ ± 0%   68.85µ ± 15%  -100.00% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=100-12    100000000.0µ ± 0%   652.4µ ± 11%  -100.00% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=500-12     500000.000m ± 0%   3.226m ±  9%  -100.00% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=1000-12   1000000.000m ± 0%   6.389m ±  5%  -100.00% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=5000-12    5000000.00m ± 0%   39.23m ± 16%  -100.00% (p=0.002 n=6)
geomean                                            301.7        2.051m        -100.00%

                                          │   before.txt   │              after.txt              │
                                          │      B/op      │     B/op      vs base               │
RouteGetRuleStatuses_DBMode/rules=10-12      86.28Ki ±  9%   81.07Ki ± 5%        ~ (p=0.093 n=6)
RouteGetRuleStatuses_DBMode/rules=100-12     869.3Ki ±  3%   724.7Ki ± 1%  -16.63% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=500-12     5.686Mi ±  5%   3.510Mi ± 1%  -38.26% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=1000-12   17.109Mi ± 12%   7.697Mi ± 1%  -55.01% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=5000-12   249.34Mi ±  0%   48.31Mi ± 3%  -80.63% (p=0.002 n=6)
geomean                                      4.445Mi         2.360Mi       -46.91%

                                          │  before.txt  │             after.txt             │
                                          │  allocs/op   │  allocs/op   vs base              │
RouteGetRuleStatuses_DBMode/rules=10-12      910.5 ± 12%    860.5 ± 5%       ~ (p=0.119 n=6)
RouteGetRuleStatuses_DBMode/rules=100-12    8.127k ±  2%   7.721k ± 3%  -5.00% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=500-12    39.84k ±  1%   37.66k ± 2%  -5.46% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=1000-12   79.91k ±  0%   75.60k ± 1%  -5.39% (p=0.002 n=6)
RouteGetRuleStatuses_DBMode/rules=5000-12   397.1k ±  0%   377.3k ± 0%  -4.98% (p=0.002 n=6)
geomean                                     24.78k         23.48k       -5.26%
```

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

