### PR TITLE
Preferences: Close behaviour gaps between legacy and unified storage

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
+	"github.com/open-feature/go-sdk/openfeature"
+
 	claims "github.com/grafana/authlib/types"
 	dashboardsV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	dashboardsV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
@@ -33,6 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	dashver "github.com/grafana/grafana/pkg/services/dashboardversion"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	pref "github.com/grafana/grafana/pkg/services/preference"
@@ -685,10 +688,16 @@ func (hs *HTTPServer) GetHomeDashboard(c *contextmodel.ReqContext) response.Resp
 		userID = id
 	}
 
-	prefsQuery := pref.GetPreferenceWithDefaultsQuery{OrgID: c.GetOrgID(), UserID: userID, Teams: c.GetTeams()}
 	homePage := hs.Cfg.HomePage
 
-	preference, err := hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)
+	var preference *pref.Preference
+	var err error
+	if ofClient.Boolean(ctx, featuremgmt.FlagPreferencesRerouteLegacyAPIs, false, openfeature.TransactionContext(ctx)) {
+		preference, err = hs.preferenceK8sHandler.GetPreferencesWithDefaults(c)
+	} else {
+		prefsQuery := pref.GetPreferenceWithDefaultsQuery{OrgID: c.GetOrgID(), UserID: userID, Teams: c.GetTeams()}
+		preference, err = hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)
+	}
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to get preferences", err)
 	}

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -57,13 +57,18 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 
 	userID, _ := identity.UserIdentifier(c.GetID())
 
-	prefsQuery := pref.GetPreferenceWithDefaultsQuery{
-		UserID: userID,
-		OrgID:  c.GetOrgID(),
-		Teams:  c.TeamIDs, // nolint:staticcheck
-	}
 	c, prefsSpan := hs.injectSpan(c, "api.setIndexViewData.preferences")
-	prefs, err := hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)
+	var prefs *pref.Preference
+	if ofClient.Boolean(c.Req.Context(), featuremgmt.FlagPreferencesRerouteLegacyAPIs, false, openfeature.TransactionContext(c.Req.Context())) {
+		prefs, err = hs.preferenceK8sHandler.GetPreferencesWithDefaults(c)
+	} else {
+		prefsQuery := pref.GetPreferenceWithDefaultsQuery{
+			UserID: userID,
+			OrgID:  c.GetOrgID(),
+			Teams:  c.TeamIDs, // nolint:staticcheck
+		}
+		prefs, err = hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)
+	}
 	prefsSpan.End()
 	if err != nil {
 		return nil, err
@@ -102,7 +107,6 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		appSubURL = ""
 		settings.AppSubUrl = ""
 	}
-	ofClient := openfeature.NewDefaultClient()
 	ctx := c.Req.Context()
 	renderBindingSupported, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagReportRenderBinding, false, openfeature.TransactionContext(ctx))
 	grafanaAssetSriChecks, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagGrafanaAssetSriChecks, false, openfeature.TransactionContext(ctx))

--- a/pkg/registry/apis/preferences/preferences_merged.go
+++ b/pkg/registry/apis/preferences/preferences_merged.go
@@ -33,19 +33,27 @@ type merger struct {
 }
 
 func newMerger(cfg *setting.Cfg) *merger {
-	m := &merger{
-		defaults: preferences.PreferencesSpec{
-			Theme:     &cfg.DefaultTheme,
-			Timezone:  &cfg.DateFormats.DefaultTimezone,
-			WeekStart: &cfg.DateFormats.DefaultWeekStart,
-			Language:  &cfg.DefaultLanguage,
-			HomeURL:   &cfg.HomePage, // [users] home_page
-		},
+	return &merger{
+		defaults: DefaultSpec(cfg),
+	}
+}
+
+// DefaultSpec returns the configured default preferences — the values the
+// merged route falls back to for fields no user, team, or namespace
+// preference defines. It is also what merging resolves to for a requester
+// with no preferences at all (e.g. an unauthenticated request).
+func DefaultSpec(cfg *setting.Cfg) preferences.PreferencesSpec {
+	spec := preferences.PreferencesSpec{
+		Theme:     &cfg.DefaultTheme,
+		Timezone:  &cfg.DateFormats.DefaultTimezone,
+		WeekStart: &cfg.DateFormats.DefaultWeekStart,
+		Language:  &cfg.DefaultLanguage,
+		HomeURL:   &cfg.HomePage, // [users] home_page
 	}
 	if home.HasCustomHome(cfg) {
-		m.defaults.HomeDashboardUID = new(home.DASHBOARD_NAME)
+		spec.HomeDashboardUID = new(home.DASHBOARD_NAME)
 	}
-	return m
+	return spec
 }
 
 func (s *merger) GetAPIRoutes(defs map[string]common.OpenAPIDefinition) *builder.APIRoutes {

--- a/pkg/registry/apis/preferences/register.go
+++ b/pkg/registry/apis/preferences/register.go
@@ -130,7 +130,7 @@ func (b *APIBuilder) storageForVersion(
 			return nil, err
 		}
 	}
-	wrappedStorage := &preferencesStorage{store}
+	wrappedStorage := &preferencesStorage{Storage: store, gvk: prefs.GroupVersionKind()}
 	storage[prefs.StoragePath()] = wrappedStorage
 
 	apiGroupInfo.VersionedResourcesStorageMap[prefs.GroupVersion().Version] = storage

--- a/pkg/registry/apis/preferences/store.go
+++ b/pkg/registry/apis/preferences/store.go
@@ -39,34 +39,33 @@ func (s *preferencesStorage) List(ctx context.Context, options *internalversion.
 	return s.ListPreferences(ctx, options)
 }
 
-// Update with upsert: a PUT or PATCH for an
-// owner whose preferences don't exist yet creates them instead of returning
-// 404. The legacy storage upserts on its own (see legacy.preferenceStorage.Update)
+// Update with upsert: an Update for an owner whose preferences don't
+// exist yet creates them instead of returning 404. The update is attempted
+// first; only a NotFound failure takes the create path. The legacy storage
+// upserts on its own (see legacy.preferenceStorage.Update)
 func (s *preferencesStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	_, err := s.Get(ctx, name, &metav1.GetOptions{})
+	updated, created, err := s.Storage.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+	if err == nil || !k8serrors.IsNotFound(err) {
+		return updated, created, err
+	}
+
+	// Nothing stored yet -- apply the update to an empty placeholder and create it
+	placeholder, err := s.newEmptyPreferences(ctx, name)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return nil, false, err
-		}
+		return nil, false, err
+	}
+	obj, err := objInfo.UpdatedObject(ctx, placeholder)
+	if err != nil {
+		return nil, false, err
+	}
 
