### PR TITLE
Unified storage: add embeddable UnimplementedStorageBackend

### DIFF
--- a/pkg/registry/apis/iam/noopstorage/storage_backend.go
+++ b/pkg/registry/apis/iam/noopstorage/storage_backend.go
@@ -3,9 +3,7 @@ package noopstorage
 import (
 	"context"
 	"errors"
-	"iter"
 	"net/http"
-	"time"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -17,34 +15,22 @@ var (
 	errNoopStorage = errors.New("unavailable functionality")
 )
 
-type StorageBackendImpl struct{}
+// StorageBackendImpl is a StorageBackend that supports no operations. It embeds
+// UnimplementedStorageBackend so it does not need to be updated when the
+// StorageBackend interface grows.
+type StorageBackendImpl struct {
+	resource.UnimplementedStorageBackend
+}
 
 func ProvideStorageBackend() *StorageBackendImpl {
 	return &StorageBackendImpl{}
 }
 
-// GetResourceStats implements resource.StorageBackend.
-func (c *StorageBackendImpl) GetResourceStats(ctx context.Context, nsr resource.NamespacedResource, minCount int) ([]resource.ResourceStats, error) {
-	return []resource.ResourceStats{}, errNoopStorage
-}
-
-// ListHistory implements resource.StorageBackend.
-func (c *StorageBackendImpl) ListHistory(context.Context, *resourcepb.ListRequest, func(resource.ListIterator) error) (int64, error) {
-	return 0, errNoopStorage
-}
-
-// ListIterator implements resource.StorageBackend.
-func (c *StorageBackendImpl) ListIterator(context.Context, *resourcepb.ListRequest, func(resource.ListIterator) error) (int64, error) {
-	return 0, errNoopStorage
-}
-
-func (c *StorageBackendImpl) ListModifiedSince(ctx context.Context, key resource.NamespacedResource, sinceRv int64, _ *time.Time) (int64, iter.Seq2[*resource.ModifiedResource, error]) {
-	return 0, func(yield func(*resource.ModifiedResource, error) bool) {
-		yield(nil, errors.New("not implemented"))
-	}
-}
-
-// ReadResource implements resource.StorageBackend.
+// The read/list/write methods below are overridden (rather than inherited from
+// UnimplementedStorageBackend) because they are the operations surfaced to API
+// clients when a backend falls back to this noop storage (for example on an
+// invalid license), and callers rely on the "unavailable functionality" message
+// and Forbidden status. Everything else is inherited from the base.
 func (c *StorageBackendImpl) ReadResource(_ context.Context, req *resourcepb.ReadRequest) *resource.BackendReadResponse {
 	return &resource.BackendReadResponse{
 		Key:   req.GetKey(),
@@ -52,19 +38,10 @@ func (c *StorageBackendImpl) ReadResource(_ context.Context, req *resourcepb.Rea
 	}
 }
 
-// WatchWriteEvents implements resource.StorageBackend.
-func (c *StorageBackendImpl) WatchWriteEvents(ctx context.Context) (<-chan *resource.WrittenEvent, error) {
-	stream := make(chan *resource.WrittenEvent, 10)
-	return stream, nil
-}
-
-// WriteEvent implements resource.StorageBackend.
-func (c *StorageBackendImpl) WriteEvent(context.Context, resource.WriteEvent) (int64, error) {
+func (c *StorageBackendImpl) ListIterator(context.Context, *resourcepb.ListRequest, func(resource.ListIterator) error) (int64, error) {
 	return 0, errNoopStorage
 }
 
-func (c *StorageBackendImpl) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
-	return func(yield func(resource.ResourceLastImportTime, error) bool) {
-		yield(resource.ResourceLastImportTime{}, errNoopStorage)
-	}
+func (c *StorageBackendImpl) WriteEvent(context.Context, resource.WriteEvent) (int64, error) {
+	return 0, errNoopStorage
 }

--- a/pkg/registry/apis/iam/resourcepermission/models.go
+++ b/pkg/registry/apis/iam/resourcepermission/models.go
@@ -24,7 +24,6 @@ var (
 	timeNow = func() time.Time { return time.Now() }
 
 	errDatabaseHelper       = errors.New("failed to get database")
-	errNotImplemented       = errors.New("not supported by this storage backend")
 	errNameMismatch         = errors.New("name mismatch")
 	errNamespaceMismatch    = errors.New("namespace mismatch")
 	errUnknownGroupResource = errors.New("unknown group/resource")

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"iter"
 	"sync"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -29,6 +27,8 @@ var (
 )
 
 type ResourcePermSqlBackend struct {
+	resource.UnimplementedStorageBackend
+
 	dbProvider    legacysql.LegacyDatabaseProvider
 	identityStore IdentityStore
 	logger        log.Logger
@@ -48,14 +48,6 @@ func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider, mappers 
 		subscribers:   make([]chan *resource.WrittenEvent, 0),
 		mutex:         sync.Mutex{},
 	}
-}
-
-func (s *ResourcePermSqlBackend) GetResourceStats(ctx context.Context, nsr resource.NamespacedResource, minCount int) ([]resource.ResourceStats, error) {
-	return []resource.ResourceStats{}, errNotImplemented
-}
-
-func (s *ResourcePermSqlBackend) ListHistory(context.Context, *resourcepb.ListRequest, func(resource.ListIterator) error) (int64, error) {
-	return 0, errNotImplemented
 }
 
 func (s *ResourcePermSqlBackend) ListIterator(ctx context.Context, req *resourcepb.ListRequest, callback func(resource.ListIterator) error) (int64, error) {
@@ -120,12 +112,6 @@ func (s *ResourcePermSqlBackend) ListIterator(ctx context.Context, req *resource
 	return s.latestUpdate(ctx, dbHelper, ns), nil
 }
 
-func (s *ResourcePermSqlBackend) ListModifiedSince(ctx context.Context, key resource.NamespacedResource, sinceRv int64, _ *time.Time) (int64, iter.Seq2[*resource.ModifiedResource, error]) {
-	return 0, func(yield func(*resource.ModifiedResource, error) bool) {
-		yield(nil, errNotImplemented)
-	}
-}
-
 func (s *ResourcePermSqlBackend) ReadResource(ctx context.Context, req *resourcepb.ReadRequest) *resource.BackendReadResponse {
 	rsp := &resource.BackendReadResponse{Key: req.GetKey()}
 
@@ -177,11 +163,6 @@ func (s *ResourcePermSqlBackend) ReadResource(ctx context.Context, req *resource
 	}
 
 	return rsp
-}
-
-func (s *ResourcePermSqlBackend) WatchWriteEvents(ctx context.Context) (<-chan *resource.WrittenEvent, error) {
-	stream := make(chan *resource.WrittenEvent, 10)
-	return stream, nil
 }
 
 func isValidKey(key *resourcepb.ResourceKey, requireName bool) error {
@@ -296,10 +277,4 @@ func (s *ResourcePermSqlBackend) WriteEvent(ctx context.Context, event resource.
 	}
 
 	return rv, err
-}
-
-func (s *ResourcePermSqlBackend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
-	return func(yield func(resource.ResourceLastImportTime, error) bool) {
-		yield(resource.ResourceLastImportTime{}, errNotImplemented)
-	}
 }

--- a/pkg/storage/unified/resource/unimplemented.go
+++ b/pkg/storage/unified/resource/unimplemented.go
@@ -1,0 +1,77 @@
+package resource
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"net/http"
+	"time"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// errUnimplemented is returned by UnimplementedStorageBackend for every method
+// that an embedding backend has not overridden.
+var errUnimplemented = errors.New("not implemented by this storage backend")
+
+// UnimplementedStorageBackend is a StorageBackend that does not support any
+// operation. It is meant to be embedded by backends that only implement a
+// subset of StorageBackend (for example the IAM apiserver backends, which serve
+// a single resource from legacy SQL and do not participate in unified storage
+// discovery, stats or history).
+//
+// Embedding it means such backends only implement the methods they actually
+// support, and automatically get a safe default for the rest. It also means new
+// StorageBackend methods do not have to be added to every partial backend.
+//
+// Trade-off: because the embedded methods satisfy the interface, the compiler no
+// longer forces an embedding backend to implement a method it genuinely should.
+// Only embed this in backends that intentionally implement a subset.
+type UnimplementedStorageBackend struct{}
+
+var _ StorageBackend = (*UnimplementedStorageBackend)(nil)
+
+func (UnimplementedStorageBackend) WriteEvent(context.Context, WriteEvent) (int64, error) {
+	return 0, errUnimplemented
+}
+
+func (UnimplementedStorageBackend) ReadResource(_ context.Context, req *resourcepb.ReadRequest) *BackendReadResponse {
+	return &BackendReadResponse{
+		Key: req.GetKey(),
+		Error: &resourcepb.ErrorResult{
+			Code:    http.StatusNotImplemented,
+			Message: errUnimplemented.Error(),
+		},
+	}
+}
+
+func (UnimplementedStorageBackend) ListIterator(context.Context, *resourcepb.ListRequest, func(ListIterator) error) (int64, error) {
+	return 0, errUnimplemented
+}
+
+func (UnimplementedStorageBackend) ListHistory(context.Context, *resourcepb.ListRequest, func(ListIterator) error) (int64, error) {
+	return 0, errUnimplemented
+}
+
+func (UnimplementedStorageBackend) ListModifiedSince(context.Context, NamespacedResource, int64, *time.Time) (int64, iter.Seq2[*ModifiedResource, error]) {
+	return 0, func(yield func(*ModifiedResource, error) bool) {
+		yield(nil, errUnimplemented)
+	}
+}
+
+// WatchWriteEvents returns an open channel that never emits, rather than an
+// error. The storage server's watcher treats a WatchWriteEvents error as fatal,
+// so a backend that produces no events must still return a usable channel.
+func (UnimplementedStorageBackend) WatchWriteEvents(context.Context) (<-chan *WrittenEvent, error) {
+	return make(chan *WrittenEvent), nil
+}
+
+func (UnimplementedStorageBackend) GetResourceStats(context.Context, NamespacedResource, int) ([]ResourceStats, error) {
+	return nil, errUnimplemented
+}
+
+func (UnimplementedStorageBackend) GetResourceLastImportTimes(context.Context) iter.Seq2[ResourceLastImportTime, error] {
+	return func(yield func(ResourceLastImportTime, error) bool) {
+		yield(ResourceLastImportTime{}, errUnimplemented)
+	}
+}


### PR DESCRIPTION
Adds `UnimplementedStorageBackend`, a base that partial `StorageBackend` implementations can embed to get safe defaults for the operations they don't support. Backends then only implement what they actually support, and adding a method to the `StorageBackend` interface no longer requires touching every partial backend.

Embeds it in the two IAM apiserver backends that implement a subset (`noopstorage`, `resourcepermission`), replacing their hand-written stubs.

`WatchWriteEvents` returns an open channel rather than an error, because the storage server treats a `WatchWriteEvents` error as fatal.

Trade-off: embedding satisfies the interface, so the compiler no longer forces an embedding backend to implement a method it genuinely should. It's only meant for backends that intentionally implement a subset. The full storage backends (KV, SQL) are unchanged.

Intended to merge before #127717. Once this lands, that PR no longer needs to touch the partial OSS backends, and a follow-up can have the enterprise IAM backends embed this base instead of hand-writing stubs.
