### PR TITLE
Unified storage: use ListStoredResources for search discovery

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -385,10 +385,16 @@ func (s *searchServer) ListManagedObjects(ctx context.Context, req *resourcepb.L
 	}
 
 	rsp := &resourcepb.ListManagedObjectsResponse{}
+	if req.Namespace == "" {
+		rsp.Error = NewBadRequestError("missing namespace")
+		return rsp, nil
+	}
 	nsr := NamespacedResource{
 		Namespace: req.Namespace,
 	}
-	resourceStats, err := s.storage.GetResourceStats(ctx, nsr, 0)
+	// Discover which resource types exist in the namespace, then query each
+	// managed-object index. Discovery avoids the cost of counting via stats.
+	stored, err := s.storage.ListStoredResources(ctx, nsr)
 	if err != nil {
 		rsp.Error = AsErrorResult(err)
 		return rsp, nil
@@ -397,7 +403,7 @@ func (s *searchServer) ListManagedObjects(ctx context.Context, req *resourcepb.L
 	stats := NewSearchStats("ListManagedObjects")
 	defer s.logStats(ctx, stats, span, "namespace", req.Namespace)
 
-	for _, info := range resourceStats {
+	for _, info := range stored {
 		idx, err := s.getOrCreateIndex(ctx, stats, NamespacedResource{
 			Namespace: req.Namespace,
 			Group:     info.Group,
@@ -471,16 +477,22 @@ func (s *searchServer) CountManagedObjects(ctx context.Context, req *resourcepb.
 	defer s.logStats(ctx, stats, span, "namespace", req.Namespace)
 
 	rsp := &resourcepb.CountManagedObjectsResponse{}
+	if req.Namespace == "" {
+		rsp.Error = NewBadRequestError("missing namespace")
+		return rsp, nil
+	}
 	nsr := NamespacedResource{
 		Namespace: req.Namespace,
 	}
-	resourceStats, err := s.storage.GetResourceStats(ctx, nsr, 0)
+	// Discover which resource types exist in the namespace, then count
+	// managed objects from each index. Discovery avoids the cost of counting via stats.
+	stored, err := s.storage.ListStoredResources(ctx, nsr)
 	if err != nil {
 		rsp.Error = AsErrorResult(err)
 		return rsp, nil
 	}
 
-	for _, info := range resourceStats {
+	for _, info := range stored {
 		idx, err := s.getOrCreateIndex(ctx, stats, NamespacedResource{
 			Namespace: req.Namespace,
 			Group:     info.Group,

--- a/pkg/storage/unified/resource/search_managed_test.go
+++ b/pkg/storage/unified/resource/search_managed_test.go
@@ -1,0 +1,99 @@
+package resource
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// newDiscoveryTestSearchServer builds a searchServer wired to the given storage and
+// search backends, with the minimal options the constructor requires.
+func newDiscoveryTestSearchServer(t *testing.T, storage StorageBackend, search SearchBackend) *searchServer {
+	t.Helper()
+	opts := SearchOptions{
+		Backend:      search,
+		Resources:    &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
+		InitMinCount: 1,
+	}
+	server, err := newSearchServer(opts, storage, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	return server
+}
+
+func TestListManagedObjectsUsesDiscovery(t *testing.T) {
+	const ns = "ns"
+	gr := NamespacedResource{Namespace: ns, Group: "group", Resource: "dashboards"}
+
+	storage := &mockStorageBackend{
+		resourceStats: []ResourceStats{{NamespacedResource: gr, Count: 5}},
+	}
+	search := &mockSearchBackend{
+		cache: map[NamespacedResource]ResourceIndex{
+			gr: &MockResourceIndex{managedObjects: &resourcepb.ListManagedObjectsResponse{
+				Items: []*resourcepb.ListManagedObjectsResponse_Item{{Path: "p1"}, {Path: "p2"}},
+			}},
+		},
+	}
+	server := newDiscoveryTestSearchServer(t, storage, search)
+
+	rsp, err := server.ListManagedObjects(t.Context(), &resourcepb.ListManagedObjectsRequest{Namespace: ns})
+	require.NoError(t, err)
+	require.Nil(t, rsp.Error)
+	require.Len(t, rsp.Items, 2)
+
+	require.Zero(t, storage.statsCalls.Load(), "GetResourceStats must not be called")
+	require.Positive(t, storage.listStoredCalls.Load(), "discovery must be used")
+}
+
+func TestCountManagedObjectsUsesDiscovery(t *testing.T) {
+	const ns = "ns"
+	gr := NamespacedResource{Namespace: ns, Group: "group", Resource: "dashboards"}
+
+	storage := &mockStorageBackend{
+		resourceStats: []ResourceStats{{NamespacedResource: gr, Count: 5}},
+	}
+	search := &mockSearchBackend{
+		cache: map[NamespacedResource]ResourceIndex{
+			gr: &MockResourceIndex{managedCounts: []*resourcepb.CountManagedObjectsResponse_ResourceCount{
+				{Kind: "dashboard", Count: 4},
+			}},
+		},
+	}
+	server := newDiscoveryTestSearchServer(t, storage, search)
+
+	rsp, err := server.CountManagedObjects(t.Context(), &resourcepb.CountManagedObjectsRequest{Namespace: ns})
+	require.NoError(t, err)
+	require.Nil(t, rsp.Error)
+	require.Len(t, rsp.Items, 1)
+	require.Equal(t, int64(4), rsp.Items[0].Count)
+
+	require.Zero(t, storage.statsCalls.Load(), "GetResourceStats must not be called")
+	require.Positive(t, storage.listStoredCalls.Load(), "discovery must be used")
+}
+
+// Discovery requires a namespace, so these RPCs must reject an empty one before
+// reaching the backend.
+func TestManagedObjectsRequireNamespace(t *testing.T) {
+	storage := &mockStorageBackend{}
+	server := newDiscoveryTestSearchServer(t, storage, &mockSearchBackend{})
+
+	t.Run("ListManagedObjects", func(t *testing.T) {
+		rsp, err := server.ListManagedObjects(t.Context(), &resourcepb.ListManagedObjectsRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.Error)
+		require.Equal(t, int32(http.StatusBadRequest), rsp.Error.Code)
+	})
+
+	t.Run("CountManagedObjects", func(t *testing.T) {
+		rsp, err := server.CountManagedObjects(t.Context(), &resourcepb.CountManagedObjectsRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.Error)
+		require.Equal(t, int32(http.StatusBadRequest), rsp.Error.Code)
+	})
+
+	require.Zero(t, storage.listStoredCalls.Load(), "discovery must not run without a namespace")
+}

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -37,6 +37,11 @@ type MockResourceIndex struct {
 
 	buildInfo IndexBuildInfo
 	docCount  int64
+
+	// Optional configured results for the managed-object RPCs. When nil the
+	// methods return an error, matching the default "not expected" behaviour.
+	managedObjects *resourcepb.ListManagedObjectsResponse
+	managedCounts  []*resourcepb.CountManagedObjectsResponse_ResourceCount
 }
 
 func (m *MockResourceIndex) BuildInfo() (IndexBuildInfo, error) {
@@ -52,6 +57,9 @@ func (m *MockResourceIndex) Search(_ context.Context, _ types.AccessClient, _ *r
 }
 
 func (m *MockResourceIndex) CountManagedObjects(_ context.Context, _ *SearchStats) ([]*resourcepb.CountManagedObjectsResponse_ResourceCount, error) {
+	if m.managedCounts != nil {
+		return m.managedCounts, nil
+	}
 	return nil, fmt.Errorf("not expected")
 }
 
@@ -60,6 +68,9 @@ func (m *MockResourceIndex) DocCount(_ context.Context, _ string, _ *SearchStats
 }
 
 func (m *MockResourceIndex) ListManagedObjects(_ context.Context, _ *resourcepb.ListManagedObjectsRequest, _ *SearchStats) (*resourcepb.ListManagedObjectsResponse, error) {
+	if m.managedObjects != nil {
+		return m.managedObjects, nil
+	}
 	return nil, fmt.Errorf("not expected")
 }
 
@@ -85,6 +96,8 @@ type mockStorageBackend struct {
 	resourceStats   []ResourceStats
 	lastImportTimes []ResourceLastImportTime
 	statsCalls      atomic.Int32
+	listStoredCalls atomic.Int32
+	listStoredErr   error
 }
 
 func (m *mockStorageBackend) GetResourceStats(ctx context.Context, nsr NamespacedResource, minCount int) ([]ResourceStats, error) {
@@ -95,6 +108,33 @@ func (m *mockStorageBackend) GetResourceStats(ctx context.Context, nsr Namespace
 		if stat.Count > int64(minCount) {
 			result = append(result, stat)
 		}
+	}
+	return result, nil
+}
+
+// ListStoredResources reports the distinct group/resource identities in the
+// namespace, derived from the configured resourceStats. It is the discovery
+// primitive the search server uses instead of counting via GetResourceStats.
+func (m *mockStorageBackend) ListStoredResources(_ context.Context, filter NamespacedResource) ([]NamespacedResource, error) {
+	m.listStoredCalls.Add(1)
+	if m.listStoredErr != nil {
+		return nil, m.listStoredErr
+	}
+	if filter.Namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	var result []NamespacedResource
+	for _, stat := range m.resourceStats {
+		if stat.Namespace != filter.Namespace {
+			continue
+		}
+		if filter.Group != "" && stat.Group != filter.Group {
+			continue
+		}
+		if filter.Resource != "" && stat.Resource != filter.Resource {
+			continue
+		}
+		result = append(result, stat.NamespacedResource)
 	}
 	return result, nil
 }

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -630,10 +630,8 @@ func TestListStoredResources(t *testing.T) {
 	})
 
 	t.Run("backend errors are returned as codes.Internal", func(t *testing.T) {
-		// mockStorageBackend inherits ListStoredResources from
-		// UnimplementedStorageBackend, which returns an error.
 		errServer, err := NewResourceServer(ResourceServerOptions{
-			Backend: &mockStorageBackend{},
+			Backend: &mockStorageBackend{listStoredErr: errors.New("boom")},
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() {


### PR DESCRIPTION
Follow-up to #127717, which added the `ListStoredResources` discovery API. This PR switches the in-process search paths that only need to know which resource types exist in a namespace — not their counts — from `GetResourceStats` to `ListStoredResources`, which is cheaper because it checks existence instead of counting live resources.

Changed call sites in `searchServer`:

- `ListManagedObjects` — discovers resource types, then queries each managed-object index.
- `CountManagedObjects` — discovers resource types, then counts managed objects per index.

Both now reject an empty namespace with a bad-request error, since discovery requires a namespace.

`GetStats` is intentionally left on `GetResourceStats` for now. The datasource migrator calls `GetStats` purely for discovery, and switching `GetStats` to count via indexes would force on-demand index builds during migration. That migrator caller will move to `ListStoredResources` in a later PR, after which `GetStats` can change safely.

The startup prebuild path also stays on `GetResourceStats` because it needs `initMinSize` count filtering, which discovery does not provide.

Tests cover both switched paths (discovery is used, `GetResourceStats` is not) and the empty-namespace rejection.
