### PR TITLE
Provisioning: Resolve folder API version via discovery

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2555,10 +2555,6 @@ max_repositories = 10
 # Default is 0, which means unlimited.
 max_resources_per_repository = 0
 
-# The folder API version to use. Supported values: v1, v1beta1.
-# Default is v1 for on-prem (OSS) installations.
-folders_api_version = v1
-
 # The maximum number of changes allowed in a single incremental sync.
 # If the number of changes exceeds this value, a full sync will be performed.
 # Default is 100. If set to 0, the size check is disabled.

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -95,7 +95,6 @@ type ControllerConfig struct {
 // dashboards_server_url =
 // folders_server_url =
 // aggregated_server_url =
-// folders_api_version =
 // tls_insecure =
 // tls_cert_file =
 // tls_key_file =

--- a/pkg/operators/provisioning/jobqueue_operator.go
+++ b/pkg/operators/provisioning/jobqueue_operator.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
-	folderv1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/controller"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/informer"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
@@ -75,7 +74,6 @@ func RunJobQueueController(ctx context.Context, deps server.OperatorDependencies
 			jobInterval:          controllerCfg.jobInterval,
 			leaseRenewalInterval: controllerCfg.leaseRenewalInterval,
 			maxSyncWorkers:       controllerCfg.maxSyncWorkers,
-			folderAPIVersion:     controllerCfg.folderAPIVersion,
 		},
 		jobStore,
 		jobHistoryWriter,
@@ -135,7 +133,6 @@ type jobQueueControllerConfig struct {
 	leaseRenewalInterval time.Duration
 	concurrentDrivers    int
 	maxSyncWorkers       int
-	folderAPIVersion     string
 }
 
 func setupJobQueueControllerFromConfig(cfg *setting.Cfg, registry prometheus.Registerer) (*jobQueueControllerConfig, error) {
@@ -145,7 +142,6 @@ func setupJobQueueControllerFromConfig(cfg *setting.Cfg, registry prometheus.Reg
 	}
 
 	operatorSec := cfg.SectionWithEnvOverrides("operator")
-	folderAPIVersion := operatorSec.Key("folders_api_version").MustString(folderv1beta1.APIVersion)
 
 	return &jobQueueControllerConfig{
 		ControllerConfig:     *controllerCfg,
@@ -154,6 +150,5 @@ func setupJobQueueControllerFromConfig(cfg *setting.Cfg, registry prometheus.Reg
 		maxJobTimeout:        operatorSec.Key("max_job_timeout").MustDuration(20 * time.Minute),
 		jobInterval:          operatorSec.Key("job_interval").MustDuration(30 * time.Second),
 		leaseRenewalInterval: operatorSec.Key("lease_renewal_interval").MustDuration(jobClaimExpiry / 3),
-		folderAPIVersion:     folderAPIVersion,
 	}, nil
 }

--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -29,7 +29,6 @@ type driverConfig struct {
 	jobInterval          time.Duration
 	leaseRenewalInterval time.Duration
 	maxSyncWorkers       int
-	folderAPIVersion     string
 }
 
 // buildDriver constructs the full ConcurrentJobDriver including all workers.
@@ -44,7 +43,7 @@ func buildDriver(
 	jobHistoryWriter jobs.HistoryWriter,
 	notifications chan struct{},
 ) (*jobs.ConcurrentJobDriver, error) {
-	workers, metrics, err := buildWorkers(cfg, controllerCfg, registry, tracer, dc.maxSyncWorkers, dc.folderAPIVersion)
+	workers, metrics, err := buildWorkers(cfg, controllerCfg, registry, tracer, dc.maxSyncWorkers)
 	if err != nil {
 		return nil, fmt.Errorf("build workers: %w", err)
 	}
@@ -79,7 +78,7 @@ func buildDriver(
 	)
 }
 
-func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry prometheus.Registerer, tracer tracing.Tracer, maxSyncWorkers int, folderAPIVersion string) ([]jobs.Worker, *jobs.JobMetrics, error) {
+func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry prometheus.Registerer, tracer tracing.Tracer, maxSyncWorkers int) ([]jobs.Worker, *jobs.JobMetrics, error) {
 	featureManager, err := featuremgmt.ProvideManagerService(cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to provide feature manager: %w", err)
@@ -105,7 +104,7 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 		return nil, nil, fmt.Errorf("failed to create provisioning client: %w", err)
 	}
 
-	repositoryResources := resources.NewRepositoryResourcesFactory(parsers, clients, resourceLister, folderMetadataEnabled, folderAPIVersion)
+	repositoryResources := resources.NewRepositoryResourcesFactory(parsers, clients, resourceLister, folderMetadataEnabled)
 	statusPatcher := controller.NewRepositoryStatusPatcher(provisioningClient.ProvisioningV0alpha1())
 
 	urlProvider, err := controllerCfg.URLProvider()
@@ -139,7 +138,6 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 		stageIfPossible,
 		metrics,
 		exportEnabled,
-		folderAPIVersion,
 	)
 
 	// Migration export preserves original names so the takeover
@@ -152,7 +150,6 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 		stageIfPossible,
 		metrics,
 		exportEnabled,
-		folderAPIVersion,
 	)
 	cleaner := migrate.NewNamespaceCleaner(clients)
 	unifiedStorageMigrator := migrate.NewUnifiedStorageMigrator(
@@ -169,7 +166,7 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 	moveWorker := move.NewWorker(syncWorker, stageIfPossible, repositoryResources, metrics)
 
 	// Fix Metadata
-	fixMetadataWorker := fixfoldermetadata.NewWorker(resources.FolderGVKForVersion(folderAPIVersion))
+	fixMetadataWorker := fixfoldermetadata.NewWorker(clients)
 
 	// Release Resources (orphan cleanup — removes ownership annotations)
 	releaseResourcesWorker := releaseresourcespkg.NewWorker(resourceLister, clients, 10)

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
-	folderv1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	appcontroller "github.com/grafana/grafana/apps/provisioning/pkg/controller"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"k8s.io/client-go/tools/cache"
@@ -110,7 +109,6 @@ func RunRepoController(ctx context.Context, deps server.OperatorDependencies) er
 			resources.IsFolderMetadataEnabled(controllerCfg.Settings),
 			controllerCfg.Settings.SectionWithEnvOverrides("provisioning").Key("max_incremental_changes").MustInt(100),
 		),
-		controllerCfg.Settings.SectionWithEnvOverrides("operator").Key("folders_api_version").MustString(folderv1beta1.APIVersion),
 		controllerCfg.Settings.SectionWithEnvOverrides("provisioning").Key("webhook_secret_rotation_interval").MustDuration(30*24*time.Hour),
 	)
 	reg, err := repoSource.AddEventHandler(controller.EventHandler())

