### PR TITLE
Provisioning: make GitHub webhook creation idempotent (fix repos stuck unhealthy with HTTP 422)

### DIFF
--- a/apps/provisioning/pkg/repository/github/impl.go
+++ b/apps/provisioning/pkg/repository/github/impl.go
@@ -424,7 +424,10 @@ func (r *githubClient) adoptExistingWebhook(ctx context.Context, cfg webhookConf
 	}
 
 	// GitHub said the hook exists but no hook matched our URL; surface it.
-	logging.FromContext(ctx).Error("GitHub said webhook exists but no hook with URL: %s exists when queried", cfg.URL)
+	logging.FromContext(ctx).Error(
+		"GitHub said webhook exists but no hook with URL exists when queried",
+		slog.String("url", cfg.URL),
+	)
 	return nil, ErrWebhookAlreadyExists
 }
 

--- a/apps/provisioning/pkg/repository/github/impl.go
+++ b/apps/provisioning/pkg/repository/github/impl.go
@@ -356,7 +356,7 @@ func (r *githubClient) CreateWebhook(ctx context.Context, url string, events []s
 		// idempotent so the repository can self-heal rather than looping unhealthy.
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) && isWebhookAlreadyExists(ghErr) {
-			return r.findExistingWebhook(ctx, cfg)
+			return r.adoptExistingWebhook(ctx, cfg)
 		}
 		return nil, translateGitHubError(err)
 	}
@@ -373,13 +373,13 @@ func (r *githubClient) CreateWebhook(ctx context.Context, url string, events []s
 	}, nil
 }
 
-// findExistingWebhook recovers the hook already registered for cfg.URL after
+// adoptExistingWebhook recovers the hook already registered for cfg.URL after
 // CreateHook reported it exists. GitHub's 422 does not include the hook ID, so we
 // list the repo's hooks and match on the payload URL (GitHub's uniqueness key).
 // The stored secret is never returned by GitHub, so the matched hook is edited to
 // use cfg's secret and events, leaving a fully-owned webhook whose ID the caller
 // can persist to Status.Webhook.
