### PR TITLE
MySQL: Preserve SQLCommenter tags in stripSQLComments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -372,6 +372,7 @@
 # OSS Big Tent backend code
 /pkg/tsdb/mysql/ @grafana/data-sources-plugins
 /pkg/tsdb/grafana-postgresql-datasource/ @grafana/data-sources-plugins
+/pkg/tsdb/sqlmacro/ @grafana/data-sources-plugins
 /pkg/tsdb/jaeger/ @grafana/data-sources-plugins
 
 # Partner Datasources backend code

--- a/pkg/tsdb/grafana-postgresql-datasource/macros.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros.go
@@ -15,6 +15,13 @@ import (
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
 
+// sqlCommenterRegExp matches a SQLCommenter attribution block: a block comment
+// made up of one or more key='value' pairs, e.g. /*application='grafana',source='bi'*/.
+var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9_.-]+='[^']*'(\s*,\s*[a-zA-Z0-9_.-]+='[^']*')*\s*\*/$`)
+
+// macroRegExp matches a Grafana macro of the form $name(...).
+var macroRegExp = regexp.MustCompile(sExpr)
+
 // isDollarTagChar reports whether b is valid inside a PostgreSQL dollar-quote tag
 // (letters and digits only; underscore is also allowed per identifier rules).
 func isDollarTagChar(b byte) bool {
@@ -67,7 +74,8 @@ func consumeDollarQuoted(sql string, i int, closing string, out *strings.Builder
 // stripSQLComments removes SQL line comments (--) and block comments (/* */)
 // from the query string. It is quote-aware: comment sequences inside single-quoted
 // string literals, double-quoted identifiers, and dollar-quoted strings are
-// preserved verbatim.
+// preserved verbatim. SQLCommenter attribution blocks are also preserved so query
+// tagging metadata reaches the database, unless they embed a macro.
 func stripSQLComments(sql string) string {
 	var out strings.Builder
 	out.Grow(len(sql))
@@ -106,13 +114,25 @@ func stripSQLComments(sql string) string {
 			i = consumeQuoted(sql, i, n, '"', &out)
 		case i+1 < n && sql[i] == '/' && sql[i+1] == '*':
 			// Block comment: skip to closing */.
+			start := i
 			i += 2
+			closed := false
 			for i+1 < n {
 				if sql[i] == '*' && sql[i+1] == '/' {
 					i += 2
+					closed = true
 					break
 				}
 				i++
+			}
+			// Preserve SQLCommenter attribution tags so query-tagging metadata
+			// reaches the database; strip every other block comment, and also strip
+			// a tag-shaped comment that embeds a macro so the macro is not interpolated.
+			if closed {
+				comment := sql[start:i]
+				if sqlCommenterRegExp.MatchString(comment) && !macroRegExp.MatchString(comment) {
+					out.WriteString(comment)
+				}
 			}
 		case i+1 < n && sql[i] == '-' && sql[i+1] == '-':
 			// Line comment: skip to end of line (newline is preserved).

--- a/pkg/tsdb/grafana-postgresql-datasource/macros.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -12,12 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/grafana-postgresql-datasource/sqleng"
 	"github.com/grafana/grafana/pkg/tsdb/sqlmacro"
 )
-
-// sqlCommenterRegExp matches a SQLCommenter attribution block: one or more
-// key='value' pairs in a block comment, e.g. /*application='grafana',source='bi'*/.
-// Keys allow '%' for URL-encoded serialization; values exclude '*' so the run
-// cannot contain '*/' and close the comment early.
-var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9%_.-]+='[^'*]*'(\s*,\s*[a-zA-Z0-9%_.-]+='[^'*]*')*\s*\*/$`)
 
 // isDollarTagChar reports whether b is valid inside a PostgreSQL dollar-quote tag
 // (letters and digits only; underscore is also allowed per identifier rules).
@@ -111,25 +104,13 @@ func stripSQLComments(sql string) string {
 			i = consumeQuoted(sql, i, n, '"', &out)
 		case i+1 < n && sql[i] == '/' && sql[i+1] == '*':
 			// Block comment: skip to closing */.
-			start := i
 			i += 2
-			closed := false
 			for i+1 < n {
 				if sql[i] == '*' && sql[i+1] == '/' {
 					i += 2
-					closed = true
 					break
 				}
 				i++
-			}
-			// Preserve SQLCommenter attribution tags so query-tagging metadata
-			// reaches the database; strip every other block comment, and also strip
-			// a tag-shaped comment that embeds a macro so the macro is not interpolated.
-			if closed {
-				comment := sql[start:i]
-				if sqlCommenterRegExp.MatchString(comment) && !sqlmacro.ContainsMacro(comment) {
-					out.WriteString(comment)
-				}
 			}
 		case i+1 < n && sql[i] == '-' && sql[i+1] == '-':
 			// Line comment: skip to end of line (newline is preserved).
@@ -157,11 +138,9 @@ func newPostgresMacroEngine(timescaledb bool) sqleng.SQLMacroEngine {
 }
 
 func (m *postgresMacroEngine) Interpolate(query *backend.DataQuery, timeRange backend.TimeRange, sql string) (string, error) {
-	// Strip comments before any interpolation so the SQLCommenter guard sees
-	// macro tokens before the interval substitutions below rewrite them; then
-	// apply the global interval substitutions, then expand the paren-form macros.
+	// Strip SQL comments before macro interpolation so that only macros present
+	// in executable SQL are evaluated.
 	sql = stripSQLComments(sql)
-	sql = sqleng.Interpolate(*query, timeRange, "", sql)
 
 	var macroError error
 

--- a/pkg/tsdb/grafana-postgresql-datasource/macros.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros.go
@@ -10,17 +10,14 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 
 	"github.com/grafana/grafana/pkg/tsdb/grafana-postgresql-datasource/sqleng"
+	"github.com/grafana/grafana/pkg/tsdb/sqlmacro"
 )
 
-const rsIdentifier = `([_a-zA-Z0-9]+)`
-const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
-
-// sqlCommenterRegExp matches a SQLCommenter attribution block: a block comment
-// made up of one or more key='value' pairs, e.g. /*application='grafana',source='bi'*/.
-var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9_.-]+='[^']*'(\s*,\s*[a-zA-Z0-9_.-]+='[^']*')*\s*\*/$`)
-
-// macroRegExp matches a Grafana macro of the form $name(...).
-var macroRegExp = regexp.MustCompile(sExpr)
+// sqlCommenterRegExp matches a SQLCommenter attribution block: one or more
+// key='value' pairs in a block comment, e.g. /*application='grafana',source='bi'*/.
+// Keys allow '%' for URL-encoded serialization; values exclude '*' so the run
+// cannot contain '*/' and close the comment early.
+var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9%_.-]+='[^'*]*'(\s*,\s*[a-zA-Z0-9%_.-]+='[^'*]*')*\s*\*/$`)
 
 // isDollarTagChar reports whether b is valid inside a PostgreSQL dollar-quote tag
 // (letters and digits only; underscore is also allowed per identifier rules).