--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -23,11 +23,10 @@ import (
 )
 
 type finalizer struct {
-	lister           resources.ResourceLister
-	clientFactory    resources.ClientFactory
-	metrics          *finalizerMetrics
-	maxWorkers       int
-	folderAPIVersion string
+	lister        resources.ResourceLister
+	clientFactory resources.ClientFactory
+	metrics       *finalizerMetrics
+	maxWorkers    int
 }
 
 func (f *finalizer) process(ctx context.Context,
@@ -105,18 +104,13 @@ func (f *finalizer) newItemProcessor(
 ) itemProcessor {
 	baseLogger := logging.FromContext(ctx)
 	return func(jobCtx context.Context, item *provisioning.ResourceListItem) error {
-		// If the item is a folder, use the configured folder API version.
 		logger := baseLogger
-		var version string
-		if item.Group == resources.FolderResource.Group && item.Resource == resources.FolderResource.Resource {
-			version = f.folderAPIVersion
-			logger = logger.With("version", version)
-		}
 
+		// Version is left empty so the client resolves the server's preferred
+		// version via discovery (this covers folders and any other resource).
 		res, _, err := clients.ForResource(jobCtx, schema.GroupVersionResource{
 			Group:    item.Group,
 			Resource: item.Resource,
-			Version:  version,
 		})
 		if err != nil {
 			logger.Error("error getting client for resource", "resource", item.Resource, "error", err)

--- a/pkg/registry/apis/provisioning/controller/finalizers_test.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers_test.go
@@ -1044,10 +1044,6 @@ func TestFinalizer_processExistingItems_Concurrency(t *testing.T) {
 				On("ForResource", mock.Anything, mock.Anything).
 				Return(client, schema.GroupVersionKind{}, nil).
 				Maybe()
-			clients.
-				On("Folder", mock.Anything, "v1").
-				Return(client, schema.GroupVersionKind{}, nil).
-				Maybe()
 
 			metrics := registerFinalizerMetrics(prometheus.NewRegistry())
 			f := &finalizer{

--- a/pkg/registry/apis/provisioning/controller/finalizers_test.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers_test.go
@@ -527,10 +527,9 @@ func TestFinalizer_process(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			metrics := registerFinalizerMetrics(prometheus.NewRegistry())
 			f := &finalizer{
-				lister:           tc.lister,
-				clientFactory:    tc.clientFactory,
-				metrics:          &metrics,
-				folderAPIVersion: "v1",
+				lister:        tc.lister,
+				clientFactory: tc.clientFactory,
+				metrics:       &metrics,
 			}
 			err := f.process(context.Background(), tc.repo, tc.finalizers)
 			if tc.expectedErr == "" {
@@ -714,15 +713,13 @@ func TestDeleteExistingItems_ResourcesBeforeFolders(t *testing.T) {
 	clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
 		Group:    "folder.grafana.app",
 		Resource: "folders",
-		Version:  "v1",
 	}).Return(client, schema.GroupVersionKind{}, nil).Twice()
 
 	f := &finalizer{
-		lister:           resourceLister,
-		clientFactory:    clientFactory,
-		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-		maxWorkers:       1,
-		folderAPIVersion: "v1",
+		lister:        resourceLister,
+		clientFactory: clientFactory,
+		metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:    1,
 	}
 
 	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
@@ -771,15 +768,13 @@ func TestReleaseExistingItems_FoldersBeforeResources(t *testing.T) {
 	clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
 		Group:    "folder.grafana.app",
 		Resource: "folders",
-		Version:  "v1",
 	}).Return(client, schema.GroupVersionKind{}, nil).Twice()
 
 	f := &finalizer{
-		lister:           resourceLister,
-		clientFactory:    clientFactory,
-		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-		maxWorkers:       1,
-		folderAPIVersion: "v1",
+		lister:        resourceLister,
+		clientFactory: clientFactory,
+		metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:    1,
 	}
 
 	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
@@ -792,120 +787,107 @@ func TestReleaseExistingItems_FoldersBeforeResources(t *testing.T) {
 	assert.Equal(t, []string{"dash-2", "dash-1"}, order[2:], "non-folder resources should be released after folders")
 }
 
-func TestFinalizer_FolderAPIVersion_RoutesFolderItemsToFolderClient(t *testing.T) {
-	testCases := []struct {
-		name             string
-		folderAPIVersion string
-	}{
-		{name: "v1beta1 folder client (cloud default)", folderAPIVersion: "v1beta1"},
-		{name: "v1 folder client (on-prem default)", folderAPIVersion: "v1"},
-	}
+func TestFinalizer_RoutesItemsToVersionlessClient(t *testing.T) {
+	// The finalizer no longer pins a folder version: every item (folders included)
+	// is resolved with an empty version so the client picks the server's preferred
+	// version via discovery.
+	t.Run("release path", func(t *testing.T) {
+		items := provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Group: folders.GroupVersion.Group, Resource: "folders", Name: "folder-a", Path: "a"},
+				{Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash-a", Path: "dash.json"},
+			},
+		}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Run("release path", func(t *testing.T) {
-				items := provisioning.ResourceList{
-					Items: []provisioning.ResourceListItem{
-						{Group: folders.GroupVersion.Group, Resource: "folders", Name: "folder-a", Path: "a"},
-						{Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash-a", Path: "dash.json"},
-					},
-				}
+		resourceLister := resources.NewMockResourceLister(t)
+		resourceLister.On("List", mock.Anything, "default", "my-repo").Return(&items, nil)
 
-				resourceLister := resources.NewMockResourceLister(t)
-				resourceLister.On("List", mock.Anything, "default", "my-repo").Return(&items, nil)
+		clientFactory := resources.NewMockClientFactory(t)
+		clients := resources.NewMockResourceClients(t)
+		clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
 
-				clientFactory := resources.NewMockClientFactory(t)
-				clients := resources.NewMockResourceClients(t)
-				clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
+		folderClient := &mockDynamicClient{
+			patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, nil
+			},
+		}
+		dashboardClient := &mockDynamicClient{
+			patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, nil
+			},
+		}
 
-				folderClient := &mockDynamicClient{
-					patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
-						return nil, nil
-					},
-				}
-				dashboardClient := &mockDynamicClient{
-					patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
-						return nil, nil
-					},
-				}
+		clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+			Group:    "folder.grafana.app",
+			Resource: "folders",
+		}).Return(folderClient, schema.GroupVersionKind{}, nil).Once()
+		clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+			Group:    "dashboard.grafana.app",
+			Resource: "dashboards",
+		}).Return(dashboardClient, schema.GroupVersionKind{}, nil).Once()
 
-				clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
-					Group:    "folder.grafana.app",
-					Resource: "folders",
-					Version:  tc.folderAPIVersion,
-				}).Return(folderClient, schema.GroupVersionKind{}, nil).Once()
-				clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
-					Group:    "dashboard.grafana.app",
-					Resource: "dashboards",
-				}).Return(dashboardClient, schema.GroupVersionKind{}, nil).Once()
+		f := &finalizer{
+			lister:        resourceLister,
+			clientFactory: clientFactory,
+			metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+			maxWorkers:    1,
+		}
 
-				f := &finalizer{
-					lister:           resourceLister,
-					clientFactory:    clientFactory,
-					metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-					maxWorkers:       1,
-					folderAPIVersion: tc.folderAPIVersion,
-				}
+		repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
+		count, err := f.releaseExistingItems(context.Background(), repo)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, count)
+		clients.AssertExpectations(t)
+	})
 
-				repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
-				count, err := f.releaseExistingItems(context.Background(), repo)
-				assert.NoError(t, err)
-				assert.Equal(t, 2, count)
-				clients.AssertExpectations(t)
-			})
+	t.Run("delete path", func(t *testing.T) {
+		items := provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Group: folders.GroupVersion.Group, Resource: "folders", Name: "folder-a", Path: "a"},
+				{Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash-a", Path: "dash.json"},
+			},
+		}
 
-			t.Run("delete path", func(t *testing.T) {
-				items := provisioning.ResourceList{
-					Items: []provisioning.ResourceListItem{
-						{Group: folders.GroupVersion.Group, Resource: "folders", Name: "folder-a", Path: "a"},
-						{Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash-a", Path: "dash.json"},
-					},
-				}
+		resourceLister := resources.NewMockResourceLister(t)
+		resourceLister.On("List", mock.Anything, "default", "my-repo").Return(&items, nil)
 
-				resourceLister := resources.NewMockResourceLister(t)
-				resourceLister.On("List", mock.Anything, "default", "my-repo").Return(&items, nil)
+		clientFactory := resources.NewMockClientFactory(t)
+		clients := resources.NewMockResourceClients(t)
+		clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
 
-				clientFactory := resources.NewMockClientFactory(t)
-				clients := resources.NewMockResourceClients(t)
-				clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
+		folderClient := &mockDynamicClient{
+			deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+				return nil
+			},
+		}
+		dashboardClient := &mockDynamicClient{
+			deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+				return nil
+			},
+		}
 
-				folderClient := &mockDynamicClient{
-					deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
-						return nil
-					},
-				}
-				dashboardClient := &mockDynamicClient{
-					deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
-						return nil
-					},
-				}
+		clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+			Group:    "folder.grafana.app",
+			Resource: "folders",
+		}).Return(folderClient, schema.GroupVersionKind{}, nil).Once()
+		clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+			Group:    "dashboard.grafana.app",
+			Resource: "dashboards",
+		}).Return(dashboardClient, schema.GroupVersionKind{}, nil).Once()
 
-				clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
-					Group:    "folder.grafana.app",
-					Resource: "folders",
-					Version:  tc.folderAPIVersion,
-				}).Return(folderClient, schema.GroupVersionKind{}, nil).Once()
-				clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
-					Group:    "dashboard.grafana.app",
-					Resource: "dashboards",
-				}).Return(dashboardClient, schema.GroupVersionKind{}, nil).Once()
+		f := &finalizer{
+			lister:        resourceLister,
+			clientFactory: clientFactory,
+			metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+			maxWorkers:    1,
+		}
 
