### PR TITLE
Homepage: Add analytics for card interactions and home-dashboard changes

### DIFF
--- a/public/app/core/components/SharedPreferences/SharedPreferences.test.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.test.tsx
@@ -9,6 +9,14 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { captureRequests } from 'app/features/alerting/unified/mocks/server/events';
 
 import { SharedPreferences } from './SharedPreferences';
+import { homeDashboardChanged } from './analytics/main';
+
+jest.mock('./analytics/main', () => ({
+  saveButtonClicked: jest.fn(),
+  themeChanged: jest.fn(),
+  languageChanged: jest.fn(),
+  homeDashboardChanged: jest.fn(),
+}));
 
 setBackendSrv(backendSrv);
 setupMockServer();
@@ -54,6 +62,11 @@ afterAll(() => {
     writable: true,
     value: original,
   });
+});
+
+beforeEach(() => {
+  mockReload.mockClear();
+  jest.mocked(homeDashboardChanged).mockClear();
 });
 
 describe('SharedPreferences', () => {
@@ -179,5 +192,33 @@ describe('SharedPreferences', () => {
     const { user } = await setup();
     await user.click(screen.getByText('Save preferences'));
     expect(mockReload).toHaveBeenCalled();
+  });
+
+  it('fires home_dashboard_changed with action set when a new home dashboard is saved', async () => {
+    const { user } = await setup();
+
+    await selectComboboxOptionInTest(
+      await screen.findByRole('combobox', { name: /home dashboard/i }),
+      new RegExp(dashbdE.item.title)
+    );
+    await user.click(screen.getByText('Save preferences'));
+
+    await waitFor(() => {
+      expect(jest.mocked(homeDashboardChanged)).toHaveBeenCalledWith({
+        preferenceType: 'user',
+        action: 'set',
+        unifiedHomepageEnabled: false,
+      });
+    });
+  });
+
+  it('does not fire home_dashboard_changed when the home dashboard is unchanged', async () => {
+    const { user } = await setup();
+
+    await selectOptionInTest(screen.getByLabelText('Timezone'), 'Sydney');
+    await user.click(screen.getByText('Save preferences'));
+
+    await waitFor(() => expect(mockReload).toHaveBeenCalled());
+    expect(jest.mocked(homeDashboardChanged)).not.toHaveBeenCalled();
   });
 });

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.test.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.test.tsx
@@ -1,16 +1,24 @@
 import { HttpResponse } from 'msw';
 import { getSelectParent, selectOptionInTest } from 'test/helpers/selectOptionInTest';
-import { render, screen, userEvent, waitFor, within } from 'test/test-utils';
+import { act, render, screen, userEvent, waitFor, within } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
 import { mockComboboxRect } from '@grafana/test-utils';
 import { preferencesHandlers } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
