### PR TITLE
Datasources: Migrate EditDataSource to useDataSourceInstanceSettings

### DIFF
--- a/public/app/features/datasources/components/EditDataSource.test.tsx
+++ b/public/app/features/datasources/components/EditDataSource.test.tsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 
 import { type DataSourceJsonData, type PluginExtensionDataSourceConfigContext, PluginState } from '@grafana/data';
 import { setPluginComponentsHook, setPluginLinksHook } from '@grafana/runtime';
+import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { createComponentWithMeta } from 'app/features/plugins/extensions/usePluginComponents';
 import { configureStore } from 'app/store/configureStore';
 
@@ -15,14 +16,17 @@ import { EditDataSourceView, type ViewProps } from './EditDataSource';
 
 const onOptionsChange = jest.fn();
 
-jest.mock('@grafana/runtime', () => {
+jest.mock('@grafana/runtime/unstable', () => {
   return {
-    ...jest.requireActual('@grafana/runtime'),
-    getDataSourceSrv: jest.fn(() => ({
-      getInstanceSettings: (uid: string) => ({
-        uid,
-        meta: getMockDataSourceMeta(),
-      }),
+    ...jest.requireActual('@grafana/runtime/unstable'),
+    useDataSourceInstanceSettings: jest.fn((uid?: string) => ({
+      isLoading: false,
+      settings: uid
+        ? {
+            uid,
+            meta: getMockDataSourceMeta(),
+          }
+        : undefined,
     })),
   };
 });
@@ -121,6 +125,17 @@ describe('<EditDataSource>', () => {
       setup({
         dataSource: getMockDataSource({ name: 'My Datasource' }),
         dataSourceSettings: getMockDataSourceSettingsState({ loading: true }),
+      });
+
+      expect(screen.queryByText('Loading ...')).toBeVisible();
+      expect(screen.queryByText('My Datasource')).not.toBeInTheDocument();
+    });
+
+    it('should render a loading indicator while the data source instance settings are being fetched', () => {
+      jest.mocked(useDataSourceInstanceSettings).mockReturnValueOnce({ isLoading: true });
+
+      setup({
+        dataSource: getMockDataSource({ name: 'My Datasource' }),
       });
 
       expect(screen.queryByText('Loading ...')).toBeVisible();

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -11,7 +11,8 @@ import {
   type PluginExtensionDataSourceConfigContext,
   DataSourceUpdatedSuccessfully,
 } from '@grafana/data';
-import { getDataSourceSrv, usePluginComponents, type UsePluginComponentsResult } from '@grafana/runtime';
+import { usePluginComponents, type UsePluginComponentsResult } from '@grafana/runtime';
+import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { appEvents } from 'app/core/app_events';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { type DataSourceSettingsState } from 'app/types/datasources';
@@ -111,6 +112,9 @@ export function EditDataSourceView({
   const { readOnly, hasWriteRights, hasDeleteRights } = dataSourceRights;
   const hasDataSource = dataSource.id > 0 && dataSource.uid;
   const { components, isLoading } = useDataSourceConfigPluginExtensions();
+  const { settings: instanceSettings, isLoading: isLoadingInstanceSettings } = useDataSourceInstanceSettings(
+    dataSource.uid
+  );
 
   // Validation API passed to the config editor. validate() is called in onSubmit
   // — if it returns false the save and health check are both skipped.
@@ -167,8 +171,6 @@ export function EditDataSourceView({
     },
   };
 
-  const dsi = getDataSourceSrv()?.getInstanceSettings(dataSource.uid);
-
   const onSubmit = useCallback(
     async (e: React.MouseEvent<HTMLButtonElement> | React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
@@ -201,14 +203,14 @@ export function EditDataSourceView({
     [validation, onUpdate, dataSource, onTest, dispatch, retryAdvisorCheck]
   );
 
-  if (loading || isLoading) {
+  if (loading || isLoading || isLoadingInstanceSettings) {
     return <PageLoader />;
   }
 
-  if (loadError || !hasDataSource || !dsi) {
+  if (loadError || !hasDataSource || !instanceSettings) {
     return (
       <DataSourceLoadError
-        notFound={!hasDataSource || !dsi}
+        notFound={!hasDataSource || !instanceSettings}
         errorMsg={loadError}
         dataSourceRights={dataSourceRights}
         onDelete={() => {
@@ -221,7 +223,7 @@ export function EditDataSourceView({
 
   if (pageId) {
     return (
-      <DataSourcePluginContextProvider instanceSettings={dsi}>
+      <DataSourcePluginContextProvider instanceSettings={instanceSettings}>
         <DataSourcePluginConfigPage pageId={pageId} plugin={plugin} />
       </DataSourcePluginContextProvider>
     );
@@ -236,7 +238,7 @@ export function EditDataSourceView({
       <CloudInfoBox dataSource={dataSource} />
 
       {plugin && (
-        <DataSourcePluginContextProvider instanceSettings={dsi}>
+        <DataSourcePluginContextProvider instanceSettings={instanceSettings}>
           <DataSourcePluginSettings
             plugin={plugin}
             dataSource={dataSourceWithIsPDCInjected}


### PR DESCRIPTION
Part of #127035
Partly addresses https://github.com/grafana/grafana/issues/125083

### What changed?
Migrates `EditDataSource.tsx` from the deprecated sync `getDataSourceSrv().getInstanceSettings()` to the async `useDataSourceInstanceSettings` hook from `@grafana/runtime/unstable`.

The hook's `isLoading` state is included in the existing `PageLoader` gate, so while the instance settings resolve the page shows the loader instead of briefly flashing the "Data source not found" state.