### PR TITLE
TestData: Add Predictable Annotations scenario

### DIFF
--- a/pkg/tsdb/grafana-testdata-datasource/kinds/query.go
+++ b/pkg/tsdb/grafana-testdata-datasource/kinds/query.go
@@ -65,6 +65,7 @@ const (
 	TestDataQueryTypeManualEntry                  TestDataQueryType = "manual_entry"
 	TestDataQueryTypeNoDataPoints                 TestDataQueryType = "no_data_points"
 	TestDataQueryTypeNodeGraph                    TestDataQueryType = "node_graph"
+	TestDataQueryTypePredictableAnnotations       TestDataQueryType = "predictable_annotations"
 	TestDataQueryTypePredictableCsvWave           TestDataQueryType = "predictable_csv_wave"
 	TestDataQueryTypePredictablePulse             TestDataQueryType = "predictable_pulse"
 	TestDataQueryTypeQueryMeta                    TestDataQueryType = "query_meta"
@@ -117,11 +118,28 @@ type TestDataQuery struct {
 	SpanCount       int         `json:"spanCount,omitempty"`
 	ErrorSource     ErrorSource `json:"errorSource,omitempty"`
 
-	Nodes     *NodesQuery      `json:"nodes,omitempty"`
-	PulseWave *PulseWaveQuery  `json:"pulseWave,omitempty"`
-	Sim       *SimulationQuery `json:"sim,omitempty"`
-	Stream    *StreamingQuery  `json:"stream,omitempty"`
-	Usa       *USAQuery        `json:"usa,omitempty"`
+	Nodes                  *NodesQuery                  `json:"nodes,omitempty"`
+	PredictableAnnotations *PredictableAnnotationsQuery `json:"predictableAnnotations,omitempty"`
+	PulseWave              *PulseWaveQuery              `json:"pulseWave,omitempty"`
+	Sim                    *SimulationQuery             `json:"sim,omitempty"`
+	Stream                 *StreamingQuery              `json:"stream,omitempty"`
+	Usa                    *USAQuery                    `json:"usa,omitempty"`
+}
+
+// PredictableAnnotationsQuery defines model for PredictableAnnotationsQuery.
+type PredictableAnnotationsQuery struct {
+	// How often a point-in-time event annotation occurs, as a Go duration string (e.g. "1h", "10m").
+	EventFrequency string `json:"eventFrequency,omitempty"`
+
+	// How often an incident (region) annotation starts, as a Go duration string (e.g. "6h").
+	IncidentFrequency string `json:"incidentFrequency,omitempty"`
+
+	// How long each incident lasts, as a Go duration string (e.g. "20m").
+	IncidentDuration string `json:"incidentDuration,omitempty"`
+
+	// Seed used to deterministically pick each annotation's text and tags. The same
+	// seed always produces the same annotations, independent of the selected time range.
+	Seed int64 `json:"seed,omitempty"`
 }
 
 // CSVWave defines model for CSVWave.

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -9,6 +9,7 @@ import (
 	"hash/fnv"
 	"math"
 	"math/rand"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -65,6 +66,22 @@ Timestamps will line up evenly on timeStepSeconds (For example, 60 seconds means
 		ID:      kinds.TestDataQueryTypePredictableCsvWave,
 		Name:    "Predictable CSV Wave",
 		handler: s.handlePredictableCSVWaveScenario,
+	})
+
+	s.registerScenario(&Scenario{
+		ID:      kinds.TestDataQueryTypePredictableAnnotations,
+		Name:    "Predictable Annotations",
+		handler: s.handlePredictableAnnotationsScenario,
+		Description: `Predictable Annotations returns annotations generated on the backend.
+Unlike the client-side "Annotations" scenario (which spreads a fixed count across whatever time range is selected),
+these are anchored to absolute time (from the epoch) so a given annotation always occurs at the same instant.
+Panning or zooming the time range only changes which annotations fall inside it, not the annotations themselves.
+
+Two kinds are produced:
+  - events:    point-in-time annotations, one every eventFrequency.
+  - incidents: region annotations lasting incidentDuration, one starting every incidentFrequency.
+
+Each annotation's text and tags are chosen deterministically from the seed, so the same seed always yields the same content.`,
 	})
 
 	s.registerScenario(&Scenario{
@@ -513,6 +530,28 @@ func (s *Service) handlePredictablePulseScenario(ctx context.Context, req *backe
 		if err != nil {
 			continue
 		}
+		respD.Frames = append(respD.Frames, frame)
+		resp.Responses[q.RefID] = respD
+	}
+
+	return resp, nil
+}
+
+func (s *Service) handlePredictableAnnotationsScenario(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	resp := backend.NewQueryDataResponse()
+
+	for _, q := range req.Queries {
+		model, err := GetJSONModel(q.JSON)
+		if err != nil {
+			return nil, err
+		}
+
+		frame, err := predictableAnnotations(q, model)
+		if err != nil {
+			return nil, err
+		}
+
+		respD := resp.Responses[q.RefID]
 		respD.Frames = append(respD.Frames, frame)
 		resp.Responses[q.RefID] = respD
 	}
@@ -1135,6 +1174,181 @@ func predictablePulse(query backend.DataQuery, model kinds.TestDataQuery) (*data
 	setFrameType(frame, data.FrameTypeTimeSeriesMulti, data.FrameTypeVersion{0, 0})
 
 	return frame, nil
+}
+
+// Default annotation cadence, used when the query leaves a value unset.
+const (
+	defaultAnnotationEventFrequency    = time.Hour
+	defaultAnnotationIncidentFrequency = 6 * time.Hour
+	defaultAnnotationIncidentDuration  = 10 * time.Minute
+	// maxAnnotations caps the response so a huge range with a tiny frequency
+	// can't generate an unbounded number of rows.
+	maxAnnotations = 10000
+)
+
+var (
+	annotationEventTexts = []string{
+		"Deployment completed",
+		"Config reloaded",
+		"Cache flushed",
+		"Autoscaler scaled up",
+		"Feature flag toggled",
+		"Backup finished",
+		"Certificate rotated",
+	}
+	annotationIncidentTexts = []string{
+		"High request latency",
+		"Elevated error rate",
+		"Service degradation",
+		"Database saturation",
+		"Upstream provider outage",
+	}
+	annotationIncidentSeverities = []string{"critical", "warning", "minor"}
+	annotationTagPool            = []string{"server", "database", "network", "deploy", "cache", "cpu", "memory", "disk", "api"}
+)
+
+// annotationRow is one generated annotation before it is split into frame fields.
+type annotationRow struct {
+	time    time.Time
+	timeEnd *time.Time // nil for point-in-time events, set for incident regions
+	text    string
+	tags    string // comma-separated; the annotation mapper splits this into a tag list
+}
+
+// annotationHash deterministically maps (seed, kind, index) to a value so that a
+// given annotation always renders with the same text and tags regardless of the
+// selected time range.
+func annotationHash(seed int64, kind string, index int64) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(fmt.Sprintf("%d|%s|%d", seed, kind, index)))
+	return h.Sum64()
+}
+
+// annotationDuration parses a Go duration string, falling back to def when empty.
+func annotationDuration(s string, def time.Duration) (time.Duration, error) {
+	if strings.TrimSpace(s) == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, err
+	}
+	return d, nil
+}
+
+// predictableAnnotations builds a single annotations data frame. Events and incidents
+// are anchored to absolute time (the epoch), so the same annotation always occurs at
+// the same instant; the time range only controls which ones are returned.
+func predictableAnnotations(query backend.DataQuery, model kinds.TestDataQuery) (*data.Frame, error) {
+	opts := model.PredictableAnnotations
+	if opts == nil {
+		opts = &kinds.PredictableAnnotationsQuery{}
+	}
+
+	eventFreq, err := annotationDuration(opts.EventFrequency, defaultAnnotationEventFrequency)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse eventFrequency '%s': %w", opts.EventFrequency, err)
+	}
+	incidentFreq, err := annotationDuration(opts.IncidentFrequency, defaultAnnotationIncidentFrequency)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse incidentFrequency '%s': %w", opts.IncidentFrequency, err)
+	}
+	incidentDur, err := annotationDuration(opts.IncidentDuration, defaultAnnotationIncidentDuration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse incidentDuration '%s': %w", opts.IncidentDuration, err)
+	}
+	if incidentDur < 0 {
+		return nil, fmt.Errorf("incidentDuration must not be negative")
+	}
+
+	from := query.TimeRange.From.UnixMilli()
+	to := query.TimeRange.To.UnixMilli()
+	seed := opts.Seed
+
+	rows := make([]annotationRow, 0)
+
+	// Events: a point annotation every eventFreq, aligned to the epoch.
+	if eventFreqMs := eventFreq.Milliseconds(); eventFreqMs > 0 {
+		for n := ceilDiv(from, eventFreqMs); ; n++ {
+			t := n * eventFreqMs
+			if t > to || len(rows) >= maxAnnotations {
+				break
+			}
+			h := annotationHash(seed, "event", n)
+			text := annotationEventTexts[h%uint64(len(annotationEventTexts))]
+			tag := annotationTagPool[(h>>8)%uint64(len(annotationTagPool))]
+			rows = append(rows, annotationRow{
+				time: time.UnixMilli(t),
+				text: text,
+				tags: "event," + tag,
+			})
+		}
+	}
+
+	// Incidents: a region annotation lasting incidentDur, starting every incidentFreq,
+	// aligned to the epoch. Included when the region overlaps the requested range.
+	if incidentFreqMs := incidentFreq.Milliseconds(); incidentFreqMs > 0 {
+		durMs := incidentDur.Milliseconds()
+		nStart := ceilDiv(from-durMs, incidentFreqMs)
+		if nStart < 0 {
+			nStart = 0
+		}
+		for n := nStart; ; n++ {
+			start := n * incidentFreqMs
+			if start > to || len(rows) >= maxAnnotations {
+				break
+			}
+			end := start + durMs
+			if end < from {
+				continue
+			}
+			h := annotationHash(seed, "incident", n)
+			text := annotationIncidentTexts[h%uint64(len(annotationIncidentTexts))]
+			severity := annotationIncidentSeverities[(h>>8)%uint64(len(annotationIncidentSeverities))]
+			tag := annotationTagPool[(h>>16)%uint64(len(annotationTagPool))]
+			endT := time.UnixMilli(end)
+			rows = append(rows, annotationRow{
+				time:    time.UnixMilli(start),
+				timeEnd: &endT,
+				text:    text,
+				tags:    "incident," + severity + "," + tag,
+			})
+		}
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].time.Before(rows[j].time)
+	})
+
+	times := make([]time.Time, len(rows))
+	timeEnds := make([]*time.Time, len(rows))
+	texts := make([]string, len(rows))
+	tags := make([]string, len(rows))
+	for i, r := range rows {
+		times[i] = r.time
+		timeEnds[i] = r.timeEnd
+		texts[i] = r.text
+		tags[i] = r.tags
+	}
+
+	frame := data.NewFrame("annotations",
+		data.NewField("time", nil, times),
+		data.NewField("timeEnd", nil, timeEnds),
+		data.NewField("text", nil, texts),
+		data.NewField("tags", nil, tags),
+	)
+	frame.SetMeta(&data.FrameMeta{DataTopic: data.DataTopicAnnotations})
+
+	return frame, nil
+}
+
+// ceilDiv returns ceil(a/b) for b > 0, handling negative a correctly.
+func ceilDiv(a, b int64) int64 {
+	q := a / b
+	if a%b > 0 {
+		q++
+	}
+	return q
 }
 
 func randomHeatmapData(query backend.DataQuery, fnBucketGen func(index int) float64) *data.Frame {

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
@@ -177,6 +177,154 @@ func TestTestdataScenarios(t *testing.T) {
 	})
 }
 
