### PR TITLE
Alerting: RuleEditorCloudRules test flakiness in CI

### DIFF
--- a/public/app/features/alerting/unified/rule-editor/RuleEditorCloudRules.test.tsx
+++ b/public/app/features/alerting/unified/rule-editor/RuleEditorCloudRules.test.tsx
@@ -1,3 +1,4 @@
+import { type UserEvent } from '@testing-library/user-event';
 import { renderRuleEditor, ui } from 'test/helpers/alertingRuleEditor';
 import { clickSelectOption } from 'test/helpers/selectOptionInTest';
 import { screen } from 'test/test-utils';
@@ -27,11 +28,21 @@ jest.mock('app/core/components/AppChrome/AppChromeUpdate', () => ({
   AppChromeUpdate: ({ actions }: { actions: React.ReactNode }) => <div>{actions}</div>,
 }));
 
+jest.setTimeout(60 * 1000);
+
 setupMswServer();
 mimirDataSource();
 
 // Setup plugin extensions hook to prevent setPluginLinksHook errors
 setupPluginsExtensionsHook();
+
+// Paste in one event instead of typing char-by-char, which re-renders the heavy
+// rule-editor form on every keystroke and is the largest CI-amplified cost here.
+async function pasteIntoInput(user: UserEvent, input: HTMLElement, value: string) {
+  await user.click(input);
+  await user.clear(input);
+  await user.paste(value);
+}
 
 describe('RuleEditor cloud', () => {
   beforeAll(() => {
@@ -80,17 +91,14 @@ describe('RuleEditor cloud', () => {
     await user.click(dataSourceSelect);
     await user.click(screen.getByText(MIMIR_DATASOURCE_UID));
 
-    await user.type(await ui.inputs.expr.find(), 'up == 1');
+    await pasteIntoInput(user, await ui.inputs.expr.find(), 'up == 1');
 
-    await user.type(ui.inputs.name.get(), 'my great new rule');
+    await pasteIntoInput(user, ui.inputs.name.get(), 'my great new rule');
     await clickSelectOption(ui.inputs.namespace.get(), NAMESPACE_2);
     await clickSelectOption(ui.inputs.group.get(), GROUP_3);
 
-    await user.type(ui.inputs.annotationValue(0).get(), 'some summary');
-    await user.type(ui.inputs.annotationValue(1).get(), 'some description');
-
-    // TODO remove skipPointerEventsCheck once https://github.com/jsdom/jsdom/issues/3232 is fixed
-    await user.click(ui.buttons.addLabel.get());
+    await pasteIntoInput(user, ui.inputs.annotationValue(0).get(), 'some summary');
+    await pasteIntoInput(user, ui.inputs.annotationValue(1).get(), 'some description');
 
     // save and check what was sent to backend
     const capture = captureRequests();
@@ -125,17 +133,14 @@ describe('RuleEditor cloud', () => {
     await user.click(dataSourceSelect);
     await user.click(screen.getByText(MIMIR_DATASOURCE_UID));
 
-    await user.type(await ui.inputs.expr.find(), 'up == 1');
+    await pasteIntoInput(user, await ui.inputs.expr.find(), 'up == 1');
 
-    await user.type(ui.inputs.name.get(), 'my great new rule with 3m interval');
+    await pasteIntoInput(user, ui.inputs.name.get(), 'my great new rule with 3m interval');
     await clickSelectOption(ui.inputs.namespace.get(), NAMESPACE_2);
     await clickSelectOption(ui.inputs.group.get(), GROUP_4);
 
-    await user.type(ui.inputs.annotationValue(0).get(), 'some summary');
-    await user.type(ui.inputs.annotationValue(1).get(), 'some description');
-
-    // TODO remove skipPointerEventsCheck once https://github.com/jsdom/jsdom/issues/3232 is fixed
-    await user.click(ui.buttons.addLabel.get());
+    await pasteIntoInput(user, ui.inputs.annotationValue(0).get(), 'some summary');
+    await pasteIntoInput(user, ui.inputs.annotationValue(1).get(), 'some description');
 
     // save and check what was sent to backend
     const capture = captureRequests();


### PR DESCRIPTION
**Changes**

The two cloud rule-editor tests ran right at the 30s per-test Jest timeout and intermittently exceeded it on contended CI runners. Applied the following changes to avoid that issue in CI:
  - Fill free-text fields via paste instead of char-by-char typing
  - Remove the inert "Add label" click (adds an empty label that cleanLabels strips, so the payload is unchanged) and its stale TODO
  - Raise the per-test timeout to 60s to match sibling rule-editor tests

The snapshot and all assertions are unchanged.