-import { getFolderFixtures } from '@grafana/test-utils/unstable';
+import { getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { captureRequests } from 'app/features/alerting/unified/mocks/server/events';
 
 import { SharedPreferencesFunctional } from './SharedPreferencesFunctional';
+import { homeDashboardChanged } from './analytics/main';
+
+jest.mock('./analytics/main', () => ({
+  saveButtonClicked: jest.fn(),
+  themeChanged: jest.fn(),
+  languageChanged: jest.fn(),
+  homeDashboardChanged: jest.fn(),
+}));
 
 setBackendSrv(backendSrv);
 setupMockServer();
@@ -41,6 +49,15 @@ const originalLocation = window.location;
 
 beforeEach(() => {
   mockReload.mockClear();
+  jest.mocked(homeDashboardChanged).mockClear();
+});
+
+afterEach(async () => {
+  // Wrap in act() because setTestFlags fires OpenFeature events that can trigger React state
+  // updates while the component is still mounted (RTL cleanup runs in a separate afterEach).
+  await act(async () => {
+    setTestFlags({});
+  });
 });
 
 beforeAll(() => {
@@ -224,5 +241,71 @@ describe('SharedPreferencesFunctional', () => {
     await waitFor(() => expect(themeSelect).toBeDisabled());
 
     expect(screen.getByText('Save preferences').closest('button')).not.toBeDisabled();
+  });
+
+  it('fires home_dashboard_changed with action set when a new home dashboard is saved', async () => {
+    const { user } = await setup();
+
+    await selectComboboxOptionInTest(
+      await screen.findByRole('combobox', { name: /home dashboard/i }),
+      new RegExp(dashbdE.item.title)
+    );
+    await user.click(screen.getByText('Save preferences'));
+
+    await waitFor(() => {
+      expect(jest.mocked(homeDashboardChanged)).toHaveBeenCalledWith({
+        preferenceType: 'user',
+        action: 'set',
+        unifiedHomepageEnabled: false,
+      });
+    });
+  });
+
+  it('reports unifiedHomepageEnabled true when the flag is on', async () => {
+    setTestFlags({ 'grafana.unifiedHomepage': true });
+    const { user } = await setup();
+
+    await selectComboboxOptionInTest(
+      await screen.findByRole('combobox', { name: /home dashboard/i }),
+      new RegExp(dashbdE.item.title)
+    );
+    await user.click(screen.getByText('Save preferences'));
+
+    await waitFor(() => {
+      expect(jest.mocked(homeDashboardChanged)).toHaveBeenCalledWith({
+        preferenceType: 'user',
+        action: 'set',
+        unifiedHomepageEnabled: true,
+      });
+    });
+  });
+
+  it('does not fire home_dashboard_changed when the home dashboard is unchanged', async () => {
+    const { user } = await setup();
+
+    await selectOptionInTest(screen.getByLabelText('Timezone'), 'Sydney');
+    await user.click(screen.getByText('Save preferences'));
+
+    await waitFor(() => expect(mockReload).toHaveBeenCalled());
+    expect(jest.mocked(homeDashboardChanged)).not.toHaveBeenCalled();
+  });
+
+  it('fires home_dashboard_changed with action cleared when the dashboard is cleared', async () => {
+    const { user } = await setup();
+
+    const dashboardSelect = screen.getByTestId('User preferences home dashboard drop down');
+    // The Clear value button only renders once the loaded dashboard (dashbdD) resolves, so awaiting it
+    // guarantees a non-empty starting value to clear.
+    await within(dashboardSelect).findByRole('button', { name: 'Clear value' });
+    await user.click(within(dashboardSelect).getByRole('button', { name: 'Clear value' }));
+    await user.click(screen.getByText('Save preferences'));
+
+    await waitFor(() => {
+      expect(jest.mocked(homeDashboardChanged)).toHaveBeenCalledWith({
+        preferenceType: 'user',
+        action: 'cleared',
+        unifiedHomepageEnabled: false,
+      });
+    });
   });
 });

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
@@ -5,6 +5,7 @@ import { FeatureState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   Alert,
   Box,
@@ -27,7 +28,7 @@ import { changeTheme } from 'app/core/services/theme';
 import { DashboardPicker } from '../Select/DashboardPicker';
 import { getSelectableThemes } from '../ThemeSelector/getSelectableThemes';
 
-import { languageChanged, saveButtonClicked, themeChanged } from './analytics/main';
+import { homeDashboardChanged, languageChanged, saveButtonClicked, themeChanged } from './analytics/main';
 import { useSharedPreferences } from './useSharedPreferences';
 import { getLanguageOptions, getStyles, getTranslatedThemeName, type PrefsState, type Props } from './utils';
 
@@ -90,6 +91,10 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
       });
     }
 
