### PR TITLE
InfluxDB: Fix field type handling in query builder WHERE clauses

### DIFF
--- a/pkg/tsdb/influxdb/models/model_parser.go
+++ b/pkg/tsdb/influxdb/models/model_parser.go
@@ -178,6 +178,13 @@ func parseTags(model *simplejson.Json) ([]*Tag, error) {
 			tag.Condition = condition
 		}
 
+		// dataType is optional. When the UI resolves the InfluxDB field type it
+		// is sent along so renderTags can quote "::field" values correctly.
+		dataType, err := tagJson.Get("dataType").String()
+		if err == nil {
+			tag.Type = dataType
+		}
+
 		result = append(result, tag)
 	}
 

--- a/pkg/tsdb/influxdb/models/model_parser_test.go
+++ b/pkg/tsdb/influxdb/models/model_parser_test.go
@@ -121,6 +121,40 @@ func TestInfluxdbQueryParser_Parse(t *testing.T) {
 		require.Equal(t, "series alias", res.Alias)
 	})
 
+	t.Run("can parse tag dataType into tag type", func(t *testing.T) {
+		json := `
+      {
+        "measurement": "cpu",
+        "policy": "default",
+        "resultFormat": "time_series",
+        "tags": [
+          {
+            "key": "usage::field",
+            "operator": "=",
+            "value": "42",
+            "dataType": "integer"
+          },
+          {
+            "key": "host",
+            "operator": "=",
+            "value": "server1"
+          }
+        ]
+      }
+      `
+
+		query := backend.DataQuery{
+			JSON:     []byte(json),
+			Interval: time.Second * 20,
+		}
+
+		res, err := QueryParse(query, nil)
+		require.NoError(t, err)
+		require.Len(t, res.Tags, 2)
+		require.Equal(t, "integer", res.Tags[0].Type)
+		require.Empty(t, res.Tags[1].Type)
+	})
+
 	t.Run("can parse raw query json model", func(t *testing.T) {
 		json := `
       {

--- a/pkg/tsdb/influxdb/models/models.go
+++ b/pkg/tsdb/influxdb/models/models.go
@@ -31,6 +31,11 @@ type Tag struct {
 	Operator  string
 	Value     string
 	Condition string
+	// Type holds the InfluxDB field data type (for example "float", "integer",
+	// "boolean" or "string") when it is known. It lets renderTags decide whether
+	// a "::field" value should be quoted in a WHERE clause. It is optional and
+	// may be empty, in which case the type is inferred from the value.
+	Type string
 }
 
 type Select []QueryPart

--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -17,6 +17,7 @@ var (
 	regexpMeasurementPattern        = regexp.MustCompile(`^\/.*\/$`)
 	regexMatcherWithStartEndPattern = regexp.MustCompile(`^/\^(.*)\$/$`)
 	regexpRawQueryWhere             = regexp.MustCompile(`(?i)WHERE`)
+	regexpNumberPattern             = regexp.MustCompile(`^-?[0-9.]+$`)
 )
 
 func (query *Query) getRawQueryWithAdhocFilters() string {
@@ -99,6 +100,36 @@ func (query *Query) renderAdhocFilters() []string {
 	return renderTags(query.AdhocFilters)
 }
 
+// renderFieldValue formats the value of a "::field" comparison for a WHERE
+// clause. Numeric and boolean fields must stay unquoted so InfluxDB compares
+// them by value; string fields (and any value we cannot classify) are quoted.
+// A known fieldType is authoritative, which lets saved queries with a stored
+// dataType render correctly. Otherwise the type is inferred from the value
+// itself, so existing dashboards are fixed without any extra metadata.
+func renderFieldValue(value string, fieldType string) string {
+	quoted := fmt.Sprintf("'%s'", strings.ReplaceAll(value, `\`, `\\`))
+	lowerValue := strings.ToLower(value)
+
+	switch strings.ToLower(fieldType) {
+	case "float", "integer", "unsigned":
+		return value
+	case "boolean":
+		return lowerValue
+	case "string":
+		return quoted
+	}
+
+	// Without a usable field type, fall back to inferring it from the value.
+	switch {
+	case lowerValue == "true" || lowerValue == "false":
+		return lowerValue
+	case regexpNumberPattern.MatchString(value):
+		return value
+	default:
+		return quoted
+	}
+}
+
 func renderTags(tags []*Tag) []string {
 	res := make([]string, 0, len(tags))
 	for i, tag := range tags {
@@ -123,10 +154,6 @@ func renderTags(tags []*Tag) []string {
 		}
 
 		isOperatorTypeHandler := func(tag *Tag) (string, string) {
-			// Attempt to identify the type of the supplied value
-			var lowerValue = strings.ToLower(tag.Value)
-			var r = regexp.MustCompile(`^(-?)[0-9\.]+$`)
-			var textValue string
 			var operator string
 
 			// Perform operator replacements
@@ -142,23 +169,12 @@ func renderTags(tags []*Tag) []string {
 
 			// Always quote tag values
 			if strings.HasSuffix(tag.Key, "::tag") {
-				textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
-				return textValue, operator
+				return fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`)), operator
 			}
 
-			// Try and discern the type of fields
-			if lowerValue == "true" || lowerValue == "false" {
-				// boolean, don't quote, but make lowercase
-				textValue = lowerValue
-			} else if r.MatchString(tag.Value) {
-				// Integer or float, don't quote
-				textValue = tag.Value
-			} else {
-				// String (or unknown) - quote
-				textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
-			}
-
-			return removeRegexWrappers(textValue, `'`), operator
+			// Fields keep their natural type: numbers and booleans are left
+			// unquoted, everything else is quoted as a string.
+			return removeRegexWrappers(renderFieldValue(tag.Value, tag.Type), `'`), operator
 		}
 
 		// quote value unless regex or number