-		placeholder, err := s.newEmptyPreferences(ctx, name)
-		if err != nil {
-			return nil, false, err
-		}
-		obj, err := objInfo.UpdatedObject(ctx, placeholder)
-		if err != nil {
-			return nil, false, err
-		}
-
-		created, err := s.Create(ctx, obj, createValidation, createOptionsFrom(options))
-		if err == nil {
-			return created, true, nil
-		}
-		// Lost a race with a concurrent create -- fall through and apply as a
-		// regular update
-		if !k8serrors.IsAlreadyExists(err) {
-			return nil, false, err
-		}
+	createdObj, err := s.Create(ctx, obj, createValidation, createOptionsFrom(options))
+	if err == nil {
+		return createdObj, true, nil
+	}
+	// Lost a race with a concurrent create -- apply as a regular update
+	if !k8serrors.IsAlreadyExists(err) {
+		return nil, false, err
 	}
 	return s.Storage.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
 }

--- a/pkg/registry/apis/preferences/store.go
+++ b/pkg/registry/apis/preferences/store.go
@@ -39,9 +39,9 @@ func (s *preferencesStorage) List(ctx context.Context, options *internalversion.
 	return s.ListPreferences(ctx, options)
 }
 
-// Update implements rest.Updater with upsert semantics: a PUT or PATCH for an
+// Update with upsert: a PUT or PATCH for an
 // owner whose preferences don't exist yet creates them instead of returning
-// 404. The legacy storage upserts on its own (see legacy.preferenceStorage.Update).
+// 404. The legacy storage upserts on its own (see legacy.preferenceStorage.Update)
 func (s *preferencesStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	_, err := s.Storage.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {

--- a/pkg/registry/apis/preferences/store.go
+++ b/pkg/registry/apis/preferences/store.go
@@ -43,7 +43,7 @@ func (s *preferencesStorage) List(ctx context.Context, options *internalversion.
 // owner whose preferences don't exist yet creates them instead of returning
 // 404. The legacy storage upserts on its own (see legacy.preferenceStorage.Update)
 func (s *preferencesStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	_, err := s.Storage.Get(ctx, name, &metav1.GetOptions{})
+	_, err := s.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return nil, false, err
@@ -58,7 +58,7 @@ func (s *preferencesStorage) Update(ctx context.Context, name string, objInfo re
 			return nil, false, err
 		}
 
-		created, err := s.Storage.Create(ctx, obj, createValidation, createOptionsFrom(options))
+		created, err := s.Create(ctx, obj, createValidation, createOptionsFrom(options))
 		if err == nil {
 			return created, true, nil
 		}

--- a/pkg/registry/apis/preferences/store.go
+++ b/pkg/registry/apis/preferences/store.go
@@ -6,16 +6,21 @@ import (
 	"slices"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
+	requestK8s "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	authlib "github.com/grafana/authlib/types"
 	preferences "github.com/grafana/grafana/apps/preferences/pkg/apis/preferences/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/registry/apis/preferences/utils"
+	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 )
 
 // The maximum number of teams per user to use when listing preferences and for the merged endpoint. Teams beyond this limit
@@ -27,10 +32,69 @@ var PreferencesTeamLimit = 25
 // This converts the query into explicitly picking the preferences the caller should have access
 type preferencesStorage struct {
 	grafanarest.Storage
+	gvk schema.GroupVersionKind
 }
 
 func (s *preferencesStorage) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
 	return s.ListPreferences(ctx, options)
+}
+
+// Update implements rest.Updater with upsert semantics: a PUT or PATCH for an
+// owner whose preferences don't exist yet creates them instead of returning
+// 404. The legacy storage upserts on its own (see legacy.preferenceStorage.Update).
+func (s *preferencesStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	_, err := s.Storage.Get(ctx, name, &metav1.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, false, err
+		}
+
+		placeholder, err := s.newEmptyPreferences(ctx, name)
+		if err != nil {
+			return nil, false, err
+		}
+		obj, err := objInfo.UpdatedObject(ctx, placeholder)
+		if err != nil {
+			return nil, false, err
+		}
+
+		created, err := s.Storage.Create(ctx, obj, createValidation, createOptionsFrom(options))
+		if err == nil {
+			return created, true, nil
+		}
+		// Lost a race with a concurrent create -- fall through and apply as a
+		// regular update
+		if !k8serrors.IsAlreadyExists(err) {
+			return nil, false, err
+		}
+	}
+	return s.Storage.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+}
+
+// newEmptyPreferences builds the object a patch/update is applied against
+// when nothing is stored yet. It must carry a UID because the apiserver's
+// patch handler refuses to merge-patch an object without one
+func (s *preferencesStorage) newEmptyPreferences(ctx context.Context, name string) (runtime.Object, error) {
+	obj := s.New()
+	obj.GetObjectKind().SetGroupVersionKind(s.gvk)
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	accessor.SetName(name)
+	accessor.SetNamespace(requestK8s.NamespaceValue(ctx))
+	accessor.SetUID(gapiutil.CalculateClusterWideUID(obj))
+	return obj, nil
+}
+
+func createOptionsFrom(options *metav1.UpdateOptions) *metav1.CreateOptions {
+	opts := &metav1.CreateOptions{}
+	if options != nil {
+		opts.DryRun = options.DryRun
+		opts.FieldManager = options.FieldManager
+		opts.FieldValidation = options.FieldValidation
+	}
+	return opts
 }
 
 // ListPreferences wraps a regular storage object and populates the results with:

--- a/pkg/registry/apis/preferences/store_test.go
+++ b/pkg/registry/apis/preferences/store_test.go
@@ -13,6 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	requestK8s "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/utils/ptr"
 
 	claims "github.com/grafana/authlib/types"
 	preferences "github.com/grafana/grafana/apps/preferences/pkg/apis/preferences/v1"
@@ -307,12 +310,118 @@ func TestListPreferences_Errors(t *testing.T) {
 	})
 }
 
