### PR TITLE
PanelEdit: Fixes crash when changing to panel type with no data provider

### DIFF
--- a/public/app/features/dashboard-scene/solo/SoloPanelContext.tsx
+++ b/public/app/features/dashboard-scene/solo/SoloPanelContext.tsx
@@ -12,11 +12,13 @@ export interface SoloPanelContextValue {
   matches: (VizPanel: VizPanel) => boolean;
   matchFound: boolean;
   matchedPanels?: VizPanel[];
+  showControlsPane?: boolean;
 }
 
 export class SoloPanelContextWithPathIdFilter implements SoloPanelContextValue {
   public matchFound = false;
   public matchedPanels: VizPanel[] = [];
+  public showControlsPane = true;
 
   public constructor(public keyPath: string) {}
 
@@ -44,6 +46,7 @@ export class SoloPanelContextWithPathIdFilter implements SoloPanelContextValue {
 export class SoloPanelContextForPanelEdit implements SoloPanelContextValue {
   public matchFound = false;
   public matchedPanels: VizPanel[] = [];
+  public showControlsPane = false;
 
   public constructor(panel: VizPanel) {
     this.matchFound = true;
@@ -85,7 +88,9 @@ export function renderMatchingSoloPanels(
           </LazyLoader>
         );
       } else {
-        matches.push(<ViewPanelWrapper panel={panel} key={panel.state.key} />);
+        matches.push(
+          <ViewPanelWrapper panel={panel} key={panel.state.key} showControlsPane={soloPanelContext.showControlsPane} />
+        );
       }
     }
   }

--- a/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { useFlagGrafanaViewPanelPane } from '@grafana/runtime/internal';
-import { type VizPanel, useSceneObjectState } from '@grafana/scenes';
+import { type SceneDataProvider, type VizPanel, useSceneObjectState } from '@grafana/scenes';
 import { SceneContext, SceneContextObject } from '@grafana/scenes-react';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 
@@ -11,24 +11,21 @@ import { getDashboardSceneLike } from '../scene/types/dashboard';
 import { FanoutPanel } from './FanoutPanel';
 import { ViewPanelSidePane } from './ViewPanelSidePane';
 
-interface ViewPanelProps {
-  panel: VizPanel;
-}
-
-export function ViewPanelWrapper({ panel }: ViewPanelProps) {
+export function ViewPanelWrapper({ panel, showControlsPane }: { panel: VizPanel; showControlsPane?: boolean }) {
   const viewPanelPane = useFlagGrafanaViewPanelPane();
-  if (!viewPanelPane || !panel.state.$data) {
+  const { $data } = useSceneObjectState(panel, { shouldActivateOrKeepAlive: true });
+
+  if (!viewPanelPane || !$data || !showControlsPane) {
     return <panel.Component model={panel} />;
   }
 
-  return <ViewPanelWithPane panel={panel} />;
+  return <ViewPanelWithPane panel={panel} dataProvider={$data} />;
 }
 
-function ViewPanelWithPane({ panel }: ViewPanelProps) {
+function ViewPanelWithPane({ panel, dataProvider }: { panel: VizPanel; dataProvider: SceneDataProvider }) {
   const dashboard = getDashboardSceneLike(panel);
   const { editPane } = dashboard.useState();
-  const { $data } = useSceneObjectState(panel, { shouldActivateOrKeepAlive: true });
-  const { data } = $data!.useState();
+  const { data } = dataProvider.useState();
   const context = usePanelSceneContextObject(panel);
   const isSmallScreen = !useMediaQueryMinWidth('sm');
   const viewPanelPane = useMemo(() => new ViewPanelSidePane({ panelRef: panel.getRef() }), [panel]);


### PR DESCRIPTION
Fixes issue with new ViewPanel with side pane controls. 

ViewPanelWrapper is used from panel edit as well (as we use SoloPanelContext to render a single panel in isolation), made some extra guards so that we not render  ViewPanelWithPane from panel edit, as well as the moved the data provider null check from inside ViewPanelWithPane to the outside so that this undefined crash cannot happen 