### PR TITLE
CI: Replace jest-monocart-coverage with native istanbul reporters

### DIFF
--- a/jest.config.codeowner.js
+++ b/jest.config.codeowner.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const open = require('open').default;
 const path = require('path');
 
 const baseConfig = require('./jest.config.js');
@@ -14,7 +13,6 @@ if (!codeownerName) {
 }
 
 const outputDir = path.join('./coverage/by-team', buildCodeownerDirectoryPath(codeownerName));
-const COVERAGE_SUMMARY_OUTPUT_PATH = './coverage-summary.json';
 
 const codeownersFilePath = path.join(__dirname, CODEOWNERS_MANIFEST_FILENAMES_BY_TEAM_PATH);
 
@@ -77,118 +75,16 @@ module.exports = {
   ...baseConfig,
 
   collectCoverage: true,
+  // collectCoverageFrom scopes the report to the team's owned source files and includes untested
+  // ones at 0%, so the reporters need no extra filtering (this replaces monocart's sourceFilter/all).
   collectCoverageFrom: sourceFiles.map((file) => `<rootDir>/${file}`),
-  coverageReporters: ['none'],
-  coverageDirectory: '/tmp/jest-coverage-ignore',
-
   coverageProvider: 'babel',
-  reporters: [
-    'default',
-    [
-      'jest-monocart-coverage',
-      {
-        name: `Coverage Report - ${codeownerName} owned files`,
-        outputDir: outputDir,
-        reports: ['console-summary', 'json', 'lcov', ['html-spa', { subdir: 'html' }]],
-        sourceFilter: (coveredFile) => sourceFiles.includes(coveredFile),
-        all: {
-          dir: ['./packages', './public'],
-          filter: (filePath) => {
-            const relativePath = filePath.replace(process.cwd() + '/', '');
-            return sourceFiles.includes(relativePath);
-          },
-        },
-        cleanCache: true,
-        onEnd: (coverageResults) => {
-          const reportURL = `file://${path.resolve(outputDir)}/html/index.html`;
-          console.log(`📄 Coverage report saved to ${reportURL}`);
-
-          if (process.env.SHOULD_OPEN_COVERAGE_REPORT === 'true') {
-            openCoverageReport(reportURL);
-          }
-
-          writeCoverageSummaryArtifact(coverageResults);
-
-          // TODO: Emit coverage metrics https://github.com/grafana/grafana/issues/111208
-        },
-      },
-    ],
-  ],
+  coverageDirectory: outputDir,
+  // html `subdir: 'html'` keeps the CI artifact path (<outputDir>/html) stable; json-summary feeds
+  // the per-team summary artifact assembled after the run in test-coverage-by-codeowner.js.
+  coverageReporters: [['html', { subdir: 'html' }], 'json-summary', 'lcov', 'text-summary'],
 
   testRegex: undefined,
 
   testMatch: testFiles.map((file) => `<rootDir>/${file}`),
 };
