### PR TITLE
feat(explore): add unit option

### DIFF
--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -60,7 +60,7 @@ export interface ExplorePanelsState extends Partial<Record<PreferredVisualisatio
   graph?: ExploreGraphPanelState;
 }
 
-export interface ExploreGraphPanelState {
+interface ExploreGraphPanelState {
   unit?: string;
 }
 

--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -57,6 +57,11 @@ export interface ExploreUrlState<T extends DataQuery = AnyQuery> {
 export interface ExplorePanelsState extends Partial<Record<PreferredVisualisationType, {}>> {
   trace?: ExploreTracePanelState;
   logs?: ExploreLogsPanelState;
+  graph?: ExploreGraphPanelState;
+}
+
+export interface ExploreGraphPanelState {
+  unit?: string;
 }
 
 /**

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -24,8 +24,10 @@ export interface CascaderProps {
   /** Changes the value for every selection, including branch nodes. Defaults to true. */
   changeOnSelect?: boolean;
   onSelect(val: string): void;
-  /** Sets the width to a multiple of 8px. Should only be used with inline forms. Setting width of the container is preferred in other cases.*/
-  width?: number;
+  /** Sets the width to a multiple of 8px, or 'auto' to size to content. Should only be used with inline forms. Setting width of the container is preferred in other cases.*/
+  width?: number | 'auto';
+  /** Sets the minimum width of the input. Useful with width='auto'. */
+  minWidth?: string;
   /** Single string that needs to be the same as value of the last item in the selection chain. */
   initialValue?: string;
   allowCustomValue?: boolean;
@@ -111,6 +113,7 @@ export const Cascader = memo(
     changeOnSelect = true,
     onSelect,
     width,
+    minWidth,
     initialValue,
     allowCustomValue,
     formatCreateLabel,
@@ -252,6 +255,7 @@ export const Cascader = memo(
             onCreateOption={handleCreateOption}
             formatCreateLabel={formatCreateLabel}
             width={width}
+            minWidth={minWidth}
             onInputChange={handleSelectInputChange}
             disabled={disabled}
             inputValue={inputValue}
@@ -272,7 +276,8 @@ export const Cascader = memo(
             <div className={disableDivFocus}>
               <Input
                 autoFocus={autoFocus}
-                width={width}
+                width={typeof width === 'number' ? width : undefined}
+                className={minWidth ? css({ minWidth }) : undefined}
                 placeholder={placeholder}
                 onBlur={handleBlurCascade}
                 value={activeLabel}

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -150,6 +150,7 @@ export function SelectBase<T, Rest = {}>({
   virtualized = false,
   noMultiValueWrap,
   width,
+  minWidth,
   isValidNewOption,
   formatOptionLabel,
   hideSelectedOptions,
@@ -166,7 +167,7 @@ export function SelectBase<T, Rest = {}>({
 
   const reactSelectRef = useRef<HTMLElement & { controlRef: HTMLElement }>(null);
   const [closeToBottom, setCloseToBottom] = useState<boolean>(false);
-  const selectStyles = useCustomSelectStyles(theme, width);
+  const selectStyles = useCustomSelectStyles(theme, width, minWidth);
   const [hasInputValue, setHasInputValue] = useState<boolean>(!!inputValue);
   // local state to track when menu is open - used to stop Escape key from propagating to parent overlays when menu is open
   const [open, setOpen] = useState(!!isOpen);

--- a/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
@@ -47,7 +47,7 @@ export default function resetSelectStyles(theme: GrafanaTheme2): Partial<StylesC
   };
 }
 
-export function useCustomSelectStyles(theme: GrafanaTheme2, width: number | string | undefined): Partial<StylesConfig> {
+export function useCustomSelectStyles(theme: GrafanaTheme2, width: number | string | undefined, minWidth?: string): Partial<StylesConfig> {
   return useMemo(() => {
     return {
       ...resetSelectStyles(theme),
@@ -71,6 +71,7 @@ export function useCustomSelectStyles(theme: GrafanaTheme2, width: number | stri
       },
       container: () => ({
         width: width ? theme.spacing(width) : '100%',
+        minWidth,
         display: width === 'auto' ? 'inline-flex' : 'flex',
       }),
       option: (provided, state) => ({
@@ -78,5 +79,5 @@ export function useCustomSelectStyles(theme: GrafanaTheme2, width: number | stri
         opacity: state.isDisabled ? 0.5 : 1,
       }),
     };
-  }, [theme, width]);
+  }, [theme, width, minWidth]);
 }

--- a/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
@@ -47,7 +47,11 @@ export default function resetSelectStyles(theme: GrafanaTheme2): Partial<StylesC
   };
 }
 
-export function useCustomSelectStyles(theme: GrafanaTheme2, width: number | string | undefined, minWidth?: string): Partial<StylesConfig> {
+export function useCustomSelectStyles(
+  theme: GrafanaTheme2,
+  width: number | string | undefined,
+  minWidth?: string
+): Partial<StylesConfig> {
   return useMemo(() => {
     return {
       ...resetSelectStyles(theme),

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -106,6 +106,8 @@ export interface SelectCommonProps<T> {
   virtualized?: boolean;
   /** Sets the width to a multiple of 8px. Should only be used with inline forms. Setting width of the container is preferred in other cases.*/
   width?: number | 'auto';
+  /** Sets the minimum width of the container. Useful with width='auto' to prevent the picker from shrinking too small. */
+  minWidth?: string;
   isOptionDisabled?: (option: SelectableValue<T>) => boolean;
   /** allowCustomValue must be enabled. Determines whether the "create new" option should be displayed based on the current input value, select value and options array. */
   isValidNewOption?: (

--- a/packages/grafana-ui/src/components/UnitPicker/UnitPicker.tsx
+++ b/packages/grafana-ui/src/components/UnitPicker/UnitPicker.tsx
@@ -9,7 +9,9 @@ import { Cascader, type CascaderOption } from '../Cascader/Cascader';
 export interface UnitPickerProps {
   onChange: (item?: string) => void;
   value?: string;
-  width?: number;
+  width?: number | 'auto';
+  minWidth?: string;
+  placeholder?: string;
   id?: string;
 }
 
@@ -20,7 +22,7 @@ function formatCreateLabel(input: string) {
 /**
  * https://developers.grafana.com/ui/latest/index.html?path=/docs/pickers-unitpicker--docs
  */
-export const UnitPicker = memo<UnitPickerProps>(({ onChange, value, width, id }) => {
+export const UnitPicker = memo<UnitPickerProps>(({ onChange, value, width, minWidth, placeholder, id }) => {
   // Set the current selection
   let current: SelectableValue<string> | undefined = undefined;
 
@@ -52,16 +54,22 @@ export const UnitPicker = memo<UnitPickerProps>(({ onChange, value, width, id })
     current = { value, label: value };
   }
 
+  // Auto-size to the displayed label when no explicit width given.
+  // Label chars * ~0.875 (7px/8px spacing unit) + 4 units for padding/clear button, min 14.
+  const placeholderLen = placeholder?.length ?? 4;
+  const effectiveWidth = width ?? Math.max(14, Math.ceil((current?.label?.length ?? placeholderLen) * 0.875) + 4);
+
   return (
     <Cascader
       id={id}
-      width={width}
+      width={effectiveWidth}
+      minWidth={minWidth}
       initialValue={current && current.label}
       allowCustomValue
       changeOnSelect={false}
       formatCreateLabel={formatCreateLabel}
       options={groupOptions}
-      placeholder={t('grafana-ui.unit-picker.placeholder', 'Choose')}
+      placeholder={placeholder ?? t('grafana-ui.unit-picker.placeholder', 'Choose')}
       isClearable
       onSelect={onChange}
       data-testid={selectors.components.UnitPicker.container}

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -388,11 +388,12 @@ export class Explore extends PureComponent<Props, ExploreState> {
   }
 
   renderGraphPanel(width: number) {
-    const { graphResult, timeZone, queryResponse, showFlameGraph, queriesChangedIndexAtRun } = this.props;
+    const { exploreId, graphResult, timeZone, queryResponse, showFlameGraph, queriesChangedIndexAtRun } = this.props;
 
     return (
       <ContentOutlineItem panelId="Graph" title={t('explore.explore.title-graph', 'Graph')} icon="graph-bar">
         <GraphContainer
+          exploreId={exploreId}
           data={graphResult!}
           height={showFlameGraph ? 180 : 400}
           width={width}

--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -56,6 +56,7 @@ interface Props {
   splitOpenFn: SplitOpen;
   onChangeTime: (timeRange: AbsoluteTimeRange) => void;
   graphStyle: ExploreGraphStyle;
+  unit?: string;
   anchorToZero?: boolean;
   yAxisMaximum?: number;
   thresholdsConfig?: ThresholdsConfig;
@@ -78,6 +79,7 @@ export function ExploreGraph({
   onHiddenSeriesChanged,
   splitOpenFn,
   graphStyle,
+  unit,
   tooltipDisplayMode = TooltipDisplayMode.Single,
   anchorToZero = false,
   yAxisMaximum,
@@ -99,7 +101,7 @@ export function ExploreGraph({
     defaults: {
       min: anchorToZero ? 0 : undefined,
       max: yAxisMaximum || undefined,
-      unit: 'short',
+      unit: unit ?? 'short',
       color: {
         mode: FieldColorModeId.PaletteClassic,
       },
@@ -118,6 +120,13 @@ export function ExploreGraph({
       overrides: fieldConfig.overrides.filter((rule) => !isHideSeriesOverride(rule)),
     }));
   }, [queriesChangedIndexAtRun]);
+
+  useEffect(() => {
+    setFieldConfig((fieldConfig) => ({
+      ...fieldConfig,
+      defaults: { ...fieldConfig.defaults, unit: unit ?? 'short' },
+    }));
+  }, [unit]);
 
   const styledFieldConfig = useMemo(() => {
     const withGraphStyle = applyGraphStyle(fieldConfig, graphStyle, yAxisMaximum);

--- a/public/app/features/explore/Graph/ExploreGraphLabel.test.tsx
+++ b/public/app/features/explore/Graph/ExploreGraphLabel.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ExploreGraphLabel } from './ExploreGraphLabel';
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  UnitPicker: ({ value, onChange }: { value?: string; onChange: (unit: string | undefined) => void }) => (
+    <button data-testid="unit-picker" onClick={() => onChange('bytes')}>
+      {value ?? 'Unit'}
+    </button>
+  ),
+  RadioButtonGroup: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <button data-testid="graph-style-picker" onClick={() => onChange('lines')}>
+      {value}
+    </button>
+  ),
+}));
+
+describe('ExploreGraphLabel', () => {
+  const defaultProps = {
+    graphStyle: 'lines' as const,
+    onChangeGraphStyle: jest.fn(),
+    onChangeUnit: jest.fn(),
+  };
+
+  it('renders unit picker and graph style picker', () => {
+    render(<ExploreGraphLabel {...defaultProps} />);
+    expect(screen.getByTestId('unit-picker')).toBeInTheDocument();
+    expect(screen.getByTestId('graph-style-picker')).toBeInTheDocument();
+  });
+
+  it('shows the selected unit value', () => {
+    render(<ExploreGraphLabel {...defaultProps} unit="bytes" />);
+    expect(screen.getByTestId('unit-picker')).toHaveTextContent('bytes');
+  });
+
+  it('calls onChangeUnit when unit is changed', async () => {
+    const onChangeUnit = jest.fn();
+    render(<ExploreGraphLabel {...defaultProps} onChangeUnit={onChangeUnit} />);
+    await userEvent.click(screen.getByTestId('unit-picker'));
+    expect(onChangeUnit).toHaveBeenCalledWith('bytes');
+  });
+
+  it('calls onChangeGraphStyle when graph style is changed', async () => {
+    const onChangeGraphStyle = jest.fn();
+    render(<ExploreGraphLabel {...defaultProps} onChangeGraphStyle={onChangeGraphStyle} />);
+    await userEvent.click(screen.getByTestId('graph-style-picker'));
+    expect(onChangeGraphStyle).toHaveBeenCalledWith('lines');
+  });
+});

--- a/public/app/features/explore/Graph/ExploreGraphLabel.tsx
+++ b/public/app/features/explore/Graph/ExploreGraphLabel.tsx
@@ -1,5 +1,5 @@
 import { type SelectableValue } from '@grafana/data';
-import { RadioButtonGroup } from '@grafana/ui';
+import { RadioButtonGroup, UnitPicker } from '@grafana/ui';
 import { EXPLORE_GRAPH_STYLES, type ExploreGraphStyle } from 'app/types/explore';
 
 const ALL_GRAPH_STYLE_OPTIONS: Array<SelectableValue<ExploreGraphStyle>> = EXPLORE_GRAPH_STYLES.map((style) => ({
@@ -11,11 +11,16 @@ const ALL_GRAPH_STYLE_OPTIONS: Array<SelectableValue<ExploreGraphStyle>> = EXPLO
 type Props = {
   graphStyle: ExploreGraphStyle;
   onChangeGraphStyle: (style: ExploreGraphStyle) => void;
+  unit?: string;
+  onChangeUnit: (unit: string | undefined) => void;
 };
 
 export function ExploreGraphLabel(props: Props) {
-  const { graphStyle, onChangeGraphStyle } = props;
+  const { graphStyle, onChangeGraphStyle, unit, onChangeUnit } = props;
   return (
-    <RadioButtonGroup size="sm" options={ALL_GRAPH_STYLE_OPTIONS} value={graphStyle} onChange={onChangeGraphStyle} />
+    <>
+      <UnitPicker value={unit} onChange={onChangeUnit} placeholder="Unit" />
+      <RadioButtonGroup size="sm" options={ALL_GRAPH_STYLE_OPTIONS} value={graphStyle} onChange={onChangeGraphStyle} />
+    </>
   );
 }

--- a/public/app/features/explore/Graph/ExploreGraphLabel.tsx
+++ b/public/app/features/explore/Graph/ExploreGraphLabel.tsx
@@ -20,7 +20,11 @@ export function ExploreGraphLabel(props: Props) {
   const { graphStyle, onChangeGraphStyle, unit, onChangeUnit } = props;
   return (
     <>
-      <UnitPicker value={unit} onChange={onChangeUnit} placeholder={t('explore.graph-label.unit-placeholder', 'Unit')} />
+      <UnitPicker
+        value={unit}
+        onChange={onChangeUnit}
+        placeholder={t('explore.graph-label.unit-placeholder', 'Unit')}
+      />
       <RadioButtonGroup size="sm" options={ALL_GRAPH_STYLE_OPTIONS} value={graphStyle} onChange={onChangeGraphStyle} />
     </>
   );

--- a/public/app/features/explore/Graph/ExploreGraphLabel.tsx
+++ b/public/app/features/explore/Graph/ExploreGraphLabel.tsx
@@ -1,4 +1,5 @@
 import { type SelectableValue } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { RadioButtonGroup, UnitPicker } from '@grafana/ui';
 import { EXPLORE_GRAPH_STYLES, type ExploreGraphStyle } from 'app/types/explore';
 
@@ -19,7 +20,7 @@ export function ExploreGraphLabel(props: Props) {
   const { graphStyle, onChangeGraphStyle, unit, onChangeUnit } = props;
   return (
     <>
-      <UnitPicker value={unit} onChange={onChangeUnit} placeholder="Unit" />
+      <UnitPicker value={unit} onChange={onChangeUnit} placeholder={t('explore.graph-label.unit-placeholder', 'Unit')} />
       <RadioButtonGroup size="sm" options={ALL_GRAPH_STYLE_OPTIONS} value={graphStyle} onChange={onChangeGraphStyle} />
     </>
   );

--- a/public/app/features/explore/Graph/GraphContainer.tsx
+++ b/public/app/features/explore/Graph/GraphContainer.tsx
@@ -1,7 +1,4 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useSelector } from 'react-redux';
-
-import { useDispatch } from 'app/types/store';
 import { useToggle } from 'react-use';
 
 import {
@@ -16,8 +13,8 @@ import {
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { type GraphThresholdsStyleConfig, PanelChrome, type PanelChromeProps } from '@grafana/ui';
-import { type StoreState } from 'app/types/store';
 import { type ExploreGraphStyle } from 'app/types/explore';
+import { type StoreState, useDispatch, useSelector } from 'app/types/store';
 
 import { LimitedDataDisclaimer } from '../LimitedDataDisclaimer';
 import { changePanelState } from '../state/explorePane';

--- a/public/app/features/explore/Graph/GraphContainer.tsx
+++ b/public/app/features/explore/Graph/GraphContainer.tsx
@@ -1,4 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useDispatch } from 'app/types/store';
 import { useToggle } from 'react-use';
 
 import {
@@ -13,9 +16,11 @@ import {
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { type GraphThresholdsStyleConfig, PanelChrome, type PanelChromeProps } from '@grafana/ui';
+import { type StoreState } from 'app/types/store';
 import { type ExploreGraphStyle } from 'app/types/explore';
 
 import { LimitedDataDisclaimer } from '../LimitedDataDisclaimer';
+import { changePanelState } from '../state/explorePane';
 import { storeGraphStyle } from '../state/utils';
 
 import { ExploreGraph } from './ExploreGraph';
@@ -25,6 +30,7 @@ import { loadGraphStyle } from './utils';
 const MAX_NUMBER_OF_TIME_SERIES = 20;
 
 interface Props extends Pick<PanelChromeProps, 'statusMessage'> {
+  exploreId?: string;
   width: number;
   height: number;
   data: DataFrame[];
@@ -41,6 +47,7 @@ interface Props extends Pick<PanelChromeProps, 'statusMessage'> {
 }
 
 export const GraphContainer = ({
+  exploreId,
   data,
   eventBus,
   height,
@@ -56,6 +63,11 @@ export const GraphContainer = ({
   statusMessage,
   queriesChangedIndexAtRun,
 }: Props) => {
+  const dispatch = useDispatch();
+  const unit = useSelector((state: StoreState) =>
+    exploreId ? state.explore.panes[exploreId]?.panelsState?.graph?.unit : undefined
+  );
+
   const [showAllSeries, toggleShowAllSeries] = useToggle(false);
   const [graphStyle, setGraphStyle] = useState(loadGraphStyle);
 
@@ -63,6 +75,15 @@ export const GraphContainer = ({
     storeGraphStyle(graphStyle);
     setGraphStyle(graphStyle);
   }, []);
+
+  const onChangeUnit = useCallback(
+    (unit: string | undefined) => {
+      if (exploreId) {
+        dispatch(changePanelState(exploreId, 'graph', { unit }));
+      }
+    },
+    [dispatch, exploreId]
+  );
 
   const slicedData = useMemo(() => {
     return showAllSeries ? data : data.slice(0, MAX_NUMBER_OF_TIME_SERIES);
@@ -93,11 +114,19 @@ export const GraphContainer = ({
       height={height}
       loadingState={loadingState}
       statusMessage={statusMessage}
-      actions={<ExploreGraphLabel graphStyle={graphStyle} onChangeGraphStyle={onGraphStyleChange} />}
+      actions={
+        <ExploreGraphLabel
+          graphStyle={graphStyle}
+          onChangeGraphStyle={onGraphStyleChange}
+          unit={unit}
+          onChangeUnit={onChangeUnit}
+        />
+      }
     >
       {(innerWidth, innerHeight) => (
         <ExploreGraph
           graphStyle={graphStyle}
+          unit={unit}
           data={slicedData}
           height={innerHeight}
           width={innerWidth}

--- a/public/app/features/explore/Table/TableContainer.test.tsx
+++ b/public/app/features/explore/Table/TableContainer.test.tsx
@@ -44,6 +44,7 @@ const defaultProps = {
   splitOpenFn: () => {},
   range: getDefaultTimeRange(),
   timeZone: InternalTimeZones.utc,
+  graphUnit: undefined,
 };
 
 describe('TableContainer', () => {

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -52,6 +52,7 @@ function mapStateToProps(state: StoreState, { exploreId }: TableContainerProps) 
     loading,
     tableResult,
     range,
+    graphUnit: item.panelsState?.graph?.unit,
     queryStreaming: item.queryResponse.state === LoadingState.Streaming || Boolean(hasTempoStreamingProgressTable),
   };
 }
@@ -69,6 +70,7 @@ export const TableContainer = memo(function TableContainer({
   timeZone,
   eventBus,
   queryStreaming = false,
+  graphUnit,
 }: Props) {
   const theme = useTheme2();
   const [showAll, setShowAll] = useState(false);
@@ -139,7 +141,7 @@ export const TableContainer = memo(function TableContainer({
       theme: config.theme2,
       replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
       fieldConfig: {
-        defaults: {},
+        defaults: graphUnit ? { unit: graphUnit } : {},
         overrides: [],
       },
       dataLinkPostProcessor,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8454,6 +8454,9 @@
     "get-matches-metadata": {
       "matches": "0 matches"
     },
+    "graph-label": {
+      "unit-placeholder": "Unit"
+    },
     "legacy-create-span-link-factory": {
       "text": {
         "tags": "Tags"


### PR DESCRIPTION
This introduces a new drop-down option to the graph panel in Explore, to let you select a unit.

Quite often, I end up using Explore to look through memory usage and similar, and having numbers in the billions pop up is not particularly useful to me. This enables us to change the unit to e.g. `Bytes (IEC)`. By default, no change happens; if you choose a unit, however, you will from then on see that unit in the graph.

<img width="2535" height="1266" alt="image" src="https://github.com/user-attachments/assets/4e16aa6c-a412-418f-8d71-78d8bc00a294" />

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
