### PR TITLE
Provisioning: Migrate `ProvisionedImportOverview` to async DataSource API

### DIFF
--- a/public/app/features/provisioning/components/Dashboards/ProvisionedImportOverview.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/ProvisionedImportOverview.test.tsx
@@ -3,7 +3,9 @@ import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';
 import { render, screen, waitFor } from 'test/test-utils';
 
+import { type DataSourceInstanceSettings } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
@@ -13,7 +15,12 @@ import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 import { AnnoKeySourcePath } from 'app/features/apiserver/types';
 import { dashboardAPIVersionResolver } from 'app/features/dashboard/api/DashboardAPIVersionResolver';
 import { validateUid } from 'app/features/manage-dashboards/import/utils/validation';
-import { type DashboardInputs, DashboardSource, LibraryPanelInputState } from 'app/features/manage-dashboards/types';
+import {
+  type DashboardInputs,
+  DashboardSource,
+  InputType,
+  LibraryPanelInputState,
+} from 'app/features/manage-dashboards/types';
 
 import { RepoViewStatus } from '../../hooks/useGetResourceRepositoryView';
 import { setupProvisioningMswServer } from '../../mocks/server';
@@ -43,7 +50,27 @@ jest.mock('app/features/manage-dashboards/import/utils/validation', () => ({
   validateUid: jest.fn().mockResolvedValue(true),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(),
+}));
+
+// Render the datasource picker as a button that selects a fixed datasource, so a
+// V1 import with datasource inputs can be exercised without the real picker.
+jest.mock('app/features/datasources/components/picker/DataSourcePicker', () => ({
+  DataSourcePicker: ({ onChange }: { onChange: (ds: { uid: string; type: string; name: string }) => void }) => (
+    <button
+      type="button"
+      data-testid="mock-datasource-picker"
+      onClick={() => onChange({ uid: 'prom-uid', type: 'prometheus', name: 'Prometheus' })}
+    >
+      Datasource picker
+    </button>
+  ),
+}));
+
 const mockValidateUid = jest.mocked(validateUid);
+const mockGetDataSourceInstanceSettings = jest.mocked(getDataSourceInstanceSettings);
 
 const repository: RepositoryView = {
   name: 'test-repo',
@@ -188,6 +215,40 @@ describe('ProvisionedImportOverview', () => {
       expect(call.apiVersion).toBe('v1');
       expect(call.folderUid).toBe('folder-1');
       expect(call.title).toBe('V1 Dashboard');
+    });
+
+    it('resolves selected datasource instance settings before saving', async () => {
+      const promSettings = {
+        uid: 'prom-uid',
+        type: 'prometheus',
+        name: 'Prometheus',
+      } as DataSourceInstanceSettings;
+      mockGetDataSourceInstanceSettings.mockResolvedValue(promSettings);
+
+      const inputsWithDataSource: DashboardInputs = {
+        ...emptyInputs,
+        dataSources: [
+          {
+            name: 'DS_PROM',
+            label: 'Prometheus',
+            info: 'Select a Prometheus data source',
+            value: '',
+            type: InputType.DataSource,
+            pluginId: 'prometheus',
+          },
+        ],
+      };
+
+      await setup({ inputs: inputsWithDataSource });
+
+      await userEvent.click(screen.getByTestId('mock-datasource-picker'));
+
+      const submitBtn = screen.getByTestId(selectors.components.ImportDashboardForm.submit);
+      await waitFor(() => expect(submitBtn).not.toBeDisabled());
+      await userEvent.click(submitBtn);
+
+      await waitFor(() => expect(mockSave).toHaveBeenCalledTimes(1));
+      expect(mockGetDataSourceInstanceSettings).toHaveBeenCalledWith('prom-uid');
     });
 
     it('disables submit synchronously and stays disabled while save is pending', async () => {

--- a/public/app/features/provisioning/components/Dashboards/ProvisionedImportOverview.tsx
+++ b/public/app/features/provisioning/components/Dashboards/ProvisionedImportOverview.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { Alert } from '@grafana/ui';
@@ -131,7 +131,7 @@ function ProvisionedImportOverviewReady({
   async function onSubmit(form: ProvisionedImportFormData) {
     const spec = isV2
       ? buildV2Spec(dashboard, form, normalizedLayout, hasFloatGridItems)
-      : buildV1Spec(dashboard, form, inputs);
+      : await buildV1Spec(dashboard, form, inputs);
 
     await save({
       spec,
@@ -188,7 +188,21 @@ function buildV2Spec(
   };
 }
 
-function buildV1Spec(dash: Dashboard, form: ProvisionedImportFormData, inputs: DashboardInputs): Dashboard {
+async function buildV1Spec(
+  dash: Dashboard,
+  form: ProvisionedImportFormData,
+  inputs: DashboardInputs
+): Promise<Dashboard> {
+  const resolvedDataSources = await Promise.all(
+    inputs.dataSources.map((ds) => {
+      const selected = form[`datasource-${ds.name}`];
+      if (!isRecord(selected) || typeof selected.uid !== 'string') {
+        return undefined;
+      }
+      return getDataSourceInstanceSettings(selected.uid);
+    })
+  );
+
   const v1Form: ImportDashboardDTO = {
     title: form.title,
     uid: form.uid,
@@ -197,14 +211,7 @@ function buildV1Spec(dash: Dashboard, form: ProvisionedImportFormData, inputs: D
       const val = form[`constant-${c.name}`];
       return typeof val === 'string' ? val : c.value;
     }),
-    dataSources: inputs.dataSources.flatMap((ds) => {
-      const selected = form[`datasource-${ds.name}`];
-      if (!isRecord(selected) || typeof selected.uid !== 'string') {
-        return [];
-      }
-      const settings = getDataSourceSrv().getInstanceSettings(selected.uid);
-      return settings ? [settings] : [];
-    }),
+    dataSources: resolvedDataSources.filter((settings) => settings !== undefined),
     elements: [],
     folder: { uid: form.folderUid },
   };


### PR DESCRIPTION
Part of #125083
Related issue: #127035

### What changed?
Migrated `ProvisionedImportOverview.tsx` off the deprecated synchronous `getDataSourceSrv().getInstanceSettings()` to the new async `getDataSourceInstanceSettings()` from `@grafana/runtime/unstable`. `buildV1Spec` is now `async` and resolves each selected datasource via `Promise.all` before building the spec; `onSubmit` awaits it. The V2 path is untouched since it never used `DataSourceSrv`.

Used the async function API rather than the `useDataSourceInstanceSettings` hook because the lookup happens at submit time inside an already-`async` handler, not during render.

**Notes for the reviewer:**
Added a test that exercises the datasource-resolution path (previously untested) — it mocks `DataSourcePicker` and `getDataSourceInstanceSettings`, selects a datasource, submits, and asserts the settings are resolved by uid before `save` is called. Verified with `yarn jest` (29/29), `yarn eslint`, `yarn prettier --check`, and `tsc --noEmit` — all clean.