### PR TITLE
NPM: Limit pre-release NPM publishes to e2e-selectors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1137,6 +1137,7 @@ scripts/verify-pkg-stig.sh @grafana/grafana-backend-services-squad
 /scripts/generate-alerting-rtk-apis.ts @grafana/alerting-frontend
 /scripts/codemods/explicit-barrel-imports.cjs @grafana/frontend-ops
 /scripts/view-playwright-ci.sh @grafana/grafana-frontend-platform
+/scripts/estimate-npm-packument-size.sh @grafana/grafana-frontend-platform
 
 /scripts/codeowners-manifest/ @grafana/dataviz-squad
 /scripts/test-coverage-by-codeowner.js @grafana/dataviz-squad
@@ -1335,6 +1336,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/scripts/pr-notify.mts @grafana/grafana-community-support
 /.github/workflows/scripts/utils.mts @grafana/grafana-community-support
 /.github/workflows/scripts/levitate/ @grafana/grafana-frontend-platform
+/.github/workflows/scripts/detect-e2e-selectors-change.sh @grafana/grafana-frontend-platform
 /.github/workflows/stale.yml @grafana/grafana-backend-services-squad
 /.github/workflows/storybook-a11y.yml @grafana/grafana-frontend-platform
 /.github/workflows/scripts/create-security-branch/create-security-branch.sh @grafana/grafana-backend-services-squad

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -39,13 +39,11 @@ permissions: {}
 
 jobs:
   # Publishing behaviour by version_type:
-  # - 'stable':                    build + publish ALL @grafana/* packages to NPM.
-  # - 'nightly' / 'canary' (pre-releases): we no longer publish pre-releases of the
-  #   @grafana/* packages to the public NPM registry. The single exception is
-  #   @grafana/e2e-selectors, which plugin e2e tooling follows via the 'nightly'
-  #   dist-tag. It is published (and only that package, tagged 'nightly') when it has
-  #   actually changed since the last 'nightly' publish, so we stop churning out
-  #   unnecessary versions.
+  # - 'stable':  build + publish ALL @grafana/* packages to NPM.
+  # - 'nightly': only @grafana/e2e-selectors is published if it changed since
+  #              the last published nightly, for plugin-e2e tooling.
+  #              no other packages are published.
+  # - 'canary':  do nothing - canary releases are no longer pubblished
 
   publish:
     name: Publish NPM packages
@@ -54,7 +52,7 @@ jobs:
     # https://docs.npmjs.com/trusted-publishers#supported-cicd-providers
     runs-on: github-hosted-ubuntu-x64-small
 
-    if: inputs.version_type == 'stable' || inputs.version_type == 'nightly' || inputs.version_type == 'canary'
+    if: inputs.version_type == 'nightly' || inputs.version_type == 'stable'
     # Required for this workflow to have permission to publish NPM packages
     environment: npm-publish
     permissions:
@@ -94,9 +92,9 @@ jobs:
           fetch-depth: 1
 
       # Decide what this run publishes:
-      # - stable:          all packages, dist-tag resolved from the version.
-      # - nightly/canary:  @grafana/e2e-selectors only, tagged 'nightly', and only if
-      #                    it changed since the last 'nightly' publish.
+      # - stable:   all packages, dist-tag resolved from the version.
+      # - nightly:  @grafana/e2e-selectors only, tagged 'nightly', and only if it
+      #             changed since the last 'nightly' publish.
       - name: Plan publish
         id: plan
         env:
@@ -175,4 +173,3 @@ jobs:
         env:
           NPM_TAG: ${{ steps.plan.outputs.npm_tag }}
         run: ./scripts/publish-npm-packages.sh --dist-tag "$NPM_TAG" --registry 'https://registry.npmjs.org/'
-

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -38,8 +38,14 @@ on:
 permissions: {}
 
 jobs:
