### PR TITLE
Folder: rename misleading ManagerKindClassicFP command field

### DIFF
--- a/pkg/apimachinery/utils/manager.go
+++ b/pkg/apimachinery/utils/manager.go
@@ -36,6 +36,16 @@ const (
 	// Deprecated: this is used as a shim/migration path for legacy file provisioning
 	// Previously this was a "file:" prefix
 	ManagerKindClassicFP ManagerKind = "classic-file-provisioning"
+
+	// Deprecated: this is used as a shim/migration path for legacy API provisioning,
+	// where the resource was managed via the provisioning HTTP API but the specific
+	// tool (Terraform, script, etc.) was not recorded. Use ManagerKindTerraform,
+	// ManagerKindKubectl, etc. for new resources.
+	ManagerKindClassicAPI ManagerKind = "classic-api-provisioning"
+
+	// Deprecated: this is used as a shim/migration path for resources that were
+	// converted from Prometheus definitions.
+	ManagerKindClassicConvertedPrometheus ManagerKind = "classic-converted-prometheus"
 )
 
 // ParseManagerKindString parses a string into a ManagerKind.
@@ -55,9 +65,23 @@ func ParseManagerKindString(v string) ManagerKind {
 		return ManagerKindGrafana
 	case string(ManagerKindClassicFP): // nolint:staticcheck
 		return ManagerKindClassicFP // nolint:staticcheck
+	case string(ManagerKindClassicAPI): // nolint:staticcheck
+		return ManagerKindClassicAPI // nolint:staticcheck
+	case string(ManagerKindClassicConvertedPrometheus): // nolint:staticcheck
+		return ManagerKindClassicConvertedPrometheus // nolint:staticcheck
 	default:
 		return ManagerKindUnknown
 	}
+}
+
+// IsClassic returns true for shim kinds that represent legacy provisioning mechanisms.
+// Classic kinds do not require a manager Identity.
+func (k ManagerKind) IsClassic() bool {
+	switch k { //nolint:staticcheck
+	case ManagerKindClassicFP, ManagerKindClassicAPI, ManagerKindClassicConvertedPrometheus:
+		return true
+	}
+	return false
 }
 
 // SourceProperties is used to identify the source of a provisioned resource.

