### PR TITLE
Tests: Fix flaky provisioning, storage, and dashboard integration tests

### DIFF
--- a/pkg/storage/unified/sql/rvmanager/rv_manager.go
+++ b/pkg/storage/unified/sql/rvmanager/rv_manager.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/snowflake"
+	"github.com/go-sql-driver/mysql"
 	"github.com/grafana/dskit/backoff"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -379,7 +380,7 @@ func (m *ResourceVersionManager) execBatch(ctx context.Context, group, resource 
 	}
 
 	err = runBatch()
-	if err != nil && sqlite.IsBusyOrLocked(err) {
+	if isRetryableTxError(err) {
 		boff := backoff.New(ctx, backoff.Config{
 			MinBackoff: sqliteBusyMinBackoff,
 			MaxBackoff: sqliteBusyMaxBackoff,
@@ -395,7 +396,7 @@ func (m *ResourceVersionManager) execBatch(ctx context.Context, group, resource 
 				break
 			}
 			err = runBatch()
-			if err == nil || !sqlite.IsBusyOrLocked(err) {
+			if !isRetryableTxError(err) {
 				break
 			}
 		}
@@ -495,4 +496,15 @@ func (m *ResourceVersionManager) SaveRV(ctx context.Context, x db.ContextExecer,
 		return fmt.Errorf("save resource version: %w", err)
 	}
 	return nil
+}
+
+func isRetryableTxError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if sqlite.IsBusyOrLocked(err) {
+		return true
+	}
+	var mysqlErr *mysql.MySQLError
+	return errors.As(err, &mysqlErr) && mysqlErr.Number == 1213
 }

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -1363,9 +1364,15 @@ func runAuthorizationTests(t *testing.T, ctx TestContext) {
 			// TODO: Check if viewing permission can be revoked as well.
 			// Test dashboard viewing for all roles
 			t.Run("dashboard viewing", func(t *testing.T) {
-				// Create a dashboard with admin
-				dash, err := createDashboard(t, adminClient, "Dashboard for "+identity.Name+" to view", nil, nil, ctx.Helper)
-				require.NoError(t, err)
+				// Create a dashboard with admin. Retry: under SQLite write
+				// contention the create can fail server-side with a transient
+				// "database is locked" error.
+				var dash *unstructured.Unstructured
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					var err error
+					dash, err = createDashboard(t, adminClient, "Dashboard for "+identity.Name+" to view", nil, nil, ctx.Helper)
+					assert.NoError(c, err)
+				}, 30*time.Second, 250*time.Millisecond, "admin should be able to create dashboard")
 				require.NotNil(t, dash)
 
 				// Get the dashboard with the test identity
@@ -1532,9 +1539,15 @@ func runDashboardPermissionTests(t *testing.T, ctx TestContext) {
 		// Set permissions for folder2 - give viewer edit access
 		setResourceUserPermission(t, ctx, ctx.AdminUser, false, folder2UID, addUserPermission(t, nil, ctx.ViewerUser, ResourcePermissionLevelEdit))
 
-		// Have the viewer create a dashboard in folder2
-		viewerDash, err := createDashboard(t, viewerClient, "Dashboard created by Viewer in Edit Permission Folder", &folder2UID, nil, ctx.Helper)
-		require.NoError(t, err, "Viewer should be able to create dashboard in folder with edit permissions")
+		// Have the viewer create a dashboard in folder2. Retry: Zanzana/OpenFGA
+		// permission propagation is asynchronous, so the create can transiently
+		// be denied right after setResourceUserPermission.
+		var viewerDash *unstructured.Unstructured
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			var err error
+			viewerDash, err = createDashboard(t, viewerClient, "Dashboard created by Viewer in Edit Permission Folder", &folder2UID, nil, ctx.Helper)
+			assert.NoError(c, err, "Viewer should be able to create dashboard in folder with edit permissions")
+		}, 30*time.Second, 250*time.Millisecond, "viewer create should succeed once folder permissions propagate")
 		require.NotNil(t, viewerDash)
 		dashUID := viewerDash.GetName()
 

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -73,6 +73,8 @@ const (
 	// is a safety margin for the delete/list round-trips under SQLite write
 	// contention when many folders are left over.
 	waitTimeoutFolderCleanup = 4 * WaitTimeoutDefault
+
+	waitTimeoutJobHistory = 2 * WaitTimeoutDefault
 )
 
 //nolint:gosec // Test RSA private key (generated for testing purposes only, never used in production)
@@ -446,7 +448,7 @@ func (h *ProvisioningTestHelper) AwaitJob(t *testing.T, ctx context.Context, job
 		}
 
 		lastResult = result
-	}, WaitTimeoutDefault, WaitIntervalDefault)
+	}, waitTimeoutJobHistory, WaitIntervalDefault)
 	require.NotNil(t, lastResult, "expected job result to be non-nil")
 
 	return lastResult

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1058,7 +1057,7 @@ func findFolderUIDBySourcePath(t *testing.T, helper *common.ProvisioningTestHelp
 			}
 		}
 		c.Errorf("no folder managed by %q with sourcePath %q found", repoName, sourcePath)
