### PR TITLE
Stars: Allow org-admin and access policies to manage resources

### DIFF
--- a/pkg/registry/apis/collections/register.go
+++ b/pkg/registry/apis/collections/register.go
@@ -49,6 +49,7 @@ func RegisterAPIService(
 	sql := legacy.NewLegacySQL(legacysql.NewDatabaseProvider(db))
 	builder := &APIBuilder{
 		authorizer: &utils.AuthorizeFromName{
+			AllowOrgAdmin: true,
 			Resource: map[string][]utils.ResourceOwner{
 				"stars": {utils.UserResourceOwner},
 			},

--- a/pkg/registry/apis/collections/stars_update.go
+++ b/pkg/registry/apis/collections/stars_update.go
@@ -9,10 +9,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	collections "github.com/grafana/grafana/apps/collections/pkg/apis/collections/v1alpha1"
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/registry/apis/preferences/utils"
 )
@@ -54,17 +54,15 @@ func (r *starsREST) NewConnectOptions() (runtime.Object, bool, string) {
 	return nil, true, "" // true means you can use the trailing path as a variable
 }
 
+// NOTE: the authorizer has already verified that the user is allowed to modify this resource
 func (r *starsREST) Connect(ctx context.Context, name string, _ runtime.Object, responder rest.Responder) (http.Handler, error) {
-	user, err := identity.GetRequester(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("must be logged in")
+	namespace, ok := request.NamespaceFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("only works with user stars")
 	}
 	parsed, found := utils.ParseOwnerFromName(name)
 	if !found || parsed.Owner != utils.UserResourceOwner {
 		return nil, fmt.Errorf("only works with user stars")
-	}
-	if user.GetIdentifier() != parsed.Identifier {
-		return nil, fmt.Errorf("must request as the given user")
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -97,7 +95,7 @@ func (r *starsREST) Connect(ctx context.Context, name string, _ runtime.Object, 
 				current = &collections.Stars{
 					ObjectMeta: v1.ObjectMeta{
 						Name:      name,
-						Namespace: user.GetNamespace(),
+						Namespace: namespace,
 					},
 				}
 			}

--- a/pkg/registry/apis/collections/stars_update.go
+++ b/pkg/registry/apis/collections/stars_update.go
@@ -58,7 +58,7 @@ func (r *starsREST) NewConnectOptions() (runtime.Object, bool, string) {
 func (r *starsREST) Connect(ctx context.Context, name string, _ runtime.Object, responder rest.Responder) (http.Handler, error) {
 	namespace, ok := request.NamespaceFrom(ctx)
 	if !ok {
-		return nil, fmt.Errorf("only works with user stars")
+		return nil, fmt.Errorf("stars must belong to a namespace")
 	}
 	parsed, found := utils.ParseOwnerFromName(name)
 	if !found || parsed.Owner != utils.UserResourceOwner {

--- a/pkg/registry/apis/preferences/utils/authorizer.go
+++ b/pkg/registry/apis/preferences/utils/authorizer.go
@@ -13,9 +13,10 @@ import (
 )
 
 type AuthorizeFromName struct {
-	AccessClient authlib.AccessClient
-	OKNames      []string
-	Resource     map[string][]ResourceOwner // may include unknown
+	AccessClient  authlib.AccessClient
+	AllowOrgAdmin bool
+	OKNames       []string
+	Resource      map[string][]ResourceOwner // may include unknown
 }
 
 func (a *AuthorizeFromName) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
@@ -45,6 +46,13 @@ func (a *AuthorizeFromName) Authorize(ctx context.Context, attr authorizer.Attri
 			"permissions", len(res.Permissions),
 		)
 		return authorizer.DecisionDeny, "calling service lacks required permissions", nil
+	}
+	if res.ServiceCall { // request is from an access policy with explicit permissions
+		return authorizer.DecisionAllow, "", nil
+	}
+
+	if a.AllowOrgAdmin && user.GetOrgRole() == identity.RoleAdmin {
+		return authorizer.DecisionAllow, "", nil
 	}
 
 	if attr.GetName() == "" {

--- a/pkg/registry/apis/preferences/utils/authorizer_test.go
+++ b/pkg/registry/apis/preferences/utils/authorizer_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,10 +39,44 @@ func TestAuthorizer_Authorize(t *testing.T) {
 		},
 	}
 
+	// Access policy (service) identity with explicit token permissions rather
+	// than delegated (on-behalf-of) permissions.
+	serviceStars := &identity.StaticRequester{
+		Type:    authlib.TypeAccessPolicy,
+		UserUID: "svc",
+		AccessTokenClaims: &authn.Claims[authn.AccessTokenClaims]{
+			Rest: authn.AccessTokenClaims{
+				Permissions: []string{"group/stars:*"},
+			},
+		},
+	}
+	serviceNoPerms := &identity.StaticRequester{
+		Type:    authlib.TypeAccessPolicy,
+		UserUID: "svc",
+		AccessTokenClaims: &authn.Claims[authn.AccessTokenClaims]{
+			Rest: authn.AccessTokenClaims{
+				Permissions: []string{""},
+			},
+		},
+	}
+	orgAdmin := &identity.StaticRequester{
+		UserUID: "admin",
+		Groups:  []string{}, // not a member of any team
+		OrgRole: identity.RoleAdmin,
+		AccessTokenClaims: &authn.Claims[authn.AccessTokenClaims]{
+			Rest: authn.AccessTokenClaims{
+				DelegatedPermissions: []string{"group/preferences:*"},
+			},
+		},
+	}
+
 	tests := []struct {
-		name     string
-		resource map[string][]ResourceOwner
-		check    []testCase
+		name          string
+		resource      map[string][]ResourceOwner
+		allowOrgAdmin bool
+		okNames       []string
+		accessClient  authlib.AccessClient
+		check         []testCase
 	}{
 		{
 			name: "stars",
@@ -302,14 +337,188 @@ func TestAuthorizer_Authorize(t *testing.T) {
 					reason:   "no edit permissions for the team",
 				},
 			}},
+		}, {
+			name: "service call",
+			resource: map[string][]ResourceOwner{
+				"stars": {UserResourceOwner},
+			},
+			check: []testCase{{
+				// An access policy with explicit permissions is allowed before
+				// any name/owner checks run - even a mutating request with no name
+				// (which would otherwise be denied).
+				name: "allowed for mutating request without a name",
+				user: serviceStars,
+				attrs: authorizer.AttributesRecord{
+					APIGroup:        "group",
+					Resource:        "stars",
+					ResourceRequest: true,
+					Verb:            "create", // missing name
+				},
+				expect: expect{
+					decision: authorizer.DecisionAllow,
+				},
+			}, {
+				// The owner would not otherwise match this service identity, but
+				// the explicit service permissions short-circuit the check.
+				name: "allowed regardless of owner",
+				user: serviceStars,
+				attrs: authorizer.AttributesRecord{
+					APIGroup:        "group",
+					Resource:        "stars",
+					ResourceRequest: true,
+					Verb:            "delete",
+					Name:            "user-someone-else",
+				},
+				expect: expect{
+					decision: authorizer.DecisionAllow,
+				},
+			}, {
+				name: "denied without service permissions",
+				user: serviceNoPerms,
+				attrs: authorizer.AttributesRecord{
+					APIGroup:        "group",
+					Resource:        "stars",
+					ResourceRequest: true,
+					Verb:            "get",
+					Name:            "user-svc",
+				},
+				expect: expect{
+					decision: authorizer.DecisionDeny,
+					reason:   "calling service lacks required permissions",
+				},
+			}},
+		}, {
+			name:          "allow org admin",
+			allowOrgAdmin: true,
+			resource: map[string][]ResourceOwner{
+				"preferences": {TeamResourceOwner},
+			},
+			check: []testCase{{
+				// With AllowOrgAdmin, an org admin is allowed before the owner
+				// checks - here for a team they are not a member of.
+				name: "org admin bypasses owner checks",
+				user: orgAdmin,
+				attrs: authorizer.AttributesRecord{
+					Verb:            "get",
+					APIGroup:        "group",
+					Resource:        "preferences",
+					Name:            "team-zzz", // admin is not in this team
+					ResourceRequest: true,
+				},
+				expect: expect{
+					decision: authorizer.DecisionAllow,
+				},
+			}, {
+				// A non-admin still follows the normal owner checks.
+				name: "non-admin is not bypassed",
+				user: userABC,
+				attrs: authorizer.AttributesRecord{
+					Verb:            "get",
+					APIGroup:        "group",
+					Resource:        "preferences",
+					Name:            "team-456", // not a group userABC belongs to
+					ResourceRequest: true,
+				},
+				expect: expect{
+					decision: authorizer.DecisionDeny,
+					reason:   "no edit permissions for the team",
+				},
+			}},
+		}, {
+			// Without AllowOrgAdmin, an org admin gets no special treatment and
+			// falls through to the normal owner checks.
+			name: "org admin not allowed when AllowOrgAdmin is false",
+			resource: map[string][]ResourceOwner{
+				"preferences": {TeamResourceOwner},
+			},
+			check: []testCase{{
+				name: "org admin follows owner checks",
+				user: orgAdmin,
+				attrs: authorizer.AttributesRecord{
+					Verb:            "get",
+					APIGroup:        "group",
+					Resource:        "preferences",
+					Name:            "team-zzz",
+					ResourceRequest: true,
+				},
+				expect: expect{
+					decision: authorizer.DecisionDeny,
+					reason:   "no edit permissions for the team",
+				},
+			}},
+		}, {
+			name:    "ok names",
+			okNames: []string{"special"},
+			resource: map[string][]ResourceOwner{
+				"stars": {UserResourceOwner},
+			},
+			check: []testCase{{
+				// A name in OKNames is a pseudo sub-resource that is always allowed.
+				name: "allowed pseudo sub-resource",
+				user: userABC,
+				attrs: authorizer.AttributesRecord{
+					Verb:            "get",
+					APIGroup:        "group",
+					Resource:        "stars",
+					Name:            "special",
+					ResourceRequest: true,
+				},
+				expect: expect{
+					decision: authorizer.DecisionAllow,
+				},
+			}, {
+				// A name not in OKNames falls through to the normal owner checks.
+				name: "other name follows owner checks",
+				user: userABC,
+				attrs: authorizer.AttributesRecord{
+					Verb:            "get",
+					APIGroup:        "group",
+					Resource:        "stars",
+					Name:            "user-XYZ", // not abc
+					ResourceRequest: true,
+				},
+				expect: expect{
+					decision: authorizer.DecisionDeny,
+					reason:   "your are not the owner of the resource",
+				},
+			}},
+		}, {
+			name:         "team access client error",
+			accessClient: &errAccessClient{err: errors.New("boom")},
+			resource: map[string][]ResourceOwner{
+				"preferences": {TeamResourceOwner},
+			},
+			check: []testCase{{
+				// An error checking team permissions is surfaced as a denial.
+				name: "surfaces the error",
+				user: userABC,
+				attrs: authorizer.AttributesRecord{
+					Verb:            "get",
+					APIGroup:        "group",
+					Resource:        "preferences",
+					Name:            "team-456", // not a group userABC belongs to
+					ResourceRequest: true,
+				},
+				expect: expect{
+					decision: authorizer.DecisionDeny,
+					reason:   "error fetching team permissions",
+					err:      "boom",
+				},
+			}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			accessClient := tt.accessClient
+			if accessClient == nil {
+				accessClient = authlib.FixedAccessClient(false)
+			}
 			authz := &AuthorizeFromName{
-				Resource:     tt.resource,
-				AccessClient: authlib.FixedAccessClient(false),
+				Resource:      tt.resource,
+				AllowOrgAdmin: tt.allowOrgAdmin,
+				OKNames:       tt.okNames,
+				AccessClient:  accessClient,
 			}
 			for _, check := range tt.check {
 				t.Run(check.name, func(t *testing.T) {
@@ -386,4 +595,22 @@ func TestAuthorizer_TeamAccessClient(t *testing.T) {
 		require.Equal(t, authorizer.DecisionDeny, d)
 		require.NotEmpty(t, reason)
 	})
+}
+
+// errAccessClient is an AccessClient whose Check always returns an error, used
+// to exercise the team permission error path.
+type errAccessClient struct {
+	err error
+}
+
+func (c *errAccessClient) Check(_ context.Context, _ authlib.AuthInfo, _ authlib.CheckRequest, _ string) (authlib.CheckResponse, error) {
+	return authlib.CheckResponse{}, c.err
+}
+
+func (c *errAccessClient) Compile(_ context.Context, _ authlib.AuthInfo, _ authlib.ListRequest) (authlib.ItemChecker, authlib.Zookie, error) {
+	return nil, nil, c.err
+}
+
+func (c *errAccessClient) BatchCheck(_ context.Context, _ authlib.AuthInfo, _ authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+	return authlib.BatchCheckResponse{}, c.err
 }

--- a/pkg/registry/apis/preferences/utils/names_test.go
+++ b/pkg/registry/apis/preferences/utils/names_test.go
@@ -24,7 +24,7 @@ func TestLegacyAuthorizer(t *testing.T) {
 		{
 			name:   "with user",
 			input:  "user-a",
-			output: utils.OwnerReference{Owner: utils.UserResourceOwner, Identifier: "a"},
+			output: utils.UserOwner("a"),
 			found:  true,
 		},
 		{
@@ -36,7 +36,7 @@ func TestLegacyAuthorizer(t *testing.T) {
 		{
 			name:   "with team",
 			input:  "team-b",
-			output: utils.OwnerReference{Owner: utils.TeamResourceOwner, Identifier: "b"},
+			output: utils.TeamOwner("b"),
 			found:  true,
 		},
 		{
@@ -48,7 +48,7 @@ func TestLegacyAuthorizer(t *testing.T) {
 		{
 			name:   "for namespace",
 			input:  "namespace",
-			output: utils.OwnerReference{Owner: utils.NamespaceResourceOwner},
+			output: utils.NamespaceOwner(),
 			found:  true,
 		},
 	}

--- a/pkg/tests/apis/collections/stars_test.go
+++ b/pkg/tests/apis/collections/stars_test.go
@@ -226,6 +226,29 @@ func TestIntegrationStars(t *testing.T) {
 			require.Error(t, err)
 			require.Nil(t, rspObj)
 
+			// An org admin can star a dashboard on behalf of another user
+			viewerStarName := "user-" + starsClientViewer.Args.User.Identity.GetIdentifier()
+			res = client.Put().AbsPath("apis", "collections.grafana.app", "v1alpha1",
+				"namespaces", "default",
+				"stars", viewerStarName,
+				"update", "dashboard.grafana.app", "Dashboard", "test-2").Do(ctx)
+			require.NoError(t, res.Error(), "org admin can star for another user")
+
+			// The star landed on the target user's stars object, not the admin's
+			rspObj, err = starsClientViewer.Resource.Get(ctx, viewerStarName, metav1.GetOptions{})
+			require.NoError(t, err)
+			viewerStars := typed(t, rspObj, &collections.Stars{})
+			require.Len(t, viewerStars.Spec.Resource, 1)
+			require.Contains(t, viewerStars.Spec.Resource[0].Names, "test-2")
+
+			// A non-admin still cannot star on behalf of another user
+			viewerClient := helper.Org1.Viewer.RESTClient(t, &collections.GroupVersion)
+			res = viewerClient.Put().AbsPath("apis", "collections.grafana.app", "v1alpha1",
+				"namespaces", "default",
+				"stars", adminStarName,
+				"update", "dashboard.grafana.app", "Dashboard", "test-2").Do(ctx)
+			require.Error(t, res.Error(), "viewer cannot star for another user")
+
 			// Use the API to star a non-dashboard resource
 			res = client.Put().AbsPath("apis", "collections.grafana.app", "v1alpha1",
 				"namespaces", "default",


### PR DESCRIPTION
As implemented, the stars (and preferences) authorizer only allows the actual user to manage settings.  This change will allow admin users to edit user+team resources