### PR TITLE
Alerting: Add Start investigation menu item for Grafana alerting rules

### DIFF
--- a/public/app/features/alerting/unified/components/assistant/StartInvestigationButton.tsx
+++ b/public/app/features/alerting/unified/components/assistant/StartInvestigationButton.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+
+import { type OpenAssistantProps, createAssistantContextItem, useAssistant } from '@grafana/assistant';
+import { t } from '@grafana/i18n';
+import { Menu } from '@grafana/ui';
+import { type GrafanaAlertingRule } from 'app/types/unified-alerting';
+
+interface StartInvestigationButtonProps {
+  /** Alerting rule to investigate */
+  rule: GrafanaAlertingRule;
+}
+
+/**
+ * A menu item that starts an assistant investigation for an alert rule.
+ * Opens the assistant in investigations mode with rule context.
+ */
+export function StartInvestigationButton(props: StartInvestigationButtonProps) {
+  const { isAvailable, openAssistant } = useAssistant();
+
+  if (!isAvailable || !openAssistant) {
+    return null;
+  }
+
+  return <StartInvestigationButtonView {...props} openAssistant={openAssistant} />;
+}
+
+function StartInvestigationButtonView({
+  rule,
+  openAssistant,
+}: StartInvestigationButtonProps & {
+  openAssistant: (props: OpenAssistantProps) => void;
+}) {
+  const alertContext = useMemo(() => {
+    return createAssistantContextItem('structured', {
+      title: `Alert: ${rule.name}`,
+      data: {
+        rule: {
+          name: rule.name,
+          uid: rule.uid,
+          labels: rule.labels,
+          query: rule.query,
+        },
+      },
+    });
+  }, [rule]);
+
+  const investigationPrompt = useMemo(() => buildStartAlertingRuleInvestigationPrompt(rule), [rule]);
+
+  const handleClick = () => {
+    openAssistant({
+      origin: 'alerting/start-investigation-menu-item',
+      mode: 'investigations',
+      prompt: investigationPrompt,
+      context: [alertContext],
+      autoSend: true,
+    });
+  };
+
+  return (
+    <Menu.Item
+      label={t('alerting.alert-menu.start-investigation', 'Start investigation')}
+      icon="search-plus"
+      onClick={handleClick}
+      data-testid="start-investigation-menu-item"
+    />
+  );
+}
+
+function buildStartAlertingRuleInvestigationPrompt(rule: GrafanaAlertingRule): string {
+  const state = rule.state || 'firing';
+  const timeInfo = rule.activeAt ? ` starting at ${new Date(rule.activeAt).toISOString()}` : '';
+
+  let prompt = `Start an investigation for the ${state} alert "${rule.name} (uid: ${rule.uid})"${timeInfo}.
+- Get the rule definition and understand its conditions
+- Investigate the current alert state and active instances
+- Identify the root cause and contributing factors
+- Summarize findings and suggest remediation steps`;
+
+  const description = rule.annotations?.description || rule.annotations?.summary || '';
+  if (description) {
+    prompt += ` ${description}`;
+  }
+
+  const labelsStr = rule.labels
+    ? Object.entries(rule.labels)
+        .map(([k, v]) => `${k}="${v}"`)
+        .join(', ')
+    : '';
+  if (labelsStr) {
+    prompt += ` Labels: ${labelsStr}.`;
+  }
+
+  return prompt;
+}

--- a/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx
@@ -1402,10 +1402,13 @@ describe('AlertRuleMenu', () => {
             uid: 'test-recording-rule-uid',
             folderUid: 'test-folder-uid',
           }),
