### PR TITLE
Provisioning: Fallback to folder-level dashboards:write for Git Sync …

### DIFF
--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -305,8 +305,14 @@ func (c *jobsConnector) authorizeJob(ctx context.Context, repo repository.Reposi
 	if spec.Action == provisioning.JobActionPullRequest {
 		return apierrors.NewBadRequest("pull request jobs cannot be created via the API; they are triggered by webhooks")
 	}
-	if spec.Action == provisioning.JobActionFixFolderMetadata && !c.folderMetadataEnabled {
-		return apierrors.NewBadRequest("fixFolderMetadata jobs require the provisioningFolderMetadata feature flag")
+	if spec.Action == provisioning.JobActionFixFolderMetadata {
+		if !c.folderMetadataEnabled {
+			return apierrors.NewBadRequest("fixFolderMetadata jobs require the provisioningFolderMetadata feature flag")
+		}
+		// Editor-only. The jobs subresource authorizer may allow Folder Admins via
+		// folder dashboards:write fallback (for move/delete), but this action has no
+		// path/resource-level checks of its own, so re-require jobs:create here.
+		return c.authorizeEditorJob(ctx, cfg)
 	}
 	if spec.Action == provisioning.JobActionTest && (c.perfTestingEnabled == nil || !c.perfTestingEnabled(ctx)) {
 		return apierrors.NewBadRequest("test jobs require the provisioning.performance feature flag")
@@ -314,8 +320,17 @@ func (c *jobsConnector) authorizeJob(ctx context.Context, repo repository.Reposi
 
 	switch spec.Action {
 	case provisioning.JobActionPush:
+		// Keep push editor-only: the folder dashboards:write route fallback is for
+		// move/delete. authorizePushJob only checks read, which is too weak alone.
+		if err := c.authorizeEditorJob(ctx, cfg); err != nil {
+			return err
+		}
 		return c.authorizePushJob(ctx, repo, cfg)
 	case provisioning.JobActionMigrate:
+		// Same as push: do not let Folder Admins reach migrate via the jobs fallback.
+		if err := c.authorizeEditorJob(ctx, cfg); err != nil {
+			return err
+		}
 		return c.authorizeMigrateJob(ctx, repo, cfg, spec)
 	case provisioning.JobActionDelete:
 		if spec.Delete != nil {
@@ -328,6 +343,7 @@ func (c *jobsConnector) authorizeJob(ctx context.Context, repo repository.Reposi
 	case provisioning.JobActionPull, provisioning.JobActionPullRequest, provisioning.JobActionFixFolderMetadata, provisioning.JobActionTest:
 		// Read-only / no-op operations don't require pre-flight resource authorization.
 		// Pull and test are authorized inline in handleCreateJob (admin-only).
+		// FixFolderMetadata is handled above via authorizeEditorJob.
 	case provisioning.JobActionReleaseResources, provisioning.JobActionDeleteResources:
 		// Orphan cleanup actions are handled separately via handleOrphanCleanupJob
 		// and never reach authorizeJob.
@@ -406,6 +422,18 @@ func (c *jobsConnector) authorizeAdminJob(ctx context.Context, cfg *provisioning
 		Verb:      utils.VerbUpdate,
 		Group:     provisioning.GROUP,
 		Resource:  provisioning.RepositoryResourceInfo.GetName(),
+		Namespace: cfg.Namespace,
+	}, "")
+}
+
+// authorizeEditorJob checks jobs:create with Editor fallback.
+// Used for job actions that must stay editor-only after the jobs subresource
+// authorizer allows Folder Admins via folder-level dashboards:write.
+func (c *jobsConnector) authorizeEditorJob(ctx context.Context, cfg *provisioning.Repository) error {
+	return c.access.WithFallbackRole(identity.RoleEditor).Check(ctx, authlib.CheckRequest{
+		Verb:      utils.VerbCreate,
+		Group:     provisioning.GROUP,
+		Resource:  provisioning.JobResourceInfo.GetName(),
 		Namespace: cfg.Namespace,
 	}, "")
 }

--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -305,15 +305,6 @@ func (c *jobsConnector) authorizeJob(ctx context.Context, repo repository.Reposi
 	if spec.Action == provisioning.JobActionPullRequest {
 		return apierrors.NewBadRequest("pull request jobs cannot be created via the API; they are triggered by webhooks")
 	}
-	if spec.Action == provisioning.JobActionFixFolderMetadata {
-		if !c.folderMetadataEnabled {
-			return apierrors.NewBadRequest("fixFolderMetadata jobs require the provisioningFolderMetadata feature flag")
-		}
-		// Editor-only. The jobs subresource authorizer may allow Folder Admins via
-		// folder dashboards:write fallback (for move/delete), but this action has no
-		// path/resource-level checks of its own, so re-require jobs:create here.
-		return c.authorizeEditorJob(ctx, cfg)
-	}
 	if spec.Action == provisioning.JobActionTest && (c.perfTestingEnabled == nil || !c.perfTestingEnabled(ctx)) {
 		return apierrors.NewBadRequest("test jobs require the provisioning.performance feature flag")
 	}
@@ -340,10 +331,17 @@ func (c *jobsConnector) authorizeJob(ctx context.Context, repo repository.Reposi
 		if spec.Move != nil {
 			return c.authorizeMoveJob(ctx, repo, cfg, spec.Move)
 		}
-	case provisioning.JobActionPull, provisioning.JobActionPullRequest, provisioning.JobActionFixFolderMetadata, provisioning.JobActionTest:
+	case provisioning.JobActionFixFolderMetadata:
+		if !c.folderMetadataEnabled {
+			return apierrors.NewBadRequest("fixFolderMetadata jobs require the provisioningFolderMetadata feature flag")
+		}
+		// Editor-only. The jobs subresource authorizer may allow Folder Admins via
+		// folder dashboards:write fallback (for move/delete), but this action has no
+		// path/resource-level checks of its own, so re-require jobs:create here.
+		return c.authorizeEditorJob(ctx, cfg)
+	case provisioning.JobActionPull, provisioning.JobActionPullRequest, provisioning.JobActionTest:
 		// Read-only / no-op operations don't require pre-flight resource authorization.
 		// Pull and test are authorized inline in handleCreateJob (admin-only).
-		// FixFolderMetadata is handled above via authorizeEditorJob.
 	case provisioning.JobActionReleaseResources, provisioning.JobActionDeleteResources:
 		// Orphan cleanup actions are handled separately via handleOrphanCleanupJob
 		// and never reach authorizeJob.

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -105,28 +105,89 @@ func TestPullRequestJobRejected(t *testing.T) {
 }
 
 func TestFixFolderMetadataFeatureGate(t *testing.T) {
+	ctx := context.Background()
 	cfg := newTestRepo("my-repo", "default")
+	spec := provisioning.JobSpec{Action: provisioning.JobActionFixFolderMetadata}
+
+	jobsCreateReq := func(req authlib.CheckRequest) bool {
+		return req.Verb == utils.VerbCreate &&
+			req.Group == provisioning.GROUP &&
+			req.Resource == provisioning.JobResourceInfo.GetName() &&
+			req.Namespace == cfg.Namespace
+	}
 
 	t.Run("rejected when flag is disabled", func(t *testing.T) {
 		c := &jobsConnector{folderMetadataEnabled: false}
-		spec := provisioning.JobSpec{
-			Action: provisioning.JobActionFixFolderMetadata,
-		}
-
-		err := c.authorizeJob(context.Background(), nil, cfg, spec)
+		err := c.authorizeJob(ctx, nil, cfg, spec)
 		require.Error(t, err)
 		assert.True(t, apierrors.IsBadRequest(err))
 		assert.Contains(t, err.Error(), "provisioningFolderMetadata feature flag")
 	})
 
-	t.Run("allowed when flag is enabled", func(t *testing.T) {
-		c := &jobsConnector{folderMetadataEnabled: true}
-		spec := provisioning.JobSpec{
-			Action: provisioning.JobActionFixFolderMetadata,
-		}
+	t.Run("allowed when flag is enabled and user has jobs:create", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(jobsCreateReq), "").Return(nil)
 
-		err := c.authorizeJob(context.Background(), nil, cfg, spec)
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().WithFallbackRole(identity.RoleEditor).Return(editorChecker)
+
+		c := &jobsConnector{access: accessMock, folderMetadataEnabled: true}
+		err := c.authorizeJob(ctx, nil, cfg, spec)
 		require.NoError(t, err)
+	})
+
+	t.Run("forbidden when flag is enabled but user lacks jobs:create", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(jobsCreateReq), "").Return(
+			apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("editor role is required")),
+		)
+
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().WithFallbackRole(identity.RoleEditor).Return(editorChecker)
+
+		c := &jobsConnector{access: accessMock, folderMetadataEnabled: true}
+		err := c.authorizeJob(ctx, nil, cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+}
+
+func TestAuthorizeEditorJob(t *testing.T) {
+	ctx := context.Background()
+	cfg := newTestRepo("my-repo", "default")
+
+	t.Run("editor is authorized", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == utils.VerbCreate &&
+				req.Group == provisioning.GROUP &&
+				req.Resource == provisioning.JobResourceInfo.GetName() &&
+				req.Namespace == cfg.Namespace
+		}), "").Return(nil)
+
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().WithFallbackRole(identity.RoleEditor).Return(editorChecker)
+
+		c := &jobsConnector{access: accessMock}
+		err := c.authorizeEditorJob(ctx, cfg)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-editor is forbidden", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == utils.VerbCreate &&
+				req.Group == provisioning.GROUP &&
+				req.Resource == provisioning.JobResourceInfo.GetName()
+		}), "").Return(apierrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("editor role is required")))
+
+		accessMock := auth.NewMockAccessChecker(t)
+		accessMock.EXPECT().WithFallbackRole(identity.RoleEditor).Return(editorChecker)
+
+		c := &jobsConnector{access: accessMock}
+		err := c.authorizeEditorJob(ctx, cfg)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
 	})
 }
 

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -631,12 +631,43 @@ func (b *APIBuilder) authorizeRepositorySubresource(ctx context.Context, a autho
 
 	// Jobs subresource - check jobs permissions with the verb (editors can manage jobs)
 	case "jobs":
-		return toAuthorizerDecision(b.accessWithEditor.Check(ctx, authlib.CheckRequest{
+		err := b.accessWithEditor.Check(ctx, authlib.CheckRequest{
 			Verb:      a.GetVerb(),
 			Group:     provisioning.GROUP,
 			Resource:  provisioning.JobResourceInfo.GetName(),
 			Namespace: a.GetNamespace(),
-		}, ""))
+		}, "")
+		if err == nil {
+			return authorizer.DecisionAllow, "", nil
+		}
+
+		// Fallback for Git Sync: Users with write permissions on the sync root folder can manage sync jobs
+		if a.GetName() != "" {
+			obj, getErr := b.repoStore.Get(ctx, a.GetName(), &metav1.GetOptions{})
+			if getErr == nil && obj != nil {
+				if repo, ok := obj.(*provisioning.Repository); ok {
+					if repo.Spec.Sync.Target == provisioning.SyncTargetTypeFolder {
+						folderUID := repo.Name
+						verb := a.GetVerb()
+						if verb == apiutils.VerbList {
+							verb = apiutils.VerbGet
+						}
+						// Check if the user has dashboard edit permissions in this root folder.
+						folderErr := b.access.Check(ctx, authlib.CheckRequest{
+							Verb:      verb,
+							Group:     resources.DashboardResource.Group,
+							Resource:  resources.DashboardResource.Resource,
+							Namespace: a.GetNamespace(),
+						}, folderUID)
+						if folderErr == nil {
+							return authorizer.DecisionAllow, "", nil
+						}
+					}
+				}
+			}
+		}
+
+		return toAuthorizerDecision(err)
 
 	default:
 		id, err := identity.GetRequester(ctx)

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -629,7 +629,12 @@ func (b *APIBuilder) authorizeRepositorySubresource(ctx context.Context, a autho
 			Namespace: a.GetNamespace(),
 		}, ""))
 
