### PR TITLE
Alerting: add alerting.listViewV3 toggle and routing skeleton

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -49,6 +49,7 @@ declare module "@openfeature/core" {
     | "assistant.frontend.tools.dashboardTemplates"
     | "grafana.unifiedHomepage"
     | "alerting.syncExternalAlertmanager"
+    | "alerting.listViewV3"
     | "grafana.enableScopesFirstMode"
     | "grafana.logLevelInference"
     | "plugins.initDataSourcesAsync"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -13,6 +13,8 @@ import {
 
 // Flag key constants for programmatic access
 export const FlagKeys = {
+  /** Enables the pure k8s-backed alert list view design */
+  AlertingListViewV3: "alerting.listViewV3",
   /** Automatically syncs external Alertmanager datasource configuration as ExtraConfiguration in Grafana */
   AlertingSyncExternalAlertmanager: "alerting.syncExternalAlertmanager",
   /** Enables new analytics framework */
@@ -102,6 +104,17 @@ export const FlagKeys = {
   /** Enables the 'Customize with Assistant' button on suggested dashboard cards */
   SuggestedDashboardsAssistantButton: "suggestedDashboardsAssistantButton",
 } as const;
+
+/**
+ * Enables the pure k8s-backed alert list view design
+ *
+ * **Details:**
+ * - flag key: `alerting.listViewV3`
+ * - default value: `false`
+ */
+export const useFlagAlertingListViewV3 = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("alerting.listViewV3", false, options).value;
+};
 
 /**
  * Automatically syncs external Alertmanager datasource configuration as ExtraConfiguration in Grafana

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3118,6 +3118,14 @@ var (
 			Expression:      "false",
 		},
 		{
+			Name:        "alerting.listViewV3",
+			Description: "Enables the pure k8s-backed alert list view design",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaAlertingSquad,
+			Generate:    Generate{React: true},
+			Expression:  "false",
+		},
+		{
 			Name:         "grafana.enableScopesFirstMode",
 			Description:  "Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button)",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -363,10 +363,11 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,preferences.rerouteLegacyAPIs,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-05-22,plugins.marketplaceLicensing,experimental,@grafana/grafana-catalog,false,true,false
 2026-05-22,alerting.syncExternalAlertmanager,experimental,@grafana/alerting-squad,false,true,false
+2026-07-03,alerting.listViewV3,experimental,@grafana/alerting-squad,false,false,true
 2026-05-22,grafana.enableScopesFirstMode,experimental,@grafana/grafana-operator-experience-squad,false,false,true
 2026-05-22,grafana.logLevelInference,deprecated,@grafana/observability-logs,false,false,true
 2026-05-26,plugins.initDataSourcesAsync,experimental,@grafana/grafana-catalog,false,false,true
 2026-05-22,frontendService.reducedBootDataAPI,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-05-27,grafana.panelEditNextFeedbackEvent,experimental,@grafana/datapro,false,false,true
-2026-06-09,dashboard.vectorSearch,experimental,@grafana/search-and-storage,false,false,false
 2026-06-12,grafana.visualDesignRefresh,experimental,@grafana/grafana-frontend-platform,false,false,true
+2026-06-09,dashboard.vectorSearch,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -118,6 +118,20 @@
     },
     {
       "metadata": {
+        "name": "alerting.listViewV3",
+        "resourceVersion": "1783073098017",
+        "creationTimestamp": "2026-07-03T10:04:58Z"
+      },
+      "spec": {
+        "description": "Enables the pure k8s-backed alert list view design",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alerting.notificationsAPIV1Beta1",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2026-05-22T09:03:04Z"
@@ -437,6 +451,21 @@
       "spec": {
         "description": "Enables the alerting list view v2 preview toggle",
         "stage": "preview",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingListViewV3",
+        "resourceVersion": "1783070337443",
+        "creationTimestamp": "2026-07-03T09:18:57Z",
+        "deletionTimestamp": "2026-07-03T10:04:58Z"
+      },
+      "spec": {
+        "description": "Enables the pure k8s-backed alert list view design",
+        "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
         "expression": "false"

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -467,9 +467,9 @@ export function trackViewExperienceToggleConfirmed(
 }
 
 /**
- * Track which rule list version (V1 or V2) is displayed on page load.
+ * Track which rule list version (V1, V2 or V3) is displayed on page load.
  * Fired once per mount in the RuleList router component.
  */
-export function trackRuleListPageView(payload: { view: 'v1' | 'v2' }) {
+export function trackRuleListPageView(payload: { view: 'v1' | 'v2' | 'v3' }) {
   reportInteraction('grafana_alerting_rule_list_page_view', payload);
 }

--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -1,11 +1,12 @@
 import { type SerializedError } from '@reduxjs/toolkit';
 import { TestProvider } from 'test/helpers/TestProvider';
-import { render, screen, waitFor, within } from 'test/test-utils';
+import { act, render, screen, waitFor, within } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import { PluginExtensionTypes } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { locationService, setAppEvents, usePluginLinks } from '@grafana/runtime';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { appEvents } from 'app/core/app_events';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { setAlertmanagerChoices } from 'app/features/alerting/unified/mocks/server/configure';
@@ -163,8 +164,25 @@ describe('RuleList', () => {
     setupDataSources(...Object.values(dataSources));
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     jest.resetAllMocks();
+    // Wrap in act() because setTestFlags fires OpenFeature events that trigger React state
+    // updates while the component is still mounted (RTL cleanup runs in a separate afterEach).
+    await act(async () => {
+      setTestFlags({});
+    });
+  });
+
+  it('renders the v3 list view when alerting.listViewV3 is enabled', async () => {
+    setTestFlags({ 'alerting.listViewV3': true });
+
+    mocks.api.fetchRules.mockResolvedValue([]);
+    mocks.api.fetchRulerRules.mockResolvedValue({});
+
+    renderRuleList();
+
+    await waitFor(() => expect(mocks.api.fetchRules).not.toHaveBeenCalled());
+    expect(ui.rulesFilterInput.query()).not.toBeInTheDocument();
   });
 
   it('load & show rule groups from multiple cloud data sources', async () => {

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -1,24 +1,48 @@
 import { Suspense, lazy, useEffect, useRef } from 'react';
 
+import { useFlagAlertingListViewV3 } from '@grafana/runtime/internal';
+
 import { trackRuleListPageView } from './Analytics';
 import { shouldUseAlertingListViewV2 } from './featureToggles';
-import RuleListV1 from './rule-list/RuleList.v1';
 import { withPageErrorBoundary } from './withPageErrorBoundary';
 
-const RuleListV2 = lazy(() => import('./rule-list/RuleList.v2'));
+const ruleListVersions = {
+  v1: lazy(() => import('./rule-list/RuleList.v1')),
+  v2: lazy(() => import('./rule-list/RuleList.v2')),
+  v3: lazy(() => import('./rule-list/RuleList.v3')),
+};
 
 const RuleList = () => {
-  const newView = shouldUseAlertingListViewV2();
+  const listVersion = useRuleListVersion();
   const tracked = useRef(false);
 
   useEffect(() => {
     if (!tracked.current) {
-      trackRuleListPageView({ view: newView ? 'v2' : 'v1' });
+      trackRuleListPageView({ view: listVersion });
       tracked.current = true;
     }
-  }, [newView]);
+  }, [listVersion]);
 
-  return <Suspense>{newView ? <RuleListV2 /> : <RuleListV1 />}</Suspense>;
+  const RuleListContent = ruleListVersions[listVersion];
+
+  return (
+    <Suspense>
+      <RuleListContent />
+    </Suspense>
+  );
 };
+
+function useRuleListVersion(): keyof typeof ruleListVersions {
+  const useV3 = useFlagAlertingListViewV3();
+  const useV2 = shouldUseAlertingListViewV2();
+
+  if (useV3) {
+    return 'v3';
+  }
+  if (useV2) {
+    return 'v2';
+  }
+  return 'v1';
+}
 
 export default withPageErrorBoundary(RuleList);

--- a/public/app/features/alerting/unified/rule-list/RuleList.v3.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v3.tsx
@@ -1,0 +1,8 @@
+import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
+import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
+
+export default function RuleListPage() {
+  const { navId, pageNav } = useAlertRulesNav();
+
+  return <AlertingPageWrapper navId={navId} pageNav={pageNav} />;
+}


### PR DESCRIPTION
## Summary
- First step of the RuleList.v3 stack (see plan): a dark, OpenFeature-backed `alerting.listViewV3` toggle that routes to a minimal, empty `RuleList.v3` page shell.
- No behavior change with the toggle off; v1/v2 are untouched.
- Based on #126119 (`moustafab/rules-search`), which this stack builds on top of.

## Test plan
- [x] `yarn test --watchAll=false` (RuleList + featureToggles suites)
- [x] `yarn lint:fix` clean
- [x] `yarn typecheck` clean
- [x] `go test ./pkg/services/featuremgmt/...` / `go vet` clean