### PR TITLE
Navigation: Make app title a working home link

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
@@ -8,7 +8,7 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { useSelector } from 'app/types/store';
 
-import { HomeLogo } from '../../Branding/Branding';
+import { HomeLogo, HomeTitle } from '../../Branding/Branding';
 import { OrganizationSwitcher } from '../OrganizationSwitcher/OrganizationSwitcher';
 import { getChromeHeaderLevelHeight } from '../TopBar/useChromeHeaderHeight';
 
@@ -31,7 +31,9 @@ export function MegaMenuHeader({ handleDockedMenu, onClose }: Props) {
     <div className={styles.header}>
       <Stack alignItems="center" minWidth={0} gap={1}>
         <HomeLogo homeNav={homeNav} onClick={state.megaMenuDocked ? undefined : onClose} />
-        <OrganizationSwitcher />
+        <OrganizationSwitcher>
+          <HomeTitle homeNav={homeNav} onClick={state.megaMenuDocked ? undefined : onClose} />
+        </OrganizationSwitcher>
       </Stack>
       <div className={styles.flexGrow} />
       <IconButton

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
@@ -8,7 +8,7 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { useSelector } from 'app/types/store';
 
-import { HomeLink } from '../../Branding/Branding';
+import { HomeLogo } from '../../Branding/Branding';
 import { OrganizationSwitcher } from '../OrganizationSwitcher/OrganizationSwitcher';
 import { getChromeHeaderLevelHeight } from '../TopBar/useChromeHeaderHeight';
 
@@ -30,7 +30,7 @@ export function MegaMenuHeader({ handleDockedMenu, onClose }: Props) {
   return (
     <div className={styles.header}>
       <Stack alignItems="center" minWidth={0} gap={1}>
-        <HomeLink homeNav={homeNav} onClick={state.megaMenuDocked ? undefined : onClose} />
+        <HomeLogo homeNav={homeNav} onClick={state.megaMenuDocked ? undefined : onClose} />
         <OrganizationSwitcher />
       </Stack>
       <div className={styles.flexGrow} />

--- a/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.tsx
+++ b/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.tsx
@@ -2,17 +2,14 @@ import { useEffect } from 'react';
 
 import type { SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Text } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getUserOrganizations, setUserOrganization } from 'app/features/org/state/actions';
 import { useDispatch, useSelector } from 'app/types/store';
 import { type UserOrg } from 'app/types/user';
 
-import { Branding } from '../../Branding/Branding';
-
 import { OrganizationSelect } from './OrganizationSelect';
 
-export function OrganizationSwitcher() {
+export function OrganizationSwitcher({ children }: { children?: React.ReactNode }) {
   const dispatch = useDispatch();
   const orgs = useSelector((state) => state.organization.userOrgs);
   const onSelectChange = async (option: SelectableValue<UserOrg>) => {
@@ -40,7 +37,7 @@ export function OrganizationSwitcher() {
   }, [dispatch]);
 
   if (orgs?.length <= 1) {
-    return <Text truncate>{Branding.AppTitle}</Text>;
+    return children;
   }
 
   return <OrganizationSelect orgs={orgs} onSelectChange={onSelectChange} />;

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -15,7 +15,7 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { ScopesSelector } from 'app/features/scopes/selector/ScopesSelector';
 import { useSelector } from 'app/types/store';
 
-import { HomeLink } from '../../Branding/Branding';
+import { HomeLogo } from '../../Branding/Branding';
 import { Breadcrumbs } from '../../Breadcrumbs/Breadcrumbs';
 import { buildBreadcrumbs } from '../../Breadcrumbs/utils';
 import { ExtensionToolbarItem } from '../ExtensionSidebar/ExtensionToolbarItem';
@@ -82,7 +82,7 @@ export const SingleTopBar = memo(function SingleTopBar({
               </Stack>
             </ToolbarButton>
           )}
-          {!menuDockedAndOpen && <HomeLink homeNav={homeNav} />}
+          {!menuDockedAndOpen && <HomeLogo homeNav={homeNav} />}
           {topLevelScopes ? <ScopesSelector /> : undefined}
           <Breadcrumbs breadcrumbs={breadcrumbs} className={styles.breadcrumbsWrapper} />
           {!showToolbarLevel && breadcrumbActions}

--- a/public/app/core/components/Branding/Branding.tsx
+++ b/public/app/core/components/Branding/Branding.tsx
@@ -54,8 +54,8 @@ const MenuLogo: FC<BrandComponentProps> = ({ className }) => {
   return <img className={className} src={grafanaIconSvg} alt="Grafana" />;
 };
 
-export function HomeLink({ homeNav, onClick }: { homeNav?: NavModelItem; onClick?: () => void }) {
-  const styles = useStyles2(homeLinkStyles);
+export function HomeLogo({ homeNav, onClick }: { homeNav?: NavModelItem; onClick?: () => void }) {
+  const styles = useStyles2(homeLogoStyles);
 
   const onHomeClicked = () => {
     reportInteraction('grafana_home_clicked');
@@ -67,7 +67,7 @@ export function HomeLink({ homeNav, onClick }: { homeNav?: NavModelItem; onClick
       <a
         onClick={onHomeClicked}
         data-testid={selectors.components.Breadcrumbs.breadcrumb('Home')}
-        className={styles.homeLink}
+        className={styles.homeLogo}
         title={homeNav?.text || 'Home'}
         href={homeNav?.url}
       >
@@ -77,9 +77,9 @@ export function HomeLink({ homeNav, onClick }: { homeNav?: NavModelItem; onClick
   );
 }
 
-function homeLinkStyles(theme: GrafanaTheme2) {
+function homeLogoStyles(theme: GrafanaTheme2) {
   return {
-    homeLink: css({
+    homeLogo: css({
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',

--- a/public/app/core/components/Branding/Branding.tsx
+++ b/public/app/core/components/Branding/Branding.tsx
@@ -4,7 +4,7 @@ import { type FC, type JSX } from 'react';
 import { colorManipulator, type GrafanaTheme2, type NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
-import { Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
+import { Text, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
 import g8LoginDarkSvg from 'img/g8_login_dark.svg';
 import g8LoginLightSvg from 'img/g8_login_light.svg';
 import grafanaIconSvg from 'img/grafana_icon.svg';
@@ -89,6 +89,45 @@ function homeLogoStyles(theme: GrafanaTheme2) {
       img: {
         maxHeight: '100%',
         maxWidth: '100%',
+      },
+    }),
+  };
+}
+
+export function HomeTitle({ homeNav, onClick }: { homeNav?: NavModelItem; onClick?: () => void }) {
+  const styles = useStyles2(homeTitleStyles);
+
+  const onHomeClicked = () => {
+    reportInteraction('grafana_home_clicked');
+    onClick?.();
+  };
+
+  return (
+    <a onClick={onHomeClicked} className={styles.homeTitle} title={homeNav?.text || 'Home'} href={homeNav?.url}>
+      <Text variant="body" truncate>
+        {Branding.AppTitle}
+      </Text>
+    </a>
+  );
+}
+
+function homeTitleStyles(theme: GrafanaTheme2) {
+  return {
+    homeTitle: css({
+      borderRadius: theme.shape.radius.default,
+      color: theme.colors.text.primary,
+      padding: theme.spacing(0.25, 0.75),
+      margin: theme.spacing(0, -0.75),
+      textDecoration: 'none',
+
+      '&:hover, &:focus': {
+        backgroundColor: theme.colors.secondary.transparent,
+      },
+
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: theme.transitions.create(['background-color'], {
+          duration: theme.transitions.duration.short,
+        }),
       },
     }),
   };


### PR DESCRIPTION
**What is this feature?**

Makes the `Grafana` (or branded) app title shown at the top of the mega menu a clickable link to take the user home, like the logo beside it.

**Why do we need this feature?**

With the dedicated home link removed from the nav in #125835, it is a lot less obvious (even with the logo link) how the user should get home, and I have many times clicked the title expecting it to take me home.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