-  # If called with version_type 'nightly' or 'stable', build + publish to NPM
-  # If called with version_type 'canary', do nothing (temporarily stopping canary releases)
+  # Publishing behaviour by version_type:
+  # - 'stable':                    build + publish ALL @grafana/* packages to NPM.
+  # - 'nightly' / 'canary' (pre-releases): we no longer publish pre-releases of the
+  #   @grafana/* packages to the public NPM registry. The single exception is
+  #   @grafana/e2e-selectors, which plugin e2e tooling follows via the 'nightly'
+  #   dist-tag. It is published (and only that package, tagged 'nightly') when it has
+  #   actually changed since the last 'nightly' publish, so we stop churning out
+  #   unnecessary versions.
 
   publish:
     name: Publish NPM packages
@@ -48,7 +54,7 @@ jobs:
     # https://docs.npmjs.com/trusted-publishers#supported-cicd-providers
     runs-on: github-hosted-ubuntu-x64-small
 
-    if: inputs.version_type == 'nightly' || inputs.version_type == 'stable'
+    if: inputs.version_type == 'stable' || inputs.version_type == 'nightly' || inputs.version_type == 'canary'
     # Required for this workflow to have permission to publish NPM packages
     environment: npm-publish
     permissions:
@@ -78,40 +84,66 @@ jobs:
         run: ./.github/workflows/scripts/validate-commit-in-head.sh
         shell: bash
 
-      - name: Map version type to NPM tag
-        id: npm-tag
-        env:
-          VERSION: ${{ inputs.version }}
-          VERSION_TYPE: ${{ inputs.version_type }}
-          REFERENCE_PKG: "@grafana/runtime"
-        run: |
-          TAG=$(./.github/workflows/scripts/determine-npm-tag.sh)
-          echo "NPM_TAG=$TAG" >> "$GITHUB_OUTPUT"
-        shell: bash
-
       - name: Checkout build commit
         uses: actions/checkout@v5
         with:
           persist-credentials: false
           ref: ${{ inputs.grafana_commit }}
-          fetch-depth: 2  # Need HEAD~1 for e2e-selectors change detection
+          # Shallow checkout. For pre-release runs the plan step deepens history on
+          # demand (bounded by the last publish date) to detect e2e-selectors changes.
+          fetch-depth: 1
+
+      # Decide what this run publishes:
+      # - stable:          all packages, dist-tag resolved from the version.
+      # - nightly/canary:  @grafana/e2e-selectors only, tagged 'nightly', and only if
+      #                    it changed since the last 'nightly' publish.
+      - name: Plan publish
+        id: plan
+        env:
+          VERSION: ${{ inputs.version }}
+          VERSION_TYPE: ${{ inputs.version_type }}
+          GRAFANA_COMMIT: ${{ inputs.grafana_commit }}
+          REFERENCE_PKG: "@grafana/runtime"
+        run: |
+          if [ "$VERSION_TYPE" = "stable" ]; then
+            TAG=$(./.github/workflows/scripts/determine-npm-tag.sh)
+            {
+              echo "should_publish=true"
+              echo "e2e_only=false"
+              echo "npm_tag=$TAG"
+            } >> "$GITHUB_OUTPUT"
+          else
+            SHOULD=$(PACKAGE_DIR="packages/grafana-e2e-selectors" NPM_TAG="nightly" \
+              ./.github/workflows/scripts/detect-e2e-selectors-change.sh)
+            {
+              echo "should_publish=$SHOULD"
+              echo "e2e_only=true"
+              echo "npm_tag=nightly"
+            } >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
 
       - name: Setup Node
+        if: steps.plan.outputs.should_publish == 'true'
         uses: ./.github/actions/setup-node
 
       # Trusted Publishing is only available in npm v11.5.1 and later
       - name: Update npm
+        if: steps.plan.outputs.should_publish == 'true'
         run: npm install -g npm@^11.5.1
 
       - name: Install yarn dependencies
+        if: steps.plan.outputs.should_publish == 'true'
         uses: ./.github/actions/yarn-install
         with:
           hardened-mode: 'true'
 
       - name: Typecheck packages
