### PR TITLE
Provisioning: treat classic-managed resources as managed in jobs

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/folders.go
+++ b/pkg/registry/apis/provisioning/jobs/export/folders.go
@@ -32,9 +32,10 @@ func ExportFolders(ctx context.Context, repoName string, options provisioning.Ex
 			return fmt.Errorf("extract meta accessor: %w", err)
 		}
 
-		manager, _ := meta.GetManagerProperties()
-		// Skip if already managed by any manager (repository, file provisioning, etc.)
-		if manager.Identity != "" {
+		_, managed := meta.GetManagerProperties()
+		// Skip if already managed by any manager (repository, file provisioning, etc.).
+		// Classic shim kinds are managed without an identity, so rely on the managed flag.
+		if managed {
 			return nil
 		}
 
@@ -135,7 +136,7 @@ func collectFolderAncestry(ctx context.Context, folderUID string, folderClient d
 		}
 		seen[current] = struct{}{}
 
-		if manager, _ := meta.GetManagerProperties(); manager.Identity != "" {
+		if _, managed := meta.GetManagerProperties(); managed {
 			return nil
 		}
 

--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -229,12 +229,12 @@ func exportItem(ctx context.Context,
 		return nil
 	}
 
-	manager, _ := meta.GetManagerProperties()
-	if manager.Identity != "" {
+	manager, managed := meta.GetManagerProperties()
+	if managed {
 		if explicitlyRequested {
 			// Leave the default action in place: the recorder discards errors
 			// on FileActionIgnored results, and we want this failure to count.
-			resultBuilder.WithError(fmt.Errorf("%s %q is managed by %q and cannot be exported", kindName, name, manager.Identity))
+			resultBuilder.WithError(fmt.Errorf("%s %q is managed by %q and cannot be exported", kindName, name, manager.Kind))
 			progress.Record(ctx, resultBuilder.Build())
 			return progress.TooManyErrors()
 		}

--- a/pkg/registry/apis/provisioning/jobs/migrate/clean.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/clean.go
@@ -52,9 +52,11 @@ func (c *namespaceCleaner) Clean(ctx context.Context, namespace string, progress
 				return nil // Continue with next resource
 			}
 
-			manager, _ := meta.GetManagerProperties()
-			// Skip if resource is managed by any provisioning system
-			if manager.Identity != "" {
+			_, managed := meta.GetManagerProperties()
+			// Skip if resource is managed by any provisioning system. Use the managed
+			// flag rather than a non-empty identity: classic shim kinds are reported as
+			// managed without an identity and would otherwise be deleted as orphans.
+			if managed {
 				resultBuilder.WithAction(repository.FileActionIgnored)
 				progress.Record(ctx, resultBuilder.Build())
 				return nil // Skip this resource

--- a/pkg/registry/apis/provisioning/jobs/migrate/clean_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/clean_test.go
@@ -292,6 +292,59 @@ func TestNamespaceCleaner_Clean(t *testing.T) {
 		clients.AssertExpectations(t)
 		progress.AssertExpectations(t)
 	})
+
+	t.Run("should skip classic-managed resources without an identity", func(t *testing.T) {
+		// A classic shim kind is reported as managed even though it has no manager
+		// identity. It must be ignored, not deleted as an orphan. Under the previous
+		// "identity != empty" check this resource would have been deleted.
+		mockDynamicClient := &mockDynamicInterface{
+			items: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "dashboard.grafana.app/v1alpha1",
+						"kind":       "Dashboard",
+						"metadata": map[string]interface{}{
+							"name": "classic-managed-dashboard",
+							"annotations": map[string]interface{}{
+								// Manager kind is set, but there is no manager identity.
+								"grafana.app/managedBy": "classic-converted-prometheus",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		clients := &mockClients{}
+		clients.On("ForKind", mock.Anything, schema.GroupVersionKind{Group: resources.DashboardResource.Group, Kind: resources.DashboardKind.Kind}).
+			Return(mockDynamicClient, resources.DashboardResource, nil)
+		clients.On("ForKind", mock.Anything, schema.GroupVersionKind{Group: resources.FolderResource.Group, Kind: resources.FolderKind.Kind}).
+			Return(mockDynamicClient, resources.FolderResource, nil)
+
+		mockClientFactory := resources.NewMockClientFactory(t)
+		mockClientFactory.On("Clients", mock.Anything, "test-namespace").
+			Return(clients, nil)
+
+		cleaner := NewNamespaceCleaner(mockClientFactory)
+		progress := jobs.NewMockJobProgressRecorder(t)
+		progress.On("SetMessage", mock.Anything, "remove unprovisioned folders").Return()
+		progress.On("SetMessage", mock.Anything, "remove unprovisioned dashboards").Return()
+
+		// The classic-managed resource must be ignored; a FileActionDeleted result
+		// would be an unexpected call and fail the test.
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action() == repository.FileActionIgnored &&
+				result.Name() == "classic-managed-dashboard" &&
+				result.Error() == nil
+		})).Return()
+
+		err := cleaner.Clean(context.Background(), "test-namespace", progress)
+		require.NoError(t, err)
+
+		mockClientFactory.AssertExpectations(t)
+		clients.AssertExpectations(t)
+		progress.AssertExpectations(t)
+	})
 }
 
 // mockDynamicInterface implements a simplified version of the dynamic.ResourceInterface

--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -155,7 +155,9 @@ func (r *ResourcesManager) WriteResourceFileFromObject(ctx context.Context, obj 
 
 	manager, _ := meta.GetManagerProperties()
 	// TODO: how should we handle this?
-	if manager.Identity == r.repo.Config().GetName() {
+	// Only treat it as already-in-repository when a repository manager owns it;
+	// matching on identity alone would misclassify other manager kinds.
+	if manager.Kind == utils.ManagerKindRepo && manager.Identity == r.repo.Config().GetName() {
 		// If it's already in the repository, we don't need to write it
 		return "", ErrAlreadyInRepository
 	}


### PR DESCRIPTION
Stacked on top of `moustafab/apimachinery-classic-shim-kinds` (which now includes the merged docs/guard change).

### Why

Now that classic shim kinds (`classic-file-provisioning`, `classic-api-provisioning`, `classic-converted-prometheus`) are reported as **managed even without a manager identity**, several provisioning jobs were left checking `manager.Identity != ""` (and ignoring `manager.Kind`) as their "is it managed?" test. Those spots disagree with the storage layer for classic-managed resources: they'd treat a managed resource as unmanaged.

The most serious case is the migrate cleaner, which **deletes** resources it considers unmanaged.

### Spots fixed

| File | Before | After |
|------|--------|-------|
| `jobs/migrate/clean.go` | `if manager.Identity != ""` → else **delete** | gate on the managed flag → classic-managed resource is ignored, not deleted |
| `jobs/export/resources.go` | `if manager.Identity != ""` skip export | gate on managed flag; error message now reports `manager.Kind` (identity may be empty) |
| `jobs/export/folders.go` (×2) | `if manager.Identity != ""` skip | gate on managed flag |
| `resources/resources.go` | `if manager.Identity == repoName` | also require `manager.Kind == ManagerKindRepo` |

### Tests

Adds a `NamespaceCleaner` case for a classic-managed resource with no identity: it must be **ignored, not deleted**. This case fails under the previous `Identity != ""` logic.

### Verification

`go build` + `go test ./pkg/registry/apis/provisioning/jobs/... ./pkg/registry/apis/provisioning/resources/...` pass; gofmt clean.