### PR TITLE
Provisioning: fix flaky TestIntegrationLibraryPanels folder reads

### DIFF
--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -9,11 +9,33 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+// waitForSingleFolder waits until the folder List reports exactly one folder and
+// returns it. The folder List is served by the eventually-consistent search
+// index, which can briefly report zero right after an initial sync completes —
+// even though CreateLocalRepo already observed the folder — so callers must poll
+// rather than read once.
+func waitForSingleFolder(t *testing.T, helper *common.ProvisioningTestHelper) *unstructured.Unstructured {
+	t.Helper()
+	var folder *unstructured.Unstructured
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(collect, err) {
+			return
+		}
+		if !assert.Len(collect, folders.Items, 1) {
+			return
+		}
+		folder = &folders.Items[0]
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "expected exactly one folder to be listable after sync")
+	return folder
+}
 
 // We currently block the creation of library panels in provisioned folders.
 func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
@@ -25,11 +47,7 @@ func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
 	})
 
 	t.Run("should fail to create library element in provisioned folder", func(t *testing.T) {
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, folders.Items, 1)
-
-		managedFolderName := folders.Items[0].GetName()
+		managedFolderName := waitForSingleFolder(t, helper).GetName()
 		libraryElement := map[string]interface{}{
 			"kind":      1,
 			"name":      "Library Panel",
@@ -49,10 +67,7 @@ func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
 
 	t.Run("should fail to patch library element, moving it in a provisioned folder", func(t *testing.T) {
 		// Getting managed folder
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, folders.Items, 1)
-		managedFolderName := folders.Items[0].GetName()
+		managedFolderName := waitForSingleFolder(t, helper).GetName()
 
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -124,14 +139,12 @@ func TestIntegrationLibraryPanels_UnprovisionedFolders(t *testing.T) {
 	})
 
 	t.Run("should create library element when folder is released", func(t *testing.T) {
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, folders.Items, 1)
-		managedFolderName := folders.Items[0].GetName()
-		require.Contains(t, folders.Items[0].GetAnnotations(), utils.AnnoKeyManagerKind, "folder should be managed")
-		require.Contains(t, folders.Items[0].GetAnnotations(), utils.AnnoKeyManagerIdentity, "folder should be managed")
+		managedFolder := waitForSingleFolder(t, helper)
+		managedFolderName := managedFolder.GetName()
+		require.Contains(t, managedFolder.GetAnnotations(), utils.AnnoKeyManagerKind, "folder should be managed")
+		require.Contains(t, managedFolder.GetAnnotations(), utils.AnnoKeyManagerIdentity, "folder should be managed")
 
-		_, err = helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
+		_, err := helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
 		{
 			"op": "replace",
 			"path": "/metadata/finalizers",


### PR DESCRIPTION
## Summary

`TestIntegrationLibraryPanels_ProvisionedFolders` (and the unprovisioned variant) intermittently failed with:

```
librarypanels_test.go:30: "[]" should have 1 item(s), but has 0
```

The subtests read the folder `List` once and asserted exactly one folder. That `List` is served by the eventually-consistent unified-storage search index, which can briefly flap back to reporting **0** right after the initial sync completes — even though `CreateLocalRepo` already observed the folder (the failure's own debug dump printed `Total folders: 1`). A single unguarded read after index lag produced 0 items and failed the test.

## Changes

- Add a `waitForSingleFolder` helper that polls the folder `List` with `require.EventuallyWithT` until it reports exactly one folder, and returns that item.
- Replace the three one-shot `List` + `require.Len(..., 1)` reads across both `TestIntegrationLibraryPanels_ProvisionedFolders` subtests and `TestIntegrationLibraryPanels_UnprovisionedFolders` with the helper. The unprovisioned case still receives the folder object so its `AnnoKeyManagerKind`/`AnnoKeyManagerIdentity` annotation assertions are preserved.

This matches the pattern already used throughout the package (`CreateLocalRepo`, `bom_test.go`, `managed_test.go`, ...) which wrap search-backed reads in `EventuallyWithT`, and reuses the existing `common.WaitTimeoutDefault`/`WaitIntervalDefault` constants.

## Testing

- `go vet ./pkg/tests/apis/provisioning/` passes.
- Full validation runs via CI (`make test-go-integration`); the test requires the provisioning integration harness.

## Checklist

- [x] Test-only change (no production code affected)
- [x] No breaking changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)