### PR TITLE
Theme: System preference to follow system

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -530,6 +530,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/solo-route.spec.ts @grafana/dashboards-squad
 /e2e-playwright/various-suite/splash-screen.spec.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/swagger.spec.ts @grafana/grafana-frontend-platform
+/e2e-playwright/various-suite/theme-system-preference.spec.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/trace-view-scrolling.spec.ts @grafana/observability-traces-and-profiling
 /e2e-playwright/various-suite/verify-i18n.spec.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/visualization-suggestions*.spec.ts @grafana/dataviz-squad
@@ -930,6 +931,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/services/PreferencesService.ts @grafana/grafana-frontend-platform
 /public/app/core/services/ResponseQueue* @grafana/grafana-frontend-platform
 /public/app/core/services/StateManagerBase.ts @grafana/grafana-frontend-platform
+/public/app/core/services/systemThemeListener.ts @grafana/grafana-frontend-platform
 /public/app/core/services/theme* @grafana/grafana-frontend-platform
 /public/app/core/specs/backend_srv.test.ts @grafana/grafana-frontend-platform
 /public/app/core/specs/factors.test.ts @grafana/dashboards-squad

--- a/e2e-playwright/various-suite/theme-system-preference.spec.ts
+++ b/e2e-playwright/various-suite/theme-system-preference.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const USER = 'theme-system-pref-test';
+const PASSWORD = 'theme-system-pref-test';
+
+test.use({
+  user: { user: USER, password: PASSWORD },
+  storageState: { cookies: [], origins: [] },
+});
+
+test.describe(
+  'System preference theme',
+  {
+    tag: ['@various'],
+  },
+  () => {
+    test.beforeEach(async ({ createUser, page, selectors }) => {
+      await createUser();
+      await page.getByTestId(selectors.pages.Login.username).fill(USER);
+      await page.getByTestId(selectors.pages.Login.password).fill(PASSWORD);
+      await page.getByTestId(selectors.pages.Login.submit).click();
+      await expect(page.getByTestId(selectors.components.NavToolbar.commandPaletteTrigger)).toBeVisible();
+
+      await page.request.patch('/api/user/preferences', { data: { theme: 'system' } });
+    });
+
+    test('applies dark theme when system prefers dark', async ({ page }) => {
+      await page.emulateMedia({ colorScheme: 'dark' });
+      await page.goto('/');
+
+      await expect(page.locator('body')).toHaveClass(/theme-dark/);
+      await expect(page.locator('body')).not.toHaveClass(/theme-light/);
+    });
+
+    test('applies light theme when system prefers light', async ({ page }) => {
+      await page.emulateMedia({ colorScheme: 'light' });
+      await page.goto('/');
+
+      await expect(page.locator('body')).toHaveClass(/theme-light/);
+      await expect(page.locator('body')).not.toHaveClass(/theme-dark/);
+    });
+
+    test('defaults to dark when no system color scheme preference', async ({ page }) => {
+      await page.emulateMedia({ colorScheme: 'no-preference' });
+      await page.goto('/');
+
+      await expect(page.locator('body')).toHaveClass(/theme-dark/);
+      await expect(page.locator('body')).not.toHaveClass(/theme-light/);
+    });
+
+    test('follows system preference change at runtime without page reload', async ({ page }) => {
+      await page.emulateMedia({ colorScheme: 'dark' });
+      await page.goto('/');
+      await expect(page.locator('body')).toHaveClass(/theme-dark/);
+
+      await page.emulateMedia({ colorScheme: 'light' });
+      await expect(page.locator('body')).toHaveClass(/theme-light/);
+      await expect(page.locator('body')).not.toHaveClass(/theme-dark/);
+    });
+  }
+);

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -104,7 +104,6 @@ for (const [name, json] of Object.entries(extraThemes)) {
 }
 
 function getSystemPreferenceTheme() {
-  const mediaResult = window.matchMedia('(prefers-color-scheme: dark)');
-  const id = mediaResult.matches ? 'dark' : 'light';
+  const id = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
   return getThemeById(id);
 }

--- a/public/app/core/components/ThemeSelector/ThemeSelectorDrawer.tsx
+++ b/public/app/core/components/ThemeSelector/ThemeSelectorDrawer.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/css';
 import { type GrafanaTheme2, type ThemeRegistryItem } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
