### PR TITLE
SSOSettings: add storage-mode lever for the SSOSetting kind

### DIFF
--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -55,6 +55,7 @@ type IdentityAccessManagementAPIBuilder struct {
 	externalGroupReconciler    legacy.ExternalGroupReconciler
 	teamBindingLegacyStore     *teambinding.LegacyBindingStore
 	ssoLegacyStore             *sso.LegacyStore
+	ssoUseMTSettings           bool
 	roleApiInstaller           RoleApiInstaller
 	globalRoleApiInstaller     GlobalRoleApiInstaller
 	teamLBACApiInstaller       TeamLBACApiInstaller

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -128,6 +128,15 @@ func RegisterAPIService(
 		resourcePermsSearchAuthorizer = iamauthorizer.NewResourcePermissionsAuthorizer(accessClient, resourceParentProvider)
 	}
 
+	// Mode lever for the SSO settings migration: any configured storage mode
+	// above 0 hands the SSOSetting kind to the MT-Settings store.
+	ssoUseMTSettings := false
+	if cfg != nil {
+		if resCfg, ok := cfg.UnifiedStorage[legacyiamv0.SSOSettingResourceInfo.GroupResource().String()]; ok && resCfg.DualWriterMode > grafanarest.Mode0 {
+			ssoUseMTSettings = true
+		}
+	}
+
 	builder := &IdentityAccessManagementAPIBuilder{
 		store:                             store,
 		userLegacyStore:                   user.NewLegacyStore(store, accessClient, tracing),
@@ -136,6 +145,7 @@ func RegisterAPIService(
 		externalGroupReconciler:           externalGroupReconciler,
 		teamBindingLegacyStore:            teambinding.NewLegacyBindingStore(store, tracing),
 		ssoLegacyStore:                    sso.NewLegacyStore(ssoService, tracing),
+		ssoUseMTSettings:                  ssoUseMTSettings,
 		roleApiInstaller:                  roleApiInstaller,
 		globalRoleApiInstaller:            globalRoleApiInstaller,
 		teamLBACApiInstaller:              teamLBACApiInstaller,
@@ -435,7 +445,17 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	// SSO settings apis
 	if enableSsoSettingsApi && b.ssoLegacyStore != nil {
 		ssoResource := legacyiamv0.SSOSettingResourceInfo
-		storage[ssoResource.StoragePath()] = b.ssoLegacyStore
+		// The storage mode of [unified_storage.ssosettings.iam.grafana.app]
+		// decides which store serves the kind: at mode 0 (the default) the
+		// legacy store behaves as before; any higher mode engages the
+		// MT-Settings store, which fails loudly until it is implemented.
+		// The standard dual-writer cannot wrap this kind yet: it requires
+		// rest.CreaterUpdater and SSO settings are update-only.
+		if b.ssoUseMTSettings {
+			storage[ssoResource.StoragePath()] = sso.NewMTSettingsStore()
+		} else {
+			storage[ssoResource.StoragePath()] = b.ssoLegacyStore
+		}
 	}
 
 	if enableRolesApi {

--- a/pkg/registry/apis/iam/sso/mtsettings_store.go
+++ b/pkg/registry/apis/iam/sso/mtsettings_store.go
@@ -1,0 +1,85 @@
+package sso
+
+import (
+	"context"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+var (
+	_ rest.Storage              = (*MTSettingsStore)(nil)
+	_ rest.Scoper               = (*MTSettingsStore)(nil)
+	_ rest.Getter               = (*MTSettingsStore)(nil)
+	_ rest.Lister               = (*MTSettingsStore)(nil)
+	_ rest.Updater              = (*MTSettingsStore)(nil)
+	_ rest.SingularNameProvider = (*MTSettingsStore)(nil)
+	_ rest.GracefulDeleter      = (*MTSettingsStore)(nil)
+)
+
+// MTSettingsStore is the MT-Settings-backed storage for the SSOSetting kind
+// and the "unified" side of the resource's dual-writer. At storage mode 0 the
+// dual-writer serves the legacy store and this one is never reached; at any
+// higher mode it fails loudly until the MT-Settings pipes are implemented.
+type MTSettingsStore struct{}
+
+func NewMTSettingsStore() *MTSettingsStore {
+	return &MTSettingsStore{}
+}
+
+// Destroy implements rest.Storage.
+func (s *MTSettingsStore) Destroy() {}
+
+// NamespaceScoped implements rest.Scoper.
+func (s *MTSettingsStore) NamespaceScoped() bool {
+	return true
+}
+
+// GetSingularName implements rest.SingularNameProvider.
+func (s *MTSettingsStore) GetSingularName() string {
+	return resource.GetSingularName()
+}
+
+// New implements rest.Storage.
+func (s *MTSettingsStore) New() runtime.Object {
+	return resource.NewFunc()
+}
+
+// NewList implements rest.Lister.
+func (s *MTSettingsStore) NewList() runtime.Object {
+	return resource.NewListFunc()
+}
+
+// ConvertToTable implements rest.Lister.
+func (s *MTSettingsStore) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return resource.TableConverter().ConvertToTable(ctx, object, tableOptions)
+}
+
+// Get implements rest.Getter.
+func (s *MTSettingsStore) Get(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
+	return nil, s.notImplemented("get", name)
+}
+
+// List implements rest.Lister.
+func (s *MTSettingsStore) List(_ context.Context, _ *internalversion.ListOptions) (runtime.Object, error) {
+	return nil, s.notImplemented("list", "")
+}
+
+// Update implements rest.Updater.
+func (s *MTSettingsStore) Update(_ context.Context, name string, _ rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return nil, false, s.notImplemented("update", name)
+}
+
+// Delete implements rest.GracefulDeleter.
+func (s *MTSettingsStore) Delete(_ context.Context, name string, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	return nil, false, s.notImplemented("delete", name)
+}
+
+func (s *MTSettingsStore) notImplemented(verb string, name string) error {
+	return apierrors.NewGenericServerResponse(http.StatusNotImplemented, verb, resource.GroupResource(), name,
+		"MT-Settings storage for SSO settings is not implemented yet", 0, false)
+}


### PR DESCRIPTION
Adds the storage-mode lever for the SSOSetting kind: `[unified_storage.ssosettings.iam.grafana.app] dualWriterMode`.

- Mode 0 (or key absent, the default): the legacy store serves the kind exactly as before.
- Any higher mode: an MT-Settings store stub serves and fails loudly (501 on every verb) until it is implemented.

The standard dual-writer cannot wrap this kind yet — `grafanarest.Storage` requires `rest.CreaterUpdater` and the SSO LegacyStore is update-only — so this is a config-driven store selection (same pattern as the resource-permissions Mode5 check in this file).

Fixes grafana/identity-access-team#2211

## How to test

Requires the `kubernetesSsoSettingsApi` feature toggle — the SSOSetting kind is not registered without it.

1. **Default (mode 0 / key absent)** — start Grafana and, as admin:
   ```
   curl -s -u admin:admin http://localhost:3000/apis/iam.grafana.app/v0alpha1/namespaces/default/ssosettings
   ```
   The legacy store serves the kind exactly as before this PR.
2. **Lever engaged** — add to `conf/custom.ini` and restart:
   ```ini
   [unified_storage.ssosettings.iam.grafana.app]
   dualWriterMode = 1
   ```
   The same request (and any get/update/delete on the kind) now returns `501 Not Implemented` with "MT-Settings storage for SSO settings is not implemented yet".
3. The legacy HTTP endpoints (`/api/v1/sso-settings`) are untouched in both modes — they go through `ssosettings.Service` directly, not this store.

## Risks / notes

- Zero impact by default: the key is absent in shipped config, so the legacy store keeps serving. The stub is only reachable by explicitly setting the mode above 0.
- If the mode is set prematurely, the failure is loud and deliberate (501 on every verb) rather than silent misbehavior.
- The composite/dual-writer mismatch (`rest.CreaterUpdater` vs the update-only LegacyStore) is a Stage-3 design item in the epic — not addressed here.
