### PR TITLE
Logs: update color for info

### DIFF
--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -540,7 +540,7 @@ export const getStyles = (
     warning: '#FBAD37',
     debug: '#6E9FFF',
     trace: '#6ed0e0',
-    info: '#6CCF8E',
+    info: '#6E9FFF',
     metadata: theme.colors.text.secondary,
     default: colorDefault,
     parsedField: theme.colors.text.secondary,

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -57,7 +57,7 @@ export const LogLevelColor = {
   [LogLevel.critical]: colors[7],
   [LogLevel.error]: colors[4],
   [LogLevel.warning]: colors[1],
-  [LogLevel.info]: colors[0],
+  [LogLevel.info]: colors[5],
   [LogLevel.debug]: colors[5],
   [LogLevel.trace]: colors[2],
   [LogLevel.unknown]: getThemeColor('#8e8e8e', '#bdc4cd'),


### PR DESCRIPTION
Volume:

<img width="1177" height="244" alt="imagen" src="https://github.com/user-attachments/assets/2017f551-db56-4cc2-9c8c-639360ccf629" />

Logs:

<img width="578" height="150" alt="imagen" src="https://github.com/user-attachments/assets/e9dcd4f5-398d-4ec6-93ce-29c1d9859778" />

Table:

<img width="423" height="262" alt="imagen" src="https://github.com/user-attachments/assets/537093aa-19b7-4ab4-bb16-25f91315fcc2" />
