### PR TITLE
Provisioning: Improve Git Sync pull-request comment

### DIFF
--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -347,9 +347,13 @@ func (r *githubRepository) ResourceURLs(ctx context.Context, file *repository.Fi
 		ref = branch
 	}
 
+	// file.Path is relative to the configured Spec.GitHub.Path (Read joins that
+	// prefix before fetching), so re-apply it here or scoped repos get 404 links.
+	repoPath := safepath.Join(r.config.Spec.GitHub.Path, file.Path)
+
 	urls := &provisioning.RepositoryURLs{
 		RepositoryURL: r.config.URL(),
-		SourceURL:     fmt.Sprintf("%s/blob/%s/%s", url, ref, file.Path),
+		SourceURL:     fmt.Sprintf("%s/blob/%s/%s", url, ref, repoPath),
 	}
 
 	if ref != branch {

--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -335,6 +335,17 @@ func (r *githubRepository) ListRefs(ctx context.Context) ([]provisioning.RefItem
 }
 
 // ResourceURLs implements RepositoryWithURLs.
+// encodeGitPath percent-encodes each segment of a slash-separated repository
+// path so characters that are valid in git paths but reserved in URLs (#, ?, %,
+// spaces, …) don't corrupt the resulting blob link.
+func encodeGitPath(p string) string {
+	segments := strings.Split(p, "/")
+	for i, s := range segments {
+		segments[i] = url.PathEscape(s)
+	}
+	return strings.Join(segments, "/")
+}
+
 func (r *githubRepository) ResourceURLs(ctx context.Context, file *repository.FileInfo) (*provisioning.RepositoryURLs, error) {
 	url := r.config.URL()
 	branch := r.config.Branch()
@@ -355,7 +366,7 @@ func (r *githubRepository) ResourceURLs(ctx context.Context, file *repository.Fi
 
 	urls := &provisioning.RepositoryURLs{
 		RepositoryURL: r.config.URL(),
-		SourceURL:     fmt.Sprintf("%s/blob/%s/%s", url, ref, repoPath),
+		SourceURL:     fmt.Sprintf("%s/blob/%s/%s", url, ref, encodeGitPath(repoPath)),
 	}
 
 	if ref != branch {

--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -347,9 +347,11 @@ func (r *githubRepository) ResourceURLs(ctx context.Context, file *repository.Fi
 		ref = branch
 	}
 
-	// file.Path is relative to the configured Spec.GitHub.Path (Read joins that
+	// file.Path is relative to the configured repository path (Read joins that
 	// prefix before fetching), so re-apply it here or scoped repos get 404 links.
-	repoPath := safepath.Join(r.config.Spec.GitHub.Path, file.Path)
+	// Use the provider-agnostic Path() so this is nil-safe for GitHub Enterprise
+	// (Spec.GitHub is nil there).
+	repoPath := safepath.Join(r.config.Path(), file.Path)
 
 	urls := &provisioning.RepositoryURLs{
 		RepositoryURL: r.config.URL(),

--- a/apps/provisioning/pkg/repository/github/repository_test.go
+++ b/apps/provisioning/pkg/repository/github/repository_test.go
@@ -658,6 +658,27 @@ func TestGitHubRepositoryResourceURLs(t *testing.T) {
 			},
 		},
 		{
+			name: "path with URL-reserved characters is encoded",
+			file: &repo.FileInfo{
+				Path: "dashboards/a #b?.json",
+				Ref:  "feature-branch",
+			},
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/grafana/grafana",
+						Branch: "main",
+					},
+				},
+			},
+			expectedURLs: &provisioning.RepositoryURLs{
+				RepositoryURL:     "https://github.com/grafana/grafana",
+				SourceURL:         "https://github.com/grafana/grafana/blob/feature-branch/dashboards/a%20%23b%3F.json",
+				CompareURL:        "https://github.com/grafana/grafana/compare/main...feature-branch",
+				NewPullRequestURL: "https://github.com/grafana/grafana/compare/main...feature-branch?quick_pull=1&labels=grafana",
+			},
+		},
+		{
 			name: "file without ref uses default branch",
 			file: &repo.FileInfo{
 				Path: "dashboards/test.json",

--- a/apps/provisioning/pkg/repository/github/repository_test.go
+++ b/apps/provisioning/pkg/repository/github/repository_test.go
@@ -636,6 +636,28 @@ func TestGitHubRepositoryResourceURLs(t *testing.T) {
 			},
 		},
 		{
+			name: "scoped repo includes configured path",
+			file: &repo.FileInfo{
+				Path: "dashboards/test.json",
+				Ref:  "feature-branch",
+			},
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/grafana/grafana",
+						Branch: "main",
+						Path:   "grafana",
+					},
+				},
+			},
+			expectedURLs: &provisioning.RepositoryURLs{
+				RepositoryURL:     "https://github.com/grafana/grafana",
+				SourceURL:         "https://github.com/grafana/grafana/blob/feature-branch/grafana/dashboards/test.json",
+				CompareURL:        "https://github.com/grafana/grafana/compare/main...feature-branch",
+				NewPullRequestURL: "https://github.com/grafana/grafana/compare/main...feature-branch?quick_pull=1&labels=grafana",
+			},
+		},
+		{
 			name: "file without ref uses default branch",
 			file: &repo.FileInfo{
 				Path: "dashboards/test.json",

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -120,7 +120,12 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 	}
 
 	rendererAvailable := e.render.IsAvailable(ctx)
-	shouldRender := rendererAvailable && len(changes) == 1 && cfg.Spec.GitHub.GenerateDashboardPreviews
+	// GenerateDashboardPreviews lives on the type-specific config, which is nil
+	// for the other provider(s) — guard against a nil dereference (e.g. a GitHub
+	// Enterprise repo has Spec.GitHubEnterprise set, not Spec.GitHub).
+	generatePreviews := (cfg.Spec.GitHub != nil && cfg.Spec.GitHub.GenerateDashboardPreviews) ||
+		(cfg.Spec.GitHubEnterprise != nil && cfg.Spec.GitHubEnterprise.GenerateDashboardPreviews)
+	shouldRender := rendererAvailable && len(changes) == 1 && generatePreviews
 	info := changeInfo{
 		GrafanaBaseURL:       e.urls.Internal(ctx, cfg.Namespace),
 		RepositoryName:       cfg.Name,
@@ -176,6 +181,16 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 		return info
 	}
 
+	// Best-effort link back to the file in the git repository. Computed before
+	// parsing so that parse/validation failures still link reviewers to the
+	// source file. Repositories that don't expose web URLs (e.g. non-GitHub
+	// backends) leave this empty.
+	if urlsRepo, ok := repo.(repository.RepositoryWithURLs); ok {
+		if urls, urlErr := urlsRepo.ResourceURLs(ctx, fileInfo); urlErr == nil && urls != nil {
+			info.SourceURL = urls.SourceURL
+		}
+	}
+
 	// Read the file as a resource
 	info.Parsed, err = parser.Parse(ctx, fileInfo)
 	if err != nil {
@@ -199,14 +214,6 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 	// Find a name within the file
 	obj := info.Parsed.Obj
 	info.Title = info.Parsed.Meta.FindTitle(obj.GetName())
-
-	// Best-effort link back to the file in the git repository. Repositories
-	// that don't expose web URLs (e.g. non-GitHub backends) leave this empty.
-	if urlsRepo, ok := repo.(repository.RepositoryWithURLs); ok {
-		if urls, urlErr := urlsRepo.ResourceURLs(ctx, fileInfo); urlErr == nil && urls != nil {
-			info.SourceURL = urls.SourceURL
-		}
-	}
 
 	// Check what happens when we apply changes
 	// NOTE: this will also invoke any server side validation

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -130,7 +130,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 		GrafanaBaseURL:       e.urls.Internal(ctx, cfg.Namespace),
 		RepositoryName:       cfg.Name,
 		RepositoryTitle:      cfg.Spec.Title,
-		RepositoryURL:        cfg.URL(),
+		RepositoryURL:        stripUserinfo(cfg.URL()),
 		MissingImageRenderer: !rendererAvailable,
 	}
 	screenshotBaseURL := e.urls.Public(ctx, cfg.Namespace)
@@ -155,6 +155,22 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 }
 
 var dashboardKind = dashboard.DashboardResourceInfo.GroupVersionKind().Kind
+
+// stripUserinfo removes any embedded credentials (userinfo) from a URL so a
+// repository configured with an HTTPS URL like https://user:token@host/org/repo
+// never renders that token into a public PR comment. Returns "" when the URL
+// cannot be parsed, to avoid leaking a malformed credential-bearing string.
+func stripUserinfo(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	u.User = nil
+	return u.String()
+}
 
 // orgIDForLinks returns the org to pin on PR-comment links when the repo lives
 // in a non-primary org (on-prem org-N, N>=2). Main org (default), Cloud
