### PR TITLE
Search sort by name as tie-breaker

### DIFF
--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -32,8 +32,7 @@ const (
 	// analyzer). Requires SearchCapabilityText.
 	SearchCapabilityPartial SearchCapability = "partial"
 	// SearchCapabilitySort makes the field sortable. It also enables DocValues
-	// on the keyword variant, which the authz searcher reads column-wise to
-	// check folder permissions on every matching document.
+	// on the keyword variant for column-wise reads and stable sort tie-breakers.
 	SearchCapabilitySort     SearchCapability = "sort"
 	SearchCapabilityFacet    SearchCapability = "facet"    // facetable on the keyword variant
 	SearchCapabilityRetrieve SearchCapability = "retrieve" // value is stored and returned in search results

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -233,7 +233,8 @@ func TestMapProvider_IndexAffectingHash_GoldenHash(t *testing.T) {
 		},
 	}, nil)
 
-	const expected = "fde7f709479cdb925bf11296f3d422c58ad2c2cbfa0fd457218c2e0bd638827f"
+	// The standard name field has sort capability so Bleve can use it as a stable pagination tie-breaker.
+	const expected = "c4587931c884566e46c37eb573565b9b0d7246aeef6d7b7e3bf95d5aac24ca01"
 	assert.Equal(t, expected, p.IndexAffectingHash(group, resource),
 		"canonical hash drifted. If json.Marshal output changed (Go release), update the literal; otherwise a code change shifted the canonical form.")
 }

