### PR TITLE
Dashboards: Fix datasource refs not templated in row/tab section vari…

### DIFF
--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -807,6 +807,110 @@ describe('dashboard exporter v2', () => {
     expect(panel.spec.data.spec.queries[0].spec.query.group).toBe('prometheus');
   });
 
+  it.each(['RowsLayout', 'TabsLayout'] as const)(
+    'should template datasource refs in %s section variables when sharing externally',
+    async (layoutKind) => {
+      const schemaCopy = JSON.parse(JSON.stringify(handyTestingSchema));
+      const sectionVariable = schemaCopy.variables[0];
+
+      schemaCopy.variables = [];
+      schemaCopy.layout =
+        layoutKind === 'RowsLayout'
+          ? {
+              kind: 'RowsLayout',
+              spec: {
+                rows: [
+                  {
+                    kind: 'RowsLayoutRow',
+                    spec: {
+                      title: 'Section row',
+                      collapse: false,
+                      layout: { kind: 'GridLayout', spec: { items: [] } },
+                      variables: [sectionVariable],
+                    },
+                  },
+                ],
+              },
+            }
+          : {
+              kind: 'TabsLayout',
+              spec: {
+                tabs: [
+                  {
+                    kind: 'TabsLayoutTab',
+                    spec: {
+                      title: 'Section tab',
+                      layout: { kind: 'GridLayout', spec: { items: [] } },
+                      variables: [sectionVariable],
+                    },
+                  },
+                ],
+              },
+            };
+
+      const dashboard = await makeExportableV2(schemaCopy, true);
+      if (typeof dashboard === 'object' && 'error' in dashboard) {
+        throw dashboard.error;
+      }
+
+      const sectionVariableResult =
+        layoutKind === 'RowsLayout'
+          ? dashboard.layout.kind === 'RowsLayout' && dashboard.layout.spec.rows[0].spec.variables?.[0]
+          : dashboard.layout.kind === 'TabsLayout' && dashboard.layout.spec.tabs[0].spec.variables?.[0];
+
+      if (!sectionVariableResult || sectionVariableResult.kind !== 'QueryVariable') {
+        throw new Error('Expected a query variable to be exported from the section');
+      }
+
+      expect(sectionVariableResult.spec.query.datasource).toBeUndefined();
+      expect(sectionVariableResult.spec.query.labels?.[ExportLabel]).toBeDefined();
+    }
+  );
+
+  it('should still template row section variables when the nested row layout is missing', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const schemaCopy = JSON.parse(JSON.stringify(handyTestingSchema));
+    const sectionVariable = schemaCopy.variables[0];
+
+    schemaCopy.variables = [];
+    schemaCopy.layout = {
+      kind: 'RowsLayout',
+      spec: {
+        rows: [
+          {
+            kind: 'RowsLayoutRow',
+            spec: {
+              title: 'Broken section row',
+              collapse: false,
+              variables: [sectionVariable],
+              layout: null,
+            },
+          },
+        ],
+      },
+    };
+
+    const dashboard = await makeExportableV2(schemaCopy, true);
+    if (typeof dashboard === 'object' && 'error' in dashboard) {
+      throw dashboard.error;
+    }
+
+    const rowVariable =
+      dashboard.layout.kind === 'RowsLayout' ? dashboard.layout.spec.rows[0].spec.variables?.[0] : undefined;
+
+    if (!rowVariable || rowVariable.kind !== 'QueryVariable') {
+      throw new Error('Expected a query variable to remain exportable from the row');
+    }
+
+    expect(rowVariable.spec.query.datasource).toBeUndefined();
+    expect(rowVariable.spec.query.labels?.[ExportLabel]).toBeDefined();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Export skipped a row section variable layout because its nested layout was missing or invalid.'
+    );
+
+    consoleSpy.mockRestore();
+  });
+
   it('should convert library panels to inline panels when sharing externally', async () => {
     const setupWithLibraryPanel = async (isSharingExternally: boolean) => {
       const schemaCopy = JSON.parse(JSON.stringify(handyTestingSchema));

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -12,6 +12,7 @@ import {
   type DataQueryKind,
   type AdhocVariableKind,
   type GroupByVariableKind,
+  type VariableKind,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import config from 'app/core/config';
 import { createErrorNotification } from 'app/core/copy/appNotification';
@@ -508,6 +509,74 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     return `${datasourceGroup}-${index}`;
   };
 
+  const processVariable = (variable: VariableKind) => {
+    if (variable.kind === 'QueryVariable') {
+      processDataQueryKind(variable.spec.query);
+      variable.spec.options = [];
+      variable.spec.current = {
+        text: '',
+        value: '',
+      };
+      return;
+    }
+
+    if (variable.kind === 'DatasourceVariable') {
+      variable.spec.current = {
+        text: '',
+        value: '',
+      };
+      return;
+    }
+
+    if (variable.kind === 'AdhocVariable' || variable.kind === 'GroupByVariable') {
+      processAdHocAndGroupByVariables(variable);
+    }
+  };
+
+  const processSectionVariableList = (variables?: VariableKind[]) => {
+    for (const variable of variables ?? []) {
+      processVariable(variable);
+    }
+  };
+
+  const logMissingSectionLayout = (scope: 'row' | 'tab') => {
+    console.error(`Export skipped a ${scope} section variable layout because its nested layout was missing or invalid.`);
+  };
+
+  const processSectionVariables = (layout: DashboardV2Spec['layout']) => {
+    if (!layout || typeof layout !== 'object' || !('kind' in layout)) {
+      return;
+    }
+
+    if (layout.kind === 'RowsLayout') {
+      for (const row of layout.spec.rows) {
+        processSectionVariableList(row.spec.variables);
+
+        if (!row.spec.layout || typeof row.spec.layout !== 'object') {
+          logMissingSectionLayout('row');
+          continue;
+        }
+
+        processSectionVariables(row.spec.layout);
+      }
+
+      return;
+    }
+
+    if (layout.kind === 'TabsLayout') {
+      for (const tab of layout.spec.tabs) {
+        processSectionVariableList(tab.spec.variables);
+
+        if (!tab.spec.layout || typeof tab.spec.layout !== 'object') {
+          logMissingSectionLayout('tab');
+          continue;
+        }
+
+        processSectionVariables(tab.spec.layout);
+      }
+    }
+  };
+
   const processPanel = (panel: PanelKind) => {
     if (panel.spec.data.spec.queries) {
       for (const query of panel.spec.data.spec.queries) {
@@ -538,22 +607,10 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
 
     // process template variables
     for (const variable of dashboard.variables) {
-      if (variable.kind === 'QueryVariable') {
-        processDataQueryKind(variable.spec.query);
-        variable.spec.options = [];
-        variable.spec.current = {
-          text: '',
-          value: '',
-        };
-      } else if (variable.kind === 'DatasourceVariable') {
-        variable.spec.current = {
-          text: '',
-          value: '',
-        };
-      } else if (variable.kind === 'AdhocVariable' || variable.kind === 'GroupByVariable') {
-        processAdHocAndGroupByVariables(variable);
-      }
+      processVariable(variable);
     }
+
+    processSectionVariables(dashboard.layout);
 
     // process annotations vars
     for (const annotation of dashboard.annotations) {


### PR DESCRIPTION
Hi! I investigated the issue and found that the root cause was in makeExportableV2, the V2 external export serializer.

The serializer was only processing dashboard.variables when applying datasource templating. However, row- and tab-scoped variables introduced in 13.1 are stored inside the layout tree (RowsLayout / TabsLayout -> row.spec.variables / tab.spec.variables). Because those variables were outside the existing traversal path, their datasource references were exported with the original datasource UIDs instead of being converted into export-safe placeholders.

The fix adds recursive traversal of the layout tree and applies the existing datasource templating logic to section-scoped variables as well. This handles nested row/tab layouts and ensures that variables defined at any supported scope follow the same export behavior as top-level variables during external sharing.

While working on this, I also reviewed the assumptions around row.spec.layout and tab.spec.layout. They are defined as required in the schema, but nested layouts are not explicitly validated by validateDashboardSchemaV2. In the current flow, they are always populated by RowsLayoutSerializer / TabsLayoutSerializer before export, so this path is not expected to fail. I added a small defensive guard around the recursive traversal to make the serializer more resilient if that invariant changes in the future.

I also added regression tests covering:

- row-scoped variables during export
- tab-scoped variables during export
- defensive handling of missing nested layouts