### PR TITLE
Explore: Resolve template-variable datasource when opening a panel in Explore

### DIFF
--- a/public/app/features/dashboard-scene/utils/urlBuilders.test.ts
+++ b/public/app/features/dashboard-scene/utils/urlBuilders.test.ts
@@ -1,0 +1,71 @@
+import {
+  ConstantVariable,
+  EmbeddedScene,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneQueryRunner,
+  SceneTimeRange,
+  SceneVariableSet,
+  VizPanel,
+} from '@grafana/scenes';
+import { contextSrv } from 'app/core/services/context_srv';
+import { getExploreUrl } from 'app/core/utils/explore';
+
+import { tryGetExploreUrlForPanel } from './urlBuilders';
+
+jest.mock('app/core/utils/explore', () => ({
+  getExploreUrl: jest.fn().mockResolvedValue('/explore'),
+}));
+
+const getExploreUrlMock = jest.mocked(getExploreUrl);
+
+describe('tryGetExploreUrlForPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(contextSrv, 'hasAccessToExplore').mockReturnValue(true);
+  });
+
+  it('interpolates a template-variable datasource ($datasource) to a concrete uid', async () => {
+    const queryRunner = new SceneQueryRunner({
+      queries: [{ refId: 'A', expr: 'up', datasource: { uid: '$datasource', type: '' } }],
+    });
+    const panel = new VizPanel({ pluginId: 'timeseries', $data: queryRunner });
+
+    const scene = new EmbeddedScene({
+      $timeRange: new SceneTimeRange({ from: 'now-1h', to: 'now' }),
+      $variables: new SceneVariableSet({
+        variables: [new ConstantVariable({ name: 'datasource', value: 'gdev-prometheus' })],
+      }),
+      body: new SceneFlexLayout({ children: [new SceneFlexItem({ body: panel })] }),
+    });
+    scene.activate();
+
+    await tryGetExploreUrlForPanel(panel);
+
+    expect(getExploreUrlMock).toHaveBeenCalledTimes(1);
+    const args = getExploreUrlMock.mock.calls[0][0];
+    // Both the per-query datasource and the pane datasource must be resolved to a concrete uid,
+    // not the raw `$datasource` variable, otherwise Explore cannot resolve the datasource.
+    expect(args.queries[0].datasource).toMatchObject({ uid: 'gdev-prometheus' });
+    expect(args.dsRef).toMatchObject({ uid: 'gdev-prometheus' });
+  });
+
+  it('leaves a concrete datasource uid unchanged', async () => {
+    const queryRunner = new SceneQueryRunner({
+      queries: [{ refId: 'A', expr: 'up', datasource: { uid: 'gdev-prometheus', type: 'prometheus' } }],
+    });
+    const panel = new VizPanel({ pluginId: 'timeseries', $data: queryRunner });
+
+    const scene = new EmbeddedScene({
+      $timeRange: new SceneTimeRange({ from: 'now-1h', to: 'now' }),
+      body: new SceneFlexLayout({ children: [new SceneFlexItem({ body: panel })] }),
+    });
+    scene.activate();
+
+    await tryGetExploreUrlForPanel(panel);
+
+    const args = getExploreUrlMock.mock.calls[0][0];
+    expect(args.queries[0].datasource).toMatchObject({ uid: 'gdev-prometheus', type: 'prometheus' });
+    expect(args.dsRef).toMatchObject({ uid: 'gdev-prometheus' });
+  });
+});

--- a/public/app/features/dashboard-scene/utils/urlBuilders.ts
+++ b/public/app/features/dashboard-scene/utils/urlBuilders.ts
@@ -1,6 +1,7 @@
 import { locationUtil } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { sceneGraph, type VizPanel } from '@grafana/scenes';
+import { type DataSourceRef } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getExploreUrl } from 'app/core/utils/explore';
 
