### PR TITLE
Search: share the search-field capability rules with the app SDK

### DIFF
--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-github/v82 v82.0.0
 	github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana-plugin-sdk-go v0.292.1
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0

--- a/apps/advisor/go.sum
+++ b/apps/advisor/go.sum
@@ -500,8 +500,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-aws-sdk v1.4.4 h1:D9h1+fm0h77atG9vsSbaHv8WeAHt27R45wq+9/DYXlk=

--- a/apps/alerting/notifications/go.mod
+++ b/apps/alerting/notifications/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/alerting/notifications
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	k8s.io/apimachinery v0.36.1
 	k8s.io/apiserver v0.36.0

--- a/apps/alerting/notifications/go.sum
+++ b/apps/alerting/notifications/go.sum
@@ -94,8 +94,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=

--- a/apps/alerting/rules/go.mod
+++ b/apps/alerting/rules/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/getkin/kin-openapi v0.140.0
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/prometheus/common v0.68.1
 	github.com/stretchr/testify v1.11.1

--- a/apps/alerting/rules/go.sum
+++ b/apps/alerting/rules/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/annotation/go.mod
+++ b/apps/annotation/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/annotation
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/annotation/go.sum
+++ b/apps/annotation/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/collections/go.mod
+++ b/apps/collections/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/collections
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.36.1

--- a/apps/collections/go.sum
+++ b/apps/collections/go.sum
@@ -57,8 +57,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/apps/correlations/go.mod
+++ b/apps/correlations/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/correlations
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/correlations/go.sum
+++ b/apps/correlations/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/dashboard/go.mod
+++ b/apps/dashboard/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	cuelang.org/go v0.11.1
 	github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana-plugin-sdk-go v0.292.1
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6

--- a/apps/dashboard/go.sum
+++ b/apps/dashboard/go.sum
@@ -113,8 +113,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-plugin-sdk-go v0.292.1 h1:8wvKUqIOtbHC43WIr6kheIGdV6q4SMyWU9+jxcUA6mE=

--- a/apps/dashvalidator/go.mod
+++ b/apps/dashvalidator/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0
 	github.com/prometheus/prometheus v0.312.0

--- a/apps/dashvalidator/go.sum
+++ b/apps/dashvalidator/go.sum
@@ -580,8 +580,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-aws-sdk v1.4.4 h1:D9h1+fm0h77atG9vsSbaHv8WeAHt27R45wq+9/DYXlk=

--- a/apps/example/go.mod
+++ b/apps/example/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/example
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	k8s.io/apimachinery v0.36.1

