### PR TITLE
[release-12.4.6] LibraryElements: Avoid redundant library element fetch in permission resolver

### DIFF
--- a/pkg/services/libraryelements/accesscontrol.go
+++ b/pkg/services/libraryelements/accesscontrol.go
@@ -61,24 +61,34 @@ func LibraryPanelUIDScopeResolver(l *LibraryElementService, folderSvc folder.Ser
 			}
 		}
 
-		libElDTO, err := l.getLibraryElementByUid(ctx, user, model.GetLibraryElementCommand{
-			UID:        uid,
-			FolderName: dashboards.RootFolderName,
-		}, tree)
-		if err != nil {
-			return nil, err
+		// The caller (e.g. the list endpoint) may already know this panel's folder.
+		// If so, use it and skip the per-panel database lookup; otherwise fetch it.
+		folderUID, ok := panelFolderFromContext(ctx, uid)
+		if !ok {
+			libElDTO, err := l.getLibraryElementByUid(ctx, user, model.GetLibraryElementCommand{
+				UID:        uid,
+				FolderName: dashboards.RootFolderName,
+			}, tree)
+			if err != nil {
+				return nil, err
+			}
+			folderUID = libElDTO.FolderUID
+		} else if folderUID == "" {
+			// The list endpoint represents the general folder as "", but the scope
+			// machinery (and getLibraryElementByUid) uses the General folder UID.
+			folderUID = ac.GeneralFolderUID
 		}
 
 		var inheritedScopes []string
 		if tree != nil {
-			inheritedScopes = getInheritedScopesFromTree(libElDTO.FolderUID, tree)
+			inheritedScopes = getInheritedScopesFromTree(folderUID, tree)
 		} else {
-			inheritedScopes, err = dashboards.GetInheritedScopes(ctx, orgID, libElDTO.FolderUID, folderSvc)
+			inheritedScopes, err = dashboards.GetInheritedScopes(ctx, orgID, folderUID, folderSvc)
 			if err != nil {
 				return nil, err
 			}
 		}
-		return append(inheritedScopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(libElDTO.FolderUID), ScopeLibraryPanelsProvider.GetResourceScopeUID(uid)), nil
+		return append(inheritedScopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID), ScopeLibraryPanelsProvider.GetResourceScopeUID(uid)), nil
 	})
 }
 

