### PR TITLE
Provisioning: integration tests for NATS-based controller watch

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -977,7 +977,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 
 			// Informer resync interval used for health check and reconciliation of
 			// the repository, connection, and job controllers. Configurable via
-			// [provisioning] controller_resync_interval; <=0 falls back to the default.
+			// [provisioning] resync_interval; <=0 falls back to the default.
 			informerFactoryResyncInterval := b.controllerResyncInterval
 			if informerFactoryResyncInterval <= 0 {
 				informerFactoryResyncInterval = setting.ProvisioningControllerResyncIntervalDefault

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -157,6 +157,14 @@ type APIBuilder struct {
 	incrementalPolicy             repository.IncrementalSyncPolicy
 	folderAPIVersion              string
 	webhookSecretRotationInterval time.Duration
+	// controllerResyncInterval is the informer re-list interval for the
+	// repository, connection, and job controllers; historyExpiration is both the
+	// HistoricJob retention and the historic-job informer's resync;
+	// jobPollInterval is the job driver's fallback poll for new jobs. All fall
+	// back to their defaults when <=0 (see the controller post-start hook).
+	controllerResyncInterval time.Duration
+	historyExpiration        time.Duration
+	jobPollInterval          time.Duration
 
 	// natsSubscriber feeds the controllers' event handlers when NATS is enabled.
 	// Instead of an apiserver-backed informer, each controller's handler is driven
@@ -391,6 +399,9 @@ func RegisterAPIService(
 	}
 	builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
 	builder.syncResourceTimeout = cfg.ProvisioningSyncResourceTimeout
+	builder.controllerResyncInterval = cfg.ProvisioningControllerResyncInterval
+	builder.historyExpiration = cfg.ProvisioningHistoryExpiration
+	builder.jobPollInterval = cfg.ProvisioningJobPollInterval
 	builder.usageNamespaceLister = usage.UsageNamespaceLister(cfg, orgSvc)
 	builder.natsSubscriber = natsSubscriber
 	apiregistration.RegisterAPI(builder)
@@ -434,6 +445,9 @@ func RegisterAPIService(
 	}
 	v1beta1Builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
 	v1beta1Builder.syncResourceTimeout = cfg.ProvisioningSyncResourceTimeout
+	v1beta1Builder.controllerResyncInterval = cfg.ProvisioningControllerResyncInterval
+	v1beta1Builder.historyExpiration = cfg.ProvisioningHistoryExpiration
+	v1beta1Builder.jobPollInterval = cfg.ProvisioningJobPollInterval
 	v1beta1Builder.usageNamespaceLister = usage.UsageNamespaceLister(cfg, orgSvc)
 	v1beta1Builder.natsSubscriber = natsSubscriber
 	apiregistration.RegisterAPI(v1beta1Builder)
@@ -961,8 +975,13 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				return nil
 			}
 
-			// Informer with resync interval used for health check and reconciliation
-			informerFactoryResyncInterval := 60 * time.Second
+			// Informer resync interval used for health check and reconciliation of
+			// the repository, connection, and job controllers. Configurable via
+			// [provisioning] controller_resync_interval; <=0 falls back to the default.
+			informerFactoryResyncInterval := b.controllerResyncInterval
+			if informerFactoryResyncInterval <= 0 {
+				informerFactoryResyncInterval = setting.ProvisioningControllerResyncIntervalDefault
+			}
 			if nats.Enabled(b.natsSubscriber) {
 				logging.DefaultLogger.Info("provisioning controllers using NATS-backed informer")
 			}
@@ -1078,11 +1097,19 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			// considered abandoned.
 			leaseRenewalInterval := jobClaimExpiry / 3
 
+			// Fallback poll for new jobs; the driver is also woken immediately by
+			// the job-create notification. Configurable via [provisioning]
+			// job_poll_interval; <=0 falls back to the default.
+			jobPollInterval := b.jobPollInterval
+			if jobPollInterval <= 0 {
+				jobPollInterval = setting.ProvisioningJobPollIntervalDefault
+			}
+
 			// This is basically our own JobQueue system
 			driver, err := jobs.NewConcurrentJobDriver(
 				3,                    // 3 drivers for now
 				20*time.Minute,       // Max time for each job
-				30*time.Second,       // Periodically look for new jobs
+				jobPollInterval,      // Periodically look for new jobs
 				leaseRenewalInterval, // Lease renewal interval
 				b.jobs, repoGetter, jobHistoryWriter,
 				jobController.InsertNotifications(),
@@ -1185,8 +1212,12 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			if b.jobHistoryLoki == nil {
 				// Create HistoryJobController for cleanup of old job history entries.
 				// Its resync interval is the history expiration, and cleanup is
-				// resync-driven.
-				historyJobExpiration := 10 * time.Minute
+				// resync-driven. Configurable via [provisioning] history_expiration;
+				// <=0 falls back to the default.
+				historyJobExpiration := b.historyExpiration
+				if historyJobExpiration <= 0 {
+					historyJobExpiration = setting.ProvisioningHistoryExpirationDefault
+				}
 				historyJobController := appcontroller.NewHistoryJobController(
 					b.GetClient(),
 					historyJobExpiration,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -78,6 +78,24 @@ const ProvisioningMaxFileSizeDefault int64 = 5 * 1024 * 1024
 // timeout used by the provisioning files write API.
 const ProvisioningSyncResourceTimeoutDefault = 30 * time.Second
 
+// ProvisioningControllerResyncIntervalDefault is the default value for the
+// [provisioning] controller_resync_interval key. It sets how often the
+// provisioning controllers' informers re-list (repository, connection, job) as
+// a fallback to the live watch/NATS notifications. A shorter value reconciles
+// stale state sooner at the cost of more full LISTs.
+const ProvisioningControllerResyncIntervalDefault = 60 * time.Second
+
+// ProvisioningHistoryExpirationDefault is the default value for the
+// [provisioning] history_expiration key. It is both how long a HistoricJob is
+// retained before the resync-driven cleanup removes it and the resync interval
+// of the historic-job informer that feeds that cleanup.
+const ProvisioningHistoryExpirationDefault = 10 * time.Minute
+
+// ProvisioningJobPollIntervalDefault is the default value for the [provisioning]
+// job_poll_interval key. It is how often the job driver polls for new jobs as a
+// fallback to the live watch/NATS notification that wakes it on job creation.
+const ProvisioningJobPollIntervalDefault = 30 * time.Second
+
 var (
 	customInitPath = "conf/custom.ini"
 
@@ -183,6 +201,9 @@ type Cfg struct {
 	ProvisioningMaxFileSize                   int64         // bytes; default 5 MiB (5242880); <=0 = unlimited
 	ProvisioningSyncResourceTimeout           time.Duration // per-resource apply timeout during sync; default 30s; <=0 = default
 	ProvisioningWebhookSecretRotationInterval time.Duration // default 30 days
+	ProvisioningControllerResyncInterval      time.Duration // informer re-list interval for repo/connection/job controllers; default 60s; <=0 = default
+	ProvisioningHistoryExpiration             time.Duration // HistoricJob retention and historic-job informer resync; default 10m; <=0 = default
+	ProvisioningJobPollInterval               time.Duration // job driver poll interval (fallback to the live job-create notification); default 30s; <=0 = default
 	ProvisioningPublicRootURL                 string        // public-facing root URL of this Grafana instance for provisioning consumers (webhooks, screenshots); falls back to AppURL when empty
 	DataPath                                  string
 	LogsPath                                  string
@@ -2605,6 +2626,9 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	cfg.ProvisioningMaxFileSize = iniFile.Section("provisioning").Key("max_file_size").MustInt64(ProvisioningMaxFileSizeDefault)
 	cfg.ProvisioningSyncResourceTimeout = iniFile.Section("provisioning").Key("sync_resource_timeout").MustDuration(ProvisioningSyncResourceTimeoutDefault)
 	cfg.ProvisioningWebhookSecretRotationInterval = iniFile.Section("provisioning").Key("webhook_secret_rotation_interval").MustDuration(30 * 24 * time.Hour)
+	cfg.ProvisioningControllerResyncInterval = iniFile.Section("provisioning").Key("controller_resync_interval").MustDuration(ProvisioningControllerResyncIntervalDefault)
+	cfg.ProvisioningHistoryExpiration = iniFile.Section("provisioning").Key("history_expiration").MustDuration(ProvisioningHistoryExpirationDefault)
+	cfg.ProvisioningJobPollInterval = iniFile.Section("provisioning").Key("job_poll_interval").MustDuration(ProvisioningJobPollIntervalDefault)
 	cfg.ProvisioningPublicRootURL = strings.TrimRight(valueAsString(iniFile.Section("provisioning"), "public_root_url", ""), "/")
 
 	// Read job history configuration

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -79,7 +79,7 @@ const ProvisioningMaxFileSizeDefault int64 = 5 * 1024 * 1024
 const ProvisioningSyncResourceTimeoutDefault = 30 * time.Second
 
 // ProvisioningControllerResyncIntervalDefault is the default value for the
-// [provisioning] controller_resync_interval key. It sets how often the
+// [provisioning] resync_interval key. It sets how often the
 // provisioning controllers' informers re-list (repository, connection, job) as
 // a fallback to the live watch/NATS notifications. A shorter value reconciles
 // stale state sooner at the cost of more full LISTs.
@@ -2626,7 +2626,7 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	cfg.ProvisioningMaxFileSize = iniFile.Section("provisioning").Key("max_file_size").MustInt64(ProvisioningMaxFileSizeDefault)
 	cfg.ProvisioningSyncResourceTimeout = iniFile.Section("provisioning").Key("sync_resource_timeout").MustDuration(ProvisioningSyncResourceTimeoutDefault)
 	cfg.ProvisioningWebhookSecretRotationInterval = iniFile.Section("provisioning").Key("webhook_secret_rotation_interval").MustDuration(30 * 24 * time.Hour)
-	cfg.ProvisioningControllerResyncInterval = iniFile.Section("provisioning").Key("controller_resync_interval").MustDuration(ProvisioningControllerResyncIntervalDefault)
+	cfg.ProvisioningControllerResyncInterval = iniFile.Section("provisioning").Key("resync_interval").MustDuration(ProvisioningControllerResyncIntervalDefault)
 	cfg.ProvisioningHistoryExpiration = iniFile.Section("provisioning").Key("history_expiration").MustDuration(ProvisioningHistoryExpirationDefault)
 	cfg.ProvisioningJobPollInterval = iniFile.Section("provisioning").Key("job_poll_interval").MustDuration(ProvisioningJobPollIntervalDefault)
 	cfg.ProvisioningPublicRootURL = strings.TrimRight(valueAsString(iniFile.Section("provisioning"), "public_root_url", ""), "/")

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1382,6 +1382,13 @@ func WithNATS() GrafanaOption {
 		opts.NATSListenAddress = "127.0.0.1"
 		opts.NATSClientPort = freePort()
 		opts.NATSClusterPort = freePort()
+		// Push the informer re-list and the job driver's fallback poll far out so
+		// any reconcile/job pickup observed within a test's wait budget can only
+		// have come from a live NATS notification, not the periodic LIST/poll.
+		// Tests that specifically exercise the re-list path (e.g. historic-job
+		// cleanup) override the relevant interval.
+		opts.ProvisioningControllerResyncInterval = 10 * time.Minute
+		opts.ProvisioningJobPollInterval = 10 * time.Minute
 	}
 }
 
@@ -1397,6 +1404,15 @@ func freePort() int {
 	}
 	defer func() { _ = l.Close() }()
 	return l.Addr().(*net.TCPAddr).Port
+}
+
+// WithProvisioningHistoryExpiration overrides [provisioning] history_expiration,
+// which is both the HistoricJob retention and the historic-job informer's
+// resync. A short value lets tests exercise the re-list-driven cleanup quickly.
+func WithProvisioningHistoryExpiration(d time.Duration) GrafanaOption {
+	return func(opts *testinfra.GrafanaOpts) {
+		opts.ProvisioningHistoryExpiration = d
+	}
 }
 
 // WithoutExportFeatureFlag disables the provisioningExport feature flag.

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1392,6 +1392,27 @@ func WithNATS() GrafanaOption {
 	}
 }
 
+// WithNATSReListOnly enables the embedded NATS bus but deliberately leaves the
+// SQL KV backend off, so no component ever publishes a watch notification. The
+// provisioning informers still run on the NATS path (they subscribe and
+// re-list) but receive no live events, so reconciliation is driven purely by
+// the periodic re-list, whose interval is set to resync. This isolates the
+// re-list fallback that guarantees eventual reconciliation when live
+// notifications are missed (round-robined to another replica, a startup or
+// reconnect gap). Keep resync short so the re-list fires within a test budget.
+func WithNATSReListOnly(resync time.Duration) GrafanaOption {
+	return func(opts *testinfra.GrafanaOpts) {
+		opts.NATSEnabled = true
+		opts.NATSListenAddress = "127.0.0.1"
+		opts.NATSClientPort = freePort()
+		opts.NATSClusterPort = freePort()
+		// EnableSQLKVBackend stays false: only the KV backend publishes watch
+		// notifications, so leaving it off means the informers never receive a
+		// live event and the re-list is the sole reconcile driver.
+		opts.ProvisioningControllerResyncInterval = resync
+	}
+}
+
 // freePort asks the kernel for an available TCP port on the loopback interface
 // and returns it after closing the listener. There is an inherent (small) race
 // between closing and the embedded NATS server binding, but it is the same

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -337,6 +337,32 @@ func (h *ProvisioningTestHelper) TriggerJobAndWaitForComplete(t *testing.T, repo
 	return h.AwaitJob(t, t.Context(), unstruct)
 }
 
+// CreatePullJob creates a pull Job resource directly, bypassing the
+// repositories/{name}/jobs subresource, and returns the created object. The
+// repository name need not refer to an existing repository — this lets tests
+// drive the job pipeline (pickup, processing, archival) without standing up a
+// repository. A job against a missing repository fails fast and is archived.
+func (h *ProvisioningTestHelper) CreatePullJob(t *testing.T, jobName, repository string) *unstructured.Unstructured {
+	t.Helper()
+	job := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "provisioning.grafana.app/v0alpha1",
+		"kind":       "Job",
+		"metadata": map[string]any{
+			"name":      jobName,
+			"namespace": h.Namespace,
+			"labels":    map[string]any{jobs.LabelRepository: repository},
+		},
+		"spec": map[string]any{
+			"action":     string(provisioning.JobActionPull),
+			"repository": repository,
+			"pull":       map[string]any{},
+		},
+	}}
+	created, err := h.Jobs.Resource.Create(t.Context(), job, metav1.CreateOptions{})
+	require.NoError(t, err, "should create job %s directly", jobName)
+	return created
+}
+
 // AwaitLatestHistoricJob waits for the repo's queue to empty and returns the most recent historic job.
 func (h *ProvisioningTestHelper) AwaitLatestHistoricJob(t *testing.T, repo string) *unstructured.Unstructured {
 	t.Helper()
@@ -1192,6 +1218,56 @@ func (h *ProvisioningTestHelper) WaitForUnhealthyRepository(t *testing.T, name s
 		assert.True(collect, found, "repository %s does not have health status", name)
 		assert.False(collect, status, "repository %s should be unhealthy", name)
 	}, WaitTimeoutDefault, WaitIntervalDefault, "repository %s should become unhealthy", name)
+}
+
+// WaitForHealthyConnection polls until the connection controller has reconciled
+// the connection: its ObservedGeneration has caught up to the object
+// generation, a health check has run, it is healthy, and the Ready condition is
+// True. This is the connection analogue of WaitForHealthyRepository.
+func (h *ProvisioningTestHelper) WaitForHealthyConnection(t *testing.T, name string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		obj, err := h.Connections.Resource.Get(t.Context(), name, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "failed to get connection %s", name) {
+			return
+		}
+		conn := MustFromUnstructured[provisioning.Connection](t, obj)
+		assert.Equal(collect, conn.Generation, conn.Status.ObservedGeneration,
+			"controller should reconcile the observed generation")
+		assert.Greater(collect, conn.Status.Health.Checked, int64(0),
+			"connection %s health check has not run yet", name)
+		assert.True(collect, conn.Status.Health.Healthy, "connection %s is not healthy yet", name)
+		ready := FindCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
+		if assert.NotNil(collect, ready, "connection %s should have a Ready condition", name) {
+			assert.Equal(collect, metav1.ConditionTrue, ready.Status, "connection %s Ready condition should be true", name)
+		}
+	}, WaitTimeoutDefault, WaitIntervalDefault, "connection %s should be reconciled and healthy", name)
+}
+
+// RequireRepositoryReReconciles ages the repository's health timestamp and
+// asserts the controller re-runs the health check (status.health.checked
+// advances), proving it reacts to update/resync events. Pairs with a create
+// that first brings the repository to healthy.
+func (h *ProvisioningTestHelper) RequireRepositoryReReconciles(t *testing.T, name string) {
+	t.Helper()
+	ctx := t.Context()
+
+	obj, err := h.Repositories.Resource.Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err, "failed to get repository %s", name)
+	before, found := mustNestedInt64(obj.Object, "status", "health", "checked")
+	require.True(t, found, "repository %s should already have a health checked timestamp", name)
+
+	h.TriggerRepositoryReconciliation(t, name)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		cur, err := h.Repositories.Resource.Get(ctx, name, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "failed to get repository %s", name) {
+			return
+		}
+		after, found := mustNestedInt64(cur.Object, "status", "health", "checked")
+		assert.True(collect, found, "repository %s should have a health checked timestamp", name)
+		assert.Greater(collect, after, before, "controller should re-check health after the update")
+	}, WaitTimeoutDefault, WaitIntervalDefault, "repository %s health should be re-checked", name)
 }
 
 // WaitForRepositoryDeleted polls until the named repository reports NotFound.

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -1366,6 +1367,36 @@ func WithProvisioningMaxFileSize(n int64) GrafanaOption {
 	return func(opts *testinfra.GrafanaOpts) {
 		opts.ProvisioningMaxFileSize = &n
 	}
+}
+
+// WithNATS enables the embedded Core NATS bus and the SQL KV storage backend so
+// the provisioning controllers reconcile off NATS-delivered resource-change
+// notifications instead of the apiserver watch. The KV backend is what publishes
+// those notifications, so both must be on together. Two free TCP ports are
+// allocated for the embedded server's client and cluster listeners so parallel
+// test binaries don't collide on the conventional 4222/6222.
+func WithNATS() GrafanaOption {
+	return func(opts *testinfra.GrafanaOpts) {
+		opts.NATSEnabled = true
+		opts.EnableSQLKVBackend = true
+		opts.NATSListenAddress = "127.0.0.1"
+		opts.NATSClientPort = freePort()
+		opts.NATSClusterPort = freePort()
+	}
+}
+
+// freePort asks the kernel for an available TCP port on the loopback interface
+// and returns it after closing the listener. There is an inherent (small) race
+// between closing and the embedded NATS server binding, but it is the same
+// approach used by the unified-storage NATS round-trip test and is adequate for
+// test isolation.
+func freePort() int {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(fmt.Sprintf("failed to allocate a free port for NATS: %v", err))
+	}
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port
 }
 
 // WithoutExportFeatureFlag disables the provisioningExport feature flag.

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -919,6 +919,25 @@ func (h *ProvisioningTestHelper) CreateGitHubRepository(t *testing.T, repo GitHu
 	return createdName
 }
 