-				f := &finalizer{
-					lister:           resourceLister,
-					clientFactory:    clientFactory,
-					metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-					maxWorkers:       1,
-					folderAPIVersion: tc.folderAPIVersion,
-				}
-
-				repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
-				count, err := f.deleteExistingItems(context.Background(), repo)
-				assert.NoError(t, err)
-				assert.Equal(t, 2, count)
-				clients.AssertExpectations(t)
-			})
-		})
-	}
+		repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
+		count, err := f.deleteExistingItems(context.Background(), repo)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, count)
+		clients.AssertExpectations(t)
+	})
 }
 
 func TestReleaseExistingItems_ResourcesConcurrent(t *testing.T) {
@@ -948,11 +930,10 @@ func TestReleaseExistingItems_ResourcesConcurrent(t *testing.T) {
 	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
 
 	f := &finalizer{
-		lister:           resourceLister,
-		clientFactory:    clientFactory,
-		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-		maxWorkers:       5,
-		folderAPIVersion: "v1",
+		lister:        resourceLister,
+		clientFactory: clientFactory,
+		metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:    5,
 	}
 
 	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
@@ -1070,11 +1051,10 @@ func TestFinalizer_processExistingItems_Concurrency(t *testing.T) {
 
 			metrics := registerFinalizerMetrics(prometheus.NewRegistry())
 			f := &finalizer{
-				lister:           resourceLister,
-				clientFactory:    clientFactory,
-				metrics:          &metrics,
-				maxWorkers:       tc.maxWorkers,
-				folderAPIVersion: "v1",
+				lister:        resourceLister,
+				clientFactory: clientFactory,
+				metrics:       &metrics,
+				maxWorkers:    tc.maxWorkers,
 			}
 
 			repo := &provisioning.Repository{
@@ -1143,11 +1123,10 @@ func TestReleaseExistingItems_RetriesOnConflict(t *testing.T) {
 	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
 
 	f := &finalizer{
-		lister:           resourceLister,
-		clientFactory:    clientFactory,
-		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-		maxWorkers:       1,
-		folderAPIVersion: "v1",
+		lister:        resourceLister,
+		clientFactory: clientFactory,
+		metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:    1,
 	}
 
 	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
@@ -1190,11 +1169,10 @@ func TestDeleteExistingItems_RetriesOnConflict(t *testing.T) {
 	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
 
 	f := &finalizer{
-		lister:           resourceLister,
-		clientFactory:    clientFactory,
-		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-		maxWorkers:       1,
-		folderAPIVersion: "v1",
+		lister:        resourceLister,
+		clientFactory: clientFactory,
+		metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:    1,
 	}
 
 	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
@@ -1235,11 +1213,10 @@ func TestReleaseExistingItems_ReturnsErrorWhenConflictPersists(t *testing.T) {
 	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
 
 	f := &finalizer{
-		lister:           resourceLister,
-		clientFactory:    clientFactory,
-		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-		maxWorkers:       1,
-		folderAPIVersion: "v1",
+		lister:        resourceLister,
+		clientFactory: clientFactory,
+		metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:    1,
 	}
 
 	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -102,7 +102,6 @@ func NewRepositoryController(
 	quotaGetter quotas.QuotaGetter,
 	quotaChecker *RepositoryQuotaChecker,
 	incrementalPolicy repository.IncrementalSyncPolicy,
-	folderAPIVersion string,
 	webhookSecretRotationInterval time.Duration,
 ) *RepositoryController {
 	finalizerMetrics := registerFinalizerMetrics(registry)
@@ -123,11 +122,10 @@ func NewRepositoryController(
 		quotaChecker:      quotaChecker,
 		statusPatcher:     statusPatcher,
 		finalizer: &finalizer{
-			lister:           resourceLister,
-			clientFactory:    clients,
-			metrics:          &finalizerMetrics,
-			maxWorkers:       parallelOperations,
-			folderAPIVersion: folderAPIVersion,
+			lister:        resourceLister,
+			clientFactory: clients,
+			metrics:       &finalizerMetrics,
+			maxWorkers:    parallelOperations,
 		},
 		jobs:                          jobs,
 		logger:                        logging.DefaultLogger.With("logger", loggerName),

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -29,20 +29,18 @@ type filesConnector struct {
 	parsers               resources.ParserFactory
 	clients               resources.ClientFactory
 	folderMetadataEnabled bool
-	folderAPIVersion      string
 	// maxFileSize caps the size in bytes of files read from or written to the
 	// repository through this connector. <=0 disables the check.
 	maxFileSize int64
 }
 
-func NewFilesConnector(getter RepoGetter, parsers resources.ParserFactory, clients resources.ClientFactory, access auth.AccessChecker, folderMetadataEnabled bool, folderAPIVersion string, maxFileSize int64) *filesConnector {
+func NewFilesConnector(getter RepoGetter, parsers resources.ParserFactory, clients resources.ClientFactory, access auth.AccessChecker, folderMetadataEnabled bool, maxFileSize int64) *filesConnector {
 	return &filesConnector{
 		getter:                getter,
 		parsers:               parsers,
 		clients:               clients,
 		access:                access,
 		folderMetadataEnabled: folderMetadataEnabled,
-		folderAPIVersion:      folderAPIVersion,
 		maxFileSize:           maxFileSize,
 	}
 }
@@ -175,7 +173,7 @@ func (c *filesConnector) createDualReadWriter(ctx context.Context, repo reposito
 		return nil, nil, fmt.Errorf("failed to get clients: %w", err)
 	}
 
-	folderClient, folderGVK, err := clients.Folder(ctx, c.folderAPIVersion)
+	folderClient, folderGVK, err := clients.Folder(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get folder client: %w", err)
 	}

--- a/pkg/registry/apis/provisioning/jobs/export/all.go
+++ b/pkg/registry/apis/provisioning/jobs/export/all.go
@@ -11,20 +11,20 @@ import (
 // ExportAll exports all resources preserving their original metadata.name.
 // Used by the migrate worker so the takeover allowlist can correlate
 // exported resources back to the originals during the sync phase.
-func ExportAll(ctx context.Context, repoName string, options provisioning.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, folderAPIVersion string) error {
-	return exportAll(ctx, repoName, options, clients, repositoryResources, progress, false, folderAPIVersion)
+func ExportAll(ctx context.Context, repoName string, options provisioning.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder) error {
+	return exportAll(ctx, repoName, options, clients, repositoryResources, progress, false)
 }
 
 // ExportAllWithNewUIDs exports all resources with newly generated metadata.name values.
 // Used by the standalone export worker so exported files don't reference
 // existing resource identifiers, avoiding conflicts on subsequent sync.
-func ExportAllWithNewUIDs(ctx context.Context, repoName string, options provisioning.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, folderAPIVersion string) error {
-	return exportAll(ctx, repoName, options, clients, repositoryResources, progress, true, folderAPIVersion)
+func ExportAllWithNewUIDs(ctx context.Context, repoName string, options provisioning.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder) error {
+	return exportAll(ctx, repoName, options, clients, repositoryResources, progress, true)
 }
 
-func exportAll(ctx context.Context, repoName string, options provisioning.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, generateNewUIDs bool, folderAPIVersion string) error {
+func exportAll(ctx context.Context, repoName string, options provisioning.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, generateNewUIDs bool) error {
 	// FIXME: should we sign with grafana user?
-	folderClient, _, err := clients.Folder(ctx, folderAPIVersion)
+	folderClient, _, err := clients.Folder(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/registry/apis/provisioning/jobs/export/mock_export_fn.go
+++ b/pkg/registry/apis/provisioning/jobs/export/mock_export_fn.go
@@ -26,17 +26,17 @@ func (_m *MockExportFn) EXPECT() *MockExportFn_Expecter {
 	return &MockExportFn_Expecter{mock: &_m.Mock}
 }
 
-// Execute provides a mock function with given fields: ctx, repoName, options, clients, repositoryResources, progress, folderAPIVersion
-func (_m *MockExportFn) Execute(ctx context.Context, repoName string, options v0alpha1.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, folderAPIVersion string) error {
-	ret := _m.Called(ctx, repoName, options, clients, repositoryResources, progress, folderAPIVersion)
+// Execute provides a mock function with given fields: ctx, repoName, options, clients, repositoryResources, progress
+func (_m *MockExportFn) Execute(ctx context.Context, repoName string, options v0alpha1.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder) error {
+	ret := _m.Called(ctx, repoName, options, clients, repositoryResources, progress)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, v0alpha1.ExportJobOptions, resources.ResourceClients, resources.RepositoryResources, jobs.JobProgressRecorder, string) error); ok {
-		r0 = rf(ctx, repoName, options, clients, repositoryResources, progress, folderAPIVersion)
+	if rf, ok := ret.Get(0).(func(context.Context, string, v0alpha1.ExportJobOptions, resources.ResourceClients, resources.RepositoryResources, jobs.JobProgressRecorder) error); ok {
+		r0 = rf(ctx, repoName, options, clients, repositoryResources, progress)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -56,14 +56,13 @@ type MockExportFn_Execute_Call struct {
 //   - clients resources.ResourceClients
 //   - repositoryResources resources.RepositoryResources
 //   - progress jobs.JobProgressRecorder
-//   - folderAPIVersion string
-func (_e *MockExportFn_Expecter) Execute(ctx interface{}, repoName interface{}, options interface{}, clients interface{}, repositoryResources interface{}, progress interface{}, folderAPIVersion interface{}) *MockExportFn_Execute_Call {
-	return &MockExportFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repoName, options, clients, repositoryResources, progress, folderAPIVersion)}
+func (_e *MockExportFn_Expecter) Execute(ctx interface{}, repoName interface{}, options interface{}, clients interface{}, repositoryResources interface{}, progress interface{}) *MockExportFn_Execute_Call {
+	return &MockExportFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repoName, options, clients, repositoryResources, progress)}
 }
 
-func (_c *MockExportFn_Execute_Call) Run(run func(ctx context.Context, repoName string, options v0alpha1.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, folderAPIVersion string)) *MockExportFn_Execute_Call {
+func (_c *MockExportFn_Execute_Call) Run(run func(ctx context.Context, repoName string, options v0alpha1.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder)) *MockExportFn_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(v0alpha1.ExportJobOptions), args[3].(resources.ResourceClients), args[4].(resources.RepositoryResources), args[5].(jobs.JobProgressRecorder), args[6].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(v0alpha1.ExportJobOptions), args[3].(resources.ResourceClients), args[4].(resources.RepositoryResources), args[5].(jobs.JobProgressRecorder))
 	})
 	return _c
 }

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -20,7 +20,7 @@ import (
 )
 
 //go:generate mockery --name ExportFn --structname MockExportFn --inpackage --filename mock_export_fn.go --with-expecter
-type ExportFn func(ctx context.Context, repoName string, options provisioning.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, folderAPIVersion string) error
+type ExportFn func(ctx context.Context, repoName string, options provisioning.ExportJobOptions, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder) error
 
 //go:generate mockery --name WrapWithStageFn --structname MockWrapWithStageFn --inpackage --filename mock_wrap_with_stage_fn.go --with-expecter
 type WrapWithStageFn func(ctx context.Context, repo repository.Repository, stageOptions repository.StageOptions, fn func(repo repository.Repository, staged bool) error) error
@@ -33,7 +33,6 @@ type ExportWorker struct {
 	wrapWithStageFn     WrapWithStageFn
 	metrics             jobs.JobMetrics
 	enabled             bool
-	folderAPIVersion    string
 }
 
 func NewExportWorker(
@@ -44,7 +43,6 @@ func NewExportWorker(
 	wrapWithStageFn WrapWithStageFn,
 	metrics jobs.JobMetrics,
 	enabled bool,
-	folderAPIVersion string,
 ) *ExportWorker {
 	return &ExportWorker{
 		clientFactory:       clientFactory,
@@ -54,7 +52,6 @@ func NewExportWorker(
 		wrapWithStageFn:     wrapWithStageFn,
 		metrics:             metrics,
 		enabled:             enabled,
-		folderAPIVersion:    folderAPIVersion,
 	}
 }
 
@@ -138,7 +135,7 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 			return fmt.Errorf("create repository resource client: %w", err)
 		}
 
-		return r.exportFn(ctx, cfg.Name, *options, clients, repositoryResources, progress, r.folderAPIVersion)
+		return r.exportFn(ctx, cfg.Name, *options, clients, repositoryResources, progress)
 	}
 
 	err = r.wrapWithStageFn(ctx, repo, cloneOptions, fn)

--- a/pkg/registry/apis/provisioning/jobs/export/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker_test.go
@@ -80,7 +80,7 @@ func TestExportWorker_IsSupported(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewExportWorker(nil, nil, nil, nil, nil, metrics, true, "v1beta1")
+			r := NewExportWorker(nil, nil, nil, nil, nil, metrics, true)
 			got := r.IsSupported(context.Background(), tt.job)
 			require.Equal(t, tt.want, got)
 		})
@@ -94,7 +94,7 @@ func TestExportWorker_ProcessNoExportSettings(t *testing.T) {
 		},
 	}
 
-	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), nil, job, nil)
 	require.EqualError(t, err, "missing export settings")
 }
@@ -117,7 +117,7 @@ func TestExportWorker_ProcessWriteNotAllowed(t *testing.T) {
 		},
 	})
 
-	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, nil)
 	require.EqualError(t, err, "repositories.provisioning.grafana.app is forbidden: write operations are not allowed for this repository")
 }
@@ -141,7 +141,7 @@ func TestExportWorker_ProcessBranchNotAllowedForLocal(t *testing.T) {
 		},
 	})
 
-	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, nil)
 	require.EqualError(t, err, "repositories.provisioning.grafana.app is forbidden: branch workflow is not allowed for this repository")
 }
