### PR TITLE
Docker: Update Alpine base image to 3.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG JS_SRC=js-builder
 
 # Dependabot cannot update dependencies listed in ARGs
 # By using FROM instructions we can delegate dependency updates to dependabot
-FROM alpine:3.24.1 AS alpine-base
+FROM alpine:3.24.2 AS alpine-base
 FROM ubuntu:24.04 AS ubuntu-base
 FROM golang:1.26.4-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:24-alpine AS js-builder-base


### PR DESCRIPTION
**What is this feature?**

This update resolves the reported dependency vulnerabilities by upgrading the Alpine base image used in the Docker build to a patched version.

**Why do we need this feature?**

The current image includes vulnerable curl/libcurl packages. Updating the base image removes the reported container-level security issues without changing application behavior.

**Who is this feature for?**

This is for Grafana users, operators, and security reviewers who need the build artifacts to be free of the reported CVEs.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Reported vulnerabilities addressed in this PR:**
- Alpine `curl/libcurl` CVEs:
  - CVE-2026-12064
  - CVE-2026-8925
  - CVE-2026-10536
  - CVE-2026-11564
  - CVE-2026-8926
  - CVE-2026-8927
  - CVE-2026-9079
  - CVE-2026-8286
  - CVE-2026-9080
  - CVE-2026-11586
  - CVE-2026-8458
  - CVE-2026-11352
  - CVE-2026-8932
  - CVE-2026-9545
  - CVE-2026-8924
  - CVE-2026-9546
  - CVE-2026-11856
  - CVE-2026-9547

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/release-notes/) doc.