### PR TITLE
Search: move IAM search fields into CUE manifests

### DIFF
--- a/apps/iam/kinds/externalgroupmapping.cue
+++ b/apps/iam/kinds/externalgroupmapping.cue
@@ -21,4 +21,20 @@ externalGroupMappingv0alpha1: externalGroupMappingKind & {
 		"spec.teamRef.name",
 		"spec.externalGroupId",
 	]
+	searchFields: [
+		{
+			name: "team"
+			path: "spec.teamRef.name"
+			type: "string"
+			capabilities: ["filter", "retrieve"]
+			description: "The team name associated with the external group mapping"
+		},
+		{
+			name: "external_group"
+			path: "spec.externalGroupId"
+			type: "string"
+			capabilities: ["filter", "retrieve"]
+			description: "The external group name/id associated with the external group mapping"
+		},
+	]
 }

--- a/apps/iam/kinds/team.cue
+++ b/apps/iam/kinds/team.cue
@@ -18,6 +18,45 @@ teamv0alpha1: teamKind & {
 	schema: {
 		spec: v0alpha1.TeamSpec
 	}
+	searchFields: [
+		{
+			name: "email"
+			path: "spec.email"
+			type: "string"
+			capabilities: ["retrieve"]
+			description: "Email of the team"
+		},
+		{
+			name: "provisioned"
+			path: "spec.provisioned"
+			type: "boolean"
+			capabilities: ["retrieve"]
+			description: "Whether the team is provisioned"
+		},
+		{
+			name: "externalUID"
+			path: "spec.externalUID"
+			type: "string"
+			capabilities: ["retrieve"]
+			description: "External UID of the team"
+		},
+		{
+			name:  "members"
+			path:  "spec.members[*].name"
+			type:  "string"
+			array: true
+			capabilities: ["filter", "retrieve"]
+			description: "UIDs of users that are members of the team"
+		},
+		{
+			name:  "externalGroups"
+			path:  "spec.externalGroups"
+			type:  "string"
+			array: true
+			capabilities: ["filter", "retrieve"]
+			description: "External group identifiers mapped to the team"
+		},
+	]
 	routes: {
 		"/groups": {
 			"GET": {

--- a/apps/iam/kinds/teambinding.cue
+++ b/apps/iam/kinds/teambinding.cue
@@ -22,4 +22,33 @@ teambindingv0alpha1: teambindingKind & {
 		"spec.subject.name",
 		"spec.external",
 	]
+	searchFields: [
+		{
+			name: "subject"
+			path: "spec.subject.name"
+			type: "string"
+			capabilities: ["filter", "retrieve"]
+		},
+		{
+			name: "team"
+			path: "spec.teamRef.name"
+			type: "string"
+			capabilities: ["filter", "retrieve"]
+		},
+		{
+			name: "permission"
+			path: "spec.permission"
+			type: "string"
+			capabilities: ["retrieve"]
+		},
+		{
+			name: "external"
+			path: "spec.external"
+			type: "boolean"
+			capabilities: ["retrieve"]
+			// Index the field even when the JSON omits it, so every team binding
+			// carries a value like the original custom builder did.
+			emitZeroIfAbsent: true
+		},
+	]
 }

--- a/apps/iam/kinds/user.cue
+++ b/apps/iam/kinds/user.cue
@@ -22,6 +22,50 @@ userv0alpha1: userKind & {
 		"spec.email",
 		"spec.login",
 	]
+	// createdAt mirrors the standard document's Created value into the per-kind
+	// fields and is declared in Go, not here, because it reads from a standard
+	// field rather than a resource path.
+	searchFields: [
+		{
+			name: "email"
+			path: "spec.email"
+			type: "string"
+			capabilities: ["filter", "retrieve"]
+			description: "The email address of the user"
+		},
+		{
+			name: "login"
+			path: "spec.login"
+			type: "string"
+			capabilities: ["filter", "retrieve"]
+			description: "The login of the user"
+		},
+		{
+			name: "lastSeenAt"
+			path: "status.lastSeenAt"
+			type: "int64"
+			capabilities: ["filter", "retrieve"]
+			// Sort on last-seen puts missing values last; index the zero value so
+			// never-seen users keep their historical epoch-0 sort position.
+			emitZeroIfAbsent: true
+			description:      "The last seen timestamp of the user"
+		},
+		{
+			name: "role"
+			path: "spec.role"
+			type: "string"
+			capabilities: ["filter", "retrieve"]
+			description: "The role of the user"
+		},
+		{
+			name: "disabled"
+			path: "spec.disabled"
+			type: "boolean"
+			capabilities: ["filter", "retrieve"]
+			emitZeroIfAbsent: true
+			description:      "Whether the user is disabled"
+		},
+	]
 	routes: {
 		"/teams": {
 			"GET": {

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -72,6 +72,45 @@ var appManifestData = app.ManifestData{
 						"spec.email",
 						"spec.login",
 					},
+					SearchFields: []app.ManifestVersionKindSearchField{
+						{
+							Name:         "email",
+							Path:         "spec.email",
+							Type:         "string",
+							Capabilities: []string{"filter", "retrieve"},
+							Description:  "The email address of the user",
+						},
+						{
+							Name:         "login",
+							Path:         "spec.login",
+							Type:         "string",
+							Capabilities: []string{"filter", "retrieve"},
+							Description:  "The login of the user",
+						},
+						{
+							Name:             "lastSeenAt",
+							Path:             "status.lastSeenAt",
+							Type:             "int64",
+							Capabilities:     []string{"filter", "retrieve"},
+							EmitZeroIfAbsent: true,
+							Description:      "The last seen timestamp of the user",
+						},
+						{
+							Name:         "role",
+							Path:         "spec.role",
+							Type:         "string",
+							Capabilities: []string{"filter", "retrieve"},
+							Description:  "The role of the user",
+						},
+						{
+							Name:             "disabled",
+							Path:             "spec.disabled",
+							Type:             "boolean",
+							Capabilities:     []string{"filter", "retrieve"},
+							EmitZeroIfAbsent: true,
+							Description:      "Whether the user is disabled",
+						},
+					},
 					Routes: map[string]spec3.PathProps{
 						"/teams": {
 							Get: &spec3.Operation{
@@ -171,6 +210,45 @@ var appManifestData = app.ManifestData{
 					Plural:     "Teams",
 					Scope:      "Namespaced",
 					Conversion: false,
+					SearchFields: []app.ManifestVersionKindSearchField{
+						{
+							Name:         "email",
+							Path:         "spec.email",
+							Type:         "string",
+							Capabilities: []string{"retrieve"},
+							Description:  "Email of the team",
+						},
+						{
+							Name:         "provisioned",
+							Path:         "spec.provisioned",
+							Type:         "boolean",
+							Capabilities: []string{"retrieve"},
+							Description:  "Whether the team is provisioned",
+						},
+						{
+							Name:         "externalUID",
+							Path:         "spec.externalUID",
+							Type:         "string",
+							Capabilities: []string{"retrieve"},
+							Description:  "External UID of the team",
+						},
+						{
+							Name:         "members",
+							Path:         "spec.members[*].name",
+							Type:         "string",
+							Array:        true,
+							Capabilities: []string{"filter", "retrieve"},
+							Description:  "UIDs of users that are members of the team",
+						},
+						{
+							Name:         "externalGroups",
+							Path:         "spec.externalGroups",
+							Type:         "string",
+							Array:        true,
+							Capabilities: []string{"filter", "retrieve"},
+							Description:  "External group identifiers mapped to the team",
+						},
+					},
 					Routes: map[string]spec3.PathProps{
 						"/addmember": {
 							Post: &spec3.Operation{
@@ -484,6 +562,33 @@ var appManifestData = app.ManifestData{
 						"spec.subject.name",
 						"spec.external",
 					},
+					SearchFields: []app.ManifestVersionKindSearchField{
+						{
+							Name:         "subject",
+							Path:         "spec.subject.name",
+							Type:         "string",
+							Capabilities: []string{"filter", "retrieve"},
+						},
+						{
+							Name:         "team",
+							Path:         "spec.teamRef.name",
+							Type:         "string",
+							Capabilities: []string{"filter", "retrieve"},
+						},
+						{
+							Name:         "permission",
+							Path:         "spec.permission",
+							Type:         "string",
+							Capabilities: []string{"retrieve"},
+						},
+						{
+							Name:             "external",
+							Path:             "spec.external",
+							Type:             "boolean",
+							Capabilities:     []string{"retrieve"},
+							EmitZeroIfAbsent: true,
+						},
+					},
 				},
 
 				{
@@ -789,6 +894,22 @@ var appManifestData = app.ManifestData{
 					SelectableFields: []string{
 						"spec.teamRef.name",
 						"spec.externalGroupId",
+					},
+					SearchFields: []app.ManifestVersionKindSearchField{
+						{
+							Name:         "team",
+							Path:         "spec.teamRef.name",
+							Type:         "string",
+							Capabilities: []string{"filter", "retrieve"},
+							Description:  "The team name associated with the external group mapping",
+						},
+						{
+							Name:         "external_group",
+							Path:         "spec.externalGroupId",
+							Type:         "string",
+							Capabilities: []string{"filter", "retrieve"},
+							Description:  "The external group name/id associated with the external group mapping",
+						},
 					},
 				},
 			},

--- a/pkg/storage/unified/search/builders/document_test.go
+++ b/pkg/storage/unified/search/builders/document_test.go
@@ -82,6 +82,7 @@ func TestTeamSearchBuilder(t *testing.T) {
 		Resource:  "teams",
 	}, []string{
 		"with-email-and-external-uid",
+		"with-members-and-groups",
 	})
 }
 

--- a/pkg/storage/unified/search/builders/external_group_mapping.go
+++ b/pkg/storage/unified/search/builders/external_group_mapping.go
@@ -18,13 +18,11 @@ const (
 // kept for symmetry with the other IAM builders.
 var ExternalGroupMappingTableColumnDefinitions = tableColumnsByName(ExternalGroupMappingSearchFields)
 
-// ExternalGroupMappingSearchFields declares paths and types for each external
-// group mapping search field. The standard document builder uses these to
-// extract spec values from the raw JSON, avoiding a custom builder.
-var ExternalGroupMappingSearchFields = []resource.SearchFieldDefinition{
-	{Name: EXTERNAL_GROUP_MAPPING_TEAM, Path: "spec.teamRef.name", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, Description: "The team name associated with the external group mapping"},
-	{Name: EXTERNAL_GROUP_MAPPING_EXTERNAL_GROUP, Path: "spec.externalGroupId", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, Description: "The external group name/id associated with the external group mapping"},
-}
+// ExternalGroupMappingSearchFields are read from the generated IAM manifest,
+// where they are declared in apps/iam/kinds/externalgroupmapping.cue.
+var ExternalGroupMappingSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
+	iamv0.ExternalGroupMappingResourceInfo.GroupVersionResource(),
+)
 
 func GetExternalGroupMappingBuilder() (resource.DocumentBuilderInfo, error) {
 	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(ExternalGroupMappingTableColumnDefinitions))

--- a/pkg/storage/unified/search/builders/team.go
+++ b/pkg/storage/unified/search/builders/team.go
@@ -26,17 +26,11 @@ var TeamSortableExtraFields = []string{
 // IAM legacy SQL backend in team/legacy_search.go.
 var TeamSearchTableColumnDefinitions = tableColumnsByName(TeamSearchFields)
 
-// TeamSearchFields declares paths and types for each team search field. The
-// standard document builder uses these to extract spec values from the raw
-// JSON, avoiding a custom builder. Members is a projection over
-// spec.members[*].name so the indexed array contains member UIDs only.
-var TeamSearchFields = []resource.SearchFieldDefinition{
-	{Name: TEAM_SEARCH_EMAIL, Path: "spec.email", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}, Description: "Email of the team"},
-	{Name: TEAM_SEARCH_PROVISIONED, Path: "spec.provisioned", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}, Description: "Whether the team is provisioned"},
-	{Name: TEAM_SEARCH_EXTERNAL_UID, Path: "spec.externalUID", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}, Description: "External UID of the team"},
-	{Name: TEAM_SEARCH_MEMBERS, Path: "spec.members[*].name", Type: resource.SearchFieldTypeString, Array: true, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, Description: "UIDs of users that are members of the team"},
-	{Name: TEAM_SEARCH_EXTERNAL_GROUPS, Path: "spec.externalGroups", Type: resource.SearchFieldTypeString, Array: true, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, Description: "External group identifiers mapped to the team"},
-}
+// TeamSearchFields are read from the generated IAM manifest, where they are
+// declared in apps/iam/kinds/team.cue.
+var TeamSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
+	v0alpha1.TeamResourceInfo.GroupVersionResource(),
+)
 
 func GetTeamSearchBuilder() (resource.DocumentBuilderInfo, error) {
 	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(TeamSearchTableColumnDefinitions))

--- a/pkg/storage/unified/search/builders/teambinding.go
+++ b/pkg/storage/unified/search/builders/teambinding.go
@@ -19,21 +19,11 @@ const (
 // IAM legacy SQL backend in teambinding/legacy_search.go.
 var TeamBindingTableColumnDefinitions = tableColumnsByName(TeamBindingSearchFields)
 
-// TeamBindingSearchFields declares paths and types for each team binding
-// search field. The standard document builder uses these to extract values
-// from the raw JSON, avoiding a custom builder.
-//
-// external sets EmitZeroIfAbsent so the field is always indexed, matching
-// the old custom builder which set doc.Fields[external] unconditionally.
-// The generated TeamBindingSpec uses json:"external" without omitempty,
-// so today the JSON always carries the value; the flag preserves intent
-// against a future schema change that adds omitempty.
-var TeamBindingSearchFields = []resource.SearchFieldDefinition{
-	{Name: TEAM_BINDING_SUBJECT, Path: "spec.subject.name", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
-	{Name: TEAM_BINDING_TEAM, Path: "spec.teamRef.name", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
-	{Name: TEAM_BINDING_PERMISSION, Path: "spec.permission", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}},
-	{Name: TEAM_BINDING_EXTERNAL, Path: "spec.external", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}, EmitZeroIfAbsent: true},
-}
+// TeamBindingSearchFields are read from the generated IAM manifest, where they
+// are declared in apps/iam/kinds/teambinding.cue.
+var TeamBindingSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
+	iamv0.TeamBindingResourceInfo.GroupVersionResource(),
+)
 
 func GetTeamBindingBuilder() (resource.DocumentBuilderInfo, error) {
 	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(TeamBindingTableColumnDefinitions))

--- a/pkg/storage/unified/search/builders/testdata/doc/team-with-members-and-groups-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/team-with-members-and-groups-out.json
@@ -1,0 +1,24 @@
+{
+  "key": {
+    "namespace": "default",
+    "group": "iam.grafana.app",
+    "resource": "teams",
+    "name": "with-members-and-groups"
+  },
+  "name": "with-members-and-groups",
+  "rv": 1234,
+  "title": "Team With Members And Groups",
+  "title_ngram": "Team With Members And Groups",
+  "title_phrase": "team with members and groups",
+  "fields": {
+    "email": "team@example.com",
+    "externalGroups": [
+      "group-a",
+      "group-b"
+    ],
+    "members": [
+      "user-uid-1",
+      "user-uid-2"
+    ]
+  }
+}

--- a/pkg/storage/unified/search/builders/testdata/doc/team-with-members-and-groups.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/team-with-members-and-groups.json
@@ -1,0 +1,16 @@
+{
+    "apiVersion": "iam.grafana.app/v0alpha1",
+    "kind": "Team",
+    "metadata": {
+        "name": "with-members-and-groups"
+    },
+    "spec": {
+        "title": "Team With Members And Groups",
+        "email": "team@example.com",
+        "members": [
+            {"kind": "User", "name": "user-uid-1", "permission": "admin", "external": false},
+            {"kind": "User", "name": "user-uid-2", "permission": "member", "external": true}
+        ],
+        "externalGroups": ["group-a", "group-b"]
+    }
+}

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -1,6 +1,8 @@
 package builders
 
 import (
+	"slices"
+
 	"github.com/grafana/grafana-app-sdk/app"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -39,35 +41,27 @@ var UserSortableExtraFields = []string{
 // production consumer and is not preserved.
 var UserTableColumnDefinitions = tableColumnsByName(UserSearchFields)
 
-// UserSearchFields declares paths and types for each user search field. The
-// standard document builder uses these to extract spec/status values from the
-// raw JSON, avoiding a custom builder.
+// UserSearchFields are read from the generated IAM manifest (declared in
+// apps/iam/kinds/user.cue), plus the createdAt field appended below.
 //
-// lastSeenAt and disabled set EmitZeroIfAbsent so every indexed user document
-// carries those fields. The user-search API sorts on lastSeenAt and missing
-// values would otherwise sort last, putting never-seen users in a different
-// position than the historical "sort by epoch 0" behaviour.
-//
-// createdAt mirrors the standard IndexableDocument.Created field into the
-// per-kind fields.* sub-document because the top-level created field has no
-// bleve mapping today. See PR #126405 for context.
-//
-// lastSeenAt (int64) and disabled (boolean) declare SearchCapabilityFilter to
-// record that these fields are intended to be filterable, and to drive the
-// bleve mapping (numeric / boolean under dynamic mapping). End-to-end
-// numeric and boolean equality filters in ResourceSearchRequest are still a
-// follow-up: the query path treats filter values as strings, so a request
-// against these fields would not match a numeric-indexed term yet. No
-// in-tree client filters by lastSeenAt or disabled today, so this is a
-// known gap rather than a rollout concern.
-var UserSearchFields = []resource.SearchFieldDefinition{
-	{Name: USER_EMAIL, Path: "spec.email", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, Description: "The email address of the user"},
-	{Name: USER_LOGIN, Path: "spec.login", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, Description: "The login of the user"},
-	{Name: USER_LAST_SEEN_AT, Path: "status.lastSeenAt", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, EmitZeroIfAbsent: true, Description: "The last seen timestamp of the user"},
-	{Name: USER_ROLE, Path: "spec.role", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, Description: "The role of the user"},
-	{Name: USER_DISABLED, Path: "spec.disabled", Type: resource.SearchFieldTypeBoolean, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}, EmitZeroIfAbsent: true, Description: "Whether the user is disabled"},
-	{Name: USER_CREATED, CopyFromStandard: resource.StandardFieldCreated, Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}, Description: "The creation timestamp of the user, in epoch milliseconds"},
-}
+// lastSeenAt (int64) and disabled (boolean) declare the filter capability to
+// record that they are meant to be filterable and to drive the bleve mapping
+// (numeric / boolean under dynamic mapping). End-to-end numeric and boolean
+// equality filters in ResourceSearchRequest are still a follow-up: the query
+// path treats filter values as strings, so a request against these fields
+// would not match a numeric-indexed term yet. No in-tree client filters by
+// lastSeenAt or disabled today, so this is a known gap rather than a rollout
+// concern.
+var UserSearchFields = slices.Concat(
+	resource.NewManifestBackedProvider(iamManifests).Fields(iamv0.UserResourceInfo.GroupVersionResource()),
+	[]resource.SearchFieldDefinition{
+		// createdAt reads from the standard document's Created value rather than a
+		// resource path, so it cannot be declared in the manifest and stays here.
+		// It mirrors that value into the per-kind fields.* sub-document because
+		// the top-level created field has no bleve mapping today.
+		{Name: USER_CREATED, CopyFromStandard: resource.StandardFieldCreated, Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}, Description: "The creation timestamp of the user, in epoch milliseconds"},
+	},
+)
 
 func GetUserBuilder() (resource.DocumentBuilderInfo, error) {
 	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(UserTableColumnDefinitions))


### PR DESCRIPTION
The IAM kinds (team, team binding, user, and external group mapping) declared their search fields as hard-coded Go slices in the search builders. This moves those declarations into each kind's CUE manifest, so the fields live next to the rest of the kind's definition and flow through code generation into the embedded manifest. The builders now read the fields back from the generated manifest instead of keeping their own copy.

Behaviour is unchanged: every kind ends up with exactly the same search fields as before, so there is no golden-file churn and no search index rebuild. The user builder keeps its createdAt field in Go, because that field copies a standard document value rather than reading a value out of the resource, which the manifest cannot express yet.

It also adds a team document fixture that includes the members and external groups paths, so extraction of those two fields stays covered by a golden.

Follows grafana/grafana#127633. Part of grafana/search-and-storage-team#827.
