### PR TITLE
[DO NOT MERGE] PoC: consume generic_oauth SSO settings from MT-Settings

### DIFF
--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -41,6 +41,7 @@ var _ ssosettings.Reloadable = (*SocialGenericOAuth)(nil)
 
 type SocialGenericOAuth struct {
 	*SocialBase
+	ssoSettings          ssosettings.Service // PoC: live read-through source (MT-Settings via our strategy)
 	allowedOrganizations []string
 	teamsUrl             string
 	emailAttributeName   string
@@ -68,6 +69,7 @@ func NewGenericOAuthProvider(info *social.OAuthInfo, cfg *setting.Cfg, orgRoleMa
 
 	provider := &SocialGenericOAuth{
 		SocialBase:           newSocialBaseWithCache(social.GenericOAuthProviderName, orgRoleMapper, info, features, cfg, cache),
+		ssoSettings:          ssoSettings,
 		teamsUrl:             info.TeamsUrl,
 		emailAttributeName:   info.EmailAttributeName,
 		emailAttributePath:   info.EmailAttributePath,
@@ -163,6 +165,60 @@ func (s *SocialGenericOAuth) Reload(ctx context.Context, settings ssoModels.SSOS
 
 	return nil
 }
+
+// --- PoC read-through (REMOVE / flag-gate before commit) ---
+// liveInfo resolves the provider config live from the settings service on each
+// call, instead of the cached snapshot. GetForProvider routes through our
+// ConfigProviderOAuthStrategy -> cfgProvider.Get (namespace baked in, 1s/5s
+// cached), so this is a cheap read, not a network round-trip per call.
+func (s *SocialGenericOAuth) liveInfo(ctx context.Context) (*social.OAuthInfo, error) {
+	ss, err := s.ssoSettings.GetForProvider(ctx, social.GenericOAuthProviderName)
+	if err != nil {
+		return nil, err
+	}
+	info, err := CreateOAuthInfoFromKeyValuesWithLogging(s.log, social.GenericOAuthProviderName, ss.Settings)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+// liveConfig builds a fresh oauth2.Config from live settings (no stored snapshot,
+// no lock). Falls back to the bootstrapped snapshot if the live read fails.
+func (s *SocialGenericOAuth) liveConfig(ctx context.Context) (*oauth2.Config, *social.OAuthInfo) {
+	info, err := s.liveInfo(ctx)
+	if err != nil || info == nil {
+		return s.Config, s.GetOAuthInfo()
+	}
+	return createOAuthConfig(info, s.cfg, social.GenericOAuthProviderName), info
+}
+
+func (s *SocialGenericOAuth) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+	// AuthCodeURL has no ctx; safe to use Background because cfgProvider bakes in
+	// the namespace and detaches the caller ctx internally.
+	cfg, info := s.liveConfig(context.Background())
+	if info != nil && info.LoginPrompt != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", info.LoginPrompt))
+	}
+	return cfg.AuthCodeURL(state, opts...)
+}
+
+func (s *SocialGenericOAuth) Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	cfg, _ := s.liveConfig(ctx)
+	return cfg.Exchange(ctx, code, opts...)
+}
+
+func (s *SocialGenericOAuth) Client(ctx context.Context, t *oauth2.Token) *http.Client {
+	cfg, _ := s.liveConfig(ctx)
+	return cfg.Client(ctx, t)
+}
+
+func (s *SocialGenericOAuth) TokenSource(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {
+	cfg, _ := s.liveConfig(ctx)
+	return cfg.TokenSource(ctx, t)
+}
+
+// --- end PoC read-through ---
 
 func (s *SocialGenericOAuth) isTeamMember(ctx context.Context, client *http.Client) bool {
 	if len(s.teamIds) == 0 {

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -479,7 +479,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 		return nil, err
 	}
 	licensingService := licensing2.ProvideLicensing(cfg, ossLicensingService)
-	ssosettingsimplService := ssosettingsimpl.ProvideService(cfg, sqlStore, accessControl, routeRegisterImpl, featureToggles, secretsService, usageStats, registerer, ossImpl, ossLicensingService)
+	ssosettingsimplService := ssosettingsimpl.ProvideService(cfg, sqlStore, accessControl, routeRegisterImpl, featureToggles, secretsService, usageStats, registerer, ossImpl, ossLicensingService, configProvider)
 	defaultSettingsProvider := pluginsso.ProvideDefaultSettingsProvider(ssosettingsimplService)
 	envVarsProvider := pluginconfig.NewEnvVarsProvider(pluginInstanceCfg, licensingService, defaultSettingsProvider)
 	noop := provisionedplugins.NewNoop()
@@ -1203,7 +1203,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	licensingService := licensing2.ProvideLicensing(cfg, ossLicensingService)
-	ssosettingsimplService := ssosettingsimpl.ProvideService(cfg, sqlStore, accessControl, routeRegisterImpl, featureToggles, secretsService, usageStats, registerer, ossImpl, ossLicensingService)
+	ssosettingsimplService := ssosettingsimpl.ProvideService(cfg, sqlStore, accessControl, routeRegisterImpl, featureToggles, secretsService, usageStats, registerer, ossImpl, ossLicensingService, configProvider)
 	defaultSettingsProvider := pluginsso.ProvideDefaultSettingsProvider(ssosettingsimplService)
 	envVarsProvider := pluginconfig.NewEnvVarsProvider(pluginInstanceCfg, licensingService, defaultSettingsProvider)
 	noop := provisionedplugins.NewNoop()

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
@@ -54,10 +55,18 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 	secrets secrets.Service, //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	usageStats usagestats.Service, registerer prometheus.Registerer,
 	settingsProvider setting.Provider, licensing licensing.Licensing,
+	cfgProvider configprovider.ConfigProvider,
 ) *Service {
 	fbStrategies := []ssosettings.FallbackStrategy{
 		strategies.NewOAuthStrategy(cfg),
 		strategies.NewLDAPStrategy(cfg),
+	}
+
+	// PoC: resolve OAuth settings live from MT-Settings ahead of the static-cfg strategy.
+	if cfgProvider != nil {
+		fbStrategies = append([]ssosettings.FallbackStrategy{
+			strategies.NewConfigProviderOAuthStrategy(cfgProvider),
+		}, fbStrategies...)
 	}
 
 	configurableProviders := make(map[string]bool)

--- a/pkg/services/ssosettings/strategies/configprovider_oauth_strategy.go
+++ b/pkg/services/ssosettings/strategies/configprovider_oauth_strategy.go
@@ -1,0 +1,45 @@
+package strategies
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/configprovider"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+)
+
+// ConfigProviderOAuthStrategy resolves OAuth provider settings live from the
+// cloud config provider (MT-Settings) on each request, instead of the static
+// boot-time *setting.Cfg used by OAuthStrategy. The config provider fetches on a
+// short TTL, so updates in MT-Settings are picked up without a restart.
+type ConfigProviderOAuthStrategy struct {
+	cfgProvider configprovider.ConfigProvider
+	logger      log.Logger
+}
+
+var _ ssosettings.FallbackStrategy = (*ConfigProviderOAuthStrategy)(nil)
+
+func NewConfigProviderOAuthStrategy(cfgProvider configprovider.ConfigProvider) *ConfigProviderOAuthStrategy {
+	return &ConfigProviderOAuthStrategy{
+		cfgProvider: cfgProvider,
+		logger:      log.New("ssosettings.configprovider_strategy"),
+	}
+}
+
+// PoC scope: only generic_oauth, so every other provider falls through to OAuthStrategy.
+func (s *ConfigProviderOAuthStrategy) IsMatch(provider string) bool {
+	return provider == social.GenericOAuthProviderName
+}
+
+func (s *ConfigProviderOAuthStrategy) GetProviderConfig(ctx context.Context, provider string) (map[string]any, error) {
+	cfg, err := s.cfgProvider.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reuse the exact OAuth section parsing, but against the freshly-fetched
+	// (live, decrypted) cfg rather than the static boot cfg.
+	live := &OAuthStrategy{cfg: cfg, settingsByProvider: make(map[string]map[string]any)}
+	return live.loadSettingsForProvider(provider), nil
+}


### PR DESCRIPTION
Proof-of-concept, not for merge. Demonstrates reading `generic_oauth` SSO settings live from MT-Settings through the ConfigProvider seam (no restart, no sso_setting row required). Reference artifact for the SSO settings migration research.