### PR TITLE
MT Annotations: override 4xx response for custom routes

### DIFF
--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -136,10 +136,10 @@ func NewAppInstaller(
 		// We could consider combining the TagProvider with the Store interface to avoid this type assertion?
 		return nil, fmt.Errorf("store does not implement TagProvider, cannot serve tags API")
 	}
-	tagHandler := newTagsHandler(tagProvider, accessClient, installer.tracer, installer.metrics, logger)
+	tagHandler := withAPIStatusErrorResponse(newTagsHandler(tagProvider, accessClient, installer.tracer, installer.metrics, logger))
 
 	// Create the search handler
-	searchHandler := newSearchHandler(instrumentedStore, accessClient, folderResolver, installer.tracer, installer.metrics, logger)
+	searchHandler := withAPIStatusErrorResponse(newSearchHandler(instrumentedStore, accessClient, folderResolver, installer.tracer, installer.metrics, logger))
 
 	// Create the graphite handler
 	graphiteHandler := withAPIStatusErrorResponse(newGraphiteHandler(installer.k8sAdapter, installer.tracer, installer.metrics, logger))

--- a/pkg/tests/apis/annotations/annotations_test.go
+++ b/pkg/tests/apis/annotations/annotations_test.go
@@ -254,6 +254,19 @@ func TestIntegrationAnnotationTags(t *testing.T) {
 	for _, tag := range rsp.Result.Tags {
 		require.Contains(t, tag.Tag, "env")
 	}
+
+	// A caller without organization annotation read is rejected with the handler's 403.
+	errorRsp := apis.DoRequest(helper, apis.RequestParams{
+		User: helper.Org1.None,
+		Path: basePath,
+	}, &metav1.Status{})
+	require.Equal(t, http.StatusForbidden, errorRsp.Response.StatusCode)
+
+	status := errorRsp.Result
+	require.NotNil(t, status)
+	require.Equal(t, int32(http.StatusForbidden), status.Code)
+	require.Equal(t, metav1.StatusReasonForbidden, status.Reason)
+	require.Contains(t, status.Message, "requires the annotations:read permission with the organization scope")
 }
 
 func TestIntegrationAnnotationGraphite(t *testing.T) {


### PR DESCRIPTION
Related to [grafana/grafana-org/issues/962](https://github.com/grafana/grafana-org/issues/962)
Related to [comment](https://github.com/grafana/grafana/pull/126901#discussion_r3452566396)
Follow up to #127987 

This updates the annotation `tags` and `search` custom route handlers to use the same `withAPIStatusErrorResponse` wrapper already used by the Graphite custom route in PR #127987 .