+        if: steps.plan.outputs.should_publish == 'true'
         run: yarn run packages:typecheck
 
       - name: Version, build, and pack packages
+        if: steps.plan.outputs.should_publish == 'true'
         env:
           VERSION: ${{ inputs.version }}
         run: |
@@ -124,14 +156,23 @@ jobs:
             --yes
           yarn run packages:pack
 
+      # For pre-releases we only ship @grafana/e2e-selectors, so drop every other
+      # packed tarball before validating and publishing.
+      - name: Keep only e2e-selectors for pre-release publish
+        if: steps.plan.outputs.should_publish == 'true' && steps.plan.outputs.e2e_only == 'true'
+        run: find ./npm-artifacts -type f -name '*.tgz' ! -name '*e2e-selectors*' -print -delete
+
       - name: Debug packed files
+        if: steps.plan.outputs.should_publish == 'true'
         run: tree -a ./npm-artifacts
 
       - name: Validate packages
+        if: steps.plan.outputs.should_publish == 'true'
         run: ./scripts/validate-npm-packages.sh
 
       - name: Publish packages
+        if: steps.plan.outputs.should_publish == 'true'
         env:
-          NPM_TAG: ${{ steps.npm-tag.outputs.NPM_TAG }}
+          NPM_TAG: ${{ steps.plan.outputs.npm_tag }}
         run: ./scripts/publish-npm-packages.sh --dist-tag "$NPM_TAG" --registry 'https://registry.npmjs.org/'
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -95,6 +95,9 @@ jobs:
       # - stable:   all packages, dist-tag resolved from the version.
       # - nightly:  @grafana/e2e-selectors only, tagged 'nightly', and only if it
       #             changed since the last 'nightly' publish.
+      #
+      # Canary releases are set to hard fail to prevent accidental publishing. If we wish to start publishing them again
+      # we'll need to solve the problem of spamming the registry with too many versions.
       - name: Plan publish
         id: plan
         env:
@@ -103,7 +106,10 @@ jobs:
           GRAFANA_COMMIT: ${{ inputs.grafana_commit }}
           REFERENCE_PKG: "@grafana/runtime"
         run: |
-          if [ "$VERSION_TYPE" = "stable" ]; then
+          if [ "$VERSION_TYPE" = "canary" ]; then
+            echo "canary publishes are not supported" >&2
+            exit 1
+          elif [ "$VERSION_TYPE" = "stable" ]; then
             TAG=$(./.github/workflows/scripts/determine-npm-tag.sh)
             {
               echo "should_publish=true"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -43,7 +43,7 @@ jobs:
   # - 'nightly': only @grafana/e2e-selectors is published if it changed since
   #              the last published nightly, for plugin-e2e tooling.
   #              no other packages are published.
-  # - 'canary':  do nothing - canary releases are no longer pubblished
+  # - 'canary':  do nothing - canary releases are no longer published
 
   publish:
     name: Publish NPM packages
@@ -87,8 +87,8 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.grafana_commit }}
-          # Shallow checkout. For pre-release runs the plan step deepens history on
-          # demand (bounded by the last publish date) to detect e2e-selectors changes.
+          # Shallow checkout. For nightly runs the plan step fetches just the previous
+          # published commit (its gitHead) to diff e2e-selectors against.
           fetch-depth: 1
 
       # Decide what this run publishes:
@@ -144,6 +144,7 @@ jobs:
         if: steps.plan.outputs.should_publish == 'true'
         env:
           VERSION: ${{ inputs.version }}
+          GRAFANA_COMMIT: ${{ inputs.grafana_commit }}
         run: |
           yarn run packages:build
           yarn lerna version "$VERSION" \
@@ -152,6 +153,10 @@ jobs:
             --no-push \
             --force-publish \
             --yes
