### PR TITLE
Search: collapse the IAM search document builders

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/go-jose/go-jose/v4"
 	_ "github.com/go-jose/go-jose/v4/jwt"
 	_ "github.com/go-openapi/strfmt"
+	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/gobwas/glob"
 	_ "github.com/golang/snappy"
 	_ "github.com/google/go-cmp/cmp"

--- a/pkg/storage/unified/search/builders/document.go
+++ b/pkg/storage/unified/search/builders/document.go
@@ -7,6 +7,7 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 	sdkResource "github.com/grafana/grafana-app-sdk/resource"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -97,6 +98,36 @@ func tableColumnsByName(sfds []resource.SearchFieldDefinition) map[string]*resou
 		out[c.Name] = c
 	}
 	return out
+}
+
+// iamBuilder assembles the DocumentBuilderInfo for an IAM kind. Every IAM kind
+// is wired the same way: its search fields come from the generated IAM manifest
+// and its documents are extracted by the standard builder, so only the resource
+// and its field set differ per kind.
+func iamBuilder(ri utils.ResourceInfo, searchFields []resource.SearchFieldDefinition) (resource.DocumentBuilderInfo, error) {
+	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(searchFields))
+	if err != nil {
+		return resource.DocumentBuilderInfo{}, err
+	}
+
+	gvr := ri.GroupVersionResource()
+	gr := ri.GroupResource()
+	provider := resource.NewMapProvider(
+		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{gvr: searchFields},
+		// The preferred version for this resource. Documents stored with an
+		// apiVersion the server does not recognise fall back to it when their
+		// fields are extracted. IAM kinds serve a single version, so that is the
+		// value here.
+		map[schema.GroupResource]string{gr: gvr.Version},
+	)
+
+	return resource.DocumentBuilderInfo{
+		GroupResource:        gr,
+		Fields:               fields,
+		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
+		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
+		SearchFieldsProvider: provider,
+	}, nil
 }
 
 // NewIndexableDocumentFromValue parses provided bytes value into object, and initializes IndexableDocument from it.

--- a/pkg/storage/unified/search/builders/external_group_mapping.go
+++ b/pkg/storage/unified/search/builders/external_group_mapping.go
@@ -1,55 +1,16 @@
 package builders
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
-const (
-	EXTERNAL_GROUP_MAPPING_TEAM           = "team"
-	EXTERNAL_GROUP_MAPPING_EXTERNAL_GROUP = "external_group"
-)
-
-// ExternalGroupMappingTableColumnDefinitions exposes column-defs by name.
-// No legacy SQL backend currently consumes this map for this kind; it is
-// kept for symmetry with the other IAM builders.
-var ExternalGroupMappingTableColumnDefinitions = tableColumnsByName(ExternalGroupMappingSearchFields)
-
-// ExternalGroupMappingSearchFields are read from the generated IAM manifest,
+// externalGroupMappingSearchFields are read from the generated IAM manifest,
 // where they are declared in apps/iam/kinds/externalgroupmapping.cue.
-var ExternalGroupMappingSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
+var externalGroupMappingSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
 	iamv0.ExternalGroupMappingResourceInfo.GroupVersionResource(),
 )
 
 func GetExternalGroupMappingBuilder() (resource.DocumentBuilderInfo, error) {
-	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(ExternalGroupMappingTableColumnDefinitions))
-	for _, v := range ExternalGroupMappingTableColumnDefinitions {
-		values = append(values, v)
-	}
-	fields, err := resource.NewSearchableDocumentFields(values)
-	if err != nil {
-		return resource.DocumentBuilderInfo{}, err
-	}
-
-	gvr := iamv0.ExternalGroupMappingResourceInfo.GroupVersionResource()
-	provider := resource.NewMapProvider(
-		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
-			gvr: ExternalGroupMappingSearchFields,
-		},
-		map[schema.GroupResource]string{
-			gvr.GroupResource(): gvr.Version,
-		},
-	)
-
-	gr := iamv0.ExternalGroupMappingResourceInfo.GroupResource()
-	return resource.DocumentBuilderInfo{
-		GroupResource:        gr,
-		Fields:               fields,
-		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
-		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
-		SearchFieldsProvider: provider,
-	}, nil
+	return iamBuilder(iamv0.ExternalGroupMappingResourceInfo, externalGroupMappingSearchFields)
 }

