### PR TITLE
chore(annotations): integrate soft-deletion with migration proxy

### DIFF
--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
-	annotationpkg "github.com/grafana/grafana/pkg/registry/apps/annotation"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -111,26 +110,42 @@ func (s *annotationAPIClient) Delete(ctx context.Context, orgID int64, name stri
 	return s.k8sClient.Delete(ctx, name, orgID, v1.DeleteOptions{})
 }
 
+// GetByLegacyID fetches an annotation by its legacy ID, returning a tombstone if it has been soft-deleted.
+//
 // TODO: expensive — the legacyID index does not cover the time partition, so this scans
 // every partition. Carrying the annotation time to the call sites would let us prune them.
 func (s *annotationAPIClient) GetByLegacyID(ctx context.Context, orgID int64, annotationID int64) (*annotationV0.Annotation, error) {
-	list, err := s.k8sClient.List(ctx, orgID, v1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%d", annotationpkg.LabelKeyLegacyID, annotationID),
-	})
+	rc, err := s.getRESTClient()
 	if err != nil {
 		return nil, err
+	}
+
+	namespace := s.k8sClient.GetNamespace(orgID)
+	raw, err := rc.Get().
+		AbsPath("apis", annotationV0.APIGroup, annotationV0.APIVersion, "namespaces", namespace, "search").
+		Param("legacyID", strconv.FormatInt(annotationID, 10)).
+		Param("includeDeleted", "true").
+		DoRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var list annotationV0.AnnotationList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
 	}
 	if len(list.Items) == 0 {
 		return nil, ErrNotFound
 	}
-	return fromUnstructured(&list.Items[0])
+	return &list.Items[0], nil
 }
 
 func (s *annotationAPIClient) GetUsersFromMeta(ctx context.Context, usersMeta []string) (map[string]*user.User, error) {
 	return s.k8sClient.GetUsersFromMeta(ctx, usersMeta)
 }
 