+    // Capture before the mutation: RTK refetches prefs after updatePreferences, so comparing afterwards would race.
+    const previousHomeDashboardUID = prefs?.homeDashboardUID ?? '';
+    const nextHomeDashboardUID = state.homeDashboardUID ?? '';
+
     const prefsData = state;
     // prevent page reload on save failure so the error banner remains visible
     try {
@@ -97,6 +102,14 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
     } catch {
       // error is surfaced via isUpdateError — just prevent the reload below
       return;
+    }
+
+    if (nextHomeDashboardUID !== previousHomeDashboardUID) {
+      homeDashboardChanged({
+        preferenceType: props.preferenceType,
+        action: nextHomeDashboardUID ? 'set' : 'cleared',
+        unifiedHomepageEnabled: getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaUnifiedHomepage, false),
+      });
     }
 
     window.location.reload();

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
@@ -5,7 +5,6 @@ import { FeatureState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   Alert,
   Box,
@@ -39,6 +38,7 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
     useSharedPreferences(resourceUri);
 
   const isAnalyticsFrameworkEnabled = useBooleanFlagValue('analyticsFramework', true);
+  const unifiedHomepageEnabled = useBooleanFlagValue('grafana.unifiedHomepage', false);
   const [state, setState] = useState<PrefsState>({
     theme: undefined,
     timezone: '',
@@ -108,7 +108,7 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
       homeDashboardChanged({
         preferenceType: props.preferenceType,
         action: nextHomeDashboardUID ? 'set' : 'cleared',
-        unifiedHomepageEnabled: getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaUnifiedHomepage, false),
+        unifiedHomepageEnabled,
       });
     }
 

--- a/public/app/core/components/SharedPreferences/SharedPreferencesOld.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesOld.tsx
@@ -5,6 +5,7 @@ import { FeatureState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   Button,
   Field,
@@ -24,12 +25,15 @@ import { changeTheme } from 'app/core/services/theme';
 
 import { getSelectableThemes } from '../ThemeSelector/getSelectableThemes';
 
+import { homeDashboardChanged } from './analytics/main';
 import { getLanguageOptions, getStyles, getTranslatedThemeName, type Props, type State } from './utils';
 
 class SharedPreferences extends PureComponent<Props, State> {
   service: PreferencesService;
   themeOptions: ComboboxOption[];
   languageOptions: ComboboxOption[];
+  // Server value stashed at load so a save can tell whether the home dashboard actually changed.
+  initialHomeDashboardUID = '';
 
   constructor(props: Props) {
     super(props);
@@ -66,6 +70,7 @@ class SharedPreferences extends PureComponent<Props, State> {
       isLoading: true,
     });
     const prefs = await this.service.load();
+    this.initialHomeDashboardUID = prefs.homeDashboardUID ?? '';
 
     this.setState({
       isLoading: false,
@@ -104,6 +109,15 @@ class SharedPreferences extends PureComponent<Props, State> {
         .finally(() => {
           this.setState({ isSubmitting: false });
         });
+      const nextHomeDashboardUID = homeDashboardUID ?? '';
+      if (nextHomeDashboardUID !== this.initialHomeDashboardUID) {
+        homeDashboardChanged({
+          preferenceType: this.props.preferenceType,
+          action: nextHomeDashboardUID ? 'set' : 'cleared',
+          unifiedHomepageEnabled: getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaUnifiedHomepage, false),
+        });
+      }
+
       window.location.reload();
     }
   };

--- a/public/app/core/components/SharedPreferences/analytics/main.ts
+++ b/public/app/core/components/SharedPreferences/analytics/main.ts
@@ -1,6 +1,6 @@
 import { defineFeatureEvents } from '@grafana/runtime/unstable';
 
-import { type LanguageChanged, type SaveButtonClicked, type ThemeChanged } from './types';
+import { type HomeDashboardChanged, type LanguageChanged, type SaveButtonClicked, type ThemeChanged } from './types';
 
 /** @owner grafana-frontend-platform */
 const createSharedPreferencesEvents = defineFeatureEvents('grafana', 'preferences');
@@ -13,3 +13,6 @@ export const themeChanged = createSharedPreferencesEvents<ThemeChanged>('theme_c
 
 /** Fired immediately when the user selects a new language from the language picker, before saving. */
 export const languageChanged = createSharedPreferencesEvents<LanguageChanged>('language_changed');
+
+/** Fired after preferences save succeeds with a changed home dashboard — the user switched to/from a custom homepage. */
+export const homeDashboardChanged = createSharedPreferencesEvents<HomeDashboardChanged>('home_dashboard_changed');

--- a/public/app/core/components/SharedPreferences/analytics/types.ts
+++ b/public/app/core/components/SharedPreferences/analytics/types.ts
@@ -22,3 +22,12 @@ export interface LanguageChanged extends EventProperty {
   /** The language the user switched to. */
   toLanguage: string;
 }
+
+export interface HomeDashboardChanged extends EventProperty {
+  /** Whether the preference being changed belongs to an org, team, or individual user. */
+  preferenceType: 'org' | 'team' | 'user';
+  /** Whether a custom home dashboard was set, or the preference was cleared back to the default homepage. */
+  action: 'set' | 'cleared';
+  /** Whether the unified homepage (grafana.unifiedHomepage) is enabled for this user. */
+  unifiedHomepageEnabled: boolean;
+}

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.test.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.test.tsx
@@ -3,13 +3,24 @@ import { render, screen } from 'test/test-utils';
 
 import { config, setBackendSrv, setPluginComponentsHook } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
+import { interceptLinkClicks } from 'app/core/navigation/patch/interceptLinkClicks';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertState, type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { alertsCardClicked } from '../analytics/main';
+
 import { FiringAlertsCard } from './FiringAlertsCard';
 import { HOME_CARD_MAX_ITEMS } from './constants';
+
+jest.mock('../analytics/main', () => ({
+  alertsCardClicked: jest.fn(),
+  incidentsCardClicked: jest.fn(),
+  tabChanged: jest.fn(),
+  clearHistoryClicked: jest.fn(),
+  emptyCtaClicked: jest.fn(),
+}));
 
 setBackendSrv(backendSrv);
 setupMockServer();
@@ -321,5 +332,96 @@ describe('FiringAlertsCard', () => {
       'href',
       '/grafana/alerting/list?search=source%3Agrafana'
     );
+  });
+
+  describe('analytics', () => {
+    // LinkButton renders a plain <a href>; clicking it would trigger a real jsdom
+    // navigation (console.error -> jest-fail-on-console). Route anchor clicks through
+    // the SPA history the way the app does so the onClick fires without navigating.
+    beforeEach(() => {
+      document.addEventListener('click', interceptLinkClicks);
+    });
+
+    afterEach(() => {
+      document.removeEventListener('click', interceptLinkClicks);
+    });
+
+    it('tracks alert_detail when an alert title link is clicked', async () => {
+      const linkedAlert = makeAlert({
+        generatorURL: 'https://grafana.example/alerting/foo?bar=1',
+        labels: { alertname: 'Linked alert', severity: 'critical', team: 'platform' },
+      });
+      mockTeams([]);
+      mockAlerts([linkedAlert]);
+
+      const { user } = render(<FiringAlertsCard />);
+
+      await user.click(await screen.findByRole('link', { name: 'Linked alert' }));
+
+      expect(jest.mocked(alertsCardClicked)).toHaveBeenCalledWith({
+        action: 'alert_detail',
+        placement: 'list',
+        severity: 'critical',
+      });
+    });
+
+    it('tracks create_rule from the empty-state CTA', async () => {
+      jest
+        .spyOn(contextSrv, 'hasPermission')
+        .mockImplementation(
+          (action: string) =>
+            action === AccessControlAction.AlertingInstanceRead || action === AccessControlAction.AlertingRuleCreate
+        );
+      mockTeams([]);
+      mockAlerts([]);
+
+      const { user } = render(<FiringAlertsCard />);
+
+      await user.click(await screen.findByRole('link', { name: /create an alert rule/i }));
+
+      expect(jest.mocked(alertsCardClicked)).toHaveBeenCalledWith({
+        action: 'create_rule',
+        placement: 'empty_state',
+      });
+    });
+
+    it('tracks create_rule and view_all_alerts from the footer when alerts exist', async () => {
+      jest
+        .spyOn(contextSrv, 'hasPermission')
+        .mockImplementation(
+          (action: string) =>
+            action === AccessControlAction.AlertingInstanceRead || action === AccessControlAction.AlertingRuleCreate
+        );
+      mockTeams([]);
+      mockAlerts([criticalAlert]);
+
+      const { user } = render(<FiringAlertsCard />);
+
+      await user.click(await screen.findByRole('link', { name: /create an alert rule/i }));
+      expect(jest.mocked(alertsCardClicked)).toHaveBeenCalledWith({
+        action: 'create_rule',
+        placement: 'footer',
+      });
+
+      await user.click(screen.getByRole('link', { name: /view all firing alerts/i }));
+      expect(jest.mocked(alertsCardClicked)).toHaveBeenCalledWith({
+        action: 'view_all_alerts',
+        placement: 'footer',
+      });
+    });
+
+    it('tracks view_all_rules from the footer in the empty state', async () => {
+      mockTeams([]);
+      mockAlerts([]);
+
+      const { user } = render(<FiringAlertsCard />);
+
+      await user.click(await screen.findByRole('link', { name: /view all alert rules/i }));
+
+      expect(jest.mocked(alertsCardClicked)).toHaveBeenCalledWith({
+        action: 'view_all_rules',
+        placement: 'footer',
+      });
+    });
   });
 });

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
@@ -16,6 +16,8 @@ import { type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/type
 import { AccessControlAction } from 'app/types/accessControl';
 import { type Team } from 'app/types/teams';
 
+import { alertsCardClicked } from '../analytics/main';
+
 import { SummaryCard, SummaryCardAge, SummaryCardTitle } from './SummaryCard';
 import { HOME_CARD_MAX_ITEMS } from './constants';
 import { severityLevelColor, severityLevelRank } from './severity';
@@ -184,7 +186,12 @@ function FiringAlertsCardInner() {
         return (
           <>
             <Badge text={severityLabel(level)} color={severityLevelColor(level)} />
-            <SummaryCardTitle href={detailHref}>{alert.labels.alertname}</SummaryCardTitle>
+            <SummaryCardTitle
+              href={detailHref}
+              onClick={() => alertsCardClicked({ action: 'alert_detail', placement: 'list', severity: level })}
+            >
+              {alert.labels.alertname}
+            </SummaryCardTitle>
             {alert.labels.team && (
               <Text color="secondary" variant="bodySmall" truncate>
                 {alert.labels.team}
@@ -196,7 +203,12 @@ function FiringAlertsCardInner() {
       }}
       emptyAction={
         canCreate ? (
-          <LinkButton variant="primary" icon="plus" href={newRuleHref}>
+          <LinkButton
+            variant="primary"
+            icon="plus"
+            href={newRuleHref}
+            onClick={() => alertsCardClicked({ action: 'create_rule', placement: 'empty_state' })}
+          >
             <Trans i18nKey="home.firing-alerts-card.create">Create an alert rule</Trans>
           </LinkButton>
         ) : undefined
@@ -204,11 +216,29 @@ function FiringAlertsCardInner() {
       footer={
         <>
           {hasAlerts && canCreate && (
-            <LinkButton variant="secondary" size="sm" fill="text" icon="plus" href={newRuleHref}>
+            <LinkButton
+              variant="secondary"
+              size="sm"
+              fill="text"
+              icon="plus"
+              href={newRuleHref}
+              onClick={() => alertsCardClicked({ action: 'create_rule', placement: 'footer' })}
+            >
               <Trans i18nKey="home.firing-alerts-card.create">Create an alert rule</Trans>
             </LinkButton>
           )}
-          <LinkButton variant="secondary" size="sm" fill="text" href={viewAllHref}>
+          <LinkButton
+            variant="secondary"
+            size="sm"
+            fill="text"
+            href={viewAllHref}
+            onClick={() =>
+              alertsCardClicked({
+                action: hasAlerts ? 'view_all_alerts' : 'view_all_rules',
+                placement: 'footer',
+              })
+            }
+          >
             {hasAlerts ? (
               <Trans i18nKey="home.firing-alerts-card.view-all">View all firing alerts</Trans>
             ) : (

--- a/public/app/features/home/AlertsIncidents/IncidentsCard.test.tsx
+++ b/public/app/features/home/AlertsIncidents/IncidentsCard.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from 'test/test-utils';
 import { PluginIncludeType } from '@grafana/data';
 import { setBackendSrv, setPluginComponentsHook } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
+import { interceptLinkClicks } from 'app/core/navigation/patch/interceptLinkClicks';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import { ACTIVE_INCIDENTS_QUERY_LIMIT, type IncidentPreview } from 'app/features/alerting/unified/api/incidentsApi';
@@ -12,11 +13,20 @@ import { pluginMeta } from 'app/features/alerting/unified/testSetup/plugins';
 import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 import { configureStore } from 'app/store/configureStore';
 
+import { incidentsCardClicked } from '../analytics/main';
+
 import { IncidentsCard } from './IncidentsCard';
 
 jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
   ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
   useIrmPlugin: jest.fn(),
+}));
+jest.mock('../analytics/main', () => ({
+  incidentsCardClicked: jest.fn(),
+  alertsCardClicked: jest.fn(),
+  tabChanged: jest.fn(),
+  clearHistoryClicked: jest.fn(),
+  emptyCtaClicked: jest.fn(),
 }));
 
 setBackendSrv(backendSrv);
@@ -265,5 +275,71 @@ describe('IncidentsCard', () => {
     // refetchOnMountOrArgChange forces a refetch on remount; without it the stale empty
     // cache would persist and this assertion would time out.
     expect(await screen.findByText('Database outage')).toBeInTheDocument();
+  });
+
+  describe('analytics', () => {
+    // LinkButton renders a plain <a href>; clicking it would trigger a real jsdom
+    // navigation (console.error -> jest-fail-on-console). Route anchor clicks through
+    // the SPA history the way the app does so the onClick fires without navigating.
+    beforeEach(() => {
+      document.addEventListener('click', interceptLinkClicks);
+    });
+
+    afterEach(() => {
+      document.removeEventListener('click', interceptLinkClicks);
+    });
+
+    it('tracks incident_detail when an incident title link is clicked', async () => {
+      mockIncidents(activeIncidents);
+
+      const { user } = render(<IncidentsCard />);
+
+      await user.click(await screen.findByRole('link', { name: 'Database outage' }));
+
+      expect(jest.mocked(incidentsCardClicked)).toHaveBeenCalledWith({
+        action: 'incident_detail',
+        placement: 'list',
+        severity: 'critical',
+      });
+    });
+
+    it('tracks declare_incident from the empty-state CTA', async () => {
+      mockIncidents([]);
+
+      const { user } = render(<IncidentsCard />);
+
+      await user.click(await screen.findByRole('link', { name: /declare an incident/i }));
+
+      expect(jest.mocked(incidentsCardClicked)).toHaveBeenCalledWith({
+        action: 'declare_incident',
+        placement: 'empty_state',
+      });
+    });
+
+    it('tracks declare_incident from the footer when incidents exist', async () => {
+      mockIncidents(activeIncidents);
+
+      const { user } = render(<IncidentsCard />);
+
+      await user.click(await screen.findByRole('link', { name: /declare an incident/i }));
+
+      expect(jest.mocked(incidentsCardClicked)).toHaveBeenCalledWith({
+        action: 'declare_incident',
+        placement: 'footer',
+      });
+    });
+
+    it('tracks view_all_incidents from the footer', async () => {
+      mockIncidents(activeIncidents);
+
+      const { user } = render(<IncidentsCard />);
+
+      await user.click(await screen.findByRole('link', { name: /view all incidents/i }));
+
+      expect(jest.mocked(incidentsCardClicked)).toHaveBeenCalledWith({
+        action: 'view_all_incidents',
+        placement: 'footer',
+      });
+    });
   });
 });

--- a/public/app/features/home/AlertsIncidents/IncidentsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/IncidentsCard.tsx
@@ -9,6 +9,8 @@ import { canAccessPluginPage, useIrmPlugin } from 'app/features/alerting/unified
 import { canonicalSeverity } from 'app/features/alerting/unified/triage/scene/filters/severity';
 import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 
+import { incidentsCardClicked } from '../analytics/main';
+
 import { SummaryCard, SummaryCardAge, SummaryCardTitle } from './SummaryCard';
 import { HOME_CARD_MAX_ITEMS } from './constants';
 import { severityLevelColor } from './severity';
@@ -83,6 +85,13 @@ function IncidentsCardInner({ pluginId, canAccess, canDeclare }: IncidentsCardIn
           <Badge text={incident.severityLabel} color={severityLevelColor(canonicalSeverity(incident.severityLabel))} />
           <SummaryCardTitle
             href={canAccess ? createBridgeURL(pluginId, `/incidents/${incident.incidentID}`) : undefined}
+            onClick={() =>
+              incidentsCardClicked({
+                action: 'incident_detail',
+                placement: 'list',
+                severity: canonicalSeverity(incident.severityLabel),
+              })
+            }
           >
             {incident.title}
           </SummaryCardTitle>
@@ -91,7 +100,12 @@ function IncidentsCardInner({ pluginId, canAccess, canDeclare }: IncidentsCardIn
       )}
       emptyAction={
         canDeclare ? (
-          <LinkButton variant="primary" icon="fire" href={createBridgeURL(pluginId, '/incidents', { declare: 'new' })}>
+          <LinkButton
+            variant="primary"
+            icon="fire"
+            href={createBridgeURL(pluginId, '/incidents', { declare: 'new' })}
+            onClick={() => incidentsCardClicked({ action: 'declare_incident', placement: 'empty_state' })}
+          >
             <Trans i18nKey="home.incidents-card.declare">Declare an incident</Trans>
           </LinkButton>
         ) : undefined
@@ -105,12 +119,19 @@ function IncidentsCardInner({ pluginId, canAccess, canDeclare }: IncidentsCardIn
               fill="text"
               icon="fire"
               href={createBridgeURL(pluginId, '/incidents', { declare: 'new' })}
+              onClick={() => incidentsCardClicked({ action: 'declare_incident', placement: 'footer' })}
             >
               <Trans i18nKey="home.incidents-card.declare">Declare an incident</Trans>
             </LinkButton>
           )}
           {canAccess && (
-            <LinkButton variant="secondary" size="sm" fill="text" href={createBridgeURL(pluginId, '/incidents')}>
+            <LinkButton
+              variant="secondary"
+              size="sm"
+              fill="text"
+              href={createBridgeURL(pluginId, '/incidents')}
+              onClick={() => incidentsCardClicked({ action: 'view_all_incidents', placement: 'footer' })}
+            >
               <Trans i18nKey="home.incidents-card.view-all">View all incidents</Trans>
             </LinkButton>
           )}

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -108,11 +108,19 @@ export function SummaryCard<T>({
 }
 
 /** Item title: a plugin/detail link when `href` is set, otherwise plain truncated text. */
-export function SummaryCardTitle({ href, children }: { href?: string; children: string }) {
+export function SummaryCardTitle({
+  href,
+  onClick,
+  children,
+}: {
+  href?: string;
+  onClick?: () => void;
+  children: string;
+}) {
   const styles = useStyles2(getStyles);
   if (href) {
     return (
-      <TextLink href={href} inline={false} color="primary" className={styles.title}>
+      <TextLink href={href} onClick={onClick} inline={false} color="primary" className={styles.title}>
         {children}
       </TextLink>
     );

--- a/public/app/features/home/analytics/main.ts
+++ b/public/app/features/home/analytics/main.ts
@@ -1,6 +1,12 @@
 import { defineFeatureEvents } from '@grafana/runtime/unstable';
 
-import { type ClearHistoryClicked, type EmptyCtaClicked, type TabChanged } from './types';
+import {
+  type AlertsCardClicked,
+  type ClearHistoryClicked,
+  type EmptyCtaClicked,
+  type IncidentsCardClicked,
+  type TabChanged,
+} from './types';
 
 const createHomepageEvent = defineFeatureEvents('grafana', 'homepage');
 
@@ -12,3 +18,9 @@ export const clearHistoryClicked = createHomepageEvent<ClearHistoryClicked>('cle
 
 /** Fired when the user clicks the empty-state call-to-action on the Recent tab. */
 export const emptyCtaClicked = createHomepageEvent<EmptyCtaClicked>('empty_cta_clicked');
+
+/** Fired when the user clicks any control on the homepage Firing alerts card. */
+export const alertsCardClicked = createHomepageEvent<AlertsCardClicked>('alerts_card_clicked');
+
+/** Fired when the user clicks any control on the homepage Active incidents card. */
+export const incidentsCardClicked = createHomepageEvent<IncidentsCardClicked>('incidents_card_clicked');

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -14,3 +14,27 @@ export interface EmptyCtaClicked extends EventProperty {
   /** Which empty-state button was clicked. */
   cta_type: 'create_dashboard' | 'browse_dashboards';
 }
+
+export interface AlertsCardClicked extends EventProperty {
+  /** Which control on the Firing alerts card was clicked. */
+  action: 'alert_detail' | 'create_rule' | 'view_all_alerts' | 'view_all_rules';
+  /**
+   * Where the control lives on the card. For create_rule this also encodes card state:
+   * 'empty_state' renders only when the card has zero alerts, 'footer' only when alerts exist.
+   */
+  placement: 'list' | 'empty_state' | 'footer';
+  /** Canonical severity of the clicked alert (alert_detail only). */
+  severity?: string;
+}
+
+export interface IncidentsCardClicked extends EventProperty {
+  /** Which control on the Active incidents card was clicked. */
+  action: 'incident_detail' | 'declare_incident' | 'view_all_incidents';
+  /**
+   * Where the control lives on the card. For declare_incident this also encodes card state:
+   * 'empty_state' renders only when the card has zero incidents, 'footer' only when incidents exist.
+   */
+  placement: 'list' | 'empty_state' | 'footer';
+  /** Canonical severity of the clicked incident (incident_detail only). */
+  severity?: string;
+}


### PR DESCRIPTION
**What is this feature?**

Adds typed analytics events for interactions with the Firing alerts and Active incidents cards on the unified homepage, and tracks when a user switches away from the new homepage by setting (or clearing) a custom home dashboard in preferences. Instrumentation only — no user-facing behavior changes.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/127995

**Special notes for your reviewer:**

- `grafana_homepage_alerts_card_clicked` and `grafana_homepage_incidents_card_clicked` — one event per card with an `action` discriminator (mirrors the existing `empty_cta_clicked` + `cta_type` pattern). `placement` (`list` / `empty_state` / `footer`) doubles as a card-state signal, since the empty-state CTA only renders with zero items and the footer create/declare only when items exist.
- `grafana_preferences_home_dashboard_changed` — fired after a successful save when `homeDashboardUID` actually changed, in BOTH the new `SharedPreferencesFunctional` and the legacy `SharedPreferencesOld`, carrying the `grafana.unifiedHomepage` flag value. The functional path captures the previous UID *before* the RTK mutation to avoid a post-refetch race.
