### PR TITLE
[release-13.0.4] Alerting: Return 403 instead of 500 on contact point provenance mismatch

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/util"
@@ -297,7 +298,7 @@ func (ecp *ContactPointService) UpdateContactPoint(ctx context.Context, orgID in
 		return err
 	}
 	if storedProvenance != provenance && storedProvenance != models.ProvenanceNone {
-		return fmt.Errorf("cannot change provenance from '%s' to '%s'", storedProvenance, provenance)
+		return validation.MakeErrProvenanceChangeNotAllowed(storedProvenance, provenance)
 	}
 
 	// Check protected fields authorization

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -377,7 +377,8 @@ func TestIntegrationContactPointService(t *testing.T) {
 					require.Equal(t, newCp.UID, cps[0].UID)
 					require.Equal(t, test.to, models.Provenance(cps[0].Provenance))
 				} else {
-					require.Error(t, err, fmt.Sprintf("cannot change provenance from '%s' to '%s'", test.from, test.to))
+					require.Error(t, err)
+					require.Truef(t, validation.ErrProvenanceChangeNotAllowed.Base.Is(err), "expected ErrProvenanceChangeNotAllowed but got %s", err)
 				}
 			})
 		}


### PR DESCRIPTION
Backport 33048dab81ba1b8963c056ff2a2353f662e77bfd from #127699

---

**What is this feature?**

The provisioning API endpoint `PUT /api/v1/provisioning/contact-points/{UID}` returned an HTTP 500 when a request attempted a disallowed provenance change on a contact point (for example, changing provenance from `api` to none). This changes that path to return the existing `ErrProvenanceChangeNotAllowed` error, which maps to HTTP 403, the same behavior as the other provisioning notification endpoints (notification policies, templates, mute timings).

**Why do we need this feature?**

Rejecting a disallowed provenance change is a client-side contract violation, not an internal server error, so it should not be surfaced as a 500. Contact points were the last provisioning notification endpoint still returning 500 for this case; the others already return 403.

**Who is this feature for?**

Users of the alerting provisioning API.

**Special notes for your reviewer:**

Contact points enforce a hard provenance guard (the change is disallowed regardless of the caller's permissions), so this reuses `validation.ErrProvenanceChangeNotAllowed` (403) to stay consistent with the sibling notification endpoints. The alerting rule provisioning endpoint intentionally returns 409 for its equivalent guard and is deliberately left unchanged.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
