### PR TITLE
Table: Remove panel padding so header sits flush with panel title

### DIFF
--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -20,6 +20,7 @@ function getTableNoValuePlaceholder(): string {
 }
 
 export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
+  .setNoPadding()
   .setPanelChangeHandler(tablePanelChangedHandler)
   .setMigrationHandler(tableMigrationHandler)
   .useFieldConfig({


### PR DESCRIPTION
## What do these changes accomplish?

Removes the table panel's content padding so the table header sits flush against the panel title, closing the visible gap between them.

## Why?

The table panel currently gets the standard `md` panel padding, which is applied on all sides of the content — including the top. Because the table draws its own header row at the top of the content area, that top padding shows up as an unwanted gap between the panel title and the first header row (see #128058).


## Screenshots

| Before | After |
|---|---|
| gap between title and header | header flush with title |

Closes #128058