### PR TITLE
Grafana UI: Restore getTagColor and getTagColorIndexFromName exports

### DIFF
--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -445,7 +445,7 @@ export {
 export { EventsWithValidation, validate, hasValidationEvent, regexValidation } from './utils/validate';
 export { SCHEMA, makeFragment, makeValue } from './utils/slate';
 export { linkModelToContextMenuItems } from './utils/dataLinks';
-export { getTagColorsFromName } from './utils/tags';
+export { getTagColorIndexFromName, getTagColorsFromName, getTagColor } from './utils/tags';
 export { getScrollbarWidth } from './utils/scrollbar';
 export { getCellLinks } from './utils/table';
 export { getCanvasContext, measureText, calculateFontSize } from './utils/measureText';

--- a/packages/grafana-ui/src/utils/tags.ts
+++ b/packages/grafana-ui/src/utils/tags.ts
@@ -1,7 +1,7 @@
 import { type GrafanaTheme2 } from '@grafana/data';
 import { DEFAULT_TAG_COLORS } from '@grafana/data/unstable';
 
-function getTagColorIndexFromName(name = '', theme?: GrafanaTheme2): number {
+export function getTagColorIndexFromName(name = '', theme?: GrafanaTheme2): number {
   const colors = theme?.components.tag.colors ?? DEFAULT_TAG_COLORS;
   const hash = djb2(name.toLowerCase());
   return Math.abs(hash % colors.length);


### PR DESCRIPTION
**What is this feature?**

Restores the `getTagColor` and `getTagColorIndexFromName` exports from `@grafana/ui`, which #127236 dropped from the package entry. External/private plugins importing them now crash at runtime (reported for the service center plugin). 
