### PR TITLE
FeatureToggles: Remove clearPreviousFieldValues feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1476,11 +1476,6 @@ export interface FeatureToggles {
   */
   tracesDrilldownTimeSeeker?: boolean;
   /**
-  * Mitigates React fiber's retention of previous props/state, causing 2x memory use: https://github.com/facebook/react/issues/36176
-  * @default true
-  */
-  clearPreviousFieldValues?: boolean;
-  /**
   * Enables new colorblind safe palette and line fill patterns for panels
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2767,15 +2767,6 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:         "clearPreviousFieldValues",
-			Description:  "Mitigates React fiber's retention of previous props/state, causing 2x memory use: https://github.com/facebook/react/issues/36176",
-			Stage:        FeatureStageGeneralAvailability,
-			Generate:     Generate{LegacyFrontend: true},
-			Owner:        grafanaDatavizSquad,
-			Expression:   "true",
-			HideFromDocs: true,
-		},
-		{
 			Name:        "enableColorblindSafePanelOptions",
 			Description: "Enables new colorblind safe palette and line fill patterns for panels",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -321,7 +321,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,queryFetchConfigFromSettingsService,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-05-22,profilesHeatmap,experimental,@grafana/observability-traces-and-profiling,false,false,false
 2026-05-22,tracesDrilldownTimeSeeker,experimental,@grafana/observability-traces-and-profiling,false,false,true
-2026-04-01,clearPreviousFieldValues,GA,@grafana/dataviz-squad,false,false,true
 2026-05-22,enableColorblindSafePanelOptions,experimental,@grafana/dataviz-squad,false,false,true
 2026-05-22,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-operator-experience-squad,false,true,false
 2026-05-22,querycaching.redirectToK8SApi,experimental,@grafana/grafana-operator-experience-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1232,6 +1232,7 @@
         "name": "clearPreviousFieldValues",
         "resourceVersion": "1779387149898",
         "creationTimestamp": "2026-04-01T19:07:25Z",
+        "deletionTimestamp": "2026-07-07T16:17:13Z",
         "annotations": {
           "grafana.app/updatedTimestamp": "2026-05-21 18:12:29.898776 +0000 UTC"
         }


### PR DESCRIPTION
Removes the `clearPreviousFieldValues` feature toggle from the registry and regenerates the derived toggle metadata.

All usages of this toggle were already removed in prior changes, so this is a registry-only cleanup:
- Removed the entry from `pkg/services/featuremgmt/registry.go`
- Regenerated `toggles_gen.csv`, `toggles_gen.json` (adds a `deletionTimestamp` tombstone), `featureToggles.gen.ts`, and the feature-toggle docs via `make gen-feature-toggles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)