--- a/pkg/apimachinery/utils/manager.go
+++ b/pkg/apimachinery/utils/manager.go
@@ -80,8 +80,9 @@ func (k ManagerKind) IsClassic() bool {
 	switch k { //nolint:staticcheck
 	case ManagerKindClassicFP, ManagerKindClassicAPI, ManagerKindClassicConvertedPrometheus:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 // SourceProperties is used to identify the source of a provisioned resource.

--- a/pkg/apimachinery/utils/manager.go
+++ b/pkg/apimachinery/utils/manager.go
@@ -33,18 +33,30 @@ const (
 	ManagerKindPlugin    ManagerKind = "plugin"
 	ManagerKindGrafana   ManagerKind = "grafana"
 
-	// Deprecated: this is used as a shim/migration path for legacy file provisioning
-	// Previously this was a "file:" prefix
+	// ManagerKindClassicFP marks resources that originate from the
+	// legacy on-disk file provisioning system (dashboards, folders, correlations,
+	// alerting with the "file" provenance). The manager identity, when present, is
+	// the provisioner/reader name from the provisioning config. Previously this was
+	// a "file:" prefix.
+	//
+	// Deprecated: shim/migration path only. New resources should use a real manager
+	// kind (repo, terraform, kubectl, ...).
 	ManagerKindClassicFP ManagerKind = "classic-file-provisioning"
 
-	// Deprecated: this is used as a shim/migration path for legacy API provisioning,
-	// where the resource was managed via the provisioning HTTP API but the specific
-	// tool (Terraform, script, etc.) was not recorded. Use ManagerKindTerraform,
+	// ManagerKindClassicAPI marks resources created through the legacy provisioning
+	// HTTP API (alerting "api" provenance) where the concrete tool that made the
+	// call was not recorded, so there is no meaningful manager identity.
+	//
+	// Deprecated: shim/migration path only. Prefer ManagerKindTerraform,
 	// ManagerKindKubectl, etc. for new resources.
 	ManagerKindClassicAPI ManagerKind = "classic-api-provisioning"
 
-	// Deprecated: this is used as a shim/migration path for resources that were
-	// converted from Prometheus definitions.
+	// ManagerKindClassicConvertedPrometheus marks resources imported by the Grafana
+	// Alerting "Convert Prometheus" API, which converts Prometheus/Mimir/Cortex rule
+	// groups into Grafana-managed rules (alerting "converted_prometheus" provenance).
+	// The import has no owning manager instance, so there is no manager identity.
+	//
+	// Deprecated: shim/migration path only.
 	ManagerKindClassicConvertedPrometheus ManagerKind = "classic-converted-prometheus"
 )
 
@@ -74,8 +86,11 @@ func ParseManagerKindString(v string) ManagerKind {
 	}
 }
 
-// IsClassic returns true for shim kinds that represent legacy provisioning mechanisms.
-// Classic kinds do not require a manager Identity.
+// IsClassic returns true for shim kinds that represent legacy provisioning
+// mechanisms (file/API provisioning, converted Prometheus). These origins have no
+// stable per-instance manager, so unlike other kinds they are considered managed
+// even without a manager Identity. Because their identity is absent or unstable, it
+// must not be treated as immutable the way user-defined identities are.
 func (k ManagerKind) IsClassic() bool {
 	switch k { //nolint:staticcheck
 	case ManagerKindClassicFP, ManagerKindClassicAPI, ManagerKindClassicConvertedPrometheus:

--- a/pkg/apimachinery/utils/meta.go
+++ b/pkg/apimachinery/utils/meta.go
@@ -679,11 +679,16 @@ func (m *grafanaMetaAccessor) GetManagerProperties() (ManagerProperties, bool) {
 			}, true
 		}
 
-		// If the identity is not set, we should ignore the other annotations and return the default values.
-		//
-		// This is to prevent inadvertently marking resources as managed,
-		// since that can potentially block updates from other sources.
-		return res, false
+		// Classic shim kinds (legacy file/API provisioning) have no meaningful identity,
+		// so allow them through without one.
+		kind := ParseManagerKindString(annot[AnnoKeyManagerKind])
+		if !kind.IsClassic() {
+			// If the identity is not set, we should ignore the other annotations and return the default values.
+			//
+			// This is to prevent inadvertently marking resources as managed,
+			// since that can potentially block updates from other sources.
+			return res, false
+		}
 	}
 	res.Identity = id
 

--- a/pkg/apimachinery/utils/meta_test.go
+++ b/pkg/apimachinery/utils/meta_test.go
@@ -783,6 +783,41 @@ func TestMetaAccessor(t *testing.T) {
 				},
 				wantOK: true,
 			},