-	}, 30*time.Second, 100*time.Millisecond,
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault,
 		"expected folder with sourcePath %q for repo %q", sourcePath, repoName)
 	return uid
 }
@@ -1088,7 +1087,7 @@ func requireDashboardParents(t *testing.T, helper *common.ProvisioningTestHelper
 			}
 			assert.Equal(c, expectedParent, actualParent, "dashboard %q parent folder", sourcePath)
 		}
-	}, 30*time.Second, 100*time.Millisecond,
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault,
 		"expected dashboards with correct parents for repo %q", repoName)
 }
 
@@ -1109,7 +1108,7 @@ func assertNoFolderAtPath(t *testing.T, helper *common.ProvisioningTestHelper, r
 				return
 			}
 		}
-	}, 30*time.Second, 100*time.Millisecond,
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault,
 		"folder at path %q should be absent for repo %q", sourcePath, repoName)
 }
 
@@ -1123,7 +1122,7 @@ func assertNoFolderByUID(t *testing.T, helper *common.ProvisioningTestHelper, fo
 		}
 		assert.True(c, apierrors.IsNotFound(err),
 			"expected NotFound error for folder %q, got: %v", folderUID, err)
-	}, 30*time.Second, 100*time.Millisecond,
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault,
 		"folder %q should be deleted", folderUID)
 }
 
@@ -1142,7 +1141,7 @@ func requireFolderSourcePathCount(t *testing.T, helper *common.ProvisioningTestH
 			}
 		}
 		assert.Equal(c, expected, count, "folder count for sourcePath %q", sourcePath)
-	}, 30*time.Second, 100*time.Millisecond,
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault,
 		"expected %d folders with sourcePath %q for repo %q", expected, sourcePath, repoName)
 }
 

--- a/pkg/tests/apis/provisioning/jobs/pending_delete_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pending_delete_test.go
@@ -36,12 +36,10 @@ func TestIntegrationProvisioning_JobPendingDeleteLabel_SkipsExecution(t *testing
 		},
 	})
 
-	// Remove the file from disk. A real pull job would propagate this deletion to
-	// Grafana; a skipped job must leave the dashboard intact.
-	err := os.Remove(filepath.Join(helper.ProvisioningPath, "dashboard.json"))
-	require.NoError(t, err)
-
-	// Label the repository as pending-delete before submitting the job.
+	// Label the repository as pending-delete BEFORE removing the file from disk.
+	// The repository was created with sync enabled, so a controller-triggered pull
+	// could otherwise run in the window between the file removal and the label
+	// update and delete the dashboard this test expects preserved.
 	repoObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 	require.NoError(t, err)
 
@@ -53,6 +51,11 @@ func TestIntegrationProvisioning_JobPendingDeleteLabel_SkipsExecution(t *testing
 	repoObj.SetLabels(labels)
 
 	_, err = helper.Repositories.Resource.Update(t.Context(), repoObj, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Remove the file from disk. A real pull job would propagate this deletion to
+	// Grafana; a skipped job must leave the dashboard intact.
+	err = os.Remove(filepath.Join(helper.ProvisioningPath, "dashboard.json"))
 	require.NoError(t, err)
 
 	// Submit a pull job. Without the pending-delete skip this would sync the
@@ -68,11 +71,10 @@ func TestIntegrationProvisioning_JobPendingDeleteLabel_SkipsExecution(t *testing
 	require.Equal(t, string(provisioning.JobStateWarning), jobState,
 		"skipped job should complete with a warning")
 
-	// The dashboard must still exist because the pull was skipped.
-	dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err)
-	require.Len(t, dashboards.Items, 1,
-		"dashboard should be preserved because the pull job was skipped")
+	// The dashboard must still exist because the pull was skipped. Scope the
+	// check to this repo's managed dashboards so resources leaked by other
+	// tests in the shared server don't affect the count.
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	// Sanity-check: removing the label lets the next pull run normally and remove
 	// the dashboard that is no longer on disk.
@@ -91,8 +93,7 @@ func TestIntegrationProvisioning_JobPendingDeleteLabel_SkipsExecution(t *testing
 		Pull:   &provisioning.SyncJobOptions{},
 	})
 
-	dashboards, err = helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err)
-	require.Empty(t, dashboards.Items,
-		"dashboard should be deleted once the pull job runs without the pending-delete label (the repository root folder remains)")
+	// The dashboard should be deleted once the pull job runs without the
+	// pending-delete label (the repository root folder remains).
+	helper.RequireRepoDashboardCount(t, repoName, 0)
 }