--- a/pkg/storage/unified/search/builders/team.go
+++ b/pkg/storage/unified/search/builders/team.go
@@ -1,19 +1,15 @@
 package builders
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 const (
-	TEAM_SEARCH_EMAIL           = "email"
-	TEAM_SEARCH_PROVISIONED     = "provisioned"
-	TEAM_SEARCH_EXTERNAL_UID    = "externalUID"
-	TEAM_SEARCH_MEMBERS         = "members"
-	TEAM_SEARCH_EXTERNAL_GROUPS = "externalGroups"
+	TEAM_SEARCH_EMAIL        = "email"
+	TEAM_SEARCH_PROVISIONED  = "provisioned"
+	TEAM_SEARCH_EXTERNAL_UID = "externalUID"
+	TEAM_SEARCH_MEMBERS      = "members"
 )
 
 // TeamSortableExtraFields are the additional fields that can be used for sorting team search results.
@@ -22,42 +18,16 @@ var TeamSortableExtraFields = []string{
 	TEAM_SEARCH_EMAIL,
 }
 
-// TeamSearchTableColumnDefinitions exposes column-defs by name for the
-// IAM legacy SQL backend in team/legacy_search.go.
-var TeamSearchTableColumnDefinitions = tableColumnsByName(TeamSearchFields)
-
-// TeamSearchFields are read from the generated IAM manifest, where they are
+// teamSearchFields are read from the generated IAM manifest, where they are
 // declared in apps/iam/kinds/team.cue.
-var TeamSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
+var teamSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
 	v0alpha1.TeamResourceInfo.GroupVersionResource(),
 )
 
+// TeamSearchTableColumnDefinitions exposes column-defs by name for the
+// IAM legacy SQL backend in team/legacy_search.go.
+var TeamSearchTableColumnDefinitions = tableColumnsByName(teamSearchFields)
+
 func GetTeamSearchBuilder() (resource.DocumentBuilderInfo, error) {
-	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(TeamSearchTableColumnDefinitions))
-	for _, v := range TeamSearchTableColumnDefinitions {
-		values = append(values, v)
-	}
-	fields, err := resource.NewSearchableDocumentFields(values)
-	if err != nil {
-		return resource.DocumentBuilderInfo{}, err
-	}
-
-	gvr := v0alpha1.TeamResourceInfo.GroupVersionResource()
-	provider := resource.NewMapProvider(
-		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
-			gvr: TeamSearchFields,
-		},
-		map[schema.GroupResource]string{
-			gvr.GroupResource(): gvr.Version,
-		},
-	)
-
-	gr := v0alpha1.TeamResourceInfo.GroupResource()
-	return resource.DocumentBuilderInfo{
-		GroupResource:        gr,
-		Fields:               fields,
-		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
-		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
-		SearchFieldsProvider: provider,
-	}, nil
+	return iamBuilder(v0alpha1.TeamResourceInfo, teamSearchFields)
 }

--- a/pkg/storage/unified/search/builders/team.go
+++ b/pkg/storage/unified/search/builders/team.go
@@ -10,6 +10,9 @@ const (
 	TEAM_SEARCH_PROVISIONED  = "provisioned"
 	TEAM_SEARCH_EXTERNAL_UID = "externalUID"
 	TEAM_SEARCH_MEMBERS      = "members"
+	// TEAM_SEARCH_EXTERNAL_GROUPS names the team index column that the
+	// enterprise external-group-mapping search reads.
+	TEAM_SEARCH_EXTERNAL_GROUPS = "externalGroups"
 )
 
 // TeamSortableExtraFields are the additional fields that can be used for sorting team search results.

--- a/pkg/storage/unified/search/builders/teambinding.go
+++ b/pkg/storage/unified/search/builders/teambinding.go
@@ -1,11 +1,8 @@
 package builders
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 const (
@@ -15,42 +12,16 @@ const (
 	TEAM_BINDING_EXTERNAL   = "external"
 )
 
-// TeamBindingTableColumnDefinitions exposes column-defs by name for the
-// IAM legacy SQL backend in teambinding/legacy_search.go.
-var TeamBindingTableColumnDefinitions = tableColumnsByName(TeamBindingSearchFields)
-
-// TeamBindingSearchFields are read from the generated IAM manifest, where they
+// teamBindingSearchFields are read from the generated IAM manifest, where they
 // are declared in apps/iam/kinds/teambinding.cue.
-var TeamBindingSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
+var teamBindingSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
 	iamv0.TeamBindingResourceInfo.GroupVersionResource(),
 )
 
