### PR TITLE
Search: derive a kind's column fields from its provider

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -36,10 +36,6 @@ type DocumentBuilderInfo struct {
 	// The target resource (empty will be used to match anything)
 	GroupResource schema.GroupResource
 
-	// Defines the searchable fields
-	// NOTE: this does not include the root/common fields, only values specific to the the builder
-	Fields SearchableDocumentFields
-
 	// simple/static builders that do not depend on the environment can be declared once
 	Builder DocumentBuilder
 
@@ -58,10 +54,25 @@ type DocumentBuilderInfo struct {
 	// SearchFieldsProvider is the manifest-driven source of truth for this
 	// builder's search fields. When non-nil, the bleve mapping for
 	// GroupResource is built from the provider's SearchFieldDefinition
-	// declarations rather than from the legacy Fields (column-definition)
-	// translation. Fields may still be populated alongside the provider for
-	// downstream consumers that read column metadata directly.
+	// declarations. The provider is also the source for the column-definition
+	// view of the kind's fields that the search backend uses for result
+	// metadata and sort-field prefixing (see SearchableFields).
 	SearchFieldsProvider SearchFieldsProvider
+}
+
+// SearchableFields returns the column-definition view of this kind's custom
+// search fields, derived from its provider. The provider is the single source
+// of truth; the search backend uses this view for result column metadata and
+// sort-field prefixing. Returns nil when the builder has no provider.
+func (b DocumentBuilderInfo) SearchableFields() (SearchableDocumentFields, error) {
+	if b.SearchFieldsProvider == nil {
+		return nil, nil
+	}
+	sfds := b.SearchFieldsProvider.Fields(schema.GroupVersionResource{
+		Group:    b.GroupResource.Group,
+		Resource: b.GroupResource.Resource,
+	})
+	return NewSearchableDocumentFields(SearchFieldDefinitionsToTableColumns(sfds))
 }
 
 // SearchFieldsHashesForBuilders returns a lower-cased "group/resource" map

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -1964,8 +1964,11 @@ func newBuilderCache(cfg []DocumentBuilderInfo, nsCacheSize int, ttl time.Durati
 		}
 		g[b.GroupResource.Resource] = b
 
-		// Any custom fields
-		cache.fields[b.GroupResource] = b.Fields
+		f, err := b.SearchableFields()
+		if err != nil {
+			return cache, err
+		}
+		cache.fields[b.GroupResource] = f
 	}
 	return cache, nil
 }

--- a/pkg/storage/unified/search/bleve_lifecycle_test.go
+++ b/pkg/storage/unified/search/bleve_lifecycle_test.go
@@ -279,7 +279,9 @@ func newFileBackedDashboardIndex(t *testing.T, key resource.NamespacedResource, 
 	})
 	require.NoError(t, err)
 
-	resourceIndex, err := backend.BuildIndex(ctx, key, docCount, info.Fields, "test", func(index resource.ResourceIndex) (int64, error) {
+	fields, err := info.SearchableFields()
+	require.NoError(t, err)
+	resourceIndex, err := backend.BuildIndex(ctx, key, docCount, fields, "test", func(index resource.ResourceIndex) (int64, error) {
 		return 0, nil
 	}, nil, false, time.Time{}, 0)
 	require.NoError(t, err)

--- a/pkg/storage/unified/search/bleve_performance_test.go
+++ b/pkg/storage/unified/search/bleve_performance_test.go
@@ -84,10 +84,12 @@ func benchmarkBuildIndex(b *testing.B, docs int, fileThreshold int64) {
 	require.NoError(b, err)
 	writer := newTestWriter(docs, docs)
 
+	fields, err := info.SearchableFields()
+	require.NoError(b, err)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		idx, err := backend.BuildIndex(ctx, key, int64(docs), info.Fields, "benchmark", writer, nil, true, time.Time{}, 0)
+		idx, err := backend.BuildIndex(ctx, key, int64(docs), fields, "benchmark", writer, nil, true, time.Time{}, 0)
 		require.NoError(b, err)
 
 		b.StopTimer()

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -682,11 +682,13 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer re
 	})
 	require.NoError(t, err)
 
+	fields, err := info.SearchableFields()
+	require.NoError(t, err)
 	index, err := backend.BuildIndex(ctx, resource.NamespacedResource{
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, size, info.Fields, "test", writer, nil, false, time.Time{}, 0)
+	}, size, fields, "test", writer, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	return index

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -113,11 +113,13 @@ func TestBleveSearchRootFolderExpansion(t *testing.T) {
 			},
 		}
 	}