-          rulerRule: mockRulerGrafanaRecordingRule({
-            uid: 'test-recording-rule-uid',
-            folderUid: 'test-folder-uid',
-          }),
+          rulerRule: mockRulerGrafanaRecordingRule(
+            {},
+            {
+              uid: 'test-recording-rule-uid',
+              namespace_uid: 'test-folder-uid',
+            }
+          ),
         });
         const identifier = fromCombinedRule('grafana', mockRule);
         const groupIdentifier = {

--- a/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx
@@ -75,6 +75,7 @@ const ui = {
     manageEnrichments: byRole('menuitem', { name: /Manage enrichments/i }),
     declareIncident: byRole('menuitem', { name: /Declare incident/i }),
     analyzeRule: byRole('menuitem', { name: /Analyze rule/i }),
+    startInvestigation: byRole('menuitem', { name: /Start investigation/i }),
   },
 };
 
@@ -1325,6 +1326,7 @@ describe('AlertRuleMenu', () => {
 
         await openMenu();
         expect(await ui.menuItems.analyzeRule.find()).toBeInTheDocument();
+        expect(await ui.menuItems.startInvestigation.find()).toBeInTheDocument();
       });
 
       it('hides Analyze Rule when assistant is unavailable', async () => {
@@ -1351,6 +1353,7 @@ describe('AlertRuleMenu', () => {
 
         await openMenu();
         expect(ui.menuItems.analyzeRule.query()).not.toBeInTheDocument();
+        expect(ui.menuItems.startInvestigation.query()).not.toBeInTheDocument();
       });
 
       it('hides Analyze Rule for datasource-managed rules even when assistant is available', async () => {
@@ -1384,6 +1387,48 @@ describe('AlertRuleMenu', () => {
 
         await openMenu();
         expect(ui.menuItems.analyzeRule.query()).not.toBeInTheDocument();
+        expect(ui.menuItems.startInvestigation.query()).not.toBeInTheDocument();
+      });
+
+      it('hides Start investigation for Grafana-managed recording rules even when assistant is available', async () => {
+        mockUseAssistant.mockReturnValue({
+          isLoading: false,
+          isAvailable: true,
+          openAssistant: mockOpenAssistant,
+        } as unknown as ReturnType<typeof useAssistant>);
+
+        const mockRule = getGrafanaRule({
+          promRule: mockPromRecordingRule({
+            uid: 'test-recording-rule-uid',
+            folderUid: 'test-folder-uid',
+          }),
+          rulerRule: mockRulerGrafanaRecordingRule({
+            uid: 'test-recording-rule-uid',
+            folderUid: 'test-folder-uid',
+          }),
+        });
+        const identifier = fromCombinedRule('grafana', mockRule);
+        const groupIdentifier = {
+          groupOrigin: 'grafana' as const,
+          namespace: { uid: 'namespace-uid' },
+          groupName: 'group-name',
+        };
+
+        render(
+          <AlertRuleMenu
+            promRule={mockRule.promRule}
+            rulerRule={mockRule.rulerRule}
+            identifier={identifier}
+            groupIdentifier={groupIdentifier}
+            handleSilence={handleSilence}
+            handleDelete={handleDelete}
+            handleDuplicateRule={handleDuplicateRule}
+          />
+        );
+
+        await openMenu();
+        expect(await ui.menuItems.analyzeRule.find()).toBeInTheDocument();
+        expect(ui.menuItems.startInvestigation.query()).not.toBeInTheDocument();
       });
     });
   });

