### PR TITLE
Provisioning: Make jobs queue size metric reliable

### DIFF
--- a/pkg/operators/provisioning/jobs_operator.go
+++ b/pkg/operators/provisioning/jobs_operator.go
@@ -80,6 +80,18 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 		logger.Info("job cleanup controller stopped")
 	}()
 
+	if controllerCfg.queueSizeMetricInterval > 0 {
+		queueSizeReporter := jobs.NewQueueSizeReporter(jobStore, deps.Registerer, controllerCfg.queueSizeMetricInterval)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := queueSizeReporter.Run(ctx); err != nil {
+				logger.Error("queue size reporter failed", "error", err)
+			}
+			logger.Info("queue size reporter stopped")
+		}()
+	}
+
 	// Start the history informer; cleanup relies on its resync events.
 	if historyInformer != nil {
 		go historyInformer.Run(ctx.Done())
@@ -111,8 +123,9 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 
 type jobsControllerConfig struct {
 	ControllerConfig
-	historyExpiration time.Duration
-	cleanupInterval   time.Duration
+	historyExpiration       time.Duration
+	cleanupInterval         time.Duration
+	queueSizeMetricInterval time.Duration
 }
 
 func setupJobsControllerFromConfig(cfg *setting.Cfg, registry prometheus.Registerer) (*jobsControllerConfig, error) {
@@ -124,8 +137,9 @@ func setupJobsControllerFromConfig(cfg *setting.Cfg, registry prometheus.Registe
 	operatorSec := cfg.SectionWithEnvOverrides("operator")
 
 	return &jobsControllerConfig{
-		ControllerConfig:  *controllerCfg,
-		historyExpiration: operatorSec.Key("history_expiration").MustDuration(0),
-		cleanupInterval:   operatorSec.Key("cleanup_interval").MustDuration(time.Minute),
+		ControllerConfig:        *controllerCfg,
+		historyExpiration:       operatorSec.Key("history_expiration").MustDuration(0),
+		cleanupInterval:         operatorSec.Key("cleanup_interval").MustDuration(time.Minute),
+		queueSizeMetricInterval: operatorSec.Key("queue_size_metric_interval").MustDuration(30 * time.Second),
 	}, nil
 }

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -24,7 +24,6 @@ type JobMetrics struct {
 }
 
 type QueueMetrics struct {
-	queueSize     *prometheus.GaugeVec
 	queueWaitTime *prometheus.HistogramVec
 }
 
@@ -38,15 +37,6 @@ var (
 
 func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 	queueOnce.Do(func() {
-		queueSize := prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "grafana_provisioning_jobs_queue_size",
-				Help: "Number of jobs currently in the queue",
-			},
-			[]string{"action"},
-		)
-		registry.MustRegister(queueSize)
-
 		queueWaitTime := prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name:    "grafana_provisioning_jobs_queue_wait_seconds",
@@ -58,19 +48,10 @@ func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 		registry.MustRegister(queueWaitTime)
 
 		queueMetrics = QueueMetrics{
-			queueSize:     queueSize,
 			queueWaitTime: queueWaitTime,
 		}
 	})
 	return queueMetrics
-}
-
-func (m *QueueMetrics) IncreaseQueueSize(action string) {
-	m.queueSize.WithLabelValues(action).Inc()
-}
-
-func (m *QueueMetrics) DecreaseQueueSize(action string) {
-	m.queueSize.WithLabelValues(action).Dec()
 }
 
 func (m *QueueMetrics) RecordWaitTime(action string, waitSeconds float64) {

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -323,7 +323,6 @@ func (s *persistentStore) Complete(ctx context.Context, job *provisioning.Job) e
 		job.Labels = make(map[string]string)
 	}
 	delete(job.Labels, LabelJobClaim)
-	s.queueMetrics.DecreaseQueueSize(string(job.Spec.Action))
 
 	logger.Debug("complete job complete")
 	return nil