-	// Jobs subresource - check jobs permissions with the verb (editors can manage jobs)
+	// Jobs subresource - editors can manage jobs via provisioning.jobs:*.
+	//
+	// Folder-targeted Git Sync also allows users with dashboards:write on the
+	// repository root folder so Folder Admins can create move/delete sync jobs
+	// without global jobs:create. Finer-grained checks still run in the jobs
+	// connector (authorizeDeleteJob / authorizeMoveJob) for the specific action.
 	case "jobs":
 		err := b.accessWithEditor.Check(ctx, authlib.CheckRequest{
 			Verb:      a.GetVerb(),
@@ -640,33 +645,37 @@ func (b *APIBuilder) authorizeRepositorySubresource(ctx context.Context, a autho
 		if err == nil {
 			return authorizer.DecisionAllow, "", nil
 		}
-
-		// Fallback for Git Sync: Users with write permissions on the sync root folder can manage sync jobs
-		if a.GetName() != "" {
-			obj, getErr := b.repoStore.Get(ctx, a.GetName(), &metav1.GetOptions{})
-			if getErr == nil && obj != nil {
-				if repo, ok := obj.(*provisioning.Repository); ok {
-					if repo.Spec.Sync.Target == provisioning.SyncTargetTypeFolder {
-						folderUID := repo.Name
-						verb := a.GetVerb()
-						if verb == apiutils.VerbList {
-							verb = apiutils.VerbGet
-						}
-						// Check if the user has dashboard edit permissions in this root folder.
-						folderErr := b.access.Check(ctx, authlib.CheckRequest{
-							Verb:      verb,
-							Group:     resources.DashboardResource.Group,
-							Resource:  resources.DashboardResource.Resource,
-							Namespace: a.GetNamespace(),
-						}, folderUID)
-						if folderErr == nil {
-							return authorizer.DecisionAllow, "", nil
-						}
-					}
-				}
-			}
+		// Only fall back on permission denied. Unauthorized (and other non-Forbidden
+		// errors) must not trigger repository lookups or an alternate auth path.
+		if !apierrors.IsForbidden(err) || a.GetName() == "" {
+			return toAuthorizerDecision(err)
 		}
 
+		obj, getErr := b.repoStore.Get(ctx, a.GetName(), &metav1.GetOptions{})
+		if getErr != nil || obj == nil {
+			return toAuthorizerDecision(err)
+		}
+		repo, ok := obj.(*provisioning.Repository)
+		if !ok || repo.Spec.Sync.Target != provisioning.SyncTargetTypeFolder {
+			return toAuthorizerDecision(err)
+		}
+
+		// Jobs POST uses verb "create"; map mutating job verbs to dashboards:write
+		// (update). Read verbs keep dashboards:read (get).
+		verb := apiutils.VerbUpdate
+		switch a.GetVerb() {
+		case apiutils.VerbGet, apiutils.VerbList, apiutils.VerbWatch:
+			verb = apiutils.VerbGet
+		}
+
+		if folderErr := b.access.Check(ctx, authlib.CheckRequest{
+			Verb:      verb,
+			Group:     resources.DashboardResource.Group,
+			Resource:  resources.DashboardResource.Resource,
+			Namespace: a.GetNamespace(),
+		}, repo.Name); folderErr == nil {
+			return authorizer.DecisionAllow, "", nil
+		}
 		return toAuthorizerDecision(err)
 
 	default:

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -633,8 +633,9 @@ func (b *APIBuilder) authorizeRepositorySubresource(ctx context.Context, a autho
 	//
 	// Folder-targeted Git Sync also allows users with dashboards:write on the
 	// repository root folder so Folder Admins can create move/delete sync jobs
-	// without global jobs:create. Finer-grained checks still run in the jobs
-	// connector (authorizeDeleteJob / authorizeMoveJob) for the specific action.
+	// (and inspect those jobs) without global jobs:create. The fallback always
+	// requires dashboards:write so Viewers cannot list job history. Push/migrate
+	// and fixFolderMetadata still re-require jobs:create in the jobs connector.
 	case "jobs":
 		err := b.accessWithEditor.Check(ctx, authlib.CheckRequest{
 			Verb:      a.GetVerb(),
@@ -660,16 +661,9 @@ func (b *APIBuilder) authorizeRepositorySubresource(ctx context.Context, a autho
 			return toAuthorizerDecision(err)
 		}
 
-		// Jobs POST uses verb "create"; map mutating job verbs to dashboards:write
-		// (update). Read verbs keep dashboards:read (get).
-		verb := apiutils.VerbUpdate
-		switch a.GetVerb() {
-		case apiutils.VerbGet, apiutils.VerbList, apiutils.VerbWatch:
-			verb = apiutils.VerbGet
-		}
-
+		// Require dashboards:write (update) for all jobs verbs, including list/get.
 		if folderErr := b.access.Check(ctx, authlib.CheckRequest{
-			Verb:      verb,
+			Verb:      apiutils.VerbUpdate,
 			Group:     resources.DashboardResource.Group,
 			Resource:  resources.DashboardResource.Resource,
 			Namespace: a.GetNamespace(),

--- a/pkg/registry/apis/provisioning/register_authz_test.go
+++ b/pkg/registry/apis/provisioning/register_authz_test.go
@@ -144,12 +144,6 @@ func TestAuthorizeJobsSubresource(t *testing.T) {
 			req.Resource == resources.DashboardResource.Resource &&
 			req.Namespace == ns
 	}
-	dashboardReadOnFolder := func(req authlib.CheckRequest) bool {
-		return req.Verb == utils.VerbGet &&
-			req.Group == resources.DashboardResource.Group &&
-			req.Resource == resources.DashboardResource.Resource &&
-			req.Namespace == ns
-	}
 
 	newFolderRepo := func(name string) *provisioning.Repository {
 		return &provisioning.Repository{
@@ -270,12 +264,32 @@ func TestAuthorizeJobsSubresource(t *testing.T) {
 		assert.Contains(t, reason, "no auth info in context")
 	})
 
-	t.Run("list verb maps to dashboards:read for folder access check", func(t *testing.T) {
+	t.Run("list/get/watch fallback requires dashboards:write not read", func(t *testing.T) {
+		for _, verb := range []string{utils.VerbList, utils.VerbGet, utils.VerbWatch} {
+			t.Run(verb, func(t *testing.T) {
+				editorChecker := auth.NewMockAccessChecker(t)
+				editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
+
+				accessChecker := auth.NewMockAccessChecker(t)
+				accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(dashboardWriteOnFolder), name).Return(nil)
+
+				repoStore := grafanarest.NewMockStorage(t)
+				repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
+
+				b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
+				decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(verb, name, ns))
+				require.NoError(t, err)
+				assert.Equal(t, authorizer.DecisionAllow, decision)
+			})
+		}
+	})
+
+	t.Run("viewer with only dashboards:read is denied via fallback", func(t *testing.T) {
 		editorChecker := auth.NewMockAccessChecker(t)
 		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
 
 		accessChecker := auth.NewMockAccessChecker(t)
-		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(dashboardReadOnFolder), name).Return(nil)
+		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(dashboardWriteOnFolder), name).Return(mockForbidden())
 
 		repoStore := grafanarest.NewMockStorage(t)
 		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
@@ -283,39 +297,7 @@ func TestAuthorizeJobsSubresource(t *testing.T) {
 		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
 		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbList, name, ns))
 		require.NoError(t, err)
-		assert.Equal(t, authorizer.DecisionAllow, decision)
-	})
-
-	t.Run("get verb maps to dashboards:read for folder access check", func(t *testing.T) {
-		editorChecker := auth.NewMockAccessChecker(t)
-		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
-
-		accessChecker := auth.NewMockAccessChecker(t)
-		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(dashboardReadOnFolder), name).Return(nil)
-
-		repoStore := grafanarest.NewMockStorage(t)
-		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
-
-		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbGet, name, ns))
-		require.NoError(t, err)
-		assert.Equal(t, authorizer.DecisionAllow, decision)
-	})
-
-	t.Run("watch verb maps to dashboards:read for folder access check", func(t *testing.T) {
-		editorChecker := auth.NewMockAccessChecker(t)
-		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
-
-		accessChecker := auth.NewMockAccessChecker(t)
-		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(dashboardReadOnFolder), name).Return(nil)
-
-		repoStore := grafanarest.NewMockStorage(t)
-		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
-
-		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbWatch, name, ns))
-		require.NoError(t, err)
-		assert.Equal(t, authorizer.DecisionAllow, decision)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
 	})
 
 	t.Run("folderless repo skips folder fallback and is denied", func(t *testing.T) {

--- a/pkg/registry/apis/provisioning/register_authz_test.go
+++ b/pkg/registry/apis/provisioning/register_authz_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
 
 func mockForbidden() error {
@@ -39,6 +42,15 @@ func subresourceAttrs(sub, name, ns string) authorizer.Attributes {
 //
 // resources/history/status are admin-only and gated on repositories:write so that the
 // repository-scoped Name is preserved (rather than proxying through an unrelated resource).
+func jobsSubresourceAttrs(verb, name, ns string) authorizer.Attributes {
+	return authorizer.AttributesRecord{
+		Verb:        verb,
+		Subresource: "jobs",
+		Name:        name,
+		Namespace:   ns,
+	}
+}
+
 func TestAuthorizeRepositorySubresource(t *testing.T) {
 	ctx := context.Background()
 	const ns, name = "default", "my-repo"
@@ -112,4 +124,188 @@ func TestAuthorizeRepositorySubresource(t *testing.T) {
 			assert.Equal(t, authorizer.DecisionDeny, decision)
 		})
 	}
+}
+
+// TestAuthorizeJobsSubresource verifies the jobs subresource authorization,
+// including the folder-level fallback for Git Sync (issue #127254).
+//
+// When a user moves or deletes a dashboard in a Git Sync folder, a sync job is
+// triggered via the repositories/{name}/jobs subresource. The primary check
+// requires the global provisioning.jobs:create permission (Editor role). The
+// fallback allows users who lack this global permission but have dashboards:write
+// on the repository's root folder (Folder Admins) to manage sync jobs.
+func TestAuthorizeJobsSubresource(t *testing.T) {
+	ctx := context.Background()
+	const ns, name = "default", "my-repo"
+
+	newFolderRepo := func(name string) *provisioning.Repository {
+		return &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: provisioning.RepositorySpec{
+				Sync: provisioning.SyncOptions{
+					Target: provisioning.SyncTargetTypeFolder,
+				},
+			},
+		}
+	}
+
+	newInstanceRepo := func(name string) *provisioning.Repository {
+		return &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: provisioning.RepositorySpec{
+				Sync: provisioning.SyncOptions{
+					Target: provisioning.SyncTargetTypeInstance,
+				},
+			},
+		}
+	}
+
+	t.Run("editor with global jobs permission is allowed without fallback", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == "create" &&
+				req.Group == provisioning.GROUP &&
+				req.Resource == provisioning.JobResourceInfo.GetName() &&
+				req.Namespace == ns
+		}), "").Return(nil)
+
+		b := &APIBuilder{accessWithEditor: editorChecker}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+	})
+
+	t.Run("folder admin with dashboards:write on folder-targeted repo is allowed via fallback", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
+
+		accessChecker := auth.NewMockAccessChecker(t)
+		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == "create" &&
+				req.Group == resources.DashboardResource.Group &&
+				req.Resource == resources.DashboardResource.Resource &&
+				req.Namespace == ns
+		}), name).Return(nil)
+
+		repoStore := grafanarest.NewMockStorage(t)
+		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
+
+		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+	})
+
+	t.Run("viewer without any permission is denied", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
+
+		accessChecker := auth.NewMockAccessChecker(t)
+		accessChecker.EXPECT().Check(mock.Anything, mock.Anything, name).Return(mockForbidden())
+
+		repoStore := grafanarest.NewMockStorage(t)
+		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
+
+		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+	})
+
+	t.Run("instance-targeted repo skips folder fallback and is denied", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
+
+		repoStore := grafanarest.NewMockStorage(t)
+		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newInstanceRepo(name), nil)
+
+		b := &APIBuilder{accessWithEditor: editorChecker, repoStore: repoStore}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+	})
+
+	t.Run("empty name skips fallback and is denied", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
+
+		b := &APIBuilder{accessWithEditor: editorChecker}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", "", ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+	})
+
+	t.Run("repo store error skips fallback and is denied", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
+
+		repoStore := grafanarest.NewMockStorage(t)
+		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(nil, fmt.Errorf("not found"))
+
+		b := &APIBuilder{accessWithEditor: editorChecker, repoStore: repoStore}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+	})
+
+	t.Run("list verb maps to get for folder access check", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
+
+		accessChecker := auth.NewMockAccessChecker(t)
+		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == "get" &&
+				req.Group == resources.DashboardResource.Group &&
+				req.Resource == resources.DashboardResource.Resource
+		}), name).Return(nil)
+
+		repoStore := grafanarest.NewMockStorage(t)
+		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
+
+		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("list", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+	})
+
+	t.Run("get verb passes through to folder access check", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
+
+		accessChecker := auth.NewMockAccessChecker(t)
+		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
+			return req.Verb == "get" &&
+				req.Group == resources.DashboardResource.Group &&
+				req.Resource == resources.DashboardResource.Resource
+		}), name).Return(nil)
+
+		repoStore := grafanarest.NewMockStorage(t)
+		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
+
+		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("get", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+	})
+
+	t.Run("folderless repo skips folder fallback and is denied", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
+
+		folderlessRepo := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: provisioning.RepositorySpec{
+				Sync: provisioning.SyncOptions{
+					Target: provisioning.SyncTargetTypeFolderless,
+				},
+			},
+		}
+		repoStore := grafanarest.NewMockStorage(t)
+		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(folderlessRepo, nil)
+
+		b := &APIBuilder{accessWithEditor: editorChecker, repoStore: repoStore}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+	})
 }

