### PR TITLE
Provisioning: normalize folder titles into safe export paths

### DIFF
--- a/apps/provisioning/pkg/safepath/safe.go
+++ b/apps/provisioning/pkg/safepath/safe.go
@@ -77,6 +77,34 @@ func IsSafe(path string) error {
 	return nil
 }
 
+// SanitizeSegment converts an arbitrary folder title into a single path segment
+// that satisfies IsSafe. Characters outside the allowed set ([a-zA-Z0-9 _.-])
+// are dropped, and leading/trailing spaces and dots are trimmed so the result
+// is neither a hidden path (leading dot) nor a traversal token ("." / "..").
+// The result never contains a path separator, so a title always maps to exactly
+// one directory level. When no usable characters remain (e.g. a title made up
+// entirely of unsupported symbols), fallback is returned so the segment is
+// always non-empty.
+func SanitizeSegment(title, fallback string) string {
+	var b strings.Builder
+	b.Grow(len(title))
+	for _, r := range title {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == ' ', r == '_', r == '.', r == '-':
+			b.WriteRune(r)
+		}
+	}
+
+	cleaned := strings.Trim(b.String(), " .")
+	if cleaned == "" {
+		return fallback
+	}
+	return cleaned
+}
+
 // SafeSegment returns a safe part of the path
 // It ensures the path is free from traversal attempts, hidden files,
 // and other potentially dangerous patterns.