@@ -377,6 +376,41 @@ func (s *persistentStore) ListExpiredJobs(ctx context.Context, expiredBefore tim
 	logger.Debug("found expired jobs", "count", len(result))
 
 	return result, nil
+}
+
+// CountJobsByAction counts all active jobs (pending and claimed) across all
+// namespaces, grouped by action.
+func (s *persistentStore) CountJobsByAction(ctx context.Context) (map[provisioning.JobAction]int, error) {
+	ctx, span := tracing.Start(ctx, "provisioning.jobs.count_jobs_by_action")
+	defer span.End()
+
+	// Set up provisioning identity to access jobs across all namespaces
+	ctx, _, err := identity.WithProvisioningIdentity(ctx, "*")
+	if err != nil {
+		span.RecordError(err)
+		return nil, apifmt.Errorf("failed to grant provisioning identity for counting jobs: %w", err)
+	}
+
+	counts := make(map[provisioning.JobAction]int)
+	opts := metav1.ListOptions{Limit: 500}
+	for {
+		jobList, err := s.client.Jobs("").List(ctx, opts)
+		if err != nil {
+			span.RecordError(err)
+			return nil, apifmt.Errorf("failed to list jobs: %w", err)
+		}
+
+		for i := range jobList.Items {
+			counts[jobList.Items[i].Spec.Action]++
+		}
+
+		if jobList.Continue == "" {
+			break
+		}
+		opts.Continue = jobList.Continue
+	}
+
+	return counts, nil
 }
 
 // RenewLease renews the lease for a claimed job, extending its expiry time.
@@ -514,8 +548,6 @@ func (s *persistentStore) Insert(ctx context.Context, namespace string, spec pro
 		span.RecordError(err)
 		return nil, apifmt.Errorf("failed to create job '%s' in '%s': %w", job.GetName(), job.GetNamespace(), err)
 	}
-
-	s.queueMetrics.IncreaseQueueSize(string(job.Spec.Action))
 
 	logger.Info("insert job complete")
 	return created, nil

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -34,7 +34,6 @@ func TestRenewLease_StaleResourceVersion(t *testing.T) {
 		clock:  time.Now,
 		expiry: 30 * time.Second,
 		queueMetrics: QueueMetrics{
-			queueSize:     nil,
 			queueWaitTime: nil,
 		},
 	}
@@ -85,7 +84,6 @@ func TestRenewLease_ResourceVersionProgresses(t *testing.T) {
 		clock:  time.Now,
 		expiry: 30 * time.Second,
 		queueMetrics: QueueMetrics{
-			queueSize:     nil,
 			queueWaitTime: nil,
 		},
 	}
@@ -137,7 +135,6 @@ func TestRenewLease_ThenUpdateDoesNotConflict(t *testing.T) {
 		clock:  time.Now,
 		expiry: 30 * time.Second,
 		queueMetrics: QueueMetrics{
-			queueSize:     nil,
 			queueWaitTime: nil,
 		},
 	}
