### PR TITLE
chore: add transactional context middleware to the mt feature flag lib

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -2647,6 +2647,7 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260519071638-aa98bba5eb94/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260615183401-62b3387ff324/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.18.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.58.2/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1774,6 +1774,7 @@ github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+
 github.com/prometheus/common v0.67.4/go.mod h1:gP0fq6YjjNCLssJCQp0yk4M8W6ikLURwkdd/YKtTbyI=
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/common v0.68.0/go.mod h1:4soH+U8yJSROk7OJ//hmTiWKsxapv6zRGgTt3keN8gQ=
+github.com/prometheus/common v0.68.1/go.mod h1:ZzL3f6u94qUxh9p+tJTrF+FvBS1XXbbRAZCQkytAL0Y=
 github.com/prometheus/common/assets v0.2.0 h1:0P5OrzoHrYBOSM1OigWL3mY8ZvV2N4zIE/5AahrSrfM=
 github.com/prometheus/exporter-toolkit v0.15.1/go.mod h1:P/NR9qFRGbCFgpklyhix9F6v6fFr/VQB/CVsrMDGKo4=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=

--- a/pkg/infra/features/baggage.go
+++ b/pkg/infra/features/baggage.go
@@ -10,12 +10,10 @@ import (
 )
 
 const (
-	SlugKey           = "slug"
-	PlanKey           = "plan"
-	ChannelKey        = "channel"
-	NamespaceKey      = "namespace"
-	GrafanaVersionKey = "grafana_version"
-	StackIdKey        = "stackId"
+	SlugKey      = "slug"
+	PlanKey      = "plan"
+	ChannelKey   = "channel"
+	NamespaceKey = "namespace"
 )
 
 // InstanceContextFromBaggage extracts per-tenant attributes from OTel baggage
@@ -38,8 +36,6 @@ func InstanceContextFromBaggage(ctx context.Context) openfeature.EvaluationConte
 	set(PlanKey)
 	set(ChannelKey)
 	set(NamespaceKey)
-	set(GrafanaVersionKey)
-	set(StackIdKey)
 
 	targetingKey := bag.Member(NamespaceKey).Value()
 	return openfeature.NewEvaluationContext(targetingKey, contextAtributes)

--- a/pkg/infra/features/baggage.go
+++ b/pkg/infra/features/baggage.go
@@ -1,0 +1,58 @@
+package features
+
+import (
+	"context"
+	"net/http"
+
+	"go.opentelemetry.io/otel/baggage"
+
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+const (
+	SlugKey           = "slug"
+	PlanKey           = "plan"
+	ChannelKey        = "channel"
+	NamespaceKey      = "namespace"
+	GrafanaVersionKey = "grafana_version"
+	StackIdKey        = "stackId"
+)
+
+// InstanceContextFromBaggage extracts per-tenant attributes from OTel baggage
+// and injects them into an OpenFeature evaluation context. The HG gateway
+// populates these baggage members on every proxied request, so MT services get
+// a full per-tenant eval context with no extra metadata API calls. namespace is
+// used as the targeting key.
+func InstanceContextFromBaggage(ctx context.Context) openfeature.EvaluationContext {
+	bag := baggage.FromContext(ctx)
+
+	contextAtributes := map[string]any{}
+
+	set := func(attrKey string) {
+		if v := bag.Member(attrKey).Value(); v != "" {
+			contextAtributes[attrKey] = v
+		}
+	}
+
+	set(SlugKey)
+	set(PlanKey)
+	set(ChannelKey)
+	set(NamespaceKey)
+	set(GrafanaVersionKey)
+	set(StackIdKey)
+
+	targetingKey := bag.Member(NamespaceKey).Value()
+	return openfeature.NewEvaluationContext(targetingKey, contextAtributes)
+}
+
+// WithTransactionContextMiddleware is an HTTP middleware that reads OTel baggage
+// from the incoming request and sets it as the OpenFeature transaction context.
+// Register it in each MT service's HTTP middleware chain.
+func WithTransactionContextMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		evalCtx := InstanceContextFromBaggage(r.Context())
+		ctx := openfeature.MergeTransactionContext(r.Context(), evalCtx)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+
+}

--- a/pkg/infra/features/baggage.go
+++ b/pkg/infra/features/baggage.go
@@ -50,5 +50,4 @@ func WithTransactionContextMiddleware(next http.Handler) http.Handler {
 		ctx := openfeature.MergeTransactionContext(r.Context(), evalCtx)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
-
 }

