### PR TITLE
Dashboards: Skip fanning out for data-less panels

### DIFF
--- a/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { useFlagGrafanaViewPanelPane } from '@grafana/runtime/internal';
-import { type VizPanel, useSceneObjectState } from '@grafana/scenes';
+import { type SceneDataProvider, type VizPanel, useSceneObjectState } from '@grafana/scenes';
 import { SceneContext, SceneContextObject } from '@grafana/scenes-react';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 
@@ -28,7 +28,6 @@ function ViewPanelWithPane({ panel }: ViewPanelProps) {
   const dashboard = getDashboardSceneLike(panel);
   const { editPane } = dashboard.useState();
   const { $data } = useSceneObjectState(panel, { shouldActivateOrKeepAlive: true });
-  const { data } = $data!.useState();
   const context = usePanelSceneContextObject(panel);
   const isSmallScreen = !useMediaQueryMinWidth('sm');
   const viewPanelPane = useMemo(() => new ViewPanelSidePane({ panelRef: panel.getRef() }), [panel]);
@@ -55,13 +54,32 @@ function ViewPanelWithPane({ panel }: ViewPanelProps) {
     return () => sub.unsubscribe();
   }, [viewPanelPane, editPane]);
 
-  if (!context || !data || !fanoutMode) {
+  // $data might be undefined when skipDataQuery=true, e.g. in TextPanel
+  // see also: createPanelDataProvider.ts
+  if (!context || !$data || !fanoutMode) {
+    return <panel.Component model={panel} />;
+  }
+
+  return <FanoutPanelWrapper panel={panel} dataProvider={$data} context={context} fanoutMode={fanoutMode} />;
+}
+
+interface FanoutPanelWrapperProps {
+  panel: VizPanel;
+  dataProvider: SceneDataProvider;
+  context: SceneContextObject;
+  fanoutMode: string;
+}
+
+function FanoutPanelWrapper({ panel, dataProvider, context, fanoutMode }: FanoutPanelWrapperProps) {
+  const { data } = dataProvider.useState();
+
+  if (!data) {
     return <panel.Component model={panel} />;
   }
 
   return (
     <SceneContext.Provider value={context}>
-      <FanoutPanel panel={panel} panelDataIn={data!} fanoutMode={fanoutMode} />
+      <FanoutPanel panel={panel} panelDataIn={data} fanoutMode={fanoutMode} />
     </SceneContext.Provider>
   );
 }


### PR DESCRIPTION
Bug:

1. Use flag `grafana.viewPanelPane = true`
2. Create a panel
3. Change viz type to "text"

Current: throws an error:

```typescript
function ViewPanelWithPane({ panel }: ViewPanelProps) {
  const dashboard = getDashboardSceneLike(panel);
  const { editPane } = dashboard.useState();
  const { $data } = useSceneObjectState(panel, { shouldActivateOrKeepAlive: true });
  // !! HERE: $data is undefined
  const { data } = $data!.useState(); 
  const context = usePanelSceneContextObject(panel);
``` 

`$data!` runtime assertion is incorrect as it can be undefined in some cases, e.g. when `skipDataQuery=true` (see here: https://github.com/grafana/grafana/blob/b10025b40d21c047176f1f4384fddc165211e5e8/public/app/features/dashboard-scene/utils/createPanelDataProvider.ts#L18) 