@@ -175,4 +172,55 @@ func TestRenewLease_ThenUpdateDoesNotConflict(t *testing.T) {
 	assert.NoError(t, err,
 		"Update after RenewLease should not conflict. "+
 			"If it does, RenewLease stored a stale ResourceVersion.")
+}
+
+func TestCountJobsByAction(t *testing.T) {
+	fakeClient := newTestClientset()
+
+	store := &persistentStore{
+		client: fakeClient,
+		clock:  time.Now,
+		expiry: 30 * time.Second,
+		queueMetrics: QueueMetrics{
+			queueWaitTime: nil,
+		},
+	}
+
+	counts, err := store.CountJobsByAction(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, counts, "empty store should return no counts")
+
+	// Jobs across namespaces, both claimed and unclaimed, must all be counted.
+	for _, job := range []*provisioning.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pull-1", Namespace: "stacks-123"},
+			Spec:       provisioning.JobSpec{Repository: "repo-1", Action: provisioning.JobActionPull},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pull-2",
+				Namespace: "stacks-123",
+				Labels:    map[string]string{LabelJobClaim: "1000000000000"},
+			},
+			Spec: provisioning.JobSpec{Repository: "repo-2", Action: provisioning.JobActionPull},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pull-3", Namespace: "stacks-456"},
+			Spec:       provisioning.JobSpec{Repository: "repo-3", Action: provisioning.JobActionPull},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "migrate-1", Namespace: "stacks-456"},
+			Spec:       provisioning.JobSpec{Repository: "repo-3", Action: provisioning.JobActionMigrate},
+		},
+	} {
+		_, err := fakeClient.Jobs(job.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	counts, err = store.CountJobsByAction(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, map[provisioning.JobAction]int{
+		provisioning.JobActionPull:    3,
+		provisioning.JobActionMigrate: 1,
+	}, counts)
 }

--- a/pkg/registry/apis/provisioning/jobs/queue_size_reporter.go
+++ b/pkg/registry/apis/provisioning/jobs/queue_size_reporter.go
@@ -1,0 +1,113 @@
+package jobs
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+// knownJobActions is used to pre-seed the queue size gauge so that every
+// action reports 0 instead of having no series at all.
+var knownJobActions = []provisioning.JobAction{
+	provisioning.JobActionPull,
+	provisioning.JobActionPush,
+	provisioning.JobActionPullRequest,
+	provisioning.JobActionMigrate,
+	provisioning.JobActionDelete,
+	provisioning.JobActionMove,
+	provisioning.JobActionFixFolderMetadata,
+	provisioning.JobActionReleaseResources,
+	provisioning.JobActionDeleteResources,
+}
+
+// QueueCounter counts active jobs grouped by action.
+type QueueCounter interface {
+	CountJobsByAction(ctx context.Context) (map[provisioning.JobAction]int, error)
+}
+
+// QueueSizeReporter periodically counts the jobs in the queue and reports the
+// result as a gauge. It is the single source of truth for the queue size
+// metric and must only run in one workload per deployment: counting the actual
+// Job resources (rather than incrementing/decrementing on insert/complete
+// events) keeps the value correct across process restarts and regardless of
+// which process inserts or completes a job.
+type QueueSizeReporter struct {
+	counter  QueueCounter
+	gauge    *prometheus.GaugeVec
+	interval time.Duration
+
+	// seen tracks every action ever reported so that actions outside
+	// knownJobActions still drop to 0 once they leave the queue.
+	seen map[provisioning.JobAction]struct{}
+}
+
+// NewQueueSizeReporter creates a reporter and registers the queue size gauge
+// on the given registry.
+func NewQueueSizeReporter(counter QueueCounter, registry prometheus.Registerer, interval time.Duration) *QueueSizeReporter {
+	gauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "grafana_provisioning_jobs_queue_size",
+			Help: "Number of jobs currently in the queue",
+		},
+		[]string{"action"},
+	)
+	registry.MustRegister(gauge)
+
+	seen := make(map[provisioning.JobAction]struct{}, len(knownJobActions))
+	for _, action := range knownJobActions {
+		gauge.WithLabelValues(string(action)).Set(0)
+		seen[action] = struct{}{}
+	}
+
+	return &QueueSizeReporter{
+		counter:  counter,
+		gauge:    gauge,
+		interval: interval,
+		seen:     seen,
+	}
+}
+
+// Run refreshes the gauge once and then on every interval tick. This is a
+// blocking function that runs until the context is canceled.
+func (r *QueueSizeReporter) Run(ctx context.Context) error {
+	logger := logging.FromContext(ctx).With("logger", "queue-size-reporter")
+	ctx = logging.Context(ctx, logger)
+
+	logger.Debug("starting queue size reporter", "interval", r.interval)
+
+	r.refresh(ctx)
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			r.refresh(ctx)
+		case <-ctx.Done():
+			logger.Debug("queue size reporter stopping")
+			return ctx.Err()
+		}
+	}
+}
+
+// refresh sets the gauge from the current job counts. On error the previous
+// values are kept until the next tick.
+func (r *QueueSizeReporter) refresh(ctx context.Context) {
+	counts, err := r.counter.CountJobsByAction(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Debug("failed to refresh job queue size", "error", err)
+		return
+	}
+
+	for action := range counts {
+		r.seen[action] = struct{}{}
+	}
+	for action := range r.seen {
+		r.gauge.WithLabelValues(string(action)).Set(float64(counts[action]))
+	}
+}

