### PR TITLE
`Auth-Proxy`: Rehydrate external groups from headers on cache hit

### DIFF
--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -92,6 +92,12 @@ func (c *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 	if c.cfg.AuthProxy.SyncTTL != 0 && ok {
 		identity, errCache := c.retrieveIDFromCache(ctx, cacheKey, r)
 		if errCache == nil {
+			// Rehydrate from the Groups header when configured as ExternalGroups are not persisted.
+			// GAP: LDAP external groups cannot be rehydrated here which can be a problem with
+			// the id_use_external_groups_for_groups_claim config.
+			if v, ok := additional[proxyFieldGroups]; ok {
+				identity.ExternalGroups = util.SplitString(v)
+			}
 			return identity, nil
 		}
 

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -92,11 +92,16 @@ func (c *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 	if c.cfg.AuthProxy.SyncTTL != 0 && ok {
 		identity, errCache := c.retrieveIDFromCache(ctx, cacheKey, r)
 		if errCache == nil {
-			// Rehydrate from the Groups header when configured as ExternalGroups are not persisted.
-			// GAP: LDAP external groups cannot be rehydrated here which can be a problem with
-			// the id_use_external_groups_for_groups_claim config.
-			if v, ok := additional[proxyFieldGroups]; ok {
-				identity.ExternalGroups = util.SplitString(v)
+			// Rehydrate ExternalGroups from the live Groups header.
+			// Safe as the groups header value is part of the cache key.
+			// Only matters when IDUseExternalGroupsForGroupsClaim is true as
+			// we rely directly on ExternalGroups to determine team membership.
+			// Sync hooks that consume ExternalGroups (e.g. team sync) are not run on a cache hit.
+			// GAP: LDAP external groups cannot be rehydrated here.
+			if c.cfg.IDUseExternalGroupsForGroupsClaim {
+				if v, ok := additional[proxyFieldGroups]; ok {
+					identity.ExternalGroups = util.SplitString(v)
+				}
 			}
 			return identity, nil
 		}

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -146,6 +146,7 @@ func TestProxy_Authenticate_CacheHitExternalGroups(t *testing.T) {
 			proxyHeaders: map[string]string{
 				proxyFieldGroups: "X-Group",
 			},
+			useExternalGroups: true,
 			expectCacheHit:    true,
 			expectedExtGroups: []string{"editors-viewers", "everyone"},
 		},
@@ -154,7 +155,20 @@ func TestProxy_Authenticate_CacheHitExternalGroups(t *testing.T) {
 			reqHeaders: map[string][]string{
 				"X-Username": {"johndoe"},
 			},
-			expectCacheHit: true,
+			useExternalGroups: true,
+			expectCacheHit:    true,
+		},
+		{
+			desc: "cache hit does not rehydrate when id_use_external_groups_for_groups_claim is off",
+			reqHeaders: map[string][]string{
+				"X-Username": {"johndoe"},
+				"X-Group":    {"editors-viewers,everyone"},
+			},
+			proxyHeaders: map[string]string{
+				proxyFieldGroups: "X-Group",
+			},
+			useExternalGroups: false,
+			expectCacheHit:    true,
 		},
 	}
 

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -125,6 +125,86 @@ func TestProxy_Authenticate(t *testing.T) {
 	}
 }
 
+func TestProxy_Authenticate_CacheHitExternalGroups(t *testing.T) {
+	type testCase struct {
+		desc              string
+		reqHeaders        map[string][]string
+		proxyHeaders      map[string]string
+		useExternalGroups bool
+		expectCacheHit    bool
+		clientExtGroups   []string
+		expectedExtGroups []string
+	}
+
+	tests := []testCase{
+		{
+			desc: "rehydrates ExternalGroups from Groups header on cache hit",
+			reqHeaders: map[string][]string{
+				"X-Username": {"johndoe"},
+				"X-Group":    {"editors-viewers,everyone"},
+			},
+			proxyHeaders: map[string]string{
+				proxyFieldGroups: "X-Group",
+			},
+			expectCacheHit:    true,
+			expectedExtGroups: []string{"editors-viewers", "everyone"},
+		},
+		{
+			desc: "cache hit with no Groups header leaves ExternalGroups empty",
+			reqHeaders: map[string][]string{
+				"X-Username": {"johndoe"},
+			},
+			expectCacheHit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.AuthProxy.HeaderName = "X-Username"
+			cfg.AuthProxy.Headers = tt.proxyHeaders
+			cfg.AuthProxy.SyncTTL = 15
+			cfg.IDUseExternalGroupsForGroupsClaim = tt.useExternalGroups
+
+			req := &authn.Request{
+				HTTPRequest: &http.Request{
+					Header:     tt.reqHeaders,
+					RemoteAddr: "127.0.0.1:333",
+				},
+			}
+
+			additional := getAdditionalProxyHeaders(req, cfg)
+			cacheKey, ok := getProxyCacheKey("johndoe", additional)
+			require.True(t, ok)
+			cache := &fakeCache{data: map[string][]byte{cacheKey: []byte("42")}}
+
+			clientCalled := false
+			proxyClient := authntest.MockProxyClient{AuthenticateProxyFunc: func(ctx context.Context, r *authn.Request, username string, additional map[string]string) (*authn.Identity, error) {
+				clientCalled = true
+				return &authn.Identity{
+					ID:             "99",
+					Type:           claims.TypeUser,
+					ExternalGroups: tt.clientExtGroups,
+				}, nil
+			}}
+
+			c, err := ProvideProxy(cfg, cache, tracing.InitializeTracerForTest(), proxyClient)
+			require.NoError(t, err)
+
+			got, err := c.Authenticate(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.expectCacheHit, !clientCalled)
+			if tt.expectCacheHit {
+				assert.Equal(t, "42", got.ID)
+			} else {
+				assert.Equal(t, "99", got.ID)
+			}
+			assert.Equal(t, tt.expectedExtGroups, got.ExternalGroups)
+		})
+	}
+}
+
 func TestProxy_Test(t *testing.T) {
 	type testCase struct {
 		desc       string


### PR DESCRIPTION
This PR rehydrates `ExternalGroups` from the `Groups` header on auth-proxy cache hit.

**Why**

On cache hit, the auth-proxy client returns a slim identity (user ID only) and skips the proxy client. `ExternalGroups` are not persisted to the user record, so they are absent on the cached identity.

`GroupsClaimSync` then sets `Groups = ExternalGroups`, which is empty, and team-granted permissions under `id_use_external_groups_for_groups_claim` silently disappear after the first request.

The cache key already binds the `Groups` header value, so rehydrating from the live request on hit is safe.
Applies when groups are passed via header; LDAP-sourced groups are not on the request and remain a known limitation.

