### PR TITLE
MT Annotations: override 4xx response code for custom graphite handler

### DIFF
--- a/pkg/registry/apps/annotation/custom_route_response.go
+++ b/pkg/registry/apps/annotation/custom_route_response.go
@@ -1,0 +1,37 @@
+package annotation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+type customRouteHandler func(context.Context, app.CustomRouteResponseWriter, *app.CustomRouteRequest) error
+
+func withAPIStatusErrorResponse(next customRouteHandler) customRouteHandler {
+	return func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {
+		err := next(ctx, writer, request)
+		if err == nil {
+			return nil
+		}
+
+		var statusErr apierrors.APIStatus
+		if !errors.As(err, &statusErr) {
+			return err
+		}
+
+		status := statusErr.Status()
+		if status.Code < http.StatusBadRequest || status.Code >= http.StatusInternalServerError {
+			return err
+		}
+
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(int(status.Code))
+		_ = json.NewEncoder(writer).Encode(status)
+		return nil
+	}
+}

--- a/pkg/registry/apps/annotation/custom_route_response_test.go
+++ b/pkg/registry/apps/annotation/custom_route_response_test.go
@@ -1,0 +1,68 @@
+package annotation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWithAPIStatusErrorResponse(t *testing.T) {
+	request := &app.CustomRouteRequest{}
+
+	t.Run("writes 4xx API status response", func(t *testing.T) {
+		forbidden := apierrors.NewForbidden(annotationGR, "graphite", errors.New("denied"))
+		handler := withAPIStatusErrorResponse(func(context.Context, app.CustomRouteResponseWriter, *app.CustomRouteRequest) error {
+			return fmt.Errorf("wrapped: %w", forbidden)
+		})
+		writer := &mockResponseWriter{header: make(http.Header), body: &bytes.Buffer{}}
+
+		err := handler(t.Context(), writer, request)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, writer.code)
+		assert.Equal(t, "application/json", writer.header.Get("Content-Type"))
+
+		var status metav1.Status
+		require.NoError(t, json.Unmarshal(writer.body.Bytes(), &status))
+		assert.Equal(t, int32(http.StatusForbidden), status.Code)
+		assert.Equal(t, metav1.StatusReasonForbidden, status.Reason)
+	})
+
+	t.Run("passes through non API status errors", func(t *testing.T) {
+		boom := errors.New("boom")
+		handler := withAPIStatusErrorResponse(func(context.Context, app.CustomRouteResponseWriter, *app.CustomRouteRequest) error {
+			return boom
+		})
+		writer := &mockResponseWriter{header: make(http.Header), body: &bytes.Buffer{}}
+
+		err := handler(t.Context(), writer, request)
+
+		require.ErrorIs(t, err, boom)
+		assert.Zero(t, writer.code)
+		assert.Empty(t, writer.body.String())
+	})
+
+	t.Run("passes through API status errors outside 4xx", func(t *testing.T) {
+		internal := apierrors.NewInternalError(errors.New("database unavailable"))
+		handler := withAPIStatusErrorResponse(func(context.Context, app.CustomRouteResponseWriter, *app.CustomRouteRequest) error {
+			return internal
+		})
+		writer := &mockResponseWriter{header: make(http.Header), body: &bytes.Buffer{}}
+
+		err := handler(t.Context(), writer, request)
+
+		require.ErrorIs(t, err, internal)
+		assert.Zero(t, writer.code)
+		assert.Empty(t, writer.body.String())
+	})
+}

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -142,7 +142,7 @@ func NewAppInstaller(
 	searchHandler := newSearchHandler(instrumentedStore, accessClient, folderResolver, installer.tracer, installer.metrics, logger)
 
 	// Create the graphite handler
-	graphiteHandler := newGraphiteHandler(installer.k8sAdapter, installer.tracer, installer.metrics, logger)
+	graphiteHandler := withAPIStatusErrorResponse(newGraphiteHandler(installer.k8sAdapter, installer.tracer, installer.metrics, logger))
 
 	provider := simple.NewAppProvider(apis.LocalManifest(), nil, annotationapp.New)
 

--- a/pkg/registry/apps/annotation/register_test.go
+++ b/pkg/registry/apps/annotation/register_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	authtypes "github.com/grafana/authlib/types"
-	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -14,6 +12,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
 func TestK8sRESTAdapter_Create(t *testing.T) {

--- a/pkg/registry/apps/annotation/register_test.go
+++ b/pkg/registry/apps/annotation/register_test.go
@@ -1,10 +1,19 @@
 package annotation
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 
 	authtypes "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/resource"
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -12,9 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-
-	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	restclient "k8s.io/client-go/rest"
 )
 
 func TestK8sRESTAdapter_Create(t *testing.T) {
@@ -362,4 +369,67 @@ func TestK8sRESTAdapter_NotFound(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, apierrors.IsNotFound(err), "expected IsNotFound, got: %v", err)
 	})