--- a/pkg/tests/apis/provisioning/jobs/pulljob_folder_depth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_folder_depth_test.go
@@ -99,32 +99,41 @@ func TestIntegrationProvisioning_PullJobFolderDepthExceeded(t *testing.T) {
 	// but the legal ancestors up to the depth limit are created normally.
 	// `grafana.app/sourcePath` stores folder paths without a trailing slash,
 	// e.g. "shallow", "level1/level2".
-	folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err)
-
-	managedSourcePaths := make(map[string]struct{})
-	for _, f := range folders.Items {
-		managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
-		if managerID != repo {
-			continue
+	// Poll the folders list: the sync job completing does not guarantee the
+	// folders-list index has observed the newly-created folders (their
+	// grafana.app/managerId annotation lags independently of the dashboards
+	// index under SQLite write contention). A single List here races that lag.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err) {
+			return
 		}
-		sourcePath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
-		managedSourcePaths[sourcePath] = struct{}{}
-	}
 
-	// The shallow folder must be created normally despite the depth violation
-	// in another branch.
-	assert.Contains(t, managedSourcePaths, "shallow",
-		"the shallow folder must be created normally despite the depth violation in another branch; got managed paths: %v",
-		managedSourcePaths)
+		managedSourcePaths := make(map[string]struct{})
+		for _, f := range folders.Items {
+			managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+			if managerID != repo {
+				continue
+			}
+			sourcePath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
+			managedSourcePaths[sourcePath] = struct{}{}
+		}
 
-	// The deepest folder in the test tree must not exist. The folder API's
-	// hard ceiling for max depth is 7, so the 8th nested folder is guaranteed
-	// to fail under any valid configuration. This keeps the test stable
-	// without coupling to the runtime value of MaxNestedFolderDepth.
-	assert.NotContains(t, managedSourcePaths,
-		"level1/level2/level3/level4/level5/level6/level7/level8",
-		"the deepest folder must not be created — it exceeds the maximum folder depth allowed by the folder API")
+		// The shallow folder must be created normally despite the depth violation
+		// in another branch.
+		assert.Contains(c, managedSourcePaths, "shallow",
+			"the shallow folder must be created normally despite the depth violation in another branch; got managed paths: %v",
+			managedSourcePaths)
+
+		// The deepest folder in the test tree must not exist. The folder API's
+		// hard ceiling for max depth is 7, so the 8th nested folder is guaranteed
+		// to fail under any valid configuration. This keeps the test stable
+		// without coupling to the runtime value of MaxNestedFolderDepth.
+		assert.NotContains(c, managedSourcePaths,
+			"level1/level2/level3/level4/level5/level6/level7/level8",
+			"the deepest folder must not be created — it exceeds the maximum folder depth allowed by the folder API")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault,
+		"expected the shallow folder to be created and managed by repo %s", repo)
 
 	// Pull condition must be a warning state, not Failure. The condition
 	// reason currently buckets generic warnings under ReasonCompletedWithWarnings;