+          # packages:pack runs each package's prepack (scripts/prepare-npm-package.js),
+          # which stamps GRAFANA_COMMIT as gitHead into the packed manifest. npm doesn't
+          # record gitHead for tarball publishes, and the nightly change-detection reads
+          # it back to anchor on the exact commit the last artifact was built from.
           yarn run packages:pack
 
       # For pre-releases we only ship @grafana/e2e-selectors, so drop every other

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -109,7 +109,7 @@ jobs:
               echo "should_publish=true"
               echo "e2e_only=false"
               echo "npm_tag=$TAG"
-            } >> "$GITHUB_OUTPUT"
+            } | tee -a "$GITHUB_OUTPUT"
           else
             SHOULD=$(PACKAGE_DIR="packages/grafana-e2e-selectors" NPM_TAG="nightly" \
               ./.github/workflows/scripts/detect-e2e-selectors-change.sh)
@@ -117,7 +117,7 @@ jobs:
               echo "should_publish=$SHOULD"
               echo "e2e_only=true"
               echo "npm_tag=nightly"
-            } >> "$GITHUB_OUTPUT"
+            } | tee -a "$GITHUB_OUTPUT"
           fi
         shell: bash
 

--- a/.github/workflows/scripts/detect-e2e-selectors-change.sh
+++ b/.github/workflows/scripts/detect-e2e-selectors-change.sh
@@ -43,8 +43,13 @@ if ! git fetch --quiet --shallow-since="$PUBLISH_TIME" origin "$GIT_COMMIT" 2>/d
   exit 0
 fi
 
-if [ -n "$(git log --since="$PUBLISH_TIME" --format='%H' -- "$PACKAGE_DIR" 2>/dev/null)" ]; then
-  echo "${PACKAGE_DIR} changed since ${PUBLISH_TIME}; publishing." >&2
+# --min-parents=1 excludes the shallow-clone boundary commit: after the date-bounded
+# deepen above it is grafted parentless, so git treats it as a root that "adds" the
+# whole tree and would otherwise report every path (including this one) as changed.
+CHANGES="$(git log --min-parents=1 --since="$PUBLISH_TIME" --format='  %h %ad %s' --date=short -- "$PACKAGE_DIR" 2>/dev/null)"
+if [ -n "$CHANGES" ]; then
+  echo "${PACKAGE_DIR} changed since ${PUBLISH_TIME}; publishing. Commits:" >&2
+  echo "$CHANGES" >&2
   echo "true"
 else
   echo "${PACKAGE_DIR} unchanged since ${PUBLISH_TIME}; skipping publish." >&2

--- a/.github/workflows/scripts/detect-e2e-selectors-change.sh
+++ b/.github/workflows/scripts/detect-e2e-selectors-change.sh
@@ -4,61 +4,67 @@ set -euo pipefail
 # Decides whether the pre-release @grafana/e2e-selectors package needs publishing.
 # Prints "true" or "false" on stdout; all diagnostics go to stderr.
 #
-# We publish e2e-selectors as a pre-release only when it has actually changed since
-# the last time we published it under the given dist-tag. To avoid an unbounded git
-# history fetch (main is very active), we look up the publish time of the last tagged
-# release from NPM and deepen the shallow checkout back to that point *by date*.
+# We anchor on the exact source commit of the last published artifact rather than on
+# wall-clock time: npm records `gitHead` in the packument, so `npm view <pkg>@<tag>
+# gitHead` yields the SHA the published tarball was built from. Comparing the package
+# directory between that commit and the commit being built is exact - no date fuzz and
+# no shallow-clone graft/boundary edge cases. `git diff` needs only the two commit
+# snapshots (not the history between them), so it works in a shallow checkout once the
+# previous commit is fetched.
 #
-# When we cannot determine the answer confidently we default to publishing, so a
-# selector change is never silently withheld from consumers.
+# We fail open (publish) whenever the answer can't be determined confidently - no
+# published version yet, no recorded gitHead, or any git failure - so a real selector
+# change is never silently withheld from consumers.
 
 PACKAGE="${PACKAGE:-@grafana/e2e-selectors}"
 NPM_TAG="${NPM_TAG:-nightly}"
 PACKAGE_DIR="${PACKAGE_DIR:-packages/grafana-e2e-selectors}"
 GIT_COMMIT="${GRAFANA_COMMIT:-HEAD}"
 
