### PR TITLE
FS: Add flag for client-side blocking of legacy apis

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1102,6 +1102,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/dev.ts @grafana/frontend-ops
 /public/app/core/utils/metrics.ts @grafana/grafana-catalog
 /public/app/index.ts @grafana/frontend-ops
+/public/app/legacyAPIHandling.ts @grafana/grafana-frontend-platform
 /public/app/initApp.ts @grafana/frontend-ops
 /public/app/AppWrapper.tsx @grafana/frontend-ops
 

--- a/devenv/frontend-service/goff-flags.yaml
+++ b/devenv/frontend-service/goff-flags.yaml
@@ -40,3 +40,11 @@ frontendService.reducedBootDataAPI:
     disabled: false
   defaultRule:
     variation: enabled
+
+grafana.frontendLegacyAPIHandling:
+  variations:
+    off: 'off'
+    alert: 'alert'
+    block: 'block'
+  defaultRule:
+    variation: block

--- a/devenv/frontend-service/goff-flags.yaml
+++ b/devenv/frontend-service/goff-flags.yaml
@@ -39,7 +39,7 @@ frontendService.reducedBootDataAPI:
     enabled: true
     disabled: false
   defaultRule:
-    variation: enabled
+    variation: disabled
 
 grafana.frontendLegacyAPIHandling:
   variations:
@@ -47,4 +47,4 @@ grafana.frontendLegacyAPIHandling:
     alert: 'alert'
     block: 'block'
   defaultRule:
-    variation: block
+    variation: off

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3116,6 +3116,15 @@ var (
 			Expression:  "false",
 			Generate:    Generate{Go: true, React: true},
 		},