--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -557,9 +557,10 @@ func TestIntegrationProvisioning_BlockManagerChange(t *testing.T) {
 		Copies: map[string]string{
 			"testdata/all-panels.json": "all-panels.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    1,
+		SkipResourceAssertions: true,
 	})
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	const dashboardUID = "n1jR8vnnz"
 	var dashboard *unstructured.Unstructured

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -716,8 +716,6 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 
 	// Test that enabling sync on a repo with a conflicting path is rejected
 	t.Run("Git repository path conflict detected when enabling sync", func(t *testing.T) {
-		t.Skip("currently blocking many PRs")
-
 		baseURL := "https://github.com/grafana/test-repo-enable-sync-conflict"
 
 		// Create an initial repo with sync enabled and a specific path
@@ -744,9 +742,17 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		created, err := helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Second repository with child path should succeed when sync is disabled")
 
-		// Now try to enable sync on the second repo - this should fail due to parent/child conflict
-		created.Object["spec"].(map[string]interface{})["sync"].(map[string]interface{})["enabled"] = true
-		_, err = helper.Repositories.Resource.Update(ctx, created, metav1.UpdateOptions{FieldValidation: "Strict"})
+		// Now try to enable sync on the second repo - this should fail due to parent/child conflict.
+		// Always re-Get to avoid stale resourceVersion conflicts from concurrent status updates.
+		err = common.RetryOnConflict(t, func() error {
+			obj, err := helper.Repositories.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			obj.Object["spec"].(map[string]interface{})["sync"].(map[string]interface{})["enabled"] = true
+			_, err = helper.Repositories.Resource.Update(ctx, obj, metav1.UpdateOptions{FieldValidation: "Strict"})
+			return err
+		})
 		require.Error(t, err, "Enabling sync should fail due to parent/child path conflict")
 		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryParentFolderConflict.Error())
 	})


### PR DESCRIPTION
**What is this feature?**

Deflakes eight integration tests that rank among the most frequent CI failures owned by the app platform squad (plus two storage/dashboard ones surfaced by the same flake report). One commit per fix:

- **`TestIntegrationProvisioning_BlockManagerChange`** — asserted namespace-wide dashboard/folder counts on the shared test server, so resources leaked by sibling tests failed it. Now uses repo-scoped counts (same treatment as #127523). [failing run](https://github.com/grafana/grafana/actions/runs/28226228075/job/83621267145)
- **`AwaitJob` timeout** — the jobs subresource only serves completed jobs via a lagging history index, so 60s wasn't enough under CI DB contention. Doubled the poll timeout. Deflakes [folderless](https://github.com/grafana/grafana/actions/runs/27775864503/job/82187748206), [incremental permissions move](https://github.com/grafana/grafana/actions/runs/28381110029/job/84083653777), [incremental folder metadata](https://github.com/grafana/grafana/actions/runs/27343548007/job/80786987515), and [sync folder metadata (enterprise CI)](https://github.com/grafana/grafana-enterprise/actions/runs/27400842973/job/80978332209).
- **Full-sync move tests** — polled the eventually-consistent list index with hardcoded 30s timeouts instead of the package-standard 60s. [run 1](https://github.com/grafana/grafana-enterprise/actions/runs/28190784016/job/83504562342), [run 2](https://github.com/grafana/grafana/actions/runs/28487659324/job/84438783895)
- **`TestIntegrationProvisioning_PullJobFolderDepthExceeded`** — one-shot folder list raced index lag; now polled, mirroring #127763. [failing run](https://github.com/grafana/grafana/actions/runs/28229516023/job/83630803807)
- **Repository path-conflict validation test** — un-skipped. It updated the repository with a stale resourceVersion and raced the status controller into a 409; the update now retries on conflict with a fresh read. Verified passing locally. [failing run](https://github.com/grafana/grafana/actions/runs/27167071643/job/80196896148)
- **`TestIntegrationProvisioning_JobPendingDeleteLabel_SkipsExecution`** — a controller-triggered sync could run a real pull in the window between deleting the file and applying the pending-delete label, deleting the dashboard the test expects preserved. Label is now applied first, and assertions are repo-scoped. [failing run](https://github.com/grafana/grafana/actions/runs/27451930631/job/81148816586)
- **Unified storage: retry MySQL deadlocks** — the resource-version batch transaction already retried SQLite busy errors; MySQL deadlocks (error 1213, explicitly retryable) now go through the same backoff instead of failing the operation. Root cause of the classic-delete flake. [failing run](https://github.com/grafana/grafana/actions/runs/27816797489/job/82321562927)
- **Dashboard API Zanzana tests** — dashboard creates raced async permission propagation and SQLite lock contention; both are now polled. [run 1](https://github.com/grafana/grafana/actions/runs/28102402422/job/83207553870), [run 2 (enterprise CI)](https://github.com/grafana/grafana-enterprise/actions/runs/28019185929/job/82930956550)

**Why do we need this feature?**

These tests fail PRs unrelated to their code. The remaining enterprise-side flakes from the same report are fixed in grafana/grafana-enterprise#12590.

**Who is this feature for?**

Grafana developers.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

The webhook, uid-too-long, move-resources, library-panels, and manager-consistency flakes from the same report were already fixed on main (#127241, #127763, #127456, #127523, #127778) and are not touched here.

---
*Description generated by Claude Code.*
