### PR TITLE
CI: Update Dependabot PR updater to sign commits

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,7 +31,7 @@ jobs:
       # finish within its timeout, so every push is rejected with "workflows scope may
       # be required" -- even when no workflow files are touched. workflows:write tells
       # GitHub to skip that scan. grafana-writer is the only app installed with that
-      # scope here. Commits go through the Git Data API via kminehart/ghcommit-action
+      # scope here. Commits go through the Git Data API via planetscale/ghcommit-action
       # so they're automatically signed under grafana-writer[bot]'s identity, satisfying
       # upcoming required_signatures rules.
       - name: Get GitHub App token
@@ -60,7 +60,7 @@ jobs:
             -f "sha=${BASE_SHA}"
       - if: ${{ inputs.push == true || inputs.push == 'true' }}
         name: Commit bump-version changes
-        uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         with:
           commit_message: "bump version ${{ env.VERSION }}"
           repo: ${{ github.repository }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -168,7 +168,7 @@ jobs:
       # the previous `git commit --allow-empty` behaviour for runs with no changelog diff.
       - name: "Commit changelog changes"
         if: inputs.dry_run != true
-        uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         with:
           commit_message: "Update changelog"
           repo: ${{ github.repository }}

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -59,7 +59,7 @@ jobs:
       # grafana/grafana is too large for GitHub's pre-receive workflow-file scan to finish
       # within its timeout, so every push is rejected with "workflows scope may be required"
       # unless the token has workflows:write. grafana-writer is the only app installed with
-      # that scope; commits go through the Git Data API via kminehart/ghcommit-action so
+      # that scope; commits go through the Git Data API via planetscale/ghcommit-action so
       # they're auto-signed under grafana-writer[bot]'s identity.
       - name: Get GitHub App token (writer)
         id: get-writer-app-token
@@ -90,7 +90,7 @@ jobs:
             -f "sha=${BASE_SHA}"
       - if: ${{ !inputs.dry_run }}
         name: Commit version pin to release branch
-        uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         with:
           commit_message: "Release: set version to ${{ env.RELEASE_VERSION }}"
           repo: ${{ github.repository }}
@@ -147,7 +147,7 @@ jobs:
             -f "sha=${BASE_SHA}"
       - if: ${{ !inputs.dry_run }}
         name: Commit bump-version changes
-        uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         with:
           commit_message: "Release: bump version to ${{ env.NEXT_VERSION }}"
           repo: ${{ github.repository }}

--- a/.github/workflows/pr-dependabot-update-go-workspace.yml
+++ b/.github/workflows/pr-dependabot-update-go-workspace.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Commit and push workspace changes
       if: steps.changes.outputs.changed == 'true'
-      uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
+      uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
       with:
         commit_message: "update workspace"
         repo: ${{ github.repository }}

--- a/.github/workflows/pr-dependabot-update-go-workspace.yml
+++ b/.github/workflows/pr-dependabot-update-go-workspace.yml
@@ -41,21 +41,24 @@ jobs:
       with:
         cache-build: 'false'
 
-    - name: Configure Git
-      run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
     - name: Update workspace
       run: make update-workspace
 
-    - name: Commit and push workspace changes
-      env:
-        BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-        GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+    - name: Check for workspace changes
+      id: changes
       run: |
-        if ! git diff --exit-code --quiet; then
-          echo "Committing and pushing workspace changes"
-          git commit -a -m "update workspace"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/grafana/grafana.git" "HEAD:${BRANCH_NAME}"
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=false" >> "$GITHUB_OUTPUT"
         fi
+
+    - name: Commit and push workspace changes
+      if: steps.changes.outputs.changed == 'true'
+      uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
+      with:
+        commit_message: "update workspace"
+        repo: ${{ github.repository }}
+        branch: ${{ github.head_ref || github.ref_name }}
+      env:
+        GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -159,7 +159,7 @@ jobs:
           go-version-file: .grafana-main/go.mod
           cache: false
 
-      # kminehart/ghcommit-action commits to an existing remote branch; it doesn't
+      # planetscale/ghcommit-action commits to an existing remote branch; it doesn't
       # create the branch itself. Pre-create the ref at the release branch's HEAD via
       # the Git Data API so subsequent commits have a target.
       - name: Pre-create branch on remote
@@ -254,7 +254,7 @@ jobs:
       # hits when multiple sequential API commits are made on the same branch (each
       # commit advances the remote ref while local HEAD doesn't).
       - name: Commit release-PR changes
-        uses: kminehart/ghcommit-action@4bb24db6682acdccc9c91291e44b1d328a379ea8
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         with:
           commit_message: "Release: ${{ env.VERSION }}"
           repo: ${{ github.repository }}


### PR DESCRIPTION
Uses `planetscale/ghcommit-action` so commits from the App are signed!