### PR TITLE
Search: Migrate columns to async DataSource APIs

### DIFF
--- a/public/app/features/search/page/components/SearchResultsTable.test.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.test.tsx
@@ -11,6 +11,7 @@ import {
   toDataFrame,
 } from '@grafana/data';
 import { usePanelPluginMetasMap } from '@grafana/runtime/internal';
+import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { type DashboardQueryResult, type QueryResponse } from '../../service/types';
 import { DashboardSearchItemType } from '../../types';
@@ -22,7 +23,13 @@ jest.mock('@grafana/runtime/internal', () => ({
   usePanelPluginMetasMap: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  useDataSourceInstanceSettings: jest.fn(),
+}));
+
 const usePanelPluginMetasMapMock = jest.mocked(usePanelPluginMetasMap);
+const useDataSourceInstanceSettingsMock = jest.mocked(useDataSourceInstanceSettings);
 
 describe('SearchResultsTable', () => {
   beforeEach(() => {
@@ -31,6 +38,7 @@ describe('SearchResultsTable', () => {
       error: undefined,
       value: { graph: { id: 'graph', name: 'Graph (old)' } as PanelPluginMeta },
     });
+    useDataSourceInstanceSettingsMock.mockReturnValue({ isLoading: false, error: undefined, settings: undefined });
   });
 
   const mockOnTagSelected = jest.fn();
@@ -237,6 +245,66 @@ describe('SearchResultsTable', () => {
       );
       await screen.findByRole('table');
       expect(screen.getByTitle('Graph (old)')).toBeInTheDocument();
+    });
+  });
+
+  describe('when there are datasources', () => {
+    const searchData = toDataFrame({
+      name: 'C',
+      fields: [
+        { name: 'kind', type: FieldType.string, config: {}, values: [DashboardSearchItemType.DashDB] },
+        { name: 'uid', type: FieldType.string, config: {}, values: ['my-dashboard-1'] },
+        { name: 'name', type: FieldType.string, config: {}, values: ['My dashboard 1'] },
+        { name: 'panel_type', type: FieldType.string, config: {}, values: [''] },
+        { name: 'url', type: FieldType.string, config: {}, values: ['/my-dashboard-1'] },
+        { name: 'tags', type: FieldType.other, config: {}, values: [[]] },
+        { name: 'ds_uid', type: FieldType.other, config: {}, values: [['prometheus-uid']] },
+        { name: 'location', type: FieldType.string, config: {}, values: ['/my-dashboard-1'] },
+      ],
+    });
+    const dataFrames = applyFieldOverrides({
+      data: [searchData],
+      fieldConfig: { defaults: {}, overrides: [] },
+      replaceVariables: (value) => value,
+      theme: createTheme(),
+    });
+    const mockSearchResult: QueryResponse = {
+      isItemLoaded: jest.fn().mockReturnValue(true),
+      loadMoreItems: jest.fn(),
+      totalRows: searchData.length,
+      view: new DataFrameView<DashboardQueryResult>(dataFrames[0]),
+    };
+
+    it('resolves the datasource via the async instance-settings hook', async () => {
+      useDataSourceInstanceSettingsMock.mockReturnValue({
+        isLoading: false,
+        error: undefined,
+        settings: {
+          uid: 'prometheus-uid',
+          name: 'My Prometheus',
+          type: 'prometheus',
+          meta: { info: { logos: { small: 'prometheus-logo.svg' } } },
+        } as ReturnType<typeof useDataSourceInstanceSettings>['settings'],
+      });
+
+      render(
+        <SearchResultsTable
+          keyboardEvents={mockKeyboardEvents}
+          response={mockSearchResult}
+          onTagSelected={mockOnTagSelected}
+          onDatasourceChange={jest.fn()}
+          selection={mockSelection}
+          selectionToggle={mockSelectionToggle}
+          clearSelection={mockClearSelection}
+          height={1000}
+          width={1000}
+        />
+      );
+      await screen.findByRole('table');
+
+      expect(useDataSourceInstanceSettingsMock).toHaveBeenCalledWith('prometheus-uid');
+      expect(screen.getByText('My Prometheus')).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Data source' })).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -11,8 +11,9 @@ import {
   getFieldDisplayName,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { type PanelPluginMetas } from '@grafana/runtime/internal';
+import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { Checkbox, Icon, type IconName, TagList, Text, Tooltip } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { formatDate, formatDuration } from 'app/core/internationalization/dates';
@@ -365,6 +366,43 @@ function hasValue(f: Field): boolean {
   return false;
 }
 
+interface DataSourceItemProps {
+  dsUid: string;
+  iconClass: string;
+  invalidDatasourceItemClass: string;
+  onDatasourceChange: (datasource?: string) => void;
+}
+
+function DataSourceItem({ dsUid, iconClass, invalidDatasourceItemClass, onDatasourceChange }: DataSourceItemProps) {
+  const { isLoading, settings } = useDataSourceInstanceSettings(dsUid);
+  const icon = settings?.meta?.info?.logos?.small;
+
+  // While the settings are being resolved we don't yet know whether the datasource
+  // is valid, so avoid flashing the invalid-datasource fallback.
+  if (isLoading) {
+    return null;
+  }
+
+  if (settings && icon) {
+    return (
+      // TODO: fix keyboard a11y
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+      <span
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          onDatasourceChange(settings.uid);
+        }}
+      >
+        <img src={icon} alt="" width={14} height={14} title={settings.type} className={iconClass} />
+        {settings.name}
+      </span>
+    );
+  }
+
+  return <span className={invalidDatasourceItemClass}>{dsUid}</span>;
+}
+
 function makeDataSourceColumn(
   field: Field<string[]>,
   width: number,
@@ -373,7 +411,6 @@ function makeDataSourceColumn(
   invalidDatasourceItemClass: string,
   onDatasourceChange: (datasource?: string) => void
 ): TableColumn {
-  const srv = getDataSourceSrv();
   return {
     id: `column-datasource`,
     field,
@@ -386,32 +423,15 @@ function makeDataSourceColumn(
       const { key, ...cellProps } = p.cellProps;
       return (
         <div key={key} {...cellProps} className={cx(datasourceItemClass)}>
-          {dslist.map((v, i) => {
-            const settings = srv.getInstanceSettings(v);
-            const icon = settings?.meta?.info?.logos?.small;
-            if (icon) {
-              return (
-                // TODO: fix keyboard a11y
-                // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-                <span
-                  key={i}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    onDatasourceChange(settings.uid);
-                  }}
-                >
-                  <img src={icon} alt="" width={14} height={14} title={settings.type} className={iconClass} />
-                  {settings.name}
-                </span>
-              );
-            }
-            return (
-              <span className={invalidDatasourceItemClass} key={i}>
-                {v}
-              </span>
-            );
-          })}
+          {dslist.map((v, i) => (
+            <DataSourceItem
+              key={i}
+              dsUid={v}
+              iconClass={iconClass}
+              invalidDatasourceItemClass={invalidDatasourceItemClass}
+              onDatasourceChange={onDatasourceChange}
+            />
+          ))}
         </div>
       );
     },


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/127035
Related issue: https://github.com/grafana/grafana/issues/125083

### What changed?
Migrated `public/app/features/search/page/components/columns.tsx` from using  `getDataSourceSrv().getInstanceSettings()` API onto the new async `useDataSourceInstanceSettings` hook.
