### PR TITLE
Revert "DataPro (migration): Migrate `core/utils/explore.ts` (#127578)"

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -1,6 +1,5 @@
 import {
   type DataSourceApi,
-  type DataSourceRef,
   dateTime,
   type ExploreUrlState,
   type GrafanaConfig,
@@ -70,11 +69,6 @@ const getDataSourceSrvMock = jest.fn().mockReturnValue(datasourceSrv);
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: () => getDataSourceSrvMock(),
-}));
-
-jest.mock('@grafana/runtime/unstable', () => ({
-  ...jest.requireActual('@grafana/runtime/unstable'),
-  getDataSourceInstance: (ref?: DataSourceRef | string) => datasourceSrv.get(ref),
 }));
 
 // Avoids errors caused by circular dependencies

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -24,7 +24,7 @@ import {
   urlUtil,
   generateUUID,
 } from '@grafana/data';
-import { getDataSourceInstance } from '@grafana/runtime/unstable';
+import { getDataSourceSrv } from '@grafana/runtime';
 import { RefreshPicker } from '@grafana/ui';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { type QueryOptions, type QueryTransaction } from 'app/types/explore';
@@ -74,7 +74,7 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
         .map(async (q) => {
           // if the query defines a datasource, use that one, otherwise use the one from the panel, which should always be defined.
           // this will rejects if the datasource is not found, or return the default one if dsRef is not provided.
-          const queryDs = await getDataSourceInstance(q.datasource || dsRef);
+          const queryDs = await getDataSourceSrv().get(q.datasource || dsRef);
 
           return {
             // interpolate the query using its datasource `interpolateVariablesInQueries` method if defined, othewise return the query as-is.
@@ -186,13 +186,13 @@ export async function generateEmptyQuery(
     // otherwise use last queries' datasource
     datasourceRef = queries[queries.length - 1].datasource;
   } else {
-    datasourceInstance = await getDataSourceInstance();
+    datasourceInstance = await getDataSourceSrv().get();
     defaultQuery = datasourceInstance.getDefaultQuery?.(CoreApp.Explore);
     datasourceRef = datasourceInstance.getRef();
   }
 
   if (!datasourceInstance) {
-    datasourceInstance = await getDataSourceInstance(datasourceRef);
+    datasourceInstance = await getDataSourceSrv().get(datasourceRef);
     defaultQuery = datasourceInstance.getDefaultQuery?.(CoreApp.Explore);
   }
 
@@ -230,7 +230,7 @@ export async function ensureQueries(
       let validDS = true;
       if (query.datasource) {
         try {
-          await getDataSourceInstance(query.datasource.uid);
+          await getDataSourceSrv().get(query.datasource.uid);
         } catch {
           console.error(`One of the queries has a datasource that is no longer available and was removed.`);
           validDS = false;
@@ -249,7 +249,7 @@ export async function ensureQueries(
   }
   try {
     // if a datasource override get its ref, otherwise get the default datasource
-    const emptyQueryRef = newQueryDataSourceOverride ?? (await getDataSourceInstance()).getRef();
+    const emptyQueryRef = newQueryDataSourceOverride ?? (await getDataSourceSrv().get()).getRef();
     const emptyQuery = await generateEmptyQuery(queries ?? [], undefined, emptyQueryRef);
     return [emptyQuery];
   } catch {

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -109,17 +109,6 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
-jest.mock('@grafana/runtime/unstable', () => ({
-  ...jest.requireActual('@grafana/runtime/unstable'),
-  getDataSourceInstance: (ref?: DataSourceRef | string) => {
-    if (!ref) {
-      return datasources[0];
-    }
-
-    return datasources.find((ds) => (typeof ref === 'string' ? ds.uid === ref : ds.uid === ref.uid)) || datasources[0];
-  },
-}));
-
 function setupQueryResponse(state: StoreState) {
   const leftDatasourceInstance = assertIsDefined(state.explore.panes.left!.datasourceInstance);
 


### PR DESCRIPTION
This reverts commit 3103327a3f9e8444a6345039cf66e6987fbe07da from https://github.com/grafana/grafana/pull/127578 which introduced the bug addressed by https://github.com/grafana/grafana/pull/127857.

**Special notes for your reviewer:**
Reverting the earlier PR is probably less risky over a holiday weekend, especially because it was supposed to be a noop migration to a new API.

Should follow up with investigating upstream fix in `getDataSourceInstance` as it doesn't have functional parity with `getDataSourceSrv`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
