### PR TITLE
Provisioning: Disable next button until a branch is selected in the Git Sync wizard

### DIFF
--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -391,7 +391,7 @@ describe('ProvisioningWizard', () => {
   });
 
   describe('Form Validation', () => {
-    it('should validate required fields on connection step', async () => {
+    it('should disable next button until a branch is selected on connection step', async () => {
       const { user } = setup(<ProvisioningWizard type="github" />);
 
       // Select PAT option (GitHub App is the default)
@@ -410,11 +410,14 @@ describe('ProvisioningWizard', () => {
       const clearButtons = screen.getAllByTitle(/Clear value/i);
       await user.click(clearButtons[0]); // Clear the branch combobox
 
-      await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
+      expect(screen.getByRole('button', { name: /Choose what to synchronize/i })).toBeDisabled();
 
-      // Should still be on connection step due to validation
-      expect(screen.getByRole('heading', { name: /2\. Configure repository/i })).toBeInTheDocument();
-      expect(screen.getByText(/Branch is required/i)).toBeInTheDocument();
+      const branchCombobox = screen.getAllByRole('combobox')[0];
+      await user.click(branchCombobox);
+      await user.paste('main');
+      await user.keyboard('{Enter}');
+
+      expect(screen.getByRole('button', { name: /Choose what to synchronize/i })).toBeEnabled();
     });
   });
 

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -14,7 +14,7 @@ import { getDefaultValues } from '../Config/defaults';
 import { ProvisioningAlert } from '../Shared/ProvisioningAlert';
 import { PROVISIONING_URL } from '../constants';
 import { useCreateOrUpdateRepository } from '../hooks/useCreateOrUpdateRepository';
-import { isGitHubBased } from '../utils/repositoryTypes';
+import { isGitHubBased, isGitProvider } from '../utils/repositoryTypes';
 
 import { useStepStatus } from './StepStatusContext';
 import { Stepper } from './Stepper';
@@ -67,12 +67,13 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
     handleSubmit,
   } = methods;
 
-  const [repoName = '', repoType, syncTarget, githubAuthType, githubAppMode] = watch([
+  const [repoName = '', repoType, syncTarget, githubAuthType, githubAppMode, branch] = watch([
     'repositoryName',
     'repository.type',
     'repository.sync.target',
     'githubAuthType',
     'githubAppMode',
+    'repository.branch',
   ]);
 
   const steps = useMemo(() => getSteps(repoType), [repoType]);
@@ -247,7 +248,7 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
               previousText={previousButtonText}
               nextText={nextButtonText}
               isPreviousDisabled={isPreviousDisabled}
-              isNextDisabled={isNextDisabled}
+              isNextDisabled={isNextDisabled || (activeStep === 'connection' && isGitProvider(repoType) && !branch)}
               isSubmitting={isSubmitting}
               onPrevious={handlePrevious}
             />


### PR DESCRIPTION
**What is this feature?**

In the Git Sync setup wizard, the button to continue past the repository configuration step is now disabled until a branch is selected.

Before:

https://github.com/user-attachments/assets/fbb52973-c1e8-4e3d-848b-7daa2f215a4a


After:

https://github.com/user-attachments/assets/33a39656-b7ec-4502-924a-dbde0095e120

