### PR TITLE
nats: select connection auth with an explicit auth_mode

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -180,18 +180,21 @@ tls_server_name =
 # For testing only; never enable in production.
 tls_insecure_skip_verify = false
 
-# Connection identity. token is the simplest form; credentials_file points to a NATS .creds file (JWT + NKEY).
-# Per-role files let each role present a least-privilege identity; an empty value falls back to credentials_file.
+# Connection identity. auth_mode selects the mechanism explicitly; the fields it reads depend on the value:
+#   none           - connect without credentials (default).
+#   token          - present the static token below.
+#   credentials    - present a NATS .creds file (JWT + NKEY). Per-role files let each role use a
+#                    least-privilege identity; an empty per-role value falls back to credentials_file.
+#   token_exchange - mint a short-lived authlib access token per (re)connect and present it as the connect
+#                    token, so an external auth-callout service can verify it and grant least-privilege
+#                    permissions from its claims. Set token_exchange_audiences (comma-separated); the exchange
+#                    endpoint and bootstrap token come from [grpc_client_authentication] (token_exchange_url,
+#                    token, token_namespace).
+auth_mode = none
 token =
 credentials_file =
 publisher_credentials_file =
 subscriber_credentials_file =
-
-# Alternatively, mint a short-lived authlib access token per (re)connect and present it as the connect token,
-# so an external auth-callout service can verify it and grant least-privilege permissions from its claims.
-# Set token_exchange_audiences (comma-separated) to turn this on; the exchange endpoint and bootstrap token are
-# taken from [grpc_client_authentication] (token_exchange_url, token, token_namespace). Precedence:
-# credentials_file > token_exchange_audiences > token.
 token_exchange_audiences =
 
 #################################### Grafana API server (Kubernetes-style APIs) #########################

