### PR TITLE
PanelChrome: Add subtitle prop for showing text in sub header 

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -144,7 +144,16 @@ export const Examples = () => {
           })}
           {renderPanel('Content', {
             loadingState: LoadingState.Error,
-            title: 'No title, loadingState is Error, no statusMessage',
+            title: 'loadingState is Error, no statusMessage',
+          })}
+          {renderPanel('Content', {
+            title: 'With description',
+            description: 'This is a description',
+          })}
+          {renderPanel('Content', {
+            title: 'With description in sub-header',
+            description: 'This is a description',
+            descriptionInSubHeader: true,
           })}
           {renderPanel('Content', {
             title: 'loadingState is Streaming',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -151,9 +151,8 @@ export const Examples = () => {
             description: 'This is a description',
           })}
           {renderPanel('Content', {
-            title: 'With description in sub-header',
-            description: 'This is a description',
-            descriptionInSubHeader: true,
+            title: 'With a subtitle',
+            subtitle: 'This is a sub title with <a href="http://www.google.com">Link</a> and <em>emphasized</em> text',
           })}
           {renderPanel('Content', {
             title: 'loadingState is Streaming',
@@ -379,6 +378,7 @@ const description =
 
 Basic.argTypes = {
   description: { control: { type: 'text' } },
+  subtitle: { control: { type: 'text' } },
   leftItems: {
     options: Object.keys(leftItems),
     mapping: leftItems,

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -152,7 +152,7 @@ export const Examples = () => {
           })}
           {renderPanel('Content', {
             title: 'With a subtitle',
-            subtitle: 'This is a sub title with <a href="http://www.google.com">Link</a> and <em>emphasized</em> text',
+            subtitle: 'This is a sub title with',
           })}
           {renderPanel('Content', {
             title: 'loadingState is Streaming',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -33,6 +33,8 @@ interface BaseProps {
   padding?: PanelPadding;
   title?: string | React.ReactElement;
   description?: string | (() => string);
+  /** If true, the description will be displayed in the sub-header area instead of the main header. */
+  descriptionInSubHeader?: boolean;
   titleItems?: ReactNode;
   menu?: ReactElement | (() => ReactElement);
   dragClass?: string;
@@ -163,6 +165,7 @@ export function PanelChrome({
   onDragStart,
   showMenuAlways = false,
   subHeaderContent,
+  descriptionInSubHeader = false,
 }: PanelChromeProps) {
   const theme = useTheme2();
   const visualRefreshEnabled = theme.flags.visualDesignRefresh;
@@ -187,12 +190,21 @@ export function PanelChrome({
     collapsed = !isOpen;
   }
 
+  const descriptionTitleItem = description && !descriptionInSubHeader && (
+    <PanelDescription description={description} className={dragClassCancel} />
+  );
+
+  const descriptionSubHeader = description && descriptionInSubHeader && (
+    <PanelDescription description={description} inSubHeader />
+  );
+
   // hover menu is only shown on hover when not on touch devices
   const showOnHoverClass = showMenuAlways ? 'always-show' : 'show-on-hover';
   const isPanelTransparent = displayMode === 'transparent';
+  const showSubHeader = !collapsed && Boolean(subHeaderContent || descriptionSubHeader);
 
-  const headerHeight = getHeaderHeight(theme, hasHeader);
-  const subHeaderHeight = Math.min(measuredSubHeaderHeight, headerHeight);
+  const headerHeight = getHeaderHeight(theme, hasHeader, showSubHeader);
+  const subHeaderHeight = showSubHeader ? Math.max(measuredSubHeaderHeight - 0, 0) : 0;
   const { contentStyle, innerWidth, innerHeight } = getContentStyle(
     padding,
     theme,
@@ -319,9 +331,9 @@ export function PanelChrome({
         </div>
       )}
 
-      {(titleItems || description) && (
+      {(titleItems || descriptionTitleItem) && (
         <div className={cx(styles.titleItems, dragClassCancel)} data-testid="title-items-container">
-          <PanelDescription description={description} className={dragClassCancel} />
+          {descriptionTitleItem}
           {titleItems}
         </div>
       )}
@@ -452,8 +464,9 @@ export function PanelChrome({
                 />
               )}
             </div>
-            {!collapsed && subHeaderContent && (
+            {!collapsed && (subHeaderContent || descriptionSubHeader) && (
               <div className={styles.subHeader} ref={subHeaderRef}>
+                {descriptionSubHeader}
                 {subHeaderContent}
               </div>
             )}
@@ -483,9 +496,9 @@ const itemsRenderer = (items: ReactNode[] | ReactNode, renderer: (items: ReactNo
   return toRender.length > 0 ? renderer(toRender) : null;
 };
 
-const getHeaderHeight = (theme: GrafanaTheme2, hasHeader: boolean) => {
+const getHeaderHeight = (theme: GrafanaTheme2, hasHeader: boolean, showSubHeader: boolean) => {
   if (hasHeader) {
-    return theme.spacing.gridSize * theme.components.panel.headerHeight;
+    return theme.spacing.gridSize * theme.components.panel.headerHeight - (showSubHeader ? 8 : 0);
   }
 
   return 0;

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -32,9 +32,10 @@ export type PanelChromeProps = (AutoSize | FixedDimensions) & (Collapsible | Hov
 interface BaseProps {
   padding?: PanelPadding;
   title?: string | React.ReactElement;
+  /** Shown in info icon tooltip next to the title, supports simple html markup */
   description?: string | (() => string);
-  /** If true, the description will be displayed in the sub-header area instead of the main header. */
-  descriptionInSubHeader?: boolean;
+  /** Shown in as text below the title, supports simple html markup */
+  subtitle?: string | (() => string);
   titleItems?: ReactNode;
   menu?: ReactElement | (() => ReactElement);
   dragClass?: string;
@@ -165,7 +166,7 @@ export function PanelChrome({
   onDragStart,
   showMenuAlways = false,
   subHeaderContent,
-  descriptionInSubHeader = false,
+  subtitle,
 }: PanelChromeProps) {
   const theme = useTheme2();
   const visualRefreshEnabled = theme.flags.visualDesignRefresh;
@@ -190,18 +191,16 @@ export function PanelChrome({
     collapsed = !isOpen;
   }
 
-  const descriptionTitleItem = description && !descriptionInSubHeader && (
+  const descriptionTitleItem = description && (
     <PanelDescription description={description} className={dragClassCancel} />
   );
 
-  const descriptionSubHeader = description && descriptionInSubHeader && (
-    <PanelDescription description={description} inSubHeader />
-  );
+  const subtitleContent = subtitle && <PanelDescription description={subtitle} inSubHeader />;
 
   // hover menu is only shown on hover when not on touch devices
   const showOnHoverClass = showMenuAlways ? 'always-show' : 'show-on-hover';
   const isPanelTransparent = displayMode === 'transparent';
-  const showSubHeader = !collapsed && Boolean(subHeaderContent || descriptionSubHeader);
+  const showSubHeader = !collapsed && Boolean(subHeaderContent || subtitleContent);
 
   // in dashboards we always have a subHeaderContent react node that sometimes is empty so showSubHeader can be true but 0 height
   const subHeaderHeight = showSubHeader ? measuredSubHeaderHeight : 0;
@@ -466,9 +465,9 @@ export function PanelChrome({
                 />
               )}
             </div>
-            {!collapsed && (subHeaderContent || descriptionSubHeader) && (
+            {!collapsed && (subHeaderContent || subtitleContent) && (
               <div className={styles.subHeader} ref={subHeaderRef}>
-                {descriptionSubHeader}
+                {subtitleContent}
                 {subHeaderContent}
               </div>
             )}

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -501,7 +501,9 @@ const itemsRenderer = (items: ReactNode[] | ReactNode, renderer: (items: ReactNo
 const getHeaderHeight = (theme: GrafanaTheme2, hasHeader: boolean, subHeaderHeight: number) => {
   if (hasHeader) {
     // To reduce spacing between subHeader and content, we remove some height from the header when subHeader is present.
-    return theme.spacing.gridSize * theme.components.panel.headerHeight - (subHeaderHeight > 0 ? 8 : 0);
+    return (
+      theme.spacing.gridSize * theme.components.panel.headerHeight - (subHeaderHeight > 0 ? theme.spacing.gridSize : 0)
+    );
   }
 
   return 0;

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -203,8 +203,10 @@ export function PanelChrome({
   const isPanelTransparent = displayMode === 'transparent';
   const showSubHeader = !collapsed && Boolean(subHeaderContent || descriptionSubHeader);
 
-  const headerHeight = getHeaderHeight(theme, hasHeader, showSubHeader);
-  const subHeaderHeight = showSubHeader ? Math.max(measuredSubHeaderHeight - 0, 0) : 0;
+  // in dashboards we always have a subHeaderContent react node that sometimes is empty so showSubHeader can be true but 0 height
+  const subHeaderHeight = showSubHeader ? measuredSubHeaderHeight : 0;
+  const headerHeight = getHeaderHeight(theme, hasHeader, subHeaderHeight);
+
   const { contentStyle, innerWidth, innerHeight } = getContentStyle(
     padding,
     theme,
@@ -496,9 +498,10 @@ const itemsRenderer = (items: ReactNode[] | ReactNode, renderer: (items: ReactNo
   return toRender.length > 0 ? renderer(toRender) : null;
 };
 
-const getHeaderHeight = (theme: GrafanaTheme2, hasHeader: boolean, showSubHeader: boolean) => {
+const getHeaderHeight = (theme: GrafanaTheme2, hasHeader: boolean, subHeaderHeight: number) => {
   if (hasHeader) {
-    return theme.spacing.gridSize * theme.components.panel.headerHeight - (showSubHeader ? 8 : 0);
+    // To reduce spacing between subHeader and content, we remove some height from the header when subHeader is present.
+    return theme.spacing.gridSize * theme.components.panel.headerHeight - (subHeaderHeight > 0 ? 8 : 0);
   }
 
   return 0;

--- a/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
@@ -5,6 +5,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { Icon } from '../Icon/Icon';
+import { Text } from '../Text/Text';
 import { Tooltip } from '../Tooltip/Tooltip';
 
 import { TitleItem } from './TitleItem';
@@ -12,9 +13,10 @@ import { TitleItem } from './TitleItem';
 interface Props {
   description: string | (() => string);
   className?: string;
+  inSubHeader?: boolean;
 }
 
-export function PanelDescription({ description, className }: Props) {
+export function PanelDescription({ description, className, inSubHeader }: Props) {
   const styles = useStyles2(getStyles);
 
   const getDescriptionContent = (): JSX.Element => {
@@ -27,6 +29,14 @@ export function PanelDescription({ description, className }: Props) {
       </div>
     );
   };
+
+  if (inSubHeader) {
+    return (
+      <Text variant="bodySmall" color="secondary">
+        {getDescriptionContent()}
+      </Text>
+    );
+  }
 
   return description !== '' ? (
     <Tooltip interactive content={getDescriptionContent}>


### PR DESCRIPTION
Initial step in supporting description in sub header (Next is to add it to schema and UI option). 

Technically, we could do this without a change to PanelChrome using subHeaderContent prop but feels like this should be part of the PanelChrome component. Having it be part of PanelChrome also makes it more consistent and logic wise more easy (as the descriptionInSubHeader option will propagate from schema to VizPanel to PanelChrome)  

Also fixes an issue where it would not adapt to sub header being shown and then hidden again (old sub header size would be still considered). 


Test (not part of this PR): 

<img width="2236" height="1324" alt="image" src="https://github.com/user-attachments/assets/926ca3b9-1660-415a-8728-c54ea5f6b623" />


