### PR TITLE
Dashboards: Remove unlimitedLayoutsNesting feature toggle usage

### DIFF
--- a/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from 'react';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
 
 import { DashboardInteractions } from '../../utils/interactions';
@@ -120,10 +119,6 @@ const MAX_NESTING_DEPTH = 3;
 
 export function useNestingRestrictions(layoutManager: DashboardLayoutManager) {
   return useMemo(() => {
-    if (config.featureToggles.unlimitedLayoutsNesting) {
-      return { disableGrouping: false, disableTabs: false };
-    }
-
     const layouts: string[] = [];
     let parent = layoutManager.parent;
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { RadioButtonGroup, Box, ConfirmModal } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -24,10 +23,6 @@ export function DashboardLayoutSelector({ layoutManager }: Props) {
   const [newLayout, setNewLayout] = useState<LayoutRegistryItem | undefined>();
 
   const disableTabsReason = useMemo(() => {
-    if (config.featureToggles.unlimitedLayoutsNesting) {
-      return undefined;
-    }
-
     // Check parent hierarchy
     let parent = layoutManager.parent;
     while (parent) {


### PR DESCRIPTION
## What this PR does

Removes usage of the experimental `unlimitedLayoutsNesting` feature toggle (default `false`) from the dashboard scene layout code.

The now-dead `config.featureToggles.unlimitedLayoutsNesting` guards are dropped from `useNestingRestrictions` (`CanvasGridAddActions.tsx`) and `disableTabsReason` (`DashboardLayoutSelector.tsx`), keeping the default behavior: grouping limited to 3 levels and tabs cannot be nested inside tabs.

## Which issue(s) this PR fixes

Part of removing the `unlimitedLayoutsNesting` toggle. The toggle definition and generated files are removed in a separate backend PR stacked on top of this one.