-// fakeStorage is a minimal grafanarest.Storage implementation that only
-// supports Get; ListPreferences only ever calls Get on the wrapped store.
+func TestPreferencesStorage_Update(t *testing.T) {
+	ctx := requestK8s.WithNamespace(context.Background(), "default")
+
+	// setTheme mimics the apiserver's merge-patch transformer: it requires
+	// the current object to carry a UID (the real transformer returns 404
+	// otherwise) and applies a single-field change on top of it.
+	setTheme := func(theme string) rest.UpdatedObjectInfo {
+		return rest.DefaultUpdatedObjectInfo(nil, func(_ context.Context, _, oldObj runtime.Object) (runtime.Object, error) {
+			old, ok := oldObj.(*preferences.Preferences)
+			if !ok {
+				return nil, fmt.Errorf("expected preferences, got %T", oldObj)
+			}
+			if old.UID == "" {
+				return nil, k8serrors.NewNotFound(
+					schema.GroupResource{Group: preferences.APIGroup, Resource: "preferences"},
+					old.Name,
+				)
+			}
+			patched := old.DeepCopy()
+			patched.Spec.Theme = ptr.To(theme)
+			return patched, nil
+		})
+	}
+
+	newStore := func(fake *fakeStorage) *preferencesStorage {
+		return &preferencesStorage{Storage: fake, gvk: preferences.PreferencesResourceInfo.GroupVersionKind()}
+	}
+
+	t.Run("creates preferences that do not exist yet", func(t *testing.T) {
+		fake := &fakeStorage{items: map[string]*preferences.Preferences{}}
+		store := newStore(fake)
+
+		obj, created, err := store.Update(ctx, "user-abc", setTheme("dark"), nil, nil, false, &metav1.UpdateOptions{})
+		require.NoError(t, err)
+		require.True(t, created)
+
+		p, ok := obj.(*preferences.Preferences)
+		require.True(t, ok)
+		require.Equal(t, "user-abc", p.Name)
+		require.Equal(t, "default", p.Namespace)
+		require.Equal(t, ptr.To("dark"), p.Spec.Theme)
+
+		require.Equal(t, []string{"user-abc"}, fake.created)
+		require.Empty(t, fake.updated)
+	})
+
+	t.Run("updates preferences that already exist", func(t *testing.T) {
+		existing := newPref("user-abc")
+		existing.UID = "existing-uid"
+		existing.Spec.Theme = ptr.To("light")
+		fake := &fakeStorage{items: map[string]*preferences.Preferences{"user-abc": existing}}
+		store := newStore(fake)
+
+		obj, created, err := store.Update(ctx, "user-abc", setTheme("dark"), nil, nil, false, &metav1.UpdateOptions{})
+		require.NoError(t, err)
+		require.False(t, created)
+
+		p, ok := obj.(*preferences.Preferences)
+		require.True(t, ok)
+		require.Equal(t, ptr.To("dark"), p.Spec.Theme)
+
+		require.Empty(t, fake.created)
+		require.Equal(t, []string{"user-abc"}, fake.updated)
+	})
+
+	t.Run("falls back to update when losing a create race", func(t *testing.T) {
+		// Get reports NotFound but Create collides with AlreadyExists, as if
+		// another request created the preferences in between
+		existing := newPref("user-abc")
+		existing.UID = "existing-uid"
+		fake := &fakeStorage{
+			items: map[string]*preferences.Preferences{"user-abc": existing},
+			createErr: k8serrors.NewAlreadyExists(
+				schema.GroupResource{Group: preferences.APIGroup, Resource: "preferences"},
+				"user-abc",
+			),
+		}
+		store := &preferencesStorage{
+			Storage: &notFoundGetStorage{fakeStorage: fake},
+			gvk:     preferences.PreferencesResourceInfo.GroupVersionKind(),
+		}
+
+		obj, created, err := store.Update(ctx, "user-abc", setTheme("dark"), nil, nil, false, &metav1.UpdateOptions{})
+		require.NoError(t, err)
+		require.False(t, created)
+
+		p, ok := obj.(*preferences.Preferences)
+		require.True(t, ok)
+		require.Equal(t, ptr.To("dark"), p.Spec.Theme)
+		require.Equal(t, []string{"user-abc"}, fake.updated)
+	})
+
+	t.Run("non-NotFound errors from Get bubble up", func(t *testing.T) {
+		fake := &forbiddenStorage{}
+		store := &preferencesStorage{Storage: fake, gvk: preferences.PreferencesResourceInfo.GroupVersionKind()}
+
+		_, _, err := store.Update(ctx, "user-abc", setTheme("dark"), nil, nil, false, &metav1.UpdateOptions{})
+		require.Error(t, err)
+		require.True(t, k8serrors.IsForbidden(err))
+	})
+}
+
+// fakeStorage is a minimal grafanarest.Storage implementation supporting
+// Get, Create and Update -- everything the preferencesStorage wrapper calls
+// on the wrapped store.
 type fakeStorage struct {
 	grafanarest.Storage
-	items map[string]*preferences.Preferences
-	calls []string
+	items     map[string]*preferences.Preferences
+	calls     []string
+	created   []string
+	updated   []string
+	createErr error
 }
 
 func (f *fakeStorage) Get(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
@@ -324,6 +433,50 @@ func (f *fakeStorage) Get(_ context.Context, name string, _ *metav1.GetOptions) 
 		schema.GroupResource{Group: preferences.APIGroup, Resource: "preferences"},
 		name,
 	)
