### PR TITLE
Visual refresh: Remap dark/light themes when flag is enabled

### DIFF
--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -1,5 +1,4 @@
 import { getBuiltInThemes } from '@grafana/data';
-import { getFeatureFlagClient, FlagKeys } from '@grafana/runtime/internal';
 
 export function getSelectableThemes() {
   const allowedExtraThemes = [
@@ -13,10 +12,6 @@ export function getSelectableThemes() {
     'tron',
     'gloom',
   ];
-
-  if (getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaVisualDesignRefresh, false)) {
-    allowedExtraThemes.push('visual_refresh_dark', 'visual_refresh_light');
-  }
 
   return getBuiltInThemes(allowedExtraThemes);
 }

--- a/public/app/core/utils/ConfigProvider.tsx
+++ b/public/app/core/utils/ConfigProvider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
 import { SkeletonTheme } from 'react-loading-skeleton';
 
@@ -11,11 +11,13 @@ import 'react-loading-skeleton/dist/skeleton.css';
 
 // temporarily remap dark/light to the visual refresh themes if the flag is enabled
 // when delivering the visual refresh, remove this remapping and use the updated dark/light themes directly
-function remapThemeForVisualDesignRefresh(theme: GrafanaTheme2): GrafanaTheme2 {
-  if (theme.name === 'Dark') {
-    return getThemeById('visual_refresh_dark');
-  } else if (theme.name === 'Light') {
-    return getThemeById('visual_refresh_light');
+function maybeRemapTheme(theme: GrafanaTheme2, visualRefreshEnabled: boolean): GrafanaTheme2 {
+  if (visualRefreshEnabled) {
+    if (theme.name === 'Dark') {
+      return getThemeById('visual_refresh_dark');
+    } else if (theme.name === 'Light') {
+      return getThemeById('visual_refresh_light');
+    }
   }
   return theme;
 }
@@ -23,12 +25,7 @@ function remapThemeForVisualDesignRefresh(theme: GrafanaTheme2): GrafanaTheme2 {
 export const ThemeProvider = ({ children, value }: { children: React.ReactNode; value: GrafanaTheme2 }) => {
   const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
 
-  const maybeRemapTheme = useCallback(
-    (theme: GrafanaTheme2) => (visualRefreshEnabled ? remapThemeForVisualDesignRefresh(theme) : theme),
-    [visualRefreshEnabled]
-  );
-
-  const [theme, setTheme] = useState(() => maybeRemapTheme(value));
+  const [theme, setTheme] = useState(() => maybeRemapTheme(value, visualRefreshEnabled));
 
   const themeWithFlags = useMemo(
     () => ({
@@ -43,17 +40,17 @@ export const ThemeProvider = ({ children, value }: { children: React.ReactNode; 
 
   useEffect(() => {
     const sub = appEvents.subscribe(ThemeChangedEvent, (event) => {
-      const newTheme = maybeRemapTheme(event.payload);
+      const newTheme = maybeRemapTheme(event.payload, visualRefreshEnabled);
       config.theme2 = newTheme;
       setTheme(newTheme);
     });
 
     return () => sub.unsubscribe();
-  }, [maybeRemapTheme]);
+  }, [visualRefreshEnabled]);
 
   useEffect(() => {
-    setTheme(maybeRemapTheme(value));
-  }, [value, maybeRemapTheme]);
+    setTheme(maybeRemapTheme(value, visualRefreshEnabled));
+  }, [value, visualRefreshEnabled]);
 
   return (
     <ThemeContext.Provider value={themeWithFlags}>

--- a/public/app/core/utils/ConfigProvider.tsx
+++ b/public/app/core/utils/ConfigProvider.tsx
@@ -1,18 +1,34 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
 import { SkeletonTheme } from 'react-loading-skeleton';
 
-import { type GrafanaTheme2, ThemeContext } from '@grafana/data';
+import { getThemeById, type GrafanaTheme2, ThemeContext } from '@grafana/data';
 import { ThemeChangedEvent, config } from '@grafana/runtime';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 
 import { appEvents } from '../app_events';
-
 import 'react-loading-skeleton/dist/skeleton.css';
 
+// temporarily remap dark/light to the visual refresh themes if the flag is enabled
+// when delivering the visual refresh, remove this remapping and use the updated dark/light themes directly
+function remapThemeForVisualDesignRefresh(theme: GrafanaTheme2): GrafanaTheme2 {
+  if (theme.name === 'Dark') {
+    return getThemeById('visual_refresh_dark');
+  } else if (theme.name === 'Light') {
+    return getThemeById('visual_refresh_light');
+  }
+  return theme;
+}
+
 export const ThemeProvider = ({ children, value }: { children: React.ReactNode; value: GrafanaTheme2 }) => {
-  const [theme, setTheme] = useState(value);
   const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
+
+  const maybeRemapTheme = useCallback(
+    (theme: GrafanaTheme2) => (visualRefreshEnabled ? remapThemeForVisualDesignRefresh(theme) : theme),
+    [visualRefreshEnabled]
+  );
+
+  const [theme, setTheme] = useState(() => maybeRemapTheme(value));
 
   const themeWithFlags = useMemo(
     () => ({
@@ -27,16 +43,17 @@ export const ThemeProvider = ({ children, value }: { children: React.ReactNode; 
 
   useEffect(() => {
     const sub = appEvents.subscribe(ThemeChangedEvent, (event) => {
-      config.theme2 = event.payload;
-      setTheme(event.payload);
+      const newTheme = maybeRemapTheme(event.payload);
+      config.theme2 = newTheme;
+      setTheme(newTheme);
     });
 
     return () => sub.unsubscribe();
-  }, []);
+  }, [maybeRemapTheme]);
 
   useEffect(() => {
-    setTheme(value);
-  }, [value]);
+    setTheme(maybeRemapTheme(value));
+  }, [value, maybeRemapTheme]);
 
   return (
     <ThemeContext.Provider value={themeWithFlags}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- remaps the standard dark/light themes to the visual refresh equivalents if the feature flag is enabled

**Why do we need this feature?**

- this will allow us to deliver the new themes safely behind the feature flag 🥳 

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana-frontend-platform/issues/165

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
