### PR TITLE
Loki: Use store abstraction instead of direct localStorage access

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2999,19 +2999,9 @@
       "count": 1
     }
   },
-  "public/app/plugins/datasource/loki/components/LokiContextUi.tsx": {
-    "@grafana/no-direct-local-storage-access": {
-      "count": 7
-    }
-  },
   "public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1
-    }
-  },
-  "public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx": {
-    "@grafana/no-direct-local-storage-access": {
-      "count": 2
     }
   },
   "public/app/plugins/datasource/loki/components/LokiQueryField.tsx": {
@@ -3038,16 +3028,6 @@
   "public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
-    }
-  },
-  "public/app/plugins/datasource/loki/querybuilder/state.ts": {
-    "@grafana/no-direct-local-storage-access": {
-      "count": 2
-    }
-  },
-  "public/app/plugins/datasource/loki/shardQuerySplitting.ts": {
-    "@grafana/no-direct-local-storage-access": {
-      "count": 2
     }
   },
   "public/app/plugins/datasource/mssql/azureauth/AzureCredentialsForm.tsx": {

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -2,7 +2,14 @@ import { css } from '@emotion/css';
 import { useRef, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
-import { dateTime, type GrafanaTheme2, type LogRowModel, renderMarkdown, type SelectableValue } from '@grafana/data';
+import {
+  dateTime,
+  type GrafanaTheme2,
+  type LogRowModel,
+  renderMarkdown,
+  type SelectableValue,
+  store,
+} from '@grafana/data';
 import { RawQuery } from '@grafana/plugin-ui';
 import { reportInteraction } from '@grafana/runtime';
 import {
@@ -121,9 +128,9 @@ export function LokiContextUi(props: LokiContextUiProps) {
 
   const [initialized, setInitialized] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [isOpen, setIsOpen] = useState(window.localStorage.getItem(IS_LOKI_LOG_CONTEXT_UI_OPEN) === 'true');
+  const [isOpen, setIsOpen] = useState(store.get(IS_LOKI_LOG_CONTEXT_UI_OPEN) === 'true');
   const [includePipelineOperations, setIncludePipelineOperations] = useState(
-    window.localStorage.getItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS) === 'true'
+    store.get(SHOULD_INCLUDE_PIPELINE_OPERATIONS) === 'true'
   );
 
   const timerHandle = useRef<number | undefined>(undefined);
@@ -186,7 +193,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
         }
       });
 
-      window.localStorage.setItem(LOKI_LOG_CONTEXT_PRESERVED_LABELS, JSON.stringify(preservedLabels));
+      store.set(LOKI_LOG_CONTEXT_PRESERVED_LABELS, JSON.stringify(preservedLabels));
       setLoading(false);
     }, 1500);
 
@@ -292,8 +299,8 @@ export function LokiContextUi(props: LokiContextUiProps) {
               }));
             });
             // We are removing the preserved labels from local storage so we can preselect the labels in the UI
-            window.localStorage.removeItem(LOKI_LOG_CONTEXT_PRESERVED_LABELS);
-            window.localStorage.removeItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS);
+            store.delete(LOKI_LOG_CONTEXT_PRESERVED_LABELS);
+            store.delete(SHOULD_INCLUDE_PIPELINE_OPERATIONS);
             setIncludePipelineOperations(false);
           }}
         />
