### PR TITLE
Go: Update version to 1.26.5

### DIFF
--- a/.citools/src/air/go.mod
+++ b/.citools/src/air/go.mod
@@ -1,6 +1,6 @@
 module air
 
-go 1.26.4
+go 1.26.5
 
 tool github.com/air-verse/air
 

--- a/.citools/src/cue/go.mod
+++ b/.citools/src/cue/go.mod
@@ -1,6 +1,6 @@
 module cue
 
-go 1.26.4
+go 1.26.5
 
 tool cuelang.org/go/cmd/cue
 

--- a/.citools/src/golangci-lint/go.mod
+++ b/.citools/src/golangci-lint/go.mod
@@ -1,6 +1,6 @@
 module golangci-lint
 
-go 1.26.4
+go 1.26.5
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 

--- a/.citools/src/govulncheck/go.mod
+++ b/.citools/src/govulncheck/go.mod
@@ -1,6 +1,6 @@
 module govulncheck
 
-go 1.26.4
+go 1.26.5
 
 tool golang.org/x/vuln/cmd/govulncheck
 

--- a/.citools/src/lefthook/go.mod
+++ b/.citools/src/lefthook/go.mod
@@ -1,6 +1,6 @@
 module lefthook
 
-go 1.26.4
+go 1.26.5
 
 tool github.com/evilmartians/lefthook
 

--- a/.citools/src/swagger/go.mod
+++ b/.citools/src/swagger/go.mod
@@ -1,6 +1,6 @@
 module swagger
 
-go 1.26.4
+go 1.26.5
 
 tool github.com/go-swagger/go-swagger/cmd/swagger
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG JS_SRC=js-builder
 # By using FROM instructions we can delegate dependency updates to dependabot
 FROM alpine:3.24.1 AS alpine-base
 FROM ubuntu:24.04 AS ubuntu-base
-FROM golang:1.26.4-alpine AS go-builder-base
+FROM golang:1.26.5-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:24-alpine AS js-builder-base
 FROM gcr.io/distroless/static-debian13 AS distroless-base
 # Javascript build stage

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WIRE_TAGS = "oss"
 include .citools/Variables.mk
 
 GO = go
-GO_VERSION = 1.26.4
+GO_VERSION = 1.26.5
 GO_HOST_OS := $(shell $(GO) env GOHOSTOS)
 GO_HOST_ARCH := $(shell $(GO) env GOHOSTARCH)
 GO_LINT_FILES ?= $(shell ./scripts/go-workspace/golangci-lint-includes.sh)

--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/advisor
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/apps/alerting/alertenrichment/go.mod
+++ b/apps/alerting/alertenrichment/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/alerting/alertenrichment
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6

--- a/apps/alerting/notifications/go.mod
+++ b/apps/alerting/notifications/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/alerting/notifications
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/alerting/rules/go.mod
+++ b/apps/alerting/rules/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/alerting/rules
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/getkin/kin-openapi v0.140.0

--- a/apps/annotation/go.mod
+++ b/apps/annotation/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/annotation
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/collections/go.mod
+++ b/apps/collections/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/collections
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/correlations/go.mod
+++ b/apps/correlations/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/correlations
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/dashboard/go.mod
+++ b/apps/dashboard/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/dashboard
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cuelang.org/go v0.11.1

--- a/apps/dashvalidator/go.mod
+++ b/apps/dashvalidator/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/dashvalidator
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/authlib/types v0.0.0-20260621220415-f6aaf60e82b2

--- a/apps/example/go.mod
+++ b/apps/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/example
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/folder/go.mod
+++ b/apps/folder/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/folder
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/iam/go.mod
+++ b/apps/iam/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/iam
 
-go 1.26.4
+go 1.26.5
 
 // transitive dependencies that need replaced
 // TODO: stop depending on grafana core(

--- a/apps/live/go.mod
+++ b/apps/live/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/live
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/logsdrilldown/go.mod
+++ b/apps/logsdrilldown/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/logsdrilldown
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/playlist/go.mod
+++ b/apps/playlist/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/playlist
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/plugins/go.mod
+++ b/apps/plugins/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/plugins
 
-go 1.26.4
+go 1.26.5
 
 replace github.com/grafana/grafana => ../..
 

--- a/apps/preferences/go.mod
+++ b/apps/preferences/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/preferences
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/provisioning
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/bwmarrin/snowflake v0.3.0

--- a/apps/quotas/go.mod
+++ b/apps/quotas/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/quotas
 
-go 1.26.4
+go 1.26.5
 
 // transitive dependencies that need replaced
 // TODO: stop depending on grafana core(

--- a/apps/scope/go.mod
+++ b/apps/scope/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/scope
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6

--- a/apps/secret/go.mod
+++ b/apps/secret/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/secret
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/apps/shorturl/go.mod
+++ b/apps/shorturl/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/shorturl
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/grafana/grafana-app-sdk v0.56.4

--- a/devenv/docker/blocks/prometheus_high_card/go.mod
+++ b/devenv/docker/blocks/prometheus_high_card/go.mod
@@ -1,6 +1,6 @@
 module high-card
 
