### PR TITLE
IAM: Let users list the teams they can read

### DIFF
--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -126,11 +126,23 @@ func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 	}
 	getPermissions := check(utils.VerbGetPermissions, "requires team getpermissions")
 	update := check(utils.VerbUpdate, "requires team update")
-	return gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
+	base := gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
 		"members":      getPermissions,
 		"groups":       getPermissions,
 		"addmember":    update,
 		"removemember": update,
+	})
+	// Collection list is authorized here as allow and filtered per-team in
+	// unified storage (listAuthorized). Zanzana maps a nameless list check to a
+	// group_resource (wildcard) check, so routing it through the base authorizer
+	// would only let users who can read *every* team list *any* team. Deferring
+	// to storage lets a user list the teams they can read, matching dashboards
+	// and folders. Named get/update/delete and the subresources stay strict.
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		if attr.IsResourceRequest() && attr.GetSubresource() == "" && attr.GetName() == "" && attr.GetVerb() == utils.VerbList {
+			return authorizer.DecisionAllow, "", nil
+		}
+		return base.Authorize(ctx, attr)
 	})
 }
 

--- a/pkg/registry/apis/iam/authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer_test.go
@@ -240,6 +240,59 @@ func TestAuthorizerDecisionMatrix(t *testing.T) {
 	}
 }
 
+// TestTeamAuthorizerListDefersToStorage verifies that a collection list of teams
+// (no subresource, no name) is allowed at the authorizer layer without a
+// per-request RBAC Check, so unified storage can filter the results per-team.
+// Zanzana maps a nameless list to a group_resource (wildcard) check, so routing
+// it through the ResourceAuthorizer would 403 any user who cannot read every
+// team. Named get stays strict.
+func TestTeamAuthorizerListDefersToStorage(t *testing.T) {
+	teamAttr := func(verb, name string) authorizer.AttributesRecord {
+		return authorizer.AttributesRecord{
+			ResourceRequest: true,
+			APIGroup:        iamv0.TeamResourceInfo.GroupResource().Group,
+			Resource:        iamv0.TeamResourceInfo.GroupResource().Resource,
+			Name:            name,
+			Verb:            verb,
+			Namespace:       "org-1",
+		}
+	}
+
+	t.Run("list is allowed without calling Check", func(t *testing.T) {
+		checkCalled := false
+		fakeClient := &fakeAccessClient{
+			checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
+				checkCalled = true
+				return types.CheckResponse{Allowed: false}, nil
+			},
+		}
+		auth := newTeamAuthorizer(fakeClient)
+		ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
+
+		decision, _, err := auth.Authorize(ctx, teamAttr("list", ""))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+		assert.False(t, checkCalled, "list must not perform a group-resource Check; storage filters per-team")
+	})
+
+	t.Run("named get still delegates to Check", func(t *testing.T) {
+		checkCalled := false
+		fakeClient := &fakeAccessClient{
+			checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
+				checkCalled = true
+				return types.CheckResponse{Allowed: false}, nil
+			},
+		}
+		auth := newTeamAuthorizer(fakeClient)
+		ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
+
+		decision, _, err := auth.Authorize(ctx, teamAttr("get", "team-abc"))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+		assert.True(t, checkCalled, "named get must still be authorized per-team")
+	})
+}
+
 // TestUserAuthorizerStatusVerbMapping verifies that the user/status subresource
 // maps request verbs to the correct RBAC check verbs (GET→get, UPDATE→update, PATCH→update).
 func TestUserAuthorizerStatusVerbMapping(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Lets a user list the teams they can read (`GET /apis/iam.grafana.app/v0alpha1/namespaces/default/teams`) instead of getting a `403`. The team collection `list` is authorized at the API layer and per-team filtering is deferred to unified storage (`listAuthorized`), matching dashboards and folders. Named `get`/`update`/`delete` and the `members`/`groups`/`addmember`/`removemember` subresources stay strict.

**Why do we need this feature?**

When teams are served from unified storage, team `list` is authorized through the `ResourceAuthorizer`, which issues an `accessClient.Check` for `verb=list` with an empty `Name`. Zanzana maps that to a `group_resource` (wildcard) check on `iam.grafana.app/teams`, so only users who can read *every* team could list *any* team — a user with per-team grants got `403`. Dashboards and folders already authorize `list` at the API layer and filter per-item in storage; this brings teams in line.

**Who is this feature for?**

Grafana instances serving teams from unified storage (the in-progress teams→unified-storage migration). Not reachable in production today (teams still read from legacy storage, which filters via SQL `ac.Filter`).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

This is the **API-layer half** of a two-PR change, split to satisfy `pr-unified-storage-compatibility` (unified storage/search deploys independently from the API layer):

- **Companion PR (server-side): #127788** adds `iam.grafana.app/teams` to the `authzLimitedClient` allowlist so unified storage filters teams per-item. **It must be deployed first.**
- This PR relies on that storage-side enforcement. Per `pkg/storage/unified/AGENTS.md` (rule 1: ship server-side support first, switch client behavior in a follow-up after the server change is released), **merge/roll out #127788 before this PR**. Otherwise a nameless team `list` would fail open on a storage server that does not yet filter teams.

Design note — the `list`-verb handling in `newTeamAuthorizer` is intentionally targeted, not a generalization. The same "authorize list at the API layer, filter in storage" concept already exists via `ServiceAuthorizer` (dashboards/folders/`searchTeams`) and the `LegacyAccessClient` list branch (*"for list request we need to filter out in storage layer"*), but neither fits teams cleanly: `ServiceAuthorizer` has no per-item/subresource authz, and the legacy list-defer lives on the legacy client while teams authorize through the main (Zanzana-backed) `accessClient`. The same latent 403-on-list applies to `iam.grafana.app/users` and `serviceaccounts` (same `ResourceAuthorizer` path) — out of scope here.

Verified against a fully-unified (dual-writer mode 5) environment with the companion storage change deployed:
- A scoped user (org Editor with per-team `teams:read`) lists only its readable teams; a team it cannot read never appears.
- A wildcard user (Grafana Admin) lists all teams.
- `get` on an unreadable team still returns `403`.

Unit test `TestTeamAuthorizerListDefersToStorage` covers the collection list (allowed, no per-item Check) and named get (stays strict).

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.