+func TestPredictableAnnotationsScenario(t *testing.T) {
+	// A UTC midnight is an exact multiple of 1h and 6h from the epoch, which makes
+	// the anchored event/incident counts easy to reason about.
+	base := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	annotationsFor := func(t *testing.T, from, to time.Time, model kinds.PredictableAnnotationsQuery) *data.Frame {
+		t.Helper()
+		frame, err := predictableAnnotations(backend.DataQuery{
+			RefID:     "Anno",
+			TimeRange: backend.TimeRange{From: from, To: to},
+		}, kinds.TestDataQuery{PredictableAnnotations: &model})
+		require.NoError(t, err)
+		require.NotNil(t, frame)
+		return frame
+	}
+
+	field := func(t *testing.T, frame *data.Frame, name string) *data.Field {
+		t.Helper()
+		for _, f := range frame.Fields {
+			if f.Name == name {
+				return f
+			}
+		}
+		t.Fatalf("field %q not found in frame", name)
+		return nil
+	}
+
+	t.Run("returns an annotations frame with the expected shape", func(t *testing.T) {
+		frame := annotationsFor(t, base, base.Add(5*time.Hour), kinds.PredictableAnnotationsQuery{
+			EventFrequency:    "1h",
+			IncidentFrequency: "6h",
+			IncidentDuration:  "30m",
+			Seed:              42,
+		})
+
+		require.NotNil(t, frame.Meta)
+		require.Equal(t, data.DataTopicAnnotations, frame.Meta.DataTopic)
+		for _, name := range []string{"time", "timeEnd", "text", "tags"} {
+			require.NotNil(t, field(t, frame, name))
+		}
+
+		timeField := field(t, frame, "time")
+		timeEndField := field(t, frame, "timeEnd")
+		var events, incidents int
+		for i := 0; i < timeField.Len(); i++ {
+			ts := timeField.At(i).(time.Time)
+			require.False(t, ts.Before(base), "annotation before range start")
+			require.False(t, ts.After(base.Add(5*time.Hour)), "annotation after range end")
+
+			end := timeEndField.At(i).(*time.Time)
+			if end == nil {
+				events++
+			} else {
+				incidents++
+				require.Equal(t, 30*time.Minute, end.Sub(ts), "incident duration should match incidentDuration")
+			}
+		}
+
+		// Events at +0h..+5h (6), one incident starting at the range start (aligned to 6h).
+		require.Equal(t, 6, events)
+		require.Equal(t, 1, incidents)
+	})
+
+	t.Run("is stable across time ranges - overlapping annotations are identical", func(t *testing.T) {
+		model := kinds.PredictableAnnotationsQuery{EventFrequency: "1h", IncidentFrequency: "6h", IncidentDuration: "30m", Seed: 7}
+
+		collect := func(frame *data.Frame) map[int64][2]string {
+			out := map[int64][2]string{}
+			timeField := field(t, frame, "time")
+			textField := field(t, frame, "text")
+			tagsField := field(t, frame, "tags")
+			for i := 0; i < timeField.Len(); i++ {
+				ts := timeField.At(i).(time.Time).UnixMilli()
+				out[ts] = [2]string{textField.At(i).(string), tagsField.At(i).(string)}
+			}
+			return out
+		}
+
+		rangeA := collect(annotationsFor(t, base, base.Add(5*time.Hour), model))
+		// A different, shifted range.
+		rangeB := collect(annotationsFor(t, base.Add(2*time.Hour), base.Add(10*time.Hour), model))
+
+		overlaps := 0
+		for ts, a := range rangeA {
+			if b, ok := rangeB[ts]; ok {
+				overlaps++
+				require.Equal(t, a, b, "annotation at %d changed between time ranges", ts)
+			}
+		}
+		require.Greater(t, overlaps, 0, "expected some annotations to appear in both ranges")
+	})
+
+	t.Run("same seed is deterministic, different seed changes content", func(t *testing.T) {
+		from, to := base, base.Add(6*time.Hour)
+		textsFor := func(seed int64) []string {
+			frame := annotationsFor(t, from, to, kinds.PredictableAnnotationsQuery{EventFrequency: "1h", Seed: seed})
+			textField := field(t, frame, "text")
+			tagsField := field(t, frame, "tags")
+			out := make([]string, textField.Len())
+			for i := range out {
+				out[i] = textField.At(i).(string) + "|" + tagsField.At(i).(string)
+			}
+			return out
+		}
+
+		require.Equal(t, textsFor(1), textsFor(1), "same seed should produce identical annotations")
+		require.NotEqual(t, textsFor(1), textsFor(2), "different seeds should produce different annotations")
+	})
+
+	t.Run("defaults are used when durations are omitted", func(t *testing.T) {
+		frame := annotationsFor(t, base, base.Add(24*time.Hour), kinds.PredictableAnnotationsQuery{Seed: 1})
+		// Default event frequency is 1h -> 25 events across a 24h range (inclusive of both ends).
+		timeEndField := field(t, frame, "timeEnd")
+		var events int
+		for i := 0; i < timeEndField.Len(); i++ {
+			if timeEndField.At(i).(*time.Time) == nil {
+				events++
+			}
+		}
+		require.Equal(t, 25, events)
+	})
+
+	t.Run("invalid duration returns an error", func(t *testing.T) {
+		_, err := predictableAnnotations(backend.DataQuery{
+			TimeRange: backend.TimeRange{From: base, To: base.Add(time.Hour)},
+		}, kinds.TestDataQuery{PredictableAnnotations: &kinds.PredictableAnnotationsQuery{EventFrequency: "not-a-duration"}})
+		require.Error(t, err)
+	})
+
+	t.Run("handler wires the scenario end to end", func(t *testing.T) {
+		s := &Service{}
+		query := backend.DataQuery{
+			RefID:     "Anno",
+			TimeRange: backend.TimeRange{From: base, To: base.Add(3 * time.Hour)},
+			JSON:      []byte(`{"scenarioId":"predictable_annotations","predictableAnnotations":{"eventFrequency":"1h","seed":3}}`),
+		}
+		resp, err := s.handlePredictableAnnotationsScenario(context.Background(), &backend.QueryDataRequest{
+			Queries: []backend.DataQuery{query},
+		})
+		require.NoError(t, err)
+		dResp, ok := resp.Responses["Anno"]
+		require.True(t, ok)
+		require.NoError(t, dResp.Error)
+		require.Len(t, dResp.Frames, 1)
+		require.Equal(t, data.DataTopicAnnotations, dResp.Frames[0].Meta.DataTopic)
+	})
+}
+
 func TestParseLabels(t *testing.T) {
 	expectedTags := data.Labels{
 		"job":      "foo",

--- a/public/app/plugins/datasource/grafana-testdata-datasource/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/QueryEditor.tsx
@@ -12,13 +12,14 @@ import ErrorEditor from './components/ErrorEditor';
 import ErrorWithSourceQueryEditor from './components/ErrorWithSourceEditor';
 import { GrafanaLiveEditor } from './components/GrafanaLiveEditor';
 import { NodeGraphEditor } from './components/NodeGraphEditor';
+import { PredictableAnnotationsEditor } from './components/PredictableAnnotationsEditor';
 import { PredictablePulseEditor } from './components/PredictablePulseEditor';
 import { RandomWalkEditor } from './components/RandomWalkEditor';
 import { RawFrameEditor } from './components/RawFrameEditor';
 import { SimulationQueryEditor } from './components/SimulationQueryEditor';
 import { StreamingClientEditor } from './components/StreamingClientEditor';
 import { USAQueryEditor, usaQueryModes } from './components/USAQueryEditor';
-import { defaultCSVWaveQuery, defaultPulseQuery, defaultQuery } from './constants';
+import { defaultCSVWaveQuery, defaultPredictableAnnotationsQuery, defaultPulseQuery, defaultQuery } from './constants';
 import { type CSVWave, type NodesQuery, type TestDataDataQuery, TestDataQueryType, type USAQuery } from './dataquery';
 import { type TestDataDataSource } from './datasource';
 import { defaultStreamQuery } from './runStreams';
@@ -58,7 +59,11 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
     }
 
     const vals = await datasource.getScenarios();
-    const hideAlias = [TestDataQueryType.Simulation, TestDataQueryType.Annotations];
+    const hideAlias = [
+      TestDataQueryType.Simulation,
+      TestDataQueryType.Annotations,
+      TestDataQueryType.PredictableAnnotations,
+    ];
     return vals.map((v) => ({
       ...v,
       hideAliasField: hideAlias.includes(v.id as TestDataQueryType),
@@ -115,6 +120,9 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
       case TestDataQueryType.PredictableCSVWave:
         update.csvWave = defaultCSVWaveQuery;
         break;
+      case TestDataQueryType.PredictableAnnotations:
+        update.predictableAnnotations = defaultPredictableAnnotationsQuery;
+        break;
       case TestDataQueryType.Annotations:
         update.lines = 10;
         break;
@@ -165,6 +173,7 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
 
   const onStreamClientChange = onFieldChange('stream');
   const onPulseWaveChange = onFieldChange('pulseWave');
+  const onPredictableAnnotationsChange = onFieldChange('predictableAnnotations');
   const onUSAStatsChange = (usa?: USAQuery) => {
     onUpdate({ ...query, usa });
   };
@@ -366,6 +375,9 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
 
       {scenarioId === TestDataQueryType.PredictablePulse && (
         <PredictablePulseEditor onChange={onPulseWaveChange} query={query} ds={datasource} />
+      )}
+      {scenarioId === TestDataQueryType.PredictableAnnotations && (
+        <PredictableAnnotationsEditor onChange={onPredictableAnnotationsChange} query={query} ds={datasource} />
       )}
       {scenarioId === TestDataQueryType.PredictableCSVWave && (
         <CSVWavesEditor onChange={onCSVWaveChange} waves={query.csvWave} />

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/PredictableAnnotationsEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/PredictableAnnotationsEditor.tsx
@@ -1,0 +1,77 @@
+import { type ChangeEvent } from 'react';
+
+import { InlineField, InlineFieldRow, Input } from '@grafana/ui';
+
+import { type EditorProps } from '../QueryEditor';
+import { type PredictableAnnotationsQuery } from '../dataquery';
+
+const durationFields: Array<{
+  label: string;
+  id: keyof PredictableAnnotationsQuery;
+  placeholder: string;
+  tooltip: string;
+}> = [
+  {
+    label: 'Event frequency',
+    id: 'eventFrequency',
+    placeholder: '1h',
+    tooltip: 'How often a point-in-time event annotation occurs, as a Go duration string (e.g. "1h", "10m").',
+  },
+  {
+    label: 'Incident frequency',
+    id: 'incidentFrequency',
+    placeholder: '6h',
+    tooltip: 'How often an incident (region) annotation starts, as a Go duration string (e.g. "6h").',
+  },
+  {
+    label: 'Incident duration',
+    id: 'incidentDuration',
+    placeholder: '10m',
+    tooltip: 'How long each incident lasts, as a Go duration string (e.g. "20m").',
+  },
+];
+
+export const PredictableAnnotationsEditor = ({ onChange, query }: EditorProps) => {
+  const onDurationChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    onChange({ target: { name, value } });
+  };
+
+  const onSeedChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    onChange({ target: { name, value: Number(value) } });
+  };
+
+  return (
+    <InlineFieldRow>
+      {durationFields.map(({ label, id, placeholder, tooltip }) => (
+        <InlineField label={label} labelWidth={18} key={id} tooltip={tooltip}>
+          <Input
+            width={12}
+            type="text"
+            name={id}
+            id={`predictableAnnotations.${id}-${query.refId}`}
+            value={query.predictableAnnotations?.[id]}
+            placeholder={placeholder}
+            onChange={onDurationChange}
+          />
+        </InlineField>
+      ))}
+      <InlineField
+        label="Seed"
+        labelWidth={14}
+        tooltip="Seed used to deterministically pick each annotation's text and tags. The same seed always produces the same annotations, independent of the selected time range."
+      >
+        <Input
+          width={12}
+          type="number"
+          name="seed"
+          id={`predictableAnnotations.seed-${query.refId}`}
+          value={query.predictableAnnotations?.seed}
+          placeholder="1"
+          onChange={onSeedChange}
+        />
+      </InlineField>
+    </InlineFieldRow>
+  );
+};

--- a/public/app/plugins/datasource/grafana-testdata-datasource/constants.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/constants.ts
@@ -1,4 +1,10 @@
-import { type CSVWave, type PulseWaveQuery, type TestDataDataQuery, TestDataQueryType } from './dataquery';
+import {
+  type CSVWave,
+  type PredictableAnnotationsQuery,
+  type PulseWaveQuery,
+  type TestDataDataQuery,
+  TestDataQueryType,
+} from './dataquery';
 
 export const defaultPulseQuery: PulseWaveQuery = {
   timeStep: 60,
@@ -6,6 +12,13 @@ export const defaultPulseQuery: PulseWaveQuery = {
   onValue: 2,
   offCount: 3,
   offValue: 1,
+};
+
+export const defaultPredictableAnnotationsQuery: PredictableAnnotationsQuery = {
+  eventFrequency: '1h',
+  incidentFrequency: '6h',
+  incidentDuration: '10m',
+  seed: 1,
 };
 
 export const defaultCSVWaveQuery: CSVWave[] = [

--- a/public/app/plugins/datasource/grafana-testdata-datasource/dataquery.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/dataquery.ts
@@ -19,6 +19,7 @@ export enum TestDataQueryType {
   ManualEntry = 'manual_entry',
   NoDataPoints = 'no_data_points',
   NodeGraph = 'node_graph',
+  PredictableAnnotations = 'predictable_annotations',
   PredictableCSVWave = 'predictable_csv_wave',
   PredictablePulse = 'predictable_pulse',
   QueryMeta = 'query_meta',
@@ -45,6 +46,26 @@ export interface StreamingQuery {
   spread: number;
   type: 'signal' | 'logs' | 'fetch' | 'traces' | 'watch';
   url?: string;
+}
+
+export interface PredictableAnnotationsQuery {
+  /**
+   * How often a point-in-time event annotation occurs, as a Go duration string (e.g. "1h", "10m").
+   */
+  eventFrequency?: string;
+  /**
+   * How often an incident (region) annotation starts, as a Go duration string (e.g. "6h").
+   */
+  incidentFrequency?: string;
+  /**
+   * How long each incident lasts, as a Go duration string (e.g. "20m").
+   */
+  incidentDuration?: string;
+  /**
+   * Seed used to deterministically pick each annotation's text and tags. The same seed
+   * always produces the same annotations, independent of the selected time range.
+   */
+  seed?: number;
 }
 
 export interface PulseWaveQuery {
@@ -114,6 +135,7 @@ export interface TestDataDataQuery extends common.DataQuery {
   lines?: number;
   nodes?: NodesQuery;
   points?: Array<Array<string | number>>;
+  predictableAnnotations?: PredictableAnnotationsQuery;
   pulseWave?: PulseWaveQuery;
   rawFrameContent?: string;
   scenarioId?: TestDataQueryType;

--- a/public/app/plugins/datasource/grafana-testdata-datasource/mocks/scenarios.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/mocks/scenarios.ts
@@ -63,6 +63,12 @@ export const scenarios = [
   },
   {
     description: '',
+    id: TestDataQueryType.PredictableAnnotations,
+    name: 'Predictable Annotations',
+    stringInput: '',
+  },
+  {
+    description: '',
     id: TestDataQueryType.PredictableCSVWave,
     name: 'Predictable CSV Wave',
     stringInput: '',

--- a/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1.json
@@ -188,7 +188,7 @@
       {
         "metadata": {
           "name": "default",
-          "resourceVersion": "1776878010416",
+          "resourceVersion": "1783529158521",
           "creationTimestamp": "2026-04-22T17:13:30Z"
         },
         "spec": {
@@ -253,6 +253,28 @@
               },
               "noise": { "type": "number" },
               "points": { "items": { "type": "array" }, "type": "array" },
+              "predictableAnnotations": {
+                "additionalProperties": false,
+                "properties": {
+                  "eventFrequency": {
+                    "description": "How often a point-in-time event annotation occurs, as a Go duration string (e.g. \"1h\", \"10m\").",
+                    "type": "string"
+                  },
+                  "incidentDuration": {
+                    "description": "How long each incident lasts, as a Go duration string (e.g. \"20m\").",
+                    "type": "string"
+                  },
+                  "incidentFrequency": {
+                    "description": "How often an incident (region) annotation starts, as a Go duration string (e.g. \"6h\").",
+                    "type": "string"
+                  },
+                  "seed": {
+                    "description": "Seed used to deterministically pick each annotation's text and tags. The same\nseed always produces the same annotations, independent of the selected time range.",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
               "pulseWave": {
                 "additionalProperties": false,
                 "properties": {
@@ -266,7 +288,7 @@
               },
               "rawFrameContent": { "type": "string" },
               "scenarioId": {
-                "description": "Possible enum values:\n - `\"annotations\"` \n - `\"arrow\"` \n - `\"csv_content\"` \n - `\"csv_file\"` \n - `\"csv_metric_values\"` \n - `\"datapoints_outside_range\"` \n - `\"error_with_source\"` \n - `\"exponential_heatmap_bucket_data\"` \n - `\"flame_graph\"` \n - `\"grafana_api\"` \n - `\"linear_heatmap_bucket_data\"` \n - `\"live\"` \n - `\"logs\"` \n - `\"manual_entry\"` \n - `\"no_data_points\"` \n - `\"node_graph\"` \n - `\"predictable_csv_wave\"` \n - `\"predictable_pulse\"` \n - `\"query_meta\"` \n - `\"random_walk\"` \n - `\"random_walk_table\"` \n - `\"random_walk_with_error\"` \n - `\"raw_frame\"` \n - `\"server_error_500\"` \n - `\"steps\"` \n - `\"simulation\"` \n - `\"slow_query\"` \n - `\"streaming_client\"` \n - `\"table_static\"` \n - `\"trace\"` \n - `\"usa\"` \n - `\"variables-query\"` ",
+                "description": "Possible enum values:\n - `\"annotations\"` \n - `\"arrow\"` \n - `\"csv_content\"` \n - `\"csv_file\"` \n - `\"csv_metric_values\"` \n - `\"datapoints_outside_range\"` \n - `\"error_with_source\"` \n - `\"exponential_heatmap_bucket_data\"` \n - `\"flame_graph\"` \n - `\"grafana_api\"` \n - `\"linear_heatmap_bucket_data\"` \n - `\"live\"` \n - `\"logs\"` \n - `\"manual_entry\"` \n - `\"no_data_points\"` \n - `\"node_graph\"` \n - `\"predictable_annotations\"` \n - `\"predictable_csv_wave\"` \n - `\"predictable_pulse\"` \n - `\"query_meta\"` \n - `\"random_walk\"` \n - `\"random_walk_table\"` \n - `\"random_walk_with_error\"` \n - `\"raw_frame\"` \n - `\"server_error_500\"` \n - `\"steps\"` \n - `\"simulation\"` \n - `\"slow_query\"` \n - `\"streaming_client\"` \n - `\"table_static\"` \n - `\"trace\"` \n - `\"usa\"` \n - `\"variables-query\"` ",
                 "enum": [
                   "annotations",
                   "arrow",
@@ -284,6 +306,7 @@
                   "manual_entry",
                   "no_data_points",
                   "node_graph",
+                  "predictable_annotations",
                   "predictable_csv_wave",
                   "predictable_pulse",
                   "query_meta",

--- a/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1/query.types.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1/query.types.json
@@ -8,7 +8,7 @@
     {
       "metadata": {
         "name": "default",
-        "resourceVersion": "1776878010416",
+        "resourceVersion": "1783529158521",
         "creationTimestamp": "2026-04-22T17:13:30Z"
       },
       "spec": {
@@ -113,6 +113,28 @@
               },
               "type": "array"
             },
+            "predictableAnnotations": {
+              "additionalProperties": false,
+              "properties": {
+                "eventFrequency": {
+                  "description": "How often a point-in-time event annotation occurs, as a Go duration string (e.g. \"1h\", \"10m\").",
+                  "type": "string"
+                },
+                "incidentDuration": {
+                  "description": "How long each incident lasts, as a Go duration string (e.g. \"20m\").",
+                  "type": "string"
+                },
+                "incidentFrequency": {
+                  "description": "How often an incident (region) annotation starts, as a Go duration string (e.g. \"6h\").",
+                  "type": "string"
+                },
+                "seed": {
+                  "description": "Seed used to deterministically pick each annotation's text and tags. The same\nseed always produces the same annotations, independent of the selected time range.",
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
             "pulseWave": {
               "additionalProperties": false,
               "properties": {
@@ -138,7 +160,7 @@
               "type": "string"
             },
             "scenarioId": {
-              "description": "Possible enum values:\n - `\"annotations\"` \n - `\"arrow\"` \n - `\"csv_content\"` \n - `\"csv_file\"` \n - `\"csv_metric_values\"` \n - `\"datapoints_outside_range\"` \n - `\"error_with_source\"` \n - `\"exponential_heatmap_bucket_data\"` \n - `\"flame_graph\"` \n - `\"grafana_api\"` \n - `\"linear_heatmap_bucket_data\"` \n - `\"live\"` \n - `\"logs\"` \n - `\"manual_entry\"` \n - `\"no_data_points\"` \n - `\"node_graph\"` \n - `\"predictable_csv_wave\"` \n - `\"predictable_pulse\"` \n - `\"query_meta\"` \n - `\"random_walk\"` \n - `\"random_walk_table\"` \n - `\"random_walk_with_error\"` \n - `\"raw_frame\"` \n - `\"server_error_500\"` \n - `\"steps\"` \n - `\"simulation\"` \n - `\"slow_query\"` \n - `\"streaming_client\"` \n - `\"table_static\"` \n - `\"trace\"` \n - `\"usa\"` \n - `\"variables-query\"` ",
+              "description": "Possible enum values:\n - `\"annotations\"` \n - `\"arrow\"` \n - `\"csv_content\"` \n - `\"csv_file\"` \n - `\"csv_metric_values\"` \n - `\"datapoints_outside_range\"` \n - `\"error_with_source\"` \n - `\"exponential_heatmap_bucket_data\"` \n - `\"flame_graph\"` \n - `\"grafana_api\"` \n - `\"linear_heatmap_bucket_data\"` \n - `\"live\"` \n - `\"logs\"` \n - `\"manual_entry\"` \n - `\"no_data_points\"` \n - `\"node_graph\"` \n - `\"predictable_annotations\"` \n - `\"predictable_csv_wave\"` \n - `\"predictable_pulse\"` \n - `\"query_meta\"` \n - `\"random_walk\"` \n - `\"random_walk_table\"` \n - `\"random_walk_with_error\"` \n - `\"raw_frame\"` \n - `\"server_error_500\"` \n - `\"steps\"` \n - `\"simulation\"` \n - `\"slow_query\"` \n - `\"streaming_client\"` \n - `\"table_static\"` \n - `\"trace\"` \n - `\"usa\"` \n - `\"variables-query\"` ",
               "enum": [
                 "annotations",
                 "arrow",
@@ -156,6 +178,7 @@
                 "manual_entry",
                 "no_data_points",
                 "node_graph",
+                "predictable_annotations",
                 "predictable_csv_wave",
                 "predictable_pulse",
                 "query_meta",


### PR DESCRIPTION
## What

Adds a new **Predictable Annotations** scenario (`predictable_annotations`) to the built-in TestData datasource, generated on the **backend**.

Unlike the existing client-side "Annotations" scenario (which spreads a fixed number of annotations across whatever time range is selected), this scenario anchors annotations to **absolute time (from the epoch)**:

- **Events** — point-in-time annotations, one every `eventFrequency`.
- **Incidents** — region annotations (`time` → `timeEnd`) lasting `incidentDuration`, one starting every `incidentFrequency`.

A given annotation always occurs at the same instant; panning/zooming the time range only changes **which** annotations fall inside it, not the annotations themselves. Each annotation's text and tags are chosen deterministically from a `seed` (like the other `predictable_*` scenarios), so the same seed always yields the same content.

## Why

Makes it possible to build stable, reproducible dashboards and tests that exercise annotations from the backend, without the markers shifting every time the time range changes.

## Configuration

| Field | Meaning | Default |
| --- | --- | --- |
| `eventFrequency` | how often a point-in-time event occurs (Go duration string) | `1h` |
| `incidentFrequency` | how often an incident starts (Go duration string) | `6h` |
| `incidentDuration` | how long each incident lasts (Go duration string) | `10m` |
| `seed` | deterministic text/tag selection | `1` |

Output is capped at 10k rows.

## How it works

- The backend handler returns a single frame with `meta.dataTopic = annotations` and `time` / `timeEnd` / `text` / `tags` fields (the shape Grafana's annotation mapper expects). `timeEnd` is null for events and set for incidents.
- The mux's existing `scenarioId` fallback dispatch routes the query to the new handler, so no extra wiring was needed.
- Works both as a dashboard annotation query and as a normal panel query (renders as annotation markers on time series panels).

## Notes

- Backend and frontend changes are kept in two separate commits for reviewability. Per the repo convention they could be split into separate PRs — happy to do that if preferred.

## Testing

- **Go:** `go test` (incl. `-race`), `go vet`, `golangci-lint` (0 issues). New tests cover frame shape/`dataTopic`, event/incident counts, **stability across shifted time ranges**, seed determinism, defaults, and the invalid-duration error path. The `kinds` schema golden test regenerates and passes.
- **Frontend:** full-repo `tsc --noEmit` (0 errors), ESLint, Prettier, and the plugin's Jest suite — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
