### PR TITLE
alerting: allow import to gma wizard navigation for non admin users when sync is not active

### DIFF
--- a/public/app/features/alerting/routes.test.tsx
+++ b/public/app/features/alerting/routes.test.tsx
@@ -64,4 +64,43 @@ describe('alerting route guards', () => {
       expect(guard()).toEqual([]);
     });
   });
+
+  describe('Import to Grafana Alerting route', () => {
+    const importToGmaPath = '/alerting/import-to-gma';
+
+    it('allows users holding both convert permissions', () => {
+      contextSrv.user.permissions = {
+        [AccessControlAction.AlertingRuleCreate]: true,
+        [AccessControlAction.AlertingProvisioningSetStatus]: true,
+      };
+
+      const guard = getRouteRolesGuard(importToGmaPath);
+      expect(guard()).toEqual([]);
+    });
+
+    it('rejects users with only rule-create permission', () => {
+      contextSrv.user.permissions = {
+        [AccessControlAction.AlertingRuleCreate]: true,
+      };
+
+      const guard = getRouteRolesGuard(importToGmaPath);
+      expect(guard()).toEqual(['Reject']);
+    });
+
+    it('rejects users with only provisioning-set-status permission', () => {
+      contextSrv.user.permissions = {
+        [AccessControlAction.AlertingProvisioningSetStatus]: true,
+      };
+
+      const guard = getRouteRolesGuard(importToGmaPath);
+      expect(guard()).toEqual(['Reject']);
+    });
+
+    it('rejects users with neither permission', () => {
+      contextSrv.user.permissions = {};
+
+      const guard = getRouteRolesGuard(importToGmaPath);
+      expect(guard()).toEqual(['Reject']);
+    });
+  });
 });

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -13,7 +13,7 @@ import {
   PERMISSIONS_TIME_INTERVALS_MODIFY,
   PERMISSIONS_TIME_INTERVALS_READ,
 } from './unified/hooks/abilities/alertmanager/useTimeIntervalAbility';