--- a/pkg/registry/apis/provisioning/register_authz_test.go
+++ b/pkg/registry/apis/provisioning/register_authz_test.go
@@ -42,15 +42,6 @@ func subresourceAttrs(sub, name, ns string) authorizer.Attributes {
 //
 // resources/history/status are admin-only and gated on repositories:write so that the
 // repository-scoped Name is preserved (rather than proxying through an unrelated resource).
-func jobsSubresourceAttrs(verb, name, ns string) authorizer.Attributes {
-	return authorizer.AttributesRecord{
-		Verb:        verb,
-		Subresource: "jobs",
-		Name:        name,
-		Namespace:   ns,
-	}
-}
-
 func TestAuthorizeRepositorySubresource(t *testing.T) {
 	ctx := context.Background()
 	const ns, name = "default", "my-repo"
@@ -126,6 +117,15 @@ func TestAuthorizeRepositorySubresource(t *testing.T) {
 	}
 }
 
+func jobsSubresourceAttrs(verb, name, ns string) authorizer.Attributes {
+	return authorizer.AttributesRecord{
+		Verb:        verb,
+		Subresource: "jobs",
+		Name:        name,
+		Namespace:   ns,
+	}
+}
+
 // TestAuthorizeJobsSubresource verifies the jobs subresource authorization,
 // including the folder-level fallback for Git Sync (issue #127254).
 //
@@ -137,6 +137,19 @@ func TestAuthorizeRepositorySubresource(t *testing.T) {
 func TestAuthorizeJobsSubresource(t *testing.T) {
 	ctx := context.Background()
 	const ns, name = "default", "my-repo"
+
+	dashboardWriteOnFolder := func(req authlib.CheckRequest) bool {
+		return req.Verb == utils.VerbUpdate &&
+			req.Group == resources.DashboardResource.Group &&
+			req.Resource == resources.DashboardResource.Resource &&
+			req.Namespace == ns
+	}
+	dashboardReadOnFolder := func(req authlib.CheckRequest) bool {
+		return req.Verb == utils.VerbGet &&
+			req.Group == resources.DashboardResource.Group &&
+			req.Resource == resources.DashboardResource.Resource &&
+			req.Namespace == ns
+	}
 
 	newFolderRepo := func(name string) *provisioning.Repository {
 		return &provisioning.Repository{
@@ -163,14 +176,14 @@ func TestAuthorizeJobsSubresource(t *testing.T) {
 	t.Run("editor with global jobs permission is allowed without fallback", func(t *testing.T) {
 		editorChecker := auth.NewMockAccessChecker(t)
 		editorChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
-			return req.Verb == "create" &&
+			return req.Verb == utils.VerbCreate &&
 				req.Group == provisioning.GROUP &&
 				req.Resource == provisioning.JobResourceInfo.GetName() &&
 				req.Namespace == ns
 		}), "").Return(nil)
 
 		b := &APIBuilder{accessWithEditor: editorChecker}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbCreate, name, ns))
 		require.NoError(t, err)
 		assert.Equal(t, authorizer.DecisionAllow, decision)
 	})
@@ -180,18 +193,13 @@ func TestAuthorizeJobsSubresource(t *testing.T) {
 		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
 
 		accessChecker := auth.NewMockAccessChecker(t)
-		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
-			return req.Verb == "create" &&
-				req.Group == resources.DashboardResource.Group &&
-				req.Resource == resources.DashboardResource.Resource &&
-				req.Namespace == ns
-		}), name).Return(nil)
+		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(dashboardWriteOnFolder), name).Return(nil)
 
 		repoStore := grafanarest.NewMockStorage(t)
 		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
 
 		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbCreate, name, ns))
 		require.NoError(t, err)
 		assert.Equal(t, authorizer.DecisionAllow, decision)
 	})