@@ -24,10 +25,24 @@ export function tryGetExploreUrlForPanel(vizPanel: VizPanel): Promise<string | u
   const datasource = getDatasourceFromQueryRunner(queryRunner);
 
   return getExploreUrl({
-    queries: queryRunner.state.queries,
-    dsRef: datasource,
+    queries: queryRunner.state.queries.map((query) => ({
+      ...query,
+      datasource: interpolateDatasourceRef(query.datasource, vizPanel),
+    })),
+    dsRef: interpolateDatasourceRef(datasource, vizPanel),
     timeRange: timeRange.state.value,
     scopedVars: { __sceneObject: { value: vizPanel } },
     adhocFilters: queryRunner.state.data?.request?.filters,
   });
+}
+
+// A datasource ref on a scene query runner may use a template variable as its uid (e.g.
+// `$datasource`). Explore cannot resolve dashboard variables, so interpolate the ref against the
+// panel's scene into a concrete datasource uid before building the Explore URL. Without this the
+// unresolved variable ends up in the URL, and Explore falls back to the default datasource.
+function interpolateDatasourceRef<T extends DataSourceRef | null | undefined>(ref: T, vizPanel: VizPanel): T {
+  if (!ref?.uid) {
+    return ref;
+  }
+  return { ...ref, uid: sceneGraph.interpolate(vizPanel, ref.uid) };
 }


### PR DESCRIPTION
## What this PR does / why we need it

Opening **Explore** from a panel whose datasource is a template variable (e.g. `$datasource`) opened Explore on the **default datasource with a default query** instead of the panel's actual datasource and query. This is most visible with `dashboardNewLayouts` enabled, where v2 panels deserialize a variable datasource into a scene query datasource ref of `{ uid: "$datasource", type: "" }`.

`tryGetExploreUrlForPanel` passed the raw, uninterpolated query and datasource refs from the scene query runner straight into the Explore URL. Explore cannot resolve dashboard variables, so the unresolved `$datasource` ended up in the URL; Explore then failed to resolve it and fell back to the default datasource (e.g. gdev-testdata) with a freshly generated default query.

## Fix

In `tryGetExploreUrlForPanel` (`public/app/features/dashboard-scene/utils/urlBuilders.ts`) — which has the `VizPanel` and therefore the scene — interpolate each query's datasource ref **and** the pane datasource ref against the panel's scene via `sceneGraph.interpolate(vizPanel, ref.uid)` into a concrete uid **before** building the Explore URL. Refs without a uid (type-only) and already-concrete uids are left unchanged.

This is the same principle scenes' own `getExploreURL` relies on: hand Explore fully-resolved datasource refs. It's a **frontend-only** change.

## Which issue(s) this PR fixes

<!-- Replace with the actual issue number if there is one -->
Fixes #<issue>

## Special notes for your reviewer

- **Why not fix `getExploreUrl`?** An earlier attempt threaded `scopedVars` into `getDataSourceInstance` inside `getExploreUrl`. That is insufficient: `getDataSourceInstance`'s template-variable branch returns an instance whose `.uid` stays the literal `"$datasource"` (only `rawRef.uid` holds the concrete uid), so `getRef().uid` still emits `$datasource` into the URL. Resolving at the scene-aware caller is the correct layer.
- **Repro:** a v2 dashboard with a `DatasourceVariable` and a panel whose query datasource is `{ name: "$datasource" }` (empty `group`). Panel menu → Explore. Before: Explore opens on the default datasource with a default query. After: Explore opens on the resolved datasource with the panel's query.

## Verification

- New `public/app/features/dashboard-scene/utils/urlBuilders.test.ts` builds a real `EmbeddedScene` with a `ConstantVariable datasource=gdev-prometheus`; asserts `getExploreUrl` receives `uid: "gdev-prometheus"` (RED before fix showed `$datasource`). Second test covers concrete-uid pass-through.
- `urlBuilders.test.ts` + `PanelMenuBehavior.test.tsx` + `explore.test.ts` — 89/89 pass
- ESLint, Prettier, and full `yarn typecheck` — clean

## Release notes

Fixed an issue where opening Explore from a dashboard panel whose datasource is a template variable (e.g. `$datasource`) opened Explore on the default datasource instead of the panel's datasource and query.


Test dashboard (for local)
[dashboard-1783080420024.json](https://github.com/user-attachments/files/29635223/dashboard-1783080420024.json)

