### PR TITLE
CloudMigration: Hide alerting resources in Migrate to Cloud when alerting is disabled

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -143,7 +143,7 @@ func ProvideService(
 		libraryElementsService: libraryElementsService,
 		ngAlert:                ngAlert,
 	}
-	s.api = api.RegisterApi(routeRegister, s, tracer, accessControl, cloudmigration.ResourceDependency)
+	s.api = api.RegisterApi(routeRegister, s, tracer, accessControl, cloudmigration.ResourceDependency(cfg.UnifiedAlerting.IsEnabled()))
 
 	httpClientS3, err := httpClientProvider.New()
 	if err != nil {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -162,8 +162,14 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 		}
 	}
 
+	// Alerting resources are only fetched when alerting is enabled. Snapshot
+	// creation rejects alerting types when it is disabled, but a snapshot
+	// created while alerting was enabled could be built after it is disabled,
+	// at which point s.ngAlert.Api is nil and would panic.
+	alertingEnabled := s.cfg.UnifiedAlerting.IsEnabled()
+
 	// Alerts: Mute Timings
-	if resourceTypes.Has(cloudmigration.MuteTimingType) {
+	if alertingEnabled && resourceTypes.Has(cloudmigration.MuteTimingType) {
 		muteTimings, err := s.getAlertMuteTimings(ctx, signedInUser)
 		if err != nil {
 			s.log.Error("Failed to get alert mute timings", "err", err)
@@ -181,7 +187,7 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 	}
 
 	// Alerts: Notification Templates
-	if resourceTypes.Has(cloudmigration.NotificationTemplateType) {
+	if alertingEnabled && resourceTypes.Has(cloudmigration.NotificationTemplateType) {
 		notificationTemplates, err := s.getNotificationTemplates(ctx, signedInUser)
 		if err != nil {
 			s.log.Error("Failed to get alert notification templates", "err", err)
@@ -199,7 +205,7 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 	}
 
 	// Alerts: Contact Points
-	if resourceTypes.Has(cloudmigration.ContactPointType) {
+	if alertingEnabled && resourceTypes.Has(cloudmigration.ContactPointType) {
 		contactPoints, err := s.getContactPoints(ctx, signedInUser)
 		if err != nil {
 			s.log.Error("Failed to get alert contact points", "err", err)
@@ -217,7 +223,7 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 	}
 
 	// Alerts: Notification Policies
-	if resourceTypes.Has(cloudmigration.NotificationPolicyType) {
+	if alertingEnabled && resourceTypes.Has(cloudmigration.NotificationPolicyType) {
 		notificationPolicies, err := s.getNotificationPolicies(ctx, signedInUser)
 		if err != nil {
 			s.log.Error("Failed to get alert notification policies", "err", err)
@@ -236,7 +242,7 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 	}
 
 	// Alerts: Alert Rule Groups
-	if resourceTypes.Has(cloudmigration.AlertRuleGroupType) {
+	if alertingEnabled && resourceTypes.Has(cloudmigration.AlertRuleGroupType) {
 		alertRuleGroups, err := s.getAlertRuleGroups(ctx, signedInUser)
 		if err != nil {
 			s.log.Error("Failed to get alert rule groups", "err", err)
@@ -254,7 +260,7 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 	}
 
 	// Alerts: Alert Rules
-	if resourceTypes.Has(cloudmigration.AlertRuleType) {
+	if alertingEnabled && resourceTypes.Has(cloudmigration.AlertRuleType) {
 		alertRules, err := s.getAlertRules(ctx, signedInUser)
 		if err != nil {
 			s.log.Error("Failed to get alert rules", "err", err)

--- a/pkg/services/cloudmigration/resource_dependency.go
+++ b/pkg/services/cloudmigration/resource_dependency.go
@@ -13,20 +13,42 @@ var (
 // DependencyMap is a map of resource types to their direct dependencies.
 type DependencyMap map[MigrateDataType][]MigrateDataType
 
-// ResourceDependency is a map of resource types to their direct dependencies.
-// This is used to determine which resources can be filtered out from the snapshot without breaking the dependency chain.
-var ResourceDependency = DependencyMap{
-	PluginDataType:           nil,
-	FolderDataType:           nil,
-	DatasourceDataType:       {PluginDataType},
-	LibraryElementDataType:   {FolderDataType},
-	DashboardDataType:        {FolderDataType, DatasourceDataType, LibraryElementDataType},
+// baseResourceDependency holds the resources that are always migratable,
+// mapped to their direct dependencies.
+var baseResourceDependency = DependencyMap{
+	PluginDataType:         nil,
+	FolderDataType:         nil,
+	DatasourceDataType:     {PluginDataType},
+	LibraryElementDataType: {FolderDataType},
+	DashboardDataType:      {FolderDataType, DatasourceDataType, LibraryElementDataType},
+}
+
+// alertingResourceDependency holds the alerting resources, mapped to their
+// direct dependencies. These are only migratable when alerting is enabled.
+var alertingResourceDependency = DependencyMap{
 	MuteTimingType:           nil,
 	NotificationTemplateType: nil,
 	ContactPointType:         {NotificationTemplateType},
 	NotificationPolicyType:   {ContactPointType, MuteTimingType},
 	AlertRuleType:            {DatasourceDataType, FolderDataType, DashboardDataType, MuteTimingType, ContactPointType, NotificationPolicyType},
 	AlertRuleGroupType:       {AlertRuleType},
+}
+
+// ResourceDependency returns the resource dependency graph for the current
+// set of migratable resources. Alerting resources are only included when
+// alerting is enabled, so that they are neither offered in the UI nor accepted
+// by snapshot creation on instances where alerting is disabled.
+func ResourceDependency(alertingEnabled bool) DependencyMap {
+	depMap := make(DependencyMap, len(baseResourceDependency)+len(alertingResourceDependency))
+	for resourceType, dependencies := range baseResourceDependency {
+		depMap[resourceType] = dependencies
+	}
+	if alertingEnabled {
+		for resourceType, dependencies := range alertingResourceDependency {
+			depMap[resourceType] = dependencies
+		}
+	}
+	return depMap
 }
 
 // Parse a raw slice of resource types and returns a set of them if it has all correct dependencies.

--- a/pkg/services/cloudmigration/resource_dependency_test.go
+++ b/pkg/services/cloudmigration/resource_dependency_test.go
@@ -7,31 +7,33 @@ import (
 )
 
 func TestResourceDependencyParse(t *testing.T) {
+	depMap := ResourceDependency(true)
+
 	t.Run("empty input returns an empty set", func(t *testing.T) {
-		result, err := ResourceDependency.Parse(nil)
+		result, err := depMap.Parse(nil)
 		require.NoError(t, err)
 		require.Empty(t, result)
 	})
 
 	t.Run("input with duplicates returns an error", func(t *testing.T) {
-		_, err := ResourceDependency.Parse([]MigrateDataType{FolderDataType, FolderDataType})
+		_, err := depMap.Parse([]MigrateDataType{FolderDataType, FolderDataType})
 		require.ErrorIs(t, err, ErrDuplicateResourceType)
 	})
 
 	t.Run("unknown resource type returns an error", func(t *testing.T) {
-		_, err := ResourceDependency.Parse([]MigrateDataType{"does not exist"})
+		_, err := depMap.Parse([]MigrateDataType{"does not exist"})
 		require.ErrorIs(t, err, ErrUnknownResourceType)
 	})
 
 	t.Run("PluginDataType has no dependencies", func(t *testing.T) {
-		result, err := ResourceDependency.Parse([]MigrateDataType{PluginDataType})
+		result, err := depMap.Parse([]MigrateDataType{PluginDataType})
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		require.Contains(t, result, PluginDataType)
 	})
 
 	t.Run("FolderDataType has no dependencies", func(t *testing.T) {
-		result, err := ResourceDependency.Parse([]MigrateDataType{FolderDataType})
+		result, err := depMap.Parse([]MigrateDataType{FolderDataType})
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		require.Contains(t, result, FolderDataType)
@@ -39,14 +41,14 @@ func TestResourceDependencyParse(t *testing.T) {
 
 	t.Run("DatasourceDataType requires PluginDataType", func(t *testing.T) {
 		t.Run("when the dependency is missing returns an error", func(t *testing.T) {
-			_, err := ResourceDependency.Parse([]MigrateDataType{DatasourceDataType})
+			_, err := depMap.Parse([]MigrateDataType{DatasourceDataType})
 			require.ErrorIs(t, err, ErrMissingDependency)
 			require.Contains(t, err.Error(), string(PluginDataType))
 		})
 
 		t.Run("when the dependency is present returns the correct set", func(t *testing.T) {
 			input := []MigrateDataType{DatasourceDataType, PluginDataType}
-			result, err := ResourceDependency.Parse(input)
+			result, err := depMap.Parse(input)
 			require.NoError(t, err)
 			require.Len(t, result, 2)
 		})
@@ -54,14 +56,14 @@ func TestResourceDependencyParse(t *testing.T) {
 
 	t.Run("LibraryElementDataType requires FolderDataType", func(t *testing.T) {
 		t.Run("when the dependency is missing returns an error", func(t *testing.T) {
-			_, err := ResourceDependency.Parse([]MigrateDataType{LibraryElementDataType})
+			_, err := depMap.Parse([]MigrateDataType{LibraryElementDataType})
 			require.ErrorIs(t, err, ErrMissingDependency)
 			require.Contains(t, err.Error(), string(FolderDataType))
 		})
 
 		t.Run("when the dependency is present returns the correct set", func(t *testing.T) {
 			input := []MigrateDataType{LibraryElementDataType, FolderDataType}
-			result, err := ResourceDependency.Parse(input)
+			result, err := depMap.Parse(input)
 			require.NoError(t, err)
 			require.Len(t, result, 2)
 		})
@@ -70,11 +72,11 @@ func TestResourceDependencyParse(t *testing.T) {
 	t.Run("DashboardDataType requires multiple dependencies", func(t *testing.T) {
 		t.Run("when the dependency is missing returns an error", func(t *testing.T) {
 			// Missing: FolderDataType, DatasourceDataType, LibraryElementDataType, PluginDataType
-			_, err := ResourceDependency.Parse([]MigrateDataType{DashboardDataType})
+			_, err := depMap.Parse([]MigrateDataType{DashboardDataType})
 			require.ErrorIs(t, err, ErrMissingDependency)
 
 			// Missing: DatasourceDataType, PluginDataType
-			_, err = ResourceDependency.Parse([]MigrateDataType{
+			_, err = depMap.Parse([]MigrateDataType{
 				DashboardDataType,
 				LibraryElementDataType,
 				FolderDataType,
@@ -90,21 +92,21 @@ func TestResourceDependencyParse(t *testing.T) {
 				LibraryElementDataType,
 				PluginDataType,
 			}
-			result, err := ResourceDependency.Parse(input)
+			result, err := depMap.Parse(input)
 			require.NoError(t, err)
 			require.Len(t, result, len(input))
 		})
 	})
 
 	t.Run("MuteTimingType has no dependencies", func(t *testing.T) {
-		result, err := ResourceDependency.Parse([]MigrateDataType{MuteTimingType})
+		result, err := depMap.Parse([]MigrateDataType{MuteTimingType})
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		require.Contains(t, result, MuteTimingType)
 	})
 
 	t.Run("NotificationTemplateType has no dependencies", func(t *testing.T) {
-		result, err := ResourceDependency.Parse([]MigrateDataType{NotificationTemplateType})
+		result, err := depMap.Parse([]MigrateDataType{NotificationTemplateType})
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		require.Contains(t, result, NotificationTemplateType)
@@ -112,14 +114,14 @@ func TestResourceDependencyParse(t *testing.T) {
 
 	t.Run("ContactPointType requires NotificationTemplateType", func(t *testing.T) {
 		t.Run("when the dependency is missing returns an error", func(t *testing.T) {
-			_, err := ResourceDependency.Parse([]MigrateDataType{ContactPointType})
+			_, err := depMap.Parse([]MigrateDataType{ContactPointType})
 			require.ErrorIs(t, err, ErrMissingDependency)
 			require.Contains(t, err.Error(), string(NotificationTemplateType))
 		})
 
 		t.Run("when the dependency is present returns the correct set", func(t *testing.T) {
 			input := []MigrateDataType{ContactPointType, NotificationTemplateType}
-			result, err := ResourceDependency.Parse(input)
+			result, err := depMap.Parse(input)
 			require.NoError(t, err)
 			require.Len(t, result, 2)
 		})
@@ -128,11 +130,11 @@ func TestResourceDependencyParse(t *testing.T) {
 	t.Run("NotificationPolicyType requires multiple dependencies", func(t *testing.T) {
 		t.Run("when the dependency is missing returns an error", func(t *testing.T) {
 			// Missing: ContactPointType, NotificationTemplateType
-			_, err := ResourceDependency.Parse([]MigrateDataType{NotificationPolicyType})
+			_, err := depMap.Parse([]MigrateDataType{NotificationPolicyType})
 			require.ErrorIs(t, err, ErrMissingDependency)
 
 			// Missing: NotificationTemplateType
-			_, err = ResourceDependency.Parse([]MigrateDataType{
+			_, err = depMap.Parse([]MigrateDataType{
 				NotificationPolicyType,
 				ContactPointType,
 			})
@@ -146,7 +148,7 @@ func TestResourceDependencyParse(t *testing.T) {
 				NotificationTemplateType,
 				MuteTimingType,
 			}
-			result, err := ResourceDependency.Parse(input)
+			result, err := depMap.Parse(input)
 			require.NoError(t, err)
 			require.Len(t, result, len(input))
 		})
@@ -155,11 +157,11 @@ func TestResourceDependencyParse(t *testing.T) {
 	t.Run("AlertRuleType requires multiple dependencies", func(t *testing.T) {
 		t.Run("when the dependency is missing returns an error", func(t *testing.T) {
 			// Missing all dependencies
-			_, err := ResourceDependency.Parse([]MigrateDataType{AlertRuleType})
+			_, err := depMap.Parse([]MigrateDataType{AlertRuleType})
 			require.ErrorIs(t, err, ErrMissingDependency)
 
 			// Missing some dependencies
-			_, err = ResourceDependency.Parse([]MigrateDataType{
+			_, err = depMap.Parse([]MigrateDataType{
 				AlertRuleType,
 				DatasourceDataType,
 				FolderDataType,
@@ -180,7 +182,7 @@ func TestResourceDependencyParse(t *testing.T) {
 				LibraryElementDataType,
 				NotificationTemplateType,
 			}
-			result, err := ResourceDependency.Parse(input)
+			result, err := depMap.Parse(input)
 			require.NoError(t, err)
 			require.Len(t, result, len(input))
 		})
@@ -189,11 +191,11 @@ func TestResourceDependencyParse(t *testing.T) {
 	t.Run("AlertRuleGroupType requires AlertRuleType and all its dependencies", func(t *testing.T) {
 		t.Run("when the dependency is missing returns an error", func(t *testing.T) {
 			// Missing all dependencies
-			_, err := ResourceDependency.Parse([]MigrateDataType{AlertRuleGroupType})
+			_, err := depMap.Parse([]MigrateDataType{AlertRuleGroupType})
 			require.ErrorIs(t, err, ErrMissingDependency)
 
 			// With partial dependencies
-			_, err = ResourceDependency.Parse([]MigrateDataType{
+			_, err = depMap.Parse([]MigrateDataType{
 				AlertRuleGroupType,
 				AlertRuleType,
 				FolderDataType,
@@ -217,7 +219,7 @@ func TestResourceDependencyParse(t *testing.T) {
 				LibraryElementDataType,
 				NotificationTemplateType,
 			}
-			result, err := ResourceDependency.Parse(input)
+			result, err := depMap.Parse(input)
 			require.NoError(t, err)
 			require.Len(t, result, len(input))
 		})
@@ -231,7 +233,7 @@ func TestResourceDependencyParse(t *testing.T) {
 				MuteTimingType,
 				NotificationTemplateType,
 			}
-			result, err := ResourceDependency.Parse(input)
+			result, err := depMap.Parse(input)
 			require.NoError(t, err)
 			require.Len(t, result, 4)
 		})
@@ -249,7 +251,7 @@ func TestResourceDependencyParse(t *testing.T) {
 				ContactPointType,
 				NotificationTemplateType,
 			}
-			result, err := ResourceDependency.Parse(input)
+			result, err := depMap.Parse(input)
 			require.NoError(t, err)
 			require.Len(t, result, 7)
 		})
@@ -261,8 +263,41 @@ func TestResourceDependencyParse(t *testing.T) {
 				ContactPointType,
 				DatasourceDataType,
 			}
-			_, err := ResourceDependency.Parse(input)
+			_, err := depMap.Parse(input)
 			require.ErrorIs(t, err, ErrMissingDependency)
 		})
+	})
+}
+
+func TestResourceDependency(t *testing.T) {
+	alertingTypes := []MigrateDataType{
+		MuteTimingType,
+		NotificationTemplateType,
+		ContactPointType,
+		NotificationPolicyType,
+		AlertRuleType,
+		AlertRuleGroupType,
+	}
+
+	t.Run("when alerting is enabled the alerting resources are included", func(t *testing.T) {
+		depMap := ResourceDependency(true)
+		for _, resourceType := range alertingTypes {
+			require.Contains(t, depMap, resourceType)
+		}
+	})
+
+	t.Run("when alerting is disabled the alerting resources are excluded", func(t *testing.T) {
+		depMap := ResourceDependency(false)
+		for _, resourceType := range alertingTypes {
+			require.NotContains(t, depMap, resourceType)
+		}
+		// Base resources are still present.
+		require.Contains(t, depMap, DashboardDataType)
+	})
+
+	t.Run("when alerting is disabled selecting an alerting resource is rejected", func(t *testing.T) {
+		depMap := ResourceDependency(false)
+		_, err := depMap.Parse([]MigrateDataType{ContactPointType, NotificationTemplateType})
+		require.ErrorIs(t, err, ErrUnknownResourceType)
 	})
 }


### PR DESCRIPTION
**What is this feature?**

When Grafana alerting is disabled (`[unified_alerting] enabled = false`), the
Migrate to Cloud flow no longer offers the alerting resource types (alert rules,
alert rule groups, contact points, notification policies, notification templates,
and mute timings). Previously these options were always shown and always accepted.

The resource dependency graph is now built based on whether alerting is enabled,
so `GET /api/cloudmigration/resources/dependencies` (which drives the UI list) and
snapshot creation validation are both alerting-aware. As defense in depth, snapshot
gathering skips alerting resources when alerting is disabled, preventing a
nil-pointer panic for a snapshot created while alerting was enabled but built after
it was disabled.

**Why do we need this feature?**

The set of migratable resource types was static and never checked whether alerting
was enabled, so instances with alerting turned off still presented alerting options
that could not be meaningfully migrated and could error at snapshot time.

**Who is this feature for?**

Operators of self-managed Grafana instances that run with alerting disabled and use
Migrate to Cloud.

**Special notes for your reviewer:**

Backend-only change; the frontend renders whatever `GetResourceDependencies` returns,
so no frontend change is required. Verified with `[unified_alerting] enabled = false`
that the six alerting types disappear from the configure-snapshot step and reappear
when re-enabled.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A — bug fix)
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New. (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