--- a/apps/provisioning/pkg/safepath/safe_test.go
+++ b/apps/provisioning/pkg/safepath/safe_test.go
@@ -24,6 +24,21 @@ func TestIsSafe(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name:    "directory with a space and trailing slash",
+			path:    "Grafana Backend/",
+			wantErr: nil,
+		},
+		{
+			name:    "nested directories with spaces",
+			path:    "Grafana Backend/Cloud App Platform/dashboard.json",
+			wantErr: nil,
+		},
+		{
+			name:    "nested directories with spaces and trailing slash",
+			path:    "Grafana Backend/Cloud App Platform/",
+			wantErr: nil,
+		},
+		{
 			name:    "valid path with extension",
 			path:    "path/to/file.json",
 			wantErr: nil,

--- a/apps/provisioning/pkg/safepath/safe_test.go
+++ b/apps/provisioning/pkg/safepath/safe_test.go
@@ -25,17 +25,17 @@ func TestIsSafe(t *testing.T) {
 		},
 		{
 			name:    "directory with a space and trailing slash",
-			path:    "Grafana Backend/",
+			path:    "My Group/",
 			wantErr: nil,
 		},
 		{
 			name:    "nested directories with spaces",
-			path:    "Grafana Backend/Cloud App Platform/dashboard.json",
+			path:    "My Group/Sub Group/dashboard.json",
 			wantErr: nil,
 		},
 		{
 			name:    "nested directories with spaces and trailing slash",
-			path:    "Grafana Backend/Cloud App Platform/",
+			path:    "My Group/Sub Group/",
 			wantErr: nil,
 		},
 		{
@@ -326,13 +326,13 @@ func TestSanitizeSegment(t *testing.T) {
 	}{
 		{
 			name:  "plain title unchanged",
-			title: "Applications",
-			want:  "Applications",
+			title: "Reports",
+			want:  "Reports",
 		},
 		{
 			name:  "title with spaces preserved",
-			title: "Cloud App Platform",
-			want:  "Cloud App Platform",
+			title: "My Group Folder",
+			want:  "My Group Folder",
 		},
 		{
 			name:  "title with allowed punctuation preserved",
@@ -341,8 +341,8 @@ func TestSanitizeSegment(t *testing.T) {
 		},
 		{
 			name:  "invalid character dropped and leading space trimmed",
-			title: "» Applications",
-			want:  "Applications",
+			title: "» Reports",
+			want:  "Reports",
 		},
 		{
 			name:  "slash dropped so title stays a single segment",

--- a/apps/provisioning/pkg/safepath/safe_test.go
+++ b/apps/provisioning/pkg/safepath/safe_test.go
@@ -301,3 +301,71 @@ func TestSafeSegment(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeSegment(t *testing.T) {
+	const fallback = "abc123"
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{
+			name:  "plain title unchanged",
+			title: "Applications",
+			want:  "Applications",
+		},
+		{
+			name:  "title with spaces preserved",
+			title: "Cloud App Platform",
+			want:  "Cloud App Platform",
+		},
+		{
+			name:  "title with allowed punctuation preserved",
+			title: "my-folder_v1.2",
+			want:  "my-folder_v1.2",
+		},
+		{
+			name:  "invalid character dropped and leading space trimmed",
+			title: "» Applications",
+			want:  "Applications",
+		},
+		{
+			name:  "slash dropped so title stays a single segment",
+			title: "Team A/Team B",
+			want:  "Team ATeam B",
+		},
+		{
+			name:  "leading dot trimmed to avoid hidden path",
+			title: ".hidden",
+			want:  "hidden",
+		},
+		{
+			name:  "traversal token collapses to fallback",
+			title: "..",
+			want:  fallback,
+		},
+		{
+			name:  "unsupported-only title falls back to uid",
+			title: "🎉🚀",
+			want:  fallback,
+		},
+		{
+			name:  "empty title falls back to uid",
+			title: "",
+			want:  fallback,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeSegment(tt.title, fallback)
+			if got != tt.want {
+				t.Errorf("SanitizeSegment(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+			// A sanitized segment must always be a safe path on its own.
+			if err := IsSafe(got); err != nil {
+				t.Errorf("SanitizeSegment(%q) produced unsafe path %q: %v", tt.title, got, err)
+			}
+		})
+	}
+}

--- a/pkg/registry/apis/provisioning/files_test.go
+++ b/pkg/registry/apis/provisioning/files_test.go
@@ -460,9 +460,9 @@ func TestParseRequestOptionsPathValidation(t *testing.T) {
 }
 
 // TestParseRequestOptionsPathWithSpace verifies the /files endpoint accepts a
-// path whose folder segment contains a space (e.g. a folder titled "Grafana
-// Backend"). The apiserver decodes %20 into r.URL.Path before we extract the
-// file path, and IsSafe explicitly allows spaces, so the path is served as-is.
+// path whose folder segment contains a space (e.g. a folder titled "My Group").
+// The apiserver decodes %20 into r.URL.Path before we extract the file path, and
+// IsSafe explicitly allows spaces, so the path is served as-is.
 func TestParseRequestOptionsPathWithSpace(t *testing.T) {
 	mockRepo := repository.NewMockRepository(t)
 	mockRepo.On("Config").Return(&provisioningapi.Repository{
@@ -473,11 +473,11 @@ func TestParseRequestOptionsPathWithSpace(t *testing.T) {
 
 	connector := &filesConnector{}
 	// The space is percent-encoded on the wire; the server decodes it into URL.Path.
-	r := httptest.NewRequest(http.MethodGet, "/test-repo/files/Grafana%20Backend/dashboard.json", nil)
+	r := httptest.NewRequest(http.MethodGet, "/test-repo/files/My%20Group/dashboard.json", nil)
 
 	opts, err := connector.parseRequestOptions(r, "test-repo", mockRepo)
 	require.NoError(t, err)
-	require.Equal(t, "Grafana Backend/dashboard.json", opts.Path)
+	require.Equal(t, "My Group/dashboard.json", opts.Path)
 }
 
 func TestParseRequestOptionsRefValidation(t *testing.T) {

--- a/pkg/registry/apis/provisioning/files_test.go
+++ b/pkg/registry/apis/provisioning/files_test.go
@@ -459,6 +459,27 @@ func TestParseRequestOptionsPathValidation(t *testing.T) {
 	}
 }
 
+// TestParseRequestOptionsPathWithSpace verifies the /files endpoint accepts a
+// path whose folder segment contains a space (e.g. a folder titled "Grafana
+// Backend"). The apiserver decodes %20 into r.URL.Path before we extract the
+// file path, and IsSafe explicitly allows spaces, so the path is served as-is.
+func TestParseRequestOptionsPathWithSpace(t *testing.T) {
+	mockRepo := repository.NewMockRepository(t)
+	mockRepo.On("Config").Return(&provisioningapi.Repository{
+		Spec: provisioningapi.RepositorySpec{
+			Title: "test-repo",
+		},
+	}).Maybe()
+
+	connector := &filesConnector{}
+	// The space is percent-encoded on the wire; the server decodes it into URL.Path.
+	r := httptest.NewRequest(http.MethodGet, "/test-repo/files/Grafana%20Backend/dashboard.json", nil)
+
+	opts, err := connector.parseRequestOptions(r, "test-repo", mockRepo)
+	require.NoError(t, err)
+	require.Equal(t, "Grafana Backend/dashboard.json", opts.Path)
+}
+
 func TestParseRequestOptionsRefValidation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/registry/apis/provisioning/jobs/export/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders.go
@@ -63,11 +63,14 @@ func writeFolderTree(ctx context.Context, options provisioning.ExportJobOptions,
 		OnFolder: func(folder resources.Folder, created bool, err error) error {
 			resultBuilder := jobs.NewFolderResult(folder.Path).WithName(folder.ID).WithAction(repository.FileActionCreated)
 
-			if err != nil {
+			// A folder that failed to write must keep a non-ignored action: the
+			// recorder discards errors on FileActionIgnored results, so labelling
+			// a failure as ignored would let a broken export (e.g. an invalid
+			// folder path) drop the error and report the job as a success.
+			switch {
+			case err != nil:
 				resultBuilder.WithError(fmt.Errorf("creating folder %s at path %s: %w", folder.ID, folder.Path, err))
-			}
-
-			if !created {
+			case !created:
 				resultBuilder.WithAction(repository.FileActionIgnored)
 			}
 			progress.Record(ctx, resultBuilder.Build())

--- a/pkg/registry/apis/provisioning/jobs/export/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders.go
@@ -56,6 +56,10 @@ func ExportFolders(ctx context.Context, repoName string, options provisioning.Ex
 // selective export, which only assembles the folders that the requested
 // resources actually need.
 func writeFolderTree(ctx context.Context, options provisioning.ExportJobOptions, repositoryResources resources.RepositoryResources, tree resources.FolderTree, progress jobs.JobProgressRecorder) error {
+	if err := checkFolderPathCollisions(ctx, tree); err != nil {
+		return err
+	}
+
 	return repositoryResources.EnsureFolderTreeExists(ctx, tree, resources.EnsureFolderTreeExistsOptions{
 		Ref:                  options.Branch,
 		Path:                 options.Path,
@@ -77,6 +81,27 @@ func writeFolderTree(ctx context.Context, options provisioning.ExportJobOptions,
 
 			return progress.TooManyErrors()
 		},
+	})
+}
+
+// checkFolderPathCollisions fails the export when two distinct folders normalize
+// to the same repository path. SanitizeSegment can map different titles under the
+// same parent onto one segment (for example "» Reports" and "Reports", or "A&B"
+// and "AB"). Writing both would let the second folder be treated as already
+// present — its _folder.json skipped or overwriting the first — while dashboards
+// still land under the shared path, so one folder's on-disk metadata would
+// silently represent the wrong UID/title. Refuse loudly instead, naming both
+// folders so the user can rename one.
+func checkFolderPathCollisions(ctx context.Context, tree resources.FolderTree) error {
+	seen := make(map[string]resources.Folder)
+	return tree.Walk(ctx, func(_ context.Context, folder resources.Folder, _ string) error {
+		if prev, dup := seen[folder.Path]; dup && prev.ID != folder.ID {
+			return fmt.Errorf(
+				"folders %q (%s) and %q (%s) both export to path %q; rename one so their normalized paths differ",
+				prev.Title, prev.ID, folder.Title, folder.ID, folder.Path)
+		}
+		seen[folder.Path] = folder
+		return nil
 	})
 }
 

--- a/pkg/registry/apis/provisioning/jobs/export/folders_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders_test.go
@@ -546,3 +546,37 @@ func (m *mockDynamicInterface) Get(ctx context.Context, name string, opts metav1
 	}
 	return &m.items[0], nil
 }
+
+// TestWriteFolderTree_PathCollisionFails verifies that two distinct folders whose
+// titles normalize to the same repository path fail the export loudly, instead of
+// silently letting one folder's _folder.json represent the wrong UID/title.
+func TestWriteFolderTree_PathCollisionFails(t *testing.T) {
+	tree := resources.NewEmptyFolderTree()
+	// Two distinct root folders whose titles both sanitize to "Reports".
+	tree.Add(resources.Folder{ID: "uid-a", Title: "» Reports"}, "")
+	tree.Add(resources.Folder{ID: "uid-b", Title: "Reports"}, "")
+
+	// Leaving both mocks without expectations asserts EnsureFolderTreeExists (and
+	// therefore any per-folder Record) is never reached once a collision is found.
+	repoResources := resources.NewMockRepositoryResources(t)
+	progress := jobs.NewMockJobProgressRecorder(t)
+
+	err := writeFolderTree(context.Background(), v0alpha1.ExportJobOptions{}, repoResources, tree, progress)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "both export to path")
+}
+
+// TestWriteFolderTree_NoCollisionProceeds verifies that folders with distinct
+// normalized paths pass the collision check and reach EnsureFolderTreeExists.
+func TestWriteFolderTree_NoCollisionProceeds(t *testing.T) {
+	tree := resources.NewEmptyFolderTree()
+	tree.Add(resources.Folder{ID: "uid-a", Title: "Reports"}, "")
+	tree.Add(resources.Folder{ID: "uid-b", Title: "Metrics"}, "")
+
+	repoResources := resources.NewMockRepositoryResources(t)
+	repoResources.On("EnsureFolderTreeExists", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	progress := jobs.NewMockJobProgressRecorder(t)
+
+	err := writeFolderTree(context.Background(), v0alpha1.ExportJobOptions{}, repoResources, tree, progress)
+	require.NoError(t, err)
+}

--- a/pkg/registry/apis/provisioning/jobs/export/folders_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders_test.go
@@ -193,7 +193,7 @@ func TestExportFolders(t *testing.T) {
 				progress.On("SetMessage", mock.Anything, "read folder tree from API server").Return()
 				progress.On("SetMessage", mock.Anything, "write folders to repository").Return()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-					return result.Name() == "folder-1-uid" && result.Action() == repository.FileActionIgnored && result.Error() != nil && result.Error().Error() == "creating folder folder-1-uid at path grafana/folder-1: didn't work"
+					return result.Name() == "folder-1-uid" && result.Action() == repository.FileActionCreated && result.Error() != nil && result.Error().Error() == "creating folder folder-1-uid at path grafana/folder-1: didn't work"
 				})).Return()
 				progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 					return result.Name() == "folder-2-uid" && result.Action() == repository.FileActionCreated

--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -224,9 +224,11 @@ func exportItem(ctx context.Context,
 	meta, err := utils.MetaAccessor(item)
 	if err != nil {
 		metaError := fmt.Errorf("extracting meta accessor for resource %s: %w", name, err)
-		resultBuilder.WithAction(repository.FileActionIgnored).WithError(metaError)
+		// Keep the default (created) action so the failure is counted rather
+		// than silently discarded as an ignored result.
+		resultBuilder.WithError(metaError)
 		progress.Record(ctx, resultBuilder.Build())
-		return nil
+		return progress.TooManyErrors()
 	}
 
 	manager, _ := meta.GetManagerProperties()
@@ -264,8 +266,10 @@ func exportItem(ctx context.Context,
 	if errors.Is(err, resources.ErrAlreadyInRepository) {
 		resultBuilder.WithAction(repository.FileActionIgnored)
 	} else if err != nil {
-		resultBuilder.WithAction(repository.FileActionIgnored).
-			WithError(fmt.Errorf("writing resource file for %s: %w", name, err))
+		// Keep the default (created) action so the error is counted: recording a
+		// genuine write failure as FileActionIgnored would let the recorder
+		// discard the error and pass the export off as successful.
+		resultBuilder.WithError(fmt.Errorf("writing resource file for %s: %w", name, err))
 	}
 
 	progress.Record(ctx, resultBuilder.Build())

--- a/pkg/registry/apis/provisioning/jobs/export/resources_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources_test.go
@@ -142,7 +142,7 @@ func TestExportResources_Dashboards_WithErrors(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name() == "dashboard-1" && result.Action() == repository.FileActionIgnored && result.Error() != nil && result.Error().Error() == "writing resource file for dashboard-1: failed to export dashboard"
+			return result.Name() == "dashboard-1" && result.Action() == repository.FileActionCreated && result.Error() != nil && result.Error().Error() == "writing resource file for dashboard-1: failed to export dashboard"
 		})).Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 			return result.Name() == "dashboard-2" && result.Action() == repository.FileActionCreated
@@ -180,7 +180,7 @@ func TestExportResources_Dashboards_TooManyErrors(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name() == "dashboard-1" && result.Action() == repository.FileActionIgnored && result.Error() != nil && result.Error().Error() == "writing resource file for dashboard-1: failed to export dashboard"
+			return result.Name() == "dashboard-1" && result.Action() == repository.FileActionCreated && result.Error() != nil && result.Error().Error() == "writing resource file for dashboard-1: failed to export dashboard"
 		})).Return()
 		progress.On("TooManyErrors").Return(fmt.Errorf("too many errors encountered"))
 	}
@@ -257,7 +257,7 @@ func TestExportResources_Dashboards_SavedVersion(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "start resource export").Return()
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-			return result.Name() == "existing-dashboard" && result.Action() == repository.FileActionIgnored
+			return result.Name() == "existing-dashboard" && result.Action() == repository.FileActionCreated
 		})).Return()
 		progress.On("TooManyErrors").Return(nil)
 	}
@@ -322,7 +322,7 @@ func TestExportResources_Dashboards_FailedConversionNoStoredVersion(t *testing.T
 		progress.On("SetMessage", mock.Anything, "export dashboards").Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 			return result.Name() == "dashboard-no-stored-version" &&
-				result.Action() == repository.FileActionIgnored &&
+				result.Action() == repository.FileActionCreated &&
 				result.Error() != nil
 		})).Return()
 		progress.On("TooManyErrors").Return(nil)
@@ -477,7 +477,7 @@ func TestExportResources_Dashboards_Versions(t *testing.T) {
 						if result.Name() != tt.dashboardName {
 							return false
 						}
-						if result.Action() != repository.FileActionIgnored {
+						if result.Action() != repository.FileActionCreated {
 							return false
 						}
 						if result.Error() == nil {

--- a/pkg/registry/apis/provisioning/resources/tree.go
+++ b/pkg/registry/apis/provisioning/resources/tree.go
@@ -107,7 +107,11 @@ func (t *folderTree) dirPath(folder, baseFolder string) (fid Folder, ok bool) {
 	}
 
 	fid = t.folders[folder]
-	fid.Path = fid.Title
+	// Derive the path from titles, normalizing each title into a safe segment so
+	// a folder named with characters outside the allowed path set (e.g. "»") is
+	// exported under a sanitized path instead of failing the write. The UID is
+	// used as a fallback so the segment is always non-empty.
+	fid.Path = safepath.SanitizeSegment(fid.Title, folder)
 	ok = baseFolder == ""
 
 	parent := t.tree[folder]
@@ -117,7 +121,7 @@ func (t *folderTree) dirPath(folder, baseFolder string) (fid Folder, ok bool) {
 			break
 		}
 		// FIXME: missing slash here
-		fid.Path = safepath.Join(t.folders[parent].Title, fid.Path)
+		fid.Path = safepath.Join(safepath.SanitizeSegment(t.folders[parent].Title, parent), fid.Path)
 		parent = t.tree[parent]
 	}
 	return fid, ok

--- a/pkg/registry/apis/provisioning/resources/tree.go
+++ b/pkg/registry/apis/provisioning/resources/tree.go
@@ -120,8 +120,13 @@ func (t *folderTree) dirPath(folder, baseFolder string) (fid Folder, ok bool) {
 			ok = true
 			break
 		}
-		// FIXME: missing slash here
-		fid.Path = safepath.Join(safepath.SanitizeSegment(t.folders[parent].Title, parent), fid.Path)
+		// Only prepend ancestors that are actually part of the tree. A parent that
+		// was skipped (e.g. a managed-folder boundary during a partial export) is
+		// absent from t.folders; using its UID as a segment here would wrongly root
+		// the child under that UID instead of at the highest exported ancestor.
+		if pf, found := t.folders[parent]; found {
+			fid.Path = safepath.Join(safepath.SanitizeSegment(pf.Title, parent), fid.Path)
+		}
 		parent = t.tree[parent]
 	}
 	return fid, ok

--- a/pkg/registry/apis/provisioning/resources/tree_test.go
+++ b/pkg/registry/apis/provisioning/resources/tree_test.go
@@ -132,6 +132,22 @@ func TestFolderTree(t *testing.T) {
 		}
 	})
 
