### PR TITLE
Alerting: Use a non-cancelled context when sending resolved notifications for a deleted rule

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -386,7 +386,9 @@ func (a *alertRule) Run() error {
 				// Clean up the state and send resolved notifications for firing alerts only if the reason for stopping
 				// the evaluation loop is that the rule was deleted.
 				stateTransitions := a.stateManager.DeleteStateByRuleUID(ngmodels.WithRuleKey(ctx, a.key.AlertRuleKey), a.key, ngmodels.StateReasonRuleDeleted)
-				a.expireAndSend(grafanaCtx, stateTransitions)
+				// Use the cleanup context: grafanaCtx is already done here, and sending
+				// resolved notifications with a cancelled context drops them silently.
+				a.expireAndSend(ctx, stateTransitions)
 				return nil
 			}
 			// Otherwise, just clean up the cache.

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -797,6 +797,35 @@ func TestRuleRoutine(t *testing.T) {
 			require.Empty(t, sch.stateManager.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID))
 			sender.AssertExpectations(t)
 		})
+
+		t.Run("and use a non-cancelled context when sending resolved notifications for a deleted rule", func(t *testing.T) {
+			stoppedChan := make(chan error)
+			sender := NewSyncAlertsSenderMock()
+			var sendCalled bool
+			var sendCtxErr error
+			sender.EXPECT().Send(mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, _ models.AlertRuleKey, _ definitions.PostableAlerts) {
+				sendCalled = true
+				sendCtxErr = ctx.Err()
+			}).Times(1)
+			sch, _, _, _ := createSchedule(make(chan time.Time), sender, clock.NewMock())
+
+			_ = sch.stateManager.ProcessEvalResults(context.Background(), sch.clock.Now(), rule, genEvalResults(sch.clock.Now()), nil, nil)
+			require.NotEmpty(t, sch.stateManager.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID))
+
+			factory := ruleFactoryFromScheduler(sch)
+			ruleInfo := factory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
+			go func() {
+				stoppedChan <- ruleInfo.Run()
+			}()
+
+			ruleInfo.Stop(errRuleDeleted)
+			err := waitForErrChannel(t, stoppedChan)
+			require.NoError(t, err)
+
+			require.True(t, sendCalled)
+			require.NoError(t, sendCtxErr, "resolved notifications for a deleted rule must be sent with a non-cancelled context, otherwise they are dropped")
+			sender.AssertExpectations(t)
+		})
 	})
 
 	t.Run("when a message is sent to update channel", func(t *testing.T) {


### PR DESCRIPTION
**What is this change?**

Uses the fresh cleanup context instead of the already-cancelled routine context when sending resolved notifications for a deleted alert rule.

When an alert rule's evaluation loop stops because the rule was deleted, a fresh `context.WithTimeout(context.Background(), time.Minute)` is created for cleanup and correctly used for `DeleteStateByRuleUID`. The next line, however, called `a.expireAndSend(grafanaCtx, stateTransitions)` with the outer `grafanaCtx` — which is already `Done()` at that point, since we are inside `case <-grafanaCtx.Done()`. `expireAndSend` hands that context to the alerts sender, so the notification request runs with an already-cancelled context and the resolved notifications for firing alerts are silently dropped.

**Why do we need this change?**

Deleting a firing alert rule should send resolved notifications (that is the explicit purpose of this branch of the code), but with a cancelled context they never reach the Alertmanager. Fixes #123583.

**Who is this feature for?**

Anyone using Grafana-managed alerts who expects firing alerts to resolve when the rule is deleted.

**Testing**

Added a regression test asserting the context handed to the alerts sender is not already cancelled at send time. The test fails without the one-line fix (the sender previously received the cancelled `grafanaCtx`) and passes with it. Ran `go test ./pkg/services/ngalert/schedule/` — all tests pass.

**Which issue(s) does this PR fix?**

Fixes #123583