+// CreateRepositoryNoWait renders and creates a local repository from the spec
+// but does NOT wait for it to become healthy (unlike CreateLocalRepo). Use it
+// when the test needs to assert the controller's reconcile explicitly — e.g.
+// WaitForHealthyRepository — rather than have that wait hidden inside creation.
+func (h *ProvisioningTestHelper) CreateRepositoryNoWait(t *testing.T, repo TestRepo) {
+	t.Helper()
+	if repo.SyncTarget == "" {
+		repo.SyncTarget = "instance"
+	}
+	repo.SyncEnabled = !repo.SkipSync
+	repo.WorkflowsJSON = marshalWorkflows(t, repo.Workflows)
+	if repo.Path == "" {
+		repo.Path = h.ProvisioningPath
+	}
+	obj := h.RenderObject(t, TestdataPath("local.json.tmpl"), repo)
+	_, err := h.Repositories.Resource.Create(t.Context(), obj, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create repository %q", repo.Name)
+}
+
 func (h *ProvisioningTestHelper) CreateLocalRepo(t *testing.T, repo TestRepo) {
 	if repo.SyncTarget == "" {
 		repo.SyncTarget = "instance"

--- a/pkg/tests/apis/provisioning/nats/connection_test.go
+++ b/pkg/tests/apis/provisioning/nats/connection_test.go
@@ -4,30 +4,25 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
-	clientset "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
 // TestIntegrationProvisioningNATS_ConnectionReconciledOverNATS proves the
 // connection controller is driven by a live NATS notification: a created
-// Connection must be reconciled (health + Ready condition) within
-// liveDeliveryWait. Like the repository controller, its only event source is
-// the informer, whose re-list is 10 minutes out, so a reconcile this fast can
-// only be the live ADDED notification.
+// Connection is reconciled to healthy (WaitForHealthyConnection) with the
+// re-list pushed to 10m, so the reconcile can only be the live ADDED
+// notification.
 func TestIntegrationProvisioningNATS_ConnectionReconciledOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := t.Context()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	const connName = "nats-connection"
-
 	conn := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "provisioning.grafana.app/v0alpha1",
 		"kind":       "Connection",
@@ -56,24 +51,5 @@ func TestIntegrationProvisioningNATS_ConnectionReconciledOverNATS(t *testing.T) 
 		_ = helper.Connections.Resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{})
 	})
 
-	provisioningClient, err := clientset.NewForConfig(helper.Org1.Admin.NewRestConfig())
-	require.NoError(t, err)
-	connClient := provisioningClient.ProvisioningV0alpha1().Connections("default")
-
-	// The controller must observe the create over NATS and reconcile the status.
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		updated, err := connClient.Get(ctx, created.GetName(), metav1.GetOptions{})
-		if !assert.NoError(collect, err) {
-			return
-		}
-		assert.Equal(collect, updated.Generation, updated.Status.ObservedGeneration,
-			"controller should reconcile the observed generation")
-		assert.Greater(collect, updated.Status.Health.Checked, int64(0),
-			"controller should set the health check timestamp")
-		assert.True(collect, updated.Status.Health.Healthy, "connection should be healthy")
-		readyCondition := meta.FindStatusCondition(updated.Status.Conditions, provisioning.ConditionTypeReady)
-		if assert.NotNil(collect, readyCondition, "Ready condition should be set") {
-			assert.Equal(collect, metav1.ConditionTrue, readyCondition.Status)
-		}
-	}, liveDeliveryWait, liveDeliveryTick, "connection should be reconciled over NATS within %s", liveDeliveryWait)
+	helper.WaitForHealthyConnection(t, created.GetName())
 }

--- a/pkg/tests/apis/provisioning/nats/connection_test.go
+++ b/pkg/tests/apis/provisioning/nats/connection_test.go
@@ -3,7 +3,6 @@ package nats
 import (
 	"encoding/base64"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,12 +15,13 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
-// TestIntegrationProvisioningNATS_ConnectionControllerReconciles verifies the
-// connection controller reacts to a Connection create event delivered over the
-// NATS-backed informer: it runs the health check (against the mocked GitHub
-// client) and writes ObservedGeneration, health, and the Ready condition back to
-// status.
-func TestIntegrationProvisioningNATS_ConnectionControllerReconciles(t *testing.T) {
+// TestIntegrationProvisioningNATS_ConnectionReconciledOverNATS proves the
+// connection controller is driven by a live NATS notification: a created
+// Connection must be reconciled (health + Ready condition) within
+// liveDeliveryWait. Like the repository controller, its only event source is
+// the informer, whose re-list is 10 minutes out, so a reconcile this fast can
+// only be the live ADDED notification.
+func TestIntegrationProvisioningNATS_ConnectionReconciledOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := t.Context()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
@@ -75,5 +75,5 @@ func TestIntegrationProvisioningNATS_ConnectionControllerReconciles(t *testing.T
 		if assert.NotNil(collect, readyCondition, "Ready condition should be set") {
 			assert.Equal(collect, metav1.ConditionTrue, readyCondition.Status)
 		}
-	}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled over NATS")
+	}, liveDeliveryWait, liveDeliveryTick, "connection should be reconciled over NATS within %s", liveDeliveryWait)
 }