+}
+
+func (f *fakeStorage) New() runtime.Object {
+	return &preferences.Preferences{}
+}
+
+func (f *fakeStorage) Create(_ context.Context, obj runtime.Object, _ rest.ValidateObjectFunc, _ *metav1.CreateOptions) (runtime.Object, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	p, ok := obj.(*preferences.Preferences)
+	if !ok {
+		return nil, fmt.Errorf("expected preferences, got %T", obj)
+	}
+	if _, exists := f.items[p.Name]; exists {
+		return nil, k8serrors.NewAlreadyExists(
+			schema.GroupResource{Group: preferences.APIGroup, Resource: "preferences"},
+			p.Name,
+		)
+	}
+	f.created = append(f.created, p.Name)
+	f.items[p.Name] = p
+	return p, nil
+}
+
+func (f *fakeStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	old, exists := f.items[name]
+	if !exists {
+		return nil, false, k8serrors.NewNotFound(
+			schema.GroupResource{Group: preferences.APIGroup, Resource: "preferences"},
+			name,
+		)
+	}
+	obj, err := objInfo.UpdatedObject(ctx, old)
+	if err != nil {
+		return nil, false, err
+	}
+	p, ok := obj.(*preferences.Preferences)
+	if !ok {
+		return nil, false, fmt.Errorf("expected preferences, got %T", obj)
+	}
+	f.updated = append(f.updated, name)
+	f.items[name] = p
+	return p, false, nil
 }
 
 func newPref(name string) *preferences.Preferences {
@@ -348,4 +501,32 @@ type errorStorage struct {
 
 func (e *errorStorage) Get(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
 	return &preferences.PreferencesList{}, nil
+}
+
+// notFoundGetStorage always misses on Get but otherwise behaves like the
+// wrapped fakeStorage, simulating a concurrent create between the upsert's
+// existence check and its Create call.
+type notFoundGetStorage struct {
+	*fakeStorage
+}
+
+func (n *notFoundGetStorage) Get(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
+	return nil, k8serrors.NewNotFound(
+		schema.GroupResource{Group: preferences.APIGroup, Resource: "preferences"},
+		name,
+	)
+}
+
+// forbiddenStorage fails Get with a non-NotFound error to verify such errors
+// are not treated as "missing, create it".
+type forbiddenStorage struct {
+	grafanarest.Storage
+}
+
+func (f *forbiddenStorage) Get(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
+	return nil, k8serrors.NewForbidden(
+		schema.GroupResource{Group: preferences.APIGroup, Resource: "preferences"},
+		name,
+		fmt.Errorf("nope"),
+	)
 }

--- a/pkg/registry/apis/preferences/store_test.go
+++ b/pkg/registry/apis/preferences/store_test.go
@@ -376,8 +376,9 @@ func TestPreferencesStorage_Update(t *testing.T) {
 	})
 
 	t.Run("falls back to update when losing a create race", func(t *testing.T) {
-		// Get reports NotFound but Create collides with AlreadyExists, as if
-		// another request created the preferences in between
+		// The first Update reports NotFound but Create collides with
+		// AlreadyExists, as if another request created the preferences in
+		// between; the retried Update must then succeed
 		existing := newPref("user-abc")
 		existing.UID = "existing-uid"
 		fake := &fakeStorage{
@@ -388,7 +389,7 @@ func TestPreferencesStorage_Update(t *testing.T) {
 			),
 		}
 		store := &preferencesStorage{
-			Storage: &notFoundGetStorage{fakeStorage: fake},
+			Storage: &failFirstUpdateStorage{fakeStorage: fake},
 			gvk:     preferences.PreferencesResourceInfo.GroupVersionKind(),
 		}
 
@@ -402,7 +403,7 @@ func TestPreferencesStorage_Update(t *testing.T) {
 		require.Equal(t, []string{"user-abc"}, fake.updated)
 	})
 
-	t.Run("non-NotFound errors from Get bubble up", func(t *testing.T) {
+	t.Run("non-NotFound errors from Update bubble up", func(t *testing.T) {
 		fake := &forbiddenStorage{}
 		store := &preferencesStorage{Storage: fake, gvk: preferences.PreferencesResourceInfo.GroupVersionKind()}
 
@@ -503,28 +504,33 @@ func (e *errorStorage) Get(_ context.Context, _ string, _ *metav1.GetOptions) (r
 	return &preferences.PreferencesList{}, nil
 }
 
-// notFoundGetStorage always misses on Get but otherwise behaves like the
-// wrapped fakeStorage, simulating a concurrent create between the upsert's
-// existence check and its Create call.
-type notFoundGetStorage struct {
+// failFirstUpdateStorage fails the first Update with NotFound but otherwise
+// behaves like the wrapped fakeStorage, simulating a concurrent create
+// between the failed optimistic update and the upsert's Create call.
+type failFirstUpdateStorage struct {
 	*fakeStorage
+	failed bool
 }
 
-func (n *notFoundGetStorage) Get(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
-	return nil, k8serrors.NewNotFound(
-		schema.GroupResource{Group: preferences.APIGroup, Resource: "preferences"},
-		name,
-	)
+func (n *failFirstUpdateStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	if !n.failed {
+		n.failed = true
+		return nil, false, k8serrors.NewNotFound(
+			schema.GroupResource{Group: preferences.APIGroup, Resource: "preferences"},
+			name,
+		)
+	}
+	return n.fakeStorage.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
 }
 
-// forbiddenStorage fails Get with a non-NotFound error to verify such errors
-// are not treated as "missing, create it".
+// forbiddenStorage fails Update with a non-NotFound error to verify such
+// errors are not treated as "missing, create it".
 type forbiddenStorage struct {
 	grafanarest.Storage
 }
 
-func (f *forbiddenStorage) Get(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
-	return nil, k8serrors.NewForbidden(
+func (f *forbiddenStorage) Update(_ context.Context, name string, _ rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return nil, false, k8serrors.NewForbidden(
 		schema.GroupResource{Group: preferences.APIGroup, Resource: "preferences"},
 		name,
 		fmt.Errorf("nope"),

--- a/pkg/services/preference/prefapi/k8s.go
+++ b/pkg/services/preference/prefapi/k8s.go
@@ -6,13 +6,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
 
+	claims "github.com/grafana/authlib/types"
 	preferences "github.com/grafana/grafana/apps/preferences/pkg/apis/preferences/v1"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
+	prefsregistry "github.com/grafana/grafana/pkg/registry/apis/preferences"
 	prefutils "github.com/grafana/grafana/pkg/registry/apis/preferences/utils"
 	grafanaapiserver "github.com/grafana/grafana/pkg/services/apiserver"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	pref "github.com/grafana/grafana/pkg/services/preference"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -22,23 +25,22 @@ import (
 type K8sHandler struct {
 	client     K8sClient
 	dashboards dashboards.DashboardService
+	defaults   preferences.PreferencesSpec
 }
 
 // ProvideK8sHandler is the Wire provider for the legacy preferences
 // bridge.
 func ProvideK8sHandler(cfg *setting.Cfg, configProvider grafanaapiserver.DirectRestConfigProvider, ds dashboards.DashboardService) *K8sHandler {
-	return &K8sHandler{
-		client:     NewK8sClient(cfg, configProvider),
-		dashboards: ds,
-	}
+	return NewK8sHandler(NewK8sClient(cfg, configProvider), ds, prefsregistry.DefaultSpec(cfg))
 }
 
 // NewK8sHandler builds a handler with an explicit client; tests can pass a
 // mock implementation here.
-func NewK8sHandler(client K8sClient, ds dashboards.DashboardService) *K8sHandler {
+func NewK8sHandler(client K8sClient, ds dashboards.DashboardService, defaults preferences.PreferencesSpec) *K8sHandler {
 	return &K8sHandler{
 		client:     client,
 		dashboards: ds,
+		defaults:   defaults,
 	}
 }
 
@@ -50,6 +52,55 @@ func (h *K8sHandler) GetPreferences(c *contextmodel.ReqContext, owner prefutils.
 		return responseFromError(err)
 	}
 	return response.JSON(http.StatusOK, spec)
+}
+
+// GetPreferencesWithDefaults returns the requester's merged preferences
+// (user > teams > org > configured defaults) in the legacy pref.Preference
+// shape, for server-side consumers that render with preferences (e.g. the
+// index page). It is the flag-gated replacement for pref.Service.GetWithDefaults
+// and handles every identity shape, so callers don't need to.
+func (h *K8sHandler) GetPreferencesWithDefaults(c *contextmodel.ReqContext) (*pref.Preference, error) {
+	// No usable identity (e.g. rendering the login page): there are no
+	// user/team/org preferences to merge, so the merged result is exactly the
+	// configured defaults. The API call also cannot be made — an
+	// unauthenticated request has no org/namespace and no token permissions.
+	if !c.IsSignedIn && !c.IsIdentityType(claims.TypeAnonymous) {
+		return specToPreference(&h.defaults), nil
+	}
+
+	spec, err := h.client.GetMerged(c.Req.Context())
+	if err != nil {
+		return nil, err
+	}
+	return specToPreference(spec), nil
+}
+
+// specToPreference maps the app-platform spec onto the legacy model. JSONData
+// is always non-nil because consumers dereference it without checking.
+func specToPreference(spec *preferences.PreferencesSpec) *pref.Preference {
+	p := &pref.Preference{
+		WeekStart: spec.WeekStart,
+		JSONData:  &pref.PreferenceJSONData{},
+	}
+	if spec.Theme != nil {
+		p.Theme = *spec.Theme
+	}
+	if spec.Timezone != nil {
+		p.Timezone = *spec.Timezone
+	}
+	if spec.HomeDashboardUID != nil {
+		p.HomeDashboardUID = *spec.HomeDashboardUID
+	}
+	if spec.Language != nil {
+		p.JSONData.Language = *spec.Language
+	}
+	if spec.QueryHistory != nil && spec.QueryHistory.HomeTab != nil {
+		p.JSONData.QueryHistory.HomeTab = *spec.QueryHistory.HomeTab
+	}
+	if spec.Navbar != nil {
+		p.JSONData.Navbar.BookmarkUrls = spec.Navbar.BookmarkUrls
+	}
+	return p
 }
 
 // UpdatePreferences performs a full replace of the preferences for the

--- a/pkg/services/preference/prefapi/k8s_client.go
+++ b/pkg/services/preference/prefapi/k8s_client.go
@@ -69,9 +69,7 @@ func (k *k8sClient) Get(ctx context.Context, owner prefutils.OwnerReference) (*p
 
 // GetMerged fetches the merged preferences for the requester: user, team and
 // namespace preferences combined with the configured defaults, in that
-// priority order. The custom "preferences/merged" route shares the URL shape
-// of a resource named "merged", so the dynamic client fetches it like a
-// regular object.
+// priority order.
 func (k *k8sClient) GetMerged(ctx context.Context) (*preferences.PreferencesSpec, error) {
 	client, err := k.getClient(ctx)
 	if err != nil {

--- a/pkg/services/preference/prefapi/k8s_client.go
+++ b/pkg/services/preference/prefapi/k8s_client.go
@@ -29,6 +29,7 @@ import (
 // be mocked in tests of the legacy handlers.
 type K8sClient interface {
 	Get(ctx context.Context, owner prefutils.OwnerReference) (*preferences.PreferencesSpec, error)
+	GetMerged(ctx context.Context) (*preferences.PreferencesSpec, error)
 	Update(ctx context.Context, owner prefutils.OwnerReference, spec *preferences.PreferencesSpec) error
 	Patch(ctx context.Context, owner prefutils.OwnerReference, spec *preferences.PreferencesSpec) error
 }
@@ -61,6 +62,23 @@ func (k *k8sClient) Get(ctx context.Context, owner prefutils.OwnerReference) (*p
 		if errors.IsNotFound(err) {
 			return &preferences.PreferencesSpec{}, nil
 		}
+		return nil, err
+	}
+	return unstructuredToSpec(out)
+}
+
+// GetMerged fetches the merged preferences for the requester: user, team and
+// namespace preferences combined with the configured defaults, in that
+// priority order. The custom "preferences/merged" route shares the URL shape
+// of a resource named "merged", so the dynamic client fetches it like a
+// regular object.
+func (k *k8sClient) GetMerged(ctx context.Context) (*preferences.PreferencesSpec, error) {
+	client, err := k.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out, err := client.Get(ctx, "merged", v1.GetOptions{})
+	if err != nil {
 		return nil, err
 	}
 	return unstructuredToSpec(out)

--- a/pkg/services/preference/prefapi/k8s_client_mock.go
+++ b/pkg/services/preference/prefapi/k8s_client_mock.go
@@ -82,6 +82,64 @@ func (_c *MockK8sClient_Get_Call) RunAndReturn(run func(context.Context, utils.O
 	return _c
 }
 
+// GetMerged provides a mock function with given fields: ctx
+func (_m *MockK8sClient) GetMerged(ctx context.Context) (*v1alpha1.PreferencesSpec, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMerged")
+	}
+
+	var r0 *v1alpha1.PreferencesSpec
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*v1alpha1.PreferencesSpec, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) *v1alpha1.PreferencesSpec); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.PreferencesSpec)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockK8sClient_GetMerged_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMerged'
+type MockK8sClient_GetMerged_Call struct {
+	*mock.Call
+}
+
+// GetMerged is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockK8sClient_Expecter) GetMerged(ctx interface{}) *MockK8sClient_GetMerged_Call {
+	return &MockK8sClient_GetMerged_Call{Call: _e.mock.On("GetMerged", ctx)}
+}
+
+func (_c *MockK8sClient_GetMerged_Call) Run(run func(ctx context.Context)) *MockK8sClient_GetMerged_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockK8sClient_GetMerged_Call) Return(_a0 *v1alpha1.PreferencesSpec, _a1 error) *MockK8sClient_GetMerged_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockK8sClient_GetMerged_Call) RunAndReturn(run func(context.Context) (*v1alpha1.PreferencesSpec, error)) *MockK8sClient_GetMerged_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Patch provides a mock function with given fields: c, owner, spec
 func (_m *MockK8sClient) Patch(c context.Context, owner utils.OwnerReference, spec *v1alpha1.PreferencesSpec) error {
 	ret := _m.Called(c, owner, spec)

--- a/pkg/services/preference/prefapi/k8s_test.go
+++ b/pkg/services/preference/prefapi/k8s_test.go
@@ -29,6 +29,25 @@ func newReqContext(orgID int64, identifier string) *contextmodel.ReqContext {
 	return &contextmodel.ReqContext{
 		Context:      &web.Context{Req: httpReq},
 		SignedInUser: &user.SignedInUser{OrgID: orgID, UserUID: identifier},
+		IsSignedIn:   true,
+	}
+}
+
+// newUnauthenticatedReqContext mirrors what contexthandler builds when
+// authentication fails: a bare SignedInUser with no identity type or org.
+func newUnauthenticatedReqContext() *contextmodel.ReqContext {
+	httpReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	return &contextmodel.ReqContext{
+		Context:      &web.Context{Req: httpReq},
+		SignedInUser: &user.SignedInUser{Permissions: map[int64]map[string][]string{}},
+	}
+}
+
+func newAnonymousReqContext(orgID int64) *contextmodel.ReqContext {
+	httpReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	return &contextmodel.ReqContext{
+		Context:      &web.Context{Req: httpReq},
+		SignedInUser: &user.SignedInUser{OrgID: orgID, IsAnonymous: true},
 	}
 }
 
@@ -38,7 +57,7 @@ func TestK8sHandler_GetPreferences(t *testing.T) {
 		spec := &preferences.PreferencesSpec{Theme: ptr.To("dark")}
 		client.EXPECT().Get(mock.Anything, prefutils.OwnerReference{Owner: prefutils.UserResourceOwner, Identifier: "u1"}).Return(spec, nil)
 
-		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t))
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
 		resp := h.GetPreferences(newReqContext(1, "u1"), prefutils.UserOwner("u1"))
 
 		require.Equal(t, http.StatusOK, resp.Status())
@@ -51,7 +70,7 @@ func TestK8sHandler_GetPreferences(t *testing.T) {
 		client := NewMockK8sClient(t)
 		client.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, apierrors.NewForbidden(schema.GroupResource{}, "x", errors.New("nope")))
 
-		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t))
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
 		resp := h.GetPreferences(newReqContext(1, "u1"), prefutils.NamespaceOwner())
 
 		assert.Equal(t, http.StatusForbidden, resp.Status())
@@ -61,7 +80,7 @@ func TestK8sHandler_GetPreferences(t *testing.T) {
 		client := NewMockK8sClient(t)
 		client.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
 
-		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t))
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
 		resp := h.GetPreferences(newReqContext(1, "u1"), prefutils.NamespaceOwner())
 
 		assert.Equal(t, http.StatusInternalServerError, resp.Status())
@@ -77,7 +96,7 @@ func TestK8sHandler_UpdatePreferences(t *testing.T) {
 				captured = spec
 			}).Return(nil)
 
-		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t))
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
 		resp := h.UpdatePreferences(newReqContext(1, "u1"), prefutils.UserOwner("u1"), &dtos.UpdatePrefsCmd{
 			Theme:    "dark",
 			Timezone: "",
@@ -105,7 +124,7 @@ func TestK8sHandler_UpdatePreferences(t *testing.T) {
 				captured = spec
 			}).Return(nil)
 
-		h := NewK8sHandler(client, ds)
+		h := NewK8sHandler(client, ds, preferences.PreferencesSpec{})
 		resp := h.UpdatePreferences(newReqContext(1, "u1"), prefutils.UserOwner("u1"), &dtos.UpdatePrefsCmd{
 			HomeDashboardID: 42,
 		})
@@ -120,7 +139,7 @@ func TestK8sHandler_UpdatePreferences(t *testing.T) {
 		client.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		ds := dashboards.NewFakeDashboardService(t) // no expectations — must not be called
-		h := NewK8sHandler(client, ds)
+		h := NewK8sHandler(client, ds, preferences.PreferencesSpec{})
 		resp := h.UpdatePreferences(newReqContext(1, "u1"), prefutils.UserOwner("u1"), &dtos.UpdatePrefsCmd{
 			HomeDashboardUID: ptr.To("supplied"),
 			HomeDashboardID:  42,
@@ -133,7 +152,7 @@ func TestK8sHandler_UpdatePreferences(t *testing.T) {
 		ds := dashboards.NewFakeDashboardService(t)
 		ds.On("GetDashboard", mock.Anything, mock.Anything).Return(nil, dashboards.ErrDashboardNotFound)
 
-		h := NewK8sHandler(NewMockK8sClient(t), ds)
+		h := NewK8sHandler(NewMockK8sClient(t), ds, preferences.PreferencesSpec{})
 		resp := h.UpdatePreferences(newReqContext(1, "u1"), prefutils.UserOwner("u1"), &dtos.UpdatePrefsCmd{
 			HomeDashboardID: 42,
 		})
@@ -151,7 +170,7 @@ func TestK8sHandler_PatchPreferences(t *testing.T) {
 				captured = spec
 			}).Return(nil)
 
-		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t))
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
 		resp := h.PatchPreferences(newReqContext(1, "u1"), prefutils.UserOwner("u1"), &dtos.PatchPrefsCmd{
 			Theme: ptr.To("light"),
 		})
@@ -168,7 +187,7 @@ func TestK8sHandler_PatchPreferences(t *testing.T) {
 		client := NewMockK8sClient(t)
 		client.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t))
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
 		resp := h.PatchPreferences(newReqContext(1, "u1"), prefutils.UserOwner("u1"), &dtos.PatchPrefsCmd{
 			Theme: ptr.To("light"),
 		})
@@ -181,9 +200,95 @@ func TestK8sHandler_PatchPreferences(t *testing.T) {
 		client.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything).
 			Return(apierrors.NewNotFound(schema.GroupResource{Resource: "preferences"}, "user-u1"))
 
-		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t))
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
 		resp := h.PatchPreferences(newReqContext(1, "u1"), prefutils.UserOwner("u1"), &dtos.PatchPrefsCmd{})
 
 		assert.Equal(t, http.StatusNotFound, resp.Status())
+	})
+}
+
+func TestK8sHandler_GetPreferencesWithDefaults(t *testing.T) {
+	t.Run("maps the merged spec onto the legacy model", func(t *testing.T) {
+		client := NewMockK8sClient(t)
+		client.EXPECT().GetMerged(mock.Anything).Return(&preferences.PreferencesSpec{
+			Theme:            ptr.To("dark"),
+			Timezone:         ptr.To("Europe/London"),
+			WeekStart:        ptr.To("monday"),
+			Language:         ptr.To("en-GB"),
+			HomeDashboardUID: ptr.To("abc123"),
+			QueryHistory:     &preferences.PreferencesQueryHistoryPreference{HomeTab: ptr.To("starred")},
+			Navbar:           &preferences.PreferencesNavbarPreference{BookmarkUrls: []string{"/dashboards"}},
+		}, nil)
+
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
+		got, err := h.GetPreferencesWithDefaults(newReqContext(1, "u1"))
+		require.NoError(t, err)
+
+		assert.Equal(t, "dark", got.Theme)
+		assert.Equal(t, "Europe/London", got.Timezone)
+		require.NotNil(t, got.WeekStart)
+		assert.Equal(t, "monday", *got.WeekStart)
+		assert.Equal(t, "abc123", got.HomeDashboardUID)
+		require.NotNil(t, got.JSONData)
+		assert.Equal(t, "en-GB", got.JSONData.Language)
+		assert.Equal(t, "starred", got.JSONData.QueryHistory.HomeTab)
+		assert.Equal(t, []string{"/dashboards"}, got.JSONData.Navbar.BookmarkUrls)
+	})
+
+	t.Run("empty spec yields zero values with non-nil JSONData", func(t *testing.T) {
+		client := NewMockK8sClient(t)
+		client.EXPECT().GetMerged(mock.Anything).Return(&preferences.PreferencesSpec{}, nil)
+
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
+		got, err := h.GetPreferencesWithDefaults(newReqContext(1, "u1"))
+		require.NoError(t, err)
+
+		assert.Empty(t, got.Theme)
+		assert.Empty(t, got.Timezone)
+		assert.Nil(t, got.WeekStart)
+		assert.Empty(t, got.HomeDashboardUID)
+		// consumers dereference JSONData without checking (e.g. index.go reads
+		// prefs.JSONData.Language), so it must never be nil
+		require.NotNil(t, got.JSONData)
+		assert.Empty(t, got.JSONData.Language)
+	})
+
+	t.Run("propagates client errors", func(t *testing.T) {
+		client := NewMockK8sClient(t)
+		client.EXPECT().GetMerged(mock.Anything).Return(nil, errors.New("boom"))
+
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
+		_, err := h.GetPreferencesWithDefaults(newReqContext(1, "u1"))
+		require.Error(t, err)
+	})
+
+	t.Run("unauthenticated request returns configured defaults without an API call", func(t *testing.T) {
+		// no expectations on the mock — a GetMerged call would fail the test
+		client := NewMockK8sClient(t)
+		defaults := preferences.PreferencesSpec{
+			Theme:    ptr.To("system"),
+			Timezone: ptr.To("browser"),
+		}
+
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), defaults)
+		got, err := h.GetPreferencesWithDefaults(newUnauthenticatedReqContext())
+		require.NoError(t, err)
+
+		assert.Equal(t, "system", got.Theme)
+		assert.Equal(t, "browser", got.Timezone)
+		require.NotNil(t, got.JSONData)
+	})
+
+	t.Run("anonymous request goes through the merged API", func(t *testing.T) {
+		client := NewMockK8sClient(t)
+		client.EXPECT().GetMerged(mock.Anything).Return(&preferences.PreferencesSpec{
+			Theme: ptr.To("dark"),
+		}, nil)
+
+		h := NewK8sHandler(client, dashboards.NewFakeDashboardService(t), preferences.PreferencesSpec{})
+		got, err := h.GetPreferencesWithDefaults(newAnonymousReqContext(1))
+		require.NoError(t, err)
+
+		assert.Equal(t, "dark", got.Theme)
 	})
 }

