### PR TITLE
Apimachinery: document classic shim kinds and guard classic identity changes

### DIFF
--- a/pkg/apimachinery/utils/manager.go
+++ b/pkg/apimachinery/utils/manager.go
@@ -33,18 +33,30 @@ const (
 	ManagerKindPlugin    ManagerKind = "plugin"
 	ManagerKindGrafana   ManagerKind = "grafana"
 
-	// Deprecated: this is used as a shim/migration path for legacy file provisioning
-	// Previously this was a "file:" prefix
+	// ManagerKindClassicFP marks resources that originate from the
+	// legacy on-disk file provisioning system (dashboards, folders, correlations,
+	// alerting with the "file" provenance). The manager identity, when present, is
+	// the provisioner/reader name from the provisioning config. Previously this was
+	// a "file:" prefix.
+	//
+	// Deprecated: shim/migration path only. New resources should use a real manager
+	// kind (repo, terraform, kubectl, ...).
 	ManagerKindClassicFP ManagerKind = "classic-file-provisioning"
 
-	// Deprecated: this is used as a shim/migration path for legacy API provisioning,
-	// where the resource was managed via the provisioning HTTP API but the specific
-	// tool (Terraform, script, etc.) was not recorded. Use ManagerKindTerraform,
+	// ManagerKindClassicAPI marks resources created through the legacy provisioning
+	// HTTP API (alerting "api" provenance) where the concrete tool that made the
+	// call was not recorded, so there is no meaningful manager identity.
+	//
+	// Deprecated: shim/migration path only. Prefer ManagerKindTerraform,
 	// ManagerKindKubectl, etc. for new resources.
 	ManagerKindClassicAPI ManagerKind = "classic-api-provisioning"
 
-	// Deprecated: this is used as a shim/migration path for resources that were
-	// converted from Prometheus definitions.
+	// ManagerKindClassicConvertedPrometheus marks resources imported by the Grafana
+	// Alerting "Convert Prometheus" API, which converts Prometheus/Mimir/Cortex rule
+	// groups into Grafana-managed rules (alerting "converted_prometheus" provenance).
+	// The import has no owning manager instance, so there is no manager identity.
+	//
+	// Deprecated: shim/migration path only.
 	ManagerKindClassicConvertedPrometheus ManagerKind = "classic-converted-prometheus"
 )
 
@@ -74,8 +86,11 @@ func ParseManagerKindString(v string) ManagerKind {
 	}
 }
 
-// IsClassic returns true for shim kinds that represent legacy provisioning mechanisms.
-// Classic kinds do not require a manager Identity.
+// IsClassic returns true for shim kinds that represent legacy provisioning
+// mechanisms (file/API provisioning, converted Prometheus). These origins have no
+// stable per-instance manager, so unlike other kinds they are considered managed
+// even without a manager Identity. Because their identity is absent or unstable, it
+// must not be treated as immutable the way user-defined identities are.
 func (k ManagerKind) IsClassic() bool {
 	switch k { //nolint:staticcheck
 	case ManagerKindClassicFP, ManagerKindClassicAPI, ManagerKindClassicConvertedPrometheus:

--- a/pkg/services/correlations/conversions_test.go
+++ b/pkg/services/correlations/conversions_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	correlationsV0 "github.com/grafana/grafana/apps/correlations/pkg/apis/correlation/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
 func TestConversion(t *testing.T) {
@@ -107,4 +108,25 @@ func TestConversion(t *testing.T) {
 			require.Equal(t, &tt.update, update, "update")
 		})
 	}
+}
+
+// TestProvisionedCorrelationIsManaged locks in the behavior that a provisioned
+// correlation is converted with the classic file-provisioning manager kind but no
+// manager identity, and must still be reported as managed. Classic kinds are exempt
+// from the "no identity => not managed" guard so this provisioning origin is not lost.
+func TestProvisionedCorrelationIsManaged(t *testing.T) {
+	res, err := ToResource(Correlation{
+		UID:         "uid",
+		OrgID:       2,
+		Provisioned: true,
+	})
+	require.NoError(t, err)
+
+	meta, err := utils.MetaAccessor(res)
+	require.NoError(t, err)
+
+	mgr, ok := meta.GetManagerProperties()
+	require.True(t, ok, "provisioned correlation should be reported as managed")
+	require.Equal(t, utils.ManagerKindClassicFP, mgr.Kind) //nolint:staticcheck
+	require.Empty(t, mgr.Identity, "classic file-provisioning correlation has no manager identity")
 }

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -105,7 +105,11 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 
 	// For non-Terraform managers, identity changes are also blocked.
 	// Remove the old manager first, then add a new one with a different identity.
