### PR TITLE
IAM: Defer list authorization to storage for teams, users and service accounts

### DIFF
--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -126,11 +126,22 @@ func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 	}
 	getPermissions := check(utils.VerbGetPermissions, "requires team getpermissions")
 	update := check(utils.VerbUpdate, "requires team update")
-	return gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
+	base := gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
 		"members":      getPermissions,
 		"groups":       getPermissions,
 		"addmember":    update,
 		"removemember": update,
+	})
+
+	// Authorize the team collection list at the API layer and defer per-team
+	// filtering to unified storage (listAuthorized), so a user can list the teams
+	// they can read — matching dashboards and folders. Named get/update/delete
+	// and the subresources stay strict.
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		if attr.IsResourceRequest() && attr.GetSubresource() == "" && attr.GetName() == "" && attr.GetVerb() == utils.VerbList {
+			return authorizer.DecisionAllow, "", nil
+		}
+		return base.Authorize(ctx, attr)
 	})
 }
 

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -99,6 +99,25 @@ func (s *iamAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribute
 	return authz.Authorize(ctx, attr)
 }
 
+// allowListAuthorizer allows a nameless list (resource request, no subresource, no name, verb=list)
+// at the API layer, deferring per-item filtering to unified storage.
+// Otherwise Zanzana maps a nameless list to a group_resource (wildcard) check,
+// so only a user who can read every item could list.
+//
+// Only safe for resources that unified storage filters per-item on list (see
+// the authzLimitedClient allowlist in pkg/storage/unified/resource/access.go).
+func allowListAuthorizer(base authorizer.Authorizer) authorizer.Authorizer {
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		if attr.IsResourceRequest() && attr.GetSubresource() == "" && attr.GetName() == "" && attr.GetVerb() == utils.VerbList {
+			if _, ok := authlib.AuthInfoFrom(ctx); ok {
+				return authorizer.DecisionAllow, "", nil
+			}
+			return authorizer.DecisionDeny, "cannot list resource without an identity", nil
+		}
+		return base.Authorize(ctx, attr)
+	})
+}
+
 // newTeamAuthorizer authorizes the "members", "groups", "addmember" and
 // "removemember" subresources:
 //   - members / groups: read paths, gated on `get_permissions` on the
@@ -133,23 +152,14 @@ func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 		"removemember": update,
 	})
 
-	// Authorize the team collection list at the API layer and defer per-team
-	// filtering to unified storage (listAuthorized), so a user can list the teams
-	// they can read — matching dashboards and folders. Named get/update/delete
-	// and the subresources stay strict.
-	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-		if attr.IsResourceRequest() && attr.GetSubresource() == "" && attr.GetName() == "" && attr.GetVerb() == utils.VerbList {
-			return authorizer.DecisionAllow, "", nil
-		}
-		return base.Authorize(ctx, attr)
-	})
+	return allowListAuthorizer(base)
 }
 
 // newUserAuthorizer creates an authorizer for users that handles the "teams" and "status" subresources.
 // "teams" is read-only (Connecter/GET), so it checks user get.
 // "status" supports both GET and PUT, so the check verb mirrors the request verb.
 func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
-	return gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
+	base := gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
 		"teams": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
 				Verb:      utils.VerbGet,
@@ -187,6 +197,8 @@ func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 			return authorizer.DecisionAllow, "", nil
 		},
 	})
+
+	return allowListAuthorizer(base)
 }
 
 // newServiceAccountAuthorizer creates an authorizer for service accounts that handles the "tokens" subresource.
@@ -194,8 +206,11 @@ func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 //   - GET  (get/list) → serviceaccounts:read  (verb "get")
 //   - POST (create)   → serviceaccounts:write  (verb "update")
 //   - DELETE           → serviceaccounts:write  (verb "update")
+//
+// The nameless list is allowed at the API layer (see
+// allowList); unified storage filters service accounts per-item.
 func newServiceAccountAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
-	return gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
+	base := gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
 		"tokens": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 			// Map verbs to match the legacy API: read operations use "get",
 			// write operations (create/delete) use "update" → serviceaccounts:write.
