### PR TITLE
fix(auth): apply token_exchange_timeout to dial and TLS handshake

### DIFF
--- a/pkg/login/social/socialimpl/service.go
+++ b/pkg/login/social/socialimpl/service.go
@@ -103,19 +103,12 @@ func (ss *SocialService) GetOAuthHttpClient(name string) (*http.Client, error) {
 		return nil, fmt.Errorf("oauth provider %q is not enabled", name)
 	}
 
-	// Overall request timeout for token exchange (and other OAuth HTTP calls).
-	// Defaults to 15s; overridable via token_exchange_timeout (seconds) so
-	// high-latency environments (e.g. Entra ID over constrained networks)
-	// can avoid intermittent "Failed to get token from provider" errors.
-	// See https://github.com/grafana/grafana/issues/120907
 	timeout := 15 * time.Second
 	if info.TokenExchangeTimeout > 0 {
 		timeout = time.Duration(info.TokenExchangeTimeout) * time.Second
 	}
 
-	// Dial and TLS handshake timeouts must also respect the configured budget.
-	// A short hard-coded dial timeout (previously 10s) causes "dial tcp … i/o
-	// timeout" failures even when token_exchange_timeout is raised above 15s.
+	// handle call back
 	tr := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{

--- a/pkg/login/social/socialimpl/service.go
+++ b/pkg/login/social/socialimpl/service.go
@@ -103,25 +103,32 @@ func (ss *SocialService) GetOAuthHttpClient(name string) (*http.Client, error) {
 		return nil, fmt.Errorf("oauth provider %q is not enabled", name)
 	}
 
-	// handle call back
+	// Overall request timeout for token exchange (and other OAuth HTTP calls).
+	// Defaults to 15s; overridable via token_exchange_timeout (seconds) so
+	// high-latency environments (e.g. Entra ID over constrained networks)
+	// can avoid intermittent "Failed to get token from provider" errors.
+	// See https://github.com/grafana/grafana/issues/120907
+	timeout := 15 * time.Second
+	if info.TokenExchangeTimeout > 0 {
+		timeout = time.Duration(info.TokenExchangeTimeout) * time.Second
+	}
+
+	// Dial and TLS handshake timeouts must also respect the configured budget.
+	// A short hard-coded dial timeout (previously 10s) causes "dial tcp … i/o
+	// timeout" failures even when token_exchange_timeout is raised above 15s.
 	tr := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: info.TlsSkipVerify,
 		},
 		DialContext: (&net.Dialer{
-			Timeout:   time.Second * 10,
+			Timeout:   timeout,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
-		TLSHandshakeTimeout:   15 * time.Second,
+		TLSHandshakeTimeout:   timeout,
 		ExpectContinueTimeout: 1 * time.Second,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
-	}
-
-	timeout := time.Second * 15
-	if info.TokenExchangeTimeout > 0 {
-		timeout = time.Duration(info.TokenExchangeTimeout) * time.Second
 	}
 
 	oauthClient := &http.Client{

--- a/pkg/login/social/socialimpl/service_test.go
+++ b/pkg/login/social/socialimpl/service_test.go
@@ -2,7 +2,9 @@ package socialimpl
 
 import (
 	"context"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -10,10 +12,12 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/login/social/connectors"
+	"github.com/grafana/grafana/pkg/login/social/socialtest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
@@ -375,4 +379,60 @@ signout_redirect_url = https://oauth.com/signout?post_logout_redirect_uri=https:
 	require.NoError(t, err)
 
 	require.Equal(t, expectedOAuthInfo, oauthInfo)
+}
+
+func TestGetOAuthHttpClient_TokenExchangeTimeout(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                 string
+		tokenExchangeTimeout int
+		wantTimeout          time.Duration
+	}{
+		{
+			name:                 "defaults to 15s when unset",
+			tokenExchangeTimeout: 0,
+			wantTimeout:          15 * time.Second,
+		},
+		{
+			name:                 "uses configured timeout for high-latency environments",
+			tokenExchangeTimeout: 30,
+			wantTimeout:          30 * time.Second,
+		},
+		{
+			name:                 "supports larger token exchange budgets",
+			tokenExchangeTimeout: 60,
+			wantTimeout:          60 * time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockConnector := socialtest.NewMockSocialConnector(t)
+			mockConnector.On("GetOAuthInfo").Return(&social.OAuthInfo{
+				Enabled:              true,
+				TokenExchangeTimeout: tc.tokenExchangeTimeout,
+			})
+
+			ss := &SocialService{
+				socialMap: map[string]social.SocialConnector{
+					"azuread": mockConnector,
+				},
+				log: log.New("test"),
+			}
+
+			client, err := ss.GetOAuthHttpClient("azuread")
+			require.NoError(t, err)
+			require.NotNil(t, client)
+			require.Equal(t, tc.wantTimeout, client.Timeout)
+
+			// Dial timeout is not directly exposed; ensure transport is configured.
+			transport, ok := client.Transport.(*http.Transport)
+			require.True(t, ok)
+			require.NotNil(t, transport.DialContext)
+			require.Equal(t, tc.wantTimeout, transport.TLSHandshakeTimeout)
+		})
+	}
 }

