### PR TITLE
Unified Storage: fix flaky list history error reporting test

### DIFF
--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -1127,7 +1127,10 @@ func runTestIntegrationBackendListHistory(t *testing.T, backend resource.Storage
 }
 
 func runTestIntegrationBackendListHistoryErrorReporting(t *testing.T, backend resource.StorageBackend, nsPrefix string) {
-	ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+	// The deadline must comfortably cover writing the fixture events below on a
+	// loaded CI runner. The List call under test uses its own 1µs timeout, so
+	// this budget only guards setup, not the assertion.
+	ctx := testutil.NewTestContext(t, time.Now().Add(2*time.Minute))
 	server := newServer(t, backend)
 
 	ns := nsPrefix + "-short"


### PR DESCRIPTION
`list_history_error_reporting` occasionally fails on CI with `DeadlineExceeded` while writing its 500 fixture events. The setup shared the whole test's 30s deadline, so on a loaded runner the writes could time out before the actual assertion ran.

Bumped the deadline to 2 minutes. The `List` call under test keeps its own 1µs timeout, so what the test verifies is unchanged.

Seen in: https://github.com/grafana/grafana/actions/runs/28457995272/job/84338102194