### PR TITLE
nats: add token-exchange audience for the us-nats auth callout

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -193,11 +193,6 @@ subscriber_credentials_file =
 # taken from [grpc_client_authentication] (token_exchange_url, token, token_namespace). Precedence:
 # credentials_file > token_exchange_audiences > token.
 token_exchange_audiences =
-# Per-role audiences let the publisher and subscriber connections mint tokens scoped to distinct audiences, so an
-# auth-callout service can derive least-privilege permissions from the token's audience rather than a client hint.
-# Each falls back to token_exchange_audiences when empty.
-publisher_token_exchange_audiences =
-subscriber_token_exchange_audiences =
 
 #################################### Grafana API server (Kubernetes-style APIs) #########################
 [grafana-apiserver]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -187,6 +187,18 @@ credentials_file =
 publisher_credentials_file =
 subscriber_credentials_file =
 
+# Alternatively, mint a short-lived authlib access token per (re)connect and present it as the connect token,
+# so an external auth-callout service can verify it and grant least-privilege permissions from its claims.
+# Set token_exchange_audiences (comma-separated) to turn this on; the exchange endpoint and bootstrap token are
+# taken from [grpc_client_authentication] (token_exchange_url, token, token_namespace). Precedence:
+# credentials_file > token_exchange_audiences > token.
+token_exchange_audiences =
+# Per-role audiences let the publisher and subscriber connections mint tokens scoped to distinct audiences, so an
+# auth-callout service can derive least-privilege permissions from the token's audience rather than a client hint.
+# Each falls back to token_exchange_audiences when empty.
+publisher_token_exchange_audiences =
+subscriber_token_exchange_audiences =
+
 #################################### Grafana API server (Kubernetes-style APIs) #########################
 [grafana-apiserver]
 # Comma-separated list of group/version entries. For each entry, discovery uses that version as the

--- a/pkg/infra/nats/config.go
+++ b/pkg/infra/nats/config.go
@@ -52,35 +52,21 @@ func (c *Config) TLS() setting.NATSTLSSettings { return c.cfg.TLS }
 // Token returns the shared auth token, if any.
 func (c *Config) Token() string { return c.cfg.Auth.Token }
 