--- a/pkg/tests/apis/provisioning/nats/connection_test.go
+++ b/pkg/tests/apis/provisioning/nats/connection_test.go
@@ -1,0 +1,79 @@
+package nats
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	clientset "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioningNATS_ConnectionControllerReconciles verifies the
+// connection controller reacts to a Connection create event delivered over the
+// NATS-backed informer: it runs the health check (against the mocked GitHub
+// client) and writes ObservedGeneration, health, and the Ready condition back to
+// status.
+func TestIntegrationProvisioningNATS_ConnectionControllerReconciles(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := t.Context()
+	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
+
+	const connName = "nats-connection"
+
+	conn := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "provisioning.grafana.app/v0alpha1",
+		"kind":       "Connection",
+		"metadata": map[string]any{
+			"name":      connName,
+			"namespace": "default",
+		},
+		"spec": map[string]any{
+			"title": "NATS Test Connection",
+			"type":  provisioning.GitHubRepositoryType,
+			"github": map[string]any{
+				"appID":          "12345",
+				"installationID": "67890",
+			},
+		},
+		"secure": map[string]any{
+			"privateKey": map[string]any{
+				"create": privateKeyBase64,
+			},
+		},
+	}}
+
+	created, err := helper.CreateGithubConnection(t, ctx, conn)
+	require.NoError(t, err, "failed to create connection")
+	t.Cleanup(func() {
+		_ = helper.Connections.Resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{})
+	})
+
+	provisioningClient, err := clientset.NewForConfig(helper.Org1.Admin.NewRestConfig())
+	require.NoError(t, err)
+	connClient := provisioningClient.ProvisioningV0alpha1().Connections("default")
+
+	// The controller must observe the create over NATS and reconcile the status.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		updated, err := connClient.Get(ctx, created.GetName(), metav1.GetOptions{})
+		if !assert.NoError(collect, err) {
+			return
+		}
+		assert.Equal(collect, updated.Generation, updated.Status.ObservedGeneration,
+			"controller should reconcile the observed generation")
+		assert.Greater(collect, updated.Status.Health.Checked, int64(0),
+			"controller should set the health check timestamp")
+		assert.True(collect, updated.Status.Health.Healthy, "connection should be healthy")
+		readyCondition := meta.FindStatusCondition(updated.Status.Conditions, provisioning.ConditionTypeReady)
+		if assert.NotNil(collect, readyCondition, "Ready condition should be set") {
+			assert.Equal(collect, metav1.ConditionTrue, readyCondition.Status)
+		}
+	}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled over NATS")
+}

--- a/pkg/tests/apis/provisioning/nats/helpers_test.go
+++ b/pkg/tests/apis/provisioning/nats/helpers_test.go
@@ -2,8 +2,11 @@ package nats
 
 import (
 	"testing"
+	"time"
 
 	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
@@ -11,15 +14,46 @@ import (
 // env starts a single shared Grafana server with the embedded NATS bus and the
 // SQL KV storage backend enabled (common.WithNATS). The provisioning
 // controllers therefore reconcile off NATS-delivered resource-change
-// notifications instead of the apiserver watch. See the package tests for the
-// behaviors this validates.
+// notifications instead of the apiserver watch.
+//
+// WithNATS also pushes the informer re-list and the job driver's fallback poll
+// out to 10 minutes. That is what makes these tests proofs of live delivery
+// rather than smoke tests: any reconcile or job pickup observed within
+// liveDeliveryWait (well under 10 minutes) cannot be explained by the periodic
+// LIST/poll — it can only have been driven by a NATS notification.
 var env = common.NewSharedEnv(common.WithNATS())
+
+const (
+	// liveDeliveryWait bounds how long a reconcile driven by a live NATS
+	// notification may take. It must stay far below the 10-minute re-list/poll
+	// interval set by WithNATS so a reconcile within it is attributable to NATS,
+	// yet be generous enough to absorb bus warm-up and slow CI.
+	liveDeliveryWait = 20 * time.Second
+	liveDeliveryTick = 200 * time.Millisecond
+)
 
 func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
 	t.Helper()
 	helper := env.GetCleanHelper(t)
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
 	return helper
+}
+
+// createLocalRepo creates a sync-disabled, folderless local repository and
+// returns immediately without waiting for it to become healthy — the caller
+// asserts the reconcile timing itself. Folderless + sync-disabled keeps the
+// repo side-effect free so it does not provision resources the shared cleanup
+// would have to remove.
+func createLocalRepo(t *testing.T, helper *common.ProvisioningTestHelper, name string) {
+	t.Helper()
+	repo := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), common.TestRepo{
+		Name:          name,
+		SyncTarget:    "folderless",
+		Path:          helper.ProvisioningPath,
+		WorkflowsJSON: "[]",
+	})
+	_, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create local repository %q", name)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/tests/apis/provisioning/nats/helpers_test.go
+++ b/pkg/tests/apis/provisioning/nats/helpers_test.go
@@ -1,0 +1,27 @@
+package nats
+
+import (
+	"testing"
+
+	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// env starts a single shared Grafana server with the embedded NATS bus and the
+// SQL KV storage backend enabled (common.WithNATS). The provisioning
+// controllers therefore reconcile off NATS-delivered resource-change
+// notifications instead of the apiserver watch. See the package tests for the
+// behaviors this validates.
+var env = common.NewSharedEnv(common.WithNATS())
+
+func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
+	t.Helper()
+	helper := env.GetCleanHelper(t)
+	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
+	return helper
+}
+
+func TestMain(m *testing.M) {
+	env.RunTestMain(m)
+}

--- a/pkg/tests/apis/provisioning/nats/helpers_test.go
+++ b/pkg/tests/apis/provisioning/nats/helpers_test.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
-	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
@@ -37,23 +35,6 @@ func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
 	helper := env.GetCleanHelper(t)
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
 	return helper
-}
-
-// createLocalRepo creates a sync-disabled, folderless local repository and
-// returns immediately without waiting for it to become healthy — the caller
-// asserts the reconcile timing itself. Folderless + sync-disabled keeps the
-// repo side-effect free so it does not provision resources the shared cleanup
-// would have to remove.
-func createLocalRepo(t *testing.T, helper *common.ProvisioningTestHelper, name string) {
-	t.Helper()
-	repo := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), common.TestRepo{
-		Name:          name,
-		SyncTarget:    "folderless",
-		Path:          helper.ProvisioningPath,
-		WorkflowsJSON: "[]",
-	})
-	_, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{})
-	require.NoError(t, err, "failed to create local repository %q", name)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/tests/apis/provisioning/nats/historicjob/helpers_test.go
+++ b/pkg/tests/apis/provisioning/nats/historicjob/helpers_test.go
@@ -18,7 +18,11 @@ import (
 // expiration would race the other packages' historic-job reads.
 var env = common.NewSharedEnv(
 	common.WithNATS(),
-	common.WithProvisioningHistoryExpiration(10*time.Second),
+	// Short retention: it is both how long a HistoricJob lives and the
+	// historic-job informer's resync, so it bounds how quickly the
+	// listing-driven cleanup runs. Kept small to keep the test fast; the poll
+	// loop tolerates the correspondingly small observation window.
+	common.WithProvisioningHistoryExpiration(3*time.Second),
 )
 
 func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {

--- a/pkg/tests/apis/provisioning/nats/historicjob/helpers_test.go
+++ b/pkg/tests/apis/provisioning/nats/historicjob/helpers_test.go
@@ -1,0 +1,33 @@
+package historicjob
+
+import (
+	"testing"
+	"time"
+
+	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// env starts a shared Grafana server with NATS enabled (via common.WithNATS)
+// and a deliberately short history_expiration. HistoricJob is the one
+// provisioning CRD whose informer has no live NATS events — it is re-list only
+// (nil newObject) — so its cleanup controller is driven entirely by the
+// periodic LIST. The short expiration lets that listing-driven cleanup run
+// within a test's budget. This lives in its own package because the short
+// expiration would race the other packages' historic-job reads.
+var env = common.NewSharedEnv(
+	common.WithNATS(),
+	common.WithProvisioningHistoryExpiration(5*time.Second),
+)
+
+func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
+	t.Helper()
+	helper := env.GetCleanHelper(t)
+	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
+	return helper
+}
+
+func TestMain(m *testing.M) {
+	env.RunTestMain(m)
+}

--- a/pkg/tests/apis/provisioning/nats/historicjob/helpers_test.go
+++ b/pkg/tests/apis/provisioning/nats/historicjob/helpers_test.go
@@ -18,7 +18,7 @@ import (
 // expiration would race the other packages' historic-job reads.
 var env = common.NewSharedEnv(
 	common.WithNATS(),
-	common.WithProvisioningHistoryExpiration(5*time.Second),
+	common.WithProvisioningHistoryExpiration(10*time.Second),
 )
 
 func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {

--- a/pkg/tests/apis/provisioning/nats/historicjob/historicjob_test.go
+++ b/pkg/tests/apis/provisioning/nats/historicjob/historicjob_test.go
@@ -55,16 +55,20 @@ func TestIntegrationProvisioningNATSHistoricJob_CleanedViaListing(t *testing.T) 
 	_, err := helper.Jobs.Resource.Create(ctx, job, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create a job directly")
 
-	// Phase 1: the failed job must be archived into a HistoricJob (confirms the
-	// resource actually exists before we assert it is cleaned up).
+	// The failed job must first be archived into a HistoricJob and then removed
+	// by the re-list-driven cleanup. A single loop tracks that we observed the
+	// archived job at least once (so an always-empty list can't pass trivially)
+	// and that the list has since drained. This tolerates the short retention
+	// window without racing a two-phase assertion.
+	var archived bool
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.NotEmpty(collect, listHistoricJobs(ctx, collect, historicJobs), "a historic job should be archived")
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "the failed job should be archived into a historic job")
-
-	// Phase 2: the re-list-driven cleanup must then remove aged historic jobs.
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Empty(collect, listHistoricJobs(ctx, collect, historicJobs), "historic jobs should be removed by the re-list-driven cleanup")
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "historic jobs should be swept by the listing-driven cleanup")
+		items := listHistoricJobs(ctx, collect, historicJobs)
+		if len(items) > 0 {
+			archived = true
+		}
+		assert.True(collect, archived, "the failed job should be archived into a historic job")
+		assert.Empty(collect, items, "historic jobs should be removed by the re-list-driven cleanup")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "historic job should be archived then swept by the listing-driven cleanup")
 }
 
 func listHistoricJobs(ctx context.Context, collect *assert.CollectT, client *apis.K8sResourceClient) []unstructured.Unstructured {

--- a/pkg/tests/apis/provisioning/nats/historicjob/historicjob_test.go
+++ b/pkg/tests/apis/provisioning/nats/historicjob/historicjob_test.go
@@ -1,0 +1,48 @@
+package historicjob
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioningNATSHistoricJob_CleanedViaListing proves the
+// historic-job cleanup path that is driven by the informer's periodic re-list
+// (LIST), not by live NATS notifications. HistoricJob is re-list only, so its
+// cleanup controller only ever acts on what the re-list surfaces. With a short
+// history_expiration, a HistoricJob produced by a completed sync must be swept
+// away by that listing-driven cleanup.
+func TestIntegrationProvisioningNATSHistoricJob_CleanedViaListing(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := t.Context()
+
+	const repo = "nats-historicjob-repo"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folderless",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	// Run one pull job to completion, which writes exactly one HistoricJob
+	// (sync is disabled, so nothing else queues jobs). SyncAndWait only returns
+	// after the historic entry exists, so a subsequent empty list can only be
+	// the result of the cleanup having removed it.
+	helper.SyncAndWait(t, repo, nil)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		result, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "jobs")
+		if !assert.NoError(collect, err, "should list historic jobs") {
+			return
+		}
+		list, err := result.ToList()
+		if !assert.NoError(collect, err, "historic jobs result should be a list") {
+			return
+		}
+		assert.Empty(collect, list.Items, "historic jobs should be removed by the re-list-driven cleanup")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "historic jobs should be swept by the listing-driven cleanup")
+}