-func (r *githubClient) findExistingWebhook(ctx context.Context, cfg webhookConfig) (repo.WebhookConfig, error) {
+func (r *githubClient) adoptExistingWebhook(ctx context.Context, cfg webhookConfig) (repo.WebhookConfig, error) {
 	opts := &github.ListOptions{PerPage: 100}
 	for {
 		hooks, resp, err := r.gh.Repositories.ListHooks(ctx, r.owner, r.repo, opts)
@@ -424,6 +424,7 @@ func (r *githubClient) findExistingWebhook(ctx context.Context, cfg webhookConfi
 	}
 
 	// GitHub said the hook exists but no hook matched our URL; surface it.
+	logging.FromContext(ctx).Error("GitHub said webhook exists but no hook with URL: %s exists when queried", cfg.URL)
 	return nil, ErrWebhookAlreadyExists
 }
 

--- a/apps/provisioning/pkg/repository/github/impl.go
+++ b/apps/provisioning/pkg/repository/github/impl.go
@@ -76,6 +76,26 @@ func translateGitHubError(err error) error {
 	}
 }
 
+// When receiving a 422 hook already exists error, we query
+// for all the repo's hooks and match against its payload URL.
+// If none match, we return this error
+var ErrWebhookAlreadyExists = errors.New("webhook already exists on repository but could not be queried based on payload url")
+
+func isWebhookAlreadyExists(ghErr *github.ErrorResponse) bool {
+	if ghErr.Response == nil || ghErr.Response.StatusCode != http.StatusUnprocessableEntity {
+		return false
+	}
+	if strings.Contains(strings.ToLower(ghErr.Message), "already exists") {
+		return true
+	}
+	for _, e := range ghErr.Errors {
+		if strings.Contains(strings.ToLower(e.Message), "already exists") {
+			return true
+		}
+	}
+	return false
+}
+
 // formatGitHubErrorDetails renders the per-field error details GitHub returns
 // alongside a validation error into a single readable string.
 func formatGitHubErrorDetails(errs []github.Error) string {
@@ -329,6 +349,15 @@ func (r *githubClient) CreateWebhook(ctx context.Context, url string, events []s
 
 	createdHook, _, err := r.gh.Repositories.CreateHook(ctx, r.owner, r.repo, hook)
 	if err != nil {
+		// GitHub returns 422 when a hook with the same payload URL already exists
+		// (e.g. Status.Webhook was lost while the hook still lives on the repo).
+		// The 422 body carries no ID, so recover the existing hook by URL and
+		// take ownership of it instead of failing — this keeps CreateWebhook
+		// idempotent so the repository can self-heal rather than looping unhealthy.
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && isWebhookAlreadyExists(ghErr) {
+			return r.findExistingWebhook(ctx, cfg)
+		}
 		return nil, translateGitHubError(err)
 	}
 
@@ -342,6 +371,60 @@ func (r *githubClient) CreateWebhook(ctx context.Context, url string, events []s
 		// Secret is not returned by GitHub.
 		Secret: cfg.Secret,
 	}, nil
+}
+
+// findExistingWebhook recovers the hook already registered for cfg.URL after
+// CreateHook reported it exists. GitHub's 422 does not include the hook ID, so we
+// list the repo's hooks and match on the payload URL (GitHub's uniqueness key).
+// The stored secret is never returned by GitHub, so the matched hook is edited to
+// use cfg's secret and events, leaving a fully-owned webhook whose ID the caller
+// can persist to Status.Webhook.
+func (r *githubClient) findExistingWebhook(ctx context.Context, cfg webhookConfig) (repo.WebhookConfig, error) {
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		hooks, resp, err := r.gh.Repositories.ListHooks(ctx, r.owner, r.repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list webhooks to adopt existing: %w", translateGitHubError(err))
+		}
+
+		for _, h := range hooks {
+			if h.GetConfig().GetURL() != cfg.URL {
+				continue
+			}
+
+			edit := &github.Hook{
+				URL:    &cfg.URL,
+				Events: cfg.Events,
+				Active: &cfg.Active,
+				Config: &github.HookConfig{
+					ContentType: &cfg.ContentType,
+					Secret:      &cfg.Secret,
+					URL:         &cfg.URL,
+				},
+			}
+			if _, _, err := r.gh.Repositories.EditHook(ctx, r.owner, r.repo, h.GetID(), edit); err != nil {
+				return nil, fmt.Errorf("adopt existing webhook %d: %w", h.GetID(), translateGitHubError(err))
+			}
+
+			logging.FromContext(ctx).Info("adopted existing webhook", "url", cfg.URL, "id", h.GetID())
+			return &webhookConfig{
+				ID:          h.GetID(),
+				Events:      cfg.Events,
+				Active:      true,
+				URL:         cfg.URL,
+				ContentType: cfg.ContentType,
+				Secret:      cfg.Secret,
+			}, nil
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	// GitHub said the hook exists but no hook matched our URL; surface it.
+	return nil, ErrWebhookAlreadyExists
 }
 
 func (r *githubClient) GetWebhook(ctx context.Context, webhookID int64) (repo.WebhookConfig, error) {

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -492,10 +492,10 @@ func TestGithubClient_CreateWebhook(t *testing.T) {
 				mockhub.WithRequestMatchHandler(
 					mockhub.GetReposHooksByOwnerByRepo,
 					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						hooks := []*github.Hook{
-							{ID: new(int64(111)), Config: &github.HookConfig{URL: new("https://other.example.com/webhook")}},
-							{ID: new(int64(456)), Config: &github.HookConfig{URL: new("https://example.com/webhook")}},
-						}
+hooks := []*github.Hook{
+	{ID: github.Ptr(int64(111)), Config: &github.HookConfig{URL: github.Ptr("https://other.example.com/webhook")}},
+	{ID: github.Ptr(int64(456)), Config: &github.HookConfig{URL: github.Ptr("https://example.com/webhook")}},
+}
 						w.WriteHeader(http.StatusOK)
 						require.NoError(t, json.NewEncoder(w).Encode(hooks))
 					}),

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -492,10 +492,10 @@ func TestGithubClient_CreateWebhook(t *testing.T) {
 				mockhub.WithRequestMatchHandler(
 					mockhub.GetReposHooksByOwnerByRepo,
 					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-hooks := []*github.Hook{
-	{ID: github.Ptr(int64(111)), Config: &github.HookConfig{URL: github.Ptr("https://other.example.com/webhook")}},
-	{ID: github.Ptr(int64(456)), Config: &github.HookConfig{URL: github.Ptr("https://example.com/webhook")}},
-}
+						hooks := []*github.Hook{
+							{ID: github.Ptr(int64(111)), Config: &github.HookConfig{URL: github.Ptr("https://other.example.com/webhook")}},
+							{ID: github.Ptr(int64(456)), Config: &github.HookConfig{URL: github.Ptr("https://example.com/webhook")}},
+						}
 						w.WriteHeader(http.StatusOK)
 						require.NoError(t, json.NewEncoder(w).Encode(hooks))
 					}),
@@ -513,10 +513,10 @@ hooks := []*github.Hook{
 
 						w.WriteHeader(http.StatusOK)
 						require.NoError(t, json.NewEncoder(w).Encode(&github.Hook{
-ID:     github.Ptr(int64(456)),
-Events: []string{"push", "pull_request"},
-Active: github.Ptr(true),
-Config: &github.HookConfig{URL: github.Ptr("https://example.com/webhook"), ContentType: github.Ptr("json")}
+							ID:     github.Ptr(int64(456)),
+							Events: []string{"push", "pull_request"},
+							Active: github.Ptr(true),
+							Config: &github.HookConfig{URL: github.Ptr("https://example.com/webhook"), ContentType: github.Ptr("json")},
 						}))
 					}),
 				),
@@ -553,9 +553,9 @@ Config: &github.HookConfig{URL: github.Ptr("https://example.com/webhook"), Conte
 				mockhub.WithRequestMatchHandler(
 					mockhub.GetReposHooksByOwnerByRepo,
 					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-hooks := []*github.Hook{
-	{ID: github.Ptr(int64(111)), Config: &github.HookConfig{URL: github.Ptr("https://other.example.com/webhook")}},
-}
+						hooks := []*github.Hook{
+							{ID: github.Ptr(int64(111)), Config: &github.HookConfig{URL: github.Ptr("https://other.example.com/webhook")}},
+						}
 						w.WriteHeader(http.StatusOK)
 						require.NoError(t, json.NewEncoder(w).Encode(hooks))
 					}),

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -513,10 +513,10 @@ hooks := []*github.Hook{
 
 						w.WriteHeader(http.StatusOK)
 						require.NoError(t, json.NewEncoder(w).Encode(&github.Hook{
-							ID:     new(int64(456)),
-							Events: []string{"push", "pull_request"},
-							Active: new(true),
-							Config: &github.HookConfig{URL: new("https://example.com/webhook"), ContentType: new("json")},
+ID:     github.Ptr(int64(456)),
+Events: []string{"push", "pull_request"},
+Active: github.Ptr(true),
+Config: &github.HookConfig{URL: github.Ptr("https://example.com/webhook"), ContentType: github.Ptr("json")}
 						}))
 					}),
 				),

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -475,6 +475,100 @@ func TestGithubClient_CreateWebhook(t *testing.T) {
 			want:       nil,
 			wantErr:    errors.New("GitHub API error (HTTP 500: Internal server error)"),
 		},