--- a/pkg/registry/apis/provisioning/jobs/queue_size_reporter_test.go
+++ b/pkg/registry/apis/provisioning/jobs/queue_size_reporter_test.go
@@ -1,0 +1,128 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+type stubQueueCounter struct {
+	counts map[provisioning.JobAction]int
+	err    error
+}
+
+func (s *stubQueueCounter) CountJobsByAction(_ context.Context) (map[provisioning.JobAction]int, error) {
+	return s.counts, s.err
+}
+
+// gatherQueueSize returns the current queue size gauge values by action.
+func gatherQueueSize(t *testing.T, registry *prometheus.Registry) map[string]float64 {
+	t.Helper()
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	values := map[string]float64{}
+	for _, family := range families {
+		if family.GetName() != "grafana_provisioning_jobs_queue_size" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			require.Len(t, metric.GetLabel(), 1)
+			values[metric.GetLabel()[0].GetValue()] = metric.GetGauge().GetValue()
+		}
+	}
+	return values
+}
+
+func TestQueueSizeReporter_PreSeedsKnownActions(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	NewQueueSizeReporter(&stubQueueCounter{}, registry, time.Second)
+
+	values := gatherQueueSize(t, registry)
+	require.Len(t, values, len(knownJobActions))
+	for _, action := range knownJobActions {
+		assert.Zero(t, values[string(action)], "action %q should be pre-seeded to 0", action)
+	}
+}
+
+func TestQueueSizeReporter_RefreshSetsCounts(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	counter := &stubQueueCounter{
+		counts: map[provisioning.JobAction]int{
+			provisioning.JobActionPull:      3,
+			provisioning.JobActionMigrate:   1,
+			provisioning.JobAction("newer"): 2, // action unknown to this build
+		},
+	}
+	reporter := NewQueueSizeReporter(counter, registry, time.Second)
+
+	reporter.refresh(context.Background())
+
+	values := gatherQueueSize(t, registry)
+	assert.Equal(t, float64(3), values["pull"])
+	assert.Equal(t, float64(1), values["migrate"])
+	assert.Equal(t, float64(2), values["newer"])
+	assert.Zero(t, values["push"], "actions not in the queue stay at 0")
+}
+
+func TestQueueSizeReporter_ActionDropsToZero(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	counter := &stubQueueCounter{
+		counts: map[provisioning.JobAction]int{
+			provisioning.JobActionPull:      2,
+			provisioning.JobAction("newer"): 1,
+		},
+	}
+	reporter := NewQueueSizeReporter(counter, registry, time.Second)
+
+	reporter.refresh(context.Background())
+	counter.counts = map[provisioning.JobAction]int{}
+	reporter.refresh(context.Background())
+
+	values := gatherQueueSize(t, registry)
+	assert.Zero(t, values["pull"])
+	assert.Zero(t, values["newer"], "previously seen unknown action must drop to 0, not go stale")
+}
+
+func TestQueueSizeReporter_ErrorKeepsPreviousValues(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	counter := &stubQueueCounter{
+		counts: map[provisioning.JobAction]int{provisioning.JobActionPull: 5},
+	}
+	reporter := NewQueueSizeReporter(counter, registry, time.Second)
+
+	reporter.refresh(context.Background())
+	counter.counts = nil
+	counter.err = errors.New("list failed")
+	reporter.refresh(context.Background())
+
+	values := gatherQueueSize(t, registry)
+	assert.Equal(t, float64(5), values["pull"], "failed refresh must keep the last value")
+}
+
+func TestQueueSizeReporter_RunStopsOnContextCancel(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	reporter := NewQueueSizeReporter(&stubQueueCounter{}, registry, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- reporter.Run(ctx)
+	}()
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not stop after context cancellation")
+	}
+}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -933,10 +933,11 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			b.client = c.ProvisioningV0alpha1()
 
 			// Initialize the API client-based job store
-			b.jobs, err = jobs.NewJobStore(b.client, 30*time.Second, b.registry)
+			jobStore, err := jobs.NewJobStore(b.client, 30*time.Second, b.registry)
 			if err != nil {
 				return fmt.Errorf("create API client job store: %w", err)
 			}
+			b.jobs = jobStore
 
 			b.statusPatcher = appcontroller.NewRepositoryStatusPatcher(b.GetClient())
 			healthMetricsRecorder := controller.NewHealthMetricsRecorder(b.registry)
