### PR TITLE
Alerting: Support Amazon Managed Prometheus recording rule writes

### DIFF
--- a/pkg/services/ngalert/writer/datasourcewriter.go
+++ b/pkg/services/ngalert/writer/datasourcewriter.go
@@ -39,7 +39,28 @@ type backendType string
 const (
 	grafanaCloudPromType backendType = "grafanacloud-prom"
 	prometheusType       backendType = "prometheus"
+	amazonPrometheusType backendType = "amazon-prometheus"
+	azurePrometheusType  backendType = "azure-prometheus"
 )
+
+const (
+	// amazonPrometheusRemoteWritePath is appended to an Amazon Managed Prometheus
+	// workspace URL to form the remote write endpoint.
+	amazonPrometheusRemoteWritePath = "/api/v1/remote_write"
+
+	// azurePrometheusRemoteWritePath is appended to an Azure Managed Prometheus
+	// endpoint URL to form the remote write endpoint.
+	azurePrometheusRemoteWritePath = "/api/v1/write"
+)
+
+// supportedRemoteWriteTypes is the set of data source types that recording rules
+// can write to. In addition to core Prometheus, the purpose-built Amazon and Azure
+// managed Prometheus data source plugins are supported.
+var supportedRemoteWriteTypes = map[string]bool{
+	datasources.DS_PROMETHEUS:        true,
+	datasources.DS_AMAZON_PROMETHEUS: true,
+	datasources.DS_AZURE_PROMETHEUS:  true,
+}
 
 type DatasourceWriterConfig struct {
 	// Timeout is the maximum time to wait for a remote write to succeed.
@@ -121,6 +142,19 @@ func getRemoteWriteURL(ds *datasources.DataSource) (*url.URL, error) {
 		return nil, err
 	}
 
+	// Amazon Managed Prometheus: the data source URL points at the workspace root
+	// (e.g. https://aps-workspaces.<region>.amazonaws.com/workspaces/<ws-id>), so the
+	// remote write path is appended directly. The generic Mimir/Cortex handling below
+	// would drop the /workspaces/<ws-id> prefix, so AMP must be handled explicitly.
+	if ds.Type == datasources.DS_AMAZON_PROMETHEUS {
+		return u.JoinPath(amazonPrometheusRemoteWritePath), nil
+	}
+
+	// Azure Managed Prometheus: append the standard write path to the endpoint URL.
+	if ds.Type == datasources.DS_AZURE_PROMETHEUS {
+		return u.JoinPath(azurePrometheusRemoteWritePath), nil
+	}
+
 	if getPrometheusType(ds) == "Prometheus" {
 		return u.JoinPath("/api/v1/write"), nil
 	}
@@ -176,8 +210,9 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 		return nil, err
 	}
 
-	if ds.Type != datasources.DS_PROMETHEUS {
-		return nil, errors.New("can only write to data sources of type prometheus")
+	if !supportedRemoteWriteTypes[ds.Type] {
+		return nil, fmt.Errorf("can only write to data sources of type prometheus, "+
+			"amazon managed prometheus, or azure managed prometheus, but got %q", ds.Type)
 	}
 
 	is, err := adapters.ModelToInstanceSettings(ds, w.decrypt)
@@ -227,9 +262,14 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 	}
 
 	var backend backendType
-	if dsUID == string(grafanaCloudPromType) {
+	switch {
+	case dsUID == string(grafanaCloudPromType):
 		backend = grafanaCloudPromType
-	} else {
+	case ds.Type == datasources.DS_AMAZON_PROMETHEUS:
+		backend = amazonPrometheusType
+	case ds.Type == datasources.DS_AZURE_PROMETHEUS:
+		backend = azurePrometheusType
+	default:
 		backend = prometheusType
 	}
 
@@ -241,6 +281,13 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 			BasicAuth:    ho.BasicAuth,
 			Header:       headers,
 			ProxyOptions: ho.ProxyOptions,
+			// SigV4 is required for Amazon Managed Prometheus, which only accepts
+			// SigV4-signed remote_write requests. CustomOptions and Middlewares carry
+			// plugin-specific auth (e.g. the AMP/Azure data source plugins) that must
+			// reach the writer's HTTP client for signing to work.
+			SigV4:         ho.SigV4,
+			CustomOptions: ho.CustomOptions,
+			Middlewares:   ho.Middlewares,
 		},
 		Timeout:     w.cfg.Timeout,
 		BackendType: backend,

