### PR TITLE
Unified storage: Enforce RBAC for serviceaccount search/list/read

### DIFF
--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -104,7 +104,7 @@ func NewAuthzLimitedClient(client claims.AccessClient, opts AuthzOptions) claims
 		allowlist: groupResource{
 			"dashboard.grafana.app": map[string]interface{}{"dashboards": nil},
 			"folder.grafana.app":    map[string]interface{}{"folders": nil},
-			"iam.grafana.app":       map[string]interface{}{"users": nil, "teams": nil},
+			"iam.grafana.app":       map[string]interface{}{"users": nil, "teams": nil, "serviceaccounts": nil},
 		},
 		logger:  logger,
 		metrics: newMetrics(opts.Registry),


### PR DESCRIPTION
Similar to https://github.com/grafana/grafana/pull/127788

This PR adds uniStore filtering to the iam app `service accounts` resource.

**Why**
This allows listing service accounts based on user permissions.