+		{
+			name: "hook already exists is adopted by URL",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.PostReposHooksByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusUnprocessableEntity)
+						require.NoError(t, json.NewEncoder(w).Encode(github.ErrorResponse{
+							Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+							Message:  "Validation Failed",
+							Errors:   []github.Error{{Resource: "Hook", Code: "custom", Message: "Hook already exists on this repository"}},
+						}))
+					}),
+				),
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetReposHooksByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						hooks := []*github.Hook{
+							{ID: new(int64(111)), Config: &github.HookConfig{URL: new("https://other.example.com/webhook")}},
+							{ID: new(int64(456)), Config: &github.HookConfig{URL: new("https://example.com/webhook")}},
+						}
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(hooks))
+					}),
+				),
+				mockhub.WithRequestMatchHandler(
+					mockhub.PatchReposHooksByOwnerByRepoByHookId,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						// The adopted hook must be reset to our secret and events.
+						body, err := io.ReadAll(r.Body)
+						require.NoError(t, err)
+						hook := &github.Hook{}
+						require.NoError(t, json.Unmarshal(body, hook))
+						assert.Equal(t, "secret123", hook.Config.GetSecret())
+						assert.Equal(t, []string{"push", "pull_request"}, hook.Events)
+
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(&github.Hook{
+							ID:     new(int64(456)),
+							Events: []string{"push", "pull_request"},
+							Active: new(true),
+							Config: &github.HookConfig{URL: new("https://example.com/webhook"), ContentType: new("json")},
+						}))
+					}),
+				),
+			),
+			owner:      "test-owner",
+			repository: "test-repo",
+			url:        "https://example.com/webhook",
+			events:     []string{"push", "pull_request"},
+			secret:     "secret123",
+			want: &webhookConfig{
+				ID:          456,
+				Events:      []string{"push", "pull_request"},
+				Active:      true,
+				URL:         "https://example.com/webhook",
+				ContentType: "json",
+				Secret:      "secret123",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "hook already exists but no url match returns sentinel",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.PostReposHooksByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusUnprocessableEntity)
+						require.NoError(t, json.NewEncoder(w).Encode(github.ErrorResponse{
+							Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+							Message:  "Validation Failed",
+							Errors:   []github.Error{{Resource: "Hook", Code: "custom", Message: "Hook already exists on this repository"}},
+						}))
+					}),
+				),
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetReposHooksByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						hooks := []*github.Hook{
+							{ID: new(int64(111)), Config: &github.HookConfig{URL: new("https://other.example.com/webhook")}},
+						}
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(hooks))
+					}),
+				),
+			),
+			owner:      "test-owner",
+			repository: "test-repo",
+			url:        "https://example.com/webhook",
+			events:     []string{"push", "pull_request"},
+			secret:     "secret123",
+			want:       nil,
+			wantErr:    ErrWebhookAlreadyExists,
+		},
 	}
 
 	for _, tt := range tests {

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -553,9 +553,9 @@ Config: &github.HookConfig{URL: github.Ptr("https://example.com/webhook"), Conte
 				mockhub.WithRequestMatchHandler(
 					mockhub.GetReposHooksByOwnerByRepo,
 					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						hooks := []*github.Hook{
-							{ID: new(int64(111)), Config: &github.HookConfig{URL: new("https://other.example.com/webhook")}},
-						}
+hooks := []*github.Hook{
+	{ID: github.Ptr(int64(111)), Config: &github.HookConfig{URL: github.Ptr("https://other.example.com/webhook")}},
+}
 						w.WriteHeader(http.StatusOK)
 						require.NoError(t, json.NewEncoder(w).Encode(hooks))
 					}),

--- a/pkg/registry/apis/provisioning/controller/webhook_integration_test.go
+++ b/pkg/registry/apis/provisioning/controller/webhook_integration_test.go
@@ -1,0 +1,250 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/google/go-github/v82/github"
+	mockhub "github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	githubrepo "github.com/grafana/grafana/apps/provisioning/pkg/repository/github"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// TestIntegrationWebhookController_ReconcileLifecycle drives the controller's
+// webhook hooks (webhookOnCreate -> webhookOnUpdate -> webhookOnDelete) across
+// several reconcile passes against the REAL github webhook client talking to a
+// stateful GitHub mock. Unlike the unit tests (which mock repository.WebhookClient),
+// this exercises the full controller-to-provider path, including the 422
+// "hook already exists" self-heal that lets a repo recover a lost Status.Webhook.
+func TestIntegrationWebhookController_ReconcileLifecycle(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	const (
+		owner      = "test-owner"
+		repoName   = "test-repo"
+		repoURL    = "https://github.com/test-owner/test-repo"
+		webhookURL = "https://grafana.example.com/webhook"
+	)
+
+	// Stateful in-memory hook store modelling GitHub's uniqueness-by-payload-URL:
+	// a second create for an existing URL returns 422, matching real GitHub.
+	var (
+		mu     sync.Mutex
+		hooks  []*github.Hook
+		nextID int64
+	)
+	findByURL := func(url string) *github.Hook {
+		for _, h := range hooks {
+			if h.GetConfig().GetURL() == url {
+				return h
+			}
+		}
+		return nil
+	}
+
+	mockHandler := mockhub.NewMockedHTTPClient(
+		mockhub.WithRequestMatchHandler(
+			mockhub.PostReposHooksByOwnerByRepo,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				in := &github.Hook{}
+				require.NoError(t, json.Unmarshal(body, in))
+				url := in.GetConfig().GetURL()
+
+				if findByURL(url) != nil {
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					require.NoError(t, json.NewEncoder(w).Encode(github.ErrorResponse{
+						Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+						Message:  "Validation Failed",
+						Errors: []github.Error{
+							{Resource: "Hook", Code: "custom", Message: "Hook already exists on this repository"},
+						},
+					}))
+					return
+				}
+
+				nextID++
+				created := &github.Hook{
+					ID:     github.Ptr(nextID),
+					Events: in.Events,
+					Active: github.Ptr(in.GetActive()),
+					Config: &github.HookConfig{
+						URL:         github.Ptr(url),
+						ContentType: github.Ptr(in.GetConfig().GetContentType()),
+					},
+				}
+				hooks = append(hooks, created)
+				w.WriteHeader(http.StatusCreated)
+				require.NoError(t, json.NewEncoder(w).Encode(created))
+			}),
+		),
+		mockhub.WithRequestMatchHandler(
+			mockhub.GetReposHooksByOwnerByRepo,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				require.NoError(t, json.NewEncoder(w).Encode(hooks))
+			}),
+		),
+		mockhub.WithRequestMatchHandler(
+			mockhub.PatchReposHooksByOwnerByRepoByHookId,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				id, err := strconv.ParseInt(path.Base(r.URL.Path), 10, 64)
+				require.NoError(t, err)
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				edit := &github.Hook{}
+				require.NoError(t, json.Unmarshal(body, edit))
+
+				var matched *github.Hook
+				for _, h := range hooks {
+					if h.GetID() == id {
+						h.Events = edit.Events
+						h.Active = github.Ptr(edit.GetActive())
+						h.Config = &github.HookConfig{
+							URL:         github.Ptr(edit.GetConfig().GetURL()),
+							ContentType: github.Ptr("json"),
+						}
+						matched = h
+						break
+					}
+				}
+				require.NotNilf(t, matched, "PATCH for unknown hook id %d", id)
+				w.WriteHeader(http.StatusOK)
+				require.NoError(t, json.NewEncoder(w).Encode(matched))
+			}),
+		),
+		mockhub.WithRequestMatchHandler(
+			mockhub.DeleteReposHooksByOwnerByRepoByHookId,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				id, err := strconv.ParseInt(path.Base(r.URL.Path), 10, 64)
+				require.NoError(t, err)
+				remaining := hooks[:0]
+				for _, h := range hooks {
+					if h.GetID() != id {
+						remaining = append(remaining, h)
+					}
+				}
+				hooks = remaining
+				w.WriteHeader(http.StatusNoContent)
+			}),
+		),
+	)
+
+	// Real github client (no custom server URL, so the default github.com API
+	// paths match mockhub's matchers). It satisfies repository.WebhookClient.
+	factory := githubrepo.ProvideFactory()
+	factory.Client = mockHandler
+	ghClient, err := factory.New(context.Background(), owner, repoName, "")
+	require.NoError(t, err)
+
+	// A repo whose spec enables a workflow so the hooks actually register a webhook.
+	config := &provisioning.Repository{
+		Spec: provisioning.RepositorySpec{
+			Type:      provisioning.GitHubRepositoryType,
+			Workflows: []provisioning.Workflow{provisioning.WriteWorkflow},
+			GitHub:    &provisioning.GitHubRepositoryConfig{URL: repoURL, Branch: "main"},
+		},
+	}
+
+	// WebhookRepository shell: config/URL/events are test data, but WebhookClient
+	// is the real github client so the hooks hit the mock GitHub over HTTP.
+	repo := repository.NewMockWebhookRepository(t)
+	repo.EXPECT().Config().Return(config).Maybe()
+	repo.EXPECT().WebhookURL().Return(webhookURL).Maybe()
+	repo.EXPECT().SubscribedEvents().Return(subscribedEvents).Maybe()
+	repo.EXPECT().WebhookClient().Return(ghClient).Maybe()
+
+	ctx := context.Background()
+
+	// applyStatus mimics the controller persisting the hooks' returned status patch.
+	applyStatus := func(patches []map[string]any) {
+		for _, p := range patches {
+			if p["path"] != "/status/webhook" {
+				continue
+			}
+			if p["value"] == nil {
+				config.Status.Webhook = nil
+				continue
+			}
+			status, ok := p["value"].(*provisioning.WebhookStatus)
+			require.True(t, ok, "unexpected status patch value type")
+			config.Status.Webhook = status
+		}
+	}
+
+	// secretFromPatches extracts the webhook secret carried by the
+	// /secure/webhookSecret patch that accompanies every status update — the
+	// secret is persisted to the secure store, not into Status.Webhook itself.
+	secretFromPatches := func(patches []map[string]any) string {
+		for _, p := range patches {
+			if p["path"] != "/secure/webhookSecret" {
+				continue
+			}
+			v, ok := p["value"].(map[string]string)
+			require.True(t, ok, "unexpected webhookSecret patch value type")
+			return v["create"]
+		}
+		return ""
+	}
+
+	// Pass 1 — OnCreate registers the webhook.
+	patches, err := webhookOnCreate(ctx, repo)
+	require.NoError(t, err)
+	require.NotEmpty(t, patches, "OnCreate should register a webhook and return status patches")
+	applyStatus(patches)
+	require.NotNil(t, config.Status.Webhook)
+	createdID := config.Status.Webhook.ID
+	assert.NotZero(t, createdID)
+	createdSecret := secretFromPatches(patches)
+	assert.NotEmpty(t, createdSecret, "OnCreate should persist a webhook secret")
+	mu.Lock()
+	assert.Len(t, hooks, 1, "OnCreate should create exactly one hook")
+	mu.Unlock()
+
+	// Simulate Status.Webhook being lost while the hook still lives on the remote.
+	config.Status.Webhook = nil
+
+	// Pass 2 — OnUpdate must self-heal: create hits GitHub's 422 (URL exists) and
+	// adopts the existing hook by URL, recovering the same ID without duplicating.
+	patches, err = webhookOnUpdate(ctx, repo)
+	require.NoError(t, err)
+	require.NotEmpty(t, patches, "OnUpdate should re-adopt the existing hook and return status patches")
+	applyStatus(patches)
+	require.NotNil(t, config.Status.Webhook)
+	assert.Equal(t, createdID, config.Status.Webhook.ID, "adopt must recover the same hook ID, not create a new one")
+	adoptedSecret := secretFromPatches(patches)
+	assert.NotEmpty(t, adoptedSecret, "self-heal should persist a webhook secret")
+	assert.NotEqual(t, createdSecret, adoptedSecret, "self-heal should rotate to a fresh webhook secret")
+	mu.Lock()
+	assert.Len(t, hooks, 1, "self-heal must not create a duplicate hook")
+	mu.Unlock()
+
+	// Pass 3 — OnDelete removes the remote hook.
+	require.NoError(t, webhookOnDelete(ctx, repo))
+	mu.Lock()
+	assert.Empty(t, hooks, "OnDelete must remove the remote hook")
+	mu.Unlock()
+}


