### PR TITLE
Dashboards: Fix breadcrumb dashboard link dropping root_url subpath in panel edit

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -2738,6 +2738,27 @@ describe('DashboardScene', () => {
         expect(pageNav.parentItem?.url).toBe('/subUrl/dashboard/provisioning/my-repo/preview/path/to/dash.json');
       });
     });
+
+    it('prefixes the dashboard crumb url with the app sub url', () => {
+      const scene = buildTestScene({ meta: { slug: 'dash-1-slug' } });
+      const location = { pathname: '/d/dash-1/dash-1-slug', search: '', hash: '', state: null, key: '' };
+
+      const pageNav = scene.getPageNav(location, {} as NavIndex);
+
+      expect(pageNav.url).toBe('/subUrl/d/dash-1/dash-1-slug');
+    });
+
+    it('prefixes the dashboard parent crumb url with the app sub url when editing a panel', () => {
+      const scene = buildTestScene({ meta: { slug: 'dash-1-slug' } });
+      const panel = findVizPanelByKey(scene, 'panel-1')!;
+      scene.setState({ editPanel: buildPanelEditScene(panel) });
+      const location = { pathname: '/d/dash-1/dash-1-slug', search: '?editPanel=1', hash: '', state: null, key: '' };
+
+      const pageNav = scene.getPageNav(location, {} as NavIndex);
+
+      expect(pageNav.text).toBe('Edit panel');
+      expect(pageNav.parentItem?.url).toBe('/subUrl/d/dash-1/dash-1-slug');
+    });
   });
 });
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -571,14 +571,16 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       text: title,
       url: isProvisioningPreview
         ? locationUtil.getUrlForPartial(location, clearPanelView)
-        : getDashboardUrl({
-            uid,
-            slug: meta.slug,
-            currentQueryParams: location.search,
-            updateQuery: clearPanelView,
-            isHomeDashboard: !meta.url && !meta.slug && !isNew && !meta.isSnapshot,
-            isSnapshot: meta.isSnapshot,
-          }),
+        : locationUtil.assureBaseUrl(
+            getDashboardUrl({
+              uid,
+              slug: meta.slug,
+              currentQueryParams: location.search,
+              updateQuery: clearPanelView,
+              isHomeDashboard: !meta.url && !meta.slug && !isNew && !meta.isSnapshot,
+              isSnapshot: meta.isSnapshot,
+            })
+          ),
     };
 
     const { folderUid } = meta;


### PR DESCRIPTION
**What is this feature?**

When Grafana is served from a subpath (`root_url` with a subpath and `serve_from_sub_path = true`), the dashboard-name breadcrumb shown while editing or viewing a panel now links to `/<subpath>/d/<uid>/<slug>` instead of `/d/<uid>/<slug>`.

**Why do we need this feature?**

The breadcrumb renders as a plain `<a href>`, so the router basename is never applied. With a subpath configured, clicking the dashboard crumb during panel edit navigated outside the Grafana subpath and returned a 404.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/127646
