### PR TITLE
test: fix flake in TestIntegrationProvisioning_ConnectionValidation

### DIFF
--- a/pkg/tests/apis/provisioning/connection/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection/connection_test.go
@@ -495,7 +495,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 			"apiVersion": "provisioning.grafana.app/v0alpha1",
 			"kind":       "Connection",
 			"metadata": map[string]any{
-				"name":      "connection",
+				"name":      "connection-api-unavailable",
 				"namespace": "default",
 			},
 			"spec": map[string]any{
@@ -590,7 +590,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 			"apiVersion": "provisioning.grafana.app/v0alpha1",
 			"kind":       "Connection",
 			"metadata": map[string]any{
-				"name":      "connection",
+				"name":      "connection-appid-mismatch",
 				"namespace": "default",
 			},
 			"spec": map[string]any{


### PR DESCRIPTION
## Summary

Fixes an intermittent failure in `TestIntegrationProvisioning_ConnectionValidation`:

```
connections.provisioning.grafana.app "connection" already exists
    Test: .../should_fail_when_type_is_github_and_returned_app_ID_doesn't_match_given_one
    Messages: CREATE should succeed
```

## Root cause

Several subtests reuse the hardcoded resource name `"connection"`. The subtests that fail validation *at* CREATE never persist a resource, so they're safe. But the two subtests where CREATE **succeeds** — `"github API is unavailable"` and `"app ID doesn't match"` — each created a real `Connection` named `"connection"` and cleaned it up with an **async** `Delete` in `t.Cleanup`.

`Connection` resources have finalizers, so the delete does not complete synchronously. When the second subtest ran, the first subtest's connection could still be terminating, producing `connection already exists` on `Create`.

## Changes

- Renamed the two resource-creating subtests to use distinct names so they cannot collide regardless of finalizer/delete timing:
  - `"connection"` → `"connection-api-unavailable"`
  - `"connection"` → `"connection-appid-mismatch"`
- Validation-only subtests keep `"connection"` since they never persist anything.

## Testing

- `go vet ./pkg/tests/apis/provisioning/connection/` passes.
- Backend-only test change; no frontend counterpart needed.

## Checklist
- [x] Tests updated
- [ ] Documentation updated (n/a)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)