+// TeamBindingTableColumnDefinitions exposes column-defs by name for the
+// IAM legacy SQL backend in teambinding/legacy_search.go.
+var TeamBindingTableColumnDefinitions = tableColumnsByName(teamBindingSearchFields)
+
 func GetTeamBindingBuilder() (resource.DocumentBuilderInfo, error) {
-	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(TeamBindingTableColumnDefinitions))
-	for _, v := range TeamBindingTableColumnDefinitions {
-		values = append(values, v)
-	}
-	fields, err := resource.NewSearchableDocumentFields(values)
-	if err != nil {
-		return resource.DocumentBuilderInfo{}, err
-	}
-
-	gvr := iamv0.TeamBindingResourceInfo.GroupVersionResource()
-	provider := resource.NewMapProvider(
-		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
-			gvr: TeamBindingSearchFields,
-		},
-		map[schema.GroupResource]string{
-			gvr.GroupResource(): gvr.Version,
-		},
-	)
-
-	gr := iamv0.TeamBindingResourceInfo.GroupResource()
-	return resource.DocumentBuilderInfo{
-		GroupResource:        gr,
-		Fields:               fields,
-		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
-		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
-		SearchFieldsProvider: provider,
-	}, nil
+	return iamBuilder(iamv0.TeamBindingResourceInfo, teamBindingSearchFields)
 }

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -4,12 +4,10 @@ import (
 	"slices"
 
 	"github.com/grafana/grafana-app-sdk/app"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	iam "github.com/grafana/grafana/apps/iam/pkg/apis"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 // iamManifests is the slice the IAM builders pass to the standard document
@@ -34,14 +32,7 @@ var UserSortableExtraFields = []string{
 	USER_LAST_SEEN_AT,
 }
 
-// UserTableColumnDefinitions exposes column-defs by name for wire-API
-// consumers (the IAM legacy SQL backend in user/legacy_search.go).
-// Derived from UserSearchFields via tableColumnsByName. UniqueValues was
-// set on the historical hand-written email/login entries but has no
-// production consumer and is not preserved.
-var UserTableColumnDefinitions = tableColumnsByName(UserSearchFields)
-
-// UserSearchFields are read from the generated IAM manifest (declared in
+// userSearchFields are read from the generated IAM manifest (declared in
 // apps/iam/kinds/user.cue), plus the createdAt field appended below.
 //
 // lastSeenAt (int64) and disabled (boolean) declare the filter capability to
@@ -52,7 +43,7 @@ var UserTableColumnDefinitions = tableColumnsByName(UserSearchFields)
 // would not match a numeric-indexed term yet. No in-tree client filters by
 // lastSeenAt or disabled today, so this is a known gap rather than a rollout
 // concern.
-var UserSearchFields = slices.Concat(
+var userSearchFields = slices.Concat(
 	resource.NewManifestBackedProvider(iamManifests).Fields(iamv0.UserResourceInfo.GroupVersionResource()),
 	[]resource.SearchFieldDefinition{
 		// createdAt reads from the standard document's Created value rather than a
@@ -63,34 +54,13 @@ var UserSearchFields = slices.Concat(
 	},
 )
 
+// UserTableColumnDefinitions exposes column-defs by name for wire-API
+// consumers (the IAM legacy SQL backend in user/legacy_search.go).
+// Derived from userSearchFields via tableColumnsByName. UniqueValues was
+// set on the historical hand-written email/login entries but has no
+// production consumer and is not preserved.
+var UserTableColumnDefinitions = tableColumnsByName(userSearchFields)
+
 func GetUserBuilder() (resource.DocumentBuilderInfo, error) {
-	values := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(UserTableColumnDefinitions))
-	for _, v := range UserTableColumnDefinitions {
-		values = append(values, v)
-	}
-	fields, err := resource.NewSearchableDocumentFields(values)
-	if err != nil {
-		return resource.DocumentBuilderInfo{}, err
-	}
-
-	gvr := iamv0.UserResourceInfo.GroupVersionResource()
-	provider := resource.NewMapProvider(
-		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
-			gvr: UserSearchFields,
-		},
-		// Documents stored without an explicit apiVersion fall back to the
-		// served version so extraction still happens for legacy payloads.
-		map[schema.GroupResource]string{
-			gvr.GroupResource(): gvr.Version,
-		},
-	)
-
-	gr := iamv0.UserResourceInfo.GroupResource()
-	return resource.DocumentBuilderInfo{
-		GroupResource:        gr,
-		Fields:               fields,
-		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
-		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
-		SearchFieldsProvider: provider,
-	}, nil
+	return iamBuilder(iamv0.UserResourceInfo, userSearchFields)
 }


### PR DESCRIPTION
The four IAM search document builders (team, team binding, user, external group mapping) were near-identical: each built its searchable fields, a map provider, and a `DocumentBuilderInfo` with the same wiring, differing only in the resource and its field set. This extracts that shared wiring into one `iamBuilder` helper so each builder is a single call.

The per-kind search-field slices are now unexported, since nothing outside the package reads them; the column-definition maps that the legacy SQL search backends look fields up by name stay exported. A few field-name constants with no remaining references are removed. There is no behaviour change, so no golden-file churn and no search index rebuild.

Part of grafana/search-and-storage-team#827.