--- a/pkg/tests/apis/provisioning/nats/historicjob/historicjob_test.go
+++ b/pkg/tests/apis/provisioning/nats/historicjob/historicjob_test.go
@@ -36,24 +36,7 @@ func TestIntegrationProvisioningNATSHistoricJob_CleanedViaListing(t *testing.T) 
 
 	// Create a Job directly against a non-existent repository so the driver
 	// fails it fast and archives it — producing a HistoricJob without a repo.
-	job := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "provisioning.grafana.app/v0alpha1",
-		"kind":       "Job",
-		"metadata": map[string]any{
-			"name":      "nats-historicjob-src",
-			"namespace": "default",
-			"labels": map[string]any{
-				"provisioning.grafana.app/repository": "ghost-repo",
-			},
-		},
-		"spec": map[string]any{
-			"action":     "pull",
-			"repository": "ghost-repo",
-			"pull":       map[string]any{},
-		},
-	}}
-	_, err := helper.Jobs.Resource.Create(ctx, job, metav1.CreateOptions{})
-	require.NoError(t, err, "should be able to create a job directly")
+	helper.CreatePullJob(t, "nats-historicjob-src", "ghost-repo")
 
 	// The failed job must first be archived into a HistoricJob and then removed
 	// by the re-list-driven cleanup. A single loop tracks that we observed the

--- a/pkg/tests/apis/provisioning/nats/historicjob/historicjob_test.go
+++ b/pkg/tests/apis/provisioning/nats/historicjob/historicjob_test.go
@@ -1,48 +1,76 @@
 package historicjob
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
 // TestIntegrationProvisioningNATSHistoricJob_CleanedViaListing proves the
-// historic-job cleanup path that is driven by the informer's periodic re-list
-// (LIST), not by live NATS notifications. HistoricJob is re-list only, so its
-// cleanup controller only ever acts on what the re-list surfaces. With a short
-// history_expiration, a HistoricJob produced by a completed sync must be swept
-// away by that listing-driven cleanup.
+// historic-job cleanup path driven by the informer's periodic re-list (LIST),
+// not by live NATS notifications. HistoricJob is re-list only, so its cleanup
+// controller only acts on what the re-list surfaces.
+//
+// HistoricJobs are read-only through the API, so they cannot be created
+// directly; instead a Job is created directly (referencing a repository that
+// does not exist) so it fails fast and is archived into a HistoricJob — no
+// repository resource involved. With a short history_expiration, that
+// HistoricJob must then be swept by the listing-driven cleanup.
 func TestIntegrationProvisioningNATSHistoricJob_CleanedViaListing(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := t.Context()
 
-	const repo = "nats-historicjob-repo"
-	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folderless",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+	historicJobs := helper.GetResourceClient(apis.ResourceClientArgs{
+		User:      helper.Org1.Admin,
+		Namespace: "default",
+		GVR:       provisioning.HistoricJobResourceInfo.GroupVersionResource(),
 	})
 
-	// Run one pull job to completion, which writes exactly one HistoricJob
-	// (sync is disabled, so nothing else queues jobs). SyncAndWait only returns
-	// after the historic entry exists, so a subsequent empty list can only be
-	// the result of the cleanup having removed it.
-	helper.SyncAndWait(t, repo, nil)
+	// Create a Job directly against a non-existent repository so the driver
+	// fails it fast and archives it — producing a HistoricJob without a repo.
+	job := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "provisioning.grafana.app/v0alpha1",
+		"kind":       "Job",
+		"metadata": map[string]any{
+			"name":      "nats-historicjob-src",
+			"namespace": "default",
+			"labels": map[string]any{
+				"provisioning.grafana.app/repository": "ghost-repo",
+			},
+		},
+		"spec": map[string]any{
+			"action":     "pull",
+			"repository": "ghost-repo",
+			"pull":       map[string]any{},
+		},
+	}}
+	_, err := helper.Jobs.Resource.Create(ctx, job, metav1.CreateOptions{})
+	require.NoError(t, err, "should be able to create a job directly")
 
+	// Phase 1: the failed job must be archived into a HistoricJob (confirms the
+	// resource actually exists before we assert it is cleaned up).
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		result, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "jobs")
-		if !assert.NoError(collect, err, "should list historic jobs") {
-			return
-		}
-		list, err := result.ToList()
-		if !assert.NoError(collect, err, "historic jobs result should be a list") {
-			return
-		}
-		assert.Empty(collect, list.Items, "historic jobs should be removed by the re-list-driven cleanup")
+		assert.NotEmpty(collect, listHistoricJobs(ctx, collect, historicJobs), "a historic job should be archived")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "the failed job should be archived into a historic job")
+
+	// Phase 2: the re-list-driven cleanup must then remove aged historic jobs.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.Empty(collect, listHistoricJobs(ctx, collect, historicJobs), "historic jobs should be removed by the re-list-driven cleanup")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "historic jobs should be swept by the listing-driven cleanup")
+}
+
+func listHistoricJobs(ctx context.Context, collect *assert.CollectT, client *apis.K8sResourceClient) []unstructured.Unstructured {
+	list, err := client.Resource.List(ctx, metav1.ListOptions{})
+	if !assert.NoError(collect, err, "should list historic jobs") {
+		return nil
+	}
+	return list.Items
 }

--- a/pkg/tests/apis/provisioning/nats/jobs_test.go
+++ b/pkg/tests/apis/provisioning/nats/jobs_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -13,58 +14,50 @@ import (
 )
 
 // TestIntegrationProvisioningNATS_JobProcessedOverNATS proves the job-queue
-// driver is woken by a live NATS notification. The driver has two wake sources:
-// the job-create notification (fed by the job informer) and a fallback poll,
-// which WithNATS pushes out to 10 minutes. So a job that reaches a terminal
-// historic state within liveDeliveryWait must have been picked up because the
-// live ADDED notification woke the driver, not the poll.
+// driver is woken by a live NATS notification, without depending on a
+// repository. A Job created directly references a repository that does not
+// exist, so the driver fails it fast — but it can only act that quickly if the
+// job-create notification woke it: the driver's fallback poll is 10 minutes out
+// (WithNATS). Reaching a terminal state (or being archived away) within
+// liveDeliveryWait therefore proves live delivery.
 func TestIntegrationProvisioningNATS_JobProcessedOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := t.Context()
 
-	const repo = "nats-job-repo"
-	createLocalRepo(t, helper, repo)
+	const jobName = "nats-job-direct"
+	job := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "provisioning.grafana.app/v0alpha1",
+		"kind":       "Job",
+		"metadata": map[string]any{
+			"name":      jobName,
+			"namespace": "default",
+			"labels": map[string]any{
+				"provisioning.grafana.app/repository": "ghost-repo",
+			},
+		},
+		"spec": map[string]any{
+			"action":     "pull",
+			"repository": "ghost-repo",
+			"pull":       map[string]any{},
+		},
+	}}
 
-	// The repository must be healthy before a pull job can succeed; this first
-	// reconcile itself rides on NATS.
+	_, err := helper.Jobs.Resource.Create(ctx, job, metav1.CreateOptions{})
+	require.NoError(t, err, "should be able to create a job directly")
+
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+		got, err := helper.Jobs.Resource.Get(ctx, jobName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// Archived to a historic job — it was picked up and processed.
+			return
+		}
 		if !assert.NoError(collect, err) {
 			return
 		}
-		healthy, found, err := unstructured.NestedBool(obj.Object, "status", "health", "healthy")
-		assert.NoError(collect, err)
-		assert.True(collect, found && healthy, "repository should be healthy before syncing")
-	}, liveDeliveryWait, liveDeliveryTick, "repository should become healthy over NATS")
-
-	// Post a pull job directly (sync is disabled, so nothing else queues one).
-	body := common.AsJSON(&provisioning.JobSpec{
-		Action: provisioning.JobActionPull,
-		Pull:   &provisioning.SyncJobOptions{},
-	})
-	result := helper.AdminREST.Post().
-		Namespace("default").
-		Resource("repositories").
-		Name(repo).
-		SubResource("jobs").
-		Body(body).
-		SetHeader("Content-Type", "application/json").
-		Do(ctx)
-	obj, err := result.Get()
-	require.NoError(t, err, "should be able to queue a pull job")
-	job, ok := obj.(*unstructured.Unstructured)
-	require.True(t, ok, "expected unstructured job, got %T", obj)
-	uid := string(job.GetUID())
-	require.NotEmpty(t, uid, "queued job should have a UID")
-
-	// The historic job (keyed by the active job's UID) must reach success within
-	// the live-delivery window.
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		hj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "jobs", uid)
-		if !assert.NoError(collect, err, "historic job should be retrievable") {
-			return
-		}
-		state := common.MustNestedString(hj.Object, "status", "state")
-		assert.Equal(collect, string(provisioning.JobStateSuccess), state, "job should succeed")
-	}, liveDeliveryWait, liveDeliveryTick, "pull job should be processed over NATS within %s", liveDeliveryWait)
+		state := common.MustNestedString(got.Object, "status", "state")
+		assert.Contains(collect, []string{
+			string(provisioning.JobStateSuccess),
+			string(provisioning.JobStateError),
+		}, state, "job should be picked up and reach a terminal state")
+	}, liveDeliveryWait, liveDeliveryTick, "job should be processed over NATS within %s", liveDeliveryWait)
 }

