### PR TITLE
Unified Storage: Fix flaky list history error reporting test

### DIFF
--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -1127,7 +1127,15 @@ func runTestIntegrationBackendListHistory(t *testing.T, backend resource.Storage
 }
 
 func runTestIntegrationBackendListHistoryErrorReporting(t *testing.T, backend resource.StorageBackend, nsPrefix string) {
-	ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
+	// The behaviour under test is the List below, which uses its own 1µs
+	// timeout. This deadline only bounds the fixture setup: 500 serial writes
+	// (the count is deliberate — it guarantees the List is large enough that
+	// every backend observes the cancelled context and reports the error).
+	// On slower backends (e.g. sqlkv, where each write is its own transaction)
+	// under CI load those writes can exceed a tighter budget and fail with
+	// DeadlineExceeded, so give the setup generous headroom while still bounding
+	// it. NewTestContext caps this at `go test -timeout` if that is shorter.
+	ctx := testutil.NewTestContext(t, time.Now().Add(2*time.Minute))
 	server := newServer(t, backend)
 
 	ns := nsPrefix + "-short"


### PR DESCRIPTION
## What this PR does

Fixes a flake in `TestIntegrationKVBackendWithStorageBackendTestSuite/sqlkv/list_history_error_reporting` (seen in the `Grafana Enterprise` backend unit test job).

## The flake

The subtest failed at **exactly 30.00s** with:

```
storage_backend.go:1148: failed to save event: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

The failure is on the `require.NoError` inside the **fixture setup loop**, not on the assertion the test actually exercises.

## Root cause

`runTestIntegrationBackendListHistoryErrorReporting` runs its entire body — including a fixture that writes **500 events serially** — under a single 30s deadline. That deadline was conceptually meant to bound the *behaviour under test* (a `List` call that uses its own separate 1µs timeout and needs only microseconds), not the heavy setup.

500 serial writes in 30s is a ~60ms/write budget. On the `sqlkv` backend each write is its own transaction, so under CI load those round-trips routinely exceed 60ms and the setup blows the budget before the test reaches its assertion. It's the only 30s test in this file doing 500 serial DB writes as setup, which is why it's the one that flakes.

## The fix

Give the fixture setup a more generous deadline (2 minutes, still bounded by `go test -timeout`). The setup and the behaviour under test already use separate contexts — the `List` derives its own 1µs child — so this only affects setup headroom.

The 500-event count is **kept intentionally**: it guarantees the `List` is large enough that every backend reliably observes the cancelled context and reports the error. Reducing it would risk the opposite intermittent failure (`err` and `res.Error` both nil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)