### PR TITLE
Search: build search field providers from manifests only

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -80,22 +80,6 @@ func SearchFieldsHashesForBuilders(builders []DocumentBuilderInfo) map[string]st
 	return out
 }
 
-// SearchFieldProvidersForBuilders returns a lower-cased "group/resource" map
-// of SearchFieldsProvider values collected from the given DocumentBuilderInfo
-// entries. Builders with a nil provider are skipped, so the map's keys list
-// the kinds whose bleve mapping is provider-driven.
-func SearchFieldProvidersForBuilders(builders []DocumentBuilderInfo) map[string]SearchFieldsProvider {
-	out := map[string]SearchFieldsProvider{}
-	for _, b := range builders {
-		if b.SearchFieldsProvider == nil {
-			continue
-		}
-		key := strings.ToLower(b.GroupResource.Group + "/" + b.GroupResource.Resource)
-		out[key] = b.SearchFieldsProvider
-	}
-	return out
-}
-
 type DocumentBuilderSupplier interface {
 	GetDocumentBuilders() ([]DocumentBuilderInfo, error)
 }

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -1,7 +1,6 @@
 package resource
 
 import (
-	"maps"
 	"strings"
 
 	"github.com/grafana/grafana-app-sdk/app"
@@ -88,7 +87,8 @@ func manifestSearchFieldsToDefinitions(in []app.ManifestVersionKindSearchField) 
 
 // manifestDeclaredKindKeys returns the lower-cased "group/resource" keys of
 // every kind that declares at least one search field in any version. The key
-// format matches SearchFieldProvidersForBuilders so the two maps merge.
+// format matches the lower-cased "group/resource" used throughout the
+// search-fields boot wiring.
 func manifestDeclaredKindKeys(manifests []app.Manifest) map[string]bool {
 	keys := map[string]bool{}
 	for _, m := range manifests {
@@ -108,18 +108,12 @@ func manifestDeclaredKindKeys(manifests []app.Manifest) map[string]bool {
 }
 
 // SearchFieldProviders returns the per-("group/resource") provider map that
-// drives bleve mappings. A kind's search fields come from its manifest when the
-// manifest declares any; otherwise the builder-supplied provider is used. Keys
-// are lower-cased "group/resource", matching SearchFieldProvidersForBuilders.
-//
-// Until kinds migrate their search fields into CUE, no manifest declares any,
-// so this returns exactly the builder providers and boot behaviour is
-// unchanged.
-func SearchFieldProviders(manifests []app.Manifest, builderProviders map[string]SearchFieldsProvider) map[string]SearchFieldsProvider {
-	out := make(map[string]SearchFieldsProvider, len(builderProviders))
-	maps.Copy(out, builderProviders)
-
+// drives bleve mappings. Every kind that declares search fields in its manifest
+// is mapped to a single manifest-backed provider; each entry queries it for its
+// own (group, resource). Keys are lower-cased "group/resource".
+func SearchFieldProviders(manifests []app.Manifest) map[string]SearchFieldsProvider {
 	declared := manifestDeclaredKindKeys(manifests)
+	out := make(map[string]SearchFieldsProvider, len(declared))
 	if len(declared) == 0 {
 		return out
 	}

--- a/pkg/storage/unified/resource/search_field_manifest_test.go
+++ b/pkg/storage/unified/resource/search_field_manifest_test.go
@@ -93,35 +93,21 @@ func TestNewManifestBackedProvider_DefaultsPluralAndPreferredVersion(t *testing.
 	assert.Equal(t, "v2", p.PreferredVersion("widgets.example.test", "gadgets"))
 }
 
-// stubProvider is a SearchFieldsProvider used only to assert identity in the
-// merge test; its methods are never exercised for their return values.
-type stubProvider struct{ SearchFieldsProvider }
+func TestSearchFieldProviders_MapsDeclaredKinds(t *testing.T) {
+	got := SearchFieldProviders([]app.Manifest{manifestWithSearchFields()})
 
-func TestSearchFieldProviders_ManifestWinsBuilderFallback(t *testing.T) {
-	widgetBuilder := &stubProvider{}
-	gadgetBuilder := &stubProvider{}
-	builderProviders := map[string]SearchFieldsProvider{
-		"widgets.example.test/widgets": widgetBuilder, // manifest also declares this one
-		"widgets.example.test/gadgets": gadgetBuilder, // builder-only, manifest declares nothing
-	}
+	// The one kind that declares search fields is present and provider-backed.
+	require.Len(t, got, 1)
+	provider := got["widgets.example.test/widgets"]
+	require.NotNil(t, provider)
 
-	got := SearchFieldProviders([]app.Manifest{manifestWithSearchFields()}, builderProviders)
-
-	// Widget is declared in the manifest, so its provider is replaced.
-	require.NotSame(t, widgetBuilder, got["widgets.example.test/widgets"])
-	require.NotNil(t, got["widgets.example.test/widgets"])
-
-	// Gadget is not in the manifest, so it keeps the builder provider.
-	assert.Same(t, gadgetBuilder, got["widgets.example.test/gadgets"])
+	// The mapped provider answers for that kind's own (group, resource).
+	gvr := schema.GroupVersionResource{Group: "widgets.example.test", Version: "v2", Resource: "widgets"}
+	assert.Len(t, provider.Fields(gvr), 2)
 }
 
-func TestSearchFieldProviders_NoManifestDeclarationsIsNoOp(t *testing.T) {
-	widgetBuilder := &stubProvider{}
-	builderProviders := map[string]SearchFieldsProvider{
-		"widgets.example.test/widgets": widgetBuilder,
-	}
-
-	// A manifest that declares no search fields must not change anything.
+func TestSearchFieldProviders_NoManifestDeclarationsIsEmpty(t *testing.T) {
+	// A manifest that declares no search fields yields an empty map.
 	manifestNoFields := app.Manifest{ManifestData: &app.ManifestData{
 		Group: "widgets.example.test",
 		Versions: []app.ManifestVersion{{
@@ -130,7 +116,6 @@ func TestSearchFieldProviders_NoManifestDeclarationsIsNoOp(t *testing.T) {
 		}},
 	}}
 
-	got := SearchFieldProviders([]app.Manifest{manifestNoFields}, builderProviders)
-	assert.Same(t, widgetBuilder, got["widgets.example.test/widgets"])
-	assert.Len(t, got, 1)
+	got := SearchFieldProviders([]app.Manifest{manifestNoFields})
+	assert.Empty(t, got)
 }

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -97,10 +97,9 @@ func NewSearchOptions(
 				return resource.SearchOptions{}, err
 			}
 			searchFieldsHashes = resource.SearchFieldsHashesForBuilders(builders)
-			// Prefer search fields declared in manifests, falling back to the
-			// builder-supplied provider for kinds that don't declare any in CUE.
-			builderProviders := resource.SearchFieldProvidersForBuilders(builders)
-			searchFieldsProviders = resource.SearchFieldProviders(resource.AppManifests(), builderProviders)
+			// Search fields come from the app manifests: every in-tree kind that
+			// has custom search fields declares them in its CUE manifest.
+			searchFieldsProviders = resource.SearchFieldProviders(resource.AppManifests())
 		}
 
 		bleve, err := NewBleveBackend(BleveOptions{


### PR DESCRIPTION
Every in-tree kind that has custom search fields now declares them in its CUE manifest, so the search backend no longer needs to fall back to the builder-supplied provider. This removes that fallback: `SearchFieldProviders` takes just the manifests and maps every declared kind to a single manifest-backed provider, and `SearchFieldProvidersForBuilders` is deleted along with the boot-time merge.

The resulting provider map is identical to before — every declared kind was already overridden with the manifest-backed provider — so there is no golden-file churn and no search index rebuild. Per-kind hashes still come from the builders, unchanged.

Part of grafana/search-and-storage-team#827.
