### PR TITLE
Dashboard DS: coalesce the chained re-run

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -1369,7 +1369,88 @@ describe('DashboardDatasourceBehaviour', () => {
         },
       });
 
-      // The consumer must re-run to pick up the fresh forwarded data.
+      // The consumer must re-run to pick up the fresh forwarded data. The chained
+      // re-run is coalesced on a trailing window, so wait for it to fire.
+      await new Promise((r) => setTimeout(r, 150));
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should coalesce a burst of forwarded Done updates into a single consumer re-run', async () => {
+      jest.spyOn(console, 'error').mockImplementation();
+
+      const sourcePanel = new VizPanel({
+        title: 'Intermediate dashboard-DS panel',
+        pluginId: 'table',
+        key: 'panel-1',
+        $data: new SceneDataTransformer({
+          transformations: [{ id: 'transformA', options: {} }],
+          $data: new SceneQueryRunner({
+            datasource: { uid: SHARED_DASHBOARD_QUERY },
+            queries: [{ refId: 'A', panelId: 44 }],
+            $behaviors: [new DashboardDatasourceBehaviour({})],
+          }),
+        }),
+      });
+
+      const dashboardDSPanel = new VizPanel({
+        title: 'Consumer panel',
+        pluginId: 'table',
+        key: 'panel-2',
+        $data: new SceneDataTransformer({
+          transformations: [],
+          $data: new SceneQueryRunner({
+            datasource: { uid: MIXED_DATASOURCE_NAME },
+            queries: [{ datasource: { uid: SHARED_DASHBOARD_QUERY }, refId: 'B', panelId: 1 }],
+            $behaviors: [new DashboardDatasourceBehaviour({})],
+          }),
+        }),
+      });
+
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        meta: { canEdit: true },
+        body: DefaultGridLayoutManager.fromVizPanels([sourcePanel, dashboardDSPanel]),
+      });
+
+      activateFullSceneTree(scene);
+      await new Promise((r) => setTimeout(r, 1));
+
+      const spy = jest
+        .spyOn(dashboardDSPanel.state.$data!.state.$data as SceneQueryRunner, 'runQueries')
+        .mockImplementation();
+
+      const sameRequestId = 'SQR100';
+      const t = sourcePanel.state.$data as SceneDataTransformer;
+
+      // First (stale) Done, then a rapid burst of forwarded Done updates under the
+      // SAME requestId (as a slow chained upstream progressively forwards).
+      t.setState({
+        data: {
+          state: LoadingState.Done,
+          series: [{ fields: [], length: 0 }],
+          timeRange: getDefaultTimeRange(),
+          request: { requestId: sameRequestId } as DataQueryRequest,
+        },
+      });
+      spy.mockClear();
+
+      for (let i = 1; i <= 4; i++) {
+        t.setState({
+          data: {
+            state: LoadingState.Done,
+            series: [{ fields: [], length: i * 10 }],
+            timeRange: getDefaultTimeRange(),
+            request: { requestId: sameRequestId } as DataQueryRequest,
+          },
+        });
+      }
+
+      // Not run synchronously — coalesced on the trailing window.
+      expect(spy).not.toHaveBeenCalled();
+
+      // After the window, exactly ONE re-run fires (not one per forward).
+      await new Promise((r) => setTimeout(r, 150));
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -1458,7 +1539,9 @@ describe('DashboardDatasourceBehaviour', () => {
         },
       });
 
-      // The consumer must re-run to pick up the fresh forwarded data.
+      // The consumer must re-run to pick up the fresh forwarded data (coalesced,
+      // trailing), so wait for the window before asserting.
+      await new Promise((r) => setTimeout(r, 150));
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -1541,7 +1624,9 @@ describe('DashboardDatasourceBehaviour', () => {
         },
       });
 
