### PR TITLE
Provisioning: Surface github error details

### DIFF
--- a/apps/provisioning/pkg/repository/github/error_translation_test.go
+++ b/apps/provisioning/pkg/repository/github/error_translation_test.go
@@ -112,6 +112,23 @@ func TestTranslateGitHubError(t *testing.T) {
 			},
 			expectedMsgContains: "GitHub API error (HTTP 500: Internal server error)",
 		},
+		{
+			name: "422 surfaces the error detail alongside the generic message",
+			inputErr: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+				Message:  "Validation Failed",
+				Errors:   []github.Error{{Resource: "Hook", Code: "custom", Message: "Hook already exists on this repository"}},
+			},
+			expectedMsgContains: "GitHub API error (HTTP 422: Validation Failed: Hook already exists on this repository)",
+		},
+		{
+			name: "422 without error details keeps the generic message",
+			inputErr: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+				Message:  "Validation Failed",
+			},
+			expectedMsgContains: "GitHub API error (HTTP 422: Validation Failed)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -156,4 +173,52 @@ func TestTranslateGitHubError_PreservesErrorChain(t *testing.T) {
 	// The error message should contain both the descriptive text and the wrapped error
 	assert.Contains(t, result.Error(), "authentication token has expired")
 	assert.Contains(t, result.Error(), "authentication failed")
+}
+
+func TestFormatGitHubErrorDetails(t *testing.T) {
+	tests := []struct {
+		name string
+		errs []github.Error
+		want string
+	}{
+		{
+			name: "no errors",
+			errs: nil,
+			want: "",
+		},
+		{
+			name: "message is preferred",
+			errs: []github.Error{{Resource: "Hook", Code: "custom", Message: "Hook already exists on this repository"}},
+			want: "Hook already exists on this repository",
+		},
+		{
+			name: "field and code when message is empty",
+			errs: []github.Error{{Resource: "Hook", Field: "config", Code: "invalid"}},
+			want: "config invalid",
+		},
+		{
+			name: "code only when field and message are empty",
+			errs: []github.Error{{Resource: "Hook", Code: "missing_field"}},
+			want: "missing_field",
+		},
+		{
+			name: "empty error contributes nothing",
+			errs: []github.Error{{Resource: "Hook"}},
+			want: "",
+		},
+		{
+			name: "multiple errors are joined",
+			errs: []github.Error{
+				{Message: "Hook already exists on this repository"},
+				{Field: "config", Code: "invalid"},
+			},
+			want: "Hook already exists on this repository; config invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatGitHubErrorDetails(tt.errs))
+		})
+	}
 }

--- a/apps/provisioning/pkg/repository/github/impl.go
+++ b/apps/provisioning/pkg/repository/github/impl.go
@@ -69,8 +69,28 @@ func translateGitHubError(err error) error {
 
 	default:
 		// Other errors - return with GitHub message context
+		if details := formatGitHubErrorDetails(ghErr.Errors); details != "" {
+			return fmt.Errorf("GitHub API error (HTTP %d: %s: %s)", statusCode, ghMessage, details)
+		}
 		return fmt.Errorf("GitHub API error (HTTP %d: %s)", statusCode, ghMessage)
 	}
+}
+
+// formatGitHubErrorDetails renders the per-field error details GitHub returns
+// alongside a validation error into a single readable string.
+func formatGitHubErrorDetails(errs []github.Error) string {
+	details := make([]string, 0, len(errs))
+	for _, e := range errs {
+		switch {
+		case e.Message != "":
+			details = append(details, e.Message)
+		case e.Field != "" && e.Code != "":
+			details = append(details, fmt.Sprintf("%s %s", e.Field, e.Code))
+		case e.Code != "":
+			details = append(details, e.Code)
+		}
+	}
+	return strings.Join(details, "; ")
 }
 
 const (


### PR DESCRIPTION
**What is this feature?**
Include error details when parsing Github errors. 

**Why do we need this feature?**
Right now, we have very non-descriptive github errors such as `error running OnUpdate: GitHub API error (HTTP 422: Validation Failed)`. 

For unexpected errors (outside of 429, 503, 404 etc), we should parse the error details.
Example format of an error: 
```
{
    "message": "Validation Failed",
    "errors": [
        {
            "message": "The listed users and repositories cannot be searched either because the resources do not exist or you do not have permission to view them.",
            "resource": "Search",
            "field": "q",
            "code": "invalid",
        }
    ],
    "documentation_url": "https://docs.github.com/v3/search/",
    "status": "422",
}
```

**Which issue(s) does this PR fix?**:
Doesn't fully fix issue: https://github.com/grafana/grafana/issues/127638, but will help with debugging at least. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
