### PR TITLE
Alerting: Include rule labels in template data when expanding annotations

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -149,9 +149,12 @@ func expandAnnotationsAndLabels(ctx context.Context, log log.Logger, alertRule *
 			log.Debug("Found collision of result labels and system reserved. Renamed labels with suffix '_user'", "renamedLabels", strings.Join(reserved, ","))
 		}
 	}
-	// Merge both the extra labels and the labels from the evaluation into a common set
+	// Merge extra labels, rule labels, and result labels into a common set
 	// of labels that can be expanded in custom labels and annotations.
-	templateData := template.NewData(mergeLabels(extraLabels, resultLabels), result)
+	// Rule labels are included so that manually-set labels (e.g., environment: production)
+	// are available in $labels when templating annotations and labels.
+	// Extra labels take precedence over rule labels; result labels have lowest priority.
+	templateData := template.NewData(mergeLabels(mergeLabels(extraLabels, alertRule.Labels), resultLabels), result)
 
 	// For now, do nothing with these errors as they are already logged in expand.
 	// In the future, we want to show these errors to the user somehow.

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -1042,6 +1042,22 @@ func TestNewState(t *testing.T) {
 			assert.Equal(t, expected, state.Annotations["rule-"+key])
 		}
 	})
+	t.Run("rule labels should be available in $labels when expanding annotations", func(t *testing.T) {
+		rule := generateRule()
+		rule.Annotations["summary"] = "{{ $labels.environment }}: {{ $labels.severity }}"
+		rule.Labels = data.Labels{
+			"environment": "production",
+			"severity":    "critical",
+		}
+
+		extraLabels := ngmodels.GenerateAlertLabels(1, "extra-")
+		result := eval.Result{
+			Instance: ngmodels.GenerateAlertLabels(1, "result-"),
+		}
+
+		state := newState(context.Background(), l, rule, result, extraLabels, url)
+		assert.Equal(t, "production: critical", state.Annotations["summary"])
+	})
 	t.Run("when result labels collide with system labels from LabelsUserCannotSpecify", func(t *testing.T) {
 		result := eval.Result{
 			Instance: ngmodels.GenerateAlertLabels(5, "result-"),


### PR DESCRIPTION
## What this PR does

Fixes #116074 — Manually-set alert rule labels (e.g., `environment: production`) are not available in `$labels` when templating annotations and notification messages.

### Root Cause

In `pkg/services/ngalert/state/cache.go`, the `expandAnnotationsAndLabels` function creates template data by merging only `extraLabels` + `resultLabels`. The `alertRule.Labels` (the manually-set labels from the alert rule definition) are **not** included. When annotations reference `{{ $labels }}`, rule-level labels are missing.

### Fix

Added `alertRule.Labels` to the template data merge, with the same precedence order used in the final label assembly:
```
extraLabels > ruleLabels > resultLabels
```

**Before:**
```go
templateData := template.NewData(mergeLabels(extraLabels, resultLabels), result)
```

**After:**
```go
templateData := template.NewData(mergeLabels(mergeLabels(extraLabels, alertRule.Labels), resultLabels), result)
```

### Test

Added `TestNewState/rule_labels_should_be_available_in_$labels_when_expanding_annotations` which verifies that a rule with `environment: production` and `severity: critical` labels, and an annotation template `{{ $labels.environment }}: {{ $labels.severity }}`, produces the expected output `"production: critical"`.

### What this does NOT change

- The final assembled labels (`lbs`) already included rule labels correctly (lines 174-208). The bug was only in the **template data** used during expansion.
- No change to the notification template path — that lives in `grafana/alerting` and may benefit from a similar fix but is out of scope.

### Related

- The earlier PR grafana/alerting#468 attempted a similar fix but in the wrong repo (targeted notification templates, not ruler evaluation).
- This fix follows the approach suggested by @JacobsonMT in the issue comments.