### PR TITLE
Provisioning: make sync per-resource write timeout configurable

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2558,8 +2558,9 @@ max_file_size = 5242880
 
 # Per-resource apply timeout during a repository sync. Bounds how long applying a single
 # resource (or folder) may take before that operation is cancelled. Large resources (e.g.
-# multi-MB dashboards) can exceed a short timeout and fail with "context canceled". Accepts
-# a duration (e.g. 30s, 2m). Default is 30s. A non-positive value falls back to the default.
+# multi-MB dashboards) can exceed a short timeout and fail with "context deadline exceeded"
+# (or "context canceled" from the apiserver as the client aborts). Accepts a duration (e.g.
+# 30s, 2m). Default is 30s. A non-positive value falls back to the default.
 sync_resource_timeout = 30s
 
 # Public-facing root URL of this Grafana instance, used by provisioning to construct URLs

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2556,6 +2556,12 @@ max_incremental_changes = 100
 # non-positive value) for unlimited.
 max_file_size = 5242880
 
+# Per-resource apply timeout during a repository sync. Bounds how long applying a single
+# resource (or folder) may take before that operation is cancelled. Large resources (e.g.
+# multi-MB dashboards) can exceed a short timeout and fail with "context canceled". Accepts
+# a duration (e.g. 30s, 2m). Default is 30s. A non-positive value falls back to the default.
+sync_write_timeout = 30s
+
 # Public-facing root URL of this Grafana instance, used by provisioning to construct URLs
 # that must be reachable from external systems (e.g. GitHub PR-comment image fetchers and
 # GitHub webhook deliveries). When empty, falls back to [server] root_url. Set this when

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2560,7 +2560,7 @@ max_file_size = 5242880
 # resource (or folder) may take before that operation is cancelled. Large resources (e.g.
 # multi-MB dashboards) can exceed a short timeout and fail with "context canceled". Accepts
 # a duration (e.g. 30s, 2m). Default is 30s. A non-positive value falls back to the default.
-sync_write_timeout = 30s
+sync_resource_timeout = 30s
 
 # Public-facing root URL of this Grafana instance, used by provisioning to construct URLs
 # that must be reachable from external systems (e.g. GitHub PR-comment image fetchers and

--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -115,7 +115,7 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 
 	metrics := jobs.RegisterJobMetrics(registry)
 