@@ -221,6 +236,8 @@ func newServiceAccountAuthorizer(accessClient authlib.AccessClient) authorizer.A
 			return authorizer.DecisionAllow, "", nil
 		},
 	})
+
+	return allowListAuthorizer(base)
 }
 
 func newLegacyAccessClient(ac accesscontrol.AccessControl, store legacy.LegacyIdentityStore) authlib.AccessClient {

--- a/pkg/registry/apis/iam/authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer_test.go
@@ -240,48 +240,69 @@ func TestAuthorizerDecisionMatrix(t *testing.T) {
 	}
 }
 
-// TestTeamAuthorizerListDefersToStorage verifies that a collection list of teams (no
-// subresource, no name) is allowed at the authorizer layer without a
-// per-request RBAC Check, so unified storage can filter the results per-team.
+// TestAuthorizerListDefersToStorage verifies that a nameless collection list
+// (no subresource, no name) is allowed at the authorizer layer without a
+// per-request RBAC Check, so unified storage can filter results per-item.
 // Zanzana maps a nameless list to a group_resource (wildcard) check, so routing
 // it through the ResourceAuthorizer would 403 any user who cannot read every
-// team.
-func TestTeamAuthorizerListDefersToStorage(t *testing.T) {
-	teamAttr := func(verb, name string) authorizer.AttributesRecord {
-		return authorizer.AttributesRecord{
-			ResourceRequest: true,
-			APIGroup:        iamv0.TeamResourceInfo.GroupResource().Group,
-			Resource:        iamv0.TeamResourceInfo.GroupResource().Resource,
-			Name:            name,
-			Verb:            verb,
-			Namespace:       "org-1",
-		}
-	}
-	newAuth := func(checkCalled *bool) authorizer.Authorizer {
-		return newTeamAuthorizer(&fakeAccessClient{
-			checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
-				*checkCalled = true
-				return types.CheckResponse{Allowed: false}, nil
-			},
-		})
-	}
+// item. Named get and named list stay strict.
+func TestAuthorizerListDefersToStorage(t *testing.T) {
 	ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
 
-	t.Run("list is allowed without calling Check", func(t *testing.T) {
-		checkCalled := false
-		decision, _, err := newAuth(&checkCalled).Authorize(ctx, teamAttr("list", ""))
-		require.NoError(t, err)
-		assert.Equal(t, authorizer.DecisionAllow, decision)
-		assert.False(t, checkCalled, "list must not perform a group-resource Check; storage filters per-team")
-	})
+	for _, sc := range authorizerScenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			attr := func(verb, name string) authorizer.AttributesRecord {
+				return authorizer.AttributesRecord{
+					ResourceRequest: true,
+					APIGroup:        sc.group,
+					Resource:        sc.resource,
+					Name:            name,
+					Verb:            verb,
+					Namespace:       "org-1",
+				}
+			}
+			newAuth := func(checkCalled *bool) authorizer.Authorizer {
+				return sc.newAuthorizer(&fakeAccessClient{
+					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
+						*checkCalled = true
+						return types.CheckResponse{Allowed: false}, nil
+					},
+				})
+			}
 
