### PR TITLE
Deps: Bump react-i18next from 15.6.1 to 16.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -338,7 +338,7 @@
     "file-saver": "2.0.5",
     "history": "4.10.1",
     "html-to-image": "1.11.13",
-    "i18next": "^25.0.0",
+    "i18next": "^25.10.9",
     "idb": "^8.0.3",
     "immer": "10.2.0",
     "immutable": "5.1.5",

--- a/package.json
+++ b/package.json
@@ -377,7 +377,7 @@
     "react-draggable": "4.5.0",
     "react-highlight-words": "0.21.0",
     "react-hook-form": "^7.49.2",
-    "react-i18next": "^15.0.0",
+    "react-i18next": "^16.6.6",
     "react-inlinesvg": "4.3.0",
     "react-loading-skeleton": "3.5.0",
     "react-moveable": "0.56.0",

--- a/packages/grafana-i18n/package.json
+++ b/packages/grafana-i18n/package.json
@@ -55,7 +55,7 @@
     "@formatjs/intl-durationformat": "^0.7.0",
     "@typescript-eslint/utils": "^8.33.1",
     "fast-deep-equal": "^3.1.3",
-    "i18next": "^25.0.0",
+    "i18next": "^25.10.9",
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-pseudo": "^2.2.1",
     "micro-memoize": "^4.1.2",

--- a/packages/grafana-i18n/package.json
+++ b/packages/grafana-i18n/package.json
@@ -59,7 +59,7 @@
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-pseudo": "^2.2.1",
     "micro-memoize": "^4.1.2",
