### PR TITLE
Alerting: add Silence button to rule details drawer in Alert Activity

### DIFF
--- a/public/app/features/alerting/unified/triage/rule-details/RuleDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/rule-details/RuleDetailsDrawer.tsx
@@ -74,9 +74,6 @@ interface LoadedRuleDetailsDrawerProps {
 function LoadedRuleDetailsDrawer({ rule, ruleUID, onClose }: LoadedRuleDetailsDrawerProps) {
   const [activeTab, setActiveTab] = useState<DrawerTab>(DrawerTab.Query);
   const [showSilenceDrawer, setShowSilenceDrawer] = useState(false);
-
-  // useAlertRuleAbility encapsulates both the rule-type support check (Grafana alerting rules only)
-  // and the permission check (global + folder-scoped AlertingSilenceCreate)
   const [silenceSupported, silenceAllowed] = useAlertRuleAbility(rule, AlertRuleAction.Silence);
 
   const { rulerRule, promRule } = rule;

--- a/public/app/features/alerting/unified/triage/rule-details/RuleDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/rule-details/RuleDetailsDrawer.tsx
@@ -2,14 +2,16 @@ import { useMemo, useState } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
-import { Alert, Box, Drawer, LinkButton, Stack, Tab, TabContent, TabsBar, Text } from '@grafana/ui';
-import { type GrafanaRuleIdentifier } from 'app/types/unified-alerting';
+import { Alert, Box, Button, Drawer, LinkButton, Stack, Tab, TabContent, TabsBar, Text, Tooltip } from '@grafana/ui';
+import { type CombinedRule, type GrafanaRuleIdentifier } from 'app/types/unified-alerting';
 
 import { Spacer } from '../../components/Spacer';
 import { WithReturnButton } from '../../components/WithReturnButton';
 import { Details } from '../../components/rule-viewer/Details';
 import { Title } from '../../components/rule-viewer/RuleViewer';
 import { QueryAndCondition } from '../../components/rule-viewer/tabs/QueryAndCondition';
+import SilenceGrafanaRuleDrawer from '../../components/silences/SilenceGrafanaRuleDrawer';
+import { AlertRuleAction, useAlertRuleAbility } from '../../hooks/useAbilities';
 import { useCombinedRule } from '../../hooks/useCombinedRule';
 import { stringifyErrorLike } from '../../utils/misc';
 import { rulesNav } from '../../utils/navigation';
@@ -26,8 +28,6 @@ enum DrawerTab {
 }
 
 export function RuleDetailsDrawer({ ruleUID, onClose }: RuleDetailsDrawerProps) {
-  const [activeTab, setActiveTab] = useState<DrawerTab>(DrawerTab.Query);
-
   // Create rule identifier for Grafana managed rules
   const ruleIdentifier: GrafanaRuleIdentifier = useMemo(
     () => ({
@@ -62,68 +62,109 @@ export function RuleDetailsDrawer({ ruleUID, onClose }: RuleDetailsDrawerProps) 
     );
   }
 
+  return <LoadedRuleDetailsDrawer rule={rule} ruleUID={ruleUID} onClose={onClose} />;
+}
+
+interface LoadedRuleDetailsDrawerProps {
+  rule: CombinedRule;
+  ruleUID: string;
+  onClose: () => void;
+}
+
+function LoadedRuleDetailsDrawer({ rule, ruleUID, onClose }: LoadedRuleDetailsDrawerProps) {
+  const [activeTab, setActiveTab] = useState<DrawerTab>(DrawerTab.Query);
+  const [showSilenceDrawer, setShowSilenceDrawer] = useState(false);
+
+  // useAlertRuleAbility encapsulates both the rule-type support check (Grafana alerting rules only)
+  // and the permission check (global + folder-scoped AlertingSilenceCreate)
+  const [silenceSupported, silenceAllowed] = useAlertRuleAbility(rule, AlertRuleAction.Silence);
+
   const { rulerRule, promRule } = rule;
   const isPaused = rulerRuleType.grafana.rule(rulerRule) && isPausedRule(rulerRule);
   const ruleOrigin = rulerRule ? getRulePluginOrigin(rulerRule) : getRulePluginOrigin(promRule);
 
   return (
-    <Drawer
-      onClose={onClose}
-      title={
-        <Stack direction="column">
-          <Stack direction="row" alignItems="center">
-            <Title
-              name={rule.name}
-              paused={isPaused}
-              state={prometheusRuleType.alertingRule(promRule) ? promRule.state : undefined}
-              health={promRule?.health}
-              ruleType={promRule?.type}
-              ruleOrigin={ruleOrigin}
-            />
-            <Spacer />
-            <Box marginRight={4}>
-              <WithReturnButton
-                component={
-                  <LinkButton
-                    icon="eye"
-                    variant="secondary"
-                    href={rulesNav.detailsPageLink('grafana', {
-                      ruleSourceName: 'grafana',
-                      uid: rule.uid ?? '',
-                    })}
-                    target="_blank"
-                    size="sm"
-                  >
-                    <Trans i18nKey="alerting.rule-details-drawer.go-to-detail-view">View alert rule</Trans>
-                  </LinkButton>
-                }
+    <>
+      <Drawer
+        onClose={onClose}
+        title={
+          <Stack direction="column">
+            <Stack direction="row" alignItems="center">
+              <Title
+                name={rule.name}
+                paused={isPaused}
+                state={prometheusRuleType.alertingRule(promRule) ? promRule.state : undefined}
+                health={promRule?.health}
+                ruleType={promRule?.type}
+                ruleOrigin={ruleOrigin}
               />
-            </Box>
+              <Spacer />
+              <Stack direction="row" gap={1} alignItems="center">
+                {silenceSupported &&
+                  (silenceAllowed ? (
+                    <Button icon="bell-slash" variant="secondary" size="sm" onClick={() => setShowSilenceDrawer(true)}>
+                      <Trans i18nKey="alerting.rule-details-drawer.silence-button">Silence</Trans>
+                    </Button>
+                  ) : (
+                    <Tooltip
+                      content={t(
+                        'alerting.triage.instance-details-drawer.silence-no-permission',
+                        'You do not have permission to create silences'
+                      )}
+                    >
+                      <Button icon="bell-slash" variant="secondary" size="sm" disabled>
+                        <Trans i18nKey="alerting.rule-details-drawer.silence-button">Silence</Trans>
+                      </Button>
+                    </Tooltip>
+                  ))}
+                <Box marginRight={4}>
+                  <WithReturnButton
+                    component={
+                      <LinkButton
+                        icon="eye"
+                        variant="secondary"
+                        href={rulesNav.detailsPageLink('grafana', {
+                          ruleSourceName: 'grafana',
+                          uid: rule.uid ?? '',
+                        })}
+                        target="_blank"
+                        size="sm"
+                      >
+                        <Trans i18nKey="alerting.rule-details-drawer.go-to-detail-view">View alert rule</Trans>
+                      </LinkButton>
+                    }
+                  />
+                </Box>
+              </Stack>
+            </Stack>
+            <Text color="secondary">{t('alerting.triage.rule-details.subtitle', 'Rule details and conditions')}</Text>
           </Stack>
-          <Text color="secondary">{t('alerting.triage.rule-details.subtitle', 'Rule details and conditions')}</Text>
-        </Stack>
-      }
-      size="md"
-      tabs={
-        <TabsBar>
-          <Tab
-            label={t('alerting.rule-viewer.tab.query-conditions', 'Query and conditions')}
-            active={activeTab === DrawerTab.Query}
-            onChangeTab={() => setActiveTab(DrawerTab.Query)}
-          />
-          <Tab
-            label={t('alerting.rule-viewer.tab.details', 'Details')}
-            active={activeTab === DrawerTab.Details}
-            onChangeTab={() => setActiveTab(DrawerTab.Details)}
-          />
-        </TabsBar>
-      }
-    >
-      <TabContent>
-        {activeTab === DrawerTab.Query && <QueryAndCondition rule={rule} />}
-        {activeTab === DrawerTab.Details && <Details rule={rule} />}
-      </TabContent>
-    </Drawer>
+        }
+        size="md"
+        tabs={
+          <TabsBar>
+            <Tab
+              label={t('alerting.rule-viewer.tab.query-conditions', 'Query and conditions')}
+              active={activeTab === DrawerTab.Query}
+              onChangeTab={() => setActiveTab(DrawerTab.Query)}
+            />
+            <Tab
+              label={t('alerting.rule-viewer.tab.details', 'Details')}
+              active={activeTab === DrawerTab.Details}
+              onChangeTab={() => setActiveTab(DrawerTab.Details)}
+            />
+          </TabsBar>
+        }
+      >
+        <TabContent>
+          {activeTab === DrawerTab.Query && <QueryAndCondition rule={rule} />}
+          {activeTab === DrawerTab.Details && <Details rule={rule} />}
+        </TabContent>
+      </Drawer>
+      {silenceSupported && showSilenceDrawer && (
+        <SilenceGrafanaRuleDrawer ruleUid={ruleUID} onClose={() => setShowSilenceDrawer(false)} />
+      )}
+    </>
   );
 }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2822,7 +2822,8 @@
       "label-data-source": "Data source"
     },
     "rule-details-drawer": {
-      "go-to-detail-view": "View alert rule"
+      "go-to-detail-view": "View alert rule",
+      "silence-button": "Silence"
     },
     "rule-details-expression": {
       "label-expression": "Expression"


### PR DESCRIPTION
**What is this feature?**

Adds a Silence button to the rule details drawer in the Alert Activity (triage) view, next to the existing "View alert rule" button.

**Why do we need this feature?**

When triaging alerts in the Alert Activity view, users can open a rule details drawer to inspect a rule's query and conditions. There was no way to silence the rule from this context — you had to either navigate to the full rule details page or open an individual instance details drawer. The instance details drawer already has a Silence button; this brings the same capability to the rule-level drawer for consistency.

**Who is this feature for?**

Alert operators and on-call engineers using the Alert Activity triage view to investigate and act on firing rules.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The button only appears for Grafana-managed alerting rules (not recording rules or datasource-managed rules).
- Permission checks mirror those in `InstanceDetailsDrawerTitle`: checks both the global `AlertingSilenceCreate`/`AlertingInstanceCreate` permissions and the folder-scoped `AlertingSilenceCreate` permission. Shows a disabled button with a tooltip when the user lacks permission.
- Clicking opens `SilenceGrafanaRuleDrawer` (the same component used by the rule actions menu on the rules list and rule detail page), which creates a rule-scoped silence.
- Also fixes a pre-existing typo in the file: `app/types/unified-alerter` → `app/types/unified-alerting`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.