+}
+
+func TestNewAppInstaller_GraphiteHandlerWritesAPIStatusResponse(t *testing.T) {
+	tests := []struct {
+		name            string
+		accessClient    authtypes.AccessClient
+		body            string
+		statusCode      int
+		reason          metav1.StatusReason
+		messageContains string
+	}{
+		{
+			name:            "malformed json writes 400",
+			accessClient:    authtypes.FixedAccessClient(true),
+			body:            `not json`,
+			statusCode:      http.StatusBadRequest,
+			reason:          metav1.StatusReasonBadRequest,
+			messageContains: "bad request data",
+		},
+		{
+			name:            "unauthorized create writes 403",
+			accessClient:    &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return false }},
+			body:            `{"what":"deploy","tags":[]}`,
+			statusCode:      http.StatusForbidden,
+			reason:          metav1.StatusReasonForbidden,
+			messageContains: "insufficient permissions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installer, err := NewAppInstaller(Config{
+				StoreBackend: "memory",
+				RetentionTTL: defaultRetentionTTL,
+			}, nil, nil, tt.accessClient, newFakeFolderResolver(nil), tracing.InitializeTracerForTest(), nil)
+			require.NoError(t, err)
+			require.NoError(t, installer.InitializeApp(restclient.Config{}))
+			annotationApp, err := installer.App()
+			require.NoError(t, err)
+
+			writer := &mockResponseWriter{header: make(http.Header), body: &bytes.Buffer{}}
+			ctx := identity.WithServiceIdentityContext(t.Context(), 1)
+			err = annotationApp.CallCustomRoute(ctx, writer, &app.CustomRouteRequest{
+				ResourceIdentifier: resource.FullIdentifier{
+					Version:   "v0alpha1",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Path:   "graphite",
+				Method: http.MethodPost,
+				Body:   io.NopCloser(strings.NewReader(tt.body)),
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.statusCode, writer.code)
+			assert.Equal(t, "application/json", writer.header.Get("Content-Type"))
+
+			var status metav1.Status
+			require.NoError(t, json.Unmarshal(writer.body.Bytes(), &status))
+			assert.Equal(t, int32(tt.statusCode), status.Code)
+			assert.Equal(t, tt.reason, status.Reason)
+			assert.Contains(t, status.Message, tt.messageContains)
+		})
+	}
 }

--- a/pkg/registry/apps/annotation/register_test.go
+++ b/pkg/registry/apps/annotation/register_test.go
@@ -1,19 +1,12 @@
 package annotation
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
-	"net/http"
 	"strings"
 	"testing"
 
 	authtypes "github.com/grafana/authlib/types"
-	"github.com/grafana/grafana-app-sdk/app"
-	"github.com/grafana/grafana-app-sdk/resource"
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-	restclient "k8s.io/client-go/rest"
 )
 
 func TestK8sRESTAdapter_Create(t *testing.T) {
@@ -369,67 +361,4 @@ func TestK8sRESTAdapter_NotFound(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, apierrors.IsNotFound(err), "expected IsNotFound, got: %v", err)
 	})
