### PR TITLE
Provisioning: Enable Dashboard Previews for Github Enterprise in UI

### DIFF
--- a/public/app/features/provisioning/Config/PullRequestOptionsSection.test.tsx
+++ b/public/app/features/provisioning/Config/PullRequestOptionsSection.test.tsx
@@ -88,6 +88,17 @@ describe('PullRequestOptionsSection', () => {
     expect(screen.queryByText('Pull request title template')).not.toBeInTheDocument();
   });
 
+  it('renders the dashboard previews toggle for GitHub Enterprise even when the gitConventions flag is off', async () => {
+    setTestFlags({ 'provisioning.gitConventions': false });
+    const { user } = render(<Wrapper repoType="githubEnterprise" dashboardPreviewName="generateDashboardPreviews" />);
+
+    await user.click(screen.getByText('Pull request options'));
+
+    expect(screen.getByRole('checkbox', { name: /Enable dashboard previews in pull requests/i })).toBeInTheDocument();
+    // Template fields stay hidden while the flag is off.
+    expect(screen.queryByText('Pull request title template')).not.toBeInTheDocument();
+  });
+
   it('does not render the dashboard previews toggle for non-GitHub providers', () => {
     setTestFlags({ 'provisioning.gitConventions': false });
     const { container } = render(<Wrapper repoType="gitlab" dashboardPreviewName="generateDashboardPreviews" />);

--- a/public/app/features/provisioning/Config/PullRequestOptionsSection.tsx
+++ b/public/app/features/provisioning/Config/PullRequestOptionsSection.tsx
@@ -48,7 +48,7 @@ export function PullRequestOptionsSection<T extends FieldValues>({
 
   // Dashboard previews currently apply only to GitHub and require image rendering to be allowed.
   const showDashboardPreviews = Boolean(
-    repoType === 'github' && dashboardPreviewName && checkImageRenderingAllowed(settings.data)
+    isGitHubBased(repoType) && dashboardPreviewName && checkImageRenderingAllowed(settings.data)
   );
 
   if (!gitConventionsEnabled && !showDashboardPreviews) {


### PR DESCRIPTION
**What is this feature?**
Enable Dashboard Previews for Github Enterprise in the frontend options. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1254

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.