--- a/pkg/services/ngalert/writer/datasourcewriter.go
+++ b/pkg/services/ngalert/writer/datasourcewriter.go
@@ -40,26 +40,20 @@ const (
 	grafanaCloudPromType backendType = "grafanacloud-prom"
 	prometheusType       backendType = "prometheus"
 	amazonPrometheusType backendType = "amazon-prometheus"
-	azurePrometheusType  backendType = "azure-prometheus"
 )
 
 const (
 	// amazonPrometheusRemoteWritePath is appended to an Amazon Managed Prometheus
 	// workspace URL to form the remote write endpoint.
 	amazonPrometheusRemoteWritePath = "/api/v1/remote_write"
-
-	// azurePrometheusRemoteWritePath is appended to an Azure Managed Prometheus
-	// endpoint URL to form the remote write endpoint.
-	azurePrometheusRemoteWritePath = "/api/v1/write"
 )
 
 // supportedRemoteWriteTypes is the set of data source types that recording rules
-// can write to. In addition to core Prometheus, the purpose-built Amazon and Azure
-// managed Prometheus data source plugins are supported.
+// can write to. In addition to core Prometheus, the purpose-built Amazon Managed
+// Prometheus data source plugin is supported.
 var supportedRemoteWriteTypes = map[string]bool{
 	datasources.DS_PROMETHEUS:        true,
 	datasources.DS_AMAZON_PROMETHEUS: true,
-	datasources.DS_AZURE_PROMETHEUS:  true,
 }
 
 type DatasourceWriterConfig struct {
@@ -150,11 +144,6 @@ func getRemoteWriteURL(ds *datasources.DataSource) (*url.URL, error) {
 		return u.JoinPath(amazonPrometheusRemoteWritePath), nil
 	}
 
-	// Azure Managed Prometheus: append the standard write path to the endpoint URL.
-	if ds.Type == datasources.DS_AZURE_PROMETHEUS {
-		return u.JoinPath(azurePrometheusRemoteWritePath), nil
-	}
-
 	if getPrometheusType(ds) == "Prometheus" {
 		return u.JoinPath("/api/v1/write"), nil
 	}
@@ -211,8 +200,8 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 	}
 
 	if !supportedRemoteWriteTypes[ds.Type] {
-		return nil, fmt.Errorf("can only write to data sources of type prometheus, "+
-			"amazon managed prometheus, or azure managed prometheus, but got %q", ds.Type)
+		return nil, fmt.Errorf("can only write to data sources of type prometheus "+
+			"or amazon managed prometheus, but got %q", ds.Type)
 	}
 
 	is, err := adapters.ModelToInstanceSettings(ds, w.decrypt)
@@ -267,8 +256,6 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 		backend = grafanaCloudPromType
 	case ds.Type == datasources.DS_AMAZON_PROMETHEUS:
 		backend = amazonPrometheusType
-	case ds.Type == datasources.DS_AZURE_PROMETHEUS:
-		backend = azurePrometheusType
 	default:
 		backend = prometheusType
 	}
@@ -283,7 +270,7 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 			ProxyOptions: ho.ProxyOptions,
 			// SigV4 is required for Amazon Managed Prometheus, which only accepts
 			// SigV4-signed remote_write requests. CustomOptions and Middlewares carry
-			// plugin-specific auth (e.g. the AMP/Azure data source plugins) that must
+			// plugin-specific auth (e.g. the AMP data source plugin) that must
 			// reach the writer's HTTP client for signing to work.
 			SigV4:         ho.SigV4,
 			CustomOptions: ho.CustomOptions,

