### PR TITLE
Elasticsearch: Remove elasticsearchRawDSLQuery and elasticsearchESQLQuery feature toggles

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1196,16 +1196,6 @@ export interface FeatureToggles {
   */
   panelTimeSettings?: boolean;
   /**
-  * Enables the raw DSL query editor in the Elasticsearch data source
-  * @default false
-  */
-  elasticsearchRawDSLQuery?: boolean;
-  /**
-  * Enables the ES|QL query editor in the Elasticsearch data source
-  * @default false
-  */
-  elasticsearchESQLQuery?: boolean;
-  /**
   * Enables http proxy settings for aws datasources
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2217,22 +2217,6 @@ var (
 			Expression:      "false",
 		},
 		{
-			Name:        "elasticsearchRawDSLQuery",
-			Description: "Enables the raw DSL query editor in the Elasticsearch data source",
-			Stage:       FeatureStageExperimental,
-			Owner:       grafanaDataSourcesPlugins,
-			Expression:  "false",
-			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
-			Name:        "elasticsearchESQLQuery",
-			Description: "Enables the ES|QL query editor in the Elasticsearch data source",
-			Stage:       FeatureStageExperimental,
-			Owner:       grafanaDataSourcesPlugins,
-			Expression:  "false",
-			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:        "awsDatasourcesHttpProxy",
 			Description: "Enables http proxy settings for aws datasources",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -257,8 +257,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,excludeRedundantManagedPermissions,experimental,@grafana/identity-access-team,false,false,false
 2025-12-16,pluginInsights,experimental,@grafana/grafana-catalog,false,false,true
 2025-10-29,panelTimeSettings,preview,@grafana/dashboards-squad,false,false,false
-2025-12-15,elasticsearchRawDSLQuery,experimental,@grafana/data-sources-plugins,false,false,false
-2026-05-22,elasticsearchESQLQuery,experimental,@grafana/data-sources-plugins,false,false,false
 2025-11-12,awsDatasourcesHttpProxy,experimental,@grafana/data-sources-plugins,false,false,false
 2025-11-17,transformationsEmptyPlaceholder,preview,@grafana/datapro,false,false,true
 2025-11-18,ttlPluginInstanceManager,experimental,@grafana/grafana-catalog,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -718,14 +718,6 @@ const (
 	// Enables a new panel time settings drawer
 	FlagPanelTimeSettings = "panelTimeSettings"
 
-	// FlagElasticsearchRawDSLQuery
-	// Enables the raw DSL query editor in the Elasticsearch data source
-	FlagElasticsearchRawDSLQuery = "elasticsearchRawDSLQuery"
-
-	// FlagElasticsearchESQLQuery
-	// Enables the ES|QL query editor in the Elasticsearch data source
-	FlagElasticsearchESQLQuery = "elasticsearchESQLQuery"
-
 	// FlagAwsDatasourcesHttpProxy
 	// Enables http proxy settings for aws datasources
 	FlagAwsDatasourcesHttpProxy = "awsDatasourcesHttpProxy"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1986,7 +1986,8 @@
       "metadata": {
         "name": "elasticsearchESQLQuery",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "deletionTimestamp": "2026-07-08T21:29:18Z"
       },
       "spec": {
         "description": "Enables the ES|QL query editor in the Elasticsearch data source",
@@ -2012,7 +2013,8 @@
       "metadata": {
         "name": "elasticsearchRawDSLQuery",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-12-15T19:11:05Z"
+        "creationTimestamp": "2025-12-15T19:11:05Z",
+        "deletionTimestamp": "2026-07-08T21:29:18Z"
       },
       "spec": {
         "description": "Enables the raw DSL query editor in the Elasticsearch data source",


### PR DESCRIPTION
## What

Removes the `elasticsearchRawDSLQuery` and `elasticsearchESQLQuery` feature toggles from the registry and regenerates the toggle codegen. Tombstone entries with a `deletionTimestamp` remain in `toggles_gen.json`.

Both toggles gated the raw DSL and ES|QL query editors in the externalised Elasticsearch data source plugin. The plugin removes its toggle checks in grafana/grafana-elasticsearch-datasource#358, making the editors always available, so the registry entries become dead plumbing. There are no consumers of either toggle in this repo (no `FlagElasticsearchRawDSLQuery` or `FlagElasticsearchESQLQuery` references outside the generated files).

Both toggles were `experimental` and default-false. The features remain and no longer need a toggle to enable them. The plugin PR should land and ship first so plugin versions that still check the toggles are not affected by the registry removal.

## Verification

- `make gen-feature-toggles` passes (featuremgmt tests green)
- `go build ./pkg/services/featuremgmt/...` passes
- `grep` for both toggle names and both `Flag*` constants finds no remaining consumers