-
-/**
- * @typedef {Object} CoverageMetric
- * @property {number} pct - Percentage value
- */
-
-/**
- * @typedef {Object} CoverageSummary
- * @property {CoverageMetric} lines
- * @property {CoverageMetric} statements
- * @property {CoverageMetric} functions
- * @property {CoverageMetric} branches
- */
-
-/**
- * @typedef {Object} CoverageResults
- * @property {CoverageSummary} summary
- */
-
-/**
- * Writes coverage summary artifact for CI/CD consumption
- * @param {CoverageResults} coverageResults - Coverage results from jest-monocart-coverage
- */
-function writeCoverageSummaryArtifact(coverageResults) {
-  if (!coverageResults || !coverageResults.summary) {
-    return;
-  }
-
-  const files = {};
-  if (coverageResults.files) {
-    for (const file of coverageResults.files) {
-      const relativePath = file.sourcePath.replace(process.cwd() + '/', '');
-      files[relativePath] = {
-        lines: { pct: file.summary.lines.pct },
-        statements: { pct: file.summary.statements.pct },
-        functions: { pct: file.summary.functions.pct },
-        branches: { pct: file.summary.branches.pct },
-      };
-    }
-  }
-
-  const summary = {
-    team: codeownerName,
-    commit: process.env.GITHUB_SHA || 'unknown',
-    timestamp: new Date().toISOString(),
-    summary: {
-      lines: { pct: coverageResults.summary.lines.pct },
-      statements: { pct: coverageResults.summary.statements.pct },
-      functions: { pct: coverageResults.summary.functions.pct },
-      branches: { pct: coverageResults.summary.branches.pct },
-    },
-    files,
-  };
-
-  try {
-    fs.writeFileSync(COVERAGE_SUMMARY_OUTPUT_PATH, JSON.stringify(summary, null, 2));
-    console.log(`📊 Coverage summary written to ${COVERAGE_SUMMARY_OUTPUT_PATH}`);
-  } catch (err) {
-    console.error(`Failed to write coverage summary: ${err}`);
-  }
-}
-
-/**
- * Opens the coverage report in the default browser
- * @param {string} reportURL - File URL to the coverage report HTML
- */
-async function openCoverageReport(reportURL) {
-  try {
-    await open(reportURL);
-  } catch (err) {
-    console.error(`Failed to open coverage report: ${err}`);
-  }
-}

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -53,9 +53,6 @@ const config: KnipConfig = {
         // used by yarn test:ci
         'jest-junit',
 
-        // used by coverage script, see jest.config.codeowner.js
-        'jest-monocart-coverage',
-
         // needed by github actions
         '@grafana/levitate',
         'wait-on',

--- a/package.json
+++ b/package.json
@@ -205,7 +205,6 @@
     "jest-environment-jsdom": "29.7.0",
     "jest-fail-on-console": "3.3.1",
     "jest-junit": "16.0.0",
-    "jest-monocart-coverage": "^1.1.1",
     "jest-watch-typeahead": "^2.2.2",
     "jimp": "^1.6.0",
     "json-schema-to-typescript": "15.0.4",

--- a/scripts/test-coverage-by-codeowner.js
+++ b/scripts/test-coverage-by-codeowner.js
@@ -2,12 +2,16 @@
 
 const { AutoComplete } = require('enquirer');
 const cp = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const open = require('open').default;
 const { hideBin } = require('yargs/helpers');
 const yargs = require('yargs/yargs');
 
-const { getCodeowners } = require('./codeowners-manifest/utils.js');
+const { getCodeowners, buildCodeownerDirectoryPath } = require('./codeowners-manifest/utils.js');
 
 const JEST_CONFIG_PATH = 'jest.config.codeowner.js';
+const COVERAGE_SUMMARY_OUTPUT_PATH = './coverage-summary.json';
 
 async function promptCodeownerName() {
   const teams = await getCodeowners();
@@ -44,14 +48,90 @@ async function runTestCoverageByCodeowner(codeownerName, noOpen = process.env.CI
       reject(new Error(`Failed to start Jest: ${error.message}`));
     });
 
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
+    child.on('close', async (code) => {
+      if (code !== 0) {
         reject(new Error(`Jest exited with code ${code}`));
+        return;
       }
+
+      try {
+        writeCoverageSummaryArtifact(codeownerName);
+        await maybeOpenCoverageReport(codeownerName, noOpen);
+      } catch (err) {
+        console.error(`Post-run coverage processing failed: ${err}`);
+      }
+
+      resolve();
     });
   });