--- a/pkg/services/ngalert/writer/datasourcewriter.go
+++ b/pkg/services/ngalert/writer/datasourcewriter.go
@@ -46,6 +46,11 @@ const (
 	// amazonPrometheusRemoteWritePath is appended to an Amazon Managed Prometheus
 	// workspace URL to form the remote write endpoint.
 	amazonPrometheusRemoteWritePath = "/api/v1/remote_write"
+
+	// amazonPrometheusSigV4Service is the AWS service namespace used to sign
+	// Amazon Managed Prometheus requests. It matches the value Grafana's core
+	// data source service derives for this type.
+	amazonPrometheusSigV4Service = "aps"
 )
 
 // supportedRemoteWriteTypes is the set of data source types that recording rules
@@ -260,6 +265,17 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 		backend = prometheusType
 	}
 
+	// The SDK's HTTPClientOptions never populates SigV4.Service; only Grafana's
+	// core data source service sets it (via awsServiceNamespace). The AWS signer
+	// uses the service name verbatim with no default, so leaving it empty
+	// produces a signature AWS rejects with 403. Set it explicitly for AMP.
+	sigV4 := ho.SigV4
+	if sigV4 != nil && ds.Type == datasources.DS_AMAZON_PROMETHEUS && sigV4.Service == "" {
+		sigV4Copy := *sigV4
+		sigV4Copy.Service = amazonPrometheusSigV4Service
+		sigV4 = &sigV4Copy
+	}
+
 	cfg := PrometheusWriterConfig{
 		URL: u.String(),
 		HTTPOptions: httpclient.Options{
@@ -272,7 +288,7 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 			// SigV4-signed remote_write requests. CustomOptions and Middlewares carry
 			// plugin-specific auth (e.g. the AMP data source plugin) that must
 			// reach the writer's HTTP client for signing to work.
-			SigV4:         ho.SigV4,
+			SigV4:         sigV4,
 			CustomOptions: ho.CustomOptions,
 			Middlewares:   ho.Middlewares,
 		},

--- a/pkg/services/ngalert/writer/datasourcewriter_test.go
+++ b/pkg/services/ngalert/writer/datasourcewriter_test.go
@@ -452,15 +452,6 @@ func TestDatasourceWriterGetRemoteWriteURL(t *testing.T) {
 			},
 			"https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-abc123/api/v1/remote_write",
 		},
