### PR TITLE
Search: map per-kind fields explicitly by their declared capabilities

### DIFF
--- a/apps/iam/kinds/team.cue
+++ b/apps/iam/kinds/team.cue
@@ -23,7 +23,9 @@ teamv0alpha1: teamKind & {
 			name: "email"
 			path: "spec.email"
 			type: "string"
-			capabilities: ["retrieve"]
+			// Sorted via the ?sort=email option in team search, and returned in
+			// results. Not filtered.
+			capabilities: ["sort", "retrieve"]
 			description: "Email of the team"
 		},
 		{

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -215,7 +215,7 @@ var appManifestData = app.ManifestData{
 							Name:         "email",
 							Path:         "spec.email",
 							Type:         "string",
-							Capabilities: []string{"retrieve"},
+							Capabilities: []string{"sort", "retrieve"},
 							Description:  "Email of the team",
 						},
 						{

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1662,6 +1662,7 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 	}
 
 	batch := b.index.NewBatch()
+	var undeclaredFields map[string]struct{}
 	for _, item := range req.Items {
 		switch item.Action {
 		case resource.ActionIndex:
@@ -1669,6 +1670,18 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 				return fmt.Errorf("missing document")
 			}
 			doc := item.Doc.UpdateCopyFields()
+
+			// The static fields.* mapping drops values written under an undeclared
+			// name; collect them so the loss is logged, not silent.
+			for name := range doc.Fields {
+				if b.isDeclaredField(name) {
+					continue
+				}
+				if undeclaredFields == nil {
+					undeclaredFields = map[string]struct{}{}
+				}
+				undeclaredFields[name] = struct{}{}
+			}
 
 			err := batch.Index(resource.SearchID(doc.Key), doc)
 			if err != nil {
@@ -1678,11 +1691,24 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 			batch.Delete(resource.SearchID(item.Key))
 		}
 	}
+	for name := range undeclaredFields {
+		b.logger.Warn("search field written to document is not declared for this kind, so it is dropped from the index and cannot be stored or queried", "field", name)
+	}
 
 	if err := b.index.Batch(batch); err != nil {
 		return err
 	}
 	return b.addSnapshotMutationCount(int64(len(req.Items)))
+}
+
+// isDeclaredField reports whether name is a declared search field for this
+// index (per-kind or standard). The fields.* prefix is stripped, so a bare
+// doc.Fields key matches.
+func (b *bleveIndex) isDeclaredField(name string) bool {
+	if b.fields != nil && b.fields.Field(name) != nil {
+		return true
+	}
+	return b.standard != nil && b.standard.Field(name) != nil
 }
 
 func (b *bleveIndex) updateResourceVersion(rv int64) error {

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -16,10 +16,7 @@ import (
 // fieldDefinitionsForMapping returns the SearchFieldDefinition slice that
 // drives the per-kind fields.* sub-document mapping. The provider is the
 // only source of truth: a kind that wants per-kind bleve mappings must
-// register a SearchFieldsProvider. Anything the helper does not emit a
-// mapping for (retrieve-only fields, non-string fields with only
-// filter/facet under the type-aware mapper) is left to Bleve's dynamic
-// mapping at index time.
+// register a SearchFieldsProvider.
 func fieldDefinitionsForMapping(provider resource.SearchFieldsProvider, group, kindResource string) []resource.SearchFieldDefinition {
 	if provider == nil {
 		return nil
@@ -63,24 +60,17 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 	hasRetrieve := def.HasCapability(resource.SearchCapabilityRetrieve)
 	hasUnranked := def.HasCapability(resource.SearchCapabilityUnranked)
 
-	// Non-string fields (int64, double, boolean) get a mapping matching their
-	// type, never a keyword: bleve turns a numeric or boolean value into a
-	// keyword mapping's processString no-op and drops it entirely. Under a
-	// dynamic parent bleve's dynamic path already produces the typed mapping,
-	// so emit nothing explicit. Under a static parent (the top-level mapper)
-	// there is no dynamic fallback, so emit an explicit typed mapping when the
-	// field is filtered or retrieved. Text, partial, facet and sort are all
-	// validated as string-only, so filter and retrieve are the only
-	// capabilities that reach here for non-strings.
+	// Non-string fields (int64, double, boolean) must be mapped to their own
+	// type: bleve silently drops a numeric or boolean value fed through a
+	// keyword mapping. Text, partial and facet are validated as string-only, so
+	// only filter, sort and retrieve reach here for non-strings.
 	if def.Type != resource.SearchFieldTypeString {
-		if !parent.Dynamic && (hasFilter || hasRetrieve) {
+		if hasFilter || hasSort || hasRetrieve {
 			m := typedNonStringFieldMapping(def.Type)
-			m.Index = hasFilter
+			// bleve can sort an indexed numeric field even without doc values, so
+			// sort only needs the field indexed.
+			m.Index = hasFilter || hasSort
 			m.Store = hasRetrieve
-			// Doc values are only needed for sort. Sort on non-string types is
-			// gated off in the validator today, so hasSort is always false here;
-			// wiring numeric/boolean sort is a follow-up and this line is ready
-			// for it.
 			m.DocValues = hasSort
 			m.IncludeInAll = false
 			parent.AddFieldMappingsAt(def.Name, m)
@@ -126,15 +116,24 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 		parent.AddFieldMappingsAt(def.Name+"_ngram", m)
 	}
 
-	// retrieve without any other capability has no place to live; today's
-	// translation never produces such a shape. Silently ignored.
+	// A retrieve-only string has no mapping above, so store it explicitly;
+	// otherwise the static parent would drop it entirely.
+	if hasRetrieve && !needKeyword && !hasText && !hasPartial {
+		m := bleve.NewKeywordFieldMapping()
+		m.Index = false
+		m.Store = true
+		m.IncludeTermVectors = false
+		m.SkipFreqNorm = true
+		m.DocValues = false
+		m.IncludeInAll = false
+		parent.AddFieldMappingsAt(def.Name, m)
+	}
 }
 
 // typedNonStringFieldMapping returns a bleve field mapping matching a
 // non-string search field's type, so the value is indexed and stored in its
 // native form instead of being coerced through keyword analysis (which drops
-// it). Only int64 standard fields (created, updated) reach this on the static
-// top-level parent today; custom fields go through the dynamic parent.
+// it).
 func typedNonStringFieldMapping(t resource.SearchFieldType) *mapping.FieldMapping {
 	switch t {
 	case resource.SearchFieldTypeBoolean:
@@ -212,7 +211,9 @@ func getBleveDocMappings(provider resource.SearchFieldsProvider, group, kindReso
 	labelMapper := bleve.NewDocumentMapping()
 	mapper.AddSubDocumentMapping(resource.SEARCH_FIELD_LABELS, labelMapper)
 
-	fieldMapper := bleve.NewDocumentMapping()
+	// Static so undeclared keys are dropped rather than dynamically indexed
+	// (BulkIndex warns when a document carries one).
+	fieldMapper := bleve.NewDocumentStaticMapping()
 	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
 		addCapabilityFieldMappings(fieldMapper, def)
 	}

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -19,7 +19,9 @@ import (
 // SearchFieldDefinition, keyed by the resulting field name.
 func flatMappings(t *testing.T, def resource.SearchFieldDefinition) map[string]*mapping.FieldMapping {
 	t.Helper()
-	parent := bleve.NewDocumentMapping()
+	// Production uses a static parent for both the top-level and fields.*
+	// mappings, so mirror that here.
+	parent := bleve.NewDocumentStaticMapping()
 	addCapabilityFieldMappings(parent, def)
 
 	out := map[string]*mapping.FieldMapping{}
@@ -209,15 +211,41 @@ func TestAddCapabilityFieldMappings_FacetOnly(t *testing.T) {
 	assert.False(t, m.Store)
 }
 
-func TestAddCapabilityFieldMappings_RetrieveOnly_NoMapping(t *testing.T) {
-	// A retrieve-only field gets no explicit mapping; Bleve's dynamic
-	// mapping handles it at index time, matching pre-refactor behaviour for
-	// non-filterable, non-string fields.
-	parent := bleve.NewDocumentMapping()
-	addCapabilityFieldMappings(parent, resource.SearchFieldDefinition{
-		Name:         "linkCount",
-		Type:         resource.SearchFieldTypeInt64,
-		Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve},
+func TestAddCapabilityFieldMappings_RetrieveOnly_StoreOnly(t *testing.T) {
+	// With no dynamic fallback, a retrieve-only field must be stored explicitly.
+	t.Run("int64", func(t *testing.T) {
+		m := flatMappings(t, resource.SearchFieldDefinition{
+			Name:         "linkCount",
+			Type:         resource.SearchFieldTypeInt64,
+			Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve},
+		})["linkCount"]
+		require.NotNil(t, m)
+		assert.False(t, m.Index, "retrieve-only field is not indexed")
+		assert.True(t, m.Store, "retrieve-only field is stored")
 	})
-	assert.Empty(t, parent.Properties, "retrieve-only fields fall back to dynamic mapping")
+	t.Run("string", func(t *testing.T) {
+		m := flatMappings(t, resource.SearchFieldDefinition{
+			Name:         "permission",
+			Type:         resource.SearchFieldTypeString,
+			Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve},
+		})["permission"]
+		require.NotNil(t, m)
+		assert.False(t, m.Index, "retrieve-only string is not indexed")
+		assert.True(t, m.Store, "retrieve-only string is stored")
+	})
+}
+
+func TestBleveIndex_isDeclaredField(t *testing.T) {
+	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
+		[]resource.SearchFieldDefinition{
+			{Name: "email", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}},
+		},
+	))
+	require.NoError(t, err)
+	b := &bleveIndex{fields: fields, standard: resource.StandardSearchFields()}
+
+	assert.True(t, b.isDeclaredField("email"), "declared per-kind field")
+	assert.True(t, b.isDeclaredField(resource.SEARCH_FIELD_PREFIX+"email"), "declared per-kind field with fields. prefix")
+	assert.True(t, b.isDeclaredField(resource.SEARCH_FIELD_TITLE), "standard field")
+	assert.False(t, b.isDeclaredField("undeclaredCustomField"), "undeclared field is not reported as declared")
 }

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -51,9 +51,17 @@ func TestBleveBackend(t *testing.T) {
 	tmpdir, err := os.MkdirTemp("", "grafana-bleve-test")
 	require.NoError(t, err)
 
+	// Register the dashboard provider so the static fields.* mapping is built
+	// from declared fields, as in production; without it custom fields drop.
+	dashInfo, err := builders.DashboardBuilder(nil)
+	require.NoError(t, err)
+
 	backend, err := NewBleveBackend(BleveOptions{
 		Root:          tmpdir,
 		FileThreshold: 5, // with more than 5 items we create a file on disk
+		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{
+			"dashboard.grafana.app/dashboards": dashInfo.SearchFieldsProvider,
+		},
 	}, nil)
 	require.NoError(t, err)
 	t.Cleanup(backend.Stop)

--- a/pkg/storage/unified/search/builders/dashboard.go
+++ b/pkg/storage/unified/search/builders/dashboard.go
@@ -151,7 +151,6 @@ func (s *DashboardDocumentBuilder) BuildDocument(ctx context.Context, key *resou
 	}
 	// metadata name is the dashboard uid
 	summary.UID = obj.GetName()
-	summary.ID = obj.GetDeprecatedInternalID() // nolint:staticcheck
 
 	doc := resource.NewIndexableDocument(key, rv, obj, summary.Title)
 	// TODO: add selectable fields
@@ -201,9 +200,8 @@ func (s *DashboardDocumentBuilder) BuildDocument(ctx context.Context, key *resou
 	}
 
 	doc.Fields = map[string]any{
-		DASHBOARD_SCHEMA_VERSION:        summary.SchemaVersion,
-		DASHBOARD_LINK_COUNT:            summary.LinkCount,
-		resource.SEARCH_FIELD_LEGACY_ID: summary.ID,
+		DASHBOARD_SCHEMA_VERSION: summary.SchemaVersion,
+		DASHBOARD_LINK_COUNT:     summary.LinkCount,
 	}
 
 	if len(panelTitles) > 0 {

--- a/pkg/storage/unified/search/builders/testdata/doc/dashboard-aaa-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/dashboard-aaa-out.json
@@ -30,7 +30,6 @@
     ],
     "errors_last_1_days": 1,
     "errors_last_7_days": 1,
-    "grafana.app/deprecatedInternalID": 141,
     "link_count": 0,
     "panel_title": [
       "green pie",

--- a/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
@@ -45,7 +45,7 @@
       },
       "fields": {
         "enabled": true,
-        "dynamic": true,
+        "dynamic": false,
         "properties": {
           "ds_types": {
             "enabled": true,
@@ -57,6 +57,72 @@
                 "store": true,
                 "index": true,
                 "skip_freq_norm": true
+              }
+            ]
+          },
+          "errors_last_1_days": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "errors_last_30_days": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "errors_last_7_days": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "errors_today": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "errors_total": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "link_count": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
               }
             ]
           },
@@ -85,6 +151,72 @@
               }
             ]
           },
+          "queries_last_1_days": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "queries_last_30_days": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "queries_last_7_days": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "queries_today": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "queries_total": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "schema_version": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
           "transformation": {
             "enabled": true,
             "dynamic": true,
@@ -95,6 +227,61 @@
                 "store": true,
                 "index": true,
                 "skip_freq_norm": true
+              }
+            ]
+          },
+          "views_last_1_days": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "views_last_30_days": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "views_last_7_days": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "views_today": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "views_total": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
               }
             ]
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -45,7 +45,7 @@
       },
       "fields": {
         "enabled": true,
-        "dynamic": true
+        "dynamic": false
       },
       "folder": {
         "enabled": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
@@ -45,7 +45,7 @@
       },
       "fields": {
         "enabled": true,
-        "dynamic": true,
+        "dynamic": false,
         "properties": {
           "external_group": {
             "enabled": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
@@ -45,8 +45,30 @@
       },
       "fields": {
         "enabled": true,
-        "dynamic": true,
+        "dynamic": false,
         "properties": {
+          "active": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "boolean",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
+          "count": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
           "description": {
             "enabled": true,
             "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -45,7 +45,7 @@
       },
       "fields": {
         "enabled": true,
-        "dynamic": true
+        "dynamic": false
       },
       "folder": {
         "enabled": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team.json
@@ -45,8 +45,22 @@
       },
       "fields": {
         "enabled": true,
-        "dynamic": true,
+        "dynamic": false,
         "properties": {
+          "email": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "index": true,
+                "docvalues": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
           "externalGroups": {
             "enabled": true,
             "dynamic": true,
@@ -56,6 +70,18 @@
                 "analyzer": "keyword",
                 "store": true,
                 "index": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
+          "externalUID": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
                 "skip_freq_norm": true
               }
             ]
@@ -70,6 +96,16 @@
                 "store": true,
                 "index": true,
                 "skip_freq_norm": true
+              }
+            ]
+          },
+          "provisioned": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "boolean",
+                "store": true
               }
             ]
           }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
