### PR TITLE
FS: Set frontend OpenFeature context from backend context

### DIFF
--- a/devenv/frontend-service/goff-flags.yaml
+++ b/devenv/frontend-service/goff-flags.yaml
@@ -39,4 +39,4 @@ frontendService.reducedBootDataAPI:
     enabled: true
     disabled: false
   defaultRule:
-    variation: disabled
+    variation: enabled

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -1,6 +1,8 @@
 package frontend
 
 import (
+	"fmt"
+	"maps"
 	"net/http"
 
 	"github.com/open-feature/go-sdk/openfeature"
@@ -49,7 +51,26 @@ func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, sett
 			}
 
 			if fullFrontendSettingsEnabled && requestConfig.FullFrontendSettings != nil {
-				requestConfig.FullFrontendSettings.Namespace = request.NamespaceValue(ctx)
+				namespace := request.NamespaceValue(ctx)
+				requestConfig.FullFrontendSettings.Namespace = namespace
+
+				// Merge the per-request OpenFeature evaluation context into the base
+				// context already on the settings, so the frontend can evaluate feature
+				// flags with the same context. Per-request values take precedence.
+				evalCtx := openfeature.TransactionContext(ctx)
+				openFeatureContext := make(map[string]string, len(requestConfig.FullFrontendSettings.OpenFeatureContext)+len(evalCtx.Attributes())+1)
+				maps.Copy(openFeatureContext, requestConfig.FullFrontendSettings.OpenFeatureContext)
+				for key, value := range evalCtx.Attributes() {
+					if str, ok := value.(string); ok {
+						openFeatureContext[key] = str
+					} else {
+						openFeatureContext[key] = fmt.Sprintf("%v", value)
+					}
+				}
+
+				// Explicitly set namespace
+				openFeatureContext["namespace"] = namespace
+				requestConfig.FullFrontendSettings.OpenFeatureContext = openFeatureContext
 			}
 
 			// Fetch tenant-specific configuration if the settings service is configured and namespace is present

--- a/pkg/services/frontend/request_config_middleware_test.go
+++ b/pkg/services/frontend/request_config_middleware_test.go
@@ -413,6 +413,56 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		// The plugins CDN base URL is sourced from the plugins CDN service.
 		assert.Equal(t, "https://cdn.example.com", capturedConfig.FullFrontendSettings.PluginsCDNBaseURL)
 	})
+
+	t.Run("merges the per-request OpenFeature evaluation context into the base context when the reduced boot data flag is enabled", func(t *testing.T) {
+		enableReducedBootDataToggle(t)
+
+		license := &licensing.OSSLicensingService{}
+		cfg := setting.NewCfg()
+		cfg.AppURL = "https://grafana.example.com"
+		// Base context attributes are configured globally and should be preserved.
+		cfg.OpenFeature.ContextAttrs = map[string]string{
+			"grafana_version": "12.0.0",
+			"hostname":        "base.example.com",
+		}
+
+		middleware := RequestConfigMiddleware(cfg, license, nil, nil)
+
+		var capturedConfig FSRequestConfig
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var err error
+			capturedConfig, err = FSRequestConfigFromContext(r.Context())
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := middleware(testHandler)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req = setupTestContextWithUser(req, "stacks-123")
+
+		// Simulate the per-request evaluation context that the context middleware
+		// sets earlier in the chain.
+		evalCtx := openfeature.NewEvaluationContext("stacks-123", map[string]any{
+			"namespace": "stacks-123",
+			"hostname":  "foo.example.com",
+		})
+		req = req.WithContext(openfeature.MergeTransactionContext(req.Context(), evalCtx))
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		require.NotNil(t, capturedConfig.FullFrontendSettings)
+		assert.Equal(t, map[string]string{
+			// Preserved from the base context.
+			"grafana_version": "12.0.0",
+			// Per-request value overrides the base context value.
+			"hostname": "foo.example.com",
+			// Added by the per-request context.
+			"namespace": "stacks-123",
+		}, capturedConfig.FullFrontendSettings.OpenFeatureContext)
+	})
 }
 
 // mockSettingsService is a simple mock for testing


### PR DESCRIPTION
**What is this feature?**

When the `frontendService.reducedBootDataAPI` feature toggle is enabled, the frontend-service now copies the per-request OpenFeature evaluation context into the boot settings sent to the frontend (`settings.openFeatureContext`).

The per-request context (namespace, hostname, and any configured baggage members) is merged into the base context that was already populated from global config (`cfg.OpenFeature.ContextAttrs`). Per-request values take precedence over base values on key collisions, and the request `namespace` is always set explicitly.

**Why do we need this feature?**

OpenFeature evaluation requires the `namespace` property always to be set. When `frontendService.reducedBootDataAPI` is enabled, the context is no longer loaded from the ST backend, so its empty and flag evaluation always fails.

This is a temporary solution until we can get something longer term for more automatic frontend context.

Fixes https://github.com/grafana/grafana-frontend-platform/issues/197