@@ -201,13 +209,13 @@ func TestAuthorizeJobsSubresource(t *testing.T) {
 		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
 
 		accessChecker := auth.NewMockAccessChecker(t)
-		accessChecker.EXPECT().Check(mock.Anything, mock.Anything, name).Return(mockForbidden())
+		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(dashboardWriteOnFolder), name).Return(mockForbidden())
 
 		repoStore := grafanarest.NewMockStorage(t)
 		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
 
 		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbCreate, name, ns))
 		require.NoError(t, err)
 		assert.Equal(t, authorizer.DecisionDeny, decision)
 	})
@@ -220,7 +228,7 @@ func TestAuthorizeJobsSubresource(t *testing.T) {
 		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newInstanceRepo(name), nil)
 
 		b := &APIBuilder{accessWithEditor: editorChecker, repoStore: repoStore}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbCreate, name, ns))
 		require.NoError(t, err)
 		assert.Equal(t, authorizer.DecisionDeny, decision)
 	})
@@ -230,7 +238,7 @@ func TestAuthorizeJobsSubresource(t *testing.T) {
 		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
 
 		b := &APIBuilder{accessWithEditor: editorChecker}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", "", ns))
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbCreate, "", ns))
 		require.NoError(t, err)
 		assert.Equal(t, authorizer.DecisionDeny, decision)
 	})