-import { evaluateAccess } from './unified/utils/access-control';
+import { evaluateAccess, evaluateAccessAll } from './unified/utils/access-control';
 
 export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
   const routes = [
@@ -307,10 +307,9 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
     },
     {
       path: '/alerting/import-to-gma',
-      roles: evaluateAccess([
+      roles: evaluateAccessAll([
         AccessControlAction.AlertingRuleCreate,
         AccessControlAction.AlertingProvisioningSetStatus,
-        AccessControlAction.AlertingNotificationsWrite,
       ]),
       component: config.featureToggles.alertingMigrationWizardUI
         ? importAlertingComponent(

--- a/public/app/features/alerting/unified/components/AlertingPageWrapper.test.tsx
+++ b/public/app/features/alerting/unified/components/AlertingPageWrapper.test.tsx
@@ -2,12 +2,12 @@ import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils
 import { byRole } from 'testing-library-selector';
 
 import { type NavModelItem, OrgRole } from '@grafana/data';
-import { type AlertManagerDataSourceJsonData, AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
+import { type AlertManagerDataSourceJsonData } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../mockApi';
 import { grantUserPermissions, grantUserRole, mockDataSource } from '../mocks';
-import { setupAdminConfigGet } from '../mocks/server/configure/admin_config';
+import { setupAutoSyncConfig } from '../mocks/server/handlers/k8s/config.k8s';
 import { setupDataSources } from '../testSetup/datasources';
 import { ALERTMANAGER_NAME_QUERY_KEY } from '../utils/constants';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
@@ -245,16 +245,14 @@ describe('AlertmanagerPageWrapper', () => {
           AccessControlAction.AlertingNotificationsRead,
           AccessControlAction.AlertingNotificationsExternalRead,
           AccessControlAction.AlertingNotificationsWrite,
+          AccessControlAction.ActionAlertingNotificationsConfigRead,
         ]);
-        setupAdminConfigGet(server, {
-          alertmanagersChoice: AlertmanagerChoice.Internal,
-          external_alertmanager_uid: 'mimir-uid',
-        });
+        setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
 
         renderWithSelectedAlertmanager(externalAm.name);
 
         expect(await screen.findByText('Test content')).toBeInTheDocument();
-        // The banner renders before the admin_config query resolves, then hides once auto-sync
+        // The banner renders before the Config query resolves, then hides once auto-sync
         // is known to be active, so wait for it to be removed.
         await waitFor(() => {
           expect(importBanner.query()).not.toBeInTheDocument();

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -34,6 +34,7 @@ import {
   trackImportToGMAWizardStepSkipped,
 } from '../../Analytics';
 import { fetchAlertManagerConfig } from '../../api/alertmanager';
+import { useIsAutoSyncActive } from '../../hooks/useIsAutoSyncActive';
 import { getAlertRulesNavId } from '../../navigation/useAlertRulesNav';
 import { ALERTING_SETTINGS_URL } from '../../settings/navigation';
 import { type Folder } from '../../types/rule-form';
@@ -43,7 +44,6 @@ import { createListFilterLink } from '../../utils/navigation';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
 import { useGetRulerRules } from '../rule-editor/useAlertRuleSuggestions';
-import { hasConfiguredUid, useAutoSyncConfiguration } from '../settings/useAutoSyncConfiguration';
 
 import { RenamedResourcesList } from './CollapsibleRenameList';
 import { PolicyTreeNameHelp } from './PolicyTreeNameHelp';
@@ -127,21 +127,14 @@ function Wizard() {
   );
 }
 
-// Blocks the whole import flow while auto-sync is active
+// Blocks the whole import flow while auto-sync is active. Mirrors how the menu entry point (useImportEntrypointState) gates the same action.
 export function ImportWizardGate() {
-  if (!isAutoSyncSegmentEnabled()) {
-    return <Wizard />;
-  }
-  return <ImportWizardAutoSyncGuard />;
-}
-
-function ImportWizardAutoSyncGuard() {
-  const { state, isLoading } = useAutoSyncConfiguration();
+  const { isActive, isLoading } = useIsAutoSyncActive();
 
   if (isLoading) {
     return <LoadingPlaceholder text={t('alerting.import-to-gma.loading', 'Loading…')} />;
   }
-  if (hasConfiguredUid(state)) {
+  if (isActive) {
     return <AutoSyncActiveBlock />;
   }
   return <Wizard />;

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -55,7 +55,7 @@ import { getPauseRulesLabel } from './Wizard/steps';
 import { type ImportMethod, StepKey } from './Wizard/types';
 import { Step1Content, useStep1Validation } from './steps/Step1AlertmanagerResources';
 import { Step2Content, useStep2Validation } from './steps/Step2AlertRules';
-import { StepImportMethod, isAutoSyncSegmentEnabled } from './steps/StepImportMethod';
+import { StepImportMethod } from './steps/StepImportMethod';
 import { StepReviewEnableAutoSync } from './steps/StepReviewEnableAutoSync';
 import { type DryRunValidationResult, type PromoteStatsSummary } from './types';
 import { useCanImportToGMA } from './useCanImportToGMA';

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -3,9 +3,9 @@ import { isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, OrgRole } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import {
   Alert,
   Box,
@@ -21,6 +21,7 @@ import {
   useStyles2,
 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
+import { contextSrv } from 'app/core/services/context_srv';
 import { type RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
 import {
@@ -40,7 +41,8 @@ import { ALERTING_SETTINGS_URL } from '../../settings/navigation';
 import { type Folder } from '../../types/rule-form';
 import { DOCS_URL_ALERTING_MIGRATION } from '../../utils/docs';
 import { stringifyErrorLike } from '../../utils/misc';
-import { createListFilterLink } from '../../utils/navigation';
+import { ALERTING_PATHS, createListFilterLink } from '../../utils/navigation';
+import { createRelativeUrl } from '../../utils/url';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
 import { useGetRulerRules } from '../rule-editor/useAlertRuleSuggestions';
@@ -141,16 +143,41 @@ export function ImportWizardGate() {
 }
 
 function AutoSyncActiveBlock() {
+  // Both the Alerting settings route and its nav entry are gated on the Org Admin role, so linking
+  // anyone else there would bounce them to the home page. Rule import stays available to every user
+  // who can reach the wizard: the sync worker mirrors only the Alertmanager configuration, and the
+  // convert endpoint rejects notification imports alone.
+  const canManageAutoSync = contextSrv.hasRole(OrgRole.Admin);
+  const isRulesImportEnabled = Boolean(config.featureToggles.alertingMigrationUI);
+
   return (
     <Alert severity="warning" title={t('alerting.import-to-gma.autosync-active-block.title', 'Auto-sync is enabled')}>
       <Stack direction="column" gap={1} alignItems="flex-start">
-        <Trans i18nKey="alerting.import-to-gma.autosync-active-block.description">
-          Grafana is continuously syncing alert configuration from a data source, so the configuration is a read-only
-          mirror and cannot be imported into. To import, disable auto-sync in Alerting settings first.
-        </Trans>
-        <TextLink href={ALERTING_SETTINGS_URL} icon="cog">
-          {t('alerting.import-to-gma.autosync-active-block.go-to-settings', 'Go to Alerting settings')}
-        </TextLink>
+        <Text>
+          <Trans i18nKey="alerting.import-to-gma.autosync-active-block.description">
+            Grafana is continuously syncing alert configuration from a data source, so notification resources are a
+            read-only mirror and cannot be imported into. You can still import alert rules.
+          </Trans>
+        </Text>
+        {canManageAutoSync && (
+          <Text>
+            <Trans i18nKey="alerting.import-to-gma.autosync-active-block.disable-sync">
+              To import notification resources, disable auto-sync in Alerting settings first.
+            </Trans>
+          </Text>
+        )}
+        <Stack direction="row" gap={2} alignItems="center" wrap="wrap">
+          {isRulesImportEnabled && (
+            <TextLink href={createRelativeUrl(ALERTING_PATHS.IMPORT_DATASOURCE_MANAGED_RULES)} icon="upload">
+              {t('alerting.import-to-gma.autosync-active-block.import-rules', 'Import alert rules')}
+            </TextLink>
+          )}
+          {canManageAutoSync && (
+            <TextLink href={ALERTING_SETTINGS_URL} icon="cog">
+              {t('alerting.import-to-gma.autosync-active-block.go-to-settings', 'Go to Alerting settings')}
+            </TextLink>
+          )}
+        </Stack>
       </Stack>
     </Alert>
   );

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMAAutoSyncBlock.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMAAutoSyncBlock.test.tsx
@@ -1,12 +1,12 @@
 import { render, testWithFeatureToggles, waitFor } from 'test/test-utils';
 import { byRole, byText } from 'testing-library-selector';
 
-import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
+import { OrgRole } from '@grafana/data';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../../mockApi';
-import { grantUserRole } from '../../mocks';
-import { setupAdminConfigGet, setupAlertmanagersStatus } from '../../mocks/server/configure/admin_config';
-import { mimirAlertmanagerDataSourcePayload, setupDatasourcesEndpoint } from '../../mocks/server/configure/datasources';
+import { grantUserPermissions, grantUserRole } from '../../mocks';
+import { setupAutoSyncConfig } from '../../mocks/server/handlers/k8s/config.k8s';
 
 import { ImportWizardGate } from './ImportToGMA';
 
@@ -21,28 +21,31 @@ const ui = {
 };
 
 describe('Import wizard auto-sync gate', () => {
-  it('renders the wizard normally when auto-sync is unavailable to the user (flag off)', async () => {
+  it('renders the wizard normally when the sync feature is off, regardless of config', async () => {
+    setupAutoSyncConfig(server, { specUid: MIMIR_DS_UID });
+
     render(<ImportWizardGate />);
 
-    // No auto-sync block; the method selector is shown.
+    // Flag off -> the sync query is skipped and the wizard renders.
     expect(await ui.stageRadio.find()).toBeInTheDocument();
     expect(ui.blockTitle.query()).not.toBeInTheDocument();
   });
 
-  describe('when auto-sync is available (flag on + org admin)', () => {
+  describe('when the sync feature is enabled', () => {
     testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
 
     beforeEach(() => {
-      grantUserRole('Admin');
-      setupAlertmanagersStatus(server);
-      setupDatasourcesEndpoint(server, [mimirAlertmanagerDataSourcePayload({ uid: MIMIR_DS_UID })]);
+      // Read access to the sync Config plus the permissions the wizard itself needs. Note: no admin
+      // role — the block must apply to any user allowed to reach the wizard.
+      grantUserPermissions([
+        AccessControlAction.ActionAlertingNotificationsConfigRead,
+        AccessControlAction.AlertingRuleCreate,
+        AccessControlAction.AlertingProvisioningSetStatus,
+      ]);
     });
 
     it('blocks the whole wizard and links to Settings when auto-sync is active', async () => {
-      setupAdminConfigGet(server, {
-        alertmanagersChoice: AlertmanagerChoice.Internal,
-        external_alertmanager_uid: MIMIR_DS_UID,
-      });
+      setupAutoSyncConfig(server, { specUid: MIMIR_DS_UID });
 
       render(<ImportWizardGate />);
 
@@ -52,8 +55,18 @@ describe('Import wizard auto-sync gate', () => {
       expect(ui.stageRadio.query()).not.toBeInTheDocument();
     });
 
+    it('blocks non-admins with read access too (the gap this fixes)', async () => {
+      grantUserRole(OrgRole.Viewer);
+      setupAutoSyncConfig(server, { specUid: MIMIR_DS_UID });
+
+      render(<ImportWizardGate />);
+
+      expect(await ui.blockTitle.find()).toBeInTheDocument();
+      expect(ui.stageRadio.query()).not.toBeInTheDocument();
+    });
+
     it('renders the wizard when auto-sync is not active', async () => {
-      setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+      setupAutoSyncConfig(server, {});
 
       render(<ImportWizardGate />);
 

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMAAutoSyncBlock.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMAAutoSyncBlock.test.tsx
@@ -17,8 +17,20 @@ const MIMIR_DS_UID = 'mimir-uid';
 const ui = {
   blockTitle: byText(/auto-sync is enabled/i),
   goToSettings: byRole('link', { name: /go to alerting settings/i }),
+  importRules: byRole('link', { name: /import alert rules/i }),
+  disableSyncHint: byText(/disable auto-sync in Alerting settings/i),
   stageRadio: byRole('radio', { name: /stage/i }),
 };
+
+// Read access to the sync Config plus the permissions the wizard itself needs. Note: no admin role —
+// the block must apply to any user allowed to reach the wizard.
+function grantWizardPermissions() {
+  grantUserPermissions([
+    AccessControlAction.ActionAlertingNotificationsConfigRead,
+    AccessControlAction.AlertingRuleCreate,
+    AccessControlAction.AlertingProvisioningSetStatus,
+  ]);
+}
 
 describe('Import wizard auto-sync gate', () => {
   it('renders the wizard normally when the sync feature is off, regardless of config', async () => {
@@ -32,25 +44,19 @@ describe('Import wizard auto-sync gate', () => {
   });
 
   describe('when the sync feature is enabled', () => {
-    testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
+    testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager', 'alertingMigrationUI'] });
 
-    beforeEach(() => {
-      // Read access to the sync Config plus the permissions the wizard itself needs. Note: no admin
-      // role — the block must apply to any user allowed to reach the wizard.
-      grantUserPermissions([
-        AccessControlAction.ActionAlertingNotificationsConfigRead,
-        AccessControlAction.AlertingRuleCreate,
-        AccessControlAction.AlertingProvisioningSetStatus,
-      ]);
-    });
+    beforeEach(grantWizardPermissions);
 
-    it('blocks the whole wizard and links to Settings when auto-sync is active', async () => {
+    it('blocks the whole wizard and links admins to Settings when auto-sync is active', async () => {
+      grantUserRole(OrgRole.Admin);
       setupAutoSyncConfig(server, { specUid: MIMIR_DS_UID });
 
       render(<ImportWizardGate />);
 
       expect(await ui.blockTitle.find()).toBeInTheDocument();
       expect(ui.goToSettings.get()).toBeInTheDocument();
+      expect(ui.disableSyncHint.get()).toBeInTheDocument();
       // The method selector is not rendered at all.
       expect(ui.stageRadio.query()).not.toBeInTheDocument();
     });
@@ -65,6 +71,20 @@ describe('Import wizard auto-sync gate', () => {
       expect(ui.stageRadio.query()).not.toBeInTheDocument();
     });
 
+    it('offers rules-only import instead of the admin-only Settings link to non-admins', async () => {
+      // The Settings route is gated on the Org Admin role, so linking non-admins there would bounce
+      // them to the home page. Rules-only import is what they can actually do from here.
+      grantUserRole(OrgRole.Editor);
+      setupAutoSyncConfig(server, { specUid: MIMIR_DS_UID });
+
+      render(<ImportWizardGate />);
+
+      expect(await ui.blockTitle.find()).toBeInTheDocument();
+      expect(ui.importRules.get()).toHaveAttribute('href', expect.stringContaining('import-datasource-managed-rules'));
+      expect(ui.goToSettings.query()).not.toBeInTheDocument();
+      expect(ui.disableSyncHint.query()).not.toBeInTheDocument();
+    });
+
     it('renders the wizard when auto-sync is not active', async () => {
       setupAutoSyncConfig(server, {});
 
@@ -72,6 +92,25 @@ describe('Import wizard auto-sync gate', () => {
 
       expect(await ui.stageRadio.find()).toBeInTheDocument();
       await waitFor(() => expect(ui.blockTitle.query()).not.toBeInTheDocument());
+    });
+  });
+
+  describe('when the sync feature is enabled but rules import is not', () => {
+    testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
+
+    beforeEach(grantWizardPermissions);
+
+    // Without alertingMigrationUI the rules-only route redirects away, so the block must explain the
+    // situation without offering a link that goes nowhere.
+    it('blocks without offering the rules-only import link', async () => {
+      grantUserRole(OrgRole.Editor);
+      setupAutoSyncConfig(server, { specUid: MIMIR_DS_UID });
+
+      render(<ImportWizardGate />);
+
+      expect(await ui.blockTitle.find()).toBeInTheDocument();
+      expect(ui.importRules.query()).not.toBeInTheDocument();
+      expect(ui.goToSettings.query()).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/StepImportMethod.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/StepImportMethod.tsx
@@ -18,7 +18,7 @@ import { MethodPanelCard } from './MethodPanelCard';
  * Whether the Auto-sync method may be offered: gated by the external-alertmanager-sync
  * feature toggle and Org Admin (the admin_config endpoint requires org admin).
  */
-export function isAutoSyncSegmentEnabled(): boolean {
+function isAutoSyncSegmentEnabled(): boolean {
   return Boolean(config.featureToggles['alerting.syncExternalAlertmanager']) && contextSrv.hasRole(OrgRole.Admin);
 }
 

--- a/public/app/features/alerting/unified/components/import-to-gma/useShowImportToGMARulesBanner.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/useShowImportToGMARulesBanner.test.tsx
@@ -2,12 +2,11 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { getWrapper, testWithFeatureToggles } from 'test/test-utils';
 
 import { OrgRole } from '@grafana/data';
-import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../../mockApi';
 import { grantUserPermissions, grantUserRole, mockDataSource } from '../../mocks';
-import { setupAdminConfigGet } from '../../mocks/server/configure/admin_config';
+import { setupAutoSyncConfig } from '../../mocks/server/handlers/k8s/config.k8s';
 import { setupDataSources } from '../../testSetup/datasources';
 import { DataSourceType } from '../../utils/datasource';
 
@@ -38,6 +37,7 @@ describe('useShowImportToGMARulesBanner', () => {
       AccessControlAction.AlertingRuleCreate,
       AccessControlAction.AlertingProvisioningSetStatus,
       AccessControlAction.AlertingRuleExternalRead,
+      AccessControlAction.ActionAlertingNotificationsConfigRead,
     ]);
     setupExternalRulesSource();
   });
@@ -61,10 +61,7 @@ describe('useShowImportToGMARulesBanner', () => {
     testWithFeatureToggles({ enable: ['alertingMigrationWizardUI', 'alerting.syncExternalAlertmanager'] });
 
     it('hides the banner while Mimir Alertmanager auto-sync is active', async () => {
-      setupAdminConfigGet(server, {
-        alertmanagersChoice: AlertmanagerChoice.Internal,
-        external_alertmanager_uid: 'mimir-uid',
-      });
+      setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
 
       const { result } = renderUseShowImportToGMARulesBanner();
 
@@ -74,9 +71,9 @@ describe('useShowImportToGMARulesBanner', () => {
     });
 
     it('does not flash the banner before the auto-sync state has loaded', async () => {
-      // Auto-sync is NOT active, but while the admin_config query is in flight we do not yet
+      // Auto-sync is NOT active, but while the Config query is in flight we do not yet
       // know that, so the banner stays hidden and only appears once the response arrives.
-      setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+      setupAutoSyncConfig(server, {});
 
       const { result } = renderUseShowImportToGMARulesBanner();
 

--- a/public/app/features/alerting/unified/components/rules/CloudRules.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.test.tsx
@@ -4,13 +4,12 @@ import { byRole } from 'testing-library-selector';
 
 import { OrgRole } from '@grafana/data';
 import { setPluginComponentsHook, setPluginLinksHook } from '@grafana/runtime';
-import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../../mockApi';
 import { grantUserPermissions, grantUserRole, mockUnifiedAlertingStore } from '../../mocks';
 import { mimirDataSource } from '../../mocks/server/configure';
-import { setupAdminConfigGet } from '../../mocks/server/configure/admin_config';
+import { setupAutoSyncConfig } from '../../mocks/server/handlers/k8s/config.k8s';
 
 import { CloudRules } from './CloudRules';
 
@@ -47,6 +46,8 @@ describe('CloudRules — Mimir AM auto-sync gate', () => {
       // Both grafana-managed perms are required to enable canMigrateToGMA.
       AccessControlAction.AlertingRuleCreate,
       AccessControlAction.AlertingProvisioningSetStatus,
+      // Required for useIsAutoSyncActive to read the Config resource.
+      AccessControlAction.ActionAlertingNotificationsConfigRead,
     ]);
   });
 
@@ -54,10 +55,7 @@ describe('CloudRules — Mimir AM auto-sync gate', () => {
     testWithFeatureToggles({ enable: ['alertingMigrationUI', 'alerting.syncExternalAlertmanager'] });
 
     it('disables the data source import button with a tooltip when Mimir AM auto-sync is configured', async () => {
-      setupAdminConfigGet(server, {
-        alertmanagersChoice: AlertmanagerChoice.Internal,
-        external_alertmanager_uid: 'mimir-uid',
-      });
+      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
 
       const { user } = renderWithCloudResults();
 
@@ -76,7 +74,7 @@ describe('CloudRules — Mimir AM auto-sync gate', () => {
     });
 
     it('enables the data source import button when Mimir AM auto-sync is not configured', async () => {
-      setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+      setupAutoSyncConfig(server, {});
 
       renderWithCloudResults();
 
@@ -88,7 +86,9 @@ describe('CloudRules — Mimir AM auto-sync gate', () => {
   describe('with alerting.syncExternalAlertmanager feature flag off', () => {
     testWithFeatureToggles({ enable: ['alertingMigrationUI'] });
 
-    it('enables the data source import button regardless of admin_config state', async () => {
+    it('enables the data source import button regardless of Config state', async () => {
+      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+
       renderWithCloudResults();
 
       const btn = await ui.migrateButton.find();

--- a/public/app/features/alerting/unified/components/rules/CloudRules.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.test.tsx
@@ -55,7 +55,7 @@ describe('CloudRules — Mimir AM auto-sync gate', () => {
     testWithFeatureToggles({ enable: ['alertingMigrationUI', 'alerting.syncExternalAlertmanager'] });
 
     it('disables the data source import button with a tooltip when Mimir AM auto-sync is configured', async () => {
-      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+      setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
 
       const { user } = renderWithCloudResults();
 
@@ -87,12 +87,16 @@ describe('CloudRules — Mimir AM auto-sync gate', () => {
     testWithFeatureToggles({ enable: ['alertingMigrationUI'] });
 
     it('enables the data source import button regardless of Config state', async () => {
-      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+      // Flag off ⇒ useIsAutoSyncActive short-circuits via skipToken; the Config query must
+      // never fire even when a sync is configured. Asserting the request never fired is what
+      // makes this fail on a missing gate — the button starts enabled anyway.
+      const { requestSpy } = setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
 
       renderWithCloudResults();
 
       const btn = await ui.migrateButton.find();
       expect(btn).not.toHaveAttribute('aria-disabled', 'true');
+      expect(requestSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/public/app/features/alerting/unified/components/rules/CloudRules.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.test.tsx
@@ -1,5 +1,5 @@
 import { Provider } from 'react-redux';
-import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
+import { render, testWithFeatureToggles } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
 import { OrgRole } from '@grafana/data';
@@ -37,7 +37,7 @@ function renderWithCloudResults() {
   );
 }
 
-describe('CloudRules — Mimir AM auto-sync gate', () => {
+describe('CloudRules — Mimir AM auto-sync', () => {
   beforeEach(() => {
     grantUserRole(OrgRole.Admin);
     grantUserPermissions([
@@ -46,7 +46,7 @@ describe('CloudRules — Mimir AM auto-sync gate', () => {
       // Both grafana-managed perms are required to enable canMigrateToGMA.
       AccessControlAction.AlertingRuleCreate,
       AccessControlAction.AlertingProvisioningSetStatus,
-      // Required for useIsAutoSyncActive to read the Config resource.
+      // Read access to the sync Config, so a reinstated gate would resolve rather than fail open.
       AccessControlAction.ActionAlertingNotificationsConfigRead,
     ]);
   });
@@ -54,42 +54,11 @@ describe('CloudRules — Mimir AM auto-sync gate', () => {
   describe('with alertingMigrationUI and alerting.syncExternalAlertmanager enabled', () => {
     testWithFeatureToggles({ enable: ['alertingMigrationUI', 'alerting.syncExternalAlertmanager'] });
 
-    it('disables the data source import button with a tooltip when Mimir AM auto-sync is configured', async () => {
-      setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
-
-      const { user } = renderWithCloudResults();
-
-      // Re-query each tick — the LinkButton re-mounts as `disabled` flips, so a single captured
-      // reference can become stale.
-      await waitFor(() => {
-        expect(ui.migrateButton.get()).toHaveAttribute('aria-disabled', 'true');
-      });
-
-      // The disabled `<a>` has `pointer-events: none`; the tooltip handlers attach to the wrapping
-      // span. Hover that ancestor so the floating-ui hover registers in jsdom.
-      // eslint-disable-next-line testing-library/no-node-access
-      const tooltipTarget = ui.migrateButton.get().parentElement!;
-      await user.hover(tooltipTarget);
-      expect(await screen.findByRole('tooltip', { name: /auto-sync/i })).toBeInTheDocument();
-    });
-
-    it('enables the data source import button when Mimir AM auto-sync is not configured', async () => {
-      setupAutoSyncConfig(server, {});
-
-      renderWithCloudResults();
-
-      const btn = await ui.migrateButton.find();
-      expect(btn).not.toHaveAttribute('aria-disabled', 'true');
-    });
-  });
-
-  describe('with alerting.syncExternalAlertmanager feature flag off', () => {
-    testWithFeatureToggles({ enable: ['alertingMigrationUI'] });
-
-    it('enables the data source import button regardless of Config state', async () => {
-      // Flag off ⇒ useIsAutoSyncActive short-circuits via skipToken; the Config query must
-      // never fire even when a sync is configured. Asserting the request never fired is what
-      // makes this fail on a missing gate — the button starts enabled anyway.
+    // Auto-sync mirrors only the Alertmanager configuration, and the rule convert endpoints have no
+    // sync check, so this rules-only button must not consult the sync state at all. Asserting the
+    // Config query never fires is what makes this fail if the gate is reinstated — the button starts
+    // enabled either way.
+    it('keeps the data source import button enabled while Mimir AM auto-sync is configured', async () => {
       const { requestSpy } = setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
 
       renderWithCloudResults();

--- a/public/app/features/alerting/unified/components/rules/CloudRules.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.tsx
@@ -5,28 +5,18 @@ import { useLocation } from 'react-router-dom-v5-compat';
 import { type GrafanaTheme2, urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import {
-  Badge,
-  LinkButton,
-  LoadingPlaceholder,
-  Pagination,
-  Spinner,
-  Stack,
-  Text,
-  Tooltip,
-  useStyles2,
-} from '@grafana/ui';
+import { Badge, LinkButton, LoadingPlaceholder, Pagination, Spinner, Stack, Text, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type CombinedRuleNamespace } from 'app/types/unified-alerting';
 
 import { DEFAULT_PER_PAGE_PAGINATION } from '../../../../../core/constants';
 import { AlertingAction, useAlertingAbility } from '../../hooks/useAbilities';
-import { useImportEntrypointState } from '../../hooks/useImportEntrypointState';
 import { usePagination } from '../../hooks/usePagination';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { getPaginationStyles } from '../../styles/pagination';
 import { getRulesDataSources, getRulesSourceUid } from '../../utils/datasource';
+import { ALERTING_PATHS } from '../../utils/navigation';
 import { isAsyncRequestStatePending } from '../../utils/redux';
 import { createRelativeUrl } from '../../utils/url';
 
@@ -61,8 +51,6 @@ export const CloudRules = ({ namespaces, expandAll }: Props) => {
     DEFAULT_PER_PAGE_PAGINATION
   );
 
-  const { disabled: importDisabled, reason: importDisabledReason } = useImportEntrypointState();
-
   const canMigrateToGMA =
     hasDataSourcesConfigured &&
     config.featureToggles.alertingMigrationUI &&
@@ -90,9 +78,7 @@ export const CloudRules = ({ namespaces, expandAll }: Props) => {
               <div />
             )}
             <Stack gap={1}>
-              {canMigrateToGMA && hasSomeResults && (
-                <MigrateToGMAButton disabled={importDisabled} disabledReason={importDisabledReason} />
-              )}
+              {canMigrateToGMA && hasSomeResults && <MigrateToGMAButton />}
               <CreateRecordingRuleButton />
             </Stack>
           </div>
@@ -184,16 +170,12 @@ function CreateRecordingRuleButton() {
   return null;
 }
 
-interface MigrateToGMAButtonProps {
-  disabled: boolean;
-  disabledReason?: string;
-}
+// Not gated on Alertmanager auto-sync: this imports rules only, which the sync worker never touches.
+function MigrateToGMAButton() {
+  const importUrl = createRelativeUrl(ALERTING_PATHS.IMPORT_DATASOURCE_MANAGED_RULES);
 
-function MigrateToGMAButton({ disabled, disabledReason }: MigrateToGMAButtonProps) {
-  const importUrl = createRelativeUrl('/alerting/import-datasource-managed-rules');
-
-  const button = (
-    <LinkButton variant="secondary" href={importUrl} icon="arrow-up" disabled={disabled}>
+  return (
+    <LinkButton variant="secondary" href={importUrl} icon="arrow-up">
       <Stack direction="row" gap={1} alignItems="center">
         <Trans i18nKey="alerting.rule-list.import-to-gma.text">Import to Grafana-managed rules</Trans>
         <Badge
@@ -205,16 +187,4 @@ function MigrateToGMAButton({ disabled, disabledReason }: MigrateToGMAButtonProp
       </Stack>
     </LinkButton>
   );
-
-  // LinkButton applies `pointer-events: none` when disabled, which suppresses tooltip hover.
-  // Wrap in a span so the Tooltip's hover handlers attach to an element that still receives events.
-  if (disabled && disabledReason) {
-    return (
-      <Tooltip content={disabledReason}>
-        <span>{button}</span>
-      </Tooltip>
-    );
-  }
-
-  return button;
 }

--- a/public/app/features/alerting/unified/hooks/useImportEntrypointState.test.ts
+++ b/public/app/features/alerting/unified/hooks/useImportEntrypointState.test.ts
@@ -26,7 +26,7 @@ describe('useImportEntrypointState', () => {
     testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
 
     it('returns disabled with a localized reason when the Config status reports an active sync', async () => {
-      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+      setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
 
       const { result } = renderUseImportEntrypointState();
 
@@ -38,7 +38,7 @@ describe('useImportEntrypointState', () => {
 
     it('blocks non-admins with read access too (the gap this fixes)', async () => {
       grantUserRole(OrgRole.Viewer);
-      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+      setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
 
       const { result } = renderUseImportEntrypointState();
 
@@ -47,7 +47,7 @@ describe('useImportEntrypointState', () => {
       });
     });
 
-    it('returns not disabled when the Config status reports no active sync', async () => {
+    it('returns not disabled when the Config spec reports no active sync', async () => {
       setupAutoSyncConfig(server, {});
 
       const { result } = renderUseImportEntrypointState();
@@ -59,9 +59,23 @@ describe('useImportEntrypointState', () => {
       expect(result.current.reason).toBeUndefined();
     });
 
+    it('ignores a stale status when spec has no sync configured, so imports stay enabled', async () => {
+      // status lags spec: it still reports the last synced UID after sync was disabled. The hook
+      // must read spec, not status, so imports stay enabled here.
+      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+
+      const { result } = renderUseImportEntrypointState();
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+      expect(result.current.disabled).toBe(false);
+      expect(result.current.reason).toBeUndefined();
+    });
+
     it('skips the Config query when the user lacks read access, so imports stay enabled', async () => {
       grantUserPermissions([]);
-      const { requestSpy } = setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+      const { requestSpy } = setupAutoSyncConfig(server, { specUid: 'mimir-uid', statusUid: 'mimir-uid' });
 
       const { result } = renderUseImportEntrypointState();
 
@@ -79,7 +93,7 @@ describe('useImportEntrypointState', () => {
     });
 
     it('reports isLoading while the Config query is in flight, then false', async () => {
-      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+      setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
 
       const { result } = renderUseImportEntrypointState();
 
@@ -93,7 +107,7 @@ describe('useImportEntrypointState', () => {
 
   describe('with alerting.syncExternalAlertmanager feature flag disabled', () => {
     it('returns not disabled regardless of Config state', () => {
-      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+      setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
 
       const { result } = renderUseImportEntrypointState();
 

--- a/public/app/features/alerting/unified/hooks/useImportEntrypointState.test.ts
+++ b/public/app/features/alerting/unified/hooks/useImportEntrypointState.test.ts
@@ -1,12 +1,12 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { getWrapper, testWithFeatureToggles } from 'test/test-utils';
 
 import { OrgRole } from '@grafana/data';
-import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../mockApi';
-import { grantUserRole } from '../mocks';
-import { setupAdminConfigGet } from '../mocks/server/configure/admin_config';
+import { grantUserPermissions, grantUserRole } from '../mocks';
+import { setupAutoSyncConfig } from '../mocks/server/handlers/k8s/config.k8s';
 
 import { useImportEntrypointState } from './useImportEntrypointState';
 
@@ -19,17 +19,14 @@ function renderUseImportEntrypointState() {
 
 describe('useImportEntrypointState', () => {
   beforeEach(() => {
-    grantUserRole(OrgRole.Admin);
+    grantUserPermissions([AccessControlAction.ActionAlertingNotificationsConfigRead]);
   });
 
   describe('with alerting.syncExternalAlertmanager feature flag enabled', () => {
     testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
 
-    it('returns disabled with a localized reason when admin_config has external_alertmanager_uid', async () => {
-      setupAdminConfigGet(server, {
-        alertmanagersChoice: AlertmanagerChoice.Internal,
-        external_alertmanager_uid: 'mimir-uid',
-      });
+    it('returns disabled with a localized reason when the Config status reports an active sync', async () => {
+      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
 
       const { result } = renderUseImportEntrypointState();
 
@@ -39,8 +36,19 @@ describe('useImportEntrypointState', () => {
       expect(result.current.reason).toMatch(/auto-sync/i);
     });
 
-    it('returns not disabled when admin_config has no external_alertmanager_uid', async () => {
-      setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    it('blocks non-admins with read access too (the gap this fixes)', async () => {
+      grantUserRole(OrgRole.Viewer);
+      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+
+      const { result } = renderUseImportEntrypointState();
+
+      await waitFor(() => {
+        expect(result.current.disabled).toBe(true);
+      });
+    });
+
+    it('returns not disabled when the Config status reports no active sync', async () => {
+      setupAutoSyncConfig(server, {});
 
       const { result } = renderUseImportEntrypointState();
 
@@ -51,8 +59,27 @@ describe('useImportEntrypointState', () => {
       expect(result.current.reason).toBeUndefined();
     });
 
-    it('reports isLoading while the admin_config query is in flight, then false', async () => {
-      setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    it('skips the Config query when the user lacks read access, so imports stay enabled', async () => {
+      grantUserPermissions([]);
+      const { requestSpy } = setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+
+      const { result } = renderUseImportEntrypointState();
+
+      // Flush mount effects and any dispatched query + its response. The permission gate must
+      // short-circuit the query (skipToken); if it were removed, the Config endpoint would be
+      // hit and report an active sync. Asserting the request never fired is what makes this
+      // test fail on a missing gate — `disabled` alone starts false, so it cannot.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(requestSpy).not.toHaveBeenCalled();
+      expect(result.current.disabled).toBe(false);
+      expect(result.current.reason).toBeUndefined();
+    });
+
+    it('reports isLoading while the Config query is in flight, then false', async () => {
+      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
 
       const { result } = renderUseImportEntrypointState();
 
@@ -65,11 +92,8 @@ describe('useImportEntrypointState', () => {
   });
 
   describe('with alerting.syncExternalAlertmanager feature flag disabled', () => {
-    it('returns not disabled regardless of admin_config state', () => {
-      setupAdminConfigGet(server, {
-        alertmanagersChoice: AlertmanagerChoice.Internal,
-        external_alertmanager_uid: 'mimir-uid',
-      });
+    it('returns not disabled regardless of Config state', () => {
+      setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
 
       const { result } = renderUseImportEntrypointState();
 

--- a/public/app/features/alerting/unified/hooks/useImportEntrypointState.ts
+++ b/public/app/features/alerting/unified/hooks/useImportEntrypointState.ts
@@ -8,6 +8,12 @@ export interface ImportEntrypointState {
   isLoading: boolean;
 }
 
+/**
+ * Gates the entry points that import Alertmanager resources (the import wizard and its promo
+ * banners): the convert endpoint rejects those with a 409 while external Alertmanager sync is
+ * configured. Rules-only import is unaffected — the sync worker never touches alert rules and the
+ * rule convert endpoints have no sync check — so those entry points must not use this hook.
+ */
 export function useImportEntrypointState(): ImportEntrypointState {
   const { isActive, isLoading } = useIsAutoSyncActive();
   if (isActive) {

--- a/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
+++ b/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
@@ -1,24 +1,38 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 
+import { useGetConfigQuery } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
 
-import { alertmanagerApi } from '../api/alertmanagerApi';
-import { isAdmin } from '../utils/misc';
+// The per-org alerting Config resource is a singleton at this fixed name (backend
+// ConfigSingletonName).
+const CONFIG_SINGLETON_NAME = 'default';
 
 interface AutoSyncState {
   isActive: boolean;
   isLoading: boolean;
 }
 
-// GET /api/v1/ngalert/admin_config is gated behind ReqOrgAdmin server-side
-// (pkg/services/ngalert/api/authorization.go), so non-admins cannot read sync
-// state and this hook returns isActive=false for them (the query is skipped, so
-// isLoading is also false). The convert API's IsExternalAMSyncConfiguredForOrg
-// check is the server-side safety net.
+// Reports whether external (Mimir/Cortex) Alertmanager sync is actively running for the org.
+//
+// Sourced from the per-org Config resource (notifications.alerting.grafana.app), whose read
+// action is granted to Viewer — so this works for non-admins too, unlike the legacy
+// admin-only /api/v1/ngalert/admin_config it replaces. The Config resource is also the
+// syncer's own source of truth, so this mirrors what the backend actually syncs.
+//
+// We read status (not spec): status.externalAlertmanagerSync.datasourceUid is the UID used on
+// the last sync attempt, so it reflects an actually-active sync regardless of how it was
+// configured — including the `ini` operator override, which never appears in spec. Trade-off:
+// in the brief window after sync is first enabled (before the first tick writes status) this
+// returns false; the backend convert API rejects imports there, so it's a UX gap, not a hole.
+//
+// Fail-open: while loading or on a 404/403 (resource absent or no read access) data is
+// undefined, so isActive is false. When the query is skipped (flag off or no read access)
+// isLoading is also false.
 export function useIsAutoSyncActive(): AutoSyncState {
   const flagOn = config.featureToggles['alerting.syncExternalAlertmanager'] === true;
-  const { data, isLoading } = alertmanagerApi.endpoints.getGrafanaAlertingConfiguration.useQuery(
-    isAdmin() && flagOn ? undefined : skipToken
-  );
-  return { isActive: Boolean(data?.external_alertmanager_uid), isLoading };
+  const canReadConfig = contextSrv.hasPermission(AccessControlAction.ActionAlertingNotificationsConfigRead);
+  const { data, isLoading } = useGetConfigQuery(flagOn && canReadConfig ? { name: CONFIG_SINGLETON_NAME } : skipToken);
+  return { isActive: Boolean(data?.status?.externalAlertmanagerSync?.datasourceUid), isLoading };
 }

--- a/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
+++ b/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
@@ -16,13 +16,21 @@ interface AutoSyncState {
 
 // Reports whether external (Mimir/Cortex) Alertmanager sync is actively running for the org.
 //
-// Sourced from the per-org Config resource (notifications.alerting.grafana.app)
-// Fail-open: while loading or on a 404/403 (resource absent or no read access) data is
-// undefined, so isActive is false. When the query is skipped (flag off or no read access)
-// isLoading is also false.
+// Sourced from spec.externalAlertmanagerSync on the per-org Config resource
+// (notifications.alerting.grafana.app). We read spec (the desired configuration), not status: status
+// holds the last sync attempt and lags — it stays populated after sync is disabled + restarted, so it
+// reports active when it isn't. Gated on the ActionAlertingNotificationsConfigRead permission so
+// non-admins who legitimately hold it are also blocked while sync is active. Fail-open: while loading
+// or on a 404/403 (resource absent or no read access) data is undefined, so isActive is false; when
+// the query is skipped (flag off or no read access) isLoading is also false.
+//
+// Known gap: spec does not reflect an ini-configured sync (unified_alerting.external_alertmanager_uid),
+// which surfaces only in status with origin='ini'. The backend convert endpoint's
+// IsExternalAMSyncConfiguredForOrg check is the real safety net; covering the ini case in the frontend
+// would require exposing the setting through frontend settings (a separate backend change).
 export function useIsAutoSyncActive(): AutoSyncState {
   const flagOn = config.featureToggles['alerting.syncExternalAlertmanager'] === true;
   const canReadConfig = contextSrv.hasPermission(AccessControlAction.ActionAlertingNotificationsConfigRead);
   const { data, isLoading } = useGetConfigQuery(flagOn && canReadConfig ? { name: CONFIG_SINGLETON_NAME } : skipToken);
-  return { isActive: Boolean(data?.status?.externalAlertmanagerSync?.datasourceUid), isLoading };
+  return { isActive: Boolean(data?.spec?.externalAlertmanagerSync?.datasourceUid), isLoading };
 }

--- a/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
+++ b/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
@@ -16,17 +16,7 @@ interface AutoSyncState {
 
 // Reports whether external (Mimir/Cortex) Alertmanager sync is actively running for the org.
 //
-// Sourced from the per-org Config resource (notifications.alerting.grafana.app), whose read
-// action is granted to Viewer — so this works for non-admins too, unlike the legacy
-// admin-only /api/v1/ngalert/admin_config it replaces. The Config resource is also the
-// syncer's own source of truth, so this mirrors what the backend actually syncs.
-//
-// We read status (not spec): status.externalAlertmanagerSync.datasourceUid is the UID used on
-// the last sync attempt, so it reflects an actually-active sync regardless of how it was
-// configured — including the `ini` operator override, which never appears in spec. Trade-off:
-// in the brief window after sync is first enabled (before the first tick writes status) this
-// returns false; the backend convert API rejects imports there, so it's a UX gap, not a hole.
-//
+// Sourced from the per-org Config resource (notifications.alerting.grafana.app)
 // Fail-open: while loading or on a 404/403 (resource absent or no read access) data is
 // undefined, so isActive is false. When the query is skipped (flag off or no read access)
 // isLoading is also false.

--- a/public/app/features/alerting/unified/mocks/server/all-handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/all-handlers.ts
@@ -10,6 +10,7 @@ import evalHandlers from 'app/features/alerting/unified/mocks/server/handlers/ev
 import folderHandlers from 'app/features/alerting/unified/mocks/server/handlers/folders';
 import grafanaRulerHandlers from 'app/features/alerting/unified/mocks/server/handlers/grafanaRuler';
 import historianHandlers from 'app/features/alerting/unified/mocks/server/handlers/historian';
+import configK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/config.k8s';
 import inhibitionRulesK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/inhibitionRules.k8s';
 import integrationTypeSchemasK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/integrationTypeSchemas.k8s';
 import receiverK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/receivers.k8s';
@@ -38,6 +39,7 @@ export const alertingHandlers = [
   ...provisioningHandlers,
 
   // Kubernetes-style handlers
+  ...configK8sHandlers,
   ...inhibitionRulesK8sHandlers,
   ...integrationTypeSchemasK8sHandlers,
   ...timeIntervalK8sHandlers,

--- a/public/app/features/alerting/unified/mocks/server/handlers/k8s/config.k8s.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/k8s/config.k8s.ts
@@ -1,0 +1,47 @@
+import { HttpResponse, http } from 'msw';
+import { type SetupServer } from 'msw/node';
+
+import { API_GROUP, API_VERSION, type Config } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
+import { ALERTING_API_SERVER_BASE_URL } from 'app/features/alerting/unified/mocks/server/utils';
+
+const CONFIG_URL = `${ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/configs/:name`;
+
+interface AutoSyncConfigOptions {
+  /**
+   * UID on status.externalAlertmanagerSync — what's actually synced, and the only field
+   * `useIsAutoSyncActive` reads. Set it to simulate an active sync; omit it for an inactive sync.
+   */
+  statusUid?: string;
+}
+
+function buildConfig(name: string, { statusUid }: AutoSyncConfigOptions = {}): Config {
+  return {
+    apiVersion: `${API_GROUP}/${API_VERSION}`,
+    kind: 'Config',
+    metadata: { name },
+    spec: {},
+    status: statusUid ? { externalAlertmanagerSync: { datasourceUid: statusUid, origin: 'api' } } : {},
+  };
+}
+
+const configHandler = (options: AutoSyncConfigOptions = {}, onRequest?: () => void) =>
+  http.get<{ namespace: string; name: string }>(CONFIG_URL, ({ params }) => {
+    onRequest?.();
+    return HttpResponse.json(buildConfig(params.name, options));
+  });
+
+/**
+ * Override the Config GET to drive external Alertmanager auto-sync state. Pass `statusUid` to
+ * simulate an active sync (what `useIsAutoSyncActive` reads); omit it for an inactive, empty Config.
+ *
+ * Returns a `requestSpy` that fires on every GET, so a test can assert the query was — or, when a
+ * permission gate should short-circuit it, was not — made.
+ */
+export function setupAutoSyncConfig(server: SetupServer, options: AutoSyncConfigOptions = {}) {
+  const requestSpy = jest.fn();
+  server.use(configHandler(options, requestSpy));
+  return { requestSpy };
+}
+
+const handlers = [configHandler()];
+export default handlers;

--- a/public/app/features/alerting/unified/mocks/server/handlers/k8s/config.k8s.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/k8s/config.k8s.ts
@@ -8,18 +8,24 @@ const CONFIG_URL = `${ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/config
 
 interface AutoSyncConfigOptions {
   /**
-   * UID on status.externalAlertmanagerSync — what's actually synced, and the only field
+   * UID on spec.externalAlertmanagerSync — the desired configuration, and the field
    * `useIsAutoSyncActive` reads. Set it to simulate an active sync; omit it for an inactive sync.
+   */
+  specUid?: string;
+  /**
+   * UID on status.externalAlertmanagerSync — the last sync attempt, which can lag spec.
+   * `useIsAutoSyncActive` does NOT read this; set it (with specUid omitted) to simulate a stale
+   * status that must not be treated as an active sync.
    */
   statusUid?: string;
 }
 
-function buildConfig(name: string, { statusUid }: AutoSyncConfigOptions = {}): Config {
+function buildConfig(name: string, { specUid, statusUid }: AutoSyncConfigOptions = {}): Config {
   return {
     apiVersion: `${API_GROUP}/${API_VERSION}`,
     kind: 'Config',
     metadata: { name },
-    spec: {},
+    spec: specUid ? { externalAlertmanagerSync: { datasourceUid: specUid } } : {},
     status: statusUid ? { externalAlertmanagerSync: { datasourceUid: statusUid, origin: 'api' } } : {},
   };
 }
@@ -31,8 +37,9 @@ const configHandler = (options: AutoSyncConfigOptions = {}, onRequest?: () => vo
   });
 
 /**
- * Override the Config GET to drive external Alertmanager auto-sync state. Pass `statusUid` to
+ * Override the Config GET to drive external Alertmanager auto-sync state. Pass `specUid` to
  * simulate an active sync (what `useIsAutoSyncActive` reads); omit it for an inactive, empty Config.
+ * Pass `statusUid` alone to simulate a stale status that must not count as active.
  *
  * Returns a `requestSpy` that fires on every GET, so a test can assert the query was — or, when a
  * permission gate should short-circuit it, was not — made.

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -342,8 +342,7 @@ describe('RuleListActions', () => {
       expect(ui.menuOptions.importToGma.query(menu)).toBeInTheDocument();
     });
 
-    it('does not show "Import to Grafana Alerting" without import permissions, even for an admin', async () => {
-      grantUserRole(OrgRole.Admin);
+    it('does not show "Import to Grafana Alerting" without import permissions', async () => {
       grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingNotificationsWrite]);
 
       const { user } = render(<RuleListActions />);

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -446,10 +446,10 @@ describe('RuleListActions', () => {
       enable: ['alerting.syncExternalAlertmanager', 'alertingMigrationUI', 'alertingMigrationWizardUI'],
     });
 
-    // Drive auto-sync state via the Config resource (what useIsAutoSyncActive reads). The
-    // status UID reflects an actually-active sync.
+    // Drive auto-sync state via the Config resource: useIsAutoSyncActive reads
+    // spec.externalAlertmanagerSync.datasourceUid, so specUid is the active-sync signal.
     function mockAutoSync(uid?: string) {
-      setupAutoSyncConfig(server, uid ? { statusUid: uid } : {});
+      setupAutoSyncConfig(server, uid ? { specUid: uid } : {});
     }
 
     async function findDisabledItem(menu: HTMLElement, role: 'importAlertRules' | 'importToGma') {

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -1,4 +1,4 @@
-import { HttpResponse, http } from 'msw';
+import { HttpResponse } from 'msw';
 import { render, testWithFeatureToggles, waitFor } from 'test/test-utils';
 import { byRole, byTestId } from 'testing-library-selector';
 
@@ -10,6 +10,7 @@ import { setupMswServer } from '../mockApi';
 import { grantUserPermissions, grantUserRole, mockDataSource } from '../mocks';
 import { setGrafanaRuleGroupExportResolver } from '../mocks/server/configure';
 import { alertingFactory } from '../mocks/server/db';
+import { setupAutoSyncConfig } from '../mocks/server/handlers/k8s/config.k8s';
 import { type RulesFilter } from '../search/rulesSearchParser';
 import { setupDataSources } from '../testSetup/datasources';
 
@@ -330,9 +331,9 @@ describe('RuleListActions', () => {
   describe('Import to Grafana Alerting Wizard', () => {
     testWithFeatureToggles({ enable: ['alertingMigrationWizardUI'] });
 
-    it('should show "Import to Grafana Alerting" option when user is admin with required permissions', async () => {
-      grantUserRole(OrgRole.Admin);
-      grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingNotificationsWrite]);
+    it('shows "Import to Grafana Alerting" for a non-admin with import permissions', async () => {
+      grantUserRole(OrgRole.Editor);
+      grantUserPermissions([AccessControlAction.AlertingRuleCreate, AccessControlAction.AlertingProvisioningSetStatus]);
 
       const { user } = render(<RuleListActions />);
       await user.click(ui.moreButton.get());
@@ -341,8 +342,8 @@ describe('RuleListActions', () => {
       expect(ui.menuOptions.importToGma.query(menu)).toBeInTheDocument();
     });
 
-    it('should not show "Import to Grafana Alerting" option when user is not admin', async () => {
-      grantUserRole(OrgRole.Viewer);
+    it('does not show "Import to Grafana Alerting" without import permissions, even for an admin', async () => {
+      grantUserRole(OrgRole.Admin);
       grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingNotificationsWrite]);
 
       const { user } = render(<RuleListActions />);
@@ -446,12 +447,10 @@ describe('RuleListActions', () => {
       enable: ['alerting.syncExternalAlertmanager', 'alertingMigrationUI', 'alertingMigrationWizardUI'],
     });
 
-    function mockAdminConfig(uid?: string) {
-      server.use(
-        http.get('/api/v1/ngalert/admin_config', () =>
-          HttpResponse.json({ alertmanagersChoice: 'internal', ...(uid ? { external_alertmanager_uid: uid } : {}) })
-        )
-      );
+    // Drive auto-sync state via the Config resource (what useIsAutoSyncActive reads). The
+    // status UID reflects an actually-active sync.
+    function mockAutoSync(uid?: string) {
+      setupAutoSyncConfig(server, uid ? { statusUid: uid } : {});
     }
 
     async function findDisabledItem(menu: HTMLElement, role: 'importAlertRules' | 'importToGma') {
@@ -468,8 +467,29 @@ describe('RuleListActions', () => {
         AccessControlAction.AlertingRuleRead,
         AccessControlAction.AlertingRuleCreate,
         AccessControlAction.AlertingProvisioningSetStatus,
+        AccessControlAction.ActionAlertingNotificationsConfigRead,
       ]);
-      mockAdminConfig('mimir-uid');
+      mockAutoSync('mimir-uid');
+
+      const { user } = render(<RuleListActions />);
+      await user.click(ui.moreButton.get());
+      const menu = await ui.moreMenu.find();
+
+      const item = await findDisabledItem(menu, 'importAlertRules');
+      expect(item).toHaveAttribute('aria-disabled', 'true');
+      expect(item).not.toHaveAttribute('href');
+      expect(item).toHaveTextContent(/auto-sync/i);
+    });
+
+    it('blocks "Import alert rules" for a non-admin with import permission when sync is active', async () => {
+      grantUserRole(OrgRole.Editor);
+      grantUserPermissions([
+        AccessControlAction.AlertingRuleRead,
+        AccessControlAction.AlertingRuleCreate,
+        AccessControlAction.AlertingProvisioningSetStatus,
+        AccessControlAction.ActionAlertingNotificationsConfigRead,
+      ]);
+      mockAutoSync('mimir-uid');
 
       const { user } = render(<RuleListActions />);
       await user.click(ui.moreButton.get());
@@ -482,9 +502,13 @@ describe('RuleListActions', () => {
     });
 
     it('disables "Import to Grafana Alerting" with a reason when sync is configured for the org', async () => {
-      grantUserRole(OrgRole.Admin);
-      grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingNotificationsWrite]);
-      mockAdminConfig('mimir-uid');
+      grantUserRole(OrgRole.Editor);
+      grantUserPermissions([
+        AccessControlAction.AlertingRuleCreate,
+        AccessControlAction.AlertingProvisioningSetStatus,
+        AccessControlAction.ActionAlertingNotificationsConfigRead,
+      ]);
+      mockAutoSync('mimir-uid');
 
       const { user } = render(<RuleListActions />);
       await user.click(ui.moreButton.get());
@@ -503,8 +527,9 @@ describe('RuleListActions', () => {
         AccessControlAction.AlertingRuleCreate,
         AccessControlAction.AlertingProvisioningSetStatus,
         AccessControlAction.AlertingNotificationsWrite,
+        AccessControlAction.ActionAlertingNotificationsConfigRead,
       ]);
-      mockAdminConfig();
+      mockAutoSync();
 
       const { user } = render(<RuleListActions />);
       await user.click(ui.moreButton.get());

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -441,7 +441,7 @@ describe('RuleListActions', () => {
     });
   });
 
-  describe('Auto-sync Mimir Alertmanager — disables import menu items', () => {
+  describe('Auto-sync Mimir Alertmanager — disables Alertmanager import menu items', () => {
     testWithFeatureToggles({
       enable: ['alerting.syncExternalAlertmanager', 'alertingMigrationUI', 'alertingMigrationWizardUI'],
     });
@@ -452,53 +452,35 @@ describe('RuleListActions', () => {
       setupAutoSyncConfig(server, uid ? { specUid: uid } : {});
     }
 
-    async function findDisabledItem(menu: HTMLElement, role: 'importAlertRules' | 'importToGma') {
+    async function findDisabledWizardItem(menu: HTMLElement) {
       // The menu item renders the disabled reason in its `description` slot, so the accessible
       // name expands beyond the original label — match via a name regex that ignores the suffix.
-      return await byRole('menuitem', {
-        name: role === 'importAlertRules' ? /import alert rules/i : /import to grafana alerting/i,
-      }).find(menu);
+      return await byRole('menuitem', { name: /import to grafana alerting/i }).find(menu);
     }
 
-    it('disables "Import alert rules" with a reason when sync is configured for the org', async () => {
-      grantUserRole(OrgRole.Admin);
-      grantUserPermissions([
-        AccessControlAction.AlertingRuleRead,
-        AccessControlAction.AlertingRuleCreate,
-        AccessControlAction.AlertingProvisioningSetStatus,
-        AccessControlAction.ActionAlertingNotificationsConfigRead,
-      ]);
-      mockAutoSync('mimir-uid');
+    // Auto-sync only mirrors the Alertmanager configuration, and the rule convert endpoints have no
+    // sync check, so the rules-only import stays available to admins and non-admins alike.
+    it.each([OrgRole.Admin, OrgRole.Editor])(
+      'keeps "Import alert rules" enabled for %s when sync is configured for the org',
+      async (role) => {
+        grantUserRole(role);
+        grantUserPermissions([
+          AccessControlAction.AlertingRuleRead,
+          AccessControlAction.AlertingRuleCreate,
+          AccessControlAction.AlertingProvisioningSetStatus,
+          AccessControlAction.ActionAlertingNotificationsConfigRead,
+        ]);
+        mockAutoSync('mimir-uid');
 
-      const { user } = render(<RuleListActions />);
-      await user.click(ui.moreButton.get());
-      const menu = await ui.moreMenu.find();
+        const { user } = render(<RuleListActions />);
+        await user.click(ui.moreButton.get());
+        const menu = await ui.moreMenu.find();
 
-      const item = await findDisabledItem(menu, 'importAlertRules');
-      expect(item).toHaveAttribute('aria-disabled', 'true');
-      expect(item).not.toHaveAttribute('href');
-      expect(item).toHaveTextContent(/auto-sync/i);
-    });
-
-    it('blocks "Import alert rules" for a non-admin with import permission when sync is active', async () => {
-      grantUserRole(OrgRole.Editor);
-      grantUserPermissions([
-        AccessControlAction.AlertingRuleRead,
-        AccessControlAction.AlertingRuleCreate,
-        AccessControlAction.AlertingProvisioningSetStatus,
-        AccessControlAction.ActionAlertingNotificationsConfigRead,
-      ]);
-      mockAutoSync('mimir-uid');
-
-      const { user } = render(<RuleListActions />);
-      await user.click(ui.moreButton.get());
-      const menu = await ui.moreMenu.find();
-
-      const item = await findDisabledItem(menu, 'importAlertRules');
-      expect(item).toHaveAttribute('aria-disabled', 'true');
-      expect(item).not.toHaveAttribute('href');
-      expect(item).toHaveTextContent(/auto-sync/i);
-    });
+        const item = ui.menuOptions.importAlertRules.get(menu);
+        expect(item).toHaveAttribute('href', '/alerting/import-datasource-managed-rules');
+        expect(item).not.toHaveAttribute('aria-disabled', 'true');
+      }
+    );
 
     it('disables "Import to Grafana Alerting" with a reason when sync is configured for the org', async () => {
       grantUserRole(OrgRole.Editor);
@@ -513,7 +495,7 @@ describe('RuleListActions', () => {
       await user.click(ui.moreButton.get());
       const menu = await ui.moreMenu.find();
 
-      const item = await findDisabledItem(menu, 'importToGma');
+      const item = await findDisabledWizardItem(menu);
       expect(item).toHaveAttribute('aria-disabled', 'true');
       expect(item).not.toHaveAttribute('href');
       expect(item).toHaveTextContent(/auto-sync/i);

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -18,7 +18,6 @@ import { useRulesFilter } from '../hooks/useFilteredRules';
 import { useImportEntrypointState } from '../hooks/useImportEntrypointState';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
 import { getRulesDataSources } from '../utils/datasource';
-import { isAdmin } from '../utils/misc';
 
 import { AlertsActivityBanner } from './AlertsActivityBanner';
 import { FilterView } from './FilterView';
@@ -69,13 +68,16 @@ export function RuleListActions() {
   const canExportRules = exportRulesSupported && exportRulesAllowed;
 
   const canCreateRules = canCreateGrafanaRules || canCreateCloudRules;
-  // Align import UI permission with convert endpoint requirements: rule create + provisioning set status
-  const canImportRulesToGMA =
-    config.featureToggles.alertingMigrationUI &&
+  // Align import UI permission with convert endpoint requirements: rule create + provisioning set status.
+  // Gates both import entry points (and their routes in ../../routes) so non-admins with these
+  // permissions get the same experience as admins.
+  const hasImportToGMAPermissions =
     contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate) &&
     contextSrv.hasPermission(AccessControlAction.AlertingProvisioningSetStatus);
 
-  const canAccessMigrationWizardUI = config.featureToggles.alertingMigrationWizardUI && isAdmin();
+  const canImportRulesToGMA = config.featureToggles.alertingMigrationUI && hasImportToGMAPermissions;
+
+  const canAccessMigrationWizardUI = config.featureToggles.alertingMigrationWizardUI && hasImportToGMAPermissions;
 
   const { disabled: importDisabled, reason: importDisabledReason } = useImportEntrypointState();
 

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -68,9 +68,6 @@ export function RuleListActions() {
   const canExportRules = exportRulesSupported && exportRulesAllowed;
 
   const canCreateRules = canCreateGrafanaRules || canCreateCloudRules;
-  // Align import UI permission with convert endpoint requirements: rule create + provisioning set status.
-  // Gates both import entry points (and their routes in ../../routes) so non-admins with these
-  // permissions get the same experience as admins.
   const hasImportToGMAPermissions =
     contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate) &&
     contextSrv.hasPermission(AccessControlAction.AlertingProvisioningSetStatus);

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -18,6 +18,7 @@ import { useRulesFilter } from '../hooks/useFilteredRules';
 import { useImportEntrypointState } from '../hooks/useImportEntrypointState';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
 import { getRulesDataSources } from '../utils/datasource';
+import { ALERTING_PATHS } from '../utils/navigation';
 
 import { AlertsActivityBanner } from './AlertsActivityBanner';
 import { FilterView } from './FilterView';
@@ -96,20 +97,19 @@ export function RuleListActions() {
               onClick={toggleShowExportDrawer}
             />
           )}
+          {/* Not gated on auto-sync: this imports rules only, which the sync worker never touches. */}
           {canImportRulesToGMA && (
             <Menu.Item
               label={t('alerting.rule-list-v2.import-to-gma', 'Import alert rules')}
               icon="upload"
-              url="/alerting/import-datasource-managed-rules"
-              disabled={importDisabled}
-              description={importDisabled ? importDisabledReason : undefined}
+              url={ALERTING_PATHS.IMPORT_DATASOURCE_MANAGED_RULES}
             />
           )}
           {canAccessMigrationWizardUI && (
             <Menu.Item
               label={t('alerting.rule-list-v2.import-to-gma-tool', 'Import to Grafana Alerting')}
               icon="exchange-alt"
-              url="/alerting/import-to-gma"
+              url={ALERTING_PATHS.IMPORT_TO_GMA}
               disabled={importDisabled}
               description={importDisabled ? importDisabledReason : undefined}
             />

--- a/public/app/features/alerting/unified/utils/access-control.ts
+++ b/public/app/features/alerting/unified/utils/access-control.ts
@@ -14,6 +14,7 @@
  *    in `useMemo` or call them via the `useRulesAccess()` hook in `accessControlHooks.ts`.
  */
 
+import { userHasAllPermissions } from '@grafana/data';
 import { getConfig } from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -151,6 +152,16 @@ export function evaluateAccess(actions: AccessControlAction[]) {
   return () => {
     return contextSrv.evaluatePermission(actions);
   };
+}
+
+/**
+ * Like `evaluateAccess`, but requires the user to hold ALL of the given actions (AND
+ * semantics) rather than any one of them. Use when access depends on a combination of
+ * permissions — e.g. the import-to-GMA route, which needs both the convert endpoint's
+ * rule-create and provisioning-set-status permissions.
+ */
+export function evaluateAccessAll(actions: AccessControlAction[]) {
+  return () => (userHasAllPermissions(actions, contextSrv.user) ? [] : ['Reject']);
 }
 
 /**

--- a/public/app/features/alerting/unified/utils/navigation.ts
+++ b/public/app/features/alerting/unified/utils/navigation.ts
@@ -40,6 +40,7 @@ export const ALERTING_PATHS: Record<string, RelativeUrl> = {
   ROUTES: '/alerting/routes',
   ALERTS_ACTIVITY: '/alerting/alerts',
   IMPORT_TO_GMA: '/alerting/import-to-gma',
+  IMPORT_DATASOURCE_MANAGED_RULES: '/alerting/import-datasource-managed-rules',
 };
 
 /**

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -158,7 +158,7 @@ export enum AccessControlAction {
   AlertingRoutesRead = 'alert.notifications.routes:read',
   AlertingRoutesWrite = 'alert.notifications.routes:write',
 
-  // Alerting notifications config actions (new, scoped per-resource). Read is granted to Viewer.
+  // Alerting notifications config actions (new, scoped per-resource)
   ActionAlertingNotificationsConfigRead = 'notifications.alerting.grafana.app/configs:get',
 
   // Alerting managed routes actions (new, scoped per-resource)

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -158,6 +158,9 @@ export enum AccessControlAction {
   AlertingRoutesRead = 'alert.notifications.routes:read',
   AlertingRoutesWrite = 'alert.notifications.routes:write',
 
+  // Alerting notifications config actions (new, scoped per-resource). Read is granted to Viewer.
+  ActionAlertingNotificationsConfigRead = 'notifications.alerting.grafana.app/configs:get',
+
   // Alerting managed routes actions (new, scoped per-resource)
   ActionAlertingManagedRoutesRead = 'notifications.alerting.grafana.app/routingtrees:get',
   ActionAlertingManagedRoutesWrite = 'notifications.alerting.grafana.app/routingtrees:update',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1614,8 +1614,10 @@
       "additional-settings": "Additional settings",
       "alert-rules": "Alert rules",
       "autosync-active-block": {
-        "description": "Grafana is continuously syncing alert configuration from a data source, so the configuration is a read-only mirror and cannot be imported into. To import, disable auto-sync in Alerting settings first.",
+        "description": "Grafana is continuously syncing alert configuration from a data source, so notification resources are a read-only mirror and cannot be imported into. You can still import alert rules.",
+        "disable-sync": "To import notification resources, disable auto-sync in Alerting settings first.",
         "go-to-settings": "Go to Alerting settings",
+        "import-rules": "Import alert rules",
         "title": "Auto-sync is enabled"
       },
       "autosync-review": {


### PR DESCRIPTION
**What is this feature?**

The "Import to Grafana Alerting" entry points and the `/alerting/import-to-gma` are now available to users who holds the two permissions the convert endpoint requires (`alert.rules:create` and `alert.provisioning.provenance:write`) when the alertmanager config sync is NOT active. Previously the menu items and route were gated on the Org Admin role, now it delivers the same UX for both admin and non admin users with the right set of permissions.

**Why do we need this feature?**

Non-admin users who already have permission to create rules and set provisioning status could not reach the import flow, because the route and menu were restricted to Admins. This aligns the frontend gate with what the backend convert endpoint actually enforces. 

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1771

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
