### PR TITLE
Provisioning: Attribute Git Sync commits to the acting user

### DIFF
--- a/apps/provisioning/pkg/jobs/validator.go
+++ b/apps/provisioning/pkg/jobs/validator.go
@@ -13,7 +13,16 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository/git"
 	"github.com/grafana/grafana/apps/provisioning/pkg/resources"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+)
+
+// AnnoTriggeredBy and AnnoTriggeredByEmail carry the display name and email of
+// the user that triggered the job. They are set by the server at creation time
+// and are immutable.
+const (
+	AnnoTriggeredBy      = "provisioning.grafana.app/triggeredBy"
+	AnnoTriggeredByEmail = "provisioning.grafana.app/triggeredByEmail"
 )
 
 // ValidateJob performs validation on the Job specification and returns an error if validation fails.
@@ -316,7 +325,37 @@ func (v *AdmissionValidator) Validate(ctx context.Context, a admission.Attribute
 		return fmt.Errorf("expected job, got %T", obj)
 	}
 
+	if err := validateTriggeredBy(ctx, a, job); err != nil {
+		return err
+	}
+
 	return ValidateJob(job, v.supportedResources)
+}
+
+func validateTriggeredBy(ctx context.Context, a admission.Attributes, job *provisioning.Job) error {
+	name := job.Annotations[AnnoTriggeredBy]
+	email := job.Annotations[AnnoTriggeredByEmail]
+
+	switch a.GetOperation() {
+	case admission.Create:
+		if (name == "" && email == "") || identity.IsServiceIdentity(ctx) {
+			return nil
+		}
+		id, err := identity.GetRequester(ctx)
+		if err != nil || (name != "" && name != id.GetName()) || (email != "" && email != id.GetEmail()) {
+			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s must match the requesting user", AnnoTriggeredBy))
+		}
+	case admission.Update:
+		old, ok := a.GetOldObject().(*provisioning.Job)
+		if !ok {
+			return nil
+		}
+		if old.Annotations[AnnoTriggeredBy] != name || old.Annotations[AnnoTriggeredByEmail] != email {
+			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s is immutable", AnnoTriggeredBy))
+		}
+	}
+
+	return nil
 }
 
 // HistoricJobAdmissionValidator handles validation for HistoricJob resources during admission.

--- a/apps/provisioning/pkg/jobs/validator.go
+++ b/apps/provisioning/pkg/jobs/validator.go
@@ -353,6 +353,7 @@ func validateTriggeredBy(ctx context.Context, a admission.Attributes, job *provi
 		if old.Annotations[AnnoTriggeredBy] != name || old.Annotations[AnnoTriggeredByEmail] != email {
 			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s is immutable", AnnoTriggeredBy))
 		}
+	case admission.Delete, admission.Connect:
 	}
 
 	return nil

--- a/apps/provisioning/pkg/jobs/validator.go
+++ b/apps/provisioning/pkg/jobs/validator.go
@@ -17,12 +17,13 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
-// AnnoTriggeredBy and AnnoTriggeredByEmail carry the display name and email of
-// the user that triggered the job. They are set by the server at creation time
-// and are immutable.
+// AnnoAuthor, AnnoAuthorEmail and AnnoAuthorID carry the display name, email
+// and stable identity of the user that triggered the job. They are set by the
+// server at creation time and are immutable.
 const (
-	AnnoTriggeredBy      = "provisioning.grafana.app/triggeredBy"
-	AnnoTriggeredByEmail = "provisioning.grafana.app/triggeredByEmail"
+	AnnoAuthor      = "provisioning.grafana.app/author"
+	AnnoAuthorEmail = "provisioning.grafana.app/authorEmail"
+	AnnoAuthorID    = "provisioning.grafana.app/authorID"
 )
 
 // ValidateJob performs validation on the Job specification and returns an error if validation fails.
@@ -325,33 +326,49 @@ func (v *AdmissionValidator) Validate(ctx context.Context, a admission.Attribute
 		return fmt.Errorf("expected job, got %T", obj)
 	}
 
-	if err := validateTriggeredBy(ctx, a, job); err != nil {
+	if err := validateAuthor(ctx, a, job); err != nil {
 		return err
 	}
 
 	return ValidateJob(job, v.supportedResources)
 }
 
