### PR TITLE
Provisioning: remove job queue from jobs operator

### DIFF
--- a/pkg/operators/provisioning/jobs_operator.go
+++ b/pkg/operators/provisioning/jobs_operator.go
@@ -9,13 +9,11 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
-	folderv1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/controller"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/server"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/client-go/tools/cache"
 )
 
 func RunJobController(ctx context.Context, deps server.OperatorDependencies) error {
@@ -29,19 +27,10 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 		return fmt.Errorf("failed to setup operator: %w", err)
 	}
 
-	tracer, err := controllerCfg.Tracer()
-	if err != nil {
-		return fmt.Errorf("failed to provide tracing service: %w", err)
-	}
-
 	provisioningClient, err := controllerCfg.ProvisioningClient()
 	if err != nil {
 		return fmt.Errorf("failed to create provisioning client: %w", err)
 	}
-
-	// Jobs informer and controller (resync ~60s like in register.go)
-	jobInformerFactory := newInformerFactory(provisioningClient, controllerCfg.ResyncInterval())
-	jobInformer := jobInformerFactory.Provisioning().V0alpha1().Jobs()
 
 	var startHistoryInformers func()
 	if controllerCfg.historyExpiration > 0 {
@@ -78,46 +67,6 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 
 	var wg sync.WaitGroup
 
-	if controllerCfg.jobProcessingEnabled {
-		jobController := controller.NewJobController()
-		if _, err := jobInformer.Informer().AddEventHandler(jobController.EventHandler()); err != nil {
-			return fmt.Errorf("failed to add job event handler: %w", err)
-		}
-
-		driver, err := buildDriver(
-			deps.Config,
-			&controllerCfg.ControllerConfig,
-			deps.Registerer,
-			tracer,
-			driverConfig{
-				concurrentDrivers:    controllerCfg.concurrentDrivers,
-				maxJobTimeout:        controllerCfg.maxJobTimeout,
-				jobInterval:          controllerCfg.jobInterval,
-				leaseRenewalInterval: controllerCfg.leaseRenewalInterval,
-				maxSyncWorkers:       controllerCfg.maxSyncWorkers,
-				folderAPIVersion:     controllerCfg.folderAPIVersion,
-			},
-			jobStore,
-			jobHistoryWriter,
-			jobController.InsertNotifications(),
-		)
-		if err != nil {
-			return fmt.Errorf("build driver: %w", err)
-		}
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			logger.Info("jobs controller started")
-			if err := driver.Run(ctx); err != nil {
-				logger.Error("job driver failed", "error", err)
-			}
-			logger.Info("job driver stopped")
-		}()
-	} else {
-		logger.Info("job driver disabled via operator config (jobs_processing_enabled=false)")
-	}
-
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -133,13 +82,7 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 	}()
 
 	// Start informers
-	go jobInformerFactory.Start(ctx.Done())
 	go startHistoryInformers()
-
-	// Optionally wait for job cache sync; history cleanup can rely on resync events
-	if !cache.WaitForCacheSync(ctx.Done(), jobInformer.Informer().HasSynced) {
-		return fmt.Errorf("failed to sync job informer cache")
-	}
 
 	logger.Info("jobs operator is ready")
 	deps.HealthNotifier.SetReady()
@@ -148,7 +91,7 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 	deps.HealthNotifier.SetNotReady()
 	logger.Info("shutdown signal received, waiting for goroutines to finish")
 