+	fields, err := info.SearchableFields()
+	require.NoError(t, err)
 	index, err := backend.BuildIndex(ctx, resource.NamespacedResource{
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, 3, info.Fields, "test", func(index resource.ResourceIndex) (int64, error) {
+	}, 3, fields, "test", func(index resource.ResourceIndex) (int64, error) {
 		if err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				doc("legacy-root", ""),
@@ -202,11 +204,13 @@ func testBleveBackend(t *testing.T, backend *bleveBackend) {
 		})
 		require.NoError(t, err)
 
+		fields, err := info.SearchableFields()
+		require.NoError(t, err)
 		index, err := backend.BuildIndex(ctx, resource.NamespacedResource{
 			Namespace: key.Namespace,
 			Group:     key.Group,
 			Resource:  key.Resource,
-		}, 2, info.Fields, "test", func(index resource.ResourceIndex) (int64, error) {
+		}, 2, fields, "test", func(index resource.ResourceIndex) (int64, error) {
 			err := index.BulkIndex(&resource.BulkIndexRequest{
 				Items: []*resource.BulkIndexItem{
 					{
@@ -834,7 +838,8 @@ func testBleveBackend(t *testing.T, backend *bleveBackend) {
 func TestGetSortFields(t *testing.T) {
 	dashboardInfo, err := builders.DashboardBuilder(nil)
 	require.NoError(t, err)
-	dashboardFields := dashboardInfo.Fields
+	dashboardFields, err := dashboardInfo.SearchableFields()
+	require.NoError(t, err)
 
 	t.Run("will prepend 'fields.' to sort fields when they are dashboard fields", func(t *testing.T) {
 		searchReq := &resourcepb.ResourceSearchRequest{

--- a/pkg/storage/unified/search/builders/dashboard.go
+++ b/pkg/storage/unified/search/builders/dashboard.go
@@ -53,11 +53,6 @@ var DashboardSearchFields = resource.NewManifestBackedProvider(
 ).Fields(dashV1.DashboardResourceInfo.GroupVersionResource())
 
 func DashboardBuilder(namespaced resource.NamespacedDocumentSupplier) (resource.DocumentBuilderInfo, error) {
-	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(DashboardSearchFields))
-	if err != nil {
-		return resource.DocumentBuilderInfo{}, err
-	}
-
 	if namespaced == nil {
 		namespaced = func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
 			return &DashboardDocumentBuilder{
@@ -83,7 +78,6 @@ func DashboardBuilder(namespaced resource.NamespacedDocumentSupplier) (resource.
 	gr := dashV1.DashboardResourceInfo.GroupResource()
 	return resource.DocumentBuilderInfo{
 		GroupResource:        gr,
-		Fields:               fields,
 		Namespaced:           namespaced,
 		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
 		SearchFieldsProvider: provider,

--- a/pkg/storage/unified/search/builders/document.go
+++ b/pkg/storage/unified/search/builders/document.go
@@ -105,11 +105,6 @@ func tableColumnsByName(sfds []resource.SearchFieldDefinition) map[string]*resou
 // and its documents are extracted by the standard builder, so only the resource
 // and its field set differ per kind.
 func iamBuilder(ri utils.ResourceInfo, searchFields []resource.SearchFieldDefinition) (resource.DocumentBuilderInfo, error) {
-	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(searchFields))
-	if err != nil {
-		return resource.DocumentBuilderInfo{}, err
-	}
-
 	gvr := ri.GroupVersionResource()
 	gr := ri.GroupResource()
 	provider := resource.NewMapProvider(
@@ -123,7 +118,6 @@ func iamBuilder(ri utils.ResourceInfo, searchFields []resource.SearchFieldDefini
 
 	return resource.DocumentBuilderInfo{
 		GroupResource:        gr,
-		Fields:               fields,
 		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
 		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
 		SearchFieldsProvider: provider,


### PR DESCRIPTION
`DocumentBuilderInfo` carried two views of a kind's declared search fields: a `SearchFieldsProvider` and a `Fields` column-definition projection built from the same declarations. Keeping both around invited new search builders to populate the legacy `Fields` path instead of declaring a provider.

This removes the `Fields` struct field and adds a `SearchableFields` method that derives the column-definition view from the provider on demand, so the provider is the single source. The builder cache builds the view once when it registers a kind, and tests call the method where they previously read the field. The derived view is identical for the current kinds — each declares its fields on a single served version, so the order is preserved — so there is no index or search-result change.

Part of grafana/search-and-storage-team#827.
