### PR TITLE
Unified storage: Enforce RBAC for team search/list/read

### DIFF
--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -104,7 +104,7 @@ func NewAuthzLimitedClient(client claims.AccessClient, opts AuthzOptions) claims
 		allowlist: groupResource{
 			"dashboard.grafana.app": map[string]interface{}{"dashboards": nil},
 			"folder.grafana.app":    map[string]interface{}{"folders": nil},
-			"iam.grafana.app":       map[string]interface{}{"users": nil},
+			"iam.grafana.app":       map[string]interface{}{"users": nil, "teams": nil},
 		},
 		logger:  logger,
 		metrics: newMetrics(opts.Registry),


### PR DESCRIPTION
**What is this feature?**

Adds `iam.grafana.app/teams` to the `authzLimitedClient` allowlist in `pkg/storage/unified/resource/access.go`. That client only enforces authorization for group/resource pairs in its allowlist; anything unlisted short-circuits to allow-all in `Check`/`Compile`/`BatchCheck`. `teams` was missing, so when teams are served from unified storage (dual-writer mode 4/5), `searchTeams`, `list`, and `read` returned every team to every user regardless of `teams:read`. With `teams` in the allowlist, team authorization is resolved by the real access client, like `users`, `dashboards`, and `folders`.

**Why do we need this feature?**

With teams reading from unified storage, `searchTeams` leaked all teams to any authenticated user. This makes the unified resource/search server enforce `teams:read` per-item for search, list, and read.

**Who is this feature for?**

Grafana instances serving teams from unified storage (the in-progress teams→unified-storage migration). Not reachable in production today (teams still read from legacy storage, which filters via SQL `ac.Filter`); this closes the gap ahead of the cutover.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

This is the **unified-storage (server-side)** half of a two-PR change, split to satisfy `pr-unified-storage-compatibility` (unified storage/search deploys independently from the API layer):

- This PR (server) is backwards compatible on its own: an old API layer + this new storage server just filters more (safe), and it fully fixes the `searchTeams` leak, since `searchTeams` already routes through storage.
- **Companion PR (API layer): #127804** lets users *list* the teams they can read (the API authorizer currently 403s non-wildcard users on collection `list`). It is gated behind a feature toggle, default off, and **depends on this PR being deployed first** so storage enforces `iam.grafana.app/teams` before the API layer relaxes `list`.

Per `pkg/storage/unified/AGENTS.md` (rule 1: "ship server-side support first; switch client behavior in a follow-up after the server change is released"), **merge and roll out this PR first**, then #127804.

Verified against a fully-unified (dual-writer mode 5) environment: a scoped user (org Editor) sees only its readable teams via `searchTeams`; a wildcard user (Grafana Admin) sees all; filtering happens in the search backend before pagination. Existing `authzLimitedClient` `Check`/`Compile`/`BatchCheck` tests stay green.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.