### PR TITLE
MySQL: Add connection collation setting to fix MySQL 8.4 compatibility

### DIFF
--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -96,12 +96,24 @@ func NewInstanceSettings(logger log.Logger) datasource.InstanceFactoryFunc {
 			}
 		}
 
-		cnnstr := fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&parseTime=true&loc=UTC&allowNativePasswords=true",
+		// Extract custom collation from JSONData, fallback to utf8mb4_unicode_ci for backward compatibility
+		var customSettings struct {
+			Collation string `json:"collation"`
+		}
+		_ = json.Unmarshal(settings.JSONData, &customSettings)
+
+		collation := "utf8mb4_unicode_ci"
+		if customSettings.Collation != "" {
+			collation = customSettings.Collation
+		}
+
+		cnnstr := fmt.Sprintf("%s:%s@%s(%s)/%s?collation=%s&parseTime=true&loc=UTC&allowNativePasswords=true",
 			characterEscape(dsInfo.User, ":"),
 			dsInfo.DecryptedSecureJSONData["password"],
 			protocol,
 			characterEscape(dsInfo.URL, ")"),
 			characterEscape(dsInfo.Database, "?"),
+			collation,
 		)
 
 		if dsInfo.JsonData.AllowCleartextPasswords {

--- a/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx
@@ -209,6 +209,34 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<My
                   placeholder="Europe/Berlin or +02:00"
                 />
               </Field>
+              <Field
+                noMargin
+                label={
+                  <Label>
+                    <EditorStack gap={0.5}>
+                      <span>Connection collation</span>
+                      <Tooltip
+                        content={
+                          <span>
+                            Specify the connection collation, such as <code>utf8mb4_0900_ai_ci</code> or{' '}
+                            <code>utf8mb4_unicode_ci</code>. Leave empty to use the default (
+                            <code>utf8mb4_unicode_ci</code>).
+                          </span>
+                        }
+                      >
+                        <Icon name="info-circle" size="sm" />
+                      </Tooltip>
+                    </EditorStack>
+                  </Label>
+                }
+              >
+                <Input
+                  width={WIDTH_LONG}
+                  value={jsonData.collation || ''}
+                  onChange={onUpdateDatasourceJsonDataOption(props, 'collation')}
+                  placeholder="utf8mb4_unicode_ci"
+                />
+              </Field>
 
               <Field
                 noMargin

--- a/public/app/plugins/datasource/mysql/types.ts
+++ b/public/app/plugins/datasource/mysql/types.ts
@@ -2,4 +2,5 @@ import { type SQLOptions } from '@grafana/sql';
 
 export interface MySQLOptions extends SQLOptions {
   allowCleartextPasswords?: boolean;
+  collation?: string;
 }


### PR DESCRIPTION
**What is this feature?**

This PR adds a new "Connection collation" text input to the MySQL datasource configuration page. It updates the Go backend to read this setting and apply it to the connection string. If left blank, it falls back to `utf8mb4_unicode_ci` to maintain backward compatibility for existing dashboards.

**Why do we need this feature?**

Currently, Grafana hardcodes the connection collation to `utf8mb4_unicode_ci`. This causes an `Error 1267 (HY000): Illegal mix of collations` when querying a database/view in MySQL 8.4, which natively defaults to `utf8mb4_0900_ai_ci`. This PR gives users the flexibility to match their database's collation, completely fixing the bug.

**Who is this feature for?**

Grafana users connecting to MySQL 8.x/8.4 databases, or any user who needs to define a custom connection collation.

**Which issue(s) does this PR fix?**:

<!-- Replace the [ISSUE_NUMBER] below with the actual number of the GitHub issue you found! -->
Fixes #127388

**Special notes for your reviewer:**

To test this locally:
1. Spin up a MySQL 8.4 container: `docker run --name grafana-mysql-bug-test -e MYSQL_ROOT_PASSWORD=grafana -p 3306:3306 -d mysql:8.4`
2. Create a database and view using the default `utf8mb4_0900_ai_ci` collation.
3. Add the MySQL datasource in Grafana and set the new **Connection collation** field to `utf8mb4_0900_ai_ci`.
4. Run a query against the view—it will successfully return data instead of throwing the collation mismatch error.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.