-	shutdownTimeout := controllerCfg.maxJobTimeout + 30*time.Second
+	shutdownTimeout := 30 * time.Second
 	done := make(chan struct{})
 	go func() {
 		wg.Wait()
@@ -167,15 +110,8 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 
 type jobsControllerConfig struct {
 	ControllerConfig
-	jobProcessingEnabled bool
-	historyExpiration    time.Duration
-	cleanupInterval      time.Duration
-	maxJobTimeout        time.Duration
-	jobInterval          time.Duration
-	leaseRenewalInterval time.Duration
-	concurrentDrivers    int
-	maxSyncWorkers       int
-	folderAPIVersion     string
+	historyExpiration time.Duration
+	cleanupInterval   time.Duration
 }
 
 func setupJobsControllerFromConfig(cfg *setting.Cfg, registry prometheus.Registerer) (*jobsControllerConfig, error) {
@@ -185,18 +121,10 @@ func setupJobsControllerFromConfig(cfg *setting.Cfg, registry prometheus.Registe
 	}
 
 	operatorSec := cfg.SectionWithEnvOverrides("operator")
-	folderAPIVersion := operatorSec.Key("folders_api_version").MustString(folderv1beta1.APIVersion)
 
 	return &jobsControllerConfig{
-		ControllerConfig:     *controllerCfg,
-		jobProcessingEnabled: operatorSec.Key("jobs_processing_enabled").MustBool(true),
-		historyExpiration:    operatorSec.Key("history_expiration").MustDuration(0),
-		concurrentDrivers:    operatorSec.Key("concurrent_drivers").MustInt(3),
-		maxSyncWorkers:       operatorSec.Key("max_sync_workers").MustInt(10),
-		maxJobTimeout:        operatorSec.Key("max_job_timeout").MustDuration(20 * time.Minute),
-		cleanupInterval:      operatorSec.Key("cleanup_interval").MustDuration(time.Minute),
-		jobInterval:          operatorSec.Key("job_interval").MustDuration(30 * time.Second),
-		leaseRenewalInterval: operatorSec.Key("lease_renewal_interval").MustDuration(30 * time.Second),
-		folderAPIVersion:     folderAPIVersion,
+		ControllerConfig:  *controllerCfg,
+		historyExpiration: operatorSec.Key("history_expiration").MustDuration(0),
+		cleanupInterval:   operatorSec.Key("cleanup_interval").MustDuration(time.Minute),
 	}, nil
 }

--- a/pkg/operators/register.go
+++ b/pkg/operators/register.go
@@ -20,7 +20,7 @@ func init() {
 	})
 	server.RegisterOperator(server.Operator{
 		Name:        "provisioning-jobs",
-		Description: "Watch provisioning jobs and manage job history cleanup",
+		Description: "Manage provisioning job and history cleanup",
 		RunFunc:     provisioning.RunJobController,
 	})
 	server.RegisterOperator(server.Operator{


### PR DESCRIPTION
## Summary

The provisioning job queue driver is now run exclusively by the separate `provisioning-jobqueue` operator, which is deployed everywhere. The `provisioning-jobs` operator was *also* building and running the driver (gated behind `jobs_processing_enabled`), duplicating job processing.

This PR removes the driver from the `provisioning-jobs` operator, leaving it responsible only for **history job cleanup** and **expired-job cleanup**. Job execution is owned solely by `provisioning-jobqueue`.

## Changes

**`pkg/operators/provisioning/jobs_operator.go`**
- Removed the `ConcurrentJobDriver` construction (`buildDriver`) and its goroutine, including the `jobs_processing_enabled` toggle.
- Removed the jobs informer + `controller.NewJobController()` + insert-notification wiring, which existed only to feed the driver.
- Removed the driver's `WaitForCacheSync` on the jobs informer and the `Tracer()` setup (only used by the driver).
- Trimmed `jobsControllerConfig` to `historyExpiration` and `cleanupInterval`; dropped the now-unused driver fields (`jobProcessingEnabled`, `maxJobTimeout`, `jobInterval`, `leaseRenewalInterval`, `concurrentDrivers`, `maxSyncWorkers`, `folderAPIVersion`) — the `jobqueue` operator retains its own copies.
- Shutdown timeout is now a fixed `30s` (previously derived from `maxJobTimeout`).
- Dropped now-unused `folderv1beta1` and `k8s.io/client-go/tools/cache` imports.

**`pkg/operators/register.go`**
- Updated the `provisioning-jobs` operator description to reflect it now only handles job/history cleanup.

`buildDriver`/`buildWorkers` in `jobs.go` are untouched and remain in use by the `provisioning-jobqueue` operator.

## Testing

- `go build ./pkg/operators/... ./pkg/registry/apis/provisioning/... ./pkg/server/...` — clean
- `go vet ./pkg/operators/...` — clean
- `gofmt` — clean
- No test files exist for the operator package; driver/cleanup unit tests in `pkg/registry/apis/provisioning/jobs/` are unaffected.

## Checklist
- [ ] Tests added/updated (n/a — no behavior change to tested units; removal of duplicate wiring)
- [x] No documentation changes needed
- [x] No breaking changes (config keys still consumed by `provisioning-jobqueue`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)