@@ -169,7 +169,7 @@ func TestExportWorker_ProcessFailedToCreateClients(t *testing.T) {
 
 	mockClients.On("Clients", mock.Anything, "test-namespace").Return(nil, errors.New("failed to create clients"))
 
-	r := NewExportWorker(mockClients, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	mockProgress := jobs.NewMockJobProgressRecorder(t)
 
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
@@ -205,7 +205,7 @@ func TestExportWorker_ProcessNotReaderWriter(t *testing.T) {
 		return fn(repo, true)
 	})
 
-	r := NewExportWorker(mockClients, nil, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, nil, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "export job submitted targeting repository that is not a ReaderWriter")
 }
@@ -241,7 +241,7 @@ func TestExportWorker_ProcessRepositoryResourcesError(t *testing.T) {
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
-	r := NewExportWorker(mockClients, mockRepoResources, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, mockRepoResources, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "create repository resource client: failed to create repository resources client")
 }
@@ -281,7 +281,7 @@ func TestExportWorker_ProcessStageOptions(t *testing.T) {
 	mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 	mockExportFn := NewMockExportFn(t)
-	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	mockStageFn := NewMockWrapWithStageFn(t)
 	// Verify all stage options including Ref (branch), Timeout, and PushOnWrites
@@ -293,7 +293,7 @@ func TestExportWorker_ProcessStageOptions(t *testing.T) {
 		return fn(repo, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
 }
@@ -363,7 +363,7 @@ func TestExportWorker_ProcessStageOptionsWithBranch(t *testing.T) {
 			mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 			mockExportFn := NewMockExportFn(t)
-			mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 			mockStageFn := NewMockWrapWithStageFn(t)
 			// Verify that the stage options contain the correct branch reference and other parameters
@@ -375,7 +375,7 @@ func TestExportWorker_ProcessStageOptionsWithBranch(t *testing.T) {
 				return fn(repo, true)
 			})
 
-			r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+			r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 			err := r.Process(context.Background(), mockRepo, job, mockProgress)
 			require.NoError(t, err)
 		})
@@ -411,14 +411,14 @@ func TestExportWorker_ProcessExportFnError(t *testing.T) {
 	mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 	mockExportFn := NewMockExportFn(t)
-	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("export failed"))
+	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("export failed"))
 
 	mockStageFn := NewMockWrapWithStageFn(t)
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "export failed")
 }
@@ -449,7 +449,7 @@ func TestExportWorker_ProcessWrapWithStageFnError(t *testing.T) {
 	mockClients := resources.NewMockClientFactory(t)
 	mockClients.On("Clients", mock.Anything, "test-namespace").Return(resources.NewMockResourceClients(t), nil)
 
-	r := NewExportWorker(mockClients, nil, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, nil, nil, nil, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "stage failed")
 }
@@ -475,7 +475,7 @@ func TestExportWorker_ProcessBranchNotAllowedForStageableRepositories(t *testing
 	mockProgress := jobs.NewMockJobProgressRecorder(t)
 	// No progress messages expected in current implementation
 
-	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(nil, nil, nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "repositories.provisioning.grafana.app is forbidden: branch workflow is not allowed for this repository")
 }
@@ -517,7 +517,7 @@ func TestExportWorker_ProcessGitRepository(t *testing.T) {
 	mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 	mockExportFn := NewMockExportFn(t)
-	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	mockStageFn := NewMockWrapWithStageFn(t)
 	// Verify clone and push options
@@ -527,7 +527,7 @@ func TestExportWorker_ProcessGitRepository(t *testing.T) {
 		return fn(repo, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
 }
@@ -566,14 +566,14 @@ func TestExportWorker_ProcessGitRepositoryExportFnError(t *testing.T) {
 	mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 	mockExportFn := NewMockExportFn(t)
-	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("export failed"))
+	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("export failed"))
 
 	mockStageFn := NewMockWrapWithStageFn(t)
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.EqualError(t, err, "export failed")
 }
@@ -640,7 +640,7 @@ func TestExportWorker_CommitMessagePrecedence(t *testing.T) {
 			mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 			mockExportFn := NewMockExportFn(t)
-			mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 			mockReaderWriter := repository.NewMockReaderWriter(t)
 			mockStageFn := NewMockWrapWithStageFn(t)
@@ -650,7 +650,7 @@ func TestExportWorker_CommitMessagePrecedence(t *testing.T) {
 				return fn(mockReaderWriter, true)
 			})
 
-			r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+			r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 			err := r.Process(context.Background(), mockRepo, job, mockProgress)
 			require.NoError(t, err)
 		})
