### PR TITLE
Docs: Clarify Git Sync network connectivity and IP allowlisting

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -27,7 +27,30 @@ Before you begin to set up Git Sync, ensure you have the following:
 - If you're [using webhooks or image rendering](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend), a public instance with external access
   - Optional: The [Image Renderer service](https://github.com/grafana/grafana-image-renderer) to save image previews with your PRs
 
-Moreover, make sure you're not blocking any of the Grafana services IPs. For a list of IPs you need to add to your allowlist, refer to [Hosted Grafana source IPs](https://grafana.com/docs/grafana-cloud/security-and-account-management/allow-list/#hosted-grafana).
+## Network connectivity and IP allowlisting
+
+Git Sync requires network connectivity between your Grafana instance and Git server. Understanding the traffic patterns helps you configure firewalls and allowlists correctly.
+
+### Traffic types
+
+Git Sync uses two types of network traffic:
+
+- **Sync operations (pull and push)**: Grafana → Git Server
+  - Egress traffic from Hosted Grafana IPs
+  - Customer Git servers must allow inbound traffic from these IPs
+  - For a list of IPs to add to your Git server's allowlist, refer to [Hosted Grafana source IPs](https://grafana.com/docs/grafana-cloud/security-and-account-management/allow-list/#hosted-grafana)
+- **Webhooks (instantaneous sync)**: Git Server → Grafana stack
+  - Inbound traffic to the stack's public endpoint
+  - The Git server must be able to reach `*.grafana.net`
+  - Required only if you're [using webhooks](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend)
+
+### AWS PrivateLink and Private Data Source Connect
+
+Git Sync does not route over AWS PrivateLink or Private Data Source Connect (PDC).
+
+AWS PrivateLink and PDC provide a separate tunnel for data-source query traffic (Grafana → your private databases or data sources). Git Sync uses the normal public path from the Hosted Grafana IPs and is independent of PrivateLink/PDC.
+
+If you use AWS PrivateLink or PDC for data sources, you can still use Git Sync. The two features neither interfere with nor depend on each other.
 
 Finally, get acquainted with the following topics:
 

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -29,7 +29,7 @@ Before you begin to set up Git Sync, ensure you have the following:
 
 ## Network connectivity and IP allowlisting
 
-Git Sync requires network connectivity between your Grafana instance and Git server. Understanding the traffic patterns helps you configure firewalls and allowlists correctly.
+Git Sync requires network connectivity between your Grafana instance and Git server. Understanding the traffic patterns helps you configure firewall rules and allowlists correctly.
 
 ### Traffic types
 
@@ -48,7 +48,7 @@ Git Sync uses two types of network traffic:
 
 Git Sync does not route over AWS PrivateLink or Private Data Source Connect (PDC).
 
-AWS PrivateLink and PDC provide a separate tunnel for data-source query traffic (Grafana → your private databases or data sources). Git Sync uses the normal public path from the Hosted Grafana IPs and is independent of PrivateLink/PDC.
+AWS PrivateLink and PDC provide a separate tunnel for data source query traffic (Grafana → your private databases or data sources). Git Sync uses the normal public path from the Hosted Grafana IPs and is independent of PrivateLink/PDC.
 
 If you use AWS PrivateLink or PDC for data sources, you can still use Git Sync. The two features neither interfere with nor depend on each other.
 

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
@@ -70,7 +70,9 @@ The per-repository `spec.webhook.baseUrl` field still overrides `public_root_url
 
 ### Expose necessary paths only
 
-If your security setup doesn't permit publicly exposing the Grafana instance, you can either choose to allowlist the GitHub IP addresses, or expose only the necessary paths.
+If your security setup doesn't permit publicly exposing the Grafana instance, you can either choose to allowlist the Git provider's IP addresses, or expose only the necessary paths.
+
+For information about the traffic between Grafana and your Git server, refer to [Network connectivity and IP allowlisting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before/#network-connectivity-and-ip-allowlisting).
 
 The necessary paths required to be exposed are, in RegExp:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

This PR updates the Git Sync setup documentation to provide comprehensive information about network connectivity, IP allowlisting, and AWS PrivateLink/PDC compatibility.

**Why do we need this feature?**

Customers have been confused about:
- Which IP addresses need to be allowlisted for Git Sync
- How AWS PrivateLink/PDC interacts with Git Sync
- The different types of network traffic used by Git Sync

The previous documentation only briefly mentioned allowlisting without explaining the traffic patterns or addressing common questions about PrivateLink/PDC.

**Who is this feature for?**

This documentation update is for:
- Grafana Cloud customers configuring Git Sync with self-hosted Git servers
- Network/security teams who need to configure firewalls and allowlists
- Customers using AWS PrivateLink or Private Data Source Connect who want to understand Git Sync compatibility

**Which issue(s) does this PR fix?**:

N/A - Documentation improvement based on customer questions

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (N/A - documentation only)
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

## Changes

### `set-up-before.md`
- Added new section "Network connectivity and IP allowlisting"
- Documented two types of network traffic:
  - Sync operations (pull/push): Grafana → Git Server
  - Webhooks (instantaneous sync): Git Server → Grafana
- Clarified AWS PrivateLink/PDC independence from Git Sync
- Explained that PrivateLink/PDC is for data-source query traffic only

### `set-up-extend.md`
- Updated webhook section to reference the detailed network connectivity section
- Changed "GitHub IP addresses" to "Git provider's IP addresses" for broader applicability
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://raintank-corp.slack.com/archives/C07V91MA04B/p1782985218914279?thread_ts=1782985218.914279&cid=C07V91MA04B)

<div><a href="https://cursor.com/agents/bc-95a18639-9c92-5016-a107-1c6670428082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95a18639-9c92-5016-a107-1c6670428082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