--- a/apps/example/go.sum
+++ b/apps/example/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/apps/folder/go.mod
+++ b/apps/folder/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/folder
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/folder/go.sum
+++ b/apps/folder/go.sum
@@ -57,8 +57,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/apps/iam/go.mod
+++ b/apps/iam/go.mod
@@ -44,7 +44,7 @@ replace (
 
 require (
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/iam/go.sum
+++ b/apps/iam/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/live/go.mod
+++ b/apps/live/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/live
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/live/go.sum
+++ b/apps/live/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/logsdrilldown/go.mod
+++ b/apps/logsdrilldown/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/logsdrilldown
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/logsdrilldown/go.sum
+++ b/apps/logsdrilldown/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/playlist/go.mod
+++ b/apps/playlist/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/playlist
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
 	k8s.io/klog/v2 v2.140.0

--- a/apps/playlist/go.sum
+++ b/apps/playlist/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/apps/plugins/go.mod
+++ b/apps/plugins/go.mod
@@ -15,7 +15,7 @@ replace github.com/grafana/grafana/pkg/plugins => ../../pkg/plugins
 require (
 	github.com/emicklei/go-restful/v3 v3.13.0
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0
 	github.com/grafana/grafana/pkg/apiserver v0.0.0

--- a/apps/plugins/go.sum
+++ b/apps/plugins/go.sum
@@ -433,8 +433,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-aws-sdk v1.4.4 h1:D9h1+fm0h77atG9vsSbaHv8WeAHt27R45wq+9/DYXlk=

--- a/apps/preferences/go.mod
+++ b/apps/preferences/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/preferences
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	k8s.io/apimachinery v0.36.1
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a

--- a/apps/preferences/go.sum
+++ b/apps/preferences/go.sum
@@ -57,8 +57,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-github/v82 v82.0.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/apps/dashboard v0.0.0-20260424050122-76eba5631b44
 	github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6

--- a/apps/provisioning/go.sum
+++ b/apps/provisioning/go.sum
@@ -101,8 +101,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/apps/dashboard v0.0.0-20260424050122-76eba5631b44 h1:/aHFQcMfdIWkNMGMAdx3URhRc9sulLVfhOKTw3xvQ8Y=

--- a/apps/quotas/go.mod
+++ b/apps/quotas/go.mod
@@ -44,7 +44,7 @@ replace (
 
 require (
 	github.com/grafana/grafana v0.0.0-00010101000000-000000000000
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/pkg/storage/unified/resourcepb v0.0.0
 	github.com/stretchr/testify v1.11.1

--- a/apps/quotas/go.sum
+++ b/apps/quotas/go.sum
@@ -603,8 +603,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-aws-sdk v1.4.4 h1:D9h1+fm0h77atG9vsSbaHv8WeAHt27R45wq+9/DYXlk=

--- a/apps/sdk.mk
+++ b/apps/sdk.mk
@@ -1,4 +1,4 @@
-APP_SDK_VERSION = v0.56.3
+APP_SDK_VERSION = v0.56.4
 APP_SDK_DIR     = $(shell go env GOPATH)/bin/app-sdk-$(APP_SDK_VERSION)
 APP_SDK_BIN     = $(APP_SDK_DIR)/grafana-app-sdk
 

--- a/apps/secret/go.mod
+++ b/apps/secret/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/secret
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1

--- a/apps/secret/go.sum
+++ b/apps/secret/go.sum
@@ -61,8 +61,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/apps/shorturl/go.mod
+++ b/apps/shorturl/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/grafana/apps/shorturl
 go 1.26.4
 
 require (
-	github.com/grafana/grafana-app-sdk v0.56.3
+	github.com/grafana/grafana-app-sdk v0.56.4
 	github.com/grafana/grafana-app-sdk/logging v0.56.2
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	github.com/stretchr/testify v1.11.1

--- a/apps/shorturl/go.sum
+++ b/apps/shorturl/go.sum
@@ -76,8 +76,8 @@ github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2 h1:8lFEFsViK
 github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2/go.mod h1:j+YTXmAcD4zCNyl4QSNqYSEe/q9KgrH1btodnhK29hI=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3 h1:/m/qmt7Ay+HK+GVbIvXrJIRHC07xFM6nWFMmyePmAUs=
 github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3/go.mod h1:6zFIzal2FCd0JC1pE0ZTb2ftC0Jr/zsQR4zRNRdDfZA=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/grafana/gofpdf v0.0.0-20250307124105-3b9c5d35577f // @grafana/sharing-squad
 	github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b // @grafana/grafana-operator-experience-squad
 	github.com/grafana/grafana-api-golang-client v0.27.0 // @grafana/alerting-backend
-	github.com/grafana/grafana-app-sdk v0.56.3 // @grafana/grafana-app-platform-squad
+	github.com/grafana/grafana-app-sdk v0.56.4 // @grafana/grafana-app-platform-squad
 	github.com/grafana/grafana-app-sdk/logging v0.56.2 // @grafana/grafana-app-platform-squad
 	github.com/grafana/grafana-aws-sdk v1.4.4 // @grafana/data-sources-plugins
 	github.com/grafana/grafana-azure-sdk-go/v2 v2.4.1 // @grafana/data-sources-plugins

--- a/go.sum
+++ b/go.sum
@@ -1620,8 +1620,8 @@ github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b h1:5qp8/5YPt/Z2
 github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/grafana-api-golang-client v0.27.0 h1:zIwMXcbCB4n588i3O2N6HfNcQogCNTd/vPkEXTr7zX8=
 github.com/grafana/grafana-api-golang-client v0.27.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
-github.com/grafana/grafana-app-sdk v0.56.3 h1:5QkBdWnIU7Gp/7t9qlbEitPj8IJE/GeY+7UWI3rTOZ8=
-github.com/grafana/grafana-app-sdk v0.56.3/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
+github.com/grafana/grafana-app-sdk v0.56.4 h1:N+6TQkn4qEBGk1hStOCwwa2glIGLrSVA5BIgJruLToQ=
+github.com/grafana/grafana-app-sdk v0.56.4/go.mod h1:G1Ky4rrII1FHY6pcANrAhg4O4jl4c7dTP80CXIeOdow=
 github.com/grafana/grafana-app-sdk/logging v0.56.2 h1:PMNxGOjXytX8aIYZY11llLRAHICjbpbIEEzIX1DrXZY=
 github.com/grafana/grafana-app-sdk/logging v0.56.2/go.mod h1:19HroGkdv9aVjfToKYYDOo+kVqoWHcPgewlJs7ole5A=
 github.com/grafana/grafana-aws-sdk v1.4.4 h1:D9h1+fm0h77atG9vsSbaHv8WeAHt27R45wq+9/DYXlk=

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -11,6 +11,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/grafana/grafana-app-sdk/searchfields"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -284,24 +285,6 @@ func NewMapProvider(fields map[schema.GroupVersionResource][]SearchFieldDefiniti
 	}
 }
 
-// sortableTypes lists SearchFieldTypes that can carry SearchCapabilitySort
-// under today's bleve mapper. The mapper emits a keyword/text mapping for
-// every field regardless of Type, so sort works only for fields whose
-// extracted value is already string-shaped. The allowlist is intentionally
-// minimal: extend it when a concrete consumer needs sort on a new type.
-var sortableTypes = []SearchFieldType{
-	SearchFieldTypeString,
-}
-
-// stringOnlyCapabilities lists capabilities that require a string-mapped
-// Type. These rely on text/keyword analysis under the bleve text engine
-// and have no meaningful semantics on numeric or boolean fields.
-var stringOnlyCapabilities = []SearchCapability{
-	SearchCapabilityText,
-	SearchCapabilityPartial,
-	SearchCapabilityFacet,
-}
-
 // mappingAttributes is the bleve-mapping-affecting projection of a
 // SearchFieldDefinition used for cross-version equality. Only Type, Array,
 // and Capabilities count: those are what GetBleveMappings reads to produce
@@ -434,26 +417,20 @@ func validateCrossVersionConsistency(fields map[schema.GroupVersionResource][]Se
 }
 
 // validateSearchFieldDefinitions returns a non-nil error when any declaration
-// uses a capability that the current bleve mapper cannot honour. The only
-// rule enforced today is that SearchCapabilitySort requires a string-mapped
-// Type: numeric sort is not wired yet (it needs doc values and every index
-// rebuilt with the numeric mapping), so we reject sort on non-string fields
-// rather than sort them incorrectly. The validator also rejects
-// text/partial/facet capabilities on non-string fields: these rely on text
-// or keyword analysis that has no meaning on numeric or boolean values.
+// pairs a capability with a field type that cannot support it. The rules live
+// in the shared searchfields package, which the app-SDK codegen validator also
+// uses, so the two cannot drift: text, partial and facet require a string
+// type; sort works on string, numeric and boolean; filter, retrieve and
+// unranked work on any type.
 func validateSearchFieldDefinitions(sfds []SearchFieldDefinition) error {
 	var violations []string
 	for _, sfd := range sfds {
-		isStringTyped := sfd.Type == SearchFieldTypeString
-		if slices.Contains(sfd.Capabilities, SearchCapabilitySort) && !slices.Contains(sortableTypes, sfd.Type) {
-			violations = append(violations, "field "+sfd.Name+": sort capability is not supported for type "+string(sfd.Type))
+		caps := make([]string, len(sfd.Capabilities))
+		for i, c := range sfd.Capabilities {
+			caps[i] = string(c)
 		}
-		if !isStringTyped {
-			for _, cap := range stringOnlyCapabilities {
-				if slices.Contains(sfd.Capabilities, cap) {
-					violations = append(violations, "field "+sfd.Name+": "+string(cap)+" capability requires a string-typed field (got "+string(sfd.Type)+")")
-				}
-			}
+		if err := searchfields.Validate(string(sfd.Type), caps); err != nil {
+			violations = append(violations, "field "+sfd.Name+": "+err.Error())
 		}
 	}
 	if len(violations) == 0 {

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -257,27 +257,23 @@ func TestValidateSearchFieldDefinitions(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
-	t.Run("int64 with sort is rejected", func(t *testing.T) {
+	t.Run("int64 with sort is valid", func(t *testing.T) {
 		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
 			{Name: "created", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilitySort}},
 		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "created")
-		assert.Contains(t, err.Error(), "int64")
+		require.NoError(t, err)
 	})
-	t.Run("boolean with sort is rejected", func(t *testing.T) {
+	t.Run("boolean with sort is valid", func(t *testing.T) {
 		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
 			{Name: "disabled", Type: SearchFieldTypeBoolean, Capabilities: []SearchCapability{SearchCapabilitySort}},
 		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "boolean")
+		require.NoError(t, err)
 	})
-	t.Run("double with sort is rejected", func(t *testing.T) {
+	t.Run("double with sort is valid", func(t *testing.T) {
 		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
 			{Name: "score", Type: SearchFieldTypeDouble, Capabilities: []SearchCapability{SearchCapabilitySort}},
 		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "double")
+		require.NoError(t, err)
 	})
 	t.Run("numeric without sort is valid", func(t *testing.T) {
 		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
@@ -287,8 +283,8 @@ func TestValidateSearchFieldDefinitions(t *testing.T) {
 	})
 	t.Run("multiple violations reported together", func(t *testing.T) {
 		err := validateSearchFieldDefinitions([]SearchFieldDefinition{
-			{Name: "a", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilitySort}},
-			{Name: "b", Type: SearchFieldTypeBoolean, Capabilities: []SearchCapability{SearchCapabilitySort}},
+			{Name: "a", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityText}},
+			{Name: "b", Type: SearchFieldTypeBoolean, Capabilities: []SearchCapability{SearchCapabilityFacet}},
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "a")
@@ -298,7 +294,7 @@ func TestValidateSearchFieldDefinitions(t *testing.T) {
 		gvr := schema.GroupVersionResource{Group: "example.test", Version: "v0", Resource: "widgets"}
 		assert.Panics(t, func() {
 			NewMapProvider(map[schema.GroupVersionResource][]SearchFieldDefinition{
-				gvr: {{Name: "bad", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilitySort}}},
+				gvr: {{Name: "bad", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityText}}},
 			}, nil)
 		})
 	})


### PR DESCRIPTION
Grafana's search-field validator and the app SDK's codegen-time validator each kept their own copy of the rules for which capability is valid on which field type, and the two had started to drift. The SDK's v0.56.4 release moves those rules into a small, standard-library-only `searchfields` package that both sides can import.

This bumps the App SDK to v0.56.4 across the workspace and replaces Grafana's copy of the rules in `validateSearchFieldDefinitions` with a call to `searchfields.Validate`, so there is one source of truth. As part of that, `sort` is now permitted on numeric and boolean fields in addition to strings; no field declares sort on those types yet, so every current declaration validates exactly as before. A follow-up will declare sort on the fields that need it (the dashboard usage counters and the user last-seen timestamp).

Part of grafana/search-and-storage-team#827.
