### PR TITLE
SQL Expressions: Add function signature help to the SQL editor

### DIFF
--- a/packages/grafana-ui/src/components/CodeMirror/signatureHelp.test.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/signatureHelp.test.ts
@@ -38,6 +38,12 @@ describe('signatureHelp extension', () => {
     expect(activeTooltip(stateFor(() => null))).toBeUndefined();
   });
 
+  it('shows no tooltip when the provider returns help without signatures', () => {
+    const emptyHelp: SignatureHelp = { signatures: [], activeSignature: 0, activeParameter: 0 };
+
+    expect(activeTooltip(stateFor(() => emptyHelp))).toBeUndefined();
+  });
+
   it('recomputes the tooltip when the selection changes', () => {
     const provider: SignatureHelpProvider = (_state, pos) => (pos >= 3 ? HELP : null);
     const initial = stateFor(provider, 'abcdef', 0);

--- a/packages/grafana-ui/src/components/CodeMirror/signatureHelp.test.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/signatureHelp.test.ts
@@ -1,0 +1,74 @@
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { showTooltip, type EditorView, type Tooltip } from '@codemirror/view';
+
+import { signatureHelp } from './signatureHelp';
+import { type SignatureHelp, type SignatureHelpProvider } from './types';
+
+const HELP: SignatureHelp = {
+  signatures: [
+    {
+      name: 'round',
+      parameters: [{ label: 'value: number' }, { label: 'decimals: number' }],
+      returnType: 'number',
+      documentation: 'Rounds a number.',
+    },
+  ],
+  activeSignature: 0,
+  activeParameter: 1,
+};
+
+const stateFor = (provider: SignatureHelpProvider, doc = 'abcdef', pos = 0) =>
+  EditorState.create({ doc, selection: EditorSelection.single(pos), extensions: [signatureHelp(provider)] });
+
+const activeTooltip = (state: EditorState): Tooltip | undefined =>
+  state.facet(showTooltip).find((tooltip): tooltip is Tooltip => tooltip != null);
+
+// The rendering code ignores the view argument, so a stub is sufficient for tests.
+const createTooltipDom = (tooltip: Tooltip) => tooltip.create({} as EditorView).dom;
+
+describe('signatureHelp extension', () => {
+  it('shows a tooltip anchored at the cursor when the provider returns help', () => {
+    const tooltip = activeTooltip(stateFor(() => HELP, 'abcdef', 3));
+
+    expect(tooltip).toBeDefined();
+    expect(tooltip?.pos).toBe(3);
+  });
+
+  it('shows no tooltip when the provider returns null', () => {
+    expect(activeTooltip(stateFor(() => null))).toBeUndefined();
+  });
+
+  it('recomputes the tooltip when the selection changes', () => {
+    const provider: SignatureHelpProvider = (_state, pos) => (pos >= 3 ? HELP : null);
+    const initial = stateFor(provider, 'abcdef', 0);
+
+    expect(activeTooltip(initial)).toBeUndefined();
+
+    const moved = initial.update({ selection: EditorSelection.single(3) }).state;
+
+    expect(activeTooltip(moved)?.pos).toBe(3);
+  });
+
+  it('renders the signature with the active parameter marked', () => {
+    const dom = createTooltipDom(activeTooltip(stateFor(() => HELP))!);
+
+    expect(dom.querySelector('.cm-signature-help-label')?.textContent).toBe(
+      'round(value: number, decimals: number): number'
+    );
+    expect(dom.querySelector('.cm-signature-help-active-param')?.textContent).toBe('decimals: number');
+    expect(dom.querySelector('.cm-signature-help-doc')?.textContent).toBe('Rounds a number.');
+  });
+
+  it('renders parameter-less signatures without an active parameter', () => {
+    const piHelp: SignatureHelp = {
+      signatures: [{ name: 'pi', parameters: [], returnType: 'number' }],
+      activeSignature: 0,
+      activeParameter: 0,
+    };
+
+    const dom = createTooltipDom(activeTooltip(stateFor(() => piHelp))!);
+
+    expect(dom.querySelector('.cm-signature-help-label')?.textContent).toBe('pi(): number');
+    expect(dom.querySelector('.cm-signature-help-active-param')).toBeNull();
+  });
+});

--- a/packages/grafana-ui/src/components/CodeMirror/signatureHelp.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/signatureHelp.ts
@@ -1,0 +1,204 @@
+import { StateField, type Extension } from '@codemirror/state';
+import { EditorView, showTooltip, type Tooltip } from '@codemirror/view';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+
+import { type SignatureHelp, type SignatureHelpProvider, type SignatureInformation } from './types';
+
+export interface SignatureHelpOptions {
+  /**
+   * Grafana theme used to style the tooltip. When omitted the tooltip falls
+   * back to CodeMirror's default tooltip chrome plus the structural base styles.
+   */
+  theme?: GrafanaTheme2;
+}
+
+interface SignatureHelpState {
+  help: SignatureHelp;
+  pos: number;
+}
+
+/**
+ * Builds a CodeMirror extension that shows a signature-help tooltip while the
+ * cursor sits inside a function call. The provider owns language-specific
+ * detection; this extension owns the state tracking and tooltip rendering.
+ */
+export function signatureHelp(provider: SignatureHelpProvider, options: SignatureHelpOptions = {}): Extension {
+  const field = StateField.define<SignatureHelpState | null>({
+    create(state) {
+      const pos = state.selection.main.head;
+      const help = provider(state, pos);
+      return help ? { help, pos } : null;
+    },
+    update(value, tr) {
+      // Only recompute when the document or selection changes; other transactions
+      // (for example focus or config changes) leave the signature untouched.
+      if (!tr.docChanged && !tr.selection) {
+        return value;
+      }
+
+      const pos = tr.state.selection.main.head;
+      const help = provider(tr.state, pos);
+      return help ? { help, pos } : null;
+    },
+    provide: (stateField) =>
+      showTooltip.from(stateField, (value) => (value ? createSignatureTooltip(value.help, value.pos) : null)),
+  });
+
+  const extensions: Extension[] = [field, baseTheme];
+
+  if (options.theme) {
+    extensions.push(getSignatureHelpTheme(options.theme));
+  }
+
+  return extensions;
+}
+
+function createSignatureTooltip(help: SignatureHelp, pos: number): Tooltip {
+  const signature = help.signatures[help.activeSignature] ?? help.signatures[0];
+
+  return {
+    pos,
+    above: true,
+    strictSide: false,
+    create() {
+      const dom = document.createElement('div');
+      dom.className = 'cm-signature-help';
+      dom.appendChild(renderSignature(signature, help.activeParameter));
+
+      if (signature.documentation) {
+        const doc = document.createElement('div');
+        doc.className = 'cm-signature-help-doc';
+        doc.textContent = signature.documentation;
+        dom.appendChild(doc);
+      }
+
+      return { dom };
+    },
+  };
+}
+
+function renderSignature(signature: SignatureInformation, activeParameter: number): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'cm-signature-help-label';
+
+  const { parameters } = signature;
+
+  // When we have structured parameters, render each so the active one can be
+  // emphasized. Fall back to the raw label otherwise.
+  if (parameters.length === 0) {
+    container.textContent = signature.label;
+    return container;
+  }
+
+  const name = getSignatureName(signature.label);
+  container.appendChild(document.createTextNode(`${name}(`));
+
+  parameters.forEach((parameter, index) => {
+    if (index > 0) {
+      container.appendChild(document.createTextNode(', '));
+    }
+
+    const paramEl = document.createElement('span');
+    paramEl.textContent = parameter.label;
+
+    if (index === activeParameter) {
+      paramEl.className = 'cm-signature-help-active-param';
+    }
+
+    container.appendChild(paramEl);
+  });
+
+  container.appendChild(document.createTextNode(')'));
+
+  const returnType = getSignatureReturnType(signature.label);
+  if (returnType) {
+    container.appendChild(document.createTextNode(`: ${returnType}`));
+  }
+
+  return container;
+}
+
+/**
+ * Extracts the function name from a label like `round(value, decimals): number`.
+ */
+function getSignatureName(label: string): string {
+  const parenIndex = label.indexOf('(');
+  return parenIndex === -1 ? label : label.slice(0, parenIndex);
+}
+
+/**
+ * Extracts the return type from a label like `round(value, decimals): number`.
+ */
+function getSignatureReturnType(label: string): string | undefined {
+  const closingParenIndex = label.lastIndexOf(')');
+  if (closingParenIndex === -1) {
+    return undefined;
+  }
+
+  const afterParen = label.slice(closingParenIndex + 1);
+  const colonIndex = afterParen.indexOf(':');
+  if (colonIndex === -1) {
+    return undefined;
+  }
+
+  const returnType = afterParen.slice(colonIndex + 1).trim();
+  return returnType || undefined;
+}
+
+// Structural styles that apply regardless of theme. Colors are layered on top by
+// getSignatureHelpTheme when a Grafana theme is provided.
+const baseTheme = EditorView.baseTheme({
+  '.cm-tooltip.cm-signature-help': {
+    padding: '6px 10px',
+    maxWidth: '480px',
+    borderRadius: '2px',
+  },
+  '.cm-signature-help-label': {
+    fontFamily: 'monospace',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+  },
+  '.cm-signature-help-active-param': {
+    fontWeight: 'bold',
+  },
+  '.cm-signature-help-doc': {
+    marginTop: '6px',
+    paddingTop: '6px',
+    borderTop: '1px solid rgba(127, 127, 127, 0.3)',
+  },
+});
+
+/**
+ * Applies Grafana theme tokens to the tooltip so it matches the surrounding UI
+ * in both light and dark modes, VSCode signature-help style.
+ */
+function getSignatureHelpTheme(theme: GrafanaTheme2): Extension {
+  return EditorView.theme({
+    '.cm-tooltip.cm-signature-help': {
+      padding: theme.spacing(0.75, 1.25),
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+      backgroundColor: theme.colors.background.elevated,
+      color: theme.colors.text.primary,
+      boxShadow: theme.shadows.z2,
+      fontSize: theme.typography.bodySmall.fontSize,
+    },
+    '.cm-signature-help-label': {
+      fontFamily: theme.typography.fontFamilyMonospace,
+      lineHeight: theme.typography.bodySmall.lineHeight,
+    },
+    '.cm-signature-help-active-param': {
+      color: theme.colors.primary.text,
+      fontWeight: theme.typography.fontWeightBold,
+    },
+    '.cm-signature-help-doc': {
+      marginTop: theme.spacing(0.75),
+      paddingTop: theme.spacing(0.75),
+      borderTop: `1px solid ${theme.colors.border.weak}`,
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      lineHeight: theme.typography.bodySmall.lineHeight,
+    },
+  });
+}

--- a/packages/grafana-ui/src/components/CodeMirror/signatureHelp.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/signatureHelp.ts
@@ -82,19 +82,9 @@ function renderSignature(signature: SignatureInformation, activeParameter: numbe
   const container = document.createElement('div');
   container.className = 'cm-signature-help-label';
 
-  const { parameters } = signature;
+  container.appendChild(document.createTextNode(`${signature.name}(`));
 
-  // When we have structured parameters, render each so the active one can be
-  // emphasized. Fall back to the raw label otherwise.
-  if (parameters.length === 0) {
-    container.textContent = signature.label;
-    return container;
-  }
-
-  const name = getSignatureName(signature.label);
-  container.appendChild(document.createTextNode(`${name}(`));
-
-  parameters.forEach((parameter, index) => {
+  signature.parameters.forEach((parameter, index) => {
     if (index > 0) {
       container.appendChild(document.createTextNode(', '));
     }
@@ -111,39 +101,11 @@ function renderSignature(signature: SignatureInformation, activeParameter: numbe
 
   container.appendChild(document.createTextNode(')'));
 
-  const returnType = getSignatureReturnType(signature.label);
-  if (returnType) {
-    container.appendChild(document.createTextNode(`: ${returnType}`));
+  if (signature.returnType) {
+    container.appendChild(document.createTextNode(`: ${signature.returnType}`));
   }
 
   return container;
-}
-
-/**
- * Extracts the function name from a label like `round(value, decimals): number`.
- */
-function getSignatureName(label: string): string {
-  const parenIndex = label.indexOf('(');
-  return parenIndex === -1 ? label : label.slice(0, parenIndex);
-}
-
-/**
- * Extracts the return type from a label like `round(value, decimals): number`.
- */
-function getSignatureReturnType(label: string): string | undefined {
-  const closingParenIndex = label.lastIndexOf(')');
-  if (closingParenIndex === -1) {
-    return undefined;
-  }
-
-  const afterParen = label.slice(closingParenIndex + 1);
-  const colonIndex = afterParen.indexOf(':');
-  if (colonIndex === -1) {
-    return undefined;
-  }
-
-  const returnType = afterParen.slice(colonIndex + 1).trim();
-  return returnType || undefined;
 }
 
 // Structural styles that apply regardless of theme. Colors are layered on top by

--- a/packages/grafana-ui/src/components/CodeMirror/signatureHelp.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/signatureHelp.ts
@@ -27,8 +27,7 @@ export function signatureHelp(provider: SignatureHelpProvider, options: Signatur
   const field = StateField.define<SignatureHelpState | null>({
     create(state) {
       const pos = state.selection.main.head;
-      const help = provider(state, pos);
-      return help ? { help, pos } : null;
+      return toState(provider(state, pos), pos);
     },
     update(value, tr) {
       // Only recompute when the document or selection changes; other transactions
@@ -38,8 +37,7 @@ export function signatureHelp(provider: SignatureHelpProvider, options: Signatur
       }
 
       const pos = tr.state.selection.main.head;
-      const help = provider(tr.state, pos);
-      return help ? { help, pos } : null;
+      return toState(provider(tr.state, pos), pos);
     },
     provide: (stateField) =>
       showTooltip.from(stateField, (value) => (value ? createSignatureTooltip(value.help, value.pos) : null)),
@@ -52,6 +50,12 @@ export function signatureHelp(provider: SignatureHelpProvider, options: Signatur
   }
 
   return extensions;
+}
+
+// Treat help without any signatures as "no help" so the tooltip is never created
+// with an empty signature list (which would otherwise fail to render).
+function toState(help: SignatureHelp | null, pos: number): SignatureHelpState | null {
+  return help?.signatures.length ? { help, pos } : null;
 }
 
 function createSignatureTooltip(help: SignatureHelp, pos: number): Tooltip {

--- a/packages/grafana-ui/src/components/CodeMirror/types.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/types.ts
@@ -28,20 +28,27 @@ export interface SignatureParameter {
 
 /**
  * A callable signature, such as `round(value: number, decimals: number): number`.
+ *
+ * The pieces are kept structured (rather than a single pre-formatted string) so
+ * the tooltip can render and highlight them without having to parse a label.
  */
 export interface SignatureInformation {
   /**
-   * Full signature label shown in the tooltip header.
+   * Function name shown before the parameter list.
    */
-  label: string;
-  /**
-   * Optional description of the function.
-   */
-  documentation?: string;
+  name: string;
   /**
    * Ordered list of parameters used to highlight the active argument.
    */
   parameters: SignatureParameter[];
+  /**
+   * Optional return type shown after the parameter list.
+   */
+  returnType?: string;
+  /**
+   * Optional description of the function.
+   */
+  documentation?: string;
 }
 
 /**

--- a/packages/grafana-ui/src/components/CodeMirror/types.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/types.ts
@@ -1,5 +1,5 @@
 import type { Completion, CompletionContext, CompletionResult, CompletionSource } from '@codemirror/autocomplete';
-import { type Extension } from '@codemirror/state';
+import { type EditorState, type Extension } from '@codemirror/state';
 
 export type CodeMirrorCompletion = Completion;
 export type CodeMirrorCompletionContext = CompletionContext;
@@ -11,6 +11,61 @@ export type CodeMirrorExtension = Extension;
 export type CodeMirrorCompletionMode = 'override' | 'merge';
 
 export type CodeMirrorEditorLanguage = 'json' | 'sql';
+
+/**
+ * A single parameter within a function signature, such as `decimals: number`.
+ */
+export interface SignatureParameter {
+  /**
+   * Display label for the parameter, for example `decimals: number`.
+   */
+  label: string;
+  /**
+   * Optional human-readable description of the parameter.
+   */
+  documentation?: string;
+}
+
+/**
+ * A callable signature, such as `round(value: number, decimals: number): number`.
+ */
+export interface SignatureInformation {
+  /**
+   * Full signature label shown in the tooltip header.
+   */
+  label: string;
+  /**
+   * Optional description of the function.
+   */
+  documentation?: string;
+  /**
+   * Ordered list of parameters used to highlight the active argument.
+   */
+  parameters: SignatureParameter[];
+}
+
+/**
+ * The signature help returned by a provider for the current cursor position.
+ */
+export interface SignatureHelp {
+  /**
+   * Candidate signatures. Overloads can supply more than one.
+   */
+  signatures: SignatureInformation[];
+  /**
+   * Index into `signatures` of the signature to display.
+   */
+  activeSignature: number;
+  /**
+   * Index of the parameter the cursor is currently on.
+   */
+  activeParameter: number;
+}
+
+/**
+ * Computes signature help for the cursor position, or `null` when none applies.
+ */
+export type SignatureHelpProvider = (state: EditorState, pos: number) => SignatureHelp | null;
 
 export interface CodeMirrorEditorProps {
   /**

--- a/packages/grafana-ui/src/unstable.ts
+++ b/packages/grafana-ui/src/unstable.ts
@@ -12,6 +12,7 @@
 export * from './utils/skeleton';
 
 export { CodeMirrorEditor } from './components/CodeMirror/CodeEditorLazy';
+export { signatureHelp } from './components/CodeMirror/signatureHelp';
 export type {
   CodeMirrorCompletion,
   CodeMirrorCompletionContext,
@@ -21,5 +22,10 @@ export type {
   CodeMirrorEditorLanguage,
   CodeMirrorEditorProps,
   CodeMirrorExtension,
+  SignatureHelp,
+  SignatureHelpProvider,
+  SignatureInformation,
+  SignatureParameter,
 } from './components/CodeMirror/types';
+export type { SignatureHelpOptions } from './components/CodeMirror/signatureHelp';
 export { TableNG } from './components/Table/TableNG/TableNG';

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/SqlEditor.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/SqlEditor.tsx
@@ -2,15 +2,17 @@ import { css } from '@emotion/css';
 import { useCallback, useMemo, type ReactNode } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
-import { CodeMirrorEditor } from '@grafana/ui/unstable';
+import { useStyles2, useTheme2 } from '@grafana/ui';
+import { CodeMirrorEditor, signatureHelp } from '@grafana/ui/unstable';
 
+import { getSqlSignatureHelpProvider, type SqlFunctionSignature } from './signatureHelp';
 import { getSqlCompletionSource, type SqlCompletionProvider } from './utils';
 
 export interface SqlEditorProps {
   value: string;
   onChange: (value: string) => void;
   completionProvider?: SqlCompletionProvider;
+  functionSignatures?: SqlFunctionSignature[];
   formatter?: (value: string) => string;
   height?: number | string;
   ariaLabel?: string;
@@ -21,12 +23,14 @@ export const SqlEditor = ({
   value,
   onChange,
   completionProvider,
+  functionSignatures,
   formatter,
   height = '200px',
   ariaLabel,
   children,
 }: SqlEditorProps) => {
   const styles = useStyles2(getStyles);
+  const theme = useTheme2();
   const completionSources = useMemo(() => {
     if (!completionProvider) {
       return undefined;
@@ -34,6 +38,14 @@ export const SqlEditor = ({
 
     return [getSqlCompletionSource(completionProvider)];
   }, [completionProvider]);
+
+  const extensions = useMemo(() => {
+    if (!functionSignatures?.length) {
+      return undefined;
+    }
+
+    return [signatureHelp(getSqlSignatureHelpProvider(functionSignatures), { theme })];
+  }, [functionSignatures, theme]);
 
   const formatQuery = useCallback(() => {
     if (formatter) {
@@ -51,6 +63,7 @@ export const SqlEditor = ({
           height={typeof height === 'number' ? `${height}px` : height}
           aria-label={ariaLabel}
           completionSources={completionSources}
+          extensions={extensions}
         />
       </div>
       {children?.({ formatQuery })}

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/completionSituation.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/completionSituation.test.ts
@@ -1,0 +1,51 @@
+import { sql as sqlLanguage } from '@codemirror/lang-sql';
+import { EditorState } from '@codemirror/state';
+
+import { getEnclosingFunctionCall } from './completionSituation';
+
+const enclosingCall = (doc: string, pos: number = doc.length) => {
+  const state = EditorState.create({ doc, extensions: [sqlLanguage()] });
+  return getEnclosingFunctionCall(state, pos);
+};
+
+describe('getEnclosingFunctionCall', () => {
+  it('detects a function name right after the opening parenthesis', () => {
+    expect(enclosingCall('SELECT round(')).toEqual({ name: 'round', activeParameter: 0 });
+  });
+
+  it('detects keyword-named functions such as count', () => {
+    expect(enclosingCall('SELECT count(')).toEqual({ name: 'count', activeParameter: 0 });
+  });
+
+  it('advances the active parameter after each argument separator', () => {
+    expect(enclosingCall('SELECT round(value, ')).toEqual({ name: 'round', activeParameter: 1 });
+  });
+
+  it('keeps the active parameter on the current argument before the comma', () => {
+    const doc = 'SELECT round(value, 2)';
+    expect(enclosingCall(doc, 'SELECT round(value'.length)).toEqual({ name: 'round', activeParameter: 0 });
+  });
+
+  it('returns the innermost call for nested function calls', () => {
+    const doc = 'SELECT pow(mod(a, b), c)';
+    expect(enclosingCall(doc, 'SELECT pow(mod(a, '.length)).toEqual({ name: 'mod', activeParameter: 1 });
+  });
+
+  it('does not count separators from nested calls in the outer active parameter', () => {
+    const doc = 'SELECT pow(mod(a, b), ';
+    expect(enclosingCall(doc)).toEqual({ name: 'pow', activeParameter: 1 });
+  });
+
+  it('preserves the function name casing from the document', () => {
+    expect(enclosingCall('SELECT ROUND(')).toEqual({ name: 'ROUND', activeParameter: 0 });
+  });
+
+  it('returns null when the cursor is not inside a call', () => {
+    expect(enclosingCall('SELECT value')).toBeNull();
+  });
+
+  it('returns null once the cursor moves past the closing parenthesis', () => {
+    const doc = 'SELECT round(value, 2) ';
+    expect(enclosingCall(doc)).toBeNull();
+  });
+});

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/completionSituation.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/completionSituation.test.ts
@@ -44,8 +44,17 @@ describe('getEnclosingFunctionCall', () => {
     expect(enclosingCall('SELECT value')).toBeNull();
   });
 
+  it('returns null when the cursor is immediately after the closing parenthesis', () => {
+    expect(enclosingCall('SELECT round(value, 2)')).toBeNull();
+  });
+
   it('returns null once the cursor moves past the closing parenthesis', () => {
     const doc = 'SELECT round(value, 2) ';
     expect(enclosingCall(doc)).toBeNull();
+  });
+
+  it('falls back to the outer call when the cursor is just after a nested call', () => {
+    const doc = 'SELECT pow(mod(a, b), c)';
+    expect(enclosingCall(doc, 'SELECT pow(mod(a, b)'.length)).toEqual({ name: 'pow', activeParameter: 0 });
   });
 });

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/completionSituation.ts
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/completionSituation.ts
@@ -12,6 +12,7 @@ const SQL_KEYWORD_NODE_NAME = 'Keyword';
 const SQL_BUILTIN_NODE_NAME = 'Builtin';
 const SQL_TYPE_NODE_NAME = 'Type';
 const SQL_PARENS_NODE_NAME = 'Parens';
+const SQL_CLOSE_PAREN_NODE_NAME = ')';
 const SQL_PUNCTUATION_NODE_NAME = 'Punctuation';
 
 // Nodes that can carry a function name immediately before a Parens group. The
@@ -139,7 +140,7 @@ export function getEnclosingFunctionCall(state: EditorState, pos: number): Enclo
   // Walk up to the innermost Parens node that actually encloses the cursor.
   let parens: SyntaxNode | null = null;
   while (node) {
-    if (node.name === SQL_PARENS_NODE_NAME && node.from < resolvedPos && resolvedPos <= node.to) {
+    if (node.name === SQL_PARENS_NODE_NAME && isCursorInsideParens(node, resolvedPos)) {
       parens = node;
       break;
     }
@@ -167,6 +168,21 @@ export function getEnclosingFunctionCall(state: EditorState, pos: number): Enclo
     name,
     activeParameter: countActiveParameter(state, parens, resolvedPos),
   };
+}
+
+/**
+ * Determines whether the cursor sits inside a call's parentheses. A closed call
+ * ends with a `)` token, so the cursor dismisses once it moves onto or past it
+ * (matching VSCode). Unclosed calls that are still being typed have no `)` and
+ * extend to the cursor, so the signature stays while typing arguments.
+ */
+function isCursorInsideParens(parens: SyntaxNode, pos: number): boolean {
+  if (pos <= parens.from) {
+    return false;
+  }
+
+  const isClosed = parens.lastChild?.name === SQL_CLOSE_PAREN_NODE_NAME;
+  return isClosed ? pos < parens.to : pos <= parens.to;
 }
 
 /**

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/completionSituation.ts
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/completionSituation.ts
@@ -1,4 +1,5 @@
 import { syntaxTree } from '@codemirror/language';
+import { type EditorState } from '@codemirror/state';
 import { type SyntaxNode } from '@lezer/common';
 
 import { type CodeMirrorCompletionContext } from '@grafana/ui/unstable';
@@ -6,8 +7,23 @@ import { type CodeMirrorCompletionContext } from '@grafana/ui/unstable';
 const SQL_STATEMENT_NODE_NAME = 'Statement';
 const SQL_COMPOSITE_IDENTIFIER_NODE_NAME = 'CompositeIdentifier';
 const SQL_IDENTIFIER_NODE_NAME = 'Identifier';
+const SQL_QUOTED_IDENTIFIER_NODE_NAME = 'QuotedIdentifier';
 const SQL_KEYWORD_NODE_NAME = 'Keyword';
+const SQL_BUILTIN_NODE_NAME = 'Builtin';
+const SQL_TYPE_NODE_NAME = 'Type';
+const SQL_PARENS_NODE_NAME = 'Parens';
 const SQL_PUNCTUATION_NODE_NAME = 'Punctuation';
+
+// Nodes that can carry a function name immediately before a Parens group. The
+// lang-sql grammar tokenizes function names as plain identifiers or, for known
+// keywords/builtins/types, as those node kinds.
+const SQL_FUNCTION_NAME_NODE_NAMES = new Set([
+  SQL_IDENTIFIER_NODE_NAME,
+  SQL_QUOTED_IDENTIFIER_NODE_NAME,
+  SQL_KEYWORD_NODE_NAME,
+  SQL_BUILTIN_NODE_NAME,
+  SQL_TYPE_NODE_NAME,
+]);
 
 const SQL_SELECT_KEYWORD = 'SELECT';
 const SQL_FROM_KEYWORD = 'FROM';
@@ -103,6 +119,79 @@ export function getSqlCompletionSituation(
     from: word.from,
     tables: getUniqueTables(tableRefs),
   };
+}
+
+export interface EnclosingFunctionCall {
+  name: string;
+  activeParameter: number;
+}
+
+/**
+ * Finds the innermost function call surrounding the cursor using the SQL syntax
+ * tree. Returns the function name and which argument the cursor is on, or null
+ * when the cursor is not inside a call's parentheses.
+ */
+export function getEnclosingFunctionCall(state: EditorState, pos: number): EnclosingFunctionCall | null {
+  const tree = syntaxTree(state);
+  const resolvedPos = Math.min(pos, state.doc.length);
+  let node: SyntaxNode | null = tree.resolveInner(resolvedPos, -1);
+
+  // Walk up to the innermost Parens node that actually encloses the cursor.
+  let parens: SyntaxNode | null = null;
+  while (node) {
+    if (node.name === SQL_PARENS_NODE_NAME && node.from < resolvedPos && resolvedPos <= node.to) {
+      parens = node;
+      break;
+    }
+
+    node = node.parent;
+  }
+
+  if (!parens) {
+    return null;
+  }
+
+  const nameNode = parens.prevSibling;
+
+  if (!nameNode || !SQL_FUNCTION_NAME_NODE_NAMES.has(nameNode.name)) {
+    return null;
+  }
+
+  const name = getStateNodeText(state, nameNode).trim();
+
+  if (!name) {
+    return null;
+  }
+
+  return {
+    name,
+    activeParameter: countActiveParameter(state, parens, resolvedPos),
+  };
+}
+
+/**
+ * Counts the argument separators that appear before the cursor within the call's
+ * parentheses. Only direct comma children are counted so nested calls do not
+ * affect the active parameter of the enclosing call.
+ */
+function countActiveParameter(state: EditorState, parens: SyntaxNode, pos: number): number {
+  let activeParameter = 0;
+
+  for (let child = parens.firstChild; child; child = child.nextSibling) {
+    if (child.to > pos) {
+      break;
+    }
+
+    if (child.name === SQL_PUNCTUATION_NODE_NAME && getStateNodeText(state, child) === ',') {
+      activeParameter++;
+    }
+  }
+
+  return activeParameter;
+}
+
+function getStateNodeText(state: EditorState, node: SyntaxNode): string {
+  return state.doc.sliceString(node.from, node.to);
 }
 
 function getStatementAtCursor(context: CodeMirrorCompletionContext): SyntaxNode | null {

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/signatureHelp.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/signatureHelp.test.ts
@@ -1,0 +1,71 @@
+import { sql as sqlLanguage } from '@codemirror/lang-sql';
+import { EditorState } from '@codemirror/state';
+
+import { getSqlSignatureHelpProvider, type SqlFunctionSignature } from './signatureHelp';
+
+const SIGNATURES: SqlFunctionSignature[] = [
+  {
+    name: 'round',
+    parameters: [{ label: 'value: number' }, { label: 'decimals: number' }],
+    returnType: 'number',
+    documentation: 'Rounds a number.',
+  },
+  {
+    name: 'coalesce',
+    parameters: [{ label: 'value: any' }, { label: '...values: any' }],
+    returnType: 'any',
+  },
+  {
+    name: 'pi',
+    parameters: [],
+    returnType: 'number',
+  },
+];
+
+const getHelp = (doc: string, pos: number = doc.length) => {
+  const provider = getSqlSignatureHelpProvider(SIGNATURES);
+  const state = EditorState.create({ doc, extensions: [sqlLanguage()] });
+  return provider(state, pos);
+};
+
+describe('getSqlSignatureHelpProvider', () => {
+  it('returns the matching signature when the cursor is inside a known call', () => {
+    expect(getHelp('SELECT round(')).toEqual({
+      signatures: [
+        {
+          name: 'round',
+          returnType: 'number',
+          documentation: 'Rounds a number.',
+          parameters: [{ label: 'value: number' }, { label: 'decimals: number' }],
+        },
+      ],
+      activeSignature: 0,
+      activeParameter: 0,
+    });
+  });
+
+  it('advances the active parameter after a comma', () => {
+    expect(getHelp('SELECT round(value, ')).toEqual(expect.objectContaining({ activeParameter: 1 }));
+  });
+
+  it('matches function names case-insensitively', () => {
+    expect(getHelp('SELECT ROUND(')).toEqual(expect.objectContaining({ activeSignature: 0 }));
+    expect(getHelp('SELECT ROUND(')?.signatures[0].name).toBe('round');
+  });
+
+  it('clamps the active parameter to the last declared parameter for variadic functions', () => {
+    expect(getHelp('SELECT coalesce(a, b, c, ')).toEqual(expect.objectContaining({ activeParameter: 1 }));
+  });
+
+  it('returns null for unknown functions', () => {
+    expect(getHelp('SELECT unknownFn(')).toBeNull();
+  });
+
+  it('returns null for grouping parentheses that follow a keyword', () => {
+    expect(getHelp('SELECT (')).toBeNull();
+  });
+
+  it('returns null when the cursor is not inside a call', () => {
+    expect(getHelp('SELECT 1')).toBeNull();
+  });
+});

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/signatureHelp.ts
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/signatureHelp.ts
@@ -2,7 +2,7 @@ import { type SignatureHelp, type SignatureHelpProvider } from '@grafana/ui/unst
 
 import { getEnclosingFunctionCall } from './completionSituation';
 
-export interface SqlFunctionParameter {
+interface SqlFunctionParameter {
   label: string;
   documentation?: string;
 }

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/signatureHelp.ts
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/signatureHelp.ts
@@ -43,7 +43,8 @@ function toSignatureHelp(signature: SqlFunctionSignature, activeParameter: numbe
   return {
     signatures: [
       {
-        label: formatSignatureLabel(signature),
+        name: signature.name,
+        returnType: signature.returnType,
         documentation: signature.documentation,
         parameters: signature.parameters.map((parameter) => ({
           label: parameter.label,
@@ -54,18 +55,6 @@ function toSignatureHelp(signature: SqlFunctionSignature, activeParameter: numbe
     activeSignature: 0,
     activeParameter: clampActiveParameter(activeParameter, signature.parameters.length),
   };
-}
-
-/**
- * Formats a signature label as `name(param, param): returnType`, matching the
- * shape the generic tooltip renderer parses for the function name and return
- * type.
- */
-function formatSignatureLabel(signature: SqlFunctionSignature): string {
-  const params = signature.parameters.map((parameter) => parameter.label).join(', ');
-  const base = `${signature.name}(${params})`;
-
-  return signature.returnType ? `${base}: ${signature.returnType}` : base;
 }
 
 /**

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/signatureHelp.ts
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/signatureHelp.ts
@@ -1,0 +1,81 @@
+import { type SignatureHelp, type SignatureHelpProvider } from '@grafana/ui/unstable';
+
+import { getEnclosingFunctionCall } from './completionSituation';
+
+export interface SqlFunctionParameter {
+  label: string;
+  documentation?: string;
+}
+
+export interface SqlFunctionSignature {
+  name: string;
+  parameters: SqlFunctionParameter[];
+  returnType?: string;
+  documentation?: string;
+}
+
+/**
+ * Builds a signature-help provider for the CodeMirror editor from a list of SQL
+ * function signatures. Detection of the enclosing call is delegated to the SQL
+ * syntax tree so the editor itself stays language-agnostic.
+ */
+export function getSqlSignatureHelpProvider(signatures: SqlFunctionSignature[]): SignatureHelpProvider {
+  const signaturesByName = new Map(signatures.map((signature) => [signature.name.toLowerCase(), signature]));
+
+  return (state, pos) => {
+    const call = getEnclosingFunctionCall(state, pos);
+
+    if (!call) {
+      return null;
+    }
+
+    const signature = signaturesByName.get(call.name.toLowerCase());
+
+    if (!signature) {
+      return null;
+    }
+
+    return toSignatureHelp(signature, call.activeParameter);
+  };
+}
+
+function toSignatureHelp(signature: SqlFunctionSignature, activeParameter: number): SignatureHelp {
+  return {
+    signatures: [
+      {
+        label: formatSignatureLabel(signature),
+        documentation: signature.documentation,
+        parameters: signature.parameters.map((parameter) => ({
+          label: parameter.label,
+          documentation: parameter.documentation,
+        })),
+      },
+    ],
+    activeSignature: 0,
+    activeParameter: clampActiveParameter(activeParameter, signature.parameters.length),
+  };
+}
+
+/**
+ * Formats a signature label as `name(param, param): returnType`, matching the
+ * shape the generic tooltip renderer parses for the function name and return
+ * type.
+ */
+function formatSignatureLabel(signature: SqlFunctionSignature): string {
+  const params = signature.parameters.map((parameter) => parameter.label).join(', ');
+  const base = `${signature.name}(${params})`;
+
+  return signature.returnType ? `${base}: ${signature.returnType}` : base;
+}
+
+/**
+ * Keeps the active parameter within range. Variadic functions and stray commas
+ * can push the count past the declared parameters, so we pin to the last one.
+ */
+function clampActiveParameter(activeParameter: number, parameterCount: number): number {
+  if (parameterCount === 0) {
+    return 0;
+  }
+
+  return Math.min(activeParameter, parameterCount - 1);
+}

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
@@ -63,6 +63,12 @@ jest.mock('./SqlQueryActions', () => ({
   SqlQueryActions: jest.fn(() => null),
 }));
 
+// The lazy signature-metadata load is covered by its own hook test; stub it here
+// so the async import doesn't schedule state updates outside act().
+jest.mock('./hooks/useFunctionSignatures', () => ({
+  useFunctionSignatures: jest.fn(() => undefined),
+}));
+
 const mockBackendSrv = {
   post: jest.fn().mockResolvedValue({
     kind: 'SQLSchemaResponse',

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -22,7 +22,7 @@ import { SchemaInspectorPanel } from './SchemaInspector/SchemaInspectorPanel';
 import { SqlEditor } from './SqlEditor/SqlEditor';
 import { type SqlCompletionProvider } from './SqlEditor/utils';
 import { SqlQueryActions } from './SqlQueryActions';
-import { FUNCTION_SIGNATURES } from './functionSignatures';
+import { useFunctionSignatures } from './hooks/useFunctionSignatures';
 import { useSQLSchemas } from './hooks/useSQLSchemas';
 
 const SQLEditor = lazy(() =>
@@ -52,6 +52,9 @@ export const SqlExpr = ({ onChange, refIds, query, alerting = false, queries, me
   const interpolationFilters = metadata?.data?.request?.filters;
   const interpolationRange = metadata?.range;
   const useCodeMirrorEditor = useBooleanFlagValue('sqlExpressionsCodeMirror', false);
+
+  // Signature metadata is large, so it is loaded lazily only for the CodeMirror path.
+  const functionSignatures = useFunctionSignatures(useCodeMirrorEditor);
 
   const completionProvider = useMemo<SqlCompletionProvider>(
     () => ({
@@ -268,7 +271,7 @@ LIMIT
                   value={query.expression ?? initialQuery}
                   onChange={onEditorChange}
                   completionProvider={completionProvider}
-                  functionSignatures={FUNCTION_SIGNATURES}
+                  functionSignatures={functionSignatures}
                   formatter={formatSQL}
                   height={editorHeight}
                   ariaLabel={t('expressions.sql-expression.editor.aria-label', 'SQL expression editor')}

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -22,6 +22,7 @@ import { SchemaInspectorPanel } from './SchemaInspector/SchemaInspectorPanel';
 import { SqlEditor } from './SqlEditor/SqlEditor';
 import { type SqlCompletionProvider } from './SqlEditor/utils';
 import { SqlQueryActions } from './SqlQueryActions';
+import { FUNCTION_SIGNATURES } from './functionSignatures';
 import { useSQLSchemas } from './hooks/useSQLSchemas';
 
 const SQLEditor = lazy(() =>
@@ -267,6 +268,7 @@ LIMIT
                   value={query.expression ?? initialQuery}
                   onChange={onEditorChange}
                   completionProvider={completionProvider}
+                  functionSignatures={FUNCTION_SIGNATURES}
                   formatter={formatSQL}
                   height={editorHeight}
                   ariaLabel={t('expressions.sql-expression.editor.aria-label', 'SQL expression editor')}

--- a/public/app/features/expressions/components/SqlExpressions/functionSignatures.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/functionSignatures.test.ts
@@ -1,0 +1,28 @@
+import { ALLOWED_FUNCTIONS } from '../../utils/metaSqlExpr';
+
+import { FUNCTION_SIGNATURES } from './functionSignatures';
+
+describe('FUNCTION_SIGNATURES', () => {
+  const names = FUNCTION_SIGNATURES.map((signature) => signature.name);
+
+  it('has no duplicate function names', () => {
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('only defines signatures for allowed functions', () => {
+    const allowed = new Set(ALLOWED_FUNCTIONS);
+    expect(names.filter((name) => !allowed.has(name))).toEqual([]);
+  });
+
+  it('covers every allowed function', () => {
+    const covered = new Set(names);
+    expect(ALLOWED_FUNCTIONS.filter((name) => !covered.has(name))).toEqual([]);
+  });
+
+  it('gives every signature a name and a parameters array', () => {
+    for (const signature of FUNCTION_SIGNATURES) {
+      expect(signature.name).toBeTruthy();
+      expect(Array.isArray(signature.parameters)).toBe(true);
+    }
+  });
+});

--- a/public/app/features/expressions/components/SqlExpressions/functionSignatures.ts
+++ b/public/app/features/expressions/components/SqlExpressions/functionSignatures.ts
@@ -1,0 +1,152 @@
+import { type SqlFunctionSignature } from './SqlEditor/signatureHelp';
+
+/**
+ * Curated signature metadata for the most common SQL Expression functions.
+ *
+ * This is intentionally a subset of ALLOWED_FUNCTIONS (see
+ * ../../utils/metaSqlExpr). To add signature help for another allowed function,
+ * append an entry here with its parameters and return type.
+ */
+export const FUNCTION_SIGNATURES: SqlFunctionSignature[] = [
+  // Math
+  {
+    name: 'abs',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the absolute value of a number.',
+  },
+  {
+    name: 'round',
+    parameters: [{ label: 'value: number' }, { label: 'decimals: number', documentation: 'Number of decimal places.' }],
+    returnType: 'number',
+    documentation: 'Rounds a number to the given number of decimal places.',
+  },
+  {
+    name: 'ceil',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the smallest integer greater than or equal to the value.',
+  },
+  {
+    name: 'floor',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the largest integer less than or equal to the value.',
+  },
+  {
+    name: 'truncate',
+    parameters: [{ label: 'value: number' }, { label: 'decimals: number', documentation: 'Number of decimal places.' }],
+    returnType: 'number',
+    documentation: 'Truncates a number to the given number of decimal places.',
+  },
+  {
+    name: 'sqrt',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the square root of a number.',
+  },
+  {
+    name: 'pow',
+    parameters: [{ label: 'base: number' }, { label: 'exponent: number' }],
+    returnType: 'number',
+    documentation: 'Returns base raised to the power of exponent.',
+  },
+  {
+    name: 'mod',
+    parameters: [{ label: 'dividend: number' }, { label: 'divisor: number' }],
+    returnType: 'number',
+    documentation: 'Returns the remainder of dividend divided by divisor.',
+  },
+  {
+    name: 'log',
+    parameters: [{ label: 'value: number' }, { label: 'base: number', documentation: 'Optional logarithm base.' }],
+    returnType: 'number',
+    documentation: 'Returns the natural logarithm, or the logarithm to the given base.',
+  },
+
+  // Conditional / null handling
+  {
+    name: 'if',
+    parameters: [
+      { label: 'condition: boolean' },
+      { label: 'then: any', documentation: 'Value returned when the condition is true.' },
+      { label: 'else: any', documentation: 'Value returned when the condition is false.' },
+    ],
+    returnType: 'any',
+    documentation: 'Returns then when the condition is true, otherwise else.',
+  },
+  {
+    name: 'ifnull',
+    parameters: [{ label: 'value: any' }, { label: 'fallback: any' }],
+    returnType: 'any',
+    documentation: 'Returns fallback when value is NULL, otherwise value.',
+  },
+  {
+    name: 'nullif',
+    parameters: [{ label: 'value: any' }, { label: 'compare: any' }],
+    returnType: 'any',
+    documentation: 'Returns NULL when the two arguments are equal, otherwise value.',
+  },
+  {
+    name: 'coalesce',
+    parameters: [{ label: 'value: any' }, { label: '...values: any', documentation: 'Additional fallback values.' }],
+    returnType: 'any',
+    documentation: 'Returns the first non-NULL value from the arguments.',
+  },
+
+  // Aggregates
+  {
+    name: 'avg',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the average of all values in the group.',
+  },
+  {
+    name: 'sum',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the sum of all values in the group.',
+  },
+  {
+    name: 'min',
+    parameters: [{ label: 'value: any' }],
+    returnType: 'any',
+    documentation: 'Returns the minimum value in the group.',
+  },
+  {
+    name: 'max',
+    parameters: [{ label: 'value: any' }],
+    returnType: 'any',
+    documentation: 'Returns the maximum value in the group.',
+  },
+  {
+    name: 'count',
+    parameters: [{ label: 'value: any' }],
+    returnType: 'number',
+    documentation: 'Returns the number of rows or non-NULL values in the group.',
+  },
+
+  // Strings
+  {
+    name: 'concat',
+    parameters: [{ label: 'value: any' }, { label: '...values: any', documentation: 'Additional values to append.' }],
+    returnType: 'string',
+    documentation: 'Concatenates the arguments into a single string.',
+  },
+  {
+    name: 'substring',
+    parameters: [
+      { label: 'value: string' },
+      { label: 'start: number', documentation: 'One-based start position.' },
+      { label: 'length: number', documentation: 'Optional number of characters.' },
+    ],
+    returnType: 'string',
+    documentation: 'Extracts a substring starting at the given position.',
+  },
+  {
+    name: 'replace',
+    parameters: [{ label: 'value: string' }, { label: 'from: string' }, { label: 'to: string' }],
+    returnType: 'string',
+    documentation: 'Replaces all occurrences of from with to in the string.',
+  },
+];

--- a/public/app/features/expressions/components/SqlExpressions/functionSignatures.ts
+++ b/public/app/features/expressions/components/SqlExpressions/functionSignatures.ts
@@ -1,69 +1,15 @@
 import { type SqlFunctionSignature } from './SqlEditor/signatureHelp';
 
 /**
- * Curated signature metadata for the most common SQL Expression functions.
+ * Signature metadata for the SQL Expression functions.
  *
- * This is intentionally a subset of ALLOWED_FUNCTIONS (see
- * ../../utils/metaSqlExpr). To add signature help for another allowed function,
- * append an entry here with its parameters and return type.
+ * This mirrors ALLOWED_FUNCTIONS (see ../../utils/metaSqlExpr, which itself
+ * mirrors the backend allow-list in pkg/expr/sql/parser_allow.go). When a
+ * function is added to or removed from the allow-list, update this list too.
+ * Signatures follow MySQL semantics; optional/variadic arguments are noted in
+ * the parameter documentation.
  */
 export const FUNCTION_SIGNATURES: SqlFunctionSignature[] = [
-  // Math
-  {
-    name: 'abs',
-    parameters: [{ label: 'value: number' }],
-    returnType: 'number',
-    documentation: 'Returns the absolute value of a number.',
-  },
-  {
-    name: 'round',
-    parameters: [{ label: 'value: number' }, { label: 'decimals: number', documentation: 'Number of decimal places.' }],
-    returnType: 'number',
-    documentation: 'Rounds a number to the given number of decimal places.',
-  },
-  {
-    name: 'ceil',
-    parameters: [{ label: 'value: number' }],
-    returnType: 'number',
-    documentation: 'Returns the smallest integer greater than or equal to the value.',
-  },
-  {
-    name: 'floor',
-    parameters: [{ label: 'value: number' }],
-    returnType: 'number',
-    documentation: 'Returns the largest integer less than or equal to the value.',
-  },
-  {
-    name: 'truncate',
-    parameters: [{ label: 'value: number' }, { label: 'decimals: number', documentation: 'Number of decimal places.' }],
-    returnType: 'number',
-    documentation: 'Truncates a number to the given number of decimal places.',
-  },
-  {
-    name: 'sqrt',
-    parameters: [{ label: 'value: number' }],
-    returnType: 'number',
-    documentation: 'Returns the square root of a number.',
-  },
-  {
-    name: 'pow',
-    parameters: [{ label: 'base: number' }, { label: 'exponent: number' }],
-    returnType: 'number',
-    documentation: 'Returns base raised to the power of exponent.',
-  },
-  {
-    name: 'mod',
-    parameters: [{ label: 'dividend: number' }, { label: 'divisor: number' }],
-    returnType: 'number',
-    documentation: 'Returns the remainder of dividend divided by divisor.',
-  },
-  {
-    name: 'log',
-    parameters: [{ label: 'value: number' }, { label: 'base: number', documentation: 'Optional logarithm base.' }],
-    returnType: 'number',
-    documentation: 'Returns the natural logarithm, or the logarithm to the given base.',
-  },
-
   // Conditional / null handling
   {
     name: 'if',
@@ -74,6 +20,12 @@ export const FUNCTION_SIGNATURES: SqlFunctionSignature[] = [
     ],
     returnType: 'any',
     documentation: 'Returns then when the condition is true, otherwise else.',
+  },
+  {
+    name: 'coalesce',
+    parameters: [{ label: 'value: any' }, { label: '...values: any', documentation: 'Additional fallback values.' }],
+    returnType: 'any',
+    documentation: 'Returns the first non-NULL value from the arguments.',
   },
   {
     name: 'ifnull',
@@ -87,14 +39,14 @@ export const FUNCTION_SIGNATURES: SqlFunctionSignature[] = [
     returnType: 'any',
     documentation: 'Returns NULL when the two arguments are equal, otherwise value.',
   },
-  {
-    name: 'coalesce',
-    parameters: [{ label: 'value: any' }, { label: '...values: any', documentation: 'Additional fallback values.' }],
-    returnType: 'any',
-    documentation: 'Returns the first non-NULL value from the arguments.',
-  },
 
   // Aggregates
+  {
+    name: 'sum',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the sum of all values in the group.',
+  },
   {
     name: 'avg',
     parameters: [{ label: 'value: number' }],
@@ -102,10 +54,10 @@ export const FUNCTION_SIGNATURES: SqlFunctionSignature[] = [
     documentation: 'Returns the average of all values in the group.',
   },
   {
-    name: 'sum',
-    parameters: [{ label: 'value: number' }],
+    name: 'count',
+    parameters: [{ label: 'value: any' }],
     returnType: 'number',
-    documentation: 'Returns the sum of all values in the group.',
+    documentation: 'Returns the number of rows or non-NULL values in the group.',
   },
   {
     name: 'min',
@@ -120,10 +72,246 @@ export const FUNCTION_SIGNATURES: SqlFunctionSignature[] = [
     documentation: 'Returns the maximum value in the group.',
   },
   {
-    name: 'count',
-    parameters: [{ label: 'value: any' }],
+    name: 'stddev',
+    parameters: [{ label: 'value: number' }],
     returnType: 'number',
-    documentation: 'Returns the number of rows or non-NULL values in the group.',
+    documentation: 'Returns the population standard deviation of the values in the group.',
+  },
+  {
+    name: 'std',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the population standard deviation of the values in the group.',
+  },
+  {
+    name: 'stddev_pop',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the population standard deviation of the values in the group.',
+  },
+  {
+    name: 'variance',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the population variance of the values in the group.',
+  },
+  {
+    name: 'var_pop',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the population variance of the values in the group.',
+  },
+  {
+    name: 'group_concat',
+    parameters: [{ label: 'value: any' }],
+    returnType: 'string',
+    documentation: 'Concatenates non-NULL values in the group into a string. Supports a SEPARATOR clause.',
+  },
+
+  // Window functions
+  {
+    name: 'row_number',
+    parameters: [],
+    returnType: 'number',
+    documentation: 'Returns the sequential number of the current row within its window.',
+  },
+  {
+    name: 'rank',
+    parameters: [],
+    returnType: 'number',
+    documentation: 'Returns the rank of the current row within its window, with gaps for ties.',
+  },
+  {
+    name: 'dense_rank',
+    parameters: [],
+    returnType: 'number',
+    documentation: 'Returns the rank of the current row within its window, without gaps for ties.',
+  },
+  {
+    name: 'lead',
+    parameters: [
+      { label: 'value: any' },
+      { label: 'offset: number', documentation: 'Number of rows ahead (default 1).' },
+      { label: 'default: any', documentation: 'Value when the offset is out of range.' },
+    ],
+    returnType: 'any',
+    documentation: 'Returns the value from a following row within the window.',
+  },
+  {
+    name: 'lag',
+    parameters: [
+      { label: 'value: any' },
+      { label: 'offset: number', documentation: 'Number of rows behind (default 1).' },
+      { label: 'default: any', documentation: 'Value when the offset is out of range.' },
+    ],
+    returnType: 'any',
+    documentation: 'Returns the value from a preceding row within the window.',
+  },
+  {
+    name: 'first_value',
+    parameters: [{ label: 'value: any' }],
+    returnType: 'any',
+    documentation: 'Returns the value from the first row of the window frame.',
+  },
+  {
+    name: 'last_value',
+    parameters: [{ label: 'value: any' }],
+    returnType: 'any',
+    documentation: 'Returns the value from the last row of the window frame.',
+  },
+
+  // Math
+  {
+    name: 'abs',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the absolute value of a number.',
+  },
+  {
+    name: 'round',
+    parameters: [
+      { label: 'value: number' },
+      { label: 'decimals: number', documentation: 'Number of decimal places (default 0).' },
+    ],
+    returnType: 'number',
+    documentation: 'Rounds a number to the given number of decimal places.',
+  },
+  {
+    name: 'floor',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the largest integer less than or equal to the value.',
+  },
+  {
+    name: 'ceiling',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the smallest integer greater than or equal to the value.',
+  },
+  {
+    name: 'ceil',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the smallest integer greater than or equal to the value.',
+  },
+  {
+    name: 'sqrt',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the square root of a number.',
+  },
+  {
+    name: 'pow',
+    parameters: [{ label: 'base: number' }, { label: 'exponent: number' }],
+    returnType: 'number',
+    documentation: 'Returns base raised to the power of exponent.',
+  },
+  {
+    name: 'power',
+    parameters: [{ label: 'base: number' }, { label: 'exponent: number' }],
+    returnType: 'number',
+    documentation: 'Returns base raised to the power of exponent.',
+  },
+  {
+    name: 'mod',
+    parameters: [{ label: 'dividend: number' }, { label: 'divisor: number' }],
+    returnType: 'number',
+    documentation: 'Returns the remainder of dividend divided by divisor.',
+  },
+  {
+    name: 'log',
+    parameters: [
+      { label: 'value: number' },
+      { label: 'base: number', documentation: 'Optional logarithm base. With one argument, returns the natural log.' },
+    ],
+    returnType: 'number',
+    documentation: 'Returns the natural logarithm, or the logarithm to the given base.',
+  },
+  {
+    name: 'log10',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the base-10 logarithm of a number.',
+  },
+  {
+    name: 'exp',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns e raised to the power of the value.',
+  },
+  {
+    name: 'sign',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns -1, 0, or 1 depending on the sign of the value.',
+  },
+  {
+    name: 'ln',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the natural logarithm of a number.',
+  },
+  {
+    name: 'truncate',
+    parameters: [{ label: 'value: number' }, { label: 'decimals: number', documentation: 'Number of decimal places.' }],
+    returnType: 'number',
+    documentation: 'Truncates a number to the given number of decimal places.',
+  },
+
+  // Trigonometric
+  {
+    name: 'sin',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the sine of the value (in radians).',
+  },
+  {
+    name: 'cos',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the cosine of the value (in radians).',
+  },
+  {
+    name: 'tan',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the tangent of the value (in radians).',
+  },
+  {
+    name: 'asin',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the arc sine of the value (in radians).',
+  },
+  {
+    name: 'acos',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the arc cosine of the value (in radians).',
+  },
+  {
+    name: 'atan',
+    parameters: [{ label: 'value: number' }],
+    returnType: 'number',
+    documentation: 'Returns the arc tangent of the value (in radians).',
+  },
+  {
+    name: 'atan2',
+    parameters: [{ label: 'y: number' }, { label: 'x: number' }],
+    returnType: 'number',
+    documentation: 'Returns the arc tangent of y / x, using the signs of both to determine the quadrant.',
+  },
+  {
+    name: 'rand',
+    parameters: [{ label: 'seed: number', documentation: 'Optional seed for a repeatable sequence.' }],
+    returnType: 'number',
+    documentation: 'Returns a random floating-point value between 0 and 1.',
+  },
+  {
+    name: 'pi',
+    parameters: [],
+    returnType: 'number',
+    documentation: 'Returns the value of pi.',
   },
 
   // Strings
@@ -132,6 +320,30 @@ export const FUNCTION_SIGNATURES: SqlFunctionSignature[] = [
     parameters: [{ label: 'value: any' }, { label: '...values: any', documentation: 'Additional values to append.' }],
     returnType: 'string',
     documentation: 'Concatenates the arguments into a single string.',
+  },
+  {
+    name: 'length',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'number',
+    documentation: 'Returns the length of the string in bytes.',
+  },
+  {
+    name: 'char_length',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'number',
+    documentation: 'Returns the length of the string in characters.',
+  },
+  {
+    name: 'lower',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'string',
+    documentation: 'Returns the string with all characters in lower case.',
+  },
+  {
+    name: 'upper',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'string',
+    documentation: 'Returns the string with all characters in upper case.',
   },
   {
     name: 'substring',
@@ -144,9 +356,432 @@ export const FUNCTION_SIGNATURES: SqlFunctionSignature[] = [
     documentation: 'Extracts a substring starting at the given position.',
   },
   {
+    name: 'substring_index',
+    parameters: [
+      { label: 'value: string' },
+      { label: 'delimiter: string' },
+      {
+        label: 'count: number',
+        documentation: 'Occurrences of the delimiter to include (negative counts from the end).',
+      },
+    ],
+    returnType: 'string',
+    documentation: 'Returns the substring before the given count of delimiter occurrences.',
+  },
+  {
+    name: 'left',
+    parameters: [{ label: 'value: string' }, { label: 'length: number' }],
+    returnType: 'string',
+    documentation: 'Returns the leftmost length characters of the string.',
+  },
+  {
+    name: 'right',
+    parameters: [{ label: 'value: string' }, { label: 'length: number' }],
+    returnType: 'string',
+    documentation: 'Returns the rightmost length characters of the string.',
+  },
+  {
+    name: 'ltrim',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'string',
+    documentation: 'Returns the string with leading spaces removed.',
+  },
+  {
+    name: 'rtrim',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'string',
+    documentation: 'Returns the string with trailing spaces removed.',
+  },
+  {
     name: 'replace',
     parameters: [{ label: 'value: string' }, { label: 'from: string' }, { label: 'to: string' }],
     returnType: 'string',
     documentation: 'Replaces all occurrences of from with to in the string.',
+  },
+  {
+    name: 'reverse',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'string',
+    documentation: 'Returns the string with the characters in reverse order.',
+  },
+  {
+    name: 'lcase',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'string',
+    documentation: 'Returns the string with all characters in lower case.',
+  },
+  {
+    name: 'ucase',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'string',
+    documentation: 'Returns the string with all characters in upper case.',
+  },
+  {
+    name: 'mid',
+    parameters: [
+      { label: 'value: string' },
+      { label: 'start: number', documentation: 'One-based start position.' },
+      { label: 'length: number', documentation: 'Number of characters.' },
+    ],
+    returnType: 'string',
+    documentation: 'Extracts a substring starting at the given position.',
+  },
+  {
+    name: 'repeat',
+    parameters: [{ label: 'value: string' }, { label: 'count: number' }],
+    returnType: 'string',
+    documentation: 'Returns the string repeated count times.',
+  },
+  {
+    name: 'position',
+    parameters: [{ label: 'substring: string' }, { label: 'string: string' }],
+    returnType: 'number',
+    documentation: 'Returns the position of substring within string. Syntax: POSITION(substring IN string).',
+  },
+  {
+    name: 'instr',
+    parameters: [{ label: 'string: string' }, { label: 'substring: string' }],
+    returnType: 'number',
+    documentation: 'Returns the position of the first occurrence of substring in string.',
+  },
+  {
+    name: 'locate',
+    parameters: [
+      { label: 'substring: string' },
+      { label: 'string: string' },
+      { label: 'start: number', documentation: 'Optional one-based position to start searching from.' },
+    ],
+    returnType: 'number',
+    documentation: 'Returns the position of the first occurrence of substring in string.',
+  },
+  {
+    name: 'ascii',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'number',
+    documentation: 'Returns the numeric ASCII code of the leftmost character.',
+  },
+  {
+    name: 'ord',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'number',
+    documentation: 'Returns the numeric code of the leftmost character (multi-byte aware).',
+  },
+  {
+    name: 'char',
+    parameters: [
+      { label: 'code: number' },
+      { label: '...codes: number', documentation: 'Additional character codes.' },
+    ],
+    returnType: 'string',
+    documentation: 'Returns a string built from the given numeric character codes.',
+  },
+  {
+    name: 'regexp_substr',
+    parameters: [{ label: 'value: string' }, { label: 'pattern: string' }],
+    returnType: 'string',
+    documentation: 'Returns the substring matching the regular expression pattern.',
+  },
+
+  // Date / time
+  {
+    name: 'str_to_date',
+    parameters: [{ label: 'value: string' }, { label: 'format: string' }],
+    returnType: 'datetime',
+    documentation: 'Parses a string into a date/time using the given format.',
+  },
+  {
+    name: 'date_format',
+    parameters: [{ label: 'date: datetime' }, { label: 'format: string' }],
+    returnType: 'string',
+    documentation: 'Formats a date/time value using the given format string.',
+  },
+  {
+    name: 'date_add',
+    parameters: [{ label: 'date: datetime' }, { label: 'interval: any' }],
+    returnType: 'datetime',
+    documentation: 'Adds a time interval to a date. Syntax: DATE_ADD(date, INTERVAL expr unit).',
+  },
+  {
+    name: 'date_sub',
+    parameters: [{ label: 'date: datetime' }, { label: 'interval: any' }],
+    returnType: 'datetime',
+    documentation: 'Subtracts a time interval from a date. Syntax: DATE_SUB(date, INTERVAL expr unit).',
+  },
+  {
+    name: 'year',
+    parameters: [{ label: 'date: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the year of the date.',
+  },
+  {
+    name: 'month',
+    parameters: [{ label: 'date: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the month of the date (1-12).',
+  },
+  {
+    name: 'day',
+    parameters: [{ label: 'date: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the day of the month (1-31).',
+  },
+  {
+    name: 'weekday',
+    parameters: [{ label: 'date: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the weekday index of the date (0 = Monday).',
+  },
+  {
+    name: 'datediff',
+    parameters: [{ label: 'date1: datetime' }, { label: 'date2: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the number of days between date1 and date2.',
+  },
+  {
+    name: 'unix_timestamp',
+    parameters: [{ label: 'date: datetime', documentation: 'Optional; defaults to the current time.' }],
+    returnType: 'number',
+    documentation: 'Returns the Unix timestamp (seconds since the epoch).',
+  },
+  {
+    name: 'from_unixtime',
+    parameters: [{ label: 'timestamp: number' }, { label: 'format: string', documentation: 'Optional format string.' }],
+    returnType: 'datetime',
+    documentation: 'Converts a Unix timestamp into a date/time value.',
+  },
+  {
+    name: 'extract',
+    parameters: [{ label: 'unit: any' }, { label: 'date: datetime' }],
+    returnType: 'number',
+    documentation: 'Extracts a part from a date. Syntax: EXTRACT(unit FROM date).',
+  },
+  {
+    name: 'hour',
+    parameters: [{ label: 'time: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the hour of the time value.',
+  },
+  {
+    name: 'minute',
+    parameters: [{ label: 'time: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the minute of the time value.',
+  },
+  {
+    name: 'second',
+    parameters: [{ label: 'time: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the second of the time value.',
+  },
+  {
+    name: 'dayname',
+    parameters: [{ label: 'date: datetime' }],
+    returnType: 'string',
+    documentation: 'Returns the name of the weekday for the date.',
+  },
+  {
+    name: 'monthname',
+    parameters: [{ label: 'date: datetime' }],
+    returnType: 'string',
+    documentation: 'Returns the name of the month for the date.',
+  },
+  {
+    name: 'dayofweek',
+    parameters: [{ label: 'date: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the weekday index of the date (1 = Sunday).',
+  },
+  {
+    name: 'dayofmonth',
+    parameters: [{ label: 'date: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the day of the month (1-31).',
+  },
+  {
+    name: 'dayofyear',
+    parameters: [{ label: 'date: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the day of the year (1-366).',
+  },
+  {
+    name: 'week',
+    parameters: [
+      { label: 'date: datetime' },
+      { label: 'mode: number', documentation: 'Optional mode controlling how weeks are numbered.' },
+    ],
+    returnType: 'number',
+    documentation: 'Returns the week number of the date.',
+  },
+  {
+    name: 'quarter',
+    parameters: [{ label: 'date: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the quarter of the year for the date (1-4).',
+  },
+  {
+    name: 'time_to_sec',
+    parameters: [{ label: 'time: datetime' }],
+    returnType: 'number',
+    documentation: 'Converts a time value to the number of seconds.',
+  },
+  {
+    name: 'sec_to_time',
+    parameters: [{ label: 'seconds: number' }],
+    returnType: 'time',
+    documentation: 'Converts a number of seconds to a time value.',
+  },
+  {
+    name: 'timestampdiff',
+    parameters: [{ label: 'unit: any' }, { label: 'start: datetime' }, { label: 'end: datetime' }],
+    returnType: 'number',
+    documentation: 'Returns the difference between two date/times in the given unit.',
+  },
+  {
+    name: 'timestampadd',
+    parameters: [{ label: 'unit: any' }, { label: 'interval: number' }, { label: 'date: datetime' }],
+    returnType: 'datetime',
+    documentation: 'Adds an interval in the given unit to a date/time.',
+  },
+
+  // Cast / convert
+  {
+    name: 'cast',
+    parameters: [{ label: 'value: any' }, { label: 'type: any' }],
+    returnType: 'any',
+    documentation: 'Converts a value to another type. Syntax: CAST(value AS type).',
+  },
+  {
+    name: 'convert',
+    parameters: [{ label: 'value: any' }, { label: 'type: any' }],
+    returnType: 'any',
+    documentation: 'Converts a value to another type or character set. Syntax: CONVERT(value, type).',
+  },
+
+  // JSON
+  {
+    name: 'json_extract',
+    parameters: [
+      { label: 'json: string' },
+      { label: 'path: string' },
+      { label: '...paths: string', documentation: 'Additional JSON paths.' },
+    ],
+    returnType: 'any',
+    documentation: 'Returns the data from a JSON document matching the given path(s).',
+  },
+  {
+    name: 'json_object',
+    parameters: [
+      { label: 'key: string' },
+      { label: 'value: any' },
+      { label: '...pairs: any', documentation: 'Additional key/value pairs.' },
+    ],
+    returnType: 'string',
+    documentation: 'Builds a JSON object from the given key/value pairs.',
+  },
+  {
+    name: 'json_array',
+    parameters: [{ label: 'value: any' }, { label: '...values: any', documentation: 'Additional array elements.' }],
+    returnType: 'string',
+    documentation: 'Builds a JSON array from the given values.',
+  },
+  {
+    name: 'json_merge_patch',
+    parameters: [
+      { label: 'json: string' },
+      { label: 'patch: string' },
+      { label: '...patches: string', documentation: 'Additional patch documents.' },
+    ],
+    returnType: 'string',
+    documentation: 'Merges JSON documents following RFC 7396 semantics.',
+  },
+  {
+    name: 'json_valid',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'number',
+    documentation: 'Returns 1 if the value is valid JSON, otherwise 0.',
+  },
+  {
+    name: 'json_contains',
+    parameters: [
+      { label: 'target: string' },
+      { label: 'candidate: string' },
+      { label: 'path: string', documentation: 'Optional path within the target.' },
+    ],
+    returnType: 'number',
+    documentation: 'Returns 1 if the target JSON contains the candidate, otherwise 0.',
+  },
+  {
+    name: 'json_length',
+    parameters: [
+      { label: 'json: string' },
+      { label: 'path: string', documentation: 'Optional path within the document.' },
+    ],
+    returnType: 'number',
+    documentation: 'Returns the number of elements in a JSON document or path.',
+  },
+  {
+    name: 'json_type',
+    parameters: [{ label: 'json: string' }],
+    returnType: 'string',
+    documentation: 'Returns the type of a JSON value as a string.',
+  },
+  {
+    name: 'json_keys',
+    parameters: [
+      { label: 'json: string' },
+      { label: 'path: string', documentation: 'Optional path within the document.' },
+    ],
+    returnType: 'string',
+    documentation: 'Returns the keys of a JSON object as a JSON array.',
+  },
+  {
+    name: 'json_search',
+    parameters: [
+      { label: 'json: string' },
+      { label: 'one_or_all: string', documentation: "Either 'one' or 'all'." },
+      { label: 'search: string' },
+    ],
+    returnType: 'string',
+    documentation: 'Returns the path(s) to values matching the search string.',
+  },
+  {
+    name: 'json_quote',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'string',
+    documentation: 'Quotes a string as a JSON value, escaping as needed.',
+  },
+  {
+    name: 'json_unquote',
+    parameters: [{ label: 'value: string' }],
+    returnType: 'string',
+    documentation: 'Unquotes a JSON value and returns it as a string.',
+  },
+  {
+    name: 'json_set',
+    parameters: [{ label: 'json: string' }, { label: 'path: string' }, { label: 'value: any' }],
+    returnType: 'string',
+    documentation: 'Inserts or updates data in a JSON document at the given path.',
+  },
+  {
+    name: 'json_insert',
+    parameters: [{ label: 'json: string' }, { label: 'path: string' }, { label: 'value: any' }],
+    returnType: 'string',
+    documentation: 'Inserts data into a JSON document without overwriting existing values.',
+  },
+  {
+    name: 'json_replace',
+    parameters: [{ label: 'json: string' }, { label: 'path: string' }, { label: 'value: any' }],
+    returnType: 'string',
+    documentation: 'Replaces existing values in a JSON document at the given path.',
+  },
+  {
+    name: 'json_remove',
+    parameters: [
+      { label: 'json: string' },
+      { label: 'path: string' },
+      { label: '...paths: string', documentation: 'Additional paths to remove.' },
+    ],
+    returnType: 'string',
+    documentation: 'Removes data from a JSON document at the given path(s).',
   },
 ];

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.test.ts
@@ -1,0 +1,19 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useFunctionSignatures } from './useFunctionSignatures';
+
+describe('useFunctionSignatures', () => {
+  it('does not load signatures when disabled', () => {
+    const { result } = renderHook(() => useFunctionSignatures(false));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('lazily loads the signature metadata when enabled', async () => {
+    const { result } = renderHook(() => useFunctionSignatures(true));
+
+    expect(result.current).toBeUndefined();
+
+    await waitFor(() => expect(result.current?.length).toBeGreaterThan(0));
+  });
+});

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+import { type SqlFunctionSignature } from '../SqlEditor/signatureHelp';
+
+/**
+ * Lazily loads the SQL function signature metadata, keeping the large table out
+ * of the chunk unless the CodeMirror editor is active.
+ */
+export function useFunctionSignatures(enabled: boolean): SqlFunctionSignature[] | undefined {
+  const [functionSignatures, setFunctionSignatures] = useState<SqlFunctionSignature[]>();
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    let cancelled = false;
+
+    import('../functionSignatures')
+      .then(({ FUNCTION_SIGNATURES }) => {
+        if (!cancelled) {
+          setFunctionSignatures(FUNCTION_SIGNATURES);
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return functionSignatures;
+}

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.ts
@@ -22,7 +22,9 @@ export function useFunctionSignatures(enabled: boolean): SqlFunctionSignature[] 
           setFunctionSignatures(FUNCTION_SIGNATURES);
         }
       })
-      .catch(() => {});
+      .catch((error) => {
+        console.warn('Failed to load SQL function signatures for signature help', error);
+      });
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## What

Adds signature-help tooltips to the CodeMirror SQL editor so that, while the cursor is inside a function call, users see the function's parameters, active argument, return type, and description.

This introduces a generic, language-agnostic `signatureHelp` CodeMirror extension in `@grafana/ui/unstable` (new `SignatureHelp`, `SignatureHelpProvider`, `SignatureInformation`, and `SignatureParameter` types plus a themed tooltip renderer). SQL Expressions consumes it via a syntax-tree-based enclosing-call detector (`getEnclosingFunctionCall`) and a curated `FUNCTION_SIGNATURES` list covering common math, conditional/null-handling, aggregate, and string functions.

## Why

SQL Expression authors had no in-editor guidance about function arguments, so they had to leave the editor to check parameter order, count, and return types. Surfacing signatures inline speeds up authoring and reduces query errors.

## Notes

The editor extension stays generic: it owns state tracking and tooltip rendering, while language-specific call detection is delegated to the provider via the SQL syntax tree. Signatures are a deliberate subset of the allowed functions and are easy to extend by appending entries to `functionSignatures.ts`.

DPRO-127