--- a/pkg/tests/apis/provisioning/nats/jobs_test.go
+++ b/pkg/tests/apis/provisioning/nats/jobs_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -15,38 +14,19 @@ import (
 
 // TestIntegrationProvisioningNATS_JobProcessedOverNATS proves the job-queue
 // driver is woken by a live NATS notification, without depending on a
-// repository. A Job created directly references a repository that does not
-// exist, so the driver fails it fast — but it can only act that quickly if the
-// job-create notification woke it: the driver's fallback poll is 10 minutes out
+// repository. The Job references a repository that does not exist, so the
+// driver fails it fast — but it can only act that quickly if the job-create
+// notification woke it: the driver's fallback poll is 10 minutes out
 // (WithNATS). Reaching a terminal state (or being archived away) within
 // liveDeliveryWait therefore proves live delivery.
 func TestIntegrationProvisioningNATS_JobProcessedOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := t.Context()
 
-	const jobName = "nats-job-direct"
-	job := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "provisioning.grafana.app/v0alpha1",
-		"kind":       "Job",
-		"metadata": map[string]any{
-			"name":      jobName,
-			"namespace": "default",
-			"labels": map[string]any{
-				"provisioning.grafana.app/repository": "ghost-repo",
-			},
-		},
-		"spec": map[string]any{
-			"action":     "pull",
-			"repository": "ghost-repo",
-			"pull":       map[string]any{},
-		},
-	}}
-
-	_, err := helper.Jobs.Resource.Create(ctx, job, metav1.CreateOptions{})
-	require.NoError(t, err, "should be able to create a job directly")
+	job := helper.CreatePullJob(t, "nats-job-direct", "ghost-repo")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		got, err := helper.Jobs.Resource.Get(ctx, jobName, metav1.GetOptions{})
+		got, err := helper.Jobs.Resource.Get(ctx, job.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			// Archived to a historic job — it was picked up and processed.
 			return

--- a/pkg/tests/apis/provisioning/nats/jobs_test.go
+++ b/pkg/tests/apis/provisioning/nats/jobs_test.go
@@ -3,42 +3,68 @@ package nats
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
-// TestIntegrationProvisioningNATS_SyncJobProcessedOverNATS verifies the
-// job-queue controller processes a sync Job whose creation is delivered over the
-// NATS-backed job informer. Posting a pull job creates a Job resource; the
-// driver only claims and runs it after the informer delivers that create event.
-// The observable result is a successful historic job for the repository.
-//
-// The repository is created with an empty, folderless sync target so the
-// completed job provisions no resources — this keeps the test focused on the
-// job-queue delivery/processing path rather than resource provisioning, and
-// leaves nothing behind for the shared server's per-test cleanup.
-func TestIntegrationProvisioningNATS_SyncJobProcessedOverNATS(t *testing.T) {
+// TestIntegrationProvisioningNATS_JobProcessedOverNATS proves the job-queue
+// driver is woken by a live NATS notification. The driver has two wake sources:
+// the job-create notification (fed by the job informer) and a fallback poll,
+// which WithNATS pushes out to 10 minutes. So a job that reaches a terminal
+// historic state within liveDeliveryWait must have been picked up because the
+// live ADDED notification woke the driver, not the poll.
+func TestIntegrationProvisioningNATS_JobProcessedOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
+	ctx := t.Context()
 
-	const repo = "nats-sync-repo"
+	const repo = "nats-job-repo"
+	createLocalRepo(t, helper, repo)
 
-	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folderless",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+	// The repository must be healthy before a pull job can succeed; this first
+	// reconcile itself rides on NATS.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+		if !assert.NoError(collect, err) {
+			return
+		}
+		healthy, found, err := unstructured.NestedBool(obj.Object, "status", "health", "healthy")
+		assert.NoError(collect, err)
+		assert.True(collect, found && healthy, "repository should be healthy before syncing")
+	}, liveDeliveryWait, liveDeliveryTick, "repository should become healthy over NATS")
+
+	// Post a pull job directly (sync is disabled, so nothing else queues one).
+	body := common.AsJSON(&provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
 	})
+	result := helper.AdminREST.Post().
+		Namespace("default").
+		Resource("repositories").
+		Name(repo).
+		SubResource("jobs").
+		Body(body).
+		SetHeader("Content-Type", "application/json").
+		Do(ctx)
+	obj, err := result.Get()
+	require.NoError(t, err, "should be able to queue a pull job")
+	job, ok := obj.(*unstructured.Unstructured)
+	require.True(t, ok, "expected unstructured job, got %T", obj)
+	uid := string(job.GetUID())
+	require.NotEmpty(t, uid, "queued job should have a UID")
 
-	// Posts a pull Job and waits for it to reach a terminal state, failing the
-	// test if it errors. This only completes if the driver claimed and ran the
-	// job after receiving its create event over NATS.
-	helper.SyncAndWait(t, repo, nil)
-
-	// The completed job must be recorded as a successful historic job.
-	job := helper.AwaitLatestHistoricJob(t, repo)
-	state := common.MustNestedString(job.Object, "status", "state")
-	require.Equal(t, string(provisioning.JobStateSuccess), state,
-		"sync job processed over NATS should succeed")
+	// The historic job (keyed by the active job's UID) must reach success within
+	// the live-delivery window.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		hj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "jobs", uid)
+		if !assert.NoError(collect, err, "historic job should be retrievable") {
+			return
+		}
+		state := common.MustNestedString(hj.Object, "status", "state")
+		assert.Equal(collect, string(provisioning.JobStateSuccess), state, "job should succeed")
+	}, liveDeliveryWait, liveDeliveryTick, "pull job should be processed over NATS within %s", liveDeliveryWait)
 }

--- a/pkg/tests/apis/provisioning/nats/jobs_test.go
+++ b/pkg/tests/apis/provisioning/nats/jobs_test.go
@@ -1,0 +1,44 @@
+package nats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioningNATS_SyncJobProcessedOverNATS verifies the
+// job-queue controller processes a sync Job whose creation is delivered over the
+// NATS-backed job informer. Posting a pull job creates a Job resource; the
+// driver only claims and runs it after the informer delivers that create event.
+// The observable result is a successful historic job for the repository.
+//
+// The repository is created with an empty, folderless sync target so the
+// completed job provisions no resources — this keeps the test focused on the
+// job-queue delivery/processing path rather than resource provisioning, and
+// leaves nothing behind for the shared server's per-test cleanup.
+func TestIntegrationProvisioningNATS_SyncJobProcessedOverNATS(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "nats-sync-repo"
+
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folderless",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	// Posts a pull Job and waits for it to reach a terminal state, failing the
+	// test if it errors. This only completes if the driver claimed and ran the
+	// job after receiving its create event over NATS.
+	helper.SyncAndWait(t, repo, nil)
+
+	// The completed job must be recorded as a successful historic job.
+	job := helper.AwaitLatestHistoricJob(t, repo)
+	state := common.MustNestedString(job.Object, "status", "state")
+	require.Equal(t, string(provisioning.JobStateSuccess), state,
+		"sync job processed over NATS should succeed")
+}

--- a/pkg/tests/apis/provisioning/nats/relist/connection_test.go
+++ b/pkg/tests/apis/provisioning/nats/relist/connection_test.go
@@ -4,14 +4,11 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
-	clientset "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
@@ -56,23 +53,5 @@ func TestIntegrationProvisioningNATSReList_ConnectionReconciledViaReList(t *test
 		_ = helper.Connections.Resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{})
 	})
 
-	provisioningClient, err := clientset.NewForConfig(helper.Org1.Admin.NewRestConfig())
-	require.NoError(t, err)
-	connClient := provisioningClient.ProvisioningV0alpha1().Connections("default")
-
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		updated, err := connClient.Get(ctx, created.GetName(), metav1.GetOptions{})
-		if !assert.NoError(collect, err) {
-			return
-		}
-		assert.Equal(collect, updated.Generation, updated.Status.ObservedGeneration,
-			"controller should reconcile the observed generation")
-		assert.Greater(collect, updated.Status.Health.Checked, int64(0),
-			"controller should set the health check timestamp")
-		assert.True(collect, updated.Status.Health.Healthy, "connection should be healthy")
-		readyCondition := meta.FindStatusCondition(updated.Status.Conditions, provisioning.ConditionTypeReady)
-		if assert.NotNil(collect, readyCondition, "Ready condition should be set") {
-			assert.Equal(collect, metav1.ConditionTrue, readyCondition.Status)
-		}
-	}, reListWait, reListTick, "connection should be reconciled via the re-list within %s", reListWait)
+	helper.WaitForHealthyConnection(t, created.GetName())
 }

--- a/pkg/tests/apis/provisioning/nats/relist/connection_test.go
+++ b/pkg/tests/apis/provisioning/nats/relist/connection_test.go
@@ -1,0 +1,78 @@
+package relist
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	clientset "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioningNATSReList_ConnectionReconciledViaReList proves the
+// connection controller's re-list fallback. As with the repository test,
+// nothing publishes watch notifications in this package, so a created
+// Connection can only be observed through the connection informer's periodic
+// re-list — yet it must still be reconciled (health + Ready condition). This
+// covers "connection resync" specifically; the connection informer uses the
+// same resync_interval as the repository and job informers.
+func TestIntegrationProvisioningNATSReList_ConnectionReconciledViaReList(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := t.Context()
+	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
+
+	const connName = "nats-relist-connection"
+	conn := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "provisioning.grafana.app/v0alpha1",
+		"kind":       "Connection",
+		"metadata": map[string]any{
+			"name":      connName,
+			"namespace": "default",
+		},
+		"spec": map[string]any{
+			"title": "NATS ReList Connection",
+			"type":  provisioning.GitHubRepositoryType,
+			"github": map[string]any{
+				"appID":          "12345",
+				"installationID": "67890",
+			},
+		},
+		"secure": map[string]any{
+			"privateKey": map[string]any{
+				"create": privateKeyBase64,
+			},
+		},
+	}}
+
+	created, err := helper.CreateGithubConnection(t, ctx, conn)
+	require.NoError(t, err, "failed to create connection")
+	t.Cleanup(func() {
+		_ = helper.Connections.Resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{})
+	})
+
+	provisioningClient, err := clientset.NewForConfig(helper.Org1.Admin.NewRestConfig())
+	require.NoError(t, err)
+	connClient := provisioningClient.ProvisioningV0alpha1().Connections("default")
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		updated, err := connClient.Get(ctx, created.GetName(), metav1.GetOptions{})
+		if !assert.NoError(collect, err) {
+			return
+		}
+		assert.Equal(collect, updated.Generation, updated.Status.ObservedGeneration,
+			"controller should reconcile the observed generation")
+		assert.Greater(collect, updated.Status.Health.Checked, int64(0),
+			"controller should set the health check timestamp")
+		assert.True(collect, updated.Status.Health.Healthy, "connection should be healthy")
+		readyCondition := meta.FindStatusCondition(updated.Status.Conditions, provisioning.ConditionTypeReady)
+		if assert.NotNil(collect, readyCondition, "Ready condition should be set") {
+			assert.Equal(collect, metav1.ConditionTrue, readyCondition.Status)
+		}
+	}, reListWait, reListTick, "connection should be reconciled via the re-list within %s", reListWait)
+}

