### PR TITLE
UnifiedHomepage: Fix redirect URL precedence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -900,6 +900,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/history/ @grafana/datapro
 /public/app/core/hooks/useBusEvent.ts @grafana/grafana-frontend-platform
 /public/app/core/hooks/useCleanup.ts @grafana/grafana-frontend-platform
+/public/app/core/hooks/useHomeNav* @grafana/grafana-frontend-navigation
 /public/app/core/hooks/useMediaQueryMinWidth.ts @grafana/grafana-frontend-platform
 /public/app/core/hooks/useNavModel.ts @grafana/grafana-frontend-navigation
 /public/app/core/hooks/useQueryParams.ts @grafana/grafana-frontend-platform

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
@@ -5,8 +5,7 @@ import { t } from '@grafana/i18n';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { IconButton, Stack, useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
-import { HOME_NAV_ID } from 'app/core/reducers/navModel';
-import { useSelector } from 'app/types/store';
+import { useHomeNav } from 'app/core/hooks/useHomeNav';
 
 import { HomeLogo, HomeTitle } from '../../Branding/Branding';
 import { OrganizationSwitcher } from '../OrganizationSwitcher/OrganizationSwitcher';
@@ -24,7 +23,7 @@ export function MegaMenuHeader({ handleDockedMenu, onClose }: Props) {
   const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
   const { chrome } = useGrafana();
   const state = chrome.useState();
-  const homeNav = useSelector((state) => state.navIndex)[HOME_NAV_ID];
+  const homeNav = useHomeNav();
   const styles = useStyles2(getStyles, visualRefreshEnabled);
 
   return (

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -9,8 +9,8 @@ import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { Icon, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { MEGA_MENU_TOGGLE_ID } from 'app/core/constants';
 import { useGrafana } from 'app/core/context/GrafanaContext';
+import { useHomeNav } from 'app/core/hooks/useHomeNav';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
-import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { contextSrv } from 'app/core/services/context_srv';
 import { ScopesSelector } from 'app/features/scopes/selector/ScopesSelector';
 import { useSelector } from 'app/types/store';
@@ -59,7 +59,7 @@ export const SingleTopBar = memo(function SingleTopBar({
   const menuDockedAndOpen = !state.chromeless && state.megaMenuDocked && state.megaMenuOpen;
   const styles = useStyles2(getStyles, menuDockedAndOpen, visualRefreshEnabled);
   const profileNode = useSelector((state) => state.navIndex['profile']);
-  const homeNav = useSelector((state) => state.navIndex)[HOME_NAV_ID];
+  const homeNav = useHomeNav();
   const breadcrumbs = buildBreadcrumbs(sectionNav, pageNav, homeNav);
   const isSmallScreen = !useMediaQueryMinWidth('sm');
   const isLargeScreen = useMediaQueryMinWidth('lg');

--- a/public/app/core/hooks/useHomeNav.test.ts
+++ b/public/app/core/hooks/useHomeNav.test.ts
@@ -1,0 +1,44 @@
+import { act, getWrapper, renderHook } from 'test/test-utils';
+
+import { setTestFlags } from '@grafana/test-utils/unstable';
+import { configureStore } from 'app/store/configureStore';
+
+import { SETUP_GUIDE_HOME_URL, useHomeNav } from './useHomeNav';
+
+const renderUseHomeNav = (url: string) => {
+  const store = configureStore({
+    navIndex: { home: { id: 'home', text: 'Home', url } },
+  });
+  return renderHook(() => useHomeNav(), { wrapper: getWrapper({ store, renderWithRouter: false }) });
+};
+
+describe('useHomeNav', () => {
+  afterEach(async () => {
+    // Wrap in act() because setTestFlags fires OpenFeature events that trigger React state updates
+    await act(async () => {
+      setTestFlags({});
+    });
+  });
+
+  it('flag off → returns the setup guide url unchanged', () => {
+    const { result } = renderUseHomeNav(SETUP_GUIDE_HOME_URL);
+
+    expect(result.current?.url).toBe(SETUP_GUIDE_HOME_URL);
+  });
+
+  it('flag on + setup guide url → rewrites the url to the homepage', () => {
+    setTestFlags({ 'grafana.unifiedHomepage': true });
+
+    const { result } = renderUseHomeNav(SETUP_GUIDE_HOME_URL);
+
+    expect(result.current?.url).toBe('/');
+  });
+
+  it('flag on + other url → returns the url unchanged', () => {
+    setTestFlags({ 'grafana.unifiedHomepage': true });
+
+    const { result } = renderUseHomeNav('/d/custom-home');
+
+    expect(result.current?.url).toBe('/d/custom-home');
+  });
+});

--- a/public/app/core/hooks/useHomeNav.ts
+++ b/public/app/core/hooks/useHomeNav.ts
@@ -1,0 +1,23 @@
+import { type NavModelItem } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { useFlagGrafanaUnifiedHomepage } from '@grafana/runtime/internal';
+import { HOME_NAV_ID } from 'app/core/reducers/navModel';
+import { useSelector } from 'app/types/store';
+
+export const SETUP_GUIDE_HOME_URL = '/a/grafana-setupguide-app/home';
+
+/**
+ * Returns the home nav item. When the unified homepage is enabled, a stale
+ * `home_page` config pointing at the setup guide app is superseded by the new
+ * homepage, so the link is rewritten to the root URL.
+ */
+export function useHomeNav(): NavModelItem | undefined {
+  const homeNav = useSelector((state) => state.navIndex[HOME_NAV_ID]);
+  const unifiedHomepageEnabled = useFlagGrafanaUnifiedHomepage();
+
+  if (unifiedHomepageEnabled && homeNav?.url === SETUP_GUIDE_HOME_URL) {
+    return { ...homeNav, url: config.appSubUrl + '/' };
+  }
+
+  return homeNav;
+}

--- a/public/app/features/home/HomeRoute.test.tsx
+++ b/public/app/features/home/HomeRoute.test.tsx
@@ -129,4 +129,24 @@ describe('HomeRoute', () => {
       expect(locationService.getLocation().pathname).toContain('/d/abc');
     });
   });
+
+  it('flag on + homeURL pointing at the setup guide → renders HomePage without redirecting', async () => {
+    setTestFlags({ 'grafana.unifiedHomepage': true });
+    stubMergedPreferences({ homeURL: '/a/grafana-setupguide-app/home' });
+
+    render(<HomeRoute {...props} />);
+
+    expect(await screen.findByText(/Welcome to Grafana/i)).toBeInTheDocument();
+    expect(locationService.getLocation().pathname).not.toContain('grafana-setupguide-app');
+  });
+
+  it('flag on + homeDashboardUID and homeURL both present → renders dashboard proxy without redirecting', async () => {
+    setTestFlags({ 'grafana.unifiedHomepage': true });
+    stubMergedPreferences({ homeDashboardUID: 'abc', homeURL: '/d/other' });
+
+    render(<HomeRoute {...props} />);
+
+    expect(await screen.findByTestId('dashboard-page-proxy-stub')).toBeInTheDocument();
+    expect(locationService.getLocation().pathname).not.toContain('/d/other');
+  });
 });

--- a/public/app/features/home/HomeRoute.tsx
+++ b/public/app/features/home/HomeRoute.tsx
@@ -4,6 +4,7 @@ import { useMergedPreferencesQuery } from '@grafana/api-clients/rtkq/preferences
 import { locationUtil } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { useFlagGrafanaUnifiedHomepage } from '@grafana/runtime/internal';
+import { SETUP_GUIDE_HOME_URL } from 'app/core/hooks/useHomeNav';
 import { GrafanaRouteLoading } from 'app/core/navigation/GrafanaRouteLoading';
 
 import { type DashboardPageProxyProps } from '../dashboard/containers/DashboardPageProxy';
@@ -22,17 +23,18 @@ function UnifiedHomeRoute(props: DashboardPageProxyProps) {
   const { data, isLoading, isError } = useMergedPreferencesQuery();
   const redirectUri = data?.spec?.homeURL;
   const homeDashboardUID = data?.spec?.homeDashboardUID;
+  // homeDashboardUID takes precedence over homeURL; the setup guide redirect is superseded by the new homepage
+  const willRedirect = Boolean(redirectUri) && !homeDashboardUID && redirectUri !== SETUP_GUIDE_HOME_URL;
 
   useEffect(() => {
-    // homeDashboardUID takes precedence over homeURL, also skip the setup guide redirect if new homepage toggle is on
-    if (homeDashboardUID || !redirectUri || redirectUri === '/a/grafana-setupguide-app/home') {
+    if (!willRedirect || !redirectUri) {
       return;
     }
     const newUrl = locationUtil.processRedirectUri(redirectUri, locationService.getLocation());
     locationService.replace(newUrl);
-  }, [redirectUri, homeDashboardUID]);
+  }, [willRedirect, redirectUri]);
 
-  if (isLoading || redirectUri) {
+  if (isLoading || willRedirect) {
     return <GrafanaRouteLoading />;
   }
 

--- a/public/app/features/home/HomeRoute.tsx
+++ b/public/app/features/home/HomeRoute.tsx
@@ -24,10 +24,10 @@ function UnifiedHomeRoute(props: DashboardPageProxyProps) {
   const redirectUri = data?.spec?.homeURL;
   const homeDashboardUID = data?.spec?.homeDashboardUID;
   // homeDashboardUID takes precedence over homeURL; the setup guide redirect is superseded by the new homepage
-  const willRedirect = Boolean(redirectUri) && !homeDashboardUID && redirectUri !== SETUP_GUIDE_HOME_URL;
+  const willRedirect = !!redirectUri && !homeDashboardUID && redirectUri !== SETUP_GUIDE_HOME_URL;
 
   useEffect(() => {
-    if (!willRedirect || !redirectUri) {
+    if (!willRedirect) {
       return;
     }
     const newUrl = locationUtil.processRedirectUri(redirectUri, locationService.getLocation());

--- a/public/app/features/home/HomeRoute.tsx
+++ b/public/app/features/home/HomeRoute.tsx
@@ -21,14 +21,16 @@ function HomeRouteInner(props: DashboardPageProxyProps) {
 function UnifiedHomeRoute(props: DashboardPageProxyProps) {
   const { data, isLoading, isError } = useMergedPreferencesQuery();
   const redirectUri = data?.spec?.homeURL;
+  const homeDashboardUID = data?.spec?.homeDashboardUID;
 
   useEffect(() => {
-    if (!redirectUri) {
+    // homeDashboardUID takes precedence over homeURL, also skip the setup guide redirect if new homepage toggle is on
+    if (homeDashboardUID || !redirectUri || redirectUri === '/a/grafana-setupguide-app/home') {
       return;
     }
     const newUrl = locationUtil.processRedirectUri(redirectUri, locationService.getLocation());
     locationService.replace(newUrl);
-  }, [redirectUri]);
+  }, [redirectUri, homeDashboardUID]);
 
   if (isLoading || redirectUri) {
     return <GrafanaRouteLoading />;
@@ -40,7 +42,6 @@ function UnifiedHomeRoute(props: DashboardPageProxyProps) {
     return <DashboardPageProxy {...props} />;
   }
 
-  const homeDashboardUID = data.spec?.homeDashboardUID;
   if (homeDashboardUID) {
     return <DashboardPageProxy {...props} />;
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Ensure that configured `homeDashboardUID` takes precedence over `homeURL` when resolving home page redirects. 
- Explicitly discard setup guide as a homeURL when the unifiedHomepage toggle is on

**Why do we need this feature?**

Unblocks the rollout of the unifiedHomepage feature toggle. 
