### PR TITLE
Home: Stubbed homepage recommendations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -881,6 +881,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/hooks/useMediaQueryMinWidth.ts @grafana/grafana-frontend-platform
 /public/app/core/hooks/useNavModel.ts @grafana/grafana-frontend-navigation
 /public/app/core/hooks/useQueryParams.ts @grafana/grafana-frontend-platform
+/public/app/core/hooks/useStoredBoolean.ts @grafana/grafana-frontend-platform @grafana/grafana-frontend-navigation
 /public/app/core/icons/ @grafana/grafana-frontend-platform
 /public/app/core/lifecycle-hooks.ts @grafana/grafana-frontend-platform
 /public/app/core/monacoEnv.ts @grafana/grafana-frontend-platform @grafana/grafana-catalog

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -62,7 +62,8 @@ declare module "@openfeature/core" {
     | "table.protoRowParser"
     | "table.refactorNested"
     | "dataviz.experimentalColorSchemes"
-    | "grafana.customizableMegaMenu";
+    | "grafana.customizableMegaMenu"
+    | "grafana.growthHomepage";
   export type NumberFlagKey = never;
   export type StringFlagKey = never;
   export type ObjectFlagKey = never;

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -47,6 +47,8 @@ export const FlagKeys = {
   GrafanaCustomizableMegaMenu: "grafana.customizableMegaMenu",
   /** Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button) */
   GrafanaEnableScopesFirstMode: "grafana.enableScopesFirstMode",
+  /** Enables PLG-focused growth redesign of the unified homepage */
+  GrafanaGrowthHomepage: "grafana.growthHomepage",
   /** Enables usage of the new annotations API client */
   GrafanaKubernetesAnnotationsClient: "grafana.kubernetesAnnotationsClient",
   /** Enables log level inference from log line contents when level is not defined as a field or a label */
@@ -306,6 +308,17 @@ export const useFlagGrafanaCustomizableMegaMenu = (options?: ReactFlagEvaluation
  */
 export const useFlagGrafanaEnableScopesFirstMode = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("grafana.enableScopesFirstMode", false, options).value;
+};
+
+/**
+ * Enables PLG-focused growth redesign of the unified homepage
+ *
+ * **Details:**
+ * - flag key: `grafana.growthHomepage`
+ * - default value: `false`
+ */
+export const useFlagGrafanaGrowthHomepage = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.growthHomepage", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3148,6 +3148,14 @@ var (
 			Generate:     Generate{Go: true},
 		},
 		{
+			Name:        "grafana.growthHomepage",
+			Description: "Enables PLG-focused growth redesign of the unified homepage",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaFrontendNavigation,
+			Generate:    Generate{React: true},
+			Expression:  "false",
+		},
+		{
 			Name:            "kubernetesReporting",
 			Description:     "Add support for Kubernetes reporting new APIs",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -366,4 +366,5 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-25,grafana.customizableMegaMenu,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-04-20,cujTracking,experimental,@grafana/dashboards-squad,false,false,true
 2026-06-26,auth.tokenRotationGracePeriod,experimental,@grafana/identity-access-team,false,false,false
+2026-07-01,grafana.growthHomepage,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-07-01,kubernetesReporting,experimental,@grafana/grafana-operator-experience-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2538,6 +2538,20 @@
     },
     {
       "metadata": {
+        "name": "grafana.growthHomepage",
+        "resourceVersion": "1782913620784",
+        "creationTimestamp": "2026-07-01T13:47:00Z"
+      },
+      "spec": {
+        "description": "Enables PLG-focused growth redesign of the unified homepage",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-navigation",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.kubernetesAnnotationsClient",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2026-05-22T09:03:04Z"

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.tsx
@@ -1,19 +1,10 @@
-import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo } from 'react';
-import { useLocalStorage } from 'react-use';
+import { createContext, type ReactNode, useContext, useEffect, useMemo } from 'react';
 
 import { locationService } from '@grafana/runtime';
+import { useStoredBoolean } from 'app/core/hooks/useStoredBoolean';
 
 const FEATURE_CONTROL_ACCESSIBLE_LOCAL_STORAGE_KEY = 'grafana.feature-control.accessible';
 const FEATURE_CONTROL_OPEN_LOCAL_STORAGE_KEY = 'grafana.feature-control.open';
-
-const useStoredBoolean = (key: string, initialValue: boolean): [boolean, (value: boolean) => void] => {
-  const [value, setValue] = useLocalStorage<boolean>(key, initialValue, {
-    raw: false,
-    serializer: (value: boolean) => value.toString(),
-    deserializer: (value: string) => value === 'true',
-  });
-  return [value ?? false, useCallback((nextValue: boolean) => setValue(nextValue), [setValue])];
-};
 
 export type FeatureControlContextType = {
   /** Whether the feature control button is in the toolbar */

--- a/public/app/core/hooks/useStoredBoolean.ts
+++ b/public/app/core/hooks/useStoredBoolean.ts
@@ -1,0 +1,11 @@
+import { useCallback } from 'react';
+import { useLocalStorage } from 'react-use';
+
+export const useStoredBoolean = (key: string, initialValue: boolean): [boolean, (value: boolean) => void] => {
+  const [value, setValue] = useLocalStorage<boolean>(key, initialValue, {
+    raw: false,
+    serializer: (value: boolean) => value.toString(),
+    deserializer: (value: string) => value === 'true',
+  });
+  return [value ?? false, useCallback((nextValue: boolean) => setValue(nextValue), [setValue])];
+};

--- a/public/app/core/hooks/useStoredBoolean.ts
+++ b/public/app/core/hooks/useStoredBoolean.ts
@@ -1,11 +1,13 @@
-import { useCallback } from 'react';
-import { useLocalStorage } from 'react-use';
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { store } from '@grafana/data';
 
 export const useStoredBoolean = (key: string, initialValue: boolean): [boolean, (value: boolean) => void] => {
-  const [value, setValue] = useLocalStorage<boolean>(key, initialValue, {
-    raw: false,
-    serializer: (value: boolean) => value.toString(),
-    deserializer: (value: string) => value === 'true',
-  });
-  return [value ?? false, useCallback((nextValue: boolean) => setValue(nextValue), [setValue])];
+  const subscribe = useCallback((onStoreChange: () => void) => store.subscribe(key, onStoreChange), [key]);
+  const getSnapshot = useCallback(() => store.getBool(key, initialValue), [key, initialValue]);
+
+  const value = useSyncExternalStore(subscribe, getSnapshot, () => initialValue);
+  const setValue = useCallback((nextValue: boolean) => store.set(key, nextValue), [key]);
+
+  return [value, setValue];
 };

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -5,6 +5,7 @@ import { PageLayoutType, PluginExtensionPoints } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { config, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
+import { useFlagGrafanaGrowthHomepage } from '@grafana/runtime/internal';
 import { Grid, Stack, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { ASSISTANT_PLUGIN_ID, SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
@@ -16,6 +17,7 @@ import { DashboardTabs } from './DashboardTabs/DashboardTabs';
 import { type HomepageTabExtensionProps } from './DashboardTabs/types';
 import { HomePageSkeleton } from './HomePageSkeleton';
 import { HomeSection } from './HomeSection';
+import Recommendations from './Recommendations/Recommendations';
 import useHomeGreeting from './useHomeGreeting';
 
 const getEdition = () => {
@@ -33,6 +35,8 @@ const getEdition = () => {
 export default function HomePage() {
   const styles = useStyles2(getStyles);
   const greeting = useHomeGreeting();
+
+  const redesignEnabled = useFlagGrafanaGrowthHomepage();
 
   const { components: assistantComponents, isLoading: isLoadingAssistant } = usePluginComponents({
     extensionPointId: PluginExtensionPoints.HomepageAssistant,
@@ -89,6 +93,8 @@ export default function HomePage() {
                 })}
                 <DashboardTabs extensionComponents={tabComponents} />
               </HomeSection>
+
+              {redesignEnabled && <Recommendations />}
 
               <Grid gap={2} columns={{ xs: 1, md: 2 }}>
                 <FiringAlertsCard />

--- a/public/app/features/home/Recommendations/RecommendationCard.tsx
+++ b/public/app/features/home/Recommendations/RecommendationCard.tsx
@@ -1,0 +1,48 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+
+import type { RecommendationItem } from './Recommendations';
+
+export default function RecommendationCard({ recommendation }: { recommendation: RecommendationItem }) {
+  const styles = useStyles2(getStyles, recommendation.color);
+
+  return (
+    <Stack direction="column" justifyContent="space-between" gap={2}>
+      <Stack direction="column" gap={2}>
+        <Text element="h3" variant="h3" color="primary">
+          {recommendation.title}
+        </Text>
+
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Icon name={recommendation.icon} className={styles.icon} />
+          <Text variant="body" color="secondary">
+            {recommendation.context}
+          </Text>
+        </Stack>
+
+        <Text variant="body">{recommendation.description}</Text>
+      </Stack>
+
+      <Stack direction="row" alignItems="center" gap={1}>
+        <LinkButton
+          variant="primary"
+          size="md"
+          fill="solid"
+          icon="arrow-right"
+          iconPlacement="right"
+          href={recommendation.href}
+        >
+          {recommendation.action}
+        </LinkButton>
+      </Stack>
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2, color: RecommendationItem['color']) => ({
+  icon: css({
+    color: typeof color === 'function' ? color(theme) : color,
+  }),
+});

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, within } from 'test/test-utils';
+
+import RecommendationExisting from './RecommendationExisting';
+
+describe('RecommendationExisting', () => {
+  it('opens the dropdown and switches the selected solution', async () => {
+    const { user } = render(<RecommendationExisting />);
+
+    const trigger = screen.getByRole('button');
+    const initialLabel = within(trigger).getByRole('heading').textContent?.trim() ?? '';
+    expect(initialLabel).not.toBe('');
+
+    await user.click(trigger);
+
+    expect(await screen.findByRole('menu')).toBeInTheDocument();
+    const menuItems = screen.getAllByRole('menuitem');
+    expect(menuItems.length).toBeGreaterThan(1);
+
+    const nextItem = menuItems.find((item) => (item.textContent?.trim() ?? '') !== initialLabel);
+    expect(nextItem).toBeDefined();
+
+    const nextLabel = nextItem?.textContent?.trim() ?? '';
+    expect(nextLabel).not.toBe('');
+
+    await user.click(nextItem!);
+
+    expect(within(trigger).getByRole('heading', { name: nextLabel })).toBeInTheDocument();
+    expect(within(trigger).queryByRole('heading', { name: initialLabel })).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/home/Recommendations/RecommendationExisting.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.tsx
@@ -1,0 +1,225 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { type IconName, type GrafanaTheme2 } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { Button, Dropdown, Icon, LinkButton, Menu, Stack, Text, useStyles2 } from '@grafana/ui';
+
+interface ExistingItem {
+  title: string;
+  icon: IconName;
+  stats: {
+    primary: string;
+    secondary: string;
+  };
+  alert: {
+    primary: string;
+    secondary: string;
+    action: string;
+    href: string;
+  };
+  action: string;
+  href: string;
+}
+
+const existing: ExistingItem[] = [
+  {
+    title: 'Kubernetes Monitoring',
+    icon: 'kubernetes',
+    stats: {
+      primary: '3 clusters',
+      secondary: '247 pods',
+    },
+    alert: {
+      primary: '2 alerts firing',
+      secondary: 'payments-api · 14 pod restarts in the last hour',
+      action: 'View',
+      href: '#',
+    },
+    action: 'Open K8s app',
+    href: '#',
+  },
+  {
+    title: 'Hosted Metrics',
+    icon: 'chart-line',
+    stats: {
+      primary: '4.2M series',
+      secondary: '12 hosts',
+    },
+    alert: {
+      primary: '3 hosts above 90% disk',
+      secondary: 'web-03 critical at 96% — ~6 h to full',
+      action: 'View',
+      href: '#',
+    },
+    action: 'Open infrastructure',
+    href: '#',
+  },
+  {
+    title: 'Hosted Logs',
+    icon: 'file-alt',
+    stats: {
+      primary: '47 GB ingested',
+      secondary: '8 sources',
+    },
+    alert: {
+      primary: 'Ingest spike detected',
+      secondary: 'checkout-service logs up 3x in the last hour',
+      action: 'View',
+      href: '#',
+    },
+    action: 'Open Explore (Logs)',
+    href: '#',
+  },
+];
+
+export default function RecommendationExisting() {
+  const styles = useStyles2(getStyles);
+  const [selected, setSelected] = useState(existing[0]);
+
+  if (!selected) {
+    return null;
+  }
+
+  return (
+    <Stack direction="column" justifyContent="space-between" gap={2} flex={1}>
+      <Dropdown
+        overlay={
+          <Menu>
+            <Menu.Group label={t('home.recommendations.switch', 'Switch to another app you run')}>
+              {existing.map((item) => (
+                <Menu.Item
+                  key={item.title}
+                  label={item.title}
+                  icon={item.icon}
+                  onClick={() => setSelected(item)}
+                  active={item === selected}
+                />
+              ))}
+            </Menu.Group>
+          </Menu>
+        }
+      >
+        <Button variant="secondary" fill="text" className={styles.dropdown}>
+          <Stack direction="row" gap={1} alignItems="center">
+            <div className={styles.icon}>
+              <Icon name={selected.icon} size="lg" />
+            </div>
+
+            <Stack direction="column" gap={0}>
+              <Text variant="bodySmall" color="secondary">
+                <span className={styles.subtitle}>
+                  <Trans i18nKey="home.recommendations.existing">Enabled solution</Trans>
+                </span>
+              </Text>
+
+              <Stack direction="row" gap={0.5} alignItems="center">
+                <Text variant="h4" color="primary" role="heading" aria-level={3}>
+                  {selected.title}
+                </Text>
+
+                <Icon name="angle-down" className={styles.chevron} />
+              </Stack>
+            </Stack>
+          </Stack>
+        </Button>
+      </Dropdown>
+
+      <Stack direction="column" gap={2}>
+        <Stack direction="row" alignItems="baseline" columnGap={0.5} rowGap={0} wrap="wrap">
+          <Text variant="h2" color="primary">
+            {selected.stats.primary}
+          </Text>
+
+          <Text variant="body" color="secondary">
+            &middot; {selected.stats.secondary}
+          </Text>
+        </Stack>
+
+        <div className={styles.alert}>
+          <Stack direction="row" alignItems="center" gap={1}>
+            <Icon name="exclamation-triangle" size="md" className={styles.warning} />
+
+            <Stack direction="row" alignItems="center" columnGap={0.5} rowGap={0} flex="1 1 auto" wrap="wrap">
+              <Text variant="body" color="primary">
+                {selected.alert.primary}
+              </Text>
+
+              <Text variant="body" color="secondary">
+                &middot; {selected.alert.secondary}
+              </Text>
+            </Stack>
+
+            <LinkButton
+              variant="secondary"
+              size="sm"
+              fill="text"
+              icon="angle-right"
+              iconPlacement="right"
+              href={selected.alert.href}
+            >
+              {selected.alert.action}
+            </LinkButton>
+          </Stack>
+        </div>
+      </Stack>
+
+      <Stack direction="row" alignItems="center" gap={1}>
+        <LinkButton
+          variant="secondary"
+          size="md"
+          fill="solid"
+          icon="arrow-right"
+          iconPlacement="right"
+          href={selected.href}
+        >
+          {selected.action}
+        </LinkButton>
+      </Stack>
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  dropdown: css({
+    alignSelf: 'flex-start',
+    height: 'auto',
+    padding: theme.spacing(1),
+    margin: theme.spacing(-1),
+    textAlign: 'left',
+
+    '&:hover': {
+      borderColor: theme.colors.border.medium,
+    },
+  }),
+  chevron: css({
+    color: theme.colors.text.secondary,
+
+    '[aria-expanded="true"] &': {
+      transform: 'rotate(180deg)',
+    },
+  }),
+  icon: css({
+    background: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.medium}`,
+    color: theme.colors.text.secondary,
+    padding: theme.spacing(1.5),
+    lineHeight: 0,
+  }),
+  subtitle: css({
+    textTransform: 'uppercase',
+    letterSpacing: theme.spacing(0.125),
+    opacity: 0.75,
+  }),
+  alert: css({
+    background: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.medium}`,
+    padding: theme.spacing(1),
+  }),
+  warning: css({
+    color: theme.colors.warning.main,
+    margin: theme.spacing(0, 0, 0, 0.5),
+  }),
+});

--- a/public/app/features/home/Recommendations/RecommendationPill.tsx
+++ b/public/app/features/home/Recommendations/RecommendationPill.tsx
@@ -1,0 +1,34 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { LinkButton, useStyles2 } from '@grafana/ui';
+
+import type { RecommendationItem } from './Recommendations';
+
+export default function RecommendationPill({ recommendation }: { recommendation: RecommendationItem }) {
+  const styles = useStyles2(getStyles, recommendation.color);
+
+  return (
+    <LinkButton
+      variant="secondary"
+      size="sm"
+      fill="solid"
+      icon={recommendation.icon}
+      href={recommendation.href}
+      className={styles.pill}
+    >
+      {recommendation.action}
+    </LinkButton>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2, color: RecommendationItem['color']) => ({
+  pill: css({
+    borderRadius: theme.shape.radius.pill,
+    border: `1px solid ${theme.colors.border.medium}`,
+
+    '& > svg': {
+      color: typeof color === 'function' ? color(theme) : color,
+    },
+  }),
+});

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -24,7 +24,7 @@ describe('Recommendations', () => {
     expect(screen.getByText('Recommendations for your stack')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Hide' })).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.queryAllByRole('link')).toHaveLength(0);
+    expect(screen.getAllByRole('link')).toHaveLength(1);
   });
 
   it('loads the collapsed state from local storage', () => {
@@ -34,5 +34,31 @@ describe('Recommendations', () => {
     expect(screen.getByRole('button', { name: 'Show' })).toBeInTheDocument();
     expect(screen.getByText('Recommendations for your stack')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Show' })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('navigates recommendations with previous/next buttons', async () => {
+    const { user } = render(<Recommendations />);
+
+    const getVisibleTitle = () => screen.getByRole('heading', { level: 3 }).textContent?.trim() ?? '';
+    const getVisibleSlide = () => screen.getByRole('heading', { level: 3 }).closest('div[aria-hidden="false"]');
+
+    const initialVisibleSlide = getVisibleSlide();
+    const initialVisibleTitle = getVisibleTitle();
+
+    expect(initialVisibleSlide).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(getVisibleSlide()).toBeInTheDocument();
+    expect(getVisibleSlide()).not.toBe(initialVisibleSlide);
+    expect(getVisibleTitle()).not.toBe(initialVisibleTitle);
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
+
+    await user.click(screen.getByRole('button', { name: 'Previous' }));
+
+    expect(getVisibleSlide()).toBe(initialVisibleSlide);
+    expect(getVisibleTitle()).toBe(initialVisibleTitle);
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
   });
 });

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from 'test/test-utils';
+
+import Recommendations from './Recommendations';
+
+describe('Recommendations', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('collapses and expands the recommendations card', async () => {
+    const { user } = render(<Recommendations />);
+
+    expect(screen.getByText('Recommendations for your stack')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Hide' }));
+
+    expect(screen.getByRole('button', { name: 'Show' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show' })).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getAllByRole('link')).toHaveLength(3);
+
+    await user.click(screen.getByRole('button', { name: 'Show' }));
+
+    expect(screen.getByText('Recommendations for your stack')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  it('loads the collapsed state from local storage', () => {
+    window.localStorage.setItem('grafana.home.recommendations.collapsed', 'true');
+    render(<Recommendations />);
+
+    expect(screen.getByRole('button', { name: 'Show' })).toBeInTheDocument();
+    expect(screen.getByText('Recommendations for your stack')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show' })).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from 'test/test-utils';
+import { act, render, screen, userEvent } from 'test/test-utils';
 
 import Recommendations from './Recommendations';
 
@@ -60,5 +60,71 @@ describe('Recommendations', () => {
     expect(getVisibleSlide()).toBe(initialVisibleSlide);
     expect(getVisibleTitle()).toBe(initialVisibleTitle);
     expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
+  });
+
+  it('navigates recommendations with dots', async () => {
+    const { user } = render(<Recommendations />);
+
+    expect(screen.queryByRole('button', { name: 'Go to recommendation 1' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to recommendation 2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to recommendation 3' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Go to recommendation 3' }));
+
+    expect(screen.getByRole('button', { name: 'Go to recommendation 1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to recommendation 2' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Go to recommendation 3' })).not.toBeInTheDocument();
+  });
+
+  it('pauses by default when reduced motion is preferred', () => {
+    const matchMediaSpy = jest.spyOn(window, 'matchMedia').mockImplementation(
+      () =>
+        ({
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+          matches: true,
+        }) as unknown as MediaQueryList
+    );
+
+    try {
+      render(<Recommendations />);
+
+      expect(screen.getByRole('button', { name: 'Resume' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Pause' })).not.toBeInTheDocument();
+    } finally {
+      matchMediaSpy.mockRestore();
+    }
+  });
+
+  it('pauses and resumes autoplay', async () => {
+    jest.useFakeTimers();
+
+    try {
+      render(<Recommendations />);
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      const pauseButton = screen.getByRole('button', { name: 'Pause' });
+      await user.click(pauseButton);
+
+      expect(screen.getByRole('button', { name: 'Resume' })).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(6000);
+      });
+
+      expect(screen.queryByRole('button', { name: 'Go to recommendation 1' })).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Resume' }));
+
+      expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(6000);
+      });
+
+      expect(screen.getByRole('button', { name: 'Go to recommendation 1' })).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -17,14 +17,16 @@ describe('Recommendations', () => {
 
     expect(screen.getByRole('button', { name: 'Show' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Show' })).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.getAllByRole('link')).toHaveLength(3);
+    expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Previous' })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Show' }));
 
     expect(screen.getByText('Recommendations for your stack')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Hide' })).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.getAllByRole('link')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeInTheDocument();
   });
 
   it('loads the collapsed state from local storage', () => {
@@ -39,27 +41,29 @@ describe('Recommendations', () => {
   it('navigates recommendations with previous/next buttons', async () => {
     const { user } = render(<Recommendations />);
 
-    const getVisibleTitle = () => screen.getByRole('heading', { level: 3 }).textContent?.trim() ?? '';
-    const getVisibleSlide = () => screen.getByRole('heading', { level: 3 }).closest('div[aria-hidden="false"]');
+    const getVisibleHeading = () =>
+      screen.getAllByRole('heading', { level: 3 }).find((heading) => heading.closest('div[aria-hidden="false"]'));
+    const getVisibleTitle = () => getVisibleHeading()?.textContent?.trim() ?? '';
+    const getVisibleSlide = () => getVisibleHeading()?.closest('div[aria-hidden="false"]');
 
     const initialVisibleSlide = getVisibleSlide();
     const initialVisibleTitle = getVisibleTitle();
 
     expect(initialVisibleSlide).toBeInTheDocument();
-    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
+    expect(getVisibleHeading()).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Next' }));
 
     expect(getVisibleSlide()).toBeInTheDocument();
     expect(getVisibleSlide()).not.toBe(initialVisibleSlide);
     expect(getVisibleTitle()).not.toBe(initialVisibleTitle);
-    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
+    expect(getVisibleHeading()).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Previous' }));
 
     expect(getVisibleSlide()).toBe(initialVisibleSlide);
     expect(getVisibleTitle()).toBe(initialVisibleTitle);
-    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
+    expect(getVisibleHeading()).toBeInTheDocument();
   });
 
   it('navigates recommendations with dots', async () => {

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -57,8 +57,9 @@ export default function Recommendations() {
   const [collapsed, setCollapsed] = useStoredBoolean(HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY, false);
 
   const [index, setIndex] = useState(0);
+  const [paused, setPaused] = useState(() => window.matchMedia('(prefers-reduced-motion: reduce)').matches);
   useEffect(() => {
-    if (collapsed || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    if (collapsed || paused) {
       return;
     }
 
@@ -67,7 +68,7 @@ export default function Recommendations() {
     }, 5000);
 
     return () => clearTimeout(timeout);
-  }, [collapsed, index]);
+  }, [collapsed, paused, index]);
 
   return (
     <div>
@@ -118,6 +119,34 @@ export default function Recommendations() {
                 aria-label={t('home.recommendations.previous', 'Previous')}
               />
 
+              {recommendations.map((_, i) =>
+                i === index ? (
+                  <Button
+                    key={i}
+                    variant="secondary"
+                    size="sm"
+                    fill="solid"
+                    icon={paused ? 'play' : 'pause'}
+                    onClick={() => setPaused(!paused)}
+                    aria-label={
+                      paused ? t('home.recommendations.resume', 'Resume') : t('home.recommendations.pause', 'Pause')
+                    }
+                    data-paused={paused ? true : undefined}
+                    className={cx(styles.dot, styles.active)}
+                  />
+                ) : (
+                  <Button
+                    key={i}
+                    variant="secondary"
+                    size="sm"
+                    fill="solid"
+                    onClick={() => setIndex(i)}
+                    aria-label={t('home.recommendations.go-to', 'Go to recommendation {{index}}', { index: i + 1 })}
+                    className={styles.dot}
+                  />
+                )
+              )}
+
               <Button
                 variant="secondary"
                 size="sm"
@@ -167,6 +196,61 @@ const getStyles = (theme: GrafanaTheme2) => ({
       background: theme.colors.gradients.brandHorizontal,
       opacity: 0.05,
       pointerEvents: 'none',
+    },
+  }),
+  dot: css({
+    background: theme.colors.background.secondary,
+    lineHeight: 0,
+    padding: 0,
+    width: theme.spacing(1),
+    height: theme.spacing(1),
+    borderRadius: theme.shape.radius.pill,
+    position: 'relative',
+
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      width: theme.spacing(2),
+      height: theme.spacing(2),
+    },
+
+    [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+      transition: theme.transitions.create(['background-color', 'width', 'height'], {
+        duration: theme.transitions.duration.short,
+      }),
+    },
+  }),
+  active: css({
+    '&, &::after': {
+      width: theme.spacing(3),
+    },
+
+    '&, &:hover, &:focus': {
+      background: theme.colors.text.maxContrast,
+      color: theme.colors.background.secondary,
+    },
+
+    '&:hover, &[data-paused]': {
+      height: theme.spacing(2),
+    },
+
+    '& > svg': {
+      margin: '0 auto',
+
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: theme.transitions.create(['opacity'], {
+          duration: theme.transitions.duration.short,
+        }),
+      },
+    },
+
+    '&:not(:hover):not([data-paused])': {
+      '& > svg': {
+        opacity: 0,
+      },
     },
   }),
   outer: css({

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -1,0 +1,102 @@
+import { css, cx } from '@emotion/css';
+
+import { type GrafanaTheme2, type IconName } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { Button, Stack, Text, useStyles2 } from '@grafana/ui';
+import { useStoredBoolean } from 'app/core/hooks/useStoredBoolean';
+
+import RecommendationPill from './RecommendationPill';
+
+const HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY = 'grafana.home.recommendations.collapsed';
+
+export interface RecommendationItem {
+  title: string;
+  icon: IconName;
+  color: string | ((theme: GrafanaTheme2) => string);
+  context: string;
+  description: string;
+  action: string;
+  href: string;
+}
+
+// Stubbed data for initial development
+const recommendations: RecommendationItem[] = [
+  {
+    title: 'Explore your service map',
+    icon: 'shield',
+    color: (theme) => theme.visualization.getColorByName('green'),
+    context: '34 services mapped automatically',
+    description: 'Grafana built a live map of your services from their telemetry — dive in.',
+    action: 'Open the map',
+    href: '#',
+  },
+  {
+    title: 'Watch your cluster from outside',
+    icon: 'plus',
+    color: (theme) => theme.visualization.getColorByName('purple'),
+    context: 'Because you set up Kubernetes Monitoring',
+    description: 'Probe your endpoints from 20+ global locations before your users notice.',
+    action: 'Add Synthetic Monitoring',
+    href: '#',
+  },
+  {
+    title: 'Define an SLO on checkout',
+    icon: 'crosshair',
+    color: (theme) => theme.visualization.getColorByName('blue'),
+    context: 'You have the metrics — set a target',
+    description: 'Turn your telemetry into a reliability target and track the error budget.',
+    action: 'Open SLOs',
+    href: '#',
+  },
+];
+
+export default function Recommendations() {
+  const styles = useStyles2(getStyles);
+  const [collapsed, setCollapsed] = useStoredBoolean(HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY, false);
+
+  return (
+    <div>
+      <Stack direction="row" alignItems="center" gap={2}>
+        <Text element="h2" variant="h5">
+          <Trans i18nKey="home.recommendations.title">Recommendations for your stack</Trans>
+        </Text>
+
+        {collapsed && (
+          <Stack direction="row" alignItems="center" gap={1}>
+            {recommendations.map((recommendation) => (
+              <RecommendationPill key={recommendation.title} recommendation={recommendation} />
+            ))}
+          </Stack>
+        )}
+
+        <div className={cx(styles.spacer, collapsed && styles.line)} />
+
+        <Button
+          variant="secondary"
+          size="sm"
+          fill="text"
+          icon={collapsed ? 'angle-down' : 'angle-up'}
+          iconPlacement="right"
+          onClick={() => setCollapsed(!collapsed)}
+          aria-expanded={!collapsed}
+        >
+          {collapsed ? (
+            <Trans i18nKey="home.recommendations.show">Show</Trans>
+          ) : (
+            <Trans i18nKey="home.recommendations.hide">Hide</Trans>
+          )}
+        </Button>
+      </Stack>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  spacer: css({
+    flex: 1,
+  }),
+  line: css({
+    background: theme.colors.border.medium,
+    height: '1px',
+  }),
+});

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -72,36 +72,40 @@ export default function Recommendations() {
 
   return (
     <div>
-      <Stack direction="row" alignItems="center" gap={2}>
+      <Stack direction="row" alignItems="center" columnGap={2} rowGap={1} wrap="wrap">
         <Text element="h2" variant="h5">
           <Trans i18nKey="home.recommendations.title">Recommendations for your stack</Trans>
         </Text>
 
         {collapsed && (
-          <Stack direction="row" alignItems="center" gap={1}>
-            {recommendations.map((recommendation) => (
-              <RecommendationPill key={recommendation.title} recommendation={recommendation} />
-            ))}
-          </Stack>
+          <div className={styles.pills}>
+            <Stack direction="row" alignItems="center" gap={1} wrap="wrap">
+              {recommendations.map((recommendation) => (
+                <RecommendationPill key={recommendation.title} recommendation={recommendation} />
+              ))}
+            </Stack>
+          </div>
         )}
 
-        <div className={cx(styles.spacer, collapsed && styles.line)} />
+        <Stack direction="row" alignItems="center" gap={1} flex="1 1 auto">
+          <div className={cx(styles.spacer, collapsed && styles.line)} />
 
-        <Button
-          variant="secondary"
-          size="sm"
-          fill="text"
-          icon={collapsed ? 'angle-down' : 'angle-up'}
-          iconPlacement="right"
-          onClick={() => setCollapsed(!collapsed)}
-          aria-expanded={!collapsed}
-        >
-          {collapsed ? (
-            <Trans i18nKey="home.recommendations.show">Show</Trans>
-          ) : (
-            <Trans i18nKey="home.recommendations.hide">Hide</Trans>
-          )}
-        </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            fill="text"
+            icon={collapsed ? 'angle-down' : 'angle-up'}
+            iconPlacement="right"
+            onClick={() => setCollapsed(!collapsed)}
+            aria-expanded={!collapsed}
+          >
+            {collapsed ? (
+              <Trans i18nKey="home.recommendations.show">Show</Trans>
+            ) : (
+              <Trans i18nKey="home.recommendations.hide">Hide</Trans>
+            )}
+          </Button>
+        </Stack>
       </Stack>
 
       {!collapsed && (
@@ -174,12 +178,19 @@ export default function Recommendations() {
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  pills: css({
+    [theme.breakpoints.down('md')]: {
+      order: 1,
+    },
+  }),
   spacer: css({
-    flex: 1,
+    flex: '1 1 0%',
   }),
   line: css({
-    background: theme.colors.border.medium,
-    height: '1px',
+    [theme.breakpoints.up('md')]: {
+      background: theme.colors.border.medium,
+      height: '1px',
+    },
   }),
   card: css({
     background: theme.colors.background.canvas,

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -3,10 +3,11 @@ import { useEffect, useState } from 'react';
 
 import { type GrafanaTheme2, type IconName } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Badge, Button, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Badge, Button, Grid, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
 import { useStoredBoolean } from 'app/core/hooks/useStoredBoolean';
 
 import RecommendationCard from './RecommendationCard';
+import RecommendationExisting from './RecommendationExisting';
 import RecommendationPill from './RecommendationPill';
 
 const HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY = 'grafana.home.recommendations.collapsed';
@@ -109,68 +110,80 @@ export default function Recommendations() {
       </Stack>
 
       {!collapsed && (
-        <div className={styles.card}>
-          <Stack direction="row" justifyContent="space-between" alignItems="center" gap={2}>
-            <Badge color="brand" icon="bolt" text={t('home.recommendations.recommended', 'Recommended')} />
+        <div className={styles.cards}>
+          <Grid gap={0} columns={{ xs: 1, md: 2 }}>
+            <div className={styles.card}>
+              <RecommendationExisting />
 
-            <Stack direction="row" alignItems="center" gap={1}>
-              <Button
-                variant="secondary"
-                size="sm"
-                fill="text"
-                icon="angle-left"
-                onClick={() => setIndex((index - 1 + recommendations.length) % recommendations.length)}
-                aria-label={t('home.recommendations.previous', 'Previous')}
-              />
-
-              {recommendations.map((_, i) =>
-                i === index ? (
-                  <Button
-                    key={i}
-                    variant="secondary"
-                    size="sm"
-                    fill="solid"
-                    icon={paused ? 'play' : 'pause'}
-                    onClick={() => setPaused(!paused)}
-                    aria-label={
-                      paused ? t('home.recommendations.resume', 'Resume') : t('home.recommendations.pause', 'Pause')
-                    }
-                    data-paused={paused ? true : undefined}
-                    className={cx(styles.dot, styles.active)}
-                  />
-                ) : (
-                  <Button
-                    key={i}
-                    variant="secondary"
-                    size="sm"
-                    fill="solid"
-                    onClick={() => setIndex(i)}
-                    aria-label={t('home.recommendations.go-to', 'Go to recommendation {{index}}', { index: i + 1 })}
-                    className={styles.dot}
-                  />
-                )
-              )}
-
-              <Button
-                variant="secondary"
-                size="sm"
-                fill="text"
-                icon="angle-right"
-                onClick={() => setIndex((index + 1) % recommendations.length)}
-                aria-label={t('home.recommendations.next', 'Next')}
-              />
-            </Stack>
-          </Stack>
-
-          <div className={styles.outer}>
-            <div className={styles.inner} style={{ transform: `translateX(-${index * 100}%)` }}>
-              {recommendations.map((recommendation, i) => (
-                <div key={recommendation.title} className={styles.item} aria-hidden={i !== index}>
-                  <RecommendationCard recommendation={recommendation} />
-                </div>
-              ))}
+              <div className={styles.arrow}>
+                <Icon name="arrow-right" size="xl" />
+              </div>
             </div>
-          </div>
+
+            <div className={cx(styles.card, styles.recommended)}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" gap={2}>
+                <Badge color="brand" icon="bolt" text={t('home.recommendations.recommended', 'Recommended')} />
+
+                <Stack direction="row" alignItems="center" gap={1}>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    fill="text"
+                    icon="angle-left"
+                    onClick={() => setIndex((index - 1 + recommendations.length) % recommendations.length)}
+                    aria-label={t('home.recommendations.previous', 'Previous')}
+                  />
+
+                  {recommendations.map((_, i) =>
+                    i === index ? (
+                      <Button
+                        key={i}
+                        variant="secondary"
+                        size="sm"
+                        fill="solid"
+                        icon={paused ? 'play' : 'pause'}
+                        onClick={() => setPaused(!paused)}
+                        aria-label={
+                          paused ? t('home.recommendations.resume', 'Resume') : t('home.recommendations.pause', 'Pause')
+                        }
+                        data-paused={paused ? true : undefined}
+                        className={cx(styles.dot, styles.active)}
+                      />
+                    ) : (
+                      <Button
+                        key={i}
+                        variant="secondary"
+                        size="sm"
+                        fill="solid"
+                        onClick={() => setIndex(i)}
+                        aria-label={t('home.recommendations.go-to', 'Go to recommendation {{index}}', { index: i + 1 })}
+                        className={styles.dot}
+                      />
+                    )
+                  )}
+
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    fill="text"
+                    icon="angle-right"
+                    onClick={() => setIndex((index + 1) % recommendations.length)}
+                    aria-label={t('home.recommendations.next', 'Next')}
+                  />
+                </Stack>
+              </Stack>
+
+              <div className={styles.outer}>
+                <div className={styles.inner} style={{ transform: `translateX(-${index * 100}%)` }}>
+                  {recommendations.map((recommendation, i) => (
+                    <div key={recommendation.title} className={styles.item} aria-hidden={i !== index}>
+                      <RecommendationCard recommendation={recommendation} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </Grid>
         </div>
       )}
     </div>
@@ -192,14 +205,20 @@ const getStyles = (theme: GrafanaTheme2) => ({
       height: '1px',
     },
   }),
-  card: css({
+  cards: css({
     background: theme.colors.background.canvas,
     borderRadius: theme.shape.radius.default,
     margin: theme.spacing(2, 0, 0),
-    padding: theme.spacing(2),
-    position: 'relative',
     overflow: 'hidden',
-
+  }),
+  card: css({
+    display: 'flex',
+    flexDirection: 'column',
+    padding: theme.spacing(3, 4),
+    position: 'relative',
+    minWidth: 0,
+  }),
+  recommended: css({
     '&::before': {
       content: '""',
       position: 'absolute',
@@ -207,6 +226,24 @@ const getStyles = (theme: GrafanaTheme2) => ({
       background: theme.colors.gradients.brandHorizontal,
       opacity: 0.05,
       pointerEvents: 'none',
+    },
+  }),
+  arrow: css({
+    background: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.circle,
+    border: `1px solid ${theme.colors.border.medium}`,
+    padding: theme.spacing(0.25),
+    lineHeight: 0,
+    position: 'absolute',
+    zIndex: 1,
+    left: '50%',
+    top: '100%',
+    transform: 'translate(-50%, -50%) rotate(90deg)',
+
+    [theme.breakpoints.up('md')]: {
+      top: theme.spacing(2),
+      left: '100%',
+      transform: 'translate(-50%, 0)',
     },
   }),
   dot: css({
@@ -277,6 +314,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     },
   }),
   item: css({
+    display: 'flex',
     minWidth: '100%',
   }),
 });

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -1,10 +1,12 @@
 import { css, cx } from '@emotion/css';
+import { useEffect, useState } from 'react';
 
 import { type GrafanaTheme2, type IconName } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
-import { Button, Stack, Text, useStyles2 } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
+import { Badge, Button, Stack, Text, useStyles2 } from '@grafana/ui';
 import { useStoredBoolean } from 'app/core/hooks/useStoredBoolean';
 
+import RecommendationCard from './RecommendationCard';
 import RecommendationPill from './RecommendationPill';
 
 const HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY = 'grafana.home.recommendations.collapsed';
@@ -54,6 +56,19 @@ export default function Recommendations() {
   const styles = useStyles2(getStyles);
   const [collapsed, setCollapsed] = useStoredBoolean(HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY, false);
 
+  const [index, setIndex] = useState(0);
+  useEffect(() => {
+    if (collapsed || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setIndex((index + 1) % recommendations.length);
+    }, 5000);
+
+    return () => clearTimeout(timeout);
+  }, [collapsed, index]);
+
   return (
     <div>
       <Stack direction="row" alignItems="center" gap={2}>
@@ -87,6 +102,44 @@ export default function Recommendations() {
           )}
         </Button>
       </Stack>
+
+      {!collapsed && (
+        <div className={styles.card}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" gap={2}>
+            <Badge color="brand" icon="bolt" text={t('home.recommendations.recommended', 'Recommended')} />
+
+            <Stack direction="row" alignItems="center" gap={1}>
+              <Button
+                variant="secondary"
+                size="sm"
+                fill="text"
+                icon="angle-left"
+                onClick={() => setIndex((index - 1 + recommendations.length) % recommendations.length)}
+                aria-label={t('home.recommendations.previous', 'Previous')}
+              />
+
+              <Button
+                variant="secondary"
+                size="sm"
+                fill="text"
+                icon="angle-right"
+                onClick={() => setIndex((index + 1) % recommendations.length)}
+                aria-label={t('home.recommendations.next', 'Next')}
+              />
+            </Stack>
+          </Stack>
+
+          <div className={styles.outer}>
+            <div className={styles.inner} style={{ transform: `translateX(-${index * 100}%)` }}>
+              {recommendations.map((recommendation, i) => (
+                <div key={recommendation.title} className={styles.item} aria-hidden={i !== index}>
+                  <RecommendationCard recommendation={recommendation} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -98,5 +151,37 @@ const getStyles = (theme: GrafanaTheme2) => ({
   line: css({
     background: theme.colors.border.medium,
     height: '1px',
+  }),
+  card: css({
+    background: theme.colors.background.canvas,
+    borderRadius: theme.shape.radius.default,
+    margin: theme.spacing(2, 0, 0),
+    padding: theme.spacing(2),
+    position: 'relative',
+    overflow: 'hidden',
+
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      inset: 0,
+      background: theme.colors.gradients.brandHorizontal,
+      opacity: 0.05,
+      pointerEvents: 'none',
+    },
+  }),
+  outer: css({
+    overflow: 'hidden',
+    flex: 1,
+    margin: theme.spacing(2, 0, 0),
+  }),
+  inner: css({
+    display: 'flex',
+
+    [theme.transitions.handleMotion('no-preference')]: {
+      transition: theme.transitions.create(['transform']),
+    },
+  }),
+  item: css({
+    minWidth: '100%',
   }),
 });

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10710,6 +10710,11 @@
       "error-title": "Could not load recently viewed dashboards",
       "loading": "Loading recently viewed dashboards..."
     },
+    "recommendations": {
+      "hide": "Hide",
+      "show": "Show",
+      "title": "Recommendations for your stack"
+    },
     "starred-dashboards-tab": {
       "empty": "Your starred dashboards will appear here.",
       "empty-description": "You can star your favorite dashboards by clicking the <1></1> from the dashboard page.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10712,6 +10712,9 @@
     },
     "recommendations": {
       "hide": "Hide",
+      "next": "Next",
+      "previous": "Previous",
+      "recommended": "Recommended",
       "show": "Show",
       "title": "Recommendations for your stack"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10711,6 +10711,7 @@
       "loading": "Loading recently viewed dashboards..."
     },
     "recommendations": {
+      "existing": "Enabled solution",
       "go-to": "Go to recommendation {{index}}",
       "hide": "Hide",
       "next": "Next",
@@ -10719,6 +10720,7 @@
       "recommended": "Recommended",
       "resume": "Resume",
       "show": "Show",
+      "switch": "Switch to another app you run",
       "title": "Recommendations for your stack"
     },
     "starred-dashboards-tab": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10711,10 +10711,13 @@
       "loading": "Loading recently viewed dashboards..."
     },
     "recommendations": {
+      "go-to": "Go to recommendation {{index}}",
       "hide": "Hide",
       "next": "Next",
+      "pause": "Pause",
       "previous": "Previous",
       "recommended": "Recommended",
+      "resume": "Resume",
       "show": "Show",
       "title": "Recommendations for your stack"
     },


### PR DESCRIPTION
**What is this feature?**

Adds an initial stubbed version of the recommendations section on the homepage.

https://github.com/user-attachments/assets/f6d5f6dd-0d46-4b38-a5f2-4bb75de56286

On mobile, when expanded, the cards are stacked vertically:

<img width="389" height="649" alt="image" src="https://github.com/user-attachments/assets/b4086901-8c0d-435f-9d7b-a01787643648" />

On mobile, when collapsed, the pills are moved below the heading/show button: 

<img width="495" height="74" alt="image" src="https://github.com/user-attachments/assets/07d505f9-73f1-4b5d-a56d-6a6589828901" />

**Why do we need this feature?**

Provide more value to users on the homepage, to allow them to get the most out of Grafana.

**Who is this feature for?**

Admins.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/127708
Fixes https://github.com/grafana/grafana/issues/127713

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.


