### PR TITLE
Advisor: Skip datasource health check when oauthPassThru is enabled

### DIFF
--- a/apps/advisor/pkg/app/checks/datasourcecheck/check_test.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/check_test.go
@@ -165,6 +165,36 @@ func TestCheck_Run(t *testing.T) {
 		assert.Empty(t, failures)
 	})
 
+	t.Run("should skip health check when datasource uses Forward OAuth Identity", func(t *testing.T) {
+		jsonData := simplejson.New()
+		jsonData.Set("oauthPassThru", true)
+		datasources := []*datasources.DataSource{
+			{UID: "valid-uid-1", Type: "prometheus", Name: "Prometheus", JsonData: jsonData},
+		}
+
+		mockDatasourceSvc := &MockDatasourceSvc{dss: datasources}
+		mockPluginContextProvider := &MockPluginContextProvider{pCtx: backend.PluginContext{}}
+		mockPluginClient := &MockPluginClient{res: &backend.CheckHealthResult{Status: backend.HealthStatusError, Message: "should not run"}}
+		mockPluginRepo := &MockPluginRepo{plugins: []repo.PluginInfo{
+			{ID: 1, Slug: "prometheus", Status: "active"},
+		}}
+		mockPluginStore := &MockPluginStore{exists: true}
+
+		check := &check{
+			DatasourceSvc: mockDatasourceSvc,
+			PluginRepo:    mockPluginRepo,
+			PluginStore:   mockPluginStore,
+			healthChecker: &checks.HealthCheckerImpl{
+				PluginContextProvider: mockPluginContextProvider,
+				PluginClient:          mockPluginClient,
+			},
+		}
+
+		failures, err := runChecks(check)
+		assert.NoError(t, err)
+		assert.Empty(t, failures)
+	})
+
 	t.Run("should skip health check when plugin does not support backend health checks", func(t *testing.T) {
 		datasources := []*datasources.DataSource{
 			{UID: "valid-uid-1", Type: "prometheus", Name: "Prometheus"},

--- a/apps/advisor/pkg/app/checks/datasourcecheck/health_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/health_check_step.go
@@ -46,6 +46,14 @@ func (s *healthCheckStep) Run(ctx context.Context, log logging.Logger, obj *advi
 		return nil, nil
 	}
 
+	// When Forward OAuth Identity (oauthPassThru) is enabled, the health check depends on the
+	// end user's OAuth token, which is not available in this context. The result would reflect
+	// the check runner's identity rather than the data source, so we can't reliably verify it.
+	if ds.JsonData != nil && ds.JsonData.Get("oauthPassThru").MustBool(false) {
+		log.Debug("Skipping health check because the data source uses Forward OAuth Identity", "datasource_uid", ds.UID, "datasource_type", ds.Type)
+		return nil, nil
+	}
+
 	// Health check execution
 	resp, err := s.HealthChecker.CheckHealth(ctx, ds)
 	if err != nil || (resp != nil && resp.Status != backend.HealthStatusOk) {


### PR DESCRIPTION
## What

Skip the advisor **datasource health check** for data sources configured with **Forward OAuth Identity** (`oauthPassThru`).

## Why

Data sources with `oauthPassThru` enabled authenticate using the end user's OAuth token. The advisor health check runs outside of a user request context, so that token isn't available — the health check would instead reflect the check runner's identity (or fail outright with an auth error) rather than the real state of the data source. We can't reliably verify these data sources, so reporting a failure is misleading.