-    "react-i18next": "^15.0.0"
+    "react-i18next": "^16.6.6"
   },
   "devDependencies": {
     "@types/react": "18.3.18",

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -8,6 +8,13 @@ import { DEFAULT_LANGUAGE, PSEUDO_LOCALE } from './constants';
 import { LANGUAGES } from './languages';
 import { type ResourceLoader, type Resources, type TFunction, type TransProps, type TransType } from './types';
 
+// FIXME: No longer needed in i18next@26: https://www.locize.com/docs/general-questions/why-was-there-a-support-notice-for-i18next
+// Set __i18next_supportNoticeShown to true to avoid the console.info message promoting Locize.
+if (typeof globalThis !== 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  (globalThis as Record<string, unknown>).__i18next_supportNoticeShown = true;
+}
+
 let tFunc: I18NextTFunction<string[], undefined> | undefined;
 let transComponent: TransType;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,7 +2378,7 @@ __metadata:
     i18next-browser-languagedetector: "npm:^8.0.0"
     i18next-pseudo: "npm:^2.2.1"
     micro-memoize: "npm:^4.1.2"
-    react-i18next: "npm:^15.0.0"
+    react-i18next: "npm:^16.6.6"
     rollup: "npm:^4.60.1"
     typescript: "npm:6.0.2"
   peerDependencies:
@@ -18580,7 +18580,7 @@ __metadata:
     react-draggable: "npm:4.5.0"
     react-highlight-words: "npm:0.21.0"
     react-hook-form: "npm:^7.49.2"
-    react-i18next: "npm:^15.0.0"
+    react-i18next: "npm:^16.6.6"
     react-inlinesvg: "npm:4.3.0"
     react-loading-skeleton: "npm:3.5.0"
     react-moveable: "npm:0.56.0"
@@ -27508,16 +27508,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-i18next@npm:^15.0.0":
-  version: 15.6.1
-  resolution: "react-i18next@npm:15.6.1"
+"react-i18next@npm:^16.6.6":
+  version: 16.6.6
+  resolution: "react-i18next@npm:16.6.6"
   dependencies:
-    "@babel/runtime": "npm:^7.27.6"
+    "@babel/runtime": "npm:^7.29.2"
     html-parse-stringify: "npm:^3.0.1"
+    use-sync-external-store: "npm:^1.6.0"
   peerDependencies:
-    i18next: ">= 23.2.3"
+    i18next: ">= 25.10.9"
     react: ">= 16.8.0"
-    typescript: ^5
+    typescript: ^5 || ^6
   peerDependenciesMeta:
     react-dom:
       optional: true
@@ -27525,7 +27526,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10/f8da83078eabbd4eadf848754881fb65a5c97de72f778b473a4a64add18d4b39794a1da9c95cce827ce30d5236328807228dfbe566dbc355cd0b46d3cbb110c3
+  checksum: 10/5916b8eb0bf2e8d6aef06077640c2ac81603b47aca82c1314c73be3604f0a64337964049d6efc07607f296209f02ffe2ba7a0fa6fbed570f3d5e1b83ee8a4059
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,7 +529,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.25.6, @babel/runtime@npm:^7.26.7, @babel/runtime@npm:^7.27.0, @babel/runtime@npm:^7.27.6, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.29.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.25.6, @babel/runtime@npm:^7.26.7, @babel/runtime@npm:^7.27.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.29.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.7":
   version: 7.29.7
   resolution: "@babel/runtime@npm:7.29.7"
   checksum: 10/9883b4951787779fd382b121f22f92966d85f19434841f65fb00b2dfec232107e139683f47c6f252891826ad8ee18317b46c3a0e4819116a9885f47b46d7126a
@@ -2374,7 +2374,7 @@ __metadata:
     "@types/react": "npm:18.3.18"
     "@typescript-eslint/utils": "npm:^8.33.1"
     fast-deep-equal: "npm:^3.1.3"
-    i18next: "npm:^25.0.0"
+    i18next: "npm:^25.10.9"
     i18next-browser-languagedetector: "npm:^8.0.0"
     i18next-pseudo: "npm:^2.2.1"
     micro-memoize: "npm:^4.1.2"
@@ -18510,7 +18510,7 @@ __metadata:
     history: "npm:4.10.1"
     html-to-image: "npm:1.11.13"
     http-server: "npm:14.1.1"
-    i18next: "npm:^25.0.0"
+    i18next: "npm:^25.10.9"
     i18next-cli: "npm:^1.48.0"
     idb: "npm:^8.0.3"
     immer: "npm:10.2.0"
@@ -19318,17 +19318,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"i18next@npm:^25.0.0":
-  version: 25.6.2
-  resolution: "i18next@npm:25.6.2"
+"i18next@npm:^25.10.9":
+  version: 25.10.10
+  resolution: "i18next@npm:25.10.10"
   dependencies:
-    "@babel/runtime": "npm:^7.27.6"
+    "@babel/runtime": "npm:^7.29.2"
   peerDependencies:
-    typescript: ^5
+    typescript: ^5 || ^6
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/bb7f3e200caac72bacaead766287dbad5ed5945430bd9f2be1c14fbccd49cf78ab751f78cf53cd0be3ec063bc4c40837d7d771f7b14d50fcb9022e1ed5d6e72f
+  checksum: 10/ee4f6ba360902a2f0550cfeef234c9e68a67487b575d204e89bdf2f2db647934aa3900a39c64174b9201a8979e455d0bf8f56b57934c34fc8f9aa3b430cb152d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Updates `react-i18next` across a major version bump from v15 to v16. The only [breaking change documented](https://github.com/i18next/react-i18next/blob/master/CHANGELOG.md#1600) for this is that the [peer dependency requirement for `i18next` is now v25](https://github.com/i18next/react-i18next/issues/1865), which is already used in `@grafana/i18n`.

This also bumps the `i18next` version to meet the [peer dependency requirements from v16.6.6,](https://github.com/i18next/react-i18next/blob/master/CHANGELOG.md#1666) which unfortunately pulls in the Locize console.info promotion (that has [since been removed in v26](https://www.locize.com/docs/general-questions/why-was-there-a-support-notice-for-i18next)), so I've had to include their recommended `globalThis` suppression.

**Why do we need this feature?**

v16.6.4 allows for TypeScript 6 as a peer dependency: https://github.com/i18next/react-i18next/blob/master/CHANGELOG.md#1664

Currently, plugins following strict peer dependency enforcement that rely on this package (or `@grafana/data`) are stuck on TypeScript 5.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