-}
-
-func TestNewAppInstaller_GraphiteHandlerWritesAPIStatusResponse(t *testing.T) {
-	tests := []struct {
-		name            string
-		accessClient    authtypes.AccessClient
-		body            string
-		statusCode      int
-		reason          metav1.StatusReason
-		messageContains string
-	}{
-		{
-			name:            "malformed json writes 400",
-			accessClient:    authtypes.FixedAccessClient(true),
-			body:            `not json`,
-			statusCode:      http.StatusBadRequest,
-			reason:          metav1.StatusReasonBadRequest,
-			messageContains: "bad request data",
-		},
-		{
-			name:            "unauthorized create writes 403",
-			accessClient:    &fakeAccessClient{fn: func(authtypes.BatchCheckItem) bool { return false }},
-			body:            `{"what":"deploy","tags":[]}`,
-			statusCode:      http.StatusForbidden,
-			reason:          metav1.StatusReasonForbidden,
-			messageContains: "insufficient permissions",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			installer, err := NewAppInstaller(Config{
-				StoreBackend: "memory",
-				RetentionTTL: defaultRetentionTTL,
-			}, nil, nil, tt.accessClient, newFakeFolderResolver(nil), tracing.InitializeTracerForTest(), nil)
-			require.NoError(t, err)
-			require.NoError(t, installer.InitializeApp(restclient.Config{}))
-			annotationApp, err := installer.App()
-			require.NoError(t, err)
-
-			writer := &mockResponseWriter{header: make(http.Header), body: &bytes.Buffer{}}
-			ctx := identity.WithServiceIdentityContext(t.Context(), 1)
-			err = annotationApp.CallCustomRoute(ctx, writer, &app.CustomRouteRequest{
-				ResourceIdentifier: resource.FullIdentifier{
-					Version:   "v0alpha1",
-					Namespace: metav1.NamespaceDefault,
-				},
-				Path:   "graphite",
-				Method: http.MethodPost,
-				Body:   io.NopCloser(strings.NewReader(tt.body)),
-			})
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.statusCode, writer.code)
-			assert.Equal(t, "application/json", writer.header.Get("Content-Type"))
-
-			var status metav1.Status
-			require.NoError(t, json.Unmarshal(writer.body.Bytes(), &status))
-			assert.Equal(t, int32(tt.statusCode), status.Code)
-			assert.Equal(t, tt.reason, status.Reason)
-			assert.Contains(t, status.Message, tt.messageContains)
-		})
-	}
 }

--- a/pkg/tests/apis/annotations/annotations_test.go
+++ b/pkg/tests/apis/annotations/annotations_test.go
@@ -284,11 +284,17 @@ func TestIntegrationAnnotationGraphite(t *testing.T) {
 	require.Equal(t, "deployment\nv1.2.3", text)
 
 	// An empty `what` is rejected.
-	rsp = apis.DoRequest(helper, apis.RequestParams{
+	errorRsp := apis.DoRequest(helper, apis.RequestParams{
 		User:   helper.Org1.Admin,
 		Method: http.MethodPost,
 		Path:   path,
-		Body:   []byte(`{"what":""}`),
-	}, &annotationV0.Annotation{})
-	require.Equal(t, http.StatusInternalServerError, rsp.Response.StatusCode)
+		Body:   []byte(`{"what":"","tags":[]}`),
+	}, &metav1.Status{})
+	require.Equal(t, http.StatusBadRequest, errorRsp.Response.StatusCode)
+
+	status := errorRsp.Result
+	require.NotNil(t, status)
+	require.Equal(t, int32(http.StatusBadRequest), status.Code)
+	require.Equal(t, metav1.StatusReasonBadRequest, status.Reason)
+	require.Contains(t, status.Message, "what field should not be empty")
 }


### PR DESCRIPTION
Related to [grafana/grafana-org/issues/962](https://github.com/grafana/grafana-org/issues/962)
Related to [comment](https://github.com/grafana/grafana/pull/126901#discussion_r3452566396)

This PR proposes to add an annotation-local custom route response wrapper so that all returned k8s 4XX API status errors for custom routes are written as 4XX HTTP responses instead of falling through to the [app-sdk custom route fallback as 500](https://github.com/grafana/grafana-app-sdk/blob/12d03cb748bc02c345b150e92860b4559c399b2d/k8s/apiserver/installer.go#L714-L721). This change is currently only applied to the /graphite endpoint in this PR.

I think a more universal fix should be to fix the sdk logic itself. However, changing the app-sdk error handling would affect all version-level custom routes. That is a broader behavior change and probably needs an explicit opt-in mechanism so each custom route can choose whether returned `APIStatus` errors should be serialized directly (one possible reason for this is that I'm not sure how these endpoints are used on the client side, e.g. on the client side, some logic is already checking a specific 500 code from the API response).

Even with an opt-in SDK design, annotations would be the only route opting in for this fix for now as I'm not sure I should / want to start an initiative to ask other teams to update this behavior right now. 

So keeping the wrapper local lets us fix the annotation routes with a smaller, more controlled change while leaving the broader SDK behavior/design question open.

Example request response with this change:
<img width="646" height="256" alt="Screenshot 2026-07-07 at 6 05 05 PM" src="https://github.com/user-attachments/assets/847d3cca-060d-47f2-9a48-cec38619f58a" />