+	t.Run("a parent missing from the tree is not prepended as a UID segment", func(t *testing.T) {
+		// The child points at a parent that was never added to the tree (e.g. a
+		// managed-folder boundary skipped during a partial export). The child must
+		// root at its own segment, not under the missing parent's UID.
+		tree := &folderTree{
+			tree:    map[string]string{"child": "missing-parent"},
+			folders: map[string]Folder{"child": newFid("child", "Child")},
+		}
+
+		id, ok := tree.DirPath("child", "")
+		if assert.True(t, ok, "child should have DirPath with empty base") {
+			assert.Equal(t, "Child", id.Path, "missing parent must not contribute a UID segment")
+			require.NoError(t, safepath.IsSafe(id.Path))
+		}
+	})
+
 	t.Run("add new folder increments count", func(t *testing.T) {
 		tree := NewEmptyFolderTree()
 		assert.Equal(t, 0, tree.Count())

--- a/pkg/registry/apis/provisioning/resources/tree_test.go
+++ b/pkg/registry/apis/provisioning/resources/tree_test.go
@@ -106,15 +106,15 @@ func TestFolderTree(t *testing.T) {
 		tree := &folderTree{
 			tree: map[string]string{"child": "parent", "parent": ""},
 			folders: map[string]Folder{
-				"parent": newFid("parent", "» Applications"),
-				"child":  newFid("child", "Cloud App Platform"),
+				"parent": newFid("parent", "» Reports"),
+				"child":  newFid("child", "My Group"),
 			},
 		}
 
 		id, ok := tree.DirPath("child", "")
 		if assert.True(t, ok, "child should have DirPath with empty base") {
-			assert.Equal(t, "Cloud App Platform", id.Title, "Title is preserved")
-			assert.Equal(t, "Applications/Cloud App Platform", id.Path, "Path is normalized")
+			assert.Equal(t, "My Group", id.Title, "Title is preserved")
+			assert.Equal(t, "Reports/My Group", id.Path, "Path is normalized")
 			require.NoError(t, safepath.IsSafe(id.Path), "normalized path must be safe")
 		}
 	})

--- a/pkg/registry/apis/provisioning/resources/tree_test.go
+++ b/pkg/registry/apis/provisioning/resources/tree_test.go
@@ -6,6 +6,7 @@ import (
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +45,9 @@ func TestFolderTree(t *testing.T) {
 		if assert.True(t, ok, "x should have DirPath with empty base") {
 			assert.Equal(t, "x", id.ID, "KubernetesName")
 			assert.Equal(t, "X!", id.Title, "Title")
-			assert.Equal(t, "X!", id.Path, "Path")
+			// Title is preserved, but the path segment is normalized: "!" is not
+			// an allowed path character and is dropped.
+			assert.Equal(t, "X", id.Path, "Path")
 		}
 	})
 
@@ -67,7 +70,7 @@ func TestFolderTree(t *testing.T) {
 		if assert.True(t, ok, "x should have DirPath with empty base") {
 			assert.Equal(t, "x", id.ID, "KubernetesName")
 			assert.Equal(t, "X!", id.Title, "Title")
-			assert.Equal(t, "X!", id.Path, "Path")
+			assert.Equal(t, "X", id.Path, "Path")
 		}
 
 		id, ok = tree.DirPath("c", "c")
@@ -81,7 +84,10 @@ func TestFolderTree(t *testing.T) {
 		if assert.True(t, ok, "a should have DirPath with x as base") {
 			assert.Equal(t, "a", id.ID, "KubernetesName")
 			assert.Equal(t, "[€]@£a", id.Title, "Title")
-			assert.Equal(t, "C :)/!!B#!/[€]@£a", id.Path, "Path")
+			// Each title is normalized into a safe segment (unsupported characters
+			// dropped, trailing spaces trimmed): "C :)"->"C", "!!B#!"->"B",
+			// "[€]@£a"->"a". Titles themselves are preserved above.
+			assert.Equal(t, "C/B/a", id.Path, "Path")
 		}
 		_, ok = tree.DirPath("x", "a")
 		assert.False(t, ok, "x should not have DirPath with a as base, because a is a subfolder of x")
@@ -91,6 +97,38 @@ func TestFolderTree(t *testing.T) {
 			assert.Empty(t, id.ID)
 			assert.Empty(t, id.Path)
 			assert.Empty(t, id.Title)
+		}
+	})
+
+	t.Run("normalizes unsafe folder titles into safe path segments", func(t *testing.T) {
+		// Reproduces a folder titled with a "»" prefix, which previously produced
+		// an unsafe path and silently failed selective export.
+		tree := &folderTree{
+			tree: map[string]string{"child": "parent", "parent": ""},
+			folders: map[string]Folder{
+				"parent": newFid("parent", "» Applications"),
+				"child":  newFid("child", "Cloud App Platform"),
+			},
+		}
+
+		id, ok := tree.DirPath("child", "")
+		if assert.True(t, ok, "child should have DirPath with empty base") {
+			assert.Equal(t, "Cloud App Platform", id.Title, "Title is preserved")
+			assert.Equal(t, "Applications/Cloud App Platform", id.Path, "Path is normalized")
+			require.NoError(t, safepath.IsSafe(id.Path), "normalized path must be safe")
+		}
+	})
+
+	t.Run("falls back to the folder UID when a title has no usable characters", func(t *testing.T) {
+		tree := &folderTree{
+			tree:    map[string]string{"emoji-uid": ""},
+			folders: map[string]Folder{"emoji-uid": newFid("emoji-uid", "🎉")},
+		}
+
+		id, ok := tree.DirPath("emoji-uid", "")
+		if assert.True(t, ok) {
+			assert.Equal(t, "emoji-uid", id.Path, "Path falls back to the UID")
+			require.NoError(t, safepath.IsSafe(id.Path))
 		}
 	})
 

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -188,4 +189,86 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 		assert.Equal(collect, backendUID, d.GetAnnotations()[utils.AnnoKeyFolder],
 			"written dashboard should be parented under the space-named folder")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "written dashboard should sync under the space folder")
