### PR TITLE
InfluxDB: Fix debug logs bypassing GF_LOG_LEVEL

### DIFF
--- a/pkg/tsdb/influxdb/flux/executor_test.go
+++ b/pkg/tsdb/influxdb/flux/executor_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -64,7 +65,7 @@ func executeMockedQuery(t *testing.T, name string, query queryModel) *backend.Da
 		query.MaxSeries = 50
 	}
 
-	dr := executeQuery(context.Background(), glog, query, runner, query.MaxSeries)
+	dr := executeQuery(context.Background(), log.NewNullLogger(), query, runner, query.MaxSeries)
 	return &dr
 }
 
@@ -229,7 +230,7 @@ func TestRealQuery(t *testing.T) {
 		runner, err := runnerFromDataSource(dsInfo)
 		require.NoError(t, err)
 
-		dr := executeQuery(context.Background(), glog, queryModel{
+		dr := executeQuery(context.Background(), log.NewNullLogger(), queryModel{
 			MaxDataPoints: 100,
 			RawQuery:      "buckets()",
 		}, runner, 50)

--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -5,19 +5,16 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/influxdata/influxdb-client-go/v2/api"
 
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
 
-var (
-	glog = backend.NewLoggerWith("logger", "tsdb.influx_flux")
-)
-
 // Query builds flux queries, executes them, and returns the results.
-func Query(ctx context.Context, dsInfo *models.DatasourceInfo, tsdbQuery backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	logger := glog.FromContext(ctx)
+func Query(ctx context.Context, dsInfo *models.DatasourceInfo, tsdbQuery backend.QueryDataRequest, logger log.Logger) (*backend.QueryDataResponse, error) {
+	logger = logger.FromContext(ctx)
 	tRes := backend.NewQueryDataResponse()
 	logger.Debug("Received a query", "query", tsdbQuery)
 	r, err := runnerFromDataSource(dsInfo)

--- a/pkg/tsdb/influxdb/fsql/client.go
+++ b/pkg/tsdb/influxdb/fsql/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -29,8 +30,8 @@ func (c *client) FlightClient() flight.Client {
 	return c.Client.Client
 }
 
-func newFlightSQLClient(addr string, metadata metadata.MD, secure bool, tlsConfig *httpclient.TLSOptions, proxyClient proxy.Client) (*client, error) {
-	dialOptions, err := grpcDialOptions(secure, tlsConfig, proxyClient)
+func newFlightSQLClient(addr string, metadata metadata.MD, secure bool, tlsConfig *httpclient.TLSOptions, proxyClient proxy.Client, logger log.Logger) (*client, error) {
+	dialOptions, err := grpcDialOptions(secure, tlsConfig, proxyClient, logger)
 	if err != nil {
 		return nil, fmt.Errorf("grpc dial options: %s", err)
 	}
@@ -47,7 +48,7 @@ func newFlightSQLClient(addr string, metadata metadata.MD, secure bool, tlsConfi
 	return &client{Client: fsqlClient, md: metadata}, nil
 }
 
-func grpcDialOptions(secure bool, tlsConfig *httpclient.TLSOptions, proxyClient proxy.Client) ([]grpc.DialOption, error) {
+func grpcDialOptions(secure bool, tlsConfig *httpclient.TLSOptions, proxyClient proxy.Client, logger log.Logger) ([]grpc.DialOption, error) {
 	dialOptions := []grpc.DialOption{}
 	secureDialOpt := grpc.WithTransportCredentials(insecure.NewCredentials())
 
@@ -70,7 +71,7 @@ func grpcDialOptions(secure bool, tlsConfig *httpclient.TLSOptions, proxyClient 
 		}
 
 		dialOptions = append(dialOptions, grpc.WithContextDialer(func(ctx context.Context, host string) (net.Conn, error) {
-			logger := glog.FromContext(ctx)
+			logger := logger.FromContext(ctx)
 			logger.Debug("Dialing secure socks proxy", "host", host)
 			conn, err := dialer.Dial("tcp", host)
 			if err != nil {

--- a/pkg/tsdb/influxdb/fsql/fsql.go
+++ b/pkg/tsdb/influxdb/fsql/fsql.go
@@ -7,15 +7,12 @@ import (
 	"net/url"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
-)
-
-var (
-	glog = backend.NewLoggerWith("logger", "tsdb.influx_flightsql")
 )
 
 type SQLOptions struct {
@@ -24,11 +21,11 @@ type SQLOptions struct {
 	Token    string              `json:"token"`
 }
 
-func Query(ctx context.Context, dsInfo *models.DatasourceInfo, req backend.QueryDataRequest) (
+func Query(ctx context.Context, dsInfo *models.DatasourceInfo, req backend.QueryDataRequest, logger log.Logger) (
 	*backend.QueryDataResponse, error) {
-	logger := glog.FromContext(ctx)
+	logger = logger.FromContext(ctx)
 	tRes := backend.NewQueryDataResponse()
-	r, err := runnerFromDataSource(dsInfo)
+	r, err := runnerFromDataSource(dsInfo, logger)
 	if err != nil {
 		return tRes, err
 	}
@@ -126,7 +123,7 @@ func ParseURL(endpoint string) (string, error) {
 }
 
 // runnerFromDataSource creates a runner from the datasource model (the datasource instance's configuration).
-func runnerFromDataSource(dsInfo *models.DatasourceInfo) (*runner, error) {
+func runnerFromDataSource(dsInfo *models.DatasourceInfo, logger log.Logger) (*runner, error) {
 	if dsInfo.URL == "" {
 		return nil, fmt.Errorf("missing URL from datasource configuration")
 	}
@@ -144,7 +141,7 @@ func runnerFromDataSource(dsInfo *models.DatasourceInfo) (*runner, error) {
 		md.Set("Authorization", fmt.Sprintf("Bearer %s", dsInfo.Token))
 	}
 
-	fsqlClient, err := newFlightSQLClient(u, md, !dsInfo.InsecureGrpc, dsInfo.TLSConfig, dsInfo.ProxyClient)
+	fsqlClient, err := newFlightSQLClient(u, md, !dsInfo.InsecureGrpc, dsInfo.TLSConfig, dsInfo.ProxyClient, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/influxdb/fsql/fsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/fsql_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql/example"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -93,6 +94,7 @@ func (suite *FSQLTestSuite) TestIntegration_QueryData() {
 					},
 				},
 			},
+			log.NewNullLogger(),
 		)
 
 		require.NoError(suite.T(), err)
@@ -159,6 +161,7 @@ func TestInvalidSchema(t *testing.T) {
 				},
 			},
 		},
+		log.NewNullLogger(),
 	)
 	require.Equal(t, backend.ErrorSourceDownstream, resp.Responses["A"].ErrorSource)
 }

--- a/pkg/tsdb/influxdb/healthcheck.go
+++ b/pkg/tsdb/influxdb/healthcheck.go
@@ -35,11 +35,11 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 
 	switch dsInfo.Version {
 	case influxVersionFlux:
-		return CheckFluxHealth(ctx, dsInfo, req, s.logger)
+		return CheckFluxHealth(ctx, dsInfo, req, s.fluxLogger)
 	case influxVersionInfluxQL:
-		return CheckInfluxQLHealth(ctx, dsInfo, req, s.logger)
+		return CheckInfluxQLHealth(ctx, dsInfo, req, s.influxqlLogger)
 	case influxVersionSQL:
-		return CheckSQLHealth(ctx, dsInfo, req, s.logger)
+		return CheckSQLHealth(ctx, dsInfo, req, s.fsqlLogger)
 	default:
 		return getHealthCheckMessage(logger, "", errors.New("unknown influx version"))
 	}
@@ -63,7 +63,7 @@ func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo,
 				},
 			},
 		},
-	})
+	}, logger)
 
 	if err != nil {
 		return getHealthCheckMessage(logger, "error performing flux query", err)
@@ -93,7 +93,7 @@ func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req
 				JSON:      []byte(`{"query": "SHOW measurements", "rawQuery": true}`),
 			},
 		},
-	})
+	}, logger)
 	if err != nil {
 		return getHealthCheckMessage(logger, "error performing influxQL query", err)
 	}
