### PR TITLE
unified-storage: fix storage_backend writeevent context cancel bug

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -796,6 +796,8 @@ type Cfg struct {
 	// TODO: remove this when sql/backend backwards compatibility is no longer needed.
 	LogSQLBackendCalls                bool
 	EnableKVLeases                    bool
+	KVLeaseTTL                        time.Duration
+	KVLeaseAutoRenew                  bool
 	EnableGarbageCollection           bool
 	GarbageCollectionDryRun           bool
 	GarbageCollectionInterval         time.Duration

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -264,9 +264,13 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	// (temporary smoke-test instrumentation; default off)
 	// TODO: remove this when sql/backend backwards compatibility is no longer needed.
 	cfg.LogSQLBackendCalls = section.Key("log_sql_backend_calls").MustBool(false)
-	// enable per-resource leases in the KV backend; only effective when the
-	// SQL RV manager is not in use.
+	// enable per-resource leases in the KV backend;
 	cfg.EnableKVLeases = section.Key("enable_kv_leases").MustBool(false)
+	// TTL for per-resource write leases; 0 uses the backend default (10s).
+	cfg.KVLeaseTTL = section.Key("kv_lease_ttl").MustDuration(0)
+	// auto-renew write leases in the background so they are not lost while a
+	// slow write is still in flight.
+	cfg.KVLeaseAutoRenew = section.Key("kv_lease_auto_renew").MustBool(false)
 
 	cfg.MaxFileIndexAge = section.Key("max_file_index_age").MustDuration(0)
 	cfg.MinFileIndexBuildVersion = section.Key("min_file_index_build_version").MustString("")

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -130,7 +130,7 @@ type kvStorageBackend struct {
 }
 
 type kvBackendMetrics struct {
-	ConflictErrors *prometheus.CounterVec
+	ConflictErrors    *prometheus.CounterVec
 	EventEmitFailures *prometheus.CounterVec
 }
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1079,7 +1079,11 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv
 	if k.rvManager != nil {
 		dataKey.GUID = uuid.New().String()
 		var err error
-		rv, err = k.rvManager.ExecWithRV(ctx, event.Key, func(txnCtx context.Context, tx db.Tx) (string, error) {
+		// ExecWithRV commits the data on its own context regardless of client cancellation.
+		// Passing a detached context makes ExecWithRV wait for that guaranteed commit
+		// instead of bailing out on cancellation and losing the assigned resource version (which would
+		// leave the data committed but the event unwritten).
+		rv, err = k.rvManager.ExecWithRV(context.WithoutCancel(ctx), event.Key, func(txnCtx context.Context, tx db.Tx) (string, error) {
 			if err := k.dataStore.Save(kv.ContextWithTx(txnCtx, tx), dataKey, bytes.NewReader(event.Value)); err != nil {
 				return "", fmt.Errorf("failed to write data: %w", err)
 			}
@@ -1114,6 +1118,10 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv
 			return 0, fmt.Errorf("failed to write data: %w", err)
 		}
 	}
+
+	// The data is now durably committed. From here on the data store and event
+	// store must not diverge, so detach from client cancellation
+	ctx = context.WithoutCancel(ctx)
 
 	// Optimistic concurrency control to verify our write is the latest version
 	// and that the resource still had the expected PreviousRV when we wrote it.

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -45,6 +45,7 @@ const (
 	defaultEventPruningInterval       = 5 * time.Minute
 	defaultSearchLookback             = 1 * time.Second
 	defaultGarbageCollectionBatchWait = 1 * time.Second
+	persistDeadline                   = 10 * time.Second
 )
 
 // IsResourceNameMixedCase reports whether a successful read returned a
@@ -104,6 +105,13 @@ type kvStorageBackend struct {
 	// resource via per-resource leases. Ignored when using `rvManager`.
 	leaseManager *lease.Manager
 
+	// leaseTTL is the TTL applied when acquiring a write lease. Zero uses the
+	// lease package default.
+	leaseTTL time.Duration
+
+	// leaseAutoRenew enables background auto-renewal of write leases.
+	leaseAutoRenew bool
+
 	// dbKeepAlive holds a reference to the database provider/connection owner to prevent it from being GC'd
 	dbKeepAlive any
 
@@ -123,6 +131,7 @@ type kvStorageBackend struct {
 
 type kvBackendMetrics struct {
 	ConflictErrors *prometheus.CounterVec
+	EventEmitFailures *prometheus.CounterVec
 }
 
 func newKVBackendMetrics(reg prometheus.Registerer) *kvBackendMetrics {
@@ -132,6 +141,11 @@ func newKVBackendMetrics(reg prometheus.Registerer) *kvBackendMetrics {
 			Name:      "optimistic_lock_conflicts_total",
 			Help:      "Total number of optimistic lock conflict errors in the KV storage backend",
 		}, []string{"resource", "action"}),
+		EventEmitFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "storage_server",
+			Name:      "event_emit_after_commit_failures_total",
+			Help:      "Total number of writes whose data was committed but whose event failed to be emitted",
+		}, []string{"resource", "action"}),
 	}
 }
 
@@ -140,6 +154,13 @@ func (m *kvBackendMetrics) recordConflict(event WriteEvent) {
 		return
 	}
 	m.ConflictErrors.WithLabelValues(event.Key.Resource, event.Type.String()).Inc()
+}
+
+func (m *kvBackendMetrics) recordEventEmitFailure(event WriteEvent) {
+	if m == nil {
+		return
+	}
+	m.EventEmitFailures.WithLabelValues(event.Key.Resource, event.Type.String()).Inc()
 }
 
 var _ KVBackend = &kvStorageBackend{}
@@ -214,6 +235,15 @@ type KVBackendOptions struct {
 	// Holder identifies this process for lease ownership. Required when
 	// EnableKVLeases is true.
 	Holder string
+
+	// LeaseTTL overrides the per-resource write lease TTL. Zero uses the lease
+	// package default (10s). Only effective when EnableKVLeases is true.
+	LeaseTTL time.Duration
+
+	// LeaseAutoRenew enables background auto-renewal of the write lease so it
+	// is not lost while a slow write is still in flight. Only effective when
+	// EnableKVLeases is true.
+	LeaseAutoRenew bool
 }
 
 var (
@@ -290,6 +320,8 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 		eventPruningInterval:    eventPruningInterval,
 		rvManager:               opts.RvManager,
 		leaseManager:            leaseManager,
+		leaseTTL:                opts.LeaseTTL,
+		leaseAutoRenew:          opts.LeaseAutoRenew,
 		dbKeepAlive:             opts.DBKeepAlive,
 		lastImportStore:         newLastImportStore(kv),
 		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
@@ -855,7 +887,15 @@ func (k *kvStorageBackend) maybeAcquireWriteLease(ctx context.Context, event Wri
 		name = event.Key.Group + "/" + event.Key.Resource + "/" + event.Key.Name
 	}
 
-	l, err := k.leaseManager.Acquire(ctx, name)
+	var acquireOpts []lease.AcquireOption
+	if k.leaseTTL > 0 {
+		acquireOpts = append(acquireOpts, lease.WithTTL(k.leaseTTL))
+	}
+	if k.leaseAutoRenew {
+		acquireOpts = append(acquireOpts, lease.WithAutoRenew())
+	}
+
+	l, err := k.leaseManager.Acquire(ctx, name, acquireOpts...)
 	if err != nil {
 		if errors.Is(err, lease.ErrLeaseAlreadyHeld) {
 			k.metrics.recordConflict(event)
@@ -1120,8 +1160,12 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv
 	}
 
 	// The data is now durably committed. From here on the data store and event
-	// store must not diverge, so detach from client cancellation
-	ctx = context.WithoutCancel(ctx)
+	// store must not diverge: detach from client/lease cancellation so the event
+	// is still emitted, but keep a bounded deadline so a stuck datastore cannot
+	// hold a worker indefinitely.
+	persistCtx, cancelPersist := context.WithTimeout(context.WithoutCancel(ctx), persistDeadline)
+	defer cancelPersist()
+	ctx = persistCtx
 
 	// Optimistic concurrency control to verify our write is the latest version
 	// and that the resource still had the expected PreviousRV when we wrote it.
@@ -1199,6 +1243,15 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv
 		PreviousRV:      event.PreviousRV,
 	}
 	if err := k.eventStore.Save(ctx, eventData); err != nil {
+		k.metrics.recordEventEmitFailure(event)
+		k.log.Error("data committed but failed to emit event; data and event store diverged",
+			"namespace", event.Key.Namespace,
+			"group", event.Key.Group,
+			"resource", event.Key.Resource,
+			"name", event.Key.Name,
+			"action", action,
+			"error", err,
+		)
 		return 0, fmt.Errorf("failed to save event: %w", err)
 	}
 

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -264,6 +264,84 @@ func TestKvStorageBackend_WriteEvent_Success(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// cancelOnDataSaveKV wraps a KV and cancels a context the first time a value is
+// durably written to the data section. This simulates a client cancelling the
+// request in the window between the data store commit and the event store
+// write, which used to leave the two stores split: the data was persisted but
+// the event never was, so watch consumers and search never saw the write.
+type cancelOnDataSaveKV struct {
+	KV
+	cancel func()
+	once   sync.Once
+}
+
+func (w *cancelOnDataSaveKV) Save(ctx context.Context, section, key string) (io.WriteCloser, error) {
+	wc, err := w.KV.Save(ctx, section, key)
+	if err != nil || section != kv.DataSection {
+		return wc, err
+	}
+	return &cancelOnCloseWriteCloser{WriteCloser: wc, w: w}, nil
+}
+
+type cancelOnCloseWriteCloser struct {
+	io.WriteCloser
+	w *cancelOnDataSaveKV
+}
+
+func (c *cancelOnCloseWriteCloser) Close() error {
+	err := c.WriteCloser.Close()
+	if err == nil {
+		c.w.once.Do(c.w.cancel)
+	}
+	return err
+}
+
+// TestKvStorageBackend_WriteEvent_ClientCancelAfterDataSave_PersistsEvent
+// verifies that once the data has been durably written, cancelling the client's
+// context does not abort the event write. Otherwise the data store and event
+// store diverge and consumers miss the event through watch and search.
+func TestKvStorageBackend_WriteEvent_ClientCancelAfterDataSave_PersistsEvent(t *testing.T) {
+	wrapper := &cancelOnDataSaveKV{KV: setupBadgerKV(t)}
+	backend := setupTestStorageBackend(t, withKV(wrapper))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wrapper.cancel = cancel
+
+	testObj, err := createTestObject()
+	require.NoError(t, err)
+	metaAccessor, err := utils.MetaAccessor(testObj)
+	require.NoError(t, err)
+
+	const resourceName = "cancel-after-data-save"
+	addEvent := WriteEvent{
+		Type: resourcepb.WatchEvent_ADDED,
+		Key: &resourcepb.ResourceKey{
+			Namespace: "default",
+			Group:     "apps",
+			Resource:  "resources",
+			Name:      resourceName,
+		},
+		Value:  objectToJSONBytes(t, testObj),
+		Object: metaAccessor,
+	}
+
+	rv, err := backend.WriteEvent(ctx, addEvent)
+	require.NoError(t, err)
+	require.Greater(t, rv, int64(0))
+
+	// The event must be persisted even though the client cancelled right after
+	// the data was committed.
+	found := false
+	for ev, err := range backend.eventStore.ListSince(context.Background(), 0, SortOrderAsc) {
+		require.NoError(t, err)
+		if ev.Name == resourceName {
+			found = true
+		}
+	}
+	require.True(t, found, "event should be persisted after data save even if the client cancels")
+}
+
 func TestKvStorageBackend_WatchWriteEvents(t *testing.T) {
 	for _, useChannel := range []bool{true, false} {
 		backend := setupTestStorageBackend(t)

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -240,6 +240,8 @@ func NewStorageBackend(
 	if cfg.EnableKVLeases {
 		kvBackendOpts.EnableKVLeases = true
 		kvBackendOpts.Holder = ResolveLeaseHolder(cfg)
+		kvBackendOpts.LeaseTTL = cfg.KVLeaseTTL
+		kvBackendOpts.LeaseAutoRenew = cfg.KVLeaseAutoRenew
 	}
 
 	return resource.NewKVStorageBackend(kvBackendOpts)


### PR DESCRIPTION
Fixes a bug when a client cancels the request while we're processing it. If we successfully process the data we should not abort the remaining of the request: event store saving, optimistic lock check, pruner, etc.

* Make lease TTL and auto renew configurable
* new metric for when we fail to save an event but successfully persist the data
* use a detached context with 10s deadline to emit the event (and do other stuff) after the data is committed to the store