-# Resolve the version currently behind the dist-tag (what plugin e2e follows).
-LAST_VERSION="$(npm view --silent "${PACKAGE}@${NPM_TAG}" version 2>/dev/null || true)"
-if [ -z "$LAST_VERSION" ]; then
-  echo "No existing '${NPM_TAG}' release of ${PACKAGE}; publishing (bootstrap)." >&2
+# gitHead (source SHA) of the version currently behind the dist-tag.
+PREV_SHA="$(npm view --silent "${PACKAGE}@${NPM_TAG}" gitHead 2>/dev/null || true)"
+if [ -z "$PREV_SHA" ]; then
+  echo "No published '${NPM_TAG}' gitHead for ${PACKAGE}; publishing (fail open)." >&2
   echo "true"
   exit 0
 fi
+echo "Last '${NPM_TAG}' publish of ${PACKAGE} was built from ${PREV_SHA}." >&2
 
-# Find when that version was published.
-PUBLISH_TIME="$(npm view --silent "${PACKAGE}" time --json 2>/dev/null \
-  | jq -r --arg v "$LAST_VERSION" '.[$v] // empty')"
-if [ -z "$PUBLISH_TIME" ]; then
-  echo "Could not resolve publish time for ${PACKAGE}@${LAST_VERSION}; publishing (safe default)." >&2
-  echo "true"
-  exit 0
-fi
-echo "Last '${NPM_TAG}' publish: ${PACKAGE}@${LAST_VERSION} at ${PUBLISH_TIME}" >&2
-
-# Ensure we have history back to the last publish. In CI the checkout is shallow
-# (fetch-depth: 1) so we deepen it — bounded by date, not commit count. We ONLY do
-# this when the repo is already shallow: running --shallow-since against a complete
-# clone would truncate it into a shallow one and destroy local history, so a full
-# clone (the usual local dev case) is left untouched and its existing history used.
-if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
-  if ! git fetch --quiet --shallow-since="$PUBLISH_TIME" origin "$GIT_COMMIT" 2>/dev/null; then
-    echo "Could not deepen shallow history to ${PUBLISH_TIME}; publishing (safe default)." >&2
-    echo "true"
-    exit 0
+# Ensure the previous commit is available locally. Fetch just that commit if missing;
+# never use --depth on a complete clone (that would truncate it into a shallow one).
+if ! git cat-file -e "${PREV_SHA}^{commit}" 2>/dev/null; then
+  if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+    git fetch --quiet --depth=1 origin "$PREV_SHA" 2>/dev/null || true
+  else
+    git fetch --quiet origin "$PREV_SHA" 2>/dev/null || true
   fi
-else
-  echo "Repository is complete; using existing history (no fetch)." >&2
 fi
 
-# --min-parents=1 excludes the shallow-clone boundary commit: after the date-bounded
-# deepen above it is grafted parentless, so git treats it as a root that "adds" the
-# whole tree and would otherwise report every path (including this one) as changed.
-CHANGES="$(git log --min-parents=1 --since="$PUBLISH_TIME" --format='  %h %ad %s' --date=short -- "$PACKAGE_DIR" 2>/dev/null)"
-if [ -n "$CHANGES" ]; then
-  echo "${PACKAGE_DIR} changed since ${PUBLISH_TIME}; publishing. Commits:" >&2
-  echo "$CHANGES" >&2
+if ! git rev-parse -q --verify "${PREV_SHA}^{commit}" >/dev/null 2>&1; then
+  echo "Could not resolve ${PREV_SHA} locally; publishing (fail open)." >&2
   echo "true"
