### PR TITLE
Provisioning: Add option to author commits as the signer

### DIFF
--- a/public/app/features/provisioning/Config/CommitOptionsSection.test.tsx
+++ b/public/app/features/provisioning/Config/CommitOptionsSection.test.tsx
@@ -29,6 +29,7 @@ function Wrapper({ defaultSigningKeyConfigured, defaultValues, onSubmit = () => 
         smimeCertificateName="smimeCertificate"
         signerNameName="commit.signerName"
         signerEmailName="commit.signerEmail"
+        signerIsAuthorName="commit.signerIsAuthor"
         defaultSigningKeyConfigured={defaultSigningKeyConfigured}
       />
       <button type="submit">Submit</button>

--- a/public/app/features/provisioning/Config/CommitOptionsSection.tsx
+++ b/public/app/features/provisioning/Config/CommitOptionsSection.tsx
@@ -41,6 +41,7 @@ interface Props<T extends FieldValues> {
   smimeCertificateName: Path<T>;
   signerNameName: Path<T>;
   signerEmailName: Path<T>;
+  signerIsAuthorName: Path<T>;
   defaultSigningKeyConfigured?: boolean;
 }
 
@@ -62,6 +63,7 @@ export function CommitOptionsSection<T extends FieldValues>({
   smimeCertificateName,
   signerNameName,
   signerEmailName,
+  signerIsAuthorName,
   defaultSigningKeyConfigured,
 }: Props<T>) {
   const gitConventionsEnabled = useBooleanFlagValue('provisioning.gitConventions', false);
@@ -79,6 +81,8 @@ export function CommitOptionsSection<T extends FieldValues>({
     setValue(smimeCertificateName, empty);
     setValue(signerNameName, empty);
     setValue(signerEmailName, empty);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    setValue(signerIsAuthorName, false as PathValue<T, Path<T>>);
     setSigningKeyConfigured(false);
   };
 
@@ -267,6 +271,15 @@ export function CommitOptionsSection<T extends FieldValues>({
                   </Field>
                 )}
               />
+            )}
+            {gitFields.signerIsAuthorConfig && (
+              <Field noMargin>
+                <Checkbox
+                  {...register(signerIsAuthorName)}
+                  label={gitFields.signerIsAuthorConfig.label}
+                  description={gitFields.signerIsAuthorConfig.description}
+                />
+              </Field>
             )}
           </>
         )}