@@ -1084,6 +1085,13 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			go func() {
 				if err := jobCleanupController.Run(postStartHookCtx.Context); err != nil {
 					logging.FromContext(postStartHookCtx.Context).Error("job cleanup controller failed", "error", err)
+				}
+			}()
+
+			queueSizeReporter := jobs.NewQueueSizeReporter(jobStore, b.registry, 30*time.Second)
+			go func() {
+				if err := queueSizeReporter.Run(postStartHookCtx.Context); err != nil {
+					logging.FromContext(postStartHookCtx.Context).Error("queue size reporter failed", "error", err)
 				}
 			}()
 


### PR DESCRIPTION
## What

Fixes the unreliable `grafana_provisioning_jobs_queue_size` gauge by making a single workload the source of truth: it periodically counts the actual `Job` resources and sets the gauge, instead of incrementing/decrementing on job insert/complete events.

Closes grafana/git-ui-sync-project#1251

## Why

The gauge was `Inc`'d in `persistentStore.Insert` and `Dec`'d in `persistentStore.Complete`, but those events happen in **four independent workloads**, each with its own Prometheus registry:

| Workload | Effect on gauge |
|---|---|
| MT API server (`/jobs`) | only **increments** (returns early before workers; series also renamed `mt_app_...` in Mimir) |
| Repo operator | only **increments** (inserts sync jobs during reconcile) |
| Jobqueue operator | only **decrements** (claims + completes jobs) |
| Jobs operator | only **decrements** (completes lease-expired jobs) |

No process sees both sides → inc-only gauges grow forever, dec-only go negative. In OSS single-binary mode the gauge also resets to 0 on restart while `Job` resources persist.

The queue is already a durable source of truth: pending/claimed jobs are `Job` resources in unified storage (completed jobs are deleted and archived as `HistoricJob`). So we count them instead of tracking deltas.

## How

- **New `QueueSizeReporter`** (`jobs/queue_size_reporter.go`): registers the gauge, pre-seeds all known `JobAction` values to 0, refreshes on an interval via a `QueueCounter`. List errors keep the last values and log at Debug; never `Reset()` (avoids scrape races / vanishing series).
- **`persistentStore.CountJobsByAction`**: paginated, cross-namespace list of active (pending + claimed) jobs grouped by action — mirrors the existing `ListExpiredJobs` access pattern.
- **Removed** the gauge + `Inc/Dec` from `QueueMetrics`. The `grafana_provisioning_jobs_queue_wait_seconds` histogram stays (histograms aggregate correctly across processes).
- **Single owner**: the reporter runs only in the **jobs operator** (cloud/MT) and in the **OSS single-binary** post-start hook (after the API-server-only guard). Interval configurable via `[operator] queue_size_metric_interval` (default `30s`, `0` disables).

Metric name and `{action}` label are unchanged — values simply become correct, and OSS no longer resets to 0 on restart.

## Testing

- Unit (`queue_size_reporter_test.go`): pre-seed to 0, refresh sets counts (incl. unknown action), action drops to 0 when it leaves the queue, list error keeps previous values, `Run` stops on ctx cancel.
- Unit (`persistentstore_test.go`): `CountJobsByAction` counts across namespaces, claimed + unclaimed; empty store → empty map.
- `go test ./pkg/registry/apis/provisioning/jobs/...` passes; `make gofmt` clean; `make lint-go-diff` → 0 issues.

## Ops follow-ups (separate, deployment_tools)

- Repoint dashboards/alerts from `mt_app_grafana_provisioning_jobs_queue_size` to the jobs-operator `grafana_provisioning_jobs_queue_size` series.
- Aggregate with `max by (action)`, not `sum` (single-value-per-replica insurance).

## Notes for reviewers

- Kept a concrete `jobStore` var in `register.go` because the shared `b.jobs` interface (`Queue`+`Store`) intentionally does **not** get `CountJobsByAction` — counting is not a driver concern.
- Alternatives (informer-cache count, server-side `GetStats`, indexing `spec.Action` in unified search) were explored and set aside; happy to discuss trade-offs. Per-action depth needs enumeration or a single writer — there is no server-side aggregation by `spec.Action` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)