@@ -187,7 +203,7 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 	// backends) leave this empty.
 	if urlsRepo, ok := repo.(repository.RepositoryWithURLs); ok {
 		if urls, urlErr := urlsRepo.ResourceURLs(ctx, fileInfo); urlErr == nil && urls != nil {
-			info.SourceURL = urls.SourceURL
+			info.SourceURL = stripUserinfo(urls.SourceURL)
 		}
 	}
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -29,6 +29,8 @@ type changeInfo struct {
 	// Attribution: identifies which provisioning repository posted this comment
 	RepositoryName  string
 	RepositoryTitle string
+	// RepositoryURL links to the git repository (empty for local repositories)
+	RepositoryURL string
 
 	// Files we tried to read
 	Changes []fileChangeInfo
@@ -57,6 +59,10 @@ type fileChangeInfo struct {
 
 	// The title from inside the resource (or name if not found)
 	Title string
+
+	// SourceURL links to the file in the git repository (empty when the
+	// repository does not expose web URLs, e.g. non-GitHub backends)
+	SourceURL string
 
 	// The URL where this will appear (target)
 	GrafanaURL           string
@@ -119,6 +125,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 		GrafanaBaseURL:       e.urls.Internal(ctx, cfg.Namespace),
 		RepositoryName:       cfg.Name,
 		RepositoryTitle:      cfg.Spec.Title,
+		RepositoryURL:        cfg.URL(),
 		MissingImageRenderer: !rendererAvailable,
 	}
 	screenshotBaseURL := e.urls.Public(ctx, cfg.Namespace)
@@ -192,6 +199,14 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 	// Find a name within the file
 	obj := info.Parsed.Obj
 	info.Title = info.Parsed.Meta.FindTitle(obj.GetName())
+
+	// Best-effort link back to the file in the git repository. Repositories
+	// that don't expose web URLs (e.g. non-GitHub backends) leave this empty.
+	if urlsRepo, ok := repo.(repository.RepositoryWithURLs); ok {
+		if urls, urlErr := urlsRepo.ResourceURLs(ctx, fileInfo); urlErr == nil && urls != nil {
+			info.SourceURL = urls.SourceURL
+		}
+	}
 
 	// Check what happens when we apply changes
 	// NOTE: this will also invoke any server side validation

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -1524,7 +1524,7 @@ func TestEvaluate_StripsCredentialsFromURLs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "creds-repo", Namespace: "x"},
 		Spec: provisioning.RepositorySpec{
 			Type:   provisioning.GitHubRepositoryType,
-			GitHub: &provisioning.GitHubRepositoryConfig{URL: "https://user:token@github.com/example/repo"},
+			GitHub: &provisioning.GitHubRepositoryConfig{URL: "https://user:token@github.com/example/repo"}, // trufflehog:ignore
 		},
 	})
 	reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
