### PR TITLE
CI: Add a comment with released version on Enterprise PR

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -7,6 +7,14 @@ on:
         type: string
         required: false
         default: workflow_dispatch
+      enterprise-commit:
+        description: >
+          When dispatched from grafana-enterprise on a main merge, the enterprise commit SHA that
+          triggered the build. Forwarded to the Pro build to attribute its PR comment; empty for
+          grafana's own builds.
+        type: string
+        required: false
+        default: ''
   schedule:
     # Every weeknight at midnight
     # "Scheduled workflows will only run on the default branch." (docs.github.com)
@@ -114,10 +122,11 @@ jobs:
           PUBLIC_COMMIT: ${{ needs.setup.outputs.public-commit }}
           SOURCE_EVENT: ${{ inputs.source-event || github.event_name }}
           REPO: ${{ github.repository }}
+          ENTERPRISE_COMMIT: ${{ inputs.enterprise-commit }}
         with:
           github-token: ${{ steps.get-github-app-token.outputs.token }}
           script: |
-            const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT, PUBLIC_COMMIT, SOURCE_EVENT, REPO} = process.env;
+            const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT, PUBLIC_COMMIT, SOURCE_EVENT, REPO, ENTERPRISE_COMMIT} = process.env;
             // grafana-enterprise has no #patched branches, so dispatch it on the plain
             // release branch (e.g. release-13.0.0#patched -> release-13.0.0).
             const enterpriseRef = REF.replace(/#patched$/, '');
@@ -147,6 +156,11 @@ jobs:
               // upstream-run-id is used with the github actions API and `gh run watch` to ensure coupled workflows
               // fail together.
               inputs["upstream-run-id"] = String(BUILD_ID);
+            }
+            // For enterprise main merges the Pro build annotates the triggering enterprise PR;
+            // forward the commit so it comments on the exact PR. Absent for grafana's own builds.
+            if (workflow === 'release-build-pro.yml' && ENTERPRISE_COMMIT) {
+              inputs["notify-enterprise-commit"] = ENTERPRISE_COMMIT;
             }
 
             await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
**What is this feature?**
Add a comment to each Enterprise PR with the build version like we have in OSS.

  **What** — Adds an optional enterprise-commit input and forwards it to the Pro build as notify-enterprise-commit, only when present.

  **Why** — Enterprise merges dispatch here; the Pro build runs back in grafana-enterprise but only knows
  enterprise main HEAD, not the triggering commit, so it can't reliably attribute a PR comment. Threading
  the triggering commit through lets the Pro build comment on the exact PR (and skip for grafana's own
  builds, which leave the input empty).

  **Notes** — No behavior change for grafana's own builds (input defaults empty). Must merge before the
  paired grafana-enterprise PR, which starts sending this input.

[Related Enterprise PR](https://github.com/grafana/grafana-enterprise/pull/12562)

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