@@ -130,7 +127,7 @@ func stripSQLComments(sql string) string {
 			// a tag-shaped comment that embeds a macro so the macro is not interpolated.
 			if closed {
 				comment := sql[start:i]
-				if sqlCommenterRegExp.MatchString(comment) && !macroRegExp.MatchString(comment) {
+				if sqlCommenterRegExp.MatchString(comment) && !sqlmacro.ContainsMacro(comment) {
 					out.WriteString(comment)
 				}
 			}
@@ -160,15 +157,15 @@ func newPostgresMacroEngine(timescaledb bool) sqleng.SQLMacroEngine {
 }
 
 func (m *postgresMacroEngine) Interpolate(query *backend.DataQuery, timeRange backend.TimeRange, sql string) (string, error) {
-	// Strip SQL comments before macro interpolation so that only macros present
-	// in executable SQL are evaluated.
+	// Strip comments before any interpolation so the SQLCommenter guard sees
+	// macro tokens before the interval substitutions below rewrite them; then
+	// apply the global interval substitutions, then expand the paren-form macros.
 	sql = stripSQLComments(sql)
+	sql = sqleng.Interpolate(*query, timeRange, "", sql)
 
-	// TODO: Handle error
-	rExp, _ := regexp.Compile(sExpr)
 	var macroError error
 
-	sql = m.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
+	sql = m.ReplaceAllStringSubmatchFunc(sqlmacro.RegExp, sql, func(groups []string) string {
 		// detect if $__timeGroup is supposed to add AS time for pre 5.3 compatibility
 		// if there is a ',' directly after the macro call $__timeGroup is probably used
 		// in the old way. Inside window function ORDER BY $__timeGroup will be followed

--- a/pkg/tsdb/grafana-postgresql-datasource/macros_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros_test.go
@@ -218,31 +218,6 @@ func TestMacroEngine(t *testing.T) {
 	})
 }
 
-func TestInterpolateSQLCommenter(t *testing.T) {
-	engine := newPostgresMacroEngine(false)
-	from := time.Date(2018, 4, 12, 18, 0, 0, 0, time.UTC)
-	timeRange := backend.TimeRange{From: from, To: from.Add(5 * time.Minute)}
-	query := &backend.DataQuery{Interval: 10 * time.Minute}
-
-	t.Run("preserves an inert trailing tag while interpolating the body", func(t *testing.T) {
-		sql, err := engine.Interpolate(query, timeRange, "SELECT $__interval /*app='grafana',source='bi'*/")
-		require.NoError(t, err)
-		require.Equal(t, "SELECT 10m /*app='grafana',source='bi'*/", sql)
-	})
-
-	t.Run("strips a tag that embeds the interval macro", func(t *testing.T) {
-		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*i='$__interval'*/")
-		require.NoError(t, err)
-		require.Equal(t, "SELECT 1 ", sql)
-	})
-
-	t.Run("strips a tag whose macro completes across the comment boundary", func(t *testing.T) {
-		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*k='$__timeFilter(t'*/ WHERE (x = 1)")
-		require.NoError(t, err)
-		require.Equal(t, "SELECT 1  WHERE (x = 1)", sql)
-	})
-}
-
 func TestMacroEngineConcurrency(t *testing.T) {
 	engine := newPostgresMacroEngine(false)
 	query1 := backend.DataQuery{
@@ -370,18 +345,8 @@ func TestStripSQLComments(t *testing.T) {
 			want:  "SELECT $1 ",
 		},
 		{
-			name:  "preserves trailing SQLCommenter tag before semicolon",
-			input: "SELECT 1 AS value\n/*application='grafana',source='bi',route='test',feature='repro'*/;",
-			want:  "SELECT 1 AS value\n/*application='grafana',source='bi',route='test',feature='repro'*/;",
-		},
-		{
-			name:  "preserves inline SQLCommenter tag",
+			name:  "strips a block comment shaped like a SQLCommenter tag",
 			input: "SELECT 1 /*application='grafana',feature='panel'*/",
-			want:  "SELECT 1 /*application='grafana',feature='panel'*/",
-		},
-		{
-			name:  "strips block comment shaped like a tag but containing a macro",
-			input: "SELECT 1 /*range='$__timeFilter(t)'*/",
 			want:  "SELECT 1 ",
 		},
 	}

--- a/pkg/tsdb/grafana-postgresql-datasource/macros_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros_test.go
@@ -344,6 +344,21 @@ func TestStripSQLComments(t *testing.T) {
 			input: "SELECT $1 -- comment",
 			want:  "SELECT $1 ",
 		},
+		{
+			name:  "preserves trailing SQLCommenter tag before semicolon",
+			input: "SELECT 1 AS value\n/*application='grafana',source='bi',route='test',feature='repro'*/;",
+			want:  "SELECT 1 AS value\n/*application='grafana',source='bi',route='test',feature='repro'*/;",
+		},
+		{
+			name:  "preserves inline SQLCommenter tag",
+			input: "SELECT 1 /*application='grafana',feature='panel'*/",
+			want:  "SELECT 1 /*application='grafana',feature='panel'*/",
+		},
+		{
+			name:  "strips block comment shaped like a tag but containing a macro",
+			input: "SELECT 1 /*range='$__timeFilter(t)'*/",
+			want:  "SELECT 1 ",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/tsdb/grafana-postgresql-datasource/macros_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros_test.go
@@ -218,6 +218,31 @@ func TestMacroEngine(t *testing.T) {
 	})
 }
 
+func TestInterpolateSQLCommenter(t *testing.T) {
+	engine := newPostgresMacroEngine(false)
+	from := time.Date(2018, 4, 12, 18, 0, 0, 0, time.UTC)
+	timeRange := backend.TimeRange{From: from, To: from.Add(5 * time.Minute)}
+	query := &backend.DataQuery{Interval: 10 * time.Minute}
+
+	t.Run("preserves an inert trailing tag while interpolating the body", func(t *testing.T) {
+		sql, err := engine.Interpolate(query, timeRange, "SELECT $__interval /*app='grafana',source='bi'*/")
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 10m /*app='grafana',source='bi'*/", sql)
+	})
+
+	t.Run("strips a tag that embeds the interval macro", func(t *testing.T) {
+		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*i='$__interval'*/")
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 1 ", sql)
+	})
+
+	t.Run("strips a tag whose macro completes across the comment boundary", func(t *testing.T) {
+		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*k='$__timeFilter(t'*/ WHERE (x = 1)")
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 1  WHERE (x = 1)", sql)
+	})
+}
+
 func TestMacroEngineConcurrency(t *testing.T) {
 	engine := newPostgresMacroEngine(false)
 	query1 := backend.DataQuery{

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
@@ -21,6 +21,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/grafana/grafana/pkg/tsdb/sqlmacro"
 )
 
 // MetaKeyExecutedQueryString is the key where the executed query should get stored
@@ -226,13 +228,22 @@ func (e *DataSourceHandler) executeQuery(queryContext context.Context, query bac
 		panic("Query model property rawSql should not be empty at this point")
 	}
 
-	// The macro engine strips comments, applies the global interval
-	// substitutions, and expands the datasource macros, in that order.
-	interpolatedQuery, err := e.macroEngine.Interpolate(&query, query.TimeRange, queryJSON.RawSql)
+	// A trailing SQLCommenter attribution tag must reach the database verbatim,
+	// so split it off before interpolation and re-append it afterwards. This
+	// keeps it out of comment stripping and macro substitution, and prevents a
+	// macro from completing across the comment boundary in either direction.
+	rawSQL, sqlCommenterTag := sqlmacro.SplitTrailingSQLCommenter(queryJSON.RawSql)
+
+	// global substitutions
+	interpolatedQuery := Interpolate(query, query.TimeRange, e.dsInfo.JsonData.TimeInterval, rawSQL)
+
+	// data source specific substitutions
+	interpolatedQuery, err := e.macroEngine.Interpolate(&query, query.TimeRange, interpolatedQuery)
 	if err != nil {
 		e.handleQueryError("interpolation failed", e.TransformQueryError(logger, err), interpolatedQuery, backend.ErrorSourceDownstream, ch, queryResult)
 		return
 	}
+	interpolatedQuery += sqlCommenterTag
 
 	results, err := e.execQuery(queryContext, interpolatedQuery)
 	if err != nil {

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
@@ -232,7 +232,7 @@ func (e *DataSourceHandler) executeQuery(queryContext context.Context, query bac
 	// so split it off before interpolation and re-append it afterwards. This
 	// keeps it out of comment stripping and macro substitution, and prevents a
 	// macro from completing across the comment boundary in either direction.
-	rawSQL, sqlCommenterTag := sqlmacro.SplitTrailingSQLCommenter(queryJSON.RawSql)
+	rawSQL, sqlCommenterTag := sqlmacro.SplitTrailingSQLCommenter(queryJSON.RawSql, "--")
 
 	// global substitutions
 	interpolatedQuery := Interpolate(query, query.TimeRange, e.dsInfo.JsonData.TimeInterval, rawSQL)

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
@@ -226,11 +226,9 @@ func (e *DataSourceHandler) executeQuery(queryContext context.Context, query bac
 		panic("Query model property rawSql should not be empty at this point")
 	}
 
-	// global substitutions
-	interpolatedQuery := Interpolate(query, query.TimeRange, e.dsInfo.JsonData.TimeInterval, queryJSON.RawSql)
-
-	// data source specific substitutions
-	interpolatedQuery, err := e.macroEngine.Interpolate(&query, query.TimeRange, interpolatedQuery)
+	// The macro engine strips comments, applies the global interval
+	// substitutions, and expands the datasource macros, in that order.
+	interpolatedQuery, err := e.macroEngine.Interpolate(&query, query.TimeRange, queryJSON.RawSql)
 	if err != nil {
 		e.handleQueryError("interpolation failed", e.TransformQueryError(logger, err), interpolatedQuery, backend.ErrorSourceDownstream, ch, queryResult)
 		return

--- a/pkg/tsdb/mssql/sqleng/macros.go
+++ b/pkg/tsdb/mssql/sqleng/macros.go
@@ -13,10 +13,18 @@ import (
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
 
+// sqlCommenterRegExp matches a SQLCommenter attribution block: a block comment
+// made up of one or more key='value' pairs, e.g. /*application='grafana',source='bi'*/.
+var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9_.-]+='[^']*'(\s*,\s*[a-zA-Z0-9_.-]+='[^']*')*\s*\*/$`)
+
+// macroRegExp matches a Grafana macro of the form $name(...).
+var macroRegExp = regexp.MustCompile(sExpr)
+
 // stripSQLComments removes SQL line comments (--) and block comments (/* */)
 // from the query string. It is quote-aware: comment sequences inside single-quoted
 // string literals, double-quoted identifiers, and T-SQL bracket-quoted identifiers
-// are preserved verbatim.
+// are preserved verbatim. SQLCommenter attribution blocks are also preserved so
+// query tagging metadata reaches the database, unless they embed a macro.
 func stripSQLComments(sql string) string {
 	var out strings.Builder
 	out.Grow(len(sql))
@@ -85,13 +93,25 @@ func stripSQLComments(sql string) string {
 			}
 		case i+1 < n && sql[i] == '/' && sql[i+1] == '*':
 			// Block comment: skip to closing */.
+			start := i
 			i += 2
+			closed := false
 			for i+1 < n {
 				if sql[i] == '*' && sql[i+1] == '/' {
 					i += 2
+					closed = true
 					break
 				}
 				i++
+			}
+			// Preserve SQLCommenter attribution tags so query-tagging metadata
+			// reaches the database; strip every other block comment, and also strip
+			// a tag-shaped comment that embeds a macro so the macro is not interpolated.
+			if closed {
+				comment := sql[start:i]
+				if sqlCommenterRegExp.MatchString(comment) && !macroRegExp.MatchString(comment) {
+					out.WriteString(comment)
+				}
 			}
 		case i+1 < n && sql[i] == '-' && sql[i+1] == '-':
 			// Line comment: skip to end of line (newline is preserved).

--- a/pkg/tsdb/mssql/sqleng/macros.go
+++ b/pkg/tsdb/mssql/sqleng/macros.go
@@ -92,27 +92,7 @@ func stripSQLComments(sql string) string {
 				}
 			}
 		case i+1 < n && sql[i] == '/' && sql[i+1] == '*':
-			// Block comment: skip to closing */.
-			start := i
-			i += 2
-			closed := false
-			for i+1 < n {
-				if sql[i] == '*' && sql[i+1] == '/' {
-					i += 2
-					closed = true
-					break
-				}
-				i++
-			}
-			// Preserve SQLCommenter attribution tags so query-tagging metadata
-			// reaches the database; strip every other block comment, and also strip
-			// a tag-shaped comment that embeds a macro so the macro is not interpolated.
-			if closed {
-				comment := sql[start:i]
-				if sqlCommenterRegExp.MatchString(comment) && !macroRegExp.MatchString(comment) {
-					out.WriteString(comment)
-				}
-			}
+			i = scanBlockComment(sql, i, &out)
 		case i+1 < n && sql[i] == '-' && sql[i+1] == '-':
 			// Line comment: skip to end of line (newline is preserved).
 			for i < n && sql[i] != '\n' {
@@ -124,6 +104,28 @@ func stripSQLComments(sql string) string {
 		}
 	}
 	return out.String()
+}
+
+// scanBlockComment consumes the /* ... */ block comment beginning at i and
+// returns the index just past it. A SQLCommenter attribution tag is written to
+// out so query-tagging metadata reaches the database, unless it embeds a macro
+// (which must not be interpolated); every other block comment is dropped.
+func scanBlockComment(sql string, i int, out *strings.Builder) int {
+	n := len(sql)
+	start := i
+	i += 2
+	for i+1 < n {
+		if sql[i] == '*' && sql[i+1] == '/' {
+			i += 2
+			comment := sql[start:i]
+			if sqlCommenterRegExp.MatchString(comment) && !macroRegExp.MatchString(comment) {
+				out.WriteString(comment)
+			}
+			return i
+		}
+		i++
+	}
+	return i
 }
 
 type msSQLMacroEngine struct {

--- a/pkg/tsdb/mssql/sqleng/macros.go
+++ b/pkg/tsdb/mssql/sqleng/macros.go
@@ -8,17 +8,15 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
+
+	"github.com/grafana/grafana/pkg/tsdb/sqlmacro"
 )
 
-const rsIdentifier = `([_a-zA-Z0-9]+)`
-const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
-
-// sqlCommenterRegExp matches a SQLCommenter attribution block: a block comment
-// made up of one or more key='value' pairs, e.g. /*application='grafana',source='bi'*/.
-var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9_.-]+='[^']*'(\s*,\s*[a-zA-Z0-9_.-]+='[^']*')*\s*\*/$`)
-
-// macroRegExp matches a Grafana macro of the form $name(...).
-var macroRegExp = regexp.MustCompile(sExpr)
+// sqlCommenterRegExp matches a SQLCommenter attribution block: one or more
+// key='value' pairs in a block comment, e.g. /*application='grafana',source='bi'*/.
+// Keys allow '%' for URL-encoded serialization; values exclude '*' so the run
+// cannot contain '*/' and close the comment early.
+var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9%_.-]+='[^'*]*'(\s*,\s*[a-zA-Z0-9%_.-]+='[^'*]*')*\s*\*/$`)
 
 // stripSQLComments removes SQL line comments (--) and block comments (/* */)
 // from the query string. It is quote-aware: comment sequences inside single-quoted
@@ -118,7 +116,7 @@ func scanBlockComment(sql string, i int, out *strings.Builder) int {
 		if sql[i] == '*' && sql[i+1] == '/' {
 			i += 2
 			comment := sql[start:i]
-			if sqlCommenterRegExp.MatchString(comment) && !macroRegExp.MatchString(comment) {
+			if sqlCommenterRegExp.MatchString(comment) && !sqlmacro.ContainsMacro(comment) {
 				out.WriteString(comment)
 			}
 			return i
@@ -138,15 +136,15 @@ func newMssqlMacroEngine() SQLMacroEngine {
 
 func (m *msSQLMacroEngine) Interpolate(query *backend.DataQuery, timeRange backend.TimeRange,
 	sql string) (string, error) {
-	// Strip SQL comments before macro interpolation so that only macros present
-	// in executable SQL are evaluated.
+	// Strip comments before any interpolation so the SQLCommenter guard sees
+	// macro tokens before the interval substitutions below rewrite them; then
+	// apply the global interval substitutions, then expand the paren-form macros.
 	sql = stripSQLComments(sql)
+	sql = Interpolate(*query, timeRange, "", sql)
 
-	// TODO: Return any error
-	rExp, _ := regexp.Compile(sExpr)
 	var macroError error
 
-	sql = m.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
+	sql = m.ReplaceAllStringSubmatchFunc(sqlmacro.RegExp, sql, func(groups []string) string {
 		args := strings.Split(groups[2], ",")
 		for i, arg := range args {
 			args[i] = strings.Trim(arg, " ")

--- a/pkg/tsdb/mssql/sqleng/macros.go
+++ b/pkg/tsdb/mssql/sqleng/macros.go
@@ -2,7 +2,6 @@ package sqleng
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -12,17 +11,10 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/sqlmacro"
 )
 
-// sqlCommenterRegExp matches a SQLCommenter attribution block: one or more
-// key='value' pairs in a block comment, e.g. /*application='grafana',source='bi'*/.
-// Keys allow '%' for URL-encoded serialization; values exclude '*' so the run
-// cannot contain '*/' and close the comment early.
-var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9%_.-]+='[^'*]*'(\s*,\s*[a-zA-Z0-9%_.-]+='[^'*]*')*\s*\*/$`)
-
 // stripSQLComments removes SQL line comments (--) and block comments (/* */)
 // from the query string. It is quote-aware: comment sequences inside single-quoted
 // string literals, double-quoted identifiers, and T-SQL bracket-quoted identifiers
-// are preserved verbatim. SQLCommenter attribution blocks are also preserved so
-// query tagging metadata reaches the database, unless they embed a macro.
+// are preserved verbatim.
 func stripSQLComments(sql string) string {
 	var out strings.Builder
 	out.Grow(len(sql))
@@ -90,7 +82,15 @@ func stripSQLComments(sql string) string {
 				}
 			}
 		case i+1 < n && sql[i] == '/' && sql[i+1] == '*':
-			i = scanBlockComment(sql, i, &out)
+			// Block comment: skip to closing */.
+			i += 2
+			for i+1 < n {
+				if sql[i] == '*' && sql[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
 		case i+1 < n && sql[i] == '-' && sql[i+1] == '-':
 			// Line comment: skip to end of line (newline is preserved).
 			for i < n && sql[i] != '\n' {
@@ -104,28 +104,6 @@ func stripSQLComments(sql string) string {
 	return out.String()
 }
 
-// scanBlockComment consumes the /* ... */ block comment beginning at i and
-// returns the index just past it. A SQLCommenter attribution tag is written to
-// out so query-tagging metadata reaches the database, unless it embeds a macro
-// (which must not be interpolated); every other block comment is dropped.
-func scanBlockComment(sql string, i int, out *strings.Builder) int {
-	n := len(sql)
-	start := i
-	i += 2
-	for i+1 < n {
-		if sql[i] == '*' && sql[i+1] == '/' {
-			i += 2
-			comment := sql[start:i]
-			if sqlCommenterRegExp.MatchString(comment) && !sqlmacro.ContainsMacro(comment) {
-				out.WriteString(comment)
-			}
-			return i
-		}
-		i++
-	}
-	return i
-}
-
 type msSQLMacroEngine struct {
 	*SQLMacroEngineBase
 }
@@ -136,11 +114,9 @@ func newMssqlMacroEngine() SQLMacroEngine {
 
 func (m *msSQLMacroEngine) Interpolate(query *backend.DataQuery, timeRange backend.TimeRange,
 	sql string) (string, error) {
-	// Strip comments before any interpolation so the SQLCommenter guard sees
-	// macro tokens before the interval substitutions below rewrite them; then
-	// apply the global interval substitutions, then expand the paren-form macros.
+	// Strip SQL comments before macro interpolation so that only macros present
+	// in executable SQL are evaluated.
 	sql = stripSQLComments(sql)
-	sql = Interpolate(*query, timeRange, "", sql)
 
 	var macroError error
 

--- a/pkg/tsdb/mssql/sqleng/macros_test.go
+++ b/pkg/tsdb/mssql/sqleng/macros_test.go
@@ -224,31 +224,6 @@ func TestMacroEngine(t *testing.T) {
 	})
 }
 
-func TestInterpolateSQLCommenter(t *testing.T) {
-	engine := &msSQLMacroEngine{}
-	from := time.Date(2018, 4, 12, 18, 0, 0, 0, time.UTC)
-	timeRange := backend.TimeRange{From: from, To: from.Add(5 * time.Minute)}
-	query := &backend.DataQuery{Interval: 10 * time.Minute}
-
-	t.Run("preserves an inert trailing tag while interpolating the body", func(t *testing.T) {
-		sql, err := engine.Interpolate(query, timeRange, "SELECT $__interval /*app='grafana',source='bi'*/")
-		require.NoError(t, err)
-		require.Equal(t, "SELECT 10m /*app='grafana',source='bi'*/", sql)
-	})
-
-	t.Run("strips a tag that embeds the interval macro", func(t *testing.T) {
-		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*i='$__interval'*/")
-		require.NoError(t, err)
-		require.Equal(t, "SELECT 1 ", sql)
-	})
-
-	t.Run("strips a tag whose macro completes across the comment boundary", func(t *testing.T) {
-		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*k='$__timeFilter(t'*/ WHERE (x = 1)")
-		require.NoError(t, err)
-		require.Equal(t, "SELECT 1  WHERE (x = 1)", sql)
-	})
-}
-
 func TestMacroEngineConcurrency(t *testing.T) {
 	engine := newMssqlMacroEngine()
 	query1 := backend.DataQuery{
@@ -364,18 +339,8 @@ func TestStripSQLComments(t *testing.T) {
 			want:  "SELECT 1 \nFROM t",
 		},
 		{
-			name:  "preserves trailing SQLCommenter tag before semicolon",
-			input: "SELECT 1 AS value\n/*application='grafana',source='bi',route='test',feature='repro'*/;",
-			want:  "SELECT 1 AS value\n/*application='grafana',source='bi',route='test',feature='repro'*/;",
-		},
-		{
-			name:  "preserves inline SQLCommenter tag",
+			name:  "strips a block comment shaped like a SQLCommenter tag",
 			input: "SELECT 1 /*application='grafana',feature='panel'*/",
-			want:  "SELECT 1 /*application='grafana',feature='panel'*/",
-		},
-		{
-			name:  "strips block comment shaped like a tag but containing a macro",
-			input: "SELECT 1 /*range='$__timeFilter(t)'*/",
 			want:  "SELECT 1 ",
 		},
 	}

--- a/pkg/tsdb/mssql/sqleng/macros_test.go
+++ b/pkg/tsdb/mssql/sqleng/macros_test.go
@@ -338,6 +338,21 @@ func TestStripSQLComments(t *testing.T) {
 			input: "SELECT 1 -- comment\nFROM t",
 			want:  "SELECT 1 \nFROM t",
 		},
+		{
+			name:  "preserves trailing SQLCommenter tag before semicolon",
+			input: "SELECT 1 AS value\n/*application='grafana',source='bi',route='test',feature='repro'*/;",
+			want:  "SELECT 1 AS value\n/*application='grafana',source='bi',route='test',feature='repro'*/;",
+		},
+		{
+			name:  "preserves inline SQLCommenter tag",
+			input: "SELECT 1 /*application='grafana',feature='panel'*/",
+			want:  "SELECT 1 /*application='grafana',feature='panel'*/",
+		},
+		{
+			name:  "strips block comment shaped like a tag but containing a macro",
+			input: "SELECT 1 /*range='$__timeFilter(t)'*/",
+			want:  "SELECT 1 ",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/tsdb/mssql/sqleng/macros_test.go
+++ b/pkg/tsdb/mssql/sqleng/macros_test.go
@@ -224,6 +224,31 @@ func TestMacroEngine(t *testing.T) {
 	})
 }
 
+func TestInterpolateSQLCommenter(t *testing.T) {
+	engine := &msSQLMacroEngine{}
+	from := time.Date(2018, 4, 12, 18, 0, 0, 0, time.UTC)
+	timeRange := backend.TimeRange{From: from, To: from.Add(5 * time.Minute)}
+	query := &backend.DataQuery{Interval: 10 * time.Minute}
+
+	t.Run("preserves an inert trailing tag while interpolating the body", func(t *testing.T) {
+		sql, err := engine.Interpolate(query, timeRange, "SELECT $__interval /*app='grafana',source='bi'*/")
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 10m /*app='grafana',source='bi'*/", sql)
+	})
+
+	t.Run("strips a tag that embeds the interval macro", func(t *testing.T) {
+		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*i='$__interval'*/")
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 1 ", sql)
+	})
+
+	t.Run("strips a tag whose macro completes across the comment boundary", func(t *testing.T) {
+		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*k='$__timeFilter(t'*/ WHERE (x = 1)")
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 1  WHERE (x = 1)", sql)
+	})
+}
+
 func TestMacroEngineConcurrency(t *testing.T) {
 	engine := newMssqlMacroEngine()
 	query1 := backend.DataQuery{

--- a/pkg/tsdb/mssql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mssql/sqleng/sql_engine.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/tsdb/mssql/kerberos"
 	"github.com/grafana/grafana/pkg/tsdb/mssql/utils"
+	"github.com/grafana/grafana/pkg/tsdb/sqlmacro"
 )
 
 // MetaKeyExecutedQueryString is the key where the executed query should get stored
@@ -342,13 +343,22 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 		ch <- queryResult
 	}
 
-	// The macro engine strips comments, applies the global interval
-	// substitutions, and expands the datasource macros, in that order.
-	interpolatedQuery, err := e.macroEngine.Interpolate(&query, timeRange, queryJson.RawSql)
+	// A trailing SQLCommenter attribution tag must reach the database verbatim,
+	// so split it off before interpolation and re-append it afterwards. This
+	// keeps it out of comment stripping and macro substitution, and prevents a
+	// macro from completing across the comment boundary in either direction.
+	rawSQL, sqlCommenterTag := sqlmacro.SplitTrailingSQLCommenter(queryJson.RawSql)
+
+	// global substitutions
+	interpolatedQuery := Interpolate(query, timeRange, e.dsInfo.JsonData.TimeInterval, rawSQL)
+
+	// data source specific substitutions
+	interpolatedQuery, err := e.macroEngine.Interpolate(&query, timeRange, interpolatedQuery)
 	if err != nil {
 		errAppendDebug("interpolation failed", e.TransformQueryError(logger, err), interpolatedQuery, backend.ErrorSourcePlugin)
 		return
 	}
+	interpolatedQuery += sqlCommenterTag
 
 	db, err := e.getDB(queryContext)
 	if err != nil {

--- a/pkg/tsdb/mssql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mssql/sqleng/sql_engine.go
@@ -347,7 +347,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 	// so split it off before interpolation and re-append it afterwards. This
 	// keeps it out of comment stripping and macro substitution, and prevents a
 	// macro from completing across the comment boundary in either direction.
-	rawSQL, sqlCommenterTag := sqlmacro.SplitTrailingSQLCommenter(queryJson.RawSql)
+	rawSQL, sqlCommenterTag := sqlmacro.SplitTrailingSQLCommenter(queryJson.RawSql, "--")
 
 	// global substitutions
 	interpolatedQuery := Interpolate(query, timeRange, e.dsInfo.JsonData.TimeInterval, rawSQL)

--- a/pkg/tsdb/mssql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mssql/sqleng/sql_engine.go
@@ -342,11 +342,9 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 		ch <- queryResult
 	}
 
-	// global substitutions
-	interpolatedQuery := Interpolate(query, timeRange, e.dsInfo.JsonData.TimeInterval, queryJson.RawSql)
-
-	// data source specific substitutions
-	interpolatedQuery, err := e.macroEngine.Interpolate(&query, timeRange, interpolatedQuery)
+	// The macro engine strips comments, applies the global interval
+	// substitutions, and expands the datasource macros, in that order.
+	interpolatedQuery, err := e.macroEngine.Interpolate(&query, timeRange, queryJson.RawSql)
 	if err != nil {
 		errAppendDebug("interpolation failed", e.TransformQueryError(logger, err), interpolatedQuery, backend.ErrorSourcePlugin)
 		return

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -14,18 +14,11 @@ import (
 
 var restrictedRegExp = regexp.MustCompile(`(?im)([\s]*show[\s]+grants|[\s,]session_user\([^\)]*\)|[\s,]current_user(\([^\)]*\))?|[\s,]system_user\([^\)]*\)|[\s,]user\([^\)]*\))([\s,;]|$)`)
 
-// sqlCommenterRegExp matches a SQLCommenter attribution block: one or more
-// key='value' pairs in a block comment, e.g. /*application='grafana',source='bi'*/.
-// Keys allow '%' for URL-encoded serialization; values exclude '*' so the run
-// cannot contain '*/' and close the comment early.
-var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9%_.-]+='[^'*]*'(\s*,\s*[a-zA-Z0-9%_.-]+='[^'*]*')*\s*\*/$`)
-
 // stripSQLComments removes SQL line comments (--, #) and block comments (/* */)
 // from the query string while preserving comment-like characters that appear
 // inside quoted strings (single-quoted, double-quoted, and backtick-quoted).
 // MySQL supports # as a line comment delimiter in addition to the standard
-// -- and /* */ forms. SQLCommenter attribution blocks are preserved so query
-// tagging metadata reaches the database, unless they embed a macro.
+// -- and /* */ forms.
 func stripSQLComments(sql string) string {
 	var result strings.Builder
 	result.Grow(len(sql))
@@ -66,26 +59,16 @@ func stripSQLComments(sql string) string {
 
 		// Block comment: /* ... */
 		if i+1 < len(sql) && sql[i] == '/' && sql[i+1] == '*' {
-			start := i
 			i += 2
-			closed := false
 			for i+1 < len(sql) {
 				if sql[i] == '*' && sql[i+1] == '/' {
 					i += 2
-					closed = true
 					break
 				}
 				i++
 			}
-			if !closed {
-				// Unterminated block comment: drop the remainder.
+			if i >= len(sql) {
 				break
-			}
-			// Keep SQLCommenter tags so attribution reaches the database; strip
-			// every other block comment so macros inside them are not interpolated.
-			comment := sql[start:i]
-			if sqlCommenterRegExp.MatchString(comment) && !sqlmacro.ContainsMacro(comment) {
-				result.WriteString(comment)
 			}
 			continue
 		}
@@ -134,11 +117,9 @@ func (m *mySQLMacroEngine) Interpolate(query *backend.DataQuery, timeRange backe
 		return "", fmt.Errorf("invalid query - %s", m.userError)
 	}
 
-	// Strip comments before any interpolation so the SQLCommenter guard sees
-	// macro tokens before the interval substitutions below rewrite them; then
-	// apply the global interval substitutions, then expand the paren-form macros.
+	// Strip SQL comments before macro interpolation so that only macros present
+	// in executable SQL are evaluated.
 	sql = stripSQLComments(sql)
-	sql = sqleng.Interpolate(*query, timeRange, "", sql)
 
 	var macroError error
 

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -16,11 +16,19 @@ const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
 
 var restrictedRegExp = regexp.MustCompile(`(?im)([\s]*show[\s]+grants|[\s,]session_user\([^\)]*\)|[\s,]current_user(\([^\)]*\))?|[\s,]system_user\([^\)]*\)|[\s,]user\([^\)]*\))([\s,;]|$)`)
 
+// sqlCommenterRegExp matches a SQLCommenter attribution block: a block comment
+// made up of one or more key='value' pairs, e.g. /*application='grafana',source='bi'*/.
+var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9_.-]+='[^']*'(\s*,\s*[a-zA-Z0-9_.-]+='[^']*')*\s*\*/$`)
+
+// macroRegExp matches a Grafana macro of the form $name(...).
+var macroRegExp = regexp.MustCompile(sExpr)
+
 // stripSQLComments removes SQL line comments (--, #) and block comments (/* */)
 // from the query string while preserving comment-like characters that appear
 // inside quoted strings (single-quoted, double-quoted, and backtick-quoted).
 // MySQL supports # as a line comment delimiter in addition to the standard
