### PR TITLE
Explore Logs: update datasourcesrv

### DIFF
--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -26,7 +26,8 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery, type TimeZone } from '@grafana/schema';
 import { Button, Collapse, Combobox, type ComboboxOption, InlineLabel, Modal, Stack, useTheme2 } from '@grafana/ui';
 import { splitOpen } from 'app/features/explore/state/main';
@@ -338,13 +339,11 @@ export const LogLineContext = memo(
 
     useEffect(() => {
       if (log.datasourceUid) {
-        getDataSourceSrv()
-          .get({ uid: log.datasourceUid })
-          .then((ds) => {
-            if (hasLogsContextSupport(ds)) {
-              setDatasourceInstance(ds);
-            }
-          });
+        getDataSourceInstance({ uid: log.datasourceUid }).then((ds) => {
+          if (hasLogsContextSupport(ds)) {
+            setDatasourceInstance(ds);
+          }
+        });
       }
     }, [log.datasourceUid]);
 

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -6,6 +6,7 @@ import {
   createDataFrame,
   type DataFrame,
   DataFrameType,
+  type DataSourceApi,
   dateTime,
   type Field,
   FieldType,
@@ -16,7 +17,8 @@ import {
   type ScopedVars,
   toDataFrame,
 } from '@grafana/data';
-import { type DataSourceSrv, getDataSourceSrv, setPluginLinksHook, usePluginLinks } from '@grafana/runtime';
+import { setPluginLinksHook, usePluginLinks } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { createLokiDatasource } from 'app/plugins/datasource/loki/mocks/datasource';
 
 import { DATAPLANE_LABEL_TYPES_NAME, DATAPLANE_LABELS_NAME } from '../../logsFrame';
@@ -53,8 +55,12 @@ jest.mock('@grafana/assistant', () => {
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: jest.fn(),
   usePluginLinks: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
 }));
 
 jest.mock('./LogListContext');
@@ -142,19 +148,15 @@ describe('LogLineDetails', () => {
       links: [],
       isLoading: false,
     });
-    jest.mocked(getDataSourceSrv).mockImplementation(
-      () =>
-        ({
-          get: (uid: string) => {
-            if (uid === 'loki-ds') {
-              return Promise.resolve(lokiDS);
-            } else if (uid === 'tempo-ds') {
-              return Promise.resolve(tempoDS);
-            }
-            return Promise.resolve(null);
-          },
-        }) as unknown as DataSourceSrv
-    );
+    jest.mocked(getDataSourceInstance).mockImplementation((ref) => {
+      const uid = typeof ref === 'string' ? ref : ref?.uid;
+      if (uid === 'loki-ds') {
+        return Promise.resolve(lokiDS as unknown as DataSourceApi);
+      } else if (uid === 'tempo-ds') {
+        return Promise.resolve(tempoDS as unknown as DataSourceApi);
+      }
+      return Promise.resolve(null as unknown as DataSourceApi);
+    });
   });
 
   test('Copy log as JSON from header copies structured JSON from the log', async () => {
@@ -639,9 +641,7 @@ describe('LogLineDetails', () => {
       });
 
       test('should fallback to a single group of Fields if not supported', async () => {
-        jest.requireMock('@grafana/runtime').getDataSourceSrv = jest.fn().mockImplementation(() => ({
-          get: (uid: string) => Promise.reject(null),
-        }));
+        jest.mocked(getDataSourceInstance).mockImplementation(() => Promise.reject(null));
 
         await setup(
           undefined,

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -11,7 +11,8 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { Box, ControlledCollapse, useStyles2 } from '@grafana/ui';
 
 import { getLabelTypeFromRow } from '../../utils';
@@ -155,8 +156,7 @@ export const LogLineDetailsComponent = memo(
     }, []);
 
     useEffect(() => {
-      getDataSourceSrv()
-        .get(log.datasourceUid)
+      getDataSourceInstance(log.datasourceUid)
         .then(setDs)
         .catch(() => setDs(null));
     }, [log.datasourceUid]);

--- a/public/app/features/logs/components/panel/LogLineDetailsTrace.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsTrace.tsx
@@ -11,7 +11,8 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { Icon, Spinner, Tooltip, useStyles2 } from '@grafana/ui';
 import { TraceView } from 'app/features/explore/TraceView/TraceView';
 import { transformDataFrames } from 'app/features/explore/TraceView/utils/transform';
@@ -40,15 +41,13 @@ export const LogLineDetailsTrace = ({ timeRange, timeZone, traceRef }: Props) =>
 
   useEffect(() => {
     setDataSource(null);
-    getDataSourceSrv()
-      .get(traceRef.dsUID)
-      .then((dataSource) => {
-        if (dataSource) {
-          setDataSource(dataSource);
-        } else {
-          setDataFrames(null);
-        }
-      });
+    getDataSourceInstance(traceRef.dsUID).then((dataSource) => {
+      if (dataSource) {
+        setDataSource(dataSource);
+      } else {
+        setDataFrames(null);
+      }
+    });
   }, [traceRef.dsUID]);
 
   useEffect(() => {

--- a/public/app/features/logs/components/panel/LogLineMenu.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { CoreApp, createTheme, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
+import { type DataSourceApi, CoreApp, createTheme, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
 import { type DataSourceSrv, getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 
 import * as logsUtils from '../../utils';
 import { createLogLine } from '../mocks/logRow';
@@ -31,6 +32,11 @@ jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
+}));
+
 const theme = createTheme();
 const styles = getStyles(theme);
 const contextProps = {
@@ -53,6 +59,7 @@ describe('LogLineMenu', () => {
     jest.mocked(getDataSourceSrv).mockReturnValue({
       get: jest.fn().mockResolvedValue({}),
     } as unknown as DataSourceSrv);
+    jest.mocked(getDataSourceInstance).mockResolvedValue({} as DataSourceApi);
   });
 
   test('Renders the component', async () => {

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -64,6 +64,10 @@ jest.mock('@grafana/runtime', () => {
     }),
   };
 });
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: () => Promise.resolve(tempoDS),
+}));
 jest.mock('../../utils', () => ({
   ...jest.requireActual('../../utils'),
   isPopoverMenuDisabled: jest.fn(),

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -25,7 +25,8 @@ import {
   store,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type PopoverContent } from '@grafana/ui';
 
 import { checkLogsError, checkLogsSampled, downloadLogs as download, type DownloadFormat } from '../../utils';
@@ -683,7 +684,7 @@ export function isDedupStrategy(value: unknown): value is LogsDedupStrategy {
 }
 
 async function handleOpenAssistant(openAssistant: (props: OpenAssistantProps) => void, log: LogListModel) {
-  const datasource = await getDataSourceSrv().get(log.datasourceUid);
+  const datasource = await getDataSourceInstance(log.datasourceUid);
   const context = [];
   if (datasource) {
     context.push(

--- a/public/app/features/logs/components/panel/export.ts
+++ b/public/app/features/logs/components/panel/export.ts
@@ -2,7 +2,7 @@ import { groupBy } from 'lodash';
 import { parse, stringify } from 'lossless-json';
 
 import { type DataSourceApi, hasLogsLabelTypesSupport, type Labels } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 
 import { getLabelTypeFromRow } from '../../utils';
 
@@ -108,6 +108,6 @@ export function buildLogLineFullJsonObject(log: LogListModel, ds: DataSourceApi)
 }
 
 export async function getLogAsJSON(log: LogListModel): Promise<string> {
-  const ds = await getDataSourceSrv().get(log.datasourceUid);
+  const ds = await getDataSourceInstance(log.datasourceUid);
   return stringify(buildLogLineFullJsonObject(log, ds), null, 2) ?? log.entry;
 }

--- a/public/app/plugins/panel/logs/useDatasourcesFromTargets.test.ts
+++ b/public/app/plugins/panel/logs/useDatasourcesFromTargets.test.ts
@@ -12,10 +12,10 @@ const datasourceSrv = new DatasourceSrvMock(defaultDs, {
   dataSource1: ds1,
   dataSource2: ds2,
 });
-const getDataSourceSrvMock = jest.fn().mockReturnValue(datasourceSrv);
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => getDataSourceSrvMock(),
+const getDataSourceInstanceMock = jest.fn((ref) => datasourceSrv.get(ref));
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: (ref: string) => getDataSourceInstanceMock(ref),
 }));
 
 describe('useDatasourcesFromTargets', () => {

--- a/public/app/plugins/panel/logs/useDatasourcesFromTargets.ts
+++ b/public/app/plugins/panel/logs/useDatasourcesFromTargets.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useAsync } from 'react-use';
 
 import { type DataSourceApi } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 
 export const useDatasourcesFromTargets = (targets: DataQuery[] | undefined): Map<string, DataSourceApi> => {
@@ -17,11 +17,7 @@ export const useDatasourcesFromTargets = (targets: DataQuery[] | undefined): Map
     const raw = await Promise.all(
       targets
         .filter((target) => !!target.datasource?.uid)
-        .map((target) =>
-          getDataSourceSrv()
-            .get(target.datasource?.uid)
-            .then((ds) => ({ key: target.refId, ds }))
-        )
+        .map((target) => getDataSourceInstance(target.datasource?.uid).then((ds) => ({ key: target.refId, ds })))
     );
 
     setDataSourcesMap(new Map<string, DataSourceApi>(raw.map(({ key, ds }) => [key, ds])));


### PR DESCRIPTION
## Summary 📝

- Migrates the logs panel components off the deprecated `getDataSourceSrv().get(...)` to the async `getDataSourceInstance(...)` from `@grafana/runtime/unstable` (`LogLineContext`, `LogLineDetailsComponent`, `LogLineDetailsTrace`, `LogListContext`, `export.ts`, and the `useDatasourcesFromTargets` hook).
- Behavior is unchanged: default-datasource resolution (empty/`default` ref), not-found rejection, and the `.catch(() => setDs(null))` fallbacks all match the previous contract.
- Updates the affected test mocks to stub `@grafana/runtime/unstable`'s `getDataSourceInstance` (issue #127038).
**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes # https://github.com/grafana/grafana/issues/127038

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
