### PR TITLE
TimelineChart: add canvas snapshot test suite

### DIFF
--- a/public/app/core/components/TimelineChart/TimelineChart.canvas.test.tsx
+++ b/public/app/core/components/TimelineChart/TimelineChart.canvas.test.tsx
@@ -1,0 +1,318 @@
+import { render, waitFor } from '@testing-library/react';
+import { type CanvasRenderingContext2DEvent } from 'jest-canvas-mock';
+import type uPlot from 'uplot';
+
+import {
+  applyFieldOverrides,
+  createTheme,
+  type DataFrame,
+  dateTime,
+  FieldColorModeId,
+  FieldType,
+  type TimeRange,
+  ThresholdsMode,
+  toDataFrame,
+} from '@grafana/data';
+import { LegendDisplayMode, MappingType, VisibilityMode } from '@grafana/schema';
+import { applyDefaultUPlotAxisMeasureTextMock, removeCanvasTransforms } from '@grafana/test-utils/canvas';
+import { measureText as uPlotAxisMeasureText, type UPlotConfigBuilder } from '@grafana/ui';
+
+import { TimelineChart } from './TimelineChart';
+import * as timelineChartUtils from './utils';
+import { prepareTimelineFields, TimelineMode } from './utils';
+
+// jest-canvas-mock reports `TextMetrics.width === text.length`, which throws off uPlot axis
+// layout vs. the browser. Route @grafana/ui's measureText through the deterministic mock and
+// share the canvas context with uPlot so gradient/axis geometry lands in the snapshot.
+let uPlotInstance: InstanceType<typeof uPlot> | undefined;
+jest.mock('@grafana/ui/src/utils/measureText', () =>
+  require('@grafana/test-utils/canvas').createGrafanaUiMeasureTextJestMock(() => uPlotInstance)
+);
+
+const width = 600;
+const height = 200;
+
+const theme = createTheme();
+
+// State values span 10-minute buckets; the time range brackets them so
+// applyNullInsertThreshold does not synthesize extra edge samples.
+const from = 1600000000000;
+const times = [from, from + 600000, from + 1200000, from + 1800000, from + 2400000];
+const timeRange: TimeRange = {
+  from: dateTime(times[0]),
+  to: dateTime(times[times.length - 1]),
+  raw: { from: dateTime(times[0]), to: dateTime(times[times.length - 1]) },
+};
+
+/**
+ * Runs raw series through the same two steps the state-timeline / status-history panels use before
+ * handing frames to TimelineChart: field overrides (to attach `display` + color resolution) followed
+ * by `prepareTimelineFields` (null insertion, sorting, span-null config).
+ */
+function prepareFrames(raw: DataFrame[], mergeValues = true): DataFrame[] {
+  const withDisplay = applyFieldOverrides({
+    data: raw,
+    // Panels supply custom field-config defaults; the timeline core reads `field.config.custom`
+    // directly when picking fill opacity, so every field (incl. the time field) needs it defined.
+    fieldConfig: { defaults: { custom: { fillOpacity: 80, lineWidth: 0 } }, overrides: [] },
+    replaceVariables: (v) => v,
+    theme,
+    timeZone: 'utc',
+  });
+
+  const { frames } = prepareTimelineFields(withDisplay, mergeValues, timeRange, theme);
+  if (!frames) {
+    throw new Error('prepareTimelineFields returned no frames for test fixture');
+  }
+  return frames;
+}
+
+/** String state series colored via value-to-text mappings (the classic state-timeline shape). */
+function stateFrame(values: Array<string | null> = ['OK', 'OK', 'Warning', 'Critical', 'OK']): DataFrame[] {
+  const raw = toDataFrame({
+    name: 'Server',
+    fields: [
+      { name: 'time', type: FieldType.time, values: times, config: { custom: {} } },
+      {
+        name: 'State',
+        type: FieldType.string,
+        values,
+        config: {
+          mappings: [
+            {
+              type: MappingType.ValueToText,
+              options: {
+                OK: { color: 'green', index: 0 },
+                Warning: { color: 'orange', index: 1 },
+                Critical: { color: 'red', index: 2 },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+  return prepareFrames([raw]);
+}
+
+/** Two string state series → exercises multi-lane vertical distribution. */
+function multiSeriesFrame(): DataFrame[] {
+  const raw = toDataFrame({
+    name: 'Cluster',
+    fields: [
+      { name: 'time', type: FieldType.time, values: times, config: { custom: {} } },
+      {
+        name: 'web',
+        type: FieldType.string,
+        values: ['OK', 'OK', 'Warning', 'OK', 'OK'],
+        config: {
+          mappings: [
+            {
+              type: MappingType.ValueToText,
+              options: { OK: { color: 'green', index: 0 }, Warning: { color: 'orange', index: 1 } },
+            },
+          ],
+        },
+      },
+      {
+        name: 'db',
+        type: FieldType.string,
+        values: ['OK', 'Critical', 'Critical', 'OK', 'OK'],
+        config: {
+          mappings: [
+            {
+              type: MappingType.ValueToText,
+              options: { OK: { color: 'green', index: 0 }, Critical: { color: 'red', index: 1 } },
+            },
+          ],
+        },
+      },
+    ],
+  });
+  return prepareFrames([raw]);
+}
+
+/** Numeric series colored by absolute thresholds (continuous-ish state coloring). */
+function thresholdFrame(): DataFrame[] {
+  const raw = toDataFrame({
+    name: 'CPU',
+    fields: [
+      { name: 'time', type: FieldType.time, values: times, config: { custom: {} } },
+      {
+        name: 'load',
+        type: FieldType.number,
+        values: [10, 55, 85, 95, 40],
+        config: {
+          color: { mode: FieldColorModeId.Thresholds },
+          thresholds: {
+            mode: ThresholdsMode.Absolute,
+            steps: [
+              { value: -Infinity, color: 'green' },
+              { value: 50, color: 'orange' },
+              { value: 80, color: 'red' },
+            ],
+          },
+        },
+      },
+    ],
+  });
+  return prepareFrames([raw]);
+}
+
+type Overrides = Partial<React.ComponentProps<typeof TimelineChart>>;
+
+function renderTimeline(frames: DataFrame[], overrides: Overrides = {}) {
+  const props: React.ComponentProps<typeof TimelineChart> = {
+    theme,
+    frames,
+    structureRev: 1,
+    width,
+    height,
+    timeRange,
+    timeZone: 'utc',
+    legend: { showLegend: false, displayMode: LegendDisplayMode.List, placement: 'bottom', calcs: [] },
+    replaceVariables: (v) => v,
+    mode: TimelineMode.Changes,
+    showValue: VisibilityMode.Auto,
+    rowHeight: 0.9,
+    ...overrides,
+  };
+  return render(<TimelineChart {...props} />);
+}
+
+describe('TimelineChart (canvas)', () => {
+  let prepConfigSpy: jest.SpyInstance;
+  const { preparePlotConfigBuilder: realPreparePlotConfigBuilder } = jest.requireActual('./utils');
+  let uPlotAxisEvents: CanvasRenderingContext2DEvent[] | null = null;
+
+  const assertUPlotReady = async () => {
+    await waitFor(() => expect(uPlotInstance?.status).toBe(1));
+    await waitFor(() => expect(document.querySelector('.u-over')).toBeInTheDocument());
+  };
+
+  const assertCanvasOutput = async (snapshotSize: { width: number; height: number } = { width, height }) => {
+    await assertUPlotReady();
+    expect(removeCanvasTransforms(uPlotInstance!.ctx.__getEvents())).toMatchCanvasSnapshot(
+      uPlotAxisEvents!,
+      snapshotSize
+    );
+  };
+
+  beforeAll(() => {
+    // timeline.ts reads the bare `devicePixelRatio` global for font sizing / char metrics;
+    // jsdom leaves it undefined, which would yield `NaNpx` fonts.
+    Object.defineProperty(window, 'devicePixelRatio', { value: 1, configurable: true, writable: true });
+  });
+
+  beforeEach(() => {
+    uPlotInstance = undefined;
+    uPlotAxisEvents = null;
+    applyDefaultUPlotAxisMeasureTextMock(jest.mocked(uPlotAxisMeasureText));
+
+    prepConfigSpy = jest
+      .spyOn(timelineChartUtils, 'preparePlotConfigBuilder')
+      .mockImplementation((opts: Parameters<typeof timelineChartUtils.preparePlotConfigBuilder>[0]) => {
+        const builder: UPlotConfigBuilder = realPreparePlotConfigBuilder(opts);
+        // Capture the live uPlot instance and separate out the axis-only draw events so the
+        // snapshot asserts on the timeline boxes/labels, not uPlot's own axis scaffolding.
+        builder.addHook('drawAxes', (u: uPlot) => {
+          uPlotInstance = u;
+          uPlotAxisEvents = u.ctx.__getEvents();
+          u.ctx.__clearDrawCalls();
+          u.ctx.__clearEvents();
+          u.ctx.__clearPath();
+        });
+        return builder;
+      });
+  });
+
+  afterEach(() => {
+    prepConfigSpy.mockRestore();
+  });
+
+  it('invokes preparePlotConfigBuilder to build the uPlot config', async () => {
+    renderTimeline(stateFrame());
+    await assertUPlotReady();
+    expect(prepConfigSpy).toHaveBeenCalled();
+  });
+
+  describe('Changes mode', () => {
+    it('draws discrete state boxes', async () => {
+      renderTimeline(stateFrame());
+      await assertCanvasOutput();
+    });
+
+    it('renders value labels when showValue is Always', async () => {
+      renderTimeline(stateFrame(), { showValue: VisibilityMode.Always });
+      await assertCanvasOutput();
+    });
+
+    it('omits value labels when showValue is Never', async () => {
+      renderTimeline(stateFrame(), { showValue: VisibilityMode.Never });
+      await assertCanvasOutput();
+    });
+
+    it('right-aligns value labels', async () => {
+      renderTimeline(stateFrame(), {
+        showValue: VisibilityMode.Always,
+        alignValue: 'right',
+      });
+      await assertCanvasOutput();
+    });
+
+    it('draws stacked lanes for multiple series', async () => {
+      renderTimeline(multiSeriesFrame(), { showValue: VisibilityMode.Always });
+      await assertCanvasOutput();
+    });
+
+    it('colors numeric series by thresholds', async () => {
+      renderTimeline(thresholdFrame(), { showValue: VisibilityMode.Always });
+      await assertCanvasOutput();
+    });
+
+    it('keeps adjacent equal states separate when mergeValues is false', async () => {
+      const raw = toDataFrame({
+        name: 'Server',
+        fields: [
+          { name: 'time', type: FieldType.time, values: times, config: { custom: {} } },
+          {
+            name: 'State',
+            type: FieldType.string,
+            values: ['OK', 'OK', 'OK', 'Critical', 'Critical'],
+            config: {
+              mappings: [
+                {
+                  type: MappingType.ValueToText,
+                  options: { OK: { color: 'green', index: 0 }, Critical: { color: 'red', index: 1 } },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      // mergeValues defaults to false at render time; the frames are prepared unmerged too, so the
+      // three consecutive OK samples stay as distinct boxes rather than collapsing into one.
+      renderTimeline(prepareFrames([raw], false), { showValue: VisibilityMode.Always });
+      await assertCanvasOutput();
+    });
+  });
+
+  describe('Samples mode', () => {
+    it('draws fixed-width sample bars', async () => {
+      renderTimeline(stateFrame(), { mode: TimelineMode.Samples });
+      await assertCanvasOutput();
+    });
+
+    it('honors colWidth for sample bar sizing', async () => {
+      renderTimeline(stateFrame(), { mode: TimelineMode.Samples, colWidth: 0.5 });
+      await assertCanvasOutput();
+    });
+  });
+
+  describe('rowHeight', () => {
+    it('renders thinner lanes with a smaller rowHeight', async () => {
+      renderTimeline(multiSeriesFrame(), { rowHeight: 0.4 });
+      await assertCanvasOutput();
+    });
+  });
+});

--- a/public/app/core/components/TimelineChart/__snapshots__/TimelineChart.canvas.test.tsx.snap
+++ b/public/app/core/components/TimelineChart/__snapshots__/TimelineChart.canvas.test.tsx.snap
@@ -1,0 +1,3582 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TimelineChart (canvas) Changes mode colors numeric series by thresholds 1`] = `
+[
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 543,
+      "x": 49,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 543,
+            "x": 49,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 136,
+            "x": 49,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 592,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#ff9830",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 136,
+            "x": 185,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#f2495c",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 135,
+            "x": 321,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 136,
+            "x": 456,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 543,
+      "x": 49,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 543,
+            "x": 49,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 543,
+                  "x": 49,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 543,
+            "x": 49,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "< 50",
+      "x": 51,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "50+",
+      "x": 187,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "80+",
+      "x": 323,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "80+",
+      "x": 458,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;
+
+exports[`TimelineChart (canvas) Changes mode draws discrete state boxes 1`] = `
+[
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 190,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 592,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#ff9830",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 324,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#f2495c",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 458,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 536,
+                  "x": 56,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 58,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 192,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Warning",
+      "x": 326,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Critical",
+      "x": 460,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;
+
+exports[`TimelineChart (canvas) Changes mode draws stacked lanes for multiple series 1`] = `
+[
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 550,
+      "x": 42,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 77,
+            "width": 138,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 77,
+            "width": 137,
+            "x": 180,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 77,
+            "width": 137,
+            "x": 455,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 77,
+            "width": 1,
+            "x": 592,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#ff9830",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 77,
+            "width": 138,
+            "x": 317,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 550,
+      "x": 42,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 77,
+            "width": 138,
+            "x": 42,
+            "y": 102,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 77,
+            "width": 137,
+            "x": 455,
+            "y": 102,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 77,
+            "width": 1,
+            "x": 592,
+            "y": 102,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#f2495c",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 77,
+            "width": 137,
+            "x": 180,
+            "y": 102,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 77,
+            "width": 138,
+            "x": 317,
+            "y": 102,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 550,
+      "x": 42,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+              {
+                "props": {
+                  "fillRule": "nonzero",
+                  "path": [
+                    {
+                      "props": {},
+                      "type": "beginPath",
+                    },
+                    {
+                      "props": {
+                        "height": 171,
+                        "width": 550,
+                        "x": 42,
+                        "y": 8,
+                      },
+                      "type": "rect",
+                    },
+                  ],
+                },
+                "type": "clip",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 44,
+      "y": 46,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 182,
+      "y": 46,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Warning",
+      "x": 319,
+      "y": 46,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 457,
+      "y": 46,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 550,
+      "x": 42,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+              {
+                "props": {
+                  "fillRule": "nonzero",
+                  "path": [
+                    {
+                      "props": {},
+                      "type": "beginPath",
+                    },
+                    {
+                      "props": {
+                        "height": 171,
+                        "width": 550,
+                        "x": 42,
+                        "y": 8,
+                      },
+                      "type": "rect",
+                    },
+                  ],
+                },
+                "type": "clip",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+              {
+                "props": {
+                  "fillRule": "nonzero",
+                  "path": [
+                    {
+                      "props": {},
+                      "type": "beginPath",
+                    },
+                    {
+                      "props": {
+                        "height": 171,
+                        "width": 550,
+                        "x": 42,
+                        "y": 8,
+                      },
+                      "type": "rect",
+                    },
+                  ],
+                },
+                "type": "clip",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+              {
+                "props": {
+                  "fillRule": "nonzero",
+                  "path": [
+                    {
+                      "props": {},
+                      "type": "beginPath",
+                    },
+                    {
+                      "props": {
+                        "height": 171,
+                        "width": 550,
+                        "x": 42,
+                        "y": 8,
+                      },
+                      "type": "rect",
+                    },
+                    {
+                      "props": {
+                        "fillRule": "nonzero",
+                        "path": [
+                          {
+                            "props": {},
+                            "type": "beginPath",
+                          },
+                          {
+                            "props": {
+                              "height": 171,
+                              "width": 550,
+                              "x": 42,
+                              "y": 8,
+                            },
+                            "type": "rect",
+                          },
+                        ],
+                      },
+                      "type": "clip",
+                    },
+                    {
+                      "props": {
+                        "height": 171,
+                        "width": 550,
+                        "x": 42,
+                        "y": 8,
+                      },
+                      "type": "rect",
+                    },
+                  ],
+                },
+                "type": "clip",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 44,
+      "y": 141,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Critical",
+      "x": 182,
+      "y": 141,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Critical",
+      "x": 319,
+      "y": 141,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 457,
+      "y": 141,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;
+
+exports[`TimelineChart (canvas) Changes mode keeps adjacent equal states separate when mergeValues is false 1`] = `
+[
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 190,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 324,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#f2495c",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 458,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 592,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 536,
+                  "x": 56,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 58,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 192,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 326,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Critical",
+      "x": 460,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;
+
+exports[`TimelineChart (canvas) Changes mode omits value labels when showValue is Never 1`] = `
+[
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 190,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 592,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#ff9830",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 324,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#f2495c",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 458,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;
+
+exports[`TimelineChart (canvas) Changes mode renders value labels when showValue is Always 1`] = `
+[
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 190,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 592,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#ff9830",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 324,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#f2495c",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 458,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 536,
+                  "x": 56,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 58,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 192,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Warning",
+      "x": 326,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Critical",
+      "x": 460,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;
+
+exports[`TimelineChart (canvas) Changes mode right-aligns value labels 1`] = `
+[
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 190,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 592,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#ff9830",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 324,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#f2495c",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 134,
+            "x": 458,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 536,
+                  "x": 56,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "right",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 188,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 322,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Warning",
+      "x": 456,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Critical",
+      "x": 590,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;
+
+exports[`TimelineChart (canvas) Samples mode draws fixed-width sample bars 1`] = `
+[
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 110,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 217,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 538,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#ff9830",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 324,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#f2495c",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 1,
+            "x": 431,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 536,
+                  "x": 56,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "center",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;
+
+exports[`TimelineChart (canvas) Samples mode honors colWidth for sample bar sizing 1`] = `
+[
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 54,
+            "x": 83,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 54,
+            "x": 190,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 54,
+            "x": 511,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#ff9830",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 54,
+            "x": 297,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#f2495c",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 171,
+            "width": 54,
+            "x": 404,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 536,
+      "x": 56,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 536,
+                  "x": 56,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 536,
+            "x": 56,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "center",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 110,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 217,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Warning",
+      "x": 324,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Critical",
+      "x": 431,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 538,
+      "y": 94,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;
+
+exports[`TimelineChart (canvas) rowHeight renders thinner lanes with a smaller rowHeight 1`] = `
+[
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 550,
+      "x": 42,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 34,
+            "width": 138,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 34,
+            "width": 137,
+            "x": 180,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 34,
+            "width": 137,
+            "x": 455,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 34,
+            "width": 1,
+            "x": 592,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#ff9830",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 34,
+            "width": 138,
+            "x": 317,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 550,
+      "x": 42,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#73bf69",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 34,
+            "width": 138,
+            "x": 42,
+            "y": 145,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 34,
+            "width": 137,
+            "x": 455,
+            "y": 145,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 34,
+            "width": 1,
+            "x": 592,
+            "y": 145,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#f2495c",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 34,
+            "width": 137,
+            "x": 180,
+            "y": 145,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "height": 34,
+            "width": 138,
+            "x": 317,
+            "y": 145,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 550,
+      "x": 42,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+              {
+                "props": {
+                  "fillRule": "nonzero",
+                  "path": [
+                    {
+                      "props": {},
+                      "type": "beginPath",
+                    },
+                    {
+                      "props": {
+                        "height": 171,
+                        "width": 550,
+                        "x": 42,
+                        "y": 8,
+                      },
+                      "type": "rect",
+                    },
+                  ],
+                },
+                "type": "clip",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 44,
+      "y": 25,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 182,
+      "y": 25,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Warning",
+      "x": 319,
+      "y": 25,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 457,
+      "y": 25,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "height": 171,
+      "width": 550,
+      "x": 42,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+              {
+                "props": {
+                  "fillRule": "nonzero",
+                  "path": [
+                    {
+                      "props": {},
+                      "type": "beginPath",
+                    },
+                    {
+                      "props": {
+                        "height": 171,
+                        "width": 550,
+                        "x": 42,
+                        "y": 8,
+                      },
+                      "type": "rect",
+                    },
+                  ],
+                },
+                "type": "clip",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+        {
+          "props": {
+            "fillRule": "nonzero",
+            "path": [
+              {
+                "props": {},
+                "type": "beginPath",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+              {
+                "props": {
+                  "fillRule": "nonzero",
+                  "path": [
+                    {
+                      "props": {},
+                      "type": "beginPath",
+                    },
+                    {
+                      "props": {
+                        "height": 171,
+                        "width": 550,
+                        "x": 42,
+                        "y": 8,
+                      },
+                      "type": "rect",
+                    },
+                  ],
+                },
+                "type": "clip",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+              {
+                "props": {
+                  "fillRule": "nonzero",
+                  "path": [
+                    {
+                      "props": {},
+                      "type": "beginPath",
+                    },
+                    {
+                      "props": {
+                        "height": 171,
+                        "width": 550,
+                        "x": 42,
+                        "y": 8,
+                      },
+                      "type": "rect",
+                    },
+                    {
+                      "props": {
+                        "fillRule": "nonzero",
+                        "path": [
+                          {
+                            "props": {},
+                            "type": "beginPath",
+                          },
+                          {
+                            "props": {
+                              "height": 171,
+                              "width": 550,
+                              "x": 42,
+                              "y": 8,
+                            },
+                            "type": "rect",
+                          },
+                        ],
+                      },
+                      "type": "clip",
+                    },
+                    {
+                      "props": {
+                        "height": 171,
+                        "width": 550,
+                        "x": 42,
+                        "y": 8,
+                      },
+                      "type": "rect",
+                    },
+                  ],
+                },
+                "type": "clip",
+              },
+              {
+                "props": {
+                  "height": 171,
+                  "width": 550,
+                  "x": 42,
+                  "y": 8,
+                },
+                "type": "rect",
+              },
+            ],
+          },
+          "type": "clip",
+        },
+        {
+          "props": {
+            "height": 171,
+            "width": 550,
+            "x": 42,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "500 12px 'Inter', 'Helvetica', 'Arial', sans-serif",
+    },
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "type": "textAlign",
+  },
+  {
+    "props": {
+      "value": "middle",
+    },
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 44,
+      "y": 162,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Critical",
+      "x": 182,
+      "y": 162,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "Critical",
+      "x": 319,
+      "y": 162,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {
+      "value": "#000000",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "maxWidth": null,
+      "text": "OK",
+      "x": 457,
+      "y": 162,
+    },
+    "type": "fillText",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;


### PR DESCRIPTION
_Coverage crusage continues!_

Adds a canvas-based test suite for the TimelineChart component using the shared jest canvas-compare utilities (toMatchCanvasSnapshot, createGrafanaUiMeasureTextJestMock). Covers Changes mode (state boxes, value label visibility/alignment, multi-series lanes, threshold coloring, unmerged states), Samples mode (bar sizing, colWidth), and rowHeight.

<img width="674" height="323" alt="Screenshot 2026-07-01 at 4 15 32 PM" src="https://github.com/user-attachments/assets/ff8387d8-f5b9-4ddd-80aa-bc13bef0094c" />
