### PR TITLE
Plugins: Clarify mandatory fields in plugin.json metadata schema

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -19,7 +19,7 @@
     },
     "info": {
       "type": "object",
-      "description": "Metadata for the plugin. Some fields are used on the plugins page in Grafana and others on grafana.com if the plugin is published.",
+      "description": "Metadata for the plugin. **Some fields are mandatory**, since they're used on the plugins page in Grafana and/or on grafana.com if the plugin is published. Read the [info section](#info) in detail.",
       "required": ["logos", "version", "updated", "keywords"],
       "additionalProperties": false,
       "properties": {
@@ -46,7 +46,7 @@
         },
         "build": {
           "type": "object",
-          "description": "Build information",
+          "description": "Build information.",
           "additionalProperties": false,
           "properties": {
             "time": {
@@ -93,7 +93,7 @@
         },
         "links": {
           "type": "array",
-          "description": "An array of link objects to be displayed on this plugin's project page in the form `{name: 'foo', url: 'http://example.com'}`",
+          "description": "An array of link objects to be displayed on this plugin's project page in the form `{name: 'foo', url: 'http://example.com'}`. **This field is mandatory**. If you leave this field blank, you'll be asked to submit your plugin again.",
           "items": {
             "type": "object",
             "additionalProperties": false,
@@ -133,7 +133,7 @@
         },
         "screenshots": {
           "type": "array",
-          "description": "An array of screenshot objects in the form `{name: 'bar', path: 'img/screenshot.png'}`",
+          "description": "An array of screenshot objects in the form `{name: 'bar', path: 'img/screenshot.png'}`.",
           "items": {
             "type": "object",
             "additionalProperties": false,
@@ -255,7 +255,7 @@
     },
     "enterpriseFeatures": {
       "type": "object",
-      "description": "Grafana Enterprise specific features",
+      "description": "Features specific to Grafana Enterprise.",
       "additionalProperties": true,
       "properties": {
         "healthDiagnosticsErrors": {
@@ -732,7 +732,7 @@
     },
     "languages": {
       "type": "array",
-      "description": "The list of languages supported by the plugin. Each entry should be a locale identifier in the format `language-COUNTRY` (for example `en-US`, `es-ES`, `de-DE`).",
+      "description": "The list of languages supported by the plugin. Each entry should be a locale identifier in the format `language-COUNTRY`, for example `en-US`, `es-ES`, or `de-DE`.",
       "items": {
         "type": "string"
       }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Clarifies and corrects several `description` fields in the plugin.json schema:

- `info` — notes that some fields are mandatory and points readers to the info section.
- `info.links` — states the field is mandatory and explains that leaving it blank
  results in the plugin being sent back for resubmission.
- `info.build`, `info.screenshots` — minor punctuation fixes (trailing periods).
- `enterpriseFeatures`, `languages` — small wording improvements for clarity.

**Why do we need this feature?**

The documentation should stress more strongly that `info.links` are expected/required, so plugin authors don't have their submissions sent back for missing them.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
