### PR TITLE
FeatureToggles: Remove groupToNestedTableV2 feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -95,7 +95,6 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `savedQueriesRBAC`                | Enables Saved queries (query library) RBAC permissions                                         |
 | `newSavedQueriesExperience`       | Enables the new Saved queries (query library) modal experience                                 |
 | `dashboardTemplates`              | Enables a flow to get started with a new dashboard from a template                             |
-| `groupToNestedTableV2`            | Enable the new matcher-based UI and config shape for the Group to Nested Tables transformation |
 | `alertRuleRestore`                | Enables the alert rule restore feature                                                         |
 | `azureMonitorLogsBuilderEditor`   | Enables the logs builder mode for the Azure Monitor data source                                |
 | `alertingListViewV2PreviewToggle` | Enables the alerting list view v2 preview toggle                                               |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -670,11 +670,6 @@ export interface FeatureToggles {
   */
   groupAttributeSync?: boolean;
   /**
-  * Enable the new matcher-based UI and config shape for the Group to Nested Tables transformation
-  * @default false
-  */
-  groupToNestedTableV2?: boolean;
-  /**
   * Enables step mode for alerting queries and expressions
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1279,14 +1279,6 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:        "groupToNestedTableV2",
-			Description: "Enable the new matcher-based UI and config shape for the Group to Nested Tables transformation",
-			Stage:       FeatureStagePublicPreview,
-			Owner:       grafanaDatavizSquad,
-			Expression:  "false",
-			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:        "alertingQueryAndExpressionsStepMode",
 			Description: "Enables step mode for alerting queries and expressions",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -147,7 +147,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-08-29,exploreLogsAggregatedMetrics,experimental,@grafana/observability-logs,false,false,true
 2024-10-14,appPlatformGrpcClientAuth,experimental,@grafana/identity-access-team,false,false,false
 2024-09-09,groupAttributeSync,privatePreview,@grafana/identity-access-team,false,false,false
-2026-03-27,groupToNestedTableV2,preview,@grafana/dataviz-squad,false,false,false
 2024-09-26,alertingQueryAndExpressionsStepMode,GA,@grafana/alerting-squad,false,false,true
 2024-09-17,improvedExternalSessionHandling,GA,@grafana/identity-access-team,false,false,false
 2024-09-23,useSessionStorageForRedirection,GA,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -415,10 +415,6 @@ const (
 	// Enable the groupsync extension for managing Group Attribute Sync feature
 	FlagGroupAttributeSync = "groupAttributeSync"
 
-	// FlagGroupToNestedTableV2
-	// Enable the new matcher-based UI and config shape for the Group to Nested Tables transformation
-	FlagGroupToNestedTableV2 = "groupToNestedTableV2"
-
 	// FlagImprovedExternalSessionHandling
 	// Enables improved support for OAuth external sessions. After enabling this feature, users might need to re-authenticate themselves.
 	FlagImprovedExternalSessionHandling = "improvedExternalSessionHandling"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2974,6 +2974,7 @@
         "name": "groupToNestedTableV2",
         "resourceVersion": "1779387430820",
         "creationTimestamp": "2026-03-27T20:18:08Z",
+        "deletionTimestamp": "2026-07-07T16:17:14Z",
         "annotations": {
           "grafana.app/updatedTimestamp": "2026-05-21 18:17:10.820324 +0000 UTC"
         }


### PR DESCRIPTION
Removes the `groupToNestedTableV2` feature toggle from the registry and regenerates the derived toggle metadata.

All usages of this toggle were already removed in prior changes, so this is a registry-only cleanup:
- Removed the entry from `pkg/services/featuremgmt/registry.go`
- Regenerated `toggles_gen.csv`, `toggles_gen.json` (adds a `deletionTimestamp` tombstone), `featureToggles.gen.ts`, and the feature-toggle docs via `make gen-feature-toggles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)