### PR TITLE
Unified storage: add ListStoredResources discovery API

### DIFF
--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -1374,6 +1374,10 @@ func (m *MockClient) List(ctx context.Context, in *resourcepb.ListRequest, opts 
 func (m *MockClient) ListManagedObjects(ctx context.Context, in *resourcepb.ListManagedObjectsRequest, opts ...grpc.CallOption) (*resourcepb.ListManagedObjectsResponse, error) {
 	return nil, nil
 }
+
+func (m *MockClient) ListStoredResources(ctx context.Context, in *resourcepb.ListStoredResourcesRequest, opts ...grpc.CallOption) (*resourcepb.ListStoredResourcesResponse, error) {
+	return nil, nil
+}
 func (m *MockClient) IsHealthy(ctx context.Context, in *resourcepb.HealthCheckRequest, opts ...grpc.CallOption) (*resourcepb.HealthCheckResponse, error) {
 	return nil, nil
 }

--- a/pkg/registry/apis/iam/team/search_test.go
+++ b/pkg/registry/apis/iam/team/search_test.go
@@ -743,6 +743,10 @@ func (m *MockClient) List(ctx context.Context, in *resourcepb.ListRequest, opts 
 func (m *MockClient) ListManagedObjects(ctx context.Context, in *resourcepb.ListManagedObjectsRequest, opts ...grpc.CallOption) (*resourcepb.ListManagedObjectsResponse, error) {
 	return nil, nil
 }
+
+func (m *MockClient) ListStoredResources(ctx context.Context, in *resourcepb.ListStoredResourcesRequest, opts ...grpc.CallOption) (*resourcepb.ListStoredResourcesResponse, error) {
+	return nil, nil
+}
 func (m *MockClient) IsHealthy(ctx context.Context, in *resourcepb.HealthCheckRequest, opts ...grpc.CallOption) (*resourcepb.HealthCheckResponse, error) {
 	return nil, nil
 }

--- a/pkg/registry/apis/iam/user/search_test.go
+++ b/pkg/registry/apis/iam/user/search_test.go
@@ -144,6 +144,10 @@ func (m *MockClient) List(ctx context.Context, in *resourcepb.ListRequest, opts 
 func (m *MockClient) ListManagedObjects(ctx context.Context, in *resourcepb.ListManagedObjectsRequest, opts ...grpc.CallOption) (*resourcepb.ListManagedObjectsResponse, error) {
 	return nil, nil
 }
+
+func (m *MockClient) ListStoredResources(ctx context.Context, in *resourcepb.ListStoredResourcesRequest, opts ...grpc.CallOption) (*resourcepb.ListStoredResourcesResponse, error) {
+	return nil, nil
+}
 func (m *MockClient) IsHealthy(ctx context.Context, in *resourcepb.HealthCheckRequest, opts ...grpc.CallOption) (*resourcepb.HealthCheckResponse, error) {
 	return nil, nil
 }

--- a/pkg/storage/unified/proto/resource.proto
+++ b/pkg/storage/unified/proto/resource.proto
@@ -626,6 +626,39 @@ service ResourceStore {
   // This will perform best-effort filtering to increase performace.
   // NOTE: storage.Interface is ultimatly responsible for the final filtering
   rpc Watch(WatchRequest) returns (stream WatchEvent);
+
+  // Discover which resource identities (namespace/group/resource) exist in
+  // storage, without returning counts. This is a cheap alternative to
+  // GetStats for callers that only need to know what is stored, not how much.
+  rpc ListStoredResources(ListStoredResourcesRequest) returns (ListStoredResourcesResponse);
+}
+
+// Discovery filter for ListStoredResources.
+message ListStoredResourcesRequest {
+  // Namespace (tenant) to discover resources in. Required: discovery across
+  // all namespaces is not supported. An empty namespace is rejected with
+  // InvalidArgument.
+  string namespace = 1;
+
+  // Optional group filter. Empty means no filter on group.
+  string group = 2;
+
+  // Optional resource filter. Empty means no filter on resource.
+  string resource = 3;
+}
+
+message ListStoredResourcesResponse {
+  message StoredResource {
+    string namespace = 1;
+    string group = 2;
+    string resource = 3;
+  }
+
+  // Resource identities that exist in live storage. This is discovery-only:
+  // it may include false positives (a returned identity may have no live
+  // objects by the time the caller queries it). Errors are returned as gRPC
+  // errors, not embedded in this response.
+  repeated StoredResource items = 1;
 }
 
 service BulkStore {

--- a/pkg/storage/unified/resource/bulk_test.go
+++ b/pkg/storage/unified/resource/bulk_test.go
@@ -289,6 +289,7 @@ func (s *testBulkProcessServer) RecvMsg(any) error {
 const errPanicBulkProcess = "panic from ProcessBulk"
 
 type panicBulkBackend struct {
+	UnimplementedStorageBackend
 	sendDone chan bool
 }
 

--- a/pkg/storage/unified/resource/client_mock.go
+++ b/pkg/storage/unified/resource/client_mock.go
@@ -690,6 +690,80 @@ func (_c *MockResourceClient_List_Call) RunAndReturn(run func(context.Context, *
 	return _c
 }
 
+// ListStoredResources provides a mock function with given fields: ctx, in, opts
+func (_m *MockResourceClient) ListStoredResources(ctx context.Context, in *resourcepb.ListStoredResourcesRequest, opts ...grpc.CallOption) (*resourcepb.ListStoredResourcesResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListStoredResources")
+	}
+
+	var r0 *resourcepb.ListStoredResourcesResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *resourcepb.ListStoredResourcesRequest, ...grpc.CallOption) (*resourcepb.ListStoredResourcesResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *resourcepb.ListStoredResourcesRequest, ...grpc.CallOption) *resourcepb.ListStoredResourcesResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcepb.ListStoredResourcesResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *resourcepb.ListStoredResourcesRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockResourceClient_ListStoredResources_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListStoredResources'
+type MockResourceClient_ListStoredResources_Call struct {
+	*mock.Call
+}
+
+// ListStoredResources is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *resourcepb.ListStoredResourcesRequest
+//   - opts ...grpc.CallOption
+func (_e *MockResourceClient_Expecter) ListStoredResources(ctx interface{}, in interface{}, opts ...interface{}) *MockResourceClient_ListStoredResources_Call {
+	return &MockResourceClient_ListStoredResources_Call{Call: _e.mock.On("ListStoredResources",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *MockResourceClient_ListStoredResources_Call) Run(run func(ctx context.Context, in *resourcepb.ListStoredResourcesRequest, opts ...grpc.CallOption)) *MockResourceClient_ListStoredResources_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*resourcepb.ListStoredResourcesRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockResourceClient_ListStoredResources_Call) Return(_a0 *resourcepb.ListStoredResourcesResponse, _a1 error) *MockResourceClient_ListStoredResources_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockResourceClient_ListStoredResources_Call) RunAndReturn(run func(context.Context, *resourcepb.ListStoredResourcesRequest, ...grpc.CallOption) (*resourcepb.ListStoredResourcesResponse, error)) *MockResourceClient_ListStoredResources_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListManagedObjects provides a mock function with given fields: ctx, in, opts
 func (_m *MockResourceClient) ListManagedObjects(ctx context.Context, in *resourcepb.ListManagedObjectsRequest, opts ...grpc.CallOption) (*resourcepb.ListManagedObjectsResponse, error) {
 	_va := make([]interface{}, len(opts))

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -682,6 +682,71 @@ func (d *dataStore) GetResourceStats(ctx context.Context, nsr NamespacedResource
 	return stats, nil
 }
 
+// ListStoredResources implements StorageBackend for the KV backend.
+//
+// A namespace is required; discovering across all namespaces would need a full
+// scan and no caller needs it. Existence matches any key under the
+// group/resource/namespace prefix, including delete tombstones, so results may
+// contain false positives.
+func (d *dataStore) ListStoredResources(ctx context.Context, filter NamespacedResource) ([]NamespacedResource, error) {
+	ctx, span := tracer.Start(ctx, "resource.dataStore.ListStoredResources")
+	defer span.End()
+
+	if filter.Namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+
+	groupResources, err := d.getGroupResources(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get group resources: %w", err)
+	}
+
+	var result []NamespacedResource
+	for _, gr := range groupResources {
+		if filter.Group != "" && gr.Group != filter.Group {
+			continue
+		}
+		if filter.Resource != "" && gr.Resource != filter.Resource {
+			continue
+		}
+
+		exists, err := d.groupResourceExistsInNamespace(ctx, gr, filter.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			result = append(result, NamespacedResource{
+				Namespace: filter.Namespace,
+				Group:     gr.Group,
+				Resource:  gr.Resource,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// groupResourceExistsInNamespace reports whether any key exists under the
+// group/resource/namespace prefix.
+func (d *dataStore) groupResourceExistsInNamespace(ctx context.Context, gr GroupResource, namespace string) (bool, error) {
+	// No namespace validation: for a discovery existence check an absent or
+	// malformed namespace simply has no keys, so it should return "not found"
+	// rather than an error (matching the SQL backend).
+	prefix := ListRequestKey{Group: gr.Group, Resource: gr.Resource, Namespace: namespace}.Prefix()
+	for _, err := range d.kv.Keys(ctx, dataSection, ListOptions{
+		StartKey: prefix,
+		EndKey:   PrefixRangeEnd(prefix),
+		Limit:    1,
+		Sort:     SortOrderAsc,
+	}) {
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
 // processGroupResourceStats processes stats for a specific group/resource combination
 func (d *dataStore) processGroupResourceStats(ctx context.Context, groupResource GroupResource, namespace string, minCount int) ([]ResourceStats, error) {
 	ctx, span := tracer.Start(ctx, "resource.dataStore.processGroupResourceStats")

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -3445,4 +3447,70 @@ func TestToSnowflakeRVIdempotent(t *testing.T) {
 				"toSnowflakeRV must not re-encode a value that is already a snowflake")
 		})
 	}
+}
+
+func TestIntegrationDataStore_ListStoredResources(t *testing.T) {
+	runDataStoreTestWith(t, "badger", setupTestDataStore, testDataStoreListStoredResources)
+	runDataStoreTestWith(t, "sqlkv", setupTestDataStoreSqlKv, testDataStoreListStoredResources)
+}
+
+func testDataStoreListStoredResources(t *testing.T, ctx context.Context, ds *dataStore) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	save := func(ns, group, resource, name string) {
+		key := DataKey{
+			Namespace:       ns,
+			Group:           group,
+			Resource:        resource,
+			Name:            name,
+			ResourceVersion: node.Generate().Int64(),
+			Action:          DataActionCreated,
+		}
+		require.NoError(t, ds.Save(ctx, key, bytes.NewReader([]byte("v"))))
+	}
+
+	sortFunc := func(a, b NamespacedResource) int {
+		if a.Namespace != b.Namespace {
+			return strings.Compare(a.Namespace, b.Namespace)
+		}
+		if a.Group != b.Group {
+			return strings.Compare(a.Group, b.Group)
+		}
+		return strings.Compare(a.Resource, b.Resource)
+	}
+
+	// Two objects of the same group/resource in ns1 must be reported once.
+	save("ns1", "apps", "deployments", "d1")
+	save("ns1", "apps", "deployments", "d2")
+	save("ns1", "apps", "services", "s1")
+	save("ns2", "apps", "deployments", "d1")
+
+	t.Run("namespace filter returns distinct identities", func(t *testing.T) {
+		got, err := ds.ListStoredResources(ctx, NamespacedResource{Namespace: "ns1"})
+		require.NoError(t, err)
+		slices.SortFunc(got, sortFunc)
+		require.Equal(t, []NamespacedResource{
+			{Namespace: "ns1", Group: "apps", Resource: "deployments"},
+			{Namespace: "ns1", Group: "apps", Resource: "services"},
+		}, got)
+	})
+
+	t.Run("resource filter is scoped to the namespace", func(t *testing.T) {
+		got, err := ds.ListStoredResources(ctx, NamespacedResource{Namespace: "ns1", Resource: "services"})
+		require.NoError(t, err)
+		require.Equal(t, []NamespacedResource{
+			{Namespace: "ns1", Group: "apps", Resource: "services"},
+		}, got)
+	})
+
+	t.Run("non-existent namespace is empty", func(t *testing.T) {
+		got, err := ds.ListStoredResources(ctx, NamespacedResource{Namespace: "missing"})
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("empty namespace is rejected", func(t *testing.T) {
+		_, err := ds.ListStoredResources(ctx, NamespacedResource{})
+		require.Error(t, err)
+	})
 }

--- a/pkg/storage/unified/resource/list_with_field_selectors_test.go
+++ b/pkg/storage/unified/resource/list_with_field_selectors_test.go
@@ -412,6 +412,7 @@ func (*stubSearchClient) VectorSearch(_ context.Context, _ *resourcepb.VectorSea
 }
 
 type fakeBackend struct {
+	UnimplementedStorageBackend
 	forbidden map[string]struct{}
 }
 
@@ -448,6 +449,7 @@ func (*fakeBackend) WatchWriteEvents(ctx context.Context) (<-chan *WrittenEvent,
 func (*fakeBackend) GetResourceStats(context.Context, NamespacedResource, int) ([]ResourceStats, error) {
 	return nil, nil
 }
+
 func (*fakeBackend) GetResourceLastImportTimes(context.Context) iter.Seq2[ResourceLastImportTime, error] {
 	return func(func(ResourceLastImportTime, error) bool) {}
 }

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -81,6 +81,7 @@ func (f *fakeDocumentBuilder) BuildDocument(_ context.Context, _ *resourcepb.Res
 
 // mockStorageBackend implements StorageBackend for testing
 type mockStorageBackend struct {
+	UnimplementedStorageBackend
 	resourceStats   []ResourceStats
 	lastImportTimes []ResourceLastImportTime
 	statsCalls      atomic.Int32

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -179,6 +179,14 @@ type StorageBackend interface {
 	// Get resource stats within the storage backend.  When namespace is empty, it will apply to all
 	GetResourceStats(ctx context.Context, nsr NamespacedResource, minCount int) ([]ResourceStats, error)
 
+	// ListStoredResources discovers which resource identities exist in storage,
+	// without returning counts. It is a cheaper alternative to GetResourceStats
+	// for callers that only need to know what is stored. The filter's Namespace
+	// is required; Group and Resource are optional (empty means no filter on that
+	// field). Results are discovery-only and may contain false positives: a
+	// returned identity may have no live objects by the time the caller queries it.
+	ListStoredResources(ctx context.Context, filter NamespacedResource) ([]NamespacedResource, error)
+
 	// GetResourceLastImportTimes returns import times for all namespaced resources in the backend.
 	GetResourceLastImportTimes(ctx context.Context) iter.Seq2[ResourceLastImportTime, error]
 }
@@ -1448,6 +1456,42 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 	default:
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("invalid list source: %v", req.Source))
 	}
+}
+
+// ListStoredResources implements the ResourceStore gRPC service by delegating
+// to the storage backend. A namespace is required.
+func (s *server) ListStoredResources(ctx context.Context, req *resourcepb.ListStoredResourcesRequest) (*resourcepb.ListStoredResourcesResponse, error) {
+	ctx, span := tracer.Start(ctx, "resource.server.ListStoredResources")
+	defer span.End()
+
+	if req.Namespace == "" {
+		return nil, status.Error(codes.InvalidArgument, "namespace is required")
+	}
+
+	if err := s.Init(ctx); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	stored, err := s.backend.ListStoredResources(ctx, NamespacedResource{
+		Namespace: req.Namespace,
+		Group:     req.Group,
+		Resource:  req.Resource,
+	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	rsp := &resourcepb.ListStoredResourcesResponse{
+		Items: make([]*resourcepb.ListStoredResourcesResponse_StoredResource, 0, len(stored)),
+	}
+	for _, r := range stored {
+		rsp.Items = append(rsp.Items, &resourcepb.ListStoredResourcesResponse_StoredResource{
+			Namespace: r.Namespace,
+			Group:     r.Group,
+			Resource:  r.Resource,
+		})
+	}
+	return rsp, nil
 }
 
 // listBackendFunc is the signature shared by ListIterator and ListHistory.

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -559,6 +559,94 @@ func TestSimpleServer(t *testing.T) {
 	})
 }
 
+func TestListStoredResources(t *testing.T) {
+	testUser := &identity.StaticRequester{
+		Type:           authlib.TypeUser,
+		Login:          "testuser",
+		UserID:         123,
+		UserUID:        "u123",
+		OrgRole:        identity.RoleAdmin,
+		IsGrafanaAdmin: true,
+	}
+	ctx := authlib.WithAuthInfo(context.Background(), testUser)
+
+	db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true).WithLogger(nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store, err := NewKVStorageBackend(KVBackendOptions{KvStore: NewBadgerKV(db)})
+	require.NoError(t, err)
+
+	server, err := NewResourceServer(ResourceServerOptions{Backend: store})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = server.Stop(stopCtx)
+	})
+
+	create := func(namespace, name string) {
+		raw := []byte(fmt.Sprintf(`{
+			"apiVersion": "playlist.grafana.app/v0alpha1",
+			"kind": "Playlist",
+			"metadata": {"name": %q, "namespace": %q},
+			"spec": {"title": "hello", "interval": "5m"}
+		}`, name, namespace))
+		resp, err := server.Create(ctx, &resourcepb.CreateRequest{
+			Value: raw,
+			Key: &resourcepb.ResourceKey{
+				Group:     "playlist.grafana.app",
+				Resource:  "playlists",
+				Namespace: namespace,
+				Name:      name,
+			},
+		})
+		require.NoError(t, err)
+		require.Nil(t, resp.Error)
+	}
+
+	// Two objects of the same group/resource in ns1 must be reported once.
+	create("ns1", "item1")
+	create("ns1", "item2")
+	create("ns2", "item3")
+
+	t.Run("discovers resources for a namespace", func(t *testing.T) {
+		resp, err := server.ListStoredResources(ctx, &resourcepb.ListStoredResourcesRequest{Namespace: "ns1"})
+		require.NoError(t, err)
+		require.Equal(t, []*resourcepb.ListStoredResourcesResponse_StoredResource{
+			{Namespace: "ns1", Group: "playlist.grafana.app", Resource: "playlists"},
+		}, resp.Items)
+	})
+
+	t.Run("non-existent namespace returns no items", func(t *testing.T) {
+		resp, err := server.ListStoredResources(ctx, &resourcepb.ListStoredResourcesRequest{Namespace: "missing"})
+		require.NoError(t, err)
+		require.Empty(t, resp.Items)
+	})
+
+	t.Run("empty namespace is rejected with InvalidArgument", func(t *testing.T) {
+		_, err := server.ListStoredResources(ctx, &resourcepb.ListStoredResourcesRequest{})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("backend errors are returned as codes.Internal", func(t *testing.T) {
+		// mockStorageBackend inherits ListStoredResources from
+		// UnimplementedStorageBackend, which returns an error.
+		errServer, err := NewResourceServer(ResourceServerOptions{
+			Backend: &mockStorageBackend{},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = errServer.Stop(stopCtx)
+		})
+
+		_, err = errServer.ListStoredResources(ctx, &resourcepb.ListStoredResourcesRequest{Namespace: "ns1"})
+		require.Equal(t, codes.Internal, status.Code(err))
+	})
+}
+
 func TestRunInQueue(t *testing.T) {
 	const testTenantID = "test-tenant"
 	t.Run("should execute successfully when queue has capacity", func(t *testing.T) {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -2221,6 +2221,18 @@ func (k *kvStorageBackend) GetResourceStats(ctx context.Context, nsr NamespacedR
 	return k.dataStore.GetResourceStats(ctx, nsr, minCount)
 }
 
+// ListStoredResources discovers resource identities in the storage backend.
+func (k *kvStorageBackend) ListStoredResources(ctx context.Context, filter NamespacedResource) ([]NamespacedResource, error) {
+	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.ListStoredResources", trace.WithAttributes(
+		attribute.String("namespace", filter.Namespace),
+		attribute.String("group", filter.Group),
+		attribute.String("resource", filter.Resource),
+	))
+	defer span.End()
+
+	return k.dataStore.ListStoredResources(ctx, filter)
+}
+
 func (k *kvStorageBackend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[ResourceLastImportTime, error] {
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.GetResourceLastImportTimes")
 

--- a/pkg/storage/unified/resource/unimplemented.go
+++ b/pkg/storage/unified/resource/unimplemented.go
@@ -70,6 +70,10 @@ func (UnimplementedStorageBackend) GetResourceStats(context.Context, NamespacedR
 	return nil, errUnimplemented
 }
 
+func (UnimplementedStorageBackend) ListStoredResources(context.Context, NamespacedResource) ([]NamespacedResource, error) {
+	return nil, errUnimplemented
+}
+
 func (UnimplementedStorageBackend) GetResourceLastImportTimes(context.Context) iter.Seq2[ResourceLastImportTime, error] {
 	return func(yield func(ResourceLastImportTime, error) bool) {
 		yield(ResourceLastImportTime{}, errUnimplemented)

--- a/pkg/storage/unified/resourcepb/resource.pb.go
+++ b/pkg/storage/unified/resourcepb/resource.pb.go
@@ -2602,6 +2602,120 @@ func (x *QuotaUsageResponse) GetLimit() int64 {
 	return 0
 }
 
+// Discovery filter for ListStoredResources.
+type ListStoredResourcesRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Namespace (tenant) to discover resources in. Required: discovery across
+	// all namespaces is not supported. An empty namespace is rejected with
+	// InvalidArgument.
+	Namespace string `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// Optional group filter. Empty means no filter on group.
+	Group string `protobuf:"bytes,2,opt,name=group,proto3" json:"group,omitempty"`
+	// Optional resource filter. Empty means no filter on resource.
+	Resource      string `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListStoredResourcesRequest) Reset() {
+	*x = ListStoredResourcesRequest{}
+	mi := &file_resource_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListStoredResourcesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListStoredResourcesRequest) ProtoMessage() {}
+
+func (x *ListStoredResourcesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListStoredResourcesRequest.ProtoReflect.Descriptor instead.
+func (*ListStoredResourcesRequest) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *ListStoredResourcesRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *ListStoredResourcesRequest) GetGroup() string {
+	if x != nil {
+		return x.Group
+	}
+	return ""
+}
+
+func (x *ListStoredResourcesRequest) GetResource() string {
+	if x != nil {
+		return x.Resource
+	}
+	return ""
+}
+
+type ListStoredResourcesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Resource identities that exist in live storage. This is discovery-only:
+	// it may include false positives (a returned identity may have no live
+	// objects by the time the caller queries it). Errors are returned as gRPC
+	// errors, not embedded in this response.
+	Items         []*ListStoredResourcesResponse_StoredResource `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListStoredResourcesResponse) Reset() {
+	*x = ListStoredResourcesResponse{}
+	mi := &file_resource_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListStoredResourcesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListStoredResourcesResponse) ProtoMessage() {}
+
+func (x *ListStoredResourcesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListStoredResourcesResponse.ProtoReflect.Descriptor instead.
+func (*ListStoredResourcesResponse) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *ListStoredResourcesResponse) GetItems() []*ListStoredResourcesResponse_StoredResource {
+	if x != nil {
+		return x.Items
+	}
+	return nil
+}
+
 type WatchEvent_Resource struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Version       int64                  `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
@@ -2612,7 +2726,7 @@ type WatchEvent_Resource struct {
 
 func (x *WatchEvent_Resource) Reset() {
 	*x = WatchEvent_Resource{}
-	mi := &file_resource_proto_msgTypes[32]
+	mi := &file_resource_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2624,7 +2738,7 @@ func (x *WatchEvent_Resource) String() string {
 func (*WatchEvent_Resource) ProtoMessage() {}
 
 func (x *WatchEvent_Resource) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[32]
+	mi := &file_resource_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2671,7 +2785,7 @@ type BulkResponse_Summary struct {
 
 func (x *BulkResponse_Summary) Reset() {
 	*x = BulkResponse_Summary{}
-	mi := &file_resource_proto_msgTypes[33]
+	mi := &file_resource_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2683,7 +2797,7 @@ func (x *BulkResponse_Summary) String() string {
 func (*BulkResponse_Summary) ProtoMessage() {}
 
 func (x *BulkResponse_Summary) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[33]
+	mi := &file_resource_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2767,7 +2881,7 @@ type BulkResponse_Rejected struct {
 
 func (x *BulkResponse_Rejected) Reset() {
 	*x = BulkResponse_Rejected{}
-	mi := &file_resource_proto_msgTypes[34]
+	mi := &file_resource_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2779,7 +2893,7 @@ func (x *BulkResponse_Rejected) String() string {
 func (*BulkResponse_Rejected) ProtoMessage() {}
 
 func (x *BulkResponse_Rejected) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[34]
+	mi := &file_resource_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2836,7 +2950,7 @@ type ListManagedObjectsResponse_Item struct {
 
 func (x *ListManagedObjectsResponse_Item) Reset() {
 	*x = ListManagedObjectsResponse_Item{}
-	mi := &file_resource_proto_msgTypes[35]
+	mi := &file_resource_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2848,7 +2962,7 @@ func (x *ListManagedObjectsResponse_Item) String() string {
 func (*ListManagedObjectsResponse_Item) ProtoMessage() {}
 
 func (x *ListManagedObjectsResponse_Item) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[35]
+	mi := &file_resource_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2919,7 +3033,7 @@ type CountManagedObjectsResponse_ResourceCount struct {
 
 func (x *CountManagedObjectsResponse_ResourceCount) Reset() {
 	*x = CountManagedObjectsResponse_ResourceCount{}
-	mi := &file_resource_proto_msgTypes[36]
+	mi := &file_resource_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2931,7 +3045,7 @@ func (x *CountManagedObjectsResponse_ResourceCount) String() string {
 func (*CountManagedObjectsResponse_ResourceCount) ProtoMessage() {}
 
 func (x *CountManagedObjectsResponse_ResourceCount) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[36]
+	mi := &file_resource_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3004,7 +3118,7 @@ type ResourceTableColumnDefinition_Properties struct {
 
 func (x *ResourceTableColumnDefinition_Properties) Reset() {
 	*x = ResourceTableColumnDefinition_Properties{}
-	mi := &file_resource_proto_msgTypes[37]
+	mi := &file_resource_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3016,7 +3130,7 @@ func (x *ResourceTableColumnDefinition_Properties) String() string {
 func (*ResourceTableColumnDefinition_Properties) ProtoMessage() {}
 
 func (x *ResourceTableColumnDefinition_Properties) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[37]
+	mi := &file_resource_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3065,6 +3179,66 @@ func (x *ResourceTableColumnDefinition_Properties) GetDefaultValue() []byte {
 		return x.DefaultValue
 	}
 	return nil
+}
+
+type ListStoredResourcesResponse_StoredResource struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Namespace     string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Group         string                 `protobuf:"bytes,2,opt,name=group,proto3" json:"group,omitempty"`
+	Resource      string                 `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListStoredResourcesResponse_StoredResource) Reset() {
+	*x = ListStoredResourcesResponse_StoredResource{}
+	mi := &file_resource_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListStoredResourcesResponse_StoredResource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListStoredResourcesResponse_StoredResource) ProtoMessage() {}
+
+func (x *ListStoredResourcesResponse_StoredResource) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListStoredResourcesResponse_StoredResource.ProtoReflect.Descriptor instead.
+func (*ListStoredResourcesResponse_StoredResource) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{33, 0}
+}
+
+func (x *ListStoredResourcesResponse_StoredResource) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *ListStoredResourcesResponse_StoredResource) GetGroup() string {
+	if x != nil {
+		return x.Group
+	}
+	return ""
+}
+
+func (x *ListStoredResourcesResponse_StoredResource) GetResource() string {
+	if x != nil {
+		return x.Resource
+	}
+	return ""
 }
 
 var File_resource_proto protoreflect.FileDescriptor
@@ -3451,40 +3625,66 @@ var file_resource_proto_rawDesc = string([]byte{
 	0x72, 0x6f, 0x72, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x52, 0x05, 0x65, 0x72, 0x72, 0x6f, 0x72,
 	0x12, 0x14, 0x0a, 0x05, 0x75, 0x73, 0x61, 0x67, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52,
 	0x05, 0x75, 0x73, 0x61, 0x67, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x18,
-	0x03, 0x20, 0x01, 0x28, 0x03, 0x52, 0x05, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x2a, 0x49, 0x0a, 0x14,
-	0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x4d,
-	0x61, 0x74, 0x63, 0x68, 0x12, 0x1b, 0x0a, 0x17, 0x44, 0x45, 0x50, 0x52, 0x45, 0x43, 0x41, 0x54,
-	0x45, 0x44, 0x5f, 0x4e, 0x6f, 0x74, 0x4f, 0x6c, 0x64, 0x65, 0x72, 0x54, 0x68, 0x61, 0x6e, 0x10,
-	0x00, 0x12, 0x14, 0x0a, 0x10, 0x44, 0x45, 0x50, 0x52, 0x45, 0x43, 0x41, 0x54, 0x45, 0x44, 0x5f,
-	0x45, 0x78, 0x61, 0x63, 0x74, 0x10, 0x01, 0x2a, 0x4d, 0x0a, 0x16, 0x52, 0x65, 0x73, 0x6f, 0x75,
-	0x72, 0x63, 0x65, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x4d, 0x61, 0x74, 0x63, 0x68, 0x56,
-	0x32, 0x12, 0x0b, 0x0a, 0x07, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x09,
-	0x0a, 0x05, 0x55, 0x6e, 0x73, 0x65, 0x74, 0x10, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x45, 0x78, 0x61,
-	0x63, 0x74, 0x10, 0x02, 0x12, 0x10, 0x0a, 0x0c, 0x4e, 0x6f, 0x74, 0x4f, 0x6c, 0x64, 0x65, 0x72,
-	0x54, 0x68, 0x61, 0x6e, 0x10, 0x03, 0x32, 0xed, 0x02, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x6f, 0x75,
-	0x72, 0x63, 0x65, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x12, 0x35, 0x0a, 0x04, 0x52, 0x65, 0x61, 0x64,
-	0x12, 0x15, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x52, 0x65, 0x61, 0x64,
-	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x16, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72,
-	0x63, 0x65, 0x2e, 0x52, 0x65, 0x61, 0x64, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12,
-	0x3b, 0x0a, 0x06, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x12, 0x17, 0x2e, 0x72, 0x65, 0x73, 0x6f,
-	0x75, 0x72, 0x63, 0x65, 0x2e, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65,
-	0x73, 0x74, 0x1a, 0x18, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x43, 0x72,
-	0x65, 0x61, 0x74, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x3b, 0x0a, 0x06,
-	0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x12, 0x17, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63,
-	0x65, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a,
-	0x18, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74,
-	0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x3b, 0x0a, 0x06, 0x44, 0x65, 0x6c,
-	0x65, 0x74, 0x65, 0x12, 0x17, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x44,
-	0x65, 0x6c, 0x65, 0x74, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x18, 0x2e, 0x72,
-	0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x52, 0x65,
-	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x35, 0x0a, 0x04, 0x4c, 0x69, 0x73, 0x74, 0x12, 0x15,
-	0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x52, 0x65,
-	0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x16, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65,
-	0x2e, 0x4c, 0x69, 0x73, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x37, 0x0a,
-	0x05, 0x57, 0x61, 0x74, 0x63, 0x68, 0x12, 0x16, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63,
-	0x65, 0x2e, 0x57, 0x61, 0x74, 0x63, 0x68, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x14,
-	0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x57, 0x61, 0x74, 0x63, 0x68, 0x45,
-	0x76, 0x65, 0x6e, 0x74, 0x30, 0x01, 0x32, 0x4b, 0x0a, 0x09, 0x42, 0x75, 0x6c, 0x6b, 0x53, 0x74,
+	0x03, 0x20, 0x01, 0x28, 0x03, 0x52, 0x05, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x22, 0x6c, 0x0a, 0x1a,
+	0x4c, 0x69, 0x73, 0x74, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x64, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72,
+	0x63, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1c, 0x0a, 0x09, 0x6e, 0x61,
+	0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x6e,
+	0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x67, 0x72, 0x6f, 0x75,
+	0x70, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x12, 0x1a,
+	0x0a, 0x08, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x08, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x22, 0xcb, 0x01, 0x0a, 0x1b, 0x4c,
+	0x69, 0x73, 0x74, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x64, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63,
+	0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x4a, 0x0a, 0x05, 0x69, 0x74,
+	0x65, 0x6d, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x34, 0x2e, 0x72, 0x65, 0x73, 0x6f,
+	0x75, 0x72, 0x63, 0x65, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x64, 0x52,
+	0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
+	0x2e, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x64, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x52,
+	0x05, 0x69, 0x74, 0x65, 0x6d, 0x73, 0x1a, 0x60, 0x0a, 0x0e, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x64,
+	0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x12, 0x1c, 0x0a, 0x09, 0x6e, 0x61, 0x6d, 0x65,
+	0x73, 0x70, 0x61, 0x63, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x6e, 0x61, 0x6d,
+	0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x12, 0x1a, 0x0a, 0x08,
+	0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08,
+	0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2a, 0x49, 0x0a, 0x14, 0x52, 0x65, 0x73, 0x6f,
+	0x75, 0x72, 0x63, 0x65, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x4d, 0x61, 0x74, 0x63, 0x68,
+	0x12, 0x1b, 0x0a, 0x17, 0x44, 0x45, 0x50, 0x52, 0x45, 0x43, 0x41, 0x54, 0x45, 0x44, 0x5f, 0x4e,
+	0x6f, 0x74, 0x4f, 0x6c, 0x64, 0x65, 0x72, 0x54, 0x68, 0x61, 0x6e, 0x10, 0x00, 0x12, 0x14, 0x0a,
+	0x10, 0x44, 0x45, 0x50, 0x52, 0x45, 0x43, 0x41, 0x54, 0x45, 0x44, 0x5f, 0x45, 0x78, 0x61, 0x63,
+	0x74, 0x10, 0x01, 0x2a, 0x4d, 0x0a, 0x16, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x56,
+	0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x4d, 0x61, 0x74, 0x63, 0x68, 0x56, 0x32, 0x12, 0x0b, 0x0a,
+	0x07, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x55, 0x6e,
+	0x73, 0x65, 0x74, 0x10, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x45, 0x78, 0x61, 0x63, 0x74, 0x10, 0x02,
+	0x12, 0x10, 0x0a, 0x0c, 0x4e, 0x6f, 0x74, 0x4f, 0x6c, 0x64, 0x65, 0x72, 0x54, 0x68, 0x61, 0x6e,
+	0x10, 0x03, 0x32, 0xd1, 0x03, 0x0a, 0x0d, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x53,
+	0x74, 0x6f, 0x72, 0x65, 0x12, 0x35, 0x0a, 0x04, 0x52, 0x65, 0x61, 0x64, 0x12, 0x15, 0x2e, 0x72,
+	0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x52, 0x65, 0x61, 0x64, 0x52, 0x65, 0x71, 0x75,
+	0x65, 0x73, 0x74, 0x1a, 0x16, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x52,
+	0x65, 0x61, 0x64, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x3b, 0x0a, 0x06, 0x43,
+	0x72, 0x65, 0x61, 0x74, 0x65, 0x12, 0x17, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65,
+	0x2e, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x18,
+	0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65,
+	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x3b, 0x0a, 0x06, 0x55, 0x70, 0x64, 0x61,
+	0x74, 0x65, 0x12, 0x17, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x55, 0x70,
+	0x64, 0x61, 0x74, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x18, 0x2e, 0x72, 0x65,
+	0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x52, 0x65, 0x73,
+	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x3b, 0x0a, 0x06, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x12,
+	0x17, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x74,
+	0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x18, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75,
+	0x72, 0x63, 0x65, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
+	0x73, 0x65, 0x12, 0x35, 0x0a, 0x04, 0x4c, 0x69, 0x73, 0x74, 0x12, 0x15, 0x2e, 0x72, 0x65, 0x73,
+	0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
+	0x74, 0x1a, 0x16, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x4c, 0x69, 0x73,
+	0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x37, 0x0a, 0x05, 0x57, 0x61, 0x74,
+	0x63, 0x68, 0x12, 0x16, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x57, 0x61,
+	0x74, 0x63, 0x68, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x14, 0x2e, 0x72, 0x65, 0x73,
+	0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x57, 0x61, 0x74, 0x63, 0x68, 0x45, 0x76, 0x65, 0x6e, 0x74,
+	0x30, 0x01, 0x12, 0x62, 0x0a, 0x13, 0x4c, 0x69, 0x73, 0x74, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x64,
+	0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x73, 0x12, 0x24, 0x2e, 0x72, 0x65, 0x73, 0x6f,
+	0x75, 0x72, 0x63, 0x65, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x64, 0x52,
+	0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a,
+	0x25, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x53,
+	0x74, 0x6f, 0x72, 0x65, 0x64, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x73, 0x52, 0x65,
+	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x32, 0x4b, 0x0a, 0x09, 0x42, 0x75, 0x6c, 0x6b, 0x53, 0x74,
 	0x6f, 0x72, 0x65, 0x12, 0x3e, 0x0a, 0x0b, 0x42, 0x75, 0x6c, 0x6b, 0x50, 0x72, 0x6f, 0x63, 0x65,
 	0x73, 0x73, 0x12, 0x15, 0x2e, 0x72, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x2e, 0x42, 0x75,
 	0x6c, 0x6b, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x16, 0x2e, 0x72, 0x65, 0x73, 0x6f,
@@ -3534,53 +3734,56 @@ func file_resource_proto_rawDescGZIP() []byte {
 }
 
 var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
+var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_resource_proto_goTypes = []any{
-	(ResourceVersionMatch)(0),                         // 0: resource.ResourceVersionMatch
-	(ResourceVersionMatchV2)(0),                       // 1: resource.ResourceVersionMatchV2
-	(ListRequest_Source)(0),                           // 2: resource.ListRequest.Source
-	(WatchEvent_Type)(0),                              // 3: resource.WatchEvent.Type
-	(BulkRequest_Action)(0),                           // 4: resource.BulkRequest.Action
-	(HealthCheckResponse_ServingStatus)(0),            // 5: resource.HealthCheckResponse.ServingStatus
-	(ResourceTableColumnDefinition_ColumnType)(0),     // 6: resource.ResourceTableColumnDefinition.ColumnType
-	(*ResourceKey)(nil),                               // 7: resource.ResourceKey
-	(*ResourceWrapper)(nil),                           // 8: resource.ResourceWrapper
-	(*ErrorResult)(nil),                               // 9: resource.ErrorResult
-	(*ErrorDetails)(nil),                              // 10: resource.ErrorDetails
-	(*ErrorCause)(nil),                                // 11: resource.ErrorCause
-	(*CreateRequest)(nil),                             // 12: resource.CreateRequest
-	(*CreateResponse)(nil),                            // 13: resource.CreateResponse
-	(*UpdateRequest)(nil),                             // 14: resource.UpdateRequest
-	(*UpdateResponse)(nil),                            // 15: resource.UpdateResponse
-	(*DeleteRequest)(nil),                             // 16: resource.DeleteRequest
-	(*DeleteResponse)(nil),                            // 17: resource.DeleteResponse
-	(*ReadRequest)(nil),                               // 18: resource.ReadRequest
-	(*ReadResponse)(nil),                              // 19: resource.ReadResponse
-	(*Requirement)(nil),                               // 20: resource.Requirement
-	(*ListOptions)(nil),                               // 21: resource.ListOptions
-	(*ListRequest)(nil),                               // 22: resource.ListRequest
-	(*ListResponse)(nil),                              // 23: resource.ListResponse
-	(*WatchRequest)(nil),                              // 24: resource.WatchRequest
-	(*WatchEvent)(nil),                                // 25: resource.WatchEvent
-	(*BulkRequest)(nil),                               // 26: resource.BulkRequest
-	(*BulkResponse)(nil),                              // 27: resource.BulkResponse
-	(*ListManagedObjectsRequest)(nil),                 // 28: resource.ListManagedObjectsRequest
-	(*ListManagedObjectsResponse)(nil),                // 29: resource.ListManagedObjectsResponse
-	(*CountManagedObjectsRequest)(nil),                // 30: resource.CountManagedObjectsRequest
-	(*CountManagedObjectsResponse)(nil),               // 31: resource.CountManagedObjectsResponse
-	(*HealthCheckRequest)(nil),                        // 32: resource.HealthCheckRequest
-	(*HealthCheckResponse)(nil),                       // 33: resource.HealthCheckResponse
-	(*ResourceTable)(nil),                             // 34: resource.ResourceTable
-	(*ResourceTableColumnDefinition)(nil),             // 35: resource.ResourceTableColumnDefinition
-	(*ResourceTableRow)(nil),                          // 36: resource.ResourceTableRow
-	(*QuotaUsageRequest)(nil),                         // 37: resource.QuotaUsageRequest
-	(*QuotaUsageResponse)(nil),                        // 38: resource.QuotaUsageResponse
-	(*WatchEvent_Resource)(nil),                       // 39: resource.WatchEvent.Resource
-	(*BulkResponse_Summary)(nil),                      // 40: resource.BulkResponse.Summary
-	(*BulkResponse_Rejected)(nil),                     // 41: resource.BulkResponse.Rejected
-	(*ListManagedObjectsResponse_Item)(nil),           // 42: resource.ListManagedObjectsResponse.Item
-	(*CountManagedObjectsResponse_ResourceCount)(nil), // 43: resource.CountManagedObjectsResponse.ResourceCount
-	(*ResourceTableColumnDefinition_Properties)(nil),  // 44: resource.ResourceTableColumnDefinition.Properties
+	(ResourceVersionMatch)(0),                          // 0: resource.ResourceVersionMatch
+	(ResourceVersionMatchV2)(0),                        // 1: resource.ResourceVersionMatchV2
+	(ListRequest_Source)(0),                            // 2: resource.ListRequest.Source
+	(WatchEvent_Type)(0),                               // 3: resource.WatchEvent.Type
+	(BulkRequest_Action)(0),                            // 4: resource.BulkRequest.Action
+	(HealthCheckResponse_ServingStatus)(0),             // 5: resource.HealthCheckResponse.ServingStatus
+	(ResourceTableColumnDefinition_ColumnType)(0),      // 6: resource.ResourceTableColumnDefinition.ColumnType
+	(*ResourceKey)(nil),                                // 7: resource.ResourceKey
+	(*ResourceWrapper)(nil),                            // 8: resource.ResourceWrapper
+	(*ErrorResult)(nil),                                // 9: resource.ErrorResult
+	(*ErrorDetails)(nil),                               // 10: resource.ErrorDetails
+	(*ErrorCause)(nil),                                 // 11: resource.ErrorCause
+	(*CreateRequest)(nil),                              // 12: resource.CreateRequest
+	(*CreateResponse)(nil),                             // 13: resource.CreateResponse
+	(*UpdateRequest)(nil),                              // 14: resource.UpdateRequest
+	(*UpdateResponse)(nil),                             // 15: resource.UpdateResponse
+	(*DeleteRequest)(nil),                              // 16: resource.DeleteRequest
+	(*DeleteResponse)(nil),                             // 17: resource.DeleteResponse
+	(*ReadRequest)(nil),                                // 18: resource.ReadRequest
+	(*ReadResponse)(nil),                               // 19: resource.ReadResponse
+	(*Requirement)(nil),                                // 20: resource.Requirement
+	(*ListOptions)(nil),                                // 21: resource.ListOptions
+	(*ListRequest)(nil),                                // 22: resource.ListRequest
+	(*ListResponse)(nil),                               // 23: resource.ListResponse
+	(*WatchRequest)(nil),                               // 24: resource.WatchRequest
+	(*WatchEvent)(nil),                                 // 25: resource.WatchEvent
+	(*BulkRequest)(nil),                                // 26: resource.BulkRequest
+	(*BulkResponse)(nil),                               // 27: resource.BulkResponse
+	(*ListManagedObjectsRequest)(nil),                  // 28: resource.ListManagedObjectsRequest
+	(*ListManagedObjectsResponse)(nil),                 // 29: resource.ListManagedObjectsResponse
+	(*CountManagedObjectsRequest)(nil),                 // 30: resource.CountManagedObjectsRequest
+	(*CountManagedObjectsResponse)(nil),                // 31: resource.CountManagedObjectsResponse
+	(*HealthCheckRequest)(nil),                         // 32: resource.HealthCheckRequest
+	(*HealthCheckResponse)(nil),                        // 33: resource.HealthCheckResponse
+	(*ResourceTable)(nil),                              // 34: resource.ResourceTable
+	(*ResourceTableColumnDefinition)(nil),              // 35: resource.ResourceTableColumnDefinition
+	(*ResourceTableRow)(nil),                           // 36: resource.ResourceTableRow
+	(*QuotaUsageRequest)(nil),                          // 37: resource.QuotaUsageRequest
+	(*QuotaUsageResponse)(nil),                         // 38: resource.QuotaUsageResponse
+	(*ListStoredResourcesRequest)(nil),                 // 39: resource.ListStoredResourcesRequest
+	(*ListStoredResourcesResponse)(nil),                // 40: resource.ListStoredResourcesResponse
+	(*WatchEvent_Resource)(nil),                        // 41: resource.WatchEvent.Resource
+	(*BulkResponse_Summary)(nil),                       // 42: resource.BulkResponse.Summary
+	(*BulkResponse_Rejected)(nil),                      // 43: resource.BulkResponse.Rejected
+	(*ListManagedObjectsResponse_Item)(nil),            // 44: resource.ListManagedObjectsResponse.Item
+	(*CountManagedObjectsResponse_ResourceCount)(nil),  // 45: resource.CountManagedObjectsResponse.ResourceCount
+	(*ResourceTableColumnDefinition_Properties)(nil),   // 46: resource.ResourceTableColumnDefinition.Properties
+	(*ListStoredResourcesResponse_StoredResource)(nil), // 47: resource.ListStoredResourcesResponse.StoredResource
 }
 var file_resource_proto_depIdxs = []int32{
 	10, // 0: resource.ErrorResult.details:type_name -> resource.ErrorDetails
@@ -3604,55 +3807,58 @@ var file_resource_proto_depIdxs = []int32{
 	9,  // 18: resource.ListResponse.error:type_name -> resource.ErrorResult
 	21, // 19: resource.WatchRequest.options:type_name -> resource.ListOptions
 	3,  // 20: resource.WatchEvent.type:type_name -> resource.WatchEvent.Type
-	39, // 21: resource.WatchEvent.resource:type_name -> resource.WatchEvent.Resource
-	39, // 22: resource.WatchEvent.previous:type_name -> resource.WatchEvent.Resource
+	41, // 21: resource.WatchEvent.resource:type_name -> resource.WatchEvent.Resource
+	41, // 22: resource.WatchEvent.previous:type_name -> resource.WatchEvent.Resource
 	7,  // 23: resource.BulkRequest.key:type_name -> resource.ResourceKey
 	4,  // 24: resource.BulkRequest.action:type_name -> resource.BulkRequest.Action
 	9,  // 25: resource.BulkResponse.error:type_name -> resource.ErrorResult
-	40, // 26: resource.BulkResponse.summary:type_name -> resource.BulkResponse.Summary
-	41, // 27: resource.BulkResponse.rejected:type_name -> resource.BulkResponse.Rejected
-	42, // 28: resource.ListManagedObjectsResponse.items:type_name -> resource.ListManagedObjectsResponse.Item
+	42, // 26: resource.BulkResponse.summary:type_name -> resource.BulkResponse.Summary
+	43, // 27: resource.BulkResponse.rejected:type_name -> resource.BulkResponse.Rejected
+	44, // 28: resource.ListManagedObjectsResponse.items:type_name -> resource.ListManagedObjectsResponse.Item
 	9,  // 29: resource.ListManagedObjectsResponse.error:type_name -> resource.ErrorResult
-	43, // 30: resource.CountManagedObjectsResponse.items:type_name -> resource.CountManagedObjectsResponse.ResourceCount
+	45, // 30: resource.CountManagedObjectsResponse.items:type_name -> resource.CountManagedObjectsResponse.ResourceCount
 	9,  // 31: resource.CountManagedObjectsResponse.error:type_name -> resource.ErrorResult
 	5,  // 32: resource.HealthCheckResponse.status:type_name -> resource.HealthCheckResponse.ServingStatus
 	35, // 33: resource.ResourceTable.columns:type_name -> resource.ResourceTableColumnDefinition
 	36, // 34: resource.ResourceTable.rows:type_name -> resource.ResourceTableRow
 	6,  // 35: resource.ResourceTableColumnDefinition.type:type_name -> resource.ResourceTableColumnDefinition.ColumnType
-	44, // 36: resource.ResourceTableColumnDefinition.properties:type_name -> resource.ResourceTableColumnDefinition.Properties
+	46, // 36: resource.ResourceTableColumnDefinition.properties:type_name -> resource.ResourceTableColumnDefinition.Properties
 	7,  // 37: resource.ResourceTableRow.key:type_name -> resource.ResourceKey
 	7,  // 38: resource.QuotaUsageRequest.key:type_name -> resource.ResourceKey
 	9,  // 39: resource.QuotaUsageResponse.error:type_name -> resource.ErrorResult
-	7,  // 40: resource.BulkResponse.Rejected.key:type_name -> resource.ResourceKey
-	4,  // 41: resource.BulkResponse.Rejected.action:type_name -> resource.BulkRequest.Action
-	7,  // 42: resource.ListManagedObjectsResponse.Item.object:type_name -> resource.ResourceKey
-	18, // 43: resource.ResourceStore.Read:input_type -> resource.ReadRequest
-	12, // 44: resource.ResourceStore.Create:input_type -> resource.CreateRequest
-	14, // 45: resource.ResourceStore.Update:input_type -> resource.UpdateRequest
-	16, // 46: resource.ResourceStore.Delete:input_type -> resource.DeleteRequest
-	22, // 47: resource.ResourceStore.List:input_type -> resource.ListRequest
-	24, // 48: resource.ResourceStore.Watch:input_type -> resource.WatchRequest
-	26, // 49: resource.BulkStore.BulkProcess:input_type -> resource.BulkRequest
-	30, // 50: resource.ManagedObjectIndex.CountManagedObjects:input_type -> resource.CountManagedObjectsRequest
-	28, // 51: resource.ManagedObjectIndex.ListManagedObjects:input_type -> resource.ListManagedObjectsRequest
-	32, // 52: resource.Diagnostics.IsHealthy:input_type -> resource.HealthCheckRequest
-	37, // 53: resource.Quotas.GetQuotaUsage:input_type -> resource.QuotaUsageRequest
-	19, // 54: resource.ResourceStore.Read:output_type -> resource.ReadResponse
-	13, // 55: resource.ResourceStore.Create:output_type -> resource.CreateResponse
-	15, // 56: resource.ResourceStore.Update:output_type -> resource.UpdateResponse
-	17, // 57: resource.ResourceStore.Delete:output_type -> resource.DeleteResponse
-	23, // 58: resource.ResourceStore.List:output_type -> resource.ListResponse
-	25, // 59: resource.ResourceStore.Watch:output_type -> resource.WatchEvent
-	27, // 60: resource.BulkStore.BulkProcess:output_type -> resource.BulkResponse
-	31, // 61: resource.ManagedObjectIndex.CountManagedObjects:output_type -> resource.CountManagedObjectsResponse
-	29, // 62: resource.ManagedObjectIndex.ListManagedObjects:output_type -> resource.ListManagedObjectsResponse
-	33, // 63: resource.Diagnostics.IsHealthy:output_type -> resource.HealthCheckResponse
-	38, // 64: resource.Quotas.GetQuotaUsage:output_type -> resource.QuotaUsageResponse
-	54, // [54:65] is the sub-list for method output_type
-	43, // [43:54] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	43, // [43:43] is the sub-list for extension extendee
-	0,  // [0:43] is the sub-list for field type_name
+	47, // 40: resource.ListStoredResourcesResponse.items:type_name -> resource.ListStoredResourcesResponse.StoredResource
+	7,  // 41: resource.BulkResponse.Rejected.key:type_name -> resource.ResourceKey
+	4,  // 42: resource.BulkResponse.Rejected.action:type_name -> resource.BulkRequest.Action
+	7,  // 43: resource.ListManagedObjectsResponse.Item.object:type_name -> resource.ResourceKey
+	18, // 44: resource.ResourceStore.Read:input_type -> resource.ReadRequest
+	12, // 45: resource.ResourceStore.Create:input_type -> resource.CreateRequest
+	14, // 46: resource.ResourceStore.Update:input_type -> resource.UpdateRequest
+	16, // 47: resource.ResourceStore.Delete:input_type -> resource.DeleteRequest
+	22, // 48: resource.ResourceStore.List:input_type -> resource.ListRequest
+	24, // 49: resource.ResourceStore.Watch:input_type -> resource.WatchRequest
+	39, // 50: resource.ResourceStore.ListStoredResources:input_type -> resource.ListStoredResourcesRequest
+	26, // 51: resource.BulkStore.BulkProcess:input_type -> resource.BulkRequest
+	30, // 52: resource.ManagedObjectIndex.CountManagedObjects:input_type -> resource.CountManagedObjectsRequest
+	28, // 53: resource.ManagedObjectIndex.ListManagedObjects:input_type -> resource.ListManagedObjectsRequest
+	32, // 54: resource.Diagnostics.IsHealthy:input_type -> resource.HealthCheckRequest
+	37, // 55: resource.Quotas.GetQuotaUsage:input_type -> resource.QuotaUsageRequest
+	19, // 56: resource.ResourceStore.Read:output_type -> resource.ReadResponse
+	13, // 57: resource.ResourceStore.Create:output_type -> resource.CreateResponse
+	15, // 58: resource.ResourceStore.Update:output_type -> resource.UpdateResponse
+	17, // 59: resource.ResourceStore.Delete:output_type -> resource.DeleteResponse
+	23, // 60: resource.ResourceStore.List:output_type -> resource.ListResponse
+	25, // 61: resource.ResourceStore.Watch:output_type -> resource.WatchEvent
+	40, // 62: resource.ResourceStore.ListStoredResources:output_type -> resource.ListStoredResourcesResponse
+	27, // 63: resource.BulkStore.BulkProcess:output_type -> resource.BulkResponse
+	31, // 64: resource.ManagedObjectIndex.CountManagedObjects:output_type -> resource.CountManagedObjectsResponse
+	29, // 65: resource.ManagedObjectIndex.ListManagedObjects:output_type -> resource.ListManagedObjectsResponse
+	33, // 66: resource.Diagnostics.IsHealthy:output_type -> resource.HealthCheckResponse
+	38, // 67: resource.Quotas.GetQuotaUsage:output_type -> resource.QuotaUsageResponse
+	56, // [56:68] is the sub-list for method output_type
+	44, // [44:56] is the sub-list for method input_type
+	44, // [44:44] is the sub-list for extension type_name
+	44, // [44:44] is the sub-list for extension extendee
+	0,  // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }
@@ -3667,7 +3873,7 @@ func file_resource_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_proto_rawDesc), len(file_resource_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   38,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   5,
 		},

--- a/pkg/storage/unified/resourcepb/resource_grpc.pb.go
+++ b/pkg/storage/unified/resourcepb/resource_grpc.pb.go
@@ -19,12 +19,13 @@ import (
 const _ = grpc.SupportPackageIsVersion8
 
 const (
-	ResourceStore_Read_FullMethodName   = "/resource.ResourceStore/Read"
-	ResourceStore_Create_FullMethodName = "/resource.ResourceStore/Create"
-	ResourceStore_Update_FullMethodName = "/resource.ResourceStore/Update"
-	ResourceStore_Delete_FullMethodName = "/resource.ResourceStore/Delete"
-	ResourceStore_List_FullMethodName   = "/resource.ResourceStore/List"
-	ResourceStore_Watch_FullMethodName  = "/resource.ResourceStore/Watch"
+	ResourceStore_Read_FullMethodName                = "/resource.ResourceStore/Read"
+	ResourceStore_Create_FullMethodName              = "/resource.ResourceStore/Create"
+	ResourceStore_Update_FullMethodName              = "/resource.ResourceStore/Update"
+	ResourceStore_Delete_FullMethodName              = "/resource.ResourceStore/Delete"
+	ResourceStore_List_FullMethodName                = "/resource.ResourceStore/List"
+	ResourceStore_Watch_FullMethodName               = "/resource.ResourceStore/Watch"
+	ResourceStore_ListStoredResources_FullMethodName = "/resource.ResourceStore/ListStoredResources"
 )
 
 // ResourceStoreClient is the client API for ResourceStore service.
@@ -48,6 +49,10 @@ type ResourceStoreClient interface {
 	// This will perform best-effort filtering to increase performace.
 	// NOTE: storage.Interface is ultimatly responsible for the final filtering
 	Watch(ctx context.Context, in *WatchRequest, opts ...grpc.CallOption) (ResourceStore_WatchClient, error)
+	// Discover which resource identities (namespace/group/resource) exist in
+	// storage, without returning counts. This is a cheap alternative to
+	// GetStats for callers that only need to know what is stored, not how much.
+	ListStoredResources(ctx context.Context, in *ListStoredResourcesRequest, opts ...grpc.CallOption) (*ListStoredResourcesResponse, error)
 }
 
 type resourceStoreClient struct {
@@ -141,6 +146,16 @@ func (x *resourceStoreWatchClient) Recv() (*WatchEvent, error) {
 	return m, nil
 }
 
+func (c *resourceStoreClient) ListStoredResources(ctx context.Context, in *ListStoredResourcesRequest, opts ...grpc.CallOption) (*ListStoredResourcesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListStoredResourcesResponse)
+	err := c.cc.Invoke(ctx, ResourceStore_ListStoredResources_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ResourceStoreServer is the server API for ResourceStore service.
 // All implementations should embed UnimplementedResourceStoreServer
 // for forward compatibility
@@ -162,6 +177,10 @@ type ResourceStoreServer interface {
 	// This will perform best-effort filtering to increase performace.
 	// NOTE: storage.Interface is ultimatly responsible for the final filtering
 	Watch(*WatchRequest, ResourceStore_WatchServer) error
+	// Discover which resource identities (namespace/group/resource) exist in
+	// storage, without returning counts. This is a cheap alternative to
+	// GetStats for callers that only need to know what is stored, not how much.
+	ListStoredResources(context.Context, *ListStoredResourcesRequest) (*ListStoredResourcesResponse, error)
 }
 
 // UnimplementedResourceStoreServer should be embedded to have forward compatible implementations.
@@ -185,6 +204,9 @@ func (UnimplementedResourceStoreServer) List(context.Context, *ListRequest) (*Li
 }
 func (UnimplementedResourceStoreServer) Watch(*WatchRequest, ResourceStore_WatchServer) error {
 	return status.Errorf(codes.Unimplemented, "method Watch not implemented")
+}
+func (UnimplementedResourceStoreServer) ListStoredResources(context.Context, *ListStoredResourcesRequest) (*ListStoredResourcesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListStoredResources not implemented")
 }
 
 // UnsafeResourceStoreServer may be embedded to opt out of forward compatibility for this service.
@@ -309,6 +331,24 @@ func (x *resourceStoreWatchServer) Send(m *WatchEvent) error {
 	return x.ServerStream.SendMsg(m)
 }
 
+func _ResourceStore_ListStoredResources_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListStoredResourcesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ResourceStoreServer).ListStoredResources(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ResourceStore_ListStoredResources_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ResourceStoreServer).ListStoredResources(ctx, req.(*ListStoredResourcesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ResourceStore_ServiceDesc is the grpc.ServiceDesc for ResourceStore service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -335,6 +375,10 @@ var ResourceStore_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "List",
 			Handler:    _ResourceStore_List_Handler,
+		},
+		{
+			MethodName: "ListStoredResources",
+			Handler:    _ResourceStore_ListStoredResources_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/storage/unified/search/embed/backfill/fakes_test.go
+++ b/pkg/storage/unified/search/embed/backfill/fakes_test.go
@@ -51,6 +51,7 @@ func (i *fakeListIterator) Value() []byte          { return i.item().Value }
 // resourceembedder tests. ReadResource looks up by full key; ListIterator yields
 // the configured items in order.
 type fakeStorage struct {
+	resource.UnimplementedStorageBackend
 	mu sync.Mutex
 	// resources[ns/group/resource/name] = (value, rv).
 	resources map[string]storedResource
@@ -158,6 +159,7 @@ func (f *fakeStorage) WatchWriteEvents(context.Context) (<-chan *resource.Writte
 func (f *fakeStorage) GetResourceStats(context.Context, resource.NamespacedResource, int) ([]resource.ResourceStats, error) {
 	panic("not implemented")
 }
+
 func (f *fakeStorage) GetResourceLastImportTimes(context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
 	panic("not implemented")
 }

--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -18,6 +18,7 @@ import (
 // and a latestRv equal to the highest RV in the slice. Empty namespace
 // on the request runs cross-namespace, mirroring the real backends.
 type fakeStorage struct {
+	resource.UnimplementedStorageBackend
 	mu       sync.Mutex
 	changes  []*resource.ModifiedResource
 	listErr  error
@@ -101,6 +102,7 @@ func (f *fakeStorage) GetResourceStats(_ context.Context, nsr resource.Namespace
 	}
 	return out, nil
 }
+
 func (f *fakeStorage) GetResourceLastImportTimes(context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
 	panic("not implemented")
 }

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -790,6 +790,46 @@ func (b *backend) GetResourceStats(ctx context.Context, nsr resource.NamespacedR
 	return res, err
 }
 
+// ListStoredResources implements Backend.
+func (b *backend) ListStoredResources(ctx context.Context, filter resource.NamespacedResource) ([]resource.NamespacedResource, error) {
+	b.logCall("ListStoredResources")
+	ctx, span := tracer.Start(ctx, "sql.backend.ListStoredResources", trace.WithAttributes(
+		attribute.String("namespace", filter.Namespace),
+		attribute.String("group", filter.Group),
+		attribute.String("resource", filter.Resource),
+	))
+	defer span.End()
+
+	if filter.Namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+
+	req := &sqlStoredResourcesRequest{
+		SQLTemplate: sqltemplate.New(b.dialect),
+		Namespace:   filter.Namespace,
+		Group:       filter.Group,
+		Resource:    filter.Resource,
+	}
+
+	res := make([]resource.NamespacedResource, 0, 100)
+	err := b.db.WithTx(ctx, ReadCommittedRO, func(ctx context.Context, tx db.Tx) error {
+		rows, err := dbutil.QueryRows(ctx, tx, sqlResourceStoredList, req)
+		if err != nil {
+			return err
+		}
+		for rows.Next() {
+			row := resource.NamespacedResource{}
+			if err := rows.Scan(&row.Namespace, &row.Group, &row.Resource); err != nil {
+				return err
+			}
+			res = append(res, row)
+		}
+		return rows.Err()
+	})
+
+	return res, err
+}
+
 // toMicrosecondRV converts a snowflake RV to microsecond format if needed.
 // This ensures that RVs arriving at the SQL backend are in the native
 // microsecond format. No-op for values ≤ 0 or values already in microsecond format.

--- a/pkg/storage/unified/sql/data/resource_stored_list.sql
+++ b/pkg/storage/unified/sql/data/resource_stored_list.sql
@@ -1,0 +1,20 @@
+SELECT DISTINCT
+  {{ .Ident "namespace" }},
+  {{ .Ident "group"     }},
+  {{ .Ident "resource"  }}
+FROM {{ .Ident "resource" }}
+WHERE 1 = 1
+{{ if .Namespace }}
+  AND {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+{{ end}}
+{{ if .Group }}
+  AND {{ .Ident "group" }} = {{ .Arg .Group }}
+{{ end}}
+{{ if .Resource }}
+  AND {{ .Ident "resource" }} = {{ .Arg .Resource }}
+{{ end}}
+ORDER BY
+  {{ .Ident "namespace" }},
+  {{ .Ident "group"     }},
+  {{ .Ident "resource"  }}
+;

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -35,6 +35,7 @@ var (
 	sqlResourceUpdate                      = mustTemplate("resource_update.sql")
 	sqlResourceRead                        = mustTemplate("resource_read.sql")
 	sqlResourceStats                       = mustTemplate("resource_stats.sql")
+	sqlResourceStoredList                  = mustTemplate("resource_stored_list.sql")
 	sqlResourceList                        = mustTemplate("resource_list.sql")
 	sqlResourceHistoryList                 = mustTemplate("resource_history_list.sql")
 	sqlResourceHistoryListModifiedSince    = mustTemplate("resource_history_list_since_modified.sql")
@@ -181,6 +182,17 @@ func (r sqlStatsRequest) Validate() error {
 	if len(r.Folders) > 0 && r.Namespace == "" {
 		return fmt.Errorf("folder constraint requires a namespace")
 	}
+	return nil
+}
+
+type sqlStoredResourcesRequest struct {
+	sqltemplate.SQLTemplate
+	Namespace string
+	Group     string
+	Resource  string
+}
+
+func (r sqlStoredResourcesRequest) Validate() error {
 	return nil
 }
 

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -561,6 +561,30 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					},
 				},
 			},
+			sqlResourceStoredList: {
+				{
+					Name: "global",
+					Data: &sqlStoredResourcesRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+					},
+				},
+				{
+					Name: "namespace",
+					Data: &sqlStoredResourcesRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Namespace:   "default",
+					},
+				},
+				{
+					Name: "resource",
+					Data: &sqlStoredResourcesRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Namespace:   "default",
+						Group:       "dashboard.grafana.app",
+						Resource:    "dashboards",
+					},
+				},
+			},
 			sqlResourceBlobInsert: {
 				{
 					Name: "basic",

--- a/pkg/storage/unified/sql/testdata/mysql--resource_stored_list-global.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_stored_list-global.sql
@@ -1,0 +1,11 @@
+SELECT DISTINCT
+  `namespace`,
+  `group`,
+  `resource`
+FROM `resource`
+WHERE 1 = 1
+ORDER BY
+  `namespace`,
+  `group`,
+  `resource`
+;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_stored_list-namespace.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_stored_list-namespace.sql
@@ -1,0 +1,12 @@
+SELECT DISTINCT
+  `namespace`,
+  `group`,
+  `resource`
+FROM `resource`
+WHERE 1 = 1
+  AND `namespace` = 'default'
+ORDER BY
+  `namespace`,
+  `group`,
+  `resource`
+;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_stored_list-resource.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_stored_list-resource.sql
@@ -1,0 +1,14 @@
+SELECT DISTINCT
+  `namespace`,
+  `group`,
+  `resource`
+FROM `resource`
+WHERE 1 = 1
+  AND `namespace` = 'default'
+  AND `group` = 'dashboard.grafana.app'
+  AND `resource` = 'dashboards'
+ORDER BY
+  `namespace`,
+  `group`,
+  `resource`
+;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_stored_list-global.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_stored_list-global.sql
@@ -1,0 +1,11 @@
+SELECT DISTINCT
+  "namespace",
+  "group",
+  "resource"
+FROM "resource"
+WHERE 1 = 1
+ORDER BY
+  "namespace",
+  "group",
+  "resource"
+;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_stored_list-namespace.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_stored_list-namespace.sql
@@ -1,0 +1,12 @@
+SELECT DISTINCT
+  "namespace",
+  "group",
+  "resource"
+FROM "resource"
+WHERE 1 = 1
+  AND "namespace" = 'default'
+ORDER BY
+  "namespace",
+  "group",
+  "resource"
+;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_stored_list-resource.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_stored_list-resource.sql
@@ -1,0 +1,14 @@
+SELECT DISTINCT
+  "namespace",
+  "group",
+  "resource"
+FROM "resource"
+WHERE 1 = 1
+  AND "namespace" = 'default'
+  AND "group" = 'dashboard.grafana.app'
+  AND "resource" = 'dashboards'
+ORDER BY
+  "namespace",
+  "group",
+  "resource"
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_stored_list-global.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_stored_list-global.sql
@@ -1,0 +1,11 @@
+SELECT DISTINCT
+  "namespace",
+  "group",
+  "resource"
+FROM "resource"
+WHERE 1 = 1
+ORDER BY
+  "namespace",
+  "group",
+  "resource"
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_stored_list-namespace.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_stored_list-namespace.sql
@@ -1,0 +1,12 @@
+SELECT DISTINCT
+  "namespace",
+  "group",
+  "resource"
+FROM "resource"
+WHERE 1 = 1
+  AND "namespace" = 'default'
+ORDER BY
+  "namespace",
+  "group",
+  "resource"
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_stored_list-resource.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_stored_list-resource.sql
@@ -1,0 +1,14 @@
+SELECT DISTINCT
+  "namespace",
+  "group",
+  "resource"
+FROM "resource"
+WHERE 1 = 1
+  AND "namespace" = 'default'
+  AND "group" = 'dashboard.grafana.app'
+  AND "resource" = 'dashboards'
+ORDER BY
+  "namespace",
+  "group",
+  "resource"
+;

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -36,6 +36,7 @@ const (
 	TestList                      = "list"
 	TestBlobSupport               = "blob support"
 	TestGetResourceStats          = "get resource stats"
+	TestListStoredResources       = "list stored resources"
 	TestListHistory               = "list history"
 	TestListHistoryErrorReporting = "list history error reporting"
 	TestListModifiedSince         = "list events since rv"
@@ -87,6 +88,7 @@ func RunStorageBackendTest(t *testing.T, newBackend NewBackendFunc, opts *TestOp
 		{TestList, runTestIntegrationBackendList},
 		{TestBlobSupport, runTestIntegrationBlobSupport},
 		{TestGetResourceStats, runTestIntegrationBackendGetResourceStats},
+		{TestListStoredResources, runTestIntegrationBackendListStoredResources},
 		{TestListHistory, runTestIntegrationBackendListHistory},
 		{TestListHistoryErrorReporting, runTestIntegrationBackendListHistoryErrorReporting},
 		{TestListTrash, runTestIntegrationBackendTrash},
@@ -336,6 +338,73 @@ func runTestIntegrationBackendGetResourceStats(t *testing.T, backend resource.St
 	})
 }
 
+func runTestIntegrationBackendListStoredResources(t *testing.T, backend resource.StorageBackend, nsPrefix string) {
+	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
+
+	sortFunc := func(a, b resource.NamespacedResource) int {
+		if a.Namespace != b.Namespace {
+			return strings.Compare(a.Namespace, b.Namespace)
+		}
+		if a.Group != b.Group {
+			return strings.Compare(a.Group, b.Group)
+		}
+		return strings.Compare(a.Resource, b.Resource)
+	}
+
+	ns1 := nsPrefix + "-stored-ns1"
+	ns2 := nsPrefix + "-stored-ns2"
+
+	// Two objects of the same group/resource in ns1 must be reported once.
+	_, err := WriteEvent(ctx, backend, "item1", resourcepb.WatchEvent_ADDED,
+		WithNamespace(ns1), WithGroup("group"), WithResource("resource1"))
+	require.NoError(t, err)
+	_, err = WriteEvent(ctx, backend, "item2", resourcepb.WatchEvent_ADDED,
+		WithNamespace(ns1), WithGroup("group"), WithResource("resource1"))
+	require.NoError(t, err)
+	_, err = WriteEvent(ctx, backend, "item3", resourcepb.WatchEvent_ADDED,
+		WithNamespace(ns1), WithGroup("group"), WithResource("resource2"))
+	require.NoError(t, err)
+	_, err = WriteEvent(ctx, backend, "item4", resourcepb.WatchEvent_ADDED,
+		WithNamespace(ns2), WithGroup("group"), WithResource("resource1"))
+	require.NoError(t, err)
+
+	t.Run("discover resources in ns1", func(t *testing.T) {
+		got, err := backend.ListStoredResources(ctx, resource.NamespacedResource{Namespace: ns1})
+		require.NoError(t, err)
+		slices.SortFunc(got, sortFunc)
+		require.Equal(t, []resource.NamespacedResource{
+			{Namespace: ns1, Group: "group", Resource: "resource1"},
+			{Namespace: ns1, Group: "group", Resource: "resource2"},
+		}, got)
+	})
+
+	t.Run("discover resources in ns2", func(t *testing.T) {
+		got, err := backend.ListStoredResources(ctx, resource.NamespacedResource{Namespace: ns2})
+		require.NoError(t, err)
+		require.Equal(t, []resource.NamespacedResource{
+			{Namespace: ns2, Group: "group", Resource: "resource1"},
+		}, got)
+	})
+
+	t.Run("resource filter", func(t *testing.T) {
+		got, err := backend.ListStoredResources(ctx, resource.NamespacedResource{Namespace: ns1, Resource: "resource2"})
+		require.NoError(t, err)
+		require.Equal(t, []resource.NamespacedResource{
+			{Namespace: ns1, Group: "group", Resource: "resource2"},
+		}, got)
+	})
+
+	t.Run("non-existent namespace is empty", func(t *testing.T) {
+		got, err := backend.ListStoredResources(ctx, resource.NamespacedResource{Namespace: nsPrefix + "-stored-missing"})
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("empty namespace is rejected", func(t *testing.T) {
+		_, err := backend.ListStoredResources(ctx, resource.NamespacedResource{})
+		require.Error(t, err)
+	})
+}
 func runTestIntegrationBackendWatchWriteEvents(t *testing.T, backend resource.StorageBackend, nsPrefix string) {
 	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
 


### PR DESCRIPTION
Adds `ListStoredResources`, a cheap storage discovery primitive that reports which resource identities (namespace/group/resource) exist, without counting objects. It's an alternative to `GetResourceStats` for the search paths that only need to know which group/resource pairs exist in a namespace, not how many. `GetResourceStats` stays for the startup prebuild path, which still needs counts.

New method on the `StorageBackend` interface and the `ResourceStore` gRPC service. The KV backend reuses the cached group/resource discovery with a single bounded existence seek per group/resource; the SQL backend uses `SELECT DISTINCT` over the resource table (covered by existing indexes). A namespace is required; group and resource are optional filters. An empty namespace is rejected with `InvalidArgument`, and backend errors are returned as gRPC `codes.Internal`.

No callers are switched to this yet — that follows in later PRs.

Builds on #127721 — merge that first, after which this PR no longer needs to change the partial OSS backends. The enterprise IAM backends are handled by a follow-up that embeds `UnimplementedStorageBackend` (superseding grafana-enterprise#12541), landing when enterprise picks up a grafana version containing both PRs.

---

The only API-layer changes are test-only mock updates (three `search_test.go` files) needed to compile against the new `ResourceStoreClient` method. There is no runtime or deployment-compatibility impact — no caller is added, and a new gRPC method is backwards compatible — so this carries the `no-check-unified-storage-compatibility` label.