--- a/pkg/tests/apis/preferences/anonymous_test.go
+++ b/pkg/tests/apis/preferences/anonymous_test.go
@@ -1,0 +1,101 @@
+package preferences
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	preferences "github.com/grafana/grafana/apps/preferences/pkg/apis/preferences/v1"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// TestIntegrationPreferences_Anonymous verifies that with the reroute flag on,
+// anonymous requests are served through the app-platform preferences API: the
+// merged route accepts the anonymous identity directly, and server-side
+// consumers (index page, home dashboard) surface org preferences to anonymous
+// visitors through it.
+func TestIntegrationPreferences_Anonymous(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		AppModeProduction: false,
+		DisableAnonymous:  false,          // keep [auth.anonymous] enabled = true (the harness default)
+		AnonymousUserRole: org.RoleViewer, // anonymous lands in org 1 "Main Org."
+		EnableFeatureToggles: []string{
+			featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs,
+			featuremgmt.FlagPreferencesRerouteLegacyAPIs,
+		},
+	})
+
+	// Seed org preferences as admin. The default theme is dark, so a light org
+	// theme distinguishes "org preference applied" from "fell back to defaults".
+	dash := struct {
+		UID string `json:"uid"`
+	}{}
+	dashResp := apis.DoRequest(helper, apis.RequestParams{
+		User:   helper.Org1.Admin,
+		Method: http.MethodPost,
+		Path:   "/api/dashboards/db",
+		Body:   []byte(`{"dashboard": {"title": "anon org home"}, "overwrite": true}`),
+	}, &dash)
+	require.Equal(t, http.StatusOK, dashResp.Response.StatusCode, string(dashResp.Body))
+	require.NotEmpty(t, dash.UID)
+
+	putResp := apis.DoRequest(helper, apis.RequestParams{
+		User:   helper.Org1.Admin,
+		Method: http.MethodPut,
+		Path:   "/api/org/preferences",
+		Body:   fmt.Appendf(nil, `{"theme":"light","homeDashboardUID":%q}`, dash.UID),
+	}, &map[string]any{})
+	require.Equal(t, http.StatusOK, putResp.Response.StatusCode, string(putResp.Body))
+
+	t.Run("merged route serves the anonymous identity", func(t *testing.T) {
+		// No User -> the request is sent without credentials and is resolved
+		// as the anonymous identity
+		merged := preferences.Preferences{}
+		resp := apis.DoRequest(helper, apis.RequestParams{
+			Method: http.MethodGet,
+			Path:   "/apis/preferences.grafana.app/v1/namespaces/default/preferences/merged",
+		}, &merged)
+		require.Equal(t, http.StatusOK, resp.Response.StatusCode, string(resp.Body))
+
+		require.NotNil(t, merged.Spec.Theme)
+		require.Equal(t, "light", *merged.Spec.Theme, "org preference must reach anonymous requesters")
+		require.Contains(t, merged.Annotations[preferences.APIGroup+"/source"], "namespace",
+			"merged response must record the org preferences as a source")
+	})
+
+	t.Run("index page renders org preferences for anonymous visitors", func(t *testing.T) {
+		// nolint:gosec
+		resp, err := http.Get(fmt.Sprintf("http://%s/", helper.GetListenerAddress()))
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.True(t, strings.Contains(string(body), `"theme":"light"`),
+			"anonymous index page must carry the org theme in its boot data")
+	})
+
+	t.Run("home dashboard endpoint reads org preferences for anonymous visitors", func(t *testing.T) {
+		redirect := struct {
+			RedirectURI string `json:"redirectUri"`
+		}{}
+		resp := apis.DoRequest(helper, apis.RequestParams{
+			Method: http.MethodGet,
+			Path:   "/api/dashboards/home",
+		}, &redirect)
+		require.Equal(t, http.StatusOK, resp.Response.StatusCode, string(resp.Body))
+		require.Contains(t, redirect.RedirectURI, dash.UID,
+			"home endpoint must redirect anonymous visitors to the org home dashboard")
+	})
+}