-      // Must NOT re-run on cancel (regression guard for #116767 on the #118629 branch).
+      // Must NOT re-run on cancel (regression guard for #116767 on the #118629
+      // branch) — not synchronously, and not via a coalesced trailing re-run.
+      await new Promise((r) => setTimeout(r, 150));
       expect(spy).not.toHaveBeenCalled();
     });
   });

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.test.tsx
@@ -1454,6 +1454,92 @@ describe('DashboardDatasourceBehaviour', () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
+    it('Should cancel a pending coalesced re-run when a normal completion arrives', async () => {
+      jest.spyOn(console, 'error').mockImplementation();
+
+      const sourcePanel = new VizPanel({
+        title: 'Intermediate dashboard-DS panel',
+        pluginId: 'table',
+        key: 'panel-1',
+        $data: new SceneDataTransformer({
+          transformations: [{ id: 'transformA', options: {} }],
+          $data: new SceneQueryRunner({
+            datasource: { uid: SHARED_DASHBOARD_QUERY },
+            queries: [{ refId: 'A', panelId: 44 }],
+            $behaviors: [new DashboardDatasourceBehaviour({})],
+          }),
+        }),
+      });
+
+      const dashboardDSPanel = new VizPanel({
+        title: 'Consumer panel',
+        pluginId: 'table',
+        key: 'panel-2',
+        $data: new SceneDataTransformer({
+          transformations: [],
+          $data: new SceneQueryRunner({
+            datasource: { uid: MIXED_DATASOURCE_NAME },
+            queries: [{ datasource: { uid: SHARED_DASHBOARD_QUERY }, refId: 'B', panelId: 1 }],
+            $behaviors: [new DashboardDatasourceBehaviour({})],
+          }),
+        }),
+      });
+
+      const scene = new DashboardScene({
+        title: 'hello',
+        uid: 'dash-1',
+        meta: { canEdit: true },
+        body: DefaultGridLayoutManager.fromVizPanels([sourcePanel, dashboardDSPanel]),
+      });
+
+      activateFullSceneTree(scene);
+      await new Promise((r) => setTimeout(r, 1));
+
+      const spy = jest
+        .spyOn(dashboardDSPanel.state.$data!.state.$data as SceneQueryRunner, 'runQueries')
+        .mockImplementation();
+
+      const sameRequestId = 'SQR100';
+      const t = sourcePanel.state.$data as SceneDataTransformer;
+
+      t.setState({
+        data: {
+          state: LoadingState.Done,
+          series: [{ fields: [], length: 10 }],
+          timeRange: getDefaultTimeRange(),
+          request: { requestId: sameRequestId } as DataQueryRequest,
+        },
+      });
+      spy.mockClear();
+
+      // Chained forward under the same requestId — schedules the coalesce timer.
+      t.setState({
+        data: {
+          state: LoadingState.Done,
+          series: [{ fields: [], length: 20 }],
+          timeRange: getDefaultTimeRange(),
+          request: { requestId: sameRequestId } as DataQueryRequest,
+        },
+      });
+      expect(spy).not.toHaveBeenCalled();
+
+      // Genuine new completion within the coalesce window — must run immediately
+      // and cancel the pending coalesced re-run.
+      t.setState({
+        data: {
+          state: LoadingState.Done,
+          series: [{ fields: [], length: 30 }],
+          timeRange: getDefaultTimeRange(),
+          request: { requestId: 'SQR101' } as DataQueryRequest,
+        },
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // The stale coalesce timer must not fire a second re-run.
+      await new Promise((r) => setTimeout(r, 150));
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
     // With no transformations the intermediate runs through the #118629 branch that
     // subscribes to the source's SceneQueryRunner directly. The two tests below cover
     // re-running on a fresh Done under the same requestId, and the #116767 cancel guard.

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
@@ -24,8 +24,18 @@ import { type LibraryPanelBehaviorState } from './LibraryPanelBehavior';
 
 interface DashboardDatasourceBehaviourState extends SceneObjectState {}
 
+// Trailing-edge window (ms) used to coalesce chained dashboard-DS re-runs. When a
+// chained source forwards fresh data under an unchanged requestId (see #126378),
+// several forwards can arrive close together (e.g. a stale->fresh pair, or multiple
+// sources settling near-simultaneously). Coalescing them into a single trailing
+// re-run avoids re-processing/re-rendering the consumer panel once per forward. Only
+// the chained-forward path is coalesced; normal completions (new requestId) and
+// streaming keep re-running immediately.
+const CHAINED_FORWARD_RERUN_COALESCE_MS = 100;
+
 export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatasourceBehaviourState> {
   private prevRequestIds: Map<number, string> = new Map();
+  private coalescedRerunTimeout?: ReturnType<typeof setTimeout>;
   public constructor(state: DashboardDatasourceBehaviourState) {
     super(state);
 
@@ -137,8 +147,19 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
         const hasNewRequest = newRequestId !== oldRequestId;
         const isStreaming = newState.data?.state === LoadingState.Streaming;
         const forwardedNewData = isTerminal(oldState.data?.state) && isTerminal(newState.data?.state);
-        if (newState.data !== oldState.data && (hasNewRequest || isStreaming || forwardedNewData)) {
+        if (newState.data === oldState.data) {
+          return;
+        }
+        if (hasNewRequest || isStreaming) {
+          // Normal completion or streaming update: re-run immediately.
           queryRunner.runQueries();
+        } else if (forwardedNewData) {
+          // Chained dashboard-DS forward under an unchanged requestId. Coalesce
+          // bursts of forwards into a single trailing re-run so the consumer
+          // re-processes once against the final forwarded frame instead of once
+          // per forward. runQueries() reads the source's latest data at fire time,
+          // so the coalesced re-run still lands on the freshest frame.
+          this.scheduleCoalescedRerun(queryRunner);
         }
       };
 
@@ -168,6 +189,12 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
 
     // Return cleanup function that unsubscribes from ALL subscriptions
     return () => {
+      // Cancel any pending coalesced re-run so it can't fire after deactivation.
+      if (this.coalescedRerunTimeout !== undefined) {
+        clearTimeout(this.coalescedRerunTimeout);
+        this.coalescedRerunTimeout = undefined;
+      }
+
       // Store all current requestIds before cleanup
       for (const dashboardQuery of dashboardQueries) {
         const panelId = dashboardQuery.panelId;
@@ -193,6 +220,16 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
       libraryPanelSubs.forEach((sub) => sub.unsubscribe());
       transformerSubs.forEach((sub) => sub.unsubscribe());
     };
+  }
+
+  private scheduleCoalescedRerun(queryRunner: SceneQueryRunner) {
+    if (this.coalescedRerunTimeout !== undefined) {
+      clearTimeout(this.coalescedRerunTimeout);
+    }
+    this.coalescedRerunTimeout = setTimeout(() => {
+      this.coalescedRerunTimeout = undefined;
+      queryRunner.runQueries();
+    }, CHAINED_FORWARD_RERUN_COALESCE_MS);
   }
 
   private containsDashboardDSQueries(queryRunner: SceneQueryRunner): boolean {

--- a/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDatasourceBehaviour.tsx
@@ -152,6 +152,9 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
         }
         if (hasNewRequest || isStreaming) {
           // Normal completion or streaming update: re-run immediately.
+          // Cancel any pending coalesced re-run so a prior chained forward cannot
+          // trigger a redundant second runQueries() after this one.
+          this.cancelCoalescedRerun();
           queryRunner.runQueries();
         } else if (forwardedNewData) {
           // Chained dashboard-DS forward under an unchanged requestId. Coalesce
@@ -190,10 +193,7 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
     // Return cleanup function that unsubscribes from ALL subscriptions
     return () => {
       // Cancel any pending coalesced re-run so it can't fire after deactivation.
-      if (this.coalescedRerunTimeout !== undefined) {
-        clearTimeout(this.coalescedRerunTimeout);
-        this.coalescedRerunTimeout = undefined;
-      }
+      this.cancelCoalescedRerun();
 
       // Store all current requestIds before cleanup
       for (const dashboardQuery of dashboardQueries) {
@@ -222,10 +222,15 @@ export class DashboardDatasourceBehaviour extends SceneObjectBase<DashboardDatas
     };
   }
 
-  private scheduleCoalescedRerun(queryRunner: SceneQueryRunner) {
+  private cancelCoalescedRerun() {
     if (this.coalescedRerunTimeout !== undefined) {
       clearTimeout(this.coalescedRerunTimeout);
+      this.coalescedRerunTimeout = undefined;
     }
+  }
+
+  private scheduleCoalescedRerun(queryRunner: SceneQueryRunner) {
+    this.cancelCoalescedRerun();
     this.coalescedRerunTimeout = setTimeout(() => {
       this.coalescedRerunTimeout = undefined;
       queryRunner.runQueries();


### PR DESCRIPTION
## What this PR does

Coalesces the "chained dashboard-datasource" re-run so a burst of forwarded updates collapses into a **single** re-run of the consuming panel, instead of one full re-run (re-read + transforms + re-render) per forwarded emission.

## Background

A `-- Dashboard --` panel can read another `-- Dashboard --` panel (a "chained" reference). #126378 fixed a bug where the consuming panel showed stale data in this case: when the intermediate forwards fresh upstream data on its already-open subscription it does **not** re-run, so its `request.requestId` is unchanged, and the consumer's `DashboardDatasourceBehaviour` (which gated re-runs on a changed requestId, per #116767 / #118629) never re-ran. #126378 added a re-run on a terminal→terminal (`Done`/`Error`) transition to pick up that forwarded data.

## The problem this PR addresses

That re-run fires on **every** forwarded emission. A chained source typically forwards more than once (e.g. a stale frame then the fresh frame, or several rapid emissions as an upstream progressively completes), so the consumer does a full `runQueries()` — re-reading its sources, re-applying transformations and re-rendering — once per forward. On dashboards with chained panels this is redundant re-processing/re-rendering work.

## The fix

Route only the chained-forward re-run through a short **trailing-edge coalesce window (100ms)**. A burst of forwards schedules a single re-run that reads the source's latest data when it fires, so the consumer settles once on the final frame. Normal completions (new `requestId`) and streaming updates keep re-running **immediately** — unchanged. The pending timer is cleared on deactivation.

## Results

Consumer re-runs / query executions, measured in a unit harness (fix present vs the re-run term reverted):

| Scenario | pre-#126378 | #126378 (no coalesce) | #126378 + coalesce (this PR) |
| --- | --- | --- | --- |
| Control (non-chained completion) | 1 | 1 | 1 |
| Correctness (single forward) | 0 (stale) | 1 | 1 |
| Amplification (4 rapid forwards) | 0 | 4 | 1 |
| EXEC (runQueries / runRequest) | 0/0 | 4/4 | 1/1 |
| THRASH (forwards over a slow query) | 0 starts (stale) | 5 starts, 4 cancelled | 1 start, 0 wasted |

## Correctness

- A single forward still produces exactly one re-run that lands on the fresh frame — the #126378 staleness fix is intact.
- The #116767 cancel guard is preserved: a cancel is `Loading→Done` (not terminal→terminal), so it never schedules a re-run.
- Non-chained and streaming timing is unchanged.

## Tests

`DashboardDatasourceBehaviour.test.tsx`:
- new: a burst of forwarded `Done` updates coalesces into a single consumer re-run;
- new/kept: single forwarded `Done` still re-runs once (both the transformer and no-transformations source branches);
- kept: cancel does not re-run (regression guard).