### PR TITLE
Provisioning: fix zero-margin job lease renewal, raise claim expiry to 60s

### DIFF
--- a/pkg/operators/provisioning/jobqueue_operator.go
+++ b/pkg/operators/provisioning/jobqueue_operator.go
@@ -19,6 +19,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// jobClaimExpiry is how long a job claim is considered valid before the cleanup
+// controller treats it as abandoned. The lease renewal interval must stay well
+// below this so a worker renews several times before its claim goes stale;
+// otherwise a single delayed renewal can let a running job be reaped and
+// re-run by another worker.
+const jobClaimExpiry = 30 * time.Second
+
 func RunJobQueueController(ctx context.Context, deps server.OperatorDependencies) error {
 	logger := logging.NewSLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
@@ -52,7 +59,7 @@ func RunJobQueueController(ctx context.Context, deps server.OperatorDependencies
 	}
 
 	jobHistoryWriter := jobs.NewAPIClientHistoryWriter(provisioningClient.ProvisioningV0alpha1())
-	jobStore, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), 30*time.Second, deps.Registerer)
+	jobStore, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), jobClaimExpiry, deps.Registerer)
 	if err != nil {
 		return fmt.Errorf("create API client job store: %w", err)
 	}
@@ -146,7 +153,7 @@ func setupJobQueueControllerFromConfig(cfg *setting.Cfg, registry prometheus.Reg
 		maxSyncWorkers:       operatorSec.Key("max_sync_workers").MustInt(10),
 		maxJobTimeout:        operatorSec.Key("max_job_timeout").MustDuration(20 * time.Minute),
 		jobInterval:          operatorSec.Key("job_interval").MustDuration(30 * time.Second),
-		leaseRenewalInterval: operatorSec.Key("lease_renewal_interval").MustDuration(30 * time.Second),
+		leaseRenewalInterval: operatorSec.Key("lease_renewal_interval").MustDuration(jobClaimExpiry / 3),
 		folderAPIVersion:     folderAPIVersion,
 	}, nil
 }

--- a/pkg/operators/provisioning/jobqueue_operator.go
+++ b/pkg/operators/provisioning/jobqueue_operator.go
@@ -24,7 +24,7 @@ import (
 // below this so a worker renews several times before its claim goes stale;
 // otherwise a single delayed renewal can let a running job be reaped and
 // re-run by another worker.
-const jobClaimExpiry = 30 * time.Second
+const jobClaimExpiry = 60 * time.Second
 
 func RunJobQueueController(ctx context.Context, deps server.OperatorDependencies) error {
 	logger := logging.NewSLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{

--- a/pkg/operators/provisioning/jobs_operator.go
+++ b/pkg/operators/provisioning/jobs_operator.go
@@ -59,7 +59,7 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 	// }
 
 	jobHistoryWriter := jobs.NewAPIClientHistoryWriter(provisioningClient.ProvisioningV0alpha1())
-	jobStore, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), 30*time.Second, deps.Registerer)
+	jobStore, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), jobClaimExpiry, deps.Registerer)
 	if err != nil {
 		return fmt.Errorf("create API client job store: %w", err)
 	}

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -42,7 +42,7 @@ func RunRepoController(ctx context.Context, deps server.OperatorDependencies) er
 	}
 
 	resourceLister := resources.NewResourceLister(unified)