@@ -243,47 +251,69 @@ func TestAuthorizeJobsSubresource(t *testing.T) {
 		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(nil, fmt.Errorf("not found"))
 
 		b := &APIBuilder{accessWithEditor: editorChecker, repoStore: repoStore}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbCreate, name, ns))
 		require.NoError(t, err)
 		assert.Equal(t, authorizer.DecisionDeny, decision)
 	})
 
-	t.Run("list verb maps to get for folder access check", func(t *testing.T) {
+	t.Run("unauthorized skips folder fallback", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(
+			apierrors.NewUnauthorized("no auth info in context"),
+		)
+
+		// repoStore/access deliberately unset: fallback must not run on Unauthorized.
+		b := &APIBuilder{accessWithEditor: editorChecker}
+		decision, reason, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbCreate, name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+		assert.Contains(t, reason, "no auth info in context")
+	})
+
+	t.Run("list verb maps to dashboards:read for folder access check", func(t *testing.T) {
 		editorChecker := auth.NewMockAccessChecker(t)
 		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
 
 		accessChecker := auth.NewMockAccessChecker(t)
-		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
-			return req.Verb == "get" &&
-				req.Group == resources.DashboardResource.Group &&
-				req.Resource == resources.DashboardResource.Resource
-		}), name).Return(nil)
+		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(dashboardReadOnFolder), name).Return(nil)
 
 		repoStore := grafanarest.NewMockStorage(t)
 		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
 
 		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("list", name, ns))
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbList, name, ns))
 		require.NoError(t, err)
 		assert.Equal(t, authorizer.DecisionAllow, decision)
 	})
 