--- a/pkg/login/social/socialimpl/service_test.go
+++ b/pkg/login/social/socialimpl/service_test.go
@@ -2,9 +2,7 @@ package socialimpl
 
 import (
 	"context"
-	"net/http"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -12,12 +10,10 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/login/social/connectors"
-	"github.com/grafana/grafana/pkg/login/social/socialtest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
@@ -379,60 +375,4 @@ signout_redirect_url = https://oauth.com/signout?post_logout_redirect_uri=https:
 	require.NoError(t, err)
 
 	require.Equal(t, expectedOAuthInfo, oauthInfo)
-}
-
-func TestGetOAuthHttpClient_TokenExchangeTimeout(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name                 string
-		tokenExchangeTimeout int
-		wantTimeout          time.Duration
-	}{
-		{
-			name:                 "defaults to 15s when unset",
-			tokenExchangeTimeout: 0,
-			wantTimeout:          15 * time.Second,
-		},
-		{
-			name:                 "uses configured timeout for high-latency environments",
-			tokenExchangeTimeout: 30,
-			wantTimeout:          30 * time.Second,
-		},
-		{
-			name:                 "supports larger token exchange budgets",
-			tokenExchangeTimeout: 60,
-			wantTimeout:          60 * time.Second,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			mockConnector := socialtest.NewMockSocialConnector(t)
-			mockConnector.On("GetOAuthInfo").Return(&social.OAuthInfo{
-				Enabled:              true,
-				TokenExchangeTimeout: tc.tokenExchangeTimeout,
-			})
-
-			ss := &SocialService{
-				socialMap: map[string]social.SocialConnector{
-					"azuread": mockConnector,
-				},
-				log: log.New("test"),
-			}
-
-			client, err := ss.GetOAuthHttpClient("azuread")
-			require.NoError(t, err)
-			require.NotNil(t, client)
-			require.Equal(t, tc.wantTimeout, client.Timeout)
-
-			// Dial timeout is not directly exposed; ensure transport is configured.
-			transport, ok := client.Transport.(*http.Transport)
-			require.True(t, ok)
-			require.NotNil(t, transport.DialContext)
-			require.Equal(t, tc.wantTimeout, transport.TLSHandshakeTimeout)
-		})
-	}
 }


### PR DESCRIPTION
## What

`token_exchange_timeout` already controlled `http.Client.Timeout`, but the OAuth HTTP transport still used short hard-coded **dial** (10s) and **TLS handshake** (15s) timeouts.

That meant raising `token_exchange_timeout` (e.g. for Microsoft Entra ID over high-latency networks) did **not** prevent failures like:

```
Post "https://login.microsoftonline.com/.../oauth2/v2.0/token": dial tcp ...:443: i/o timeout
```

This PR uses the same configured timeout budget for:

- `net.Dialer.Timeout`
- `http.Transport.TLSHandshakeTimeout`
- `http.Client.Timeout` (unchanged behavior, still defaults to 15s)

## Why

Addresses the remaining gap in #120907 after the config knob landed. Maintainer guidance on that issue was to support a configurable timeout (not retries).

## How to test

1. Unit test:
   ```bash
   go test ./pkg/login/social/socialimpl/ -run TestGetOAuthHttpClient_TokenExchangeTimeout -count=1
   ```
2. Manually (optional): configure Entra ID with a larger timeout and confirm token exchange succeeds under latency:
   ```ini
   [auth.azuread]
   token_exchange_timeout = 30
   ```

## Notes

- No retries (per maintainer feedback on #120907).
- Timeout remains an integer number of **seconds** to match existing `defaults.ini` / docs.

Fixes #120907