-	jobs, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), 30*time.Second, deps.Registerer)
+	jobs, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), jobClaimExpiry, deps.Registerer)
 	if err != nil {
 		return fmt.Errorf("create API client job store: %w", err)
 	}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -70,6 +70,14 @@ import (
 
 const repoControllerWorkers = 1
 
+// jobClaimExpiry is how long a job claim is considered valid before it is
+// treated as abandoned. It governs both claim staleness in the job store and
+// the cleanup controller that reaps expired jobs, so the two must use the same
+// value. The lease renewal interval is derived as a fraction of this so a
+// worker renews several times before its claim goes stale; otherwise a single
+// delayed renewal can let a running job be reaped and re-run by another worker.
+const jobClaimExpiry = 60 * time.Second
+
 var (
 	_ builder.APIGroupBuilder               = (*APIBuilder)(nil)
 	_ builder.APIGroupMutation              = (*APIBuilder)(nil)
@@ -933,7 +941,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			b.client = c.ProvisioningV0alpha1()
 
 			// Initialize the API client-based job store
-			b.jobs, err = jobs.NewJobStore(b.client, 30*time.Second, b.registry)
+			b.jobs, err = jobs.NewJobStore(b.client, jobClaimExpiry, b.registry)
 			if err != nil {
 				return fmt.Errorf("create API client job store: %w", err)
 			}
@@ -1052,21 +1060,20 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			repoGetter := resources.NewRepositoryGetter(b.repoFactory, b.client)
 
 			// Create job cleanup controller
-			jobExpiry := 30 * time.Second
 			jobCleanupController := jobs.NewJobCleanupController(
 				b.jobs,
 				jobHistoryWriter,
-				jobExpiry,
+				jobClaimExpiry,
 			)
 
-			// Renew the lease well before it expires. Using jobExpiry as the
-			// renewal interval would schedule the single renewal at the exact
-			// moment the claim goes stale, so any delay (GC pause, apiserver
-			// blip) lets the cleanup controller reap a job that is still
-			// running and risks duplicate execution. A third of the expiry
-			// gives three renewal attempts before the claim is considered
-			// abandoned.
-			leaseRenewalInterval := jobExpiry / 3
+			// Renew the lease well before it expires. Using jobClaimExpiry as
+			// the renewal interval would schedule the single renewal at the
+			// exact moment the claim goes stale, so any delay (GC pause,
+			// apiserver blip) lets the cleanup controller reap a job that is
+			// still running and risks duplicate execution. A third of the
+			// expiry gives three renewal attempts before the claim is
+			// considered abandoned.
+			leaseRenewalInterval := jobClaimExpiry / 3
 
 			// This is basically our own JobQueue system
 			driver, err := jobs.NewConcurrentJobDriver(

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -1059,12 +1059,21 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				jobExpiry,
 			)
 
+			// Renew the lease well before it expires. Using jobExpiry as the
+			// renewal interval would schedule the single renewal at the exact
+			// moment the claim goes stale, so any delay (GC pause, apiserver
+			// blip) lets the cleanup controller reap a job that is still
+			// running and risks duplicate execution. A third of the expiry
+			// gives three renewal attempts before the claim is considered
+			// abandoned.
+			leaseRenewalInterval := jobExpiry / 3
+
 			// This is basically our own JobQueue system
 			driver, err := jobs.NewConcurrentJobDriver(
-				3,              // 3 drivers for now
-				20*time.Minute, // Max time for each job
-				30*time.Second, // Periodically look for new jobs
-				jobExpiry,      // Lease renewal interval
+				3,                    // 3 drivers for now
+				20*time.Minute,       // Max time for each job
+				30*time.Second,       // Periodically look for new jobs
+				leaseRenewalInterval, // Lease renewal interval
 				b.jobs, repoGetter, jobHistoryWriter,
 				jobController.InsertNotifications(),
 				b.registry,


### PR DESCRIPTION
## What

- Renew a job's lease at `expiry / 3` instead of at `expiry`, in both the in-process API server (`register.go`) and the standalone job queue operator (`jobqueue_operator.go`).
- Raise the job claim expiry from `30s` to **`60s`** (renewal interval becomes `20s`).
- Funnel every job store and the cleanup controller through a single `jobClaimExpiry` constant per package.

## Why

The lease renewal interval was equal to the claim expiry (`30s == 30s`). The cleanup controller treats any claim older than the expiry as abandoned, so the worker's single renewal tick was scheduled at the *exact* moment its claim goes stale — **zero margin**.

If a renewal runs even slightly late (GC pause, apiserver blip, busy CPU), the claim on the server is momentarily 30+ seconds old and looks abandoned. The cleanup controller then reaps a job that is **still running**; if a fresh copy of that job is picked up by another worker, both execute it → **duplicate execution**.

Raising the expiry to `60s` (renewal `20s`) adds headroom, and centralizing the value in one constant stops the claim-staleness threshold, the reaper, and the derived renewal interval from silently drifting apart in the future.

> **Why not just drop the renewal argument?** Passing `0` falls through to the driver default `jobTimeout / 3` = `20m / 3` ≈ **6.7 min** — far larger than the expiry, which would make the race dramatically worse. The interval must stay explicitly tied to the expiry.

## How

- `pkg/registry/apis/provisioning/register.go`: add `jobClaimExpiry = 60s`; use it for the job store and cleanup controller; derive `leaseRenewalInterval = jobClaimExpiry / 3`.
- `pkg/operators/provisioning/jobqueue_operator.go`: add `jobClaimExpiry = 60s`; use it for the job store; default `lease_renewal_interval` to `jobClaimExpiry / 3` (still overridable via `operator.lease_renewal_interval`).
- `pkg/operators/provisioning/repo_operator.go`, `jobs_operator.go`: point their job stores at the same constant so no stale `30s` literal remains.

**Scope notes**
- Only the jobqueue driver runs the renewal loop. `repo_operator` (producer) and `jobs_operator` (reaper) create stores whose `expiry` only bites at `Claim`/`RenewLease` time, which they don't do — switching them to the constant is consistency, not a behavior change.
- The split-deployment reaper (`jobs_operator`) still sources its cleanup expiry from the `operator.cleanup_interval` config (default `1m`), a separate knob from `jobClaimExpiry`. At defaults they align (≥60s); hard-tying them is a possible follow-up.

## Testing

- `go build ./pkg/registry/apis/provisioning/... ./pkg/operators/...`
- `go vet ./pkg/operators/provisioning/`
- `go test ./pkg/registry/apis/provisioning/jobs/` (existing lease/driver tests pass)

## Checklist

- [ ] Tests added/updated (behavior is timing-based; covered by existing driver/lease tests)
- [x] No breaking changes
- [x] No migrations needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)