-	t.Run("get verb passes through to folder access check", func(t *testing.T) {
+	t.Run("get verb maps to dashboards:read for folder access check", func(t *testing.T) {
 		editorChecker := auth.NewMockAccessChecker(t)
 		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
 
 		accessChecker := auth.NewMockAccessChecker(t)
-		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(func(req authlib.CheckRequest) bool {
-			return req.Verb == "get" &&
-				req.Group == resources.DashboardResource.Group &&
-				req.Resource == resources.DashboardResource.Resource
-		}), name).Return(nil)
+		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(dashboardReadOnFolder), name).Return(nil)
 
 		repoStore := grafanarest.NewMockStorage(t)
 		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
 
 		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("get", name, ns))
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbGet, name, ns))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+	})
+
+	t.Run("watch verb maps to dashboards:read for folder access check", func(t *testing.T) {
+		editorChecker := auth.NewMockAccessChecker(t)
+		editorChecker.EXPECT().Check(mock.Anything, mock.Anything, "").Return(mockForbidden())
+
+		accessChecker := auth.NewMockAccessChecker(t)
+		accessChecker.EXPECT().Check(mock.Anything, mock.MatchedBy(dashboardReadOnFolder), name).Return(nil)
+
+		repoStore := grafanarest.NewMockStorage(t)
+		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(newFolderRepo(name), nil)
+
+		b := &APIBuilder{accessWithEditor: editorChecker, access: accessChecker, repoStore: repoStore}
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbWatch, name, ns))
 		require.NoError(t, err)
 		assert.Equal(t, authorizer.DecisionAllow, decision)
 	})