--- a/pkg/tests/apis/provisioning/nats/relist/helpers_test.go
+++ b/pkg/tests/apis/provisioning/nats/relist/helpers_test.go
@@ -19,14 +19,6 @@ import (
 // far out).
 var env = common.NewSharedEnv(common.WithNATSReListOnly(2 * time.Second))
 
-const (
-	// reListWait bounds how long reconciliation via the periodic re-list may
-	// take. It is a comfortable multiple of the 2s resync so the assertion is
-	// not tight, while staying short enough to keep the test quick.
-	reListWait = 30 * time.Second
-	reListTick = 200 * time.Millisecond
-)
-
 func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
 	t.Helper()
 	helper := env.GetCleanHelper(t)

--- a/pkg/tests/apis/provisioning/nats/relist/helpers_test.go
+++ b/pkg/tests/apis/provisioning/nats/relist/helpers_test.go
@@ -1,0 +1,39 @@
+package relist
+
+import (
+	"testing"
+	"time"
+
+	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// env starts a shared Grafana server with the embedded NATS bus enabled but the
+// SQL KV backend left off (common.WithNATSReListOnly), so no watch
+// notifications are ever published. The provisioning informers run on the NATS
+// path but receive no live events, which isolates the periodic re-list as the
+// sole reconcile driver. The short resync keeps that re-list within a test's
+// budget. This is its own package because the config is incompatible with the
+// live-delivery packages (which need the KV backend on and the re-list pushed
+// far out).
+var env = common.NewSharedEnv(common.WithNATSReListOnly(2 * time.Second))
+
+const (
+	// reListWait bounds how long reconciliation via the periodic re-list may
+	// take. It is a comfortable multiple of the 2s resync so the assertion is
+	// not tight, while staying short enough to keep the test quick.
+	reListWait = 30 * time.Second
+	reListTick = 200 * time.Millisecond
+)
+
+func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
+	t.Helper()
+	helper := env.GetCleanHelper(t)
+	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
+	return helper
+}
+
+func TestMain(m *testing.M) {
+	env.RunTestMain(m)
+}

--- a/pkg/tests/apis/provisioning/nats/relist/relist_test.go
+++ b/pkg/tests/apis/provisioning/nats/relist/relist_test.go
@@ -1,0 +1,94 @@
+package relist
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioningNATSReList_RepositoryReconciledViaReList proves the
+// re-list fallback reconciles a newly-created repository. Nothing publishes
+// watch notifications in this package, and the informer's initial list ran at
+// startup before this repo existed, so the controller can only have observed
+// the repository through the periodic re-list. It must still reach healthy.
+func TestIntegrationProvisioningNATSReList_RepositoryReconciledViaReList(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := t.Context()
+
+	const repo = "nats-relist-create"
+	createLocalRepo(t, helper, repo)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+		if !assert.NoError(collect, err) {
+			return
+		}
+		observedGeneration, found, err := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
+		assert.NoError(collect, err)
+		assert.True(collect, found, "controller should set status.observedGeneration")
+		assert.Greater(collect, observedGeneration, int64(0))
+
+		healthy, found, err := unstructured.NestedBool(obj.Object, "status", "health", "healthy")
+		assert.NoError(collect, err)
+		assert.True(collect, found && healthy, "repository should be healthy")
+	}, reListWait, reListTick, "repository should be reconciled to healthy via the re-list within %s", reListWait)
+}
+
+// TestIntegrationProvisioningNATSReList_RepositoryReCheckedViaReList proves the
+// re-list also picks up updates: after the repository is healthy, aging its
+// health timestamp must trigger a fresh health check on a subsequent re-list,
+// advancing status.health.checked — again with no live notification in play.
+func TestIntegrationProvisioningNATSReList_RepositoryReCheckedViaReList(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := t.Context()
+
+	const repo = "nats-relist-update"
+	createLocalRepo(t, helper, repo)
+
+	var before int64
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		checked, ok := repositoryHealthChecked(ctx, collect, helper, repo)
+		if assert.True(collect, ok, "repository should have a health checked timestamp") {
+			before = checked
+		}
+	}, reListWait, reListTick, "repository should first become healthy via the re-list")
+
+	helper.TriggerRepositoryReconciliation(t, repo)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		checked, ok := repositoryHealthChecked(ctx, collect, helper, repo)
+		if assert.True(collect, ok) {
+			assert.Greater(collect, checked, before, "controller should re-check health on a re-list after the update")
+		}
+	}, reListWait, reListTick, "repository health should be re-checked via the re-list within %s", reListWait)
+}
+
+// createLocalRepo creates a sync-disabled, folderless local repository without
+// waiting for it to become healthy — the caller asserts the reconcile itself.
+func createLocalRepo(t *testing.T, helper *common.ProvisioningTestHelper, name string) {
+	t.Helper()
+	repo := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), common.TestRepo{
+		Name:          name,
+		SyncTarget:    "folderless",
+		Path:          helper.ProvisioningPath,
+		WorkflowsJSON: "[]",
+	})
+	_, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create local repository %q", name)
+}
+
+func repositoryHealthChecked(ctx context.Context, collect *assert.CollectT, helper *common.ProvisioningTestHelper, repo string) (int64, bool) {
+	obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+	if !assert.NoError(collect, err, "should read back the repository") {
+		return 0, false
+	}
+	checked, found, err := unstructured.NestedInt64(obj.Object, "status", "health", "checked")
+	assert.NoError(collect, err)
+	return checked, found
+}

--- a/pkg/tests/apis/provisioning/nats/relist/relist_test.go
+++ b/pkg/tests/apis/provisioning/nats/relist/relist_test.go
@@ -6,25 +6,22 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
-// localRepo is the sync-disabled, folderless local repository used by the
-// re-list tests.
-func localRepo(name string) common.TestRepo {
-	return common.TestRepo{
-		Name:                   name,
-		SyncTarget:             "folderless",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
-	}
-}
-
 // TestIntegrationProvisioningNATSReList_RepositoryReconciledViaReList proves the
 // re-list fallback reconciles a newly-created repository. Nothing publishes
 // watch notifications in this package, and the informer's initial list ran at
-// startup before this repo existed, so CreateLocalRepo's wait-for-healthy can
-// only be satisfied by the periodic re-list.
+// startup before this repo existed, so WaitForHealthyRepository can only be
+// satisfied by the periodic re-list.
 func TestIntegrationProvisioningNATSReList_RepositoryReconciledViaReList(t *testing.T) {
 	helper := sharedHelper(t)
-	helper.CreateLocalRepo(t, localRepo("nats-relist-create"))
+	const repo = "nats-relist-create"
+
+	helper.CreateRepositoryNoWait(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+	helper.WaitForHealthyRepository(t, repo)
 }
 
 // TestIntegrationProvisioningNATSReList_RepositoryReCheckedViaReList proves the
@@ -34,6 +31,13 @@ func TestIntegrationProvisioningNATSReList_RepositoryReconciledViaReList(t *test
 func TestIntegrationProvisioningNATSReList_RepositoryReCheckedViaReList(t *testing.T) {
 	helper := sharedHelper(t)
 	const repo = "nats-relist-update"
-	helper.CreateLocalRepo(t, localRepo(repo))
+
+	helper.CreateRepositoryNoWait(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+	helper.WaitForHealthyRepository(t, repo)
 	helper.RequireRepositoryReReconciles(t, repo)
 }

--- a/pkg/tests/apis/provisioning/nats/relist/relist_test.go
+++ b/pkg/tests/apis/provisioning/nats/relist/relist_test.go
@@ -1,94 +1,39 @@
 package relist
 
 import (
-	"context"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
+// localRepo is the sync-disabled, folderless local repository used by the
+// re-list tests.
+func localRepo(name string) common.TestRepo {
+	return common.TestRepo{
+		Name:                   name,
+		SyncTarget:             "folderless",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	}
+}
+
 // TestIntegrationProvisioningNATSReList_RepositoryReconciledViaReList proves the
 // re-list fallback reconciles a newly-created repository. Nothing publishes
 // watch notifications in this package, and the informer's initial list ran at
-// startup before this repo existed, so the controller can only have observed
-// the repository through the periodic re-list. It must still reach healthy.
+// startup before this repo existed, so CreateLocalRepo's wait-for-healthy can
+// only be satisfied by the periodic re-list.
 func TestIntegrationProvisioningNATSReList_RepositoryReconciledViaReList(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
-
-	const repo = "nats-relist-create"
-	createLocalRepo(t, helper, repo)
-
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
-		if !assert.NoError(collect, err) {
-			return
-		}
-		observedGeneration, found, err := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
-		assert.NoError(collect, err)
-		assert.True(collect, found, "controller should set status.observedGeneration")
-		assert.Greater(collect, observedGeneration, int64(0))
-
-		healthy, found, err := unstructured.NestedBool(obj.Object, "status", "health", "healthy")
-		assert.NoError(collect, err)
-		assert.True(collect, found && healthy, "repository should be healthy")
-	}, reListWait, reListTick, "repository should be reconciled to healthy via the re-list within %s", reListWait)
+	helper.CreateLocalRepo(t, localRepo("nats-relist-create"))
 }
 
 // TestIntegrationProvisioningNATSReList_RepositoryReCheckedViaReList proves the
 // re-list also picks up updates: after the repository is healthy, aging its
-// health timestamp must trigger a fresh health check on a subsequent re-list,
-// advancing status.health.checked — again with no live notification in play.
+// health timestamp triggers a fresh health check on a subsequent re-list — with
+// no live notification in play.
 func TestIntegrationProvisioningNATSReList_RepositoryReCheckedViaReList(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
-
 	const repo = "nats-relist-update"
-	createLocalRepo(t, helper, repo)
-
-	var before int64
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		checked, ok := repositoryHealthChecked(ctx, collect, helper, repo)
-		if assert.True(collect, ok, "repository should have a health checked timestamp") {
-			before = checked
-		}
-	}, reListWait, reListTick, "repository should first become healthy via the re-list")
-
-	helper.TriggerRepositoryReconciliation(t, repo)
-
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		checked, ok := repositoryHealthChecked(ctx, collect, helper, repo)
-		if assert.True(collect, ok) {
-			assert.Greater(collect, checked, before, "controller should re-check health on a re-list after the update")
-		}
-	}, reListWait, reListTick, "repository health should be re-checked via the re-list within %s", reListWait)
-}
-
-// createLocalRepo creates a sync-disabled, folderless local repository without
-// waiting for it to become healthy — the caller asserts the reconcile itself.
-func createLocalRepo(t *testing.T, helper *common.ProvisioningTestHelper, name string) {
-	t.Helper()
-	repo := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), common.TestRepo{
-		Name:          name,
-		SyncTarget:    "folderless",
-		Path:          helper.ProvisioningPath,
-		WorkflowsJSON: "[]",
-	})
-	_, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{})
-	require.NoError(t, err, "failed to create local repository %q", name)
-}
-
-func repositoryHealthChecked(ctx context.Context, collect *assert.CollectT, helper *common.ProvisioningTestHelper, repo string) (int64, bool) {
-	obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
-	if !assert.NoError(collect, err, "should read back the repository") {
-		return 0, false
-	}
-	checked, found, err := unstructured.NestedInt64(obj.Object, "status", "health", "checked")
-	assert.NoError(collect, err)
-	return checked, found
+	helper.CreateLocalRepo(t, localRepo(repo))
+	helper.RequireRepositoryReReconciles(t, repo)
 }

--- a/pkg/tests/apis/provisioning/nats/repository_test.go
+++ b/pkg/tests/apis/provisioning/nats/repository_test.go
@@ -6,35 +6,40 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
-// localRepo is the sync-disabled, folderless local repository used by the
-// repository tests. Sync-disabled + folderless keeps it side-effect free (it
-// provisions nothing the shared cleanup must remove).
-func localRepo(name string) common.TestRepo {
-	return common.TestRepo{
-		Name:                   name,
-		SyncTarget:             "folderless",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
-	}
-}
-
 // TestIntegrationProvisioningNATS_RepositoryCreateReconciledOverNATS proves the
-// repository controller is driven by a live NATS notification. CreateLocalRepo
-// blocks until the controller marks the repository healthy; with the re-list
-// pushed to 10m (WithNATS) and the informer's initial list predating this repo,
-// that reconcile can only have come from the live ADDED notification.
+// repository controller is driven by a live NATS notification. The repository
+// is created without waiting, and WaitForHealthyRepository is the explicit
+// reconcile assertion: with the re-list pushed to 10m (WithNATS) and the
+// informer's initial list predating this repo, the controller could only have
+// marked it healthy in response to the live ADDED notification. Sync is
+// disabled so the repo provisions nothing the shared cleanup must remove.
 func TestIntegrationProvisioningNATS_RepositoryCreateReconciledOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
-	helper.CreateLocalRepo(t, localRepo("nats-repo-create"))
+	const repo = "nats-repo-create"
+
+	helper.CreateRepositoryNoWait(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+	helper.WaitForHealthyRepository(t, repo)
 }
 
 // TestIntegrationProvisioningNATS_RepositoryUpdateReconciledOverNATS proves the
-// controller also reacts to update events over NATS: after the repository is
-// healthy, aging its health timestamp triggers a fresh health check that
-// advances status.health.checked — again far sooner than the 10m re-list.
+// controller also reacts to update events over NATS: once the repo is healthy,
+// RequireRepositoryReReconciles ages its health timestamp and asserts the
+// controller re-runs the health check — again far sooner than the 10m re-list.
 func TestIntegrationProvisioningNATS_RepositoryUpdateReconciledOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
 	const repo = "nats-repo-update"
-	helper.CreateLocalRepo(t, localRepo(repo))
+
+	helper.CreateRepositoryNoWait(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+	helper.WaitForHealthyRepository(t, repo)
 	helper.RequireRepositoryReReconciles(t, repo)
 }