-// -- and /* */ forms.
+// -- and /* */ forms. SQLCommenter attribution blocks are preserved so query
+// tagging metadata reaches the database, unless they embed a macro.
 func stripSQLComments(sql string) string {
 	var result strings.Builder
 	result.Grow(len(sql))
@@ -61,16 +69,26 @@ func stripSQLComments(sql string) string {
 
 		// Block comment: /* ... */
 		if i+1 < len(sql) && sql[i] == '/' && sql[i+1] == '*' {
+			start := i
 			i += 2
+			closed := false
 			for i+1 < len(sql) {
 				if sql[i] == '*' && sql[i+1] == '/' {
 					i += 2
+					closed = true
 					break
 				}
 				i++
 			}
-			if i >= len(sql) {
+			if !closed {
+				// Unterminated block comment: drop the remainder.
 				break
+			}
+			// Keep SQLCommenter tags so attribution reaches the database; strip
+			// every other block comment so macros inside them are not interpolated.
+			comment := sql[start:i]
+			if sqlCommenterRegExp.MatchString(comment) && !macroRegExp.MatchString(comment) {
+				result.WriteString(comment)
 			}
 			continue
 		}

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -9,19 +9,16 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana/pkg/tsdb/mysql/sqleng"
+	"github.com/grafana/grafana/pkg/tsdb/sqlmacro"
 )
-
-const rsIdentifier = `([_a-zA-Z0-9]+)`
-const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
 
 var restrictedRegExp = regexp.MustCompile(`(?im)([\s]*show[\s]+grants|[\s,]session_user\([^\)]*\)|[\s,]current_user(\([^\)]*\))?|[\s,]system_user\([^\)]*\)|[\s,]user\([^\)]*\))([\s,;]|$)`)
 
-// sqlCommenterRegExp matches a SQLCommenter attribution block: a block comment
-// made up of one or more key='value' pairs, e.g. /*application='grafana',source='bi'*/.
-var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9_.-]+='[^']*'(\s*,\s*[a-zA-Z0-9_.-]+='[^']*')*\s*\*/$`)
-
-// macroRegExp matches a Grafana macro of the form $name(...).
-var macroRegExp = regexp.MustCompile(sExpr)
+// sqlCommenterRegExp matches a SQLCommenter attribution block: one or more
+// key='value' pairs in a block comment, e.g. /*application='grafana',source='bi'*/.
+// Keys allow '%' for URL-encoded serialization; values exclude '*' so the run
+// cannot contain '*/' and close the comment early.
+var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9%_.-]+='[^'*]*'(\s*,\s*[a-zA-Z0-9%_.-]+='[^'*]*')*\s*\*/$`)
 
 // stripSQLComments removes SQL line comments (--, #) and block comments (/* */)
 // from the query string while preserving comment-like characters that appear