-	if hasOld && managerNew.Kind != utils.ManagerKindTerraform && managerNew.Identity != managerOld.Identity {
+	//
+	// Classic shim kinds are exempt: their identity is absent or unstable (e.g. a
+	// file-provisioning reader name, or empty for API/converted-Prometheus origins),
+	// so it is not a user-defined stable ID and must not be treated as immutable.
+	if hasOld && managerNew.Kind != utils.ManagerKindTerraform && !managerNew.Kind.IsClassic() && managerNew.Identity != managerOld.Identity {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
 			Status:  metav1.StatusFailure,
 			Code:    http.StatusForbidden,

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -148,6 +148,103 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
+			// Classic kinds have an unstable or absent identity (a file-provisioning
+			// reader name, or empty for API/converted-Prometheus), so identity changes
+			// within the same classic kind are allowed rather than blocked.
+			name: "classic file-provisioning: identity change is allowed",
+			auth: provisioner,
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindClassicFP), //nolint:staticcheck
+						utils.AnnoKeyManagerIdentity: "reader-b",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindClassicFP), //nolint:staticcheck
+						utils.AnnoKeyManagerIdentity: "reader-a",
+					},
+				},
+			},
+		},
+		{
+			name: "classic converted-prometheus: identity change is allowed",
+			auth: user,
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindClassicConvertedPrometheus), //nolint:staticcheck
+						utils.AnnoKeyManagerIdentity: "b",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindClassicConvertedPrometheus), //nolint:staticcheck
+						utils.AnnoKeyManagerIdentity: "a",
+					},
+				},
+			},
+		},
+		{
+			// The classic exemption must not open a bypass: switching an existing
+			// non-classic manager to a classic kind is still a kind change and is
+			// blocked by the kind guard before the identity check is reached.
+			name: "changing a repo manager to a classic kind is blocked",
+			auth: provisioner,
+			err:  "Cannot change resource manager kind",
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindClassicFP), //nolint:staticcheck
+						utils.AnnoKeyManagerIdentity: "reader-a",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
+						utils.AnnoKeyManagerIdentity: "reader-a",
+					},
+				},
+			},
+		},
+		{
+			// Non-classic managers keep the identity-immutability guarantee.
+			name: "kubectl: identity change is still blocked",
+			auth: provisioner,
+			err:  "Cannot change resource manager identity",
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindKubectl),
+						utils.AnnoKeyManagerIdentity: "b",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindKubectl),
+						utils.AnnoKeyManagerIdentity: "a",
+					},
+				},
+			},
+		},
+		{
 			name: "changing manager kind is blocked",
 			auth: provisioner,
 			err:  "Cannot change resource manager",


### PR DESCRIPTION
Stacked on top of #127698 to address the review feedback on that PR.

### What & why

Follow-ups to the classic provisioning shim kinds. The existing exported constant `ManagerKindClassicFP` is **intentionally left unchanged** to avoid breaking downstream callers (e.g. grafana-enterprise).

- **Docs.** Expanded the godoc on the three classic shim kinds and on `IsClassic`, describing which legacy origin each maps to (`file` / `api` / `converted_prometheus`) and *why* classic kinds are reported as managed even without a manager identity. `ManagerKindClassicConvertedPrometheus` is documented as the Grafana Alerting "Convert Prometheus" import API (Prometheus/Mimir/Cortex rule groups → Grafana-managed rules).
- **Naming.** Renamed the misleading folder command field `ManagerKindClassicFP` → `FileProvisioningReaderName`. The field is named after a manager *kind* but actually holds a file-provisioning *reader name* (used as the manager identity).
- **Update guard.** Exempted classic kinds from the identity-immutability `403` in `checkManagerPropertiesOnUpdateSpec`. Because classic identities are absent or unstable (a reader name, or empty for API/converted-Prometheus origins), they must not be treated as a stable, immutable ID the way user-defined identities are.
- **Test.** Added `TestProvisionedCorrelationIsManaged`, locking in that a provisioned correlation is reported as managed with the classic file-provisioning kind and an empty identity — the pre-existing path most affected by the `GetManagerProperties` exemption.

### Notes for reviewers

- The `//nolint:staticcheck` comments are required: the classic kinds carry `// Deprecated` markers, so `staticcheck` SA1019 flags every reference. They are kept per-line, consistent with existing usage.
- No behavior change for file-provisioned dashboards/folders (they always set a non-empty identity). The only pre-existing origin whose managed-ness flips is provisioned correlations, which is now covered by a test.

### Verification

`go build`, `go vet`, and targeted `go test` pass across `pkg/apimachinery/utils`, `pkg/storage/unified/apistore`, `pkg/services/folder/...`, `pkg/services/correlations`, `pkg/services/dashboards/service`, and `pkg/registry/apis/{folders,dashboard}`.