--- a/pkg/tests/apis/provisioning/nats/repository_test.go
+++ b/pkg/tests/apis/provisioning/nats/repository_test.go
@@ -1,0 +1,85 @@
+package nats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioningNATS_RepositoryControllerReconciles verifies the
+// repository controller reacts to a Repository create event delivered over the
+// NATS-backed informer: it runs the health check and writes the result back to
+// status. CreateLocalRepo blocks on WaitForHealthyRepository, so this only
+// passes if the controller processed the event and set status.health.healthy.
+func TestIntegrationProvisioningNATS_RepositoryControllerReconciles(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := t.Context()
+
+	const repo = "nats-repo-reconcile"
+
+	// Blocks until the controller marks the repository healthy.
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+	require.NoError(t, err, "should read back the repository")
+
+	// The controller advances observedGeneration once it has reconciled the spec.
+	observedGeneration, found, err := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
+	require.NoError(t, err)
+	require.True(t, found, "controller should set status.observedGeneration")
+	require.Greater(t, observedGeneration, int64(0), "observedGeneration should be set by the controller")
+
+	// A health check must have run (non-zero checked timestamp, healthy=true).
+	healthy, found, err := unstructured.NestedBool(obj.Object, "status", "health", "healthy")
+	require.NoError(t, err)
+	require.True(t, found, "controller should populate status.health")
+	require.True(t, healthy, "repository should be healthy after reconcile over NATS")
+}
+
+// TestIntegrationProvisioningNATS_RepositoryReconcilesOnUpdate verifies the
+// controller also reacts to update events over NATS: after the repository is
+// healthy, aging its health timestamp (an update to the status subresource)
+// triggers a fresh reconcile that advances status.health.checked.
+func TestIntegrationProvisioningNATS_RepositoryReconcilesOnUpdate(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "nats-repo-update"
+
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	before := repositoryHealthChecked(t, helper, repo)
+
+	// Age the health timestamp; the update event flows through the NATS informer
+	// and the controller re-runs the health check.
+	helper.TriggerRepositoryReconciliation(t, repo)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		checked := repositoryHealthChecked(t, helper, repo)
+		assert.Greater(collect, checked, before, "controller should re-check health after the update event")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository health should be re-checked over NATS")
+}
+
+func repositoryHealthChecked(t *testing.T, helper *common.ProvisioningTestHelper, repo string) int64 {
+	t.Helper()
+	obj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
+	require.NoError(t, err, "should read back the repository")
+	checked, found, err := unstructured.NestedInt64(obj.Object, "status", "health", "checked")
+	require.NoError(t, err)
+	require.True(t, found, "repository should have a health checked timestamp")
+	return checked
+}

--- a/pkg/tests/apis/provisioning/nats/repository_test.go
+++ b/pkg/tests/apis/provisioning/nats/repository_test.go
@@ -1,85 +1,40 @@
 package nats
 
 import (
-	"context"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
+// localRepo is the sync-disabled, folderless local repository used by the
+// repository tests. Sync-disabled + folderless keeps it side-effect free (it
+// provisions nothing the shared cleanup must remove).
+func localRepo(name string) common.TestRepo {
+	return common.TestRepo{
+		Name:                   name,
+		SyncTarget:             "folderless",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	}
+}
+
 // TestIntegrationProvisioningNATS_RepositoryCreateReconciledOverNATS proves the
-// repository controller is driven by a live NATS notification: the repository
-// is created and must be reconciled to healthy within liveDeliveryWait. The
-// repository controller's only event source is the informer, whose re-list is
-// 10 minutes out (WithNATS) and whose initial list predates this resource, so a
-// reconcile this fast can only have come from the ADDED notification.
+// repository controller is driven by a live NATS notification. CreateLocalRepo
+// blocks until the controller marks the repository healthy; with the re-list
+// pushed to 10m (WithNATS) and the informer's initial list predating this repo,
+// that reconcile can only have come from the live ADDED notification.
 func TestIntegrationProvisioningNATS_RepositoryCreateReconciledOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
-
-	const repo = "nats-repo-create"
-	createLocalRepo(t, helper, repo)
-
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		obj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
-		if !assert.NoError(collect, err) {
-			return
-		}
-		observedGeneration, found, err := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
-		assert.NoError(collect, err)
-		assert.True(collect, found, "controller should set status.observedGeneration")
-		assert.Greater(collect, observedGeneration, int64(0), "observedGeneration should be set by the controller")
-
-		healthy, found, err := unstructured.NestedBool(obj.Object, "status", "health", "healthy")
-		assert.NoError(collect, err)
-		assert.True(collect, found, "controller should populate status.health")
-		assert.True(collect, healthy, "repository should be healthy")
-	}, liveDeliveryWait, liveDeliveryTick, "repository should be reconciled to healthy over NATS within %s", liveDeliveryWait)
+	helper.CreateLocalRepo(t, localRepo("nats-repo-create"))
 }
 
 // TestIntegrationProvisioningNATS_RepositoryUpdateReconciledOverNATS proves the
 // controller also reacts to update events over NATS: after the repository is
-// healthy, aging its health timestamp (a status update) must trigger a fresh
-// health check that advances status.health.checked within liveDeliveryWait —
-// again far sooner than the 10-minute re-list could explain.
+// healthy, aging its health timestamp triggers a fresh health check that
+// advances status.health.checked — again far sooner than the 10m re-list.
 func TestIntegrationProvisioningNATS_RepositoryUpdateReconciledOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
-
 	const repo = "nats-repo-update"
-	ctx := t.Context()
-	createLocalRepo(t, helper, repo)
-
-	// Wait for the initial healthy reconcile so we have a baseline timestamp.
-	var before int64
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		checked, ok := repositoryHealthChecked(ctx, collect, helper, repo)
-		if assert.True(collect, ok, "repository should have a health checked timestamp") {
-			before = checked
-		}
-	}, liveDeliveryWait, liveDeliveryTick, "repository should first become healthy over NATS")
-
-	// Age the health timestamp; the update event flows through the NATS informer
-	// and the controller re-runs the health check.
-	helper.TriggerRepositoryReconciliation(t, repo)
-
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		checked, ok := repositoryHealthChecked(ctx, collect, helper, repo)
-		if assert.True(collect, ok) {
-			assert.Greater(collect, checked, before, "controller should re-check health after the update event")
-		}
-	}, liveDeliveryWait, liveDeliveryTick, "repository health should be re-checked over NATS within %s", liveDeliveryWait)
-}
-
-func repositoryHealthChecked(ctx context.Context, collect *assert.CollectT, helper *common.ProvisioningTestHelper, repo string) (int64, bool) {
-	obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
-	if !assert.NoError(collect, err, "should read back the repository") {
-		return 0, false
-	}
-	checked, found, err := unstructured.NestedInt64(obj.Object, "status", "health", "checked")
-	assert.NoError(collect, err)
-	return checked, found
+	helper.CreateLocalRepo(t, localRepo(repo))
+	helper.RequireRepositoryReReconciles(t, repo)
 }

--- a/pkg/tests/apis/provisioning/nats/repository_test.go
+++ b/pkg/tests/apis/provisioning/nats/repository_test.go
@@ -1,6 +1,7 @@
 package nats
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,75 +12,74 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
-// TestIntegrationProvisioningNATS_RepositoryControllerReconciles verifies the
-// repository controller reacts to a Repository create event delivered over the
-// NATS-backed informer: it runs the health check and writes the result back to
-// status. CreateLocalRepo blocks on WaitForHealthyRepository, so this only
-// passes if the controller processed the event and set status.health.healthy.
-func TestIntegrationProvisioningNATS_RepositoryControllerReconciles(t *testing.T) {
+// TestIntegrationProvisioningNATS_RepositoryCreateReconciledOverNATS proves the
+// repository controller is driven by a live NATS notification: the repository
+// is created and must be reconciled to healthy within liveDeliveryWait. The
+// repository controller's only event source is the informer, whose re-list is
+// 10 minutes out (WithNATS) and whose initial list predates this resource, so a
+// reconcile this fast can only have come from the ADDED notification.
+func TestIntegrationProvisioningNATS_RepositoryCreateReconciledOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
-	const repo = "nats-repo-reconcile"
+	const repo = "nats-repo-create"
+	createLocalRepo(t, helper, repo)
 
-	// Blocks until the controller marks the repository healthy.
-	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
-	})
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		obj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
+		if !assert.NoError(collect, err) {
+			return
+		}
+		observedGeneration, found, err := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
+		assert.NoError(collect, err)
+		assert.True(collect, found, "controller should set status.observedGeneration")
+		assert.Greater(collect, observedGeneration, int64(0), "observedGeneration should be set by the controller")
 
-	obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
-	require.NoError(t, err, "should read back the repository")
-
-	// The controller advances observedGeneration once it has reconciled the spec.
-	observedGeneration, found, err := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
-	require.NoError(t, err)
-	require.True(t, found, "controller should set status.observedGeneration")
-	require.Greater(t, observedGeneration, int64(0), "observedGeneration should be set by the controller")
-
-	// A health check must have run (non-zero checked timestamp, healthy=true).
-	healthy, found, err := unstructured.NestedBool(obj.Object, "status", "health", "healthy")
-	require.NoError(t, err)
-	require.True(t, found, "controller should populate status.health")
-	require.True(t, healthy, "repository should be healthy after reconcile over NATS")
+		healthy, found, err := unstructured.NestedBool(obj.Object, "status", "health", "healthy")
+		assert.NoError(collect, err)
+		assert.True(collect, found, "controller should populate status.health")
+		assert.True(collect, healthy, "repository should be healthy")
+	}, liveDeliveryWait, liveDeliveryTick, "repository should be reconciled to healthy over NATS within %s", liveDeliveryWait)
 }
 
-// TestIntegrationProvisioningNATS_RepositoryReconcilesOnUpdate verifies the
+// TestIntegrationProvisioningNATS_RepositoryUpdateReconciledOverNATS proves the
 // controller also reacts to update events over NATS: after the repository is
-// healthy, aging its health timestamp (an update to the status subresource)
-// triggers a fresh reconcile that advances status.health.checked.
-func TestIntegrationProvisioningNATS_RepositoryReconcilesOnUpdate(t *testing.T) {
+// healthy, aging its health timestamp (a status update) must trigger a fresh
+// health check that advances status.health.checked within liveDeliveryWait —
+// again far sooner than the 10-minute re-list could explain.
+func TestIntegrationProvisioningNATS_RepositoryUpdateReconciledOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
 
 	const repo = "nats-repo-update"
+	ctx := t.Context()
+	createLocalRepo(t, helper, repo)
 
-	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
-	})
-
-	before := repositoryHealthChecked(t, helper, repo)
+	// Wait for the initial healthy reconcile so we have a baseline timestamp.
+	var before int64
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		checked, ok := repositoryHealthChecked(ctx, collect, helper, repo)
+		if assert.True(collect, ok, "repository should have a health checked timestamp") {
+			before = checked
+		}
+	}, liveDeliveryWait, liveDeliveryTick, "repository should first become healthy over NATS")
 
 	// Age the health timestamp; the update event flows through the NATS informer
 	// and the controller re-runs the health check.
 	helper.TriggerRepositoryReconciliation(t, repo)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		checked := repositoryHealthChecked(t, helper, repo)
-		assert.Greater(collect, checked, before, "controller should re-check health after the update event")
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository health should be re-checked over NATS")
+		checked, ok := repositoryHealthChecked(ctx, collect, helper, repo)
+		if assert.True(collect, ok) {
+			assert.Greater(collect, checked, before, "controller should re-check health after the update event")
+		}
+	}, liveDeliveryWait, liveDeliveryTick, "repository health should be re-checked over NATS within %s", liveDeliveryWait)
 }
 
