### PR TITLE
Dashboards: Fix loading indicator not clipping to panel border radius

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -8,7 +8,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 
 import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
-import { getFocusStyles } from '../../themes/mixins';
+import { getFocusStyles, getInternalRadius } from '../../themes/mixins';
 import { DelayRender } from '../../utils/DelayRender';
 import { usePointerDistance } from '../../utils/usePointerDistance';
 import { useElementSelection } from '../ElementSelectionContext/ElementSelectionContext';
@@ -603,8 +603,20 @@ const getStyles = (theme: GrafanaTheme2) => {
     loadingBarContainer: css({
       label: 'panel-loading-bar-container',
       position: 'absolute',
-      top: 0,
-      width: '100%',
+      // inset by the panel border width, so the bar sits on the panel's padding box
+      // rather than on top of the border itself
+      top: 1,
+      left: 1,
+      right: 1,
+      // the clip box has to be at least as tall as the corner radius. On a 1px-tall box the
+      // corner-overlap rule scales the radii down to 1px and nothing is rounded
+      // see https://drafts.csswg.org/css-backgrounds/#corner-overlap
+      height: theme.shape.radius.lg,
+      overflow: 'hidden',
+      borderTopLeftRadius: getInternalRadius(theme, 0, { parentBorderRadius: 'lg' }),
+      borderTopRightRadius: getInternalRadius(theme, 0, { parentBorderRadius: 'lg' }),
+      // the container is taller than the bar it clips, so let hover and clicks through to the header
+      pointerEvents: 'none',
       // this is to force the loading bar container to create a new stacking context
       // otherwise, in webkit browsers on windows/linux, the aliasing of panel text changes when the loading bar is shown
       // see https://github.com/grafana/grafana/issues/88104


### PR DESCRIPTION
## Summary

- Clip the panel loading bar to the panel card's top border radius so the blue loading indicator follows the rounded corners instead of rendering as a flat line that extends past the card edges
- Use `getInternalRadius` to match the panel's `lg` border radius token, consistent with other nested Grafana UI components
- Add `overflow: hidden` on the loading bar container to ensure the animated gradient is clipped at the corners

## Problem

<img width="1118" height="436" alt="image" src="https://github.com/user-attachments/assets/890ad935-42e5-4049-ad22-0a0ffa7598a3" />

The `LoadingBar` in `PanelChrome` is positioned at `top: 0` as a flat 1px horizontal line. Panel cards use `borderRadius: theme.shape.radius.lg`, but the loading bar container had no matching radius or clipping. This causes a visible mismatch at the top-left and top-right corners of dashboard panels — especially noticeable with the visual design refresh where panel `overflow` is `unset`.

## Test plan

- [ ] Open a dashboard with panels in a loading/refreshing state
- [ ] Verify the loading bar follows the rounded top corners of the panel card
- [ ] Check both default and visual design refresh themes
- [ ] Confirm loading bar still animates correctly across panels of different widths
- [ ] Run `PanelChrome` unit tests: `yarn test packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx`