@@ -304,7 +334,7 @@ func TestAuthorizeJobsSubresource(t *testing.T) {
 		repoStore.EXPECT().Get(mock.Anything, name, mock.Anything).Return(folderlessRepo, nil)
 
 		b := &APIBuilder{accessWithEditor: editorChecker, repoStore: repoStore}
-		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs("create", name, ns))
+		decision, _, err := b.authorizeRepositorySubresource(ctx, jobsSubresourceAttrs(utils.VerbCreate, name, ns))
 		require.NoError(t, err)
 		assert.Equal(t, authorizer.DecisionDeny, decision)
 	})

--- a/pkg/tests/apis/provisioning/jobs/jobs_folder_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/jobs_folder_auth_test.go
@@ -1,0 +1,169 @@
+package jobs
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	"github.com/grafana/grafana/pkg/services/org"
+	apis "github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioning_JobsFolderAuthorization covers the jobs subresource
+// fallback that lets users with dashboards:write on a folder-targeted repository
+// root folder manage jobs without global jobs:create (issue #127254).
+func TestIntegrationProvisioning_JobsFolderAuthorization(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "jobs-folder-auth"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
+		Copies: map[string]string{
+			"../testdata/all-panels.json": "dashboard.json",
+		},
+	})
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 1)
+
+	// Org Viewer with dashboards:write on the repo root folder (Folder Admin style).
+	// No Editor role, so global jobs:create is denied and the folder fallback applies.
+	folderWriter := helper.CreateUser("FolderJobsWriter", apis.Org1, org.RoleViewer, []resourcepermissions.SetResourcePermissionCommand{
+		{
+			Actions:           []string{"dashboards:read", "dashboards:write", "dashboards:create", "dashboards:delete"},
+			Resource:          "folders",
+			ResourceAttribute: "uid",
+			ResourceID:        repo,
+		},
+	})
+	gv := &schema.GroupVersion{Group: "provisioning.grafana.app", Version: "v0alpha1"}
+	folderWriterREST := folderWriter.RESTClient(t, gv)
+
+	t.Run("folder writer can list repository jobs", func(t *testing.T) {
+		var statusCode int
+		result := folderWriterREST.Get().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Do(t.Context()).StatusCode(&statusCode)
+
+		require.NoError(t, result.Error(), "folder writer should list jobs via dashboards:write fallback")
+		require.Equal(t, http.StatusOK, statusCode)
+	})
+
+	t.Run("viewer without folder write cannot list repository jobs", func(t *testing.T) {
+		var statusCode int
+		result := helper.ViewerREST.Get().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Do(t.Context()).StatusCode(&statusCode)
+
+		require.Error(t, result.Error())
+		require.Equal(t, http.StatusForbidden, statusCode)
+		require.True(t, apierrors.IsForbidden(result.Error()))
+	})
+
+	t.Run("folder writer can create delete job", func(t *testing.T) {
+		body := common.AsJSON(provisioning.JobSpec{
+			Action: provisioning.JobActionDelete,
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"dashboard.json"},
+			},
+		})
+
+		var statusCode int
+		result := folderWriterREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(t.Context()).StatusCode(&statusCode)
+
+		require.NoError(t, result.Error(), "folder writer should create delete job via folder fallback")
+		require.Equal(t, http.StatusAccepted, statusCode)
+
+		helper.AwaitJobs(t, repo)
+	})
+
+	t.Run("viewer cannot create delete job", func(t *testing.T) {
+		helper.CopyToProvisioningPath(t, "../testdata/all-panels.json", "viewer-blocked.json")
+		helper.SyncAndWait(t, repo, nil)
+
+		body := common.AsJSON(provisioning.JobSpec{
+			Action: provisioning.JobActionDelete,
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{"viewer-blocked.json"},
+			},
+		})
+
+		var statusCode int
+		result := helper.ViewerREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(t.Context()).StatusCode(&statusCode)
+
+		require.Error(t, result.Error())
+		require.Equal(t, http.StatusForbidden, statusCode)
+		require.True(t, apierrors.IsForbidden(result.Error()))
+	})
+
+	t.Run("folder writer cannot create migrate job", func(t *testing.T) {
+		// Migrate re-requires jobs:create so the folder fallback cannot open it.
+		body := common.AsJSON(provisioning.JobSpec{
+			Action:  provisioning.JobActionMigrate,
+			Migrate: &provisioning.MigrateJobOptions{},
+		})
+
+		var statusCode int
+		result := folderWriterREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(t.Context()).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "folder writer must not create migrate jobs")
+		require.Equal(t, http.StatusForbidden, statusCode)
+		require.True(t, apierrors.IsForbidden(result.Error()))
+	})
+
+	t.Run("folder writer cannot create push job", func(t *testing.T) {
+		body := common.AsJSON(provisioning.JobSpec{
+			Action: provisioning.JobActionPush,
+			Push:   &provisioning.ExportJobOptions{},
+		})
+
+		var statusCode int
+		result := folderWriterREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(t.Context()).StatusCode(&statusCode)
+
+		require.Error(t, result.Error(), "folder writer must not create push jobs")
+		require.Equal(t, http.StatusForbidden, statusCode)
+		require.True(t, apierrors.IsForbidden(result.Error()))
+	})
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips:
1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md
2. Ensure you include and run the appropriate tests as part of your Pull Request.
3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.
6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.
7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.
-->