+		{
+			Name:         "grafana.frontendLegacyAPIHandling",
+			Description:  "Controls whether the frontend blocks calls to legacy /api/ endpoints",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaFrontendPlatformSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{Go: true},
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -362,3 +362,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-07-01,grafana.growthHomepage,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-07-01,kubernetesReporting,experimental,@grafana/grafana-operator-experience-squad,false,true,false
 2026-06-26,grafana.onDemandDiagnostics,experimental,@grafana/data-sources,false,false,false
+2026-07-08,grafana.frontendLegacyAPIHandling,experimental,@grafana/grafana-frontend-platform,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -965,4 +965,8 @@ const (
 	// FlagGrafanaOnDemandDiagnostics
 	// Adds a 'Download diagnostics' action that bundles diagnostic artifacts such as HTTP traffic (HAR), server log, dashboard and panel JSONs, and more
 	FlagGrafanaOnDemandDiagnostics = "grafana.onDemandDiagnostics"
+
+	// FlagGrafanaFrontendLegacyAPIHandling
+	// Controls whether the frontend blocks calls to legacy /api/ endpoints
+	FlagGrafanaFrontendLegacyAPIHandling = "grafana.frontendLegacyAPIHandling"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2556,6 +2556,20 @@
     },
     {
       "metadata": {
+        "name": "grafana.frontendLegacyAPIHandling",
+        "resourceVersion": "1783501568190",
+        "creationTimestamp": "2026-07-08T09:06:08Z"
+      },
+      "spec": {
+        "description": "Controls whether the frontend blocks calls to legacy /api/ endpoints",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.growthHomepage",
         "resourceVersion": "1782913620784",
         "creationTimestamp": "2026-07-01T13:47:00Z"

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -68,6 +68,9 @@ type IndexViewData struct {
 
 	// Feature flag for the new preferences page
 	NewPreferencesPage bool
+
+	// Feature flag for controlling behaviour of blocking or alerting legacy api usage from the frontend
+	LegacyAPIMode string
 }
 
 // Templates setup.
@@ -142,6 +145,7 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 	meticulousAIProductionEnvironmentFlag := meticulousAIMode == "on-prod-env"
 	reduceBootdataAPI := requestConfig.FullFrontendSettings != nil
 	newPreferencesPage, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagGrafanaNewPreferencesPage, false, openfeature.TransactionContext(ctx))
+	legacyAPIMode, _ := ofClient.StringValue(ctx, featuremgmt.FlagGrafanaFrontendLegacyAPIHandling, "off", openfeature.TransactionContext(ctx))
 
 	data := IndexViewData{
 		AppTitle:                              "Grafana",
@@ -161,6 +165,7 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 		ReduceBootdataAPI:                     reduceBootdataAPI,
 		NewPreferencesPage:                    newPreferencesPage,
 		BootScript:                            p.bootScript,
+		LegacyAPIMode:                         legacyAPIMode,
 	}
 
 	// TODO -- reevaluate with mt authnz

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -186,6 +186,7 @@
         window.__grafanaNewPreferencesPage = true;
       [[end]]
 
+      window.__grafanaLegacyAPIMode = [[.LegacyAPIMode]];
       window.__grafanaPublicDashboardAccessToken = [[.PublicDashboardAccessToken]];
 
       [[if .FullSettings]]

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -3,6 +3,7 @@
 // we delay loading the rest of the app using import() until the boot data is ready.
 
 import { initPreferences } from './initPreferences';
+import { patchFetchForLegacyAPIMode } from './legacyAPIHandling';
 
 // Check if we are hosting files on cdn and set webpack public path
 if (window.public_cdn_path) {
@@ -26,6 +27,8 @@ async function bootstrapWindowData() {
   //
   // Must be first because initPreferences depends on bootdata
   await window.__grafana_boot_data_promise;
+
+  patchFetchForLegacyAPIMode();
 
   if (window.__grafanaNewPreferencesPage) {
     await initPreferences();

--- a/public/app/legacyAPIHandling.ts
+++ b/public/app/legacyAPIHandling.ts
@@ -1,0 +1,25 @@
+// Controlled by the ``
+export function patchFetchForLegacyAPIMode() {
+  const mode = window.__grafanaLegacyAPIMode;
+  if (mode !== 'alert' && mode !== 'block') {
+    return;
+  }
+
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const rawUrl = input instanceof Request ? input.url : input.toString();
+    const url = new URL(rawUrl, window.location.href);
+    const isLegacyAPICall = url.origin === window.location.origin && url.pathname.startsWith('/api/');
+
+    if (isLegacyAPICall) {
+      if (mode === 'block') {
+        return Promise.reject(new Error(`Request to legacy api ${url.pathname} blocked`));
+      }
+
+      console.warn(`Request made to to legacy api ${url.pathname}`);
+    }
+
+    return originalFetch(input, init);
+  };
+}

--- a/public/app/legacyAPIHandling.ts
+++ b/public/app/legacyAPIHandling.ts
@@ -1,7 +1,7 @@
 // Controlled by the ``
 export function patchFetchForLegacyAPIMode() {
   const mode = window.__grafanaLegacyAPIMode;
-  if (mode !== 'alert' && mode !== 'block') {
+  if (mode !== 'log' && mode !== 'block') {
     return;
   }
 

--- a/public/app/types/window.d.ts
+++ b/public/app/types/window.d.ts
@@ -9,9 +9,9 @@ export declare global {
     __grafanaPublicDashboardAccessToken?: string;
 
     /**
-     * Controls how same-origin `/api/` requests are handled by the frontend service.
+     * Controls legacy `/api/` requests are handled in the frontend, for development.
      * - `off`: requests are left untouched
-     * - `alert`: requests are allowed but logged with a warning
+     * - `log`: requests are allowed but logged with a warning
      * - `block`: requests are rejected before they are sent
      */
     __grafanaLegacyAPIMode?: string;

--- a/public/app/types/window.d.ts
+++ b/public/app/types/window.d.ts
@@ -9,6 +9,14 @@ export declare global {
     __grafanaPublicDashboardAccessToken?: string;
 
     /**
+     * Controls how same-origin `/api/` requests are handled by the frontend service.
+     * - `off`: requests are left untouched
+     * - `alert`: requests are allowed but logged with a warning
+     * - `block`: requests are rejected before they are sent
+     */
+    __grafanaLegacyAPIMode?: string;
+
+    /**
      * (Potential) wait for API call to fetch boot data and place it on `window.grafanaBootData`.
      * Required in new index.html to fetch necessary data before app init()
      **/


### PR DESCRIPTION
Adds a flag, intended just for development, to block legacy `/api/` calls.

It does this on app startup, before any other code has ran, by monkey-patching `fetch` only if the flag is set to a value that would require it. 

Part of https://github.com/grafana/grafana-frontend-platform/issues/151