### PR TITLE
Provisioning: Show job errors in Migrate to GitOps drawer

### DIFF
--- a/public/app/features/provisioning/Migrate/MigrateDrawer.test.tsx
+++ b/public/app/features/provisioning/Migrate/MigrateDrawer.test.tsx
@@ -148,6 +148,32 @@ describe('MigrateDrawer', () => {
     await waitFor(() => expect(onMigrated).toHaveBeenCalledTimes(1));
   });
 
+  it('surfaces the error message when the migration job fails', async () => {
+    mockCreateJob(createJob());
+    mockJobList(createJob());
+
+    const { user } = render(
+      <MigrateDrawer selective={false} repos={[makeRepo('repo-1', 'My only repo')]} onDismiss={jest.fn()} />
+    );
+    await user.click(screen.getByRole('button', { name: /migrate everything/i }));
+
+    expect(await screen.findByText('Pulling...')).toBeInTheDocument();
+
+    act(() => {
+      getMockLiveSrv().emitWatchEvent('jobs', {
+        type: 'MODIFIED',
+        object: createJob({
+          status: { state: 'error', message: 'export would exceed quota: 1371/1000 resources' },
+        }),
+      });
+    });
+
+    // The failure reason must be visible directly, not hidden behind "View details".
+    expect(await screen.findByText(/export would exceed quota: 1371\/1000 resources/i)).toBeInTheDocument();
+    // Retry is rendered via Alert's buttonContent/onRemove, not as a standard named button.
+    expect((await screen.findByText('Retry')).closest('button')).not.toBeNull();
+  });
+
   describe('selective migration', () => {
     const resources = [
       { name: 'dash-1', group: 'dashboard.grafana.app', kind: 'Dashboard' },

--- a/public/app/features/provisioning/Migrate/MigrateDrawer.tsx
+++ b/public/app/features/provisioning/Migrate/MigrateDrawer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { t, Trans } from '@grafana/i18n';
 import { Alert, Button, Combobox, type ComboboxOption, Drawer, Field, Stack, Text } from '@grafana/ui';
@@ -6,6 +6,7 @@ import { type Repository, type ResourceRef } from 'app/api/clients/provisioning/
 
 import { JobStatus } from '../Job/JobStatus';
 import { GitSyncLimitationsAlert } from '../Shared/GitSyncLimitationsAlert';
+import { ProvisioningAlert } from '../Shared/ProvisioningAlert';
 import { useSyncJob } from '../Wizard/hooks/useSyncJob';
 import { type StepStatusInfo } from '../Wizard/types';
 
@@ -65,6 +66,10 @@ export function MigrateDrawer({ repos, onDismiss, onMigrated, selective, resourc
 
   const { job, startJob, isLoading } = useSyncJob({ repoName: selectedRepo ?? '' });
   const migratedRef = useRef(false);
+  // Track the job's reported status so the drawer can surface errors/warnings.
+  // Unlike the wizard, the drawer has no step-status chrome to render them, so
+  // it renders the alert itself from the latest status reported by JobStatus.
+  const [stepStatusInfo, setStepStatusInfo] = useState<StepStatusInfo>({ status: 'idle' });
 
   // Migration writes directly to the repository's configured branch (the
   // `write` workflow). A repository that only opens pull requests (`branch`
@@ -73,29 +78,37 @@ export function MigrateDrawer({ repos, onDismiss, onMigrated, selective, resourc
   const canPushToConfiguredBranch = selectedRepoObj?.spec?.workflows?.includes('write') ?? false;
   const blockedByWorkflow = Boolean(selectedRepo) && !canPushToConfiguredBranch;
 
-  const startMigration = async () => {
+  const startMigration = useCallback(async () => {
     if (!selectedRepo || !hasResourcesToMigrate) {
       return;
     }
     await startJob(true, isSelective ? { resources } : undefined);
-  };
+  }, [selectedRepo, hasResourcesToMigrate, startJob, isSelective, resources]);
 
   // Start a fresh job and let it replace the current one once created. We avoid
   // clearing `job` first so the drawer doesn't flash back to the setup form.
-  const retryMigration = () => {
+  const retryMigration = useCallback(() => {
     migratedRef.current = false;
+    setStepStatusInfo({ status: 'idle' });
     void startMigration();
-  };
+  }, [startMigration]);
 
-  // JobStatus reports status changes as it polls; notify the caller once the
+  // JobStatus reports status changes as it polls. Keep the latest status so the
+  // drawer can render error/warning alerts, and notify the caller once the
   // migration succeeds so it can refresh resource stats (the job invalidates
   // them server-side, but we trigger an explicit refetch to be safe).
-  const handleStatusChange = (info: StepStatusInfo) => {
-    if (info.status === 'success' && !migratedRef.current) {
-      migratedRef.current = true;
-      onMigrated?.();
-    }
-  };
+  // Memoized so its identity is stable — JobContent re-runs its status effect
+  // whenever this callback changes, so an unstable one would loop.
+  const handleStatusChange = useCallback(
+    (info: StepStatusInfo) => {
+      setStepStatusInfo(info);
+      if (info.status === 'success' && !migratedRef.current) {
+        migratedRef.current = true;
+        onMigrated?.();
+      }
+    },
+    [onMigrated]
+  );
 
   const title = t('provisioning.migrate.drawer-title', 'Migrate to GitOps');
 
@@ -103,7 +116,18 @@ export function MigrateDrawer({ repos, onDismiss, onMigrated, selective, resourc
   if (job) {
     return (
       <Drawer title={title} onClose={onDismiss}>
-        <JobStatus watch={job} jobType="sync" onStatusChange={handleStatusChange} onRetry={retryMigration} />
+        <Stack direction="column" gap={2}>
+          {stepStatusInfo.status === 'error' && (
+            <ProvisioningAlert error={stepStatusInfo.error} action={stepStatusInfo.action} />
+          )}
+          {'warning' in stepStatusInfo && stepStatusInfo.warning && (
+            <ProvisioningAlert
+              warning={stepStatusInfo.warning}
+              action={stepStatusInfo.status === 'warning' ? stepStatusInfo.action : undefined}
+            />
+          )}
+          <JobStatus watch={job} jobType="sync" onStatusChange={handleStatusChange} onRetry={retryMigration} />
+        </Stack>
       </Drawer>
     );
   }


### PR DESCRIPTION
## Summary

When a migration job fails in the **Migrate to GitOps** drawer, the drawer only showed a collapsed **"View details"** JSON dump — the actual failure reason (e.g. `export would exceed quota: 1371/1000 resources`) was buried in raw JSON and easy to miss.

Job error display is routed through the `onStatusChange` callback rather than rendered by `JobContent` directly. The **wizard** consumes this and renders a `ProvisioningAlert` from its step-status chrome, but `MigrateDrawer.handleStatusChange` only handled the `success` case and dropped `error`/`warning` — so on failure nothing surfaced the message.

## Changes

- `MigrateDrawer`: track the latest `StepStatusInfo` in state and render `ProvisioningAlert` for `error`/`warning` states above `JobStatus`, mirroring what the wizard does (including the **Retry** action).
- Memoized `handleStatusChange`, `retryMigration`, and `startMigration` with `useCallback`. Once the status handler calls `setState` unconditionally (including for the `running` state), an unstable callback identity makes `JobContent`'s status `useEffect` re-fire every render → infinite update loop. The wizard avoids this because its callbacks are already stable; the drawer's weren't.

The user now sees the human-readable error prominently, with the raw-JSON "View details" collapse still available below for debugging.

## Testing

- Added `surfaces the error message when the migration job fails` — emits an error watch event and asserts the message and Retry action are visible directly (not hidden behind "View details").
- All 11 `MigrateDrawer` tests pass.
- `yarn typecheck`, `eslint`, and `prettier` all clean.

Frontend-only change (no backend changes), consistent with the FE/BE separate-PR guidance.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes
- [ ] Release notes / docs (not needed — bugfix, no user-facing config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)