### PR TITLE
Fix perms for users with datasource:create but not datasrouce:write permissions

### DIFF
--- a/pkg/registry/apis/datasource/plugincontext.go
+++ b/pkg/registry/apis/datasource/plugincontext.go
@@ -3,6 +3,8 @@ package datasource
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -106,6 +108,15 @@ func (q *scopedDatasourceProvider) CreateDataSource(ctx context.Context, ds *dat
 	if err != nil {
 		return nil, err
 	}
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, err
+	}
+	userID, err := strconv.ParseInt(strings.TrimPrefix(user.GetID(), "user:"), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	cmd.UserID = userID
 	out, err := q.dsService.AddDataSource(ctx, cmd)
 	if err != nil {
 		return nil, err

--- a/pkg/registry/apis/datasource/sub_access.go
+++ b/pkg/registry/apis/datasource/sub_access.go
@@ -53,9 +53,9 @@ func (r *subAccessREST) Connect(ctx context.Context, name string, opts runtime.O
 
 func (r *subAccessREST) getAccessInfo(ctx context.Context, name string) (*datasourceV0alpha1.DatasourceAccessInfo, error) {
 	reqContext := contexthandler.FromContext(ctx)
-	resourceIDs := map[string]bool{datasources.ScopePrefix: true}
+	resourceIDs := map[string]bool{name: true}
 	access := accesscontrol.GetResourcesMetadata(reqContext.Req.Context(), reqContext.GetPermissions(), datasources.ScopePrefix, resourceIDs)
 	return &datasourceV0alpha1.DatasourceAccessInfo{
-		Permissions: access[datasources.ScopePrefix],
+		Permissions: access[name],
 	}, nil
 }


### PR DESCRIPTION
Two bugs fixed in this PR. First, when we created a new datasource with
the new APIs, we were missing a UserID field on the create command. This
caused the datasource service code to skip adding permissions that would
allow a user without general datasource write permissions to edit the
datasource they created.

Second, we were passing the wrong resource IDs when fetching permissions
for a user scoped to a datasource. This caused us to skip returning the
specific permissions fixed in the first bug.

This broke the usecase of editing a datasource instance created by a
given user, where that user did not have generic `datasources:write`
permissions.