### PR TITLE
Preferences: Cache boot-fetched merged preferences in RTK Query store

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -8,6 +8,7 @@ import 'jquery';
 import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { type Preferences } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
 import {
   locationUtil,
   monacoLanguageRegistry,
@@ -142,10 +143,16 @@ const extensionsExports = extensionsIndex.keys().map((key) => {
   return extensionsIndex(key);
 });
 
+export interface AppInitOptions {
+  // Preferences fetched during boot (see initPreferences). Passed through so we
+  // can seed the RTK Query cache and avoid a duplicate preferences/merged request.
+  mergedPreferences?: Preferences;
+}
+
 export class GrafanaApp {
   context!: GrafanaContextType;
 
-  async init() {
+  async init(options?: AppInitOptions) {
     try {
       await preInitTasks();
 
@@ -224,7 +231,7 @@ export class GrafanaApp {
 
       // Important that extension reducers are initialized before store
       addExtensionReducers();
-      configureStore();
+      configureStore(undefined, { mergedPreferences: options?.mergedPreferences });
       initExtensions();
 
       initAlerting();

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -2,6 +2,8 @@
 // Since much of Grafana depends on it in includes side effects at import time,
 // we delay loading the rest of the app using import() until the boot data is ready.
 
+import type { Preferences } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
+
 import { initPreferences } from './initPreferences';
 import { patchFetchForLegacyAPIMode } from './legacyAPIHandling';
 
@@ -30,13 +32,15 @@ async function bootstrapWindowData() {
 
   patchFetchForLegacyAPIMode();
 
+  let mergedPreferences: Preferences | undefined;
   if (window.__grafanaNewPreferencesPage) {
-    await initPreferences();
+    mergedPreferences = await initPreferences();
   }
 
   // Use eager to ensure the app is included in the initial chunk and does not
   // require additional network requests to load.
-  await import(/* webpackMode: "eager" */ './initApp');
+  const { initApp } = await import(/* webpackMode: "eager" */ './initApp');
+  initApp({ mergedPreferences });
 }
 
 bootstrapWindowData().catch((error) => {

--- a/public/app/initApp.ts
+++ b/public/app/initApp.ts
@@ -2,6 +2,8 @@
 
 // Trusted types must be initialised before the rest of the world is imported
 import './core/trustedTypePolicies';
-import app from './app';
+import app, { type AppInitOptions } from './app';
 
-app.init();
+export function initApp(options?: AppInitOptions) {
+  app.init(options);
+}

--- a/public/app/initPreferences.test.ts
+++ b/public/app/initPreferences.test.ts
@@ -125,6 +125,12 @@ describe('initPreferences', () => {
     expect(window.grafanaBootData.user.timezone).toBe('browser');
   });
 
+  it('returns the fetched preferences so the caller can seed the RTK Query cache', async () => {
+    server.use(http.get(PREFERENCES_URL, () => HttpResponse.json({ spec: { theme: 'light' } })));
+
+    await expect(initPreferences()).resolves.toEqual({ spec: { theme: 'light' } });
+  });
+
   it('does not reject when the API errors', async () => {
     server.use(http.get(PREFERENCES_URL, () => HttpResponse.json({ message: 'internal error' }, { status: 500 })));
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});

--- a/public/app/initPreferences.ts
+++ b/public/app/initPreferences.ts
@@ -1,9 +1,9 @@
-import type { PreferencesSpec } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
+import type { Preferences } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
 
-export const initPreferences = async () => {
+export const initPreferences = async (): Promise<Preferences | undefined> => {
   const preferences = await fetchMergedPreferences();
   if (!preferences) {
-    return;
+    return undefined;
   }
   // URL prefs take precedence over saved preferences, matching the backend's
   // getURLPrefs behavior used when the flag is disabled.
@@ -29,9 +29,13 @@ export const initPreferences = async () => {
   if (timezone !== undefined) {
     window.grafanaBootData.user.timezone = timezone;
   }
+
+  // Return the fetched preferences so the app boot can seed the RTK Query cache,
+  // avoiding a duplicate preferences/merged request from useMergedPreferencesQuery.
+  return preferences;
 };
 
-export async function fetchMergedPreferences(): Promise<{ spec: PreferencesSpec } | undefined> {
+export async function fetchMergedPreferences(): Promise<Preferences | undefined> {
   const namespace = window.grafanaBootData?.settings?.namespace;
   const isSignedIn = window.grafanaBootData?.user?.isSignedIn;
 

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -6,6 +6,7 @@ import { generatedAPI as migrateToCloudAPI } from '@grafana/api-clients/internal
 import { generatedAPI as preferencesUserAPI } from '@grafana/api-clients/internal/rtkq/legacy/preferences/user';
 import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/internal/rtkq/legacy/user';
 import { allMiddleware as allApiClientMiddleware } from '@grafana/api-clients/rtkq';
+import { generatedAPI as preferencesAPI, type Preferences } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
 import { legacyAPI } from 'app/api/clients/legacy';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import { browseDashboardsAPI } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
@@ -32,7 +33,14 @@ export function addExtraMiddleware(middleware: Middleware) {
   extraMiddleware.push(middleware);
 }
 
-export function configureStore(initialState?: Partial<StoreState>) {
+export interface ConfigureStoreOptions {
+  // Preferences fetched during boot (see initPreferences). Seeded into the RTK
+  // Query cache so useMergedPreferencesQuery serves the cached entry instead of
+  // issuing a duplicate preferences/merged request.
+  mergedPreferences?: Preferences;
+}
+
+export function configureStore(initialState?: Partial<StoreState>, options?: ConfigureStoreOptions) {
   const store = reduxConfigureStore({
     reducer: createRootReducer(),
     middleware: (getDefaultMiddleware) =>
@@ -72,6 +80,10 @@ export function configureStore(initialState?: Partial<StoreState>) {
 
   // this enables "refetchOnFocus" and "refetchOnReconnect" for RTK Query
   setupListeners(store.dispatch);
+
+  if (options?.mergedPreferences) {
+    store.dispatch(preferencesAPI.util.upsertQueryData('mergedPreferences', undefined, options.mergedPreferences));
+  }
 
   setStore(store);
   return store;


### PR DESCRIPTION
**What is this feature?**

When the `grafana.newPreferencesPage` toggle is enabled, `initPreferences` fetches `preferences/merged` during boot. This change threads that already-fetched response through `initApp` into `configureStore`, which seeds the RTK Query cache via `upsertQueryData` so `useMergedPreferencesQuery` (used by the unified homepage) serves the cached entry.

**Why do we need this feature?**

Previously both the boot-time fetch and the unified homepage's RTK Query hook requested `preferences/merged` independently, resulting in a wasteful duplicate API call when we already have the data.

**Who is this feature for?**

All users on the newPreferencesPage/unified homepage code paths; the change removes a redundant network request on page load.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

`initApp.ts` changes from a side-effect module to an exported `initApp()` function so the fetched preferences can be passed in; the `trustedTypePolicies`-before-`app` import order is preserved. If the boot fetch fails or the flag is off, nothing is seeded and the hook fetches as before.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.