--- a/pkg/storage/unified/resource/standard_search_fields.go
+++ b/pkg/storage/unified/resource/standard_search_fields.go
@@ -19,7 +19,7 @@ func StandardSearchFieldDefinitions() []SearchFieldDefinition {
 		{
 			Name:         SEARCH_FIELD_NAME,
 			Type:         SearchFieldTypeString,
-			Capabilities: []SearchCapability{SearchCapabilityFilter},
+			Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilitySort},
 			Description:  "Kubernetes name. Unique identifier within a namespace+group+resource.",
 		},
 		{

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2346,7 +2346,8 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	sorting := getSortFields(req, b.fields)
 	searchrequest.SortBy(sorting)
 
-	// When no sort fields are provided, sort by score if there is a query, otherwise sort by title
+	// When no sort fields are provided, sort by score if there is a query, otherwise sort by title.
+	// Always add name as the final tie-breaker so offset pagination sees a total order.
 	if len(sorting) == 0 {
 		if req.Query != "" && req.Query != "*" {
 			searchrequest.Sort = append(searchrequest.Sort, &search.SortScore{
@@ -2358,6 +2359,10 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 				Desc:  false,
 			})
 		}
+		searchrequest.Sort = append(searchrequest.Sort, &search.SortField{
+			Field: resource.SEARCH_FIELD_NAME,
+			Desc:  false,
+		})
 	}
 
 	return searchrequest, nil
@@ -2551,7 +2556,12 @@ func safeInt64ToInt(i64 int64) (int, error) {
 }
 
 func getSortFields(req *resourcepb.ResourceSearchRequest, fields resource.SearchableDocumentFields) []string {
-	sorting := make([]string, 0, len(req.SortBy))
+	if len(req.SortBy) == 0 {
+		return nil
+	}
+
+	sorting := make([]string, 0, len(req.SortBy)+1)
+	hasNameSort := false
 	for _, sort := range req.SortBy {
 		input := sort.Field
 		if field, ok := textSortFields[input]; ok {
@@ -2566,10 +2576,14 @@ func getSortFields(req *resourcepb.ResourceSearchRequest, fields resource.Search
 			input = resource.SEARCH_FIELD_PREFIX + input
 		}
 
+		hasNameSort = hasNameSort || input == resource.SEARCH_FIELD_NAME
 		if sort.Desc {
 			input = "-" + input
 		}
 		sorting = append(sorting, input)
+	}
+	if !hasNameSort {
+		sorting = append(sorting, resource.SEARCH_FIELD_NAME)
 	}
 	return sorting
 }

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -177,7 +177,7 @@ func keywordVariantName(name string, hasText bool) string {
 // mapping.
 func GetBleveMappings(provider resource.SearchFieldsProvider, group, kindResource string, selectableFields []string) (mapping.IndexMapping, error) {
 	mapper := bleve.NewIndexMapping()
-	mapper.DocValuesDynamic = false // only folder and title_phrase need DocValues
+	mapper.DocValuesDynamic = false // only explicitly sortable fields need DocValues
 	mapper.ScoringModel = index.BM25Scoring
 
 	err := RegisterCustomAnalyzers(mapper)

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -248,7 +248,7 @@ func TestDocValuesConfiguration(t *testing.T) {
 		assert.False(t, impl.DocValuesDynamic, "DocValuesDynamic should be false to prevent dynamic fields from getting DocValues")
 	})
 
-	t.Run("only folder and title_phrase have DocValues", func(t *testing.T) {
+	t.Run("only sortable fields have DocValues", func(t *testing.T) {
 		mappings, err := search.GetBleveMappings(nil, "", "", nil)
 		require.NoError(t, err)
 
@@ -271,6 +271,7 @@ func TestDocValuesConfiguration(t *testing.T) {
 		require.NoError(t, err)
 
 		fieldsWithDocValues := map[string]bool{
+			resource.SEARCH_FIELD_NAME:         true,
 			resource.SEARCH_FIELD_FOLDER:       true,
 			resource.SEARCH_FIELD_TITLE_PHRASE: true,
 		}

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/blevesearch/bleve/v2"
+	blevesearch "github.com/blevesearch/bleve/v2/search"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -834,7 +835,7 @@ func TestGetSortFields(t *testing.T) {
 			},
 		}
 		sortFields := getSortFields(searchReq, dashboardFields)
-		assert.Equal(t, []string{"fields.views_total"}, sortFields)
+		assert.Equal(t, []string{"fields.views_total", resource.SEARCH_FIELD_NAME}, sortFields)
 	})
 	t.Run("will prepend sort fields with a '-' when sort is Desc", func(t *testing.T) {
 		searchReq := &resourcepb.ResourceSearchRequest{
@@ -843,7 +844,7 @@ func TestGetSortFields(t *testing.T) {
 			},
 		}
 		sortFields := getSortFields(searchReq, dashboardFields)
-		assert.Equal(t, []string{"-fields.views_total"}, sortFields)
+		assert.Equal(t, []string{"-fields.views_total", resource.SEARCH_FIELD_NAME}, sortFields)
 	})
 	t.Run("will not prepend 'fields.' to common fields", func(t *testing.T) {
 		searchReq := &resourcepb.ResourceSearchRequest{
@@ -852,7 +853,65 @@ func TestGetSortFields(t *testing.T) {
 			},
 		}
 		sortFields := getSortFields(searchReq, dashboardFields)
-		assert.Equal(t, []string{"description"}, sortFields)
+		assert.Equal(t, []string{"description", resource.SEARCH_FIELD_NAME}, sortFields)
+	})
+	t.Run("will use title_phrase for title and append name as tie-breaker", func(t *testing.T) {
+		searchReq := &resourcepb.ResourceSearchRequest{
+			SortBy: []*resourcepb.ResourceSearchRequest_Sort{
+				{Field: resource.SEARCH_FIELD_TITLE, Desc: false},
+			},
+		}
+		sortFields := getSortFields(searchReq, dashboardFields)
+		assert.Equal(t, []string{resource.SEARCH_FIELD_TITLE_PHRASE, resource.SEARCH_FIELD_NAME}, sortFields)
+	})
+	t.Run("will not append a duplicate name sort", func(t *testing.T) {
+		searchReq := &resourcepb.ResourceSearchRequest{
+			SortBy: []*resourcepb.ResourceSearchRequest_Sort{
+				{Field: resource.SEARCH_FIELD_NAME, Desc: true},
+			},
+		}
+		sortFields := getSortFields(searchReq, dashboardFields)
+		assert.Equal(t, []string{"-" + resource.SEARCH_FIELD_NAME}, sortFields)
+	})
+}
+
+func TestBleveSearchRequestDefaultSortIncludesNameTieBreaker(t *testing.T) {
+	idx := &bleveIndex{fields: resource.StandardSearchFields()}
+
+	t.Run("sorts match-all by title then name", func(t *testing.T) {
+		searchReq, errResult := idx.toBleveSearchRequest(t.Context(), &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{},
+			Limit:   10,
+		}, nil)
+		require.Nil(t, errResult)
+		require.Len(t, searchReq.Sort, 2)
+
+		titleSort, ok := searchReq.Sort[0].(*blevesearch.SortField)
+		require.True(t, ok)
+		assert.Equal(t, resource.SEARCH_FIELD_TITLE_PHRASE, titleSort.Field)
+		assert.False(t, titleSort.Desc)
+
+		nameSort, ok := searchReq.Sort[1].(*blevesearch.SortField)
+		require.True(t, ok)
+		assert.Equal(t, resource.SEARCH_FIELD_NAME, nameSort.Field)
+		assert.False(t, nameSort.Desc)
+	})
+
+	t.Run("sorts queries by score then name", func(t *testing.T) {
+		searchReq, errResult := idx.toBleveSearchRequest(t.Context(), &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{},
+			Limit:   10,
+			Query:   "grafana",
+		}, nil)
+		require.Nil(t, errResult)
+		require.Len(t, searchReq.Sort, 2)
+		_, ok := searchReq.Sort[0].(*blevesearch.SortScore)
+		require.True(t, ok)
+
+		nameSort, ok := searchReq.Sort[1].(*blevesearch.SortField)
+		require.True(t, ok)
+		assert.Equal(t, resource.SEARCH_FIELD_NAME, nameSort.Field)
+		assert.False(t, nameSort.Desc)
 	})
 }
 

--- a/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
@@ -170,6 +170,7 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
+            "docvalues": true,
             "skip_freq_norm": true
           }
         ]

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -117,6 +117,7 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
+            "docvalues": true,
             "skip_freq_norm": true
           }
         ]

--- a/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
@@ -145,6 +145,7 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
+            "docvalues": true,
             "skip_freq_norm": true
           }
         ]

--- a/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
@@ -144,6 +144,7 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
+            "docvalues": true,
             "skip_freq_norm": true
           }
         ]

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -117,6 +117,7 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
+            "docvalues": true,
             "skip_freq_norm": true
           }
         ]

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team.json
@@ -145,6 +145,7 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
+            "docvalues": true,
             "skip_freq_norm": true
           }
         ]

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
@@ -145,6 +145,7 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
+            "docvalues": true,
             "skip_freq_norm": true
           }
         ]

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -158,6 +158,7 @@
             "type": "text",
             "analyzer": "keyword",
             "index": true,
+            "docvalues": true,
             "skip_freq_norm": true
           }
         ]


### PR DESCRIPTION
Make Bleve search sorting stable by adding `name` as a final tie-breaker.

This gives `/api/search` a total order for offset pagination, preventing duplicate or missing rows when many resources have the same title.

Fixes https://github.com/grafana/search-and-storage-team/issues/850