--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -414,6 +414,7 @@ export function ConfigForm({ data }: ConfigFormProps) {
               smimeCertificateName="smimeCertificate"
               signerNameName="commit.signerName"
               signerEmailName="commit.signerEmail"
+              signerIsAuthorName="commit.signerIsAuthor"
               defaultSigningKeyConfigured={Boolean(data?.secure?.commitSigningKey?.name)}
             />
             {/* Pull requests are not supported by the pure git type. */}

--- a/public/app/features/provisioning/Config/defaults.ts
+++ b/public/app/features/provisioning/Config/defaults.ts
@@ -23,7 +23,7 @@ export function getDefaultValues({
       signingMethod: '',
       commitSigningKey: '',
       smimeCertificate: '',
-      commit: { signerName: '', signerEmail: '' },
+      commit: { signerName: '', signerEmail: '', signerIsAuthor: false },
       url: '',
       branch: '',
       generateDashboardPreviews: false,

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -154,6 +154,7 @@ export const FinishStep = memo(function FinishStep() {
             smimeCertificateName="repository.smimeCertificate"
             signerNameName="repository.commit.signerName"
             signerEmailName="repository.commit.signerEmail"
+            signerIsAuthorName="repository.commit.signerIsAuthor"
           />
           {/* Pull requests are not supported by the pure git type. */}
           {type !== 'git' && (

--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -55,6 +55,10 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
       description: t('provisioning.shared.commit-signer-email-description', 'Must match the signing key identity.'),
       placeholder: t('provisioning.shared.commit-signer-email-placeholder', 'noreply@grafana.com'),
     },
+    signerIsAuthor: {
+      label: t('provisioning.shared.signer-is-author-label', 'Use signer as commit author'),
+      description: t('provisioning.shared.signer-is-author-description', 'Author commits as the signer.'),
+    },
   };
 
   // Shared field descriptions used across multiple providers
@@ -344,6 +348,7 @@ export const getGitProviderFields = (
       smimeCertificateConfig?: FieldConfig;
       commitSignerNameConfig?: FieldConfig;
       commitSignerEmailConfig?: FieldConfig;
+      signerIsAuthorConfig?: FieldConfig;
       urlConfig: FieldConfig;
       branchConfig: FieldConfig;
       pathConfig: FieldConfig;
@@ -363,6 +368,7 @@ export const getGitProviderFields = (
   const smimeCertificateConfig = configs.smimeCertificate; // Paired with commitSigningKey when format is smime
   const commitSignerNameConfig = configs.commitSignerName; // Paired with commitSigningKey
   const commitSignerEmailConfig = configs.commitSignerEmail; // Paired with commitSigningKey
+  const signerIsAuthorConfig = configs.signerIsAuthor; // Paired with commitSigningKey
   const urlConfig = configs.url;
   const branchConfig = configs.branch;
   const pathConfig = configs.path;
@@ -380,6 +386,7 @@ export const getGitProviderFields = (
     smimeCertificateConfig,
     commitSignerNameConfig,
     commitSignerEmailConfig,
+    signerIsAuthorConfig,
     urlConfig,
     branchConfig,
     pathConfig,

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -24,6 +24,7 @@ const buildCommitOptions = (data: RepositoryFormData): CommitOptions | undefined
   const signerName = data.commit?.signerName?.trim();
   const signerEmail = data.commit?.signerEmail?.trim();
   const signingMethod = data.signingMethod;
+  const signerIsAuthor = Boolean(signingMethod) && Boolean(data.commit?.signerIsAuthor);
 
   if (!base && !signerName && !signerEmail && !signingMethod) {
     return undefined;
@@ -38,6 +39,9 @@ const buildCommitOptions = (data: RepositoryFormData): CommitOptions | undefined
   }
   if (signingMethod) {
     commit.signingMethod = signingMethod;
+  }
+  if (signerIsAuthor) {
+    commit.signerIsAuthor = true;
   }
   if (data.smimeCertificate) {
     commit.smimeCertificate = data.smimeCertificate;
@@ -210,7 +214,12 @@ export const specToData = (spec: RepositorySpec): RepositoryFormData => {
     signingMethod: spec.commit?.signingMethod ?? '',
     smimeCertificate: spec.commit?.smimeCertificate ?? '',
     commitSigningKey: '',
-    commit: { ...spec.commit, signerName: spec.commit?.signerName ?? '', signerEmail: spec.commit?.signerEmail ?? '' },
+    commit: {
+      ...spec.commit,
+      signerName: spec.commit?.signerName ?? '',
+      signerEmail: spec.commit?.signerEmail ?? '',
+      signerIsAuthor: spec.commit?.signerIsAuthor ?? false,
+    },
   });
 };
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13810,6 +13810,8 @@
       "progress-bar": {
         "aria-label": "Progress Bar"
       },
+      "signer-is-author-description": "Author commits as the signer.",
+      "signer-is-author-label": "Use signer as commit author",
       "signing-key-description": "Private key used to sign commits. No passphrase.",
       "signing-key-label": "Signing key",
       "signing-method-description": "Sign commits so their author can be cryptographically verified.",


### PR DESCRIPTION
**What is this feature?**

Adds a checkbox to the repository settings form and wizard to author commits as the signer.

**Why do we need this feature?**

UI for #127969.

**Who is this feature for?**

Admins using git sync.

**Special notes for your reviewer:**

Stacked on #127969.

---
*Description generated by Claude Code.*