### PR TITLE
Dashboards: Stop reading legacy drilldown feature toggles

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -139,11 +139,9 @@ export function DashboardEditPaneRenderer({ dashboard }: Props) {
             data-testid={selectors.pages.Dashboard.Sidebar.outlineButton}
             active={openPane instanceof DashboardOutline}
           />
-          {config.featureToggles.dashboardNewLayouts &&
-            (config.featureToggles.dashboardFiltersOverview ||
-              config.featureToggles.dashboardUnifiedDrilldownControls) && (
-              <FiltersOverviewButton editPane={editPane} openPane={openPane} />
-            )}
+          {config.featureToggles.dashboardNewLayouts && config.featureToggles.dashboardUnifiedDrilldownControls && (
+            <FiltersOverviewButton editPane={editPane} openPane={openPane} />
+          )}
           {dashboard.isManaged() && Boolean(meta.canEdit) && <ManagedDashboardNavBarBadge dashboard={dashboard} />}
           {renderEnterpriseItems()}
           {viewPanel && viewPanelPane && (

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
@@ -435,7 +435,7 @@ describe('getDashboardChanges', () => {
   });
 });
 
-describe('getDashboardChanges with adHocFilterDefaultValues', () => {
+describe('getDashboardChanges with dashboardUnifiedDrilldownControls', () => {
   const makeDashboardWithAdhoc = (filters: AdHocVariableFilter[]): Dashboard => {
     return {
       id: 1,
@@ -451,12 +451,12 @@ describe('getDashboardChanges with adHocFilterDefaultValues', () => {
   };
 
   afterEach(() => {
-    config.featureToggles.adHocFilterDefaultValues = false;
+    config.featureToggles.dashboardUnifiedDrilldownControls = false;
   });
 
   describe('when feature flag is enabled', () => {
     beforeEach(() => {
-      config.featureToggles.adHocFilterDefaultValues = true;
+      config.featureToggles.dashboardUnifiedDrilldownControls = true;
     });
 
     it('should not report variable value changes when only origin filters differ', () => {
@@ -532,7 +532,7 @@ describe('getDashboardChanges with adHocFilterDefaultValues', () => {
 
   describe('when feature flag is disabled', () => {
     beforeEach(() => {
-      config.featureToggles.adHocFilterDefaultValues = false;
+      config.featureToggles.dashboardUnifiedDrilldownControls = false;
     });
 
     it('should not report variable value changes when only origin filters differ', () => {

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -210,10 +210,10 @@ function applyVariableKindListChanges(
       variable.kind === 'AdhocVariable' &&
       original.kind === 'AdhocVariable' &&
       !adHocVariableFiltersEqual(
-        config.featureToggles.adHocFilterDefaultValues || config.featureToggles.dashboardUnifiedDrilldownControls
+        config.featureToggles.dashboardUnifiedDrilldownControls
           ? variable.spec.filters.filter((f) => !f.origin)
           : variable.spec.filters,
-        config.featureToggles.adHocFilterDefaultValues || config.featureToggles.dashboardUnifiedDrilldownControls
+        config.featureToggles.dashboardUnifiedDrilldownControls
           ? original.spec.filters.filter((f) => !f.origin)
           : original.spec.filters
       )
@@ -223,7 +223,7 @@ function applyVariableKindListChanges(
 
     if (!saveVariables) {
       if (variable.kind === 'AdhocVariable' && original.kind === 'AdhocVariable') {
-        if (config.featureToggles.adHocFilterDefaultValues || config.featureToggles.dashboardUnifiedDrilldownControls) {
+        if (config.featureToggles.dashboardUnifiedDrilldownControls) {
           const originFilters = (variable.spec.filters ?? []).filter((f) => f.origin);
           const originalRuntimeFilters = (original.spec.filters ?? []).filter((f) => !f.origin);
           variable.spec.filters = [...originFilters, ...originalRuntimeFilters];
@@ -330,7 +330,7 @@ function applyVariableChanges(saveModel: Dashboard, originalSaveModel: Dashboard
       const typed = variable as TypedVariableModel;
 
       if (typed.type === 'adhoc') {
-        if (config.featureToggles.adHocFilterDefaultValues || config.featureToggles.dashboardUnifiedDrilldownControls) {
+        if (config.featureToggles.dashboardUnifiedDrilldownControls) {
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const changedFilters = (typed as AdHocVariableModel).filters ?? [];
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -278,12 +278,11 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
             <DashboardControlActions dashboard={dashboard} hidePlaylistNav={hidePlaylistNav} />
           </div>
         )}
-        {(config.featureToggles.dashboardFiltersOverview || config.featureToggles.dashboardUnifiedDrilldownControls) &&
-          !config.featureToggles.dashboardNewLayouts && (
-            <div className={styles.fixedControls}>
-              <DashboardFiltersOverviewPaneToggle dashboard={dashboard} />
-            </div>
-          )}
+        {config.featureToggles.dashboardUnifiedDrilldownControls && !config.featureToggles.dashboardNewLayouts && (
+          <div className={styles.fixedControls}>
+            <DashboardFiltersOverviewPaneToggle dashboard={dashboard} />
+          </div>
+        )}
       </div>
       {config.featureToggles.scopeFilters && !editPanel && (
         <ContextualNavigationPaneToggle className={styles.contextualNavToggle} hideWhenOpen={true} />

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -92,8 +92,7 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
     $data: createPanelDataProvider(panel),
     titleItems,
     headerActions: new VizPanelHeaderActions({
-      hideGroupByAction:
-        !config.featureToggles.panelGroupBy && !config.featureToggles.dashboardUnifiedDrilldownControls,
+      hideGroupByAction: !config.featureToggles.dashboardUnifiedDrilldownControls,
     }),
     subHeader: new VizPanelSubHeader({
       hideNonApplicableDrilldowns: !config.featureToggles.perPanelNonApplicableDrilldowns,
@@ -158,8 +157,7 @@ export function buildLibraryPanel(panel: LibraryPanelKind, id?: number): VizPane
     ],
     extendPanelContext: setDashboardPanelContext,
     headerActions: new VizPanelHeaderActions({
-      hideGroupByAction:
-        !config.featureToggles.panelGroupBy && !config.featureToggles.dashboardUnifiedDrilldownControls,
+      hideGroupByAction: !config.featureToggles.dashboardUnifiedDrilldownControls,
     }),
     pluginId: LibraryPanelBehavior.LOADING_VIZ_PANEL_PLUGIN_ID,
     title: panel.spec.title,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -377,8 +377,7 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       defaultKeys: variable.spec.defaultKeys.length ? variable.spec.defaultKeys : undefined,
       useQueriesAsFilterForOptions: true,
       applicabilityEnabled: !!config.featureToggles.perPanelNonApplicableDrilldowns,
-      drilldownRecommendationsEnabled:
-        config.featureToggles.drilldownRecommendations || config.featureToggles.dashboardUnifiedDrilldownControls,
+      drilldownRecommendationsEnabled: config.featureToggles.dashboardUnifiedDrilldownControls,
       $behaviors: [new ReportInteractionBehavior({})],
       supportsMultiValueOperators: Boolean(
         getDataSourceSrv().getInstanceSettings({ type: ds?.type })?.meta.multiValueFilterOperators
@@ -526,8 +525,7 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       isMulti: variable.spec.multi,
       hide: transformVariableHideToEnumV1(variable.spec.hide),
       applicabilityEnabled: !!config.featureToggles.perPanelNonApplicableDrilldowns,
-      drilldownRecommendationsEnabled:
-        config.featureToggles.drilldownRecommendations || config.featureToggles.dashboardUnifiedDrilldownControls,
+      drilldownRecommendationsEnabled: config.featureToggles.dashboardUnifiedDrilldownControls,
       // @ts-expect-error
       defaultOptions: variable.options,
       defaultValue: variable.spec.defaultValue

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -491,8 +491,7 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
     $data: createPanelDataProvider(panel),
     titleItems,
     headerActions: new VizPanelHeaderActions({
-      hideGroupByAction:
-        !config.featureToggles.panelGroupBy && !config.featureToggles.dashboardUnifiedDrilldownControls,
+      hideGroupByAction: !config.featureToggles.dashboardUnifiedDrilldownControls,
     }),
     subHeader: new VizPanelSubHeader({
       hideNonApplicableDrilldowns: !config.featureToggles.perPanelNonApplicableDrilldowns,

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
@@ -228,11 +228,9 @@ describe('AdHocFiltersVariableEditor', () => {
   describe('default group-by origin', () => {
     afterEach(() => {
       config.featureToggles.dashboardUnifiedDrilldownControls = false;
-      config.featureToggles.adHocFilterDefaultValues = false;
     });
 
     it('should show default group by editor when both flags are on and enableGroupBy is true', async () => {
-      config.featureToggles.adHocFilterDefaultValues = true;
       config.featureToggles.dashboardUnifiedDrilldownControls = true;
       getGroupByKeysMock = () => Promise.resolve([]);
 
@@ -245,7 +243,6 @@ describe('AdHocFiltersVariableEditor', () => {
     });
 
     it('should not show default group by editor when enableGroupBy is off', async () => {
-      config.featureToggles.adHocFilterDefaultValues = true;
       config.featureToggles.dashboardUnifiedDrilldownControls = true;
       getGroupByKeysMock = () => Promise.resolve([]);
 
@@ -257,21 +254,17 @@ describe('AdHocFiltersVariableEditor', () => {
       expect(renderer.queryByTestId('default-groupby-editor')).not.toBeInTheDocument();
     });
 
-    it('should not show default group by editor when dashboardUnifiedDrilldownControls is off', async () => {
-      config.featureToggles.adHocFilterDefaultValues = true;
+    it('should not show origin filters or default group by editor when dashboardUnifiedDrilldownControls is off', async () => {
       config.featureToggles.dashboardUnifiedDrilldownControls = false;
       getGroupByKeysMock = () => Promise.resolve([]);
 
       const { renderer } = await setup(undefined, { enableGroupBy: true });
 
-      await waitFor(() => {
-        expect(renderer.getByTestId('origin-filters-editor')).toBeInTheDocument();
-      });
+      expect(renderer.queryByTestId('origin-filters-editor')).not.toBeInTheDocument();
       expect(renderer.queryByTestId('default-groupby-editor')).not.toBeInTheDocument();
     });
 
     it('should update originFilters when group-by selection changes', async () => {
-      config.featureToggles.adHocFilterDefaultValues = true;
       config.featureToggles.dashboardUnifiedDrilldownControls = true;
       getGroupByKeysMock = () => Promise.resolve([]);
 
@@ -297,7 +290,6 @@ describe('AdHocFiltersVariableEditor', () => {
     });
 
     it('adhoc controller should not have enableGroupBy property', async () => {
-      config.featureToggles.adHocFilterDefaultValues = true;
       config.featureToggles.dashboardUnifiedDrilldownControls = true;
       getGroupByKeysMock = () => Promise.resolve([]);
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -59,7 +59,7 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
   );
 
   const originFiltersController = useMemo(() => {
-    if (!config.featureToggles.adHocFilterDefaultValues && !config.featureToggles.dashboardUnifiedDrilldownControls) {
+    if (!config.featureToggles.dashboardUnifiedDrilldownControls) {
       return undefined;
     }
 

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -303,8 +303,7 @@ export function getDefaultVizPanel(): VizPanel {
       $behaviors: [panelMenuBehavior],
     }),
     headerActions: new VizPanelHeaderActions({
-      hideGroupByAction:
-        !config.featureToggles.panelGroupBy && !config.featureToggles.dashboardUnifiedDrilldownControls,
+      hideGroupByAction: !config.featureToggles.dashboardUnifiedDrilldownControls,
     }),
     $data: datasourceSettings
       ? new SceneDataTransformer({

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -229,8 +229,7 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       allowCustomValue: variable.allowCustomValue,
       useQueriesAsFilterForOptions: true,
       applicabilityEnabled: !!config.featureToggles.perPanelNonApplicableDrilldowns,
-      drilldownRecommendationsEnabled:
-        config.featureToggles.drilldownRecommendations || config.featureToggles.dashboardUnifiedDrilldownControls,
+      drilldownRecommendationsEnabled: config.featureToggles.dashboardUnifiedDrilldownControls,
       collapsible: config.featureToggles.dashboardUnifiedDrilldownControls,
       supportsMultiValueOperators: Boolean(
         getDataSourceSrv().getInstanceSettings({ type: variable.datasource?.type })?.meta.multiValueFilterOperators
@@ -367,8 +366,7 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       defaultValue: variable.defaultValue,
       allowCustomValue: variable.allowCustomValue,
       applicabilityEnabled: !!config.featureToggles.perPanelNonApplicableDrilldowns,
-      drilldownRecommendationsEnabled:
-        config.featureToggles.drilldownRecommendations || config.featureToggles.dashboardUnifiedDrilldownControls,
+      drilldownRecommendationsEnabled: config.featureToggles.dashboardUnifiedDrilldownControls,
     });
     // Switch variable
     // In the old variable model we are storing the enabled and disabled values in the options:

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -183,8 +183,7 @@ export const TimeSeriesPanel = ({
 
                   const groupingFilters =
                     seriesIdx !== null &&
-                    (config.featureToggles.perPanelFiltering ||
-                      config.featureToggles.dashboardUnifiedDrilldownControls) &&
+                    config.featureToggles.dashboardUnifiedDrilldownControls &&
                     getFiltersBasedOnGrouping
                       ? getGroupedFilters(alignedFrame, seriesIdx, getFiltersBasedOnGrouping)
                       : [];
@@ -204,8 +203,7 @@ export const TimeSeriesPanel = ({
                       replaceVariables={replaceVariables}
                       dataLinks={dataLinks}
                       filterByGroupedLabels={
-                        (config.featureToggles.perPanelFiltering ||
-                          config.featureToggles.dashboardUnifiedDrilldownControls) &&
+                        config.featureToggles.dashboardUnifiedDrilldownControls &&
                         groupingFilters.length &&
                         onAddAdHocFilters
                           ? {


### PR DESCRIPTION
**What is this feature?**

Removes all frontend usages of five feature toggles that have been superseded by the GA `dashboardUnifiedDrilldownControls` toggle (enabled by default):

- `perPanelFiltering`
- `drilldownRecommendations`
- `panelGroupBy`
- `adHocFilterDefaultValues`
- `dashboardFiltersOverview`

Every usage read the old toggle in an `oldToggle || dashboardUnifiedDrilldownControls` (or `!oldToggle && !dashboardUnifiedDrilldownControls`) expression, so each check collapses to `dashboardUnifiedDrilldownControls` alone. This is behavior-preserving: `dashboardUnifiedDrilldownControls` is GA and on by default, and all five old toggles defaulted to off.

This is the first of two PRs. It only removes the *usages*; the toggle definitions and generated files are removed in a follow-up so `main` stays green (the generated TS types are produced from the registry). This PR must merge first.

**Why do we need this feature?**

The five experimental/preview toggles are fully replaced by `dashboardUnifiedDrilldownControls`. Removing the dead conditionals simplifies the code ahead of deleting the toggles themselves.

**Who is this feature for?**

Grafana maintainers / dashboards squad — no user-facing behavior change.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Frontend-only; no registry or generated-file changes here (they live in the stacked follow-up PR).
- The only intentional behavior change: a user who explicitly *disabled* `dashboardUnifiedDrilldownControls` but *enabled* one of the old experimental toggles loses that path — which is the point of the deprecation.
- `AdHocFiltersVariableEditor.test.tsx`: one test's premise genuinely changed — since origin filters are now gated solely on `dashboardUnifiedDrilldownControls`, turning it off hides both the origin-filters and default-group-by editors, so the assertion was updated accordingly.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