@@ -704,7 +704,7 @@ func TestExportWorker_RefURLsSetWithBranch(t *testing.T) {
 	mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 	mockExportFn := NewMockExportFn(t)
-	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Mock the ReaderWriter interface that the export function expects
 	mockReaderWriter := repository.NewMockReaderWriter(t)
@@ -715,7 +715,7 @@ func TestExportWorker_RefURLsSetWithBranch(t *testing.T) {
 		return fn(mockReaderWriter, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepoWithURLs, job, mockProgress)
 	require.NoError(t, err)
 
@@ -763,7 +763,7 @@ func TestExportWorker_RefURLsNotSetWithoutBranch(t *testing.T) {
 	mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 	mockExportFn := NewMockExportFn(t)
-	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	mockReaderWriter := repository.NewMockReaderWriter(t)
 
@@ -772,7 +772,7 @@ func TestExportWorker_RefURLsNotSetWithoutBranch(t *testing.T) {
 		return fn(mockReaderWriter, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepoWithURLs, job, mockProgress)
 	require.NoError(t, err)
 
@@ -820,7 +820,7 @@ func TestExportWorker_RefURLsNotSetForNonURLRepository(t *testing.T) {
 	mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 	mockExportFn := NewMockExportFn(t)
-	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	mockReaderWriter := repository.NewMockReaderWriter(t)
 
@@ -829,7 +829,7 @@ func TestExportWorker_RefURLsNotSetForNonURLRepository(t *testing.T) {
 		return fn(mockReaderWriter, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
 
@@ -1137,7 +1137,7 @@ func TestExportWorker_ProcessQuotaExceeded(t *testing.T) {
 	mockClients := resources.NewMockClientFactory(t)
 	mockClients.On("Clients", mock.Anything, "test-namespace").Return(mockResourceClients, nil)
 
-	r := NewExportWorker(mockClients, nil, mockLister, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, nil, mockLister, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 
 	require.Error(t, err)
@@ -1191,14 +1191,14 @@ func TestExportWorker_ProcessQuotaNotExceeded(t *testing.T) {
 	mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 	mockExportFn := NewMockExportFn(t)
-	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	mockStageFn := NewMockWrapWithStageFn(t)
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, mockLister, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, mockRepoResources, mockLister, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
 }
@@ -1239,14 +1239,14 @@ func TestExportWorker_ProcessQuotaUnlimited(t *testing.T) {
 	mockRepoResources.On("Client", mock.Anything, mock.Anything).Return(mockRepoResourcesClient, nil)
 
 	mockExportFn := NewMockExportFn(t)
-	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockExportFn.On("Execute", mock.Anything, "test-repo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	mockStageFn := NewMockWrapWithStageFn(t)
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
 
-	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true, "v1beta1")
+	r := NewExportWorker(mockClients, mockRepoResources, nil, mockExportFn.Execute, mockStageFn.Execute, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), true)
 	err := r.Process(context.Background(), mockRepo, job, mockProgress)
 	require.NoError(t, err)
 }
@@ -1287,7 +1287,6 @@ func TestExportWorker_ConfigurationDisabled(t *testing.T) {
 				repository.WrapWithStageAndPushIfPossible,
 				metrics,
 				tt.enabled,
-				"v1beta1",
 			)
 
 			// Create a minimal mock repository

--- a/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -28,11 +27,11 @@ const keepFileName = ".keep"
 // It also removes legacy .keep files from folders that have (or receive)
 // a _folder.json, since the metadata file supersedes the keep marker.
 type Worker struct {
-	folderGVK schema.GroupVersionKind
+	clientFactory resources.ClientFactory
 }
 
-func NewWorker(folderGVK schema.GroupVersionKind) *Worker {
-	return &Worker{folderGVK: folderGVK}
+func NewWorker(clientFactory resources.ClientFactory) *Worker {
+	return &Worker{clientFactory: clientFactory}
 }
 
 func (w *Worker) IsSupported(_ context.Context, job provisioning.Job) bool {
@@ -74,6 +73,17 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 			job,
 			fmt.Sprintf("Add folder metadata files\n\nTriggered by job %s at %s", job.Name, time.Now().UTC().Format(time.RFC3339)),
 		),
+	}
+
+	// Resolve the folder GVK via discovery (the server's preferred version) so the
+	// _folder.json manifests are written with whatever folder version the instance serves.
+	clients, err := w.clientFactory.Clients(ctx, repo.Config().Namespace)
+	if err != nil {
+		return fmt.Errorf("create clients: %w", err)
+	}
+	_, folderGVK, err := clients.Folder(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve folder client: %w", err)
 	}
 
 	fn := func(stagedRepo repository.Repository, staged bool) error {
@@ -121,7 +131,7 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 				continue
 			}
 
-			manifest := resources.NewFolderManifest(util.GenerateShortUID(), safepath.Base(folder.Path), w.folderGVK)
+			manifest := resources.NewFolderManifest(util.GenerateShortUID(), safepath.Base(folder.Path), folderGVK)
 			_, writeErr := resources.WriteFolderMetadata(ctx, rw, folder.Path, manifest, ref,
 				fmt.Sprintf("Add folder metadata for %s", folder.Path))
 

--- a/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker_test.go
@@ -17,8 +17,20 @@ import (
 
 var testFolderGVK = resources.FolderKind
 
+// newFolderClientFactory returns a ClientFactory whose folder client resolves to
+// testFolderGVK, standing in for the discovery-based version resolution the worker
+// performs at run time. Expectations are optional so it can be shared by tests that
+// never reach the client-resolution path (e.g. IsSupported).
+func newFolderClientFactory(t *testing.T) resources.ClientFactory {
+	cf := resources.NewMockClientFactory(t)
+	clients := resources.NewMockResourceClients(t)
+	cf.On("Clients", mock.Anything, mock.Anything).Return(clients, nil).Maybe()
+	clients.On("Folder", mock.Anything).Return(nil, testFolderGVK, nil).Maybe()
+	return cf
+}
+
 func TestWorker_IsSupported(t *testing.T) {
-	w := NewWorker(testFolderGVK)
+	w := NewWorker(newFolderClientFactory(t))
 
 	tests := []struct {
 		name     string
@@ -104,7 +116,7 @@ func repoConfig(name string) *provisioning.Repository {
 
 func TestWorker_CommitMessageFromJobSpec(t *testing.T) {
 	ctx := context.Background()
-	w := NewWorker(testFolderGVK)
+	w := NewWorker(newFolderClientFactory(t))
 
 	mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 	mockStaged := repository.NewMockStagedRepository(t)
@@ -133,7 +145,7 @@ func TestWorker_CommitMessageFromJobSpec(t *testing.T) {
 func TestWorker_Process(t *testing.T) {
 	t.Run("creates _folder.json for directories without metadata", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)
@@ -177,7 +189,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("skips directories that already have _folder.json", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)
@@ -209,7 +221,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("mixed: creates missing metadata and skips existing", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)
@@ -247,7 +259,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("fails immediately when Create returns an error", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)
@@ -284,7 +296,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("uses default branch when options are nil", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)
@@ -319,7 +331,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("returns error when ReadTree fails", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)
@@ -341,7 +353,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("returns error when repository does not support read/write operations", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		// mockNonRWRepo is not stageable, so WrapWithStageAndPushIfPossible calls fn with the original repo.
 		// The original repo does not implement ReaderWriter, so the cast fails.
@@ -358,7 +370,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("sets ref URLs when repository supports it and ref is specified", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepoWithURLs{
 			mockStageableRepo:      mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)},
@@ -397,7 +409,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("blob entries are not processed as directories", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)
@@ -429,7 +441,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("deletes .keep file after creating _folder.json", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)
@@ -467,7 +479,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("deletes .keep file from folder that already has _folder.json", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)
@@ -501,7 +513,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("tolerates .keep file already absent when deleting", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)
@@ -539,7 +551,7 @@ func TestWorker_Process(t *testing.T) {
 
 	t.Run("does not attempt .keep deletion when folder has no .keep", func(t *testing.T) {
 		ctx := context.Background()
-		w := NewWorker(testFolderGVK)
+		w := NewWorker(newFolderClientFactory(t))
 
 		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
 		mockStaged := repository.NewMockStagedRepository(t)

--- a/pkg/registry/apis/provisioning/jobs/migrate/clean_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/clean_test.go
@@ -39,8 +39,8 @@ func (m *mockClients) ForKind(ctx context.Context, gvk schema.GroupVersionKind) 
 	return ri, args.Get(1).(schema.GroupVersionResource), args.Error(2)
 }
 
-func (m *mockClients) Folder(ctx context.Context, folderAPIVersion string) (dynamic.ResourceInterface, schema.GroupVersionKind, error) {
-	args := m.Called(ctx, folderAPIVersion)
+func (m *mockClients) Folder(ctx context.Context) (dynamic.ResourceInterface, schema.GroupVersionKind, error) {
+	args := m.Called(ctx)
 	var ri dynamic.ResourceInterface
 	if args.Get(0) != nil {
 		ri = args.Get(0).(dynamic.ResourceInterface)

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -155,7 +155,6 @@ type APIBuilder struct {
 	maxFileSize                   int64
 	syncResourceTimeout           time.Duration
 	incrementalPolicy             repository.IncrementalSyncPolicy
-	folderAPIVersion              string
 	webhookSecretRotationInterval time.Duration
 	// controllerResyncInterval is the informer re-list interval for the
 	// repository, connection, and job controllers; historyExpiration is both the
@@ -218,7 +217,6 @@ func NewAPIBuilder(
 	useExclusivelyAccessCheckerForAuthz bool,
 	quotaGetter quotas.QuotaGetter,
 	folderMetadataEnabled bool,
-	folderAPIVersion string,
 	incrementalPolicy repository.IncrementalSyncPolicy,
 	maxFileSize int64,
 ) (*APIBuilder, error) {
@@ -256,7 +254,7 @@ func NewAPIBuilder(
 		clients:                             clients,
 		supportedResources:                  supportedResources,
 		parsers:                             parsers,
-		repositoryResources:                 resources.NewRepositoryResourcesFactory(parsers, clients, resourceLister, features.IsEnabledGlobally(featuremgmt.FlagProvisioningFolderMetadata), folderAPIVersion), //nolint:staticcheck
+		repositoryResources:                 resources.NewRepositoryResourcesFactory(parsers, clients, resourceLister, features.IsEnabledGlobally(featuremgmt.FlagProvisioningFolderMetadata)), //nolint:staticcheck
 		resourceLister:                      resourceLister,
 		unified:                             unified,
 		access:                              accessChecker,
@@ -272,7 +270,6 @@ func NewAPIBuilder(
 		useExclusivelyAccessCheckerForAuthz: useExclusivelyAccessCheckerForAuthz,
 		quotaGetter:                         quotaGetter,
 		folderMetadataEnabled:               folderMetadataEnabled,
-		folderAPIVersion:                    folderAPIVersion,
 		incrementalPolicy:                   incrementalPolicy,
 		// Per-file cap for the files API. Non-positive (<=0) disables the cap.
 		maxFileSize: maxFileSize,
@@ -356,7 +353,6 @@ func RegisterAPIService(
 
 	jobHistoryConfig := createJobHistoryConfigFromSettings(cfg)
 	folderMetadataEnabled := features.IsEnabledGlobally(featuremgmt.FlagProvisioningFolderMetadata) //nolint:staticcheck
-	folderAPIVersion := cfg.ProvisioningFolderAPIVersion
 	maxFileSize := cfg.ProvisioningMaxFileSize
 	incrementalPolicy := repository.NewIncrementalSyncPolicy(folderMetadataEnabled, cfg.ProvisioningMaxIncrementalChanges)
 
@@ -390,7 +386,6 @@ func RegisterAPIService(
 		false, // useExclusivelyAccessCheckerForAuthz - TODO: first, test this on the MT side before we enable it by default in ST as well
 		quotaGetter,
 		folderMetadataEnabled,
-		folderAPIVersion,
 		incrementalPolicy,
 		maxFileSize,
 	)
@@ -436,7 +431,6 @@ func RegisterAPIService(
 		false, // useExclusivelyAccessCheckerForAuthz
 		quotaGetter,
 		folderMetadataEnabled,
-		folderAPIVersion,
 		incrementalPolicy,
 		maxFileSize,
 	)
@@ -902,7 +896,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	// connector via ProvisioningAuthorizer.AuthorizeResource, and repository-
 	// level operations remain Admin-gated by authorizeRepositorySubresource.
 	filesAccess := auth.NewVerbAwareAccessChecker(b.accessWithViewer, b.accessWithEditor)
-	storage[provisioning.RepositoryResourceInfo.StoragePath("files")] = WithTimeout(NewFilesConnector(b, b.parsers, b.clients, filesAccess, b.folderMetadataEnabled, b.folderAPIVersion, b.maxFileSize), 30*time.Second)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("files")] = WithTimeout(NewFilesConnector(b, b.parsers, b.clients, filesAccess, b.folderMetadataEnabled, b.maxFileSize), 30*time.Second)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("refs")] = WithTimeout(NewRefsConnector(b), 30*time.Second)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("resources")] = WithTimeout(NewListConnector(b, b.resourceLister), 30*time.Second)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("history")] = WithTimeout(NewHistorySubresource(b), 30*time.Second)
@@ -1004,7 +998,6 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				stageIfPossible,
 				metrics,
 				exportEnabled,
-				b.folderAPIVersion,
 			)
 
 			syncer := sync.NewSyncer(sync.Compare, sync.FullSync, sync.IncrementalSync, b.tracer, 10, metrics, b.folderMetadataEnabled, b.syncResourceTimeout) //nolint:staticcheck
@@ -1029,7 +1022,6 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				stageIfPossible,
 				metrics,
 				exportEnabled,
-				b.folderAPIVersion,
 			)
 			cleaner := migrate.NewNamespaceCleaner(b.clients)
 			unifiedStorageMigrator := migrate.NewUnifiedStorageMigrator(
@@ -1044,7 +1036,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 
 			deleteWorker := deletepkg.NewWorker(syncWorker, stageIfPossible, b.repositoryResources, metrics)
 			moveWorker := movepkg.NewWorker(syncWorker, stageIfPossible, b.repositoryResources, metrics)
-			fixMetadataWorker := fixfoldermetadata.NewWorker(resources.FolderGVKForVersion(b.folderAPIVersion))
+			fixMetadataWorker := fixfoldermetadata.NewWorker(b.clients)
 			releaseResourcesWorker := releaseresourcespkg.NewWorker(b.resourceLister, b.clients, 10)
 			deleteResourcesWorker := deleteresourcespkg.NewWorker(b.resourceLister, b.clients, 10)
 
@@ -1160,7 +1152,6 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				b.quotaGetter,
 				controller.NewRepositoryQuotaChecker(reconcileRepoGetter),
 				b.incrementalPolicy,
-				b.folderAPIVersion,
 				webhookSecretRotationInterval,
 			)
 			repoReg, err := repoSource.AddEventHandler(repoController.EventHandler())

--- a/pkg/registry/apis/provisioning/resources/client.go
+++ b/pkg/registry/apis/provisioning/resources/client.go
@@ -143,21 +143,14 @@ func supportsFolderAnnotation(supported []SupportedResource, gvk schema.GroupVer
 	return false
 }
 
-// folderGVR builds the GVR for the folder API at the given version.
-func folderGVR(folderAPIVersion string) schema.GroupVersionResource {
+// folderVersionlessGVR builds a versionless GVR for the folder API. The concrete
+// version is resolved at runtime via API discovery (the server's preferred version),
+// so provisioning works on any instance regardless of which folder versions are enabled.
+func folderVersionlessGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    FolderResource.Group,
-		Version:  folderAPIVersion,
 		Resource: FolderResource.Resource,
-	}
-}
-
-// FolderGVKForVersion returns a GVK for the folder API at the given version.
-func FolderGVKForVersion(version string) schema.GroupVersionKind {
-	return schema.GroupVersionKind{
-		Group:   FolderKind.Group,
-		Version: version,
-		Kind:    FolderKind.Kind,
+		// Version intentionally empty: resolved via discovery.
 	}
 }
 
@@ -181,8 +174,9 @@ type clientFactory struct {
 type ResourceClients interface {
 	ForKind(ctx context.Context, gvk schema.GroupVersionKind) (dynamic.ResourceInterface, schema.GroupVersionResource, error)
 	ForResource(ctx context.Context, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, schema.GroupVersionKind, error)
-	// Folder returns a dynamic client for the folder API at the given version.
-	Folder(ctx context.Context, folderAPIVersion string) (dynamic.ResourceInterface, schema.GroupVersionKind, error)
+	// Folder returns a dynamic client for the folder API. The version is resolved
+	// via discovery (the server's preferred version); the resolved GVK is returned.
+	Folder(ctx context.Context) (dynamic.ResourceInterface, schema.GroupVersionKind, error)
 	User(ctx context.Context) (dynamic.ResourceInterface, error)
 	// SupportedResources returns the resources that can be fully managed from the UI:
 	// the static base set plus any extra resources registered with the client factory.
@@ -456,8 +450,8 @@ func (c *resourceClients) ForResource(ctx context.Context, gvr schema.GroupVersi
 	return info.client, info.gvk, nil
 }
 
-func (c *resourceClients) Folder(ctx context.Context, folderAPIVersion string) (dynamic.ResourceInterface, schema.GroupVersionKind, error) {
-	return c.ForResource(ctx, folderGVR(folderAPIVersion))
+func (c *resourceClients) Folder(ctx context.Context) (dynamic.ResourceInterface, schema.GroupVersionKind, error) {
+	return c.ForResource(ctx, folderVersionlessGVR())
 }
 
 func (c *resourceClients) User(ctx context.Context) (dynamic.ResourceInterface, error) {
@@ -506,8 +500,8 @@ func (c *multiResourceClients) ForResource(ctx context.Context, gvr schema.Group
 	return resourceClients.ForResource(ctx, gvr)
 }
 
-func (c *multiResourceClients) Folder(ctx context.Context, folderAPIVersion string) (dynamic.ResourceInterface, schema.GroupVersionKind, error) {
-	return c.ForResource(ctx, folderGVR(folderAPIVersion))
+func (c *multiResourceClients) Folder(ctx context.Context) (dynamic.ResourceInterface, schema.GroupVersionKind, error) {
+	return c.ForResource(ctx, folderVersionlessGVR())
 }
 
 func (c *multiResourceClients) User(ctx context.Context) (dynamic.ResourceInterface, error) {

--- a/pkg/registry/apis/provisioning/resources/clients_mock.go
+++ b/pkg/registry/apis/provisioning/resources/clients_mock.go
@@ -24,9 +24,9 @@ func (_m *MockResourceClients) EXPECT() *MockResourceClients_Expecter {
 	return &MockResourceClients_Expecter{mock: &_m.Mock}
 }
 
-// Folder provides a mock function with given fields: ctx, folderAPIVersion
-func (_m *MockResourceClients) Folder(ctx context.Context, folderAPIVersion string) (dynamic.ResourceInterface, schema.GroupVersionKind, error) {
-	ret := _m.Called(ctx, folderAPIVersion)
+// Folder provides a mock function with given fields: ctx
+func (_m *MockResourceClients) Folder(ctx context.Context) (dynamic.ResourceInterface, schema.GroupVersionKind, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Folder")
@@ -35,25 +35,25 @@ func (_m *MockResourceClients) Folder(ctx context.Context, folderAPIVersion stri
 	var r0 dynamic.ResourceInterface
 	var r1 schema.GroupVersionKind
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (dynamic.ResourceInterface, schema.GroupVersionKind, error)); ok {
-		return rf(ctx, folderAPIVersion)
+	if rf, ok := ret.Get(0).(func(context.Context) (dynamic.ResourceInterface, schema.GroupVersionKind, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) dynamic.ResourceInterface); ok {
-		r0 = rf(ctx, folderAPIVersion)
+	if rf, ok := ret.Get(0).(func(context.Context) dynamic.ResourceInterface); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(dynamic.ResourceInterface)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) schema.GroupVersionKind); ok {
-		r1 = rf(ctx, folderAPIVersion)
+	if rf, ok := ret.Get(1).(func(context.Context) schema.GroupVersionKind); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Get(1).(schema.GroupVersionKind)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string) error); ok {
-		r2 = rf(ctx, folderAPIVersion)
+	if rf, ok := ret.Get(2).(func(context.Context) error); ok {
+		r2 = rf(ctx)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -68,14 +68,13 @@ type MockResourceClients_Folder_Call struct {
 
 // Folder is a helper method to define mock.On call
 //   - ctx context.Context
-//   - folderAPIVersion string
-func (_e *MockResourceClients_Expecter) Folder(ctx interface{}, folderAPIVersion interface{}) *MockResourceClients_Folder_Call {
-	return &MockResourceClients_Folder_Call{Call: _e.mock.On("Folder", ctx, folderAPIVersion)}
+func (_e *MockResourceClients_Expecter) Folder(ctx interface{}) *MockResourceClients_Folder_Call {
+	return &MockResourceClients_Folder_Call{Call: _e.mock.On("Folder", ctx)}
 }
 
-func (_c *MockResourceClients_Folder_Call) Run(run func(ctx context.Context, folderAPIVersion string)) *MockResourceClients_Folder_Call {
+func (_c *MockResourceClients_Folder_Call) Run(run func(ctx context.Context)) *MockResourceClients_Folder_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -85,7 +84,7 @@ func (_c *MockResourceClients_Folder_Call) Return(_a0 dynamic.ResourceInterface,
 	return _c
 }
 
-func (_c *MockResourceClients_Folder_Call) RunAndReturn(run func(context.Context, string) (dynamic.ResourceInterface, schema.GroupVersionKind, error)) *MockResourceClients_Folder_Call {
+func (_c *MockResourceClients_Folder_Call) RunAndReturn(run func(context.Context) (dynamic.ResourceInterface, schema.GroupVersionKind, error)) *MockResourceClients_Folder_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/resources/repository.go
+++ b/pkg/registry/apis/provisioning/resources/repository.go
@@ -50,7 +50,6 @@ type repositoryResourcesFactory struct {
 	clients               ClientFactory
 	lister                ResourceLister
 	folderMetadataEnabled bool
-	folderAPIVersion      string
 }
 
 type RepositoryResourcesOption func(*repositoryResourcesOptions)
@@ -117,13 +116,12 @@ func (r *repositoryResources) FindResourcePath(ctx context.Context, name string,
 	return sourcePath, nil
 }
 
-func NewRepositoryResourcesFactory(parsers ParserFactory, clients ClientFactory, lister ResourceLister, folderMetadataEnabled bool, folderAPIVersion string) RepositoryResourcesFactory {
+func NewRepositoryResourcesFactory(parsers ParserFactory, clients ClientFactory, lister ResourceLister, folderMetadataEnabled bool) RepositoryResourcesFactory {
 	return &repositoryResourcesFactory{
 		parsers:               parsers,
 		clients:               clients,
 		lister:                lister,
 		folderMetadataEnabled: folderMetadataEnabled,
-		folderAPIVersion:      folderAPIVersion,
 	}
 }
 
@@ -133,7 +131,7 @@ func (r *repositoryResourcesFactory) Client(ctx context.Context, repo repository
 		return nil, fmt.Errorf("create clients: %w", err)
 	}
 
-	folderClient, folderGVK, err := clients.Folder(ctx, r.folderAPIVersion)
+	folderClient, folderGVK, err := clients.Folder(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("create folder client: %w", err)
 	}

--- a/pkg/services/authz/zanzana/server/reconciler/anonymous_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/anonymous_test.go
@@ -50,7 +50,7 @@ func (f fakeAnonResourceClients) ForKind(context.Context, schema.GroupVersionKin
 	return nil, schema.GroupVersionResource{}, nil
 }
 
-func (f fakeAnonResourceClients) Folder(context.Context, string) (dynamic.ResourceInterface, schema.GroupVersionKind, error) {
+func (f fakeAnonResourceClients) Folder(context.Context) (dynamic.ResourceInterface, schema.GroupVersionKind, error) {
 	return nil, schema.GroupVersionKind{}, nil
 }
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -196,7 +196,6 @@ type Cfg struct {
 	ProvisioningLokiTenantID                  string
 	ProvisioningMaxResourcesPerRepository     int64         // 0 = unlimited
 	ProvisioningMaxRepositories               int64         // default 10, 0 in config = unlimited (converted to -1 internally)
-	ProvisioningFolderAPIVersion              string        // "v1" (default for on-prem) or "v1beta1"
 	ProvisioningMaxIncrementalChanges         int           // default 100, 0 in config = unlimited
 	ProvisioningMaxFileSize                   int64         // bytes; default 5 MiB (5242880); <=0 = unlimited
 	ProvisioningSyncResourceTimeout           time.Duration // per-resource apply timeout during sync; default 30s; <=0 = default
@@ -2547,7 +2546,6 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	cfg.ProvisioningMinSyncInterval = iniFile.Section("provisioning").Key("min_sync_interval").MustDuration(10 * time.Second)
 	cfg.ProvisioningMaxResourcesPerRepository = iniFile.Section("provisioning").Key("max_resources_per_repository").MustInt64(0)
 	cfg.ProvisioningMaxRepositories = iniFile.Section("provisioning").Key("max_repositories").MustInt64(10)
-	cfg.ProvisioningFolderAPIVersion = iniFile.Section("provisioning").Key("folders_api_version").MustString("v1")
 	cfg.ProvisioningMaxIncrementalChanges = iniFile.Section("provisioning").Key("max_incremental_changes").MustInt(100)
 	cfg.ProvisioningMaxFileSize = iniFile.Section("provisioning").Key("max_file_size").MustInt64(ProvisioningMaxFileSizeDefault)
 	cfg.ProvisioningSyncResourceTimeout = iniFile.Section("provisioning").Key("sync_resource_timeout").MustDuration(ProvisioningSyncResourceTimeoutDefault)

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1435,13 +1435,6 @@ func WithProvisioningPublicRootURL(url string) GrafanaOption {
 	}
 }
 
-// WithFolderAPIVersion sets the provisioning folder API version (e.g. "v1" or "v1beta1").
-func WithFolderAPIVersion(version string) GrafanaOption {
-	return func(opts *testinfra.GrafanaOpts) {
-		opts.ProvisioningFolderAPIVersion = version
-	}
-}
-
 // WithProvisioningMaxIncrementalChanges overrides the controller-side
 // incremental-sync size threshold. A small value (e.g. 5) keeps tests fast
 // when they need to exercise the full-sync fallback; 0 disables the check.

--- a/pkg/tests/apis/provisioning/folderapiversion/folder_api_version_test.go
+++ b/pkg/tests/apis/provisioning/folderapiversion/folder_api_version_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 
 	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
-	folderv1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -22,80 +23,94 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func TestIntegrationProvisioning_FolderAPIVersionConfig(t *testing.T) {
+// TestIntegrationProvisioning_FolderAPIVersionDiscovery verifies that provisioning
+// resolves the folder API version via discovery (the server's preferred version)
+// rather than a configured value: the folders it creates carry whatever folder
+// version the API server advertises as preferred.
+func TestIntegrationProvisioning_FolderAPIVersionDiscovery(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	tests := []struct {
-		name              string
-		configuredVersion string
-		expectedGroup     string
-		expectedVersion   string
-	}{
-		{
-			name:              "v1 creates folders via folder.grafana.app/v1",
-			configuredVersion: "v1",
-			expectedGroup:     folderv1.APIGroup,
-			expectedVersion:   folderv1.APIVersion,
+	helper := common.RunGrafana(t)
+	ctx := t.Context()
+
+	// Resolve the server's preferred folder version via discovery — this is the
+	// same version provisioning is expected to use for the folders it writes.
+	preferredVersion := serverPreferredFolderVersion(t, helper.K8sTestHelper)
+
+	const repoName = "folder-version-repo"
+	repoPath := filepath.Join(helper.ProvisioningPath, repoName)
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:       repoName,
+		LocalPath:  repoPath,
+		SyncTarget: "folder",
+		Copies: map[string]string{
+			"../testdata/all-panels.json": "subfolder/dashboard.json",
 		},
-		{
-			name:              "v1beta1 creates folders via folder.grafana.app/v1beta1",
-			configuredVersion: "v1beta1",
-			expectedGroup:     folderv1beta1.APIGroup,
-			expectedVersion:   folderv1beta1.APIVersion,
-		},
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+	helper.SyncAndWait(t, repoName, nil)
+
+	// Query folders via a client targeting the preferred version.
+	folderGVR := folderv1.FolderResourceInfo.GroupVersionResource()
+	folderGVR.Version = preferredVersion
+	folderClient := helper.GetResourceClient(apis.ResourceClientArgs{
+		User:      helper.Org1.Admin,
+		Namespace: "default",
+		GVR:       folderGVR,
+	})
+
+	expectedAPIVersion := folderv1.APIGroup + "/" + preferredVersion
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		folders, err := folderClient.Resource.List(ctx, metav1.ListOptions{})
+		if !assert.NoError(collect, err) {
+			return
+		}
+
+		var managed []unstructured.Unstructured
+		for _, f := range folders.Items {
+			managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+			if managerID == repoName {
+				managed = append(managed, f)
+			}
+		}
+
+		if !assert.GreaterOrEqual(collect, len(managed), 2, "should have at least root + subfolder") {
+			return
+		}
+
+		for _, f := range managed {
+			assert.Equal(collect, expectedAPIVersion, f.GetAPIVersion(),
+				"folder %s should use the discovered preferred apiVersion %s", f.GetName(), expectedAPIVersion)
+		}
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+}
+
+// serverPreferredFolderVersion returns the folder version the API server advertises
+// as preferred, mirroring the discovery resolution provisioning performs internally.
+func serverPreferredFolderVersion(t *testing.T, helper *apis.K8sTestHelper) string {
+	t.Helper()
+
+	dc, err := discovery.NewDiscoveryClientForConfig(helper.Org1.Admin.NewRestConfig())
+	require.NoError(t, err)
+
+	groups, err := dc.ServerPreferredResources()
+	require.NoError(t, err)
+
+	folderResource := folderv1.FolderResourceInfo.GroupVersionResource()
+	for _, list := range groups {
+		gv, err := schema.ParseGroupVersion(list.GroupVersion)
+		if err != nil || gv.Group != folderResource.Group {
+			continue
+		}
+		for _, r := range list.APIResources {
+			if r.Name == folderResource.Resource {
+				return gv.Version
+			}
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			helper := common.RunGrafana(t, common.WithFolderAPIVersion(tt.configuredVersion))
-			ctx := t.Context()
-
-			const repoName = "folder-version-repo"
-			repoPath := filepath.Join(helper.ProvisioningPath, repoName)
-			helper.CreateLocalRepo(t, common.TestRepo{
-				Name:       repoName,
-				LocalPath:  repoPath,
-				SyncTarget: "folder",
-				Copies: map[string]string{
-					"../testdata/all-panels.json": "subfolder/dashboard.json",
-				},
-				SkipSync:               true,
-				SkipResourceAssertions: true,
-			})
-			helper.SyncAndWait(t, repoName, nil)
-
-			// Query folders via a client targeting the configured version.
-			folderGVR := folderv1.FolderResourceInfo.GroupVersionResource()
-			folderGVR.Version = tt.configuredVersion
-			folderClient := helper.GetResourceClient(apis.ResourceClientArgs{
-				User:      helper.Org1.Admin,
-				Namespace: "default",
-				GVR:       folderGVR,
-			})
-
-			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				folders, err := folderClient.Resource.List(ctx, metav1.ListOptions{})
-				if !assert.NoError(collect, err) {
-					return
-				}
-
-				var managed []unstructured.Unstructured
-				for _, f := range folders.Items {
-					managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
-					if managerID == repoName {
-						managed = append(managed, f)
-					}
-				}
-
-				if !assert.GreaterOrEqual(collect, len(managed), 2, "should have at least root + subfolder") {
-					return
-				}
-
-				for _, f := range managed {
-					assert.Equal(collect, tt.expectedGroup+"/"+tt.expectedVersion, f.GetAPIVersion(),
-						"folder %s should have apiVersion %s/%s", f.GetName(), tt.expectedGroup, tt.expectedVersion)
-				}
-			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-		})
-	}
+	t.Fatalf("no preferred version advertised for %s", folderResource.GroupResource())
+	return ""
 }

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -889,12 +889,6 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = provisioningSect.NewKey("max_repositories", fmt.Sprintf("%d", opts.ProvisioningMaxRepositories))
 		require.NoError(t, err)
 	}
-	if opts.ProvisioningFolderAPIVersion != "" {
-		provisioningSect, err := getOrCreateSection("provisioning")
-		require.NoError(t, err)
-		_, err = provisioningSect.NewKey("folders_api_version", opts.ProvisioningFolderAPIVersion)
-		require.NoError(t, err)
-	}
 	// nil means "use the ini default" (100). Non-nil writes the value, including
 	// 0 which disables the size check.
 	if opts.ProvisioningMaxIncrementalChanges != nil {
@@ -1100,7 +1094,6 @@ type GrafanaOpts struct {
 	ProvisioningResources                                []string
 	ProvisioningMaxResourcesPerRepository                int64
 	ProvisioningMaxRepositories                          int64
-	ProvisioningFolderAPIVersion                         string
 	ProvisioningMaxIncrementalChanges                    *int
 	ProvisioningMaxFileSize                              *int64
 	// ProvisioningControllerResyncInterval overrides [provisioning]


### PR DESCRIPTION
## Summary

Provisioning currently threads an explicit folder API version (`folders_api_version`) through the whole chain: config → API builder / operator → `RepositoryResourcesFactory` → `clients.Folder(version)` → `folderGVR(version)`, plus `FolderGVKForVersion()` for the fix-folder-metadata worker.

This PR switches folders to **dynamic discovery**, the same pattern established for dashboards in git-ui-sync #1036: use a versionless folder GVR and let `ForResource` resolve the server's **preferred version** via API discovery. Provisioning then works on any instance regardless of which folder versions are enabled, and no configuration is needed — once v1 becomes the preferred version everywhere, it is used automatically.

Per the issue's Option B, the `folders_api_version` configuration is removed entirely.

## Changes

- `resources/client.go`: `Folder(ctx)` drops the version parameter and uses a versionless folder GVR; `folderGVR()` and `FolderGVKForVersion()` are removed (mock regenerated).
- `fixfoldermetadata/worker.go`: takes a `ClientFactory` and resolves the folder GVK via `clients.Folder(ctx)` at `Process` time — it needs a concrete `apiVersion` to write `_folder.json`. Both call sites already had the factory in scope.
- `controller/finalizers.go`: no longer special-cases the folder version; every item is resolved with an empty version so discovery applies uniformly.
- Removes `folderAPIVersion` threading across `register.go`, `files.go`, `resources/repository.go`, `export/{worker,all}.go`, `controller/repository.go`, and the operator (`jobs.go`, `jobqueue_operator.go`, `repo_operator.go`, `config.go`).
- Removes the `folders_api_version` config: `setting.go`, `conf/defaults.ini`, and the test harness (`testinfra.go`, `common.WithFolderAPIVersion`).
- Rewrites the folder-api-version integration test to assert provisioning creates folders using the **discovered** preferred version.

## Testing

- `go build ./pkg/...` — clean.
- `go test` passes for `resources`, `controller`, `export`, `fixfoldermetadata`, `provisioning` (register/files), and `setting`.
- `gofmt` / `go vet` clean on changed packages.

## Breaking changes / migrations

- The `[provisioning] folders_api_version` setting and the operator `[operator] folders_api_version` key are **removed**. The version is now resolved via discovery.
- Several constructor signatures changed (`NewAPIBuilder`, `NewRepositoryController`, `NewExportWorker`, `NewFilesConnector`, `NewRepositoryResourcesFactory`, `fixfoldermetadata.NewWorker`), so this pairs with the **grafana-enterprise counterpart** grafana/grafana-enterprise#12593 (MT default + enterprise `NewAPIBuilder` caller) — mirroring how #121568 paired with grafana-enterprise#11513.

## Related

Counterpart: grafana/grafana-enterprise#12593

Fixes https://github.com/grafana/git-ui-sync-project/issues/1037
Follows the discovery pattern from https://github.com/grafana/git-ui-sync-project/issues/1036

## Checklist

- [x] Tests added/updated
- [x] Docs/config updated (`conf/defaults.ini`)
- [ ] Breaking changes documented → **enterprise counterpart PR needed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