--- a/pkg/tests/apis/preferences/k8s_preferences_test.go
+++ b/pkg/tests/apis/preferences/k8s_preferences_test.go
@@ -118,11 +118,6 @@ func TestIntegrationPreferences_K8sAPIs(t *testing.T) {
 	})
 
 	t.Run("merged preferences via resource-shaped GET", func(t *testing.T) {
-		// prefapi's K8sClient.GetMerged (used by the index page when the
-		// reroute flag is on) fetches the custom "preferences/merged" route
-		// through the dynamic client as if it were a resource named "merged".
-		// This asserts that URL shape reaches the merged handler and not the
-		// regular {name} storage handler (which would return 404).
 		admin := helper.Org1.Admin
 		adminName := "user-" + admin.Identity.GetIdentifier()
 		putResult := putUserPrefsK8s(t, helper, admin, adminName, fmt.Sprintf(`{"metadata": {"name": "%s"}, "spec": {"theme":"aubergine"}}`, adminName))

--- a/pkg/tests/apis/preferences/k8s_preferences_test.go
+++ b/pkg/tests/apis/preferences/k8s_preferences_test.go
@@ -116,6 +116,31 @@ func TestIntegrationPreferences_K8sAPIs(t *testing.T) {
 			require.Equal(t, "", *replaced.Spec.Timezone, "PUT must clear timezone it omitted")
 		}
 	})