-	t.Run("named get still delegates to Check", func(t *testing.T) {
-		checkCalled := false
-		decision, _, err := newAuth(&checkCalled).Authorize(ctx, teamAttr("get", "team-abc"))
-		require.NoError(t, err)
-		assert.Equal(t, authorizer.DecisionDeny, decision)
-		assert.True(t, checkCalled, "named get must still be authorized per-team")
-	})
+			t.Run("nameless list denied without identity", func(t *testing.T) {
+				checkCalled := false
+				decision, _, err := newAuth(&checkCalled).Authorize(context.Background(), attr("list", ""))
+				require.NoError(t, err)
+				assert.Equal(t, authorizer.DecisionDeny, decision)
+				assert.False(t, checkCalled)
+			})
+
+			t.Run("nameless list is allowed without calling Check", func(t *testing.T) {
+				checkCalled := false
+				decision, _, err := newAuth(&checkCalled).Authorize(ctx, attr("list", ""))
+				require.NoError(t, err)
+				assert.Equal(t, authorizer.DecisionAllow, decision)
+				assert.False(t, checkCalled, "nameless list must not perform a group-resource Check; storage filters per-item")
+			})
+
+			t.Run("named list still delegates to Check", func(t *testing.T) {
+				checkCalled := false
+				decision, _, err := newAuth(&checkCalled).Authorize(ctx, attr("list", sc.resourceName))
+				require.NoError(t, err)
+				assert.Equal(t, authorizer.DecisionDeny, decision)
+				assert.True(t, checkCalled, "named list must still be authorized")
+			})
+
+			t.Run("named get still delegates to Check", func(t *testing.T) {
+				checkCalled := false
+				decision, _, err := newAuth(&checkCalled).Authorize(ctx, attr("get", sc.resourceName))
+				require.NoError(t, err)
+				assert.Equal(t, authorizer.DecisionDeny, decision)
+				assert.True(t, checkCalled, "named get must still be authorized per-item")
+			})
+		})
+	}
 }
 
 // TestUserAuthorizerStatusVerbMapping verifies that the user/status subresource

--- a/pkg/registry/apis/iam/authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer_test.go
@@ -240,6 +240,50 @@ func TestAuthorizerDecisionMatrix(t *testing.T) {
 	}
 }
 
+// TestTeamAuthorizerListDefersToStorage verifies that a collection list of teams (no
+// subresource, no name) is allowed at the authorizer layer without a
+// per-request RBAC Check, so unified storage can filter the results per-team.
+// Zanzana maps a nameless list to a group_resource (wildcard) check, so routing
+// it through the ResourceAuthorizer would 403 any user who cannot read every
+// team.
+func TestTeamAuthorizerListDefersToStorage(t *testing.T) {
+	teamAttr := func(verb, name string) authorizer.AttributesRecord {
+		return authorizer.AttributesRecord{
+			ResourceRequest: true,
+			APIGroup:        iamv0.TeamResourceInfo.GroupResource().Group,
+			Resource:        iamv0.TeamResourceInfo.GroupResource().Resource,
+			Name:            name,
+			Verb:            verb,
+			Namespace:       "org-1",
+		}
+	}
+	newAuth := func(checkCalled *bool) authorizer.Authorizer {
+		return newTeamAuthorizer(&fakeAccessClient{
+			checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
+				*checkCalled = true
+				return types.CheckResponse{Allowed: false}, nil
+			},
+		})
+	}
+	ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
+
+	t.Run("list is allowed without calling Check", func(t *testing.T) {
+		checkCalled := false
+		decision, _, err := newAuth(&checkCalled).Authorize(ctx, teamAttr("list", ""))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+		assert.False(t, checkCalled, "list must not perform a group-resource Check; storage filters per-team")
+	})
+
+	t.Run("named get still delegates to Check", func(t *testing.T) {
+		checkCalled := false
+		decision, _, err := newAuth(&checkCalled).Authorize(ctx, teamAttr("get", "team-abc"))
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionDeny, decision)
+		assert.True(t, checkCalled, "named get must still be authorized per-team")
+	})
+}
+
 // TestUserAuthorizerStatusVerbMapping verifies that the user/status subresource
 // maps request verbs to the correct RBAC check verbs (GET→get, UPDATE→update, PATCH→update).
 func TestUserAuthorizerStatusVerbMapping(t *testing.T) {


### PR DESCRIPTION
Taken from #127804, minus the feature toggle. Follow-up to #127788 and #127839.

**What:**
At the API layer we allow a nameless `list` (no name, no subresource) for `teams`, `users`, and `service accounts`, and defer per-item filtering to  `unified storage`. Named get/list and subresources stay strict. A nameless list still requires an authenticated identity.

**Why:**
Zanzana treats a nameless list as a group-resource (wildcard) check, so only a user who can read *every* resource in the group could list. Deferring to the backend lets each user list the resources they can actually read.

**Note:**
Previously we would return a `403` if a user didn't have access to any resource. With that change we return `200` with an empty list.