-	syncer := jobsync.NewSyncer(jobsync.Compare, jobsync.FullSync, jobsync.IncrementalSync, tracer, maxSyncWorkers, metrics, folderMetadataEnabled, cfg.ProvisioningSyncWriteTimeout)
+	syncer := jobsync.NewSyncer(jobsync.Compare, jobsync.FullSync, jobsync.IncrementalSync, tracer, maxSyncWorkers, metrics, folderMetadataEnabled, cfg.ProvisioningSyncResourceTimeout)
 	syncWorker := jobsync.NewSyncWorker(
 		clients,
 		repositoryResources,

--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -115,7 +115,7 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 
 	metrics := jobs.RegisterJobMetrics(registry)
 
-	syncer := jobsync.NewSyncer(jobsync.Compare, jobsync.FullSync, jobsync.IncrementalSync, tracer, maxSyncWorkers, metrics, folderMetadataEnabled)
+	syncer := jobsync.NewSyncer(jobsync.Compare, jobsync.FullSync, jobsync.IncrementalSync, tracer, maxSyncWorkers, metrics, folderMetadataEnabled, cfg.ProvisioningSyncWriteTimeout)
 	syncWorker := jobsync.NewSyncWorker(
 		clients,
 		repositoryResources,

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -646,14 +646,17 @@ loop:
 	return ctx.Err()
 }
 
-// defaultResourceTimeout is the fallback per-resource apply timeout used
-// when a non-positive timeout is passed (e.g. an unset config value). It
-// matches setting.ProvisioningSyncResourceTimeoutDefault.
+// defaultResourceTimeout is the fallback per-resource apply timeout used when a
+// non-positive timeout is passed to wrapWithTimeout. Callers normally supply the
+// configured value (see the [provisioning] sync_resource_timeout setting); this
+// only guards against a caller passing <=0. Kept in sync with the setting's
+// default by convention, not by reference (this package does not import setting).
 const defaultResourceTimeout = 30 * time.Second
 
-// wrapWithTimeout runs fn with a derived context that times out after the given duration.
-// A non-positive timeout falls back to defaultResourceTimeout so a resource apply is
-// always bounded.
+// wrapWithTimeout runs fn with a context derived from ctx that is cancelled after
+// the given duration, or earlier if ctx itself is cancelled or already has a
+// nearer deadline. A non-positive timeout falls back to defaultResourceTimeout so
+// a resource apply is always bounded.
 func wrapWithTimeout(ctx context.Context, timeout time.Duration, fn func(context.Context)) {
 	if timeout <= 0 {
 		timeout = defaultResourceTimeout

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -37,6 +37,7 @@ func FullSync(
 	metrics jobs.JobMetrics,
 	quotaTracker quotas.QuotaTracker,
 	folderMetadataEnabled bool,
+	resourceWriteTimeout time.Duration,
 ) error {
 	syncStart := time.Now()
 	cfg := repo.Config()
@@ -147,7 +148,7 @@ func FullSync(
 	}
 	span.SetAttributes(attribute.Bool("pre_check_quota", true))
 
-	return applyChanges(ctx, changes, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled)
+	return applyChanges(ctx, changes, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
 }
 
 // shouldSkipChange checks if a change should be skipped based on previous failures on parent/child folders.
@@ -350,6 +351,7 @@ func applyChanges(
 	metrics jobs.JobMetrics,
 	quotaTracker quotas.QuotaTracker,
 	folderMetadataEnabled bool,
+	resourceWriteTimeout time.Duration,
 ) error {
 	progress.SetTotal(ctx, len(changes))
 
@@ -378,7 +380,7 @@ func applyChanges(
 
 	if len(buckets.fileDeletions) > 0 {
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileDeletions, func() error {
-			return applyResourcesInParallel(ctx, buckets.fileDeletions, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled)
+			return applyResourcesInParallel(ctx, buckets.fileDeletions, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
 		}, metrics); err != nil {
 			return err
 		}
@@ -389,7 +391,7 @@ func applyChanges(
 		// before children are walked to ensure consistency in moves and renames.
 		safepath.SortByDepth(buckets.folderCreations, func(c ResourceFileChange) string { return c.Path }, true)
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFolderCreations, func() error {
-			return applyFoldersSerially(ctx, buckets.folderCreations, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
+			return applyFoldersSerially(ctx, buckets.folderCreations, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
 		}, metrics); err != nil {
 			return err
 		}
@@ -397,7 +399,7 @@ func applyChanges(
 
 	if len(buckets.fileRenames) > 0 {
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileRenames, func() error {
-			return applyResourcesInParallel(ctx, buckets.fileRenames, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled)
+			return applyResourcesInParallel(ctx, buckets.fileRenames, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
 		}, metrics); err != nil {
 			return err
 		}
@@ -405,7 +407,7 @@ func applyChanges(
 
 	if len(buckets.folderDeletions) > 0 {
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFolderDeletions, func() error {
-			return applyFoldersSerially(ctx, buckets.folderDeletions, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
+			return applyFoldersSerially(ctx, buckets.folderDeletions, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
 		}, metrics); err != nil {
 			return err
 		}
@@ -413,7 +415,7 @@ func applyChanges(
 
 	if len(buckets.fileCreations) > 0 {
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileCreations, func() error {
-			return applyResourcesInParallel(ctx, buckets.fileCreations, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled)
+			return applyResourcesInParallel(ctx, buckets.fileCreations, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
 		}, metrics); err != nil {
 			return err
 		}
@@ -567,6 +569,7 @@ func applyFoldersSerially(
 	tracer tracing.Tracer,
 	quotaTracker quotas.QuotaTracker,
 	folderMetadataEnabled bool,
+	resourceWriteTimeout time.Duration,
 ) error {
 	for _, folder := range folders {
 		if ctx.Err() != nil {
@@ -577,7 +580,7 @@ func applyFoldersSerially(
 			return err
 		}
 
-		wrapWithTimeout(ctx, 15*time.Second, func(timeoutCtx context.Context) {
+		wrapWithTimeout(ctx, resourceWriteTimeout, func(timeoutCtx context.Context) {
 			applyChange(timeoutCtx, folder, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
 		})
 	}
@@ -598,6 +601,7 @@ func applyResourcesInParallel(
 	maxSyncWorkers int,
 	quotaTracker quotas.QuotaTracker,
 	folderMetadataEnabled bool,
+	resourceWriteTimeout time.Duration,
 ) error {
 	if len(resources) == 0 {
 		return nil
@@ -627,7 +631,7 @@ loop:
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			wrapWithTimeout(ctx, 15*time.Second, func(timeoutCtx context.Context) {
+			wrapWithTimeout(ctx, resourceWriteTimeout, func(timeoutCtx context.Context) {
 				applyChange(timeoutCtx, change, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
 			})
 		}(change)
@@ -642,8 +646,19 @@ loop:
 	return ctx.Err()
 }
 
+// defaultResourceWriteTimeout is the fallback per-resource apply timeout used
+// when a non-positive timeout is passed (e.g. an unset config value). It
+// matches setting.ProvisioningSyncWriteTimeoutDefault.
+const defaultResourceWriteTimeout = 30 * time.Second
+
 // wrapWithTimeout runs fn with a derived context that times out after the given duration.
+// A non-positive timeout falls back to defaultResourceWriteTimeout so a resource apply is
+// always bounded.
 func wrapWithTimeout(ctx context.Context, timeout time.Duration, fn func(context.Context)) {
+	if timeout <= 0 {
+		timeout = defaultResourceWriteTimeout
+	}
+
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -37,7 +37,7 @@ func FullSync(
 	metrics jobs.JobMetrics,
 	quotaTracker quotas.QuotaTracker,
 	folderMetadataEnabled bool,
-	resourceWriteTimeout time.Duration,
+	resourceTimeout time.Duration,
 ) error {
 	syncStart := time.Now()
 	cfg := repo.Config()
@@ -148,7 +148,7 @@ func FullSync(
 	}
 	span.SetAttributes(attribute.Bool("pre_check_quota", true))
 
-	return applyChanges(ctx, changes, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
+	return applyChanges(ctx, changes, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceTimeout)
 }
 
 // shouldSkipChange checks if a change should be skipped based on previous failures on parent/child folders.
@@ -351,7 +351,7 @@ func applyChanges(
 	metrics jobs.JobMetrics,
 	quotaTracker quotas.QuotaTracker,
 	folderMetadataEnabled bool,
-	resourceWriteTimeout time.Duration,
+	resourceTimeout time.Duration,
 ) error {
 	progress.SetTotal(ctx, len(changes))
 
@@ -380,7 +380,7 @@ func applyChanges(
 
 	if len(buckets.fileDeletions) > 0 {
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileDeletions, func() error {
-			return applyResourcesInParallel(ctx, buckets.fileDeletions, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
+			return applyResourcesInParallel(ctx, buckets.fileDeletions, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled, resourceTimeout)
 		}, metrics); err != nil {
 			return err
 		}
@@ -391,7 +391,7 @@ func applyChanges(
 		// before children are walked to ensure consistency in moves and renames.
 		safepath.SortByDepth(buckets.folderCreations, func(c ResourceFileChange) string { return c.Path }, true)
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFolderCreations, func() error {
-			return applyFoldersSerially(ctx, buckets.folderCreations, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
+			return applyFoldersSerially(ctx, buckets.folderCreations, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled, resourceTimeout)
 		}, metrics); err != nil {
 			return err
 		}
@@ -399,7 +399,7 @@ func applyChanges(
 
 	if len(buckets.fileRenames) > 0 {
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileRenames, func() error {
-			return applyResourcesInParallel(ctx, buckets.fileRenames, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
+			return applyResourcesInParallel(ctx, buckets.fileRenames, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled, resourceTimeout)
 		}, metrics); err != nil {
 			return err
 		}
@@ -407,7 +407,7 @@ func applyChanges(
 
 	if len(buckets.folderDeletions) > 0 {
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFolderDeletions, func() error {
-			return applyFoldersSerially(ctx, buckets.folderDeletions, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
+			return applyFoldersSerially(ctx, buckets.folderDeletions, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled, resourceTimeout)
 		}, metrics); err != nil {
 			return err
 		}
@@ -415,7 +415,7 @@ func applyChanges(
 
 	if len(buckets.fileCreations) > 0 {
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileCreations, func() error {
-			return applyResourcesInParallel(ctx, buckets.fileCreations, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
+			return applyResourcesInParallel(ctx, buckets.fileCreations, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled, resourceTimeout)
 		}, metrics); err != nil {
 			return err
 		}
@@ -569,7 +569,7 @@ func applyFoldersSerially(
 	tracer tracing.Tracer,
 	quotaTracker quotas.QuotaTracker,
 	folderMetadataEnabled bool,
-	resourceWriteTimeout time.Duration,
+	resourceTimeout time.Duration,
 ) error {
 	for _, folder := range folders {
 		if ctx.Err() != nil {
@@ -580,7 +580,7 @@ func applyFoldersSerially(
 			return err
 		}
 
-		wrapWithTimeout(ctx, resourceWriteTimeout, func(timeoutCtx context.Context) {
+		wrapWithTimeout(ctx, resourceTimeout, func(timeoutCtx context.Context) {
 			applyChange(timeoutCtx, folder, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
 		})
 	}
@@ -601,7 +601,7 @@ func applyResourcesInParallel(
 	maxSyncWorkers int,
 	quotaTracker quotas.QuotaTracker,
 	folderMetadataEnabled bool,
-	resourceWriteTimeout time.Duration,
+	resourceTimeout time.Duration,
 ) error {
 	if len(resources) == 0 {
 		return nil
@@ -631,7 +631,7 @@ loop:
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			wrapWithTimeout(ctx, resourceWriteTimeout, func(timeoutCtx context.Context) {
+			wrapWithTimeout(ctx, resourceTimeout, func(timeoutCtx context.Context) {
 				applyChange(timeoutCtx, change, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
 			})
 		}(change)
@@ -646,17 +646,17 @@ loop:
 	return ctx.Err()
 }
 
-// defaultResourceWriteTimeout is the fallback per-resource apply timeout used
+// defaultResourceTimeout is the fallback per-resource apply timeout used
 // when a non-positive timeout is passed (e.g. an unset config value). It
-// matches setting.ProvisioningSyncWriteTimeoutDefault.
-const defaultResourceWriteTimeout = 30 * time.Second
+// matches setting.ProvisioningSyncResourceTimeoutDefault.
+const defaultResourceTimeout = 30 * time.Second
 
 // wrapWithTimeout runs fn with a derived context that times out after the given duration.
-// A non-positive timeout falls back to defaultResourceWriteTimeout so a resource apply is
+// A non-positive timeout falls back to defaultResourceTimeout so a resource apply is
 // always bounded.
 func wrapWithTimeout(ctx context.Context, timeout time.Duration, fn func(context.Context)) {
 	if timeout <= 0 {
-		timeout = defaultResourceWriteTimeout
+		timeout = defaultResourceTimeout
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
@@ -420,7 +420,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 			quotaTracker.EXPECT().Release().Maybe()
 			quotaTracker.EXPECT().AllowOverLimit(mock.Anything).Maybe()
 
-			err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotaTracker, false)
+			err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotaTracker, false, 0)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/pkg/registry/apis/provisioning/jobs/sync/full_sync_fn_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_sync_fn_mock.go
@@ -14,6 +14,8 @@ import (
 
 	resources "github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 
+	time "time"
+
 	tracing "github.com/grafana/grafana/pkg/infra/tracing"
 )
 
@@ -30,17 +32,17 @@ func (_m *MockFullSyncFn) EXPECT() *MockFullSyncFn_Expecter {
 	return &MockFullSyncFn_Expecter{mock: &_m.Mock}
 }
 
-// Execute provides a mock function with given fields: ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled
-func (_m *MockFullSyncFn) Execute(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool) error {
-	ret := _m.Called(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled)
+// Execute provides a mock function with given fields: ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceWriteTimeout
+func (_m *MockFullSyncFn) Execute(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool, resourceWriteTimeout time.Duration) error {
+	ret := _m.Called(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, CompareFn, resources.ResourceClients, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, int, jobs.JobMetrics, quotas.QuotaTracker, bool) error); ok {
-		r0 = rf(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled)
+	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, CompareFn, resources.ResourceClients, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, int, jobs.JobMetrics, quotas.QuotaTracker, bool, time.Duration) error); ok {
+		r0 = rf(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -66,13 +68,14 @@ type MockFullSyncFn_Execute_Call struct {
 //   - metrics jobs.JobMetrics
 //   - quotaTracker quotas.QuotaTracker
 //   - folderMetadataEnabled bool
-func (_e *MockFullSyncFn_Expecter) Execute(ctx interface{}, repo interface{}, compare interface{}, clients interface{}, currentRef interface{}, repositoryResources interface{}, progress interface{}, tracer interface{}, maxSyncWorkers interface{}, metrics interface{}, quotaTracker interface{}, folderMetadataEnabled interface{}) *MockFullSyncFn_Execute_Call {
-	return &MockFullSyncFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled)}
+//   - resourceWriteTimeout time.Duration
+func (_e *MockFullSyncFn_Expecter) Execute(ctx interface{}, repo interface{}, compare interface{}, clients interface{}, currentRef interface{}, repositoryResources interface{}, progress interface{}, tracer interface{}, maxSyncWorkers interface{}, metrics interface{}, quotaTracker interface{}, folderMetadataEnabled interface{}, resourceWriteTimeout interface{}) *MockFullSyncFn_Execute_Call {
+	return &MockFullSyncFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)}
 }
 
-func (_c *MockFullSyncFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool)) *MockFullSyncFn_Execute_Call {
+func (_c *MockFullSyncFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool, resourceWriteTimeout time.Duration)) *MockFullSyncFn_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(repository.Reader), args[2].(CompareFn), args[3].(resources.ResourceClients), args[4].(string), args[5].(resources.RepositoryResources), args[6].(jobs.JobProgressRecorder), args[7].(tracing.Tracer), args[8].(int), args[9].(jobs.JobMetrics), args[10].(quotas.QuotaTracker), args[11].(bool))
+		run(args[0].(context.Context), args[1].(repository.Reader), args[2].(CompareFn), args[3].(resources.ResourceClients), args[4].(string), args[5].(resources.RepositoryResources), args[6].(jobs.JobProgressRecorder), args[7].(tracing.Tracer), args[8].(int), args[9].(jobs.JobMetrics), args[10].(quotas.QuotaTracker), args[11].(bool), args[12].(time.Duration))
 	})
 	return _c
 }
@@ -82,7 +85,7 @@ func (_c *MockFullSyncFn_Execute_Call) Return(_a0 error) *MockFullSyncFn_Execute
 	return _c
 }
 
-func (_c *MockFullSyncFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Reader, CompareFn, resources.ResourceClients, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, int, jobs.JobMetrics, quotas.QuotaTracker, bool) error) *MockFullSyncFn_Execute_Call {
+func (_c *MockFullSyncFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Reader, CompareFn, resources.ResourceClients, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, int, jobs.JobMetrics, quotas.QuotaTracker, bool, time.Duration) error) *MockFullSyncFn_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/full_sync_fn_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_sync_fn_mock.go
@@ -32,9 +32,9 @@ func (_m *MockFullSyncFn) EXPECT() *MockFullSyncFn_Expecter {
 	return &MockFullSyncFn_Expecter{mock: &_m.Mock}
 }
 
-// Execute provides a mock function with given fields: ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceWriteTimeout
-func (_m *MockFullSyncFn) Execute(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool, resourceWriteTimeout time.Duration) error {
-	ret := _m.Called(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
+// Execute provides a mock function with given fields: ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceTimeout
+func (_m *MockFullSyncFn) Execute(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool, resourceTimeout time.Duration) error {
+	ret := _m.Called(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceTimeout)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
@@ -42,7 +42,7 @@ func (_m *MockFullSyncFn) Execute(ctx context.Context, repo repository.Reader, c
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, CompareFn, resources.ResourceClients, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, int, jobs.JobMetrics, quotas.QuotaTracker, bool, time.Duration) error); ok {
-		r0 = rf(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)
+		r0 = rf(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceTimeout)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -68,12 +68,12 @@ type MockFullSyncFn_Execute_Call struct {
 //   - metrics jobs.JobMetrics
 //   - quotaTracker quotas.QuotaTracker
 //   - folderMetadataEnabled bool
-//   - resourceWriteTimeout time.Duration
-func (_e *MockFullSyncFn_Expecter) Execute(ctx interface{}, repo interface{}, compare interface{}, clients interface{}, currentRef interface{}, repositoryResources interface{}, progress interface{}, tracer interface{}, maxSyncWorkers interface{}, metrics interface{}, quotaTracker interface{}, folderMetadataEnabled interface{}, resourceWriteTimeout interface{}) *MockFullSyncFn_Execute_Call {
-	return &MockFullSyncFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceWriteTimeout)}
+//   - resourceTimeout time.Duration
+func (_e *MockFullSyncFn_Expecter) Execute(ctx interface{}, repo interface{}, compare interface{}, clients interface{}, currentRef interface{}, repositoryResources interface{}, progress interface{}, tracer interface{}, maxSyncWorkers interface{}, metrics interface{}, quotaTracker interface{}, folderMetadataEnabled interface{}, resourceTimeout interface{}) *MockFullSyncFn_Execute_Call {
+	return &MockFullSyncFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics, quotaTracker, folderMetadataEnabled, resourceTimeout)}
 }
 
-func (_c *MockFullSyncFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool, resourceWriteTimeout time.Duration)) *MockFullSyncFn_Execute_Call {
+func (_c *MockFullSyncFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool, resourceTimeout time.Duration)) *MockFullSyncFn_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(repository.Reader), args[2].(CompareFn), args[3].(resources.ResourceClients), args[4].(string), args[5].(resources.RepositoryResources), args[6].(jobs.JobProgressRecorder), args[7].(tracing.Tracer), args[8].(int), args[9].(jobs.JobMetrics), args[10].(quotas.QuotaTracker), args[11].(bool), args[12].(time.Duration))
 	})

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -1957,7 +1957,7 @@ func TestWrapWithTimeout(t *testing.T) {
 			deadline, ok := timeoutCtx.Deadline()
 			require.True(t, ok, "expected a deadline to be set")
 			// Allow slack for execution time; it must be well above the default fallback.
-			require.Greater(t, time.Until(deadline), defaultResourceWriteTimeout)
+			require.Greater(t, time.Until(deadline), defaultResourceTimeout)
 		})
 	})
 
@@ -1966,8 +1966,8 @@ func TestWrapWithTimeout(t *testing.T) {
 			wrapWithTimeout(context.Background(), timeout, func(timeoutCtx context.Context) {
 				deadline, ok := timeoutCtx.Deadline()
 				require.True(t, ok, "expected a deadline to be set")
-				// The fallback deadline should be close to defaultResourceWriteTimeout from now.
-				require.Greater(t, time.Until(deadline), defaultResourceWriteTimeout-time.Second)
+				// The fallback deadline should be close to defaultResourceTimeout from now.
+				require.Greater(t, time.Until(deadline), defaultResourceTimeout-time.Second)
 			})
 		}
 	})

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -48,7 +48,7 @@ func TestFullSync_ContextCancelled(t *testing.T) {
 	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{{}}, nil, nil, nil)
 	progress.On("SetTotal", mock.Anything, 1).Return()
 
-	err := FullSync(ctx, repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
+	err := FullSync(ctx, repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false, 0)
 	require.EqualError(t, err, "context canceled")
 }
 
@@ -67,7 +67,7 @@ func TestFullSync_Error(t *testing.T) {
 
 	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, fmt.Errorf("some error"))
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false, 0)
 	require.EqualError(t, err, "compare changes: some error")
 }
 
@@ -87,7 +87,7 @@ func TestFullSync_NoChanges(t *testing.T) {
 	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{}, nil, nil, nil)
 	progress.On("SetFinalMessage", mock.Anything, "no changes to sync").Return()
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false, 0)
 	require.NoError(t, err)
 }
 
@@ -118,7 +118,7 @@ func TestFullSync_SuccessfulFolderCreation(t *testing.T) {
 		Path:  "",
 	}, "").Return(nil)
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false, 0)
 	require.NoError(t, err)
 }
 
@@ -147,7 +147,7 @@ func TestFullSync_FolderCreationFailed(t *testing.T) {
 		Path:  "",
 	}, "").Return(fmt.Errorf("folder creation failed"))
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false, 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "create root folder: folder creation failed")
 }
@@ -193,7 +193,7 @@ func TestFullSync_FolderCreationFailed_UnmanagedConflictBecomesWarning(t *testin
 	})).Return()
 	progress.On("SetFinalMessage", mock.Anything, "root folder cannot be claimed by this repository").Return()
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false, 0)
 	require.NoError(t, err, "unmanaged-root conflict should not fail the whole job")
 
 	require.Nil(t, recorded.Error(), "conflict should be stored as warning, not error")
@@ -225,7 +225,7 @@ func TestFullSync_FolderCreationFailedWithInstanceTarget(t *testing.T) {
 	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil, nil, fmt.Errorf("compare error"))
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false, 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "compare changes: compare error")
 }
@@ -868,7 +868,7 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 			})
 
 			progress.On("SetTotal", mock.Anything, len(tt.changes)).Return()
-			err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), tt.folderMetadataEnabled)
+			err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), tt.folderMetadataEnabled, 0)
 			if tt.expectedError != "" {
 				require.EqualError(t, err, tt.expectedError, tt.description)
 			} else {
@@ -1187,7 +1187,7 @@ func TestFullSync_QuotaTrackerSkipsCreationsAtLimit(t *testing.T) {
 	// Tracker: 9 out of 10, so only 1 creation allowed
 	tracker := quotas.NewInMemoryQuotaTracker(9, 10)
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), tracker, false)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), tracker, false, 0)
 	require.NoError(t, err)
 
 	// WriteResourceFromFile should have been called only once (for "a.json")
@@ -1224,7 +1224,7 @@ func TestFullSync_QuotaTrackerAllowsUpdatesRegardlessOfQuota(t *testing.T) {
 	// Tracker already at limit — but updates should still proceed
 	tracker := quotas.NewInMemoryQuotaTracker(10, 10)
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), tracker, false)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), tracker, false, 0)
 	require.NoError(t, err)
 
 	repoResources.AssertCalled(t, "WriteResourceFromFile", mock.Anything, "dashboards/existing.json", "ref")
@@ -1273,7 +1273,7 @@ func TestFullSync_MissingFolderMetadata_FlagEnabled(t *testing.T) {
 		return r.Path() == "myfolder/dashboard.json"
 	})).Return()
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), true)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), true, 0)
 	require.NoError(t, err)
 }
 