-// Search calls the /search custom route, which handles all filtering server-side including tags.
+// Search calls the /search custom route, which handles all filtering server-side including
+// tags. It includes tombstones for soft-deleted annotations.
 func (s *annotationAPIClient) Search(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotationV0.Annotation, error) {
 	rc, err := s.getRESTClient()
 	if err != nil {
@@ -138,7 +153,9 @@ func (s *annotationAPIClient) Search(ctx context.Context, orgID int64, query *an
 	}
 
 	namespace := s.k8sClient.GetNamespace(orgID)
-	req := rc.Get().AbsPath("apis", annotationV0.APIGroup, annotationV0.APIVersion, "namespaces", namespace, "search")
+	req := rc.Get().
+		AbsPath("apis", annotationV0.APIGroup, annotationV0.APIVersion, "namespaces", namespace, "search").
+		Param("includeDeleted", "true")
 
 	if query.DashboardUID != "" {
 		req = req.Param("dashboardUID", query.DashboardUID)

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -22,6 +22,11 @@ import (
 // ErrNotFound is returned by proxy methods when the annotation is not in the new storage
 var ErrNotFound = errors.New("annotation not found in new store")
 
+// ErrGone is returned by proxy methods when the annotation was explicitly deleted
+// (soft-deleted / tombstoned) in the new store. Unlike ErrNotFound, callers must
+// NOT fall back to legacy on this error as the record is authoritatively deleted.
+var ErrGone = errors.New("annotation has been deleted in new store")
+
 // partialDecodeError signals that one or more optional fields could not be decoded
 // from an annotation. The annotation is still usable without those fields, so callers
 // can return the DTO (minus the affected fields) rather than dropping it.
@@ -67,17 +72,28 @@ func ProvideMigrationProxy(cfg *setting.Cfg, userSvc user.Service, exchanger aut
 }
 
 // List fetches annotations from the new store matching query and returns them as ItemDTOs.
+// It also returns a map of legacy IDs that were tombstoned in the new store, so callers can easily suppress those from the legacy results.
 // All filtering including tags is handled server-side via the /search custom route.
-func (h *MigrationProxy) List(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
+func (h *MigrationProxy) List(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotations.ItemDTO, map[int64]bool, error) {
 	annos, err := h.client.Search(ctx, orgID, query)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// Collect unique createdBy values for batch user hydration.
+	// Filter out soft-deleted annotations and collect their legacy IDs for the caller to suppress from legacy results.
+	live := make([]*annotationV0.Annotation, 0, len(annos))
+	deletedIDs := map[int64]bool{}
 	seen := make(map[string]bool)
 	var createdByMeta []string
 	for _, anno := range annos {
+		if anno.GetDeletionTimestamp() != nil {
+			if id := annotationpkg.GetLegacyID(anno); id != 0 {
+				deletedIDs[id] = true
+			}
+			continue
+		}
+		live = append(live, anno)
+		// Collect unique createdBy metadata for user hydration. This is a best-effort attempt to avoid a separate query per annotation.
 		if cb := anno.GetCreatedBy(); cb != "" && !seen[cb] {
 			createdByMeta = append(createdByMeta, cb)
 			seen[cb] = true
@@ -92,8 +108,8 @@ func (h *MigrationProxy) List(ctx context.Context, orgID int64, query *annotatio
 		}
 	}
 
-	dtos := make([]*annotations.ItemDTO, 0, len(annos))
-	for _, anno := range annos {
+	dtos := make([]*annotations.ItemDTO, 0, len(live))
+	for _, anno := range live {
 		dto, err := annoToItemDTO(anno)
 		if err != nil {
 			var decodeErr *partialDecodeError
@@ -112,12 +128,13 @@ func (h *MigrationProxy) List(ctx context.Context, orgID int64, query *annotatio
 		}
 		dtos = append(dtos, dto)
 	}
-	return dtos, nil
+	return dtos, deletedIDs, nil
 }
 
 // Merge combines new-store and legacy items, deduplicates by legacyID (new store wins),
-// sorts by time descending, and applies limit.
-func Merge(newItems, legacyItems []*annotations.ItemDTO, limit int64) []*annotations.ItemDTO {
+// drops legacy items whose legacyID is tombstoned in the new store (deletedIDs), sorts by
+// time descending, and applies limit.
+func Merge(newItems, legacyItems []*annotations.ItemDTO, deletedIDs map[int64]bool, limit int64) []*annotations.ItemDTO {
 	inNew := make(map[int64]bool, len(newItems))
 	for _, item := range newItems {
 		inNew[item.ID] = true
@@ -126,9 +143,10 @@ func Merge(newItems, legacyItems []*annotations.ItemDTO, limit int64) []*annotat
 	merged := make([]*annotations.ItemDTO, 0, len(newItems)+len(legacyItems))
 	merged = append(merged, newItems...)
 	for _, item := range legacyItems {
-		if !inNew[item.ID] {
-			merged = append(merged, item)
+		if inNew[item.ID] || deletedIDs[item.ID] {
+			continue // new store owns it, or it was explicitly deleted there
 		}
+		merged = append(merged, item)
 	}
 
 	slices.SortFunc(merged, func(a, b *annotations.ItemDTO) int {
@@ -164,6 +182,9 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	if err != nil {
 		return err
 	}
+	if existing.GetDeletionTimestamp() != nil {
+		return ErrGone
+	}
 	anno, err := itemToAnnotation(item)
 	if err != nil {
 		return err
@@ -182,20 +203,29 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	return err
 }
 
-// Delete removes from new store. Returns ErrNotFound if the record is not there yet — caller falls back to legacy.
+// Delete soft-deletes in the new store. Returns ErrNotFound if the record is not
+// there yet (caller falls back to legacy) or ErrGone if it was already deleted.
 func (h *MigrationProxy) Delete(ctx context.Context, orgID int64, annotationID int64) error {
 	existing, err := h.client.GetByLegacyID(ctx, orgID, annotationID)
 	if err != nil {
 		return err
 	}
+	if existing.GetDeletionTimestamp() != nil {
+		return ErrGone
+	}
 	return h.client.Delete(ctx, orgID, existing.GetName())
 }
 
-// TODO: soft-delete not yet implemented
+// Get reads a single annotation from the new store. Returns ErrNotFound if the
+// record is not there yet (caller falls back to legacy) or ErrGone if it was
+// explicitly deleted (caller must not fall back).
 func (h *MigrationProxy) Get(ctx context.Context, orgID int64, annotationID int64) (*annotations.ItemDTO, error) {
 	anno, err := h.client.GetByLegacyID(ctx, orgID, annotationID)
 	if err != nil {
 		return nil, err
+	}
+	if anno.GetDeletionTimestamp() != nil {
+		return nil, ErrGone
 	}
 
 	dto, err := annoToItemDTO(anno)

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -16,11 +16,12 @@ func TestMerge(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		new    []*annotations.ItemDTO
-		legacy []*annotations.ItemDTO
-		limit  int64
-		want   []*annotations.ItemDTO
+		name    string
+		new     []*annotations.ItemDTO
+		legacy  []*annotations.ItemDTO
+		deleted map[int64]bool
+		limit   int64
+		want    []*annotations.ItemDTO
 	}{
 		{
 			name:   "both empty",
@@ -57,11 +58,19 @@ func TestMerge(t *testing.T) {
 			limit:  0,
 			want:   []*annotations.ItemDTO{item(1, 30), item(2, 20), item(3, 10)},
 		},
+		{
+			name:    "tombstoned legacy item is suppressed",
+			new:     []*annotations.ItemDTO{item(1, 30)},
+			legacy:  []*annotations.ItemDTO{item(2, 20), item(3, 10)},
+			deleted: map[int64]bool{2: true},
+			limit:   10,
+			want:    []*annotations.ItemDTO{item(1, 30), item(3, 10)},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := Merge(tt.new, tt.legacy, tt.limit)
+			got := Merge(tt.new, tt.legacy, tt.deleted, tt.limit)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/services/annotations/annotationsapi/migration_repository.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository.go
@@ -18,7 +18,7 @@ type annotationProxy interface {
 	Update(ctx context.Context, orgID int64, annotationID int64, item *annotations.Item) error
 	Delete(ctx context.Context, orgID int64, annotationID int64) error
 	Get(ctx context.Context, orgID int64, annotationID int64) (*annotations.ItemDTO, error)
-	List(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error)
+	List(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotations.ItemDTO, map[int64]bool, error)
 }
 
 var _ annotations.Repository = (*migrationRepository)(nil)
@@ -67,7 +67,7 @@ func (r *migrationRepository) search(ctx context.Context, query *annotations.Ite
 	// The new store filters users by UID, so translate the query's legacy user ID first.
 	r.resolveUserUID(ctx, query)
 
-	newItems, err := r.proxy.List(ctx, query.OrgID, query)
+	newItems, deletedIDs, err := r.proxy.List(ctx, query.OrgID, query)
 	if err != nil {
 		// In proxy-all the new store is authoritative; a silent legacy fallback would
 		// hide annotations behind a 200. Only degrade while legacy still holds everything.
@@ -75,7 +75,7 @@ func (r *migrationRepository) search(ctx context.Context, query *annotations.Ite
 			return nil, err
 		}
 		r.logger.Warn("new store list failed, returning legacy results only", "err", err)
-		newItems = nil
+		newItems, deletedIDs = nil, nil
 	}
 
 	legacyItems, err := r.legacyToMerge(ctx, query)
@@ -85,7 +85,7 @@ func (r *migrationRepository) search(ctx context.Context, query *annotations.Ite
 	if legacyItems == nil {
 		return newItems, nil // new store is authoritative
 	}
-	return Merge(newItems, legacyItems, query.Limit), nil
+	return Merge(newItems, legacyItems, deletedIDs, query.Limit), nil
 }
 
 // legacyToMerge returns the legacy items to merge with the new store, or nil when the new
@@ -110,12 +110,16 @@ func (r *migrationRepository) legacyToMerge(ctx context.Context, query *annotati
 }
 
 // findByID reads a single annotation from the new store, falling back to legacy when the
-// record is not there yet (pre-migration record or an alert annotation).
+// record is not there yet (pre-migration record or an alert annotation). A record that was
+// explicitly deleted in the new store (ErrGone) must not fall back to legacy.
 func (r *migrationRepository) findByID(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
 	dto, err := r.proxy.Get(ctx, query.OrgID, query.AnnotationID)
 	switch {
 	case err == nil:
 		return []*annotations.ItemDTO{dto}, nil
+	case errors.Is(err, ErrGone):
+		// deleted in new store, don't fall back to legacy
+		return nil, nil
 	case errors.Is(err, ErrNotFound):
 		return r.legacy.Find(ctx, query)
 	default:
@@ -157,7 +161,9 @@ func (r *migrationRepository) SaveMany(ctx context.Context, items []annotations.
 }
 
 // Update writes to the new store. On ErrNotFound (older record) it falls back to legacy,
-// which preserves any Data the caller omits.
+// which preserves any Data the caller omits. On ErrGone (explicitly deleted in the new
+// store) it returns the error without falling back, so a tombstoned annotation is not
+// silently resurrected via the legacy copy.
 func (r *migrationRepository) Update(ctx context.Context, item *annotations.Item) error {
 	err := r.proxy.Update(ctx, item.OrgID, item.ID, item)
 	if err == nil || !errors.Is(err, ErrNotFound) {
@@ -166,24 +172,23 @@ func (r *migrationRepository) Update(ctx context.Context, item *annotations.Item
 	return r.legacy.Update(ctx, item)
 }
 
-// Delete removes one annotation from the new store, falling back to legacy on ErrNotFound
-// (older record).
-// TODO: this only removes the new-store copy. If the same annotation still exists in
-// legacy (e.g. migrated but not purged), the legacy row survives and reappears in the
-// merged Find results. Needs a dual-delete or a tombstone once soft-delete lands.
+// Delete soft-deletes one annotation in the new store. The legacy copy is left
+// untouched (legacy stays read-only during the migration); the tombstone in the new
+// store suppresses that copy from merged reads, so the annotation does not resurface.
 func (r *migrationRepository) Delete(ctx context.Context, params *annotations.DeleteParams) error {
 	// No ID means a mass delete by dashboard/panel, which the proxy can't express.
 	if params.ID == 0 {
 		return r.legacy.Delete(ctx, params)
 	}
 	err := r.proxy.Delete(ctx, params.OrgID, params.ID)
-	if err == nil {
+	switch {
+	case err == nil, errors.Is(err, ErrGone):
 		return nil
-	}
-	if !errors.Is(err, ErrNotFound) {
+	case errors.Is(err, ErrNotFound):
+		return r.legacy.Delete(ctx, params)
+	default:
 		return err
 	}
-	return r.legacy.Delete(ctx, params)
 }
 
 // TODO: FindTags reads from legacy only. Follow up to proxy tag searches to the new store.

--- a/pkg/services/annotations/annotationsapi/migration_repository_test.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository_test.go
@@ -44,9 +44,10 @@ func (f *fakeLegacy) FindTags(context.Context, *annotations.TagsQuery) (annotati
 }
 
 type fakeProxy struct {
-	listResult []*annotations.ItemDTO
-	listErr    error
-	listCalls  []*annotations.ItemQuery
+	listResult  []*annotations.ItemDTO
+	listDeleted map[int64]bool
+	listErr     error
+	listCalls   []*annotations.ItemQuery
 
 	getResult *annotations.ItemDTO
 	getErr    error
@@ -63,9 +64,9 @@ type fakeProxy struct {
 	deleteCalls int
 }
 
-func (f *fakeProxy) List(_ context.Context, _ int64, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
+func (f *fakeProxy) List(_ context.Context, _ int64, query *annotations.ItemQuery) ([]*annotations.ItemDTO, map[int64]bool, error) {
 	f.listCalls = append(f.listCalls, query)
-	return f.listResult, f.listErr
+	return f.listResult, f.listDeleted, f.listErr
 }
 func (f *fakeProxy) Get(_ context.Context, _ int64, _ int64) (*annotations.ItemDTO, error) {
 	f.getCalls++
@@ -202,6 +203,18 @@ func TestMigrationRepository_Find(t *testing.T) {
 		assert.Len(t, legacy.findCalls, 1)
 	})
 
+	t.Run("by-id returns empty on ErrGone and does not fall back to legacy", func(t *testing.T) {
+		legacy := &fakeLegacy{findResult: []*annotations.ItemDTO{item(5, 10)}}
+		proxy := &fakeProxy{getErr: ErrGone}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		got, err := repo.Find(context.Background(), &annotations.ItemQuery{AnnotationID: 5})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+		assert.Equal(t, 1, proxy.getCalls)
+		assert.Empty(t, legacy.findCalls)
+	})
+
 	t.Run("by-id propagates other proxy errors", func(t *testing.T) {
 		legacy := &fakeLegacy{}
 		proxy := &fakeProxy{getErr: assert.AnError}
@@ -222,6 +235,19 @@ func TestMigrationRepository_Find(t *testing.T) {
 		assert.Equal(t, []*annotations.ItemDTO{item(2, 20), item(1, 10)}, got)
 		assert.Len(t, proxy.listCalls, 1)
 		assert.Len(t, legacy.findCalls, 1)
+	})
+
+	t.Run("proxy-writes suppresses a legacy item tombstoned in the new store", func(t *testing.T) {
+		legacy := &fakeLegacy{findResult: []*annotations.ItemDTO{item(2, 20), item(3, 30)}}
+		proxy := &fakeProxy{
+			listResult:  []*annotations.ItemDTO{item(1, 10)},
+			listDeleted: map[int64]bool{2: true},
+		}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		got, err := repo.Find(context.Background(), &annotations.ItemQuery{Limit: 10})
+		require.NoError(t, err)
+		assert.Equal(t, []*annotations.ItemDTO{item(3, 30), item(1, 10)}, got)
 	})
 
 	t.Run("proxy-writes merges new and legacy, respecting the caller's limit", func(t *testing.T) {
@@ -414,6 +440,15 @@ func TestMigrationRepository_Update(t *testing.T) {
 		require.Len(t, legacy.updateItems, 1)
 		assert.Same(t, item, legacy.updateItems[0])
 	})
+
+	t.Run("ErrGone propagates without falling back to legacy", func(t *testing.T) {
+		legacy := &fakeLegacy{}
+		proxy := &fakeProxy{updateErr: ErrGone}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		require.ErrorIs(t, repo.Update(context.Background(), &annotations.Item{OrgID: 1, ID: 5}), ErrGone)
+		assert.Empty(t, legacy.updateItems)
+	})
 }
 
 // --- Delete ----------------------------------------------------------------
@@ -446,6 +481,16 @@ func TestMigrationRepository_Delete(t *testing.T) {
 		require.NoError(t, repo.Delete(context.Background(), &annotations.DeleteParams{OrgID: 1, ID: 5}))
 		assert.Equal(t, 1, proxy.deleteCalls)
 		require.Len(t, legacy.deleteParams, 1)
+	})
+
+	t.Run("single delete treats ErrGone as an idempotent success", func(t *testing.T) {
+		legacy := &fakeLegacy{}
+		proxy := &fakeProxy{deleteErr: ErrGone}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		require.NoError(t, repo.Delete(context.Background(), &annotations.DeleteParams{OrgID: 1, ID: 5}))
+		assert.Equal(t, 1, proxy.deleteCalls)
+		assert.Empty(t, legacy.deleteParams)
 	})
 
 	t.Run("mass delete by dashboard/panel goes straight to legacy", func(t *testing.T) {


### PR DESCRIPTION
Part of https://github.com/grafana/grafana-org/issues/961

This PR leverages soft-delete functionality added in https://github.com/grafana/grafana/pull/127782 to prevent deleted annotations from resurfacing while the legacy API is proxying writes to the new API. During this phase of the migration, the legacy database becomes read-only and DELETE requests will be proxied to the new API. This means that an annotation record may exist in the legacy database, but be soft-deleted in the new backend. The changes in this PR prevent these legacy records from surfacing when reading annotations as the new API's store should remain the authoritative source-of-truth.