### PR TITLE
fix: nats integration test

### DIFF
--- a/pkg/infra/nats/discovery_integration_test.go
+++ b/pkg/infra/nats/discovery_integration_test.go
@@ -36,8 +36,8 @@ func TestIntegrationDiscoveryEmbeddedCluster(t *testing.T) {
 
 		// Publisher connects (in-process) to node A, subscriber to node B, so a
 		// delivery proves interest and the message crossed the cluster route.
-		pub := ProvidePublisher(cfgA.cfg, ProvideNATSConfig(cfgA.cfg, cfgA.srv), prometheus.NewRegistry())
-		sub := ProvideSubscriber(cfgB.cfg, ProvideNATSConfig(cfgB.cfg, cfgB.srv), prometheus.NewRegistry())
+		pub := ProvidePublisher(ProvideNATSConfig(cfgA.cfg, cfgA.srv), prometheus.NewRegistry())
+		sub := ProvideSubscriber(ProvideNATSConfig(cfgB.cfg, cfgB.srv), prometheus.NewRegistry())
 		startService(t, ctx, pub)
 		startService(t, ctx, sub)
 


### PR DESCRIPTION
```bash
~ go test -tags=integration -run TestIntegration ./pkg/infra/nats/ 2>&1 | tail -40
ok  	github.com/grafana/grafana/pkg/infra/nats	1.739s
```