### PR TITLE
Add doc count to snapshot index metadata

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -152,6 +152,9 @@ func (b *bleveBackend) snapshotCopyAndUpload(ctx context.Context, key resource.N
 
 	rv, err := getRV(snapshotIdx)
 	bi, biErr := getBuildInfo(snapshotIdx)
+	// docCount is recorded in the manifest for debugging only; a read failure
+	// shouldn't fail the upload, so we log and fall back to zero ("unknown").
+	docCount, docErr := snapshotIdx.DocCount()
 	if closeErr := snapshotIdx.Close(); closeErr != nil {
 		return ulid.ULID{}, 0, fmt.Errorf("closing staged snapshot: %w", closeErr)
 	}
@@ -161,11 +164,16 @@ func (b *bleveBackend) snapshotCopyAndUpload(ctx context.Context, key resource.N
 	if biErr != nil {
 		return ulid.ULID{}, 0, fmt.Errorf("reading snapshot build info: %w", biErr)
 	}
+	if docErr != nil {
+		b.log.Warn("reading snapshot doc count; recording zero", "err", docErr)
+		docCount = 0
+	}
 
 	meta := IndexMeta{
 		BuildVersion:          bi.BuildVersion,
 		IndexFormat:           indexFormat,
 		LatestResourceVersion: rv,
+		DocCount:              docCount,
 	}
 	// bi.BuildTime is the original index creation time; it survives reopens and
 	// downloads, so periodic re-uploads keep the original build-start time.

--- a/pkg/storage/unified/search/bleve_snapshot_upload_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload_test.go
@@ -89,6 +89,9 @@ func TestUploadSnapshot_Success(t *testing.T) {
 	assert.Equal(t, int64(42), uploadedMeta.LatestResourceVersion)
 	assert.Equal(t, be.opts.BuildVersion, uploadedMeta.BuildVersion)
 	assert.NotZero(t, uploadedMeta.IndexFormat)
+	// The test index holds a single document; DocCount is recorded for
+	// debugging only, but verify it reflects the index contents.
+	assert.Equal(t, uint64(1), uploadedMeta.DocCount)
 	assert.Equal(t, be.opts.BuildVersion, store.getLastLockBuildVersion())
 	// BuildTime must be populated from the index's internal build
 	// info (set by newBleveIndex), not left zero. Compare with second-level

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -92,6 +92,11 @@ type IndexMeta struct {
 	IndexFormat string `json:"index_format,omitempty"`
 	// LatestResourceVersion is the latest resource version included in the index.
 	LatestResourceVersion int64 `json:"latest_resource_version"`
+	// DocCount is the number of documents in the index at upload time. Recorded
+	// for debugging and troubleshooting only; there is no reader that relies on
+	// it. Zero-value means "unknown" (legacy snapshot uploaded before this field
+	// was added).
+	DocCount uint64 `json:"doc_count,omitempty"`
 	// Files maps relative file paths to their sizes in bytes.
 	Files map[string]int64 `json:"files"`
 }


### PR DESCRIPTION
Record the number of documents in the index at upload time in the snapshot manifest (`IndexMeta.DocCount`). This is for debugging and troubleshooting only, and no reader relies on it.

The value is read from the already-open staged snapshot index during upload, so it adds no extra work. A read failure is logged and falls back to zero rather than failing the upload.

The manifest change is additive (new `omitempty` field), so it is backwards compatible: old servers ignore it, and new servers treat a missing field as zero ("unknown") for legacy snapshots.