@@ -131,7 +131,7 @@ func CheckSQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req *bac
 				},
 			},
 		},
-	})
+	}, logger)
 
 	if err != nil {
 		return getHealthCheckMessage(logger, "error performing sql query", err)

--- a/pkg/tsdb/influxdb/healthcheck.go
+++ b/pkg/tsdb/influxdb/healthcheck.go
@@ -23,7 +23,7 @@ const (
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult,
 	error) {
-	logger := logger.FromContext(ctx)
+	logger := s.logger.FromContext(ctx)
 	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return getHealthCheckMessage(logger, "error getting datasource info", err)
@@ -35,20 +35,20 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 
 	switch dsInfo.Version {
 	case influxVersionFlux:
-		return CheckFluxHealth(ctx, dsInfo, req)
+		return CheckFluxHealth(ctx, dsInfo, req, s.logger)
 	case influxVersionInfluxQL:
-		return CheckInfluxQLHealth(ctx, dsInfo, req)
+		return CheckInfluxQLHealth(ctx, dsInfo, req, s.logger)
 	case influxVersionSQL:
-		return CheckSQLHealth(ctx, dsInfo, req)
+		return CheckSQLHealth(ctx, dsInfo, req, s.logger)
 	default:
 		return getHealthCheckMessage(logger, "", errors.New("unknown influx version"))
 	}
 }
 
 func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo,
-	req *backend.CheckHealthRequest) (*backend.CheckHealthResult,
+	req *backend.CheckHealthRequest, logger log.Logger) (*backend.CheckHealthResult,
 	error) {
-	logger := logger.FromContext(ctx)
+	logger = logger.FromContext(ctx)
 	ds, err := flux.Query(ctx, dsInfo, backend.QueryDataRequest{
 		PluginContext: req.PluginContext,
 		Queries: []backend.DataQuery{
@@ -80,8 +80,8 @@ func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo,
 	return getHealthCheckMessage(logger, "", errors.New("error getting flux query buckets"))
 }
 
-func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	logger := logger.FromContext(ctx)
+func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req *backend.CheckHealthRequest, logger log.Logger) (*backend.CheckHealthResult, error) {
+	logger = logger.FromContext(ctx)
 	tracer := tracing.DefaultTracer()
 	resp, err := influxql.Query(ctx, tracer, dsInfo, &backend.QueryDataRequest{
 		PluginContext: req.PluginContext,
@@ -115,7 +115,8 @@ func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req
 	return getHealthCheckMessage(logger, "", errors.New("error connecting influxDB influxQL"))
 }
 
-func CheckSQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+func CheckSQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req *backend.CheckHealthRequest, logger log.Logger) (*backend.CheckHealthResult, error) {
+	logger = logger.FromContext(ctx)
 	ds, err := fsql.Query(ctx, dsInfo, backend.QueryDataRequest{
 		PluginContext: req.PluginContext,
 		Queries: []backend.DataQuery{

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -23,16 +23,21 @@ import (
 var logger log.Logger = backend.NewLoggerWith("logger", "tsdb.influxdb")
 
 type Service struct {
-	im instancemgmt.InstanceManager
+	im     instancemgmt.InstanceManager
+	logger log.Logger
 }
 
 func ProvideService(httpClient *httpclient.Provider) *Service {
+	// Constructed here (not as a package-level var) so it picks up Grafana's
+	// in-process logger override installed during coreplugin init.
+	logger := backend.NewLoggerWith("logger", "tsdb.influxdb")
 	return &Service{
-		im: datasource.NewInstanceManager(NewInstanceSettings(httpClient)),
+		im:     datasource.NewInstanceManager(NewInstanceSettings(httpClient, logger)),
+		logger: logger,
 	}
 }
 
-func NewInstanceSettings(httpClientProvider *httpclient.Provider) datasource.InstanceFactoryFunc {
+func NewInstanceSettings(httpClientProvider *httpclient.Provider, logger log.Logger) datasource.InstanceFactoryFunc {
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		opts, err := settings.HTTPClientOptions(ctx)
 		if err != nil {
@@ -97,7 +102,7 @@ func NewInstanceSettings(httpClientProvider *httpclient.Provider) datasource.Ins
 }
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	logger := logger.FromContext(ctx)
+	logger := s.logger.FromContext(ctx)
 	logger.Debug("Received a query request", "numQueries", len(req.Queries))
 
 	tracer := tracing.DefaultTracer()

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -20,11 +20,12 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
 
-var logger log.Logger = backend.NewLoggerWith("logger", "tsdb.influxdb")
-
 type Service struct {
-	im     instancemgmt.InstanceManager
-	logger log.Logger
+	im             instancemgmt.InstanceManager
+	logger         log.Logger
+	fluxLogger     log.Logger
+	influxqlLogger log.Logger
+	fsqlLogger     log.Logger
 }
 
 func ProvideService(httpClient *httpclient.Provider) *Service {
@@ -32,8 +33,11 @@ func ProvideService(httpClient *httpclient.Provider) *Service {
 	// in-process logger override installed during coreplugin init.
 	logger := backend.NewLoggerWith("logger", "tsdb.influxdb")
 	return &Service{
-		im:     datasource.NewInstanceManager(NewInstanceSettings(httpClient, logger)),
-		logger: logger,
+		im:             datasource.NewInstanceManager(NewInstanceSettings(httpClient, logger)),
+		logger:         logger,
+		fluxLogger:     backend.NewLoggerWith("logger", "tsdb.influx_flux"),
+		influxqlLogger: backend.NewLoggerWith("logger", "tsdb.influx_influxql"),
+		fsqlLogger:     backend.NewLoggerWith("logger", "tsdb.influx_flightsql"),
 	}
 }
 
@@ -116,11 +120,11 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 
 	switch dsInfo.Version {
 	case influxVersionFlux:
-		return flux.Query(ctx, dsInfo, *req)
+		return flux.Query(ctx, dsInfo, *req, s.fluxLogger)
 	case influxVersionInfluxQL:
-		return influxql.Query(ctx, tracer, dsInfo, req)
+		return influxql.Query(ctx, tracer, dsInfo, req, s.influxqlLogger)
 	case influxVersionSQL:
-		return fsql.Query(ctx, dsInfo, *req)
+		return fsql.Query(ctx, dsInfo, *req, s.fsqlLogger)
 	default:
 		return nil, fmt.Errorf("unknown influxdb version")
 	}

--- a/pkg/tsdb/influxdb/influxql/influxql.go
+++ b/pkg/tsdb/influxdb/influxql/influxql.go
@@ -30,11 +30,10 @@ const (
 var (
 	ErrInvalidHttpMode = errors.New("'httpMode' should be either 'GET' or 'POST'")
 	ErrInvalidUrl      = errors.New("URL must contain scheme and host")
-	glog               = backend.NewLoggerWith("logger", "tsdb.influx_influxql")
 )
 
-func Query(ctx context.Context, tracer trace.Tracer, dsInfo *models.DatasourceInfo, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	logger := glog.FromContext(ctx)
+func Query(ctx context.Context, tracer trace.Tracer, dsInfo *models.DatasourceInfo, req *backend.QueryDataRequest, logger log.Logger) (*backend.QueryDataResponse, error) {
+	logger = logger.FromContext(ctx)
 	response := backend.NewQueryDataResponse()
 	var err error
 

--- a/pkg/tsdb/influxdb/mocks_test.go
+++ b/pkg/tsdb/influxdb/mocks_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
@@ -115,5 +116,6 @@ func GetMockService(version string, rt RoundTripper) *Service {
 			version:          version,
 			fakeRoundTripper: rt,
 		},
+		logger: log.NewNullLogger(),
 	}
 }

--- a/pkg/tsdb/influxdb/mocks_test.go
+++ b/pkg/tsdb/influxdb/mocks_test.go
@@ -116,6 +116,9 @@ func GetMockService(version string, rt RoundTripper) *Service {
 			version:          version,
 			fakeRoundTripper: rt,
 		},
-		logger: log.NewNullLogger(),
+		logger:         log.NewNullLogger(),
+		fluxLogger:     log.NewNullLogger(),
+		influxqlLogger: log.NewNullLogger(),
+		fsqlLogger:     log.NewNullLogger(),
 	}
 }

--- a/pkg/tsdb/influxdb/standalone/main.go
+++ b/pkg/tsdb/influxdb/standalone/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	if err := datasource.Manage("influxdb", influxdb.NewInstanceSettings(httpclient.NewProvider()), datasource.ManageOpts{}); err != nil {
+	if err := datasource.Manage("influxdb", influxdb.NewInstanceSettings(httpclient.NewProvider(), log.DefaultLogger), datasource.ManageOpts{}); err != nil {
 		log.DefaultLogger.Error(err.Error())
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

- The InfluxDB datasource emitted `@level=debug` JSON lines on every query and health check regardless of `GF_LOG_LEVEL`, because `var logger = backend.NewLoggerWith(...)` at package level was evaluated before `coreplugin` could install Grafana's in-process logger override. The `var` therefore captured the SDK's default `hclog` constructor at Debug level and bypassed Grafana's log filter for the lifetime of the process.
- Fix moves logger construction into `ProvideService` and threads it through helper functions called by `QueryData` and `CheckHealth`.
- A short comment in `ProvideService` records why the loggers must not be package-level vars, to prevent regression.
- This PR applied the same fix for Pyroscope: https://github.com/grafana/grafana/pull/126289

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/tsdb/influxdb/...`
- [x] Manual: run Grafana with `GF_LOG_LEVEL=info`, configure a InfluxDB datasource, run a query and a health check, confirm no `@level=debug` lines appear in the server logs.
- [x] Manual: with `GF_LOG_LEVEL=debug`, confirm the InfluxDB debug lines reappear (and come out in Grafana's `logfmt` format, not hclog JSON).