@@ -302,7 +309,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
       <Collapse
         isOpen={isOpen}
         onToggle={() => {
-          window.localStorage.setItem(IS_LOKI_LOG_CONTEXT_UI_OPEN, (!isOpen).toString());
+          store.set(IS_LOKI_LOG_CONTEXT_UI_OPEN, (!isOpen).toString());
           setIsOpen((isOpen) => !isOpen);
           reportInteraction('grafana_explore_logs_loki_log_context_toggled', {
             logRowUid: row.uid,
@@ -433,7 +440,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
                       logRowUid: row.uid,
                       action: e.currentTarget.checked ? 'enable' : 'disable',
                     });
-                    window.localStorage.setItem(SHOULD_INCLUDE_PIPELINE_OPERATIONS, e.currentTarget.checked.toString());
+                    store.set(SHOULD_INCLUDE_PIPELINE_OPERATIONS, e.currentTarget.checked.toString());
                     setIncludePipelineOperations(e.currentTarget.checked);
                     if (runContextQuery) {
                       runContextQuery();

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -3,7 +3,7 @@ import { memo, type SyntheticEvent, useCallback, useEffect, useId, useState } fr
 import { usePrevious } from 'react-use';
 
 import { QueryWithAssistantButton } from '@grafana/assistant';
-import { CoreApp, LoadingState } from '@grafana/data';
+import { CoreApp, LoadingState, store } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import {
   EditorHeader,
@@ -42,7 +42,7 @@ export const LokiQueryEditor = memo<LokiQueryEditorProps>((props) => {
   const [dataIsStale, setDataIsStale] = useState(false);
   const [labelBrowserVisible, setLabelBrowserVisible] = useState(false);
   const [queryStats, setQueryStats] = useState<QueryStats | null>(null);
-  const [explain, setExplain] = useState(window.localStorage.getItem(lokiQueryEditorExplainKey) === 'true');
+  const [explain, setExplain] = useState(store.get(lokiQueryEditorExplainKey) === 'true');
 
   const previousTimeRange = usePrevious(timeRange);
 
@@ -58,7 +58,7 @@ export const LokiQueryEditor = memo<LokiQueryEditorProps>((props) => {
     (app === CoreApp.Explore || app === CoreApp.Dashboard || app === CoreApp.PanelEditor);
 
   const onExplainChange = (event: SyntheticEvent<HTMLInputElement>) => {
-    window.localStorage.setItem(lokiQueryEditorExplainKey, event.currentTarget.checked ? 'true' : 'false');
+    store.set(lokiQueryEditorExplainKey, event.currentTarget.checked ? 'true' : 'false');
     setExplain(event.currentTarget.checked);
   };
 

--- a/public/app/plugins/datasource/loki/querybuilder/state.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/state.ts
@@ -1,3 +1,4 @@
+import { store } from '@grafana/data';
 import { QueryEditorMode } from '@grafana/plugin-ui';
 
 import { LokiQueryType } from '../dataquery.gen';
@@ -8,7 +9,7 @@ const queryEditorModeDefaultLocalStorageKey = 'LokiQueryEditorModeDefault';
 export function changeEditorMode(query: LokiQuery, editorMode: QueryEditorMode, onChange: (query: LokiQuery) => void) {
   // If empty query store new mode as default
   if (query.expr === '') {
-    window.localStorage.setItem(queryEditorModeDefaultLocalStorageKey, editorMode);
+    store.set(queryEditorModeDefaultLocalStorageKey, editorMode);
   }
 
   onChange({ ...query, editorMode });
@@ -20,7 +21,7 @@ function getDefaultEditorMode(expr: string) {
     return QueryEditorMode.Code;
   }
 
-  const value: string | null = window.localStorage.getItem(queryEditorModeDefaultLocalStorageKey);
+  const value: string | undefined = store.get(queryEditorModeDefaultLocalStorageKey);
   switch (value) {
     case 'code':
       return QueryEditorMode.Code;

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -7,6 +7,7 @@ import {
   LoadingState,
   type QueryResultMetaStat,
   generateUUID,
+  store,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
@@ -375,7 +376,7 @@ function getInitialGroupSize(shards: number[]) {
 }
 
 // Enable to output debugging logs
-const DEBUG_ENABLED = Boolean(localStorage.getItem(`loki.sharding_debug_enabled`));
+const DEBUG_ENABLED = Boolean(store.get(`loki.sharding_debug_enabled`));
 function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;


### PR DESCRIPTION
**What is this feature?**

Replaces direct `window.localStorage` / `localStorage` access in the Loki datasource with the `store` singleton from `@grafana/data`. This resolves the `@grafana/no-direct-local-storage-access` ESLint suppressions for the affected files, dropping them from `eslint-suppressions.json`.

Files changed:
- `public/app/plugins/datasource/loki/components/LokiContextUi.tsx` (7 sites)
- `public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx` (2 sites)
- `public/app/plugins/datasource/loki/querybuilder/state.ts` (2 sites)
- `public/app/plugins/datasource/loki/shardQuerySplitting.ts` (1 site)

**Why do we need this feature?**

Part of the ongoing ESLint suppressions burndown. Direct `localStorage` access is disallowed by the `@grafana/no-direct-local-storage-access` rule; the `store` abstraction from `@grafana/data` is the sanctioned wrapper (it also notifies subscribers on change). This datasource already uses `store` in `LogContextProvider.ts`, so this brings the rest of the module in line.

**Who is this feature for?**

Grafana developers / maintainers — no user-facing behavior change.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Behavior is unchanged — `store.get`/`set`/`delete` wrap the same `localStorage` operations. The one type-level difference is that `store.get` returns `string | undefined` (vs `getItem`'s `string | null`); both are falsy in the `=== 'true'` and `Boolean(...)` comparisons used here, so the type annotation in `state.ts` was updated to `string | undefined` accordingly.

Verification:
- `yarn lint:prune` removed all 12 suppressions for these 4 files from `eslint-suppressions.json`
- `yarn eslint` on the 4 files — clean
- `yarn typecheck` — passes
- `yarn jest` (loki workspace) — 51 tests pass across the 4 affected suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErVyKk65eBwzm2skTH1EGJ)_