### PR TITLE
Table: Re-enable flaky datalinks e2e now that codemirror editor is in DataLinks modal

### DIFF
--- a/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
+++ b/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
@@ -274,7 +274,7 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     expect(fourthPageStatus.total).toBe(largeRowStatus.total);
   });
 
-  test.skip('Tests DataLinks (single and multi) and actions', async ({ gotoDashboardPage, selectors, page }) => {
+  test('Tests DataLinks (single and multi) and actions', async ({ gotoDashboardPage, selectors, page }) => {
     const addDataLink = async (title: string, url: string) => {
       await dashboardPage
         .getByGrafanaSelector(
@@ -285,11 +285,12 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
         .click();
 
       // DataLinks dialog has popped open - fill it in and add a global datalink.
+      // use click and press sequentially for codemirror
       await expect(page.getByRole('dialog')).toBeVisible();
-      await page.getByRole('dialog').locator('#link-title').fill(title);
-      // The URL field is a CodeMirror editor (contenteditable); `fill()` is
-      // unreliable on it, so click to focus and type the value key by key.
-      const urlInput = page.getByRole('dialog').locator('#data-link-input [contenteditable="true"]');
+      const titleInput = page.getByRole('dialog').getByLabel('Title');
+      await titleInput.click();
+      await titleInput.pressSequentially(title);
+      const urlInput = page.getByRole('dialog').getByLabel('URL');
       await urlInput.click();
       await urlInput.pressSequentially(url);
       await page.getByRole('dialog').locator('button[aria-disabled="false"]').filter({ hasText: 'Save' }).click();
@@ -305,18 +306,20 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
       dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title('Table - Kitchen Sink'))
     ).toBeVisible();
 
+    await waitForTableLoad(page);
+
     await disableAllTextWrap(page, selectors);
 
     const table = page.locator('.rdg');
-    const infoColumnIdx = await getColumnIdx(table, 'Info');
-    const pillColIdx = await getColumnIdx(table, 'Pills');
-    const dataLinkColIdx = await getColumnIdx(table, 'Data Link');
 
-    // Info column has a single DataLink by default.
-    const infoCell = getCell(table, 1, infoColumnIdx);
-    await expect(infoCell.locator('a')).toBeVisible();
-    expect(infoCell.locator('a')).toHaveAttribute('href');
-    expect(infoCell.locator('a')).not.toHaveAttribute('aria-haspopup');
+    // - pills column currently does not support DataLinks.
+    // - we don't apply DataLinks to Actions or DataLinks columns.
+    // - info column has both a link and an action, so it has a popup.
+    // - image w/ link already has one link, so adding a global link gives it a popover.
+    const excludedColumnIdxs = await Promise.all(
+      ['Pills', 'Data Link', 'Action', 'Info', 'Image w/ Link'].map((name) => getColumnIdx(table, name))
+    );
+    const excludedColumns = new Set<number>(excludedColumnIdxs);
 
     // now, add a DataLink to the whole table
     await addDataLink('Test link', 'https://grafana.com');
@@ -324,9 +327,7 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     // add a DataLink to the whole table, all cells will now have a single link.
     const colCount = await page.getByRole('row').nth(1).getByRole('gridcell').count();
     for (let colIdx = 0; colIdx < colCount; colIdx++) {
-      // - pills column currently does not support DataLinks.
-      // - we don't apply DataLinks to the DataLinks column itself, since they're rendered inside.
-      if (colIdx === pillColIdx || colIdx === dataLinkColIdx) {
+      if (excludedColumns.has(colIdx)) {
         continue;
       }
 
@@ -344,15 +345,7 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     // loop thru the columns, click the links, observe that the tooltip appears, and close the tooltip.
     for (let colIdx = 0; colIdx < colCount; colIdx++) {
       const cell = getCell(table, 1, colIdx);
-      if (colIdx === infoColumnIdx) {
-        // the Info column should still have its single link.
-        expect(cell.locator('a')).not.toHaveAttribute('aria-haspopup', 'menu');
-        continue;
-      }
-
-      // - pills column currently does not support DataLinks.
-      // - we don't apply DataLinks to the DataLinks column itself, since they're rendered inside.
-      if (colIdx === pillColIdx || colIdx === dataLinkColIdx) {
+      if (excludedColumns.has(colIdx)) {
         continue;
       }
 


### PR DESCRIPTION
Re-enables the previously flaky datalinks e2e test inside Table Kitchen Sink suite now that the input has move from Slate to CodeMirror (#126425). the theory is that the previous flakiness was largely coming from issues with Slate. I ran the 10x job against this test and it's working great now. the test did need a bit of love since the panel has changed since it was originally introduced.