### PR TITLE
Search: derive BuildIndex column fields from the provider

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -60,14 +60,6 @@ type DocumentBuilderInfo struct {
 	SearchFieldsProvider SearchFieldsProvider
 }
 
-// SearchableFields returns the column-definition view of this kind's custom
-// search fields, derived from its provider. The provider is the single source
-// of truth; the search backend uses this view for result column metadata and
-// sort-field prefixing. Returns nil when the builder has no provider.
-func (b DocumentBuilderInfo) SearchableFields() (SearchableDocumentFields, error) {
-	return SearchableFieldsFromProvider(b.SearchFieldsProvider, b.GroupResource.Group, b.GroupResource.Resource)
-}
-
 // SearchableFieldsFromProvider returns the column-definition view of a kind's
 // custom search fields for the given group and resource, derived from the
 // provider. The provider is the single source of truth; the search backend

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -65,12 +65,21 @@ type DocumentBuilderInfo struct {
 // of truth; the search backend uses this view for result column metadata and
 // sort-field prefixing. Returns nil when the builder has no provider.
 func (b DocumentBuilderInfo) SearchableFields() (SearchableDocumentFields, error) {
-	if b.SearchFieldsProvider == nil {
+	return SearchableFieldsFromProvider(b.SearchFieldsProvider, b.GroupResource.Group, b.GroupResource.Resource)
+}
+
+// SearchableFieldsFromProvider returns the column-definition view of a kind's
+// custom search fields for the given group and resource, derived from the
+// provider. The provider is the single source of truth; the search backend
+// uses this view for result column metadata and sort-field prefixing. Returns
+// nil when the provider is nil.
+func SearchableFieldsFromProvider(p SearchFieldsProvider, group, resource string) (SearchableDocumentFields, error) {
+	if p == nil {
 		return nil, nil
 	}
-	sfds := b.SearchFieldsProvider.Fields(schema.GroupVersionResource{
-		Group:    b.GroupResource.Group,
-		Resource: b.GroupResource.Resource,
+	sfds := p.Fields(schema.GroupVersionResource{
+		Group:    group,
+		Resource: resource,
 	})
 	return NewSearchableDocumentFields(SearchFieldDefinitionsToTableColumns(sfds))
 }

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -157,7 +157,6 @@ type SearchBackend interface {
 		ctx context.Context,
 		key NamespacedResource,
 		size int64,
-		nonStandardFields SearchableDocumentFields,
 		indexBuildReason string,
 		builder BuildFn,
 		updater UpdateFn,
@@ -1692,7 +1691,6 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 	if err != nil {
 		return nil, err
 	}
-	fields := s.builders.GetFields(nsr)
 
 	builderFn := func(index ResourceIndex) (int64, error) {
 		span := trace.SpanFromContext(ctx)
@@ -1899,7 +1897,7 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 	// within ~10% of the per-resource rebuild interval.
 	maxFreshSnapshotAge := s.getIndexMaxAge(nsr) / 10
 
-	index, err := s.search.BuildIndex(ctx, nsr, size, fields, indexBuildReason, builderFn, updaterFn, rebuild, lastImportTime, maxFreshSnapshotAge)
+	index, err := s.search.BuildIndex(ctx, nsr, size, indexBuildReason, builderFn, updaterFn, rebuild, lastImportTime, maxFreshSnapshotAge)
 
 	if err != nil {
 		return nil, err
@@ -1926,9 +1924,6 @@ type builderCache struct {
 	// Possible blob support
 	blob BlobSupport
 
-	// searchable fields initialized once on startup
-	fields map[schema.GroupResource]SearchableDocumentFields
-
 	// lookup by group, then resource (namespace)
 	// This is only modified at startup, so we do not need mutex for access
 	lookup map[string]map[string]DocumentBuilderInfo
@@ -1940,7 +1935,6 @@ type builderCache struct {
 
 func newBuilderCache(cfg []DocumentBuilderInfo, nsCacheSize int, ttl time.Duration) (*builderCache, error) {
 	cache := &builderCache{
-		fields: make(map[schema.GroupResource]SearchableDocumentFields),
 		lookup: make(map[string]map[string]DocumentBuilderInfo),
 		ns:     expirable.NewLRU[NamespacedResource, DocumentBuilder](nsCacheSize, nil, ttl),
 	}
@@ -1963,18 +1957,8 @@ func newBuilderCache(cfg []DocumentBuilderInfo, nsCacheSize int, ttl time.Durati
 			cache.lookup[b.GroupResource.Group] = g
 		}
 		g[b.GroupResource.Resource] = b
-
-		f, err := b.SearchableFields()
-		if err != nil {
-			return cache, err
-		}
-		cache.fields[b.GroupResource] = f
 	}
 	return cache, nil
-}
-
-func (s *builderCache) GetFields(key NamespacedResource) SearchableDocumentFields {
-	return s.fields[schema.GroupResource{Group: key.Group, Resource: key.Resource}]
 }
 
 // context is typically background.  Holds an LRU cache for a

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -148,9 +148,8 @@ type mockSearchBackend struct {
 }
 
 type buildIndexCall struct {
-	key    NamespacedResource
-	size   int64
-	fields SearchableDocumentFields
+	key  NamespacedResource
+	size int64
 }
 
 func (m *mockSearchBackend) LoadOpenIndexStats(_ time.Time, _ time.Duration) ([]ResourceStats, error) {
@@ -167,7 +166,7 @@ func (m *mockSearchBackend) GetIndex(key NamespacedResource) ResourceIndex {
 	return m.cache[key]
 }
 
-func (m *mockSearchBackend) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time, _ time.Duration) (ResourceIndex, error) {
+func (m *mockSearchBackend) BuildIndex(ctx context.Context, key NamespacedResource, size int64, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time, _ time.Duration) (ResourceIndex, error) {
 	index := &MockResourceIndex{}
 
 	// Call the builder function (required by the contract)
@@ -187,9 +186,8 @@ func (m *mockSearchBackend) BuildIndex(ctx context.Context, key NamespacedResour
 	// Determine if this is an empty index based on size
 	// Empty indexes are characterized by size == 0
 	m.buildIndexCalls = append(m.buildIndexCalls, buildIndexCall{
-		key:    key,
-		size:   size,
-		fields: fields,
+		key:  key,
+		size: size,
 	})
 
 	return index, nil
@@ -1317,11 +1315,11 @@ func newBlockingSearchBackend(cache map[NamespacedResource]ResourceIndex) *block
 	}
 }
 
-func (b *blockingSearchBackend) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time, maxFreshSnapshotAge time.Duration) (ResourceIndex, error) {
+func (b *blockingSearchBackend) BuildIndex(ctx context.Context, key NamespacedResource, size int64, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time, maxFreshSnapshotAge time.Duration) (ResourceIndex, error) {
 	b.buildCalls.Add(1)
 	b.startedOnce.Do(func() { close(b.onStarted) })
 	<-b.proceed
-	return b.mockSearchBackend.BuildIndex(ctx, key, size, fields, reason, builder, updater, rebuild, lastImportTime, maxFreshSnapshotAge)
+	return b.mockSearchBackend.BuildIndex(ctx, key, size, reason, builder, updater, rebuild, lastImportTime, maxFreshSnapshotAge)
 }
 
 // TestRebuildIndexConcurrentRebuildsForSameKeyAreDeduplicated verifies the

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -735,7 +735,6 @@ func (b *bleveBackend) BuildIndex(
 	ctx context.Context,
 	key resource.NamespacedResource,
 	docCount int64,
-	fields resource.SearchableDocumentFields,
 	indexBuildReason string,
 	builder resource.BuildFn,
 	updater resource.UpdateFn,
@@ -759,6 +758,13 @@ func (b *bleveBackend) BuildIndex(
 	searchFieldsProvider := b.searchFieldsProvider[sfKey]
 
 	mapper, err := GetBleveMappings(searchFieldsProvider, key.Group, key.Resource, selectableFields)
+	if err != nil {
+		return nil, err
+	}
+
+	// The kind's custom column fields come from the same provider that drives
+	// the mapping, so the index and its result columns stay in agreement.
+	fields, err := resource.SearchableFieldsFromProvider(searchFieldsProvider, key.Group, key.Resource)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/unified/search/bleve_lifecycle_test.go
+++ b/pkg/storage/unified/search/bleve_lifecycle_test.go
@@ -266,9 +266,6 @@ func dashboardSearchLifecycleSeed(t *testing.T) int64 {
 func newFileBackedDashboardIndex(t *testing.T, key resource.NamespacedResource, docCount int64) *bleveIndex {
 	t.Helper()
 
-	backend, _ := setupBleveBackend(t, withFileThreshold(0))
-	ctx := identity.WithRequester(t.Context(), &user.SignedInUser{Namespace: key.Namespace})
-
 	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
 		return &builders.DashboardDocumentBuilder{
 			Namespace:        namespace,
@@ -279,9 +276,12 @@ func newFileBackedDashboardIndex(t *testing.T, key resource.NamespacedResource, 
 	})
 	require.NoError(t, err)
 
-	fields, err := info.SearchableFields()
-	require.NoError(t, err)
-	resourceIndex, err := backend.BuildIndex(ctx, key, docCount, fields, "test", func(index resource.ResourceIndex) (int64, error) {
+	backend, _ := setupBleveBackend(t, withFileThreshold(0), withSearchFieldsProvidersForKinds(map[string]resource.SearchFieldsProvider{
+		"dashboard.grafana.app/dashboards": info.SearchFieldsProvider,
+	}))
+	ctx := identity.WithRequester(t.Context(), &user.SignedInUser{Namespace: key.Namespace})
+
+	resourceIndex, err := backend.BuildIndex(ctx, key, docCount, "test", func(index resource.ResourceIndex) (int64, error) {
 		return 0, nil
 	}, nil, false, time.Time{}, 0)
 	require.NoError(t, err)

--- a/pkg/storage/unified/search/bleve_performance_test.go
+++ b/pkg/storage/unified/search/bleve_performance_test.go
@@ -59,10 +59,23 @@ func BenchmarkBleveBuildIndexStorageSelection(b *testing.B) {
 }
 
 func benchmarkBuildIndex(b *testing.B, docs int, fileThreshold int64) {
+	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
+		return &builders.DashboardDocumentBuilder{
+			Namespace:        namespace,
+			Blob:             blob,
+			Stats:            make(map[string]map[string]int64),
+			DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{}}),
+		}, nil
+	})
+	require.NoError(b, err)
+
 	backend, err := search.NewBleveBackend(search.BleveOptions{
 		Root:          b.TempDir(),
 		FileThreshold: fileThreshold,
 		BuildVersion:  "12.3.45-789",
+		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{
+			"dashboard.grafana.app/dashboards": info.SearchFieldsProvider,
+		},
 	}, nil)
 	require.NoError(b, err)
 	defer backend.Stop()
@@ -73,23 +86,12 @@ func benchmarkBuildIndex(b *testing.B, docs int, fileThreshold int64) {
 		Group:     "dashboard.grafana.app",
 		Resource:  "dashboards",
 	}
-	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
-		return &builders.DashboardDocumentBuilder{
-			Namespace:        namespace,
-			Blob:             blob,
-			Stats:            make(map[string]map[string]int64),
-			DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{}}),
-		}, nil
-	})
-	require.NoError(b, err)
 	writer := newTestWriter(docs, docs)
 
-	fields, err := info.SearchableFields()
-	require.NoError(b, err)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		idx, err := backend.BuildIndex(ctx, key, int64(docs), fields, "benchmark", writer, nil, true, time.Time{}, 0)
+		idx, err := backend.BuildIndex(ctx, key, int64(docs), "benchmark", writer, nil, true, time.Time{}, 0)
 		require.NoError(b, err)
 
 		b.StopTimer()

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -662,16 +662,6 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer re
 		Group:     "dashboard.grafana.app",
 		Resource:  "dashboards",
 	}
-	backend, err := search.NewBleveBackend(search.BleveOptions{
-		Root:          t.TempDir(),
-		FileThreshold: threshold, // use in-memory for tests
-	}, nil)
-	require.NoError(t, err)
-
-	t.Cleanup(backend.Stop)
-
-	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
-
 	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
 		return &builders.DashboardDocumentBuilder{
 			Namespace:        namespace,
@@ -682,13 +672,24 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer re
 	})
 	require.NoError(t, err)
 
-	fields, err := info.SearchableFields()
+	backend, err := search.NewBleveBackend(search.BleveOptions{
+		Root:          t.TempDir(),
+		FileThreshold: threshold, // use in-memory for tests
+		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{
+			"dashboard.grafana.app/dashboards": info.SearchFieldsProvider,
+		},
+	}, nil)
 	require.NoError(t, err)
+
+	t.Cleanup(backend.Stop)
+
+	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
+
 	index, err := backend.BuildIndex(ctx, resource.NamespacedResource{
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, size, fields, "test", writer, nil, false, time.Time{}, 0)
+	}, size, "test", writer, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	return index
@@ -724,10 +725,8 @@ func newTestIndexWithFields(t testing.TB, key resource.NamespacedResource, colum
 	t.Cleanup(backend.Stop)
 
 	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
-	fields, err := resource.NewSearchableDocumentFields(columns)
-	require.NoError(t, err)
 
-	index, err := backend.BuildIndex(ctx, key, 2, fields, "test", noop, nil, false, time.Time{}, 0)
+	index, err := backend.BuildIndex(ctx, key, 2, "test", noop, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	return index
 }
@@ -797,7 +796,7 @@ func TestIndexAndSearchSelectableFields(t *testing.T) {
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, 10, nil, "test", noop, nil, false, time.Time{}, 0)
+	}, 10, "test", noop, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	err = index.BulkIndex(&resource.BulkIndexRequest{

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -1010,16 +1010,6 @@ func newTestDashboardsIndexPostRankWithConfig(t testing.TB, size int64, cfg sear
 		Group:     "dashboard.grafana.app",
 		Resource:  "dashboards",
 	}
-	backend, err := search.NewBleveBackend(search.BleveOptions{
-		Root:                 t.TempDir(),
-		FileThreshold:        threshold, // use in-memory for tests
-		PostRankAuthzEnabled: true,
-		PostRankAuthz:        cfg,
-	}, nil)
-	require.NoError(t, err)
-	t.Cleanup(backend.Stop)
-
-	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
 	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
 		return &builders.DashboardDocumentBuilder{
 			Namespace:        namespace,
@@ -1030,13 +1020,24 @@ func newTestDashboardsIndexPostRankWithConfig(t testing.TB, size int64, cfg sear
 	})
 	require.NoError(t, err)
 
-	fields, err := info.SearchableFields()
+	backend, err := search.NewBleveBackend(search.BleveOptions{
+		Root:                 t.TempDir(),
+		FileThreshold:        threshold, // use in-memory for tests
+		PostRankAuthzEnabled: true,
+		PostRankAuthz:        cfg,
+		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{
+			"dashboard.grafana.app/dashboards": info.SearchFieldsProvider,
+		},
+	}, nil)
 	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
 	index, err := backend.BuildIndex(ctx, resource.NamespacedResource{
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, size, fields, "test", noop, nil, false, time.Time{}, 0)
+	}, size, "test", noop, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	return index
 }
@@ -1647,7 +1648,7 @@ func newTestFoldersIndexPostRank(t testing.TB, size int64, cfg search.PostRankAu
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, size, nil, "test", noop, nil, false, time.Time{}, 0)
+	}, size, "test", noop, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	return index
 }

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -612,7 +612,7 @@ func TestBuildIndex_RebuildUsesFreshSnapshot(t *testing.T) {
 	})
 
 	builderCalled := atomic.Int32{}
-	idx, err := be.BuildIndex(context.Background(), ns, 10, nil, "rebuild",
+	idx, err := be.BuildIndex(context.Background(), ns, 10, "rebuild",
 		func(resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			return 1, nil
@@ -645,7 +645,7 @@ func TestBuildIndex_RebuildFallsBackToBuilder(t *testing.T) {
 	})
 
 	builderCalled := atomic.Int32{}
-	idx, err := be.BuildIndex(context.Background(), ns, 10, nil, "rebuild",
+	idx, err := be.BuildIndex(context.Background(), ns, 10, "rebuild",
 		func(index resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			return 1, nil
@@ -671,7 +671,7 @@ func TestBuildIndex_RebuildLeaderUploads(t *testing.T) {
 	})
 
 	builderCalled := atomic.Int32{}
-	idx, err := be.BuildIndex(t.Context(), ns, 10, nil, "rebuild",
+	idx, err := be.BuildIndex(t.Context(), ns, 10, "rebuild",
 		func(index resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			return 7, nil
@@ -701,7 +701,7 @@ func TestBuildIndex_RebuildLeaderLockLostDuringBuild(t *testing.T) {
 	})
 
 	builderCalled := atomic.Int32{}
-	idx, err := be.BuildIndex(t.Context(), ns, 10, nil, "rebuild",
+	idx, err := be.BuildIndex(t.Context(), ns, 10, "rebuild",
 		func(resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			store.signalLockLost()
@@ -742,7 +742,7 @@ func TestBuildIndex_RebuildWaiterDownloadsFreshSnapshot(t *testing.T) {
 	}
 	resultCh := make(chan buildResult, 1)
 	go func() {
-		idx, err := be.BuildIndex(ctx, ns, 10, nil, "rebuild",
+		idx, err := be.BuildIndex(ctx, ns, 10, "rebuild",
 			func(resource.ResourceIndex) (int64, error) {
 				builderCalled.Add(1)
 				return 1, nil
@@ -794,7 +794,7 @@ func TestBuildIndex_RebuildWaiterRecordsDownloadedAfterWait(t *testing.T) {
 	}
 	resultCh := make(chan buildResult, 1)
 	go func() {
-		idx, err := be.BuildIndex(ctx, ns, 10, nil, "rebuild",
+		idx, err := be.BuildIndex(ctx, ns, 10, "rebuild",
 			func(resource.ResourceIndex) (int64, error) { return 1, nil },
 			nil, true /*rebuild*/, time.Time{}, time.Hour /*maxFreshSnapshotAge*/)
 		resultCh <- buildResult{idx: idx, err: err}
@@ -830,7 +830,7 @@ func TestBuildIndex_RebuildSkipsFastPathWhenDisabled(t *testing.T) {
 	})
 
 	builderCalled := atomic.Int32{}
-	idx, err := be.BuildIndex(context.Background(), ns, 10, nil, "rebuild",
+	idx, err := be.BuildIndex(context.Background(), ns, 10, "rebuild",
 		func(resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			return 1, nil
@@ -853,7 +853,7 @@ func TestBuildIndex_SkipsDownloadBelowMinDocCount(t *testing.T) {
 		MaxIndexAge: 24 * time.Hour,
 	})
 
-	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 1, nil, "test",
+	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 1, "test",
 		func(resource.ResourceIndex) (int64, error) { return 1, nil },
 		nil, false, time.Time{}, 0)
 	require.NoError(t, err)
@@ -1035,7 +1035,7 @@ func TestBleveSnapshotLifecycleWithFileBucket(t *testing.T) {
 			beA.Stop()
 		}
 	})
-	idxA, err := beA.BuildIndex(ctx, key, 10, nil, "startup", func(index resource.ResourceIndex) (int64, error) {
+	idxA, err := beA.BuildIndex(ctx, key, 10, "startup", func(index resource.ResourceIndex) (int64, error) {
 		require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
 			{
 				Action: resource.ActionIndex,
@@ -1084,7 +1084,7 @@ func TestBleveSnapshotLifecycleWithFileBucket(t *testing.T) {
 	beB, metricsB := newConfiguredSnapshotBackend(t, bucketURL)
 	t.Cleanup(beB.Stop)
 	var builderCalled atomic.Bool
-	idxB, err := beB.BuildIndex(ctx, key, 10, nil, "startup", func(resource.ResourceIndex) (int64, error) {
+	idxB, err := beB.BuildIndex(ctx, key, 10, "startup", func(resource.ResourceIndex) (int64, error) {
 		builderCalled.Store(true)
 		return 0, fmt.Errorf("builder should not be called when a remote snapshot is available")
 	}, nil, false, time.Time{}, 0)
@@ -1170,7 +1170,7 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	t.Cleanup(be.Stop)
 
 	var builderCalled atomic.Bool
-	idx, err := be.BuildIndex(ctx, key, 10, nil, "startup", func(resource.ResourceIndex) (int64, error) {
+	idx, err := be.BuildIndex(ctx, key, 10, "startup", func(resource.ResourceIndex) (int64, error) {
 		builderCalled.Store(true)
 		return 0, nil
 	}, nil, false, time.Time{}, 0)
@@ -1633,7 +1633,7 @@ func runBuildIndexColdStart(t *testing.T, store RemoteIndexStore, builderExtra f
 		MaxIndexAge: 24 * time.Hour,
 	})
 	builderCalled := &atomic.Int32{}
-	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, nil, "startup",
+	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, "startup",
 		func(resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			if builderExtra != nil {
@@ -1728,7 +1728,7 @@ func TestBuildIndex_ColdStartRunsWhenMaxIndexAgeZero(t *testing.T) {
 	})
 
 	builderCalled := atomic.Int32{}
-	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, nil, "startup",
+	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, "startup",
 		func(resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			return 1, nil
@@ -1765,7 +1765,7 @@ func TestBuildIndex_ColdStartContextCancelPropagates(t *testing.T) {
 	}()
 
 	builderCalled := atomic.Int32{}
-	idx, err := be.BuildIndex(ctx, newTestNsResource(), 10, nil, "startup",
+	idx, err := be.BuildIndex(ctx, newTestNsResource(), 10, "startup",
 		func(resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			return 1, nil

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	foldermodel "github.com/grafana/grafana/pkg/services/folder"
-	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -74,9 +73,17 @@ func TestBleveSearchRootFolderExpansion(t *testing.T) {
 	tmpdir, err := os.MkdirTemp("", "grafana-bleve-test")
 	require.NoError(t, err)
 
+	// Register the dashboard provider so the index is built from declared
+	// fields, as in production.
+	dashInfo, err := builders.DashboardBuilder(nil)
+	require.NoError(t, err)
+
 	backend, err := NewBleveBackend(BleveOptions{
 		Root:          tmpdir,
 		FileThreshold: 5,
+		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{
+			"dashboard.grafana.app/dashboards": dashInfo.SearchFieldsProvider,
+		},
 	}, nil)
 	require.NoError(t, err)
 	t.Cleanup(backend.Stop)
@@ -87,16 +94,6 @@ func TestBleveSearchRootFolderExpansion(t *testing.T) {
 		Resource:  "dashboards",
 	}
 	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
-
-	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
-		return &builders.DashboardDocumentBuilder{
-			Namespace:        namespace,
-			Blob:             blob,
-			Stats:            make(map[string]map[string]int64),
-			DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{}}),
-		}, nil
-	})
-	require.NoError(t, err)
 
 	// Index three dashboards: one at the root using the legacy empty sentinel,
 	// one at the root using the canonical "general" sentinel, and one nested.
@@ -113,13 +110,11 @@ func TestBleveSearchRootFolderExpansion(t *testing.T) {
 			},
 		}
 	}
-	fields, err := info.SearchableFields()
-	require.NoError(t, err)
 	index, err := backend.BuildIndex(ctx, resource.NamespacedResource{
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, 3, fields, "test", func(index resource.ResourceIndex) (int64, error) {
+	}, 3, "test", func(index resource.ResourceIndex) (int64, error) {
 		if err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				doc("legacy-root", ""),
@@ -194,23 +189,12 @@ func testBleveBackend(t *testing.T, backend *bleveBackend) {
 
 	t.Run("build dashboards", func(t *testing.T) {
 		key := dashboardskey
-		info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
-			return &builders.DashboardDocumentBuilder{
-				Namespace:        namespace,
-				Blob:             blob,
-				Stats:            make(map[string]map[string]int64), // empty stats
-				DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{}}),
-			}, nil
-		})
-		require.NoError(t, err)
 
-		fields, err := info.SearchableFields()
-		require.NoError(t, err)
 		index, err := backend.BuildIndex(ctx, resource.NamespacedResource{
 			Namespace: key.Namespace,
 			Group:     key.Group,
 			Resource:  key.Resource,
-		}, 2, fields, "test", func(index resource.ResourceIndex) (int64, error) {
+		}, 2, "test", func(index resource.ResourceIndex) (int64, error) {
 			err := index.BulkIndex(&resource.BulkIndexRequest{
 				Items: []*resource.BulkIndexItem{
 					{
@@ -552,13 +536,12 @@ func testBleveBackend(t *testing.T, backend *bleveBackend) {
 
 	t.Run("build folders", func(t *testing.T) {
 		key := folderKey
-		var fields resource.SearchableDocumentFields
 
 		index, err := backend.BuildIndex(ctx, resource.NamespacedResource{
 			Namespace: key.Namespace,
 			Group:     key.Group,
 			Resource:  key.Resource,
-		}, 2, fields, "test", func(index resource.ResourceIndex) (int64, error) {
+		}, 2, "test", func(index resource.ResourceIndex) (int64, error) {
 			err := index.BulkIndex(&resource.BulkIndexRequest{
 				Items: []*resource.BulkIndexItem{
 					{
@@ -1137,6 +1120,11 @@ func withSearchFieldsHashesForKinds(m map[string]string) setupOption {
 	}
 }
 
+func withSearchFieldsProvidersForKinds(m map[string]resource.SearchFieldsProvider) setupOption {
+	return func(options *BleveOptions) {
+		options.SearchFieldsProvidersForKinds = m
+	}
+}
 func TestMemoryBleveIndexCanBeCopiedToFilesystem(t *testing.T) {
 	mapper, err := GetBleveMappings(nil, "", "", nil)
 	require.NoError(t, err)
@@ -1272,7 +1260,7 @@ func TestBuildIndexExpiration(t *testing.T) {
 			if !tc.inMemory {
 				docs = defaultFileThreshold
 			}
-			builtIndex, err := backend.BuildIndex(context.Background(), ns, int64(docs), nil, "test", indexTestDocs(ns, docs, 100), nil, false, time.Time{}, 0)
+			builtIndex, err := backend.BuildIndex(context.Background(), ns, int64(docs), "test", indexTestDocs(ns, docs, 100), nil, false, time.Time{}, 0)
 			require.NoError(t, err)
 
 			// Evict indexes.
@@ -1320,9 +1308,9 @@ func TestCloseAllIndexes(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	backend1, reg := setupBleveBackend(t, withRootDir(tmpDir))
-	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
+	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
-	_, err = backend1.BuildIndex(context.Background(), ns2, 1 /* memory based */, nil, "test", indexTestDocs(ns2, 1, 100), nil, false, time.Time{}, 0)
+	_, err = backend1.BuildIndex(context.Background(), ns2, 1 /* memory based */, "test", indexTestDocs(ns2, 1, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	// Verify two open indexes.
@@ -1360,7 +1348,7 @@ func TestBuildIndex(t *testing.T) {
 
 			{
 				backend, _ := setupBleveBackend(t, withFileThreshold(5), withRootDir(tmpDir))
-				_, err := backend.BuildIndex(context.Background(), ns, firstIndexDocsCount, nil, "test", indexTestDocs(ns, firstIndexDocsCount, 100), nil, false, lastImportTime, 0)
+				_, err := backend.BuildIndex(context.Background(), ns, firstIndexDocsCount, "test", indexTestDocs(ns, firstIndexDocsCount, 100), nil, false, lastImportTime, 0)
 				require.NoError(t, err)
 				backend.Stop()
 			}
@@ -1369,7 +1357,7 @@ func TestBuildIndex(t *testing.T) {
 			time.Sleep(1 * time.Millisecond)
 
 			newBackend, _ := setupBleveBackend(t, withFileThreshold(5), withRootDir(tmpDir))
-			idx, err := newBackend.BuildIndex(context.Background(), ns, secondIndexDocsCount, nil, "test", indexTestDocs(ns, secondIndexDocsCount, 100), nil, false, lastImportTime, 0)
+			idx, err := newBackend.BuildIndex(context.Background(), ns, secondIndexDocsCount, "test", indexTestDocs(ns, secondIndexDocsCount, 100), nil, false, lastImportTime, 0)
 			require.NoError(t, err)
 
 			cnt, err := idx.DocCount(context.Background(), "", nil)
@@ -1393,7 +1381,7 @@ func TestBuildIndexAdaptivePromotion(t *testing.T) {
 	t.Run("small build stays in memory", func(t *testing.T) {
 		backend, reg := setupBleveBackend(t, withFileThreshold(5))
 
-		idx, err := backend.BuildIndex(t.Context(), ns, 100, nil, "test", indexTestDocs(ns, 4, 100), nil, false, time.Time{}, 0)
+		idx, err := backend.BuildIndex(t.Context(), ns, 100, "test", indexTestDocs(ns, 4, 100), nil, false, time.Time{}, 0)
 		require.NoError(t, err)
 
 		bleveIdx := idx.(*bleveIndex)
@@ -1406,7 +1394,7 @@ func TestBuildIndexAdaptivePromotion(t *testing.T) {
 	t.Run("build crossing threshold promotes to filesystem", func(t *testing.T) {
 		backend, reg := setupBleveBackend(t, withFileThreshold(5))
 
-		idx, err := backend.BuildIndex(t.Context(), ns, 1, nil, "test", indexTestDocs(ns, 5, 100), nil, false, time.Time{}, 0)
+		idx, err := backend.BuildIndex(t.Context(), ns, 1, "test", indexTestDocs(ns, 5, 100), nil, false, time.Time{}, 0)
 		require.NoError(t, err)
 
 		bleveIdx := idx.(*bleveIndex)
@@ -1440,7 +1428,7 @@ func TestBuildIndexAdaptivePromotion(t *testing.T) {
 	t.Run("incremental update does not promote memory index", func(t *testing.T) {
 		backend, reg := setupBleveBackend(t, withFileThreshold(5))
 
-		idx, err := backend.BuildIndex(t.Context(), ns, 1, nil, "test", indexTestDocs(ns, 1, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
+		idx, err := backend.BuildIndex(t.Context(), ns, 1, "test", indexTestDocs(ns, 1, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 		require.NoError(t, err)
 		bleveIdx := idx.(*bleveIndex)
 		require.Equal(t, indexStorageMemory, bleveIdx.indexStorage)
@@ -1460,7 +1448,7 @@ func TestBuildIndexAdaptivePromotion(t *testing.T) {
 	t.Run("build failure before promotion leaves no filesystem directory", func(t *testing.T) {
 		backend, _ := setupBleveBackend(t, withFileThreshold(5))
 
-		idx, err := backend.BuildIndex(t.Context(), ns, 100, nil, "test", func(resource.ResourceIndex) (int64, error) {
+		idx, err := backend.BuildIndex(t.Context(), ns, 100, "test", func(resource.ResourceIndex) (int64, error) {
 			return 0, errors.New("fail before promotion")
 		}, nil, false, time.Time{}, 0)
 		require.Error(t, err)
@@ -1472,7 +1460,7 @@ func TestBuildIndexAdaptivePromotion(t *testing.T) {
 	t.Run("build failure after promotion removes filesystem directory", func(t *testing.T) {
 		backend, _ := setupBleveBackend(t, withFileThreshold(5))
 
-		idx, err := backend.BuildIndex(t.Context(), ns, 100, nil, "test", func(index resource.ResourceIndex) (int64, error) {
+		idx, err := backend.BuildIndex(t.Context(), ns, 100, "test", func(index resource.ResourceIndex) (int64, error) {
 			_, buildErr := indexTestDocs(ns, 5, 100)(index)
 			require.NoError(t, buildErr)
 			return 0, errors.New("fail after promotion")
@@ -1507,7 +1495,7 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 			if testCase.firstInMemory {
 				firstDocs = 1
 			}
-			firstIndex, err := backend.BuildIndex(context.Background(), ns, int64(firstDocs), nil, "test", indexTestDocs(ns, firstDocs, 100), nil, false, time.Time{}, 0)
+			firstIndex, err := backend.BuildIndex(context.Background(), ns, int64(firstDocs), "test", indexTestDocs(ns, firstDocs, 100), nil, false, time.Time{}, 0)
 			require.NoError(t, err)
 
 			if testCase.firstInMemory {
@@ -1523,7 +1511,7 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 				secondDocs = 1
 				openInMemoryIndexes = 1
 			}
-			secondIndex, err := backend.BuildIndex(context.Background(), ns, int64(secondDocs), nil, "test", indexTestDocs(ns, secondDocs, 100), nil, false, time.Time{}, 0)
+			secondIndex, err := backend.BuildIndex(context.Background(), ns, int64(secondDocs), "test", indexTestDocs(ns, secondDocs, 100), nil, false, time.Time{}, 0)
 			require.NoError(t, err)
 
 			if testCase.secondInMemory {
@@ -1745,7 +1733,7 @@ func TestBuildIndexConcurrentBuildsForSameKeyDoNotDeleteEachOthersDirs(t *testin
 	// Seed the cache with a file-based index so the subsequent rebuilds skip
 	// the cold-start reuse path (which would otherwise collide on the bolt
 	// lock of the already-open initial index).
-	_, err := backend.BuildIndex(t.Context(), ns, 100, nil, "init",
+	_, err := backend.BuildIndex(t.Context(), ns, 100, "init",
 		indexTestDocs(ns, 1, 1),
 		nil, false, time.Time{}, 0)
 	require.NoError(t, err)
@@ -1759,7 +1747,7 @@ func TestBuildIndexConcurrentBuildsForSameKeyDoNotDeleteEachOthersDirs(t *testin
 	aDone := make(chan struct{})
 	go func() {
 		defer close(aDone)
-		_, _ = backend.BuildIndex(t.Context(), ns, 100, nil, "build-a",
+		_, _ = backend.BuildIndex(t.Context(), ns, 100, "build-a",
 			func(index resource.ResourceIndex) (int64, error) {
 				if err := index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{{
 					Action: resource.ActionIndex,
@@ -1788,7 +1776,7 @@ func TestBuildIndexConcurrentBuildsForSameKeyDoNotDeleteEachOthersDirs(t *testin
 	require.NotEmpty(t, aDir)
 
 	// Run B to completion. B's cleanOldIndexes runs while A is still in flight.
-	_, err = backend.BuildIndex(t.Context(), ns, 100, nil, "build-b",
+	_, err = backend.BuildIndex(t.Context(), ns, 100, "build-b",
 		indexTestDocs(ns, 1, 2),
 		nil, true, time.Time{}, 0)
 	require.NoError(t, err)
@@ -1815,7 +1803,7 @@ func TestBuildIndexColdStartReuseRejectionDoesNotLeakInFlightDir(t *testing.T) {
 	ns := resource.NamespacedResource{Namespace: "ns", Group: "group", Resource: "res"}
 
 	// Build an initial file-based index so a directory exists on disk.
-	_, err := backend.BuildIndex(t.Context(), ns, 100, nil, "init",
+	_, err := backend.BuildIndex(t.Context(), ns, 100, "init",
 		func(_ resource.ResourceIndex) (int64, error) { return 1, nil },
 		nil, false, time.Time{}, 0)
 	require.NoError(t, err)
@@ -1832,7 +1820,7 @@ func TestBuildIndexColdStartReuseRejectionDoesNotLeakInFlightDir(t *testing.T) {
 	// Call BuildIndex with lastImportTime > the existing index's BuildTime.
 	// tryReuseFileIndex opens the on-disk dir, sees the build is stale, and
 	// closes + rejects it; createEmptyFileIndex then builds a fresh one.
-	_, err = backend.BuildIndex(t.Context(), ns, 100, nil, "rebuild-after-import",
+	_, err = backend.BuildIndex(t.Context(), ns, 100, "rebuild-after-import",
 		func(_ resource.ResourceIndex) (int64, error) { return 2, nil },
 		nil, false, time.Now().Add(time.Hour), 0)
 	require.NoError(t, err)
@@ -1863,7 +1851,7 @@ func testBleveIndexWithFailures(t *testing.T, fileBased bool) {
 	if fileBased {
 		docs = defaultFileThreshold
 	}
-	_, err := backend.BuildIndex(context.Background(), ns, int64(docs), nil, "test", func(index resource.ResourceIndex) (int64, error) {
+	_, err := backend.BuildIndex(context.Background(), ns, int64(docs), "test", func(index resource.ResourceIndex) (int64, error) {
 		if fileBased {
 			_, buildErr := indexTestDocs(ns, docs, 100)(index)
 			require.NoError(t, buildErr)
@@ -1873,7 +1861,7 @@ func testBleveIndexWithFailures(t *testing.T, fileBased bool) {
 	require.Error(t, err)
 
 	// Even though previous build of the index failed, new building of the index should work.
-	_, err = backend.BuildIndex(context.Background(), ns, int64(docs), nil, "test", indexTestDocs(ns, docs, 100), nil, false, time.Time{}, 0)
+	_, err = backend.BuildIndex(context.Background(), ns, int64(docs), "test", indexTestDocs(ns, docs, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 }
 
@@ -1885,7 +1873,7 @@ func TestIndexUpdate(t *testing.T) {
 	}
 
 	be, _ := setupBleveBackend(t)
-	idx, err := be.BuildIndex(t.Context(), ns, defaultFileThreshold*2 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
+	idx, err := be.BuildIndex(t.Context(), ns, defaultFileThreshold*2 /* file based */, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	resp := searchTitle(t, idx, "gen", 10, ns)
@@ -1939,7 +1927,7 @@ func TestConcurrentIndexUpdateAndBuildIndex(t *testing.T) {
 		return sinceRV + int64(5), 5, err
 	}
 
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{}, 0)
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1947,7 +1935,7 @@ func TestConcurrentIndexUpdateAndBuildIndex(t *testing.T) {
 	_, err = idx.UpdateIndex(ctx)
 	require.NoError(t, err)
 
-	_, err = be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{}, 0)
+	_, err = be.BuildIndex(t.Context(), ns, 10 /* file based */, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	_, err = idx.UpdateIndex(ctx)
@@ -1963,7 +1951,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 
 	be, _ := setupBleveBackend(t)
 
-	_, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
+	_, err := be.BuildIndex(t.Context(), ns, 10, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
@@ -2022,7 +2010,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for ctx.Err() == nil {
-			_, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
+			_, err := be.BuildIndex(t.Context(), ns, 10, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 			require.NoError(t, err)
 			rebuilds.Add(1)
 		}
@@ -2045,7 +2033,7 @@ func TestConcurrentIndexUpdateAndSearch(t *testing.T) {
 
 	be, _ := setupBleveBackend(t)
 
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
@@ -2105,7 +2093,7 @@ func TestConcurrentIndexUpdateAndSearchWithIndexMinUpdateInterval(t *testing.T) 
 	be, _ := setupBleveBackend(t, withIndexMinUpdateInterval(minInterval))
 
 	updateFn, updateCalls := updateTestDocsReturningMillisTimestamp(ns, 5)
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updateFn, false, time.Time{}, 0)
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, "test", indexTestDocs(ns, 10, 100), updateFn, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
@@ -2173,7 +2161,7 @@ func TestIndexUpdateWithErrors(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		return 0, 0, updateErr
 	}
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{}, 0)
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	t.Run("update fail", func(t *testing.T) {
@@ -2207,7 +2195,7 @@ func TestIndexBuildInfo(t *testing.T) {
 	}
 
 	be, _ := setupBleveBackend(t, withFileThreshold(100))
-	index, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
+	index, err := be.BuildIndex(t.Context(), ns, 10, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	buildInfo, err := getBuildInfo(index.(*bleveIndex).index)
@@ -2229,7 +2217,7 @@ func TestIndexBuildInfoSearchFieldsHashRoundTrip(t *testing.T) {
 	}
 
 	be, _ := setupBleveBackend(t, withFileThreshold(100), withSearchFieldsHashesForKinds(hashes))
-	index, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
+	index, err := be.BuildIndex(t.Context(), ns, 10, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	buildInfo, err := index.BuildInfo()
@@ -2238,7 +2226,7 @@ func TestIndexBuildInfoSearchFieldsHashRoundTrip(t *testing.T) {
 
 	// Indexes built without a registered hash record an empty string.
 	nsOther := resource.NamespacedResource{Namespace: "test", Group: "other", Resource: "things"}
-	indexOther, err := be.BuildIndex(t.Context(), nsOther, 10, nil, "test", indexTestDocs(nsOther, 10, 100), nil, false, time.Time{}, 0)
+	indexOther, err := be.BuildIndex(t.Context(), nsOther, 10, "test", indexTestDocs(nsOther, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	buildInfoOther, err := indexOther.BuildInfo()
@@ -2289,7 +2277,7 @@ func TestBuildIndexReturnsErrorWhenIndexLocked(t *testing.T) {
 
 	// First, create a file-based index with one backend and keep it open
 	backend1, reg1 := setupBleveBackend(t, withRootDir(tmpDir))
-	index1, err := backend1.BuildIndex(context.Background(), ns, 100 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
+	index1, err := backend1.BuildIndex(context.Background(), ns, 100 /* file based */, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	require.NotNil(t, index1)
 
@@ -2307,7 +2295,7 @@ func TestBuildIndexReturnsErrorWhenIndexLocked(t *testing.T) {
 	now := time.Now()
 	timeout, err := time.ParseDuration(boltTimeout)
 	require.NoError(t, err)
-	index2, err := backend2.BuildIndex(context.Background(), ns, 100 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
+	index2, err := backend2.BuildIndex(context.Background(), ns, 100 /* file based */, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.Error(t, err)
 	require.ErrorIs(t, err, bolterrors.ErrTimeout)
 	require.Nil(t, index2)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -821,7 +821,7 @@ func testBleveBackend(t *testing.T, backend *bleveBackend) {
 func TestGetSortFields(t *testing.T) {
 	dashboardInfo, err := builders.DashboardBuilder(nil)
 	require.NoError(t, err)
-	dashboardFields, err := dashboardInfo.SearchableFields()
+	dashboardFields, err := resource.SearchableFieldsFromProvider(dashboardInfo.SearchFieldsProvider, dashboardInfo.GroupResource.Group, dashboardInfo.GroupResource.Resource)
 	require.NoError(t, err)
 
 	t.Run("will prepend 'fields.' to sort fields when they are dashboard fields", func(t *testing.T) {

--- a/pkg/storage/unified/search/open_index_list_test.go
+++ b/pkg/storage/unified/search/open_index_list_test.go
@@ -24,9 +24,9 @@ func TestOpenIndexListWriteAndLoad(t *testing.T) {
 	first := resource.NamespacedResource{Namespace: "ns-a", Group: "group-a", Resource: "resource-a"}
 	second := resource.NamespacedResource{Namespace: "ns-b", Group: "group-b", Resource: "resource-b"}
 
-	_, err = backend.BuildIndex(context.Background(), second, 2, nil, "test", indexTestDocs(second, 2, 100), nil, false, time.Time{}, 0)
+	_, err = backend.BuildIndex(context.Background(), second, 2, "test", indexTestDocs(second, 2, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
-	_, err = backend.BuildIndex(context.Background(), first, 3, nil, "test", indexTestDocs(first, 3, 200), nil, false, time.Time{}, 0)
+	_, err = backend.BuildIndex(context.Background(), first, 3, "test", indexTestDocs(first, 3, 200), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	now := time.Now().UTC()

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -375,7 +375,7 @@ func runSearchBackendBenchmarkWriteThroughput(ctx context.Context, backend resou
 
 	// Build initial index
 	size := int64(10000) // force the index to be on disk
-	index, err := backend.BuildIndex(ctx, nr, size, nil, "benchmark", func(index resource.ResourceIndex) (int64, error) {
+	index, err := backend.BuildIndex(ctx, nr, size, "benchmark", func(index resource.ResourceIndex) (int64, error) {
 		return 0, nil
 	}, nil, false, time.Time{}, 0)
 	if err != nil {

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -63,7 +63,7 @@ func runTestSearchBackendBuildIndex(t *testing.T, backend resource.SearchBackend
 	require.Nil(t, index)
 
 	// Build the index
-	index, err := backend.BuildIndex(ctx, ns, 0, nil, "test", func(index resource.ResourceIndex) (int64, error) {
+	index, err := backend.BuildIndex(ctx, ns, 0, "test", func(index resource.ResourceIndex) (int64, error) {
 		// Write a test document
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
@@ -111,7 +111,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 	const resourceVersion = 23
 
 	// Build initial index with some test documents
-	index, err := backend.BuildIndex(ctx, ns, 3, nil, "test", func(index resource.ResourceIndex) (int64, error) {
+	index, err := backend.BuildIndex(ctx, ns, 3, "test", func(index resource.ResourceIndex) (int64, error) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
@@ -276,7 +276,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 		const newResourceVersion = 444
 
 		// Build index with dashboards that have LibraryPanel references
-		index, err := backend.BuildIndex(ctx, ns, 3, nil, "test", func(index resource.ResourceIndex) (int64, error) {
+		index, err := backend.BuildIndex(ctx, ns, 3, "test", func(index resource.ResourceIndex) (int64, error) {
 			err := index.BulkIndex(&resource.BulkIndexRequest{
 				Items: []*resource.BulkIndexItem{
 					{


### PR DESCRIPTION
The search backend already holds each kind's search-fields provider and uses it to build the index mapping. Until now `BuildIndex` also took the kind's column fields as a separate argument, which callers computed from that same provider — two paths to the same information.

This removes the argument and has `BuildIndex` derive the column fields from the provider it already has, right next to where it builds the mapping from it. The index and the result columns now come from one source, so they can't drift apart, and callers no longer carry a value the backend can work out itself. Behaviour is unchanged for every kind, since the provider is what produced that argument before.

Part of grafana/search-and-storage-team#827.