+}
+
+/**
+ * Reads the istanbul json-summary Jest wrote to the team's coverage dir and rewrites it into the
+ * per-team summary artifact consumed by compare-coverage-by-codeowner.js and grafana-bench.
+ * @param {string} codeownerName
+ */
+function writeCoverageSummaryArtifact(codeownerName) {
+  const outputDir = path.join('./coverage/by-team', buildCodeownerDirectoryPath(codeownerName));
+  const istanbulSummaryPath = path.join(outputDir, 'coverage-summary.json');
+
+  if (!fs.existsSync(istanbulSummaryPath)) {
+    console.error(`Coverage summary not found at ${istanbulSummaryPath}`);
+    return;
+  }
+
+  const istanbulSummary = JSON.parse(fs.readFileSync(istanbulSummaryPath, 'utf8'));
+  const pctOnly = (metrics) => ({
+    lines: { pct: metrics.lines.pct },
+    statements: { pct: metrics.statements.pct },
+    functions: { pct: metrics.functions.pct },
+    branches: { pct: metrics.branches.pct },
+  });
+
+  const files = {};
+  for (const [filePath, metrics] of Object.entries(istanbulSummary)) {
+    if (filePath === 'total') {
+      continue;
+    }
+    const relativePath = filePath.replace(process.cwd() + '/', '');
+    files[relativePath] = pctOnly(metrics);
+  }
+
+  const summary = {
+    team: codeownerName,
+    commit: process.env.GITHUB_SHA || 'unknown',
+    timestamp: new Date().toISOString(),
+    summary: pctOnly(istanbulSummary.total),
+    files,
+  };
+
+  try {
+    fs.writeFileSync(COVERAGE_SUMMARY_OUTPUT_PATH, JSON.stringify(summary, null, 2));
+    console.log(`📊 Coverage summary written to ${COVERAGE_SUMMARY_OUTPUT_PATH}`);
+  } catch (err) {
+    console.error(`Failed to write coverage summary: ${err}`);
+  }
+}
+
+/**
+ * Logs the HTML report location and opens it in the default browser unless disabled.
+ * @param {string} codeownerName
+ * @param {boolean} noOpen
+ */
+async function maybeOpenCoverageReport(codeownerName, noOpen) {
+  const outputDir = path.join('./coverage/by-team', buildCodeownerDirectoryPath(codeownerName));
+  const reportURL = `file://${path.resolve(outputDir)}/html/index.html`;
+  console.log(`📄 Coverage report saved to ${reportURL}`);
+
+  if (noOpen) {
+    return;
+  }
+
+  try {
+    await open(reportURL);
+  } catch (err) {
+    console.error(`Failed to open coverage report: ${err}`);
+  }
 }
 
 if (require.main === module) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11696,16 +11696,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-loose@npm:^8.5.0":
-  version: 8.5.2
-  resolution: "acorn-loose@npm:8.5.2"
-  dependencies:
-    acorn: "npm:^8.15.0"
-  checksum: 10/3a86f4263ad8eac8d5638e15608bb31b916ab95183e3c9f0cc10ab5b11645dc09fe5b3f22464e8f484b3df13f1a7254ec155a98ae50b6458721f3fee65ebfb4f
-  languageName: node
-  linkType: hard
-
-"acorn-walk@npm:8.3.5, acorn-walk@npm:^8.0.0, acorn-walk@npm:^8.0.2, acorn-walk@npm:^8.1.1, acorn-walk@npm:^8.3.4":
+"acorn-walk@npm:8.3.5, acorn-walk@npm:^8.0.0, acorn-walk@npm:^8.0.2, acorn-walk@npm:^8.1.1":
   version: 8.3.5
   resolution: "acorn-walk@npm:8.3.5"
   dependencies:
@@ -11714,7 +11705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.4, acorn@npm:^8.1.0, acorn@npm:^8.10.0, acorn@npm:^8.11.0, acorn@npm:^8.14.1, acorn@npm:^8.15.0, acorn@npm:^8.4.1, acorn@npm:^8.8.0, acorn@npm:^8.8.2":
+"acorn@npm:^8.0.4, acorn@npm:^8.1.0, acorn@npm:^8.10.0, acorn@npm:^8.11.0, acorn@npm:^8.15.0, acorn@npm:^8.4.1, acorn@npm:^8.8.0, acorn@npm:^8.8.2":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -13559,13 +13550,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^13.1.0":
-  version: 13.1.0
-  resolution: "commander@npm:13.1.0"
-  checksum: 10/d3b4b79e6be8471ddadacbb8cd441fe82154d7da7393b50e76165a9e29ccdb74fa911a186437b9a211d0fc071db6051915c94fb8ef16d77511d898e9dbabc6af
-  languageName: node
-  linkType: hard
-
 "commander@npm:^14.0.3":
   version: 14.0.3
   resolution: "commander@npm:14.0.3"