+
+	t.Run("merged preferences via resource-shaped GET", func(t *testing.T) {
+		// prefapi's K8sClient.GetMerged (used by the index page when the
+		// reroute flag is on) fetches the custom "preferences/merged" route
+		// through the dynamic client as if it were a resource named "merged".
+		// This asserts that URL shape reaches the merged handler and not the
+		// regular {name} storage handler (which would return 404).
+		admin := helper.Org1.Admin
+		adminName := "user-" + admin.Identity.GetIdentifier()
+		putResult := putUserPrefsK8s(t, helper, admin, adminName, fmt.Sprintf(`{"metadata": {"name": "%s"}, "spec": {"theme":"aubergine"}}`, adminName))
+		require.NoError(t, putResult.Error())
+
+		client := admin.RESTClient(t, &preferences.GroupVersion)
+		raw, err := client.Get().AbsPath("apis", "preferences.grafana.app", "v1",
+			"namespaces", "default",
+			"preferences", "merged").Do(context.Background()).Raw()
+		require.NoError(t, err, "GET preferences/merged: %s", string(raw))
+
+		out := &preferences.Preferences{}
+		require.NoError(t, json.Unmarshal(raw, out))
+		require.NotNil(t, out.Spec.Theme)
+		require.Equal(t, "aubergine", *out.Spec.Theme, "user preference must win in the merged view")
+		require.Contains(t, out.Annotations[preferences.APIGroup+"/source"], adminName,
+			"merged response must record the user preferences as a source")
+	})
 }
 
 func putUserPrefsK8s(t *testing.T, helper *apis.K8sTestHelper, user apis.User, name string, body string) rest.Result {

--- a/pkg/tests/apis/preferences/legacy_preferences_test.go
+++ b/pkg/tests/apis/preferences/legacy_preferences_test.go
@@ -87,6 +87,49 @@ func TestIntegrationPreferences_LegacyBridge(t *testing.T) {
 				require.Equal(t, "UTC", *got.Timezone)
 			})
 