-go 1.26.4
+go 1.26.5
 
 require github.com/prometheus/client_golang v1.23.2
 

--- a/devenv/docker/blocks/prometheus_utf8/go.mod
+++ b/devenv/docker/blocks/prometheus_utf8/go.mod
@@ -1,6 +1,6 @@
 module utf8-support
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/prometheus/client_golang v1.23.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.26.4
+go 1.26.5
 
 // Direct requirements -- every entry needs an owner
 require (
@@ -29,7 +29,6 @@ require (
 	github.com/andybalholm/brotli v1.2.1 // @grafana/data-sources-plugins
 	github.com/apache/arrow-go/v18 v18.6.0 // @grafana/grafana-catalog
 	github.com/armon/go-radix v1.0.0 // @grafana/grafana-app-platform-squad
-	github.com/aws/aws-sdk-go v1.55.8 // indirect; @grafana/data-sources-plugins
 	github.com/aws/aws-sdk-go-v2 v1.42.0 // @grafana/data-sources-plugins
 	github.com/aws/aws-sdk-go-v2/config v1.32.25 // @grafana/grafana-search-and-storage
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24 // @grafana/grafana-operator-experience-squad
@@ -55,6 +54,7 @@ require (
 	github.com/bwmarrin/snowflake v0.3.0 // @grafana/grafana-app-platform-squad
 	github.com/cenkalti/backoff/v4 v4.3.0 // @grafana/alerting-backend
 	github.com/centrifugal/centrifuge v0.38.0 // @grafana/grafana-app-platform-squad
+	github.com/cespare/xxhash/v2 v2.3.0 // @grafana/identity-access-team
 	github.com/charmbracelet/bubbles v1.0.0 // @grafana/grafana-app-platform-squad
 	github.com/charmbracelet/bubbletea v1.3.10 // @grafana/grafana-app-platform-squad
 	github.com/charmbracelet/lipgloss v1.1.0 // @grafana/grafana-app-platform-squad
@@ -131,7 +131,6 @@ require (
 	github.com/hashicorp/go-version v1.9.0 // @grafana/grafana-backend-group
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // @grafana/alerting-backend
 	github.com/hashicorp/hcl/v2 v2.24.0 // @grafana/alerting-backend
-	github.com/huandu/xstrings v1.5.0 // indirect; @grafana/data-sources-plugins
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0 // @grafana/data-sources-plugins
 	github.com/influxdata/influxql v1.4.1 // @grafana/data-sources-plugins
 	github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf // @grafana/grafana-app-platform-squad
@@ -151,6 +150,8 @@ require (
 	github.com/mocktools/go-smtp-mock/v2 v2.5.4 // @grafana/grafana-backend-group
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // @grafana/alerting-backend
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // @grafana/grafana-operator-experience-squad
+	github.com/nats-io/nats-server/v2 v2.14.2 // @grafana/grafana-search-and-storage
+	github.com/nats-io/nats.go v1.52.0 // @grafana/grafana-search-and-storage
 	github.com/oklog/ulid/v2 v2.1.1 // @grafana/grafana-search-and-storage
 	github.com/olekukonko/tablewriter v1.1.4 // @grafana/grafana-backend-group
 	github.com/open-feature/go-sdk v1.17.2 // @grafana/grafana-backend-group
@@ -350,6 +351,7 @@ require (
 	github.com/Yiling-J/theine-go v0.6.2 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
+	github.com/antithesishq/antithesis-sdk-go v0.7.0-default-no-op // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/apache/thrift v0.23.1-0.20260429145742-d2acd3c49e58 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
@@ -357,6 +359,7 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/at-wat/mqtt-go v0.19.6 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aws/aws-sdk-go v1.55.8 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
@@ -396,7 +399,6 @@ require (
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/centrifugal/protocol v0.17.0 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // @grafana/identity-access-team
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
@@ -476,6 +478,7 @@ require (
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-github/v73 v73.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
+	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
@@ -504,6 +507,7 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/huandu/go-clone v1.7.3 // indirect
 	github.com/huandu/go-sqlbuilder v1.40.2 // indirect
+	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -547,6 +551,7 @@ require (
 	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/miekg/dns v1.1.72 // indirect
+	github.com/minio/highwayhash v1.0.4 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
@@ -574,6 +579,9 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/natefinch/wrap v0.2.0 // indirect
+	github.com/nats-io/jwt/v2 v2.8.2 // indirect
+	github.com/nats-io/nkeys v0.4.16 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/nikunjy/rules v1.5.0 // indirect
 	github.com/oapi-codegen/runtime v1.0.0 // indirect
@@ -595,6 +603,7 @@ require (
 	github.com/opentracing-contrib/go-stdlib v1.1.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
+	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/phpdave11/gofpdi v1.0.14 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
@@ -666,6 +675,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.6.9 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.60.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.154.0 // indirect
 	go.opentelemetry.io/contrib/bridges/prometheus v0.68.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.42.0 // indirect
 	go.opentelemetry.io/contrib/exporters/autoexport v0.68.0 // indirect
@@ -715,22 +725,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.7.2 // indirect
-)
-
-require (
-	github.com/nats-io/nats-server/v2 v2.14.2 // @grafana/grafana-search-and-storage
-	github.com/nats-io/nats.go v1.52.0 // @grafana/grafana-search-and-storage
-)
-
-require (
-	github.com/antithesishq/antithesis-sdk-go v0.7.0-default-no-op // indirect
-	github.com/google/go-tpm v0.9.8 // indirect
-	github.com/minio/highwayhash v1.0.4 // indirect
-	github.com/nats-io/jwt/v2 v2.8.2 // indirect
-	github.com/nats-io/nkeys v0.4.16 // indirect
-	github.com/nats-io/nuid v1.0.1 // indirect
-	github.com/pborman/uuid v1.2.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.154.0 // indirect
 )
 
 replace (

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.4
+go 1.26.5
 
 // The `skip:golangci-lint` comment tag is used to exclude the package from the `golangci-lint` GitHub Action.
 // The module at the root of the repo (`.`) is excluded because ./pkg/... is included manually in the `golangci-lint` configuration.

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/hack
 
-go 1.26.4
+go 1.26.5
 
 require k8s.io/code-generator v0.36.0
 

--- a/pkg/apimachinery/go.mod
+++ b/pkg/apimachinery/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apimachinery
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-jose/go-jose/v4 v4.1.4

--- a/pkg/apiserver/go.mod
+++ b/pkg/apiserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apiserver
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/build/wire/go.mod
+++ b/pkg/build/wire/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/build/wire
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/codegen/go.mod
+++ b/pkg/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/codegen
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cuelang.org/go v0.11.1

--- a/pkg/infra/features/go.mod
+++ b/pkg/infra/features/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/infra/features
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/pkg/plugins/codegen/go.mod
+++ b/pkg/plugins/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/plugins/codegen
 
-go 1.26.4
+go 1.26.5
 
 replace github.com/grafana/grafana/pkg/codegen => ../../codegen
 

--- a/pkg/plugins/go.mod
+++ b/pkg/plugins/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/plugins
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Machiel/slugify v1.0.1

--- a/pkg/plugins/manager/testdata/test-app-with-backend/go.mod
+++ b/pkg/plugins/manager/testdata/test-app-with-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/plugins/manager/testdata/test-app-with-backend
 
-go 1.26.4
+go 1.26.5
 
 require github.com/grafana/grafana-plugin-sdk-go v0.292.0
 

--- a/pkg/storage/unified/resource/kv/go.mod
+++ b/pkg/storage/unified/resource/kv/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/storage/unified/resource/kv
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/pkg/storage/unified/resourcepb/go.mod
+++ b/pkg/storage/unified/resourcepb/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/storage/unified/resourcepb
 
-go 1.26.4
+go 1.26.5
 
 require (
 	google.golang.org/grpc v1.81.1

--- a/pkg/util/sqlite/go.mod
+++ b/pkg/util/sqlite/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/util/sqlite
 
-go 1.26.4
+go 1.26.5
 
 require modernc.org/sqlite v1.52.0
 

--- a/scripts/go-workspace/go.mod
+++ b/scripts/go-workspace/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/go-workspace
 
-go 1.26.4
+go 1.26.5
 
 require golang.org/x/mod v0.35.0

--- a/scripts/modowners/go.mod
+++ b/scripts/modowners/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/modowners
 
-go 1.26.4
+go 1.26.5
 
 require golang.org/x/mod v0.35.0


### PR DESCRIPTION
From Golang mailing list:

```
Hello gophers,

We have just released Go versions 1.26.5 and 1.25.12, minor point releases.

These releases include 2 security fixes following the [security policy](https://go.dev/doc/security/policy):

os: Root escape via symlink plus trailing slash

On Unix systems, opening a file in an os.Root improperly
followed symlinks to locations outside of the Root when
the final path component of the a path is a symbolic link
and the path ends in /.

For example, root.Open("symlink/") would open "symlink"
even when "symlink" is a symbolic link pointing outside of the root.

On Unix, openat(fd, path, O_NOFOLLOW) will follow symlinks
in path when path ends in a /. Root failed to account for
this behavior, permitting paths with a trailing / to escape.
It now properly sanitizes the path parameter provided to openat.

Thanks to Mundur (https://github.com/M0nd0R) for reporting this issue.

This is CVE-2026-39822 and Go issue https://go.dev/issue/79005.

crypto/tls: Encrypted Client Hello privacy leak

The Encrypted Client Hello implementation would leak the pre-shared key
identities during the handshake, allowing a passive network observer who can
collect handshakes to de-anonymize the hostname of the server, even when ECH was
being used.

Thanks to Coia Prant ([github.com/rbqvq](http://github.com/rbqvq)) for reporting this issue.

This is CVE-2026-42505 and Go issue https://go.dev/issue/79282.
```