### PR TITLE
FeatureToggles: Add heatmapNegativeLogBuckets

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1216,6 +1216,11 @@ export interface FeatureToggles {
   */
   vizLegendFacetedFilter?: boolean;
   /**
+  * Render native histogram (exponential and NHCB) zero and negative heatmap buckets on a symlog y-axis
+  * @default false
+  */
+  heatmapNegativeLogBuckets?: boolean;
+  /**
   * Enable gradient color scheme option for the pie chart panel
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2229,6 +2229,14 @@ var (
 			Expression:  "true",
 		},
 		{
+			Name:        "heatmapNegativeLogBuckets",
+			Description: "Render native histogram (exponential and NHCB) zero and negative heatmap buckets on a symlog y-axis",
+			Stage:       FeatureStageExperimental,
+			Generate:    Generate{LegacyFrontend: true},
+			Owner:       grafanaDatavizSquad,
+			Expression:  "false",
+		},
+		{
 			Name:        "pieChartGradientColorScheme",
 			Description: "Enable gradient color scheme option for the pie chart panel",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -259,6 +259,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-18,vizPresets,GA,@grafana/dataviz-squad,false,false,true
 2026-05-22,nestedFramesFieldOverrides,preview,@grafana/dataviz-squad,false,false,true
 2026-03-10,vizLegendFacetedFilter,GA,@grafana/dataviz-squad,false,false,true
+2026-06-03,heatmapNegativeLogBuckets,experimental,@grafana/dataviz-squad,false,false,true
 2026-05-22,pieChartGradientColorScheme,experimental,@grafana/dataviz-squad,false,false,true
 2025-10-31,jaegerEnableGrpcEndpoint,experimental,@grafana/data-sources-plugins,false,false,false
 2025-10-17,pluginStoreServiceLoading,experimental,@grafana/grafana-catalog,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2872,6 +2872,20 @@
     },
     {
       "metadata": {
+        "name": "heatmapNegativeLogBuckets",
+        "resourceVersion": "1780479590437",
+        "creationTimestamp": "2026-06-03T09:39:50Z"
+      },
+      "spec": {
+        "description": "Render native histogram (exponential and NHCB) zero and negative heatmap buckets on a symlog y-axis",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "heatmapRowsAxisOptions",
         "resourceVersion": "1782152165311",
         "creationTimestamp": "2025-12-18T22:45:00Z",


### PR DESCRIPTION
**What is this feature?**

Adds a new experimental, frontend-only feature toggle, `heatmapNegativeLogBuckets`
(off by default).

The toggle will gate automatic symlog rendering of native-histogram (Prometheus
exponential and NHCB) heatmap buckets that straddle or fall below zero. This PR only
registers the toggle and its generated artifacts.

**Why do we need this feature?**

Native histograms can contain zero and negative buckets that a pure log y-axis can't
represent, so today they silently disappear from the heatmap panel (#89263). The
upcoming behavior renders them on a symlog axis; it's placed behind this experimental
toggle while it stabilizes.

**Who is this feature for?**

Users visualizing Prometheus native histograms in the heatmap panel, particularly
any histogram whose data spans zero or includes negative values.

**Which issue(s) does this PR fix?**:

Related to #89263.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