-func repositoryHealthChecked(t *testing.T, helper *common.ProvisioningTestHelper, repo string) int64 {
-	t.Helper()
-	obj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
-	require.NoError(t, err, "should read back the repository")
+func repositoryHealthChecked(ctx context.Context, collect *assert.CollectT, helper *common.ProvisioningTestHelper, repo string) (int64, bool) {
+	obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+	if !assert.NoError(collect, err, "should read back the repository") {
+		return 0, false
+	}
 	checked, found, err := unstructured.NestedInt64(obj.Object, "status", "health", "checked")
-	require.NoError(t, err)
-	require.True(t, found, "repository should have a health checked timestamp")
-	return checked
+	assert.NoError(collect, err)
+	return checked, found
 }

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -898,7 +898,7 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 	if opts.ProvisioningControllerResyncInterval > 0 {
 		provisioningSect, err := getOrCreateSection("provisioning")
 		require.NoError(t, err)
-		_, err = provisioningSect.NewKey("controller_resync_interval", opts.ProvisioningControllerResyncInterval.String())
+		_, err = provisioningSect.NewKey("resync_interval", opts.ProvisioningControllerResyncInterval.String())
 		require.NoError(t, err)
 	}
 	if opts.ProvisioningHistoryExpiration > 0 {
@@ -1088,7 +1088,7 @@ type GrafanaOpts struct {
 	ProvisioningMaxIncrementalChanges                    *int
 	ProvisioningMaxFileSize                              *int64
 	// ProvisioningControllerResyncInterval overrides [provisioning]
-	// controller_resync_interval (repo/connection/job informer re-list). Set it
+	// resync_interval (repo/connection/job informer re-list). Set it
 	// high in NATS tests so a fast reconcile can only be a live notification, not
 	// the periodic re-list. Zero leaves the ini default (60s).
 	ProvisioningControllerResyncInterval time.Duration

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -804,6 +804,27 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = section.NewKey("enable_sqlkv_backend", "true")
 		require.NoError(t, err)
 	}
+	if opts.NATSEnabled {
+		listenAddress := opts.NATSListenAddress
+		if listenAddress == "" {
+			listenAddress = "127.0.0.1"
+		}
+		section, err := getOrCreateSection("nats")
+		require.NoError(t, err)
+		_, err = section.NewKey("enabled", "true")
+		require.NoError(t, err)
+		_, err = section.NewKey("mode", "embedded")
+		require.NoError(t, err)
+		_, err = section.NewKey("listen_address", listenAddress)
+		require.NoError(t, err)
+		_, err = section.NewKey("client_port", strconv.Itoa(opts.NATSClientPort))
+		require.NoError(t, err)
+		_, err = section.NewKey("cluster_port", strconv.Itoa(opts.NATSClusterPort))
+		require.NoError(t, err)
+		// Single-node test bus: skip KV-backed peer discovery/clustering.
+		_, err = section.NewKey("discovery_enabled", "false")
+		require.NoError(t, err)
+	}
 	if opts.PermittedProvisioningPaths != "" {
 		_, err = pathsSect.NewKey("permitted_provisioning_paths", opts.PermittedProvisioningPaths)
 		require.NoError(t, err)
@@ -1060,13 +1081,26 @@ type GrafanaOpts struct {
 	MigrationParquetBuffer                               bool
 	MigrationChunkMaxBytes                               int64
 	EnableSQLKVBackend                                   bool
-	SecretsManagerEnableDBMigrations                     bool
-	OpenFeatureAPIEnabled                                bool
-	DisableAuthZClientCache                              bool
-	ZanzanaReconciliationInterval                        time.Duration
-	ZanzanaReconcilerMode                                setting.ZanzanaReconcilerMode
-	DisableZanzanaCache                                  bool
-	DisableZanzanaServerCheckQueryCache                  bool
+	// NATSEnabled starts an embedded Core NATS bus ([nats] enabled=true,
+	// mode=embedded). Provisioning controllers then consume resource-change
+	// notifications through the NATS-backed informer instead of the apiserver
+	// watch. Publishing requires EnableSQLKVBackend=true.
+	NATSEnabled bool
+	// NATSListenAddress is the embedded server's bind address; defaults to
+	// 127.0.0.1 when empty.
+	NATSListenAddress string
+	// NATSClientPort / NATSClusterPort are the embedded server's ports. Callers
+	// should pass free ports so parallel test binaries don't collide on the
+	// conventional 4222/6222.
+	NATSClientPort                      int
+	NATSClusterPort                     int
+	SecretsManagerEnableDBMigrations    bool
+	OpenFeatureAPIEnabled               bool
+	DisableAuthZClientCache             bool
+	ZanzanaReconciliationInterval       time.Duration
+	ZanzanaReconcilerMode               setting.ZanzanaReconcilerMode
+	DisableZanzanaCache                 bool
+	DisableZanzanaServerCheckQueryCache bool
 
 	// If set to 0, the default (2) is used.
 	DBMaxConns int

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -895,6 +895,24 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = provisioningSect.NewKey("max_file_size", fmt.Sprintf("%d", *opts.ProvisioningMaxFileSize))
 		require.NoError(t, err)
 	}
+	if opts.ProvisioningControllerResyncInterval > 0 {
+		provisioningSect, err := getOrCreateSection("provisioning")
+		require.NoError(t, err)
+		_, err = provisioningSect.NewKey("controller_resync_interval", opts.ProvisioningControllerResyncInterval.String())
+		require.NoError(t, err)
+	}
+	if opts.ProvisioningHistoryExpiration > 0 {
+		provisioningSect, err := getOrCreateSection("provisioning")
+		require.NoError(t, err)
+		_, err = provisioningSect.NewKey("history_expiration", opts.ProvisioningHistoryExpiration.String())
+		require.NoError(t, err)
+	}
+	if opts.ProvisioningJobPollInterval > 0 {
+		provisioningSect, err := getOrCreateSection("provisioning")
+		require.NoError(t, err)
+		_, err = provisioningSect.NewKey("job_poll_interval", opts.ProvisioningJobPollInterval.String())
+		require.NoError(t, err)
+	}
 	if opts.EnableSCIM {
 		scimSection, err := getOrCreateSection("auth.scim")
 		require.NoError(t, err)
@@ -1069,18 +1087,32 @@ type GrafanaOpts struct {
 	ProvisioningFolderAPIVersion                         string
 	ProvisioningMaxIncrementalChanges                    *int
 	ProvisioningMaxFileSize                              *int64
-	GrafanaComSSOAPIToken                                string
-	LicensePath                                          string
-	EnableRecordingRules                                 bool
-	EnableSCIM                                           bool
-	RBACSingleOrganization                               bool
-	GlobalRoleSeedingEnabled                             bool
-	APIServerRuntimeConfig                               string
-	DisableControllers                                   bool
-	DisableDBCleanup                                     bool
-	MigrationParquetBuffer                               bool
-	MigrationChunkMaxBytes                               int64
-	EnableSQLKVBackend                                   bool
+	// ProvisioningControllerResyncInterval overrides [provisioning]
+	// controller_resync_interval (repo/connection/job informer re-list). Set it
+	// high in NATS tests so a fast reconcile can only be a live notification, not
+	// the periodic re-list. Zero leaves the ini default (60s).
+	ProvisioningControllerResyncInterval time.Duration
+	// ProvisioningHistoryExpiration overrides [provisioning] history_expiration
+	// (HistoricJob retention + historic-job informer resync). Set it low to
+	// exercise the re-list-driven cleanup quickly. Zero leaves the default (10m).
+	ProvisioningHistoryExpiration time.Duration
+	// ProvisioningJobPollInterval overrides [provisioning] job_poll_interval (job
+	// driver fallback poll). Set it high in NATS tests so a job that completes
+	// quickly can only have been woken by the live notification, not the poll.
+	// Zero leaves the default (30s).
+	ProvisioningJobPollInterval time.Duration
+	GrafanaComSSOAPIToken       string
+	LicensePath                 string
+	EnableRecordingRules        bool
+	EnableSCIM                  bool
+	RBACSingleOrganization      bool
+	GlobalRoleSeedingEnabled    bool
+	APIServerRuntimeConfig      string
+	DisableControllers          bool
+	DisableDBCleanup            bool
+	MigrationParquetBuffer      bool
+	MigrationChunkMaxBytes      int64
+	EnableSQLKVBackend          bool
 	// NATSEnabled starts an embedded Core NATS bus ([nats] enabled=true,
 	// mode=embedded). Provisioning controllers then consume resource-change
 	// notifications through the NATS-backed informer instead of the apiserver


### PR DESCRIPTION
## Summary

Adds integration tests (`pkg/tests/apis/provisioning/nats`) that boot a full Grafana server with the **embedded NATS bus** and the **SQL KV storage backend** enabled, so the provisioning controllers reconcile off NATS-delivered resource-change notifications instead of the apiserver watch.

Closes #127725.

The controllers auto-select the NATS-backed informer whenever `[nats] enabled=true` (`register.go` → `nats.Enabled(...)`); publishing only happens from the SQL KV backend (`kvStorageBackend.publishWatchNotification`).

## Proving delivery, not just behavior

The NATS-backed informer reconciles from **two** sources — live notifications **and** a periodic re-list — and the job driver additionally has its own fallback poll. So a naive "create X, wait for reconcile" test could be satisfied by the re-list/poll, proving nothing about NATS. These intervals were hardcoded.

This PR makes them configurable (defaults unchanged), mirroring the existing `sync_resource_timeout` / `webhook_secret_rotation_interval` pattern:

| `[provisioning]` key | Default | Controls |
| --- | --- | --- |
| `resync_interval` | 60s | repo/connection/job informer re-list |
| `history_expiration` | 10m | HistoricJob retention + historic-job informer resync |
| `job_poll_interval` | 30s | job driver fallback poll |

`register.go` reads these from `cfg` (new `setting.Cfg` fields) and falls back to the defaults when unset; `testinfra` writes them from `GrafanaOpts`.

Both halves of the informer's contract are covered independently:

**Live delivery** (`nats` package) — `common.WithNATS()` pushes the re-list and job poll to **10 minutes**, so any reconcile/job pickup within `liveDeliveryWait` (20s) can only be a live notification.

**Re-list fallback** (`nats/relist` package) — `common.WithNATSReListOnly()` enables NATS but leaves the KV backend off, so *nothing publishes*. The informers subscribe but receive no live events, isolating the periodic re-list (short interval) as the sole reconcile driver. This is the guarantee that reconciliation still happens when a live event is missed (round-robined to another replica, startup/reconnect gap).

## Minimal dependencies (create artifacts directly)

Tests avoid standing up a repository except where the repository itself is under test:

- **Repository** tests create a `Repository` (unavoidable — they are the repository-controller tests).
- **Connection** tests create a `Connection` (never needed a repo).
- **Job / HistoricJob** tests create a `Job` **directly** against a non-existent repository. `HistoricJob` is read-only through the API (only `historicjobs:read` exists), so it cannot be created directly; instead the directly-created Job fails fast (repo not found) and is archived into a HistoricJob — no repository resource, no sync.

## Tests (per CRD)

- **repository** — created resource reconciled to healthy within the live-delivery window; also proves reconcile-on-update. Re-list variant in `nats/relist`.
- **connection** — reconciled (health + Ready) within the live-delivery window. Re-list variant in `nats/relist` (covers connection resync explicitly).
- **job** — a directly-created Job reaches a terminal state within the window (driver woken by the job-create notification, not the 10m poll).
- **historicjob** (`nats/historicjob`, short `history_expiration`) — a directly-created Job is archived into a HistoricJob (asserted to appear), then swept by the periodic-LIST cleanup (HistoricJob has no live NATS events).

## Testing

- `go test ./pkg/tests/apis/provisioning/nats/...` — all pass. Live-delivery reconciles/job pickup land in ~0.04–0.25s (vs the 10m re-list); re-list reconciles in ~2–9s (2s cadence); historic-job archive+cleanup in ~22s.
- Live-delivery package stable across `-count=3`.
- `go build`, `gofmt`, and the repo-pinned `golangci-lint` (0 issues) clean on every changed package.

## Notes

- The `job_poll_interval` knob was needed because the job driver polls independently of the informer; without lengthening it the job test would not be a genuine live-delivery proof. Same low-risk pattern (default preserved), but it is production surface.
- With `EnableSQLKVBackend=true`, a synced **dashboard** could not be removed by the shared-server cleanup (delete timed out); avoided entirely now that no test provisions dashboards. May be a real KV-backend/dual-writer (Mode5) deletion interaction worth a separate look.

## Checklist

- [x] Tests added (live delivery + re-list fallback, all 4 CRDs)
- [x] Production intervals made configurable, defaults unchanged
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)