### PR TITLE
Plugins: Delegate Grafana Assistant overview to onboarding stub plugin

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2146,7 +2146,7 @@ disable_plugins =
 forward_host_env_vars =
 # Comma separated list of plugin ids to install as part of the startup process.
 # These will be installed, by default, asynchronously (in the background) while starting Grafana.
-preinstall = grafana-assistant-onboarding-app
+preinstall =
 # Comma separated list of plugin ids to install before the startup process
 # These will be installed before starting Grafana. Useful when used with provisioning.
 preinstall_sync =

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2146,7 +2146,7 @@ disable_plugins =
 forward_host_env_vars =
 # Comma separated list of plugin ids to install as part of the startup process.
 # These will be installed, by default, asynchronously (in the background) while starting Grafana.
-preinstall =
+preinstall = grafana-assistant-onboarding-app
 # Comma separated list of plugin ids to install before the startup process
 # These will be installed before starting Grafana. Useful when used with provisioning.
 preinstall_sync =

--- a/public/app/features/plugins/admin/components/AssistantOverview/AssistantOverview.tsx
+++ b/public/app/features/plugins/admin/components/AssistantOverview/AssistantOverview.tsx
@@ -12,6 +12,12 @@ import { ASSISTANT_ONBOARDING_OVERVIEW_COMPONENT_ID, type AssistantOverviewProps
 
 const RELOAD_DELAY_MS = 1500;
 
+interface AssistantJsonData {
+  trialMode?: boolean;
+  backendUrl?: string;
+  isAccessTokenSet?: boolean;
+}
+
 interface Props {
   plugin: CatalogPlugin;
   pluginConfig?: GrafanaPlugin | null;
@@ -24,6 +30,7 @@ export function AssistantOverview({ plugin, pluginConfig, pluginConfigLoading, f
   const { isInstalling } = useInstallStatus();
   const { component: AssistantOnboardingOverview, isLoading: isLoadingOverview } =
     usePluginComponent<AssistantOverviewProps>(ASSISTANT_ONBOARDING_OVERVIEW_COMPONENT_ID);
+  const jsonData = pluginConfig?.meta.jsonData as AssistantJsonData | undefined;
 
   if (!AssistantOnboardingOverview) {
     return isLoadingOverview ? null : <>{fallback}</>;
@@ -32,7 +39,7 @@ export function AssistantOverview({ plugin, pluginConfig, pluginConfigLoading, f
   return (
     <AssistantOnboardingOverview
       isInstalled={plugin.isInstalled}
-      isConnected={Boolean(pluginConfig?.meta.enabled)}
+      isConnected={Boolean(jsonData?.trialMode || (jsonData?.backendUrl && jsonData.isAccessTokenSet))}
       isLoading={Boolean(pluginConfigLoading)}
       isInstalling={isInstalling}
       canInstall={contextSrv.hasPermission(AccessControlAction.PluginsInstall)}

--- a/public/app/features/plugins/admin/components/AssistantOverview/AssistantOverview.tsx
+++ b/public/app/features/plugins/admin/components/AssistantOverview/AssistantOverview.tsx
@@ -18,6 +18,16 @@ interface AssistantJsonData {
   isAccessTokenSet?: boolean;
 }
 
+function isAssistantJsonData(value: unknown): value is AssistantJsonData {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (!('trialMode' in value) || typeof value.trialMode === 'boolean') &&
+    (!('backendUrl' in value) || typeof value.backendUrl === 'string') &&
+    (!('isAccessTokenSet' in value) || typeof value.isAccessTokenSet === 'boolean')
+  );
+}
+
 interface Props {
   plugin: CatalogPlugin;
   pluginConfig?: GrafanaPlugin | null;
@@ -30,7 +40,7 @@ export function AssistantOverview({ plugin, pluginConfig, pluginConfigLoading, f
   const { isInstalling } = useInstallStatus();
   const { component: AssistantOnboardingOverview, isLoading: isLoadingOverview } =
     usePluginComponent<AssistantOverviewProps>(ASSISTANT_ONBOARDING_OVERVIEW_COMPONENT_ID);
-  const jsonData = pluginConfig?.meta.jsonData as AssistantJsonData | undefined;
+  const jsonData = isAssistantJsonData(pluginConfig?.meta.jsonData) ? pluginConfig?.meta.jsonData : undefined;
 
   if (!AssistantOnboardingOverview) {
     return isLoadingOverview ? null : <>{fallback}</>;

--- a/public/app/features/plugins/admin/components/AssistantOverview/AssistantOverview.tsx
+++ b/public/app/features/plugins/admin/components/AssistantOverview/AssistantOverview.tsx
@@ -1,0 +1,47 @@
+import { type ReactNode } from 'react';
+
+import { type GrafanaPlugin } from '@grafana/data';
+import { usePluginComponent } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { useInstall, useInstallStatus } from '../../state/hooks';
+import { type CatalogPlugin } from '../../types';
+
+import { ASSISTANT_ONBOARDING_OVERVIEW_COMPONENT_ID, type AssistantOverviewProps } from './constants';
+
+const RELOAD_DELAY_MS = 1500;
+
+interface Props {
+  plugin: CatalogPlugin;
+  pluginConfig?: GrafanaPlugin | null;
+  pluginConfigLoading?: boolean;
+  fallback: ReactNode;
+}
+
+export function AssistantOverview({ plugin, pluginConfig, pluginConfigLoading, fallback }: Props) {
+  const installPlugin = useInstall();
+  const { isInstalling } = useInstallStatus();
+  const { component: AssistantOnboardingOverview, isLoading: isLoadingOverview } =
+    usePluginComponent<AssistantOverviewProps>(ASSISTANT_ONBOARDING_OVERVIEW_COMPONENT_ID);
+
+  if (!AssistantOnboardingOverview) {
+    return isLoadingOverview ? null : <>{fallback}</>;
+  }
+
+  return (
+    <AssistantOnboardingOverview
+      isInstalled={plugin.isInstalled}
+      isConnected={Boolean(pluginConfig?.meta.enabled)}
+      isLoading={Boolean(pluginConfigLoading)}
+      isInstalling={isInstalling}
+      canInstall={contextSrv.hasPermission(AccessControlAction.PluginsInstall)}
+      onInstall={async () => {
+        const result = await installPlugin(plugin.id);
+        if (!('error' in result)) {
+          window.setTimeout(() => window.location.reload(), RELOAD_DELAY_MS);
+        }
+      }}
+    />
+  );
+}

--- a/public/app/features/plugins/admin/components/AssistantOverview/constants.ts
+++ b/public/app/features/plugins/admin/components/AssistantOverview/constants.ts
@@ -1,5 +1,5 @@
 export const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
-export const ASSISTANT_ONBOARDING_PLUGIN_ID = 'grafana-assistant-onboarding-app';
+const ASSISTANT_ONBOARDING_PLUGIN_ID = 'grafana-assistant-onboarding-app';
 export const ASSISTANT_ONBOARDING_OVERVIEW_COMPONENT_ID = `${ASSISTANT_ONBOARDING_PLUGIN_ID}/plugin-overview/v1`;
 
 export interface AssistantOverviewProps {

--- a/public/app/features/plugins/admin/components/AssistantOverview/constants.ts
+++ b/public/app/features/plugins/admin/components/AssistantOverview/constants.ts
@@ -1,0 +1,12 @@
+export const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
+export const ASSISTANT_ONBOARDING_PLUGIN_ID = 'grafana-assistant-onboarding-app';
+export const ASSISTANT_ONBOARDING_OVERVIEW_COMPONENT_ID = `${ASSISTANT_ONBOARDING_PLUGIN_ID}/plugin-overview/v1`;
+
+export interface AssistantOverviewProps {
+  isInstalled: boolean;
+  isConnected: boolean;
+  isLoading: boolean;
+  isInstalling: boolean;
+  canInstall: boolean;
+  onInstall: () => void;
+}

--- a/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
@@ -7,6 +7,8 @@ import { config } from '@grafana/runtime';
 import { type PageInfoItem } from '@grafana/runtime/internal';
 import { type CellProps, type Column, InteractiveTable, Stack, useStyles2, Carousel } from '@grafana/ui';
 
+import { AssistantOverview } from '../components/AssistantOverview/AssistantOverview';
+import { ASSISTANT_PLUGIN_ID } from '../components/AssistantOverview/constants';
 import { Changelog } from '../components/Changelog';
 import { PluginDetailsPanel } from '../components/PluginDetailsPanel';
 import { VersionList } from '../components/VersionList';
@@ -29,7 +31,7 @@ type Cell<T extends keyof Permission = keyof Permission> = CellProps<Permission,
 
 export function PluginDetailsBody({ plugin, queryParams, pageId, info, showDetails }: Props): JSX.Element {
   const styles = useStyles2(getStyles);
-  const { value: pluginConfig } = usePluginConfig(plugin);
+  const { value: pluginConfig, loading: pluginConfigLoading } = usePluginConfig(plugin);
   const columns: Array<Column<Permission>> = useMemo(
     () => [
       {
@@ -51,7 +53,7 @@ export function PluginDetailsBody({ plugin, queryParams, pageId, info, showDetai
   };
 
   if (pageId === PluginTabIds.OVERVIEW) {
-    return (
+    const readme = (
       <div
         className={styles.readme}
         dangerouslySetInnerHTML={{
@@ -59,6 +61,19 @@ export function PluginDetailsBody({ plugin, queryParams, pageId, info, showDetai
         }}
       />
     );
+
+    if (plugin.id === ASSISTANT_PLUGIN_ID) {
+      return (
+        <AssistantOverview
+          plugin={plugin}
+          pluginConfig={pluginConfig}
+          pluginConfigLoading={pluginConfigLoading}
+          fallback={readme}
+        />
+      );
+    }
+
+    return readme;
   }
 
   if (pageId === PluginTabIds.VERSIONS) {

--- a/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.test.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.test.tsx
@@ -121,4 +121,17 @@ describe('usePluginDetailsTabs', () => {
     expect(configTab).toBeDefined();
     expect(configTab?.text).toBe('Configuration');
   });
+
+  it('should default to overview tab for grafana-assistant-app', () => {
+    mockUsePluginConfig.mockReturnValue({
+      loading: false,
+      error: undefined,
+      value: mockPluginConfig,
+    });
+
+    const assistantPlugin = { ...mockPlugin, id: 'grafana-assistant-app' };
+    const { result } = renderHook(() => usePluginDetailsTabs(assistantPlugin, undefined, false));
+
+    expect(result.current.activePageId).toBe('overview');
+  });
 });

--- a/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
@@ -7,6 +7,7 @@ import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { ASSISTANT_PLUGIN_ID } from '../components/AssistantOverview/constants';
 import { usePluginConfig } from '../hooks/usePluginConfig';
 import { type CatalogPlugin, PluginTabIds, PluginTabLabels } from '../types';
 
@@ -177,6 +178,10 @@ export const usePluginDetailsTabs = (
 
 function useDefaultPage(plugin: CatalogPlugin | undefined, pluginConfig: GrafanaPlugin | undefined | null) {
   if (!plugin || !pluginConfig) {
+    return PluginTabIds.OVERVIEW;
+  }
+
+  if (plugin.id === ASSISTANT_PLUGIN_ID) {
     return PluginTabIds.OVERVIEW;
   }
 


### PR DESCRIPTION
## What

Replaces the approach from #125568: instead of maintaining the Assistant onboarding UI in core, the plugin catalog Overview tab for `grafana-assistant-app` now delegates rendering to a component exposed by a new stub plugin, `grafana-assistant-onboarding-app` (lives in the grafana-assistant-app repo: grafana/grafana-assistant-app#7715).

- `AssistantOverview` wrapper computes install/connect state (catalog state, `usePluginConfig`, install permission) and passes it as props to the exposed component via `usePluginComponent`.
- Falls back to the plain README when the stub plugin is unavailable, so behavior is unchanged for instances without it.
- Defaults the Assistant plugin details page to the Overview tab.

## Why

The onboarding content iterates quickly (copy, steps, prompts, i18n). Keeping it in the Assistant repo avoids churn in core; core keeps only the thin state-computing wrapper and the props contract.

## Test plan

- [x] `usePluginDetailsTabs` test for defaulting to Overview for the Assistant plugin
- [x] Manually verified with a local build of the stub plugin: not-installed, not-connected, connected states
- [x] Manually verified README fallback when the stub is not loaded