### PR TITLE
Runtime: Resolve template-variable refs to concrete instance identity in `getDataSourceInstance`

### DIFF
--- a/packages/grafana-runtime/src/services/dataSource/constants.ts
+++ b/packages/grafana-runtime/src/services/dataSource/constants.ts
@@ -1,3 +1,4 @@
 export const FALLBACK_TO_LEGACY_SETTINGS_WARNING = `DataSource: getDataSourceInstanceSettings found nothing in the new cache but the legacy DataSourceSrv did — falling back`;
 export const FALLBACK_TO_LEGACY_LIST_WARNING = `DataSource: getDataSourceInstanceList was empty but the legacy DataSourceSrv returned results — falling back`;
 export const FALLBACK_TO_LEGACY_INSTANCE_WARNING = `DataSource: getDataSourceInstance failed via the new path but the legacy DataSourceSrv resolved it — falling back`;
+export const PLUGIN_CACHE_UID_MISMATCH_WARNING = `DataSource: cached a plugin instance whose uid does not match its cache key — instance identity is wrong`;

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -298,6 +298,34 @@ describe('plugin', () => {
         expect(result.getRef()).toEqual({ type: settings.type, uid: settings.uid });
       });
 
+      it('constructs the concrete default instance when the variable interpolates to "default"', async () => {
+        const settings = ds();
+        initDataSourceInstanceSettings({ [settings.name]: settings }, settings.name);
+        setTemplateSrv({
+          getVariables: () => [],
+          replace: (v?: string) => (v === '${myds}' ? 'default' : (v ?? '')),
+        } as unknown as TemplateSrv);
+        setDataSourcePluginImporter(
+          jest.fn().mockResolvedValue({ DataSourceClass: CapturingDataSource, components: {} })
+        );
+
+        const result = await getDataSourceInstance('${myds}');
+
+        expect(result.uid).toBe(settings.uid);
+        expect(result.name).toBe(settings.name);
+        expect(result.getRef()).toEqual({ type: settings.type, uid: settings.uid });
+      });
+
+      it('constructs the concrete instance when the variable arrives inside a ref object', async () => {
+        const settings = seedAlphaWithVariable();
+
+        const result = await getDataSourceInstance({ uid: '${myds}', type: '' });
+
+        expect(result.uid).toBe(settings.uid);
+        expect(result.name).toBe(settings.name);
+        expect(result.getRef()).toEqual({ type: settings.type, uid: settings.uid });
+      });
+
       it('does not poison the concrete-uid cache entry after a variable-ref call', async () => {
         const settings = seedAlphaWithVariable();
 

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.test.ts
@@ -1,4 +1,10 @@
-import { DataSourceApi, type DataSourceInstanceSettings, type DataSourcePluginMeta } from '@grafana/data';
+import {
+  DataSourceApi,
+  type DataQueryResponse,
+  type DataSourceInstanceSettings,
+  type DataSourcePluginMeta,
+  type TestDataSourceResponse,
+} from '@grafana/data';
 
 import { TracedError } from '../../utils/TracedError';
 import { RuntimeDataSource } from '../RuntimeDataSource';
@@ -6,7 +12,7 @@ import { type DataSourceSrv, setDataSourceSrv } from '../dataSourceSrv';
 import { setLogger } from '../logging/registry';
 import { setTemplateSrv, type TemplateSrv } from '../templateSrv';
 
-import { FALLBACK_TO_LEGACY_INSTANCE_WARNING } from './constants';
+import { FALLBACK_TO_LEGACY_INSTANCE_WARNING, PLUGIN_CACHE_UID_MISMATCH_WARNING } from './constants';
 import {
   _resetForTests as resetPlugin,
   getDataSourceInstance,
@@ -255,6 +261,92 @@ describe('plugin', () => {
       // preloaded singleton instance. getDataSourceInstance has no such short-circuit yet.
       // Tracked in the async-vs-legacy divergences issue.
       it.todo('resolves expression refs to the preloaded singleton without importing');
+    });
+
+    describe('instance identity parity with DatasourceSrv.get (template-variable refs)', () => {
+      // Unlike the preset-instance mocks used elsewhere in this file, this class derives its
+      // identity from the settings the loader passes to the constructor — the identity a real
+      // plugin would have. Legacy get('$var') interpolates and returns the concrete instance,
+      // so instance.uid must be the real uid, never the variable string.
+      class CapturingDataSource extends DataSourceApi {
+        query(): Promise<DataQueryResponse> {
+          return Promise.resolve({ data: [] });
+        }
+        testDatasource(): Promise<TestDataSourceResponse> {
+          return Promise.resolve({ status: 'success', message: '' });
+        }
+      }
+
+      const seedAlphaWithVariable = (DataSourceClass: unknown = CapturingDataSource) => {
+        const settings = ds();
+        initDataSourceInstanceSettings({ [settings.name]: settings }, settings.name);
+        setTemplateSrv({
+          getVariables: () => [],
+          replace: (v?: string) => (v === '${myds}' ? settings.uid : (v ?? '')),
+        } as unknown as TemplateSrv);
+        setDataSourcePluginImporter(jest.fn().mockResolvedValue({ DataSourceClass, components: {} }));
+        return settings;
+      };
+
+      it('constructs the instance with the concrete identity on a cold cache', async () => {
+        const settings = seedAlphaWithVariable();
+
+        const result = await getDataSourceInstance('${myds}');
+
+        expect(result.uid).toBe(settings.uid);
+        expect(result.name).toBe(settings.name);
+        expect(result.getRef()).toEqual({ type: settings.type, uid: settings.uid });
+      });
+
+      it('does not poison the concrete-uid cache entry after a variable-ref call', async () => {
+        const settings = seedAlphaWithVariable();
+
+        const viaVariable = await getDataSourceInstance('${myds}');
+        const viaUid = await getDataSourceInstance(settings.uid);
+
+        expect(viaUid.uid).toBe(settings.uid);
+        expect(viaUid.getRef()).toEqual({ type: settings.type, uid: settings.uid });
+        expect(viaUid).toBe(viaVariable);
+      });
+
+      it('returns the concrete instance for a variable ref on a warm cache', async () => {
+        const settings = seedAlphaWithVariable();
+
+        const viaUid = await getDataSourceInstance(settings.uid);
+        const viaVariable = await getDataSourceInstance('${myds}');
+
+        expect(viaVariable).toBe(viaUid);
+        expect(viaVariable.uid).toBe(settings.uid);
+      });
+
+      it('patches legacy plugins (not extending DataSourceApi) with the concrete identity', async () => {
+        const legacyInstance: Record<string, unknown> = {};
+        const settings = seedAlphaWithVariable(jest.fn().mockReturnValue(legacyInstance));
+
+        const result = (await getDataSourceInstance('${myds}')) as unknown as Record<string, unknown>;
+
+        expect(result.uid).toBe(settings.uid);
+        expect(result.name).toBe(settings.name);
+        expect((result.getRef as () => unknown)()).toEqual({ type: settings.type, uid: settings.uid });
+      });
+
+      it('warns when a plugin instance is cached under a key that does not match its uid', async () => {
+        class MangledUidDataSource extends CapturingDataSource {
+          constructor(instanceSettings: DataSourceInstanceSettings) {
+            super(instanceSettings);
+            // uid is readonly on DataSourceApi; a badly-behaved plugin can still overwrite it at runtime.
+            (this as { uid: string }).uid = 'not-the-cache-key';
+          }
+        }
+        const settings = seedAlphaWithVariable(MangledUidDataSource);
+
+        await getDataSourceInstance(settings.uid);
+
+        expect(logWarning).toHaveBeenCalledWith(PLUGIN_CACHE_UID_MISMATCH_WARNING, {
+          cacheUid: settings.uid,
+          instanceUid: 'not-the-cache-key',
+        });
+      });
     });
 
     it('passes settings.meta to the importer', async () => {

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -48,15 +48,24 @@ export async function getDataSourceInstance(
   }
 
   try {
-    const settings = await getDataSourceInstanceSettings(ref, scopedVars);
+    let settings = await getDataSourceInstanceSettings(ref, scopedVars);
     if (!settings) {
       throw new Error(`Datasource ${describeRef(ref)} was not found`);
     }
 
-    // When ref is a template variable, settings.uid is the raw variable string
-    // (e.g. "${datasource}"). Use the resolved uid as the cache key so repeated
-    // calls for the same variable don't create duplicate instances.
-    const cacheUid = settings.rawRef?.uid ?? settings.uid;
+    // When ref is a template variable, the settings keep the variable string in uid/name
+    // (e.g. "${datasource}") with the resolved uid in rawRef — correct for the settings API,
+    // but a plugin instance built from them would carry the variable as its identity. Legacy
+    // DatasourceSrv.get() interpolates and returns the concrete instance, so re-resolve
+    // through rawRef and construct/cache from the concrete settings.
+    if (settings.rawRef && settings.rawRef.uid !== settings.uid) {
+      settings = await getDataSourceInstanceSettings(settings.rawRef);
+      if (!settings) {
+        throw new Error(`Datasource ${describeRef(ref)} was not found`);
+      }
+    }
+
+    const cacheUid = settings.uid;
 
     const cached = getCachedPlugin(cacheUid);
     if (cached) {

--- a/packages/grafana-runtime/src/services/dataSource/pluginCache.ts
+++ b/packages/grafana-runtime/src/services/dataSource/pluginCache.ts
@@ -1,5 +1,8 @@
 import { type DataSourceApi } from '@grafana/data';
 
+import { PLUGIN_CACHE_UID_MISMATCH_WARNING } from './constants';
+import { logDataSourceWarning } from './logging';
+
 const cache = new Map<string, DataSourceApi>();
 const runtimeCache = new Map<string, DataSourceApi>();
 
@@ -8,6 +11,13 @@ export function getCachedPlugin(uid: string): DataSourceApi | undefined {
 }
 
 export function setCachedPlugin(uid: string, instance: DataSourceApi): void {
+  // An instance whose uid differs from its cache key would be returned with the wrong
+  // identity for every future lookup of that key, so surface it while it's still local.
+  // An undefined uid is skipped: loaded instances always have one (set by the DataSourceApi
+  // constructor or the legacy patching in loadDataSourceInstance), so it indicates a test double.
+  if (instance.uid !== undefined && instance.uid !== uid) {
+    logDataSourceWarning(PLUGIN_CACHE_UID_MISMATCH_WARNING, { cacheUid: uid, instanceUid: instance.uid });
+  }
   cache.set(uid, instance);
 }
 


### PR DESCRIPTION
**What is this feature?**

Fixes a behavioral gap between `getDataSourceInstance()` and legacy `getDataSourceSrv().get()` for template-variable datasource refs — the gap behind revert #127870 (original PR #127578, which broke "Open in Explore" for panels using a datasource variable).

Legacy `get("$datasource")` interpolates and returns the concrete datasource instance. `getDataSourceInstance("$datasource")` resolves settings that intentionally preserve the variable in `uid`/`name` (correct for the settings API, matching legacy `getInstanceSettings`) — but then constructs the plugin instance from them, so `instance.uid` and `getRef().uid` are the literal string `"$datasource"`. That wrong-identity instance is then cached under the **concrete** uid, so one variable-ref call corrupts every subsequent `getDataSourceInstance(concreteUid)` lookup for the session.

**The fix:** when resolved settings carry a `rawRef` differing from `settings.uid`, re-resolve through `rawRef` and construct/cache from the concrete settings. The settings API is unchanged; only the instance layer changes.

Also adds a cache invariant: `setCachedPlugin` warns when an instance's uid doesn't match its cache key, so any future wrong-identity path surfaces immediately instead of poisoning silently.

**Why do we need this feature?**

Every migrated call site that can receive a variable ref is exposed (#125083). Fixing identity at the source unblocks re-landing the `explore.ts` migration and the held PRs #127595, #127597, #127510, and #127508, and removes the cache-poisoning path reachable from `SharePublicDashboardUtils` (#127438).

**Tests:**

New parity suite using a datasource class that derives identity from its constructor settings — the previous mocks returned preset instances, so constructor output was never inspected. Covers:

- cold-cache variable ref → concrete `uid`/`name`/`getRef()`
- variable-ref call does not poison the concrete-uid cache entry
- warm-cache variable ref returns the concrete instance
- legacy plugins (not extending `DataSourceApi`) patched with concrete identity
- cache invariant warns on uid/key mismatch

All of these (except warm cache) fail on main today.

**Which issue(s) does this PR fix?**

Follow-up to #127870, part of #125083.