@@ -45,8 +45,30 @@
       },
       "fields": {
         "enabled": true,
-        "dynamic": true,
+        "dynamic": false,
         "properties": {
+          "external": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "boolean",
+                "store": true
+              }
+            ]
+          },
+          "permission": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "text",
+                "analyzer": "keyword",
+                "store": true,
+                "skip_freq_norm": true
+              }
+            ]
+          },
           "subject": {
             "enabled": true,
             "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -45,8 +45,29 @@
       },
       "fields": {
         "enabled": true,
-        "dynamic": true,
+        "dynamic": false,
         "properties": {
+          "createdAt": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true
+              }
+            ]
+          },
+          "disabled": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "boolean",
+                "store": true,
+                "index": true
+              }
+            ]
+          },
           "email": {
             "enabled": true,
             "dynamic": true,
@@ -57,6 +78,17 @@
                 "store": true,
                 "index": true,
                 "skip_freq_norm": true
+              }
+            ]
+          },
+          "lastSeenAt": {
+            "enabled": true,
+            "dynamic": true,
+            "fields": [
+              {
+                "type": "number",
+                "store": true,
+                "index": true
               }
             ]
           },


### PR DESCRIPTION
The per-kind `fields.*` sub-document in bleve used a dynamic mapping, which indexed and stored every custom field regardless of its declared capabilities. This makes it a static mapping and emits an explicit, capability-driven mapping for each declared search field: filtered fields are indexed, retrieved fields are stored, and retrieve-only fields become store-only instead of also being indexed. `labels.*` and `reference.*` stay dynamic because their keys are not known ahead of time.

Because a static mapping drops any value written under a name it does not know, a document that carries an undeclared field now logs a warning rather than losing it silently. The one such value in the tree — the deprecated internal id the dashboard builder wrote into `fields.*` — is removed, since search already reads that value from the object's labels.

Team `email` is now declared sortable. Team search offers `?sort=email` and relies on the field being indexed, which the dynamic mapping happened to provide; under explicit mappings a retrieve-only field is not indexed, so the declaration is corrected to match how the field is actually used.

Part of grafana/search-and-storage-team#827.
