### PR TITLE
FeatureToggles: Remove nestedFramesFieldOverrides feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -100,7 +100,6 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `azureMonitorLogsBuilderEditor`   | Enables the logs builder mode for the Azure Monitor data source                                |
 | `alertingListViewV2PreviewToggle` | Enables the alerting list view v2 preview toggle                                               |
 | `interactiveLearning`             | Enables the interactive learning app                                                           |
-| `nestedFramesFieldOverrides`      | Enable field overrides for FieldType.nestedFrames fields (like in nested tables)               |
 | `panelTimeSettings`               | Enables a new panel time settings drawer                                                       |
 | `transformationsEmptyPlaceholder` | Show transformation quick-start cards in empty transformations state                           |
 | `pyroscopeUTF8LabelNames`         | Enables support for UTF-8 label names in Pyroscope label selectors                             |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1166,11 +1166,6 @@ export interface FeatureToggles {
   */
   vizPresets?: boolean;
   /**
-  * Enable field overrides for FieldType.nestedFrames fields (like in nested tables)
-  * @default false
-  */
-  nestedFramesFieldOverrides?: boolean;
-  /**
   * Enable faceted labels filter for series visibility in the legend
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2147,14 +2147,6 @@ var (
 			Expression:  "true",
 		},
 		{
-			Name:        "nestedFramesFieldOverrides",
-			Description: "Enable field overrides for FieldType.nestedFrames fields (like in nested tables)",
-			Stage:       FeatureStagePublicPreview,
-			Generate:    Generate{LegacyFrontend: true},
-			Owner:       grafanaDatavizSquad,
-			Expression:  "false",
-		},
-		{
 			Name:        "vizLegendFacetedFilter",
 			Description: "Enable faceted labels filter for series visibility in the legend",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -249,7 +249,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,grafana.dedicatedGrafanaComProxyAPIToken,experimental,@grafana/grafana-catalog,false,false,false
 2026-02-18,panelStyleActions,GA,@grafana/dataviz-squad,false,false,true
 2026-02-18,vizPresets,GA,@grafana/dataviz-squad,false,false,true
-2026-05-22,nestedFramesFieldOverrides,preview,@grafana/dataviz-squad,false,false,true
 2026-03-10,vizLegendFacetedFilter,GA,@grafana/dataviz-squad,false,false,true
 2026-06-03,heatmapNegativeLogBuckets,experimental,@grafana/dataviz-squad,false,false,true
 2026-05-22,pieChartGradientColorScheme,experimental,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3870,7 +3870,8 @@
       "metadata": {
         "name": "nestedFramesFieldOverrides",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "deletionTimestamp": "2026-07-07T16:17:18Z"
       },
       "spec": {
         "description": "Enable field overrides for FieldType.nestedFrames fields (like in nested tables)",


### PR DESCRIPTION
Removes the `nestedFramesFieldOverrides` feature toggle from the registry and regenerates the derived toggle metadata.

All usages of this toggle were already removed in prior changes, so this is a registry-only cleanup:
- Removed the entry from `pkg/services/featuremgmt/registry.go`
- Regenerated `toggles_gen.csv`, `toggles_gen.json` (adds a `deletionTimestamp` tombstone), `featureToggles.gen.ts`, and the feature-toggle docs via `make gen-feature-toggles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)