**What is this feature?**

This PR resolves an authorization limitation in Git Sync where users with Folder Admin permissions were incorrectly blocked from moving or deleting dashboards in sync-enabled folders.

**Why do we need this feature?**

When a dashboard is moved or deleted in a Git Sync folder, a background sync job is triggered via the `repositories/{name}/jobs` subresource. The API Builder strictly required the global `provisioning.jobs:create` permission (Editor role), which resulted in Folder Admins receiving a `403 Forbidden` error despite having full write permissions on the actual folder. 

This fix implements a contextual fallback mechanism inside `authorizeRepositorySubresource`. If the global Editor check fails, it checks if the repository is configured for `SyncTargetTypeFolder` and validates if the user has `dashboards:write` explicitly on the repository's root folder (`folderUID`).

**Who is this feature for?**

Grafana users relying on Git Sync who are scoped as Folder Admins and do not have global Editor privileges.

**Which issue(s) does this PR fix?**:
<!--
- Automatically closes linked issue when the Pull Request is merged.
Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
-->
Fixes #127254

**Special notes for your reviewer:**

Extensive tests have been added to `pkg/registry/apis/provisioning/register_authz_test.go`. The test suite covers 9 edge cases (Editor, Folder Admin fallback, Viewers, instance-targeted repos, empty names, and `folderless` targets). The RBAC Group and Resource check strictly utilizes `resources.DashboardResource.Group` (`dashboard.grafana.app`) to ensure 100% integration with Grafana's existing access control translator logic.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

**Signed-off-by:** Siddhartha Singh <siddharthagithub0007@gmail.com>

