### PR TITLE
Provisioning: show webhook UI for GitLab repositories

### DIFF
--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -36,7 +36,7 @@ import { type RepositoryFormData } from '../types';
 import { dataToSpec, deriveSigningKeySecret } from '../utils/data';
 import { extractFormErrors, getConfigFormErrors } from '../utils/getFormErrors';
 import { getHasTokenInstructions } from '../utils/git';
-import { getRepositoryTypeConfig, isGitHubBased, isGitProvider } from '../utils/repositoryTypes';
+import { getRepositoryTypeConfig, isGitHubBased, isGitProvider, supportsWebhooks } from '../utils/repositoryTypes';
 
 import { BranchOptionsSection } from './BranchOptionsSection';
 import { CommitOptionsSection } from './CommitOptionsSection';
@@ -428,7 +428,7 @@ export function ConfigForm({ data }: ConfigFormProps) {
             )}
           </>
         )}
-        {isGitHubBased(type) && (
+        {supportsWebhooks(type) && (
           <WebhookSection<RepositoryFormData>
             register={register}
             control={control}

--- a/public/app/features/provisioning/Repository/RepositoryOverview.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.test.tsx
@@ -41,7 +41,7 @@ const createMockRepository = (spec: Partial<RepositorySpec>): Repository => ({
 describe('RepositoryOverview', () => {
   describe('webhook link', () => {
     it('should link to GitHub webhook settings for github repositories', () => {
-      const repo = createMockRepository({ type: 'github', github: { url: 'https://github.com/org/repo' } });
+      const repo = createMockRepository({ type: 'github', github: { url: 'https://github.com/org/repo', branch: 'main' } });
       render(<RepositoryOverview repo={repo} />);
 
       expect(screen.getByRole('link', { name: 'View Webhook' })).toHaveAttribute(
@@ -53,7 +53,7 @@ describe('RepositoryOverview', () => {
     it('should link to GitHub webhook settings for githubEnterprise repositories', () => {
       const repo = createMockRepository({
         type: 'githubEnterprise',
-        githubEnterprise: { url: 'https://github.example.com/org/repo' },
+        githubEnterprise: { url: 'https://github.example.com/org/repo', branch: 'main' },
       });
       render(<RepositoryOverview repo={repo} />);
 
@@ -64,7 +64,7 @@ describe('RepositoryOverview', () => {
     });
 
     it('should link to GitLab webhook settings for gitlab repositories', () => {
-      const repo = createMockRepository({ type: 'gitlab', gitlab: { url: 'https://gitlab.com/org/repo' } });
+      const repo = createMockRepository({ type: 'gitlab', gitlab: { url: 'https://gitlab.com/org/repo', branch: 'main' } });
       render(<RepositoryOverview repo={repo} />);
 
       expect(screen.getByRole('link', { name: 'View Webhook' })).toHaveAttribute(

--- a/public/app/features/provisioning/Repository/RepositoryOverview.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.test.tsx
@@ -41,7 +41,10 @@ const createMockRepository = (spec: Partial<RepositorySpec>): Repository => ({
 describe('RepositoryOverview', () => {
   describe('webhook link', () => {
     it('should link to GitHub webhook settings for github repositories', () => {
-      const repo = createMockRepository({ type: 'github', github: { url: 'https://github.com/org/repo', branch: 'main' } });
+      const repo = createMockRepository({
+        type: 'github',
+        github: { url: 'https://github.com/org/repo', branch: 'main' },
+      });
       render(<RepositoryOverview repo={repo} />);
 
       expect(screen.getByRole('link', { name: 'View Webhook' })).toHaveAttribute(
@@ -64,7 +67,10 @@ describe('RepositoryOverview', () => {
     });
 
     it('should link to GitLab webhook settings for gitlab repositories', () => {
-      const repo = createMockRepository({ type: 'gitlab', gitlab: { url: 'https://gitlab.com/org/repo', branch: 'main' } });
+      const repo = createMockRepository({
+        type: 'gitlab',
+        gitlab: { url: 'https://gitlab.com/org/repo', branch: 'main' },
+      });
       render(<RepositoryOverview repo={repo} />);
 
       expect(screen.getByRole('link', { name: 'View Webhook' })).toHaveAttribute(

--- a/public/app/features/provisioning/Repository/RepositoryOverview.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from 'test/test-utils';
+
+import { type Repository, type RepositorySpec } from 'app/api/clients/provisioning/v0alpha1';
+
+import { RepositoryOverview } from './RepositoryOverview';
+
+jest.mock('@openfeature/react-sdk', () => ({
+  ...jest.requireActual('@openfeature/react-sdk'),
+  useBooleanFlagValue: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../Job/RecentJobs', () => ({
+  RecentJobs: () => null,
+}));
+
+jest.mock('./RepositoryHealthCard', () => ({
+  RepositoryHealthCard: () => null,
+}));
+
+jest.mock('./RepositoryPullStatusCard', () => ({
+  RepositoryPullStatusCard: () => null,
+}));
+
+const createMockRepository = (spec: Partial<RepositorySpec>): Repository => ({
+  metadata: { name: 'test-repo' },
+  spec: {
+    title: 'Test Repository',
+    type: 'github',
+    sync: { target: 'folder', enabled: true },
+    workflows: [],
+    ...spec,
+  },
+  status: {
+    health: { healthy: true, checked: Date.now() },
+    sync: { state: 'success', message: [] },
+    observedGeneration: 1,
+    webhook: { id: 42, url: 'https://grafana.example/webhook' },
+  },
+});
+
+describe('RepositoryOverview', () => {
+  describe('webhook link', () => {
+    it('should link to GitHub webhook settings for github repositories', () => {
+      const repo = createMockRepository({ type: 'github', github: { url: 'https://github.com/org/repo' } });
+      render(<RepositoryOverview repo={repo} />);
+
+      expect(screen.getByRole('link', { name: 'View Webhook' })).toHaveAttribute(
+        'href',
+        'https://github.com/org/repo/settings/hooks/42'
+      );
+    });
+
+    it('should link to GitHub webhook settings for githubEnterprise repositories', () => {
+      const repo = createMockRepository({
+        type: 'githubEnterprise',
+        githubEnterprise: { url: 'https://github.example.com/org/repo' },
+      });
+      render(<RepositoryOverview repo={repo} />);
+
+      expect(screen.getByRole('link', { name: 'View Webhook' })).toHaveAttribute(
+        'href',
+        'https://github.example.com/org/repo/settings/hooks/42'
+      );
+    });
+
+    it('should link to GitLab webhook settings for gitlab repositories', () => {
+      const repo = createMockRepository({ type: 'gitlab', gitlab: { url: 'https://gitlab.com/org/repo' } });
+      render(<RepositoryOverview repo={repo} />);
+
+      expect(screen.getByRole('link', { name: 'View Webhook' })).toHaveAttribute(
+        'href',
+        'https://gitlab.com/org/repo/-/hooks/42/edit'
+      );
+    });
+
+    it('should not render the webhook link for repositories without webhook support', () => {
+      const repo = createMockRepository({ type: 'local', local: { path: '/tmp/repo' } });
+      render(<RepositoryOverview repo={repo} />);
+
+      expect(screen.queryByRole('link', { name: 'View Webhook' })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -167,7 +167,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                 </Card.Description>
                 {webhookURL && (
                   <Card.Actions className={styles.actions}>
-                    <LinkButton fill="outline" href={webhookURL} icon="external-link-alt">
+                    <LinkButton fill="outline" href={webhookURL} icon="external-link-alt" target="_blank">
                       <Trans i18nKey="provisioning.repository-overview.webhook-url">View Webhook</Trans>
                     </LinkButton>
                   </Card.Actions>
@@ -239,9 +239,12 @@ const getStyles = (theme: GrafanaTheme2) => {
 
 function getWebhookURL(repo: Repository) {
   const { status, spec } = repo;
-  const repoUrl = spec?.github?.url ?? spec?.githubEnterprise?.url;
+  const repoUrl = spec?.github?.url ?? spec?.githubEnterprise?.url ?? spec?.gitlab?.url;
   if (isGitHubBased(spec?.type) && status?.webhook?.url && repoUrl) {
     return textUtil.sanitizeUrl(`${repoUrl}/settings/hooks/${status.webhook?.id}`);
+  }
+  if (spec?.type === 'gitlab' && status?.webhook?.url && repoUrl) {
+    return textUtil.sanitizeUrl(`${repoUrl}/-/hooks/${status.webhook?.id}/edit`);
   }
   return undefined;
 }

--- a/public/app/features/provisioning/Wizard/FinishStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.test.tsx
@@ -102,8 +102,14 @@ describe('FinishStep', () => {
       expect(await screen.findByText('Webhook options')).toBeInTheDocument();
     });
 
-    it('does not show the webhook section for a non-GitHub repository', async () => {
+    it('shows the webhook section for a GitLab repository', async () => {
       setup('gitlab');
+
+      expect(await screen.findByText('Webhook options')).toBeInTheDocument();
+    });
+
+    it('does not show the webhook section for a git provider without webhooks', async () => {
+      setup('bitbucket');
 
       expect(await screen.findByText(PR_LABEL)).toBeInTheDocument();
       expect(screen.queryByText('Webhook options')).not.toBeInTheDocument();

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -11,7 +11,7 @@ import { EnablePushToConfiguredBranchOption } from '../Config/EnablePushToConfig
 import { PullRequestOptionsSection } from '../Config/PullRequestOptionsSection';
 import { WebhookSection } from '../Config/WebhookSection';
 import { useConnectionList } from '../hooks/useConnectionList';
-import { isGitHubBased, isGitProvider } from '../utils/repositoryTypes';
+import { isGitProvider, supportsWebhooks } from '../utils/repositoryTypes';
 
 import { useStepStatus } from './StepStatusContext';
 import { getGitProviderFields } from './fields';
@@ -36,7 +36,7 @@ export const FinishStep = memo(function FinishStep() {
 
   const isGitBased = isGitProvider(type);
 
-  const [connections] = useConnectionList(isGitHubBased(type) && githubAuthType === 'github-app' ? {} : skipToken);
+  const [connections] = useConnectionList(githubAuthType === 'github-app' ? {} : skipToken);
   const connectionWebhookDisabled = useMemo(() => {
     if (githubAuthType !== 'github-app' || !wizardConnectionName || !connections) {
       return false;
@@ -168,7 +168,7 @@ export const FinishStep = memo(function FinishStep() {
         </>
       )}
 
-      {isGitHubBased(type) && (
+      {supportsWebhooks(type) && (
         <WebhookSection<WizardFormData>
           register={register}
           control={control}

--- a/public/app/features/provisioning/utils/repositoryTypes.test.ts
+++ b/public/app/features/provisioning/utils/repositoryTypes.test.ts
@@ -1,0 +1,15 @@
+import { supportsWebhooks } from './repositoryTypes';
+
+describe('supportsWebhooks', () => {
+  it.each(['github', 'githubEnterprise', 'gitlab'] as const)('should return true for %s', (type) => {
+    expect(supportsWebhooks(type)).toBe(true);
+  });
+
+  it.each(['bitbucket', 'git', 'local'] as const)('should return false for %s', (type) => {
+    expect(supportsWebhooks(type)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(supportsWebhooks(undefined)).toBe(false);
+  });
+});

--- a/public/app/features/provisioning/utils/repositoryTypes.ts
+++ b/public/app/features/provisioning/utils/repositoryTypes.ts
@@ -100,6 +100,11 @@ export const isGitHubBased = (type?: RepoType): type is 'github' | 'githubEnterp
   return type === 'github' || type === 'githubEnterprise';
 };
 
+// Providers whose repositories can register and receive webhooks.
+export const supportsWebhooks = (type?: RepoType): type is 'github' | 'githubEnterprise' | 'gitlab' => {
+  return type === 'github' || type === 'githubEnterprise' || type === 'gitlab';
+};
+
 /**
  * Get repository configurations ordered by provider type priority:
  * 1. Git providers first (github, gitlab, bitbucket) - excludes pure git


### PR DESCRIPTION
**What is this feature?**

Frontend for GitLab webhook support in provisioning:
- Show the webhook config section for `gitlab` repositories in the config form and setup wizard.
- Build the GitLab webhook management URL on the repository overview.

**Why do we need this feature?**

Lets users configure and inspect webhooks for GitLab repositories, like GitHub.

**Who is this feature for?**

Grafana users provisioning dashboards from GitLab repositories.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Split from the backend work (separate deploy cadence). Backend: #127204. Enterprise implementation: grafana/grafana-enterprise#12339.

_PR description generated with Claude Code._