+			{
+				// Classic shim kinds have no meaningful identity, so unlike other kinds
+				// they must still be reported as managed when the identity is empty.
+				name: "classic file-provisioning kind without identity is managed",
+				setProperties: &utils.ManagerProperties{
+					Kind: utils.ManagerKindClassicFP, //nolint:staticcheck
+				},
+				wantProperties: utils.ManagerProperties{
+					Identity: "",
+					Kind:     utils.ManagerKindClassicFP, //nolint:staticcheck
+				},
+				wantOK: true,
+			},
+			{
+				name: "classic api-provisioning kind without identity is managed",
+				setProperties: &utils.ManagerProperties{
+					Kind: utils.ManagerKindClassicAPI, //nolint:staticcheck
+				},
+				wantProperties: utils.ManagerProperties{
+					Identity: "",
+					Kind:     utils.ManagerKindClassicAPI, //nolint:staticcheck
+				},
+				wantOK: true,
+			},
+			{
+				name: "classic converted-prometheus kind without identity is managed",
+				setProperties: &utils.ManagerProperties{
+					Kind: utils.ManagerKindClassicConvertedPrometheus, //nolint:staticcheck
+				},
+				wantProperties: utils.ManagerProperties{
+					Identity: "",
+					Kind:     utils.ManagerKindClassicConvertedPrometheus, //nolint:staticcheck
+				},
+				wantOK: true,
+			},
 		}
 
 		for _, tt := range tests {

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -38,10 +38,10 @@ func LegacyCreateCommandToUnstructured(cmd *folder.CreateFolderCommand) (*unstru
 	meta.SetFolder(cmd.ParentUID)
 
 	// nolint:staticcheck
-	if cmd.ManagerKindClassicFP != "" {
+	if cmd.FileProvisioningReaderName != "" {
 		meta.SetManagerProperties(utils.ManagerProperties{
 			Kind:     utils.ManagerKindClassicFP,
-			Identity: cmd.ManagerKindClassicFP,
+			Identity: cmd.FileProvisioningReaderName,
 		})
 	}
 

--- a/pkg/services/correlations/conversions_test.go
+++ b/pkg/services/correlations/conversions_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	correlationsV0 "github.com/grafana/grafana/apps/correlations/pkg/apis/correlation/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
 func TestConversion(t *testing.T) {
@@ -107,4 +108,25 @@ func TestConversion(t *testing.T) {
 			require.Equal(t, &tt.update, update, "update")
 		})
 	}
+}
+
+// TestProvisionedCorrelationIsManaged locks in the behavior that a provisioned
+// correlation is converted with the classic file-provisioning manager kind but no
+// manager identity, and must still be reported as managed. Classic kinds are exempt
+// from the "no identity => not managed" guard so this provisioning origin is not lost.
+func TestProvisionedCorrelationIsManaged(t *testing.T) {
+	res, err := ToResource(Correlation{
+		UID:         "uid",
+		OrgID:       2,
+		Provisioned: true,
+	})
+	require.NoError(t, err)
+
+	meta, err := utils.MetaAccessor(res)
+	require.NoError(t, err)
+
+	mgr, ok := meta.GetManagerProperties()
+	require.True(t, ok, "provisioned correlation should be reported as managed")
+	require.Equal(t, utils.ManagerKindClassicFP, mgr.Kind) //nolint:staticcheck
+	require.Empty(t, mgr.Identity, "classic file-provisioning correlation has no manager identity")
 }

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1026,7 +1026,7 @@ func (dr *DashboardServiceImpl) SaveFolderForProvisionedDashboards(ctx context.C
 	dto.SignedInUser = ident
 
 	// The readerName is the identifier for the file provisioning manager
-	dto.ManagerKindClassicFP = readerName // nolint:staticcheck
+	dto.FileProvisioningReaderName = readerName // nolint:staticcheck
 
 	f, err := dr.folderService.Create(ctx, dto)
 	if err != nil {
@@ -1044,12 +1044,12 @@ func (dr *DashboardServiceImpl) UpdateFolderWithManagedByAnnotation(ctx context.
 
 	ctx, ident := identity.WithServiceIdentity(ctx, f.OrgID)
 	updated, err := dr.folderService.Update(ctx, &folder.UpdateFolderCommand{
-		UID:                  f.UID,
-		OrgID:                f.OrgID,
-		SignedInUser:         ident,
-		ManagerKindClassicFP: readerName, // nolint:staticcheck
-		Overwrite:            true,
-		Version:              f.Version,
+		UID:                        f.UID,
+		OrgID:                      f.OrgID,
+		SignedInUser:               ident,
+		FileProvisioningReaderName: readerName, // nolint:staticcheck
+		Overwrite:                  true,
+		Version:                    f.Version,
 	})
 	if err != nil {
 		dr.log.Error("failed to update folder for provisioned dashboards", "folder", f.Title, "org", f.OrgID, "err", err)

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -468,7 +468,7 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 		ParentUID:    cmd.ParentUID,
 		SignedInUser: cmd.SignedInUser,
 		// pass along provisioning details
-		ManagerKindClassicFP: cmd.ManagerKindClassicFP, // nolint:staticcheck
+		FileProvisioningReaderName: cmd.FileProvisioningReaderName, // nolint:staticcheck
 	}
 
 	f, err := s.unifiedStore.Create(ctx, *cmd)
@@ -488,14 +488,14 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 	}
 
 	folder, err := s.unifiedStore.Update(ctx, folder.UpdateFolderCommand{
-		UID:                  cmd.UID,
-		OrgID:                cmd.OrgID,
-		NewTitle:             cmd.NewTitle,
-		NewDescription:       cmd.NewDescription,
-		SignedInUser:         cmd.SignedInUser,
-		Overwrite:            cmd.Overwrite,
-		Version:              cmd.Version,
-		ManagerKindClassicFP: cmd.ManagerKindClassicFP, // nolint:staticcheck
+		UID:                        cmd.UID,
+		OrgID:                      cmd.OrgID,
+		NewTitle:                   cmd.NewTitle,
+		NewDescription:             cmd.NewDescription,
+		SignedInUser:               cmd.SignedInUser,
+		Overwrite:                  cmd.Overwrite,
+		Version:                    cmd.Version,
+		FileProvisioningReaderName: cmd.FileProvisioningReaderName, // nolint:staticcheck
 	})
 
 	if err != nil {

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -139,10 +139,10 @@ func (ss *FolderUnifiedStoreImpl) Update(ctx context.Context, cmd folder.UpdateF
 	}
 
 	// nolint:staticcheck
-	if cmd.ManagerKindClassicFP != "" {
+	if cmd.FileProvisioningReaderName != "" {
 		meta.SetManagerProperties(utils.ManagerProperties{
 			Kind:     utils.ManagerKindClassicFP,
-			Identity: cmd.ManagerKindClassicFP,
+			Identity: cmd.FileProvisioningReaderName,
 		})
 	}
 

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -189,12 +189,14 @@ type CreateFolderCommand struct {
 
 	SignedInUser identity.Requester `json:"-"`
 
-	// When running classic file provisioning with folders saved in kubernetes,
-	// folders will be marked with a manager of kind ManagerKindClassicFP
+	// FileProvisioningReaderName is the reader/provisioner name of the legacy file
+	// provisioning source. When set, folders saved in kubernetes are marked with a
+	// manager of kind ManagerKindClassicFP and this value as the
+	// manager identity.
 	// NOTE: this is ignored when running legacy SQL storage
 	//
 	// Deprecated: this should only be used by the legacy file provisioning system
-	ManagerKindClassicFP string `json:"-"`
+	FileProvisioningReaderName string `json:"-"`
 }
 
 // UpdateFolderCommand captures the information required by the folder service
@@ -215,12 +217,14 @@ type UpdateFolderCommand struct {
 
 	SignedInUser identity.Requester `json:"-"`
 
-	// When running classic file provisioning with folders saved in kubernetes,
-	// folders will be marked with a manager of kind ManagerKindClassicFP
+	// FileProvisioningReaderName is the reader/provisioner name of the legacy file
+	// provisioning source. When set, folders saved in kubernetes are marked with a
+	// manager of kind ManagerKindClassicFP and this value as the
+	// manager identity.
 	// NOTE: this is ignored when running legacy SQL storage
 	//
 	// Deprecated: this should only be used by the legacy file provisioning system
-	ManagerKindClassicFP string `json:"-"`
+	FileProvisioningReaderName string `json:"-"`
 }
 
 // MoveFolderCommand captures the information required by the folder service

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -196,7 +196,10 @@ func enforceManagerProperties(auth authtypes.AuthInfo, obj utils.GrafanaMetaAcce
 		// This can fallback to writing the value with a provisioning client
 		return errResourceIsManagedInRepository
 
-	case utils.ManagerKindPlugin, utils.ManagerKindClassicFP: // nolint:staticcheck
+	case utils.ManagerKindPlugin,
+		utils.ManagerKindClassicFP,                  // nolint:staticcheck
+		utils.ManagerKindClassicAPI,                 // nolint:staticcheck
+		utils.ManagerKindClassicConvertedPrometheus: // nolint:staticcheck
 		// ?? what identity do we use for legacy internal requests?
 		return nil // no error
 

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -105,7 +105,11 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 
 	// For non-Terraform managers, identity changes are also blocked.
 	// Remove the old manager first, then add a new one with a different identity.
-	if hasOld && managerNew.Kind != utils.ManagerKindTerraform && managerNew.Identity != managerOld.Identity {
+	//
+	// Classic shim kinds are exempt: their identity is absent or unstable (e.g. a
+	// file-provisioning reader name, or empty for API/converted-Prometheus origins),
+	// so it is not a user-defined stable ID and must not be treated as immutable.
+	if hasOld && managerNew.Kind != utils.ManagerKindTerraform && !managerNew.Kind.IsClassic() && managerNew.Identity != managerOld.Identity {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
 			Status:  metav1.StatusFailure,
 			Code:    http.StatusForbidden,

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -148,6 +148,103 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
+			// Classic kinds have an unstable or absent identity (a file-provisioning
+			// reader name, or empty for API/converted-Prometheus), so identity changes
+			// within the same classic kind are allowed rather than blocked.
+			name: "classic file-provisioning: identity change is allowed",
+			auth: provisioner,
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindClassicFP), //nolint:staticcheck
+						utils.AnnoKeyManagerIdentity: "reader-b",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindClassicFP), //nolint:staticcheck
+						utils.AnnoKeyManagerIdentity: "reader-a",
+					},
+				},
+			},
+		},
+		{
+			name: "classic converted-prometheus: identity change is allowed",
+			auth: user,
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindClassicConvertedPrometheus), //nolint:staticcheck
+						utils.AnnoKeyManagerIdentity: "b",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindClassicConvertedPrometheus), //nolint:staticcheck
+						utils.AnnoKeyManagerIdentity: "a",
+					},
+				},
+			},
+		},
+		{
+			// The classic exemption must not open a bypass: switching an existing
+			// non-classic manager to a classic kind is still a kind change and is
+			// blocked by the kind guard before the identity check is reached.
+			name: "changing a repo manager to a classic kind is blocked",
+			auth: provisioner,
+			err:  "Cannot change resource manager kind",
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindClassicFP), //nolint:staticcheck
+						utils.AnnoKeyManagerIdentity: "reader-a",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
+						utils.AnnoKeyManagerIdentity: "reader-a",
+					},
+				},
+			},
+		},
+		{
+			// Non-classic managers keep the identity-immutability guarantee.
+			name: "kubectl: identity change is still blocked",
+			auth: provisioner,
+			err:  "Cannot change resource manager identity",
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindKubectl),
+						utils.AnnoKeyManagerIdentity: "b",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindKubectl),
+						utils.AnnoKeyManagerIdentity: "a",
+					},
+				},
+			},
+		},
+		{
 			name: "changing manager kind is blocked",
 			auth: provisioner,
 			err:  "Cannot change resource manager",


### PR DESCRIPTION
Stacked on top of #128020 (which is stacked on #127698).

### What & why

The `CreateFolderCommand` / `UpdateFolderCommand` field `ManagerKindClassicFP` is named after a manager *kind* but actually holds the legacy file-provisioning **reader name**, which is used as the manager *identity*. This renames it to `FileProvisioningReaderName` to make the intent clear.

The apimachinery constant `utils.ManagerKindClassicFP` is deliberately **left unchanged** (it is an exported symbol referenced by downstream repos such as grafana-enterprise).

### Scope

Field rename only — no behavior change:
- `folder.CreateFolderCommand` / `folder.UpdateFolderCommand` field declaration + godoc
- call sites in `folderimpl`, `registry/apis/folders`, and `dashboards/service`

### Verification

`go build` + `go test` pass for `pkg/services/folder/...`, `pkg/registry/apis/folders`, and `pkg/services/dashboards/service`; gofmt clean.