### PR TITLE
SSOSettings: place MT-Settings fallback adapters behind grafana.ssoSettingsToMTSettings

### DIFF
--- a/pkg/services/ssosettings/errors.go
+++ b/pkg/services/ssosettings/errors.go
@@ -21,4 +21,8 @@ var (
 	ErrInvalidProvider = errutil.ValidationFailed("sso.invalidProvider", errutil.WithPublicMessage("Provider is invalid"))
 	ErrInvalidSettings = errutil.ValidationFailed("sso.settings", errutil.WithPublicMessage("Settings field is invalid"))
 	ErrEmptyClientId   = errutil.ValidationFailed("sso.emptyClientId", errutil.WithPublicMessage("ClientId cannot be empty"))
+
+	ErrMTSettingsNotImplemented = errutil.NotImplemented("sso.mtSettingsNotImplemented",
+		errutil.WithPublicMessage("Resolving SSO settings from the MT-Settings service is not implemented yet")).
+		Errorf("MT-Settings SSO settings resolution not implemented")
 )

--- a/pkg/services/ssosettings/ssosettings.go
+++ b/pkg/services/ssosettings/ssosettings.go
@@ -50,7 +50,7 @@ type Reloadable interface {
 // than the database. This is useful for providers that are not configured in the database, but instead are configured
 // using the config file and/or environment variables. Used mostly for backwards compatibility.
 type FallbackStrategy interface {
-	IsMatch(provider string) bool
+	IsMatch(ctx context.Context, provider string) bool
 	// TODO: check if GetProviderConfig can return an error
 	GetProviderConfig(ctx context.Context, provider string) (map[string]any, error)
 }

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -384,7 +384,7 @@ func (s *Service) RegisterFallbackStrategy(providerRegex string, strategy ssoset
 }
 
 func (s *Service) loadSettingsUsingFallbackStrategy(ctx context.Context, provider string) (*models.SSOSettings, error) {
-	loadStrategy, ok := s.getFallbackStrategyFor(provider)
+	loadStrategy, ok := s.getFallbackStrategyFor(ctx, provider)
 	if !ok {
 		return nil, errors.New("no fallback strategy found for provider: " + provider)
 	}
@@ -410,9 +410,9 @@ func getSettingByProvider(provider string, settings []*models.SSOSettings) *mode
 	return nil
 }
 
-func (s *Service) getFallbackStrategyFor(provider string) (ssosettings.FallbackStrategy, bool) {
+func (s *Service) getFallbackStrategyFor(ctx context.Context, provider string) (ssosettings.FallbackStrategy, bool) {
 	for _, strategy := range s.fbStrategies {
-		if strategy.IsMatch(provider) {
+		if strategy.IsMatch(ctx, provider) {
 			return strategy, true
 		}
 	}

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -55,8 +55,14 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 	usageStats usagestats.Service, registerer prometheus.Registerer,
 	settingsProvider setting.Provider, licensing licensing.Licensing,
 ) *Service {
+	// Each provider family pairs an MT-Settings adapter with its legacy
+	// strategy. The adapter sits first: while the ssoSettingsToMTSettings
+	// feature toggle is enabled it wins the match for its family, otherwise
+	// it matches nothing and the legacy strategy behaves as before.
 	fbStrategies := []ssosettings.FallbackStrategy{
+		strategies.NewMTSettingsOAuthStrategy(),
 		strategies.NewOAuthStrategy(cfg),
+		strategies.NewMTSettingsLDAPStrategy(),
 		strategies.NewLDAPStrategy(cfg),
 	}
 
@@ -70,7 +76,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 	configurableProviders[social.LDAPProviderName] = true
 
 	if licensing.FeatureEnabled(social.SAMLProviderName) {
-		fbStrategies = append(fbStrategies, strategies.NewSAMLStrategy(settingsProvider))
+		fbStrategies = append(fbStrategies, strategies.NewMTSettingsSAMLStrategy(), strategies.NewSAMLStrategy(settingsProvider))
 		providersList = append(providersList, social.SAMLProviderName)
 		configurableProviders[social.SAMLProviderName] = true
 	}

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -2385,7 +2385,7 @@ func Test_ProviderService(t *testing.T) {
 		name                  string
 		isLicenseEnabled      bool
 		expectedProvidersList []string
-		strategiesLength      int
+		expectedStrategies    []string
 	}{
 		{
 			name:             "should return all OAuth providers but not SAML because the licensing feature is not enabled",
@@ -2400,7 +2400,12 @@ func Test_ProviderService(t *testing.T) {
 				"okta",
 				"ldap",
 			},
-			strategiesLength: 2,
+			expectedStrategies: []string{
+				"*strategies.MTSettingsOAuthStrategy",
+				"*strategies.OAuthStrategy",
+				"*strategies.MTSettingsLDAPStrategy",
+				"*strategies.LDAPStrategy",
+			},
 		},
 		{
 			name:             "should return all fallback strategies and it should return all OAuth providers and SAML because the licensing feature is enabled and the provider is setup",
@@ -2416,7 +2421,14 @@ func Test_ProviderService(t *testing.T) {
 				"ldap",
 				"saml",
 			},
-			strategiesLength: 3,
+			expectedStrategies: []string{
+				"*strategies.MTSettingsOAuthStrategy",
+				"*strategies.OAuthStrategy",
+				"*strategies.MTSettingsLDAPStrategy",
+				"*strategies.LDAPStrategy",
+				"*strategies.MTSettingsSAMLStrategy",
+				"*strategies.SAMLStrategy",
+			},
 		},
 	}
 	for _, tc := range tests {
@@ -2427,7 +2439,15 @@ func Test_ProviderService(t *testing.T) {
 			env := setupTestEnv(t, tc.isLicenseEnabled, true, false)
 
 			require.Equal(t, tc.expectedProvidersList, env.service.providersList)
-			require.Equal(t, tc.strategiesLength, len(env.service.fbStrategies))
+
+			// Each provider family pairs its MT-Settings adapter directly in
+			// front of its legacy strategy; first match wins, so the order is
+			// the design.
+			strategyTypes := make([]string, 0, len(env.service.fbStrategies))
+			for _, strategy := range env.service.fbStrategies {
+				strategyTypes = append(strategyTypes, fmt.Sprintf("%T", strategy))
+			}
+			require.Equal(t, tc.expectedStrategies, strategyTypes)
 		})
 	}
 }

--- a/pkg/services/ssosettings/ssosettingstests/fallback_strategy_fake.go
+++ b/pkg/services/ssosettings/ssosettingstests/fallback_strategy_fake.go
@@ -13,7 +13,7 @@ func NewFakeFallbackStrategy() *FakeFallbackStrategy {
 	return &FakeFallbackStrategy{}
 }
 
-func (f *FakeFallbackStrategy) IsMatch(provider string) bool {
+func (f *FakeFallbackStrategy) IsMatch(_ context.Context, provider string) bool {
 	return f.ExpectedIsMatch
 }
 

--- a/pkg/services/ssosettings/strategies/ldap_strategy.go
+++ b/pkg/services/ssosettings/strategies/ldap_strategy.go
@@ -23,7 +23,7 @@ func NewLDAPStrategy(cfg *setting.Cfg) *LDAPStrategy {
 	}
 }
 
-func (s *LDAPStrategy) IsMatch(provider string) bool {
+func (s *LDAPStrategy) IsMatch(_ context.Context, provider string) bool {
 	return provider == social.LDAPProviderName
 }
 

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy.go
@@ -1,0 +1,76 @@
+package strategies
+
+import (
+	"context"
+	"slices"
+
+	"github.com/open-feature/go-sdk/openfeature"
+
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+)
+
+// The MT-Settings strategies resolve provider settings from the MT-Settings
+// service. Each provider family has its own adapter, registered directly in
+// front of the family's legacy strategy: while the grafana.ssoSettingsToMTSettings
+// feature toggle is enabled the adapter wins the match and fails loudly
+// instead of silently falling back to the legacy mechanism.
+type mtSettingsStrategy struct {
+	matches func(provider string) bool
+}
+
+func (s *mtSettingsStrategy) IsMatch(provider string) bool {
+	// IsMatch carries no context and the toggle is an instance-global gate,
+	// so evaluation uses a background context.
+	ctx := context.Background()
+	enabled := openfeature.NewDefaultClient().Boolean(ctx,
+		featuremgmt.FlagGrafanaSsoSettingsToMTSettings, false, openfeature.TransactionContext(ctx))
+	return enabled && s.matches(provider)
+}
+
+func (s *mtSettingsStrategy) GetProviderConfig(_ context.Context, _ string) (map[string]any, error) {
+	return nil, ssosettings.ErrMTSettingsNotImplemented
+}
+
+type MTSettingsOAuthStrategy struct {
+	mtSettingsStrategy
+}
+
+var _ ssosettings.FallbackStrategy = (*MTSettingsOAuthStrategy)(nil)
+
+func NewMTSettingsOAuthStrategy() *MTSettingsOAuthStrategy {
+	return &MTSettingsOAuthStrategy{mtSettingsStrategy{
+		matches: func(provider string) bool {
+			return slices.Contains(ssosettings.AllOAuthProviders, provider)
+		},
+	}}
+}
+
+type MTSettingsLDAPStrategy struct {
+	mtSettingsStrategy
+}
+
+var _ ssosettings.FallbackStrategy = (*MTSettingsLDAPStrategy)(nil)
+
+func NewMTSettingsLDAPStrategy() *MTSettingsLDAPStrategy {
+	return &MTSettingsLDAPStrategy{mtSettingsStrategy{
+		matches: func(provider string) bool {
+			return provider == social.LDAPProviderName
+		},
+	}}
+}
+
+type MTSettingsSAMLStrategy struct {
+	mtSettingsStrategy
+}
+
+var _ ssosettings.FallbackStrategy = (*MTSettingsSAMLStrategy)(nil)
+
+func NewMTSettingsSAMLStrategy() *MTSettingsSAMLStrategy {
+	return &MTSettingsSAMLStrategy{mtSettingsStrategy{
+		matches: func(provider string) bool {
+			return provider == social.SAMLProviderName
+		},
+	}}
+}

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy.go
@@ -20,10 +20,7 @@ type mtSettingsStrategy struct {
 	matches func(provider string) bool
 }
 
-func (s *mtSettingsStrategy) IsMatch(provider string) bool {
-	// IsMatch carries no context and the toggle is an instance-global gate,
-	// so evaluation uses a background context.
-	ctx := context.Background()
+func (s *mtSettingsStrategy) IsMatch(ctx context.Context, provider string) bool {
 	enabled := openfeature.NewDefaultClient().Boolean(ctx,
 		featuremgmt.FlagGrafanaSsoSettingsToMTSettings, false, openfeature.TransactionContext(ctx))
 	return enabled && s.matches(provider)

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
@@ -1,0 +1,94 @@
+package strategies
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	oftesting "github.com/open-feature/go-sdk/openfeature/testing"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+var provider = oftesting.NewTestProvider()
+
+func TestMain(m *testing.M) {
+	if err := openfeature.SetProvider(provider); err != nil {
+		panic(err)
+	}
+
+	m.Run()
+}
+
+func toggleFlags(enabled bool) map[string]memprovider.InMemoryFlag {
+	return map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagGrafanaSsoSettingsToMTSettings: setting.NewInMemoryFlag(featuremgmt.FlagGrafanaSsoSettingsToMTSettings, enabled),
+	}
+}
+
+func TestMTSettingsStrategies_IsMatch(t *testing.T) {
+	t.Run("no adapter matches any provider when the toggle is disabled", func(t *testing.T) {
+		provider.UsingFlags(t, toggleFlags(false))
+
+		adapters := []ssosettings.FallbackStrategy{
+			NewMTSettingsOAuthStrategy(),
+			NewMTSettingsLDAPStrategy(),
+			NewMTSettingsSAMLStrategy(),
+		}
+		providers := append([]string{}, ssosettings.AllOAuthProviders...)
+		providers = append(providers, social.LDAPProviderName, social.SAMLProviderName)
+
+		for _, adapter := range adapters {
+			for _, p := range providers {
+				require.False(t, adapter.IsMatch(p))
+			}
+		}
+	})
+
+	t.Run("each adapter matches exactly its own family when the toggle is enabled", func(t *testing.T) {
+		provider.UsingFlags(t, toggleFlags(true))
+
+		oauth := NewMTSettingsOAuthStrategy()
+		ldap := NewMTSettingsLDAPStrategy()
+		saml := NewMTSettingsSAMLStrategy()
+
+		for _, p := range ssosettings.AllOAuthProviders {
+			require.True(t, oauth.IsMatch(p))
+			require.False(t, ldap.IsMatch(p))
+			require.False(t, saml.IsMatch(p))
+		}
+
+		require.True(t, ldap.IsMatch(social.LDAPProviderName))
+		require.False(t, oauth.IsMatch(social.LDAPProviderName))
+		require.False(t, saml.IsMatch(social.LDAPProviderName))
+
+		require.True(t, saml.IsMatch(social.SAMLProviderName))
+		require.False(t, oauth.IsMatch(social.SAMLProviderName))
+		require.False(t, ldap.IsMatch(social.SAMLProviderName))
+	})
+}
+
+func TestMTSettingsStrategies_GetProviderConfig(t *testing.T) {
+	provider.UsingFlags(t, toggleFlags(true))
+
+	testCases := []struct {
+		adapter  ssosettings.FallbackStrategy
+		provider string
+	}{
+		{NewMTSettingsOAuthStrategy(), social.GenericOAuthProviderName},
+		{NewMTSettingsLDAPStrategy(), social.LDAPProviderName},
+		{NewMTSettingsSAMLStrategy(), social.SAMLProviderName},
+	}
+
+	for _, tc := range testCases {
+		config, err := tc.adapter.GetProviderConfig(context.Background(), tc.provider)
+
+		require.Nil(t, config)
+		require.ErrorIs(t, err, ssosettings.ErrMTSettingsNotImplemented)
+	}
+}

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
@@ -45,7 +45,7 @@ func TestMTSettingsStrategies_IsMatch(t *testing.T) {
 
 		for _, adapter := range adapters {
 			for _, p := range providers {
-				require.False(t, adapter.IsMatch(p))
+				require.False(t, adapter.IsMatch(t.Context(), p))
 			}
 		}
 	})
@@ -58,18 +58,18 @@ func TestMTSettingsStrategies_IsMatch(t *testing.T) {
 		saml := NewMTSettingsSAMLStrategy()
 
 		for _, p := range ssosettings.AllOAuthProviders {
-			require.True(t, oauth.IsMatch(p))
-			require.False(t, ldap.IsMatch(p))
-			require.False(t, saml.IsMatch(p))
+			require.True(t, oauth.IsMatch(t.Context(), p))
+			require.False(t, ldap.IsMatch(t.Context(), p))
+			require.False(t, saml.IsMatch(t.Context(), p))
 		}
 
-		require.True(t, ldap.IsMatch(social.LDAPProviderName))
-		require.False(t, oauth.IsMatch(social.LDAPProviderName))
-		require.False(t, saml.IsMatch(social.LDAPProviderName))
+		require.True(t, ldap.IsMatch(t.Context(), social.LDAPProviderName))
+		require.False(t, oauth.IsMatch(t.Context(), social.LDAPProviderName))
+		require.False(t, saml.IsMatch(t.Context(), social.LDAPProviderName))
 
-		require.True(t, saml.IsMatch(social.SAMLProviderName))
-		require.False(t, oauth.IsMatch(social.SAMLProviderName))
-		require.False(t, ldap.IsMatch(social.SAMLProviderName))
+		require.True(t, saml.IsMatch(t.Context(), social.SAMLProviderName))
+		require.False(t, oauth.IsMatch(t.Context(), social.SAMLProviderName))
+		require.False(t, ldap.IsMatch(t.Context(), social.SAMLProviderName))
 	})
 }
 

--- a/pkg/services/ssosettings/strategies/oauth_strategy.go
+++ b/pkg/services/ssosettings/strategies/oauth_strategy.go
@@ -36,7 +36,7 @@ func NewOAuthStrategy(cfg *setting.Cfg) *OAuthStrategy {
 	return oauthStrategy
 }
 
-func (s *OAuthStrategy) IsMatch(provider string) bool {
+func (s *OAuthStrategy) IsMatch(_ context.Context, provider string) bool {
 	_, ok := s.settingsByProvider[provider]
 	return ok
 }

--- a/pkg/services/ssosettings/strategies/saml_strategy.go
+++ b/pkg/services/ssosettings/strategies/saml_strategy.go
@@ -21,7 +21,7 @@ func NewSAMLStrategy(settingsProvider setting.Provider) *SAMLStrategy {
 	}
 }
 
-func (s *SAMLStrategy) IsMatch(provider string) bool {
+func (s *SAMLStrategy) IsMatch(_ context.Context, provider string) bool {
 	return provider == social.SAMLProviderName
 }
 

--- a/pkg/services/ssosettings/strategies/saml_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/saml_strategy_test.go
@@ -98,8 +98,8 @@ var (
 func TestSAMLIsMatch(t *testing.T) {
 	cfg := setting.NewCfg()
 	strategy := NewSAMLStrategy(&setting.OSSImpl{Cfg: cfg})
-	require.True(t, strategy.IsMatch("saml"))
-	require.False(t, strategy.IsMatch("oauth"))
+	require.True(t, strategy.IsMatch(t.Context(), "saml"))
+	require.False(t, strategy.IsMatch(t.Context(), "oauth"))
 }
 
 func TestSAMLGetProviderConfig(t *testing.T) {


### PR DESCRIPTION
Places per-family MT-Settings fallback adapters (OAuth, LDAP, SAML) in the ssosettings service, each registered directly in front of its legacy strategy. First match wins:

- Toggle off: the adapters match nothing — the legacy strategies are untouched files and behave byte-identically.
- Toggle on: the adapter wins the match for its family and returns a not-implemented error until the read pipe fills it in.

The `grafana.ssoSettingsToMTSettings` toggle is evaluated at runtime through the OpenFeature client (background context — `IsMatch` carries none and the toggle is instance-global). Tests use the OpenFeature test provider.

`Test_ProviderService` now asserts the strategy list's type order (adapter-before-legacy per family) instead of a bare count.

Stacked on #127997.

Fixes grafana/identity-access-team#2210

