### PR TITLE
Provisioning: abort in-flight worker when job lease is lost

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -332,16 +332,29 @@ func (d *jobDriver) leaseRenewalLoop(ctx context.Context, logger logging.Logger,
 
 // processJobWithLeaseCheck processes a job but aborts if the lease expires or context is cancelled.
 func (d *jobDriver) processJobWithLeaseCheck(ctx context.Context, recorder JobProgressRecorder, leaseExpired <-chan struct{}) error {
+	// Derive a cancellable context for the worker so that losing the lease actively
+	// stops the in-flight work, rather than leaving the goroutine running until the
+	// caller's deferred cancel fires much later. Otherwise two pods could execute the
+	// same job concurrently once another worker takes over the reaped claim.
+	workerCtx, cancelWorker := context.WithCancel(ctx)
+	defer cancelWorker()
+
 	// Run the job processing in a goroutine so we can monitor lease expiry
 	resultChan := make(chan error, 1)
 	go func() {
-		resultChan <- d.processJob(ctx, recorder)
+		resultChan <- d.processJob(workerCtx, recorder)
 	}()
 
 	select {
 	case err := <-resultChan:
 		return err
 	case <-leaseExpired:
+		// Another worker now owns the job. Cancel our worker and wait for it to
+		// return so we don't keep running (and later complete) a job we no longer own.
+		// The wait is bounded by the parent context's timeout, since workerCtx derives
+		// from it.
+		cancelWorker()
+		<-resultChan
 		return apifmt.Errorf("job aborted due to lease expiry")
 	case <-ctx.Done():
 		// Return context error directly - caller will determine if this is due to graceful shutdown

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -351,10 +351,14 @@ func (d *jobDriver) processJobWithLeaseCheck(ctx context.Context, recorder JobPr
 	case <-leaseExpired:
 		// Another worker now owns the job. Cancel our worker and wait for it to
 		// return so we don't keep running (and later complete) a job we no longer own.
-		// The wait is bounded by the parent context's timeout, since workerCtx derives
-		// from it.
+		// Also observe ctx.Done() so a worker that ignores cancellation can't pin this
+		// goroutine forever: on job timeout or shutdown we stop waiting and let the
+		// caller run its cleanup.
 		cancelWorker()
-		<-resultChan
+		select {
+		case <-resultChan:
+		case <-ctx.Done():
+		}
 		return apifmt.Errorf("job aborted due to lease expiry")
 	case <-ctx.Done():
 		// Return context error directly - caller will determine if this is due to graceful shutdown

--- a/pkg/registry/apis/provisioning/jobs/driver_test.go
+++ b/pkg/registry/apis/provisioning/jobs/driver_test.go
@@ -465,7 +465,11 @@ func TestProcessJobWithLeaseCheck_LeaseExpiry_CancelsAndWaitsForWorker(t *testin
 	}()
 
 	// Wait until the worker is running, then signal that the lease was lost.
-	<-workerStarted
+	select {
+	case <-workerStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker.Process was not invoked")
+	}
 	close(leaseExpired)
 
 	select {

--- a/pkg/registry/apis/provisioning/jobs/driver_test.go
+++ b/pkg/registry/apis/provisioning/jobs/driver_test.go
@@ -427,3 +427,59 @@ func TestProcessJob_NilCurrentJob_ReturnsNil(t *testing.T) {
 	err := driver.processJob(context.Background(), recorder)
 	require.NoError(t, err)
 }
+
+// TestProcessJobWithLeaseCheck_LeaseExpiry_CancelsAndWaitsForWorker verifies that
+// losing the lease actively cancels the in-flight worker and does not report the
+// abort until the worker has actually stopped. Without this, a reaped-and-re-claimed
+// job could keep running on this pod while another pod runs the same job.
+func TestProcessJobWithLeaseCheck_LeaseExpiry_CancelsAndWaitsForWorker(t *testing.T) {
+	worker := &MockWorker{}
+	repoGetter := &MockRepoGetter{}
+	recorder := &MockJobProgressRecorder{}
+	driver := setupDriverForProcessJob(worker, repoGetter)
+	driver.currentJob = makeTestJob("1")
+
+	repoCfg := makeRepoConfig("test-repo", nil, nil)
+	mockRepo := &repository.MockRepository{}
+	mockRepo.On("Config").Return(repoCfg)
+
+	workerStarted := make(chan struct{})
+	workerReturned := make(chan struct{})
+
+	worker.EXPECT().IsSupported(mock.Anything, mock.Anything).Return(true)
+	repoGetter.EXPECT().GetRepository(mock.Anything, "test-ns", "test-repo").
+		Return(mockRepo, nil)
+	// A well-behaved worker: block until its context is cancelled, then return.
+	worker.EXPECT().Process(mock.Anything, mockRepo, mock.Anything, recorder).
+		RunAndReturn(func(ctx context.Context, _ repository.Repository, _ provisioning.Job, _ JobProgressRecorder) error {
+			close(workerStarted)
+			<-ctx.Done()
+			close(workerReturned)
+			return ctx.Err()
+		})
+
+	leaseExpired := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- driver.processJobWithLeaseCheck(context.Background(), recorder, leaseExpired)
+	}()
+
+	// Wait until the worker is running, then signal that the lease was lost.
+	<-workerStarted
+	close(leaseExpired)
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "aborted due to lease expiry")
+		// The worker must have observed cancellation and returned before
+		// processJobWithLeaseCheck reported the abort.
+		select {
+		case <-workerReturned:
+		default:
+			t.Fatal("processJobWithLeaseCheck returned before the worker stopped — in-flight work was not cancelled and awaited")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("processJobWithLeaseCheck did not abort after lease expiry")
+	}
+}


### PR DESCRIPTION
## What

When a job's lease is lost (reaped and re-claimed by another worker), the driver now cancels the in-flight worker and waits for it to stop before reporting the abort.

## Why

`processJobWithLeaseCheck` returned as soon as `leaseExpired` fired, but the `worker.Process` goroutine kept running on the same context. That context was only cancelled by the caller's deferred `cancel()`, which fires much later — after the driver has already written history and called `Complete`. This left a window where two pods executed the same job concurrently.

This is the third of three follow-ups from #127783. The other two — ownership verification and the zero-margin 30s/30s lease renewal — are already merged via #127783 and #127786.

## How

- Run the worker on a `workerCtx` derived from the job context.
- On lease loss, `cancelWorker()` then block on the worker's result channel so this pod can't keep running (or later complete) a job another pod now owns. The wait is bounded by the parent context's timeout, since the worker context derives from it.
- Go can't force-kill a goroutine, so cancellation remains cooperative — but the worker context is now cancelled *immediately* on lease loss rather than after the driver moves on.

## Testing

- New unit test `TestProcessJobWithLeaseCheck_LeaseExpiry_CancelsAndWaitsForWorker`: worker blocks until its context is cancelled; asserts the abort error is returned **and** that the worker had returned before `processJobWithLeaseCheck` did.
- `go test -race`, `go vet`, and `gofmt` pass on the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)