+}
+
+// TestIntegrationProvisioning_PullFoldersWithSpaces proves the sync/pull
+// direction handles repository folder paths that contain spaces in isolation —
+// with no export/migrate step first. A repository is seeded with a nested folder
+// tree whose directory names contain spaces (each with its own _folder.json) plus
+// a dashboard in the deepest folder; a full pull must read those space-containing
+// directory names out of the repo tree and reconcile the whole hierarchy into
+// Grafana, preserving each folder's title and parent relationship.
+//
+//	Repository (seeded on disk)                 Grafana (after pull)
+//	─────────────────────────────────         ─────────────────────────────────────
+//	Space Parent/_folder.json                  folder "pull-space-parent" · "Space Parent"
+//	└─ Nested Child/_folder.json               └─ folder "pull-space-child" · "Nested Child"
+//	   └─ pulled-dashboard.json                   └─ dashboard "pull-space-dash"
+func TestIntegrationProvisioning_PullFoldersWithSpaces(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := t.Context()
+
+	const (
+		repo        = "pull-space-folders-repo"
+		parentUID   = "pull-space-parent"
+		parentTitle = "Space Parent"
+		childUID    = "pull-space-child"
+		childTitle  = "Nested Child"
+		dashUID     = "pull-space-dash"
+		dashTitle   = "Pulled Dashboard"
+	)
+
+	// SkipSync so the repository exists before we seed it; the pull below is the
+	// action under test.
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		Workflows:              []string{"write"},
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	// Seed a repository whose directory names contain spaces, each carrying a
+	// _folder.json, with a dashboard in the deepest folder.
+	parentPath := parentTitle                          // "Space Parent"
+	childPath := filepath.Join(parentPath, childTitle) // "Space Parent/Nested Child"
+	helper.WriteToProvisioningPath(t, filepath.Join(parentPath, "_folder.json"), common.FolderBody(t, parentUID, parentTitle))
+	helper.WriteToProvisioningPath(t, filepath.Join(childPath, "_folder.json"), common.FolderBody(t, childUID, childTitle))
+	helper.WriteToProvisioningPath(t, filepath.Join(childPath, "pulled-dashboard.json"), common.DashboardJSON(dashUID, dashTitle, 1))
+
+	helper.TriggerJobAndWaitForSuccess(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		parent, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "parent folder should be created by the pull") {
+			return
+		}
+		assert.Equal(collect, repo, parent.GetAnnotations()[utils.AnnoKeyManagerIdentity],
+			"parent folder should be managed by the repo")
+		parentGrafanaTitle, _, _ := unstructured.NestedString(parent.Object, "spec", "title")
+		assert.Equal(collect, parentTitle, parentGrafanaTitle, "parent title should survive the pull")
+
+		child, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "nested folder should be created by the pull") {
+			return
+		}
+		assert.Equal(collect, repo, child.GetAnnotations()[utils.AnnoKeyManagerIdentity],
+			"nested folder should be managed by the repo")
+		assert.Equal(collect, parentUID, child.GetAnnotations()[utils.AnnoKeyFolder],
+			"nested folder should be parented under the space-named parent")
+		childGrafanaTitle, _, _ := unstructured.NestedString(child.Object, "spec", "title")
+		assert.Equal(collect, childTitle, childGrafanaTitle, "nested folder title should survive the pull")
+
+		d, err := helper.DashboardsV1.Resource.Get(ctx, dashUID, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "dashboard should be created by the pull") {
+			return
+		}
+		assert.Equal(collect, repo, d.GetAnnotations()[utils.AnnoKeyManagerIdentity],
+			"dashboard should be managed by the repo")
+		assert.Equal(collect, childUID, d.GetAnnotations()[utils.AnnoKeyFolder],
+			"dashboard should be parented under the deepest space folder")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "pull should reconcile the space-named folder tree into Grafana")
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
@@ -29,6 +29,30 @@ import (
 //   - the migrate completes successfully and the resources become managed, which
 //     proves the pull half of the migrate consumed the normalized/space paths.
 //
+// # How a Grafana folder tree maps into the repository
+//
+// In Grafana a folder has a stable UID (metadata.name) and a free-form display
+// title (spec.title); nesting is expressed by each folder pointing at its parent
+// UID. Titles may contain any character. When such a tree is exported, the
+// repository mirrors the *hierarchy*, but each directory name is a sanitized
+// segment derived from the title — the raw title itself lives on inside that
+// directory's _folder.json (spec.title), so display names survive untouched.
+//
+//	Grafana (UID · "title")                    Repository layout
+//	──────────────────────────────            ─────────────────────────────────────
+//	norm-rd      · "» R&D"                      RD/
+//	└─ norm-backend  · "Grafana Backend"        └─ Grafana Backend/          (space kept)
+//	   └─ norm-internal · ".internal"              └─ internal/              (leading dot trimmed)
+//	      └─ norm-rocket · "🚀🎉"                    └─ norm-rocket/         (no safe chars → UID)
+//	         └─ dash "Deep Dashboard"                  ├─ _folder.json       (metadata.name+spec.title)
+//	                                                    └─ deep-dashboard.json
+//
+// Every folder title is normalized per SanitizeSegment: "» R&D" drops the "»" and
+// "&" (leading space trimmed) → "RD"; "Grafana Backend" keeps its space;
+// ".internal" loses its leading dot; and "🚀🎉" has no representable characters so
+// the segment falls back to the folder UID "norm-rocket". A resource file name is
+// the slug of its title, so "Deep Dashboard" → deep-dashboard.json.
+//
 // Before the title-normalization fix a folder titled "» R&D" produced an unsafe
 // repository path; the write failed but was recorded as an ignored no-op, so the
 // migrate reported "no changes to sync" as a success while exporting nothing.

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -142,10 +144,12 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 
 	// 3) The /files endpoint serves a space-containing path correctly (the path is
 	// URL-encoded on the wire and decoded server-side before IsSafe validation).
+	// The /files endpoint always uses forward slashes; ToSlash keeps the path
+	// correct if filepath.Join produced OS-specific separators (e.g. on Windows).
 	files := helper.NewFilesClient(repo)
-	require.Equal(t, betaTitle, files.ReadFolderTitle(t, ctx, betaPath+"/_folder.json"),
+	require.Equal(t, betaTitle, files.ReadFolderTitle(t, ctx, filepath.ToSlash(betaPath)+"/_folder.json"),
 		"reading a _folder.json at a path with a space through the /files endpoint should work")
-	require.Equal(t, deltaUID, files.ReadFolderUID(t, ctx, deltaPath+"/_folder.json"))
+	require.Equal(t, deltaUID, files.ReadFolderUID(t, ctx, filepath.ToSlash(deltaPath)+"/_folder.json"))
 
 	// 4) The pull half of the migrate consumed the normalized/space paths: the
 	// deepest folder and the dashboard end up managed by the repository.
@@ -169,13 +173,14 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 	// space works, and a subsequent pull reconciles the new file into Grafana
 	// under the space-named folder.
 	const writtenUID = "written-sample-dash"
-	writePath := betaPath + "/written-dashboard.json" // AB/My Group/written-dashboard.json
-	resp := files.Post(t, writePath, common.DashboardJSON(writtenUID, "Written Sample", 1))
+	// Repo/HTTP path uses forward slashes; the on-disk path uses filepath.Join.
+	writeRepoPath := filepath.ToSlash(betaPath) + "/written-dashboard.json" // AB/My Group/written-dashboard.json
+	resp := files.Post(t, writeRepoPath, common.DashboardJSON(writtenUID, "Written Sample", 1))
 	require.Equal(t, http.StatusOK, resp.StatusCode,
 		"writing a dashboard under a folder path with a space should succeed: %s", resp.BodyString())
 
-	_, err = os.Stat(filepath.Join(helper.ProvisioningPath, writePath))
-	require.NoError(t, err, "written dashboard should exist on disk at the space path %s", writePath)
+	_, err = os.Stat(filepath.Join(helper.ProvisioningPath, betaPath, "written-dashboard.json"))
+	require.NoError(t, err, "written dashboard should exist on disk at the space path %s", writeRepoPath)
 
 	// A pull must read the space path back out of the repo tree and reconcile it.
 	helper.SyncAndWait(t, repo, nil)
@@ -271,4 +276,38 @@ func TestIntegrationProvisioning_PullFoldersWithSpaces(t *testing.T) {
 		assert.Equal(collect, childUID, d.GetAnnotations()[utils.AnnoKeyFolder],
 			"dashboard should be parented under the deepest space folder")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "pull should reconcile the space-named folder tree into Grafana")
+}
+
+// TestIntegrationProvisioning_MigrateFolderTitleCollisionFails verifies that when
+// two sibling folders have titles that normalize to the same repository path
+// (here "» Reports" and "Reports" both → "Reports"), the migrate fails loudly
+// instead of silently letting one folder's metadata represent the other. This is
+// the integration counterpart to the export-layer collision guard.
+func TestIntegrationProvisioning_MigrateFolderTitleCollisionFails(t *testing.T) {
+	helper := sharedHelper(t)
+
+	createUnmanagedFolder(t, helper, "collision-a", "» Reports")
+	createUnmanagedFolder(t, helper, "collision-b", "Reports")
+
+	const repo = "folder-title-collision-repo"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		Workflows:              []string{"write"},
+		SkipResourceAssertions: true,
+	})
+
+	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action:  provisioning.JobActionMigrate,
+		Migrate: &provisioning.MigrateJobOptions{Message: "Migrate colliding folder titles"},
+	})
+
+	jobObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+	require.Equal(t, provisioning.JobStateError, jobObj.Status.State,
+		"migrate should fail when two folder titles normalize to the same path")
+
+	combined := jobObj.Status.Message + " " + strings.Join(jobObj.Status.Errors, " ")
+	require.Contains(t, combined, "both export to path",
+		"failure should explain the path collision; message=%q errors=%v", jobObj.Status.Message, jobObj.Status.Errors)
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
@@ -1,0 +1,141 @@
+package foldermetadata
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioning_MigrateFolderTitleNormalization migrates a nested
+// tree of folders whose titles each contain a different path-unsafe pattern and
+// verifies the end-to-end result:
+//
+//   - each folder is exported under a normalized, IsSafe path segment while its
+//     original display title is preserved in _folder.json (spec.title),
+//   - a title with no usable characters falls back to the folder UID as its path
+//     segment (so the segment is always non-empty and deterministic),
+//   - a folder path containing a space round-trips through the /files endpoint,
+//   - the migrate completes successfully and the resources become managed, which
+//     proves the pull half of the migrate consumed the normalized/space paths.
+//
+// Before the title-normalization fix a folder titled "» R&D" produced an unsafe
+// repository path; the write failed but was recorded as an ignored no-op, so the
+// migrate reported "no changes to sync" as a success while exporting nothing.
+func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := t.Context()
+
+	// Fixed UIDs keep every assertion deterministic — including the UID-fallback
+	// case, where the path segment is the UID itself.
+	const (
+		rdUID         = "norm-rd"
+		rdTitle       = "» R&D"
+		backendUID    = "norm-backend"
+		backendTitle  = "Grafana Backend"
+		internalUID   = "norm-internal"
+		internalTitle = ".internal"
+		rocketUID     = "norm-rocket"
+		rocketTitle   = "🚀🎉"
+	)
+
+	createUnmanagedFolder(t, helper, rdUID, rdTitle)
+	createUnmanagedFolderWithParent(t, helper, backendUID, backendTitle, rdUID)
+	createUnmanagedFolderWithParent(t, helper, internalUID, internalTitle, backendUID)
+	createUnmanagedFolderWithParent(t, helper, rocketUID, rocketTitle, internalUID)
+	dashName := helper.CreateUnmanagedDashboard(t, ctx, "Deep Dashboard", rocketUID)
+
+	const repo = "folder-title-normalization-repo"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		Workflows:              []string{"write"},
+		SkipResourceAssertions: true,
+	})
+
+	// Expected normalized path segments. Titles themselves are preserved in
+	// _folder.json and asserted separately below.
+	const (
+		rdSeg       = "RD"              // "» R&D": unicode + '&' dropped, leading space trimmed
+		backendSeg  = "Grafana Backend" // interior space preserved
+		internalSeg = "internal"        // leading dot trimmed (not a hidden path)
+		rocketSeg   = rocketUID         // emoji-only title falls back to the UID
+	)
+	backendPath := filepath.Join(rdSeg, backendSeg)
+	internalPath := filepath.Join(backendPath, internalSeg)
+	rocketPath := filepath.Join(internalPath, rocketSeg)
+
+	helper.TriggerJobAndWaitForSuccess(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionMigrate,
+		Migrate: &provisioning.MigrateJobOptions{
+			Message: "Migrate folders with problematic titles",
+		},
+	})
+
+	common.PrintFileTree(t, helper.ProvisioningPath)
+
+	// 1) _folder.json at each normalized path: the path segment is sanitized but
+	// the display title survives untouched.
+	readManifest := func(t *testing.T, relPath string) foldersV1.Folder {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(helper.ProvisioningPath, relPath, "_folder.json")) //nolint:gosec // known test output path
+		require.NoError(t, err, "_folder.json should exist at %s", relPath)
+		var f foldersV1.Folder
+		require.NoError(t, json.Unmarshal(data, &f), "_folder.json at %s should be valid JSON", relPath)
+		return f
+	}
+	for _, tc := range []struct {
+		relPath   string
+		wantUID   string
+		wantTitle string
+	}{
+		{rdSeg, rdUID, rdTitle},
+		{backendPath, backendUID, backendTitle},
+		{internalPath, internalUID, internalTitle},
+		{rocketPath, rocketUID, rocketTitle},
+	} {
+		m := readManifest(t, tc.relPath)
+		assert.Equal(t, tc.wantUID, m.Name, "UID preserved for %s", tc.relPath)
+		assert.Equal(t, tc.wantTitle, m.Spec.Title, "display title preserved for %s", tc.relPath)
+	}
+
+	// 2) The dashboard lands under the deepest path, which combines a preserved
+	// space segment and the UID-fallback segment.
+	dashFile := filepath.Join(helper.ProvisioningPath, rocketPath, "deep-dashboard.json")
+	_, err := os.Stat(dashFile)
+	require.NoError(t, err, "dashboard should be exported at its normalized nested path %s", dashFile)
+
+	// 3) The /files endpoint serves a space-containing path correctly (the path is
+	// URL-encoded on the wire and decoded server-side before IsSafe validation).
+	files := helper.NewFilesClient(repo)
+	require.Equal(t, backendTitle, files.ReadFolderTitle(t, ctx, backendPath+"/_folder.json"),
+		"reading a _folder.json at a path with a space through the /files endpoint should work")
+	require.Equal(t, rocketUID, files.ReadFolderUID(t, ctx, rocketPath+"/_folder.json"))
+
+	// 4) The pull half of the migrate consumed the normalized/space paths: the
+	// deepest folder and the dashboard end up managed by the repository.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		f, err := helper.Folders.Resource.Get(ctx, rocketUID, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "deepest folder should exist") {
+			return
+		}
+		assert.Equal(collect, repo, f.GetAnnotations()[utils.AnnoKeyManagerIdentity],
+			"deepest folder should be managed by the repo after migrate")
+
+		d, err := helper.DashboardsV1.Resource.Get(ctx, dashName, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "dashboard should exist") {
+			return
+		}
+		assert.Equal(collect, repo, d.GetAnnotations()[utils.AnnoKeyManagerIdentity],
+			"dashboard should be managed by the repo after migrate")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "resources should become managed after migrate")
+}

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
@@ -2,6 +2,7 @@ package foldermetadata
 
 import (
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -138,4 +139,29 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 		assert.Equal(collect, repo, d.GetAnnotations()[utils.AnnoKeyManagerIdentity],
 			"dashboard should be managed by the repo after migrate")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "resources should become managed after migrate")