@@ -1555,7 +1555,7 @@ func TestEvaluate_StripsCredentialsFromURLs(t *testing.T) {
 
 	repo := &readerWithURLs{
 		MockReader: reader,
-		sourceURL:  "https://user:token@github.com/example/repo/blob/ref/path/to/file.json",
+		sourceURL:  "https://user:token@github.com/example/repo/blob/ref/path/to/file.json", // trufflehog:ignore
 	}
 
 	info, err := evaluator.Evaluate(context.Background(), repo, provisioning.PullRequestJobOptions{Ref: "ref"}, []repository.VersionedFileChange{{

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -1480,7 +1480,7 @@ func TestEvaluate_PopulatesSourceAndRepositoryURLs(t *testing.T) {
 	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
 
 	renderer := NewMockScreenshotRenderer(t)
-	renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
+	renderer.On("IsAvailable", mock.Anything).Return(false)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
 	progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
@@ -1543,7 +1543,7 @@ func TestEvaluate_StripsCredentialsFromURLs(t *testing.T) {
 	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
 
 	renderer := NewMockScreenshotRenderer(t)
-	renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
+	renderer.On("IsAvailable", mock.Anything).Return(false)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
 	progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
@@ -1611,7 +1611,7 @@ func TestEvaluate_GitHubEnterpriseDoesNotPanic(t *testing.T) {
 	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
 
 	renderer := NewMockScreenshotRenderer(t)
-	renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(true)
+	renderer.On("IsAvailable", mock.Anything).Return(true)
 
 	progress := jobs.NewMockJobProgressRecorder(t)
 	progress.On("SetMessage", mock.Anything, "process playlist.json").Return()

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -1421,6 +1421,92 @@ func TestCalculateChanges(t *testing.T) {
 	}
 }
 
+// readerWithURLs composes a MockReader with the RepositoryWithURLs methods so
+// the evaluator's optional type assertion succeeds in tests.
+type readerWithURLs struct {
+	*repository.MockReader
+	sourceURL string
+}
+
+func (r *readerWithURLs) ResourceURLs(_ context.Context, _ *repository.FileInfo) (*provisioning.RepositoryURLs, error) {
+	return &provisioning.RepositoryURLs{SourceURL: r.sourceURL}, nil
+}
+
+func (r *readerWithURLs) RefURLs(_ context.Context, _ string) (*provisioning.RepositoryURLs, error) {
+	return nil, nil
+}
+
+func TestEvaluate_PopulatesSourceAndRepositoryURLs(t *testing.T) {
+	finfo := &repository.FileInfo{
+		Path: "path/to/file.json",
+		Ref:  "ref",
+		Data: []byte("xxxx"),
+	}
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": resources.DashboardResource.GroupVersion().String(),
+			"kind":       dashboardKind,
+			"metadata": map[string]interface{}{
+				"name": "the-uid",
+			},
+			"spec": map[string]interface{}{
+				"title": "hello world",
+			},
+		},
+	}
+	meta, _ := utils.MetaAccessor(obj)
+
+	reader := repository.NewMockReader(t)
+	reader.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "x"},
+		Spec: provisioning.RepositorySpec{
+			Type:   provisioning.GitHubRepositoryType,
+			GitHub: &provisioning.GitHubRepositoryConfig{URL: "https://github.com/example/repo"},
+		},
+	})
+	reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+
+	parser := resources.NewMockParser(t)
+	parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+		Info:           finfo,
+		Repo:           provisioning.ResourceRepositoryInfo{Namespace: "x", Name: "y"},
+		GVK:            schema.GroupVersionKind{Kind: dashboardKind},
+		Obj:            obj,
+		Meta:           meta,
+		DryRunResponse: obj,
+	}, nil)
+
+	parserFactory := resources.NewMockParserFactory(t)
+	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+
+	renderer := NewMockScreenshotRenderer(t)
+	renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+
+	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+		Internal: func(_ context.Context, _ string) string { return "http://host/" },
+		Public:   func(_ context.Context, _ string) string { return "http://host/" },
+	}, prometheus.NewPedanticRegistry())
+
+	repo := &readerWithURLs{
+		MockReader: reader,
+		sourceURL:  "https://github.com/example/repo/blob/ref/path/to/file.json",
+	}
+
+	info, err := evaluator.Evaluate(context.Background(), repo, provisioning.PullRequestJobOptions{Ref: "ref"}, []repository.VersionedFileChange{{
+		Action: repository.FileActionCreated,
+		Path:   "path/to/file.json",
+		Ref:    "ref",
+	}}, progress)
+
+	require.NoError(t, err)
+	require.Equal(t, "https://github.com/example/repo", info.RepositoryURL)
+	require.Len(t, info.Changes, 1)
+	require.Equal(t, "https://github.com/example/repo/blob/ref/path/to/file.json", info.Changes[0].SourceURL)
+}
+
 func TestDummyImageURL(t *testing.T) {
 	urls := make([]string, 0, 10)
 	for i := range 10 {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -1507,6 +1507,71 @@ func TestEvaluate_PopulatesSourceAndRepositoryURLs(t *testing.T) {
 	require.Equal(t, "https://github.com/example/repo/blob/ref/path/to/file.json", info.Changes[0].SourceURL)
 }
 
+func TestEvaluate_StripsCredentialsFromURLs(t *testing.T) {
+	finfo := &repository.FileInfo{Path: "path/to/file.json", Ref: "ref", Data: []byte("xxxx")}
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": resources.DashboardResource.GroupVersion().String(),
+			"kind":       dashboardKind,
+			"metadata":   map[string]interface{}{"name": "the-uid"},
+			"spec":       map[string]interface{}{"title": "hello world"},
+		},
+	}
+	meta, _ := utils.MetaAccessor(obj)
+
+	reader := repository.NewMockReader(t)
+	reader.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds-repo", Namespace: "x"},
+		Spec: provisioning.RepositorySpec{
+			Type:   provisioning.GitHubRepositoryType,
+			GitHub: &provisioning.GitHubRepositoryConfig{URL: "https://user:token@github.com/example/repo"},
+		},
+	})
+	reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+
+	parser := resources.NewMockParser(t)
+	parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+		Info:           finfo,
+		Repo:           provisioning.ResourceRepositoryInfo{Namespace: "x", Name: "y"},
+		GVK:            schema.GroupVersionKind{Kind: dashboardKind},
+		Obj:            obj,
+		Meta:           meta,
+		DryRunResponse: obj,
+	}, nil)
+
+	parserFactory := resources.NewMockParserFactory(t)
+	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+
+	renderer := NewMockScreenshotRenderer(t)
+	renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+
+	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+		Internal: func(_ context.Context, _ string) string { return "http://host/" },
+		Public:   func(_ context.Context, _ string) string { return "http://host/" },
+	}, prometheus.NewPedanticRegistry())
+
+	repo := &readerWithURLs{
+		MockReader: reader,
+		sourceURL:  "https://user:token@github.com/example/repo/blob/ref/path/to/file.json",
+	}
+
+	info, err := evaluator.Evaluate(context.Background(), repo, provisioning.PullRequestJobOptions{Ref: "ref"}, []repository.VersionedFileChange{{
+		Action: repository.FileActionCreated,
+		Path:   "path/to/file.json",
+		Ref:    "ref",
+	}}, progress)
+
+	require.NoError(t, err)
+	require.Equal(t, "https://github.com/example/repo", info.RepositoryURL)
+	require.Len(t, info.Changes, 1)
+	require.Equal(t, "https://github.com/example/repo/blob/ref/path/to/file.json", info.Changes[0].SourceURL)
+	require.NotContains(t, info.RepositoryURL, "token")
+	require.NotContains(t, info.Changes[0].SourceURL, "token")
+}
+
 func TestEvaluate_GitHubEnterpriseDoesNotPanic(t *testing.T) {
 	// A GitHub Enterprise repo has Spec.GitHubEnterprise set and Spec.GitHub nil;
 	// reading GenerateDashboardPreviews off Spec.GitHub would panic. Renderer is

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -1507,6 +1507,65 @@ func TestEvaluate_PopulatesSourceAndRepositoryURLs(t *testing.T) {
 	require.Equal(t, "https://github.com/example/repo/blob/ref/path/to/file.json", info.Changes[0].SourceURL)
 }
 
+func TestEvaluate_GitHubEnterpriseDoesNotPanic(t *testing.T) {
+	// A GitHub Enterprise repo has Spec.GitHubEnterprise set and Spec.GitHub nil;
+	// reading GenerateDashboardPreviews off Spec.GitHub would panic. Renderer is
+	// available and there is a single change, so the preview branch is reached.
+	finfo := &repository.FileInfo{Path: "playlist.json", Ref: "ref", Data: []byte("xxxx")}
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "playlist.grafana.app/v0alpha1",
+			"kind":       "Playlist",
+			"metadata":   map[string]interface{}{"name": "the-uid"},
+			"spec":       map[string]interface{}{"title": "My Playlist"},
+		},
+	}
+	meta, _ := utils.MetaAccessor(obj)
+
+	reader := repository.NewMockReader(t)
+	reader.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "ghes-repo", Namespace: "x"},
+		Spec: provisioning.RepositorySpec{
+			Type:             provisioning.GitHubEnterpriseRepositoryType,
+			GitHubEnterprise: &provisioning.GitHubEnterpriseRepositoryConfig{GenerateDashboardPreviews: true},
+		},
+	})
+	reader.On("Read", mock.Anything, "playlist.json", "ref").Return(finfo, nil)
+
+	parser := resources.NewMockParser(t)
+	parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+		Info:           finfo,
+		Repo:           provisioning.ResourceRepositoryInfo{Namespace: "x", Name: "y"},
+		GVK:            schema.GroupVersionKind{Kind: "Playlist"},
+		Obj:            obj,
+		Meta:           meta,
+		DryRunResponse: obj,
+	}, nil)
+
+	parserFactory := resources.NewMockParserFactory(t)
+	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+
+	renderer := NewMockScreenshotRenderer(t)
+	renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(true)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, "process playlist.json").Return()
+
+	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+		Internal: func(_ context.Context, _ string) string { return "http://host/" },
+		Public:   func(_ context.Context, _ string) string { return "http://host/" },
+	}, prometheus.NewPedanticRegistry())
+
+	info, err := evaluator.Evaluate(context.Background(), reader, provisioning.PullRequestJobOptions{Ref: "ref"}, []repository.VersionedFileChange{{
+		Action: repository.FileActionCreated,
+		Path:   "playlist.json",
+		Ref:    "ref",
+	}}, progress)
+
+	require.NoError(t, err)
+	require.Len(t, info.Changes, 1)
+}
+
 func TestDummyImageURL(t *testing.T) {
 	urls := make([]string, 0, 10)
 	for i := range 10 {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -126,10 +125,10 @@ const commentTemplateSingleDashboard = `{{define "title"}}{{if .SourceURL}}[**{{
 
 const commentTemplateTable = `📋 Grafana detected **{{.TotalChanges}}** resource change(s) in this pull request{{- if .HasErrors}} — ⚠️ {{.ErrorCount}} need attention{{- end}}.
 
-| Action | Kind | Resource | Preview | Status |
-|--------|------|----------|---------|--------|
+| Action | Kind | Resource | File | Preview | Status |
+|--------|------|----------|------|---------|--------|
 {{- range .Changes}}
-| {{.Action}} | {{.Kind}} | {{.ExistingLink}} | {{ if .PreviewURL}}[preview]({{.PreviewURL}}){{ end }} | {{.StatusIcon}} |
+| {{.ActionLabel}} | {{.Kind}} | {{.ExistingLink}} | {{ if .SourceURL}}[source]({{.SourceURL}}){{ end }} | {{ if .PreviewURL}}[preview]({{.PreviewURL}}){{ end }} | {{.StatusIcon}} |
 {{- end -}}
 {{- if .SkippedFiles}}
 
@@ -172,14 +171,36 @@ func (f *fileChangeInfo) Action() string {
 	return string(f.Change.Action)
 }
 
-// TODO: does this have some value?
-func (f *fileChangeInfo) Kind() string {
-	if f.Parsed == nil {
-		return filepath.Ext(f.Change.Path)
+// ActionLabel returns a normalized, human-friendly label for the change action.
+// It reconciles the two action vocabularies used in the codebase: the parsed
+// ResourceAction ("create") and the raw FileAction ("created"), so the table
+// never mixes tenses.
+func (f *fileChangeInfo) ActionLabel() string {
+	switch f.Action() {
+	case "create", "created":
+		return "➕ Added"
+	case "update", "updated":
+		return "✏️ Updated"
+	case "delete", "deleted":
+		return "🗑️ Deleted"
+	case "move":
+		return "➡️ Moved"
+	case "renamed":
+		return "📝 Renamed"
+	case "ignored":
+		return "🚫 Ignored"
+	default:
+		action := f.Action()
+		if action == "" {
+			return action
+		}
+		return strings.ToUpper(action[:1]) + action[1:]
 	}
-	v := f.Parsed.GVK.Kind
-	if v == "" {
-		return filepath.Ext(f.Parsed.Info.Path)
+}
+
+func (f *fileChangeInfo) Kind() string {
+	if f.Parsed == nil || f.Parsed.GVK.Kind == "" {
+		return "File"
 	}
 	return f.Parsed.GVK.Kind
 }

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -123,12 +123,12 @@ const commentTemplateSingleDashboard = `{{define "title"}}{{if .SourceURL}}[**{{
 {{- end}}
 `
 
-const commentTemplateTable = `📋 Grafana detected **{{.TotalChanges}}** resource change(s) in this pull request{{- if .HasErrors}} — ⚠️ {{.ErrorCount}} need attention{{- end}}.
+const commentTemplateTable = `📋 Grafana detected **{{.TotalChanges}}** resource change{{if ne .TotalChanges 1}}s{{end}} in this pull request{{- if .HasErrors}} — ⚠️ {{.ErrorCount}} need{{if eq .ErrorCount 1}}s{{end}} attention{{- end}}.
 
 | Action | Kind | Resource | File | Preview | Status |
 |--------|------|----------|------|---------|--------|
 {{- range .Changes}}
-| {{.ActionLabel}} | {{.Kind}} | {{.ExistingLink}} | {{ if .SourceURL}}[source]({{.SourceURL}}){{ end }} | {{ if .PreviewURL}}[preview]({{.PreviewURL}}){{ end }} | {{.StatusIcon}} |
+| {{.ActionLabel}} | {{.Kind}} | {{.ExistingLink}} | {{ if .SourceURL}}[source]({{.SourceURL}}){{ else }}{{.SafeFilePath}}{{ end }} | {{ if .PreviewURL}}[preview]({{.PreviewURL}}){{ end }} | {{.StatusIcon}} |
 {{- end -}}
 {{- if .SkippedFiles}}
 
@@ -218,6 +218,17 @@ func (f *fileChangeInfo) ExistingLink() string {
 // table cells.
 func (f *fileChangeInfo) SafeTitle() string {
 	return escapeMarkdown(f.Title)
+}
+
+// SafeFilePath returns the change's file path escaped for a Markdown table cell.
+// It is used as the File column fallback when no source URL is available (e.g.
+// non-GitHub backends) so reviewers can still identify the file.
+func (f *fileChangeInfo) SafeFilePath() string {
+	path := f.Change.Path
+	if path == "" && f.Parsed != nil && f.Parsed.Info != nil {
+		path = f.Parsed.Info.Path
+	}
+	return escapeMarkdown(path)
 }
 
 // escapeMarkdown neutralizes characters that would break a Markdown table cell

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -92,8 +92,8 @@ func (c *commenter) generateComment(_ context.Context, info changeInfo) (string,
 	return result, nil
 }
 
-const commentTemplateSingleDashboard = `Hey there! 👋
-Grafana spotted some changes to your dashboard.
+const commentTemplateSingleDashboard = `{{define "title"}}{{if .SourceURL}}[**{{.Title}}**]({{.SourceURL}}){{else}}**{{.Title}}**{{end}}{{end -}}
+Grafana detected dashboard changes in this pull request.
 {{- if and .GrafanaScreenshotURL .PreviewScreenshotURL}}
 
 ### Side by Side Comparison of {{.Parsed.Info.Path}}
@@ -111,25 +111,20 @@ Grafana spotted some changes to your dashboard.
 {{- end -}}
 {{- if and .GrafanaURL .PreviewURL}}
 
-See the [original]({{.GrafanaURL}}) and [preview]({{.PreviewURL}}) of {{.Parsed.Info.Path}}.
+{{template "title" .}} — [view current]({{.GrafanaURL}}) · [preview changes]({{.PreviewURL}})
 {{- else if .GrafanaURL}}
 
-See the [original]({{.GrafanaURL}}) of {{.Title}}.
+{{template "title" .}} — [view current]({{.GrafanaURL}})
 {{- else if .PreviewURL}}
 
-See the [preview]({{.PreviewURL}}) of {{.Parsed.Info.Path}}.
+{{template "title" .}} — [preview changes]({{.PreviewURL}})
 {{- end}}{{ if .Error}}
 
 > ⚠️ **Validation failed:** {{.TruncatedError}}
 {{- end}}
 `
 
-const commentTemplateTable = `Hey there! 👋
-{{- if .HasErrors}}
-Grafana spotted {{.TotalChanges}} changes ({{.ErrorCount}} with issues).
-{{- else}}
-Grafana spotted {{.TotalChanges}} changes.
-{{- end}}
+const commentTemplateTable = `Grafana detected **{{.TotalChanges}}** resource change(s) in this pull request{{- if .HasErrors}} — {{.ErrorCount}} need attention{{- end}}.
 
 | Action | Kind | Resource | Preview | Status |
 |--------|------|----------|---------|--------|
@@ -168,7 +163,7 @@ NOTE: To enable dashboard previews in pull requests, refer to the [image renderi
 const commentTemplateFooter = `
 
 ---
-_Posted by [{{.GrafanaHost}}]({{.GrafanaBaseURL}}){{- if .RepositoryTitle}} · Repository: **{{.RepositoryTitle}}** (` + "`" + `{{.RepositoryName}}` + "`" + `){{- end}}_`
+_Posted by [{{.GrafanaHost}}]({{.GrafanaBaseURL}}){{- if .RepositoryTitle}} · Repository: {{if .RepositoryURL}}[**{{.RepositoryTitle}}**]({{.RepositoryURL}}){{else}}**{{.RepositoryTitle}}**{{end}} (` + "`" + `{{.RepositoryName}}` + "`" + `){{- end}}_`
 
 func (f *fileChangeInfo) Action() string {
 	if f.Parsed != nil {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -163,7 +163,7 @@ const commentTemplateMissingImageRenderer = `
 const commentTemplateFooter = `
 
 ---
-_Posted by [{{.GrafanaHost}}]({{.GrafanaBaseURL}}){{- if .RepositoryTitle}} · Repository: {{if .RepositoryURL}}[**{{.RepositoryTitle}}**]({{.RepositoryURL}}){{else}}**{{.RepositoryTitle}}**{{end}} (` + "`" + `{{.RepositoryName}}` + "`" + `){{- end}}_`
+_{{if .RepositoryTitle}}🔄 Synced from {{if .RepositoryURL}}[**{{.RepositoryTitle}}**]({{.RepositoryURL}}){{else}}**{{.RepositoryTitle}}**{{end}} · {{end}}Posted by [{{.GrafanaHost}}]({{.GrafanaBaseURL}})_`
 
 func (f *fileChangeInfo) Action() string {
 	if f.Parsed != nil {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -91,7 +91,7 @@ func (c *commenter) generateComment(_ context.Context, info changeInfo) (string,
 	return result, nil
 }
 
-const commentTemplateSingleDashboard = `{{define "title"}}{{if .SourceURL}}[**{{.Title}}**]({{.SourceURL}}){{else}}**{{.Title}}**{{end}}{{end -}}
+const commentTemplateSingleDashboard = `{{define "title"}}{{if .SourceURL}}[**{{.SafeTitle}}**]({{.SourceURL}}){{else}}**{{.SafeTitle}}**{{end}}{{end -}}
 📊 Grafana detected dashboard changes in this pull request.
 {{- if and .GrafanaScreenshotURL .PreviewScreenshotURL}}
 
@@ -101,7 +101,7 @@ const commentTemplateSingleDashboard = `{{define "title"}}{{if .SourceURL}}[**{{
 | ![Before]({{.GrafanaScreenshotURL}}) | ![Preview]({{.PreviewScreenshotURL}}) |
 {{- else if .GrafanaScreenshotURL}}
 
-### Original of {{.Title}}
+### Original of {{.SafeTitle}}
 ![Original]({{.GrafanaScreenshotURL}})
 {{- else if .PreviewScreenshotURL}}
 
@@ -162,7 +162,7 @@ const commentTemplateMissingImageRenderer = `
 const commentTemplateFooter = `
 
 ---
-_{{if .RepositoryTitle}}🔄 Synced from {{if .RepositoryURL}}[**{{.RepositoryTitle}}**]({{.RepositoryURL}}){{else}}**{{.RepositoryTitle}}**{{end}} · {{end}}Posted by [{{.GrafanaHost}}]({{.GrafanaBaseURL}})_`
+_{{if .RepositoryTitle}}🔄 Synced from {{if .RepositoryURL}}[**{{.SafeRepositoryTitle}}**]({{.RepositoryURL}}){{else}}**{{.SafeRepositoryTitle}}**{{end}} · {{end}}Posted by [{{.GrafanaHost}}]({{.GrafanaBaseURL}})_`
 
 func (f *fileChangeInfo) Action() string {
 	if f.Parsed != nil {
@@ -207,11 +207,33 @@ func (f *fileChangeInfo) Kind() string {
 
 // TODO: does this have some value?
 func (f *fileChangeInfo) ExistingLink() string {
+	title := escapeMarkdown(f.Title)
 	if f.GrafanaURL != "" {
-		return fmt.Sprintf("[%s](%s)", f.Title, f.GrafanaURL)
+		return fmt.Sprintf("[%s](%s)", title, f.GrafanaURL)
 	}
-	return f.Title
+	return title
 }
+
+// SafeTitle returns the resource title escaped for use in Markdown link text and
+// table cells.
+func (f *fileChangeInfo) SafeTitle() string {
+	return escapeMarkdown(f.Title)
+}
+
+// escapeMarkdown neutralizes characters that would break a Markdown table cell
+// or link text (pipes and brackets) and flattens newlines, so titles coming
+// from resource files render verbatim in the PR comment.
+func escapeMarkdown(s string) string {
+	return markdownEscaper.Replace(s)
+}
+
+var markdownEscaper = strings.NewReplacer(
+	"\r", "",
+	"\n", " ",
+	"|", "\\|",
+	"[", "\\[",
+	"]", "\\]",
+)
 
 func (f *fileChangeInfo) StatusIcon() string {
 	if f.Error != "" {
@@ -230,6 +252,13 @@ func (f *fileChangeInfo) TruncatedError() string {
 		return msg[:maxErrorLength] + "…"
 	}
 	return msg
+}
+
+// SafeRepositoryTitle returns the repository title escaped for use in Markdown
+// link text. It uses a value receiver because the footer template is executed
+// with a changeInfo value (see GrafanaHost).
+func (c changeInfo) SafeRepositoryTitle() string {
+	return escapeMarkdown(c.RepositoryTitle)
 }
 
 func (c *changeInfo) HasErrors() bool {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -93,7 +93,7 @@ func (c *commenter) generateComment(_ context.Context, info changeInfo) (string,
 }
 
 const commentTemplateSingleDashboard = `{{define "title"}}{{if .SourceURL}}[**{{.Title}}**]({{.SourceURL}}){{else}}**{{.Title}}**{{end}}{{end -}}
-Grafana detected dashboard changes in this pull request.
+📊 Grafana detected dashboard changes in this pull request.
 {{- if and .GrafanaScreenshotURL .PreviewScreenshotURL}}
 
 ### Side by Side Comparison of {{.Parsed.Info.Path}}
@@ -124,7 +124,7 @@ Grafana detected dashboard changes in this pull request.
 {{- end}}
 `
 
-const commentTemplateTable = `Grafana detected **{{.TotalChanges}}** resource change(s) in this pull request{{- if .HasErrors}} — {{.ErrorCount}} need attention{{- end}}.
+const commentTemplateTable = `📋 Grafana detected **{{.TotalChanges}}** resource change(s) in this pull request{{- if .HasErrors}} — ⚠️ {{.ErrorCount}} need attention{{- end}}.
 
 | Action | Kind | Resource | Preview | Status |
 |--------|------|----------|---------|--------|
@@ -154,11 +154,11 @@ const commentTemplateValidationErrors = `
 // TODO(ferruvich): let's discuss this text with the team
 const commentTemplateMetadataNotice = `
 
-> **Note:** Some metadata fields (such as ` + "`namespace`" + `, ` + "`labels`" + `, or ` + "`annotations`" + `) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.`
+> ℹ️ **Note:** Some metadata fields (such as ` + "`namespace`" + `, ` + "`labels`" + `, or ` + "`annotations`" + `) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.`
 
 const commentTemplateMissingImageRenderer = `
 
-NOTE: To enable dashboard previews in pull requests, refer to the [image rendering setup documentation](https://grafana.com/docs/grafana/latest/observability-as-code/provision-resources/git-sync-setup/#configure-webhooks-and-image-rendering).`
+💡 **Tip:** To enable dashboard previews in pull requests, refer to the [image rendering setup documentation](https://grafana.com/docs/grafana/latest/observability-as-code/provision-resources/git-sync-setup/#configure-webhooks-and-image-rendering).`
 
 const commentTemplateFooter = `
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -351,7 +351,7 @@ func TestGenerateComment_NilParsedDeletedInTableTemplate(t *testing.T) {
 	commenter := NewCommenter(false)
 	err := commenter.Comment(context.Background(), repo, 1, info)
 	require.NoError(t, err)
-	require.Contains(t, capturedComment, "**2** resource change(s)")
+	require.Contains(t, capturedComment, "**2** resource changes")
 	require.Contains(t, capturedComment, "🗑️ Deleted")
 	require.Contains(t, capturedComment, "File")
 }
@@ -381,7 +381,7 @@ func TestGenerateComment_SingleChangeNilParsed(t *testing.T) {
 	commenter := NewCommenter(false)
 	err := commenter.Comment(context.Background(), repo, 1, info)
 	require.NoError(t, err)
-	require.Contains(t, capturedComment, "**1** resource change(s)")
+	require.Contains(t, capturedComment, "**1** resource change")
 	require.Contains(t, capturedComment, "➕ Added")
 }
 
@@ -421,8 +421,8 @@ func TestGenerateComment_ParseFailureErrorSurfaced(t *testing.T) {
 	commenter := NewCommenter(false)
 	err := commenter.Comment(context.Background(), repo, 1, info)
 	require.NoError(t, err)
-	require.Contains(t, capturedComment, "**2** resource change(s)")
-	require.Contains(t, capturedComment, "1 need attention")
+	require.Contains(t, capturedComment, "**2** resource changes")
+	require.Contains(t, capturedComment, "1 needs attention")
 	require.Contains(t, capturedComment, "Validation Issues")
 	require.Contains(t, capturedComment, "broken.json")
 	require.Contains(t, capturedComment, "unable to parse resource")

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -119,6 +119,7 @@ func TestGenerateComment(t *testing.T) {
 						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
 					},
 					Title:      "Dash A",
+					SourceURL:  "https://github.com/example/repo/blob/pr/aaa.json",
 					PreviewURL: "http://grafana/admin/preview",
 				},
 				{
@@ -130,18 +131,20 @@ func TestGenerateComment(t *testing.T) {
 						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
 					},
 					Title:      "Dash B",
+					SourceURL:  "https://github.com/example/repo/blob/pr/bbb.json",
 					GrafanaURL: "http://grafana/d/bbb",
 					PreviewURL: "http://grafana/admin/preview",
 				},
 				{
 					Parsed: &resources.ParsedResource{
 						Info: &repository.FileInfo{
-							Path: "bbb.json",
+							Path: "ccc.json",
 						},
 						Action: v0alpha1.ResourceActionCreate,
 						GVK:    schema.GroupVersionKind{Kind: "Playlist"},
 					},
-					Title: "My Playlist",
+					Title:     "My Playlist",
+					SourceURL: "https://github.com/example/repo/blob/pr/ccc.json",
 				},
 			},
 		}},
@@ -197,6 +200,7 @@ func TestGenerateComment(t *testing.T) {
 						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
 					},
 					Title:      "Dashboard A",
+					SourceURL:  "https://github.com/example/repo/blob/pr/good.json",
 					PreviewURL: "http://grafana/admin/preview",
 				},
 				{
@@ -208,6 +212,7 @@ func TestGenerateComment(t *testing.T) {
 						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
 					},
 					Title:              "Dashboard B",
+					SourceURL:          "https://github.com/example/repo/blob/pr/stripped.json",
 					GrafanaURL:         "http://grafana/d/bbb",
 					PreviewURL:         "http://grafana/admin/preview",
 					HasRemovedMetadata: true,
@@ -315,8 +320,8 @@ func TestGenerateComment_NilParsedDeletedInTableTemplate(t *testing.T) {
 	err := commenter.Comment(context.Background(), repo, 1, info)
 	require.NoError(t, err)
 	require.Contains(t, capturedComment, "**2** resource change(s)")
-	require.Contains(t, capturedComment, "deleted")
-	require.Contains(t, capturedComment, ".json")
+	require.Contains(t, capturedComment, "🗑️ Deleted")
+	require.Contains(t, capturedComment, "File")
 }
 
 func TestGenerateComment_SingleChangeNilParsed(t *testing.T) {
@@ -345,7 +350,7 @@ func TestGenerateComment_SingleChangeNilParsed(t *testing.T) {
 	err := commenter.Comment(context.Background(), repo, 1, info)
 	require.NoError(t, err)
 	require.Contains(t, capturedComment, "**1** resource change(s)")
-	require.Contains(t, capturedComment, "created")
+	require.Contains(t, capturedComment, "➕ Added")
 }
 
 func TestGenerateComment_ParseFailureErrorSurfaced(t *testing.T) {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -424,7 +424,7 @@ func TestCommenter_ShowImageRendererNote(t *testing.T) {
 		commenter := NewCommenter(true)
 		err := commenter.Comment(context.Background(), repo, 1, info)
 		require.NoError(t, err)
-		require.Contains(t, capturedComment, "NOTE: To enable dashboard previews")
+		require.Contains(t, capturedComment, "💡 **Tip:** To enable dashboard previews")
 		require.Contains(t, capturedComment, "https://grafana.com/docs/grafana/latest/observability-as-code/provision-resources/git-sync-setup/#configure-webhooks-and-image-rendering")
 	})
 
@@ -460,6 +460,6 @@ func TestCommenter_ShowImageRendererNote(t *testing.T) {
 		commenter := NewCommenter(false)
 		err := commenter.Comment(context.Background(), repo, 1, info)
 		require.NoError(t, err)
-		require.NotContains(t, capturedComment, "NOTE: To enable dashboard previews")
+		require.NotContains(t, capturedComment, "💡 **Tip:** To enable dashboard previews")
 	})
 }

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -17,6 +17,38 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
 
+func TestGenerateComment_EscapesTitle(t *testing.T) {
+	repo := repository.NewMockPullRequestRepo(t)
+
+	var captured string
+	repo.On("CommentPullRequest", context.Background(), 1, mock.MatchedBy(func(comment string) bool {
+		captured = comment
+		return true
+	})).Return(nil)
+
+	info := changeInfo{
+		GrafanaBaseURL: "http://host/",
+		Changes: []fileChangeInfo{
+			{
+				Parsed: &resources.ParsedResource{
+					Info:   &repository.FileInfo{Path: "dash.json"},
+					GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+					Action: v0alpha1.ResourceActionUpdate,
+				},
+				Title:      "Pipes | Brackets [x]\nnewline",
+				SourceURL:  "https://github.com/example/repo/blob/pr/dash.json",
+				GrafanaURL: "http://grafana/d/uid",
+				PreviewURL: "http://grafana/admin/preview",
+			},
+		},
+	}
+
+	commenter := NewCommenter(false)
+	require.NoError(t, commenter.Comment(context.Background(), repo, 1, info))
+	require.Contains(t, captured, "Pipes \\| Brackets \\[x\\] newline")
+	require.NotContains(t, captured, "Brackets [x]")
+}
+
 func TestCommenter_Comment_FailedToComment(t *testing.T) {
 	repo := repository.NewMockPullRequestRepo(t)
 	repo.On("CommentPullRequest", context.Background(), 1, mock.Anything).Return(errors.New("failed"))

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -40,6 +40,7 @@ func TestGenerateComment(t *testing.T) {
 			GrafanaBaseURL:  "http://host/",
 			RepositoryName:  "my-repo",
 			RepositoryTitle: "My Repo",
+			RepositoryURL:   "https://github.com/example/repo",
 			Changes: []fileChangeInfo{
 				{
 					Parsed: &resources.ParsedResource{
@@ -50,6 +51,7 @@ func TestGenerateComment(t *testing.T) {
 						Action: v0alpha1.ResourceActionCreate,
 					},
 					Title:                "New Dashboard",
+					SourceURL:            "https://github.com/example/repo/blob/pr/file.json",
 					PreviewURL:           "http://grafana/admin/preview",
 					PreviewScreenshotURL: getDummyRenderedURL("http://grafana/admin/preview"),
 				},
@@ -59,6 +61,7 @@ func TestGenerateComment(t *testing.T) {
 			GrafanaBaseURL:  "http://host/",
 			RepositoryName:  "my-repo",
 			RepositoryTitle: "My Repo",
+			RepositoryURL:   "https://github.com/example/repo",
 			Changes: []fileChangeInfo{
 				{
 					Parsed: &resources.ParsedResource{
@@ -69,6 +72,7 @@ func TestGenerateComment(t *testing.T) {
 						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
 					},
 					Title:      "Existing Dashboard",
+					SourceURL:  "https://github.com/example/repo/blob/pr/file.json",
 					GrafanaURL: "http://grafana/d/uid",
 					PreviewURL: "http://grafana/admin/preview",
 
@@ -81,6 +85,7 @@ func TestGenerateComment(t *testing.T) {
 			GrafanaBaseURL:  "http://host/",
 			RepositoryName:  "my-repo",
 			RepositoryTitle: "My Repo",
+			RepositoryURL:   "https://github.com/example/repo",
 			Changes: []fileChangeInfo{
 				{
 					Parsed: &resources.ParsedResource{
@@ -91,6 +96,7 @@ func TestGenerateComment(t *testing.T) {
 						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
 					},
 					Title:      "Existing Dashboard",
+					SourceURL:  "https://github.com/example/repo/blob/pr/file.json",
 					GrafanaURL: "http://grafana/d/uid",
 					PreviewURL: "http://grafana/admin/preview",
 				},
@@ -101,6 +107,7 @@ func TestGenerateComment(t *testing.T) {
 			GrafanaBaseURL:  "http://host/",
 			RepositoryName:  "my-repo",
 			RepositoryTitle: "My Repo",
+			RepositoryURL:   "https://github.com/example/repo",
 			SkippedFiles:    5,
 			Changes: []fileChangeInfo{
 				{
@@ -150,6 +157,7 @@ func TestGenerateComment(t *testing.T) {
 						Action: v0alpha1.ResourceActionCreate,
 					},
 					Title:      "Broken Dashboard",
+					SourceURL:  "https://github.com/example/repo/blob/pr/broken.json",
 					PreviewURL: "http://grafana/admin/preview",
 					Error:      "strict decoding error: unknown field \"spec.invalidField\"",
 				},
@@ -167,6 +175,7 @@ func TestGenerateComment(t *testing.T) {
 						Action: v0alpha1.ResourceActionUpdate,
 					},
 					Title:              "My Dashboard",
+					SourceURL:          "https://github.com/example/repo/blob/pr/dashboard.json",
 					GrafanaURL:         "http://grafana/d/uid",
 					PreviewURL:         "http://grafana/admin/preview",
 					HasRemovedMetadata: true,
@@ -177,6 +186,7 @@ func TestGenerateComment(t *testing.T) {
 			GrafanaBaseURL:  "http://host/",
 			RepositoryName:  "my-repo",
 			RepositoryTitle: "My Repo",
+			RepositoryURL:   "https://github.com/example/repo",
 			Changes: []fileChangeInfo{
 				{
 					Parsed: &resources.ParsedResource{
@@ -304,7 +314,7 @@ func TestGenerateComment_NilParsedDeletedInTableTemplate(t *testing.T) {
 	commenter := NewCommenter(false)
 	err := commenter.Comment(context.Background(), repo, 1, info)
 	require.NoError(t, err)
-	require.Contains(t, capturedComment, "2 changes")
+	require.Contains(t, capturedComment, "**2** resource change(s)")
 	require.Contains(t, capturedComment, "deleted")
 	require.Contains(t, capturedComment, ".json")
 }
@@ -334,7 +344,7 @@ func TestGenerateComment_SingleChangeNilParsed(t *testing.T) {
 	commenter := NewCommenter(false)
 	err := commenter.Comment(context.Background(), repo, 1, info)
 	require.NoError(t, err)
-	require.Contains(t, capturedComment, "1 changes")
+	require.Contains(t, capturedComment, "**1** resource change(s)")
 	require.Contains(t, capturedComment, "created")
 }
 
@@ -374,8 +384,8 @@ func TestGenerateComment_ParseFailureErrorSurfaced(t *testing.T) {
 	commenter := NewCommenter(false)
 	err := commenter.Comment(context.Background(), repo, 1, info)
 	require.NoError(t, err)
-	require.Contains(t, capturedComment, "2 changes")
-	require.Contains(t, capturedComment, "1 with issues")
+	require.Contains(t, capturedComment, "**2** resource change(s)")
+	require.Contains(t, capturedComment, "1 need attention")
 	require.Contains(t, capturedComment, "Validation Issues")
 	require.Contains(t, capturedComment, "broken.json")
 	require.Contains(t, capturedComment, "unable to parse resource")

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
@@ -1,4 +1,4 @@
-Grafana detected **3** resource change(s) in this pull request — 2 need attention.
+📋 Grafana detected **3** resource change(s) in this pull request — ⚠️ 2 need attention.
 
 | Action | Kind | Resource | Preview | Status |
 |--------|------|----------|---------|--------|

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
@@ -1,5 +1,4 @@
-Hey there! 👋
-Grafana spotted 3 changes (2 with issues).
+Grafana detected **3** resource change(s) in this pull request — 2 need attention.
 
 | Action | Kind | Resource | Preview | Status |
 |--------|------|----------|---------|--------|

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
@@ -1,10 +1,10 @@
-📋 Grafana detected **3** resource change(s) in this pull request — ⚠️ 2 need attention.
+📋 Grafana detected **3** resource changes in this pull request — ⚠️ 2 need attention.
 
 | Action | Kind | Resource | File | Preview | Status |
 |--------|------|----------|------|---------|--------|
-| ➕ Added | Dashboard | Good Dashboard |  | [preview](http://grafana/admin/preview) | ✅ |
-| ✏️ Updated | Dashboard | [Bad Dashboard](http://grafana/d/bad) |  | [preview](http://grafana/admin/preview) | ⚠️ |
-| ➕ Added | Playlist | Broken Playlist |  |  | ⚠️ |
+| ➕ Added | Dashboard | Good Dashboard | good.json | [preview](http://grafana/admin/preview) | ✅ |
+| ✏️ Updated | Dashboard | [Bad Dashboard](http://grafana/d/bad) | bad.json | [preview](http://grafana/admin/preview) | ⚠️ |
+| ➕ Added | Playlist | Broken Playlist | invalid.yaml |  | ⚠️ |
 
 ### ⚠️ Validation Issues
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
@@ -1,10 +1,10 @@
 📋 Grafana detected **3** resource change(s) in this pull request — ⚠️ 2 need attention.
 
-| Action | Kind | Resource | Preview | Status |
-|--------|------|----------|---------|--------|
-| create | Dashboard | Good Dashboard | [preview](http://grafana/admin/preview) | ✅ |
-| update | Dashboard | [Bad Dashboard](http://grafana/d/bad) | [preview](http://grafana/admin/preview) | ⚠️ |
-| create | Playlist | Broken Playlist |  | ⚠️ |
+| Action | Kind | Resource | File | Preview | Status |
+|--------|------|----------|------|---------|--------|
+| ➕ Added | Dashboard | Good Dashboard |  | [preview](http://grafana/admin/preview) | ✅ |
+| ✏️ Updated | Dashboard | [Bad Dashboard](http://grafana/d/bad) |  | [preview](http://grafana/admin/preview) | ⚠️ |
+| ➕ Added | Playlist | Broken Playlist |  |  | ⚠️ |
 
 ### ⚠️ Validation Issues
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
@@ -1,5 +1,4 @@
-Hey there! 👋
-Grafana spotted 2 changes.
+Grafana detected **2** resource change(s) in this pull request.
 
 | Action | Kind | Resource | Preview | Status |
 |--------|------|----------|---------|--------|
@@ -11,4 +10,4 @@ All resources passed validation. ✅
 > **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.
 
 ---
-_Posted by [host](http://host/) · Repository: **My Repo** (`my-repo`)_
+_Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
@@ -1,4 +1,4 @@
-Grafana detected **2** resource change(s) in this pull request.
+📋 Grafana detected **2** resource change(s) in this pull request.
 
 | Action | Kind | Resource | Preview | Status |
 |--------|------|----------|---------|--------|
@@ -7,7 +7,7 @@ Grafana detected **2** resource change(s) in this pull request.
 
 All resources passed validation. ✅
 
-> **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.
+> ℹ️ **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.
 
 ---
 _Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
@@ -10,4 +10,4 @@ All resources passed validation. ✅
 > ℹ️ **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.
 
 ---
-_Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_
+_🔄 Synced from [**My Repo**](https://github.com/example/repo) · Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
@@ -1,9 +1,9 @@
 📋 Grafana detected **2** resource change(s) in this pull request.
 
-| Action | Kind | Resource | Preview | Status |
-|--------|------|----------|---------|--------|
-| create | Dashboard | Dashboard A | [preview](http://grafana/admin/preview) | ✅ |
-| update | Dashboard | [Dashboard B](http://grafana/d/bbb) | [preview](http://grafana/admin/preview) | ✅ |
+| Action | Kind | Resource | File | Preview | Status |
+|--------|------|----------|------|---------|--------|
+| ➕ Added | Dashboard | Dashboard A | [source](https://github.com/example/repo/blob/pr/good.json) | [preview](http://grafana/admin/preview) | ✅ |
+| ✏️ Updated | Dashboard | [Dashboard B](http://grafana/d/bbb) | [source](https://github.com/example/repo/blob/pr/stripped.json) | [preview](http://grafana/admin/preview) | ✅ |
 
 All resources passed validation. ✅
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
@@ -1,4 +1,4 @@
-📋 Grafana detected **2** resource change(s) in this pull request.
+📋 Grafana detected **2** resource changes in this pull request.
 
 | Action | Kind | Resource | File | Preview | Status |
 |--------|------|----------|------|---------|--------|

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
@@ -1,4 +1,4 @@
-📋 Grafana detected **3** resource change(s) in this pull request.
+📋 Grafana detected **3** resource changes in this pull request.
 
 | Action | Kind | Resource | File | Preview | Status |
 |--------|------|----------|------|---------|--------|

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
@@ -1,10 +1,10 @@
 📋 Grafana detected **3** resource change(s) in this pull request.
 
-| Action | Kind | Resource | Preview | Status |
-|--------|------|----------|---------|--------|
-| create | Dashboard | Dash A | [preview](http://grafana/admin/preview) | ✅ |
-| update | Dashboard | [Dash B](http://grafana/d/bbb) | [preview](http://grafana/admin/preview) | ✅ |
-| create | Playlist | My Playlist |  | ✅ |
+| Action | Kind | Resource | File | Preview | Status |
+|--------|------|----------|------|---------|--------|
+| ➕ Added | Dashboard | Dash A | [source](https://github.com/example/repo/blob/pr/aaa.json) | [preview](http://grafana/admin/preview) | ✅ |
+| ✏️ Updated | Dashboard | [Dash B](http://grafana/d/bbb) | [source](https://github.com/example/repo/blob/pr/bbb.json) | [preview](http://grafana/admin/preview) | ✅ |
+| ➕ Added | Playlist | My Playlist | [source](https://github.com/example/repo/blob/pr/ccc.json) |  | ✅ |
 
 and 5 more files.
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
@@ -1,4 +1,4 @@
-Grafana detected **3** resource change(s) in this pull request.
+📋 Grafana detected **3** resource change(s) in this pull request.
 
 | Action | Kind | Resource | Preview | Status |
 |--------|------|----------|---------|--------|

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
@@ -1,5 +1,4 @@
-Hey there! 👋
-Grafana spotted 3 changes.
+Grafana detected **3** resource change(s) in this pull request.
 
 | Action | Kind | Resource | Preview | Status |
 |--------|------|----------|---------|--------|
@@ -12,4 +11,4 @@ and 5 more files.
 All resources passed validation. ✅
 
 ---
-_Posted by [host](http://host/) · Repository: **My Repo** (`my-repo`)_
+_Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
@@ -11,4 +11,4 @@ and 5 more files.
 All resources passed validation. ✅
 
 ---
-_Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_
+_🔄 Synced from [**My Repo**](https://github.com/example/repo) · Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/new-dashboard.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/new-dashboard.md
@@ -1,10 +1,9 @@
-Hey there! 👋
-Grafana spotted some changes to your dashboard.
+Grafana detected dashboard changes in this pull request.
 
 ### Preview of file.json
 ![Preview](https://cdn2.thecatapi.com/images/99c.jpg)
 
-See the [preview](http://grafana/admin/preview) of file.json.
+[**New Dashboard**](https://github.com/example/repo/blob/pr/file.json) — [preview changes](http://grafana/admin/preview)
 
 ---
-_Posted by [host](http://host/) · Repository: **My Repo** (`my-repo`)_
+_Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/new-dashboard.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/new-dashboard.md
@@ -6,4 +6,4 @@
 [**New Dashboard**](https://github.com/example/repo/blob/pr/file.json) — [preview changes](http://grafana/admin/preview)
 
 ---
-_Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_
+_🔄 Synced from [**My Repo**](https://github.com/example/repo) · Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/new-dashboard.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/new-dashboard.md
@@ -1,4 +1,4 @@
-Grafana detected dashboard changes in this pull request.
+📊 Grafana detected dashboard changes in this pull request.
 
 ### Preview of file.json
 ![Preview](https://cdn2.thecatapi.com/images/99c.jpg)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/no-changes.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/no-changes.md
@@ -1,4 +1,4 @@
 Grafana didn't find any changes in this pull request.
 
 ---
-_Posted by [host](http://host/) · Repository: **My Repo** (`my-repo`)_
+_🔄 Synced from **My Repo** · Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-error.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-error.md
@@ -1,7 +1,6 @@
-Hey there! 👋
-Grafana spotted some changes to your dashboard.
+Grafana detected dashboard changes in this pull request.
 
-See the [preview](http://grafana/admin/preview) of broken.json.
+[**Broken Dashboard**](https://github.com/example/repo/blob/pr/broken.json) — [preview changes](http://grafana/admin/preview)
 
 > ⚠️ **Validation failed:** strict decoding error: unknown field "spec.invalidField"
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-error.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-error.md
@@ -1,4 +1,4 @@
-Grafana detected dashboard changes in this pull request.
+📊 Grafana detected dashboard changes in this pull request.
 
 [**Broken Dashboard**](https://github.com/example/repo/blob/pr/broken.json) — [preview changes](http://grafana/admin/preview)
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-stripped-metadata.md
@@ -1,8 +1,8 @@
-Grafana detected dashboard changes in this pull request.
+📊 Grafana detected dashboard changes in this pull request.
 
 [**My Dashboard**](https://github.com/example/repo/blob/pr/dashboard.json) — [view current](http://grafana/d/uid) · [preview changes](http://grafana/admin/preview)
 
-> **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.
+> ℹ️ **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.
 
 ---
 _Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-stripped-metadata.md
@@ -1,7 +1,6 @@
-Hey there! 👋
-Grafana spotted some changes to your dashboard.
+Grafana detected dashboard changes in this pull request.
 
-See the [original](http://grafana/d/uid) and [preview](http://grafana/admin/preview) of dashboard.json.
+[**My Dashboard**](https://github.com/example/repo/blob/pr/dashboard.json) — [view current](http://grafana/d/uid) · [preview changes](http://grafana/admin/preview)
 
 > **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
@@ -1,4 +1,4 @@
-Grafana detected dashboard changes in this pull request.
+📊 Grafana detected dashboard changes in this pull request.
 
 [**Existing Dashboard**](https://github.com/example/repo/blob/pr/file.json) — [view current](http://grafana/d/uid) · [preview changes](http://grafana/admin/preview)
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
@@ -1,7 +1,6 @@
-Hey there! 👋
-Grafana spotted some changes to your dashboard.
+Grafana detected dashboard changes in this pull request.
 
-See the [original](http://grafana/d/uid) and [preview](http://grafana/admin/preview) of file.json.
+[**Existing Dashboard**](https://github.com/example/repo/blob/pr/file.json) — [view current](http://grafana/d/uid) · [preview changes](http://grafana/admin/preview)
 
 ---
-_Posted by [host](http://host/) · Repository: **My Repo** (`my-repo`)_
+_Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
@@ -3,4 +3,4 @@
 [**Existing Dashboard**](https://github.com/example/repo/blob/pr/file.json) — [view current](http://grafana/d/uid) · [preview changes](http://grafana/admin/preview)
 
 ---
-_Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_
+_🔄 Synced from [**My Repo**](https://github.com/example/repo) · Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard.md
@@ -1,12 +1,11 @@
-Hey there! 👋
-Grafana spotted some changes to your dashboard.
+Grafana detected dashboard changes in this pull request.
 
 ### Side by Side Comparison of file.json
 | Before | After |
 |----------|---------|
 | ![Before](https://cdn2.thecatapi.com/images/99c.jpg) | ![Preview](https://cdn2.thecatapi.com/images/99c.jpg) |
 
-See the [original](http://grafana/d/uid) and [preview](http://grafana/admin/preview) of file.json.
+[**Existing Dashboard**](https://github.com/example/repo/blob/pr/file.json) — [view current](http://grafana/d/uid) · [preview changes](http://grafana/admin/preview)
 
 ---
-_Posted by [host](http://host/) · Repository: **My Repo** (`my-repo`)_
+_Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard.md
@@ -1,4 +1,4 @@
-Grafana detected dashboard changes in this pull request.
+📊 Grafana detected dashboard changes in this pull request.
 
 ### Side by Side Comparison of file.json
 | Before | After |

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard.md
@@ -8,4 +8,4 @@
 [**Existing Dashboard**](https://github.com/example/repo/blob/pr/file.json) — [view current](http://grafana/d/uid) · [preview changes](http://grafana/admin/preview)
 
 ---
-_Posted by [host](http://host/) · Repository: [**My Repo**](https://github.com/example/repo) (`my-repo`)_
+_🔄 Synced from [**My Repo**](https://github.com/example/repo) · Posted by [host](http://host/)_

--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -297,12 +297,12 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	require.Len(t, capturedComments, 1, "expected one pull request comment")
 
 	comment := capturedComments[0]
-	require.Contains(t, comment, "Grafana spotted some changes to your dashboard")
+	require.Contains(t, comment, "Grafana detected dashboard changes in this pull request")
 	require.Contains(t, comment, dashboardPath)
 
 	// Verify the dashboard and preview links the PR worker posted are
 	// well-formed and carry the context needed by the reviewer UI.
-	originalMarker := "[original]("
+	originalMarker := "[view current]("
 	originalStart := strings.Index(comment, originalMarker)
 	require.NotEqualf(t, -1, originalStart, "comment should contain original link:\n%s", comment)
 	originalRemainder := comment[originalStart+len(originalMarker):]
@@ -312,7 +312,7 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	require.NoError(t, err, "comment should contain a valid original URL")
 	require.Equal(t, "/d/gh-pr-comment-dash/github-pr-comment-dashboard-updated", originalURL.Path)
 
-	previewMarker := "[preview]("
+	previewMarker := "[preview changes]("
 	previewStart := strings.Index(comment, previewMarker)
 	require.NotEqualf(t, -1, previewStart, "comment should contain preview link:\n%s", comment)
 	previewRemainder := comment[previewStart+len(previewMarker):]


### PR DESCRIPTION
## Summary

Improves the pull-request comment posted by Git Sync (provisioning) to be clearer and more inviting for reviewers. Copy-focused change plus small backend additions so links point somewhere useful, light emoji accents, a decluttered footer, and a polished multi-file table. Please review the wording below.

## Example messages (for copy review)

### Single dashboard — before

> Hey there! 👋
> Grafana spotted some changes to your dashboard.
>
> See the [original](#) and [preview](#) of demo-influxdb/influxdb-time-series.json.
>
> ---
> _Posted by [playdev.grafana.net](#) · Repository: **GitSync Repository** (`gitsync-github-repository`)_

### Single dashboard — after

> 📊 Grafana detected dashboard changes in this pull request.
>
> [**InfluxDB Time Series**](#) — [view current](#) · [preview changes](#)
>
> ---
> _🔄 Synced from [**GitSync Repository**](#) · Posted by [playdev.grafana.net](#)_

(The dashboard title links to the file in the repo; the footer leads with the repository, which links to the repo.)

### Multiple changes — before

> Hey there! 👋
> Grafana spotted 3 changes.
>
> | Action | Kind | Resource | Preview | Status |
> |--------|------|----------|---------|--------|
> | create | Dashboard | Dash A | [preview](#) | ✅ |
> | update | Dashboard | [Dash B](#) | [preview](#) | ✅ |
> | create | Playlist | My Playlist |  | ✅ |
>
> All resources passed validation. ✅

### Multiple changes — after

> 📋 Grafana detected **3** resource change(s) in this pull request.
>
> | Action | Kind | Resource | File | Preview | Status |
> |--------|------|----------|------|---------|--------|
> | ➕ Added | Dashboard | Dash A | [source](#) | [preview](#) | ✅ |
> | ✏️ Updated | Dashboard | [Dash B](#) | [source](#) | [preview](#) | ✅ |
> | ➕ Added | Playlist | My Playlist | [source](#) |  | ✅ |
>
> All resources passed validation. ✅
>
> ---
> _🔄 Synced from [**My Repo**](#) · Posted by [host](#)_

When some resources have issues, the header becomes:

> 📋 Grafana detected **3** resource change(s) in this pull request — ⚠️ 2 need attention.

## Changes

- Reworked comment copy to a professional-concise tone (`comment.go`): dropped the greeting, lead with the dashboard **title** and clearer link labels (`view current` / `preview changes`).
- Added `SourceURL` to link the dashboard title (and each table row) back to the source file, populated best-effort via `RepositoryWithURLs.ResourceURLs` (plain text when the backend exposes no web URLs).
- Added `RepositoryURL` (from `repo.Config().URL()`) to link the repository in the footer.
- Decluttered footer: leads with `🔄 Synced from <repo>` and drops the internal resource name.
- Polished the multi-file table: `ActionLabel()` normalizes the mixed-tense action column into one emoji+word label (`➕ Added` / `✏️ Updated` / `🗑️ Deleted`), `Kind()` falls back to `File` instead of `.json`, and a new `File` column links each row to its source.
- Light emoji accents on section leads: 📊 single dashboard, 📋 multiple resources, ⚠️ before the error count, ℹ️ metadata notice, 💡 image-renderer tip. Functional ✅ / ⚠️ status icons unchanged.

## Testing

- `go test ./pkg/registry/apis/provisioning/webhooks/pullrequest/` — passes.
- `go vet` — clean.
- Regenerated golden `.md` fixtures; updated substring assertions; added `TestEvaluate_PopulatesSourceAndRepositoryURLs` covering the URL wiring.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (n/a — GitHub comment text, no docs/i18n)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)