-		{
-			"azure managed prometheus endpoint URL",
-			datasources.DataSource{
-				Type:     datasources.DS_AZURE_PROMETHEUS,
-				JsonData: simplejson.MustJson([]byte(`{}`)),
-				URL:      "https://myworkspace.monitor.azure.com",
-			},
-			"https://myworkspace.monitor.azure.com/api/v1/write",
-		},
 	}
 
 	for _, tt := range tc {
@@ -503,38 +494,6 @@ func TestDatasourceWriterManagedPrometheus(t *testing.T) {
 			# TYPE grafana_alerting_remote_writer_writes_total counter
 			grafana_alerting_remote_writer_writes_total{backend="%s",org="1",status_code="200"} 1
 		`, string(amazonPrometheusType))
-		require.NoError(t, testutil.CollectAndCompare(met.WritesTotal,
-			strings.NewReader(expectedMetric),
-			"grafana_alerting_remote_writer_writes_total"))
-	})
-
-	t.Run("when writing an Azure Prometheus datasource then it succeeds and uses the azure-prometheus backend", func(t *testing.T) {
-		testDS := setupDataSources(t)
-		testDS.Reset()
-
-		azureDS, _ := testDS.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
-			Name:     "azure-1",
-			UID:      "azure-1",
-			Type:     datasources.DS_AZURE_PROMETHEUS,
-			JsonData: simplejson.MustJson([]byte(`{}`)),
-		})
-		azureDS.URL = testDS.prom1.srv.URL
-		testDS.prom1.ExpectedPath = azurePrometheusRemoteWritePath
-
-		cfg := DatasourceWriterConfig{Timeout: time.Second * 5}
-		reg := prometheus.NewRegistry()
-		met := metrics.NewRemoteWriterMetrics(reg)
-		writer := NewDatasourceWriter(cfg, testDS, httpclient.NewProvider(), &mockPluginContextProvider{}, clock.New(), log.New("test"), met)
-
-		err := writer.WriteDatasource(context.Background(), "azure-1", "metric", time.Now(), frames, 1, map[string]string{})
-		require.NoError(t, err)
-		assert.Equal(t, 1, testDS.prom1.RequestsCount)
-
-		expectedMetric := fmt.Sprintf(`
-			# HELP grafana_alerting_remote_writer_writes_total The total number of remote writes attempted.
-			# TYPE grafana_alerting_remote_writer_writes_total counter
-			grafana_alerting_remote_writer_writes_total{backend="%s",org="1",status_code="200"} 1
-		`, string(azurePrometheusType))
 		require.NoError(t, testutil.CollectAndCompare(met.WritesTotal,
 			strings.NewReader(expectedMetric),
 			"grafana_alerting_remote_writer_writes_total"))

--- a/pkg/services/ngalert/writer/datasourcewriter_test.go
+++ b/pkg/services/ngalert/writer/datasourcewriter_test.go
@@ -191,7 +191,8 @@ func TestDatasourceWriter(t *testing.T) {
 
 		err := writer.WriteDatasource(context.Background(), "loki-1", "metric", time.Now(), frames, 1, map[string]string{})
 		require.Error(t, err)
-		require.EqualError(t, err, "can only write to data sources of type prometheus")
+		require.Contains(t, err.Error(), "can only write to data sources of type prometheus")
+		require.Contains(t, err.Error(), datasources.DS_LOKI)
 	})
 
 	t.Run("when writing with an empty datasource uid then the default is written", func(t *testing.T) {
@@ -433,6 +434,33 @@ func TestDatasourceWriterGetRemoteWriteURL(t *testing.T) {
 			},
 			"http://example.com/api/v1/push",
 		},
+		{
+			"amazon managed prometheus workspace URL",
+			datasources.DataSource{
+				Type:     datasources.DS_AMAZON_PROMETHEUS,
+				JsonData: simplejson.MustJson([]byte(`{}`)),
+				URL:      "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-abc123",
+			},
+			"https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-abc123/api/v1/remote_write",
+		},
+		{
+			"amazon managed prometheus workspace URL with trailing slash",
+			datasources.DataSource{
+				Type:     datasources.DS_AMAZON_PROMETHEUS,
+				JsonData: simplejson.MustJson([]byte(`{}`)),
+				URL:      "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-abc123/",
+			},
+			"https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-abc123/api/v1/remote_write",
+		},
+		{
+			"azure managed prometheus endpoint URL",
+			datasources.DataSource{
+				Type:     datasources.DS_AZURE_PROMETHEUS,
+				JsonData: simplejson.MustJson([]byte(`{}`)),
+				URL:      "https://myworkspace.monitor.azure.com",
+			},
+			"https://myworkspace.monitor.azure.com/api/v1/write",
+		},
 	}
 
 	for _, tt := range tc {
@@ -442,4 +470,102 @@ func TestDatasourceWriterGetRemoteWriteURL(t *testing.T) {
 			require.Equal(t, tt.url, res.String())
 		})
 	}
+}
+
+func TestDatasourceWriterManagedPrometheus(t *testing.T) {
+	series := []map[string]string{{"foo": "1"}, {"foo": "2"}, {"foo": "3"}, {"foo": "4"}}
+	frames := frameGenFromLabels(t, data.FrameTypeNumericWide, series)
+
+	t.Run("when writing an Amazon Prometheus datasource then it succeeds and uses the amazon-prometheus backend", func(t *testing.T) {
+		testDS := setupDataSources(t)
+		testDS.Reset()
+
+		ampDS, _ := testDS.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+			Name:     "amp-1",
+			UID:      "amp-1",
+			Type:     datasources.DS_AMAZON_PROMETHEUS,
+			JsonData: simplejson.MustJson([]byte(`{}`)),
+		})
+		ampDS.URL = testDS.prom1.srv.URL
+		testDS.prom1.ExpectedPath = amazonPrometheusRemoteWritePath
+
+		cfg := DatasourceWriterConfig{Timeout: time.Second * 5}
+		reg := prometheus.NewRegistry()
+		met := metrics.NewRemoteWriterMetrics(reg)
+		writer := NewDatasourceWriter(cfg, testDS, httpclient.NewProvider(), &mockPluginContextProvider{}, clock.New(), log.New("test"), met)
+
+		err := writer.WriteDatasource(context.Background(), "amp-1", "metric", time.Now(), frames, 1, map[string]string{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, testDS.prom1.RequestsCount)
+
+		expectedMetric := fmt.Sprintf(`
+			# HELP grafana_alerting_remote_writer_writes_total The total number of remote writes attempted.
+			# TYPE grafana_alerting_remote_writer_writes_total counter
+			grafana_alerting_remote_writer_writes_total{backend="%s",org="1",status_code="200"} 1
+		`, string(amazonPrometheusType))
+		require.NoError(t, testutil.CollectAndCompare(met.WritesTotal,
+			strings.NewReader(expectedMetric),
+			"grafana_alerting_remote_writer_writes_total"))
+	})
+
+	t.Run("when writing an Azure Prometheus datasource then it succeeds and uses the azure-prometheus backend", func(t *testing.T) {
+		testDS := setupDataSources(t)
+		testDS.Reset()
+
+		azureDS, _ := testDS.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+			Name:     "azure-1",
+			UID:      "azure-1",
+			Type:     datasources.DS_AZURE_PROMETHEUS,
+			JsonData: simplejson.MustJson([]byte(`{}`)),
+		})
+		azureDS.URL = testDS.prom1.srv.URL
+		testDS.prom1.ExpectedPath = azurePrometheusRemoteWritePath
+
+		cfg := DatasourceWriterConfig{Timeout: time.Second * 5}
+		reg := prometheus.NewRegistry()
+		met := metrics.NewRemoteWriterMetrics(reg)
+		writer := NewDatasourceWriter(cfg, testDS, httpclient.NewProvider(), &mockPluginContextProvider{}, clock.New(), log.New("test"), met)
+
+		err := writer.WriteDatasource(context.Background(), "azure-1", "metric", time.Now(), frames, 1, map[string]string{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, testDS.prom1.RequestsCount)
+
+		expectedMetric := fmt.Sprintf(`
+			# HELP grafana_alerting_remote_writer_writes_total The total number of remote writes attempted.
+			# TYPE grafana_alerting_remote_writer_writes_total counter
+			grafana_alerting_remote_writer_writes_total{backend="%s",org="1",status_code="200"} 1
+		`, string(azurePrometheusType))
+		require.NoError(t, testutil.CollectAndCompare(met.WritesTotal,
+			strings.NewReader(expectedMetric),
+			"grafana_alerting_remote_writer_writes_total"))
+	})
+
+	t.Run("when writing an Amazon Prometheus datasource then HTTP client options are constructed", func(t *testing.T) {
+		testDS := setupDataSources(t)
+		testDS.Reset()
+
+		mockProvider := newMockHTTPClientProvider()
+
+		ampDS, _ := testDS.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+			Name:     "amp-sigv4",
+			UID:      "amp-sigv4",
+			Type:     datasources.DS_AMAZON_PROMETHEUS,
+			JsonData: simplejson.MustJson([]byte(`{}`)),
+		})
+		ampDS.URL = testDS.prom1.srv.URL
+		testDS.prom1.ExpectedPath = amazonPrometheusRemoteWritePath
+
+		cfg := DatasourceWriterConfig{Timeout: time.Second * 5}
+		met := metrics.NewRemoteWriterMetrics(prometheus.NewRegistry())
+		writer := NewDatasourceWriter(cfg, testDS, mockProvider, &mockPluginContextProvider{}, clock.New(), log.New("test"), met)
+
+		err := writer.WriteDatasource(context.Background(), "amp-sigv4", "metric", time.Now(), frames, 1, map[string]string{})
+		require.NoError(t, err)
+
+		// The AMP type is accepted and a client is constructed from the datasource's
+		// HTTP options. Full SigV4 signing verification requires an integration test
+		// with real credentials; here we confirm the code path builds the client.
+		require.Equal(t, 1, mockProvider.callCount)
+		require.NotNil(t, mockProvider.lastOptions)
+	})
 }

--- a/pkg/services/ngalert/writer/datasourcewriter_test.go
+++ b/pkg/services/ngalert/writer/datasourcewriter_test.go
@@ -527,4 +527,35 @@ func TestDatasourceWriterManagedPrometheus(t *testing.T) {
 		require.Equal(t, 1, mockProvider.callCount)
 		require.NotNil(t, mockProvider.lastOptions)
 	})
+
+	t.Run("when writing an Amazon Prometheus datasource with SigV4 then the aps service namespace is set", func(t *testing.T) {
+		testDS := setupDataSources(t)
+		testDS.Reset()
+
+		mockProvider := newMockHTTPClientProvider()
+
+		ampDS, _ := testDS.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+			Name:     "amp-sigv4-service",
+			UID:      "amp-sigv4-service",
+			Type:     datasources.DS_AMAZON_PROMETHEUS,
+			JsonData: simplejson.MustJson([]byte(`{"sigV4Auth": true, "sigV4Region": "us-west-2"}`)),
+		})
+		ampDS.URL = testDS.prom1.srv.URL
+		testDS.prom1.ExpectedPath = amazonPrometheusRemoteWritePath
+
+		cfg := DatasourceWriterConfig{Timeout: time.Second * 5}
+		met := metrics.NewRemoteWriterMetrics(prometheus.NewRegistry())
+		writer := NewDatasourceWriter(cfg, testDS, mockProvider, &mockPluginContextProvider{}, clock.New(), log.New("test"), met)
+
+		err := writer.WriteDatasource(context.Background(), "amp-sigv4-service", "metric", time.Now(), frames, 1, map[string]string{})
+		require.NoError(t, err)
+
+		// The SDK's HTTPClientOptions leaves SigV4.Service empty, and the AWS signer
+		// uses it verbatim with no default, so an empty value would be signed as an
+		// empty service name and rejected with 403. It must be set to "aps".
+		require.NotNil(t, mockProvider.lastOptions)
+		require.NotNil(t, mockProvider.lastOptions.SigV4)
+		require.Equal(t, amazonPrometheusSigV4Service, mockProvider.lastOptions.SigV4.Service)
+		require.Equal(t, "us-west-2", mockProvider.lastOptions.SigV4.Region)
+	})
 }


### PR DESCRIPTION
## What this PR does

Grafana-managed recording rules currently fail when the write target is an
**Amazon Managed Service for Prometheus (AMP)** data source
(`grafana-amazonprometheus-datasource`). The core Prometheus data source works,
but the purpose-built AMP plugin is rejected.

This PR fixes three defects in `pkg/services/ngalert/writer/datasourcewriter.go`
so the recording-rule remote-write path supports AMP:

1. **Data source type gate** — the writer only allowed `DS_PROMETHEUS`. It now
   accepts an allowlist that includes `grafana-amazonprometheus-datasource`.
   The rejection error now names the unsupported type for easier debugging.

2. **Auth options were dropped** — the writer built its remote-write HTTP client
   from the data source's HTTP options but did not propagate `SigV4`,
   `CustomOptions`, or `Middlewares`. AMP only accepts SigV4-signed
   `remote_write` requests, so writes failed with 401/403. These options are now
   propagated.

3. **Remote-write URL** — `getRemoteWriteURL()` had no branch for AMP and
   the generic Mimir/Cortex fallback dropped the `/workspaces/<ws-id>` prefix of
   an AMP workspace URL. AMP now correctly resolves to
   `<workspace-url>/api/v1/remote_write`.

It also adds a distinct `amazon-prometheus` backend label to the remote-writer
metrics for observability.

## Why the fix is in Grafana core (not the data source plugin)

The recording-rule writer constructs its own remote-write HTTP client from the
stored data source settings; it never calls the plugin backend. So the behavior
can only be fixed here in core, not in `grafana-amazonprometheus-datasource`.

## Which issue(s) this PR fixes

Fixes the AMP recording-rules failure reported in
grafana/grafana-amazonprometheus-datasource#772

## Tests

- `getRemoteWriteURL` table cases for AMP (with and without trailing slash).
- End-to-end write test asserting the correct remote-write path and the
  `amazon-prometheus` backend metric label.
- A test confirming the AMP type flows through client construction.
- Updated the existing "non-prometheus datasource" test to match the new
  descriptive error.

Verified locally: `gofmt` clean, `go vet` clean,
`go test ./pkg/services/ngalert/writer/...` passes, and `go build ./pkg/...`
compiles clean.