### PR TITLE
SSOSettings: add grafana.ssoSettingsToMTSettings feature toggle

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2415,6 +2415,15 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:         "grafana.ssoSettingsToMTSettings",
+			Description:  "Enables reading and writing SSO settings through the MT-Settings service",
+			Stage:        FeatureStageExperimental,
+			Owner:        identityAccessTeam,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{Go: true},
+		},
+		{
 			Name:         "kubernetesExternalGroupMappingsApi",
 			Description:  "Enables external group mapping APIs in the app platform",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -280,6 +280,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,kubernetesServiceAccountsApi,experimental,@grafana/identity-access-team,false,false,false
 2026-05-22,kubernetesServiceAccountTokensApi,experimental,@grafana/identity-access-team,false,false,false
 2026-05-22,kubernetesSsoSettingsApi,experimental,@grafana/identity-access-team,false,false,false
+2026-07-08,grafana.ssoSettingsToMTSettings,experimental,@grafana/identity-access-team,false,false,false
 2026-05-22,kubernetesExternalGroupMappingsApi,experimental,@grafana/identity-access-team,false,false,false
 2026-05-22,kubernetesExternalGroupMappingsRedirect,experimental,@grafana/identity-access-team,false,false,false
 2026-05-22,kubernetesTeamSync,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -778,6 +778,10 @@ const (
 	// Enables SSO settings APIs in the app platform
 	FlagKubernetesSsoSettingsApi = "kubernetesSsoSettingsApi"
 
+	// FlagGrafanaSsoSettingsToMTSettings
+	// Enables reading and writing SSO settings through the MT-Settings service
+	FlagGrafanaSsoSettingsToMTSettings = "grafana.ssoSettingsToMTSettings"
+
 	// FlagKubernetesExternalGroupMappingsApi
 	// Enables external group mapping APIs in the app platform
 	FlagKubernetesExternalGroupMappingsApi = "kubernetesExternalGroupMappingsApi"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2769,6 +2769,20 @@
     },
     {
       "metadata": {
+        "name": "grafana.ssoSettingsToMTSettings",
+        "resourceVersion": "1783523719423",
+        "creationTimestamp": "2026-07-08T15:15:19Z"
+      },
+      "spec": {
+        "description": "Enables reading and writing SSO settings through the MT-Settings service",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.starredFolders",
         "resourceVersion": "1781683112920",
         "creationTimestamp": "2026-06-17T07:58:32Z"
@@ -5300,6 +5314,21 @@
         "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "ssoSettingsToMTSettings",
+        "resourceVersion": "1783417175218",
+        "creationTimestamp": "2026-07-07T09:39:35Z",
+        "deletionTimestamp": "2026-07-08T15:15:19Z"
+      },
+      "spec": {
+        "description": "Enables reading and writing SSO settings through the MT-Settings service",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
         "expression": "false"
       }
     },


### PR DESCRIPTION
Registers the `grafana.ssoSettingsToMTSettings` feature toggle (experimental, hidden, backend-only, `Generate{Go: true}`). It gates the SSO-settings-to-MT-Settings migration code paths; on its own it gates nothing yet.

No behavior change.

Fixes grafana/identity-access-team#2209