--- a/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx
@@ -136,8 +136,7 @@ const AlertRuleMenu = ({
 
   const { isAvailable: isAssistantAvailable } = useAssistant();
   const shouldShowAnalyzeRuleButton = isAssistantAvailable && prometheusRuleType.grafana.rule(promRule);
-  const shouldShowStartInvestigationButton =
-    isAssistantAvailable && prometheusRuleType.grafana.alertingRule(promRule);
+  const shouldShowStartInvestigationButton = isAssistantAvailable && prometheusRuleType.grafana.alertingRule(promRule);
 
   const shareUrl = createShareLink(identifier);
 

--- a/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../utils/rules';
 import { createRelativeUrl } from '../../utils/url';
 import { AnalyzeRuleButton } from '../assistant/AnalizeRuleButton';
+import { StartInvestigationButton } from '../assistant/StartInvestigationButton';
 import { DeclareIncidentMenuItem } from '../bridges/DeclareIncidentButton';
 
 interface Props {
@@ -135,6 +136,8 @@ const AlertRuleMenu = ({
 
   const { isAvailable: isAssistantAvailable } = useAssistant();
   const shouldShowAnalyzeRuleButton = isAssistantAvailable && prometheusRuleType.grafana.rule(promRule);
+  const shouldShowStartInvestigationButton =
+    isAssistantAvailable && prometheusRuleType.grafana.alertingRule(promRule);
 
   const shareUrl = createShareLink(identifier);
 
@@ -182,6 +185,7 @@ const AlertRuleMenu = ({
       )}
       {/* TODO Migrate Declare Incident to plugin links extensions */}
       {shouldShowDeclareIncidentButton && <DeclareIncidentMenuItem title={promRule.name} url={''} />}
+      {shouldShowStartInvestigationButton && <StartInvestigationButton rule={promRule} />}
       {shouldShowAnalyzeRuleButton && <AnalyzeRuleButton rule={promRule} />}
       {canDuplicate && (
         <Menu.Item

--- a/public/app/features/alerting/unified/rule-list/GrafanaGroupLoader.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/GrafanaGroupLoader.test.tsx
@@ -49,6 +49,7 @@ const ui = {
     delete: () => byRole('menuitem', { name: /delete/i }),
     pause: () => byRole('menuitem', { name: /pause/i }),
     analyzeRule: () => byRole('menuitem', { name: /analyze rule/i }),
+    startInvestigation: () => byRole('menuitem', { name: /start investigation/i }),
   },
 };
 
@@ -253,12 +254,13 @@ describe('GrafanaGroupLoader', () => {
     const moreButton = ui.moreButton().get(ruleListItem);
     await user.click(moreButton);
 
-    // Check that Analyze rule menu item is present
+    // Check that assistant menu items are present
+    expect(ui.menuItems.startInvestigation().get()).toBeInTheDocument();
     expect(ui.menuItems.analyzeRule().get()).toBeInTheDocument();
 
-    // With assistant enabled, there should be 7 menu items (6 + Analyze rule)
+    // With assistant enabled, there should be 8 menu items (6 + Start investigation + Analyze rule)
     const menuItems = byRole('menuitem').getAll();
-    expect(menuItems.length).toBe(7);
+    expect(menuItems.length).toBe(8);
   });
 
   it('should not render Analyze rule menu item when assistant is not available', async () => {
@@ -285,7 +287,8 @@ describe('GrafanaGroupLoader', () => {
     const moreButton = ui.moreButton().get(ruleListItem);
     await user.click(moreButton);
 
-    // Check that Analyze rule menu item is NOT present
+    // Check that assistant menu items are NOT present
+    expect(ui.menuItems.startInvestigation().query()).not.toBeInTheDocument();
     expect(ui.menuItems.analyzeRule().query()).not.toBeInTheDocument();
 
     // Without assistant, there should be 6 menu items

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -484,6 +484,7 @@
       "export": "Export",
       "manage-enrichments": "Manage enrichments",
       "silence-notifications": "Silence notifications",
+      "start-investigation": "Start investigation",
       "with-modifications": "With modifications"
     },
     "alert-missing-evaluations-to-stale": {


### PR DESCRIPTION
## Summary
- Add `StartInvestigationButton` to the alert rule menu, opening Grafana Assistant in `investigations` mode with rule context and an investigation-focused prompt
- Show the menu item only for Grafana-managed alerting rules when Assistant is available (not recording or datasource-managed rules)
- Add tests covering visibility for assistant availability, datasource-managed rules, and recording rules

## Test plan
- [ ] Open a Grafana-managed alerting rule and confirm **Start investigation** appears in the ⋮ menu when Assistant is available
- [ ] Click **Start investigation** and verify Assistant opens in investigations mode with the rule context
- [ ] Confirm the menu item is hidden for recording rules, datasource-managed rules, and when Assistant is unavailable
- [ ] Run `yarn jest --no-watch public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx`


Made with [Cursor](https://cursor.com)