@@ -13690,13 +13674,6 @@ __metadata:
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: 10/27b5fa302bc8e9ae9e98c03c66d76ca289ad0c61ce2fe20ab288d288bee875d217512d2edb2363fc83165e88f1c405180cf3f5413a46e51b4fe1a004840c6cdb
-  languageName: node
-  linkType: hard
-
-"console-grid@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "console-grid@npm:2.2.3"
-  checksum: 10/d536108a21277ebc3816a65c67d369cbdbfae7eda7874c0fb7e3a74592ef671772472cd208e02d18ca401d55660ebd59473a5b95419d59dcdfed822d48fa893d
   languageName: node
   linkType: hard
 
@@ -15621,13 +15598,6 @@ __metadata:
   version: 1.1.1
   resolution: "ee-first@npm:1.1.1"
   checksum: 10/1b4cac778d64ce3b582a7e26b218afe07e207a0f9bfe13cc7395a6d307849cfe361e65033c3251e00c27dd060cab43014c2d6b2647676135e18b77d2d05b3f4f
-  languageName: node
-  linkType: hard
-
-"eight-colors@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "eight-colors@npm:1.3.1"
-  checksum: 10/a6f7174d535ad718de9aaa70e6276a693b7d4145046328e1bb2f4a295a096e7ae883bf645ff16ef1090bb69314a79cb88143a23687b945c89c90d8d41c122042
   languageName: node
   linkType: hard
 
@@ -18465,7 +18435,6 @@ __metadata:
     jest-environment-jsdom: "npm:29.7.0"
     jest-fail-on-console: "npm:3.3.1"
     jest-junit: "npm:16.0.0"
-    jest-monocart-coverage: "npm:^1.1.1"
     jest-watch-typeahead: "npm:^2.2.2"
     jimp: "npm:^1.6.0"
     jquery: "npm:3.7.1"
@@ -20281,7 +20250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0, istanbul-lib-coverage@npm:^3.2.2":
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
   version: 3.2.2
   resolution: "istanbul-lib-coverage@npm:3.2.2"
   checksum: 10/40bbdd1e937dfd8c830fa286d0f665e81b7a78bdabcd4565f6d5667c99828bda3db7fb7ac6b96a3e2e8a2461ddbc5452d9f8bc7d00cb00075fa6a3e99f5b6a81
@@ -20349,7 +20318,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
+"istanbul-lib-report@npm:^3.0.0":
   version: 3.0.1
   resolution: "istanbul-lib-report@npm:3.0.1"
   dependencies:
@@ -20382,7 +20351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-reports@npm:^3.0.2, istanbul-reports@npm:^3.1.3, istanbul-reports@npm:^3.1.7":
+"istanbul-reports@npm:^3.0.2, istanbul-reports@npm:^3.1.3":
   version: 3.2.0
   resolution: "istanbul-reports@npm:3.2.0"
   dependencies:
@@ -20982,17 +20951,6 @@ __metadata:
     "@types/node": "npm:*"
     jest-util: "npm:^29.7.0"
   checksum: 10/ae51d1b4f898724be5e0e52b2268a68fcd876d9b20633c864a6dd6b1994cbc48d62402b0f40f3a1b669b30ebd648821f086c26c08ffde192ced951ff4670d51c
-  languageName: node
-  linkType: hard
-
-"jest-monocart-coverage@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "jest-monocart-coverage@npm:1.1.1"
-  dependencies:
-    monocart-coverage-reports: "npm:^2.8.7"
-  peerDependencies:
-    "@jest/reporters": "*"
-  checksum: 10/c614daf9d2733963d8d12ed88c5d2cc9e16834ba14180e0c9c229cb8ce59eaa41add6ab0ad2c303163ffc868ae431feae7d05b7b02083f5ad5183d53342e094a
   languageName: node
   linkType: hard
 