-else
-  echo "${PACKAGE_DIR} unchanged since ${PUBLISH_TIME}; skipping publish." >&2
-  echo "false"
+  exit 0
 fi
+
+# Compare the package directory between the two commits.
+# git diff --quiet exits 0 (identical), 1 (differs), or >1 (error -> fail open).
+set +e
+git diff --quiet "$PREV_SHA" "$GIT_COMMIT" -- "$PACKAGE_DIR"
+STATUS=$?
+set -e
+
+case "$STATUS" in
+  0)
+    echo "${PACKAGE_DIR} unchanged since ${PREV_SHA}; skipping publish." >&2
+    echo "false"
+    ;;
+  1)
+    echo "${PACKAGE_DIR} changed since ${PREV_SHA}; publishing. Changed files:" >&2
+    git diff --stat "$PREV_SHA" "$GIT_COMMIT" -- "$PACKAGE_DIR" >&2 || true
+    echo "true"
+    ;;
+  *)
+    echo "git diff failed (status ${STATUS}); publishing (fail open)." >&2
+    echo "true"
+    ;;
+esac

--- a/.github/workflows/scripts/detect-e2e-selectors-change.sh
+++ b/.github/workflows/scripts/detect-e2e-selectors-change.sh
@@ -35,12 +35,19 @@ if [ -z "$PUBLISH_TIME" ]; then
 fi
 echo "Last '${NPM_TAG}' publish: ${PACKAGE}@${LAST_VERSION} at ${PUBLISH_TIME}" >&2
 
-# Deepen only as far back as the last publish (bounded by date, not commit count).
-# If we can't deepen the history we can't compare reliably, so publish to be safe.
-if ! git fetch --quiet --shallow-since="$PUBLISH_TIME" origin "$GIT_COMMIT" 2>/dev/null; then
-  echo "Could not deepen history to ${PUBLISH_TIME}; publishing (safe default)." >&2
-  echo "true"
-  exit 0
+# Ensure we have history back to the last publish. In CI the checkout is shallow
+# (fetch-depth: 1) so we deepen it — bounded by date, not commit count. We ONLY do
+# this when the repo is already shallow: running --shallow-since against a complete
+# clone would truncate it into a shallow one and destroy local history, so a full
+# clone (the usual local dev case) is left untouched and its existing history used.
+if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+  if ! git fetch --quiet --shallow-since="$PUBLISH_TIME" origin "$GIT_COMMIT" 2>/dev/null; then
+    echo "Could not deepen shallow history to ${PUBLISH_TIME}; publishing (safe default)." >&2
+    echo "true"
+    exit 0
+  fi
+else
+  echo "Repository is complete; using existing history (no fetch)." >&2
 fi
 
 # --min-parents=1 excludes the shallow-clone boundary commit: after the date-bounded

