### PR TITLE
Frontend: stop disabling keepalive on the Faro FetchTransport

### DIFF
--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -65,17 +65,10 @@ export class GrafanaJavascriptAgentBackend
         new FetchTransport({
           url: options.customEndpoint,
           apiKey: options.apiKey,
-          // When session replay is enabled, opt this transport out of fetch keepalive and turn
-          // on gzip request compression:
-          //  - keepalive: faro enables it per request when the body is under ~60KB, but the
-          //    browser's ~64KB budget is shared across all in-flight requests, so faro's
-          //    concurrent sends can collectively exceed it — leaving requests stuck "pending"
-          //    and dropping session replay segments.
-          //  - requestCompression: gzip-compresses request bodies via the browser's
-          //    CompressionStream (session replay produces the large payloads that benefit most),
-          //    falling back to uncompressed when CompressionStream is unavailable.
-          // When session replay is off, both are omitted so faro's defaults are left untouched.
-          ...(sessionReplayEnabled ? { requestOptions: { keepalive: false }, requestCompression: true } : {}),
+          // When session replay is enabled, gzip-compress request bodies via the browser's
+          // CompressionStream — session replay produces the large payloads that benefit most.
+          // Falls back to uncompressed when CompressionStream is unavailable.
+          ...(sessionReplayEnabled ? { requestCompression: true } : {}),
         })
       );
     }


### PR DESCRIPTION
faro hardened its fetch `keepalive` handling in [grafana/faro-web-sdk#2151](https://github.com/grafana/faro-web-sdk/pull/2151), released in [v2.8.1](https://github.com/grafana/faro-web-sdk/releases/tag/v2.8.1). With that fix in place, the session-replay workaround that forced `keepalive: false` on the Faro `FetchTransport` (added in #127191) is no longer necessary, so this removes it.

Grafana already depends on `@grafana/faro-web-sdk` `^2.8.2` on `main`, which resolves to [v2.8.2](https://github.com/grafana/faro-web-sdk/releases/tag/v2.8.2) and includes the fix — no dependency change needed.

gzip request compression (`requestCompression`, enabled for session replay in #127239) is unchanged.
