### PR TITLE
Provisioning: verify claim ownership so two pods don't run the same job

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -294,13 +294,20 @@ func (d *jobDriver) leaseRenewalLoop(ctx context.Context, logger logging.Logger,
 
 			if err != nil {
 				consecutiveFailures++
-				// Lease loss (job reaped or claimed by another worker) is terminal: keeping
-				// this worker running would mean two workers process the same job. Abort now
-				// instead of retrying, which would only stomp the new owner's claim.
-				if errors.Is(err, ErrLeaseLost) ||
-					apierrors.IsNotFound(err) ||
-					strings.Contains(err.Error(), "job no longer exists") {
-					logger.Error("lease lost - aborting job", "error", err)
+				// Both cases below are terminal: continuing to run would mean two workers
+				// process the same job. Abort immediately rather than retrying, which would
+				// only stomp the new owner's claim.
+
+				// Another worker now owns the claim (job reaped and re-claimed on the same name).
+				if errors.Is(err, ErrLeaseLost) {
+					logger.Error("lease taken over by another worker - aborting job", "error", err)
+					close(leaseExpired)
+					return
+				}
+
+				// The job no longer exists in the store (deleted or reaped before renewal).
+				if apierrors.IsNotFound(err) || strings.Contains(err.Error(), "job no longer exists") {
+					logger.Error("job no longer exists - aborting job", "error", err)
 					close(leaseExpired)
 					return
 				}

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -294,9 +294,13 @@ func (d *jobDriver) leaseRenewalLoop(ctx context.Context, logger logging.Logger,
 
 			if err != nil {
 				consecutiveFailures++
-				if apierrors.IsNotFound(err) ||
+				// Lease loss (job reaped or claimed by another worker) is terminal: keeping
+				// this worker running would mean two workers process the same job. Abort now
+				// instead of retrying, which would only stomp the new owner's claim.
+				if errors.Is(err, ErrLeaseLost) ||
+					apierrors.IsNotFound(err) ||
 					strings.Contains(err.Error(), "job no longer exists") {
-					logger.Error("job no longer exists - lease expired", "error", err)
+					logger.Error("lease lost - aborting job", "error", err)
 					close(leaseExpired)
 					return
 				}

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -20,6 +20,7 @@ import (
 	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -28,11 +29,23 @@ const (
 	// The label must be formatted as milliseconds from Epoch. This grants a natural ordering, allowing for less-than operators in label selectors.
 	// The natural ordering would be broken if the number rolls over into 1 more digit. This won't happen before Nov, 2286.
 	LabelJobClaim = "provisioning.grafana.app/claim"
+	// LabelJobClaimOwner is a token unique to a single claim, identifying which worker owns it.
+	// Job names are deterministic (repository + action), so a reaped job and its re-created
+	// namesake share a name. Without an owner token, a worker cannot tell its own claim apart
+	// from a fresh claim placed by another worker on the same name, and would renew/complete a
+	// job it no longer owns -- leading to two workers running the same job. The token lets
+	// RenewLease and Complete verify the claim in the store is still the one we placed.
+	LabelJobClaimOwner = "provisioning.grafana.app/claim-owner"
 	// LabelRepository contains the repository name as a label. This allows for label selectors to find the archived version of a job.
 	LabelRepository = "provisioning.grafana.app/repository"
 	// LabelJobOriginalUID contains the Job's original uid as a label. This allows for label selectors to find the archived version of a job.
 	LabelJobOriginalUID = "provisioning.grafana.app/original-uid"
 )
+
+// ErrLeaseLost indicates the job's claim in the store is no longer the one we placed:
+// the job was reaped and re-created, or another worker has taken it over. A worker that
+// sees this must stop processing immediately so two workers do not run the same job.
+var ErrLeaseLost = errors.New("job lease lost: claimed by another worker")
 
 var ErrNoJobs = &apierrors.StatusError{
 	ErrStatus: metav1.Status{
@@ -137,6 +150,7 @@ func (s *persistentStore) Claim(ctx context.Context) (job *provisioning.Job, rol
 			job.Labels = make(map[string]string)
 		}
 		job.Labels[LabelJobClaim] = strconv.FormatInt(s.clock().UnixMilli(), 10)
+		job.Labels[LabelJobClaimOwner] = util.GenerateShortUID()
 		s.queueMetrics.RecordWaitTime(string(job.Spec.Action), s.clock().Sub(job.CreationTimestamp.Time).Seconds())
 
 		// Set up the provisioning identity for this namespace
@@ -196,6 +210,7 @@ func (s *persistentStore) Claim(ctx context.Context) (job *provisioning.Job, rol
 			// Rollback the claim.
 			refetchedJob := refetched.DeepCopy()
 			delete(refetchedJob.Labels, LabelJobClaim)
+			delete(refetchedJob.Labels, LabelJobClaimOwner)
 			refetchedJob.Status.State = provisioning.JobStatePending
 
 			timeoutCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
@@ -306,12 +321,31 @@ func (s *persistentStore) Complete(ctx context.Context, job *provisioning.Job) e
 		return apifmt.Errorf("failed to get provisioning identity for '%s': %w", job.GetNamespace(), err)
 	}
 
+	// Verify we still own the job before deleting it. Job names are deterministic, so a
+	// reaped job and its re-created namesake share a name. Deleting purely by name would let
+	// a worker that has lost its lease delete the job another worker is now running. A matching
+	// UID proves it is the same object we claimed, and a matching owner token proves the claim
+	// is still ours. If the job is gone or a different incarnation exists, report NotFound so
+	// callers treat it as already cleaned up.
+	latest, err := s.client.Jobs(job.GetNamespace()).Get(ctx, job.GetName(), metav1.GetOptions{})
+	if err != nil {
+		span.RecordError(err)
+		return apifmt.Errorf("failed to get job '%s' in '%s' for completion: %w", job.GetName(), job.GetNamespace(), err)
+	}
+	if latest.UID != job.UID || latest.Labels[LabelJobClaimOwner] != job.Labels[LabelJobClaimOwner] {
+		logger.Info("job no longer owned by this worker - skipping completion")
+		return apierrors.NewNotFound(provisioning.JobResourceInfo.GroupResource(), job.GetName())
+	}
+
 	// Delete the job from the active job store.
 	// Callers are responsible for writing the job to history after calling this.
 	//
-	// We will assume that the caller is the claimant. If this is not true, an error is returned.
-	// This is a best-effort operation; if the job is not in the claimed state, we will still attempt to delete it.
-	err = s.client.Jobs(job.GetNamespace()).Delete(ctx, job.GetName(), metav1.DeleteOptions{})
+	// The UID precondition makes the delete atomic against the ownership check above: if the
+	// object is replaced by a namesake between the Get and the Delete, the precondition fails.
+	uid := job.UID
+	err = s.client.Jobs(job.GetNamespace()).Delete(ctx, job.GetName(), metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{UID: &uid},
+	})
 	if err != nil {
 		span.RecordError(err)
 		return apifmt.Errorf("failed to delete job '%s' in '%s': %w", job.GetName(), job.GetNamespace(), err)
@@ -419,14 +453,23 @@ func (s *persistentStore) RenewLease(ctx context.Context, job *provisioning.Job)
 		return apifmt.Errorf("failed to fetch job for lease renewal '%s' in '%s': %w", job.GetName(), job.GetNamespace(), err)
 	}
 
-	// Verify we still own the lease
-	if latestJob.Labels == nil || latestJob.Labels[LabelJobClaim] == "" {
-		err := apifmt.Errorf("lease lost for job '%s' in '%s': no longer claimed", job.GetName(), job.GetNamespace())
+	// Verify we still own the lease. Checking that the job is claimed is not enough:
+	// job names are deterministic, so the claim in the store may belong to a different
+	// worker that took over after ours was reaped. A matching UID proves it is the same
+	// object we claimed (a re-created namesake gets a fresh UID), and a matching owner
+	// token proves the claim is still the one we placed. If either differs, we have lost
+	// the lease and must not renew it.
+	owner := job.Labels[LabelJobClaimOwner]
+	if latestJob.Labels == nil ||
+		latestJob.Labels[LabelJobClaim] == "" ||
+		latestJob.Labels[LabelJobClaimOwner] != owner ||
+		latestJob.UID != job.UID {
+		err := apifmt.Errorf("lease lost for job '%s' in '%s': %w", job.GetName(), job.GetNamespace(), ErrLeaseLost)
 		span.RecordError(err)
 		return err
 	}
 
-	// Update the claim timestamp to current time
+	// Update the claim timestamp to current time, preserving our owner token.
 	updatedJob := latestJob.DeepCopy()
 	updatedJob.Labels[LabelJobClaim] = strconv.FormatInt(s.clock().UnixMilli(), 10)
 

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -207,6 +207,15 @@ func (s *persistentStore) Claim(ctx context.Context) (job *provisioning.Job, rol
 				return
 			}
 
+			// Only roll back if the job in the store is still the one we claimed. Job names are
+			// deterministic, so this same name may now be a re-created job claimed by another
+			// worker. Stripping its claim would hand that worker's job to a third one and
+			// reintroduce duplicate execution, so leave it alone.
+			if refetched.UID != updatedJob.UID || refetched.Labels[LabelJobClaimOwner] != updatedJob.Labels[LabelJobClaimOwner] {
+				logger.Info("claim no longer owned by this worker - skipping rollback")
+				return
+			}
+
 			// Rollback the claim.
 			refetchedJob := refetched.DeepCopy()
 			delete(refetchedJob.Labels, LabelJobClaim)
@@ -352,11 +361,13 @@ func (s *persistentStore) Complete(ctx context.Context, job *provisioning.Job) e
 	}
 	logger.Debug("deleted job from job store")
 
-	// We need to remove the claim label before moving the job to the historic job store.
+	// We need to remove the claim labels before moving the job to the historic job store,
+	// so the per-claim owner token does not leak into the archived object.
 	if job.Labels == nil {
 		job.Labels = make(map[string]string)
 	}
 	delete(job.Labels, LabelJobClaim)
+	delete(job.Labels, LabelJobClaimOwner)
 	s.queueMetrics.DecreaseQueueSize(string(job.Spec.Action))
 
 	logger.Debug("complete job complete")

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -2,11 +2,14 @@ package jobs
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -14,6 +17,187 @@ import (
 	provisioningv0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
+
+func newTestStore(client provisioningv0alpha1.ProvisioningV0alpha1Interface) *persistentStore {
+	return &persistentStore{
+		client:       client,
+		clock:        time.Now,
+		expiry:       30 * time.Second,
+		queueMetrics: RegisterQueueMetrics(prometheus.NewPedanticRegistry()),
+	}
+}
+
+// TestClaim_StampsOwnerToken verifies that claiming a job stamps a unique owner
+// token alongside the claim timestamp, so ownership can be verified later.
+func TestClaim_StampsOwnerToken(t *testing.T) {
+	fakeClient := newTestClientset()
+	store := newTestStore(fakeClient)
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	_, err = fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "stacks-123"},
+		Spec:       provisioning.JobSpec{Repository: "test-repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	claimed, rollback, err := store.Claim(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	defer rollback()
+
+	assert.NotEmpty(t, claimed.Labels[LabelJobClaim], "claim timestamp should be set")
+	assert.NotEmpty(t, claimed.Labels[LabelJobClaimOwner], "claim owner token should be set")
+}
+
+// TestRenewLease_LostToAnotherOwner verifies that a worker cannot renew a claim
+// that now belongs to a different owner (same job name, different owner token).
+// This is the core protection against two workers processing the same job: once
+// a job is reaped and re-claimed by another worker, the original worker's renewal
+// must fail with ErrLeaseLost so it aborts instead of continuing to run.
+func TestRenewLease_LostToAnotherOwner(t *testing.T) {
+	fakeClient := newTestClientset()
+	store := newTestStore(fakeClient)
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	// The store's job is claimed by owner-B.
+	created, err := fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "stacks-123",
+			UID:       "uid-1",
+			Labels: map[string]string{
+				LabelJobClaim:      "1000000000000",
+				LabelJobClaimOwner: "owner-B",
+			},
+		},
+		Spec: provisioning.JobSpec{Repository: "test-repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// We hold a claim with owner-A on the same job name/UID.
+	ours := created.DeepCopy()
+	ours.Labels[LabelJobClaimOwner] = "owner-A"
+
+	err = store.RenewLease(ctx, ours)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrLeaseLost), "expected ErrLeaseLost, got %v", err)
+}
+
+// TestRenewLease_LostToReincarnatedJob verifies that a matching owner token is not
+// enough: if the object was deleted and re-created under the same name (new UID),
+// renewal must still fail.
+func TestRenewLease_LostToReincarnatedJob(t *testing.T) {
+	fakeClient := newTestClientset()
+	store := newTestStore(fakeClient)
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	created, err := fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "stacks-123",
+			UID:       "uid-2", // reincarnated object has a new UID
+			Labels: map[string]string{
+				LabelJobClaim:      "1000000000000",
+				LabelJobClaimOwner: "owner-A",
+			},
+		},
+		Spec: provisioning.JobSpec{Repository: "test-repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Same owner token, but we still hold the original UID.
+	ours := created.DeepCopy()
+	ours.UID = "uid-1"
+
+	err = store.RenewLease(ctx, ours)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrLeaseLost), "expected ErrLeaseLost, got %v", err)
+}
+
+// TestComplete_RefusesJobOwnedByAnother verifies that a worker which has lost its
+// lease does not delete the job now owned by another worker. Complete must report
+// NotFound and leave the job in the store untouched.
+func TestComplete_RefusesJobOwnedByAnother(t *testing.T) {
+	fakeClient := newTestClientset()
+	store := newTestStore(fakeClient)
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	// The store holds a job now owned by owner-B (a reincarnation with a new UID).
+	_, err = fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "stacks-123",
+			UID:       "uid-2",
+			Labels: map[string]string{
+				LabelJobClaim:      "2000000000000",
+				LabelJobClaimOwner: "owner-B",
+			},
+		},
+		Spec: provisioning.JobSpec{Repository: "test-repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// We try to complete our stale claim (original UID, owner-A).
+	stale := &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "stacks-123",
+			UID:       "uid-1",
+			Labels: map[string]string{
+				LabelJobClaim:      "1000000000000",
+				LabelJobClaimOwner: "owner-A",
+			},
+		},
+		Spec: provisioning.JobSpec{Repository: "test-repo", Action: provisioning.JobActionPull},
+	}
+
+	err = store.Complete(ctx, stale)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err), "expected NotFound, got %v", err)
+
+	// The job owned by owner-B must still be in the store.
+	still, err := fakeClient.Jobs("stacks-123").Get(ctx, "test-job", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "owner-B", still.Labels[LabelJobClaimOwner])
+}
+
+// TestComplete_SucceedsForOwner verifies the happy path: the rightful owner
+// completes and the job is removed from the active store.
+func TestComplete_SucceedsForOwner(t *testing.T) {
+	fakeClient := newTestClientset()
+	store := newTestStore(fakeClient)
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	created, err := fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "stacks-123",
+			UID:       "uid-1",
+			Labels: map[string]string{
+				LabelJobClaim:      "1000000000000",
+				LabelJobClaimOwner: "owner-A",
+			},
+		},
+		Spec: provisioning.JobSpec{Repository: "test-repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	err = store.Complete(ctx, created.DeepCopy())
+	require.NoError(t, err)
+
+	_, err = fakeClient.Jobs("stacks-123").Get(ctx, "test-job", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err), "job should be deleted, got %v", err)
+}
 
 func newTestClientset() provisioningv0alpha1.ProvisioningV0alpha1Interface {
 	//nolint:staticcheck // NewSimpleClientset is needed; NewClientset requires schema registration not available for this type.

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -51,6 +51,42 @@ func TestClaim_StampsOwnerToken(t *testing.T) {
 	assert.NotEmpty(t, claimed.Labels[LabelJobClaimOwner], "claim owner token should be set")
 }
 
+// TestClaim_RollbackSkipsJobOwnedByAnother verifies that the claim rollback does not
+// strip the claim from a job that is now owned by another worker. Job names are
+// deterministic, so by the time we roll back, the same name may be a re-created job
+// another worker is running; clearing its claim would reintroduce duplicate execution.
+func TestClaim_RollbackSkipsJobOwnedByAnother(t *testing.T) {
+	fakeClient := newTestClientset()
+	store := newTestStore(fakeClient)
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	_, err = fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "stacks-123"},
+		Spec:       provisioning.JobSpec{Repository: "test-repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, rollback, err := store.Claim(ctx)
+	require.NoError(t, err)
+
+	// Simulate another worker taking over the same job name after our claim.
+	taken, err := fakeClient.Jobs("stacks-123").Get(ctx, "test-job", metav1.GetOptions{})
+	require.NoError(t, err)
+	taken.Labels[LabelJobClaimOwner] = "another-worker"
+	_, err = fakeClient.Jobs("stacks-123").Update(ctx, taken, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Rolling back our (now lost) claim must not disturb the other worker's job.
+	rollback()
+
+	after, err := fakeClient.Jobs("stacks-123").Get(ctx, "test-job", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "another-worker", after.Labels[LabelJobClaimOwner], "rollback must not strip another worker's claim")
+	assert.NotEmpty(t, after.Labels[LabelJobClaim], "rollback must not clear the active claim timestamp")
+}
+
 // TestRenewLease_LostToAnotherOwner verifies that a worker cannot renew a claim
 // that now belongs to a different owner (same job name, different owner token).
 // This is the core protection against two workers processing the same job: once


### PR DESCRIPTION
## What

Adds an explicit owner identity to provisioning job claims so a worker can prove a claim in the store is still the one it placed. `RenewLease` and `Complete` now verify both an owner token and the object UID before acting; a worker that has lost its lease detects it and aborts immediately.

## Why

In a multi-pod deployment, two job-queue pods could execute the same job.

Mutual exclusion was enforced only at the *initial claim* via Kubernetes `resourceVersion` optimistic concurrency. Ongoing ownership relied on a claim label (`provisioning.grafana.app/claim`) holding **only a timestamp** — no worker identity. Because job names are deterministic (`<repository>-<action>`, e.g. `repo-sync`), a reaped job and its re-created namesake share a name, so a worker could not tell its own claim apart from a fresh claim placed by another worker on the same name.

Consequences:
- `RenewLease` only checked that *some* claim label was present, not that it was ours — so it would happily renew (and stomp) a claim now owned by another pod.
- `Complete` deleted purely by name — so a worker that lost its lease would delete the job another pod was actively running.

Combined with the cleanup controller reaping "expired" jobs on every replica (no leader election), a slow-but-alive worker could have its job reaped and re-claimed elsewhere while it kept running — two pods on the same job.

## How

- **Owner token**: new label `provisioning.grafana.app/claim-owner`, a unique token stamped in `Claim` alongside the timestamp; cleared in the claim rollback.
- **`RenewLease`**: refuses to renew unless the owner token **and** the object UID both match the claim we placed (a re-created namesake gets a fresh UID). On mismatch it returns the new sentinel `ErrLeaseLost`.
- **`Complete`**: verifies ownership (UID + owner token) via a `Get` before deleting, and deletes with a UID `Precondition` for atomicity. If the job is gone or a different incarnation exists, it returns `NotFound` — which the cleanup controller already tolerates — so a lease-losing worker can no longer delete another pod's job.
- **`leaseRenewalLoop`**: treats `ErrLeaseLost` as terminal and aborts immediately, instead of burning ~90s of retries during which both pods would run.

### Testing

- New unit tests in `persistentstore_test.go`: claim stamps the owner token; renewal fails on a different owner and on a reincarnated UID; `Complete` refuses a job owned by another (leaving it intact) and succeeds for the rightful owner.
- `go test ./pkg/registry/apis/provisioning/jobs/`, `go vet`, and `gofmt` all pass.

### Out of scope (follow-ups)

- Renewal interval equals the claim expiry (30s/30s), leaving almost no safety margin.
- Cleanup controller runs on every replica with no leader election.
- Lease loss does not force-stop the in-flight `worker.Process` goroutine (relies on context cancellation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)