### PR TITLE
Provisioning: Fix selective export quota counting whole namespace

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -106,7 +106,7 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 		return fmt.Errorf("create clients: %w", err)
 	}
 
-	if err := checkExportQuota(ctx, cfg, r.resourceLister, clients); err != nil {
+	if err := checkExportQuota(ctx, cfg, *options, r.resourceLister, clients); err != nil {
 		progress.Complete(ctx, err)
 		return err
 	}
@@ -166,7 +166,7 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 	return nil
 }
 
-func checkExportQuota(ctx context.Context, cfg *provisioning.Repository, lister resources.ResourceLister, clients resources.ResourceClients) error {
+func checkExportQuota(ctx context.Context, cfg *provisioning.Repository, options provisioning.ExportJobOptions, lister resources.ResourceLister, clients resources.ResourceClients) error {
 	quota := cfg.Status.Quota
 	if quota.MaxResourcesPerRepository == 0 {
 		return nil
@@ -174,14 +174,24 @@ func checkExportQuota(ctx context.Context, cfg *provisioning.Repository, lister 
 
 	usage := quotas.NewQuotaUsageFromStats(cfg.Status.Stats)
 
-	stats, err := lister.Stats(ctx, cfg.Namespace, "")
-	if err != nil {
-		return fmt.Errorf("get resource stats for quota check: %w", err)
-	}
+	var netChange int64
+	if len(options.Resources) > 0 {
+		// A selective export only writes the explicitly listed resources, so the
+		// net change is bounded by that list — not every unmanaged resource in
+		// the namespace. Counting the whole namespace here would reject exports
+		// whose actual selection stays well within quota.
+		netChange = int64(len(options.Resources))
+	} else {
+		// A full export takes over every unmanaged resource in the namespace.
+		stats, err := lister.Stats(ctx, cfg.Namespace, "")
+		if err != nil {
+			return fmt.Errorf("get resource stats for quota check: %w", err)
+		}
 
-	netChange, err := countSupportedResources(ctx, stats.Unmanaged, clients)
-	if err != nil {
-		return err
+		netChange, err = countSupportedResources(ctx, stats.Unmanaged, clients)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !quotas.WouldStayWithinQuota(quota, usage, netChange) {

--- a/pkg/registry/apis/provisioning/jobs/export/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker_test.go
@@ -909,6 +909,7 @@ func TestCheckExportQuota(t *testing.T) {
 		repoName    string
 		quota       v0alpha1.QuotaStatus
 		repoStats   []v0alpha1.ResourceCount
+		options     v0alpha1.ExportJobOptions
 		listerStats *v0alpha1.ResourceStats
 		expectError bool
 	}{
@@ -1018,6 +1019,46 @@ func TestCheckExportQuota(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			// Regression: a selective export must only count the resources it
+			// actually writes, not every unmanaged resource in the namespace.
+			name:     "selective export counts only listed resources, not whole namespace",
+			repoName: "test-repo",
+			quota: v0alpha1.QuotaStatus{
+				MaxResourcesPerRepository: 1000,
+			},
+			repoStats: []v0alpha1.ResourceCount{
+				{Group: "dashboard.grafana.app", Resource: "dashboards", Count: 30},
+			},
+			options: v0alpha1.ExportJobOptions{
+				Resources: []v0alpha1.ResourceRef{
+					{Group: "dashboard.grafana.app", Kind: "Dashboard", Name: "a"},
+					{Group: "dashboard.grafana.app", Kind: "Dashboard", Name: "b"},
+				},
+			},
+			// The namespace has far more unmanaged resources than the quota, but
+			// the lister must not be consulted for a selective export.
+			listerStats: nil,
+			expectError: false,
+		},
+		{
+			name:     "selective export exceeding quota via listed resources blocks export",
+			repoName: "test-repo",
+			quota: v0alpha1.QuotaStatus{
+				MaxResourcesPerRepository: 3,
+			},
+			repoStats: []v0alpha1.ResourceCount{
+				{Group: "dashboard.grafana.app", Resource: "dashboards", Count: 2},
+			},
+			options: v0alpha1.ExportJobOptions{
+				Resources: []v0alpha1.ResourceRef{
+					{Group: "dashboard.grafana.app", Kind: "Dashboard", Name: "a"},
+					{Group: "dashboard.grafana.app", Kind: "Dashboard", Name: "b"},
+				},
+			},
+			listerStats: nil,
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1042,7 +1083,7 @@ func TestCheckExportQuota(t *testing.T) {
 
 			mockClients := newSupportedResourceClients(t)
 
-			err := checkExportQuota(context.Background(), cfg, lister, mockClients)
+			err := checkExportQuota(context.Background(), cfg, tt.options, lister, mockClients)
 			if tt.expectError {
 				require.Error(t, err)
 				var quotaErr *quotas.QuotaExceededError


### PR DESCRIPTION
## What

Fixes selective provisioning exports being rejected by the repository quota check when the namespace contains many unmanaged resources. `checkExportQuota` now counts only the resources a selective export actually writes, instead of every unmanaged resource in the namespace.

## Why

A selective export failed with errors like:

```
"message": "export resources: export would exceed quota: 1371/1000 resources"
```

even though the selection itself was tiny (e.g. a couple of dashboards). `1371` is the total number of **unmanaged** resources in the whole namespace — not what the selective export writes.

`checkExportQuota` (`pkg/registry/apis/provisioning/jobs/export/worker.go`) always assumed a *full* export: it listed the whole namespace via `lister.Stats(...)` and treated every unmanaged supported resource (`stats.Unmanaged`) as the net change against the quota. But a selective export (`ExportJobOptions.Resources` non-empty) only writes the explicitly listed resources via `ExportSpecificResources`, so the check over-counted and blocked exports that stayed well within quota.

## How

`checkExportQuota` now takes `ExportJobOptions` and branches on export mode:

- **Selective export** (`len(options.Resources) > 0`): net change is bounded by `len(options.Resources)`; the namespace lister is not consulted.
- **Full export** (empty `Resources`, legacy behavior): unchanged — still counts unmanaged namespace resources.

### Testing

- `go test ./pkg/registry/apis/provisioning/jobs/export/` — passes.
- Added regression cases to `TestCheckExportQuota`:
  - selective export within quota passes without consulting the lister (namespace has far more unmanaged resources than the quota);
  - selective export whose listed resources exceed quota is still blocked.
- `gofmt` clean, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)