### PR DESCRIPTION
Fixes #127638

### What the fix is

When upgrading from 13.0.1 -> 13.1.0, some repos would get an ambiguous `error running OnUpdate: GitHub API error (HTTP 422: Validation Failed)`. Since 13.1.0, we now run the hooks if there is a spec change (existed previously) OR if a webhook is missing (PR: grafana/grafana#122725, grafana/grafana#122797). We didn't save the details of the github error but trying to create a webhook with the same URL returns a 422 which lines up with the issue:

```
{
  "message": "Validation Failed",
  "errors": [
    {
      "resource": "Hook",
      "code": "custom",
      "message": "Hook already exists on this repository"
    }
  ],
  "documentation_url": "https://docs.github.com/rest/repos/webhooks#create-a-repository-webhook",
  "status": "422"
}
```

`CreateWebhook` is now **idempotent**: on that 422 it adopts the existing hook instead of failing —
- the 422 body has no ID, so we `ListHooks` and match on the **payload URL** to recover the ID;
- we `EditHook` to reset the hook to our secret + events (GitHub never returns the stored secret);
- we return the recovered ID so a correct `status.webhook` is persisted, breaking the loop.

### How a repo gets into this state (`status.webhook == nil` while the hook still exists in GitHub)

1. A reconcile decides a webhook is needed (`OnCreate`, or `webhookMissing` on update) and calls into the webhook hook: [`OnCreate`](https://github.com/grafana/grafana/blob/v13.1.0/apps/provisioning/pkg/repository/github/webhook.go#L339) → [`createWebhook`](https://github.com/grafana/grafana/blob/v13.1.0/apps/provisioning/pkg/repository/github/webhook.go#L235).

2. `createWebhook` issues the GitHub `POST` — [the hook is live on GitHub the instant this returns](https://github.com/grafana/grafana/blob/v13.1.0/apps/provisioning/pkg/repository/github/impl.go#L343) (called via [webhook.go:249](https://github.com/grafana/grafana/blob/v13.1.0/apps/provisioning/pkg/repository/github/webhook.go#L249)). It returns patch ops `[set /status/webhook = Y]`.

3. Those ops are **appended to a batch, not applied yet** — [repository.go:732](https://github.com/grafana/grafana/blob/v13.1.0/pkg/registry/apis/provisioning/controller/repository.go#L732) (returned from [`processHooks` at repository.go:724](https://github.com/grafana/grafana/blob/v13.1.0/pkg/registry/apis/provisioning/controller/repository.go#L724)).

4. The reconcile keeps going and hits a step that **returns an error** before the batch is saved — e.g. [`GetDefaultBranch` at repository.go:751](https://github.com/grafana/grafana/blob/v13.1.0/pkg/registry/apis/provisioning/controller/repository.go#L751) → [`return` at repository.go:753](https://github.com/grafana/grafana/blob/v13.1.0/pkg/registry/apis/provisioning/controller/repository.go#L753).

5. Because it returned, the final [`statusPatcher.Patch(...)` at repository.go:817](https://github.com/grafana/grafana/blob/v13.1.0/pkg/registry/apis/provisioning/controller/repository.go#L817) is **never reached** → the `set /status/webhook = Y` op is **discarded**.

6. Result: **hook Y is live on GitHub, but `status.webhook` is still nil.** ← the entry state.

7. Next reconcile: `webhookMissing` (nil) → [`createWebhook`](https://github.com/grafana/grafana/blob/v13.1.0/apps/provisioning/pkg/repository/github/webhook.go#L235) → `POST` → GitHub `422 "Hook already exists"` → repeats every reconcile. **Stuck in the loop.**

**Once status.webhook == nil, we're in a stuck state.** You can't delete your way out: `webhookOnDelete` short-circuits when `status.webhook == nil` (it needs the ID to call GitHub), so deleting the repo leaves the hook **orphaned**, and recreating collides with that orphan → `OnCreate` 422.

## Why 13.1 and not 13.0.1
13.0.1 only attempted a create at initial repo creation (rare, one-time), and once status persisted it never touched the webhook again — so the "created-but-not-persisted" window was tiny and, if hit, mostly self-healed.
13.1's webhookMissing re-attempts the create on every reconcile while status is nil, so (a) the window gets hit far more often, and (b) once you're in the state it's retried forever (422 loop) instead of ignored. Rotation adds another way to null it plus a synchronized post-upgrade burst.

### Testing
`go test ./apps/provisioning/pkg/repository/github/` — all passing.