--- a/pkg/infra/features/baggage.go
+++ b/pkg/infra/features/baggage.go
@@ -10,9 +10,6 @@ import (
 )
 
 const (
-	SlugKey      = "slug"
-	PlanKey      = "plan"
-	ChannelKey   = "channel"
 	NamespaceKey = "namespace"
 )
 
@@ -26,16 +23,9 @@ func InstanceContextFromBaggage(ctx context.Context) openfeature.EvaluationConte
 
 	contextAtributes := map[string]any{}
 
-	set := func(attrKey string) {
-		if v := bag.Member(attrKey).Value(); v != "" {
-			contextAtributes[attrKey] = v
-		}
+	for _, member := range bag.Members() {
+		contextAtributes[member.Key()] = member.Value()
 	}
-
-	set(SlugKey)
-	set(PlanKey)
-	set(ChannelKey)
-	set(NamespaceKey)
 
 	targetingKey := bag.Member(NamespaceKey).Value()
 	return openfeature.NewEvaluationContext(targetingKey, contextAtributes)

--- a/pkg/infra/features/baggage.go
+++ b/pkg/infra/features/baggage.go
@@ -18,7 +18,7 @@ const (
 // populates these baggage members on every proxied request, so MT services get
 // a full per-tenant eval context with no extra metadata API calls. namespace is
 // used as the targeting key.
-func InstanceContextFromBaggage(ctx context.Context) openfeature.EvaluationContext {
+func EvaluationContextFromBaggage(ctx context.Context) openfeature.EvaluationContext {
 	bag := baggage.FromContext(ctx)
 
 	contextAtributes := map[string]any{}

--- a/pkg/infra/features/baggage.go
+++ b/pkg/infra/features/baggage.go
@@ -13,7 +13,7 @@ const (
 	NamespaceKey = "namespace"
 )
 
-// InstanceContextFromBaggage extracts per-tenant attributes from OTel baggage
+// EvaluationContextFromBaggage extracts per-tenant attributes from OTel baggage
 // and injects them into an OpenFeature evaluation context. The HG gateway
 // populates these baggage members on every proxied request, so MT services get
 // a full per-tenant eval context with no extra metadata API calls. namespace is
@@ -36,7 +36,7 @@ func EvaluationContextFromBaggage(ctx context.Context) openfeature.EvaluationCon
 // Register it in each MT service's HTTP middleware chain.
 func WithTransactionContextMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		evalCtx := InstanceContextFromBaggage(r.Context())
+		evalCtx := EvaluationContextFromBaggage(r.Context())
 		ctx := openfeature.MergeTransactionContext(r.Context(), evalCtx)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/pkg/infra/features/baggage_test.go
+++ b/pkg/infra/features/baggage_test.go
@@ -1,0 +1,150 @@
+package features
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
+)
+
+func baggageCtx(t *testing.T, members string) *http.Request {
+	t.Helper()
+	bag, err := baggage.Parse(members)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	return req.WithContext(baggage.ContextWithBaggage(req.Context(), bag))
+}
+
+func TestInstanceContextFromBaggage(t *testing.T) {
+	t.Run("empty context returns empty eval context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		evalCtx := InstanceContextFromBaggage(req.Context())
+
+		assert.Empty(t, evalCtx.TargetingKey())
+		assert.Empty(t, evalCtx.Attributes())
+	})
+
+	t.Run("all canonical fields are extracted", func(t *testing.T) {
+		req := baggageCtx(t, "slug=mystack,plan=pro,channel=stable,namespace=stacks-42,grafana_version=13.0.0,stackId=42,instanceURL=https://mystack.grafana.net")
+		evalCtx := InstanceContextFromBaggage(req.Context())
+
+		attrs := evalCtx.Attributes()
+		assert.Equal(t, "mystack", attrs["slug"])
+		assert.Equal(t, "pro", attrs["plan"])
+		assert.Equal(t, "stable", attrs["channel"])
+		assert.Equal(t, "stacks-42", attrs["namespace"])
+		assert.Equal(t, "13.0.0", attrs["grafana_version"])
+		assert.Equal(t, "42", attrs["stackId"])
+		assert.Equal(t, "https://mystack.grafana.net", attrs["instanceURL"])
+	})
+
+	t.Run("absent fields are not added to attributes", func(t *testing.T) {
+		req := baggageCtx(t, "slug=mystack,namespace=stacks-42")
+		evalCtx := InstanceContextFromBaggage(req.Context())
+
+		attrs := evalCtx.Attributes()
+		assert.Contains(t, attrs, "slug")
+		assert.Contains(t, attrs, "namespace")
+		assert.NotContains(t, attrs, "plan")
+		assert.NotContains(t, attrs, "channel")
+		assert.NotContains(t, attrs, "stackId")
+	})
+
+	t.Run("non-canonical baggage members are not included", func(t *testing.T) {
+		req := baggageCtx(t, "namespace=stacks-42,custom-key=should-be-ignored")
+		evalCtx := InstanceContextFromBaggage(req.Context())
+
+		assert.NotContains(t, evalCtx.Attributes(), "custom-key")
+	})
+
+	t.Run("missing namespace results in empty targeting key", func(t *testing.T) {
+		req := baggageCtx(t, "slug=mystack,plan=pro")
+		evalCtx := InstanceContextFromBaggage(req.Context())
+
+		assert.Empty(t, evalCtx.TargetingKey())
+		assert.Equal(t, "mystack", evalCtx.Attributes()["slug"])
+	})
+}
+
+func TestWithTransactionContextMiddleware(t *testing.T) {
+	t.Run("sets OF transaction context from baggage", func(t *testing.T) {
+		var capturedReq *http.Request
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedReq = r
+		})
+
+		handler := WithTransactionContextMiddleware(next)
+		req := baggageCtx(t, "slug=mystack,plan=pro,namespace=stacks-42")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+
+		require.NotNil(t, capturedReq)
+		tctx := openfeature.TransactionContext(capturedReq.Context())
+		assert.Equal(t, "stacks-42", tctx.TargetingKey())
+		assert.Equal(t, "mystack", tctx.Attributes()["slug"])
+		assert.Equal(t, "pro", tctx.Attributes()["plan"])
+	})
+
+	t.Run("empty baggage results in empty transaction context", func(t *testing.T) {
+		var capturedReq *http.Request
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedReq = r
+		})
+
+		handler := WithTransactionContextMiddleware(next)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+
+		require.NotNil(t, capturedReq)
+		tctx := openfeature.TransactionContext(capturedReq.Context())
+		assert.Empty(t, tctx.TargetingKey())
+		assert.Empty(t, tctx.Attributes())
+	})
+
+	t.Run("merges with existing transaction context", func(t *testing.T) {
+		var capturedReq *http.Request
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedReq = r
+		})
+
+		handler := WithTransactionContextMiddleware(next)
+
+		existing := openfeature.NewEvaluationContext("prior-key", map[string]any{
+			"cluster": "prod-eu-center-1",
+			"slug":    "old-slug",
+		})
+		req := baggageCtx(t, "namespace=stacks-42,slug=mystack")
+		req = req.WithContext(openfeature.WithTransactionContext(req.Context(), existing))
+
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+
+		require.NotNil(t, capturedReq)
+		tctx := openfeature.TransactionContext(capturedReq.Context())
+
+		// baggage wins on targeting key
+		assert.Equal(t, "stacks-42", tctx.TargetingKey())
+		// baggage wins on conflicting attribute
+		assert.Equal(t, "mystack", tctx.Attributes()["slug"])
+		// prior context values that don't conflict are preserved
+		assert.Equal(t, "prod-eu-center-1", tctx.Attributes()["cluster"])
+	})
+
+	t.Run("calls next handler", func(t *testing.T) {
+		called := false
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := WithTransactionContextMiddleware(next)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.True(t, called)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+}

--- a/pkg/infra/features/baggage_test.go
+++ b/pkg/infra/features/baggage_test.go
@@ -29,7 +29,7 @@ func TestInstanceContextFromBaggage(t *testing.T) {
 	})
 
 	t.Run("all canonical fields are extracted", func(t *testing.T) {
-		req := baggageCtx(t, "slug=mystack,plan=pro,channel=stable,namespace=stacks-42,grafana_version=13.0.0,stackId=42,instanceURL=https://mystack.grafana.net")
+		req := baggageCtx(t, "slug=mystack,plan=pro,channel=stable,namespace=stacks-42")
 		evalCtx := InstanceContextFromBaggage(req.Context())
 
 		attrs := evalCtx.Attributes()
@@ -37,9 +37,6 @@ func TestInstanceContextFromBaggage(t *testing.T) {
 		assert.Equal(t, "pro", attrs["plan"])
 		assert.Equal(t, "stable", attrs["channel"])
 		assert.Equal(t, "stacks-42", attrs["namespace"])
-		assert.Equal(t, "13.0.0", attrs["grafana_version"])
-		assert.Equal(t, "42", attrs["stackId"])
-		assert.Equal(t, "https://mystack.grafana.net", attrs["instanceURL"])
 	})
 
 	t.Run("absent fields are not added to attributes", func(t *testing.T) {
@@ -51,7 +48,6 @@ func TestInstanceContextFromBaggage(t *testing.T) {
 		assert.Contains(t, attrs, "namespace")
 		assert.NotContains(t, attrs, "plan")
 		assert.NotContains(t, attrs, "channel")
-		assert.NotContains(t, attrs, "stackId")
 	})
 
 	t.Run("non-canonical baggage members are not included", func(t *testing.T) {

--- a/pkg/infra/features/baggage_test.go
+++ b/pkg/infra/features/baggage_test.go
@@ -50,13 +50,6 @@ func TestInstanceContextFromBaggage(t *testing.T) {
 		assert.NotContains(t, attrs, "channel")
 	})
 
-	t.Run("non-canonical baggage members are not included", func(t *testing.T) {
-		req := baggageCtx(t, "namespace=stacks-42,custom-key=should-be-ignored")
-		evalCtx := InstanceContextFromBaggage(req.Context())
-
-		assert.NotContains(t, evalCtx.Attributes(), "custom-key")
-	})
-
 	t.Run("missing namespace results in empty targeting key", func(t *testing.T) {
 		req := baggageCtx(t, "slug=mystack,plan=pro")
 		evalCtx := InstanceContextFromBaggage(req.Context())

--- a/pkg/infra/features/baggage_test.go
+++ b/pkg/infra/features/baggage_test.go
@@ -19,10 +19,10 @@ func baggageCtx(t *testing.T, members string) *http.Request {
 	return req.WithContext(baggage.ContextWithBaggage(req.Context(), bag))
 }
 
-func TestInstanceContextFromBaggage(t *testing.T) {
+func TestEvaluationContextFromBaggage(t *testing.T) {
 	t.Run("empty context returns empty eval context", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		evalCtx := InstanceContextFromBaggage(req.Context())
+		evalCtx := EvaluationContextFromBaggage(req.Context())
 
 		assert.Empty(t, evalCtx.TargetingKey())
 		assert.Empty(t, evalCtx.Attributes())
@@ -30,7 +30,7 @@ func TestInstanceContextFromBaggage(t *testing.T) {
 
 	t.Run("all canonical fields are extracted", func(t *testing.T) {
 		req := baggageCtx(t, "slug=mystack,plan=pro,channel=stable,namespace=stacks-42")
-		evalCtx := InstanceContextFromBaggage(req.Context())
+		evalCtx := EvaluationContextFromBaggage(req.Context())
 
 		attrs := evalCtx.Attributes()
 		assert.Equal(t, "mystack", attrs["slug"])
@@ -41,7 +41,7 @@ func TestInstanceContextFromBaggage(t *testing.T) {
 
 	t.Run("absent fields are not added to attributes", func(t *testing.T) {
 		req := baggageCtx(t, "slug=mystack,namespace=stacks-42")
-		evalCtx := InstanceContextFromBaggage(req.Context())
+		evalCtx := EvaluationContextFromBaggage(req.Context())
 
 		attrs := evalCtx.Attributes()
 		assert.Contains(t, attrs, "slug")
@@ -52,7 +52,7 @@ func TestInstanceContextFromBaggage(t *testing.T) {
 
 	t.Run("missing namespace results in empty targeting key", func(t *testing.T) {
 		req := baggageCtx(t, "slug=mystack,plan=pro")
-		evalCtx := InstanceContextFromBaggage(req.Context())
+		evalCtx := EvaluationContextFromBaggage(req.Context())
 
 		assert.Empty(t, evalCtx.TargetingKey())
 		assert.Equal(t, "mystack", evalCtx.Attributes()["slug"])

--- a/pkg/infra/features/go.mod
+++ b/pkg/infra/features/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/open-feature/go-sdk-contrib/providers/ofrep v0.1.7
 	github.com/puzpuzpuz/xsync/v4 v4.5.0
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/otel v1.44.0
 )
 
 require (
@@ -38,7 +39,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.69.0 // indirect
-	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect

--- a/pkg/infra/features/go.mod
+++ b/pkg/infra/features/go.mod
@@ -38,7 +38,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.69.0 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect


### PR DESCRIPTION
Introducing WithTransactionContext middleware that can be used by MT services to get common transaction context from the baggage header with no extra efforts.