### PR TITLE
Dashboard: Fix outdated docs link in snapshots

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/UpsertSnapshot.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/UpsertSnapshot.tsx
@@ -11,7 +11,8 @@ import { getExpireOptions } from '../../ShareSnapshotTab';
 const DASHBOARD_SNAPSHOT_URL =
   'https://grafana.com/docs/grafana/latest/visualizations/dashboards/share-dashboards-panels/#share-a-snapshot';
 
-const PANEL_SNAPSHOT_URL = 'https://grafana.com/docs/grafana/latest/visualizations/dashboards/share-dashboards-panels/#panel-snapshot';
+const PANEL_SNAPSHOT_URL =
+  'https://grafana.com/docs/grafana/latest/visualizations/dashboards/share-dashboards-panels/#panel-snapshot';
 
 interface Props {
   name: string;

--- a/public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/UpsertSnapshot.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/UpsertSnapshot.tsx
@@ -9,9 +9,9 @@ import { Alert, Button, Divider, Field, Input, RadioButtonGroup, Stack, Text, us
 import { getExpireOptions } from '../../ShareSnapshotTab';
 
 const DASHBOARD_SNAPSHOT_URL =
-  'https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/#share-a-snapshot';
+  'https://grafana.com/docs/grafana/latest/visualizations/dashboards/share-dashboards-panels/#share-a-snapshot';
 
-const PANEL_SNAPSHOT_URL = 'https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/#panel-snapshot';
+const PANEL_SNAPSHOT_URL = 'https://grafana.com/docs/grafana/latest/visualizations/dashboards/share-dashboards-panels/#panel-snapshot';
 
 interface Props {
   name: string;

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
@@ -85,7 +85,7 @@ export const SnapshotListTable = () => {
           You can create a snapshot of any dashboard through the <b>Share</b> modal.{' '}
           <TextLink
             external
-            href="https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/#share-a-snapshot"
+            href="https://grafana.com/docs/grafana/latest/visualizations/dashboards/share-dashboards-panels/#share-a-snapshot"
           >
             Learn more
           </TextLink>


### PR DESCRIPTION
**What is this feature?**

This is not a new feature. It fixes three broken documentation links across two files in the dashboard snapshots UI. The docs site restructured the share-dashboards-panels page under a new `visualizations/` path segment, and the old links now 404.

**Why do we need this feature?**

Users clicking "Learn more" in the snapshots empty state, or the snapshot/panel snapshot creation drawer, hit a 404 instead of the docs. This fix takes users to the appropriate documentation pages. 

**Who is this feature for?**

Any user viewing the Dashboards > Snapshots page or creating a snapshot.

**Which issue(s) does this PR fix?**: Fixes #127805 

**Special notes for your reviewer:**

Small, low-risk change. Three constants/href values updated to the new docs path. No functional or UI changes, no tests needed. Not behind a feature toggle since it's a bugfix, and no docs updates required since the docs page itself already exists at the correct URL. Only the in-app links needed fixing.

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
