### PR TITLE
Provisioning: fix flaky FullSync_FolderUIDTooLong folder-list assertion

### DIFF
--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_uid_too_long_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_uid_too_long_test.go
@@ -96,22 +96,31 @@ func TestIntegrationProvisioning_FullSync_FolderUIDTooLong(t *testing.T) {
 	// the sync.
 	helper.RequireRepoDashboardCount(t, repo, 1)
 
-	folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err)
-
-	managedSourcePaths := make(map[string]struct{})
-	for _, f := range folders.Items {
-		managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
-		if managerID != repo {
-			continue
+	// Poll the folders list: the sync job completing does not guarantee the
+	// folders-list index has observed the newly-created shallow folder (its
+	// grafana.app/managerId annotation lags independently of the dashboards
+	// index under SQLite write contention). A single List here races that lag.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err) {
+			return
 		}
-		sourcePath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
-		managedSourcePaths[sourcePath] = struct{}{}
-	}
 
-	assert.Contains(t, managedSourcePaths, "shallow",
-		"the shallow folder must be created normally despite the UID violation in another branch; got managed paths: %v",
-		managedSourcePaths)
+		managedSourcePaths := make(map[string]struct{})
+		for _, f := range folders.Items {
+			managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+			if managerID != repo {
+				continue
+			}
+			sourcePath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
+			managedSourcePaths[sourcePath] = struct{}{}
+		}
+
+		assert.Contains(c, managedSourcePaths, "shallow",
+			"the shallow folder must be created normally despite the UID violation in another branch; got managed paths: %v",
+			managedSourcePaths)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault,
+		"expected the shallow folder to be created and managed by repo %s", repo)
 
 	// Pull condition must be a warning state, not Failure. The condition
 	// reason currently buckets generic warnings under


### PR DESCRIPTION
## Summary

`TestIntegrationProvisioning_FullSync_FolderUIDTooLong` flakes in CI (seen on the Sqlite Enterprise integration shard). The failure:

```
--- FAIL: TestIntegrationProvisioning_FullSync_FolderUIDTooLong
    full_sync_uid_too_long_test.go:112:
        Error:    map[string]struct {}{} does not contain "shallow"
        Messages: the shallow folder must be created normally despite the UID
                  violation in another branch; got managed paths: map[]
```

This is a test-side eventual-consistency race, not a product bug.

The test waits for the shallow *dashboard* via `RequireRepoDashboardCount` (which polls with `EventuallyWithT`), but then asserted the shallow *folder* was present using a **single, non-retried** `Folders.Resource.List`. The folders-list index lags independently of the dashboards index under SQLite write contention, so the one-shot List could return `map[]` (no repo-managed folders yet) and fail intermittently.

## Changes

- Wrap the folder-list / `managedSourcePaths` assertion in `require.EventuallyWithT` using `common.WaitTimeoutDefault` / `common.WaitIntervalDefault`, matching the existing `RequireRepoFolderCount` / `RequireRepoDashboardCount` pattern in this package.

No production code changed; assertion semantics are unchanged — it just tolerates index lag.

## Testing

- `go vet ./pkg/tests/apis/provisioning/foldermetadata/` — clean
- `go test -c` on the package — compiles

## Checklist

- [x] Test-only change
- [x] No breaking changes
- [x] No production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)