### PR TITLE
feat: shadow nats notifier watch events

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -164,6 +164,10 @@ advertise_address =
 discovery_interval = 5s
 discovery_ttl = 30s
 
+# For testing only: run a NATS-backed notifier alongside the storage backend's primary notifier.
+# It records comparison metrics only and never feeds the watch pipeline, so it does not change watch behavior.
+notifier_shadow = false
+
 # Transport security for client connections.
 tls_enabled = false
 tls_ca_cert_path =

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -157,6 +157,7 @@ type ModuleServer struct {
 	mtx              sync.Mutex
 	storageBackend   resource.StorageBackend
 	natsPublisher    nats.Publisher
+	natsSubscriber   nats.Subscriber
 	vectorBackend    vector.VectorBackend
 	embedder         *embedder.Embedder
 	searchClient     resourcepb.ResourceIndexClient
@@ -265,9 +266,27 @@ func (s *ModuleServer) Run() error {
 		// The publisher connects lazily on first publish, so no server is started
 		// here; in external mode the embedded server is inert. Returning it as the
 		// module service drains the connection on shutdown.
-		publisher := nats.ProvidePublisher(nats.ProvideNATSConfig(s.cfg, natsServer), s.registerer)
+		natsCfg := nats.ProvideNATSConfig(s.cfg, natsServer)
+		publisher := nats.ProvidePublisher(natsCfg, s.registerer)
 		s.natsPublisher = publisher
-		return publisher, nil
+
+		// The notifier shadow (testing) also needs a subscriber. Run both under a
+		// manager so both connections drain on shutdown. When the shadow is off,
+		// behavior is unchanged: only the publisher runs, as before.
+		if !s.cfg.NATS.NotifierShadow {
+			return publisher, nil
+		}
+		subscriber := nats.ProvideSubscriber(natsCfg, s.registerer)
+		s.natsSubscriber = subscriber
+		group, err := services.NewManager(publisher, subscriber)
+		if err != nil {
+			return nil, err
+		}
+		return services.NewBasicService(
+			func(ctx context.Context) error { return services.StartManagerAndAwaitHealthy(ctx, group) },
+			func(ctx context.Context) error { <-ctx.Done(); return nil },
+			func(_ error) error { return services.StopManagerAndAwaitStopped(context.Background(), group) },
+		).WithName(modules.NATS), nil
 	})
 
 	m.RegisterInvisibleModule(modules.UnifiedBackend, func() (services.Service, error) {
@@ -282,7 +301,11 @@ func (s *ModuleServer) Run() error {
 			if err != nil {
 				return nil, err
 			}
-			s.storageBackend, err = sql.NewStorageBackend(s.cfg, eDB, s.registerer, s.storageMetrics, disableStorageServices, kvStore, nil, sql.WithEventPublisher(s.natsPublisher))
+			opts := []sql.StorageBackendOption{sql.WithEventPublisher(s.natsPublisher)}
+			if s.cfg.NATS.NotifierShadow && s.natsSubscriber != nil {
+				opts = append(opts, sql.WithNatsNotifierShadow(natsEventSubscriber{s.natsSubscriber}))
+			}
+			s.storageBackend, err = sql.NewStorageBackend(s.cfg, eDB, s.registerer, s.storageMetrics, disableStorageServices, kvStore, nil, opts...)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -251,70 +251,9 @@ func (s *ModuleServer) Run() error {
 		return s.grpcService, nil
 	})
 
-	m.RegisterInvisibleModule(modules.NATS, func() (services.Service, error) {
-		// The embedded server relies on DB-backed peer discovery that is not wired
-		// in module mode (no sqlStore is injected here), so only external NATS is
-		// supported. Fail fast rather than fall through to ProvideServer, which would
-		// reject the nil sqlStore anyway, so operators get a mode-specific message.
-		if s.cfg.NATS.Enabled && s.cfg.NATS.Embedded() {
-			return nil, fmt.Errorf("embedded NATS is not supported in module mode; configure [nats] mode=external")
-		}
-		natsServer, err := nats.ProvideServer(s.cfg, nil, s.registerer)
-		if err != nil {
-			return nil, err
-		}
-		// The publisher connects lazily on first publish, so no server is started
-		// here; in external mode the embedded server is inert. Returning it as the
-		// module service drains the connection on shutdown.
-		natsCfg := nats.ProvideNATSConfig(s.cfg, natsServer)
-		publisher := nats.ProvidePublisher(natsCfg, s.registerer)
-		s.natsPublisher = publisher
+	m.RegisterInvisibleModule(modules.NATS, s.initNATSModule)
 
-		// The notifier shadow (testing) also needs a subscriber. Run both under a
-		// manager so both connections drain on shutdown. When the shadow is off,
-		// behavior is unchanged: only the publisher runs, as before.
-		if !s.cfg.NATS.NotifierShadow {
-			return publisher, nil
-		}
-		subscriber := nats.ProvideSubscriber(natsCfg, s.registerer)
-		s.natsSubscriber = subscriber
-		group, err := services.NewManager(publisher, subscriber)
-		if err != nil {
-			return nil, err
-		}
-		return services.NewBasicService(
-			func(ctx context.Context) error { return services.StartManagerAndAwaitHealthy(ctx, group) },
-			func(ctx context.Context) error { <-ctx.Done(); return nil },
-			func(_ error) error { return services.StopManagerAndAwaitStopped(context.Background(), group) },
-		).WithName(modules.NATS), nil
-	})
-
-	m.RegisterInvisibleModule(modules.UnifiedBackend, func() (services.Service, error) {
-		if s.storageBackend == nil {
-			// If storage server not being used, disable GC, pruner, and RV manager
-			disableStorageServices := !m.IsModuleEnabled(modules.StorageServer)
-			eDB, err := sql.ProvideResourceDB(s.cfg, nil)
-			if err != nil {
-				return nil, err
-			}
-			kvStore, err := sql.ProvideKV(s.cfg, eDB)
-			if err != nil {
-				return nil, err
-			}
-			opts := []sql.StorageBackendOption{sql.WithEventPublisher(s.natsPublisher)}
-			if s.cfg.NATS.NotifierShadow && s.natsSubscriber != nil {
-				opts = append(opts, sql.WithNatsNotifierShadow(natsEventSubscriber{s.natsSubscriber}))
-			}
-			s.storageBackend, err = sql.NewStorageBackend(s.cfg, eDB, s.registerer, s.storageMetrics, disableStorageServices, kvStore, nil, opts...)
-			if err != nil {
-				return nil, err
-			}
-		}
-		if backendService, ok := s.storageBackend.(services.Service); ok {
-			return backendService, nil
-		}
-		return services.NewIdleService(nil, nil).WithName(modules.UnifiedBackend), nil
-	})
+	m.RegisterInvisibleModule(modules.UnifiedBackend, s.initUnifiedBackendModule(m.IsModuleEnabled(modules.StorageServer)))
 
 	m.RegisterInvisibleModule(modules.UnifiedVectorBackend, s.initUnifiedVectorBackend(m.IsModuleEnabled(modules.StorageServer)))
 
@@ -348,86 +287,9 @@ func (s *ModuleServer) Run() error {
 	//	s.log.Debug("apiserver feature is disabled")
 	//}
 
-	m.RegisterModule(modules.StorageServer, func() (services.Service, error) {
-		// Only set docBuilders and indexMetrics if enable_search is true
-		var docBuilders resource.DocumentBuilderSupplier
-		var dashboardStats builders.DashboardStats
-		var indexMetrics *resource.BleveIndexMetrics
-		if s.cfg.EnableSearch {
-			s.log.Warn("Support for 'enable_search' config with 'storage-server' target is deprecated and will be removed in a future release. Please use the 'search-server' target instead.")
-			// The document builders and the vector backfiller share one
-			// stats instance; building them from one graph also avoids
-			// registering the sprinkles metrics twice.
-			support, err := InitializeSearchSupport(s.cfg, s.features, s.tracer, s.registerer)
-			if err != nil {
-				return nil, err
-			}
-			docBuilders = support.DocBuilders
-			dashboardStats = support.DashboardStats
-			indexMetrics = s.indexMetrics
-		} else if s.cfg.VectorIndexingEnabled {
-			// The vector backfiller views filter needs dashboard stats.
-			var err error
-			dashboardStats, err = InitializeDashboardStats(s.cfg, s.features, s.tracer, s.registerer)
-			if err != nil {
-				return nil, err
-			}
-		}
-		serviceOptions := s.StorageServiceOptions
-		if dashboardStats != nil {
-			serviceOptions = append(serviceOptions, sql.WithDashboardStats(dashboardStats))
-		}
-		svc, err := sql.ProvideUnifiedStorageGrpcService(s.cfg, s.features, s.log, s.registerer, docBuilders, s.storageMetrics, indexMetrics, s.vectorMetrics, s.searchServerRing, s.MemberlistKVConfig, s.httpServerRouter, s.storageBackend, s.vectorBackend, s.embedder, s.searchClient, s.grpcService, serviceOptions...)
-		if err != nil {
-			return nil, err
-		}
-		probe, ok := svc.(grpcserver.HealthProbe)
-		s.grpcService.Health.Register(grpcserver.HealthProbeFunc(func(ctx context.Context) (bool, error) {
-			if svc.State() != services.Running {
-				return false, nil
-			}
-			if ok {
-				return probe.CheckHealth(ctx)
-			}
-			return true, nil
-		}),
-			resourcepb.ResourceStore_ServiceDesc.ServiceName,
-			resourcepb.ResourceIndex_ServiceDesc.ServiceName,
-			resourcepb.ManagedObjectIndex_ServiceDesc.ServiceName,
-			resourcepb.BlobStore_ServiceDesc.ServiceName,
-			resourcepb.BulkStore_ServiceDesc.ServiceName,
-			resourcepb.Diagnostics_ServiceDesc.ServiceName,
-			resourcepb.Quotas_ServiceDesc.ServiceName,
-		)
+	m.RegisterModule(modules.StorageServer, s.initStorageServerModule)
 
-		return svc, nil
-	})
-
-	m.RegisterModule(modules.SearchServer, func() (services.Service, error) {
-		support, err := InitializeSearchSupport(s.cfg, s.features, s.tracer, s.registerer)
-		if err != nil {
-			return nil, err
-		}
-		svc, err := sql.ProvideSearchGRPCService(s.cfg, s.features, s.log, s.registerer, support.DocBuilders, s.indexMetrics, s.vectorMetrics, s.searchServerRing, s.MemberlistKVConfig, s.httpServerRouter, s.storageBackend, s.vectorBackend, s.embedder, s.grpcService, s.StorageServiceOptions...)
-		if err != nil {
-			return nil, err
-		}
-		probe, ok := svc.(grpcserver.HealthProbe)
-		s.grpcService.Health.Register(grpcserver.HealthProbeFunc(func(ctx context.Context) (bool, error) {
-			if svc.State() != services.Running {
-				return false, nil
-			}
-			if ok {
-				return probe.CheckHealth(ctx)
-			}
-			return true, nil
-		}),
-			resourcepb.ResourceIndex_ServiceDesc.ServiceName,
-			resourcepb.ManagedObjectIndex_ServiceDesc.ServiceName,
-			resourcepb.Diagnostics_ServiceDesc.ServiceName,
-		)
-		return svc, nil
-	})
+	m.RegisterModule(modules.SearchServer, s.initSearchServerModule)
 
 	m.RegisterModule(modules.ZanzanaServer, func() (services.Service, error) {
 		return authz.ProvideZanzanaService(s.cfg, s.features, s.registerer, s.storeProvider, s.reconcileCRDs)
@@ -445,6 +307,152 @@ func (s *ModuleServer) Run() error {
 	s.moduleRegisterer.RegisterModules(m)
 
 	return m.Run(s.context)
+}
+
+func (s *ModuleServer) initNATSModule() (services.Service, error) {
+	// The embedded server relies on DB-backed peer discovery that is not wired
+	// in module mode (no sqlStore is injected here), so only external NATS is
+	// supported. Fail fast rather than fall through to ProvideServer, which would
+	// reject the nil sqlStore anyway, so operators get a mode-specific message.
+	if s.cfg.NATS.Enabled && s.cfg.NATS.Embedded() {
+		return nil, fmt.Errorf("embedded NATS is not supported in module mode; configure [nats] mode=external")
+	}
+	natsServer, err := nats.ProvideServer(s.cfg, nil, s.registerer)
+	if err != nil {
+		return nil, err
+	}
+	// The publisher connects lazily on first publish, so no server is started
+	// here; in external mode the embedded server is inert. Returning it as the
+	// module service drains the connection on shutdown.
+	natsCfg := nats.ProvideNATSConfig(s.cfg, natsServer)
+	publisher := nats.ProvidePublisher(natsCfg, s.registerer)
+	s.natsPublisher = publisher
+
+	// Off by default: only the publisher runs. The shadow (testing) also needs a
+	// subscriber, so run both under a manager to drain both on shutdown.
+	if !s.cfg.NATS.NotifierShadow {
+		return publisher, nil
+	}
+	subscriber := nats.ProvideSubscriber(natsCfg, s.registerer)
+	s.natsSubscriber = subscriber
+	group, err := services.NewManager(publisher, subscriber)
+	if err != nil {
+		return nil, err
+	}
+	return services.NewBasicService(
+		func(ctx context.Context) error { return services.StartManagerAndAwaitHealthy(ctx, group) },
+		func(ctx context.Context) error { <-ctx.Done(); return nil },
+		func(_ error) error { return services.StopManagerAndAwaitStopped(context.Background(), group) },
+	).WithName(modules.NATS), nil
+}
+
+func (s *ModuleServer) initUnifiedBackendModule(storageServerEnabled bool) func() (services.Service, error) {
+	return func() (services.Service, error) {
+		if s.storageBackend == nil {
+			// If storage server not being used, disable GC, pruner, and RV manager
+			disableStorageServices := !storageServerEnabled
+			eDB, err := sql.ProvideResourceDB(s.cfg, nil)
+			if err != nil {
+				return nil, err
+			}
+			kvStore, err := sql.ProvideKV(s.cfg, eDB)
+			if err != nil {
+				return nil, err
+			}
+			opts := []sql.StorageBackendOption{sql.WithEventPublisher(s.natsPublisher)}
+			if s.cfg.NATS.NotifierShadow && s.natsSubscriber != nil {
+				opts = append(opts, sql.WithNatsNotifierShadow(natsEventSubscriber{s.natsSubscriber}))
+			}
+			s.storageBackend, err = sql.NewStorageBackend(s.cfg, eDB, s.registerer, s.storageMetrics, disableStorageServices, kvStore, nil, opts...)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if backendService, ok := s.storageBackend.(services.Service); ok {
+			return backendService, nil
+		}
+		return services.NewIdleService(nil, nil).WithName(modules.UnifiedBackend), nil
+	}
+}
+
+func (s *ModuleServer) initStorageServerModule() (services.Service, error) {
+	// Only set docBuilders and indexMetrics if enable_search is true
+	var docBuilders resource.DocumentBuilderSupplier
+	var dashboardStats builders.DashboardStats
+	var indexMetrics *resource.BleveIndexMetrics
+	if s.cfg.EnableSearch {
+		s.log.Warn("Support for 'enable_search' config with 'storage-server' target is deprecated and will be removed in a future release. Please use the 'search-server' target instead.")
+		// The document builders and the vector backfiller share one
+		// stats instance; building them from one graph also avoids
+		// registering the sprinkles metrics twice.
+		support, err := InitializeSearchSupport(s.cfg, s.features, s.tracer, s.registerer)
+		if err != nil {
+			return nil, err
+		}
+		docBuilders = support.DocBuilders
+		dashboardStats = support.DashboardStats
+		indexMetrics = s.indexMetrics
+	} else if s.cfg.VectorIndexingEnabled {
+		// The vector backfiller views filter needs dashboard stats.
+		var err error
+		dashboardStats, err = InitializeDashboardStats(s.cfg, s.features, s.tracer, s.registerer)
+		if err != nil {
+			return nil, err
+		}
+	}
+	serviceOptions := s.StorageServiceOptions
+	if dashboardStats != nil {
+		serviceOptions = append(serviceOptions, sql.WithDashboardStats(dashboardStats))
+	}
+	svc, err := sql.ProvideUnifiedStorageGrpcService(s.cfg, s.features, s.log, s.registerer, docBuilders, s.storageMetrics, indexMetrics, s.vectorMetrics, s.searchServerRing, s.MemberlistKVConfig, s.httpServerRouter, s.storageBackend, s.vectorBackend, s.embedder, s.searchClient, s.grpcService, serviceOptions...)
+	if err != nil {
+		return nil, err
+	}
+	probe, ok := svc.(grpcserver.HealthProbe)
+	s.grpcService.Health.Register(grpcserver.HealthProbeFunc(func(ctx context.Context) (bool, error) {
+		if svc.State() != services.Running {
+			return false, nil
+		}
+		if ok {
+			return probe.CheckHealth(ctx)
+		}
+		return true, nil
+	}),
+		resourcepb.ResourceStore_ServiceDesc.ServiceName,
+		resourcepb.ResourceIndex_ServiceDesc.ServiceName,
+		resourcepb.ManagedObjectIndex_ServiceDesc.ServiceName,
+		resourcepb.BlobStore_ServiceDesc.ServiceName,
+		resourcepb.BulkStore_ServiceDesc.ServiceName,
+		resourcepb.Diagnostics_ServiceDesc.ServiceName,
+		resourcepb.Quotas_ServiceDesc.ServiceName,
+	)
+	return svc, nil
+}
+
+func (s *ModuleServer) initSearchServerModule() (services.Service, error) {
+	support, err := InitializeSearchSupport(s.cfg, s.features, s.tracer, s.registerer)
+	if err != nil {
+		return nil, err
+	}
+	svc, err := sql.ProvideSearchGRPCService(s.cfg, s.features, s.log, s.registerer, support.DocBuilders, s.indexMetrics, s.vectorMetrics, s.searchServerRing, s.MemberlistKVConfig, s.httpServerRouter, s.storageBackend, s.vectorBackend, s.embedder, s.grpcService, s.StorageServiceOptions...)
+	if err != nil {
+		return nil, err
+	}
+	probe, ok := svc.(grpcserver.HealthProbe)
+	s.grpcService.Health.Register(grpcserver.HealthProbeFunc(func(ctx context.Context) (bool, error) {
+		if svc.State() != services.Running {
+			return false, nil
+		}
+		if ok {
+			return probe.CheckHealth(ctx)
+		}
+		return true, nil
+	}),
+		resourcepb.ResourceIndex_ServiceDesc.ServiceName,
+		resourcepb.ManagedObjectIndex_ServiceDesc.ServiceName,
+		resourcepb.Diagnostics_ServiceDesc.ServiceName,
+	)
+	return svc, nil
 }
 
 // initUnifiedVectorBackend constructs the shared vector backend + embedder

--- a/pkg/server/nats_subscriber_adapter.go
+++ b/pkg/server/nats_subscriber_adapter.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/nats"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+// natsEventSubscriber adapts an infra/nats.Subscriber to the storage backend's
+// resource.EventSubscriber. An adapter is needed (unlike the publisher, which
+// matches structurally) because nats.Subscriber.Subscribe takes a
+// nats.MessageHandler and variadic options that the resource-package interface
+// deliberately does not expose.
+type natsEventSubscriber struct {
+	sub nats.Subscriber
+}
+
+func (a natsEventSubscriber) Enabled() bool { return a.sub.Enabled() }
+
+func (a natsEventSubscriber) Subscribe(ctx context.Context, subject string, handler func(subject string, data []byte)) (resource.Subscription, error) {
+	// No queue group: the shadow notifier wants every message on this instance,
+	// not load-balanced delivery across a group.
+	return a.sub.Subscribe(ctx, subject, nats.MessageHandler(handler))
+}

--- a/pkg/server/nats_subscriber_adapter.go
+++ b/pkg/server/nats_subscriber_adapter.go
@@ -7,11 +7,10 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
-// natsEventSubscriber adapts an infra/nats.Subscriber to the storage backend's
-// resource.EventSubscriber. An adapter is needed (unlike the publisher, which
-// matches structurally) because nats.Subscriber.Subscribe takes a
-// nats.MessageHandler and variadic options that the resource-package interface
-// deliberately does not expose.
+// natsEventSubscriber adapts infra/nats.Subscriber to resource.EventSubscriber.
+// An adapter is needed (the publisher matches structurally) because
+// nats.Subscriber.Subscribe takes a nats.MessageHandler and variadic options
+// the resource interface deliberately does not expose.
 type natsEventSubscriber struct {
 	sub nats.Subscriber
 }

--- a/pkg/setting/setting_nats.go
+++ b/pkg/setting/setting_nats.go
@@ -39,6 +39,11 @@ type NATSSettings struct {
 	DiscoveryInterval time.Duration
 	DiscoveryTTL      time.Duration
 
+	// NotifierShadow runs a NATS-backed notifier alongside the storage backend's
+	// primary notifier for testing. It records comparison metrics only and never
+	// feeds the watch pipeline, so it does not change watch behavior.
+	NotifierShadow bool
+
 	TLS  NATSTLSSettings
 	Auth NATSAuthSettings
 }
@@ -84,6 +89,7 @@ func readNATSSettings(cfg *Cfg) error {
 
 		DiscoveryInterval: section.Key("discovery_interval").MustDuration(5 * time.Second),
 		DiscoveryTTL:      section.Key("discovery_ttl").MustDuration(30 * time.Second),
+		NotifierShadow:    section.Key("notifier_shadow").MustBool(false),
 		TLS: NATSTLSSettings{
 			Enabled:            section.Key("tls_enabled").MustBool(false),
 			CACertPath:         section.Key("tls_ca_cert_path").MustString(""),

--- a/pkg/setting/setting_nats.go
+++ b/pkg/setting/setting_nats.go
@@ -39,9 +39,8 @@ type NATSSettings struct {
 	DiscoveryInterval time.Duration
 	DiscoveryTTL      time.Duration
 
-	// NotifierShadow runs a NATS-backed notifier alongside the storage backend's
-	// primary notifier for testing. It records comparison metrics only and never
-	// feeds the watch pipeline, so it does not change watch behavior.
+	// NotifierShadow runs a NATS-backed notifier beside the primary notifier for
+	// testing: comparison metrics only, never feeds the watch pipeline.
 	NotifierShadow bool
 
 	TLS  NATSTLSSettings

--- a/pkg/storage/unified/resource/notifier_nats.go
+++ b/pkg/storage/unified/resource/notifier_nats.go
@@ -1,0 +1,143 @@
+package resource
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcewatch"
+)
+
+// Subscription is a handle to an active external-bus subscription; Unsubscribe
+// stops delivery. Its method set matches infra/nats.Subscription.
+type Subscription interface {
+	Unsubscribe() error
+}
+
+// EventSubscriber consumes resource change notifications from an external
+// message bus (NATS). It is the read-side counterpart of EventPublisher: the
+// publisher announces committed writes, the subscriber receives them on another
+// process. The handler is invoked once per delivered message with the raw
+// (subject, data) so callers never touch nats.go types.
+type EventSubscriber interface {
+	Enabled() bool
+	Subscribe(ctx context.Context, subject string, handler func(subject string, data []byte)) (Subscription, error)
+}
+
+// watchNotificationTypeToAction reverses actionToWatchNotificationType: it maps
+// a wire event type back onto the stored data action so a received notification
+// can be turned into an Event. UNKNOWN has no corresponding action and reports
+// ok=false so the caller drops it rather than emit a bogus change.
+func watchNotificationTypeToAction(t resourcepb.WatchNotification_Type) (kv.DataAction, bool) {
+	switch t {
+	case resourcepb.WatchNotification_ADDED:
+		return DataActionCreated, true
+	case resourcepb.WatchNotification_MODIFIED:
+		return DataActionUpdated, true
+	case resourcepb.WatchNotification_DELETED:
+		return DataActionDeleted, true
+	default:
+		return "", false
+	}
+}
+
+// natsNotifier is a notifier backed by the external NATS bus. Its Watch
+// subscribes to every resource's change subject and emits an Event per received
+// WatchNotification; unlike the polling notifier it learns about writes the
+// instant they are announced rather than by querying the event store.
+//
+// Two properties follow from the wire format and must be understood before
+// relying on it as anything more than a low-latency hint:
+//   - Events carry PreviousRV == 0, because WatchNotification has no previous
+//     resource version. Consumers that depend on PreviousRV (batch-event
+//     skipping, previous-object lookups) therefore behave differently than with
+//     the store-sourced notifiers.
+//   - Delivery is at-most-once (core NATS, no JetStream): a missed message is
+//     never redelivered, so this cannot be the sole source of truth. The
+//     polling notifier remains the correctness backstop.
+type natsNotifier struct {
+	subscriber EventSubscriber
+	log        log.Logger
+}
+
+func newNatsNotifier(subscriber EventSubscriber, logger log.Logger) *natsNotifier {
+	return &natsNotifier{subscriber: subscriber, log: logger}
+}
+
+func (n *natsNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan Event {
+	opts = opts.normalize()
+	n.log.Info("creating new nats notifier", "buffer_size", opts.BufferSize)
+
+	// raw is written by the NATS delivery goroutine; out is owned and closed by
+	// the pump goroutine. Splitting them means the delivery callback never sends
+	// on a closed channel: raw is never closed, so a late callback after ctx
+	// cancellation is harmless.
+	raw := make(chan Event, opts.BufferSize)
+	out := make(chan Event, opts.BufferSize)
+
+	handler := func(subject string, data []byte) {
+		var notification resourcepb.WatchNotification
+		if err := proto.Unmarshal(data, &notification); err != nil {
+			n.log.Warn("failed to unmarshal watch notification", "subject", subject, "error", err)
+			return
+		}
+		action, ok := watchNotificationTypeToAction(notification.Type)
+		if !ok {
+			n.log.Warn("dropped watch notification with unknown type", "subject", subject)
+			return
+		}
+		evt := Event{
+			Namespace:       notification.Namespace,
+			Group:           notification.Group,
+			Resource:        notification.Resource,
+			Name:            notification.Name,
+			ResourceVersion: notification.ResourceVersion,
+			Action:          action,
+			Folder:          notification.Folder,
+			// PreviousRV is unknown: WatchNotification does not carry it.
+		}
+		select {
+		case raw <- evt:
+		default:
+			n.log.Warn("dropped watch notification, channel full", "subject", subject)
+		}
+	}
+
+	sub, err := n.subscriber.Subscribe(ctx, resourcewatch.SubjectAll, handler)
+	if err != nil {
+		n.log.Error("failed to subscribe to nats", "error", err)
+		close(out)
+		return out
+	}
+
+	context.AfterFunc(ctx, func() {
+		if err := sub.Unsubscribe(); err != nil {
+			n.log.Warn("failed to unsubscribe from nats", "error", err)
+		}
+	})
+
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case evt := <-raw:
+				select {
+				case out <- evt:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	return out
+}
+
+// Publish is a no-op: like the polling notifier, natsNotifier learns about
+// writes from the bus, not from in-process callers.
+func (n *natsNotifier) Publish(_ Event) {}

--- a/pkg/storage/unified/resource/notifier_nats.go
+++ b/pkg/storage/unified/resource/notifier_nats.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -11,26 +12,21 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcewatch"
 )
 
-// Subscription is a handle to an active external-bus subscription; Unsubscribe
-// stops delivery. Its method set matches infra/nats.Subscription.
+// Subscription handle; Unsubscribe stops delivery. Matches infra/nats.Subscription.
 type Subscription interface {
 	Unsubscribe() error
 }
 
-// EventSubscriber consumes resource change notifications from an external
-// message bus (NATS). It is the read-side counterpart of EventPublisher: the
-// publisher announces committed writes, the subscriber receives them on another
-// process. The handler is invoked once per delivered message with the raw
-// (subject, data) so callers never touch nats.go types.
+// EventSubscriber is the read-side counterpart of EventPublisher: it delivers
+// change notifications from the external bus (NATS) to handler as raw
+// (subject, data), keeping nats.go types out of this package.
 type EventSubscriber interface {
 	Enabled() bool
 	Subscribe(ctx context.Context, subject string, handler func(subject string, data []byte)) (Subscription, error)
 }
 
-// watchNotificationTypeToAction reverses actionToWatchNotificationType: it maps
-// a wire event type back onto the stored data action so a received notification
-// can be turned into an Event. UNKNOWN has no corresponding action and reports
-// ok=false so the caller drops it rather than emit a bogus change.
+// watchNotificationTypeToAction maps a wire event type back to a data action.
+// UNKNOWN reports ok=false so the caller drops it rather than emit a bogus change.
 func watchNotificationTypeToAction(t resourcepb.WatchNotification_Type) (kv.DataAction, bool) {
 	switch t {
 	case resourcepb.WatchNotification_ADDED:
@@ -44,48 +40,53 @@ func watchNotificationTypeToAction(t resourcepb.WatchNotification_Type) (kv.Data
 	}
 }
 
-// natsNotifier is a notifier backed by the external NATS bus. Its Watch
-// subscribes to every resource's change subject and emits an Event per received
-// WatchNotification; unlike the polling notifier it learns about writes the
-// instant they are announced rather than by querying the event store.
+// natsNotifier emits an Event per WatchNotification received from NATS, learning
+// of writes the instant they are announced rather than by polling the store.
+// Watch subscribes to the entire stream (SubjectAll) and ignores the resource
+// selectors in WatchOptions, so it is not a drop-in per-watch notifier.
 //
-// Two properties follow from the wire format and must be understood before
-// relying on it as anything more than a low-latency hint:
-//   - Events carry PreviousRV == 0, because WatchNotification has no previous
-//     resource version. Consumers that depend on PreviousRV (batch-event
-//     skipping, previous-object lookups) therefore behave differently than with
-//     the store-sourced notifiers.
-//   - Delivery is at-most-once (core NATS, no JetStream): a missed message is
-//     never redelivered, so this cannot be the sole source of truth. The
-//     polling notifier remains the correctness backstop.
+// Two wire-format properties make it a low-latency hint, not a source of truth:
+//   - Events carry PreviousRV == 0 (WatchNotification has no previous RV), so
+//     consumers relying on PreviousRV behave differently than with store-sourced
+//     notifiers.
+//   - Delivery is at-most-once (core NATS, no JetStream); a missed message is
+//     never redelivered. The polling notifier remains the correctness backstop.
 type natsNotifier struct {
 	subscriber EventSubscriber
+	dropped    *prometheus.CounterVec // by reason; nil is allowed (no accounting)
 	log        log.Logger
 }
 
-func newNatsNotifier(subscriber EventSubscriber, logger log.Logger) *natsNotifier {
-	return &natsNotifier{subscriber: subscriber, log: logger}
+func newNatsNotifier(subscriber EventSubscriber, dropped *prometheus.CounterVec, logger log.Logger) *natsNotifier {
+	return &natsNotifier{subscriber: subscriber, dropped: dropped, log: logger}
+}
+
+func (n *natsNotifier) drop(reason string) {
+	if n.dropped != nil {
+		n.dropped.WithLabelValues(reason).Inc()
+	}
 }
 
 func (n *natsNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan Event {
 	opts = opts.normalize()
 	n.log.Info("creating new nats notifier", "buffer_size", opts.BufferSize)
 
-	// raw is written by the NATS delivery goroutine; out is owned and closed by
-	// the pump goroutine. Splitting them means the delivery callback never sends
-	// on a closed channel: raw is never closed, so a late callback after ctx
-	// cancellation is harmless.
+	// The NATS callback writes raw; the pump owns and closes out. raw is never
+	// closed, so a callback firing after ctx cancellation can't send on a closed
+	// channel.
 	raw := make(chan Event, opts.BufferSize)
 	out := make(chan Event, opts.BufferSize)
 
 	handler := func(subject string, data []byte) {
 		var notification resourcepb.WatchNotification
 		if err := proto.Unmarshal(data, &notification); err != nil {
+			n.drop("unmarshal_error")
 			n.log.Warn("failed to unmarshal watch notification", "subject", subject, "error", err)
 			return
 		}
 		action, ok := watchNotificationTypeToAction(notification.Type)
 		if !ok {
+			n.drop("unknown_type")
 			n.log.Warn("dropped watch notification with unknown type", "subject", subject)
 			return
 		}
@@ -102,6 +103,7 @@ func (n *natsNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan Even
 		select {
 		case raw <- evt:
 		default:
+			n.drop("buffer_full")
 			n.log.Warn("dropped watch notification, channel full", "subject", subject)
 		}
 	}
@@ -138,6 +140,5 @@ func (n *natsNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan Even
 	return out
 }
 
-// Publish is a no-op: like the polling notifier, natsNotifier learns about
-// writes from the bus, not from in-process callers.
+// Publish is a no-op: natsNotifier learns of writes from the bus, not callers.
 func (n *natsNotifier) Publish(_ Event) {}

--- a/pkg/storage/unified/resource/notifier_nats_test.go
+++ b/pkg/storage/unified/resource/notifier_nats_test.go
@@ -1,0 +1,193 @@
+package resource
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcewatch"
+)
+
+type fakeSubscription struct{ unsubscribed bool }
+
+func (f *fakeSubscription) Unsubscribe() error {
+	f.unsubscribed = true
+	return nil
+}
+
+type fakeEventSubscriber struct {
+	enabled bool
+	subErr  error
+
+	subject string
+	handler func(subject string, data []byte)
+	sub     *fakeSubscription
+}
+
+func (f *fakeEventSubscriber) Enabled() bool { return f.enabled }
+
+func (f *fakeEventSubscriber) Subscribe(_ context.Context, subject string, handler func(subject string, data []byte)) (Subscription, error) {
+	if f.subErr != nil {
+		return nil, f.subErr
+	}
+	f.subject = subject
+	f.handler = handler
+	f.sub = &fakeSubscription{}
+	return f.sub, nil
+}
+
+func mustMarshalNotification(t *testing.T, n *resourcepb.WatchNotification) []byte {
+	t.Helper()
+	data, err := proto.Marshal(n)
+	require.NoError(t, err)
+	return data
+}
+
+// recvEvent reads one Event from the channel, failing if none arrives promptly.
+func recvEvent(t *testing.T, ch <-chan Event) Event {
+	t.Helper()
+	select {
+	case evt, ok := <-ch:
+		require.True(t, ok, "channel closed, expected an event")
+		return evt
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
+		return Event{}
+	}
+}
+
+// expectNoEvent asserts nothing is delivered within a short window.
+func expectNoEvent(t *testing.T, ch <-chan Event) {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		t.Fatalf("expected no event, got %+v", evt)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestNatsNotifierWatch_ConvertsNotifications(t *testing.T) {
+	cases := []struct {
+		name   string
+		typ    resourcepb.WatchNotification_Type
+		action kv.DataAction
+	}{
+		{"added", resourcepb.WatchNotification_ADDED, DataActionCreated},
+		{"modified", resourcepb.WatchNotification_MODIFIED, DataActionUpdated},
+		{"deleted", resourcepb.WatchNotification_DELETED, DataActionDeleted},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sub := &fakeEventSubscriber{enabled: true}
+			n := newNatsNotifier(sub, log.NewNopLogger())
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			out := n.Watch(ctx, WatchOptions{})
+			require.NotNil(t, sub.handler)
+			assert.Equal(t, resourcewatch.SubjectAll, sub.subject)
+
+			sub.handler("some.subject", mustMarshalNotification(t, &resourcepb.WatchNotification{
+				Type:            tc.typ,
+				Group:           "playlist.grafana.app",
+				Resource:        "playlists",
+				Namespace:       "default",
+				Name:            "abc",
+				ResourceVersion: 42,
+				Folder:          "folder1",
+			}))
+
+			evt := recvEvent(t, out)
+			assert.Equal(t, "playlist.grafana.app", evt.Group)
+			assert.Equal(t, "playlists", evt.Resource)
+			assert.Equal(t, "default", evt.Namespace)
+			assert.Equal(t, "abc", evt.Name)
+			assert.Equal(t, int64(42), evt.ResourceVersion)
+			assert.Equal(t, "folder1", evt.Folder)
+			assert.Equal(t, tc.action, evt.Action)
+			// WatchNotification carries no previous RV.
+			assert.Equal(t, int64(0), evt.PreviousRV)
+		})
+	}
+}
+
+func TestNatsNotifierWatch_DropsUnknownType(t *testing.T) {
+	sub := &fakeEventSubscriber{enabled: true}
+	n := newNatsNotifier(sub, log.NewNopLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := n.Watch(ctx, WatchOptions{})
+
+	sub.handler("some.subject", mustMarshalNotification(t, &resourcepb.WatchNotification{
+		Type:            resourcepb.WatchNotification_UNKNOWN,
+		Group:           "g",
+		Resource:        "r",
+		ResourceVersion: 1,
+	}))
+
+	expectNoEvent(t, out)
+}
+
+func TestNatsNotifierWatch_DropsUnmarshalableData(t *testing.T) {
+	sub := &fakeEventSubscriber{enabled: true}
+	n := newNatsNotifier(sub, log.NewNopLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := n.Watch(ctx, WatchOptions{})
+
+	sub.handler("some.subject", []byte("not a valid protobuf"))
+
+	expectNoEvent(t, out)
+}
+
+func TestNatsNotifierWatch_ClosesAndUnsubscribesOnContextCancel(t *testing.T) {
+	sub := &fakeEventSubscriber{enabled: true}
+	n := newNatsNotifier(sub, log.NewNopLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	out := n.Watch(ctx, WatchOptions{})
+	cancel()
+
+	select {
+	case _, ok := <-out:
+		assert.False(t, ok, "channel should be closed after context cancel")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for channel to close")
+	}
+
+	// AfterFunc runs asynchronously; give it a moment.
+	require.Eventually(t, func() bool {
+		return sub.sub != nil && sub.sub.unsubscribed
+	}, 2*time.Second, 10*time.Millisecond, "expected Unsubscribe to be called")
+}
+
+func TestNatsNotifierWatch_SubscribeErrorClosesChannel(t *testing.T) {
+	sub := &fakeEventSubscriber{enabled: true, subErr: errors.New("boom")}
+	n := newNatsNotifier(sub, log.NewNopLogger())
+
+	out := n.Watch(context.Background(), WatchOptions{})
+
+	select {
+	case _, ok := <-out:
+		assert.False(t, ok, "channel should be closed when subscribe fails")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for channel to close")
+	}
+}
+
+func TestNatsNotifierPublishIsNoOp(t *testing.T) {
+	n := newNatsNotifier(&fakeEventSubscriber{enabled: true}, log.NewNopLogger())
+	assert.NotPanics(t, func() {
+		n.Publish(Event{Group: "g", Resource: "r", ResourceVersion: 1})
+	})
+}

--- a/pkg/storage/unified/resource/notifier_nats_test.go
+++ b/pkg/storage/unified/resource/notifier_nats_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -87,7 +89,7 @@ func TestNatsNotifierWatch_ConvertsNotifications(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			sub := &fakeEventSubscriber{enabled: true}
-			n := newNatsNotifier(sub, log.NewNopLogger())
+			n := newNatsNotifier(sub, nil, log.NewNopLogger())
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -121,7 +123,8 @@ func TestNatsNotifierWatch_ConvertsNotifications(t *testing.T) {
 
 func TestNatsNotifierWatch_DropsUnknownType(t *testing.T) {
 	sub := &fakeEventSubscriber{enabled: true}
-	n := newNatsNotifier(sub, log.NewNopLogger())
+	dropped := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "dropped_total"}, []string{"reason"})
+	n := newNatsNotifier(sub, dropped, log.NewNopLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -135,11 +138,13 @@ func TestNatsNotifierWatch_DropsUnknownType(t *testing.T) {
 	}))
 
 	expectNoEvent(t, out)
+	assert.Equal(t, float64(1), testutil.ToFloat64(dropped.WithLabelValues("unknown_type")))
 }
 
 func TestNatsNotifierWatch_DropsUnmarshalableData(t *testing.T) {
 	sub := &fakeEventSubscriber{enabled: true}
-	n := newNatsNotifier(sub, log.NewNopLogger())
+	dropped := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "dropped_total"}, []string{"reason"})
+	n := newNatsNotifier(sub, dropped, log.NewNopLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -148,11 +153,12 @@ func TestNatsNotifierWatch_DropsUnmarshalableData(t *testing.T) {
 	sub.handler("some.subject", []byte("not a valid protobuf"))
 
 	expectNoEvent(t, out)
+	assert.Equal(t, float64(1), testutil.ToFloat64(dropped.WithLabelValues("unmarshal_error")))
 }
 
 func TestNatsNotifierWatch_ClosesAndUnsubscribesOnContextCancel(t *testing.T) {
 	sub := &fakeEventSubscriber{enabled: true}
-	n := newNatsNotifier(sub, log.NewNopLogger())
+	n := newNatsNotifier(sub, nil, log.NewNopLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	out := n.Watch(ctx, WatchOptions{})
@@ -173,7 +179,7 @@ func TestNatsNotifierWatch_ClosesAndUnsubscribesOnContextCancel(t *testing.T) {
 
 func TestNatsNotifierWatch_SubscribeErrorClosesChannel(t *testing.T) {
 	sub := &fakeEventSubscriber{enabled: true, subErr: errors.New("boom")}
-	n := newNatsNotifier(sub, log.NewNopLogger())
+	n := newNatsNotifier(sub, nil, log.NewNopLogger())
 
 	out := n.Watch(context.Background(), WatchOptions{})
 
@@ -186,7 +192,7 @@ func TestNatsNotifierWatch_SubscribeErrorClosesChannel(t *testing.T) {
 }
 
 func TestNatsNotifierPublishIsNoOp(t *testing.T) {
-	n := newNatsNotifier(&fakeEventSubscriber{enabled: true}, log.NewNopLogger())
+	n := newNatsNotifier(&fakeEventSubscriber{enabled: true}, nil, log.NewNopLogger())
 	assert.NotPanics(t, func() {
 		n.Publish(Event{Group: "g", Resource: "r", ResourceVersion: 1})
 	})

--- a/pkg/storage/unified/resource/notifier_shadow.go
+++ b/pkg/storage/unified/resource/notifier_shadow.go
@@ -1,0 +1,86 @@
+package resource
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/dskit/instrument"
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+// natsShadowMetrics records what the NATS notifier delivers so it can be
+// compared, in dashboards, against the primary notifier's watch metrics
+// (e.g. storage_server_broadcaster_events_received_total and
+// storage_server_watch_latency_seconds). Divergence in counts signals dropped
+// notifications; the latency histogram shows the delivery-time advantage NATS
+// would give over polling.
+type natsShadowMetrics struct {
+	eventsReceived *prometheus.CounterVec
+	latency        *prometheus.HistogramVec
+}
+
+func newNatsShadowMetrics(reg prometheus.Registerer) *natsShadowMetrics {
+	return &natsShadowMetrics{
+		eventsReceived: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "storage_server_nats_notifier_shadow_events_received_total",
+			Help: "Change notifications received via the shadow NATS notifier, by group, resource, and action.",
+		}, []string{"group", "resource", "action"}),
+		latency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                            "storage_server_nats_notifier_shadow_latency_seconds",
+			Help:                            "Time between a resource version being issued and its notification arriving via the shadow NATS notifier.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"resource"}),
+	}
+}
+
+// natsShadow runs a natsNotifier alongside the backend's primary notifier for
+// testing. It consumes the NATS change stream and records metrics only; it
+// never feeds WatchWriteEvents, so enabling it cannot change what watch clients
+// observe. This is the safe way to validate NATS delivery (coverage + latency)
+// against the polling notifier on a live backend before wiring NATS into the
+// watch path for real.
+type natsShadow struct {
+	notifier  *natsNotifier
+	watchOpts WatchOptions
+	metrics   *natsShadowMetrics
+	log       log.Logger
+}
+
+func newNatsShadow(subscriber EventSubscriber, watchOpts WatchOptions, reg prometheus.Registerer, logger log.Logger) *natsShadow {
+	return &natsShadow{
+		notifier:  newNatsNotifier(subscriber, logger),
+		watchOpts: watchOpts,
+		metrics:   newNatsShadowMetrics(reg),
+		log:       logger,
+	}
+}
+
+// start consumes the NATS notifier until ctx is cancelled. It runs in its own
+// goroutine and returns immediately.
+func (s *natsShadow) start(ctx context.Context) {
+	go func() {
+		events := s.notifier.Watch(ctx, s.watchOpts)
+		for evt := range events {
+			s.metrics.eventsReceived.WithLabelValues(evt.Group, evt.Resource, string(evt.Action)).Inc()
+			latency := time.Since(resourceVersionTime(evt.ResourceVersion)).Seconds()
+			if latency > 0 {
+				s.metrics.latency.WithLabelValues(evt.Resource).Observe(latency)
+			}
+			s.log.Debug("nats shadow received event",
+				"group", evt.Group,
+				"resource", evt.Resource,
+				"namespace", evt.Namespace,
+				"name", evt.Name,
+				"rv", evt.ResourceVersion,
+				"action", evt.Action,
+				"latency_seconds", latency,
+			)
+		}
+	}()
+}

--- a/pkg/storage/unified/resource/notifier_shadow.go
+++ b/pkg/storage/unified/resource/notifier_shadow.go
@@ -48,42 +48,60 @@ func newNatsShadowMetrics(reg prometheus.Registerer) *natsShadowMetrics {
 // watch pipeline, so enabling it cannot change what watch clients observe. It
 // validates NATS delivery (coverage + latency) on a live backend before NATS is
 // wired into the watch path for real.
+// natsShadowRetryInterval is how long start waits before re-subscribing after
+// the notifier channel closes (e.g. NATS was unavailable at startup).
+const natsShadowRetryInterval = 5 * time.Second
+
 type natsShadow struct {
-	notifier  *natsNotifier
-	watchOpts WatchOptions
-	metrics   *natsShadowMetrics
-	log       log.Logger
+	notifier      *natsNotifier
+	watchOpts     WatchOptions
+	metrics       *natsShadowMetrics
+	retryInterval time.Duration
+	log           log.Logger
 }
 
 func newNatsShadow(subscriber EventSubscriber, watchOpts WatchOptions, reg prometheus.Registerer, logger log.Logger) *natsShadow {
 	metrics := newNatsShadowMetrics(reg)
 	return &natsShadow{
-		notifier:  newNatsNotifier(subscriber, metrics.dropped, logger),
-		watchOpts: watchOpts,
-		metrics:   metrics,
-		log:       logger,
+		notifier:      newNatsNotifier(subscriber, metrics.dropped, logger),
+		watchOpts:     watchOpts,
+		metrics:       metrics,
+		retryInterval: natsShadowRetryInterval,
+		log:           logger,
 	}
 }
 
-// start consumes the NATS notifier in a goroutine until ctx is cancelled.
+// start consumes the NATS notifier in a goroutine until ctx is cancelled. The
+// channel closes on ctx cancellation (exit) or subscribe failure; in the latter
+// case it re-subscribes after retryInterval so a NATS outage at startup doesn't
+// leave the shadow inert until the next process restart.
 func (s *natsShadow) start(ctx context.Context) {
 	go func() {
-		events := s.notifier.Watch(ctx, s.watchOpts)
-		for evt := range events {
-			s.metrics.eventsReceived.WithLabelValues(evt.Group, evt.Resource, string(evt.Action)).Inc()
-			latency := time.Since(resourceVersionTime(evt.ResourceVersion)).Seconds()
-			if latency > 0 {
-				s.metrics.latency.WithLabelValues(evt.Resource).Observe(latency)
+		for ctx.Err() == nil {
+			for evt := range s.notifier.Watch(ctx, s.watchOpts) {
+				s.observe(evt)
 			}
-			s.log.Debug("nats shadow received event",
-				"group", evt.Group,
-				"resource", evt.Resource,
-				"namespace", evt.Namespace,
-				"name", evt.Name,
-				"rv", evt.ResourceVersion,
-				"action", evt.Action,
-				"latency_seconds", latency,
-			)
+			select {
+			case <-ctx.Done():
+			case <-time.After(s.retryInterval):
+			}
 		}
 	}()
+}
+
+func (s *natsShadow) observe(evt Event) {
+	s.metrics.eventsReceived.WithLabelValues(evt.Group, evt.Resource, string(evt.Action)).Inc()
+	latency := time.Since(resourceVersionTime(evt.ResourceVersion)).Seconds()
+	if latency > 0 {
+		s.metrics.latency.WithLabelValues(evt.Resource).Observe(latency)
+	}
+	s.log.Debug("nats shadow received event",
+		"group", evt.Group,
+		"resource", evt.Resource,
+		"namespace", evt.Namespace,
+		"name", evt.Name,
+		"rv", evt.ResourceVersion,
+		"action", evt.Action,
+		"latency_seconds", latency,
+	)
 }

--- a/pkg/storage/unified/resource/notifier_shadow.go
+++ b/pkg/storage/unified/resource/notifier_shadow.go
@@ -11,14 +11,14 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 )
 
-// natsShadowMetrics records what the NATS notifier delivers so it can be
-// compared, in dashboards, against the primary notifier's watch metrics
-// (e.g. storage_server_broadcaster_events_received_total and
-// storage_server_watch_latency_seconds). Divergence in counts signals dropped
-// notifications; the latency histogram shows the delivery-time advantage NATS
-// would give over polling.
+// natsShadowMetrics record what the NATS notifier delivers, for dashboard
+// comparison against the primary notifier's watch metrics
+// (storage_server_broadcaster_events_received_total,
+// storage_server_watch_latency_seconds). Count divergence signals dropped
+// notifications; latency shows the delivery-time advantage over polling.
 type natsShadowMetrics struct {
 	eventsReceived *prometheus.CounterVec
+	dropped        *prometheus.CounterVec
 	latency        *prometheus.HistogramVec
 }
 
@@ -28,6 +28,10 @@ func newNatsShadowMetrics(reg prometheus.Registerer) *natsShadowMetrics {
 			Name: "storage_server_nats_notifier_shadow_events_received_total",
 			Help: "Change notifications received via the shadow NATS notifier, by group, resource, and action.",
 		}, []string{"group", "resource", "action"}),
+		dropped: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "storage_server_nats_notifier_shadow_dropped_events_total",
+			Help: "Notifications dropped by the shadow NATS notifier before delivery, by reason (unmarshal_error, unknown_type, buffer_full).",
+		}, []string{"reason"}),
 		latency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "storage_server_nats_notifier_shadow_latency_seconds",
 			Help:                            "Time between a resource version being issued and its notification arriving via the shadow NATS notifier.",
@@ -39,12 +43,11 @@ func newNatsShadowMetrics(reg prometheus.Registerer) *natsShadowMetrics {
 	}
 }
 
-// natsShadow runs a natsNotifier alongside the backend's primary notifier for
-// testing. It consumes the NATS change stream and records metrics only; it
-// never feeds WatchWriteEvents, so enabling it cannot change what watch clients
-// observe. This is the safe way to validate NATS delivery (coverage + latency)
-// against the polling notifier on a live backend before wiring NATS into the
-// watch path for real.
+// natsShadow runs a natsNotifier beside the primary notifier for testing: it
+// consumes the NATS change stream and records metrics only, never feeding the
+// watch pipeline, so enabling it cannot change what watch clients observe. It
+// validates NATS delivery (coverage + latency) on a live backend before NATS is
+// wired into the watch path for real.
 type natsShadow struct {
 	notifier  *natsNotifier
 	watchOpts WatchOptions
@@ -53,16 +56,16 @@ type natsShadow struct {
 }
 
 func newNatsShadow(subscriber EventSubscriber, watchOpts WatchOptions, reg prometheus.Registerer, logger log.Logger) *natsShadow {
+	metrics := newNatsShadowMetrics(reg)
 	return &natsShadow{
-		notifier:  newNatsNotifier(subscriber, logger),
+		notifier:  newNatsNotifier(subscriber, metrics.dropped, logger),
 		watchOpts: watchOpts,
-		metrics:   newNatsShadowMetrics(reg),
+		metrics:   metrics,
 		log:       logger,
 	}
 }
 
-// start consumes the NATS notifier until ctx is cancelled. It runs in its own
-// goroutine and returns immediately.
+// start consumes the NATS notifier in a goroutine until ctx is cancelled.
 func (s *natsShadow) start(ctx context.Context) {
 	go func() {
 		events := s.notifier.Watch(ctx, s.watchOpts)

--- a/pkg/storage/unified/resource/notifier_shadow_test.go
+++ b/pkg/storage/unified/resource/notifier_shadow_test.go
@@ -1,0 +1,58 @@
+package resource
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+// countingSubscriber records how many times Subscribe is called and fails the
+// first failFirst attempts, so a test can drive the shadow's re-subscribe loop.
+type countingSubscriber struct {
+	mu        sync.Mutex
+	calls     int
+	failFirst int
+	handler   func(subject string, data []byte)
+}
+
+func (c *countingSubscriber) Enabled() bool { return true }
+
+func (c *countingSubscriber) Subscribe(_ context.Context, _ string, handler func(subject string, data []byte)) (Subscription, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	if c.calls <= c.failFirst {
+		return nil, errors.New("nats unavailable")
+	}
+	c.handler = handler
+	return &fakeSubscription{}, nil
+}
+
+func (c *countingSubscriber) callCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+func TestNatsShadow_ReSubscribesAfterInitialFailure(t *testing.T) {
+	sub := &countingSubscriber{failFirst: 2}
+	s := newNatsShadow(sub, WatchOptions{}, prometheus.NewRegistry(), log.NewNopLogger())
+	s.retryInterval = 10 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.start(ctx)
+
+	// The first two Subscribe calls fail; the loop must keep retrying until one
+	// succeeds rather than giving up after the first failure.
+	require.Eventually(t, func() bool {
+		return sub.callCount() > 2
+	}, 2*time.Second, 5*time.Millisecond, "shadow did not re-subscribe after initial failures")
+}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -179,14 +179,11 @@ type KVBackendOptions struct {
 	// external message bus (NATS). Optional; nil disables external publishing.
 	EventPublisher EventPublisher
 
-	// EventSubscriber, when set together with EnableNatsNotifierShadow, feeds a
-	// shadow NATS notifier that runs alongside the primary notifier for testing.
-	// Optional; nil disables the shadow.
+	// EventSubscriber feeds the shadow NATS notifier; nil disables it.
 	EventSubscriber EventSubscriber
-	// EnableNatsNotifierShadow starts the shadow NATS notifier. It observes the
-	// external change stream and records comparison metrics only; it never feeds
-	// the watch pipeline, so it does not change watch behavior. Requires
-	// EventSubscriber to be set and enabled.
+	// EnableNatsNotifierShadow starts the shadow NATS notifier (see natsShadow):
+	// metrics only, never feeds the watch pipeline. Requires EventSubscriber set
+	// and enabled.
 	EnableNatsNotifierShadow bool
 	// Adding RvManager overrides the RV generated with snowflake in order to keep backwards compatibility with
 	// unified/sql
@@ -335,9 +332,7 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 	// Start the cleanup background job.
 	go backend.runCleanups(ctx)
 
-	// Optionally start the shadow NATS notifier. It only records comparison
-	// metrics and never feeds the watch pipeline, so it is safe to run beside
-	// the primary notifier for testing.
+	// Optionally start the shadow NATS notifier (metrics only; see natsShadow).
 	if opts.EnableNatsNotifierShadow && opts.EventSubscriber != nil && opts.EventSubscriber.Enabled() {
 		backend.natsShadow = newNatsShadow(opts.EventSubscriber, backend.watchOpts, opts.Reg, logger.New("notifier", "natsShadow"))
 		backend.natsShadow.start(ctx)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -82,6 +82,7 @@ type kvStorageBackend struct {
 	eventStore              *eventStore
 	notifier                notifier
 	eventPublisher          EventPublisher
+	natsShadow              *natsShadow
 	log                     log.Logger
 	disablePruner           bool
 	dashboardVersionsToKeep int
@@ -177,6 +178,16 @@ type KVBackendOptions struct {
 	// EventPublisher, when set, is used to announce committed writes on an
 	// external message bus (NATS). Optional; nil disables external publishing.
 	EventPublisher EventPublisher
+
+	// EventSubscriber, when set together with EnableNatsNotifierShadow, feeds a
+	// shadow NATS notifier that runs alongside the primary notifier for testing.
+	// Optional; nil disables the shadow.
+	EventSubscriber EventSubscriber
+	// EnableNatsNotifierShadow starts the shadow NATS notifier. It observes the
+	// external change stream and records comparison metrics only; it never feeds
+	// the watch pipeline, so it does not change watch behavior. Requires
+	// EventSubscriber to be set and enabled.
+	EnableNatsNotifierShadow bool
 	// Adding RvManager overrides the RV generated with snowflake in order to keep backwards compatibility with
 	// unified/sql
 	RvManager *rvmanager.ResourceVersionManager
@@ -323,6 +334,15 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 
 	// Start the cleanup background job.
 	go backend.runCleanups(ctx)
+
+	// Optionally start the shadow NATS notifier. It only records comparison
+	// metrics and never feeds the watch pipeline, so it is safe to run beside
+	// the primary notifier for testing.
+	if opts.EnableNatsNotifierShadow && opts.EventSubscriber != nil && opts.EventSubscriber.Enabled() {
+		backend.natsShadow = newNatsShadow(opts.EventSubscriber, backend.watchOpts, opts.Reg, logger.New("notifier", "natsShadow"))
+		backend.natsShadow.start(ctx)
+		logger.Info("nats notifier shadow enabled")
+	}
 
 	logger.Info("backend initialized", "kv", fmt.Sprintf("%T", kv))
 

--- a/pkg/storage/unified/resourcewatch/subject.go
+++ b/pkg/storage/unified/resourcewatch/subject.go
@@ -10,11 +10,9 @@ import (
 // position to watch every namespace's notifications for a resource.
 const allNamespaces = "*"
 
-// SubjectAll is the NATS multi-token wildcard (">") that matches every
-// notification subject regardless of group, namespace, or resource. A consumer
-// that needs the full change stream (rather than one resource type) subscribes
-// to this. It matches the trailing tokens of any Subject(...) value because the
-// group spans several dotted tokens.
+// SubjectAll is the NATS multi-token wildcard (">"), matching every Subject(...)
+// value regardless of group, namespace, or resource. A consumer that needs the
+// full change stream (not one resource type) subscribes to this.
 const SubjectAll = ">"
 
 // Subject returns the NATS subject that carries change notifications for a

--- a/pkg/storage/unified/resourcewatch/subject.go
+++ b/pkg/storage/unified/resourcewatch/subject.go
@@ -10,6 +10,13 @@ import (
 // position to watch every namespace's notifications for a resource.
 const allNamespaces = "*"
 
+// SubjectAll is the NATS multi-token wildcard (">") that matches every
+// notification subject regardless of group, namespace, or resource. A consumer
+// that needs the full change stream (rather than one resource type) subscribes
+// to this. It matches the trailing tokens of any Subject(...) value because the
+// group spans several dotted tokens.
+const SubjectAll = ">"
+
 // Subject returns the NATS subject that carries change notifications for a
 // resource type within a namespace, as the dotted tokens
 //

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -106,11 +106,9 @@ func WithEventPublisher(p resource.EventPublisher) StorageBackendOption {
 	return func(o *resource.KVBackendOptions) { o.EventPublisher = p }
 }
 
-// WithNatsNotifierShadow runs a NATS-backed notifier in shadow mode alongside
-// the primary (polling/channel) notifier for testing: it consumes the external
-// NATS change stream and records comparison metrics without feeding the watch
-// pipeline, so it never changes what watch clients observe. Applies only to the
-// KV backend.
+// WithNatsNotifierShadow runs a NATS-backed notifier in shadow mode beside the
+// primary notifier for testing: it records comparison metrics without feeding
+// the watch pipeline. KV backend only.
 func WithNatsNotifierShadow(s resource.EventSubscriber) StorageBackendOption {
 	return func(o *resource.KVBackendOptions) {
 		o.EventSubscriber = s

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -106,6 +106,18 @@ func WithEventPublisher(p resource.EventPublisher) StorageBackendOption {
 	return func(o *resource.KVBackendOptions) { o.EventPublisher = p }
 }
 
+// WithNatsNotifierShadow runs a NATS-backed notifier in shadow mode alongside
+// the primary (polling/channel) notifier for testing: it consumes the external
+// NATS change stream and records comparison metrics without feeding the watch
+// pipeline, so it never changes what watch clients observe. Applies only to the
+// KV backend.
+func WithNatsNotifierShadow(s resource.EventSubscriber) StorageBackendOption {
+	return func(o *resource.KVBackendOptions) {
+		o.EventSubscriber = s
+		o.EnableNatsNotifierShadow = true
+	}
+}
+
 // NewStorageBackend creates the unified storage backend based on options.StorageType.
 // It supports file-based KV backend using BadgerDB (options.StorageTypeFile).
 // Returns a nil backend if options.StorageTypeUnifiedGrpc, a remote gRPC client is expected to be used instead.


### PR DESCRIPTION
## NATS notifier shadow

Adds a **shadow NATS notifier** to the unified storage backend: it consumes the external NATS change stream alongside the primary (polling) notifier and records comparison metrics only. It **never feeds the watch pipeline**, so it can't change what watch clients see. This lets us measure NATS delivery coverage and latency against polling on a live backend before using NATS on the real watch path.

Gated behind a new `notifier_shadow` setting under `[nats]`, off by default.

### Metrics
- `..._shadow_events_received_total{group,resource,action}` — count vs. the primary notifier
- `..._shadow_latency_seconds{resource}` — RV-issue → delivery latency
- `..._shadow_dropped_events_total{reason}` — drops by reason (`unmarshal_error`, `unknown_type`, `buffer_full`)
