### PR TITLE
Docs: Update tables for 13.1 and add language around patch releases

### DIFF
--- a/docs/sources/upgrade-guide/when-to-upgrade/index.md
+++ b/docs/sources/upgrade-guide/when-to-upgrade/index.md
@@ -28,7 +28,7 @@ We split Grafana OSS and Grafana Enterprise releases into three main categories:
 
 - **Minor release (every other month)**: These releases can include new features, deprecation notices, notices about upcoming breaking changes, previously announced breaking changes, bug fixes, and security vulnerability patches.
 - **Major release (once a year, in April/May)**: These are like a minor release, but accompanied by [GrafanaCON](https://grafana.com/events/grafanacon/) and a comprehensive upgrade guide for users who like to upgrade only once a year.
-- **Patching release (every month)**: These include bug fixes for currently supported versions, as well as any security vulnerability patches.
+- **Patching release (at least every month)**: These include bug fixes for currently supported versions, as well as any security vulnerability patches.
 
 You can choose your cadence: For frequent self-managed updates, you should follow the minor release (for example, upgrade 11.1 to 11.2), which also gives you access to the latest features. If you need a longer period to review our new releases, you should follow the major releases. Both strategies get patching releases with security fixes (high severity security fixes also result in ad-hoc patch releases). We’ll get into additional guidance on upgrade cadences later in this guide.
 
@@ -50,7 +50,6 @@ Grafana currently follows a monthly release schedule. Below are the planned rele
 
 | **Release date** | **Grafana versions**      | **Release type** |
 | ---------------- | ------------------------- | ---------------- |
-| Aug. 12, 2025    | Supported versions        | Patching         |
 | Sept. 23, 2025   | 12.2 & Supported versions | Minor & patching |
 | Oct. 21, 2025    | Supported versions        | Patching         |
 | Nov. 18, 2025    | 12.3 & Supported versions | Minor & patching |
@@ -59,6 +58,7 @@ Grafana currently follows a monthly release schedule. Below are the planned rele
 | Feb. 24, 2026    | 12.4 & Supported versions | Minor & patching |
 | Mar. 24, 2026    | Supported versions        | Patching         |
 | Apr. 14, 2026    | Grafana 13                | Major            |
+| Jun. 23, 2026    | 13.1 & Supported versions | Minor & patching |
 
 ### A few important notes
 
@@ -100,16 +100,16 @@ Here is an overview of version support through 2026:
 
 | **Version**               | **Release date**   | **Support end date** | **Support level** |
 | ------------------------- | ------------------ | -------------------- | ----------------- |
-| 11.3.x                    | October 22, 2024   | July 22, 2025        | Not Supported     |
 | 11.4.x                    | December 5, 2024   | September 5, 2025    | Not Supported     |
 | 11.5.x                    | January 28, 2025   | October 28, 2025     | Not Supported     |
-| 11.6.x (Last minor of 11) | March 25, 2025     | June 25, 2026        | Patch Support     |
+| 11.6.x (Last minor of 11) | March 25, 2025     | June 25, 2026        | Not Supported     |
 | 12.0.x                    | May 5, 2025        | February 5, 2026     | Not Supported     |
 | 12.1.x                    | July 22, 2025      | April 22, 2026       | Not Supported     |
-| 12.2.x                    | September 23, 2025 | June 23, 2026        | Patch Support     |
+| 12.2.x                    | September 23, 2025 | June 23, 2026        | Not Supported     |
 | 12.3.x                    | November 19, 2025  | August 19, 2026      | Patch Support     |
 | 12.4.x (Last minor of 12) | February 24, 2026  | May 24, 2027         | Patch Support     |
 | 13.0.0                    | April 14, 2026     | January 9, 2027      | Patch Support     |
+| 13.1.x                    | June 22, 2026      | March 20, 2027       | Patch Support     |
 
 ## How are these versions supported?
 


### PR DESCRIPTION
**What is this feature?**

Updates tables to include dates for the 13.1 release and adds some language that patch releases happed __at least__ every month. This doesn't codify 2 week intervals in the docs and gives flexibility around when we deliver so long as patches happen at least monthly.

**Why do we need this feature?**

So the docs are up to date with current processes

**Who is this feature for?**

All users of Grafana documentation.