--- a/pkg/infra/nats/config.go
+++ b/pkg/infra/nats/config.go
@@ -2,6 +2,7 @@ package nats
 
 import (
 	"context"
+	"fmt"
 
 	authnlib "github.com/grafana/authlib/authn"
 	natsclient "github.com/nats-io/nats.go"
@@ -26,7 +27,7 @@ func newConfig(cfg setting.NATSSettings, server *Server) *Config {
 		cfg:    cfg,
 		server: server,
 	}
-	if cfg.Auth.TokenExchangeEnabled() {
+	if cfg.Auth.Mode == setting.NATSAuthModeTokenExchange && cfg.Auth.TokenExchangeEnabled() {
 		// NewTokenExchangeClient only errors when the token or URL is empty, and
 		// TokenExchangeEnabled has already established both are set.
 		c.tokenExchanger, _ = authnlib.NewTokenExchangeClient(authnlib.TokenExchangeConfig{
@@ -52,18 +53,17 @@ func (c *Config) TLS() setting.NATSTLSSettings { return c.cfg.TLS }
 // Token returns the shared auth token, if any.
 func (c *Config) Token() string { return c.cfg.Auth.Token }
 
-// TokenExchangeConfigured reports whether a connection should present a minted
-// access token: the exchanger was built successfully and at least one audience is
-// configured to request.
-func (c *Config) TokenExchangeConfigured() bool {
-	return c.tokenExchanger != nil && len(c.cfg.Auth.TokenExchangeAudiences) > 0
-}
+// AuthMode reports the explicitly selected connection auth mechanism.
+func (c *Config) AuthMode() setting.NATSAuthMode { return c.cfg.Auth.Mode }
 
 // exchangeAccessToken mints a fresh access token scoped to the configured
 // audiences. Callers present the returned token as the NATS connect token; an
 // external auth-callout service verifies it and grants the connection's
 // permissions.
 func (c *Config) exchangeAccessToken(ctx context.Context) (string, error) {
+	if c.tokenExchanger == nil {
+		return "", fmt.Errorf("nats token exchange is not configured")
+	}
 	resp, err := c.tokenExchanger.Exchange(ctx, authnlib.TokenExchangeRequest{
 		Namespace: c.cfg.Auth.TokenExchangeNamespace,
 		Audiences: c.cfg.Auth.TokenExchangeAudiences,

--- a/pkg/infra/nats/connection.go
+++ b/pkg/infra/nats/connection.go
@@ -11,6 +11,7 @@ import (
 	natsclient "github.com/nats-io/nats.go"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 // tokenExchangeTimeout bounds a single access-token mint so a slow or unreachable
@@ -231,16 +232,18 @@ func (c *connection) connectOptions() ([]natsclient.Option, error) {
 		options = append(options, natsclient.Secure(tc))
 	}
 
-	// Precedence: per-role creds file > shared creds file > exchanged access
-	// token > static token. TokenHandler is invoked on every (re)connect, so the
-	// minted token is always fresh; the authlib client caches it under the hood.
-	switch creds := c.credentials(); {
-	case creds != "":
-		options = append(options, natsclient.UserCredentials(creds))
-	case c.config.TokenExchangeConfigured():
+	// The auth mechanism is selected explicitly by mode, not inferred from which
+	// fields are populated. For token exchange, TokenHandler is invoked on every
+	// (re)connect so the minted token is always fresh; the authlib client caches
+	// it under the hood.
+	switch c.config.AuthMode() {
+	case setting.NATSAuthModeCredentials:
+		options = append(options, natsclient.UserCredentials(c.credentials()))
+	case setting.NATSAuthModeTokenExchange:
 		options = append(options, natsclient.TokenHandler(c.tokenHandler))
-	case c.config.Token() != "":
+	case setting.NATSAuthModeToken:
 		options = append(options, natsclient.Token(c.config.Token()))
+	case setting.NATSAuthModeNone:
 	}
 
 	return options, nil

--- a/pkg/infra/nats/connection_test.go
+++ b/pkg/infra/nats/connection_test.go
@@ -198,8 +198,8 @@ func TestConnection(t *testing.T) {
 			require.Error(t, err)
 		})
 
-		t.Run("uses a static token when set", func(t *testing.T) {
-			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{Token: "s3cret"}}
+		t.Run("token mode uses the static token", func(t *testing.T) {
+			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{Mode: setting.NATSAuthModeToken, Token: "s3cret"}}
 			c := newConnection(rolePublisher, log.NewNopLogger(), newConnectionMetrics(rolePublisher), newConfig(cfg, nil), func() string { return "" })
 
 			opts, err := c.connectOptions()
@@ -209,8 +209,9 @@ func TestConnection(t *testing.T) {
 			require.Nil(t, o.TokenHandler)
 		})
 
-		t.Run("token exchange registers a token handler over a static token", func(t *testing.T) {
+		t.Run("token_exchange mode registers a token handler", func(t *testing.T) {
 			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{
+				Mode:                   setting.NATSAuthModeTokenExchange,
 				Token:                  "s3cret",
 				TokenExchangeAudiences: []string{"us-nats"},
 				TokenExchangeURL:       "http://signer/sign",
@@ -221,17 +222,18 @@ func TestConnection(t *testing.T) {
 			opts, err := c.connectOptions()
 			require.NoError(t, err)
 			o := applyOptions(t, opts)
-			// The exchanged token takes precedence: a handler is installed and the
-			// static token is left unset.
+			// The mode selects token exchange: a handler is installed and the static
+			// token is left unset even though one is present.
 			require.NotNil(t, o.TokenHandler)
 			require.Empty(t, o.Token)
 		})
 
-		t.Run("credentials file wins over token exchange", func(t *testing.T) {
+		t.Run("credentials mode uses the creds file", func(t *testing.T) {
 			credsFile := filepath.Join(t.TempDir(), "pub.creds")
 			require.NoError(t, os.WriteFile(credsFile, []byte("dummy"), 0o600))
 
 			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{
+				Mode:                     setting.NATSAuthModeCredentials,
 				PublisherCredentialsFile: credsFile,
 				TokenExchangeAudiences:   []string{"us-nats"},
 				TokenExchangeURL:         "http://signer/sign",
@@ -243,9 +245,26 @@ func TestConnection(t *testing.T) {
 			opts, err := c.connectOptions()
 			require.NoError(t, err)
 			o := applyOptions(t, opts)
+			// The mode selects credentials: the .creds file is loaded and neither the
+			// token handler nor a static token is installed.
 			require.NotNil(t, o.UserJWT)
 			require.Nil(t, o.TokenHandler)
 			require.Empty(t, o.Token)
+		})
+
+		t.Run("none mode installs no auth", func(t *testing.T) {
+			cfg := setting.NATSSettings{Enabled: true, Auth: setting.NATSAuthSettings{
+				Mode:  setting.NATSAuthModeNone,
+				Token: "s3cret",
+			}}
+			c := newConnection(rolePublisher, log.NewNopLogger(), newConnectionMetrics(rolePublisher), newConfig(cfg, nil), func() string { return "" })
+
+			opts, err := c.connectOptions()
+			require.NoError(t, err)
+			o := applyOptions(t, opts)
+			require.Empty(t, o.Token)
+			require.Nil(t, o.TokenHandler)
+			require.Nil(t, o.UserJWT)
 		})
 	})
 

--- a/pkg/setting/setting_nats.go
+++ b/pkg/setting/setting_nats.go
@@ -16,6 +16,24 @@ const (
 	NATSModeExternal NATSMode = "external"
 )
 
+// NATSAuthMode names the connection auth mechanism explicitly, so the active
+// method is declared in configuration rather than inferred from which of several
+// credential fields happens to be populated.
+type NATSAuthMode string
+
+const (
+	// NATSAuthModeNone connects without credentials.
+	NATSAuthModeNone NATSAuthMode = "none"
+	// NATSAuthModeToken presents the static token.
+	NATSAuthModeToken NATSAuthMode = "token"
+	// NATSAuthModeCredentials presents a NATS .creds file (per-role, falling back
+	// to the shared file).
+	NATSAuthModeCredentials NATSAuthMode = "credentials"
+	// NATSAuthModeTokenExchange mints a short-lived authlib access token per
+	// (re)connect and presents it as the connect token.
+	NATSAuthModeTokenExchange NATSAuthMode = "token_exchange"
+)
+
 // NATSSettings configures the stateless Core NATS message bus that signals
 // unified-storage resource changes; a disabled or unavailable bus degrades
 // gracefully to DB polling. Keys are documented in defaults.ini.
@@ -61,16 +79,25 @@ type NATSTLSSettings struct {
 	InsecureSkipVerify bool
 }
 
-// NATSAuthSettings configures the connection identity. A per-role credentials
-// file lets each role present a least-privilege identity; an empty value falls
-// back to the shared CredentialsFile.
+// NATSAuthSettings configures the connection identity. Mode selects the auth
+// mechanism explicitly; the fields it consumes depend on that choice:
 //
-// When TokenExchangeAudiences is set, the connection instead mints a short-lived
-// authlib access token per (re)connect and presents it as the connect token, so
-// an external auth-callout service can verify it and grant least-privilege
-// permissions from its claims. The exchange endpoint and bootstrap token are
-// shared with the [grpc_client_authentication] section rather than duplicated.
+//   - "credentials": a NATS .creds file. A per-role file lets each role present a
+//     least-privilege identity; an empty value falls back to the shared
+//     CredentialsFile.
+//   - "token_exchange": mint a short-lived authlib access token per (re)connect
+//     and present it as the connect token, so an external auth-callout service can
+//     verify it and grant least-privilege permissions from its claims. The
+//     exchange endpoint and bootstrap token are shared with the
+//     [grpc_client_authentication] section rather than duplicated.
+//   - "token": the static Token.
+//   - "none": connect without credentials.
+//
+// The mode drives selection rather than a precedence over populated fields, so
+// the active mechanism is self-evident from configuration.
 type NATSAuthSettings struct {
+	Mode NATSAuthMode
+
 	Token                     string
 	CredentialsFile           string
 	PublisherCredentialsFile  string
@@ -125,6 +152,7 @@ func readNATSSettings(cfg *Cfg) error {
 			InsecureSkipVerify: section.Key("tls_insecure_skip_verify").MustBool(false),
 		},
 		Auth: NATSAuthSettings{
+			Mode:                      NATSAuthMode(section.Key("auth_mode").MustString(string(NATSAuthModeNone))),
 			Token:                     section.Key("token").MustString(""),
 			CredentialsFile:           section.Key("credentials_file").MustString(""),
 			PublisherCredentialsFile:  section.Key("publisher_credentials_file").MustString(""),
@@ -134,6 +162,39 @@ func readNATSSettings(cfg *Cfg) error {
 			TokenExchangeToken:        grpcClient.Key("token").MustString(""),
 			TokenExchangeNamespace:    grpcClient.Key("token_namespace").MustString("stacks-" + cfg.StackID),
 		},
+	}
+	if err := cfg.NATS.Auth.validate(cfg.NATS.Enabled); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validate rejects an unknown auth_mode always, and (when the bus is enabled)
+// the mode being missing the fields it needs, so a misconfiguration fails at
+// startup rather than silently connecting unauthenticated.
+func (a NATSAuthSettings) validate(enabled bool) error {
+	switch a.Mode {
+	case NATSAuthModeNone, NATSAuthModeToken, NATSAuthModeCredentials, NATSAuthModeTokenExchange:
+	default:
+		return fmt.Errorf("invalid nats auth_mode %q, expected one of %q, %q, %q, %q",
+			a.Mode, NATSAuthModeNone, NATSAuthModeToken, NATSAuthModeCredentials, NATSAuthModeTokenExchange)
+	}
+	if !enabled {
+		return nil
+	}
+	switch a.Mode {
+	case NATSAuthModeToken:
+		if a.Token == "" {
+			return fmt.Errorf("nats auth_mode %q requires token", NATSAuthModeToken)
+		}
+	case NATSAuthModeCredentials:
+		if a.PublisherCredentials() == "" || a.SubscriberCredentials() == "" {
+			return fmt.Errorf("nats auth_mode %q requires credentials_file (or both publisher_credentials_file and subscriber_credentials_file)", NATSAuthModeCredentials)
+		}
+	case NATSAuthModeTokenExchange:
+		if !a.TokenExchangeEnabled() {
+			return fmt.Errorf("nats auth_mode %q requires token_exchange_audiences plus token_exchange_url and token in [grpc_client_authentication]", NATSAuthModeTokenExchange)
+		}
 	}
 	return nil
 }

--- a/pkg/setting/setting_nats.go
+++ b/pkg/setting/setting_nats.go
@@ -183,6 +183,7 @@ func (a NATSAuthSettings) validate(enabled bool) error {
 		return nil
 	}
 	switch a.Mode {
+	case NATSAuthModeNone:
 	case NATSAuthModeToken:
 		if a.Token == "" {
 			return fmt.Errorf("nats auth_mode %q requires token", NATSAuthModeToken)

--- a/pkg/setting/setting_nats_test.go
+++ b/pkg/setting/setting_nats_test.go
@@ -24,6 +24,7 @@ func TestReadNATSSettings(t *testing.T) {
 		require.Equal(t, 6222, cfg.NATS.ClusterPort)
 		require.Empty(t, cfg.NATS.ClientURLs)
 		require.False(t, cfg.NATS.TLS.Enabled)
+		require.Equal(t, NATSAuthModeNone, cfg.NATS.Auth.Mode)
 	})
 
 	t.Run("parses overrides", func(t *testing.T) {
@@ -35,6 +36,7 @@ mode = external
 client_urls = nats://a:4222, nats://b:4222
 tls_enabled = true
 tls_ca_cert_path = /etc/ca.pem
+auth_mode = token_exchange
 token = s3cret
 publisher_credentials_file = /etc/pub.creds
 subscriber_credentials_file = /etc/sub.creds
@@ -56,6 +58,7 @@ token_namespace = *
 		require.Equal(t, []string{"nats://a:4222", "nats://b:4222"}, cfg.NATS.ClientURLs)
 		require.True(t, cfg.NATS.TLS.Enabled)
 		require.Equal(t, "/etc/ca.pem", cfg.NATS.TLS.CACertPath)
+		require.Equal(t, NATSAuthModeTokenExchange, cfg.NATS.Auth.Mode)
 		require.Equal(t, "s3cret", cfg.NATS.Auth.Token)
 		require.Equal(t, "/etc/pub.creds", cfg.NATS.Auth.PublisherCredentialsFile)
 		require.Equal(t, "/etc/sub.creds", cfg.NATS.Auth.SubscriberCredentialsFile)
@@ -76,6 +79,63 @@ token_namespace = *
 		cfg.Raw = f
 
 		require.Error(t, readNATSSettings(cfg))
+	})
+
+	t.Run("rejects invalid auth_mode even when disabled", func(t *testing.T) {
+		cfg := NewCfg()
+		f, err := ini.Load([]byte("[nats]\nauth_mode = bogus\n"))
+		require.NoError(t, err)
+		cfg.Raw = f
+
+		require.Error(t, readNATSSettings(cfg))
+	})
+
+	t.Run("rejects enabled auth_mode missing its required fields", func(t *testing.T) {
+		cases := map[string]string{
+			"token without token":              "[nats]\nenabled = true\nauth_mode = token\n",
+			"credentials without a creds file": "[nats]\nenabled = true\nauth_mode = credentials\n",
+			"token_exchange without audiences": "[nats]\nenabled = true\nauth_mode = token_exchange\n",
+		}
+		for name, raw := range cases {
+			t.Run(name, func(t *testing.T) {
+				cfg := NewCfg()
+				f, err := ini.Load([]byte(raw))
+				require.NoError(t, err)
+				cfg.Raw = f
+
+				require.Error(t, readNATSSettings(cfg))
+			})
+		}
+	})
+
+	t.Run("does not require auth fields when disabled", func(t *testing.T) {
+		cfg := NewCfg()
+		f, err := ini.Load([]byte("[nats]\nenabled = false\nauth_mode = token\n"))
+		require.NoError(t, err)
+		cfg.Raw = f
+
+		require.NoError(t, readNATSSettings(cfg))
+	})
+}
+
+func TestNATSAuthValidate(t *testing.T) {
+	t.Run("credentials mode accepts per-role files without a shared file", func(t *testing.T) {
+		a := NATSAuthSettings{
+			Mode:                      NATSAuthModeCredentials,
+			PublisherCredentialsFile:  "/pub.creds",
+			SubscriberCredentialsFile: "/sub.creds",
+		}
+		require.NoError(t, a.validate(true))
+	})
+
+	t.Run("credentials mode rejects a single per-role file", func(t *testing.T) {
+		a := NATSAuthSettings{Mode: NATSAuthModeCredentials, PublisherCredentialsFile: "/pub.creds"}
+		require.Error(t, a.validate(true))
+	})
+
+	t.Run("credentials mode accepts a shared file for both roles", func(t *testing.T) {
+		a := NATSAuthSettings{Mode: NATSAuthModeCredentials, CredentialsFile: "/shared.creds"}
+		require.NoError(t, a.validate(true))
 	})
 }
 


### PR DESCRIPTION
Replaces the implicit NATS auth precedence (per-role creds > shared creds > exchanged token > static token) with an explicit `auth_mode` setting: `none` (default), `token`, `credentials`, `token_exchange`. The active mechanism is now declared in config instead of inferred from which field is populated, and it's validated at startup when the bus is enabled.

Breaking change for the (unreleased) NATS auth feature: configs must set `auth_mode` explicitly; the default is `none`.