### PR TITLE
Dashboard: show disabled resize handle with tooltip in auto layout

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
@@ -3,7 +3,7 @@ import { memo, useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { LazyLoader, sceneGraph, type SceneComponentProps, type VizPanel } from '@grafana/scenes';
-import { useElementSelection, useStyles2 } from '@grafana/ui';
+import { Tooltip, useElementSelection, useStyles2 } from '@grafana/ui';
 
 import { type ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { useIsConditionallyHidden } from '../../conditional-rendering/hooks/useIsConditionallyHidden';
@@ -77,6 +77,7 @@ export function AutoGridItemRenderer({ model }: SceneComponentProps<AutoGridItem
                   >
                     <item.Component model={item} />
                     {conditionalRenderingOverlay}
+                    {isEditing && <DisabledResizeHandle styles={styles} />}
                   </LazyLoader>
                 ) : (
                   <div
@@ -90,6 +91,7 @@ export function AutoGridItemRenderer({ model }: SceneComponentProps<AutoGridItem
                   >
                     <item.Component model={item} />
                     {conditionalRenderingOverlay}
+                    {isEditing && <DisabledResizeHandle styles={styles} />}
                   </div>
                 )
               }
@@ -141,6 +143,24 @@ export function AutoGridItemRenderer({ model }: SceneComponentProps<AutoGridItem
   );
 }
 
+function DisabledResizeHandle({ styles }: { styles: ReturnType<typeof getStyles> }) {
+  return (
+    <Tooltip content="Panels cannot be resized in auto layout" placement="top">
+      <div className={styles.disabledResizeHandle} aria-label="Panels cannot be resized in auto layout">
+        <svg width="16px" height="16px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M21 15L15 21M21 8L8 21"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+    </Tooltip>
+  );
+}
+
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({ width: '100%', height: '100%', position: 'relative' }),
   draggedWrapper: css({
@@ -170,5 +190,17 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   hidden: css({
     display: 'none',
+  }),
+  disabledResizeHandle: css({
+    position: 'absolute',
+    bottom: 0,
+    right: 0,
+    zIndex: 999,
+    padding: theme.spacing(1.5, 0, 0, 1.5),
+    color: theme.colors.text.disabled,
+    cursor: 'not-allowed',
+    svg: {
+      display: 'block',
+    },
   }),
 });


### PR DESCRIPTION
## What is this feature?

Closes #127273

When a dashboard is in **edit mode** and using the **auto layout** (auto grid), panels currently show no resize affordance at all. Users familiar with the custom/default layout expect a resize handle in the bottom-right corner and are not told why it is absent, which creates confusion.

## How does it work?

This adds a `DisabledResizeHandle` component that renders:
- The same diagonal-lines SVG icon used by the active resize handle in the default grid layout
- Positioned absolutely at the bottom-right of each auto-grid panel (matching the active handle position)
- Styled with `cursor: not-allowed` and `theme.colors.text.disabled` (muted, clearly non-interactive)
- Wrapped in a `Tooltip` from `@grafana/ui` with the content `"Panels cannot be resized in auto layout"`
- Rendered only when `isEditing` is `true` (invisible in view mode, consistent with the active handle in the default layout)

## Which issue(s) does this fix?

Closes #127273

## Special notes for your reviewer

The `DisabledResizeHandle` is a pure presentational component with no state — it reads `styles` from the parent `getStyles` call so no additional `useStyles2` call is needed inside it. The SVG path is identical to the one in `grafana/scenes` `SceneGridLayoutRenderer.tsx` `ResizeHandle` so the icon is visually consistent between layouts.

## Checklist

- [x] Related issues linked using `Closes #127273`
- [x] Added `aria-label` on the disabled handle for accessibility
- [x] Change is limited to the auto-grid item renderer — no other layout affected
- [x] Only shown in edit mode (`isEditing === true`)