-import { Drawer, TextLink, useStyles2, useTheme2 } from '@grafana/ui';
+import { Drawer, TextLink, useStyles2 } from '@grafana/ui';
 import { changeTheme } from 'app/core/services/theme';
 
 import { ThemeCard } from './ThemeCard';
@@ -16,8 +16,6 @@ interface Props {
 export function ThemeSelectorDrawer({ onClose }: Props) {
   const styles = useStyles2(getStyles);
   const themes = getSelectableThemes();
-  const currentTheme = useTheme2();
-
   const onChange = (theme: ThemeRegistryItem) => {
     reportInteraction('grafana_preferences_theme_changed', {
       toTheme: theme.id,
@@ -54,7 +52,7 @@ export function ThemeSelectorDrawer({ onClose }: Props) {
             isExperimental={themeOption.isExtra}
             key={themeOption.id}
             onSelect={() => onChange(themeOption)}
-            isSelected={currentTheme.name === themeOption.name}
+            isSelected={config.bootData.user.theme === themeOption.id}
           />
         ))}
       </div>

--- a/public/app/core/services/systemThemeListener.ts
+++ b/public/app/core/services/systemThemeListener.ts
@@ -1,0 +1,17 @@
+let watcher: MediaQueryList | null = null;
+let callback: (() => void) | null = null;
+
+export function startSystemThemeListener(onChange: () => void) {
+  stopSystemThemeListener();
+  watcher = window.matchMedia('(prefers-color-scheme: light)');
+  callback = onChange;
+  watcher.addEventListener('change', callback);
+}
+
+export function stopSystemThemeListener() {
+  if (watcher && callback) {
+    watcher.removeEventListener('change', callback);
+    watcher = null;
+    callback = null;
+  }
+}

--- a/public/app/core/services/theme.ts
+++ b/public/app/core/services/theme.ts
@@ -8,12 +8,14 @@ import { appEvents } from '../app_events';
 import { contextSrv } from '../services/context_srv';
 
 import { PreferencesService } from './PreferencesService';
+import { startSystemThemeListener, stopSystemThemeListener } from './systemThemeListener';
 
 export async function changeTheme(themeId: string, runtimeOnly?: boolean) {
   const oldTheme = config.theme2;
 
   const newTheme = getThemeById(themeId);
 
+  config.bootData.user.theme = themeId;
   appEvents.publish(new ThemeChangedEvent(newTheme));
 
   // Add css file for new theme
@@ -38,8 +40,18 @@ export async function changeTheme(themeId: string, runtimeOnly?: boolean) {
     document.head.insertBefore(newCssLink, document.head.firstChild);
   }
 
+  // Always stop the system listener when switching to an explicit theme, even on runtime-only
+  // calls (e.g. toggleTheme), so OS changes don't silently override the user's selection.
+  if (themeId !== 'system') {
+    stopSystemThemeListener();
+  }
+
   if (runtimeOnly) {
     return;
+  }
+
+  if (themeId === 'system') {
+    startSystemThemeListener(() => changeTheme('system', true));
   }
 
   if (!contextSrv.isSignedIn) {

--- a/public/app/initPreferences.test.ts
+++ b/public/app/initPreferences.test.ts
@@ -1,6 +1,11 @@
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
+jest.mock('app/core/services/systemThemeListener', () => ({
+  startSystemThemeListener: jest.fn(),
+  stopSystemThemeListener: jest.fn(),
+}));
+
 import { fetchMergedPreferences, initPreferences } from './initPreferences';
 
 const PREFERENCES_URL = '*/apis/preferences.grafana.app/v1alpha1/namespaces/:ns/preferences/merged';
@@ -170,9 +175,9 @@ describe('applyTheme', () => {
     window.matchMedia = originalMatchMedia;
   });
 
-  function mockPrefersDark(matches: boolean) {
+  function mockColorScheme(scheme: 'dark' | 'light' | 'no-preference') {
     window.matchMedia = ((query: string) => ({
-      matches,
+      matches: scheme === 'light' && query === '(prefers-color-scheme: light)',
       media: query,
       onchange: null,
       addListener: jest.fn(),
@@ -199,12 +204,13 @@ describe('applyTheme', () => {
   });
 
   it.each([
-    { prefersDark: true, expectedClass: 'theme-dark', otherClass: 'theme-light' },
-    { prefersDark: false, expectedClass: 'theme-light', otherClass: 'theme-dark' },
+    { scheme: 'dark' as const, expectedClass: 'theme-dark', otherClass: 'theme-light' },
+    { scheme: 'light' as const, expectedClass: 'theme-light', otherClass: 'theme-dark' },
+    { scheme: 'no-preference' as const, expectedClass: 'theme-dark', otherClass: 'theme-light' },
   ])(
-    'theme "system" applies $expectedClass when prefersDark=$prefersDark',
-    async ({ prefersDark, expectedClass, otherClass }) => {
-      mockPrefersDark(prefersDark);
+    'theme "system" applies $expectedClass when color scheme is "$scheme"',
+    async ({ scheme, expectedClass, otherClass }) => {
+      mockColorScheme(scheme);
 
       server.use(http.get(PREFERENCES_URL, () => HttpResponse.json({ spec: { theme: 'system' } })));
 

--- a/public/app/initPreferences.ts
+++ b/public/app/initPreferences.ts
@@ -1,4 +1,12 @@
 import type { PreferencesSpec } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
+import { startSystemThemeListener } from 'app/core/services/systemThemeListener';
+
+// Dynamic import avoids pulling theme.ts (and its store deps) into the early bundle.
+// By the time the OS preference changes, the app is fully loaded.
+async function onSystemThemeChange() {
+  const { changeTheme } = await import('app/core/services/theme');
+  await changeTheme('system', true);
+}
 
 export const initPreferences = async () => {
   const preferences = await fetchMergedPreferences();
@@ -18,6 +26,9 @@ export const initPreferences = async () => {
   if (themeWithOverride !== undefined) {
     window.grafanaBootData.user.theme = themeWithOverride;
     applyTheme(themeWithOverride);
+    if (themeWithOverride === 'system') {
+      startSystemThemeListener(onSystemThemeChange);
+    }
   }
   if (languageWithOverride !== undefined) {
     window.grafanaBootData.user.language = languageWithOverride;
@@ -56,8 +67,7 @@ export async function fetchMergedPreferences(): Promise<{ spec: PreferencesSpec 
 // but using the merged-preferences value. Updates lightTheme, the <body> class,
 // and the theme stylesheet <link href>.
 function applyTheme(theme: string) {
-  const isLightTheme =
-    theme === 'system' ? !window.matchMedia('(prefers-color-scheme: dark)').matches : theme === 'light';
+  const isLightTheme = theme === 'system' ? window.matchMedia('(prefers-color-scheme: light)').matches : theme === 'light';
 
   window.grafanaBootData.user.lightTheme = isLightTheme;
 

--- a/public/app/initPreferences.ts
+++ b/public/app/initPreferences.ts
@@ -67,7 +67,8 @@ export async function fetchMergedPreferences(): Promise<{ spec: PreferencesSpec 
 // but using the merged-preferences value. Updates lightTheme, the <body> class,
 // and the theme stylesheet <link href>.
 function applyTheme(theme: string) {
-  const isLightTheme = theme === 'system' ? window.matchMedia('(prefers-color-scheme: light)').matches : theme === 'light';
+  const isLightTheme =
+    theme === 'system' ? window.matchMedia('(prefers-color-scheme: light)').matches : theme === 'light';
 
   window.grafanaBootData.user.lightTheme = isLightTheme;
 

--- a/public/boot/index.ts
+++ b/public/boot/index.ts
@@ -242,8 +242,7 @@ async function initGrafana() {
 
     const theme = window.grafanaBootData.user.theme;
     if (theme === 'system') {
-      const darkQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      window.grafanaBootData.user.lightTheme = !darkQuery.matches;
+      window.grafanaBootData.user.lightTheme = window.matchMedia('(prefers-color-scheme: light)').matches;
     }
 
     const isLightTheme = window.grafanaBootData.user.lightTheme;


### PR DESCRIPTION
When the system preference theme is selected, it shouldn't simply select another theme, then not follow the system. Instead, this migrates the theme option to follow the system's theme, like one would expect in nearly every single other website.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