-func validateTriggeredBy(ctx context.Context, a admission.Attributes, job *provisioning.Job) error {
-	name := job.Annotations[AnnoTriggeredBy]
-	email := job.Annotations[AnnoTriggeredByEmail]
+func validateAuthor(ctx context.Context, a admission.Attributes, job *provisioning.Job) error {
+	name := job.Annotations[AnnoAuthor]
+	email := job.Annotations[AnnoAuthorEmail]
+	authorID := job.Annotations[AnnoAuthorID]
 
 	switch a.GetOperation() {
 	case admission.Create:
-		if (name == "" && email == "") || identity.IsServiceIdentity(ctx) {
+		if (name == "" && email == "" && authorID == "") || identity.IsServiceIdentity(ctx) {
 			return nil
 		}
 		id, err := identity.GetRequester(ctx)
-		if err != nil || (name != "" && name != id.GetName()) || (email != "" && email != id.GetEmail()) {
-			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s must match the requesting user", AnnoTriggeredBy))
+		if err != nil {
+			return apierrors.NewBadRequest("job author annotations must match the requesting user")
+		}
+		if name != "" && name != id.GetName() {
+			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s must match the requesting user", AnnoAuthor))
+		}
+		if email != "" && email != id.GetEmail() {
+			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s must match the requesting user", AnnoAuthorEmail))
+		}
+		if authorID != "" && authorID != id.GetUID() {
+			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s must match the requesting user", AnnoAuthorID))
 		}
 	case admission.Update:
 		old, ok := a.GetOldObject().(*provisioning.Job)
 		if !ok {
 			return nil
 		}
-		if old.Annotations[AnnoTriggeredBy] != name || old.Annotations[AnnoTriggeredByEmail] != email {
-			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s is immutable", AnnoTriggeredBy))
+		if old.Annotations[AnnoAuthor] != name {
+			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s is immutable", AnnoAuthor))
+		}
+		if old.Annotations[AnnoAuthorEmail] != email {
+			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s is immutable", AnnoAuthorEmail))
+		}
+		if old.Annotations[AnnoAuthorID] != authorID {
+			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s is immutable", AnnoAuthorID))
 		}
 	case admission.Delete, admission.Connect:
 	}

--- a/apps/provisioning/pkg/jobs/validator_test.go
+++ b/apps/provisioning/pkg/jobs/validator_test.go
@@ -12,7 +12,10 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
 
+	authlib "github.com/grafana/authlib/types"
+
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
 func TestValidateJob(t *testing.T) {
@@ -1200,4 +1203,145 @@ func newHistoricJobAdmissionTestAttributes(obj runtime.Object, op admission.Oper
 		false,
 		&user.DefaultInfo{},
 	)
+}
+
+func TestValidateAuthor(t *testing.T) {
+	requester := &identity.StaticRequester{
+		Type:    authlib.TypeUser,
+		Name:    "Test User",
+		Email:   "test@example.com",
+		UserUID: "abc123",
+	}
+	userCtx := identity.WithRequester(t.Context(), requester)
+	serviceCtx, _, err := identity.WithProvisioningIdentity(t.Context(), "default")
+	require.NoError(t, err)
+
+	annotations := map[string]string{
+		AnnoAuthor:      requester.GetName(),
+		AnnoAuthorEmail: requester.GetEmail(),
+		AnnoAuthorID:    requester.GetUID(),
+	}
+
+	tests := []struct {
+		name            string
+		ctx             context.Context
+		operation       admission.Operation
+		annotations     map[string]string
+		oldAnnotations  map[string]string
+		wantErrContains string
+	}{
+		{
+			name:        "create without annotations",
+			ctx:         userCtx,
+			operation:   admission.Create,
+			annotations: nil,
+		},
+		{
+			name:        "create by service identity",
+			ctx:         serviceCtx,
+			operation:   admission.Create,
+			annotations: map[string]string{AnnoAuthor: "someone else"},
+		},
+		{
+			name:        "create with matching annotations",
+			ctx:         userCtx,
+			operation:   admission.Create,
+			annotations: annotations,
+		},
+		{
+			name:            "create with mismatched name",
+			ctx:             userCtx,
+			operation:       admission.Create,
+			annotations:     map[string]string{AnnoAuthor: "someone else"},
+			wantErrContains: AnnoAuthor + " must match",
+		},
+		{
+			name:            "create with mismatched email",
+			ctx:             userCtx,
+			operation:       admission.Create,
+			annotations:     map[string]string{AnnoAuthorEmail: "other@example.com"},
+			wantErrContains: AnnoAuthorEmail + " must match",
+		},
+		{
+			name:            "create with mismatched author ID",
+			ctx:             userCtx,
+			operation:       admission.Create,
+			annotations:     map[string]string{AnnoAuthorID: "user:other"},
+			wantErrContains: AnnoAuthorID + " must match",
+		},
+		{
+			name:            "create without requester",
+			ctx:             t.Context(),
+			operation:       admission.Create,
+			annotations:     map[string]string{AnnoAuthor: "Test User"},
+			wantErrContains: "job author annotations must match the requesting user",
+		},
+		{
+			name:           "update with unchanged annotations",
+			ctx:            userCtx,
+			operation:      admission.Update,
+			annotations:    annotations,
+			oldAnnotations: annotations,
+		},
+		{
+			name:            "update changing name",
+			ctx:             userCtx,
+			operation:       admission.Update,
+			annotations:     map[string]string{AnnoAuthor: "someone else"},
+			oldAnnotations:  annotations,
+			wantErrContains: AnnoAuthor + " is immutable",
+		},
+		{
+			name:            "update changing email",
+			ctx:             userCtx,
+			operation:       admission.Update,
+			annotations:     map[string]string{AnnoAuthor: requester.GetName(), AnnoAuthorEmail: "other@example.com"},
+			oldAnnotations:  annotations,
+			wantErrContains: AnnoAuthorEmail + " is immutable",
+		},
+		{
+			name:            "update removing author ID",
+			ctx:             userCtx,
+			operation:       admission.Update,
+			annotations:     map[string]string{AnnoAuthor: requester.GetName(), AnnoAuthorEmail: requester.GetEmail()},
+			oldAnnotations:  annotations,
+			wantErrContains: AnnoAuthorID + " is immutable",
+		},
+		{
+			name:        "delete is ignored",
+			ctx:         userCtx,
+			operation:   admission.Delete,
+			annotations: map[string]string{AnnoAuthor: "someone else"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &provisioning.Job{ObjectMeta: metav1.ObjectMeta{Name: "test-job", Annotations: tt.annotations}}
+			var oldObj runtime.Object
+			if tt.oldAnnotations != nil {
+				oldObj = &provisioning.Job{ObjectMeta: metav1.ObjectMeta{Name: "test-job", Annotations: tt.oldAnnotations}}
+			}
+			attr := admission.NewAttributesRecord(
+				job,
+				oldObj,
+				provisioning.JobResourceInfo.GroupVersionKind(),
+				"default",
+				"test-job",
+				provisioning.JobResourceInfo.GroupVersionResource(),
+				"",
+				tt.operation,
+				nil,
+				false,
+				&user.DefaultInfo{},
+			)
+
+			err := validateAuthor(tt.ctx, attr, job)
+			if tt.wantErrContains != "" {
+				require.ErrorContains(t, err, tt.wantErrContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -82,6 +82,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `panelTitleSearch`                | Search for dashboards using panel title                                                        |
 | `faroDatasourceSelector`          | Enable the data source selector within the Frontend Apps section of the Frontend Observability |
 | `provisioning.readmes`            | Render the README.md of a Git Sync provisioned folder inline below its dashboards list         |
+| `provisioning.userAttribution`    | Author Git Sync commits as the acting Grafana user                                             |
 | `externalServiceAccounts`         | Automatic service account and token setup for plugins                                          |
 | `feedbackButton`                  | Enables the feedback button in the dashboard edit sidebar                                      |
 | `pdfTables`                       | Enables generating table data as PDF in reporting                                              |

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
 
@@ -88,6 +89,9 @@ func (c *filesConnector) Connect(ctx context.Context, name string, opts runtime.
 
 // handleRequest processes the HTTP request for files operations.
 func (c *filesConnector) handleRequest(ctx context.Context, name string, r *http.Request, responder rest.Responder, logger logging.Logger) {
+	if sig, ok := jobs.UserAttribution(ctx); ok {
+		ctx = repository.WithAuthorSignature(ctx, sig)
+	}
 	repo, err := c.getRepo(ctx, r.Method, name)
 	if err != nil {
 		logger.Debug("failed to find repository", "error", err)

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -89,8 +89,8 @@ func (c *filesConnector) Connect(ctx context.Context, name string, opts runtime.
 
 // handleRequest processes the HTTP request for files operations.
 func (c *filesConnector) handleRequest(ctx context.Context, name string, r *http.Request, responder rest.Responder, logger logging.Logger) {
-	if sig, ok := jobs.UserAttribution(ctx); ok {
-		ctx = repository.WithAuthorSignature(ctx, sig)
+	if author, ok := jobs.UserAttribution(ctx); ok {
+		ctx = repository.WithAuthorSignature(ctx, repository.CommitSignature{Name: author.Name, Email: author.Email})
 	}
 	repo, err := c.getRepo(ctx, r.Method, name)
 	if err != nil {

--- a/pkg/registry/apis/provisioning/jobs/author.go
+++ b/pkg/registry/apis/provisioning/jobs/author.go
@@ -6,18 +6,26 @@ import (
 	authlib "github.com/grafana/authlib/types"
 	"github.com/open-feature/go-sdk/openfeature"
 
-	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
-func UserAttribution(ctx context.Context) (repository.CommitSignature, bool) {
+// Author identifies the user behind a request.
+type Author struct {
+	Name  string
+	Email string
+	ID    string
+}
+
+// UserAttribution returns the author for the user in ctx, or false when user
+// attribution is disabled or the request is not made by a user.
+func UserAttribution(ctx context.Context) (Author, bool) {
 	if !openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningUserAttribution, false, openfeature.TransactionContext(ctx)) {
-		return repository.CommitSignature{}, false
+		return Author{}, false
 	}
 	id, err := identity.GetRequester(ctx)
 	if err != nil || !id.IsIdentityType(authlib.TypeUser) {
-		return repository.CommitSignature{}, false
+		return Author{}, false
 	}
-	return repository.CommitSignature{Name: id.GetName(), Email: id.GetEmail()}, true
+	return Author{Name: id.GetName(), Email: id.GetEmail(), ID: id.GetUID()}, true
 }

--- a/pkg/registry/apis/provisioning/jobs/author.go
+++ b/pkg/registry/apis/provisioning/jobs/author.go
@@ -19,9 +19,5 @@ func UserAttribution(ctx context.Context) (repository.CommitSignature, bool) {
 	if err != nil || !id.IsIdentityType(authlib.TypeUser) {
 		return repository.CommitSignature{}, false
 	}
-	sig := repository.CommitSignature{Name: id.GetName(), Email: id.GetEmail()}
-	if sig.Name == "" && sig.Email == "" {
-		return repository.CommitSignature{}, false
-	}
-	return sig, true
+	return repository.CommitSignature{Name: id.GetName(), Email: id.GetEmail()}, true
 }

--- a/pkg/registry/apis/provisioning/jobs/author.go
+++ b/pkg/registry/apis/provisioning/jobs/author.go
@@ -1,0 +1,27 @@
+package jobs
+
+import (
+	"context"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/open-feature/go-sdk/openfeature"
+
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+func UserAttribution(ctx context.Context) (repository.CommitSignature, bool) {
+	if !openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningUserAttribution, false, openfeature.TransactionContext(ctx)) {
+		return repository.CommitSignature{}, false
+	}
+	id, err := identity.GetRequester(ctx)
+	if err != nil || !id.IsIdentityType(authlib.TypeUser) {
+		return repository.CommitSignature{}, false
+	}
+	sig := repository.CommitSignature{Name: id.GetName(), Email: id.GetEmail()}
+	if sig.Name == "" && sig.Email == "" {
+		return repository.CommitSignature{}, false
+	}
+	return sig, true
+}

--- a/pkg/registry/apis/provisioning/jobs/author_test.go
+++ b/pkg/registry/apis/provisioning/jobs/author_test.go
@@ -1,0 +1,93 @@
+package jobs
+
+import (
+	"testing"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+func TestUserAttribution(t *testing.T) {
+	tests := []struct {
+		name      string
+		requester identity.Requester
+		flag      bool
+		expected  *repository.CommitSignature
+	}{
+		{
+			name: "user identity returns signature",
+			requester: &identity.StaticRequester{
+				Type:  authlib.TypeUser,
+				Name:  "Test User",
+				Email: "test@example.com",
+			},
+			flag:     true,
+			expected: &repository.CommitSignature{Name: "Test User", Email: "test@example.com"},
+		},
+		{
+			name: "flag disabled returns nothing",
+			requester: &identity.StaticRequester{
+				Type:  authlib.TypeUser,
+				Name:  "Test User",
+				Email: "test@example.com",
+			},
+			flag:     false,
+			expected: nil,
+		},
+		{
+			name: "service identity returns nothing",
+			requester: &identity.StaticRequester{
+				Type: authlib.TypeAccessPolicy,
+				Name: "provisioning",
+			},
+			flag:     true,
+			expected: nil,
+		},
+		{
+			name:      "missing requester returns nothing",
+			requester: nil,
+			flag:      true,
+			expected:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.requester != nil {
+				ctx = identity.WithRequester(ctx, tt.requester)
+			}
+			setUserAttributionFlag(t, tt.flag)
+
+			sig, ok := UserAttribution(ctx)
+			if tt.expected == nil {
+				assert.False(t, ok)
+			} else {
+				require.True(t, ok)
+				assert.Equal(t, *tt.expected, sig)
+			}
+		})
+	}
+}
+
+func setUserAttributionFlag(t *testing.T, value bool) {
+	t.Helper()
+	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagProvisioningUserAttribution: {
+			Key:      featuremgmt.FlagProvisioningUserAttribution,
+			Variants: map[string]any{"": value},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, openfeature.SetProviderAndWait(provider))
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+	})
+}

--- a/pkg/registry/apis/provisioning/jobs/author_test.go
+++ b/pkg/registry/apis/provisioning/jobs/author_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
@@ -19,17 +18,18 @@ func TestUserAttribution(t *testing.T) {
 		name      string
 		requester identity.Requester
 		flag      bool
-		expected  *repository.CommitSignature
+		expected  *Author
 	}{
 		{
 			name: "user identity returns signature",
 			requester: &identity.StaticRequester{
-				Type:  authlib.TypeUser,
-				Name:  "Test User",
-				Email: "test@example.com",
+				Type:    authlib.TypeUser,
+				Name:    "Test User",
+				Email:   "test@example.com",
+				UserUID: "abc123",
 			},
 			flag:     true,
-			expected: &repository.CommitSignature{Name: "Test User", Email: "test@example.com"},
+			expected: &Author{Name: "Test User", Email: "test@example.com", ID: "user:abc123"},
 		},
 		{
 			name: "flag disabled returns nothing",
@@ -66,12 +66,12 @@ func TestUserAttribution(t *testing.T) {
 			}
 			setUserAttributionFlag(t, tt.flag)
 
-			sig, ok := UserAttribution(ctx)
+			author, ok := UserAttribution(ctx)
 			if tt.expected == nil {
 				assert.False(t, ok)
 			} else {
 				require.True(t, ok)
-				assert.Equal(t, *tt.expected, sig)
+				assert.Equal(t, *tt.expected, author)
 			}
 		})
 	}

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -393,7 +393,7 @@ func (d *jobDriver) processJob(ctx context.Context, recorder JobProgressRecorder
 		attribute.String("job.action", string(job.Spec.Action)),
 	)
 
-	name, email := job.Annotations[appjobs.AnnoTriggeredBy], job.Annotations[appjobs.AnnoTriggeredByEmail]
+	name, email := job.Annotations[appjobs.AnnoAuthor], job.Annotations[appjobs.AnnoAuthorEmail]
 	if (name != "" || email != "") &&
 		openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningUserAttribution, false, openfeature.TransactionContext(ctx)) {
 		ctx = repository.WithAuthorSignature(ctx, repository.CommitSignature{Name: name, Email: email})

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
 	"go.opentelemetry.io/otel/attribute"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -15,8 +16,11 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/apis/apifmt"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	appcontroller "github.com/grafana/grafana/apps/provisioning/pkg/controller"
+	appjobs "github.com/grafana/grafana/apps/provisioning/pkg/jobs"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 // Store is an abstraction for the storage API.
@@ -388,6 +392,12 @@ func (d *jobDriver) processJob(ctx context.Context, recorder JobProgressRecorder
 		attribute.String("job.repository", repoName),
 		attribute.String("job.action", string(job.Spec.Action)),
 	)
+
+	name, email := job.Annotations[appjobs.AnnoTriggeredBy], job.Annotations[appjobs.AnnoTriggeredByEmail]
+	if (name != "" || email != "") &&
+		openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagProvisioningUserAttribution, false, openfeature.TransactionContext(ctx)) {
+		ctx = repository.WithAuthorSignature(ctx, repository.CommitSignature{Name: name, Email: email})
+	}
 
 	for _, worker := range d.workers {
 		if !worker.IsSupported(ctx, *job) {

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -536,12 +536,15 @@ func (s *persistentStore) Insert(ctx context.Context, namespace string, spec pro
 	}
 
 	annotations := map[string]string{}
-	if sig, ok := UserAttribution(ctx); ok {
-		if sig.Name != "" {
-			annotations[appjobs.AnnoTriggeredBy] = sig.Name
+	if author, ok := UserAttribution(ctx); ok {
+		if author.Name != "" {
+			annotations[appjobs.AnnoAuthor] = author.Name
 		}
-		if sig.Email != "" {
-			annotations[appjobs.AnnoTriggeredByEmail] = sig.Email
+		if author.Email != "" {
+			annotations[appjobs.AnnoAuthorEmail] = author.Email
+		}
+		if author.ID != "" {
+			annotations[appjobs.AnnoAuthorID] = author.ID
 		}
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/apis/apifmt"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
+	appjobs "github.com/grafana/grafana/apps/provisioning/pkg/jobs"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/util"
@@ -534,6 +535,16 @@ func (s *persistentStore) Insert(ctx context.Context, namespace string, spec pro
 		return nil, err
 	}
 
+	annotations := map[string]string{}
+	if sig, ok := UserAttribution(ctx); ok {
+		if sig.Name != "" {
+			annotations[appjobs.AnnoTriggeredBy] = sig.Name
+		}
+		if sig.Email != "" {
+			annotations[appjobs.AnnoTriggeredByEmail] = sig.Email
+		}
+	}
+
 	// Set up the provisioning identity for this namespace
 	ctx, _, err := identity.WithProvisioningIdentity(ctx, namespace)
 	if err != nil {
@@ -547,6 +558,7 @@ func (s *persistentStore) Insert(ctx context.Context, namespace string, spec pro
 			Labels: map[string]string{
 				LabelRepository: spec.Repository,
 			},
+			Annotations: annotations,
 		},
 		Spec: spec,
 	}

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -280,6 +280,14 @@ var (
 			Generate:        Generate{Go: true, React: true},
 		},
 		{
+			Name:        "provisioning.userAttribution",
+			Description: "Author Git Sync commits as the acting Grafana user",
+			Stage:       FeatureStagePublicPreview,
+			Owner:       grafanaAppPlatformSquad,
+			Expression:  "true",
+			Generate:    Generate{Go: true},
+		},
+		{
 			Name:            "grafanaAPIServerEnsureKubectlAccess",
 			Description:     "Start an additional https handler and write kubectl options",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -30,6 +30,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,provisioningExport,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,provisioning.readmes,preview,@grafana/grafana-app-platform-squad,false,false,true
 2026-06-09,provisioning.gitConventions,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2026-07-08,provisioning.userAttribution,preview,@grafana/grafana-app-platform-squad,false,false,false
 2023-12-06,grafanaAPIServerEnsureKubectlAccess,experimental,@grafana/grafana-app-platform-squad,true,true,false
 2023-07-21,awsAsyncQueryCaching,GA,@grafana/data-sources-plugins,false,false,false
 2023-07-26,configurableSchedulerTick,experimental,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -95,6 +95,10 @@ const (
 	// Enable configurable commit message, branch name, and pull request title conventions for Git Sync
 	FlagProvisioningGitConventions = "provisioning.gitConventions"
 
+	// FlagProvisioningUserAttribution
+	// Author Git Sync commits as the acting Grafana user
+	FlagProvisioningUserAttribution = "provisioning.userAttribution"
+
 	// FlagGrafanaAPIServerEnsureKubectlAccess
 	// Start an additional https handler and write kubectl options
 	FlagGrafanaAPIServerEnsureKubectlAccess = "grafanaAPIServerEnsureKubectlAccess"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4585,6 +4585,22 @@
     },
     {
       "metadata": {
+        "name": "provisioning.userAttribution",
+        "resourceVersion": "1783531000298",
+        "creationTimestamp": "2026-07-08T13:32:58Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-08 17:16:40.298205 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Author Git Sync commits as the acting Grafana user",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "provisioningExport",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2026-05-22T09:03:04Z"

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -3709,3 +3709,12 @@ func LatestCommitSubject(t *testing.T, local *gittest.LocalRepo, ref string) str
 	require.NoError(t, err, "git log should succeed")
 	return strings.TrimSpace(out)
 }
+
+func LatestCommitAuthor(t *testing.T, local *gittest.LocalRepo, ref string) string {
+	t.Helper()
+	_, err := local.Git("fetch", "origin", ref)
+	require.NoError(t, err, fmt.Sprintf("git fetch origin %s should succeed", ref))
+	out, err := local.Git("log", "-1", "--format=%an <%ae>", fmt.Sprintf("origin/%s", ref))
+	require.NoError(t, err, "git log should succeed")
+	return strings.TrimSpace(out)
+}

--- a/pkg/tests/apis/provisioning/git/commit_author_test.go
+++ b/pkg/tests/apis/provisioning/git/commit_author_test.go
@@ -15,7 +15,7 @@ func TestIntegrationGit_Files_CommitAuthor(t *testing.T) {
 	repoName := "commit-author"
 	_, local := helper.CreateGitRepo(t, repoName, nil, "write")
 
-	result := helper.AdminREST.Post().
+	result := helper.EditorREST.Post().
 		Namespace("default").
 		Resource("repositories").
 		Name(repoName).
@@ -26,7 +26,9 @@ func TestIntegrationGit_Files_CommitAuthor(t *testing.T) {
 		Do(ctx)
 	require.NoError(t, result.Error(), "should create file")
 
-	admin := helper.Org1.Admin
-	expected := fmt.Sprintf("%s <%s>", admin.Identity.GetName(), admin.Identity.GetEmail())
-	require.Equal(t, expected, common.LatestCommitAuthor(t, local, "main"))
+	editor := helper.Org1.Editor
+	name, email := editor.Identity.GetName(), editor.Identity.GetEmail()
+	require.NotEmpty(t, name)
+	require.NotEmpty(t, email)
+	require.Equal(t, fmt.Sprintf("%s <%s>", name, email), common.LatestCommitAuthor(t, local, "main"))
 }

--- a/pkg/tests/apis/provisioning/git/commit_author_test.go
+++ b/pkg/tests/apis/provisioning/git/commit_author_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestIntegrationGit_Files_CommitAuthor(t *testing.T) {
@@ -15,7 +17,10 @@ func TestIntegrationGit_Files_CommitAuthor(t *testing.T) {
 	repoName := "commit-author"
 	_, local := helper.CreateGitRepo(t, repoName, nil, "write")
 
-	result := helper.EditorREST.Post().
+	user := helper.CreateUser("commit-author-user", "Org1", org.RoleEditor, nil)
+	userREST := user.RESTClient(t, &schema.GroupVersion{Group: "provisioning.grafana.app", Version: "v0alpha1"})
+
+	result := userREST.Post().
 		Namespace("default").
 		Resource("repositories").
 		Name(repoName).
@@ -26,8 +31,7 @@ func TestIntegrationGit_Files_CommitAuthor(t *testing.T) {
 		Do(ctx)
 	require.NoError(t, result.Error(), "should create file")
 
-	editor := helper.Org1.Editor
-	name, email := editor.Identity.GetName(), editor.Identity.GetEmail()
+	name, email := user.Identity.GetName(), user.Identity.GetEmail()
 	require.NotEmpty(t, name)
 	require.NotEmpty(t, email)
 	require.Equal(t, fmt.Sprintf("%s <%s>", name, email), common.LatestCommitAuthor(t, local, "main"))

--- a/pkg/tests/apis/provisioning/git/commit_author_test.go
+++ b/pkg/tests/apis/provisioning/git/commit_author_test.go
@@ -1,0 +1,32 @@
+package git
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationGit_Files_CommitAuthor(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := t.Context()
+
+	repoName := "commit-author"
+	_, local := helper.CreateGitRepo(t, repoName, nil, "write")
+
+	result := helper.AdminREST.Post().
+		Namespace("default").
+		Resource("repositories").
+		Name(repoName).
+		SubResource("files", "dashboard.json").
+		Param("message", "Create dashboard.json").
+		Body(common.DashboardJSON("commit-author-dash", "Commit Author", 1)).
+		SetHeader("Content-Type", "application/json").
+		Do(ctx)
+	require.NoError(t, result.Error(), "should create file")
+
+	admin := helper.Org1.Admin
+	expected := fmt.Sprintf("%s <%s>", admin.Identity.GetName(), admin.Identity.GetEmail())
+	require.Equal(t, expected, common.LatestCommitAuthor(t, local, "main"))
+}

--- a/pkg/tests/apis/provisioning/git/job_commit_author_test.go
+++ b/pkg/tests/apis/provisioning/git/job_commit_author_test.go
@@ -1,0 +1,37 @@
+package git
+
+import (
+	"fmt"
+	"testing"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIntegrationGit_ExportJob_CommitAuthor(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := t.Context()
+
+	const repoName = "export-commit-author"
+
+	dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
+	_, err := helper.DashboardsV1.Resource.Create(ctx, dash, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = helper.DashboardsV1.Resource.Delete(ctx, dash.GetName(), metav1.DeleteOptions{})
+	})
+
+	_, local := helper.CreateGitRepo(t, repoName, nil)
+
+	helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action:  provisioning.JobActionPush,
+		Message: "Export dashboards via JobSpec",
+		Push:    &provisioning.ExportJobOptions{},
+	})
+
+	admin := helper.Org1.Admin
+	expected := fmt.Sprintf("%s <%s>", admin.Identity.GetName(), admin.Identity.GetEmail())
+	require.Equal(t, expected, common.LatestCommitAuthor(t, local, "main"))
+}

--- a/pkg/tests/apis/provisioning/git/job_commit_author_test.go
+++ b/pkg/tests/apis/provisioning/git/job_commit_author_test.go
@@ -5,33 +5,62 @@ import (
 	"testing"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func TestIntegrationGit_ExportJob_CommitAuthor(t *testing.T) {
+func TestIntegrationGit_DeleteJob_CommitAuthor(t *testing.T) {
 	helper := sharedGitHelper(t)
 	ctx := t.Context()
 
-	const repoName = "export-commit-author"
+	const (
+		repoName = "job-commit-author"
+		dashUID  = "job-author-dash"
+		dashFn   = "dashboard.json"
+	)
 
-	dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err := helper.DashboardsV1.Resource.Create(ctx, dash, metav1.CreateOptions{})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = helper.DashboardsV1.Resource.Delete(ctx, dash.GetName(), metav1.DeleteOptions{})
+	_, local := helper.CreateExportGitRepo(t, repoName, map[string][]byte{
+		dashFn: common.DashboardJSON(dashUID, "Dashboard to delete", 1),
 	})
+	helper.SyncAndWait(t, repoName)
 
-	_, local := helper.CreateGitRepo(t, repoName, nil)
-
-	helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-		Action:  provisioning.JobActionPush,
-		Message: "Export dashboards via JobSpec",
-		Push:    &provisioning.ExportJobOptions{},
+	user := helper.CreateUser("job-author-user", "Org1", org.RoleEditor, nil)
+	helper.SetPermissions(user, []resourcepermissions.SetResourcePermissionCommand{
+		{
+			Actions:           []string{"dashboards:read", "dashboards:write", "dashboards:create", "dashboards:delete"},
+			Resource:          "dashboards",
+			ResourceAttribute: "uid",
+			ResourceID:        "*",
+		},
 	})
+	userREST := user.RESTClient(t, &schema.GroupVersion{Group: "provisioning.grafana.app", Version: "v0alpha1"})
 
-	admin := helper.Org1.Admin
-	expected := fmt.Sprintf("%s <%s>", admin.Identity.GetName(), admin.Identity.GetEmail())
-	require.Equal(t, expected, common.LatestCommitAuthor(t, local, "main"))
+	result := userREST.Post().
+		Namespace("default").
+		Resource("repositories").
+		Name(repoName).
+		SubResource("jobs").
+		Body(common.AsJSON(provisioning.JobSpec{
+			Action:  provisioning.JobActionDelete,
+			Message: "Delete dashboard via JobSpec",
+			Delete: &provisioning.DeleteJobOptions{
+				Paths: []string{dashFn},
+			},
+		})).
+		SetHeader("Content-Type", "application/json").
+		Do(ctx)
+	obj, err := result.Get()
+	require.NoError(t, err, "should trigger delete job")
+	unstruct, ok := obj.(*unstructured.Unstructured)
+	require.True(t, ok)
+	helper.AwaitJob(t, ctx, unstruct)
+
+	name, email := user.Identity.GetName(), user.Identity.GetEmail()
+	require.NotEmpty(t, name)
+	require.NotEmpty(t, email)
+	require.Equal(t, fmt.Sprintf("%s <%s>", name, email), common.LatestCommitAuthor(t, local, "main"))
 }


### PR DESCRIPTION
**What is this feature?**

https://github.com/user-attachments/assets/cdae02db-ca4a-4a2a-a7f7-3a522af87683

When someone changes resources in a Git Sync repository, the resulting git commits are now authored with that person's name and email instead of a generic Grafana identity. This covers direct saves through the UI as well as background jobs (export, bulk delete, bulk move): jobs record who triggered them when they are created, and that identity is used as the commit author when the job runs. Jobs also reject any attempt to alter the recorded identity after creation.

Enabled by default behind a feature toggle; when disabled, no user information is recorded and commits keep the default author.

**Why do we need this feature?**

Today every commit made through Git Sync has the same generic author, so the git history of a repository can't answer who actually made a change.

**Who is this feature for?**

Teams using Git Sync who want their repository history to reflect who did what.

**Which issue(s) does this PR fix?**:

Fixes grafana/git-ui-sync-project#1263
Fixes grafana/git-ui-sync-project#1268

**Related PRs**

- Frontend: #127984
- Enterprise: grafana/grafana-enterprise#12589 — surfaces the user's email in cloud deployments so commit attribution is complete there

---
*Description generated by Claude Code.*
