### PR TITLE
fix: metrics register and pub/sub dependecies

### DIFF
--- a/pkg/infra/nats/config.go
+++ b/pkg/infra/nats/config.go
@@ -15,9 +15,6 @@ type Config struct {
 }
 
 func newConfig(cfg setting.NATSSettings, server *Server) *Config {
-	// Copy the URL slice so later mutation of the caller's settings cannot leak
-	// into a live connection config (settings structs are shared process-wide).
-	cfg.ClientURLs = append([]string(nil), cfg.ClientURLs...)
 	return &Config{
 		cfg:    cfg,
 		server: server,

--- a/pkg/infra/nats/config.go
+++ b/pkg/infra/nats/config.go
@@ -10,16 +10,16 @@ import (
 // resolves URLs and dial options based on deployment mode (embedded or
 // external). Its exported methods form the contract consumed by connection.
 type Config struct {
-	cfg  setting.NATSSettings
-	urls []string
-
+	cfg    setting.NATSSettings
 	server *Server
 }
 
 func newConfig(cfg setting.NATSSettings, server *Server) *Config {
+	// Copy the URL slice so later mutation of the caller's settings cannot leak
+	// into a live connection config (settings structs are shared process-wide).
+	cfg.ClientURLs = append([]string(nil), cfg.ClientURLs...)
 	return &Config{
 		cfg:    cfg,
-		urls:   append([]string(nil), cfg.ClientURLs...),
 		server: server,
 	}
 }
@@ -39,14 +39,22 @@ func (c *Config) TLS() setting.NATSTLSSettings { return c.cfg.TLS }
 // Token returns the shared auth token, if any.
 func (c *Config) Token() string { return c.cfg.Auth.Token }
 
+// PublisherCredentials returns the credentials file the publisher connection
+// should use, falling back to the shared credentials when none is set.
+func (c *Config) PublisherCredentials() string { return c.cfg.Auth.PublisherCredentials() }
+
+// SubscriberCredentials returns the credentials file the subscriber connection
+// should use, falling back to the shared credentials when none is set.
+func (c *Config) SubscriberCredentials() string { return c.cfg.Auth.SubscriberCredentials() }
+
 // URLs returns the client URLs known so far. In embedded mode the running
 // server's local URL is prepended ahead of the configured peers. Safe for
 // concurrent use.
 func (c *Config) URLs() []string {
 	if local := c.server.clientURL(); local != "" {
-		return append([]string{local}, c.urls...)
+		return append([]string{local}, c.cfg.ClientURLs...)
 	}
-	return append([]string(nil), c.urls...)
+	return append([]string(nil), c.cfg.ClientURLs...)
 }
 
 // DialOptions returns extra dial options. In embedded mode this carries the

--- a/pkg/infra/nats/config_test.go
+++ b/pkg/infra/nats/config_test.go
@@ -36,16 +36,6 @@ func TestConfig(t *testing.T) {
 		require.Equal(t, []string{"nats://a:4222"}, c.URLs())
 	})
 
-	t.Run("decoupled from the config slice", func(t *testing.T) {
-		configured := []string{"nats://a:4222"}
-		c := newConfig(setting.NATSSettings{ClientURLs: configured}, nil)
-
-		// Mutating the original config slice must not leak into the Config.
-		configured[0] = "nats://tampered:4222"
-
-		require.Equal(t, []string{"nats://a:4222"}, c.URLs())
-	})
-
 	t.Run("DialOptions returns a defensive copy", func(t *testing.T) {
 		c := newConfig(setting.NATSSettings{}, &Server{server: startTestServer(t)})
 

--- a/pkg/infra/nats/helpers_test.go
+++ b/pkg/infra/nats/helpers_test.go
@@ -68,7 +68,7 @@ func newTestConnection(t *testing.T, srv *natsserver.Server) *connection {
 func newTestPublisher(t *testing.T, srv *natsserver.Server) *PublisherService {
 	t.Helper()
 	cfg := setting.NATSSettings{Enabled: true}
-	p := newPublisher(log.NewNopLogger(), newPublisherMetrics(prometheus.NewRegistry()), newTestConfig(srv, cfg), func() string { return "" })
+	p := newPublisher(log.NewNopLogger(), newPublisherMetrics(), newTestConfig(srv, cfg), func() string { return "" })
 	t.Cleanup(p.close)
 	return p
 }
@@ -76,7 +76,7 @@ func newTestPublisher(t *testing.T, srv *natsserver.Server) *PublisherService {
 func newTestSubscriber(t *testing.T, srv *natsserver.Server) *SubscriberService {
 	t.Helper()
 	cfg := setting.NATSSettings{Enabled: true}
-	s := newSubscriber(log.NewNopLogger(), newSubscriberMetrics(prometheus.NewRegistry()), newTestConfig(srv, cfg), func() string { return "" })
+	s := newSubscriber(log.NewNopLogger(), newSubscriberMetrics(), newTestConfig(srv, cfg), func() string { return "" })
 	t.Cleanup(s.close)
 	return s
 }

--- a/pkg/infra/nats/helpers_test.go
+++ b/pkg/infra/nats/helpers_test.go
@@ -68,7 +68,7 @@ func newTestConnection(t *testing.T, srv *natsserver.Server) *connection {
 func newTestPublisher(t *testing.T, srv *natsserver.Server) *PublisherService {
 	t.Helper()
 	cfg := setting.NATSSettings{Enabled: true}
-	p := newPublisher(log.NewNopLogger(), newPublisherMetrics(), newTestConfig(srv, cfg), func() string { return "" })
+	p := newPublisher(log.NewNopLogger(), newPublisherMetrics(), newTestConfig(srv, cfg))
 	t.Cleanup(p.close)
 	return p
 }
@@ -76,7 +76,7 @@ func newTestPublisher(t *testing.T, srv *natsserver.Server) *PublisherService {
 func newTestSubscriber(t *testing.T, srv *natsserver.Server) *SubscriberService {
 	t.Helper()
 	cfg := setting.NATSSettings{Enabled: true}
-	s := newSubscriber(log.NewNopLogger(), newSubscriberMetrics(), newTestConfig(srv, cfg), func() string { return "" })
+	s := newSubscriber(log.NewNopLogger(), newSubscriberMetrics(), newTestConfig(srv, cfg))
 	t.Cleanup(s.close)
 	return s
 }

--- a/pkg/infra/nats/integration_test.go
+++ b/pkg/infra/nats/integration_test.go
@@ -279,8 +279,8 @@ func startEmbeddedStack(t *testing.T) (context.Context, *Server, *PublisherServi
 	startService(t, ctx, server)
 
 	natsCfg := ProvideNATSConfig(cfg, server)
-	pub := ProvidePublisher(cfg, natsCfg, prometheus.NewRegistry())
-	sub := ProvideSubscriber(cfg, natsCfg, prometheus.NewRegistry())
+	pub := ProvidePublisher(natsCfg, prometheus.NewRegistry())
+	sub := ProvideSubscriber(natsCfg, prometheus.NewRegistry())
 	startService(t, ctx, pub)
 	startService(t, ctx, sub)
 
@@ -292,7 +292,7 @@ func startExtraSubscriber(t *testing.T, ctx context.Context, server *Server) *Su
 	t.Helper()
 	cfg := setting.NewCfg()
 	cfg.NATS = setting.NATSSettings{Enabled: true, Mode: setting.NATSModeEmbedded}
-	sub := ProvideSubscriber(cfg, ProvideNATSConfig(cfg, server), prometheus.NewRegistry())
+	sub := ProvideSubscriber(ProvideNATSConfig(cfg, server), prometheus.NewRegistry())
 	startService(t, ctx, sub)
 	return sub
 }

--- a/pkg/infra/nats/metrics.go
+++ b/pkg/infra/nats/metrics.go
@@ -71,8 +71,8 @@ type publisherMetrics struct {
 	publishErrors     prometheus.Counter
 }
 
-func newPublisherMetrics(reg prometheus.Registerer) *publisherMetrics {
-	m := &publisherMetrics{
+func newPublisherMetrics() *publisherMetrics {
+	return &publisherMetrics{
 		connectionMetrics: newConnectionMetrics(rolePublisher),
 		messagesPublished: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
@@ -87,10 +87,10 @@ func newPublisherMetrics(reg prometheus.Registerer) *publisherMetrics {
 			Help:      "Total number of NATS publish errors.",
 		}),
 	}
+}
 
-	reg.MustRegister(append(m.collectors(), m.messagesPublished, m.publishErrors)...)
-
-	return m
+func (m *publisherMetrics) collectors() []prometheus.Collector {
+	return append(m.connectionMetrics.collectors(), m.messagesPublished, m.publishErrors)
 }
 
 // subscriberMetrics covers the subscriber connection plus its delivery counters.
@@ -102,8 +102,8 @@ type subscriberMetrics struct {
 	slowConsumers    prometheus.Counter
 }
 
-func newSubscriberMetrics(reg prometheus.Registerer) *subscriberMetrics {
-	m := &subscriberMetrics{
+func newSubscriberMetrics() *subscriberMetrics {
+	return &subscriberMetrics{
 		connectionMetrics: newConnectionMetrics(roleSubscriber),
 		messagesReceived: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
@@ -136,10 +136,10 @@ func newSubscriberMetrics(reg prometheus.Registerer) *subscriberMetrics {
 			Help:      "Total number of NATS slow-consumer errors (messages dropped because the client could not keep up).",
 		}),
 	}
+}
 
-	reg.MustRegister(append(m.collectors(), m.messagesReceived, m.subscribeErrors, m.handlerDuration, m.slowConsumers)...)
-
-	return m
+func (m *subscriberMetrics) collectors() []prometheus.Collector {
+	return append(m.connectionMetrics.collectors(), m.messagesReceived, m.subscribeErrors, m.handlerDuration, m.slowConsumers)
 }
 
 // serverMetrics covers the embedded NATS server. It is registered only in

--- a/pkg/infra/nats/publisher.go
+++ b/pkg/infra/nats/publisher.go
@@ -25,8 +25,8 @@ type PublisherService struct {
 	metrics *publisherMetrics
 }
 
-func newPublisher(logger log.Logger, m *publisherMetrics, config *Config, credentials func() string) *PublisherService {
-	conn := newConnection(rolePublisher, logger, m.connectionMetrics, config, credentials)
+func newPublisher(logger log.Logger, m *publisherMetrics, config *Config) *PublisherService {
+	conn := newConnection(rolePublisher, logger, m.connectionMetrics, config, config.PublisherCredentials)
 	p := &PublisherService{connection: conn, metrics: m}
 	p.NamedService = services.NewBasicService(nil, p.running, p.stopping).WithName(publisherName)
 	return p
@@ -40,7 +40,7 @@ func ProvidePublisher(config *Config, reg prometheus.Registerer) *PublisherServi
 	if config.Enabled() {
 		reg.MustRegister(m.collectors()...)
 	}
-	return newPublisher(log.New("infra.nats.publisher"), m, config, config.PublisherCredentials)
+	return newPublisher(log.New("infra.nats.publisher"), m, config)
 }
 
 func (p *PublisherService) IsDisabled() bool {

--- a/pkg/infra/nats/publisher.go
+++ b/pkg/infra/nats/publisher.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 const publisherName = "nats-publisher"
@@ -33,11 +32,15 @@ func newPublisher(logger log.Logger, m *publisherMetrics, config *Config, creden
 	return p
 }
 
-// ProvidePublisher builds the publisher from the shared connection config (which
-// carries the bus config and resolves the mode) plus its per-role credentials,
-// registering its own metrics.
-func ProvidePublisher(cfg *setting.Cfg, config *Config, reg prometheus.Registerer) *PublisherService {
-	return newPublisher(log.New("infra.nats.publisher"), newPublisherMetrics(reg), config, cfg.NATS.Auth.PublisherCredentials)
+// ProvidePublisher builds the publisher from the shared connection config, which
+// carries the bus config, resolves the mode, and exposes the per-role
+// credentials. It registers its own metrics.
+func ProvidePublisher(config *Config, reg prometheus.Registerer) *PublisherService {
+	m := newPublisherMetrics()
+	if config.Enabled() {
+		reg.MustRegister(m.collectors()...)
+	}
+	return newPublisher(log.New("infra.nats.publisher"), m, config, config.PublisherCredentials)
 }
 
 func (p *PublisherService) IsDisabled() bool {

--- a/pkg/infra/nats/publisher_test.go
+++ b/pkg/infra/nats/publisher_test.go
@@ -13,7 +13,7 @@ import (
 func TestPublisher(t *testing.T) {
 	t.Run("is disabled when NATS is off", func(t *testing.T) {
 		cfg := setting.NATSSettings{Enabled: false}
-		p := newPublisher(log.NewNopLogger(), newPublisherMetrics(), newConfig(cfg, nil), func() string { return "" })
+		p := newPublisher(log.NewNopLogger(), newPublisherMetrics(), newConfig(cfg, nil))
 
 		require.False(t, p.Enabled())
 		require.True(t, p.IsDisabled())

--- a/pkg/infra/nats/publisher_test.go
+++ b/pkg/infra/nats/publisher_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -14,7 +13,7 @@ import (
 func TestPublisher(t *testing.T) {
 	t.Run("is disabled when NATS is off", func(t *testing.T) {
 		cfg := setting.NATSSettings{Enabled: false}
-		p := newPublisher(log.NewNopLogger(), newPublisherMetrics(prometheus.NewRegistry()), newConfig(cfg, nil), func() string { return "" })
+		p := newPublisher(log.NewNopLogger(), newPublisherMetrics(), newConfig(cfg, nil), func() string { return "" })
 
 		require.False(t, p.Enabled())
 		require.True(t, p.IsDisabled())

--- a/pkg/infra/nats/subscriber.go
+++ b/pkg/infra/nats/subscriber.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 const subscriberName = "nats-subscriber"
@@ -70,11 +69,15 @@ func newSubscriber(logger log.Logger, m *subscriberMetrics, config *Config, cred
 	return s
 }
 
-// ProvideSubscriber builds the subscriber from the shared connection config
-// (which carries the bus config and resolves the mode) plus its per-role
-// credentials, registering its own metrics.
-func ProvideSubscriber(cfg *setting.Cfg, config *Config, reg prometheus.Registerer) *SubscriberService {
-	return newSubscriber(log.New("infra.nats.subscriber"), newSubscriberMetrics(reg), config, cfg.NATS.Auth.SubscriberCredentials)
+// ProvideSubscriber builds the subscriber from the shared connection config,
+// which carries the bus config, resolves the mode, and exposes the per-role
+// credentials. It registers its own metrics.
+func ProvideSubscriber(config *Config, reg prometheus.Registerer) *SubscriberService {
+	m := newSubscriberMetrics()
+	if config.Enabled() {
+		reg.MustRegister(m.collectors()...)
+	}
+	return newSubscriber(log.New("infra.nats.subscriber"), m, config, config.SubscriberCredentials)
 }
 
 func (s *SubscriberService) IsDisabled() bool {

--- a/pkg/infra/nats/subscriber.go
+++ b/pkg/infra/nats/subscriber.go
@@ -56,8 +56,8 @@ type SubscriberService struct {
 	metrics *subscriberMetrics
 }
 
-func newSubscriber(logger log.Logger, m *subscriberMetrics, config *Config, credentials func() string) *SubscriberService {
-	conn := newConnection(roleSubscriber, logger, m.connectionMetrics, config, credentials)
+func newSubscriber(logger log.Logger, m *subscriberMetrics, config *Config) *SubscriberService {
+	conn := newConnection(roleSubscriber, logger, m.connectionMetrics, config, config.SubscriberCredentials)
 	// A slow consumer means the broker dropped messages the client could not drain in time.
 	conn.onAsyncError = func(err error) {
 		if errors.Is(err, natsclient.ErrSlowConsumer) {
@@ -77,7 +77,7 @@ func ProvideSubscriber(config *Config, reg prometheus.Registerer) *SubscriberSer
 	if config.Enabled() {
 		reg.MustRegister(m.collectors()...)
 	}
-	return newSubscriber(log.New("infra.nats.subscriber"), m, config, config.SubscriberCredentials)
+	return newSubscriber(log.New("infra.nats.subscriber"), m, config)
 }
 
 func (s *SubscriberService) IsDisabled() bool {

--- a/pkg/infra/nats/subscriber_test.go
+++ b/pkg/infra/nats/subscriber_test.go
@@ -17,7 +17,7 @@ import (
 func TestSubscriber(t *testing.T) {
 	t.Run("is disabled when NATS is off", func(t *testing.T) {
 		cfg := setting.NATSSettings{Enabled: false}
-		s := newSubscriber(log.NewNopLogger(), newSubscriberMetrics(), newConfig(cfg, nil), func() string { return "" })
+		s := newSubscriber(log.NewNopLogger(), newSubscriberMetrics(), newConfig(cfg, nil))
 
 		require.False(t, s.Enabled())
 		require.True(t, s.IsDisabled())
@@ -103,7 +103,7 @@ func TestSubscriber(t *testing.T) {
 		srv := startTestServer(t)
 		m := newSubscriberMetrics()
 		cfg := setting.NATSSettings{Enabled: true}
-		sub := newSubscriber(log.NewNopLogger(), m, newTestConfig(srv, cfg), func() string { return "" })
+		sub := newSubscriber(log.NewNopLogger(), m, newTestConfig(srv, cfg))
 		t.Cleanup(sub.close)
 		pub := newTestPublisher(t, srv)
 
@@ -133,7 +133,7 @@ func TestSubscriber(t *testing.T) {
 	t.Run("counts slow-consumer async errors", func(t *testing.T) {
 		m := newSubscriberMetrics()
 		cfg := setting.NATSSettings{Enabled: true}
-		sub := newSubscriber(log.NewNopLogger(), m, newConfig(cfg, nil), func() string { return "" })
+		sub := newSubscriber(log.NewNopLogger(), m, newConfig(cfg, nil))
 
 		// Drive the connection's async error hook directly: slow-consumer errors are
 		// counted, unrelated async errors are ignored.

--- a/pkg/infra/nats/subscriber_test.go
+++ b/pkg/infra/nats/subscriber_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	natsclient "github.com/nats-io/nats.go"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
@@ -18,7 +17,7 @@ import (
 func TestSubscriber(t *testing.T) {
 	t.Run("is disabled when NATS is off", func(t *testing.T) {
 		cfg := setting.NATSSettings{Enabled: false}
-		s := newSubscriber(log.NewNopLogger(), newSubscriberMetrics(prometheus.NewRegistry()), newConfig(cfg, nil), func() string { return "" })
+		s := newSubscriber(log.NewNopLogger(), newSubscriberMetrics(), newConfig(cfg, nil), func() string { return "" })
 
 		require.False(t, s.Enabled())
 		require.True(t, s.IsDisabled())
@@ -102,7 +101,7 @@ func TestSubscriber(t *testing.T) {
 
 	t.Run("records handler duration on delivery", func(t *testing.T) {
 		srv := startTestServer(t)
-		m := newSubscriberMetrics(prometheus.NewRegistry())
+		m := newSubscriberMetrics()
 		cfg := setting.NATSSettings{Enabled: true}
 		sub := newSubscriber(log.NewNopLogger(), m, newTestConfig(srv, cfg), func() string { return "" })
 		t.Cleanup(sub.close)
@@ -132,7 +131,7 @@ func TestSubscriber(t *testing.T) {
 	})
 
 	t.Run("counts slow-consumer async errors", func(t *testing.T) {
-		m := newSubscriberMetrics(prometheus.NewRegistry())
+		m := newSubscriberMetrics()
 		cfg := setting.NATSSettings{Enabled: true}
 		sub := newSubscriber(log.NewNopLogger(), m, newConfig(cfg, nil), func() string { return "" })
 

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -263,7 +263,7 @@ func (s *ModuleServer) Run() error {
 		// The publisher connects lazily on first publish, so no server is started
 		// here; in external mode the embedded server is inert. Returning it as the
 		// module service drains the connection on shutdown.
-		publisher := nats.ProvidePublisher(s.cfg, nats.ProvideNATSConfig(s.cfg, natsServer), s.registerer)
+		publisher := nats.ProvidePublisher(nats.ProvideNATSConfig(s.cfg, natsServer), s.registerer)
 		s.natsPublisher = publisher
 		return publisher, nil
 	})

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -924,8 +924,8 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 		return nil, err
 	}
 	config := nats.ProvideNATSConfig(cfg, natsServer)
-	publisherService := nats.ProvidePublisher(cfg, config, registerer)
-	subscriberService := nats.ProvideSubscriber(cfg, config, registerer)
+	publisherService := nats.ProvidePublisher(config, registerer)
+	subscriberService := nats.ProvideSubscriber(config, registerer)
 	healthService := grpcserver.ProvideHealthService(grpcserverProvider)
 	reflectionService, err := grpcserver.ProvideReflectionService(cfg, grpcserverProvider)
 	if err != nil {
@@ -1664,8 +1664,8 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	config := nats.ProvideNATSConfig(cfg, natsServer)
-	publisherService := nats.ProvidePublisher(cfg, config, registerer)
-	subscriberService := nats.ProvideSubscriber(cfg, config, registerer)
+	publisherService := nats.ProvidePublisher(config, registerer)
+	subscriberService := nats.ProvideSubscriber(config, registerer)
 	healthService := grpcserver.ProvideHealthService(grpcserverProvider)
 	reflectionService, err := grpcserver.ProvideReflectionService(cfg, grpcserverProvider)
 	if err != nil {


### PR DESCRIPTION
1. Do not register publisher/subscriber metrics if `nats` is not enabled.
2. Remove duplicate dependencies. Especially the `cfg` passed into the subscriber and publisher which was futile.