@@ -171,7 +187,15 @@ func renderTags(tags []*Tag) []string {
 		case "Is", "Is Not":
 			textValue, tag.Operator = isOperatorTypeHandler(tag)
 		default:
-			textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(removeRegexWrappers(tag.Value, ""), `\`, `\\`))
+			// For explicit field selectors ("name::field") we honour the field
+			// type so numeric and boolean comparisons stay unquoted. Quoting them
+			// would make InfluxDB compare against a string and return no data
+			// (issue #94472). Tags and plain keys keep the always-quote behaviour.
+			if strings.HasSuffix(tag.Key, "::field") {
+				textValue = renderFieldValue(removeRegexWrappers(tag.Value, ""), tag.Type)
+			} else {
+				textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(removeRegexWrappers(tag.Value, ""), `\`, `\\`))
+			}
 		}
 
 		escapedKey := fmt.Sprintf(`"%s"`, tag.Key)

--- a/pkg/tsdb/influxdb/models/query_test.go
+++ b/pkg/tsdb/influxdb/models/query_test.go
@@ -311,6 +311,72 @@ func TestInfluxdbQueryBuilder(t *testing.T) {
 
 			require.Equal(t, `"key" > '12.2'`, strings.Join(query.renderTags(), ""))
 		})
+
+		t.Run("can render integer field without quotes using =", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "=", Value: "42", Key: "intfield::field"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"intfield"::field = 42`)
+		})
+
+		t.Run("can render integer field without quotes using !=", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "!=", Value: "42", Key: "intfield::field"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"intfield"::field != 42`)
+		})
+
+		t.Run("can render negative number field without quotes", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "=", Value: "-1.5", Key: "temp::field"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"temp"::field = -1.5`)
+		})
+
+		t.Run("can render boolean field without quotes and lowercased", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "=", Value: "True", Key: "enabled::field"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"enabled"::field = true`)
+		})
+
+		t.Run("can render string field with quotes", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "=", Value: "hello", Key: "message::field"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"message"::field = 'hello'`)
+		})
+
+		t.Run("can escape backslashes when rendering string field", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "=", Value: `C:\test\`, Key: "path::field"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"path"::field = 'C:\\test\\'`)
+		})
+
+		t.Run("keeps quotes for string field when dataType is string even if value looks numeric", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "=", Value: "42", Key: "version::field", Type: "string"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"version"::field = '42'`)
+		})
+
+		t.Run("removes quotes for integer field when dataType is integer", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "=", Value: "42", Key: "count::field", Type: "integer"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"count"::field = 42`)
+		})
+
+		t.Run("still quotes numeric values for tag selectors", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "=", Value: "42", Key: "host::tag"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"host"::tag = '42'`)
+		})
+
+		t.Run("still quotes numeric values for plain keys", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "=", Value: "42", Key: "host"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"host" = '42'`)
+		})
+
+		t.Run("can render field without quotes using Is with integer value", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: "42", Key: "count::field"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"count"::field = 42`)
+		})
 	})
 }
 


### PR DESCRIPTION
## Summary

This is the backend fix for #94472 that @adamyeats suggested when closing the frontend attempt in #126106.

Builder queries are rendered on the Go backend in `renderTags` (`pkg/tsdb/influxdb/models/query.go`). For the `=` and `!=` operators the value was always quoted, so a numeric field comparison like `"intfield"::field = 42` was rendered as `"intfield"::field = '42'`. InfluxDB then compares a numeric field against a string and returns no data, which is exactly the behaviour reported in the issue and confirmed against a live InfluxDB in the previous discussion.

## What changed

`renderTags` now renders `::field` comparisons based on the field type:

* Numeric values (`float`, `integer`, `unsigned`) and booleans are left unquoted.
* Strings, and any value that cannot be classified, stay quoted.
* Booleans are lowercased, matching the existing `Is` / `Is Not` behaviour.

The type is inferred from the value, so existing saved dashboards are fixed without any extra metadata. When the query model carries an explicit `dataType` it takes precedence, which resolves the ambiguous case of a string field whose value happens to look numeric (for example a string `version` field equal to `42`).

Tags (`::tag`) and plain keys keep the previous behaviour of always quoting, so tag filtering is unchanged. The shared logic is also used by the `Is` / `Is Not` path so both operators stay consistent.

### Files

* `models.go`: add an optional `Type` to the `Tag` struct.
* `model_parser.go`: read the optional `dataType` from the query JSON.
* `query.go`: add `renderFieldValue`, apply type aware quoting to `::field` values, and reuse the helper from the `Is` / `Is Not` handler.
* `query_test.go`, `model_parser_test.go`: table style tests for the new behaviour.

## Testing

* `go test ./pkg/tsdb/influxdb/...` passes.
* `golangci-lint run --config .golangci.yml ./pkg/tsdb/influxdb/models/...` reports 0 issues.
* `gofmt` and `go vet` are clean.

New cases cover integer, float, negative number, boolean, and string fields for `=` and `!=`, the explicit `dataType` override in both directions, and regression guards proving tags and plain keys are still quoted. The quoting cases from #126106 are translated into table style Go tests here, as suggested.

## AI assistance

I used GitHub Copilot to help write parts of this change. I have reviewed and tested it myself, I understand what it does, and I will follow up on any review feedback.

Fixes #94472