+
+	// 5) Writing through the /files endpoint into a folder path that contains a
+	// space works, and a subsequent pull reconciles the new file into Grafana
+	// under the space-named folder.
+	const writtenUID = "space-written-dash"
+	writePath := backendPath + "/written-dashboard.json" // RD/Grafana Backend/written-dashboard.json
+	resp := files.Post(t, writePath, common.DashboardJSON(writtenUID, "Written In Space Folder", 1))
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"writing a dashboard under a folder path with a space should succeed: %s", resp.BodyString())
+
+	_, err = os.Stat(filepath.Join(helper.ProvisioningPath, writePath))
+	require.NoError(t, err, "written dashboard should exist on disk at the space path %s", writePath)
+
+	// A pull must read the space path back out of the repo tree and reconcile it.
+	helper.SyncAndWait(t, repo, nil)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		d, err := helper.DashboardsV1.Resource.Get(ctx, writtenUID, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "written dashboard should exist after pull") {
+			return
+		}
+		assert.Equal(collect, repo, d.GetAnnotations()[utils.AnnoKeyManagerIdentity],
+			"written dashboard should be managed after pull")
+		assert.Equal(collect, backendUID, d.GetAnnotations()[utils.AnnoKeyFolder],
+			"written dashboard should be parented under the space-named folder")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "written dashboard should sync under the space folder")
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
@@ -39,22 +39,22 @@ import (
 // segment derived from the title — the raw title itself lives on inside that
 // directory's _folder.json (spec.title), so display names survive untouched.
 //
-//	Grafana (UID · "title")                    Repository layout
-//	──────────────────────────────            ─────────────────────────────────────
-//	norm-rd      · "» R&D"                      RD/
-//	└─ norm-backend  · "Grafana Backend"        └─ Grafana Backend/          (space kept)
-//	   └─ norm-internal · ".internal"              └─ internal/              (leading dot trimmed)
-//	      └─ norm-rocket · "🚀🎉"                    └─ norm-rocket/         (no safe chars → UID)
-//	         └─ dash "Deep Dashboard"                  ├─ _folder.json       (metadata.name+spec.title)
-//	                                                    └─ deep-dashboard.json
+//	Grafana (UID · "title")            Repository layout
+//	────────────────────────────      ─────────────────────────────────────
+//	folder-alpha · "» A&B"             AB/
+//	└─ folder-beta · "My Group"        └─ My Group/              (space kept)
+//	   └─ folder-gamma · ".hidden"        └─ hidden/             (leading dot trimmed)
+//	      └─ folder-delta · "🚀🎉"           └─ folder-delta/     (no safe chars → UID)
+//	         └─ dash "Sample Dashboard"       ├─ _folder.json     (metadata.name+spec.title)
+//	                                          └─ sample-dashboard.json
 //
-// Every folder title is normalized per SanitizeSegment: "» R&D" drops the "»" and
-// "&" (leading space trimmed) → "RD"; "Grafana Backend" keeps its space;
-// ".internal" loses its leading dot; and "🚀🎉" has no representable characters so
-// the segment falls back to the folder UID "norm-rocket". A resource file name is
-// the slug of its title, so "Deep Dashboard" → deep-dashboard.json.
+// Every folder title is normalized per SanitizeSegment: "» A&B" drops the "»" and
+// "&" (leading space trimmed) → "AB"; "My Group" keeps its space; ".hidden" loses
+// its leading dot; and "🚀🎉" has no representable characters so the segment falls
+// back to the folder UID "folder-delta". A resource file name is the slug of its
+// title, so "Sample Dashboard" → sample-dashboard.json.
 //
-// Before the title-normalization fix a folder titled "» R&D" produced an unsafe
+// Before the title-normalization fix a folder titled "» A&B" produced an unsafe
 // repository path; the write failed but was recorded as an ignored no-op, so the
 // migrate reported "no changes to sync" as a success while exporting nothing.
 func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
@@ -64,21 +64,21 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 	// Fixed UIDs keep every assertion deterministic — including the UID-fallback
 	// case, where the path segment is the UID itself.
 	const (
-		rdUID         = "norm-rd"
-		rdTitle       = "» R&D"
-		backendUID    = "norm-backend"
-		backendTitle  = "Grafana Backend"
-		internalUID   = "norm-internal"
-		internalTitle = ".internal"
-		rocketUID     = "norm-rocket"
-		rocketTitle   = "🚀🎉"
+		alphaUID   = "folder-alpha"
+		alphaTitle = "» A&B"
+		betaUID    = "folder-beta"
+		betaTitle  = "My Group"
+		gammaUID   = "folder-gamma"
+		gammaTitle = ".hidden"
+		deltaUID   = "folder-delta"
+		deltaTitle = "🚀🎉"
 	)
 
-	createUnmanagedFolder(t, helper, rdUID, rdTitle)
-	createUnmanagedFolderWithParent(t, helper, backendUID, backendTitle, rdUID)
-	createUnmanagedFolderWithParent(t, helper, internalUID, internalTitle, backendUID)
-	createUnmanagedFolderWithParent(t, helper, rocketUID, rocketTitle, internalUID)
-	dashName := helper.CreateUnmanagedDashboard(t, ctx, "Deep Dashboard", rocketUID)
+	createUnmanagedFolder(t, helper, alphaUID, alphaTitle)
+	createUnmanagedFolderWithParent(t, helper, betaUID, betaTitle, alphaUID)
+	createUnmanagedFolderWithParent(t, helper, gammaUID, gammaTitle, betaUID)
+	createUnmanagedFolderWithParent(t, helper, deltaUID, deltaTitle, gammaUID)
+	dashName := helper.CreateUnmanagedDashboard(t, ctx, "Sample Dashboard", deltaUID)
 
 	const repo = "folder-title-normalization-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -91,14 +91,14 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 	// Expected normalized path segments. Titles themselves are preserved in
 	// _folder.json and asserted separately below.
 	const (
-		rdSeg       = "RD"              // "» R&D": unicode + '&' dropped, leading space trimmed
-		backendSeg  = "Grafana Backend" // interior space preserved
-		internalSeg = "internal"        // leading dot trimmed (not a hidden path)
-		rocketSeg   = rocketUID         // emoji-only title falls back to the UID
+		alphaSeg = "AB"       // "» A&B": unicode + '&' dropped, leading space trimmed
+		betaSeg  = "My Group" // interior space preserved
+		gammaSeg = "hidden"   // leading dot trimmed (not a hidden path)
+		deltaSeg = deltaUID   // emoji-only title falls back to the UID
 	)
-	backendPath := filepath.Join(rdSeg, backendSeg)
-	internalPath := filepath.Join(backendPath, internalSeg)
-	rocketPath := filepath.Join(internalPath, rocketSeg)
+	betaPath := filepath.Join(alphaSeg, betaSeg)
+	gammaPath := filepath.Join(betaPath, gammaSeg)
+	deltaPath := filepath.Join(gammaPath, deltaSeg)
 
 	helper.TriggerJobAndWaitForSuccess(t, repo, provisioning.JobSpec{
 		Action: provisioning.JobActionMigrate,
@@ -124,10 +124,10 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 		wantUID   string
 		wantTitle string
 	}{
-		{rdSeg, rdUID, rdTitle},
-		{backendPath, backendUID, backendTitle},
-		{internalPath, internalUID, internalTitle},
-		{rocketPath, rocketUID, rocketTitle},
+		{alphaSeg, alphaUID, alphaTitle},
+		{betaPath, betaUID, betaTitle},
+		{gammaPath, gammaUID, gammaTitle},
+		{deltaPath, deltaUID, deltaTitle},
 	} {
 		m := readManifest(t, tc.relPath)
 		assert.Equal(t, tc.wantUID, m.Name, "UID preserved for %s", tc.relPath)
@@ -136,21 +136,21 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 
 	// 2) The dashboard lands under the deepest path, which combines a preserved
 	// space segment and the UID-fallback segment.
-	dashFile := filepath.Join(helper.ProvisioningPath, rocketPath, "deep-dashboard.json")
+	dashFile := filepath.Join(helper.ProvisioningPath, deltaPath, "sample-dashboard.json")
 	_, err := os.Stat(dashFile)
 	require.NoError(t, err, "dashboard should be exported at its normalized nested path %s", dashFile)
 
 	// 3) The /files endpoint serves a space-containing path correctly (the path is
 	// URL-encoded on the wire and decoded server-side before IsSafe validation).
 	files := helper.NewFilesClient(repo)
-	require.Equal(t, backendTitle, files.ReadFolderTitle(t, ctx, backendPath+"/_folder.json"),
+	require.Equal(t, betaTitle, files.ReadFolderTitle(t, ctx, betaPath+"/_folder.json"),
 		"reading a _folder.json at a path with a space through the /files endpoint should work")
-	require.Equal(t, rocketUID, files.ReadFolderUID(t, ctx, rocketPath+"/_folder.json"))
+	require.Equal(t, deltaUID, files.ReadFolderUID(t, ctx, deltaPath+"/_folder.json"))
 
 	// 4) The pull half of the migrate consumed the normalized/space paths: the
 	// deepest folder and the dashboard end up managed by the repository.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		f, err := helper.Folders.Resource.Get(ctx, rocketUID, metav1.GetOptions{})
+		f, err := helper.Folders.Resource.Get(ctx, deltaUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "deepest folder should exist") {
 			return
 		}
@@ -168,9 +168,9 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 	// 5) Writing through the /files endpoint into a folder path that contains a
 	// space works, and a subsequent pull reconciles the new file into Grafana
 	// under the space-named folder.
-	const writtenUID = "space-written-dash"
-	writePath := backendPath + "/written-dashboard.json" // RD/Grafana Backend/written-dashboard.json
-	resp := files.Post(t, writePath, common.DashboardJSON(writtenUID, "Written In Space Folder", 1))
+	const writtenUID = "written-sample-dash"
+	writePath := betaPath + "/written-dashboard.json" // AB/My Group/written-dashboard.json
+	resp := files.Post(t, writePath, common.DashboardJSON(writtenUID, "Written Sample", 1))
 	require.Equal(t, http.StatusOK, resp.StatusCode,
 		"writing a dashboard under a folder path with a space should succeed: %s", resp.BodyString())
 
@@ -186,7 +186,7 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 		}
 		assert.Equal(collect, repo, d.GetAnnotations()[utils.AnnoKeyManagerIdentity],
 			"written dashboard should be managed after pull")
-		assert.Equal(collect, backendUID, d.GetAnnotations()[utils.AnnoKeyFolder],
+		assert.Equal(collect, betaUID, d.GetAnnotations()[utils.AnnoKeyFolder],
 			"written dashboard should be parented under the space-named folder")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "written dashboard should sync under the space folder")
 }
@@ -199,23 +199,23 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 // directory names out of the repo tree and reconcile the whole hierarchy into
 // Grafana, preserving each folder's title and parent relationship.
 //
-//	Repository (seeded on disk)                 Grafana (after pull)
-//	─────────────────────────────────         ─────────────────────────────────────
-//	Space Parent/_folder.json                  folder "pull-space-parent" · "Space Parent"
-//	└─ Nested Child/_folder.json               └─ folder "pull-space-child" · "Nested Child"
-//	   └─ pulled-dashboard.json                   └─ dashboard "pull-space-dash"
+//	Repository (seeded on disk)          Grafana (after pull)
+//	────────────────────────────       ─────────────────────────────────────
+//	Team Space/_folder.json             folder "pull-alpha" · "Team Space"
+//	└─ Sub Group/_folder.json           └─ folder "pull-beta" · "Sub Group"
+//	   └─ pulled-dashboard.json            └─ dashboard "pull-dash"
 func TestIntegrationProvisioning_PullFoldersWithSpaces(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := t.Context()
 
 	const (
 		repo        = "pull-space-folders-repo"
-		parentUID   = "pull-space-parent"
-		parentTitle = "Space Parent"
-		childUID    = "pull-space-child"
-		childTitle  = "Nested Child"
-		dashUID     = "pull-space-dash"
-		dashTitle   = "Pulled Dashboard"
+		parentUID   = "pull-alpha"
+		parentTitle = "Team Space"
+		childUID    = "pull-beta"
+		childTitle  = "Sub Group"
+		dashUID     = "pull-dash"
+		dashTitle   = "Sample Dashboard"
 	)
 
 	// SkipSync so the repository exists before we seed it; the pull below is the
@@ -230,8 +230,8 @@ func TestIntegrationProvisioning_PullFoldersWithSpaces(t *testing.T) {
 
 	// Seed a repository whose directory names contain spaces, each carrying a
 	// _folder.json, with a dashboard in the deepest folder.
-	parentPath := parentTitle                          // "Space Parent"
-	childPath := filepath.Join(parentPath, childTitle) // "Space Parent/Nested Child"
+	parentPath := parentTitle                          // "Team Space"
+	childPath := filepath.Join(parentPath, childTitle) // "Team Space/Sub Group"
 	helper.WriteToProvisioningPath(t, filepath.Join(parentPath, "_folder.json"), common.FolderBody(t, parentUID, parentTitle))
 	helper.WriteToProvisioningPath(t, filepath.Join(childPath, "_folder.json"), common.FolderBody(t, childUID, childTitle))
 	helper.WriteToProvisioningPath(t, filepath.Join(childPath, "pulled-dashboard.json"), common.DashboardJSON(dashUID, dashTitle, 1))


### PR DESCRIPTION
## What

Provisioning **export/migrate** now normalizes a folder's title into a safe git path segment instead of using the raw title, genuine export failures are no longer silently swallowed, and two folders that would normalize to the same path now fail loudly instead of clobbering each other.

## Why

A selective migrate reported **`no changes to sync`** and was marked **successful** while exporting *nothing*. The job log showed an unsafe-path error on a folder whose title contained a non-ASCII character (folder names below are redacted/generic):

```
action=migrate ... action=ignored name=<folder>
err="creating folder <folder> at path » Reports/My Group:
     unsafe folder path \"» Reports/My Group/\": path contains invalid characters"
<job>  success  migrate  6s  no changes to sync
```

Two independent bugs combined:

1. **Unsafe folder paths.** A folder's repository path was derived directly from its raw title (`folderTree.dirPath`). A folder titled `» Reports` produced the path `» Reports/…`, which fails `safepath.IsSafe` (`»` is outside the allowed `[a-zA-Z0-9 /_.-]` set). Every dashboard under that folder then failed to write. Note dashboard *filenames* were already slugified (`slugify.Slugify`) — only folder directories used the raw title, an inconsistency.

2. **Failures masked as no-ops.** The failed folder write was recorded as `FileActionIgnored`, and the progress recorder deliberately discards errors on ignored results (`progress.go:94`). So the error was logged but never counted, `StrictMaxErrors(1)` never tripped, the export aborted nothing, and the follow-up pull found an unchanged tree → `no changes to sync`, reported as success.

## How

- **Add `safepath.SanitizeSegment(title, fallback)`** and use it in `folderTree.dirPath` for every title→path segment. It keeps `[a-zA-Z0-9 _.-]`, drops everything else, trims leading/trailing spaces and dots (no hidden/traversal segments), never emits a separator (a title stays exactly one directory level), and falls back to the folder UID when nothing usable remains. The folder's **display title is untouched** — it is preserved in `_folder.json` (`spec.title`); only the derived path is normalized. This also aligns folders with how resource filenames are already generated.

- **Stop recording genuine failures as `FileActionIgnored`.** Folder-write, resource-write, and meta-accessor failures now keep a counted action so `StrictMaxErrors` fires and the job fails loudly instead of passing as a no-op. `ErrAlreadyInRepository` and managed-resource skips still correctly remain `Ignored` (they are real no-ops). The shared recorder is left unchanged, because `sync/incremental.go` intentionally relies on the ignored-error exclusion for non-fatal folder skips.

- **Fail loudly on sibling path collisions.** Because normalization is deliberately lossy, two distinct sibling titles can map to the same segment (e.g. `» Reports` and `Reports`, or `A&B` and `AB`). `checkFolderPathCollisions` walks the folder tree before writing and, if two distinct folder UIDs resolve to the same path, aborts the export with an error naming both folders — instead of letting the second folder's `_folder.json` be skipped/overwritten while dashboards still land under the shared path. The UID fallback keeps unrepresentable-title folders distinct, so only genuine title collisions trip it.

### Examples

`SanitizeSegment` transforms the **path** (the **title** in `_folder.json` is preserved as-is):

| Folder title        | Exported path segment | Note                                    |
| ------------------- | --------------------- | --------------------------------------- |
| `My Group`          | `My Group`            | unchanged (all chars allowed)           |
| `Team Reports 2024` | `Team Reports 2024`   | unchanged (spaces + digits)             |
| `» Reports`         | `Reports`             | `»` dropped, leading space trimmed      |
| `A&B`               | `AB`                  | `&` dropped                             |
| `Team/Squad`        | `TeamSquad`           | `/` dropped — stays a single level      |
| `.hidden`           | `hidden`              | leading dot trimmed (not a hidden path) |
| `🎉` (no usable chars) | `<folder-uid>`     | falls back to the UID (never empty)     |

Before this PR the first two worked but every other row produced an unsafe path and silently failed the export. If two rows above collide under the same parent (e.g. `» Reports` next to `Reports`), the export now fails with a clear message rather than silently dropping one.

### A note on spaces

Spaces are intentionally **preserved** in folder paths and are safe across every surface — read, **write**, and pull:

- `safepath.IsSafe` allows a space; the `/files` endpoint decodes `%20` into `r.URL.Path` and validates with `IsSafe` (for both reads and writes);
- the local repo uses raw filesystem paths, and git/nanogit stores tree-entry names as raw bytes (never in a URL), so a space round-trips through push and pull;
- `sync.Compare`/`Changes` are pure string operations.

So a path like `» Reports/My Group` becomes `Reports/My Group` (spaces kept) and syncs cleanly — the `»` was the only real problem.

## Testing

- `TestSanitizeSegment` (safepath): the transformation table above + the `IsSafe` invariant, incl. slash-dropping, dot-trimming, and UID fallback.
- `TestIsSafe` (safepath): added cases for **directory paths containing spaces** — single (`My Group/`), nested (`My Group/Sub Group/dashboard.json`), and trailing-slash — alongside the existing space-in-filename case.
- `TestFolderTree` (resources): new subtests for a `»`-prefixed title and an emoji-only title; updated special-char cases to assert **title preserved / path normalized**.
- `TestWriteFolderTree_PathCollisionFails` / `TestWriteFolderTree_NoCollisionProceeds` (export): two colliding sibling titles abort the export before writing; distinct paths proceed to `EnsureFolderTreeExists`.
- Updated export tests that previously asserted the masked `Ignored`-on-error behavior to expect the corrected counted-error behavior.
- **`TestIntegrationProvisioning_MigrateFolderTitleNormalization`** (foldermetadata): end-to-end migrate of a 4-level nested tree (`» A&B`→`AB`, `My Group` space-preserved, `.hidden`→`hidden`, `🎉`→UID fallback). Asserts the on-disk `_folder.json` paths + preserved titles and the dashboard at its normalized nested path, then **writes** a dashboard through the `/files` endpoint into a space folder path and runs a **pull**, asserting the file lands on disk and syncs into Grafana managed under the space-named folder — so a space path round-trips through read, write, and pull.
- **`TestIntegrationProvisioning_PullFoldersWithSpaces`** (foldermetadata): proves the **pull direction in isolation** — seeds a repository with a nested folder tree whose directory names contain spaces (each with its `_folder.json`) plus a dashboard, runs a full pull with no prior export/migrate, and asserts the whole hierarchy reconciles into Grafana with titles and parent relationships preserved.
- **`TestParseRequestOptionsPathWithSpace`** (files): the `/files` endpoint accepts a path whose folder segment contains a space.
- `go vet` + `go test` pass for `safepath`, `resources`, `jobs/export`, `jobs/migrate`, and the `foldermetadata` integration package.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (n/a — internal behavior)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)