### PR TITLE
Provisioning: decouple controllers from informer listers via read seams

### DIFF
--- a/pkg/operators/provisioning/connection_operator.go
+++ b/pkg/operators/provisioning/connection_operator.go
@@ -49,8 +49,7 @@ func RunConnectionController(ctx context.Context, deps server.OperatorDependenci
 	}
 
 	connController := controller.NewConnectionController(
-		provisioningClient.ProvisioningV0alpha1(),
-		connInformer.Lister(),
+		controller.NewCachedConnectionGetter(connInformer.Lister()),
 		statusPatcher,
 		controller.NewConnectionHealthChecker(
 			connection.NewSimpleConnectionTester(connectionFactory),

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -88,9 +88,10 @@ func RunRepoController(ctx context.Context, deps server.OperatorDependencies) er
 		return fmt.Errorf("failed to get clients: %w", err)
 	}
 
+	repoGetter := controller.NewCachedRepositoryGetter(repoInformer.Lister())
 	controller := controller.NewRepositoryController(
 		provisioningClient.ProvisioningV0alpha1(),
-		repoInformer.Lister(),
+		repoGetter,
 		repoFactory,
 		connectionFactory,
 		resourceLister,
@@ -105,6 +106,7 @@ func RunRepoController(ctx context.Context, deps server.OperatorDependencies) er
 		controllerCfg.Settings.SectionWithEnvOverrides("provisioning").Key("min_sync_interval").MustDuration(1*time.Minute),
 		controllerCfg.DrainTimeout(),
 		quotaGetter,
+		controller.NewRepositoryQuotaChecker(repoGetter),
 		repository.NewIncrementalSyncPolicy(
 			resources.IsFolderMetadataEnabled(controllerCfg.Settings),
 			controllerCfg.Settings.SectionWithEnvOverrides("provisioning").Key("max_incremental_changes").MustInt(100),

--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -17,8 +17,6 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	appcontroller "github.com/grafana/grafana/apps/provisioning/pkg/controller"
-	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
-	listers "github.com/grafana/grafana/apps/provisioning/pkg/generated/listers/provisioning/v0alpha1"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 )
 
@@ -42,9 +40,8 @@ type ConnectionStatusPatcher interface {
 
 // ConnectionController controls Connection resources.
 type ConnectionController struct {
-	client     client.ProvisioningV0alpha1Interface
-	connLister listers.ConnectionLister
-	logger     logging.Logger
+	conns  ConnectionGetter
+	logger logging.Logger
 
 	statusPatcher     ConnectionStatusPatcher
 	healthChecker     ConnectionHealthCheckerInterface
@@ -61,8 +58,7 @@ type ConnectionController struct {
 
 // NewConnectionController creates a new ConnectionController.
 func NewConnectionController(
-	provisioningClient client.ProvisioningV0alpha1Interface,
-	connLister listers.ConnectionLister,
+	conns ConnectionGetter,
 	statusPatcher ConnectionStatusPatcher,
 	healthChecker *ConnectionHealthChecker,
 	connectionFactory connection.Factory,
@@ -71,8 +67,7 @@ func NewConnectionController(
 	registry prometheus.Registerer,
 ) *ConnectionController {
 	cc := &ConnectionController{
-		client:     provisioningClient,
-		connLister: connLister,
+		conns: conns,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[*connectionQueueItem](),
 			workqueue.TypedRateLimitingQueueConfig[*connectionQueueItem]{
@@ -207,7 +202,9 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 		return err
 	}
 
-	conn, err := cc.connLister.Connections(namespace).Get(name)
+	// Reconcile the object the read seam returns; how it is sourced and kept
+	// fresh is the ConnectionGetter's concern, not the controller's.
+	conn, err := cc.conns.Get(namespace, name)
 	switch {
 	case apierrors.IsNotFound(err):
 		return errors.New("connection not found in cache")

--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -207,7 +207,7 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	conn, err := cc.conns.Get(namespace, name)
 	switch {
 	case apierrors.IsNotFound(err):
-		return errors.New("connection not found in cache")
+		return errors.New("connection not found")
 	case err != nil:
 		logger.Error("getting connection", "error", err)
 		return err

--- a/pkg/registry/apis/provisioning/controller/connection_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_test.go
@@ -1225,7 +1225,7 @@ func TestConnectionController_process(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockLister, mockHealthChecker, mockStatusPatcher, mockFactory := tt.setupMocks()
 			cc := &ConnectionController{
-				connLister:        mockLister,
+				conns:             NewCachedConnectionGetter(mockLister),
 				healthChecker:     mockHealthChecker,
 				statusPatcher:     mockStatusPatcher,
 				connectionFactory: mockFactory,
@@ -1390,7 +1390,7 @@ func TestConnectionController_process_FieldErrors(t *testing.T) {
 
 			// Create controller
 			cc := &ConnectionController{
-				connLister:        mockLister,
+				conns:             NewCachedConnectionGetter(mockLister),
 				connectionFactory: mockFactory,
 				healthChecker:     mockHealthChecker,
 				statusPatcher:     mockPatcher,

--- a/pkg/registry/apis/provisioning/controller/getters.go
+++ b/pkg/registry/apis/provisioning/controller/getters.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	listers "github.com/grafana/grafana/apps/provisioning/pkg/generated/listers/provisioning/v0alpha1"
+)
+
+// RepositoryGetter is the read seam the repository controller reconciles
+// against. It exposes exactly what the controller needs — the single repository
+// under reconciliation, and a namespace-wide list for the quota count — so the
+// source can be swapped without touching the controller.
+//
+// Get must return a current object (the reconcile acts on its spec); List backs
+// the quota count, which tolerates staleness.
+type RepositoryGetter interface {
+	Get(namespace, name string) (*provisioning.Repository, error)
+	List(namespace string) ([]*provisioning.Repository, error)
+}
+
+// ConnectionGetter is the read seam the connection controller reconciles
+// against. It exposes only the single connection under reconciliation, so the
+// source can be swapped without touching the controller.
+type ConnectionGetter interface {
+	Get(namespace, name string) (*provisioning.Connection, error)
+}
+
+// NewCachedRepositoryGetter backs a RepositoryGetter with the informer's
+// generated lister, i.e. the informer's local cache.
+func NewCachedRepositoryGetter(lister listers.RepositoryLister) RepositoryGetter {
+	return cachedRepositoryGetter{lister: lister}
+}
+
+type cachedRepositoryGetter struct {
+	lister listers.RepositoryLister
+}
+
+func (g cachedRepositoryGetter) Get(namespace, name string) (*provisioning.Repository, error) {
+	return g.lister.Repositories(namespace).Get(name)
+}
+
+func (g cachedRepositoryGetter) List(namespace string) ([]*provisioning.Repository, error) {
+	return g.lister.Repositories(namespace).List(labels.Everything())
+}
+
+// NewCachedConnectionGetter backs a ConnectionGetter with the informer's
+// generated lister, i.e. the informer's local cache.
+func NewCachedConnectionGetter(lister listers.ConnectionLister) ConnectionGetter {
+	return cachedConnectionGetter{lister: lister}
+}
+
+type cachedConnectionGetter struct {
+	lister listers.ConnectionLister
+}
+
+func (g cachedConnectionGetter) Get(namespace, name string) (*provisioning.Connection, error) {
+	return g.lister.Connections(namespace).Get(name)
+}

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -581,7 +581,7 @@ func (rc *RepositoryController) process(key string) error {
 	obj, err := rc.repos.Get(namespace, name)
 	switch {
 	case apierrors.IsNotFound(err):
-		return errors.New("repository not found in cache")
+		return errors.New("repository not found")
 	case err != nil:
 		return err
 	}

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	appcontroller "github.com/grafana/grafana/apps/provisioning/pkg/controller"
 	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
-	listers "github.com/grafana/grafana/apps/provisioning/pkg/generated/listers/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -46,9 +45,9 @@ type finalizerProcessor interface {
 
 // RepositoryController controls how and when CRD is established.
 type RepositoryController struct {
-	client     client.ProvisioningV0alpha1Interface
-	repoLister listers.RepositoryLister
-	logger     logging.Logger
+	client client.ProvisioningV0alpha1Interface
+	repos  RepositoryGetter
+	logger logging.Logger
 
 	jobs interface {
 		jobs.Queue
@@ -82,7 +81,7 @@ type RepositoryController struct {
 // NewRepositoryController creates new RepositoryController.
 func NewRepositoryController(
 	provisioningClient client.ProvisioningV0alpha1Interface,
-	repoLister listers.RepositoryLister,
+	repos RepositoryGetter,
 	repoFactory repository.Factory,
 	connectionFactory connection.Factory,
 	resourceLister resources.ResourceLister,
@@ -100,6 +99,7 @@ func NewRepositoryController(
 	minSyncInterval time.Duration,
 	drainTimeout time.Duration,
 	quotaGetter quotas.QuotaGetter,
+	quotaChecker *RepositoryQuotaChecker,
 	incrementalPolicy repository.IncrementalSyncPolicy,
 	folderAPIVersion string,
 	webhookSecretRotationInterval time.Duration,
@@ -108,8 +108,8 @@ func NewRepositoryController(
 	repoTokenMetrics := registerRepositoryTokenMetrics(registry)
 
 	rc := &RepositoryController{
-		client:     provisioningClient,
-		repoLister: repoLister,
+		client: provisioningClient,
+		repos:  repos,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
@@ -119,7 +119,7 @@ func NewRepositoryController(
 		repoFactory:       repoFactory,
 		connectionFactory: connectionFactory,
 		healthChecker:     healthChecker,
-		quotaChecker:      NewRepositoryQuotaChecker(repoLister),
+		quotaChecker:      quotaChecker,
 		statusPatcher:     statusPatcher,
 		finalizer: &finalizer{
 			lister:           resourceLister,
@@ -576,7 +576,9 @@ func (rc *RepositoryController) process(key string) error {
 		return err
 	}
 
-	obj, err := rc.repoLister.Repositories(namespace).Get(name)
+	// Reconcile the object the read seam returns; how it is sourced and kept
+	// fresh is the RepositoryGetter's concern, not the controller's.
+	obj, err := rc.repos.Get(namespace, name)
 	switch {
 	case apierrors.IsNotFound(err):
 		return errors.New("repository not found in cache")

--- a/pkg/registry/apis/provisioning/controller/repository_quota.go
+++ b/pkg/registry/apis/provisioning/controller/repository_quota.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
-	listers "github.com/grafana/grafana/apps/provisioning/pkg/generated/listers/provisioning/v0alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 const (
@@ -18,15 +16,15 @@ const (
 
 // RepositoryQuotaChecker checks if a namespace exceeds its repository quota limits.
 type RepositoryQuotaChecker struct {
-	repoLister listers.RepositoryLister
+	repos RepositoryGetter
 }
 
 // NewRepositoryQuotaChecker creates a new RepositoryQuotaChecker.
 func NewRepositoryQuotaChecker(
-	repoLister listers.RepositoryLister,
+	repos RepositoryGetter,
 ) *RepositoryQuotaChecker {
 	return &RepositoryQuotaChecker{
-		repoLister: repoLister,
+		repos: repos,
 	}
 }
 
@@ -50,8 +48,8 @@ func (c *RepositoryQuotaChecker) RepositoryQuotaConditions(
 		}, nil
 	}
 
-	// List all repositories from informer cache
-	repos, err := c.repoLister.Repositories(namespace).List(labels.Everything())
+	// List all repositories from the read seam. The count tolerates staleness.
+	repos, err := c.repos.List(namespace)
 	if err != nil {
 		return metav1.Condition{}, err
 	}

--- a/pkg/registry/apis/provisioning/controller/repository_quota_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_quota_test.go
@@ -150,7 +150,7 @@ func TestRepositoryQuotaConditions(t *testing.T) {
 			mockNamespaceLister.On("List", mock.Anything).Return(repos, nil)
 			mockRepoLister := &MockRepositoryLister{namespaceLister: mockNamespaceLister}
 
-			checker := NewRepositoryQuotaChecker(mockRepoLister)
+			checker := NewRepositoryQuotaChecker(NewCachedRepositoryGetter(mockRepoLister))
 
 			quotaStatus := provisioning.QuotaStatus{
 				MaxRepositories:           tt.maxRepos,
@@ -264,7 +264,7 @@ func TestRepositoryQuotaConditions_ExcludesDeletingRepos(t *testing.T) {
 			mockNamespaceLister.On("List", mock.Anything).Return(repos, nil)
 			mockRepoLister := &MockRepositoryLister{namespaceLister: mockNamespaceLister}
 
-			checker := NewRepositoryQuotaChecker(mockRepoLister)
+			checker := NewRepositoryQuotaChecker(NewCachedRepositoryGetter(mockRepoLister))
 
 			quotaStatus := provisioning.QuotaStatus{
 				MaxRepositories:           tt.maxRepos,

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -1032,10 +1032,11 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 				MockStore: jobs.NewMockStore(t),
 			}
 
+			repoGetter := NewCachedRepositoryGetter(repoLister)
 			rc := &RepositoryController{
-				repos:         NewCachedRepositoryGetter(repoLister),
+				repos:         repoGetter,
 				quotaGetter:   quotas.NewFixedQuotaGetter(tc.newQuota),
-				quotaChecker:  NewRepositoryQuotaChecker(NewCachedRepositoryGetter(repoLister)),
+				quotaChecker:  NewRepositoryQuotaChecker(repoGetter),
 				healthChecker: healthChecker,
 				statusPatcher: patcher,
 				repoFactory:   repoFactory,
@@ -1129,10 +1130,11 @@ func TestRepositoryController_process_ConditionsNotOverwritten(t *testing.T) {
 
 	patcher := &capturePatcher{}
 
+	repoGetter := NewCachedRepositoryGetter(mockLister)
 	rc := &RepositoryController{
-		repos:         NewCachedRepositoryGetter(mockLister),
+		repos:         repoGetter,
 		quotaGetter:   quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{}),
-		quotaChecker:  NewRepositoryQuotaChecker(NewCachedRepositoryGetter(mockLister)),
+		quotaChecker:  NewRepositoryQuotaChecker(repoGetter),
 		healthChecker: healthChecker,
 		repoFactory:   mockFactory,
 		statusPatcher: patcher,
@@ -1278,10 +1280,11 @@ func TestRepositoryController_process_TokenRefreshedWhileOverQuota(t *testing.T)
 	tester := repository.NewTester()
 	healthChecker := NewRepositoryHealthChecker(patcher, tester, healthMetrics)
 
+	repoGetter := NewCachedRepositoryGetter(repoLister)
 	rc := &RepositoryController{
-		repos:             NewCachedRepositoryGetter(repoLister),
+		repos:             repoGetter,
 		quotaGetter:       quotas.NewFixedQuotaGetter(quotaStatus),
-		quotaChecker:      NewRepositoryQuotaChecker(NewCachedRepositoryGetter(repoLister)),
+		quotaChecker:      NewRepositoryQuotaChecker(repoGetter),
 		statusPatcher:     patcher,
 		connectionFactory: mockConnFactory,
 		client:            provClient,
@@ -1489,10 +1492,11 @@ func TestRepositoryController_process_HookFailureCooldownSuppressesRetry(t *test
 		MockStore: jobs.NewMockStore(t),
 	}
 
+	repoGetter := NewCachedRepositoryGetter(repoLister)
 	rc := &RepositoryController{
-		repos:         NewCachedRepositoryGetter(repoLister),
+		repos:         repoGetter,
 		quotaGetter:   quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{}),
-		quotaChecker:  NewRepositoryQuotaChecker(NewCachedRepositoryGetter(repoLister)),
+		quotaChecker:  NewRepositoryQuotaChecker(repoGetter),
 		healthChecker: healthChecker,
 		statusPatcher: patcher,
 		repoFactory:   repoFactory,
@@ -1547,10 +1551,11 @@ func newRecoveryController(t *testing.T, repo *provisioning.Repository, stub *ho
 		MockStore: jobs.NewMockStore(t),
 	}
 
+	repoGetter := NewCachedRepositoryGetter(repoLister)
 	rc := &RepositoryController{
-		repos:         NewCachedRepositoryGetter(repoLister),
+		repos:         repoGetter,
 		quotaGetter:   quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{}),
-		quotaChecker:  NewRepositoryQuotaChecker(NewCachedRepositoryGetter(repoLister)),
+		quotaChecker:  NewRepositoryQuotaChecker(repoGetter),
 		healthChecker: healthChecker,
 		statusPatcher: patcher,
 		repoFactory:   repoFactory,

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -1033,9 +1033,9 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 			}
 
 			rc := &RepositoryController{
-				repoLister:    repoLister,
+				repos:         NewCachedRepositoryGetter(repoLister),
 				quotaGetter:   quotas.NewFixedQuotaGetter(tc.newQuota),
-				quotaChecker:  NewRepositoryQuotaChecker(repoLister),
+				quotaChecker:  NewRepositoryQuotaChecker(NewCachedRepositoryGetter(repoLister)),
 				healthChecker: healthChecker,
 				statusPatcher: patcher,
 				repoFactory:   repoFactory,
@@ -1130,9 +1130,9 @@ func TestRepositoryController_process_ConditionsNotOverwritten(t *testing.T) {
 	patcher := &capturePatcher{}
 
 	rc := &RepositoryController{
-		repoLister:    mockLister,
+		repos:         NewCachedRepositoryGetter(mockLister),
 		quotaGetter:   quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{}),
-		quotaChecker:  NewRepositoryQuotaChecker(mockLister),
+		quotaChecker:  NewRepositoryQuotaChecker(NewCachedRepositoryGetter(mockLister)),
 		healthChecker: healthChecker,
 		repoFactory:   mockFactory,
 		statusPatcher: patcher,
@@ -1279,9 +1279,9 @@ func TestRepositoryController_process_TokenRefreshedWhileOverQuota(t *testing.T)
 	healthChecker := NewRepositoryHealthChecker(patcher, tester, healthMetrics)
 
 	rc := &RepositoryController{
-		repoLister:        repoLister,
+		repos:             NewCachedRepositoryGetter(repoLister),
 		quotaGetter:       quotas.NewFixedQuotaGetter(quotaStatus),
-		quotaChecker:      NewRepositoryQuotaChecker(repoLister),
+		quotaChecker:      NewRepositoryQuotaChecker(NewCachedRepositoryGetter(repoLister)),
 		statusPatcher:     patcher,
 		connectionFactory: mockConnFactory,
 		client:            provClient,
@@ -1490,9 +1490,9 @@ func TestRepositoryController_process_HookFailureCooldownSuppressesRetry(t *test
 	}
 
 	rc := &RepositoryController{
-		repoLister:    repoLister,
+		repos:         NewCachedRepositoryGetter(repoLister),
 		quotaGetter:   quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{}),
-		quotaChecker:  NewRepositoryQuotaChecker(repoLister),
+		quotaChecker:  NewRepositoryQuotaChecker(NewCachedRepositoryGetter(repoLister)),
 		healthChecker: healthChecker,
 		statusPatcher: patcher,
 		repoFactory:   repoFactory,
@@ -1548,9 +1548,9 @@ func newRecoveryController(t *testing.T, repo *provisioning.Repository, stub *ho
 	}
 
 	rc := &RepositoryController{
-		repoLister:    repoLister,
+		repos:         NewCachedRepositoryGetter(repoLister),
 		quotaGetter:   quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{}),
-		quotaChecker:  NewRepositoryQuotaChecker(repoLister),
+		quotaChecker:  NewRepositoryQuotaChecker(NewCachedRepositoryGetter(repoLister)),
 		healthChecker: healthChecker,
 		statusPatcher: patcher,
 		repoFactory:   repoFactory,

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -1101,9 +1101,10 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				webhookSecretRotationInterval = 30 * 24 * time.Hour
 			}
 
+			cachedRepoGetter := controller.NewCachedRepositoryGetter(repoInformer.Lister())
 			repoController := controller.NewRepositoryController(
 				b.GetClient(),
-				repoInformer.Lister(),
+				cachedRepoGetter,
 				b.repoFactory,
 				b.connectionFactory,
 				b.resourceLister,
@@ -1118,6 +1119,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				b.minSyncInterval,
 				30*time.Second,
 				b.quotaGetter,
+				controller.NewRepositoryQuotaChecker(cachedRepoGetter),
 				b.incrementalPolicy,
 				b.folderAPIVersion,
 				webhookSecretRotationInterval,
@@ -1142,8 +1144,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			connTester := connection.NewSimpleConnectionTester(b.connectionFactory)
 			connHealthChecker := controller.NewConnectionHealthChecker(connTester, healthMetricsRecorder)
 			connController := controller.NewConnectionController(
-				b.GetClient(),
-				connInformer.Lister(),
+				controller.NewCachedConnectionGetter(connInformer.Lister()),
 				connStatusPatcher,
 				connHealthChecker,
 				b.connectionFactory,


### PR DESCRIPTION
## Summary

The repository and connection controllers reconciled by re-reading the object from the concrete generated informer lister. This replaces that coupling with narrow, consumer-defined read interfaces that expose exactly what each controller needs — so the read source can be swapped without touching controller logic. It's the groundwork for a NATS-backed watch, where events round-robin across replicas and a controller must reconcile from a source it doesn't have to own.

**No behavior change:** the default implementations read the informer's local store exactly as before.

## Changes

- New `controller/getters.go` with `RepositoryGetter` (`Get` + namespace `List` for the quota count) and `ConnectionGetter` (`Get`), plus cache-backed implementations `NewCachedRepositoryGetter` / `NewCachedConnectionGetter` over the informer lister.
- Repository/connection controllers and the quota checker reconcile through the getters. Queues stay string-keyed (dedup safeguard intact); reconciliation stays a local-cache read.
- `RepositoryQuotaChecker` is now built at the wiring sites and injected into the controller (like the health checker / status patcher), instead of being constructed inside `NewRepositoryController`.
- Removed the dead provisioning client from the connection controller (stored but never used; status writes go through the status patcher).
- Kept transport concerns out of the controllers — the reconcile comments describe intent only, not how the getter is sourced.

## Testing

- `go build ./pkg/registry/apis/provisioning/... ./pkg/operators/provisioning/...`
- `go vet` + `go test ./pkg/registry/apis/provisioning/controller/` (full package, green)
- gofmt clean

## Follow-up (not in this PR)

The NATS-backed watch supplies alternate `RepositoryGetter`/`ConnectionGetter` implementations at the wiring sites — no controller changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)