--- a/pkg/services/libraryelements/accesscontrol_test.go
+++ b/pkg/services/libraryelements/accesscontrol_test.go
@@ -1,0 +1,74 @@
+package libraryelements
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder/foldertest"
+	"github.com/grafana/grafana/pkg/services/libraryelements/model"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+func TestPanelFolderContext(t *testing.T) {
+	elements := []model.LibraryElementDTO{
+		{UID: "panel-1", FolderUID: "folder-a"},
+		{UID: "panel-2", FolderUID: ""}, // general folder
+	}
+	ctx := withPanelFolders(context.Background(), elements)
+
+	t.Run("returns the recorded folder for a known panel", func(t *testing.T) {
+		f, ok := panelFolderFromContext(ctx, "panel-1")
+		assert.True(t, ok)
+		assert.Equal(t, "folder-a", f)
+	})
+
+	t.Run("records the general (empty) folder", func(t *testing.T) {
+		f, ok := panelFolderFromContext(ctx, "panel-2")
+		assert.True(t, ok)
+		assert.Equal(t, "", f)
+	})
+
+	t.Run("reports miss for an unknown panel", func(t *testing.T) {
+		_, ok := panelFolderFromContext(ctx, "panel-x")
+		assert.False(t, ok)
+	})
+
+	t.Run("reports miss when no map is present", func(t *testing.T) {
+		_, ok := panelFolderFromContext(context.Background(), "panel-1")
+		assert.False(t, ok)
+	})
+}
+
+// TestLibraryPanelUIDScopeResolver_UsesContextFolder verifies that when the
+// panel's folder is provided via the request context, the resolver derives the
+// folder scope from it and does NOT perform the per-panel database lookup. The
+// service is constructed without a SQLStore, so any fallback to
+// getLibraryElementByUid would panic — proving the lookup is skipped.
+func TestLibraryPanelUIDScopeResolver_UsesContextFolder(t *testing.T) {
+	folderSvc := foldertest.NewFakeService() // GetParents returns no ancestors
+	svc := &LibraryElementService{
+		folderService: folderSvc,
+		treeCache:     newFolderTreeCache(folderSvc),
+		log:           log.NewNopLogger(),
+		// deliberately no SQLStore: getLibraryElementByUid must not be reached
+	}
+	_, resolver := LibraryPanelUIDScopeResolver(svc, folderSvc)
+
+	usr := &user.SignedInUser{UserID: 1, OrgID: 1}
+	ctx := identity.WithRequester(context.Background(), usr)
+	ctx = withPanelFolders(ctx, []model.LibraryElementDTO{{UID: "panel-1", FolderUID: "folder-a"}})
+
+	scopes, err := resolver.Resolve(ctx, 1, ScopeLibraryPanelsProvider.GetResourceScopeUID("panel-1"))
+	require.NoError(t, err)
+
+	assert.Contains(t, scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID("folder-a"),
+		"resolved scopes should include the panel's folder scope")
+	assert.Contains(t, scopes, ScopeLibraryPanelsProvider.GetResourceScopeUID("panel-1"),
+		"resolved scopes should include the panel scope")
+}

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -382,8 +382,11 @@ func (l *LibraryElementService) getByNameHandler(c *contextmodel.ReqContext) res
 
 func (l *LibraryElementService) filterLibraryPanelsByPermission(c *contextmodel.ReqContext, elements []model.LibraryElementDTO) ([]model.LibraryElementDTO, error) {
 	filteredPanels := make([]model.LibraryElementDTO, 0)
+	// Record each panel's folder so the permission scope resolver can skip the
+	// per-panel database lookup it would otherwise do to rediscover the folder.
+	ctx := withPanelFolders(c.Req.Context(), elements)
 	for _, p := range elements {
-		allowed, err := l.AccessControl.Evaluate(c.Req.Context(), c.SignedInUser, ac.EvalPermission(ActionLibraryPanelsRead, ScopeLibraryPanelsProvider.GetResourceScopeUID(p.UID)))
+		allowed, err := l.AccessControl.Evaluate(ctx, c.SignedInUser, ac.EvalPermission(ActionLibraryPanelsRead, ScopeLibraryPanelsProvider.GetResourceScopeUID(p.UID)))
 		if err != nil {
 			// This could fail because the folder that contains the library panel does not exist or the user doesn't have permissions to read it.
 			// We skip it instead of breaking the library panel list rendering flow and log the error.

--- a/pkg/services/libraryelements/cache.go
+++ b/pkg/services/libraryelements/cache.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/libraryelements/model"
 )
 
 // cacheKey is the context key for knowing if it should use cache or not.
@@ -22,6 +23,34 @@ func withCache(ctx context.Context) context.Context {
 func hasCache(ctx context.Context) bool {
 	_, ok := ctx.Value(cacheKey{}).(bool)
 	return ok
+}
+
+// panelFoldersKey is the context key carrying a request-scoped map of library
+// panel UID -> folder UID.
+type panelFoldersKey struct{}
+
+// withPanelFolders returns a context carrying the folder UID of each given
+// library element. The permission scope resolver uses this to skip re-querying
+// the database for a panel's folder when the caller already has it (e.g. the
+// list endpoint, which has just loaded the elements). The map is request-scoped,
+// so it never goes stale and needs no invalidation.
+func withPanelFolders(ctx context.Context, elements []model.LibraryElementDTO) context.Context {
+	folders := make(map[string]string, len(elements))
+	for _, e := range elements {
+		folders[e.UID] = e.FolderUID
+	}
+	return context.WithValue(ctx, panelFoldersKey{}, folders)
+}
+
+// panelFolderFromContext returns the folder UID for a library panel UID if it
+// was recorded by withPanelFolders for this request.
+func panelFolderFromContext(ctx context.Context, panelUID string) (string, bool) {
+	folders, ok := ctx.Value(panelFoldersKey{}).(map[string]string)
+	if !ok {
+		return "", false
+	}
+	folderUID, ok := folders[panelUID]
+	return folderUID, ok
 }
 
 // folderTreeCache provides caching for folder trees.


### PR DESCRIPTION
Backport 80b89fff781177f46055783d439746fefbff50d3 from #126797

---

When listing library elements, every returned panel is permission-checked through the `library.panels:uid` scope resolver. That resolver called `getLibraryElementByUid` once per panel **solely to retrieve the panel's folder UID** (needed to compute inherited folder scopes) even though the list handler had already loaded that folder UID on every element it returned.

So listing N panels issued N redundant library-element GETs (one DB query each) to fetch data the caller already had.

The fix:

`filterLibraryPanelsByPermission` now records each panel's folder UID in a **request-scoped** context map (`withPanelFolders`). `LibraryPanelUIDScopeResolver` reads the folder UID from that map and skips the per-panel `getLibraryElementByUid` query entirely.

Related escalation: https://github.com/grafana/support-escalations/issues/19103