@@ -22607,13 +22565,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lz-utils@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "lz-utils@npm:2.1.0"
-  checksum: 10/61c4c43d08770b8d71342f76a5a629dd7073d80bf2417201d7e41e0a11f98faf7e9ac68d3b61e9ee1b21c4c9966f3840d06c2f6d41e4bf259b038d4c262d15cb
-  languageName: node
-  linkType: hard
-
 "madge@npm:^8.0.0":
   version: 8.0.0
   resolution: "madge@npm:8.0.0"
@@ -23901,35 +23852,6 @@ __metadata:
   version: 1.8.0
   resolution: "monaco-promql@npm:1.8.0"
   checksum: 10/d757ecd46fb3fb3ee31d1ee06b21e2860735d24d41ca161e8d4e576a956a83e86103b7ddbecdf1e02ea9fac6a3782694c996e3ce46b7483f3c47630627b40c68
-  languageName: node
-  linkType: hard
-
-"monocart-coverage-reports@npm:^2.8.7":
-  version: 2.12.6
-  resolution: "monocart-coverage-reports@npm:2.12.6"
-  dependencies:
-    acorn: "npm:^8.14.1"
-    acorn-loose: "npm:^8.5.0"
-    acorn-walk: "npm:^8.3.4"
-    commander: "npm:^13.1.0"
-    console-grid: "npm:^2.2.3"
-    eight-colors: "npm:^1.3.1"
-    foreground-child: "npm:^3.3.1"
-    istanbul-lib-coverage: "npm:^3.2.2"
-    istanbul-lib-report: "npm:^3.0.1"
-    istanbul-reports: "npm:^3.1.7"
-    lz-utils: "npm:^2.1.0"
-    monocart-locator: "npm:^1.0.2"
-  bin:
-    mcr: lib/cli.js
-  checksum: 10/021824eb0eb3bd36f45922f10b78d115c17258eeeb650056d0b2153a05ead0dd74715b197fa99169d6bfc13a2e404c1f524e140664d8994df02013bdc6c75530
-  languageName: node
-  linkType: hard
-
-"monocart-locator@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "monocart-locator@npm:1.0.2"
-  checksum: 10/382578f8405ea22b8c62e462afbbacf7cae702c7c9b94ef700645f855f0ad39951e1a87f89fb93180e22e8e7bd20962675bd1b559a2c62d10951213ea94c1431
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Removes the `jest-monocart-coverage` dependency and switches the per-team coverage config (`jest.config.codeowner.js`) to Jest's built-in istanbul reporters (`html` / `json-summary` / `lcov` / `text-summary`). The per-team `coverage-summary.json` is now assembled in `scripts/test-coverage-by-codeowner.js` from istanbul's `json-summary` output.

## Why

monocart is a V8-first coverage reporter. On the babel/istanbul provider we use, it added a main-process processing layer plus a full `./packages` + `./public` directory scan (its `all` option) without providing anything native istanbul doesn't:

- `collectCoverageFrom` (already set to the team's owned source files) natively scopes the report **and** includes untested files at 0%, replacing monocart's `sourceFilter` + `all`.
- `html` with `subdir: 'html'` keeps the CI artifact path (`<outputDir>/html`) stable.
- `json-summary` feeds the per-team summary artifact.

## Coverage numbers are unchanged

Because the coverage provider/instrumentation is untouched, the numbers are byte-identical. Verified on `@grafana/sharing-squad`:

| Metric | monocart (before) | native istanbul (after) |
|---|---|---|
| Statements | 67.98% (2066/3039) | 67.98% (2066/3039) |
| Branches | 52.77% (943/1787) | 52.77% (943/1787) |
| Functions | 46.40% (310/668) | 46.40% (310/668) |
| Lines | 67.99% (1984/2918) | 67.99% (1984/2918) |

The custom `coverage-summary.json` shape is preserved, so `compare-coverage-by-codeowner.js` and the `grafana-bench` report step are unaffected (verified the compare script parses the new output). HTML report is now the standard multi-page istanbul view instead of the SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)