@@ -87,7 +84,7 @@ func stripSQLComments(sql string) string {
 			// Keep SQLCommenter tags so attribution reaches the database; strip
 			// every other block comment so macros inside them are not interpolated.
 			comment := sql[start:i]
-			if sqlCommenterRegExp.MatchString(comment) && !macroRegExp.MatchString(comment) {
+			if sqlCommenterRegExp.MatchString(comment) && !sqlmacro.ContainsMacro(comment) {
 				result.WriteString(comment)
 			}
 			continue
@@ -137,15 +134,15 @@ func (m *mySQLMacroEngine) Interpolate(query *backend.DataQuery, timeRange backe
 		return "", fmt.Errorf("invalid query - %s", m.userError)
 	}
 
-	// Strip SQL comments before macro interpolation so that only macros present
-	// in executable SQL are evaluated.
+	// Strip comments before any interpolation so the SQLCommenter guard sees
+	// macro tokens before the interval substitutions below rewrite them; then
+	// apply the global interval substitutions, then expand the paren-form macros.
 	sql = stripSQLComments(sql)
+	sql = sqleng.Interpolate(*query, timeRange, "", sql)
 
-	// TODO: Handle error
-	rExp, _ := regexp.Compile(sExpr)
 	var macroError error
 
-	sql = m.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
+	sql = m.ReplaceAllStringSubmatchFunc(sqlmacro.RegExp, sql, func(groups []string) string {
 		args := strings.Split(groups[2], ",")
 		for i, arg := range args {
 			args[i] = strings.Trim(arg, " ")

--- a/pkg/tsdb/mysql/macros_test.go
+++ b/pkg/tsdb/mysql/macros_test.go
@@ -298,4 +298,26 @@ func TestStripSQLComments(t *testing.T) {
 		result := stripSQLComments(sql)
 		require.Equal(t, sql, result)
 	})
+
+	t.Run("preserves trailing SQLCommenter tag before semicolon", func(t *testing.T) {
+		sql := "SELECT 1 AS value\n/*application='grafana',source='bi',route='test',feature='repro'*/;"
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+
+	t.Run("preserves inline SQLCommenter tag", func(t *testing.T) {
+		sql := "SELECT 1 /*application='grafana',feature='panel'*/"
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+
+	t.Run("still strips non-SQLCommenter block comments", func(t *testing.T) {
+		result := stripSQLComments("SELECT /* just a note */ 1")
+		require.Equal(t, "SELECT  1", result)
+	})
+
+	t.Run("strips block comment shaped like a tag but containing a macro", func(t *testing.T) {
+		result := stripSQLComments("SELECT 1 /*range='$__timeFilter(t)'*/")
+		require.Equal(t, "SELECT 1 ", result)
+	})
 }

--- a/pkg/tsdb/mysql/macros_test.go
+++ b/pkg/tsdb/mysql/macros_test.go
@@ -222,34 +222,6 @@ func TestMacroEngineConcurrency(t *testing.T) {
 	wg.Wait()
 }
 
-func TestInterpolateSQLCommenter(t *testing.T) {
-	engine := &mySQLMacroEngine{
-		logger:    backend.NewLoggerWith("logger", "test"),
-		userError: "inspect Grafana server log for details",
-	}
-	from := time.Date(2018, 4, 12, 18, 0, 0, 0, time.UTC)
-	timeRange := backend.TimeRange{From: from, To: from.Add(5 * time.Minute)}
-	query := &backend.DataQuery{Interval: 10 * time.Minute}
-
-	t.Run("preserves an inert trailing tag while interpolating the body", func(t *testing.T) {
-		sql, err := engine.Interpolate(query, timeRange, "SELECT $__interval /*app='grafana',source='bi'*/")
-		require.NoError(t, err)
-		require.Equal(t, "SELECT 10m /*app='grafana',source='bi'*/", sql)
-	})
-
-	t.Run("strips a tag that embeds the interval macro instead of interpolating it", func(t *testing.T) {
-		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*i='$__interval'*/")
-		require.NoError(t, err)
-		require.Equal(t, "SELECT 1 ", sql)
-	})
-
-	t.Run("strips a tag whose macro would otherwise complete across the comment boundary", func(t *testing.T) {
-		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*k='$__timeFilter(t'*/ WHERE (x = 1)")
-		require.NoError(t, err)
-		require.Equal(t, "SELECT 1  WHERE (x = 1)", sql)
-	})
-}
-
 func TestStripSQLComments(t *testing.T) {
 	t.Run("strips block comments", func(t *testing.T) {
 		result := stripSQLComments("SELECT /* comment */ 1")
@@ -327,25 +299,10 @@ func TestStripSQLComments(t *testing.T) {
 		require.Equal(t, sql, result)
 	})
 
-	t.Run("preserves trailing SQLCommenter tag before semicolon", func(t *testing.T) {
-		sql := "SELECT 1 AS value\n/*application='grafana',source='bi',route='test',feature='repro'*/;"
-		result := stripSQLComments(sql)
-		require.Equal(t, sql, result)
-	})
-
-	t.Run("preserves inline SQLCommenter tag", func(t *testing.T) {
-		sql := "SELECT 1 /*application='grafana',feature='panel'*/"
-		result := stripSQLComments(sql)
-		require.Equal(t, sql, result)
-	})
-
-	t.Run("still strips non-SQLCommenter block comments", func(t *testing.T) {
-		result := stripSQLComments("SELECT /* just a note */ 1")
-		require.Equal(t, "SELECT  1", result)
-	})
-
-	t.Run("strips block comment shaped like a tag but containing a macro", func(t *testing.T) {
-		result := stripSQLComments("SELECT 1 /*range='$__timeFilter(t)'*/")
+	t.Run("strips a block comment shaped like a SQLCommenter tag", func(t *testing.T) {
+		// stripSQLComments strips all comments; trailing SQLCommenter tags are
+		// preserved earlier in the pipeline by sqlmacro.SplitTrailingSQLCommenter.
+		result := stripSQLComments("SELECT 1 /*application='grafana',feature='panel'*/")
 		require.Equal(t, "SELECT 1 ", result)
 	})
 }

--- a/pkg/tsdb/mysql/macros_test.go
+++ b/pkg/tsdb/mysql/macros_test.go
@@ -222,6 +222,34 @@ func TestMacroEngineConcurrency(t *testing.T) {
 	wg.Wait()
 }
 
+func TestInterpolateSQLCommenter(t *testing.T) {
+	engine := &mySQLMacroEngine{
+		logger:    backend.NewLoggerWith("logger", "test"),
+		userError: "inspect Grafana server log for details",
+	}
+	from := time.Date(2018, 4, 12, 18, 0, 0, 0, time.UTC)
+	timeRange := backend.TimeRange{From: from, To: from.Add(5 * time.Minute)}
+	query := &backend.DataQuery{Interval: 10 * time.Minute}
+
+	t.Run("preserves an inert trailing tag while interpolating the body", func(t *testing.T) {
+		sql, err := engine.Interpolate(query, timeRange, "SELECT $__interval /*app='grafana',source='bi'*/")
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 10m /*app='grafana',source='bi'*/", sql)
+	})
+
+	t.Run("strips a tag that embeds the interval macro instead of interpolating it", func(t *testing.T) {
+		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*i='$__interval'*/")
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 1 ", sql)
+	})
+
+	t.Run("strips a tag whose macro would otherwise complete across the comment boundary", func(t *testing.T) {
+		sql, err := engine.Interpolate(query, timeRange, "SELECT 1 /*k='$__timeFilter(t'*/ WHERE (x = 1)")
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 1  WHERE (x = 1)", sql)
+	})
+}
+
 func TestStripSQLComments(t *testing.T) {
 	t.Run("strips block comments", func(t *testing.T) {
 		result := stripSQLComments("SELECT /* comment */ 1")

--- a/pkg/tsdb/mysql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mysql/sqleng/sql_engine.go
@@ -240,11 +240,9 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 		ch <- queryResult
 	}
 
-	// global substitutions
-	interpolatedQuery := Interpolate(query, timeRange, e.dsInfo.JsonData.TimeInterval, queryJson.RawSql)
-
-	// data source specific substitutions
-	interpolatedQuery, err := e.macroEngine.Interpolate(&query, timeRange, interpolatedQuery)
+	// The macro engine strips comments, applies the global interval
+	// substitutions, and expands the datasource macros, in that order.
+	interpolatedQuery, err := e.macroEngine.Interpolate(&query, timeRange, queryJson.RawSql)
 	if err != nil {
 		errAppendDebug("interpolation failed", e.TransformQueryError(logger, err), interpolatedQuery, backend.ErrorSourcePlugin)
 		return

--- a/pkg/tsdb/mysql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mysql/sqleng/sql_engine.go
@@ -19,6 +19,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+
+	"github.com/grafana/grafana/pkg/tsdb/sqlmacro"
 )
 
 // MetaKeyExecutedQueryString is the key where the executed query should get stored
@@ -240,13 +242,22 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 		ch <- queryResult
 	}
 
-	// The macro engine strips comments, applies the global interval
-	// substitutions, and expands the datasource macros, in that order.
-	interpolatedQuery, err := e.macroEngine.Interpolate(&query, timeRange, queryJson.RawSql)
+	// A trailing SQLCommenter attribution tag must reach the database verbatim,
+	// so split it off before interpolation and re-append it afterwards. This
+	// keeps it out of comment stripping and macro substitution, and prevents a
+	// macro from completing across the comment boundary in either direction.
+	rawSQL, sqlCommenterTag := sqlmacro.SplitTrailingSQLCommenter(queryJson.RawSql)
+
+	// global substitutions
+	interpolatedQuery := Interpolate(query, timeRange, e.dsInfo.JsonData.TimeInterval, rawSQL)
+
+	// data source specific substitutions
+	interpolatedQuery, err := e.macroEngine.Interpolate(&query, timeRange, interpolatedQuery)
 	if err != nil {
 		errAppendDebug("interpolation failed", e.TransformQueryError(logger, err), interpolatedQuery, backend.ErrorSourcePlugin)
 		return
 	}
+	interpolatedQuery += sqlCommenterTag
 
 	rows, err := e.db.QueryContext(queryContext, interpolatedQuery)
 	if err != nil {

--- a/pkg/tsdb/mysql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mysql/sqleng/sql_engine.go
@@ -246,7 +246,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 	// so split it off before interpolation and re-append it afterwards. This
 	// keeps it out of comment stripping and macro substitution, and prevents a
 	// macro from completing across the comment boundary in either direction.
-	rawSQL, sqlCommenterTag := sqlmacro.SplitTrailingSQLCommenter(queryJson.RawSql)
+	rawSQL, sqlCommenterTag := sqlmacro.SplitTrailingSQLCommenter(queryJson.RawSql, "--", "#")
 
 	// global substitutions
 	interpolatedQuery := Interpolate(query, timeRange, e.dsInfo.JsonData.TimeInterval, rawSQL)

--- a/pkg/tsdb/sqlmacro/sqlmacro.go
+++ b/pkg/tsdb/sqlmacro/sqlmacro.go
@@ -32,7 +32,9 @@ var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9%_.-]+='(?:\\.|[^'
 // boundary in either direction.
 func SplitTrailingSQLCommenter(sql string) (string, string) {
 	trimmed := strings.TrimRight(sql, " \t\r\n")
-	trimmed = strings.TrimRight(strings.TrimSuffix(trimmed, ";"), " \t\r\n")
+	for strings.HasSuffix(trimmed, ";") {
+		trimmed = strings.TrimRight(strings.TrimSuffix(trimmed, ";"), " \t\r\n")
+	}
 	if !strings.HasSuffix(trimmed, "*/") {
 		return sql, ""
 	}
@@ -50,6 +52,15 @@ func SplitTrailingSQLCommenter(sql string) (string, string) {
 		return sql, ""
 	}
 	if !sqlCommenterRegExp.MatchString(comment) {
+		return sql, ""
+	}
+	// A tag-shaped block inside a trailing line comment is not executable SQL and
+	// must not be revived: if the text before the tag on its own line contains a
+	// line-comment marker (-- or MySQL's #), leave the query untouched. This is
+	// conservative - a marker inside a string literal on that line also prevents
+	// splitting, which just falls back to the tag being stripped like any comment.
+	lineStart := strings.LastIndexByte(trimmed[:open], '\n') + 1
+	if strings.Contains(trimmed[lineStart:open], "--") || strings.Contains(trimmed[lineStart:open], "#") {
 		return sql, ""
 	}
 	return sql[:open], sql[open:]

--- a/pkg/tsdb/sqlmacro/sqlmacro.go
+++ b/pkg/tsdb/sqlmacro/sqlmacro.go
@@ -1,41 +1,53 @@
-// Package sqlmacro holds the shared Grafana SQL macro definitions used by the
-// MySQL, PostgreSQL and Microsoft SQL Server datasources. Keeping the macro
-// expression and the "does this text contain a macro" guard in one place stops
-// the three datasources from drifting apart, and stops the guard that decides
-// which SQL comments are safe to forward to the database from drifting away from
-// the expression that actually expands macros.
+// Package sqlmacro holds the shared Grafana SQL macro pattern and the trailing
+// SQLCommenter tag handling used by the MySQL, PostgreSQL and Microsoft SQL
+// Server datasources, so the three engines do not drift apart on either.
 package sqlmacro
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 // Expr is the regular-expression source matching a complete Grafana macro call
 // of the form $name(...). It is exported so every datasource expands macros with
-// the exact same pattern the comment guard uses to detect them.
+// the exact same pattern.
 const Expr = `\$([_a-zA-Z0-9]+)\(([^\)]*)\)`
 
 // RegExp matches a complete Grafana macro call $name(...).
 var RegExp = regexp.MustCompile(Expr)
 
-// macroTokenRegExp matches any Grafana macro token, including forms that are not
-// (yet) a complete call:
-//   - the parenthesis-less $__interval / $__interval_ms / $__unixEpoch* family,
-//     which the datasource engines expand with a plain string replacement; and
-//   - a paren-form macro that may be complete ($__timeFilter(col)) or only
-//     partially present ($__timeFilter( ), e.g. when it sits inside a comment and
-//     would otherwise complete across the comment boundary once the surrounding
-//     SQL is interpolated.
-//
-// A bare $name with neither the $__ prefix nor a following '(' (for example a
-// PostgreSQL $1 positional parameter) is intentionally not treated as a token.
-var macroTokenRegExp = regexp.MustCompile(`\$(__[a-zA-Z0-9_]*|[_a-zA-Z0-9]+\s*\()`)
+// sqlCommenterRegExp validates a SQLCommenter attribution comment made of one or
+// more key='value' pairs, e.g. /*application='grafana',source='bi'*/. Keys allow
+// '%' for the URL-encoded serialization; values allow escaped quotes (\') and any
+// other byte. The tag is forwarded to the database verbatim and never
+// interpolated, so the value charset does not need to defend against macros -
+// the caller has already ensured the comment contains no internal */.
+var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9%_.-]+='(?:\\.|[^'\\])*'(\s*,\s*[a-zA-Z0-9%_.-]+='(?:\\.|[^'\\])*')*\s*\*/$`)
 
-// ContainsMacro reports whether s contains a Grafana macro token. It is used to
-// decide whether a SQL comment must be stripped before interpolation: a comment
-// with no macro token is inert and safe to forward to the database (for example
-// a SQLCommenter attribution tag), whereas any macro token - complete, partial,
-// or the parenthesis-less $__interval family - must be removed so interpolation
-// cannot smuggle a live macro, or an expression that completes across the
-// comment boundary, into the executed query.
-func ContainsMacro(s string) bool {
-	return macroTokenRegExp.MatchString(s)
+// SplitTrailingSQLCommenter splits a trailing SQLCommenter attribution tag off
+// the end of sql. It returns the query without the tag and the tag itself
+// (including any trailing ';'), or the original query and an empty string when
+// there is none. Callers re-append the tag verbatim after interpolation, so it
+// reaches the database unchanged and no macro can complete across the comment
+// boundary in either direction.
+func SplitTrailingSQLCommenter(sql string) (string, string) {
+	trimmed := strings.TrimRight(sql, " \t\r\n")
+	trimmed = strings.TrimRight(strings.TrimSuffix(trimmed, ";"), " \t\r\n")
+	if !strings.HasSuffix(trimmed, "*/") {
+		return sql, ""
+	}
+	open := strings.LastIndex(trimmed, "/*")
+	if open < 0 {
+		return sql, ""
+	}
+	comment := trimmed[open:]
+	// The block comment must be self-contained: an internal */ means the database
+	// would close the comment early, leaving executable text we must not move.
+	if strings.Contains(comment[2:len(comment)-2], "*/") {
+		return sql, ""
+	}
+	if !sqlCommenterRegExp.MatchString(comment) {
+		return sql, ""
+	}
+	return sql[:open], sql[open:]
 }

--- a/pkg/tsdb/sqlmacro/sqlmacro.go
+++ b/pkg/tsdb/sqlmacro/sqlmacro.go
@@ -41,6 +41,9 @@ func SplitTrailingSQLCommenter(sql string) (string, string) {
 		return sql, ""
 	}
 	comment := trimmed[open:]
+	if len(comment) < len("/**/") {
+		return sql, ""
+	}
 	// The block comment must be self-contained: an internal */ means the database
 	// would close the comment early, leaving executable text we must not move.
 	if strings.Contains(comment[2:len(comment)-2], "*/") {

--- a/pkg/tsdb/sqlmacro/sqlmacro.go
+++ b/pkg/tsdb/sqlmacro/sqlmacro.go
@@ -30,7 +30,13 @@ var sqlCommenterRegExp = regexp.MustCompile(`^/\*\s*[a-zA-Z0-9%_.-]+='(?:\\.|[^'
 // there is none. Callers re-append the tag verbatim after interpolation, so it
 // reaches the database unchanged and no macro can complete across the comment
 // boundary in either direction.
-func SplitTrailingSQLCommenter(sql string) (string, string) {
+//
+// lineCommentMarkers holds the engine's line-comment introducers ("--" for all
+// three engines, plus "#" for MySQL). Only markers the engine actually treats
+// as comments should be passed: "#" is ordinary syntax in T-SQL (#temp tables)
+// and PostgreSQL (#> JSON operators), and checking it there would drop valid
+// tags.
+func SplitTrailingSQLCommenter(sql string, lineCommentMarkers ...string) (string, string) {
 	trimmed := strings.TrimRight(sql, " \t\r\n")
 	for strings.HasSuffix(trimmed, ";") {
 		trimmed = strings.TrimRight(strings.TrimSuffix(trimmed, ";"), " \t\r\n")
@@ -56,12 +62,14 @@ func SplitTrailingSQLCommenter(sql string) (string, string) {
 	}
 	// A tag-shaped block inside a trailing line comment is not executable SQL and
 	// must not be revived: if the text before the tag on its own line contains a
-	// line-comment marker (-- or MySQL's #), leave the query untouched. This is
-	// conservative - a marker inside a string literal on that line also prevents
-	// splitting, which just falls back to the tag being stripped like any comment.
+	// line-comment marker, leave the query untouched. This is conservative - a
+	// marker inside a string literal on that line also prevents splitting, which
+	// just falls back to the tag being stripped like any comment.
 	lineStart := strings.LastIndexByte(trimmed[:open], '\n') + 1
-	if strings.Contains(trimmed[lineStart:open], "--") || strings.Contains(trimmed[lineStart:open], "#") {
-		return sql, ""
+	for _, marker := range lineCommentMarkers {
+		if strings.Contains(trimmed[lineStart:open], marker) {
+			return sql, ""
+		}
 	}
 	return sql[:open], sql[open:]
 }

--- a/pkg/tsdb/sqlmacro/sqlmacro.go
+++ b/pkg/tsdb/sqlmacro/sqlmacro.go
@@ -1,0 +1,41 @@
+// Package sqlmacro holds the shared Grafana SQL macro definitions used by the
+// MySQL, PostgreSQL and Microsoft SQL Server datasources. Keeping the macro
+// expression and the "does this text contain a macro" guard in one place stops
+// the three datasources from drifting apart, and stops the guard that decides
+// which SQL comments are safe to forward to the database from drifting away from
+// the expression that actually expands macros.
+package sqlmacro
+
+import "regexp"
+
+// Expr is the regular-expression source matching a complete Grafana macro call
+// of the form $name(...). It is exported so every datasource expands macros with
+// the exact same pattern the comment guard uses to detect them.
+const Expr = `\$([_a-zA-Z0-9]+)\(([^\)]*)\)`
+
+// RegExp matches a complete Grafana macro call $name(...).
+var RegExp = regexp.MustCompile(Expr)
+
+// macroTokenRegExp matches any Grafana macro token, including forms that are not
+// (yet) a complete call:
+//   - the parenthesis-less $__interval / $__interval_ms / $__unixEpoch* family,
+//     which the datasource engines expand with a plain string replacement; and
+//   - a paren-form macro that may be complete ($__timeFilter(col)) or only
+//     partially present ($__timeFilter( ), e.g. when it sits inside a comment and
+//     would otherwise complete across the comment boundary once the surrounding
+//     SQL is interpolated.
+//
+// A bare $name with neither the $__ prefix nor a following '(' (for example a
+// PostgreSQL $1 positional parameter) is intentionally not treated as a token.
+var macroTokenRegExp = regexp.MustCompile(`\$(__[a-zA-Z0-9_]*|[_a-zA-Z0-9]+\s*\()`)
+
+// ContainsMacro reports whether s contains a Grafana macro token. It is used to
+// decide whether a SQL comment must be stripped before interpolation: a comment
+// with no macro token is inert and safe to forward to the database (for example
+// a SQLCommenter attribution tag), whereas any macro token - complete, partial,
+// or the parenthesis-less $__interval family - must be removed so interpolation
+// cannot smuggle a live macro, or an expression that completes across the
+// comment boundary, into the executed query.
+func ContainsMacro(s string) bool {
+	return macroTokenRegExp.MatchString(s)
+}

--- a/pkg/tsdb/sqlmacro/sqlmacro_test.go
+++ b/pkg/tsdb/sqlmacro/sqlmacro_test.go
@@ -56,6 +56,30 @@ func TestSplitTrailingSQLCommenter(t *testing.T) {
 			wantTag:  "",
 		},
 		{
+			name:     "repeated trailing semicolons",
+			sql:      "SELECT 1 /*app='grafana'*/;;",
+			wantBody: "SELECT 1 ",
+			wantTag:  "/*app='grafana'*/;;",
+		},
+		{
+			name:     "tag inside a trailing line comment is not revived",
+			sql:      "SELECT 1\n-- note /*k='v'*/",
+			wantBody: "SELECT 1\n-- note /*k='v'*/",
+			wantTag:  "",
+		},
+		{
+			name:     "tag inside a trailing hash comment is not revived",
+			sql:      "SELECT 1 # /*k='v'*/",
+			wantBody: "SELECT 1 # /*k='v'*/",
+			wantTag:  "",
+		},
+		{
+			name:     "tag on its own line after a line comment is still split",
+			sql:      "SELECT 1 -- note\n/*app='grafana'*/",
+			wantBody: "SELECT 1 -- note\n",
+			wantTag:  "/*app='grafana'*/",
+		},
+		{
 			name:     "inline (non-trailing) tag is left in place",
 			sql:      "SELECT 1 /*k='v'*/ WHERE x = 1",
 			wantBody: "SELECT 1 /*k='v'*/ WHERE x = 1",

--- a/pkg/tsdb/sqlmacro/sqlmacro_test.go
+++ b/pkg/tsdb/sqlmacro/sqlmacro_test.go
@@ -1,0 +1,79 @@
+package sqlmacro
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitTrailingSQLCommenter(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		wantBody string
+		wantTag  string
+	}{
+		{
+			name:     "trailing tag before terminator",
+			sql:      "SELECT 1 AS value\n/*application='grafana',source='bi'*/;",
+			wantBody: "SELECT 1 AS value\n",
+			wantTag:  "/*application='grafana',source='bi'*/;",
+		},
+		{
+			name:     "trailing tag without terminator",
+			sql:      "SELECT 1 /*application='grafana'*/",
+			wantBody: "SELECT 1 ",
+			wantTag:  "/*application='grafana'*/",
+		},
+		{
+			name:     "url-encoded key and value",
+			sql:      "SELECT 1 /*a%20b='%2Fparam*d'*/",
+			wantBody: "SELECT 1 ",
+			wantTag:  "/*a%20b='%2Fparam*d'*/",
+		},
+		{
+			name:     "escaped quote in value",
+			sql:      `SELECT 1 /*controller='it\'s'*/`,
+			wantBody: "SELECT 1 ",
+			wantTag:  `/*controller='it\'s'*/`,
+		},
+		{
+			name:     "paren in value does not let a macro complete across the boundary",
+			sql:      "SELECT $__timeFilter(t /*k='a)b'*/",
+			wantBody: "SELECT $__timeFilter(t ",
+			wantTag:  "/*k='a)b'*/",
+		},
+		{
+			name:     "value containing */ is not a self-contained tag",
+			sql:      "SELECT 1 /*k='*/ DROP TABLE t --'*/",
+			wantBody: "SELECT 1 /*k='*/ DROP TABLE t --'*/",
+			wantTag:  "",
+		},
+		{
+			name:     "inline (non-trailing) tag is left in place",
+			sql:      "SELECT 1 /*k='v'*/ WHERE x = 1",
+			wantBody: "SELECT 1 /*k='v'*/ WHERE x = 1",
+			wantTag:  "",
+		},
+		{
+			name:     "plain comment is not a tag",
+			sql:      "SELECT 1 /* just a note */",
+			wantBody: "SELECT 1 /* just a note */",
+			wantTag:  "",
+		},
+		{
+			name:     "no comment",
+			sql:      "SELECT 1 FROM t",
+			wantBody: "SELECT 1 FROM t",
+			wantTag:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, tag := SplitTrailingSQLCommenter(tt.sql)
+			require.Equal(t, tt.wantBody, body)
+			require.Equal(t, tt.wantTag, tag)
+		})
+	}
+}

--- a/pkg/tsdb/sqlmacro/sqlmacro_test.go
+++ b/pkg/tsdb/sqlmacro/sqlmacro_test.go
@@ -50,6 +50,12 @@ func TestSplitTrailingSQLCommenter(t *testing.T) {
 			wantTag:  "",
 		},
 		{
+			name:     "overlapping opener and closer is not a tag",
+			sql:      "SELECT 1 /*/",
+			wantBody: "SELECT 1 /*/",
+			wantTag:  "",
+		},
+		{
 			name:     "inline (non-trailing) tag is left in place",
 			sql:      "SELECT 1 /*k='v'*/ WHERE x = 1",
 			wantBody: "SELECT 1 /*k='v'*/ WHERE x = 1",

--- a/pkg/tsdb/sqlmacro/sqlmacro_test.go
+++ b/pkg/tsdb/sqlmacro/sqlmacro_test.go
@@ -10,6 +10,7 @@ func TestSplitTrailingSQLCommenter(t *testing.T) {
 	tests := []struct {
 		name     string
 		sql      string
+		markers  []string
 		wantBody string
 		wantTag  string
 	}{
@@ -64,19 +65,36 @@ func TestSplitTrailingSQLCommenter(t *testing.T) {
 		{
 			name:     "tag inside a trailing line comment is not revived",
 			sql:      "SELECT 1\n-- note /*k='v'*/",
+			markers:  []string{"--", "#"},
 			wantBody: "SELECT 1\n-- note /*k='v'*/",
 			wantTag:  "",
 		},
 		{
 			name:     "tag inside a trailing hash comment is not revived",
 			sql:      "SELECT 1 # /*k='v'*/",
+			markers:  []string{"--", "#"},
 			wantBody: "SELECT 1 # /*k='v'*/",
 			wantTag:  "",
 		},
 		{
 			name:     "tag on its own line after a line comment is still split",
 			sql:      "SELECT 1 -- note\n/*app='grafana'*/",
+			markers:  []string{"--", "#"},
 			wantBody: "SELECT 1 -- note\n",
+			wantTag:  "/*app='grafana'*/",
+		},
+		{
+			name:     "hash is ordinary syntax when the engine does not mark it",
+			sql:      "SELECT * FROM #tmp /*app='grafana'*/",
+			markers:  []string{"--"},
+			wantBody: "SELECT * FROM #tmp ",
+			wantTag:  "/*app='grafana'*/",
+		},
+		{
+			name:     "postgres json operator does not block the tag",
+			sql:      "SELECT data#>'{a}' FROM t /*app='grafana'*/",
+			markers:  []string{"--"},
+			wantBody: "SELECT data#>'{a}' FROM t ",
 			wantTag:  "/*app='grafana'*/",
 		},
 		{
@@ -101,7 +119,7 @@ func TestSplitTrailingSQLCommenter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			body, tag := SplitTrailingSQLCommenter(tt.sql)
+			body, tag := SplitTrailingSQLCommenter(tt.sql, tt.markers...)
 			require.Equal(t, tt.wantBody, body)
 			require.Equal(t, tt.wantTag, tag)
 		})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contributor guidelines in the CONTRIBUTING.md file.
2. Ensure you include and run the appropriate tests as part of your Pull Request.
3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.
6. Please include a screenshot or gif if the PR provides a change in the UI.

-->

### What is this feature?

`stripSQLComments()` (in `pkg/tsdb/mysql/macros.go`) runs before macro interpolation and removed **all** `/* */` block comments. That also removed trailing [SQLCommenter](https://google.github.io/sqlcommenter/) attribution tags such as:

```sql
SELECT 1 AS value
/*application='grafana',source='bi',route='test',feature='repro'*/;
```

The tags are stored in the dashboard JSON but were stripped before the query reached MySQL, so query-tagging/observability backends (e.g. PlanetScale Insights) never saw them.

This change preserves block comments that match the SQLCommenter `key='value'` format, unless the comment embeds a Grafana macro (in which case it is still stripped so the macro is not interpolated). All other comments continue to be stripped, so existing behavior is unchanged.

### Why do we need this feature?

Regression from #121327: SQLCommenter tags passed through to the database on 12.3.x but are stripped on 12.4.x, breaking query attribution.

### Who is this feature for?

Users who append SQLCommenter metadata to MySQL queries for query tagging / observability.

### Which issue(s) does this PR fix?

Fixes #127889

### Special notes for your reviewer

- Only block comments matching `^/\*\s*key='value'(,key='value')*\s*\*/$` are preserved; line comments (`--`, `#`) and all other block comments are still stripped.
- The `!macroRegExp` guard ensures a comment can never smuggle a live macro back into the executed SQL.
- Tests added in `TestStripSQLComments`: preserve trailing tag, preserve inline tag, still strip plain block comments, strip a tag-shaped comment containing a macro. Existing tests are unchanged and still pass (`go test ./pkg/tsdb/mysql/`).