--- a/.github/workflows/scripts/detect-e2e-selectors-change.sh
+++ b/.github/workflows/scripts/detect-e2e-selectors-change.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Decides whether the pre-release @grafana/e2e-selectors package needs publishing.
+# Prints "true" or "false" on stdout; all diagnostics go to stderr.
+#
+# We publish e2e-selectors as a pre-release only when it has actually changed since
+# the last time we published it under the given dist-tag. To avoid an unbounded git
+# history fetch (main is very active), we look up the publish time of the last tagged
+# release from NPM and deepen the shallow checkout back to that point *by date*.
+#
+# When we cannot determine the answer confidently we default to publishing, so a
+# selector change is never silently withheld from consumers.
+
+PACKAGE="${PACKAGE:-@grafana/e2e-selectors}"
+NPM_TAG="${NPM_TAG:-nightly}"
+PACKAGE_DIR="${PACKAGE_DIR:-packages/grafana-e2e-selectors}"
+GIT_COMMIT="${GRAFANA_COMMIT:-HEAD}"
+
+# Resolve the version currently behind the dist-tag (what plugin e2e follows).
+LAST_VERSION="$(npm view --silent "${PACKAGE}@${NPM_TAG}" version 2>/dev/null || true)"
+if [ -z "$LAST_VERSION" ]; then
+  echo "No existing '${NPM_TAG}' release of ${PACKAGE}; publishing (bootstrap)." >&2
+  echo "true"
+  exit 0
+fi
+
+# Find when that version was published.
+PUBLISH_TIME="$(npm view --silent "${PACKAGE}" time --json 2>/dev/null \
+  | jq -r --arg v "$LAST_VERSION" '.[$v] // empty')"
+if [ -z "$PUBLISH_TIME" ]; then
+  echo "Could not resolve publish time for ${PACKAGE}@${LAST_VERSION}; publishing (safe default)." >&2
+  echo "true"
+  exit 0
+fi
+echo "Last '${NPM_TAG}' publish: ${PACKAGE}@${LAST_VERSION} at ${PUBLISH_TIME}" >&2
+
+# Deepen only as far back as the last publish (bounded by date, not commit count).
+# If we can't deepen the history we can't compare reliably, so publish to be safe.
+if ! git fetch --quiet --shallow-since="$PUBLISH_TIME" origin "$GIT_COMMIT" 2>/dev/null; then
+  echo "Could not deepen history to ${PUBLISH_TIME}; publishing (safe default)." >&2
+  echo "true"
+  exit 0
+fi
+
+if [ -n "$(git log --since="$PUBLISH_TIME" --format='%H' -- "$PACKAGE_DIR" 2>/dev/null)" ]; then
+  echo "${PACKAGE_DIR} changed since ${PUBLISH_TIME}; publishing." >&2
+  echo "true"
+else
+  echo "${PACKAGE_DIR} unchanged since ${PUBLISH_TIME}; skipping publish." >&2
+  echo "false"
+fi

--- a/scripts/estimate-npm-packument-size.sh
+++ b/scripts/estimate-npm-packument-size.sh
@@ -7,16 +7,26 @@
 # package.json (more deps) grow faster and hit the cap at fewer versions.
 #
 # Usage: scripts/estimate-npm-packument-size.sh [package ...]
