### PR TITLE
CI: Bound Jest coverage memory with workerIdleMemoryLimit

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -39,6 +39,10 @@ const esModules = [
 
 module.exports = {
   verbose: false,
+  // Recycle a worker once it exceeds this cap so heap growth over a run (most acute during
+  // coverage) can't accumulate unbounded. Applies even at --maxWorkers=1, where Jest restarts
+  // the single worker between test files. Per-worker cap, not a reservation; tune via --logHeapUsage.
+  workerIdleMemoryLimit: '1GB',
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
     customExportConditions: ['@grafana-app/source', 'browser'],


### PR DESCRIPTION
## What

Adds `workerIdleMemoryLimit: '1GB'` to the base [`jest.config.js`](https://github.com/grafana/grafana/blob/main/jest.config.js).

## Why

ran with `time`: 

```
BEFORE | yarn test:coverage:by-codeowner @grafana/dataviz-squad  551.31s user 738.03s system 630% cpu 3:24.59 total
AFTER  | yarn test:coverage:by-codeowner @grafana/dataviz-squad  461.64s user 165.41s system 1071% cpu 58.536 total
```

Per-team coverage runs (`jest.config.codeowner.js`, run in CI with `--maxWorkers=1`) consume a lot of memory, and it grows with the number of test files a team owns.

The root cause: at `--maxWorkers=1` with no memory limit set, Jest runs **in-band in the main process** (see `shouldRunInBand` in `@jest/core`), so every test file's heap accumulates in one long-lived process with no opportunity to recycle. Setting `workerIdleMemoryLimit` flips Jest to a **recyclable worker even at `--maxWorkers=1`** (Jest explicitly forces worker usage when a memory limit is set), and that worker is restarted once it crosses the threshold.

## Impact

Measured on `@grafana/sharing-squad` (40 suites / 407 tests, identical results before/after):

| Metric | Before (in-band) | After (recycled worker) |
|---|---|---|
| Worker/process heap peak | 1939 MB (grows monotonically) | 1017 MB (capped) |
| Process peak RSS | 2.85 GB | 1.53 GB |

More importantly, peak memory is now **bounded regardless of team size** instead of growing with the number of test files. The 1 GB threshold is tunable via `--logHeapUsage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)