### PR TITLE
unified-storage: add default 10s keepalive config to resource client

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -179,10 +179,8 @@ subscriber_credentials_file =
 # preferred_api_version =
 
 # Interval between HTTP/2 keepalive pings on the resource-store gRPC client.
-# Enabled by default (10s) so a connection to a backend that terminated
-# ungracefully is detected and torn down in seconds instead of hanging until
-# the kernel's TCP retransmission limit gives up. Set to 0 to disable.
-# grpc_client_keepalive_time = 10s
+# Disabled by default (0).
+# grpc_client_keepalive_time = 0
 
 #################################### Database ############################
 [database]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -178,6 +178,12 @@ subscriber_credentials_file =
 # Example: dashboard.grafana.app/v1, playlists.grafana.app/v1alpha1
 # preferred_api_version =
 
+# Interval between HTTP/2 keepalive pings on the resource-store gRPC client.
+# Enabled by default (10s) so a connection to a backend that terminated
+# ungracefully is detected and torn down in seconds instead of hanging until
+# the kernel's TCP retransmission limit gives up. Set to 0 to disable.
+# grpc_client_keepalive_time = 10s
+
 #################################### Database ############################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -45,7 +45,7 @@ const (
 
 	BlobThresholdDefault int = 0
 
-	DefaultGrpcClientKeepaliveTime = 10 * time.Second
+	DefaultGrpcClientKeepaliveTime time.Duration = 0
 )
 
 type RestConfigProvider interface {

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -44,6 +44,8 @@ const (
 	StorageTypeLegacy StorageType = "legacy"
 
 	BlobThresholdDefault int = 0
+
+	DefaultGrpcClientKeepaliveTime = 10 * time.Second
 )
 
 type RestConfigProvider interface {
@@ -152,7 +154,7 @@ func NewStorageOptions() *StorageOptions {
 		Address:                                "localhost:10000",
 		GrpcClientAuthenticationTokenNamespace: "*",
 		GrpcClientAuthenticationAllowInsecure:  false,
-		GrpcClientKeepaliveTime:                0,
+		GrpcClientKeepaliveTime:                DefaultGrpcClientKeepaliveTime,
 		BlobThresholdBytes:                     BlobThresholdDefault,
 		UnifiedStorageConfig:                   make(map[string]setting.UnifiedStorageConfig),
 	}

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -78,7 +78,7 @@ func ProvideUnifiedStorageClient(opts *Options,
 		SearchServerAddress:     apiserverCfg.Key("search_server_address").MustString(""),
 		BlobStoreURL:            apiserverCfg.Key("blob_url").MustString(""),
 		BlobThresholdBytes:      apiserverCfg.Key("blob_threshold_bytes").MustInt(options.BlobThresholdDefault),
-		GrpcClientKeepaliveTime: apiserverCfg.Key("grpc_client_keepalive_time").MustDuration(0),
+		GrpcClientKeepaliveTime: apiserverCfg.Key("grpc_client_keepalive_time").MustDuration(options.DefaultGrpcClientKeepaliveTime),
 	}, opts.Cfg, opts.Features, opts.Tracer, opts.Reg, opts.Authzc, opts.Docs, storageMetrics, indexMetrics, vectorMetrics, opts.SecureValues, opts.VectorBackend, opts.Embedder, opts.DashboardStats, opts.KV, opts.EDB, gcGate)
 	if err == nil {
 		// Used to get the folder stats
@@ -259,7 +259,7 @@ func NewStorageApiSearchClient(cfg *setting.Cfg, features featuremgmt.FeatureTog
 func NewSearchClient(cfg *setting.Cfg, features featuremgmt.FeatureToggles) (resourcepb.ResourceIndexClient, error) {
 	apiserverCfg := cfg.SectionWithEnvOverrides("grafana-apiserver")
 	searchServerAddress := apiserverCfg.Key("search_server_address").MustString("")
-	grpcClientKeepaliveTime := apiserverCfg.Key("grpc_client_keepalive_time").MustDuration(0)
+	grpcClientKeepaliveTime := apiserverCfg.Key("grpc_client_keepalive_time").MustDuration(options.DefaultGrpcClientKeepaliveTime)
 
 	if searchServerAddress == "" {
 		return nil, fmt.Errorf("expecting search_server_address to be set for search client under grafana-apiserver section")


### PR DESCRIPTION
I got paged yesterday for this. The resource clients are configured with hard coded `0` keepalive configuration, so if the client is connected to a server that is shutdown ungracefully (`kill -9`, OOMKill, pod eviction, etc), the client continues to think that the connection is healthy, when it's not.