### PR TITLE
QueryEditor: Use trash icon for query editor delete confirm

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/DeleteConfirm.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/DeleteConfirm.tsx
@@ -69,7 +69,8 @@ export function DeleteConfirm({ confirmStyle, description, onConfirm, onCancel }
           size="sm"
           fill="text"
           variant="destructive"
-          icon="check"
+          icon="trash-alt"
+          className={styles.iconButton}
           aria-label={confirmDeleteAria}
           aria-description={description}
           onClick={handleConfirmClick}
@@ -85,6 +86,7 @@ export function DeleteConfirm({ confirmStyle, description, onConfirm, onCancel }
         fill="text"
         variant="secondary"
         icon="times"
+        className={confirmStyle === ConfirmationStyle.compact ? styles.iconButton : undefined}
         aria-label={cancelDeleteAria}
         onClick={handleCancelClick}
         tooltip={cancelDeleteAria}
@@ -108,5 +110,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     [theme.transitions.handleMotion('no-preference')]: {
       animation: `${slideIn} ${theme.transitions.duration.shorter}ms ${theme.transitions.easing.easeOut}`,
     },
+  }),
+  iconButton: css({
+    minWidth: theme.spacing(3.5),
+    justifyContent: 'center',
   }),
 });


### PR DESCRIPTION
Fixes DPRO-181

## What
Swap the compact delete-confirm button in the new panel edit query/transformation editor from a red checkmark to a red trash icon, and slightly widen the confirm/cancel targets.

## Why
Users found the red check non-obvious as the confirm action and instinctively clicked the X. A red trash icon reads clearly as "delete", and the wider hit area reduces misclicks.

<img width="646" height="474" alt="image" src="https://github.com/user-attachments/assets/6dd62c9a-c136-49ac-8525-1a5b1d944391" />
