### PR TITLE
Dashboards: Add dashboardVariablesBlockOnError toggle to block dependents when a variable fails

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1492,6 +1492,11 @@ export interface FeatureToggles {
   */
   analyticsFramework?: boolean;
   /**
+  * Prevents dependent variables and panels from refreshing when a template variable fails to update, avoiding unscoped backend queries
+  * @default false
+  */
+  dashboardVariablesBlockOnError?: boolean;
+  /**
   * Send Datsource health requests to /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/health route.
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2749,6 +2749,15 @@ var (
 			Generate:     Generate{React: true},
 		},
 		{
+			Name:         "dashboardVariablesBlockOnError",
+			Description:  "Prevents dependent variables and panels from refreshing when a template variable fails to update, avoiding unscoped backend queries",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaDashboardsSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
+		},
+		{
 			Name:            "datasourcesApiServerEnableHealthEndpointFrontend",
 			Description:     "Send Datsource health requests to /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/health route.",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -319,6 +319,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,analyticsFramework,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-05-06,grafana.scenesFlickeringFix,GA,@grafana/dashboards-squad,false,false,true
 2026-05-14,grafana.viewPanelPane,experimental,@grafana/dashboards-squad,false,false,true
+2026-06-23,dashboardVariablesBlockOnError,experimental,@grafana/dashboards-squad,false,false,false
 2026-05-22,datasourcesApiServerEnableHealthEndpointFrontend,experimental,@grafana/grafana-datasources-core-services,false,false,true
 2026-05-22,datasourcesApiServerEnableHealthEndpointRedirect,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-05-22,flameGraphWithCallTree,preview,@grafana/observability-traces-and-profiling,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -858,6 +858,10 @@ const (
 	// Handle datasource health requests to the legacy API routes by querying the new datasource api group endpoints behind the scenes.
 	FlagDatasourcesApiServerEnableHealthEndpoint = "datasourcesApiServerEnableHealthEndpoint"
 
+	// FlagDashboardVariablesBlockOnError
+	// Prevents dependent variables and panels from refreshing when a template variable fails to update, avoiding unscoped backend queries
+	FlagDashboardVariablesBlockOnError = "dashboardVariablesBlockOnError"
+
 	// FlagDatasourcesApiServerEnableHealthEndpointRedirect
 	// Redirect datasource health requests from the legacy API routes to the new datasource api group endpoints.
 	FlagDatasourcesApiServerEnableHealthEndpointRedirect = "datasourcesApiServerEnableHealthEndpointRedirect"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1398,21 +1398,6 @@
     },
     {
       "metadata": {
-        "name": "dashboard.variablesBlockOnError",
-        "resourceVersion": "1782232057582",
-        "creationTimestamp": "2026-06-23T16:27:37Z",
-        "deletionTimestamp": "2026-06-23T16:30:10Z"
-      },
-      "spec": {
-        "description": "Prevents dependent variables and panels from refreshing when a template variable fails to update, avoiding unscoped backend queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true,
-        "expression": "false"
-      }
-    },
-    {
-      "metadata": {
         "name": "dashboard.vectorSearch",
         "resourceVersion": "1781031364322",
         "creationTimestamp": "2026-06-09T18:56:04Z",
@@ -1617,11 +1602,7 @@
       "metadata": {
         "name": "dashboardVariablesBlockOnError",
         "resourceVersion": "1782232210390",
-        "creationTimestamp": "2026-06-23T16:26:20Z",
-        "deletionTimestamp": "2026-06-23T16:27:37Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-23 16:30:10.390291 +0000 UTC"
-        }
+        "creationTimestamp": "2026-06-23T16:26:20Z"
       },
       "spec": {
         "description": "Prevents dependent variables and panels from refreshing when a template variable fails to update, avoiding unscoped backend queries",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1398,6 +1398,21 @@
     },
     {
       "metadata": {
+        "name": "dashboard.variablesBlockOnError",
+        "resourceVersion": "1782232057582",
+        "creationTimestamp": "2026-06-23T16:27:37Z",
+        "deletionTimestamp": "2026-06-23T16:30:10Z"
+      },
+      "spec": {
+        "description": "Prevents dependent variables and panels from refreshing when a template variable fails to update, avoiding unscoped backend queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "dashboard.vectorSearch",
         "resourceVersion": "1781031364322",
         "creationTimestamp": "2026-06-09T18:56:04Z",
@@ -1595,6 +1610,24 @@
         "description": "Enables dashboard validator app to run compatibility checks between a dashboard and data source",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardVariablesBlockOnError",
+        "resourceVersion": "1782232210390",
+        "creationTimestamp": "2026-06-23T16:26:20Z",
+        "deletionTimestamp": "2026-06-23T16:27:37Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-06-23 16:30:10.390291 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Prevents dependent variables and panels from refreshing when a template variable fails to update, avoiding unscoped backend queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromDocs": true,
         "expression": "false"
       }
     },

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/sectionVariables.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/sectionVariables.test.ts
@@ -1,3 +1,4 @@
+import { config } from '@grafana/runtime';
 import { ConstantVariable, CustomVariable, SceneVariableSet } from '@grafana/scenes';
 import {
   type ConstantVariableKind,
@@ -172,5 +173,33 @@ describe('round-trip: serialize → deserialize', () => {
     expect(constantVar.state.label).toBe('Version');
     expect(constantVar.state.description).toBe('App version');
     expect((constantVar as ConstantVariable).state.value).toBe('2.0.0');
+  });
+});
+
+describe('dashboardVariablesBlockOnError feature toggle', () => {
+  const originalValue = config.featureToggles.dashboardVariablesBlockOnError;
+
+  afterEach(() => {
+    config.featureToggles.dashboardVariablesBlockOnError = originalValue;
+  });
+
+  it('should enable blockDependentsOnError on the section variable set when the toggle is on', () => {
+    config.featureToggles.dashboardVariablesBlockOnError = true;
+
+    const result = deserializeSectionVariables([makeCustomVariableKind()]);
+
+    expect(result).toBeDefined();
+    expect(result!.state.blockDependentsOnError).toBe(true);
+    expect(result!.state.treatEmptyAsError).toBe(true);
+  });
+
+  it('should not enable blockDependentsOnError on the section variable set when the toggle is off', () => {
+    config.featureToggles.dashboardVariablesBlockOnError = false;
+
+    const result = deserializeSectionVariables([makeCustomVariableKind()]);
+
+    expect(result).toBeDefined();
+    expect(result!.state.blockDependentsOnError).toBe(false);
+    expect(result!.state.treatEmptyAsError).toBe(false);
   });
 });

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/sectionVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/sectionVariables.ts
@@ -32,5 +32,14 @@ export function deserializeSectionVariables(variables?: VariableKind[]): SceneVa
     return undefined;
   }
 
-  return new SceneVariableSet({ variables: sceneVariables });
+  const blockDependentsOnError = Boolean(config.featureToggles.dashboardVariablesBlockOnError);
+
+  return new SceneVariableSet({
+    variables: sceneVariables,
+    blockDependentsOnError,
+    // Most datasources (e.g. Prometheus label_values) swallow a failed request and resolve the
+    // variable to an empty value rather than an error, so empty must be treated as an error for
+    // the block-on-error behavior to cover the common failure case.
+    treatEmptyAsError: blockDependentsOnError,
+  });
 }

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -337,8 +337,15 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
     variableObjects.push(new ScopesVariable({ enable: true }));
   }
 
+  const blockDependentsOnError = Boolean(config.featureToggles.dashboardVariablesBlockOnError);
+
   return new SceneVariableSet({
     variables: [...defaultVariableObjects, ...variableObjects],
+    blockDependentsOnError,
+    // Most datasources (e.g. Prometheus label_values) swallow a failed request and resolve the
+    // variable to an empty value rather than an error, so empty must be treated as an error for
+    // the block-on-error behavior to cover the common failure case.
+    treatEmptyAsError: blockDependentsOnError,
   });
 }
 

--- a/public/app/features/dashboard-scene/utils/variables.test.ts
+++ b/public/app/features/dashboard-scene/utils/variables.test.ts
@@ -31,7 +31,12 @@ import { ReportInteractionBehavior } from '../scene/ReportInteractionBehavior';
 import { SnapshotVariable } from '../serialization/custom-variables/SnapshotVariable';
 import { NEW_LINK } from '../settings/links/utils';
 
-import { createSceneVariableFromVariableModel, createVariablesForSnapshot, getUserDefinedVariables } from './variables';
+import {
+  createSceneVariableFromVariableModel,
+  createVariablesForDashboard,
+  createVariablesForSnapshot,
+  getUserDefinedVariables,
+} from './variables';
 
 // mock getDataSourceSrv.getInstanceSettings()
 jest.mock('@grafana/runtime', () => ({
@@ -1028,6 +1033,49 @@ describe('when creating snapshot variables from dashboard model', () => {
     expect(intervalSnapshot.state.value).toBe('10s');
     expect(intervalSnapshot.state.text).toBe('10s');
     expect(intervalSnapshot.state.isReadOnly).toBe(true);
+  });
+});
+
+describe('dashboardVariablesBlockOnError feature toggle', () => {
+  const customVariable = {
+    current: { selected: false, text: 'a', value: 'a' },
+    hide: 0,
+    includeAll: false,
+    multi: false,
+    name: 'custom0',
+    options: [],
+    query: 'a,b,c,d',
+    skipUrlSync: false,
+    type: 'custom' as VariableType,
+    rootStateKey: 'N4XLmH5Vz',
+  };
+
+  const originalValue = config.featureToggles.dashboardVariablesBlockOnError;
+
+  afterEach(() => {
+    config.featureToggles.dashboardVariablesBlockOnError = originalValue;
+  });
+
+  it('should enable blockDependentsOnError on the variable set when the toggle is on', () => {
+    config.featureToggles.dashboardVariablesBlockOnError = true;
+
+    const oldModel = new DashboardModel({ ...defaultDashboard, templating: { list: [customVariable] } });
+    const variables = createVariablesForDashboard(oldModel);
+
+    expect(variables).toBeInstanceOf(SceneVariableSet);
+    expect(variables.state.blockDependentsOnError).toBe(true);
+    expect(variables.state.treatEmptyAsError).toBe(true);
+  });
+
+  it('should not enable blockDependentsOnError on the variable set when the toggle is off', () => {
+    config.featureToggles.dashboardVariablesBlockOnError = false;
+
+    const oldModel = new DashboardModel({ ...defaultDashboard, templating: { list: [customVariable] } });
+    const variables = createVariablesForDashboard(oldModel);
+
+    expect(variables).toBeInstanceOf(SceneVariableSet);
+    expect(variables.state.blockDependentsOnError).toBe(false);
+    expect(variables.state.treatEmptyAsError).toBe(false);
   });
 });
 

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -73,8 +73,15 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
     variableObjects.push(new ScopesVariable({ enable: true }));
   }
 
+  const blockDependentsOnError = Boolean(config.featureToggles.dashboardVariablesBlockOnError);
+
   return new SceneVariableSet({
     variables: [...defaultVariableObjects, ...variableObjects],
+    blockDependentsOnError,
+    // Most datasources (e.g. Prometheus label_values) swallow a failed request and resolve the
+    // variable to an empty value rather than an error, so empty must be treated as an error for
+    // the block-on-error behavior to cover the common failure case.
+    treatEmptyAsError: blockDependentsOnError,
   });
 }
 


### PR DESCRIPTION
## What is this feature?

A new experimental, **default-off** feature toggle `dashboardVariablesBlockOnError`. When enabled, a dashboard template variable that fails to update — its datasource query errors, times out, or (commonly) resolves to an **empty** value — no longer triggers refreshes of its chained dependent variables or of the panels that reference the involved variables.

## Which issue does this PR fix?

Part of the fix for #127689 (the scenes-side companion is grafana/scenes#1564). It is intentionally **not** marked as `Fixes`, because the behavior only takes effect once the companion scenes change is released and `@grafana/scenes` is bumped here.

## Why do we need it?

Today, when a template variable fails, Grafana still cascades as if it succeeded. With the failed variable interpolating to an empty string, dependent variables and panels fire **unscoped backend queries**. For example, a panel query

```
kube_pod_container_resource_limits{resource="cpu",pod=~"$pod.*"}
```

collapses to

```
kube_pod_container_resource_limits{resource="cpu",pod=~".*"}
```

when `$pod` fails to resolve — matching **every** pod instead of one. Such queries can be extremely expensive and hammer a datasource that is already unhealthy. This feature keeps the stale value/data and issues no query for anything downstream of the failed variable.

## Who is it for?

Operators running large dashboards with chained variables against datasources that can fail or time out (Prometheus, Loki, etc.).

## How does it work?

The blocking behavior itself lives in `@grafana/scenes` (`SceneVariableSet` + `SceneQueryRunner`), exposed via two opt-in state options. This PR is the **Grafana side**:

- **Backend** — adds the toggle to `pkg/services/featuremgmt/registry.go` (stage *experimental*, owner *grafanaDashboardsSquad*, `HideFromDocs`, `Expression: "false"`) and regenerates the toggle artifacts (`toggles_gen.go/.csv/.json`, `featureToggles.gen.ts`).
- **Frontend** — where dashboard variable sets are built (`createVariablesForDashboard`, the schema-v2 deserializer `transformSaveModelSchemaV2ToScene`, and the section-scoped variable deserializer `sectionVariables`), reads `config.featureToggles.dashboardVariablesBlockOnError` and passes:
  - `blockDependentsOnError` — enable the blocking,
  - `treatEmptyAsError` — gated on the same toggle.

`treatEmptyAsError` is enabled together with the toggle on purpose: most datasources (e.g. Prometheus `label_values`) catch their own request failures and return an **empty** result with `LoadingState.Done` rather than propagating an error, so error-only blocking would be a no-op for the most common real-world failure.

## Default behavior

Fully opt-in. With the toggle off (the default), `Boolean(config.featureToggles.dashboardVariablesBlockOnError)` is `false`, both scenes options are `false`, and behavior is **identical to today** — zero impact on existing dashboards.

## How it was tested

- **Unit tests**:
  - `public/app/features/dashboard-scene/utils/variables.test.ts` — with the toggle on, the variable set is created with `blockDependentsOnError: true` and `treatEmptyAsError: true`; with the toggle off both are `false`.
  - `public/app/features/dashboard-scene/serialization/layoutSerializers/sectionVariables.test.ts` — the same wiring for section-scoped variable sets.
- **Type/lint**: `yarn typecheck` (all projects), `eslint`, `prettier` and `make gen-feature-toggles` are clean.
- **Manual end-to-end** against a local stack with the toggle on and a deliberately failing Prometheus datasource (dead URL) plus a healthy TestData datasource:
  - Dashboard with 3 variables — `t_a` (fails), `t_b` (healthy), `t_c` (chained to `t_a`) — and 3 panels `p_a`/`p_b`/`p_c` (all on the healthy datasource so blocking is the *only* thing that can stop a query).
  - Observed: `t_a` empty→treated as error, `t_c` skipped, `t_b` succeeds. Network shows **exactly one** `/api/ds/query` (only `p_b`); `p_a` and `p_c` issue no query and keep stale data. Verified in the live scene graph (`request: null` for blocked panels, a real request id for `p_b`).
  - Confirmed no behavior change with the toggle off.

## Dependency / ordering

**Depends on grafana/scenes#1564** (companion scenes PR). The behavior depends on `@grafana/scenes` support for `blockDependentsOnError` / `treatEmptyAsError`. That scenes change must merge and be released, then `@grafana/scenes` bumped here, before this is functional end-to-end.

## Release notes / labels

Pre-GA feature behind a toggle; suggest `no-changelog` until GA.

## Related upstream issues

- grafana/grafana#127689 — the bug this feature addresses.
- grafana/grafana#124092 — *Provide a Submit Button to initiate panel refresh after updating all Dashboard Variables*. Different mechanism (manual submit vs. automatic blocking when a variable errors/resolves empty), but the same underlying motivation: prevent panels from firing wasteful backend queries in response to variable state. Not a duplicate.
