### PR TITLE
Provisioning: Pretty-print generated _folder.json

### DIFF
--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -160,9 +160,11 @@ func NewFolderManifest(uid, title string, gvk schema.GroupVersionKind) *folders.
 	return f
 }
 
-// marshalFolderManifest serializes a Folder resource to JSON.
+// marshalFolderManifest serializes a Folder resource to pretty-printed JSON so
+// the _folder.json written to the repository matches the formatting of other
+// resource files (see ParsedResource.ToSaveBytes).
 func marshalFolderManifest(folder *folders.Folder) ([]byte, error) {
-	data, err := json.Marshal(folder)
+	data, err := json.MarshalIndent(folder, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal folder manifest: %w", err)
 	}

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -129,6 +130,7 @@ func TestWriteFolderMetadata(t *testing.T) {
 		const uid = "my-stable-uid"
 		manifest := NewFolderManifest(uid, "myfolder", FolderKind)
 
+		var written []byte
 		rw.On("Create", mock.Anything, "myfolder/_folder.json", "", mock.MatchedBy(func(b []byte) bool {
 			var f folders.Folder
 			if err := json.Unmarshal(b, &f); err != nil {
@@ -138,12 +140,20 @@ func TestWriteFolderMetadata(t *testing.T) {
 				f.Kind == "Folder" &&
 				f.Name == uid &&
 				f.Spec.Title == "myfolder"
-		}), "").Return(nil)
+		}), "").Run(func(args mock.Arguments) {
+			written = args.Get(3).([]byte)
+		}).Return(nil)
 
 		returnedUID, err := WriteFolderMetadata(context.Background(), rw, "myfolder/", manifest, "", "")
 
 		require.NoError(t, err)
 		assert.Equal(t, uid, returnedUID)
+
+		// The written _folder.json must be pretty-printed with two-space
+		// indentation to match the formatting of other resource files.
+		var indented bytes.Buffer
+		require.NoError(t, json.Indent(&indented, written, "", "  "))
+		assert.Equal(t, indented.String(), string(written), "_folder.json should be pretty-printed with two-space indentation")
 	})
 
 	t.Run("returns error when repo.Create fails", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/foldermetadata/export_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/export_git_test.go
@@ -1,6 +1,7 @@
 package foldermetadata
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"testing"
@@ -34,6 +35,12 @@ func TestIntegrationProvisioning_ExportJob_GitRepo_FolderMetadataEnabled(t *test
 	// a bare .keep placeholder.  Read the file directly from the git server to avoid the
 	// ownership-conflict check that the provisioning files API performs on unmanaged resources.
 	data := helper.GitReadFile(t, ctx, repoName, folderTitle+"/_folder.json")
+
+	// The committed _folder.json must be pretty-printed with two-space indentation,
+	// matching the formatting of other resource files written to the repository.
+	var indented bytes.Buffer
+	require.NoError(t, json.Indent(&indented, data, "", "  "))
+	require.Equal(t, indented.String(), string(data), "_folder.json must be pretty-printed with two-space indentation")
 
 	var manifest foldersV1.Folder
 	require.NoError(t, json.Unmarshal(data, &manifest), "_folder.json must be valid JSON")


### PR DESCRIPTION
## Summary

The `_folder.json` folder-metadata manifest written to a provisioned repository was serialized as compact, single-line JSON, unlike every other resource file (dashboards, etc.) which are pretty-printed. This makes the committed `_folder.json` hard to read and inconsistent with the rest of the repo, producing noisy diffs.

This changes `marshalFolderManifest` to use `json.MarshalIndent(folder, "", "  ")`, matching the two-space indentation used by `ParsedResource.ToSaveBytes` for all other resource files.

## Changes

- `pkg/registry/apis/provisioning/resources/folder_metadata.go` — serialize `_folder.json` with two-space indentation. This is the single choke point for all writes, so both create (`WriteFolderMetadata`) and update (`WriteFolderMetadataUpdate`) paths are covered.
- `folder_metadata_test.go` — `TestWriteFolderMetadata` now captures the written bytes and asserts they are canonically indented (via an idempotent `json.Indent` check).
- `pkg/tests/apis/provisioning/foldermetadata/export_git_test.go` — asserts the committed on-disk `_folder.json` is pretty-printed, validating the actual repository content end-to-end.

## Testing

- `go test ./pkg/registry/apis/provisioning/resources/` — passes.
- `go vet ./pkg/tests/apis/provisioning/foldermetadata/` — clean (integration test not run locally; requires the git-server harness).

## Checklist

- [x] Tests added/updated
- [x] No breaking changes (formatting-only change to generated output; reads are unaffected since they unmarshal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)