### PR TITLE
Provisioning: open the NATS subscription before the initial list

### DIFF
--- a/pkg/storage/unified/informer/informer.go
+++ b/pkg/storage/unified/informer/informer.go
@@ -174,10 +174,12 @@ func (c syncedChecker) Done() <-chan struct{} { return c.informer.syncedCh }
 
 // Run delivers events to the registered handlers until stopCh is closed,
 // mirroring cache.SharedIndexInformer.Run: it blocks, so start it with
-// `go informer.Run(stopCh)`. It subscribes to the resource's NATS subject
-// (unless live notifications are disabled), performs the initial list (marking
-// HasSynced), then serves live notifications and a periodic re-list. Register
-// handlers before calling Run.
+// `go informer.Run(stopCh)`. It first opens the resource's NATS subscription
+// (retrying until it succeeds, unless live notifications are disabled), then
+// performs the initial list (marking HasSynced), then serves live notifications
+// and a periodic re-list. Subscribing before listing means it never lists — nor
+// reports HasSynced — while it still cannot watch the resource. Register handlers
+// before calling Run.
 func (n *Informer) Run(stopCh <-chan struct{}) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -189,17 +191,54 @@ func (n *Informer) Run(stopCh <-chan struct{}) {
 		}
 	}()
 
-	// Seed the initial reconcile before reporting HasSynced, retrying until the
-	// first list succeeds. HasSynced releases WaitForCacheSync, so marking it
-	// synced after a failed list would start the controllers against an empty
-	// snapshot — existing objects would go unreconciled and quota counts read as
-	// zero until the next successful resync. A transient API error must therefore
-	// hold HasSynced false and retry, mirroring a reflector's initial ListAndWatch.
-	//
-	// This gates on the API list, not the NATS subscription: the subscription is
-	// opened afterwards and its failure is non-fatal (the periodic re-list keeps
-	// the informer correct), so a slow or not-yet-started bus never blocks the
-	// controller.
+	var sub nats.Subscription
+	defer func() {
+		if sub != nil {
+			if err := sub.Unsubscribe(); err != nil {
+				n.log.Debug("nats informer: unsubscribe", "error", err)
+			}
+		}
+	}()
+
+	// Open the live subscription before the initial list, so a change published
+	// while we are listing is delivered (core NATS has no replay) rather than
+	// dropped in a list-to-subscribe gap. If the subscription cannot be created
+	// yet — most commonly at startup, before the embedded NATS server has a client
+	// URL — keep retrying and do NOT list or report HasSynced: re-listing a
+	// resource we cannot watch would start the controller against a snapshot with
+	// no live updates until the next resync. A nil newObject or a disabled
+	// subscriber means the informer is re-list-only, so there is no subscription
+	// to wait for.
+	if n.newObject != nil && nats.Enabled(n.subscriber) {
+		subject := resourcewatch.Subject(n.gvr, n.namespace)
+		// Re-list on reconnect: a round-robin subscription can miss events
+		// published while the connection was down, so reconcile from a fresh list.
+		opts := []nats.SubscribeOption{nats.WithOnReconnect(n.signalReconnect)}
+		if n.queueGroup != "" {
+			opts = append(opts, nats.WithQueueGroup(n.queueGroup))
+		}
+		for {
+			s, err := n.subscriber.Subscribe(ctx, subject, n.onNotification(), opts...)
+			if err == nil {
+				sub = s
+				n.log.Debug("opened nats informer", "subject", subject, "gvr", n.gvr.String())
+				break
+			}
+			n.log.Warn("nats informer: subscribe failed, will retry", "subject", subject, "error", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(n.retryInterval):
+			}
+		}
+	}
+
+	// Seed the initial reconcile and report HasSynced, retrying until the first
+	// list succeeds. HasSynced releases WaitForCacheSync, so marking it synced
+	// after a failed list would start the controllers against an empty snapshot —
+	// existing objects would go unreconciled and quota counts read as zero until
+	// the next successful resync. A transient API error must therefore hold
+	// HasSynced false and retry, mirroring a reflector's initial ListAndWatch.
 	for {
 		if err := n.relist(ctx, true); err == nil {
 			break
@@ -213,56 +252,8 @@ func (n *Informer) Run(stopCh <-chan struct{}) {
 	n.synced.Store(true)
 	close(n.syncedCh)
 
-	var sub nats.Subscription
-	defer func() {
-		if sub != nil {
-			if err := sub.Unsubscribe(); err != nil {
-				n.log.Debug("nats informer: unsubscribe", "error", err)
-			}
-		}
-	}()
-
-	// subscribe opens the live subscription. The embedded NATS server may still be
-	// starting when the informer first runs (no client URL yet), so a failure is
-	// not fatal: it returns false and Run retries on retryInterval until it
-	// succeeds. A nil newObject disables live notifications entirely.
-	subscribe := func() bool {
-		// No live subscription when notifications are disabled (nil newObject) or
-		// there is no enabled subscriber (nil/typed-nil/disabled): the periodic
-		// re-list keeps the informer correct on its own. Already-subscribed is a no-op.
-		if n.newObject == nil || !nats.Enabled(n.subscriber) || sub != nil {
-			return true
-		}
-		subject := resourcewatch.Subject(n.gvr, n.namespace)
-		// Re-list on reconnect: a round-robin subscription can miss events
-		// published while the connection was down, so reconcile from a fresh list.
-		opts := []nats.SubscribeOption{nats.WithOnReconnect(n.signalReconnect)}
-		if n.queueGroup != "" {
-			opts = append(opts, nats.WithQueueGroup(n.queueGroup))
-		}
-		s, err := n.subscriber.Subscribe(ctx, subject, n.onNotification(), opts...)
-		if err != nil {
-			n.log.Warn("nats informer: subscribe failed, will retry", "subject", subject, "error", err)
-			return false
-		}
-		sub = s
-		n.log.Debug("opened nats informer", "subject", subject, "gvr", n.gvr.String())
-		// Close the gap between the initial list and the subscription becoming
-		// active: a change published in that window (including while Subscribe was
-		// retrying because the bus was not yet ready) had no interest and was
-		// dropped by core NATS. Reconcile from a fresh list now that live events
-		// flow, so a startup write is caught immediately rather than at the next
-		// resync tick.
-		_ = n.relist(ctx, false)
-		return true
-	}
-
-	subscribed := subscribe()
-
 	resync := time.NewTicker(n.resync)
 	defer resync.Stop()
-	retry := time.NewTicker(n.retryInterval)
-	defer retry.Stop()
 	for {
 		select {
 		case <-ctx.Done():
@@ -273,10 +264,6 @@ func (n *Informer) Run(stopCh <-chan struct{}) {
 		case <-n.reconnect:
 			n.log.Debug("nats reconnected; re-listing", "gvr", n.gvr.String())
 			_ = n.relist(ctx, false)
-		case <-retry.C:
-			if !subscribed {
-				subscribed = subscribe()
-			}
 		}
 	}
 }

--- a/pkg/storage/unified/informer/informer_test.go
+++ b/pkg/storage/unified/informer/informer_test.go
@@ -319,11 +319,11 @@ func TestInformer_ReconnectTriggersRelist(t *testing.T) {
 
 	sub.waitForSubscription(t, subject())
 	require.Eventually(t, n.HasSynced, 5*time.Second, 5*time.Millisecond, "informer never synced")
-	// Let startup settle: the initial list plus the gap-closing list that runs once
-	// the subscription is active. Only a reconnect can push the count beyond this
-	// (the resync is an hour away).
-	require.Eventually(t, func() bool { return calls.Load() >= 2 }, 5*time.Second, 5*time.Millisecond,
-		"initial and post-subscribe re-list should have run")
+	// Startup lists exactly once (the subscription is opened before the list, so
+	// there is no gap-closing re-list). Only the reconnect can push the count up —
+	// the resync is an hour away.
+	require.Eventually(t, func() bool { return calls.Load() == 1 }, 5*time.Second, 5*time.Millisecond,
+		"startup should have listed once")
 	before := calls.Load()
 
 	n.signalReconnect()
@@ -333,8 +333,9 @@ func TestInformer_ReconnectTriggersRelist(t *testing.T) {
 }
 
 // A subscribe failure (e.g. the embedded NATS server not yet started, so no
-// client URL) is not fatal: the informer still syncs from the initial re-list,
-// retries the subscription, and delivers live events once it opens.
+// client URL) is not fatal but does gate startup: the informer retries the
+// subscription and only lists / reports HasSynced once it opens, then delivers
+// live events.
 func TestInformer_RetriesSubscribeUntilAvailable(t *testing.T) {
 	sub := newFakeSubscriber()
 	sub.failSubscribes(2) // first two attempts fail, then it succeeds
@@ -349,24 +350,24 @@ func TestInformer_RetriesSubscribeUntilAvailable(t *testing.T) {
 	go n.Run(stopCh)
 	t.Cleanup(func() { close(stopCh) })
 
-	// HasSynced fires from the initial re-list even though subscribing failed.
-	require.Eventually(t, n.HasSynced, 5*time.Second, 5*time.Millisecond, "informer must sync despite subscribe failure")
+	// The subscription opens only after the retries succeed; the initial list and
+	// HasSynced follow it.
+	sub.waitForSubscription(t, subject())
+	require.Eventually(t, n.HasSynced, 5*time.Second, 5*time.Millisecond, "informer must sync once subscribed")
 	assert.Equal(t, []string{"a"}, handler.addedNames(), "initial list must be delivered")
 
-	// The retry eventually opens the subscription, and live events then flow.
-	sub.waitForSubscription(t, subject())
+	// Live events then flow.
 	sub.publish(t, subject(), event(resourcepb.WatchNotification_ADDED, "fresh"))
 	require.Eventually(t, func() bool {
 		return len(handler.addedNames()) == 2
-	}, 5*time.Second, 5*time.Millisecond, "live events must flow once the retry subscribes")
+	}, 5*time.Second, 5*time.Millisecond, "live events must flow once subscribed")
 	assert.Equal(t, []string{"a", "fresh"}, handler.addedNames())
 }
 
-// After the subscription opens, the informer re-lists once more to close the
-// window between the initial list and the subscription becoming active, so a
-// write published in that gap is reconciled immediately rather than at the next
-// resync tick.
-func TestInformer_RelistsAfterSubscribing(t *testing.T) {
+// The subscription is opened before the initial list, so at startup the informer
+// lists exactly once (no separate gap-closing re-list); only a resync or reconnect
+// lists again.
+func TestInformer_SubscribesBeforeListingOnce(t *testing.T) {
 	sub := newFakeSubscriber()
 	handler := &recordingHandler{}
 
@@ -375,7 +376,7 @@ func TestInformer_RelistsAfterSubscribing(t *testing.T) {
 		calls.Add(1)
 		return []runtime.Object{obj("a")}, nil
 	}
-	// A one-hour resync guarantees any extra list came from the subscribe step.
+	// A one-hour resync guarantees no extra list fires on its own at startup.
 	n := NewInformer(sub, testGVR, testNamespace, time.Hour, testQueueGroup, NewStore(), newObjectFunc, list)
 	_, err := n.AddEventHandler(handler)
 	require.NoError(t, err)
@@ -383,12 +384,11 @@ func TestInformer_RelistsAfterSubscribing(t *testing.T) {
 	go n.Run(stopCh)
 	t.Cleanup(func() { close(stopCh) })
 
+	// The subscription opens first, then the single initial list marks synced.
 	sub.waitForSubscription(t, subject())
-	// Initial list + one gap-closing list once the subscription is active.
-	require.Eventually(t, func() bool { return calls.Load() >= 2 }, 5*time.Second, 5*time.Millisecond,
-		"must re-list once after subscribing")
-	// And no further lists without a resync/reconnect.
-	require.Never(t, func() bool { return calls.Load() > 2 }, 50*time.Millisecond, 10*time.Millisecond)
+	require.Eventually(t, n.HasSynced, 5*time.Second, 5*time.Millisecond, "informer never synced")
+	require.Never(t, func() bool { return calls.Load() != 1 }, 100*time.Millisecond, 10*time.Millisecond,
+		"startup must list exactly once")
 }
 
 // A failing initial list must not mark the informer synced: HasSynced stays false


### PR DESCRIPTION
## What

Follow-up to #127660. The NATS-backed provisioning informer now opens its subscription **before** performing the initial list, instead of list-then-subscribe.

## Why

Previously `Run` listed and marked `HasSynced` first, then subscribed. Two problems:

- **Dropped startup writes.** A change published in the window between the initial list and the subscription becoming active had no registered interest, so core NATS dropped it (no replay). The controller only caught it at the next resync (up to 60s later).
- **Re-listing without a watch.** If the subscription couldn't be created yet (e.g. the embedded NATS server hadn't come up and had no client URL), the informer still listed and synced, starting the controller against a snapshot that would receive no live updates until the next resync.

## How

`Run` now:
1. Opens the live subscription first, retrying on `retryInterval` until it succeeds. It does **not** list or report `HasSynced` while it still can't subscribe.
2. Only then performs the initial list (retrying until it succeeds) and marks `HasSynced`.
3. Serves live notifications, the periodic resync, and reconnect-driven re-lists.

Because the subscription is active before the list runs, events published during the list are delivered live — so the previous "gap-closing re-list after subscribe" is no longer needed and is removed. Re-list-only informers (nil `newObject`, or a disabled subscriber — e.g. historic-jobs) are unaffected: they have no subscription to wait for and list/sync immediately as before.

**Behavior note:** for a subscribing informer, `HasSynced` now waits for the subscription. At startup that's a brief wait; if NATS is permanently unreachable, that informer's controller stays blocked on `WaitForCacheSync` rather than falling back to poll-only. This is intentional (don't reconcile from a source you can't watch), and reverses the earlier "HasSynced gated on the list, not the bus" note on #127660.

## Testing

- `go test -race ./pkg/storage/unified/informer/ ./pkg/registry/apis/provisioning/informer/` — pass.
- Updated/added coverage: subscribe-then-sync ordering (`TestInformer_RetriesSubscribeUntilAvailable`), startup lists exactly once with no gap-close (`TestInformer_SubscribesBeforeListingOnce`), reconnect still triggers a re-list, initial-list retry still gates `HasSynced`, and the OnAdd-on-new-key re-list semantics are unchanged.
- `gofmt`/`go vet` clean; builds across `pkg/storage/unified/...` and `pkg/registry/apis/provisioning/...`.

## Checklist

- [x] Tests added/updated
- [x] No API changes (internal to the informer's Run loop)
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)