### PR TITLE
Trace View: Refactor links to logs

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1979,11 +1979,6 @@
       "count": 1
     }
   },
-  "public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx": {
-    "react-hooks/rules-of-hooks": {
-      "count": 1
-    }
-  },
   "public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineColumnResizer.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.test.tsx
@@ -20,7 +20,7 @@ import { DURATION, NONE, TAG } from '@grafana/o11y-ds-frontend';
 import { type SpanLinkDef } from '../types/links';
 import { type TraceSpan } from '../types/trace';
 
-import SpanBarRow, { type SpanBarRowProps } from './SpanBarRow';
+import { type SpanBarRowProps, SpanBarRow } from './SpanBarRow';
 
 describe('<SpanBarRow>', () => {
   const spanID = 'some-id';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.test.tsx
@@ -17,10 +17,10 @@ import userEvent from '@testing-library/user-event';
 
 import { DURATION, NONE, TAG } from '@grafana/o11y-ds-frontend';
 
-import { type SpanLinkDef } from '../types/links';
+import { type SpanLinkDef, SpanLinkType } from '../types/links';
 import { type TraceSpan } from '../types/trace';
 
-import { type SpanBarRowProps, SpanBarRow } from './SpanBarRow';
+import { SpanBarRow, type SpanBarRowProps } from './SpanBarRow';
 
 describe('<SpanBarRow>', () => {
   const spanID = 'some-id';
@@ -111,7 +111,12 @@ describe('<SpanBarRow>', () => {
       <SpanBarRow
         {...(props as unknown as SpanBarRowProps)}
         span={span}
-        createSpanLink={() => [{ href: 'href' }, { href: 'href' }] as SpanLinkDef[]}
+        createSpanLink={() =>
+          [
+            { href: 'href', type: SpanLinkType.Traces },
+            { href: 'href', type: SpanLinkType.Traces },
+          ] as SpanLinkDef[]
+        }
       />
     );
     expect(screen.getAllByTestId('SpanLinksMenu')).toHaveLength(1);
@@ -138,7 +143,11 @@ describe('<SpanBarRow>', () => {
       <SpanBarRow
         {...(props as unknown as SpanBarRowProps)}
         span={span}
-        createSpanLink={() => [{ content: 'This span is referenced by another span', href: 'href' }] as SpanLinkDef[]}
+        createSpanLink={() =>
+          [
+            { content: 'This span is referenced by another span', href: 'href', type: SpanLinkType.Traces },
+          ] as SpanLinkDef[]
+        }
       />
     );
     expect(screen.getByRole('link', { name: 'This span is referenced by another span' })).toBeInTheDocument();
@@ -191,7 +200,12 @@ describe('<SpanBarRow>', () => {
       <SpanBarRow
         {...(props as unknown as SpanBarRowProps)}
         span={span}
-        createSpanLink={() => [{ href: 'href' }, { href: 'href' }] as SpanLinkDef[]}
+        createSpanLink={() =>
+          [
+            { href: 'href', type: SpanLinkType.Traces },
+            { href: 'href', type: SpanLinkType.Traces },
+          ] as SpanLinkDef[]
+        }
       />
     );
     expect(screen.getAllByTestId('SpanLinksMenu')).toHaveLength(1);

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
@@ -15,11 +15,12 @@
 import { css, keyframes } from '@emotion/css';
 import cx from 'clsx';
 import * as React from 'react';
+import { memo, useMemo } from 'react';
 
 import { type GrafanaTheme2, type TraceKeyValuePair } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { DURATION, NONE, TAG } from '@grafana/o11y-ds-frontend';
-import { Icon, stylesFactory, Tooltip, withTheme2 } from '@grafana/ui';
+import { Icon, stylesFactory, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
 
 import { autoColor } from '../Theme';
 import { type SpanBarOptions } from '../settings/SpanBarSettings';
@@ -35,7 +36,6 @@ import SpanTreeOffset from './SpanTreeOffset';
 import Ticks from './Ticks';
 import TimelineRow from './TimelineRow';
 import { type ViewedBoundsFunctionType } from './utils';
-import { memo, useMemo } from 'react';
 
 const GRAFANA_ADAPTIVE_TRACES_RESTORED_TAG_KEY = 'grafana.adaptivetraces.restored';
 
@@ -384,7 +384,7 @@ export type SpanBarRowProps = {
   criticalPath: CriticalPathSection[];
 };
 
-const SpanBarRow = memo((props: SpanBarRowProps) => {
+export const SpanBarRow = memo((props: SpanBarRowProps) => {
   const {
     className = '',
     color,
@@ -407,7 +407,6 @@ const SpanBarRow = memo((props: SpanBarRowProps) => {
     removeHoverIndentGuideId,
     clippingLeft,
     clippingRight,
-    theme,
     createSpanLink,
     datasourceType,
     showServiceName,
@@ -425,7 +424,8 @@ const SpanBarRow = memo((props: SpanBarRowProps) => {
   const viewBounds = getViewedBounds(span.startTime, span.startTime + span.duration);
   const viewStart = viewBounds.start;
   const viewEnd = viewBounds.end;
-  const styles = getStyles(theme, showSpanFilterMatchesOnly, color);
+  const theme = useTheme2();
+  const styles = useStyles2(getStyles, showSpanFilterMatchesOnly, color);
 
   const labelDetail = `${serviceDisplayName}::${operationName}`;
   let longLabel;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
@@ -341,7 +341,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme2, showSpanFilterMatchesOnly
 
 export type SpanBarRowProps = {
   className?: string;
-  theme: GrafanaTheme2;
   color: string;
   spanBarOptions: SpanBarOptions | undefined;
   columnDivision: number;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
@@ -24,7 +24,7 @@ import { Icon, stylesFactory, Tooltip, withTheme2 } from '@grafana/ui';
 import { autoColor } from '../Theme';
 import { type SpanBarOptions } from '../settings/SpanBarSettings';
 import type TNil from '../types/TNil';
-import { type SpanLinkFunc } from '../types/links';
+import { SpanLinkType, type SpanLinkFunc } from '../types/links';
 import { type TraceSpan, type CriticalPathSection } from '../types/trace';
 import { formatDuration } from '../utils/date';
 import { getServiceDisplayName } from '../utils/service-name';
@@ -35,6 +35,7 @@ import SpanTreeOffset from './SpanTreeOffset';
 import Ticks from './Ticks';
 import TimelineRow from './TimelineRow';
 import { type ViewedBoundsFunctionType } from './utils';
+import { memo, useMemo } from 'react';
 
 const GRAFANA_ADAPTIVE_TRACES_RESTORED_TAG_KEY = 'grafana.adaptivetraces.restored';
 
@@ -383,7 +384,7 @@ export type SpanBarRowProps = {
   criticalPath: CriticalPathSection[];
 };
 
-const UnthemedSpanBarRow = React.memo<SpanBarRowProps>((props) => {
+const SpanBarRow = memo((props: SpanBarRowProps) => {
   const {
     className = '',
     color,
@@ -477,6 +478,11 @@ const UnthemedSpanBarRow = React.memo<SpanBarRowProps>((props) => {
     []
   );
 
+  const links = useMemo(
+    () => (createSpanLink?.(span) || []).filter((link) => link.type === SpanLinkType.Traces),
+    [createSpanLink, span]
+  );
+
   return (
     <TimelineRow
       className={cx(
@@ -567,45 +573,31 @@ const UnthemedSpanBarRow = React.memo<SpanBarRowProps>((props) => {
               </span>
             </Tooltip>
           )}
-          {createSpanLink &&
-            (() => {
-              const links = createSpanLink(span);
-              const count = links?.length || 0;
-              if (links && count === 1) {
-                if (!links[0]) {
-                  return null;
-                }
-
-                return (
-                  <a
-                    href={links[0].href}
-                    // Needs to have target otherwise preventDefault would not work due to angularRouter.
-                    target={'_blank'}
-                    style={{
-                      borderBottom: `2px solid ${color}CF`,
-                      paddingInline: '4px',
-                    }}
-                    rel="noopener noreferrer"
-                    onClick={
-                      links[0].onClick
-                        ? (event) => {
-                            if (!(event.ctrlKey || event.metaKey || event.shiftKey) && links[0].onClick) {
-                              event.preventDefault();
-                              links[0].onClick(event);
-                            }
-                          }
-                        : undefined
+          {links.length === 1 && (
+            <a
+              href={links[0].href}
+              // Needs to have target otherwise preventDefault would not work due to angularRouter.
+              target={'_blank'}
+              style={{
+                borderBottom: `2px solid ${color}CF`,
+                paddingInline: '4px',
+              }}
+              rel="noopener noreferrer"
+              onClick={
+                links[0].onClick
+                  ? (event) => {
+                      if (!(event.ctrlKey || event.metaKey || event.shiftKey) && links[0].onClick) {
+                        event.preventDefault();
+                        links[0].onClick(event);
+                      }
                     }
-                  >
-                    {links[0].content}
-                  </a>
-                );
-              } else if (links && count > 1) {
-                return <SpanLinksMenu links={links} datasourceType={datasourceType} color={color} />;
-              } else {
-                return null;
+                  : undefined
               }
-            })()}
+            >
+              {links[0].content}
+            </a>
+          )}
+          {links.length > 1 && <SpanLinksMenu links={links} datasourceType={datasourceType} color={color} />}
         </div>
       </TimelineRow.Cell>
       <TimelineRow.Cell
@@ -639,6 +631,4 @@ const UnthemedSpanBarRow = React.memo<SpanBarRowProps>((props) => {
   );
 });
 
-UnthemedSpanBarRow.displayName = 'UnthemedSpanBarRow';
-
-export default withTheme2(UnthemedSpanBarRow);
+SpanBarRow.displayName = 'SpanBarRow';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 
 import { CoreApp, type TimeRange } from '@grafana/data';
 import { usePluginLinks } from '@grafana/runtime';
+import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { SpanLinkType } from '../../types/links';
 import { type TraceSpan } from '../../types/trace';
@@ -69,6 +70,56 @@ describe('SpanDetailLinkButtons', () => {
 
     expect(screen.getAllByRole('button')).toHaveLength(1);
     expect(screen.getByText('Related logs')).toBeInTheDocument();
+  });
+
+  describe('logs link CTA copy', () => {
+    it.each([
+      {
+        name: 'shows "Related logs" when the datasource has no settings',
+        settings: undefined,
+        expectedCTA: 'Related logs',
+      },
+      {
+        name: 'shows "Related logs" when neither filterBySpanID nor filterByTraceID is set',
+        settings: { jsonData: { tracesToLogsV2: { customQuery: false } } },
+        expectedCTA: 'Related logs',
+      },
+      {
+        name: 'shows "Logs for this trace" when filterByTraceID is set',
+        settings: { jsonData: { tracesToLogsV2: { customQuery: false, filterByTraceID: true } } },
+        expectedCTA: 'Logs for this trace',
+      },
+      {
+        name: 'shows "Logs for this span" when filterBySpanID is set',
+        settings: { jsonData: { tracesToLogsV2: { customQuery: false, filterBySpanID: true } } },
+        expectedCTA: 'Logs for this span',
+      },
+      {
+        name: 'prefers "Logs for this span" when both filterBySpanID and filterByTraceID are set',
+        settings: {
+          jsonData: { tracesToLogsV2: { customQuery: false, filterBySpanID: true, filterByTraceID: true } },
+        },
+        expectedCTA: 'Logs for this span',
+      },
+    ])('$name', ({ settings, expectedCTA }) => {
+      (useDataSourceInstanceSettings as jest.Mock).mockReturnValue({ isLoading: false, settings });
+      createSpanLink.mockReturnValue([{ type: SpanLinkType.Logs, href: '/logs', title: 'Logs' }]);
+
+      render(
+        <SpanDetailLinkButtons
+          span={span}
+          createSpanLink={createSpanLink}
+          datasourceType="test"
+          datasourceUid="test-datasource-uid"
+          traceToProfilesOptions={undefined}
+          timeRange={timeRange}
+          app={CoreApp.Explore}
+        />
+      );
+
+      expect(screen.getAllByRole('button')).toHaveLength(1);
+      expect(screen.getByText(expectedCTA)).toBeInTheDocument();
+    });
   });
 
   it('should render profile link button when profiles link exists', () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
@@ -38,6 +38,7 @@ describe('getSpanDetailLinkButtons', () => {
       span,
       createSpanLink: undefined,
       datasourceType: 'test',
+      datasourceUid: 'test-datasource-uid',
       traceToProfilesOptions: undefined,
       timeRange,
       app: CoreApp.Explore,
@@ -53,6 +54,7 @@ describe('getSpanDetailLinkButtons', () => {
       span,
       createSpanLink,
       datasourceType: 'test',
+      datasourceUid: 'test-datasource-uid',
       traceToProfilesOptions: undefined,
       timeRange,
       app: CoreApp.Explore,
@@ -70,6 +72,7 @@ describe('getSpanDetailLinkButtons', () => {
       span,
       createSpanLink,
       datasourceType: 'test',
+      datasourceUid: 'test-datasource-uid',
       traceToProfilesOptions: {
         datasourceUid: 'test-uid',
         profileTypeId: 'test-type',
@@ -91,6 +94,7 @@ describe('getSpanDetailLinkButtons', () => {
       span,
       createSpanLink,
       datasourceType: 'test',
+      datasourceUid: 'test-datasource-uid',
       traceToProfilesOptions: undefined,
       timeRange,
       app: CoreApp.Explore,
@@ -118,6 +122,7 @@ describe('getSpanDetailLinkButtons', () => {
       span,
       createSpanLink,
       datasourceType: 'test',
+      datasourceUid: 'test-datasource-uid',
       traceToProfilesOptions: {
         datasourceUid: 'test-uid',
         profileTypeId: 'test-type',
@@ -150,6 +155,7 @@ describe('getSpanDetailLinkButtons', () => {
       span,
       createSpanLink,
       datasourceType: 'test',
+      datasourceUid: 'test-datasource-uid',
       traceToProfilesOptions: {
         datasourceUid: 'test-uid',
         profileTypeId: 'test-type',

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
@@ -1,14 +1,21 @@
+import { render, screen } from '@testing-library/react';
+
 import { CoreApp, type TimeRange } from '@grafana/data';
 import { usePluginLinks } from '@grafana/runtime';
 
 import { SpanLinkType } from '../../types/links';
 import { type TraceSpan } from '../../types/trace';
 
-import { getProfileLinkButtonsContext, getSpanDetailLinkButtons, RelatedProfilesTitle } from './SpanDetailLinkButtons';
+import { getProfileLinkButtonsContext, SpanDetailLinkButtons, RelatedProfilesTitle } from './SpanDetailLinkButtons';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   usePluginLinks: jest.fn().mockReturnValue({ isLoading: false, links: [] }),
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  useDataSourceInstanceSettings: jest.fn().mockReturnValue({ isLoading: false, settings: undefined }),
 }));
 
 const span = {
@@ -24,88 +31,89 @@ const timeRange = {
   to: new Date(1000),
 } as unknown as TimeRange;
 
-function getContent(result: ReturnType<typeof getSpanDetailLinkButtons>) {
-  return result.props.children.props.children[0];
-}
-
-describe('getSpanDetailLinkButtons', () => {
+describe('SpanDetailLinkButtons', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return empty buttons when createSpanLink is not provided', () => {
-    const result = getSpanDetailLinkButtons({
-      span,
-      createSpanLink: undefined,
-      datasourceType: 'test',
-      datasourceUid: 'test-datasource-uid',
-      traceToProfilesOptions: undefined,
-      timeRange,
-      app: CoreApp.Explore,
-    });
+  it('should render nothing when createSpanLink is not provided', () => {
+    const { container } = render(
+      <SpanDetailLinkButtons
+        span={span}
+        createSpanLink={undefined}
+        datasourceType="test"
+        datasourceUid="test-datasource-uid"
+        traceToProfilesOptions={undefined}
+        timeRange={timeRange}
+        app={CoreApp.Explore}
+      />
+    );
 
-    expect(result.props.children).toBeFalsy();
+    expect(container).toBeEmptyDOMElement();
   });
 
-  it('should create log link button when logs link exists', () => {
+  it('should render log link button when logs link exists', () => {
     createSpanLink.mockReturnValue([{ type: SpanLinkType.Logs, href: '/logs', title: 'Logs' }]);
 
-    const result = getSpanDetailLinkButtons({
-      span,
-      createSpanLink,
-      datasourceType: 'test',
-      datasourceUid: 'test-datasource-uid',
-      traceToProfilesOptions: undefined,
-      timeRange,
-      app: CoreApp.Explore,
-    });
+    render(
+      <SpanDetailLinkButtons
+        span={span}
+        createSpanLink={createSpanLink}
+        datasourceType="test"
+        datasourceUid="test-datasource-uid"
+        traceToProfilesOptions={undefined}
+        timeRange={timeRange}
+        app={CoreApp.Explore}
+      />
+    );
 
-    const content = getContent(result);
-    expect(content).toHaveLength(1);
-    expect(content[0].props.spanLinkModel.linkModel.title).toBe('Logs for this span');
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(screen.getByText('Related logs')).toBeInTheDocument();
   });
 
-  it('should create profile link button when profiles link exists', () => {
+  it('should render profile link button when profiles link exists', () => {
     createSpanLink.mockReturnValue([{ type: SpanLinkType.Profiles, href: '/profiles', title: RelatedProfilesTitle }]);
 
-    const result = getSpanDetailLinkButtons({
-      span,
-      createSpanLink,
-      datasourceType: 'test',
-      datasourceUid: 'test-datasource-uid',
-      traceToProfilesOptions: {
-        datasourceUid: 'test-uid',
-        profileTypeId: 'test-type',
-        customQuery: false,
-      },
-      timeRange,
-      app: CoreApp.Dashboard,
-    });
+    render(
+      <SpanDetailLinkButtons
+        span={span}
+        createSpanLink={createSpanLink}
+        datasourceType="test"
+        datasourceUid="test-datasource-uid"
+        traceToProfilesOptions={{
+          datasourceUid: 'test-uid',
+          profileTypeId: 'test-type',
+          customQuery: false,
+        }}
+        timeRange={timeRange}
+        app={CoreApp.Dashboard}
+      />
+    );
 
-    const content = getContent(result);
-    expect(content).toHaveLength(1);
-    expect(content[0].props.spanLinkModel.linkModel.title).toBe('Profiles for this span');
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(screen.getByText('Profiles for this span')).toBeInTheDocument();
   });
 
-  it('should create session link button when session link exists', () => {
+  it('should render session link button when session link exists', () => {
     createSpanLink.mockReturnValue([{ type: SpanLinkType.Session, href: '/session', title: 'Session' }]);
 
-    const result = getSpanDetailLinkButtons({
-      span,
-      createSpanLink,
-      datasourceType: 'test',
-      datasourceUid: 'test-datasource-uid',
-      traceToProfilesOptions: undefined,
-      timeRange,
-      app: CoreApp.Explore,
-    });
+    render(
+      <SpanDetailLinkButtons
+        span={span}
+        createSpanLink={createSpanLink}
+        datasourceType="test"
+        datasourceUid="test-datasource-uid"
+        traceToProfilesOptions={undefined}
+        timeRange={timeRange}
+        app={CoreApp.Explore}
+      />
+    );
 
-    const content = getContent(result);
-    expect(content).toHaveLength(1);
-    expect(content[0].props.spanLinkModel.linkModel.title).toBe('Session for this span');
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(screen.getByText('Session for this span')).toBeInTheDocument();
   });
 
-  it('should create profile drilldown button when plugin link exists', () => {
+  it('should render profile drilldown button when plugin link exists', () => {
     createSpanLink.mockReturnValue([{ type: SpanLinkType.Profiles, href: '/profiles', title: RelatedProfilesTitle }]);
     (usePluginLinks as jest.Mock).mockReturnValue({
       isLoading: false,
@@ -118,27 +126,28 @@ describe('getSpanDetailLinkButtons', () => {
       ],
     });
 
-    const result = getSpanDetailLinkButtons({
-      span,
-      createSpanLink,
-      datasourceType: 'test',
-      datasourceUid: 'test-datasource-uid',
-      traceToProfilesOptions: {
-        datasourceUid: 'test-uid',
-        profileTypeId: 'test-type',
-        customQuery: false,
-      },
-      timeRange,
-      app: CoreApp.Explore,
-    });
+    render(
+      <SpanDetailLinkButtons
+        span={span}
+        createSpanLink={createSpanLink}
+        datasourceType="test"
+        datasourceUid="test-datasource-uid"
+        traceToProfilesOptions={{
+          datasourceUid: 'test-uid',
+          profileTypeId: 'test-type',
+          customQuery: false,
+        }}
+        timeRange={timeRange}
+        app={CoreApp.Explore}
+      />
+    );
 
-    const content = getContent(result);
-    expect(content).toHaveLength(2);
-    expect(content[0].props.spanLinkModel.linkModel.title).toBe('Profiles for this span');
-    expect(content[1].props.spanLinkModel.linkModel.title).toBe('Open in Profiles Drilldown');
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+    expect(screen.getByText('Profiles for this span')).toBeInTheDocument();
+    expect(screen.getByText('Open in Profiles Drilldown')).toBeInTheDocument();
   });
 
-  it('should not create profile drilldown button when not in Explore', () => {
+  it('should not render profile drilldown button when not in Explore', () => {
     createSpanLink.mockReturnValue([{ type: SpanLinkType.Profiles, href: '/profiles', title: RelatedProfilesTitle }]);
     (usePluginLinks as jest.Mock).mockReturnValue({
       isLoading: false,
@@ -151,23 +160,25 @@ describe('getSpanDetailLinkButtons', () => {
       ],
     });
 
-    const result = getSpanDetailLinkButtons({
-      span,
-      createSpanLink,
-      datasourceType: 'test',
-      datasourceUid: 'test-datasource-uid',
-      traceToProfilesOptions: {
-        datasourceUid: 'test-uid',
-        profileTypeId: 'test-type',
-        customQuery: false,
-      },
-      timeRange,
-      app: CoreApp.Dashboard,
-    });
+    render(
+      <SpanDetailLinkButtons
+        span={span}
+        createSpanLink={createSpanLink}
+        datasourceType="test"
+        datasourceUid="test-datasource-uid"
+        traceToProfilesOptions={{
+          datasourceUid: 'test-uid',
+          profileTypeId: 'test-type',
+          customQuery: false,
+        }}
+        timeRange={timeRange}
+        app={CoreApp.Dashboard}
+      />
+    );
 
-    const content = getContent(result);
-    expect(content).toHaveLength(1);
-    expect(content[0].props.spanLinkModel.linkModel.title).toBe('Profiles for this span');
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(screen.getByText('Profiles for this span')).toBeInTheDocument();
+    expect(screen.queryByText('Open in Profiles Drilldown')).not.toBeInTheDocument();
   });
 });
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -34,6 +34,7 @@ export type Props = {
   span: TraceSpan;
   traceToProfilesOptions?: TraceToProfilesOptions;
   datasourceType: string;
+  datasourceUid: string;
   timeRange: TimeRange;
   createSpanLink?: SpanLinkFunc;
   app: CoreApp;
@@ -61,7 +62,8 @@ const MAX_LINKS = 3;
 const ABSOLUTE_LINK_PATTERN = /^https?:\/\//i;
 
 export const getSpanDetailLinkButtons = (props: Props) => {
-  const { span, createSpanLink, traceToProfilesOptions, timeRange, datasourceType, app, shareButton } = props;
+  const { span, createSpanLink, traceToProfilesOptions, timeRange, datasourceType, datasourceUid, app, shareButton } =
+    props;
 
   let linkToProfiles: SpanLinkDef | undefined;
   let content = shareButton ? <>{shareButton}</> : undefined;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -165,15 +165,9 @@ const styles = {
   }),
 };
 
-/**
- * Data source types that expose a trace-to-logs configuration and can therefore
- * produce a span/trace specific logs CTA.
- */
-const TRACE_TO_LOGS_DATASOURCE_TYPES = ['tempo', 'jaeger', 'zipkin'];
-
 function getLogsButtonCTA(settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined) {
   const defaultCTA = 'Related logs';
-  if (!settings || !TRACE_TO_LOGS_DATASOURCE_TYPES.includes(settings.type)) {
+  if (!settings) {
     return defaultCTA;
   }
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -61,7 +61,7 @@ const MAX_LINKS = 3;
 
 const ABSOLUTE_LINK_PATTERN = /^https?:\/\//i;
 
-export const getSpanDetailLinkButtons = (props: Props) => {
+export const SpanDetailLinkButtons = (props: Props) => {
   const { span, createSpanLink, traceToProfilesOptions, timeRange, datasourceType, datasourceUid, app, shareButton } =
     props;
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -13,7 +13,10 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { type TraceToProfilesOptions } from '@grafana/o11y-ds-frontend';
+import {
+  getTraceToLogsOptions,
+  type TraceToProfilesOptions,
+} from '@grafana/o11y-ds-frontend';
 import { config, locationService, reportInteraction, usePluginLinks } from '@grafana/runtime';
 import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataSourceJsonData, type DataSourceRef } from '@grafana/schema';
@@ -165,19 +168,26 @@ const styles = {
   }),
 };
 
+/**
+ * Data source types that expose a trace-to-logs configuration and can therefore
+ * produce a span/trace specific logs CTA.
+ */
+const TRACE_TO_LOGS_DATASOURCE_TYPES = ['tempo', 'jaeger', 'zipkin'];
+
 function getLogsButtonCTA(settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined) {
   const defaultCTA = 'Related logs';
-  if (!settings || settings.type !== 'tempo') {
+  if (!settings || !TRACE_TO_LOGS_DATASOURCE_TYPES.includes(settings.type)) {
     return defaultCTA;
   }
 
-  if ('tracesToLogsV2' in settings) {
-    if ('filterBySpanId' in settings && settings.filterBySpanId) {
-      return 'Logs for this span';
-    }
-    if ('filterByTraceID' in settings && settings.filterByTraceID) {
-      return 'Logs for this trace';
-    }
+  // The trace-to-logs config lives on jsonData; getTraceToLogsOptions also
+  // migrates the legacy `tracesToLogs` shape to the v2 shape.
+  const options = getTraceToLogsOptions(settings.jsonData);
+  if (options?.filterBySpanID) {
+    return 'Logs for this span';
+  }
+  if (options?.filterByTraceID) {
+    return 'Logs for this trace';
   }
 
   return defaultCTA;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -65,6 +65,16 @@ export const SpanDetailLinkButtons = (props: Props) => {
   const { span, createSpanLink, traceToProfilesOptions, timeRange, datasourceType, datasourceUid, app, shareButton } =
     props;
 
+  // Hooks must run unconditionally on every render, so fetch the plugin links up front.
+  // The context only depends on props, and the fetched links are only consumed below when
+  // a profiles link exists and we're in Explore.
+  const context = getProfileLinkButtonsContext(span, traceToProfilesOptions, timeRange);
+  const { links: pluginLinks } = usePluginLinks({
+    extensionPointId: PluginExtensionPoints.TraceViewDetails,
+    context,
+    limitPerPlugin: 1,
+  });
+
   let linkToProfiles: SpanLinkDef | undefined;
   let content = shareButton ? <>{shareButton}</> : undefined;
 
@@ -98,9 +108,6 @@ export const SpanDetailLinkButtons = (props: Props) => {
     if (linkToProfiles && app === CoreApp.Explore) {
       // ensure we have a profile link
       const profilesDrilldownPluginId = 'grafana-pyroscope-app';
-      const context = getProfileLinkButtonsContext(span, traceToProfilesOptions, timeRange);
-      const extensionPointId = PluginExtensionPoints.TraceViewDetails;
-      const { links: pluginLinks } = usePluginLinks({ extensionPointId, context, limitPerPlugin: 1 });
       const link =
         pluginLinks && pluginLinks.length > 0
           ? pluginLinks.find((link) => link.pluginId === profilesDrilldownPluginId)

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -92,13 +92,19 @@ export const SpanDetailLinkButtons = (props: Props) => {
         }
         if (link.type === SpanLinkType.Profiles && link.title === RelatedProfilesTitle) {
           linkToProfiles = link;
-          return createLinkModel(link, SpanLinkType.Profiles, 'Profiles for this span', 'link', datasourceType);
+          return createLinkModel(
+            link,
+            SpanLinkType.Profiles,
+            t('explore.span-detail-link-buttons.profiles-for-this-span', 'Profiles for this span'),
+            'link',
+            datasourceType
+          );
         }
         if (link.type === SpanLinkType.Session) {
           return createLinkModel(
             link,
             SpanLinkType.Session,
-            'Session for this span',
+            t('explore.span-detail-link-buttons.session-for-this-span', 'Session for this span'),
             'frontend-observability',
             datasourceType
           );
@@ -116,7 +122,7 @@ export const SpanDetailLinkButtons = (props: Props) => {
         pluginLinks && pluginLinks.length > 0
           ? pluginLinks.find((link) => link.pluginId === profilesDrilldownPluginId)
           : null;
-      const label = 'Open in Profiles Drilldown';
+      const label = t('explore.span-detail-link-buttons.open-in-profiles-drilldown', 'Open in Profiles Drilldown');
       const appLink: SpanLinkDef = {
         ...linkToProfiles,
         href: '',
@@ -166,7 +172,7 @@ const styles = {
 };
 
 function getLogsButtonCTA(settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined) {
-  const defaultCTA = 'Related logs';
+  const defaultCTA = t('explore.span-detail-link-buttons.related-logs', 'Related logs');
   if (!settings) {
     return defaultCTA;
   }
@@ -175,10 +181,10 @@ function getLogsButtonCTA(settings: DataSourceInstanceSettings<DataSourceJsonDat
   // migrates the legacy `tracesToLogs` shape to the v2 shape.
   const options = getTraceToLogsOptions(settings.jsonData);
   if (options?.filterBySpanID) {
-    return 'Logs for this span';
+    return t('explore.span-detail-link-buttons.logs-for-this-span', 'Logs for this span');
   }
   if (options?.filterByTraceID) {
-    return 'Logs for this trace';
+    return t('explore.span-detail-link-buttons.logs-for-this-trace', 'Logs for this trace');
   }
 
   return defaultCTA;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -1,8 +1,10 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
+import { useMemo } from 'react';
 
 import {
   CoreApp,
+  type DataSourceInstanceSettings,
   type GrafanaTheme2,
   type IconName,
   type LinkModel,
@@ -13,7 +15,8 @@ import {
 import { Trans, t } from '@grafana/i18n';
 import { type TraceToProfilesOptions } from '@grafana/o11y-ds-frontend';
 import { config, locationService, reportInteraction, usePluginLinks } from '@grafana/runtime';
-import { type DataSourceRef } from '@grafana/schema';
+import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { type DataSourceJsonData, type DataSourceRef } from '@grafana/schema';
 import { Button, DataLinkButton, Dropdown, Menu, useStyles2 } from '@grafana/ui';
 export const RelatedProfilesTitle = 'Related profiles';
 
@@ -75,16 +78,17 @@ export const SpanDetailLinkButtons = (props: Props) => {
     limitPerPlugin: 1,
   });
 
-  let linkToProfiles: SpanLinkDef | undefined;
-  let content = shareButton ? <>{shareButton}</> : undefined;
+  const { settings } = useDataSourceInstanceSettings(datasourceUid);
 
-  if (createSpanLink) {
-    const links = (createSpanLink(span) || [])
+  const links = useMemo(() => {
+    let linkToProfiles: SpanLinkDef | undefined;
+
+    const links = (createSpanLink?.(span) || [])
       // Linked spans are shown in a separate section
       .filter((link) => link.type !== SpanLinkType.Traces)
       .map((link) => {
         if (link.type === SpanLinkType.Logs) {
-          return createLinkModel(link, SpanLinkType.Logs, 'Logs for this span', 'gf-logs', datasourceType);
+          return createLinkModel(link, SpanLinkType.Logs, getLogsButtonCTA(settings), 'gf-logs', datasourceType);
         }
         if (link.type === SpanLinkType.Profiles && link.title === RelatedProfilesTitle) {
           linkToProfiles = link;
@@ -131,44 +135,53 @@ export const SpanDetailLinkButtons = (props: Props) => {
       return aValue - bValue;
     });
 
-    if (links.length > MAX_LINKS) {
-      content = (
-        <>
-          <DropDownMenu links={links}></DropDownMenu>
-          {shareButton}
-        </>
-      );
-    } else if (links.length > 0) {
-      content = (
-        <>
-          {links.map((spanLinkModel, index) => (
-            <SingleLinkButton spanLinkModel={spanLinkModel} key={index} />
-          ))}
-          {shareButton}
-        </>
-      );
-    }
-  }
+    return links;
+  }, [app, createSpanLink, datasourceType, pluginLinks, settings, span]);
 
-  if (!content) {
-    return <></>;
+  if (!links.length && !shareButton) {
+    return null;
   }
 
   return (
-    <span
-      className={css({
-        display: 'flex',
-        width: '100%',
-        flexDisplay: 'row',
-        flexWrap: 'wrap',
-        justifyContent: 'flex-end',
-        gap: '5px',
-      })}
-    >
-      {content}
+    <span className={styles.linksContainer}>
+      {links.length > MAX_LINKS ? (
+        <DropDownMenu links={links}></DropDownMenu>
+      ) : (
+        links.map((spanLinkModel, index) => <SingleLinkButton spanLinkModel={spanLinkModel} key={index} />)
+      )}
+      {shareButton}
     </span>
   );
 };
+
+const styles = {
+  linksContainer: css({
+    display: 'flex',
+    width: '100%',
+    flexDisplay: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
+    gap: '5px',
+  }),
+};
+
+function getLogsButtonCTA(settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined) {
+  const defaultCTA = 'Related logs';
+  if (!settings || settings.type !== 'tempo') {
+    return defaultCTA;
+  }
+
+  if ('tracesToLogsV2' in settings) {
+    if ('filterBySpanId' in settings && settings.filterBySpanId) {
+      return 'Logs for this span';
+    }
+    if ('filterByTraceID' in settings && settings.filterByTraceID) {
+      return 'Logs for this trace';
+    }
+  }
+
+  return defaultCTA;
+}
 
 function getResponsibleButtonStyles(theme: GrafanaTheme2) {
   return css({

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -13,10 +13,7 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import {
-  getTraceToLogsOptions,
-  type TraceToProfilesOptions,
-} from '@grafana/o11y-ds-frontend';
+import { getTraceToLogsOptions, type TraceToProfilesOptions } from '@grafana/o11y-ds-frontend';
 import { config, locationService, reportInteraction, usePluginLinks } from '@grafana/runtime';
 import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataSourceJsonData, type DataSourceRef } from '@grafana/schema';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
@@ -22,6 +22,13 @@ jest.mock('react-use/lib/useMeasure', () => ({
   default: () => [jest.fn(), { width: mockMeasuredWidth }],
 }));
 
+// SpanDetailLinkButtons resolves data source settings via an async hook; return a
+// synchronous value so rendering doesn't trigger an un-acted state update in tests.
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  useDataSourceInstanceSettings: jest.fn().mockReturnValue({ isLoading: false, settings: undefined }),
+}));
+
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -412,6 +412,7 @@ export default function SpanDetail(props: SpanDetailProps) {
     span,
     createSpanLink,
     datasourceType,
+    datasourceUid,
     traceToProfilesOptions,
     timeRange,
     app,

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -50,7 +50,7 @@ import AccordianLogs from './AccordianLogs';
 import AccordianReferences from './AccordianReferences';
 import type DetailState from './DetailState';
 import { ShareSpanButton } from './ShareSpanButton';
-import { getSpanDetailLinkButtons } from './SpanDetailLinkButtons';
+import { SpanDetailLinkButtons } from './SpanDetailLinkButtons';
 import SpanFlameGraph from './SpanFlameGraph';
 
 const useResourceAttributesExtensionLinks = ({
@@ -408,17 +408,6 @@ export default function SpanDetail(props: SpanDetailProps) {
     spanStartTime: startTime,
   });
 
-  const linksComponent = getSpanDetailLinkButtons({
-    span,
-    createSpanLink,
-    datasourceType,
-    datasourceUid,
-    traceToProfilesOptions,
-    timeRange,
-    app,
-    shareButton: <ShareSpanButton focusSpanLink={focusSpanLink} />,
-  });
-
   const listOfContentCards = [];
 
   listOfContentCards.push(
@@ -527,7 +516,16 @@ export default function SpanDetail(props: SpanDetailProps) {
           <h6 className={styles.operationName} title={operationName}>
             {operationName}
           </h6>
-          {linksComponent}
+          <SpanDetailLinkButtons
+            span={span}
+            createSpanLink={createSpanLink}
+            datasourceType={datasourceType}
+            datasourceUid={datasourceUid}
+            traceToProfilesOptions={traceToProfilesOptions}
+            timeRange={timeRange}
+            app={app}
+            shareButton={<ShareSpanButton focusSpanLink={focusSpanLink} />}
+          />
         </div>
         <div className={styles.listWrapper}>
           <LabeledList className={styles.list} divider={false} items={overviewItems} color={color} />

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.test.tsx
@@ -17,6 +17,13 @@ import { render, screen } from '@testing-library/react';
 import { createTheme, dateTime } from '@grafana/data';
 import { setPluginLinksHook } from '@grafana/runtime';
 
+// SpanDetailLinkButtons resolves data source settings via an async hook; return a
+// synchronous value so rendering doesn't trigger an un-acted state update in tests.
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  useDataSourceInstanceSettings: jest.fn().mockReturnValue({ isLoading: false, settings: undefined }),
+}));
+
 import DetailState from './SpanDetail/DetailState';
 import SpanDetailRow, { type SpanDetailRowProps } from './SpanDetailRow';
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -35,7 +35,7 @@ import { getColorByKey } from '../utils/color-generator';
 import { getServiceColorKey, getServiceDisplayName } from '../utils/service-name';
 
 import ListView from './ListView';
-import SpanBarRow from './SpanBarRow';
+import { SpanBarRow } from './SpanBarRow';
 import { type TraceFlameGraphs } from './SpanDetail';
 import type DetailState from './SpanDetail/DetailState';
 import SpanDetailRow from './SpanDetailRow';

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8757,6 +8757,14 @@
       },
       "share-span": "Share"
     },
+    "span-detail-link-buttons": {
+      "logs-for-this-span": "Logs for this span",
+      "logs-for-this-trace": "Logs for this trace",
+      "open-in-profiles-drilldown": "Open in Profiles Drilldown",
+      "profiles-for-this-span": "Profiles for this span",
+      "related-logs": "Related logs",
+      "session-for-this-span": "Session for this span"
+    },
     "span-flame-graph": {
       "flame-graph": "Flame graph"
     },


### PR DESCRIPTION
This PR updates the Trace View component to show more accurate link to logs buttons, where the call to action reflects the underlying trace-to-logs configuration options, which optionally filters by span_id and trace_id.

<img width="303" height="82" alt="imagen" src="https://github.com/user-attachments/assets/f187b584-15dc-4afa-a925-de7113002fc1" />

When no filter is active, it shows "related logs" by default.

<img width="986" height="179" alt="Related logs" src="https://github.com/user-attachments/assets/3f61dac3-afb6-41c4-9de5-f230a4f7a364" />

Or if filters are enabled, it shows the corresponding copy:

<img width="1000" height="219" alt="Logs for this trace" src="https://github.com/user-attachments/assets/9a8848ce-d647-42bf-b0a7-8cb7a04d79a4" />

<img width="1002" height="195" alt="Logs for this span" src="https://github.com/user-attachments/assets/f737f043-518a-4fca-b694-a36b1396896c" />


Additionally, we're removing the link to logs from every span, now making it only available when expanding a particular span. The next step that we want to explore is to validate the presence of logs when showing that button.

Before:

<img width="1052" height="244" alt="Before" src="https://github.com/user-attachments/assets/a9d127ab-cbec-438b-82db-5c3019fba227" />

After:

<img width="1057" height="234" alt="After" src="https://github.com/user-attachments/assets/b57d9a3a-ea57-422f-a902-9401f970afa2" />

Part of https://github.com/grafana/grafana/issues/127150

Other changes:
- Refactored `getSpanDetailLinkButtons` to be a proper React component
- Fixed a conditionally called React hook in `SpanDetailLinkButtons`
- Migrated `SpanBarRow` from class to functional component