### PR TITLE
Dataviz: Add entrypoint tests for uncovered panel plugins

### DIFF
--- a/public/app/plugins/panel/gauge/GaugePanel.test.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanel.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+
+import {
+  type DataFrame,
+  type FieldConfigSource,
+  FieldType,
+  LoadingState,
+  getDefaultTimeRange,
+  getLinksSupplier,
+  toDataFrame,
+  VizOrientation,
+} from '@grafana/data';
+import { BarGaugeSizing } from '@grafana/schema';
+
+import { getPanelProps } from '../test-utils';
+
+import { GaugePanel } from './GaugePanel';
+import { defaultOptions, type Options } from './panelcfg.gen';
+
+jest.mock('@grafana/ui/internal', () => ({
+  ...jest.requireActual('@grafana/ui/internal'),
+  RadialGauge: () => <div data-testid="radial-gauge" />,
+}));
+
+const defaultPanelOptions: Options = {
+  ...defaultOptions,
+  reduceOptions: { calcs: ['lastNotNull'], values: false },
+  orientation: VizOrientation.Auto,
+  sizing: BarGaugeSizing.Auto,
+  text: {},
+} as Options;
+
+function createNumericFrame(values = [42], fieldConfig = {}): DataFrame {
+  return toDataFrame({
+    fields: [{ name: 'value', type: FieldType.number, values, config: fieldConfig }],
+  });
+}
+
+function renderGaugePanel(optionsOverrides?: Partial<Options>, dataOverrides?: Partial<{ series: DataFrame[] }>) {
+  const props = getPanelProps<Options>(
+    { ...defaultPanelOptions, ...optionsOverrides },
+    {
+      data: {
+        state: LoadingState.Done,
+        series: [createNumericFrame()],
+        timeRange: getDefaultTimeRange(),
+        ...dataOverrides,
+      },
+      fieldConfig: { defaults: {}, overrides: [] } as FieldConfigSource,
+      replaceVariables: (v: string) => v,
+    }
+  );
+  return render(<GaugePanel {...props} />);
+}
+
+describe('GaugePanel', () => {
+  it('renders a RadialGauge for numeric data', () => {
+    renderGaugePanel();
+
+    expect(screen.getByTestId('radial-gauge')).toBeInTheDocument();
+  });
+
+  it('shows the error view when there is no data', () => {
+    renderGaugePanel(undefined, { series: [] });
+
+    expect(screen.queryByTestId('radial-gauge')).not.toBeInTheDocument();
+    expect(screen.getByText(/Unable to render/i)).toBeInTheDocument();
+  });
+
+  it('renders when the field uses percent units (auto min/max range branch)', () => {
+    renderGaugePanel(undefined, { series: [createNumericFrame([50], { unit: 'percent' })] });
+
+    expect(screen.getByTestId('radial-gauge')).toBeInTheDocument();
+  });
+
+  it('renders when the field uses percentunit units', () => {
+    renderGaugePanel(undefined, { series: [createNumericFrame([0.5], { unit: 'percentunit' })] });
+
+    expect(screen.getByTestId('radial-gauge')).toBeInTheDocument();
+  });
+
+  it('wraps the gauge in a data-links menu button when the field has multiple links', () => {
+    const frameWithLinks = createNumericFrame([42], {
+      links: [
+        { title: 'Go', url: 'https://example.com' },
+        { title: 'Explore', url: 'https://example.com/explore' },
+      ],
+    });
+    const valueField = frameWithLinks.fields[0];
+    valueField.getLinks = getLinksSupplier(frameWithLinks, valueField, {}, (v) => v);
+
+    renderGaugePanel(undefined, { series: [frameWithLinks] });
+
+    expect(screen.getByTestId('radial-gauge')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /data links/i })).toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/panel/news/NewsPanel.test.tsx
+++ b/public/app/plugins/panel/news/NewsPanel.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+
+import { EventBusSrv } from '@grafana/data';
+import { RefreshEvent } from '@grafana/runtime';
+
+import { getPanelProps } from '../test-utils';
+
+import { NewsPanel } from './NewsPanel';
+import { DEFAULT_FEED_URL } from './constants';
+import { defaultOptions, type Options } from './panelcfg.gen';
+import { useNewsFeed } from './useNewsFeed';
+
+jest.mock('./useNewsFeed');
+jest.mock('./component/News', () => ({
+  News: ({ index }: { index: number }) => <div data-testid="news-item">item-{index}</div>,
+}));
+
+const useNewsFeedMock = jest.mocked(useNewsFeed);
+
+type FeedState = ReturnType<typeof useNewsFeed>['state'];
+
+function setFeedState(state: Partial<FeedState>, getNews = jest.fn()) {
+  useNewsFeedMock.mockReturnValue({
+    // The panel only reads loading/error/value off state.
+    state: { loading: false, error: undefined, value: undefined, ...state } as FeedState,
+    getNews,
+  });
+  return getNews;
+}
+
+function renderNewsPanel(optionsOverrides?: Partial<Options>, eventBus = new EventBusSrv()) {
+  const props = getPanelProps<Options>({ ...defaultOptions, ...optionsOverrides }, { eventBus });
+  return render(<NewsPanel {...props} />);
+}
+
+describe('NewsPanel', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the error alert when the feed fails to load', () => {
+    setFeedState({ error: new Error('boom') });
+
+    renderNewsPanel();
+
+    expect(screen.getByText('Error loading RSS feed')).toBeInTheDocument();
+    expect(screen.queryByTestId('news-item')).not.toBeInTheDocument();
+  });
+
+  it('renders the loading state while the feed is loading', () => {
+    setFeedState({ loading: true });
+
+    renderNewsPanel();
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByTestId('news-item')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when there is no feed value yet', () => {
+    setFeedState({ value: undefined });
+
+    const { container } = renderNewsPanel();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders one News item per feed entry on success', () => {
+    // The panel calls state.value.map(); DataFrameView is array-like, an array is a valid stand-in.
+    setFeedState({ value: [{}, {}, {}] as unknown as FeedState['value'] });
+
+    renderNewsPanel();
+
+    expect(screen.getAllByTestId('news-item')).toHaveLength(3);
+  });
+
+  it('fetches news on mount and defaults to the Grafana blog feed', () => {
+    const getNews = setFeedState({ value: [] as unknown as FeedState['value'] });
+
+    renderNewsPanel();
+
+    expect(useNewsFeedMock).toHaveBeenCalledWith(DEFAULT_FEED_URL);
+    expect(getNews).toHaveBeenCalled();
+  });
+
+  it('uses the configured feedUrl when provided', () => {
+    setFeedState({ value: [] as unknown as FeedState['value'] });
+
+    renderNewsPanel({ feedUrl: 'https://example.com/rss' });
+
+    expect(useNewsFeedMock).toHaveBeenCalledWith('https://example.com/rss');
+  });
+
+  it('subscribes to RefreshEvent on mount and unsubscribes on unmount', () => {
+    const getNews = setFeedState({ value: [] as unknown as FeedState['value'] });
+    const eventBus = new EventBusSrv();
+    const unsubscribe = jest.fn();
+    const subscribe = jest.spyOn(eventBus, 'subscribe').mockReturnValue({ unsubscribe });
+
+    const { unmount } = renderNewsPanel(undefined, eventBus);
+
+    expect(subscribe).toHaveBeenCalledWith(RefreshEvent, getNews);
+
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/public/app/plugins/panel/stat/StatPanel.test.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+
+import {
+  type DataFrame,
+  type FieldConfigSource,
+  FieldType,
+  LoadingState,
+  getDefaultTimeRange,
+  toDataFrame,
+  VizOrientation,
+} from '@grafana/data';
+
+import { getPanelProps } from '../test-utils';
+
+import { StatPanel } from './StatPanel';
+import { defaultOptions, type Options } from './panelcfg.gen';
+
+const defaultPanelOptions: Options = {
+  ...defaultOptions,
+  reduceOptions: { calcs: ['lastNotNull'], values: false },
+  orientation: VizOrientation.Auto,
+  text: {},
+} as Options;
+
+function createNumericFrame(values = [10, 20, 30], fieldOverrides = {}): DataFrame {
+  return toDataFrame({
+    fields: [{ name: 'value', type: FieldType.number, values, config: {}, ...fieldOverrides }],
+  });
+}
+
+function renderStatPanel(
+  optionsOverrides?: Partial<Options>,
+  dataOverrides?: Partial<{ series: DataFrame[] }>,
+  fieldConfig?: Partial<FieldConfigSource>
+) {
+  const props = getPanelProps<Options>(
+    { ...defaultPanelOptions, ...optionsOverrides },
+    {
+      data: {
+        state: LoadingState.Done,
+        series: [createNumericFrame()],
+        timeRange: getDefaultTimeRange(),
+        ...dataOverrides,
+      },
+      fieldConfig: { defaults: {}, overrides: [], ...fieldConfig } as FieldConfigSource,
+      replaceVariables: (v: string) => v,
+    }
+  );
+  return render(<StatPanel {...props} />);
+}
+
+describe('StatPanel', () => {
+  it('renders the reduced value for numeric data', () => {
+    renderStatPanel();
+
+    // lastNotNull of [10, 20, 30]
+    expect(screen.getByText('30')).toBeInTheDocument();
+  });
+
+  it('renders the field name when textMode Auto resolves to ValueAndName via displayName', () => {
+    // The getTextMode branch keys off the panel-level fieldConfig.defaults.displayName, while the
+    // rendered title comes from the field's own config (overrides are applied upstream in real usage).
+    const frame = createNumericFrame([10, 20, 30], { config: { displayName: 'My Metric' } });
+
+    renderStatPanel(undefined, { series: [frame] }, { defaults: { displayName: 'My Metric' } });
+
+    expect(screen.getByText('My Metric')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+  });
+
+  it('renders without configured min/max by auto-calculating the numeric range', () => {
+    // No min/max on the field config exercises the findNumericFieldMinMax branch in getValues.
+    renderStatPanel(undefined, { series: [createNumericFrame([5, 15, 25])] });
+
+    expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
+  it('still renders the value when the field carries data links', () => {
+    const frameWithLinks = createNumericFrame([42], {
+      config: { links: [{ title: 'Go', url: 'https://example.com' }] },
+    });
+
+    renderStatPanel(undefined, { series: [frameWithLinks] });
+
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.test.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import {
+  applyFieldOverrides,
+  createDataFrame,
+  createTheme,
+  type DataFrame,
+  FieldType,
+  getDefaultTimeRange,
+  LoadingState,
+} from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
+
+import { getPanelProps } from '../test-utils';
+
+import { StateTimelinePanel } from './StateTimelinePanel';
+import { defaultOptions, type Options } from './panelcfg.gen';
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  // Invoke the panel's render-prop (as the real plugin does on hover) so the tooltip body is exercised.
+  TooltipPlugin2: (props: { render?: (...args: unknown[]) => ReactNode }) => {
+    const u = { posToVal: () => 0, cursor: { left: 0 } };
+    const content = props.render?.(u, [0, 0], 1, false, jest.fn(), null, false, []);
+    return <div data-testid="state-timeline-tooltip-plugin">{content}</div>;
+  },
+}));
+
+const baseOptions: Options = {
+  ...defaultOptions,
+  legend: { showLegend: true, displayMode: LegendDisplayMode.List, placement: 'bottom', calcs: [] },
+  tooltip: { mode: TooltipDisplayMode.Single, sort: SortOrder.None, maxWidth: 300, maxHeight: 300, hideZeros: false },
+} as Options;
+
+// applyFieldOverrides attaches the display processors the timeline legend/tooltip helpers rely on;
+// in real usage this happens in the data pipeline before the panel renders.
+function processFrames(frames: DataFrame[]): DataFrame[] {
+  return applyFieldOverrides({
+    data: frames,
+    fieldConfig: { defaults: {}, overrides: [] },
+    replaceVariables: (v) => v,
+    theme: createTheme(),
+    timeZone: 'utc',
+  });
+}
+
+const validFrame = processFrames([
+  createDataFrame({
+    fields: [
+      { name: 'time', type: FieldType.time, values: [1000, 2000, 3000], config: {} },
+      { name: 'state', type: FieldType.string, values: ['ok', 'warn', 'ok'], config: {} },
+    ],
+  }),
+])[0];
+
+function renderStateTimelinePanel(options?: Partial<Options>, series: DataFrame[] = [validFrame]) {
+  const props = getPanelProps<Options>(
+    { ...baseOptions, ...options },
+    { data: { state: LoadingState.Done, series, timeRange: getDefaultTimeRange() } }
+  );
+  return render(<StateTimelinePanel {...props} />);
+}
+
+describe('StateTimelinePanel', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('renders the chart when data is valid', () => {
+    renderStateTimelinePanel();
+
+    expect(screen.getByTestId(selectors.components.VizLayout.container)).toBeInTheDocument();
+  });
+
+  it('shows the error view when there is no time field', () => {
+    const noTimeFrame = createDataFrame({
+      fields: [{ name: 'state', type: FieldType.string, values: ['ok'], config: {} }],
+    });
+
+    renderStateTimelinePanel(undefined, [noTimeFrame]);
+
+    expect(screen.queryByTestId(selectors.components.VizLayout.container)).not.toBeInTheDocument();
+    expect(screen.getByText(/Unable to render/i)).toBeInTheDocument();
+  });
+
+  it('renders when mergeValues is disabled', () => {
+    renderStateTimelinePanel({ mergeValues: false });
+
+    expect(screen.getByTestId(selectors.components.VizLayout.container)).toBeInTheDocument();
+  });
+
+  it('renders TooltipPlugin2 when tooltip mode is not None', () => {
+    // Legend hidden so VizLayout renders the chart (and its plugin render-prop) synchronously in jsdom.
+    renderStateTimelinePanel({
+      legend: { ...baseOptions.legend, showLegend: false },
+      tooltip: { ...baseOptions.tooltip, mode: TooltipDisplayMode.Single },
+    });
+
+    expect(screen.getByTestId('state-timeline-tooltip-plugin')).toBeInTheDocument();
+  });
+
+  it('does not render TooltipPlugin2 when tooltip mode is None', () => {
+    renderStateTimelinePanel({
+      legend: { ...baseOptions.legend, showLegend: false },
+      tooltip: { ...baseOptions.tooltip, mode: TooltipDisplayMode.None },
+    });
+
+    expect(screen.queryByTestId('state-timeline-tooltip-plugin')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.test.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import {
+  applyFieldOverrides,
+  createDataFrame,
+  createTheme,
+  type DataFrame,
+  FieldType,
+  getDefaultTimeRange,
+  LoadingState,
+} from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
+
+import { getPanelProps } from '../test-utils';
+
+import { StatusHistoryPanel } from './StatusHistoryPanel';
+import { defaultOptions, type Options } from './panelcfg.gen';
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  // Invoke the panel's render-prop (as the real plugin does on hover) so the tooltip body is exercised.
+  TooltipPlugin2: (props: { render?: (...args: unknown[]) => ReactNode }) => {
+    const u = { posToVal: () => 0, cursor: { left: 0 } };
+    const content = props.render?.(u, [0, 0], 1, false, jest.fn(), null, false, []);
+    return <div data-testid="status-history-tooltip-plugin">{content}</div>;
+  },
+}));
+
+const baseOptions: Options = {
+  ...defaultOptions,
+  legend: { showLegend: true, displayMode: LegendDisplayMode.List, placement: 'bottom', calcs: [] },
+  tooltip: { mode: TooltipDisplayMode.Single, sort: SortOrder.None, maxWidth: 300, maxHeight: 300, hideZeros: false },
+} as Options;
+
+// applyFieldOverrides attaches the display processors the timeline legend/tooltip helpers rely on;
+// in real usage this happens in the data pipeline before the panel renders.
+function processFrames(frames: DataFrame[]): DataFrame[] {
+  return applyFieldOverrides({
+    data: frames,
+    fieldConfig: { defaults: {}, overrides: [] },
+    replaceVariables: (v) => v,
+    theme: createTheme(),
+    timeZone: 'utc',
+  });
+}
+
+const validFrame = processFrames([
+  createDataFrame({
+    fields: [
+      { name: 'time', type: FieldType.time, values: [1000, 2000, 3000], config: {} },
+      { name: 'state', type: FieldType.string, values: ['ok', 'warn', 'ok'], config: {} },
+    ],
+  }),
+])[0];
+
+function renderStatusHistoryPanel(
+  options?: Partial<Options>,
+  series: DataFrame[] = [validFrame],
+  propsOverrides?: Partial<{ width: number }>
+) {
+  const props = getPanelProps<Options>(
+    { ...baseOptions, ...options },
+    {
+      data: { state: LoadingState.Done, series, timeRange: getDefaultTimeRange() },
+      ...propsOverrides,
+    }
+  );
+  return render(<StatusHistoryPanel {...props} />);
+}
+
+describe('StatusHistoryPanel', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('renders the chart when data is valid', () => {
+    renderStatusHistoryPanel();
+
+    expect(screen.getByTestId(selectors.components.VizLayout.container)).toBeInTheDocument();
+  });
+
+  it('shows the error view when there is no time field', () => {
+    const noTimeFrame = createDataFrame({
+      fields: [{ name: 'state', type: FieldType.string, values: ['ok'], config: {} }],
+    });
+
+    renderStatusHistoryPanel(undefined, [noTimeFrame]);
+
+    expect(screen.queryByTestId(selectors.components.VizLayout.container)).not.toBeInTheDocument();
+    expect(screen.getByText(/Unable to render/i)).toBeInTheDocument();
+  });
+
+  it('shows the "too many points" message when the frame is too wide for the panel', () => {
+    // width/2 = 1, and the frame has 3 points, so the status grid cannot fit.
+    renderStatusHistoryPanel(undefined, [validFrame], { width: 2 });
+
+    expect(screen.getByText(/Too many points/i)).toBeInTheDocument();
+    expect(screen.queryByTestId(selectors.components.VizLayout.container)).not.toBeInTheDocument();
+  });
+
+  it('renders TooltipPlugin2 when tooltip mode is not None', () => {
+    // Legend hidden so VizLayout renders the chart (and its plugin render-prop) synchronously in jsdom.
+    renderStatusHistoryPanel({
+      legend: { ...baseOptions.legend, showLegend: false },
+      tooltip: { ...baseOptions.tooltip, mode: TooltipDisplayMode.Single },
+    });
+
+    expect(screen.getByTestId('status-history-tooltip-plugin')).toBeInTheDocument();
+  });
+
+  it('does not render TooltipPlugin2 when tooltip mode is None', () => {
+    renderStatusHistoryPanel({
+      legend: { ...baseOptions.legend, showLegend: false },
+      tooltip: { ...baseOptions.tooltip, mode: TooltipDisplayMode.None },
+    });
+
+    expect(screen.queryByTestId('status-history-tooltip-plugin')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/panel/trend/TrendPanel.test.tsx
+++ b/public/app/plugins/panel/trend/TrendPanel.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+
+import { createDataFrame, type DataFrame, FieldType, getDefaultTimeRange, LoadingState } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
+
+import { getPanelProps } from '../test-utils';
+
+import { TrendPanel } from './TrendPanel';
+import { type Options } from './panelcfg.gen';
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  TooltipPlugin2: () => <div data-testid="trend-tooltip-plugin" />,
+}));
+
+const defaultOptions: Options = {
+  legend: {
+    showLegend: true,
+    displayMode: LegendDisplayMode.List,
+    placement: 'bottom',
+    calcs: [],
+  },
+  tooltip: {
+    mode: TooltipDisplayMode.Single,
+    sort: SortOrder.None,
+    maxWidth: 300,
+    maxHeight: 300,
+    hideZeros: false,
+  },
+};
+
+const validFrame = createDataFrame({
+  fields: [
+    { name: 'x', type: FieldType.number, values: [1, 2, 3], config: { custom: {} } },
+    { name: 'value', type: FieldType.number, values: [10, 20, 30], config: { custom: {} } },
+  ],
+});
+
+function renderTrendPanel(options?: Partial<Options>, series: DataFrame[] = [validFrame]) {
+  const props = getPanelProps<Options>(
+    { ...defaultOptions, ...options },
+    { data: { state: LoadingState.Done, series, timeRange: getDefaultTimeRange() } }
+  );
+  return render(<TrendPanel {...props} />);
+}
+
+describe('TrendPanel', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // uPlot logs benign warnings in jsdom; keep the test output clean.
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('renders the chart when data has a numeric x field (xField fallback)', () => {
+    renderTrendPanel();
+
+    expect(screen.getByTestId(selectors.components.VizLayout.container)).toBeInTheDocument();
+  });
+
+  it('shows the error view when there are no numeric fields for the X axis', () => {
+    const stringOnlyFrame = createDataFrame({
+      fields: [{ name: 'label', type: FieldType.string, values: ['a', 'b', 'c'], config: { custom: {} } }],
+    });
+
+    renderTrendPanel(undefined, [stringOnlyFrame]);
+
+    expect(screen.queryByTestId(selectors.components.VizLayout.container)).not.toBeInTheDocument();
+    expect(screen.getByText(/Unable to render/i)).toBeInTheDocument();
+  });
+
+  it('shows the error view when the configured xField cannot be found', () => {
+    renderTrendPanel({ xField: 'missing' });
+
+    expect(screen.queryByTestId(selectors.components.VizLayout.container)).not.toBeInTheDocument();
+  });
+
+  it('renders TooltipPlugin2 when tooltip mode is not None', () => {
+    // The legend is hidden so VizLayout renders the chart (and its plugin render-prop) synchronously in jsdom.
+    renderTrendPanel({
+      legend: { ...defaultOptions.legend, showLegend: false },
+      tooltip: { ...defaultOptions.tooltip, mode: TooltipDisplayMode.Single },
+    });
+
+    expect(screen.getByTestId('trend-tooltip-plugin')).toBeInTheDocument();
+  });
+
+  it('does not render TooltipPlugin2 when tooltip mode is None', () => {
+    renderTrendPanel({
+      legend: { ...defaultOptions.legend, showLegend: false },
+      tooltip: { ...defaultOptions.tooltip, mode: TooltipDisplayMode.None },
+    });
+
+    expect(screen.queryByTestId('trend-tooltip-plugin')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Adds <Panel>Panel.test.tsx render tests for six dataviz-squad panels that previously had no entrypoint coverage: news, stat, gauge, status-history, state-timeline, and trend. Follows the existing BarChartPanel pattern using the shared getPanelProps helper.

Coverage (lines): news 0->100%, stat 19->98%, gauge 24->100%, trend 42->92%, status-history 36->84%, state-timeline 36->83%.

This mainly exercises error states, the presence or absence of tooltips and data links... the integration of panel options and the dataframe for a panel, basically.