@@ -1306,7 +1306,7 @@ func TestFullSync_MissingFolderMetadata_FlagDisabled(t *testing.T) {
 		return r.Path() == "myfolder/dashboard.json"
 	})).Return()
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false, 0)
 	require.NoError(t, err)
 }
 
@@ -1333,7 +1333,7 @@ func TestFullSync_InvalidFolderMetadataWarning(t *testing.T) {
 	})).Return()
 	progress.On("SetFinalMessage", mock.Anything, "no changes to sync").Return()
 
-	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), true)
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), true, 0)
 	require.NoError(t, err)
 }
 
@@ -1379,7 +1379,7 @@ func TestFullSync_InvalidFolderMetadataWarning_ActionAware(t *testing.T) {
 			})).Return()
 			progress.On("SetFinalMessage", mock.Anything, "no changes to sync").Return()
 
-			err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), true)
+			err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), true, 0)
 			require.NoError(t, err)
 		})
 	}
@@ -1457,6 +1457,7 @@ func TestApplyChanges_DefersOldFolderDeletion(t *testing.T) {
 	err := applyChanges(
 		context.Background(), changes, clients, "test-ref", repoResources, progress, tracer, 1, metrics,
 		quotas.NewInMemoryQuotaTracker(0, 0), true,
+		0,
 	)
 	require.NoError(t, err)
 
@@ -1532,6 +1533,7 @@ func TestApplyChanges_DefersOrphanFolderDeletion(t *testing.T) {
 	err := applyChanges(
 		context.Background(), changes, clients, "test-ref", repoResources, progress, tracer, 1, metrics,
 		quotas.NewInMemoryQuotaTracker(0, 0), true,
+		0,
 	)
 	require.NoError(t, err)
 	require.Equal(t, []string{
@@ -1600,6 +1602,7 @@ func TestApplyChanges_SkipsDeferredFolderDeletionPerGuardCondition(t *testing.T)
 			err := applyChanges(
 				context.Background(), changes, clients, "test-ref", repoResources, progress, tracer, 1, metrics,
 				quotas.NewInMemoryQuotaTracker(0, 0), true,
+				0,
 			)
 			require.NoError(t, err)
 			repoResources.AssertNotCalled(t, "RemoveFolder", mock.Anything, "orphan-uid")
@@ -1686,6 +1689,7 @@ func TestApplyChanges_DefersBothRenamedAndOrphanFolderDeletion(t *testing.T) {
 	err := applyChanges(
 		context.Background(), changes, clients, "test-ref", repoResources, progress, tracer, 1, metrics,
 		quotas.NewInMemoryQuotaTracker(0, 0), true,
+		0,
 	)
 	require.NoError(t, err)
 	require.Equal(t, []string{
@@ -1732,6 +1736,7 @@ func TestApplyChanges_ExistingHashPassedToWrite(t *testing.T) {
 		err := applyChanges(
 			context.Background(), changes, clients, "test-ref", repoResources, progress, tracer, 1, metrics,
 			quotas.NewInMemoryQuotaTracker(0, 0), true,
+			0,
 		)
 		require.NoError(t, err)
 	})
@@ -1770,6 +1775,7 @@ func TestApplyChanges_ExistingHashPassedToWrite(t *testing.T) {
 		err := applyChanges(
 			context.Background(), changes, clients, "test-ref", repoResources, progress, tracer, 1, metrics,
 			quotas.NewInMemoryQuotaTracker(0, 0), true,
+			0,
 		)
 		require.NoError(t, err)
 	})
@@ -1819,6 +1825,7 @@ func TestApplyChanges_SortsFolderUpdatesShallowestFirst(t *testing.T) {
 	err := applyChanges(
 		context.Background(), changes, clients, "test-ref", repoResources, progress, tracer, 1, metrics,
 		quotas.NewInMemoryQuotaTracker(0, 0), true,
+		0,
 	)
 	require.NoError(t, err)
 	require.Equal(t, []string{
@@ -1881,6 +1888,7 @@ func TestApplyChanges_OldFolderDeletion_DeepestFirst(t *testing.T) {
 	err := applyChanges(
 		context.Background(), changes, clients, "test-ref", repoResources, progress, tracer, 1, metrics,
 		quotas.NewInMemoryQuotaTracker(0, 0), true,
+		0,
 	)
 	require.NoError(t, err)
 
@@ -1933,6 +1941,7 @@ func TestApplyChanges_OldFolderDeletion_ErrorContinues(t *testing.T) {
 	err := applyChanges(
 		context.Background(), changes, clients, "test-ref", repoResources, progress, tracer, 1, metrics,
 		quotas.NewInMemoryQuotaTracker(0, 0), true,
+		0,
 	)
 
 	// applyChanges must NOT return an error even though RemoveFolder failed
@@ -1940,4 +1949,26 @@ func TestApplyChanges_OldFolderDeletion_ErrorContinues(t *testing.T) {
 
 	// Verify RemoveFolder was actually called
 	repoResources.AssertCalled(t, "RemoveFolder", mock.Anything, "old-broken-uid")
+}
+
+func TestWrapWithTimeout(t *testing.T) {
+	t.Run("uses the provided timeout as the context deadline", func(t *testing.T) {
+		wrapWithTimeout(context.Background(), 5*time.Minute, func(timeoutCtx context.Context) {
+			deadline, ok := timeoutCtx.Deadline()
+			require.True(t, ok, "expected a deadline to be set")
+			// Allow slack for execution time; it must be well above the default fallback.
+			require.Greater(t, time.Until(deadline), defaultResourceWriteTimeout)
+		})
+	})
+
+	t.Run("falls back to the default timeout when non-positive", func(t *testing.T) {
+		for _, timeout := range []time.Duration{0, -time.Second} {
+			wrapWithTimeout(context.Background(), timeout, func(timeoutCtx context.Context) {
+				deadline, ok := timeoutCtx.Deadline()
+				require.True(t, ok, "expected a deadline to be set")
+				// The fallback deadline should be close to defaultResourceWriteTimeout from now.
+				require.Greater(t, time.Until(deadline), defaultResourceWriteTimeout-time.Second)
+			})
+		}
+	})
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/sync.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync.go
@@ -15,7 +15,7 @@ import (
 )
 
 //go:generate mockery --name FullSyncFn --structname MockFullSyncFn --inpackage --filename full_sync_fn_mock.go --with-expecter
-type FullSyncFn func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool, resourceWriteTimeout time.Duration) error
+type FullSyncFn func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool, resourceTimeout time.Duration) error
 
 //go:generate mockery --name CompareFn --structname MockCompareFn --inpackage --filename compare_fn_mock.go --with-expecter
 type CompareFn func(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string, folderMetadataEnabled bool) ([]ResourceFileChange, []string, []*resources.InvalidFolderMetadata, error)
@@ -36,10 +36,10 @@ type syncer struct {
 	metrics               jobs.JobMetrics
 	maxSyncWorkers        int
 	folderMetadataEnabled bool
-	resourceWriteTimeout  time.Duration
+	resourceTimeout       time.Duration
 }
 
-func NewSyncer(compare CompareFn, fullSync FullSyncFn, incrementalSync IncrementalSyncFn, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, folderMetadataEnabled bool, resourceWriteTimeout time.Duration) Syncer {
+func NewSyncer(compare CompareFn, fullSync FullSyncFn, incrementalSync IncrementalSyncFn, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, folderMetadataEnabled bool, resourceTimeout time.Duration) Syncer {
 	return &syncer{
 		compare:               compare,
 		fullSync:              fullSync,
@@ -48,7 +48,7 @@ func NewSyncer(compare CompareFn, fullSync FullSyncFn, incrementalSync Increment
 		metrics:               metrics,
 		maxSyncWorkers:        maxSyncWorkers,
 		folderMetadataEnabled: folderMetadataEnabled,
-		resourceWriteTimeout:  resourceWriteTimeout,
+		resourceTimeout:       resourceTimeout,
 	}
 }
 
@@ -75,5 +75,5 @@ func (r *syncer) Sync(ctx context.Context, repo repository.ReaderWriter, options
 		}
 	}
 	progress.SetMessage(ctx, "full sync")
-	return currentRef, r.fullSync(ctx, repo, r.compare, clients, currentRef, repositoryResources, progress, r.tracer, r.maxSyncWorkers, r.metrics, quotaTracker, r.folderMetadataEnabled, r.resourceWriteTimeout)
+	return currentRef, r.fullSync(ctx, repo, r.compare, clients, currentRef, repositoryResources, progress, r.tracer, r.maxSyncWorkers, r.metrics, quotaTracker, r.folderMetadataEnabled, r.resourceTimeout)
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/sync.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync.go
@@ -67,6 +67,10 @@ func (r *syncer) Sync(ctx context.Context, repo repository.ReaderWriter, options
 
 		if cfg.Status.Sync.LastRef != "" && options.Incremental && !quotas.IsQuotaExceeded(cfg.Status.Conditions) {
 			progress.SetMessage(ctx, "incremental sync")
+			// resourceTimeout is deliberately not passed to incremental sync: it has no
+			// per-resource timeout today (applies are bounded only by the overall job
+			// timeout). Imposing the default here would newly cap large incremental
+			// writes and regress repositories that currently sync them successfully.
 			return currentRef, r.incrementalSync(ctx, versionedRepo, cfg.Status.Sync.LastRef, currentRef, repositoryResources, progress, r.tracer, r.metrics, quotaTracker, r.folderMetadataEnabled)
 		}
 

--- a/pkg/registry/apis/provisioning/jobs/sync/sync.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -14,7 +15,7 @@ import (
 )
 
 //go:generate mockery --name FullSyncFn --structname MockFullSyncFn --inpackage --filename full_sync_fn_mock.go --with-expecter
-type FullSyncFn func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool) error
+type FullSyncFn func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool, resourceWriteTimeout time.Duration) error
 
 //go:generate mockery --name CompareFn --structname MockCompareFn --inpackage --filename compare_fn_mock.go --with-expecter
 type CompareFn func(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string, folderMetadataEnabled bool) ([]ResourceFileChange, []string, []*resources.InvalidFolderMetadata, error)
@@ -35,9 +36,10 @@ type syncer struct {
 	metrics               jobs.JobMetrics
 	maxSyncWorkers        int
 	folderMetadataEnabled bool
+	resourceWriteTimeout  time.Duration
 }
 
-func NewSyncer(compare CompareFn, fullSync FullSyncFn, incrementalSync IncrementalSyncFn, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, folderMetadataEnabled bool) Syncer {
+func NewSyncer(compare CompareFn, fullSync FullSyncFn, incrementalSync IncrementalSyncFn, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, folderMetadataEnabled bool, resourceWriteTimeout time.Duration) Syncer {
 	return &syncer{
 		compare:               compare,
 		fullSync:              fullSync,
@@ -46,6 +48,7 @@ func NewSyncer(compare CompareFn, fullSync FullSyncFn, incrementalSync Increment
 		metrics:               metrics,
 		maxSyncWorkers:        maxSyncWorkers,
 		folderMetadataEnabled: folderMetadataEnabled,
+		resourceWriteTimeout:  resourceWriteTimeout,
 	}
 }
 
@@ -72,5 +75,5 @@ func (r *syncer) Sync(ctx context.Context, repo repository.ReaderWriter, options
 		}
 	}
 	progress.SetMessage(ctx, "full sync")
-	return currentRef, r.fullSync(ctx, repo, r.compare, clients, currentRef, repositoryResources, progress, r.tracer, r.maxSyncWorkers, r.metrics, quotaTracker, r.folderMetadataEnabled)
+	return currentRef, r.fullSync(ctx, repo, r.compare, clients, currentRef, repositoryResources, progress, r.tracer, r.maxSyncWorkers, r.metrics, quotaTracker, r.folderMetadataEnabled, r.resourceWriteTimeout)
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/sync_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync_test.go
@@ -68,7 +68,7 @@ func TestSyncer_Sync(t *testing.T) {
 				repo.MockVersioned.On("LatestRef", mock.Anything).Return("new-ref", nil)
 
 				progress.On("SetMessage", mock.Anything, "full sync").Return()
-				fullSyncFn.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				fullSyncFn.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			expectedMessages: []string{"full sync"},
 		},
@@ -123,7 +123,7 @@ func TestSyncer_Sync(t *testing.T) {
 				})
 				repo.MockVersioned.On("LatestRef", mock.Anything).Return("new-ref", nil)
 				progress.On("SetMessage", mock.Anything, "full sync").Return()
-				fullSyncFn.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				fullSyncFn.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			expectedMessages: []string{"full sync"},
 		},
@@ -197,6 +197,7 @@ func TestSyncer_Sync(t *testing.T) {
 				10,
 				jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()),
 				false,
+				0,
 			)
 
 			quotaTracker := quotas.NewMockQuotaTracker(t)

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -153,6 +153,7 @@ type APIBuilder struct {
 	quotaGetter                   quotas.QuotaGetter
 	folderMetadataEnabled         bool
 	maxFileSize                   int64
+	syncWriteTimeout              time.Duration
 	incrementalPolicy             repository.IncrementalSyncPolicy
 	folderAPIVersion              string
 	webhookSecretRotationInterval time.Duration
@@ -389,6 +390,7 @@ func RegisterAPIService(
 		return nil, err
 	}
 	builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
+	builder.syncWriteTimeout = cfg.ProvisioningSyncWriteTimeout
 	builder.usageNamespaceLister = usage.UsageNamespaceLister(cfg, orgSvc)
 	builder.natsSubscriber = natsSubscriber
 	apiregistration.RegisterAPI(builder)
@@ -431,6 +433,7 @@ func RegisterAPIService(
 		return nil, err
 	}
 	v1beta1Builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
+	v1beta1Builder.syncWriteTimeout = cfg.ProvisioningSyncWriteTimeout
 	v1beta1Builder.usageNamespaceLister = usage.UsageNamespaceLister(cfg, orgSvc)
 	v1beta1Builder.natsSubscriber = natsSubscriber
 	apiregistration.RegisterAPI(v1beta1Builder)
@@ -985,7 +988,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				b.folderAPIVersion,
 			)
 
-			syncer := sync.NewSyncer(sync.Compare, sync.FullSync, sync.IncrementalSync, b.tracer, 10, metrics, b.folderMetadataEnabled) //nolint:staticcheck
+			syncer := sync.NewSyncer(sync.Compare, sync.FullSync, sync.IncrementalSync, b.tracer, 10, metrics, b.folderMetadataEnabled, b.syncWriteTimeout) //nolint:staticcheck
 			syncWorker := sync.NewSyncWorker(
 				b.clients,
 				b.repositoryResources,

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -153,7 +153,7 @@ type APIBuilder struct {
 	quotaGetter                   quotas.QuotaGetter
 	folderMetadataEnabled         bool
 	maxFileSize                   int64
-	syncWriteTimeout              time.Duration
+	syncResourceTimeout           time.Duration
 	incrementalPolicy             repository.IncrementalSyncPolicy
 	folderAPIVersion              string
 	webhookSecretRotationInterval time.Duration
@@ -390,7 +390,7 @@ func RegisterAPIService(
 		return nil, err
 	}
 	builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
-	builder.syncWriteTimeout = cfg.ProvisioningSyncWriteTimeout
+	builder.syncResourceTimeout = cfg.ProvisioningSyncResourceTimeout
 	builder.usageNamespaceLister = usage.UsageNamespaceLister(cfg, orgSvc)
 	builder.natsSubscriber = natsSubscriber
 	apiregistration.RegisterAPI(builder)
@@ -433,7 +433,7 @@ func RegisterAPIService(
 		return nil, err
 	}
 	v1beta1Builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
-	v1beta1Builder.syncWriteTimeout = cfg.ProvisioningSyncWriteTimeout
+	v1beta1Builder.syncResourceTimeout = cfg.ProvisioningSyncResourceTimeout
 	v1beta1Builder.usageNamespaceLister = usage.UsageNamespaceLister(cfg, orgSvc)
 	v1beta1Builder.natsSubscriber = natsSubscriber
 	apiregistration.RegisterAPI(v1beta1Builder)
@@ -988,7 +988,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				b.folderAPIVersion,
 			)
 
-			syncer := sync.NewSyncer(sync.Compare, sync.FullSync, sync.IncrementalSync, b.tracer, 10, metrics, b.folderMetadataEnabled, b.syncWriteTimeout) //nolint:staticcheck
+			syncer := sync.NewSyncer(sync.Compare, sync.FullSync, sync.IncrementalSync, b.tracer, 10, metrics, b.folderMetadataEnabled, b.syncResourceTimeout) //nolint:staticcheck
 			syncWorker := sync.NewSyncWorker(
 				b.clients,
 				b.repositoryResources,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -70,6 +70,14 @@ const DefaultRendererAuthToken = "-"
 // written to a provisioning repository through the files API.
 const ProvisioningMaxFileSizeDefault int64 = 5 * 1024 * 1024
 
+// ProvisioningSyncWriteTimeoutDefault is the default value for the
+// [provisioning] sync_write_timeout key. It bounds how long applying a
+// single resource (or folder) may take during a sync job before that
+// operation is cancelled. Large resources (e.g. multi-MB dashboards) can
+// exceed a short timeout, which is why it is configurable. 30s matches the
+// timeout used by the provisioning files write API.
+const ProvisioningSyncWriteTimeoutDefault = 30 * time.Second
+
 var (
 	customInitPath = "conf/custom.ini"
 
@@ -173,6 +181,7 @@ type Cfg struct {
 	ProvisioningFolderAPIVersion              string        // "v1" (default for on-prem) or "v1beta1"
 	ProvisioningMaxIncrementalChanges         int           // default 100, 0 in config = unlimited
 	ProvisioningMaxFileSize                   int64         // bytes; default 5 MiB (5242880); <=0 = unlimited
+	ProvisioningSyncWriteTimeout              time.Duration // per-resource apply timeout during sync; default 15s; <=0 = default
 	ProvisioningWebhookSecretRotationInterval time.Duration // default 30 days
 	ProvisioningPublicRootURL                 string        // public-facing root URL of this Grafana instance for provisioning consumers (webhooks, screenshots); falls back to AppURL when empty
 	DataPath                                  string
@@ -2585,6 +2594,7 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	cfg.ProvisioningFolderAPIVersion = iniFile.Section("provisioning").Key("folders_api_version").MustString("v1")
 	cfg.ProvisioningMaxIncrementalChanges = iniFile.Section("provisioning").Key("max_incremental_changes").MustInt(100)
 	cfg.ProvisioningMaxFileSize = iniFile.Section("provisioning").Key("max_file_size").MustInt64(ProvisioningMaxFileSizeDefault)
+	cfg.ProvisioningSyncWriteTimeout = iniFile.Section("provisioning").Key("sync_write_timeout").MustDuration(ProvisioningSyncWriteTimeoutDefault)
 	cfg.ProvisioningWebhookSecretRotationInterval = iniFile.Section("provisioning").Key("webhook_secret_rotation_interval").MustDuration(30 * 24 * time.Hour)
 	cfg.ProvisioningPublicRootURL = strings.TrimRight(valueAsString(iniFile.Section("provisioning"), "public_root_url", ""), "/")
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -70,13 +70,13 @@ const DefaultRendererAuthToken = "-"
 // written to a provisioning repository through the files API.
 const ProvisioningMaxFileSizeDefault int64 = 5 * 1024 * 1024
 
-// ProvisioningSyncWriteTimeoutDefault is the default value for the
-// [provisioning] sync_write_timeout key. It bounds how long applying a
+// ProvisioningSyncResourceTimeoutDefault is the default value for the
+// [provisioning] sync_resource_timeout key. It bounds how long applying a
 // single resource (or folder) may take during a sync job before that
 // operation is cancelled. Large resources (e.g. multi-MB dashboards) can
 // exceed a short timeout, which is why it is configurable. 30s matches the
 // timeout used by the provisioning files write API.
-const ProvisioningSyncWriteTimeoutDefault = 30 * time.Second
+const ProvisioningSyncResourceTimeoutDefault = 30 * time.Second
 
 var (
 	customInitPath = "conf/custom.ini"
@@ -181,7 +181,7 @@ type Cfg struct {
 	ProvisioningFolderAPIVersion              string        // "v1" (default for on-prem) or "v1beta1"
 	ProvisioningMaxIncrementalChanges         int           // default 100, 0 in config = unlimited
 	ProvisioningMaxFileSize                   int64         // bytes; default 5 MiB (5242880); <=0 = unlimited
-	ProvisioningSyncWriteTimeout              time.Duration // per-resource apply timeout during sync; default 15s; <=0 = default
+	ProvisioningSyncResourceTimeout           time.Duration // per-resource apply timeout during sync; default 30s; <=0 = default
 	ProvisioningWebhookSecretRotationInterval time.Duration // default 30 days
 	ProvisioningPublicRootURL                 string        // public-facing root URL of this Grafana instance for provisioning consumers (webhooks, screenshots); falls back to AppURL when empty
 	DataPath                                  string
@@ -2594,7 +2594,7 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	cfg.ProvisioningFolderAPIVersion = iniFile.Section("provisioning").Key("folders_api_version").MustString("v1")
 	cfg.ProvisioningMaxIncrementalChanges = iniFile.Section("provisioning").Key("max_incremental_changes").MustInt(100)
 	cfg.ProvisioningMaxFileSize = iniFile.Section("provisioning").Key("max_file_size").MustInt64(ProvisioningMaxFileSizeDefault)
-	cfg.ProvisioningSyncWriteTimeout = iniFile.Section("provisioning").Key("sync_write_timeout").MustDuration(ProvisioningSyncWriteTimeoutDefault)
+	cfg.ProvisioningSyncResourceTimeout = iniFile.Section("provisioning").Key("sync_resource_timeout").MustDuration(ProvisioningSyncResourceTimeoutDefault)
 	cfg.ProvisioningWebhookSecretRotationInterval = iniFile.Section("provisioning").Key("webhook_secret_rotation_interval").MustDuration(30 * 24 * time.Hour)
 	cfg.ProvisioningPublicRootURL = strings.TrimRight(valueAsString(iniFile.Section("provisioning"), "public_root_url", ""), "/")
 


### PR DESCRIPTION
## What

Adds a new `[provisioning] sync_resource_timeout` config setting that bounds how long applying a single resource (or folder) may take during a repository sync. Default is **30s**. Previously this was a hardcoded 15s.

## Why

Git sync fails on large dashboards (>2–3 MB) with `context canceled`. The full-sync apply path wrapped every resource/folder operation in a hardcoded `15s` timeout. A multi-MB dashboard's apiserver `PUT` (deserialize + strict validation + conversion + unified-storage write) can exceed 15s, so the client cancels the in-flight request mid-write — surfacing as `context canceled` on the `PUT` and `Timeout or abort while handling` on the apiserver side. There was no way to tune it.

- Support escalation
- Same class of issue as #125529 (hardcoded, unchangeable sync timeout)

## How

- New setting `[provisioning] sync_resource_timeout` (duration, e.g. `30s`, `2m`), parsed via `MustDuration`. Default `30s`, matching the timeout already used by the provisioning files write API. The name uses "resource" (not "write") because the per-change apply also covers deletes and folder ensures, and "sync" to match the existing `min_sync_interval` key.
- Threaded the value from config → `APIBuilder` / standalone operator → `NewSyncer` → `FullSync` → `applyChanges` → `applyResourcesInParallel` / `applyFoldersSerially` → `wrapWithTimeout`, alongside the existing `maxSyncWorkers` parameter.
- `wrapWithTimeout` now treats a non-positive timeout as the 30s default, so an unset/`0` value can never collapse to an instant cancel.
- Documented in `conf/defaults.ini`; hand-updated the `FullSyncFn` mock (local mockery has a Go 1.25/1.26 mismatch).
- **Incremental sync is intentionally left unchanged** — it has no per-resource timeout today (bounded only by the 20-minute job timeout), so adding one would be a regression rather than a fix.

## Testing

- `go test ./pkg/registry/apis/provisioning/jobs/sync/` passes.
- Added `TestWrapWithTimeout` covering both the configured-value and non-positive fallback paths.
- `go build`, `go vet`, and `gofmt` clean across all touched packages.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (`conf/defaults.ini`)
- [x] No breaking changes — default preserves bounded behavior (backend-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)