### PR TITLE
Plugins: Extract parameters and links from step Description/Resolution for Advisor app

### DIFF
--- a/apps/advisor/kinds/checktype.cue
+++ b/apps/advisor/kinds/checktype.cue
@@ -29,8 +29,8 @@ checktypev0alpha1: {
 			stepID: string
 			// resolution follows the same template + args + links contract as
 			// description above.
-			resolution:       string
-			resolutionArgs?:  [string]: string
+			resolution: string
+			resolutionArgs?: [string]: string
 			resolutionLinks?: [...#Link]
 		}
 		spec: {

--- a/apps/advisor/kinds/checktype.cue
+++ b/apps/advisor/kinds/checktype.cue
@@ -5,11 +5,33 @@ checktypev0alpha1: {
 	plural: "checktypes"
 	scope:  "Namespaced"
 	schema: {
+		// A named URL that the frontend substitutes into a description/resolution
+		// template via i18next's <Trans> component. The template refers to the
+		// link by name (e.g. "<docs>text</docs>"), so translators never see or
+		// touch URLs — they stay in code alongside the check.
+		#Link: {
+			name: string
+			url:  string
+		}
 		#Step: {
-			title:       string
+			title: string
+			// description may be a template containing named placeholders like
+			// "{{version}}" for values (see descriptionArgs) and "<docs>text</docs>"
+			// for links (see descriptionLinks). Frontend interpolates via
+			// @grafana/i18n's t()/<Trans>.
 			description: string
-			stepID:      string
-			resolution:  string
+			// Values substituted into description placeholders like "{{name}}".
+			// Names that must NOT be translated (product names, IDs, versions)
+			// belong here, not inline in the description text.
+			descriptionArgs?: [string]: string
+			// Named URLs substituted into description via i18next <Trans> tags.
+			descriptionLinks?: [...#Link]
+			stepID: string
+			// resolution follows the same template + args + links contract as
+			// description above.
+			resolution:       string
+			resolutionArgs?:  [string]: string
+			resolutionLinks?: [...#Link]
 		}
 		spec: {
 			name: string

--- a/apps/advisor/pkg/app/checks/authchecks/list_format_validation.go
+++ b/apps/advisor/pkg/app/checks/authchecks/list_format_validation.go
@@ -45,7 +45,19 @@ func (s *listFormatValidation) Description() string {
 }
 
 func (s *listFormatValidation) Resolution() string {
-	return "Configure the relevant SSO setting using a valid format, like space-separated (\"opt1 opt2\"), comma-separated values (\"opt1, opt2\") or JSON array format ([\"opt1\", \"opt2\"])."
+	return "Configure the relevant SSO setting using a valid format, like space-separated ({{spaceExample}}), " +
+		"comma-separated values ({{commaExample}}) or JSON array format ({{jsonExample}})."
+}
+
+// ResolutionArgs keeps the code examples out of the translatable text so
+// translators can't accidentally localise the option names or break the
+// bracket/quote syntax.
+func (s *listFormatValidation) ResolutionArgs() map[string]string {
+	return map[string]string{
+		"spaceExample": `"opt1 opt2"`,
+		"commaExample": `"opt1, opt2"`,
+		"jsonExample":  `["opt1", "opt2"]`,
+	}
 }
 
 func (s *listFormatValidation) Run(ctx context.Context, log logging.Logger, _ *advisor.CheckSpec, objToCheck any) ([]advisor.CheckReportFailure, error) {

--- a/apps/advisor/pkg/app/checks/authchecks/list_format_validation_test.go
+++ b/apps/advisor/pkg/app/checks/authchecks/list_format_validation_test.go
@@ -20,7 +20,13 @@ func TestListFormatValidation_Methods(t *testing.T) {
 	require.Equal(t, ListFormatValidationStepID, validator.ID())
 	require.Equal(t, "SSO List Setting Format Validation", validator.Title())
 	require.Equal(t, "Checks if list configs in SSO settings are in a valid list format (space-separated, comma-separated or JSON array).", validator.Description())
-	require.Equal(t, "Configure the relevant SSO setting using a valid format, like space-separated (\"opt1 opt2\"), comma-separated values (\"opt1, opt2\") or JSON array format ([\"opt1\", \"opt2\"]).", validator.Resolution())
+	// Resolution() returns a template; the rendered English is what actually
+	// reaches the frontend via the registerer (via checks.RenderResolution).
+	require.Equal(t, "Configure the relevant SSO setting using a valid format, like space-separated ({{spaceExample}}), comma-separated values ({{commaExample}}) or JSON array format ({{jsonExample}}).", validator.Resolution())
+	require.Equal(t,
+		`Configure the relevant SSO setting using a valid format, like space-separated ("opt1 opt2"), comma-separated values ("opt1, opt2") or JSON array format (["opt1", "opt2"]).`,
+		checks.RenderResolution(validator),
+	)
 }
 
 func TestListFormatValidation_Run(t *testing.T) {

--- a/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
@@ -23,7 +23,21 @@ func (s *promDepAuthStep) Description() string {
 }
 
 func (s *promDepAuthStep) Resolution() string {
-	return fmt.Sprintf("Make sure that 'Azure Monitor Managed Service for Prometheus' and/or 'Amazon Managed Service for Prometheus' plugins are installed. If the data source is provisioned, edit data source type in the provisioning file to use '%s' or '%s'.", datasources.DS_AMAZON_PROMETHEUS, datasources.DS_AZURE_PROMETHEUS)
+	return "Make sure that '{{azureProduct}}' and/or '{{amazonProduct}}' plugins are installed. " +
+		"If the data source is provisioned, edit data source type in the provisioning file to use '{{amazonID}}' or '{{azureID}}'."
+}
+
+// ResolutionArgs keeps product names and plugin IDs out of the translatable
+// text — translators see stable "{{name}}" tokens instead. Product names
+// aren't localised anywhere in Grafana; plugin IDs are code identifiers that
+// must match the actual registered plugins.
+func (s *promDepAuthStep) ResolutionArgs() map[string]string {
+	return map[string]string{
+		"azureProduct":  "Azure Monitor Managed Service for Prometheus",
+		"amazonProduct": "Amazon Managed Service for Prometheus",
+		"amazonID":      datasources.DS_AMAZON_PROMETHEUS,
+		"azureID":       datasources.DS_AZURE_PROMETHEUS,
+	}
 }
 
 func (s *promDepAuthStep) ID() string {

--- a/apps/advisor/pkg/app/checks/datasourcecheck/uid_validation_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/uid_validation_step.go
@@ -26,8 +26,13 @@ func (s *uidValidationStep) Description() string {
 }
 
 func (s *uidValidationStep) Resolution() string {
-	return "Check the <a href='https://grafana.com/docs/grafana/latest/upgrade-guide/upgrade-v11.2/#grafana-data-source-uid-format-enforcement'" +
-		"target=_blank>documentation</a> for more information or delete the data source and create a new one."
+	return "Check the <docs>documentation</docs> for more information or delete the data source and create a new one."
+}
+
+func (s *uidValidationStep) ResolutionLinks() map[string]string {
+	return map[string]string{
+		"docs": "https://grafana.com/docs/grafana/latest/upgrade-guide/upgrade-v11.2/#grafana-data-source-uid-format-enforcement",
+	}
 }
 
 func (s *uidValidationStep) Run(ctx context.Context, log logging.Logger, obj *advisor.CheckSpec, i any) ([]advisor.CheckReportFailure, error) {

--- a/apps/advisor/pkg/app/checks/instancechecks/out_of_support_step.go
+++ b/apps/advisor/pkg/app/checks/instancechecks/out_of_support_step.go
@@ -35,9 +35,13 @@ func (s *outOfSupportVersionStep) Description() string {
 
 func (s *outOfSupportVersionStep) Resolution() string {
 	return "Out of support versions will not receive security updates or bug fixes. " +
-		"Upgrade to a more recent version. " +
-		"<a href='https://grafana.com/docs/grafana/latest/upgrade-guide/when-to-upgrade/#what-to-know-about-version-support' target='_blank'>" +
-		"Learn more about version support</a>."
+		"Upgrade to a more recent version. <docs>Learn more about version support</docs>."
+}
+
+func (s *outOfSupportVersionStep) ResolutionLinks() map[string]string {
+	return map[string]string{
+		"docs": "https://grafana.com/docs/grafana/latest/upgrade-guide/when-to-upgrade/#what-to-know-about-version-support",
+	}
 }
 
 func (s *outOfSupportVersionStep) ID() string {

--- a/apps/advisor/pkg/app/checks/instancechecks/pinned_version_step.go
+++ b/apps/advisor/pkg/app/checks/instancechecks/pinned_version_step.go
@@ -29,8 +29,13 @@ func (s *pinnedVersionStep) Description() string {
 
 func (s *pinnedVersionStep) Resolution() string {
 	return "You may miss out on security updates and bug fixes if you use a pinned version. " +
-		"Contact your Grafana administrator and open a " +
-		"<a href='https://grafana.com/profile/org#support' target=_blank>support ticket</a> to help you get unpinned."
+		"Contact your Grafana administrator and open a <support>support ticket</support> to help you get unpinned."
+}
+
+func (s *pinnedVersionStep) ResolutionLinks() map[string]string {
+	return map[string]string{
+		"support": "https://grafana.com/profile/org#support",
+	}
 }
 
 func (s *pinnedVersionStep) ID() string {

--- a/apps/advisor/pkg/app/checks/plugincheck/deprecation_step.go
+++ b/apps/advisor/pkg/app/checks/plugincheck/deprecation_step.go
@@ -30,8 +30,13 @@ func (s *deprecationStep) Description() string {
 }
 
 func (s *deprecationStep) Resolution() string {
-	return "Check the <a href='https://grafana.com/legal/plugin-deprecation/#a-plugin-i-use-is-deprecated-what-should-i-do'" +
-		"target=_blank>documentation</a> for recommended steps or delete the plugin."
+	return "Check the <docs>documentation</docs> for recommended steps or delete the plugin."
+}
+
+func (s *deprecationStep) ResolutionLinks() map[string]string {
+	return map[string]string{
+		"docs": "https://grafana.com/legal/plugin-deprecation/#a-plugin-i-use-is-deprecated-what-should-i-do",
+	}
 }
 
 func (s *deprecationStep) ID() string {

--- a/apps/advisor/pkg/app/checks/plugincheck/twinmaker_sceneviewer_step.go
+++ b/apps/advisor/pkg/app/checks/plugincheck/twinmaker_sceneviewer_step.go
@@ -10,9 +10,12 @@ import (
 )
 
 const (
-	twinmakerSceneViewerStepID  = "twinmaker_sceneviewer"
-	twinmakerAppPluginID        = "grafana-iot-twinmaker-app"
-	twinmakerSceneViewerMessage = "The SceneViewer panel in the TwinMaker App will stop working in Grafana 13.1. Ignore or silence this warning if you are not using the SceneViewer panel."
+	twinmakerSceneViewerStepID = "twinmaker_sceneviewer"
+	twinmakerAppPluginID       = "grafana-iot-twinmaker-app"
+	// twinmakerDeprecationVersion is the single source of truth for the
+	// Grafana version in which SceneViewer stops working. Referenced by the
+	// step Description/Resolution templates via {{version}}.
+	twinmakerDeprecationVersion = "13.1"
 )
 
 var _ checks.Step = &twinmakerSceneViewerStep{}
@@ -24,11 +27,20 @@ func (s *twinmakerSceneViewerStep) Title() string {
 }
 
 func (s *twinmakerSceneViewerStep) Description() string {
-	return "Warns when the Grafana IoT TwinMaker App is installed that the SceneViewer panel will stop working in Grafana 13.1."
+	return "Warns when the Grafana IoT TwinMaker App is installed that the SceneViewer panel will stop working in Grafana {{version}}."
+}
+
+func (s *twinmakerSceneViewerStep) DescriptionArgs() map[string]string {
+	return map[string]string{"version": twinmakerDeprecationVersion}
 }
 
 func (s *twinmakerSceneViewerStep) Resolution() string {
-	return twinmakerSceneViewerMessage
+	return "The SceneViewer panel in the TwinMaker App will stop working in Grafana {{version}}. " +
+		"Ignore or silence this warning if you are not using the SceneViewer panel."
+}
+
+func (s *twinmakerSceneViewerStep) ResolutionArgs() map[string]string {
+	return map[string]string{"version": twinmakerDeprecationVersion}
 }
 
 func (s *twinmakerSceneViewerStep) ID() string {
@@ -48,7 +60,7 @@ func (s *twinmakerSceneViewerStep) Run(_ context.Context, log logging.Logger, _ 
 	return []advisor.CheckReportFailure{checks.NewCheckReportFailure(
 		advisor.CheckReportFailureSeverityLow,
 		s.ID(),
-		twinmakerSceneViewerMessage,
+		checks.RenderResolution(s),
 		twinmakerSceneViewerStepID,
 		[]advisor.CheckErrorLink{
 			{

--- a/apps/advisor/pkg/app/checks/template.go
+++ b/apps/advisor/pkg/app/checks/template.go
@@ -1,0 +1,125 @@
+package checks
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Steps whose Description or Resolution contain parameterised values or links
+// implement one or more of the small capability interfaces below, exposing
+// those parts separately from the surrounding text. Each interface is
+// independent so a step only implements what it actually has; a step with
+// only a link in its Resolution needs just ResolutionLinker.
+//
+// The Description() and Resolution() methods on such a step return a TEMPLATE
+// with two kinds of placeholder:
+//
+//   - "{{name}}" for values, resolved from the corresponding *Args map.
+//   - "<name>visible text</name>" for links, resolved from the *Links map.
+//
+// Rendering is done by Render() in this package. The registerer calls Render
+// at startup to bake the English form into the CheckType resource; the
+// /translations endpoint (added in a follow-up PR) will call the same Render
+// with localised templates.
+//
+// Steps that don't need any placeholders implement none of these interfaces —
+// their Description/Resolution strings pass through Render as-is.
+
+// DescriptionArgser reports the value substitutions used in Description().
+// Values are inserted verbatim and are NOT translated.
+type DescriptionArgser interface {
+	DescriptionArgs() map[string]string
+}
+
+// DescriptionLinker reports the link URLs referenced in Description().
+// A "<name>text</name>" span becomes an anchor pointing to the mapped URL.
+type DescriptionLinker interface {
+	DescriptionLinks() map[string]string
+}
+
+// ResolutionArgser reports the value substitutions used in Resolution().
+type ResolutionArgser interface {
+	ResolutionArgs() map[string]string
+}
+
+// ResolutionLinker reports the link URLs referenced in Resolution().
+type ResolutionLinker interface {
+	ResolutionLinks() map[string]string
+}
+
+// linkTagPattern matches a "<open>visible text</close>" span. RE2 doesn't
+// support backreferences, so we capture the opening name and the closing name
+// separately and enforce equality in Go code. The visible text may not contain
+// '<' so we don't accidentally match across nested tags (we don't support
+// nesting).
+var linkTagPattern = regexp.MustCompile(`<([a-zA-Z][a-zA-Z0-9_-]*)>([^<]*)</([a-zA-Z][a-zA-Z0-9_-]*)>`)
+
+// argPlaceholder builds the "{{name}}" token we substitute.
+func argPlaceholder(name string) string {
+	return "{{" + name + "}}"
+}
+
+// Render substitutes {{name}} argument placeholders and <name>text</name> link
+// spans in template. It's the single source of truth for how backend-owned
+// templated strings become the HTML that reaches the frontend.
+//
+// Args are inserted verbatim (no HTML escaping — they're trusted Go constants,
+// never user input). Links are rendered as anchors with target=_blank and
+// rel="noopener noreferrer". A tag whose name has no matching entry in links
+// is left in place unchanged, which surfaces the mistake visibly rather than
+// silently dropping content.
+func Render(template string, args, links map[string]string) string {
+	if template == "" {
+		return template
+	}
+	rendered := template
+	for name, value := range args {
+		rendered = strings.ReplaceAll(rendered, argPlaceholder(name), value)
+	}
+	rendered = linkTagPattern.ReplaceAllStringFunc(rendered, func(match string) string {
+		parts := linkTagPattern.FindStringSubmatch(match)
+		if len(parts) != 4 {
+			return match
+		}
+		openName, text, closeName := parts[1], parts[2], parts[3]
+		if openName != closeName {
+			// Mismatched tags — leave the match as-is so the mistake surfaces.
+			return match
+		}
+		url, ok := links[openName]
+		if !ok {
+			return match
+		}
+		return fmt.Sprintf(`<a href=%q target="_blank" rel="noopener noreferrer">%s</a>`, url, text)
+	})
+	return rendered
+}
+
+// RenderDescription returns the rendered Description for a step, looking up
+// its args/links from the DescriptionArgser and DescriptionLinker capability
+// interfaces if the step implements them.
+func RenderDescription(s Step) string {
+	var args, links map[string]string
+	if p, ok := s.(DescriptionArgser); ok {
+		args = p.DescriptionArgs()
+	}
+	if p, ok := s.(DescriptionLinker); ok {
+		links = p.DescriptionLinks()
+	}
+	return Render(s.Description(), args, links)
+}
+
+// RenderResolution returns the rendered Resolution for a step, looking up
+// its args/links from the ResolutionArgser and ResolutionLinker capability
+// interfaces if the step implements them.
+func RenderResolution(s Step) string {
+	var args, links map[string]string
+	if p, ok := s.(ResolutionArgser); ok {
+		args = p.ResolutionArgs()
+	}
+	if p, ok := s.(ResolutionLinker); ok {
+		links = p.ResolutionLinks()
+	}
+	return Render(s.Resolution(), args, links)
+}

--- a/apps/advisor/pkg/app/checks/template_test.go
+++ b/apps/advisor/pkg/app/checks/template_test.go
@@ -1,0 +1,89 @@
+package checks
+
+import "testing"
+
+func TestRender(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		args     map[string]string
+		links    map[string]string
+		want     string
+	}{
+		{
+			name:     "empty template",
+			template: "",
+			want:     "",
+		},
+		{
+			name:     "no placeholders",
+			template: "Follow the documentation for each element.",
+			want:     "Follow the documentation for each element.",
+		},
+		{
+			name:     "single arg",
+			template: "Panel stops working in Grafana {{version}}.",
+			args:     map[string]string{"version": "13.1"},
+			want:     "Panel stops working in Grafana 13.1.",
+		},
+		{
+			name:     "multiple args, one repeated",
+			template: "use '{{amazonID}}' or '{{azureID}}' (see {{amazonID}} docs).",
+			args: map[string]string{
+				"amazonID": "grafana-amazonprometheus-datasource",
+				"azureID":  "grafana-azureprometheus-datasource",
+			},
+			want: "use 'grafana-amazonprometheus-datasource' or 'grafana-azureprometheus-datasource' (see grafana-amazonprometheus-datasource docs).",
+		},
+		{
+			name:     "single link",
+			template: "Check <docs>the documentation</docs> for details.",
+			links:    map[string]string{"docs": "https://grafana.com/docs"},
+			want:     `Check <a href="https://grafana.com/docs" target="_blank" rel="noopener noreferrer">the documentation</a> for details.`,
+		},
+		{
+			name:     "two different links",
+			template: "See <docs>docs</docs> or open a <support>ticket</support>.",
+			links: map[string]string{
+				"docs":    "https://grafana.com/docs",
+				"support": "https://grafana.com/support",
+			},
+			want: `See <a href="https://grafana.com/docs" target="_blank" rel="noopener noreferrer">docs</a> or open a <a href="https://grafana.com/support" target="_blank" rel="noopener noreferrer">ticket</a>.`,
+		},
+		{
+			name:     "args and links combined",
+			template: "Grafana {{version}} deprecates SceneViewer. See <docs>version support</docs>.",
+			args:     map[string]string{"version": "13.1"},
+			links:    map[string]string{"docs": "https://grafana.com/docs/version-support"},
+			want:     `Grafana 13.1 deprecates SceneViewer. See <a href="https://grafana.com/docs/version-support" target="_blank" rel="noopener noreferrer">version support</a>.`,
+		},
+		{
+			name:     "unknown link tag left as-is",
+			template: "See <mystery>this</mystery>.",
+			links:    map[string]string{"docs": "https://grafana.com/docs"},
+			want:     "See <mystery>this</mystery>.",
+		},
+		{
+			name:     "unknown arg left as-is",
+			template: "Value is {{missing}}.",
+			args:     map[string]string{"other": "x"},
+			want:     "Value is {{missing}}.",
+		},
+		{
+			name:     "URL is quoted so quotes in URLs escape",
+			template: `Check <docs>docs</docs>.`,
+			links:    map[string]string{"docs": `https://example.com/?q="foo"`},
+			// %q escapes the inner quotes, producing a valid HTML attribute value.
+			want: `Check <a href="https://example.com/?q=\"foo\"" target="_blank" rel="noopener noreferrer">docs</a>.`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Render(tt.template, tt.args, tt.links)
+			if got != tt.want {
+				t.Errorf("Render(...) mismatch\ngot:  %s\nwant: %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
+++ b/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
@@ -234,9 +234,9 @@ func (r *Runner) RegisterCheckTypesInNamespace(ctx context.Context, logger loggi
 		for i, s := range steps {
 			stepTypes[i] = advisorv0alpha1.CheckTypeStep{
 				Title:       s.Title(),
-				Description: s.Description(),
+				Description: checks.RenderDescription(s),
 				StepID:      s.ID(),
-				Resolution:  s.Resolution(),
+				Resolution:  checks.RenderResolution(s),
 			}
 		}
 		obj := &advisorv0alpha1.CheckType{


### PR DESCRIPTION
First step towards backend-owned translations for the Advisor plugin. Step `Description()` and `Resolution()` now return templates with named placeholders
  (`{{version}}`, `<docs>text</docs>`) instead of pre-rendered strings. Values and URLs are exposed via new optional capability interfaces and interpolated by a small `Render` helper at CheckType registration time.
  
A follow-up PR adds the actual translation infrastructure (i18n keys, `/translations` endpoint, en-US.json, Crowdin entry). Landing this refactor first means translators will see clean templates in Crowdin — product names, plugin IDs, versions, and URLs stay in Go code and never reach translation files.

  **No API changes.** `/checktypes` still returns the same rendered English HTML (with minor cosmetic improvements: normalised attribute quoting and
  `rel="noopener noreferrer"` added on all anchors).
