### PR TITLE
Provisioning: Hide View repository button from dashboard toolbar

### DIFF
--- a/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.tsx
+++ b/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.tsx
@@ -5,7 +5,6 @@ import { Stack } from '@grafana/ui';
 import { useGetRepositoryQuery } from 'app/api/clients/provisioning/v0alpha1';
 import { ManagerKind } from 'app/features/apiserver/types';
 import { ManagedBadge } from 'app/features/provisioning/components/ManagedBadge';
-import { ViewRepositoryButton } from 'app/features/provisioning/components/ViewRepositoryButton';
 
 import { type DashboardScene } from './DashboardScene';
 
@@ -29,7 +28,6 @@ export const ManagedDashboardNavBarBadge = ({ dashboard }: { dashboard: Dashboar
   return (
     <Stack direction="row" alignItems="stretch">
       <ManagedBadge managerKind={kind} name={repoData?.spec?.title || id} isOrphaned={isOrphaned} />
-      <ViewRepositoryButton repositoryName={kind === ManagerKind.Repo ? id : undefined} isOrphaned={isOrphaned} />
     </Stack>
   );
 };


### PR DESCRIPTION
**What is this feature?**

Hide "View repository" icon button from dashboard toolbar

**Why do we need this feature?**

Remove noise from dashboard sidebar, we have this icon button on browse dashboard page level already 

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