-// audiencesFor returns the token-exchange audiences a role's connection should
-// request. Per-role audiences let the auth-callout service derive least-privilege
-// permissions from the token itself rather than a client-supplied hint.
-func (c *Config) audiencesFor(role connRole) []string {
-	switch role {
-	case rolePublisher:
-		return c.cfg.Auth.PublisherAudiences()
-	case roleSubscriber:
-		return c.cfg.Auth.SubscriberAudiences()
-	default:
-		return c.cfg.Auth.TokenExchangeAudiences
-	}
+// TokenExchangeConfigured reports whether a connection should present a minted
+// access token: the exchanger was built successfully and at least one audience is
+// configured to request.
+func (c *Config) TokenExchangeConfigured() bool {
+	return c.tokenExchanger != nil && len(c.cfg.Auth.TokenExchangeAudiences) > 0
 }
 
-// TokenExchangeConfiguredFor reports whether the given role's connection should
-// present a minted access token: the exchanger was built successfully and the
-// role resolves to at least one audience to request.
-func (c *Config) TokenExchangeConfiguredFor(role connRole) bool {
-	return c.tokenExchanger != nil && len(c.audiencesFor(role)) > 0
-}
-
-// exchangeAccessToken mints a fresh access token scoped to the given role's
+// exchangeAccessToken mints a fresh access token scoped to the configured
 // audiences. Callers present the returned token as the NATS connect token; an
-// external auth-callout service verifies it and derives the connection's
-// permissions from the token's audience.
-func (c *Config) exchangeAccessToken(ctx context.Context, role connRole) (string, error) {
+// external auth-callout service verifies it and grants the connection's
+// permissions.
+func (c *Config) exchangeAccessToken(ctx context.Context) (string, error) {
 	resp, err := c.tokenExchanger.Exchange(ctx, authnlib.TokenExchangeRequest{
 		Namespace: c.cfg.Auth.TokenExchangeNamespace,
-		Audiences: c.audiencesFor(role),
+		Audiences: c.cfg.Auth.TokenExchangeAudiences,
 	})
 	if err != nil {
 		return "", err

--- a/pkg/infra/nats/config.go
+++ b/pkg/infra/nats/config.go
@@ -1,6 +1,9 @@
 package nats
 
 import (
+	"context"
+
+	authnlib "github.com/grafana/authlib/authn"
 	natsclient "github.com/nats-io/nats.go"
 
 	"github.com/grafana/grafana/pkg/setting"
@@ -12,13 +15,26 @@ import (
 type Config struct {
 	cfg    setting.NATSSettings
 	server *Server
+	// tokenExchanger is non-nil only when token-exchange auth is configured; it
+	// mints the short-lived access token each connection presents. The authlib
+	// client caches tokens internally, so exchanging per (re)connect is cheap.
+	tokenExchanger authnlib.TokenExchanger
 }
 
 func newConfig(cfg setting.NATSSettings, server *Server) *Config {
-	return &Config{
+	c := &Config{
 		cfg:    cfg,
 		server: server,
 	}
+	if cfg.Auth.TokenExchangeEnabled() {
+		// NewTokenExchangeClient only errors when the token or URL is empty, and
+		// TokenExchangeEnabled has already established both are set.
+		c.tokenExchanger, _ = authnlib.NewTokenExchangeClient(authnlib.TokenExchangeConfig{
+			Token:            cfg.Auth.TokenExchangeToken,
+			TokenExchangeURL: cfg.Auth.TokenExchangeURL,
+		})
+	}
+	return c
 }
 
 // ProvideNATSConfig builds the shared connection config from configuration and
@@ -35,6 +51,42 @@ func (c *Config) TLS() setting.NATSTLSSettings { return c.cfg.TLS }
 
 // Token returns the shared auth token, if any.
 func (c *Config) Token() string { return c.cfg.Auth.Token }
+
+// audiencesFor returns the token-exchange audiences a role's connection should
+// request. Per-role audiences let the auth-callout service derive least-privilege
+// permissions from the token itself rather than a client-supplied hint.
+func (c *Config) audiencesFor(role connRole) []string {
+	switch role {
+	case rolePublisher:
+		return c.cfg.Auth.PublisherAudiences()
+	case roleSubscriber:
+		return c.cfg.Auth.SubscriberAudiences()
+	default:
+		return c.cfg.Auth.TokenExchangeAudiences
+	}
+}
+
+// TokenExchangeConfiguredFor reports whether the given role's connection should
+// present a minted access token: the exchanger was built successfully and the
+// role resolves to at least one audience to request.
+func (c *Config) TokenExchangeConfiguredFor(role connRole) bool {
+	return c.tokenExchanger != nil && len(c.audiencesFor(role)) > 0
+}
+
+// exchangeAccessToken mints a fresh access token scoped to the given role's
+// audiences. Callers present the returned token as the NATS connect token; an
+// external auth-callout service verifies it and derives the connection's
+// permissions from the token's audience.
+func (c *Config) exchangeAccessToken(ctx context.Context, role connRole) (string, error) {
+	resp, err := c.tokenExchanger.Exchange(ctx, authnlib.TokenExchangeRequest{
+		Namespace: c.cfg.Auth.TokenExchangeNamespace,
+		Audiences: c.audiencesFor(role),
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Token, nil
+}
 
 // PublisherCredentials returns the credentials file the publisher connection
 // should use, falling back to the shared credentials when none is set.

--- a/pkg/infra/nats/connection.go
+++ b/pkg/infra/nats/connection.go
@@ -237,7 +237,7 @@ func (c *connection) connectOptions() ([]natsclient.Option, error) {
 	switch creds := c.credentials(); {
 	case creds != "":
 		options = append(options, natsclient.UserCredentials(creds))
-	case c.config.TokenExchangeConfiguredFor(c.role):
+	case c.config.TokenExchangeConfigured():
 		options = append(options, natsclient.TokenHandler(c.tokenHandler))
 	case c.config.Token() != "":
 		options = append(options, natsclient.Token(c.config.Token()))
@@ -253,7 +253,7 @@ func (c *connection) connectOptions() ([]natsclient.Option, error) {
 func (c *connection) tokenHandler() string {
 	ctx, cancel := context.WithTimeout(context.Background(), tokenExchangeTimeout)
 	defer cancel()
-	token, err := c.config.exchangeAccessToken(ctx, c.role)
+	token, err := c.config.exchangeAccessToken(ctx)
 	if err != nil {
 		c.log.Error("nats access-token exchange failed", "role", c.role, "err", err)
 		return ""

--- a/pkg/infra/nats/connection.go
+++ b/pkg/infra/nats/connection.go
@@ -13,6 +13,10 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 )
 
+// tokenExchangeTimeout bounds a single access-token mint so a slow or unreachable
+// signer cannot stall a (re)connect indefinitely.
+const tokenExchangeTimeout = 5 * time.Second
+
 type connRole string
 
 const (
@@ -227,15 +231,34 @@ func (c *connection) connectOptions() ([]natsclient.Option, error) {
 		options = append(options, natsclient.Secure(tc))
 	}
 
-	// Precedence: per-role creds file > shared creds file > token.
+	// Precedence: per-role creds file > shared creds file > exchanged access
+	// token > static token. TokenHandler is invoked on every (re)connect, so the
+	// minted token is always fresh; the authlib client caches it under the hood.
 	switch creds := c.credentials(); {
 	case creds != "":
 		options = append(options, natsclient.UserCredentials(creds))
+	case c.config.TokenExchangeConfiguredFor(c.role):
+		options = append(options, natsclient.TokenHandler(c.tokenHandler))
 	case c.config.Token() != "":
 		options = append(options, natsclient.Token(c.config.Token()))
 	}
 
 	return options, nil
+}
+
+// tokenHandler mints a fresh access token for this connection. It satisfies
+// nats.TokenHandler, which cannot return an error: on failure it logs and
+// returns an empty token, letting the server reject the connect so the client
+// retries rather than silently proceeding unauthenticated.
+func (c *connection) tokenHandler() string {
+	ctx, cancel := context.WithTimeout(context.Background(), tokenExchangeTimeout)
+	defer cancel()
+	token, err := c.config.exchangeAccessToken(ctx, c.role)
+	if err != nil {
+		c.log.Error("nats access-token exchange failed", "role", c.role, "err", err)
+		return ""
+	}
+	return token
 }
 
 // healthy reports whether the connection is usable. It tolerates the lazy state

--- a/pkg/infra/nats/connection_test.go
+++ b/pkg/infra/nats/connection_test.go
@@ -2,6 +2,8 @@ package nats
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,6 +16,17 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 )
+
+// applyOptions resolves a set of nats options into a concrete Options struct so a
+// test can assert which auth mechanism connectOptions selected.
+func applyOptions(t *testing.T, opts []natsclient.Option) *natsclient.Options {
+	t.Helper()
+	var o natsclient.Options
+	for _, opt := range opts {
+		require.NoError(t, opt(&o))
+	}
+	return &o
+}
 
 // newDisabledConnection builds a connection with NATS turned off, for the paths
 // that must short-circuit before any dial.
@@ -183,6 +196,86 @@ func TestConnection(t *testing.T) {
 
 			_, err := c.connectOptions()
 			require.Error(t, err)
+		})
+
+		t.Run("uses a static token when set", func(t *testing.T) {
+			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{Token: "s3cret"}}
+			c := newConnection(rolePublisher, log.NewNopLogger(), newConnectionMetrics(rolePublisher), newConfig(cfg, nil), func() string { return "" })
+
+			opts, err := c.connectOptions()
+			require.NoError(t, err)
+			o := applyOptions(t, opts)
+			require.Equal(t, "s3cret", o.Token)
+			require.Nil(t, o.TokenHandler)
+		})
+
+		t.Run("token exchange registers a token handler over a static token", func(t *testing.T) {
+			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{
+				Token:                  "s3cret",
+				TokenExchangeAudiences: []string{"us-nats"},
+				TokenExchangeURL:       "http://signer/sign",
+				TokenExchangeToken:     "boot-token",
+			}}
+			c := newConnection(rolePublisher, log.NewNopLogger(), newConnectionMetrics(rolePublisher), newConfig(cfg, nil), func() string { return "" })
+
+			opts, err := c.connectOptions()
+			require.NoError(t, err)
+			o := applyOptions(t, opts)
+			// The exchanged token takes precedence: a handler is installed and the
+			// static token is left unset.
+			require.NotNil(t, o.TokenHandler)
+			require.Empty(t, o.Token)
+		})
+
+		t.Run("per-role audiences enable the token handler", func(t *testing.T) {
+			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{
+				PublisherTokenExchangeAudiences: []string{"us-nats-publish"},
+				TokenExchangeURL:                "http://signer/sign",
+				TokenExchangeToken:              "boot-token",
+			}}
+			c := newConnection(rolePublisher, log.NewNopLogger(), newConnectionMetrics(rolePublisher), newConfig(cfg, nil), func() string { return "" })
+
+			opts, err := c.connectOptions()
+			require.NoError(t, err)
+			o := applyOptions(t, opts)
+			require.NotNil(t, o.TokenHandler)
+		})
+
+		t.Run("a role with no resolvable audiences does not register a handler", func(t *testing.T) {
+			// Only the publisher audience is set, so the subscriber connection has
+			// nothing to request and must not present a token.
+			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{
+				PublisherTokenExchangeAudiences: []string{"us-nats-publish"},
+				TokenExchangeURL:                "http://signer/sign",
+				TokenExchangeToken:              "boot-token",
+			}}
+			c := newConnection(roleSubscriber, log.NewNopLogger(), newConnectionMetrics(roleSubscriber), newConfig(cfg, nil), func() string { return "" })
+
+			opts, err := c.connectOptions()
+			require.NoError(t, err)
+			o := applyOptions(t, opts)
+			require.Nil(t, o.TokenHandler)
+		})
+
+		t.Run("credentials file wins over token exchange", func(t *testing.T) {
+			credsFile := filepath.Join(t.TempDir(), "pub.creds")
+			require.NoError(t, os.WriteFile(credsFile, []byte("dummy"), 0o600))
+
+			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{
+				PublisherCredentialsFile: credsFile,
+				TokenExchangeAudiences:   []string{"us-nats"},
+				TokenExchangeURL:         "http://signer/sign",
+				TokenExchangeToken:       "boot-token",
+			}}
+			config := newConfig(cfg, nil)
+			c := newConnection(rolePublisher, log.NewNopLogger(), newConnectionMetrics(rolePublisher), config, config.PublisherCredentials)
+
+			opts, err := c.connectOptions()
+			require.NoError(t, err)
+			o := applyOptions(t, opts)
+			require.NotNil(t, o.UserJWT)
+			require.Nil(t, o.TokenHandler)
+			require.Empty(t, o.Token)
 		})
 	})
 

--- a/pkg/infra/nats/connection_test.go
+++ b/pkg/infra/nats/connection_test.go
@@ -227,36 +227,6 @@ func TestConnection(t *testing.T) {
 			require.Empty(t, o.Token)
 		})
 
-		t.Run("per-role audiences enable the token handler", func(t *testing.T) {
-			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{
-				PublisherTokenExchangeAudiences: []string{"us-nats-publish"},
-				TokenExchangeURL:                "http://signer/sign",
-				TokenExchangeToken:              "boot-token",
-			}}
-			c := newConnection(rolePublisher, log.NewNopLogger(), newConnectionMetrics(rolePublisher), newConfig(cfg, nil), func() string { return "" })
-
-			opts, err := c.connectOptions()
-			require.NoError(t, err)
-			o := applyOptions(t, opts)
-			require.NotNil(t, o.TokenHandler)
-		})
-
-		t.Run("a role with no resolvable audiences does not register a handler", func(t *testing.T) {
-			// Only the publisher audience is set, so the subscriber connection has
-			// nothing to request and must not present a token.
-			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{
-				PublisherTokenExchangeAudiences: []string{"us-nats-publish"},
-				TokenExchangeURL:                "http://signer/sign",
-				TokenExchangeToken:              "boot-token",
-			}}
-			c := newConnection(roleSubscriber, log.NewNopLogger(), newConnectionMetrics(roleSubscriber), newConfig(cfg, nil), func() string { return "" })
-
-			opts, err := c.connectOptions()
-			require.NoError(t, err)
-			o := applyOptions(t, opts)
-			require.Nil(t, o.TokenHandler)
-		})
-
 		t.Run("credentials file wins over token exchange", func(t *testing.T) {
 			credsFile := filepath.Join(t.TempDir(), "pub.creds")
 			require.NoError(t, os.WriteFile(credsFile, []byte("dummy"), 0o600))

--- a/pkg/setting/setting_nats.go
+++ b/pkg/setting/setting_nats.go
@@ -64,15 +64,42 @@ type NATSTLSSettings struct {
 // NATSAuthSettings configures the connection identity. A per-role credentials
 // file lets each role present a least-privilege identity; an empty value falls
 // back to the shared CredentialsFile.
+//
+// When TokenExchangeAudiences is set, the connection instead mints a short-lived
+// authlib access token per (re)connect and presents it as the connect token, so
+// an external auth-callout service can verify it and grant least-privilege
+// permissions from its claims. The exchange endpoint and bootstrap token are
+// shared with the [grpc_client_authentication] section rather than duplicated.
 type NATSAuthSettings struct {
 	Token                     string
 	CredentialsFile           string
 	PublisherCredentialsFile  string
 	SubscriberCredentialsFile string
+
+	// TokenExchangeAudiences are the audiences requested for the minted access
+	// token; a non-empty value (here or in a per-role field) turns token-exchange
+	// auth on. TokenExchangeURL, TokenExchangeToken and TokenExchangeNamespace are
+	// read from [grpc_client_authentication] so a service that already talks to the
+	// cloud signer reuses the same wiring.
+	//
+	// Per-role audiences let each connection mint a token scoped to its role, so an
+	// auth-callout service can derive least-privilege permissions from the token's
+	// audience rather than trusting a client-supplied hint. An empty per-role value
+	// falls back to the shared TokenExchangeAudiences.
+	TokenExchangeAudiences           []string
+	PublisherTokenExchangeAudiences  []string
+	SubscriberTokenExchangeAudiences []string
+	TokenExchangeURL                 string
+	TokenExchangeToken               string
+	TokenExchangeNamespace           string
 }
 
 func readNATSSettings(cfg *Cfg) error {
 	section := cfg.Raw.Section("nats")
+	// Token exchange reuses the cloud client wiring (signer URL + bootstrap token)
+	// that grafana-app services already configure, so the NATS client does not need
+	// its own secret plumbing. Env overrides (GF_GRPC_CLIENT_AUTHENTICATION_*) apply.
+	grpcClient := cfg.SectionWithEnvOverrides("grpc_client_authentication")
 
 	mode := NATSMode(section.Key("mode").MustString(string(NATSModeEmbedded)))
 	switch mode {
@@ -103,10 +130,16 @@ func readNATSSettings(cfg *Cfg) error {
 			InsecureSkipVerify: section.Key("tls_insecure_skip_verify").MustBool(false),
 		},
 		Auth: NATSAuthSettings{
-			Token:                     section.Key("token").MustString(""),
-			CredentialsFile:           section.Key("credentials_file").MustString(""),
-			PublisherCredentialsFile:  section.Key("publisher_credentials_file").MustString(""),
-			SubscriberCredentialsFile: section.Key("subscriber_credentials_file").MustString(""),
+			Token:                            section.Key("token").MustString(""),
+			CredentialsFile:                  section.Key("credentials_file").MustString(""),
+			PublisherCredentialsFile:         section.Key("publisher_credentials_file").MustString(""),
+			SubscriberCredentialsFile:        section.Key("subscriber_credentials_file").MustString(""),
+			TokenExchangeAudiences:           util.SplitString(section.Key("token_exchange_audiences").MustString("")),
+			PublisherTokenExchangeAudiences:  util.SplitString(section.Key("publisher_token_exchange_audiences").MustString("")),
+			SubscriberTokenExchangeAudiences: util.SplitString(section.Key("subscriber_token_exchange_audiences").MustString("")),
+			TokenExchangeURL:                 grpcClient.Key("token_exchange_url").MustString(""),
+			TokenExchangeToken:               grpcClient.Key("token").MustString(""),
+			TokenExchangeNamespace:           grpcClient.Key("token_namespace").MustString("stacks-" + cfg.StackID),
 		},
 	}
 	return nil
@@ -115,6 +148,35 @@ func readNATSSettings(cfg *Cfg) error {
 // Embedded reports whether an in-process Core NATS server should run.
 func (s NATSSettings) Embedded() bool {
 	return s.Mode == NATSModeEmbedded
+}
+
+// TokenExchangeEnabled reports whether the connection should mint short-lived
+// access tokens via authlib token exchange. It needs a target audience (shared or
+// per-role) plus the exchange endpoint and bootstrap token (shared with
+// [grpc_client_authentication]).
+func (a NATSAuthSettings) TokenExchangeEnabled() bool {
+	hasAudience := len(a.TokenExchangeAudiences) > 0 ||
+		len(a.PublisherTokenExchangeAudiences) > 0 ||
+		len(a.SubscriberTokenExchangeAudiences) > 0
+	return hasAudience && a.TokenExchangeURL != "" && a.TokenExchangeToken != ""
+}
+
+// PublisherAudiences returns the audiences the publisher connection requests for
+// its access token, falling back to the shared audiences when no per-role value
+// is set.
+func (a NATSAuthSettings) PublisherAudiences() []string {
+	if len(a.PublisherTokenExchangeAudiences) > 0 {
+		return a.PublisherTokenExchangeAudiences
+	}
+	return a.TokenExchangeAudiences
+}
+
+// SubscriberAudiences returns the audiences the subscriber connection requests.
+func (a NATSAuthSettings) SubscriberAudiences() []string {
+	if len(a.SubscriberTokenExchangeAudiences) > 0 {
+		return a.SubscriberTokenExchangeAudiences
+	}
+	return a.TokenExchangeAudiences
 }
 
 func (a NATSAuthSettings) PublisherCredentials() string {

--- a/pkg/setting/setting_nats.go
+++ b/pkg/setting/setting_nats.go
@@ -77,21 +77,16 @@ type NATSAuthSettings struct {
 	SubscriberCredentialsFile string
 
 	// TokenExchangeAudiences are the audiences requested for the minted access
-	// token; a non-empty value (here or in a per-role field) turns token-exchange
-	// auth on. TokenExchangeURL, TokenExchangeToken and TokenExchangeNamespace are
-	// read from [grpc_client_authentication] so a service that already talks to the
-	// cloud signer reuses the same wiring.
-	//
-	// Per-role audiences let each connection mint a token scoped to its role, so an
-	// auth-callout service can derive least-privilege permissions from the token's
-	// audience rather than trusting a client-supplied hint. An empty per-role value
-	// falls back to the shared TokenExchangeAudiences.
-	TokenExchangeAudiences           []string
-	PublisherTokenExchangeAudiences  []string
-	SubscriberTokenExchangeAudiences []string
-	TokenExchangeURL                 string
-	TokenExchangeToken               string
-	TokenExchangeNamespace           string
+	// token; a non-empty value turns token-exchange auth on. TokenExchangeURL,
+	// TokenExchangeToken and TokenExchangeNamespace are read from
+	// [grpc_client_authentication] so a service that already talks to the cloud
+	// signer reuses the same wiring. The publisher and subscriber connections
+	// request the same audience: the auth-callout service authorizes on the
+	// verified token, not on a per-role audience.
+	TokenExchangeAudiences []string
+	TokenExchangeURL       string
+	TokenExchangeToken     string
+	TokenExchangeNamespace string
 }
 
 func readNATSSettings(cfg *Cfg) error {
@@ -130,16 +125,14 @@ func readNATSSettings(cfg *Cfg) error {
 			InsecureSkipVerify: section.Key("tls_insecure_skip_verify").MustBool(false),
 		},
 		Auth: NATSAuthSettings{
-			Token:                            section.Key("token").MustString(""),
-			CredentialsFile:                  section.Key("credentials_file").MustString(""),
-			PublisherCredentialsFile:         section.Key("publisher_credentials_file").MustString(""),
-			SubscriberCredentialsFile:        section.Key("subscriber_credentials_file").MustString(""),
-			TokenExchangeAudiences:           util.SplitString(section.Key("token_exchange_audiences").MustString("")),
-			PublisherTokenExchangeAudiences:  util.SplitString(section.Key("publisher_token_exchange_audiences").MustString("")),
-			SubscriberTokenExchangeAudiences: util.SplitString(section.Key("subscriber_token_exchange_audiences").MustString("")),
-			TokenExchangeURL:                 grpcClient.Key("token_exchange_url").MustString(""),
-			TokenExchangeToken:               grpcClient.Key("token").MustString(""),
-			TokenExchangeNamespace:           grpcClient.Key("token_namespace").MustString("stacks-" + cfg.StackID),
+			Token:                     section.Key("token").MustString(""),
+			CredentialsFile:           section.Key("credentials_file").MustString(""),
+			PublisherCredentialsFile:  section.Key("publisher_credentials_file").MustString(""),
+			SubscriberCredentialsFile: section.Key("subscriber_credentials_file").MustString(""),
+			TokenExchangeAudiences:    util.SplitString(section.Key("token_exchange_audiences").MustString("")),
+			TokenExchangeURL:          grpcClient.Key("token_exchange_url").MustString(""),
+			TokenExchangeToken:        grpcClient.Key("token").MustString(""),
+			TokenExchangeNamespace:    grpcClient.Key("token_namespace").MustString("stacks-" + cfg.StackID),
 		},
 	}
 	return nil
@@ -151,32 +144,10 @@ func (s NATSSettings) Embedded() bool {
 }
 
 // TokenExchangeEnabled reports whether the connection should mint short-lived
-// access tokens via authlib token exchange. It needs a target audience (shared or
-// per-role) plus the exchange endpoint and bootstrap token (shared with
-// [grpc_client_authentication]).
+// access tokens via authlib token exchange. It needs a target audience plus the
+// exchange endpoint and bootstrap token (shared with [grpc_client_authentication]).
 func (a NATSAuthSettings) TokenExchangeEnabled() bool {
-	hasAudience := len(a.TokenExchangeAudiences) > 0 ||
-		len(a.PublisherTokenExchangeAudiences) > 0 ||
-		len(a.SubscriberTokenExchangeAudiences) > 0
-	return hasAudience && a.TokenExchangeURL != "" && a.TokenExchangeToken != ""
-}
-
-// PublisherAudiences returns the audiences the publisher connection requests for
-// its access token, falling back to the shared audiences when no per-role value
-// is set.
-func (a NATSAuthSettings) PublisherAudiences() []string {
-	if len(a.PublisherTokenExchangeAudiences) > 0 {
-		return a.PublisherTokenExchangeAudiences
-	}
-	return a.TokenExchangeAudiences
-}
-
-// SubscriberAudiences returns the audiences the subscriber connection requests.
-func (a NATSAuthSettings) SubscriberAudiences() []string {
-	if len(a.SubscriberTokenExchangeAudiences) > 0 {
-		return a.SubscriberTokenExchangeAudiences
-	}
-	return a.TokenExchangeAudiences
+	return len(a.TokenExchangeAudiences) > 0 && a.TokenExchangeURL != "" && a.TokenExchangeToken != ""
 }
 
 func (a NATSAuthSettings) PublisherCredentials() string {

--- a/pkg/setting/setting_nats_test.go
+++ b/pkg/setting/setting_nats_test.go
@@ -39,8 +39,6 @@ token = s3cret
 publisher_credentials_file = /etc/pub.creds
 subscriber_credentials_file = /etc/sub.creds
 token_exchange_audiences = us-nats, other
-publisher_token_exchange_audiences = us-nats-publish
-subscriber_token_exchange_audiences = us-nats-subscribe
 
 [grpc_client_authentication]
 token = boot-token
@@ -65,10 +63,6 @@ token_namespace = *
 		// Token exchange: audiences come from [nats]; endpoint/token/namespace are
 		// shared with [grpc_client_authentication].
 		require.Equal(t, []string{"us-nats", "other"}, cfg.NATS.Auth.TokenExchangeAudiences)
-		require.Equal(t, []string{"us-nats-publish"}, cfg.NATS.Auth.PublisherTokenExchangeAudiences)
-		require.Equal(t, []string{"us-nats-subscribe"}, cfg.NATS.Auth.SubscriberTokenExchangeAudiences)
-		require.Equal(t, []string{"us-nats-publish"}, cfg.NATS.Auth.PublisherAudiences())
-		require.Equal(t, []string{"us-nats-subscribe"}, cfg.NATS.Auth.SubscriberAudiences())
 		require.Equal(t, "http://signer/sign", cfg.NATS.Auth.TokenExchangeURL)
 		require.Equal(t, "boot-token", cfg.NATS.Auth.TokenExchangeToken)
 		require.Equal(t, "*", cfg.NATS.Auth.TokenExchangeNamespace)
@@ -123,36 +117,6 @@ func TestNATSAuthCredentialsPrecedence(t *testing.T) {
 	})
 }
 
-func TestNATSAuthAudiences(t *testing.T) {
-	t.Run("per-role overrides shared", func(t *testing.T) {
-		a := NATSAuthSettings{
-			TokenExchangeAudiences:          []string{"shared"},
-			PublisherTokenExchangeAudiences: []string{"us-nats-publish"},
-		}
-		require.Equal(t, []string{"us-nats-publish"}, a.PublisherAudiences())
-	})
-
-	t.Run("falls back to shared audiences", func(t *testing.T) {
-		a := NATSAuthSettings{TokenExchangeAudiences: []string{"shared"}}
-		require.Equal(t, []string{"shared"}, a.PublisherAudiences())
-		require.Equal(t, []string{"shared"}, a.SubscriberAudiences())
-	})
-
-	t.Run("subscriber per-role overrides shared", func(t *testing.T) {
-		a := NATSAuthSettings{
-			TokenExchangeAudiences:           []string{"shared"},
-			SubscriberTokenExchangeAudiences: []string{"us-nats-subscribe"},
-		}
-		require.Equal(t, []string{"us-nats-subscribe"}, a.SubscriberAudiences())
-	})
-
-	t.Run("empty when nothing set", func(t *testing.T) {
-		a := NATSAuthSettings{}
-		require.Empty(t, a.PublisherAudiences())
-		require.Empty(t, a.SubscriberAudiences())
-	})
-}
-
 func TestNATSAuthTokenExchangeEnabled(t *testing.T) {
 	base := NATSAuthSettings{
 		TokenExchangeAudiences: []string{"us-nats"},
@@ -162,13 +126,6 @@ func TestNATSAuthTokenExchangeEnabled(t *testing.T) {
 
 	t.Run("enabled when audience, url and token are set", func(t *testing.T) {
 		require.True(t, base.TokenExchangeEnabled())
-	})
-
-	t.Run("enabled via per-role audiences only", func(t *testing.T) {
-		a := base
-		a.TokenExchangeAudiences = nil
-		a.PublisherTokenExchangeAudiences = []string{"us-nats-publish"}
-		require.True(t, a.TokenExchangeEnabled())
 	})
 
 	t.Run("disabled without audiences", func(t *testing.T) {

--- a/pkg/setting/setting_nats_test.go
+++ b/pkg/setting/setting_nats_test.go
@@ -38,6 +38,14 @@ tls_ca_cert_path = /etc/ca.pem
 token = s3cret
 publisher_credentials_file = /etc/pub.creds
 subscriber_credentials_file = /etc/sub.creds
+token_exchange_audiences = us-nats, other
+publisher_token_exchange_audiences = us-nats-publish
+subscriber_token_exchange_audiences = us-nats-subscribe
+
+[grpc_client_authentication]
+token = boot-token
+token_exchange_url = http://signer/sign
+token_namespace = *
 `))
 		require.NoError(t, err)
 		cfg.Raw = f
@@ -53,6 +61,18 @@ subscriber_credentials_file = /etc/sub.creds
 		require.Equal(t, "s3cret", cfg.NATS.Auth.Token)
 		require.Equal(t, "/etc/pub.creds", cfg.NATS.Auth.PublisherCredentialsFile)
 		require.Equal(t, "/etc/sub.creds", cfg.NATS.Auth.SubscriberCredentialsFile)
+
+		// Token exchange: audiences come from [nats]; endpoint/token/namespace are
+		// shared with [grpc_client_authentication].
+		require.Equal(t, []string{"us-nats", "other"}, cfg.NATS.Auth.TokenExchangeAudiences)
+		require.Equal(t, []string{"us-nats-publish"}, cfg.NATS.Auth.PublisherTokenExchangeAudiences)
+		require.Equal(t, []string{"us-nats-subscribe"}, cfg.NATS.Auth.SubscriberTokenExchangeAudiences)
+		require.Equal(t, []string{"us-nats-publish"}, cfg.NATS.Auth.PublisherAudiences())
+		require.Equal(t, []string{"us-nats-subscribe"}, cfg.NATS.Auth.SubscriberAudiences())
+		require.Equal(t, "http://signer/sign", cfg.NATS.Auth.TokenExchangeURL)
+		require.Equal(t, "boot-token", cfg.NATS.Auth.TokenExchangeToken)
+		require.Equal(t, "*", cfg.NATS.Auth.TokenExchangeNamespace)
+		require.True(t, cfg.NATS.Auth.TokenExchangeEnabled())
 	})
 
 	t.Run("rejects invalid mode", func(t *testing.T) {
@@ -100,5 +120,72 @@ func TestNATSAuthCredentialsPrecedence(t *testing.T) {
 	t.Run("subscriber empty when nothing set", func(t *testing.T) {
 		a := NATSAuthSettings{}
 		require.Empty(t, a.SubscriberCredentials())
+	})
+}
+
+func TestNATSAuthAudiences(t *testing.T) {
+	t.Run("per-role overrides shared", func(t *testing.T) {
+		a := NATSAuthSettings{
+			TokenExchangeAudiences:          []string{"shared"},
+			PublisherTokenExchangeAudiences: []string{"us-nats-publish"},
+		}
+		require.Equal(t, []string{"us-nats-publish"}, a.PublisherAudiences())
+	})
+
+	t.Run("falls back to shared audiences", func(t *testing.T) {
+		a := NATSAuthSettings{TokenExchangeAudiences: []string{"shared"}}
+		require.Equal(t, []string{"shared"}, a.PublisherAudiences())
+		require.Equal(t, []string{"shared"}, a.SubscriberAudiences())
+	})
+
+	t.Run("subscriber per-role overrides shared", func(t *testing.T) {
+		a := NATSAuthSettings{
+			TokenExchangeAudiences:           []string{"shared"},
+			SubscriberTokenExchangeAudiences: []string{"us-nats-subscribe"},
+		}
+		require.Equal(t, []string{"us-nats-subscribe"}, a.SubscriberAudiences())
+	})
+
+	t.Run("empty when nothing set", func(t *testing.T) {
+		a := NATSAuthSettings{}
+		require.Empty(t, a.PublisherAudiences())
+		require.Empty(t, a.SubscriberAudiences())
+	})
+}
+
+func TestNATSAuthTokenExchangeEnabled(t *testing.T) {
+	base := NATSAuthSettings{
+		TokenExchangeAudiences: []string{"us-nats"},
+		TokenExchangeURL:       "http://signer/sign",
+		TokenExchangeToken:     "boot-token",
+	}
+
+	t.Run("enabled when audience, url and token are set", func(t *testing.T) {
+		require.True(t, base.TokenExchangeEnabled())
+	})
+
+	t.Run("enabled via per-role audiences only", func(t *testing.T) {
+		a := base
+		a.TokenExchangeAudiences = nil
+		a.PublisherTokenExchangeAudiences = []string{"us-nats-publish"}
+		require.True(t, a.TokenExchangeEnabled())
+	})
+
+	t.Run("disabled without audiences", func(t *testing.T) {
+		a := base
+		a.TokenExchangeAudiences = nil
+		require.False(t, a.TokenExchangeEnabled())
+	})
+
+	t.Run("disabled without exchange url", func(t *testing.T) {
+		a := base
+		a.TokenExchangeURL = ""
+		require.False(t, a.TokenExchangeEnabled())
+	})
+
+	t.Run("disabled without bootstrap token", func(t *testing.T) {
+		a := base
+		a.TokenExchangeToken = ""
+		require.False(t, a.TokenExchangeEnabled())
 	})
 }


### PR DESCRIPTION
Adds `token_exchange_audiences` to `[nats]`: the publisher and subscriber connections each mint a short-lived authlib access token per (re)connect, scoped to that audience, and present it as the NATS connect token. The us-nats auth-callout service verifies the token and derives the connection's NATS permissions from its scopes.

The exchange endpoint and bootstrap token are reused from `[grpc_client_authentication]`, so no new secret plumbing is needed. Client precedence: credentials file > token exchange > static token.