-#   With no arguments, checks the known published @grafana/* packages.
+#   With no arguments, discovers the non-private packages under ./packages.
 set -euo pipefail
 
 pkgs=("$@")
 if [ ${#pkgs[@]} -eq 0 ]; then
-  pkgs=(
-    @grafana/alerting @grafana/api-clients @grafana/data @grafana/e2e-selectors
-    @grafana/flamegraph @grafana/i18n @grafana/o11y-ds-frontend @grafana/openapi
-    @grafana/runtime @grafana/schema @grafana/sql @grafana/ui
+  # Resolve ./packages relative to this script so it works from any cwd.
+  root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  while IFS= read -r name; do
+    pkgs+=("$name")
+  done < <(
+    for manifest in "$root"/packages/*/package.json; do
+      [ -f "$manifest" ] || continue
+      # Emit the name only for packages that are not marked private.
+      jq -r 'select((.private // false) != true) | .name // empty' "$manifest"
+    done | sort
   )
+  if [ ${#pkgs[@]} -eq 0 ]; then
+    echo "No non-private packages found under $root/packages" >&2
+    exit 1
+  fi
 fi
 
 human() {

--- a/scripts/estimate-npm-packument-size.sh
+++ b/scripts/estimate-npm-packument-size.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Estimate the npm packument size for the published @grafana/* packages.
+#
+# The packument is the single JSON metadata document the registry stores per package
+# (GET https://registry.npmjs.org/<pkg>). Its byte size is what hits the registry's
+# hard cap, and it grows with every published version. Packages with larger per-version
+# package.json (more deps) grow faster and hit the cap at fewer versions.
+#
+# Usage: scripts/estimate-npm-packument-size.sh [package ...]
+#   With no arguments, checks the known published @grafana/* packages.
+set -euo pipefail
+
+pkgs=("$@")
+if [ ${#pkgs[@]} -eq 0 ]; then
+  pkgs=(
+    @grafana/alerting @grafana/api-clients @grafana/data @grafana/e2e-selectors
+    @grafana/flamegraph @grafana/i18n @grafana/o11y-ds-frontend @grafana/openapi
+    @grafana/runtime @grafana/schema @grafana/sql @grafana/ui
+  )
+fi
+
+human() {
+  if command -v numfmt >/dev/null 2>&1; then
+    numfmt --to=iec "$1"
+  else
+    echo "${1}B"
+  fi
+}
+
+{
+  printf '%-28s %10s %10s %12s\n' "package" "versions" "size" "avg/ver"
+  for pkg in "${pkgs[@]}"; do
+    enc=${pkg/\//%2F} # @grafana/ui -> @grafana%2Fui
+    # Full packument. Deliberately NOT --compressed: we want the uncompressed document
+    # size the registry stores, which is what the cap applies to.
+    if ! doc=$(curl -sf "https://registry.npmjs.org/$enc"); then
+      printf '%-28s %10s\n' "$pkg" "ERR"
+      continue
+    fi
+    bytes=$(printf '%s' "$doc" | wc -c | tr -d ' ')
+    vers=$(printf '%s' "$doc" | jq '.versions | length')
+    avg=$(( vers > 0 ? bytes / vers : 0 ))
+    printf '%-28s %10s %10s %12s\n' "$pkg" "$vers" "$(human "$bytes")" "$(human "$avg")"
+  done
+} | (read -r header; echo "$header"; sort -k3 -h -r)

--- a/scripts/prepare-npm-package.js
+++ b/scripts/prepare-npm-package.js
@@ -1,11 +1,33 @@
 //@ts-check
 import PackageJson from '@npmcli/package-json';
+import { execSync } from 'node:child_process';
 
 const cwd = process.cwd();
+
+/**
+ * Resolve the source commit to stamp as `gitHead`. npm records this automatically, but
+ * only when publishing from a git working directory - we publish pre-packed tarballs,
+ * so we set it here so published manifests carry the SHA they were built from. The
+ * release workflow passes GRAFANA_COMMIT; otherwise fall back to the current HEAD.
+ */
+function resolveGitHead() {
+  const fromEnv = process.env.GRAFANA_COMMIT?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  try {
+    return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return undefined;
+  }
+}
 
 try {
   const pkgJson = await PackageJson.load(cwd);
   const pkgJsonExports = pkgJson.content.exports;
+
+  /** @type {Record<string, unknown>} */
+  const update = {};
 
   // skip packages without exports otherwise consumers cannot import anything from the package
   if (pkgJsonExports && typeof pkgJsonExports === 'object') {
@@ -23,10 +45,16 @@ try {
       }
     }
 
-    pkgJson.update({
-      exports: pkgJsonExports,
-    });
+    update.exports = pkgJsonExports;
+  }
 
+  const gitHead = resolveGitHead();
+  if (gitHead) {
+    update.gitHead = gitHead;
+  }
+
+  if (Object.keys(update).length > 0) {
+    pkgJson.update(update);
     await pkgJson.save();
   }
 } catch (e) {


### PR DESCRIPTION
**What is this feature?**

Stops publishing nightly versions of the `@grafana/*` packages to the public npm registry. The only package we still publish on the nightly path is `@grafana/e2e-selectors`, and only when it has actually changed since the last publish.

Behaviour by version type:
 - **stable**: unchanged - builds and publishes all packages
 - **nightly**: publishes _only_ `@grafana/e2e-selectors` if it has changed since the last nightly. Every other package is dropped.
 - **canary**: unchanged - still not published

**Why do we need this feature?**

To stop needlessly publishing pre-release versions to NPM that are of little use. We accidentally started publishing on _every_ commit a while back, and that made some of our packages reach NPM limits and prevented new packages from being published.

Also added is a script that reports the current npm package size for us to run to check the current limits.

Part of https://github.com/grafana/grafana-frontend-platform/issues/199