+			t.Run("index page renders when not logged in", func(t *testing.T) {
+				// The login page renders through setIndexViewData, which also reads
+				// preferences. An unauthenticated request carries no usable identity,
+				// so the flag-gated app-platform read must not be attempted for it.
+				// nolint:gosec
+				resp, err := http.Get(fmt.Sprintf("http://%s/login", helper.GetListenerAddress()))
+				require.NoError(t, err)
+				defer func() { _ = resp.Body.Close() }()
+				require.Equal(t, http.StatusOK, resp.StatusCode)
+			})
+
+			t.Run("home dashboard reads preferences server-side", func(t *testing.T) {
+				// GetHomeDashboard consumes merged preferences on the server; with the
+				// flag on it goes through prefapi.GetPreferencesWithDefaults and the
+				// app-platform "preferences/merged" route instead of pref.Service.
+				dash := struct {
+					UID string `json:"uid"`
+				}{}
+				dashResp := apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: http.MethodPost,
+					Path:   "/api/dashboards/db",
+					Body:   []byte(`{"dashboard": {"title": "home sweet home"}, "overwrite": true}`),
+				}, &dash)
+				require.Equal(t, http.StatusOK, dashResp.Response.StatusCode, string(dashResp.Body))
+				require.NotEmpty(t, dash.UID)
+
+				putResult := putUserPrefs(t, helper, fmt.Sprintf(`{"homeDashboardUID":%q}`, dash.UID))
+				require.Equal(t, http.StatusOK, putResult)
+
+				redirect := struct {
+					RedirectURI string `json:"redirectUri"`
+				}{}
+				resp := apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: http.MethodGet,
+					Path:   "/api/dashboards/home",
+				}, &redirect)
+				require.Equal(t, http.StatusOK, resp.Response.StatusCode, string(resp.Body))
+				require.Contains(t, redirect.RedirectURI, dash.UID,
+					"home endpoint must redirect to the dashboard saved in preferences")
+			})
+
 			t.Run("PATCH on missing upserts", func(t *testing.T) {
 				// Use the Editor user — no other subtest writes preferences for them, so
 				// the PATCH below is genuinely against a non-existent record. Both the

--- a/pkg/tests/apis/preferences/legacy_preferences_test.go
+++ b/pkg/tests/apis/preferences/legacy_preferences_test.go
@@ -87,49 +87,6 @@ func TestIntegrationPreferences_LegacyBridge(t *testing.T) {
 				require.Equal(t, "UTC", *got.Timezone)
 			})
 
-			t.Run("index page renders when not logged in", func(t *testing.T) {
-				// The login page renders through setIndexViewData, which also reads
-				// preferences. An unauthenticated request carries no usable identity,
-				// so the flag-gated app-platform read must not be attempted for it.
-				// nolint:gosec
-				resp, err := http.Get(fmt.Sprintf("http://%s/login", helper.GetListenerAddress()))
-				require.NoError(t, err)
-				defer func() { _ = resp.Body.Close() }()
-				require.Equal(t, http.StatusOK, resp.StatusCode)
-			})
-
-			t.Run("home dashboard reads preferences server-side", func(t *testing.T) {
-				// GetHomeDashboard consumes merged preferences on the server; with the
-				// flag on it goes through prefapi.GetPreferencesWithDefaults and the
-				// app-platform "preferences/merged" route instead of pref.Service.
-				dash := struct {
-					UID string `json:"uid"`
-				}{}
-				dashResp := apis.DoRequest(helper, apis.RequestParams{
-					User:   helper.Org1.Admin,
-					Method: http.MethodPost,
-					Path:   "/api/dashboards/db",
-					Body:   []byte(`{"dashboard": {"title": "home sweet home"}, "overwrite": true}`),
-				}, &dash)
-				require.Equal(t, http.StatusOK, dashResp.Response.StatusCode, string(dashResp.Body))
-				require.NotEmpty(t, dash.UID)
-
-				putResult := putUserPrefs(t, helper, fmt.Sprintf(`{"homeDashboardUID":%q}`, dash.UID))
-				require.Equal(t, http.StatusOK, putResult)
-
-				redirect := struct {
-					RedirectURI string `json:"redirectUri"`
-				}{}
-				resp := apis.DoRequest(helper, apis.RequestParams{
-					User:   helper.Org1.Admin,
-					Method: http.MethodGet,
-					Path:   "/api/dashboards/home",
-				}, &redirect)
-				require.Equal(t, http.StatusOK, resp.Response.StatusCode, string(resp.Body))
-				require.Contains(t, redirect.RedirectURI, dash.UID,
-					"home endpoint must redirect to the dashboard saved in preferences")
-			})
-
 			t.Run("PATCH on missing upserts", func(t *testing.T) {
 				// Use the Editor user — no other subtest writes preferences for them, so
 				// the PATCH below is genuinely against a non-existent record. Both the


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- ensures `PATCH` requests will create if there is no existing preference stored
  - this matches the legacy sql implementation
  - i have no idea if this is the behaviour we want - opinions welcome!
    - we could call e.g. `PUT` on the profile page no problem, since we already have access to the full preferences object
    - that becomes trickier for other callers (e.g. theme selector drawer or bookmarking in the nav) since they don't request the full preferences object up front, so we can't PUT (or decide between PUT/PATCH) without first making a GET. 
- ensures a few extra places are correctly calling the k8s implementation when `preferences.rerouteLegacyAPIs` flag is enabled
  - have widened the `/merged` route to also handle being called when not logged in
    - needed for e.g. `index.go` to render the login page
- tests!

**Why do we need this feature?**

- so we can start using the new k8s `/preferences` apis

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-frontend-platform/issues/171

**Special notes for your reviewer:**

In theory this could be split into 2 (basically commit 1 + commit 2), but both are needed for mode5 enablement so 🤷 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
