### PR TITLE
Chore: Modify `PageHeader` according to visual refresh designs

### DIFF
--- a/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_dark.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_dark.json
@@ -69,6 +69,9 @@
     "borderRadius": 8,
     "borderRadiusLg": 12
   },
+  "typography": {
+    "fontWeightBold": 600
+  },
   "components": {
     "tag": {
       "colors": [

--- a/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_light.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_light.json
@@ -64,6 +64,9 @@
       "focus": "palette.neutral300"
     }
   },
+  "typography": {
+    "fontWeightBold": 600
+  },
   "components": {
     "tag": {
       "colors": [

--- a/public/app/core/components/Page/EditableTitle.test.tsx
+++ b/public/app/core/components/Page/EditableTitle.test.tsx
@@ -1,3 +1,4 @@
+import { OpenFeatureTestProvider } from '@openfeature/react-sdk';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -21,18 +22,24 @@ describe('EditableTitle', () => {
 
   const mockEdit = jest.fn().mockImplementation((newValue: string) => Promise.resolve(newValue));
 
+  const editableTitleWithOpenFeatureProvider = (
+    <OpenFeatureTestProvider>
+      <EditableTitle value={value} onEdit={mockEdit} />
+    </OpenFeatureTestProvider>
+  );
+
   it('displays the provided text correctly', () => {
-    render(<EditableTitle value={value} onEdit={mockEdit} />);
+    render(editableTitleWithOpenFeatureProvider);
     expect(screen.getByRole('heading', { name: value })).toBeInTheDocument();
   });
 
   it('displays an edit button', () => {
-    render(<EditableTitle value={value} onEdit={mockEdit} />);
+    render(editableTitleWithOpenFeatureProvider);
     expect(screen.getByRole('button', { name: 'Edit title' })).toBeInTheDocument();
   });
 
   it('clicking the edit button changes the text to an input and autofocuses', async () => {
-    render(<EditableTitle value={value} onEdit={mockEdit} />);
+    render(editableTitleWithOpenFeatureProvider);
 
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
 
@@ -45,7 +52,7 @@ describe('EditableTitle', () => {
   });
 
   it('blurring the input calls the onEdit callback and reverts back to text', async () => {
-    render(<EditableTitle value={value} onEdit={mockEdit} />);
+    render(editableTitleWithOpenFeatureProvider);
 
     const editButton = screen.getByRole('button', { name: 'Edit title' });
     await user.click(editButton);
@@ -67,7 +74,7 @@ describe('EditableTitle', () => {
   });
 
   it('pressing enter calls the onEdit callback and reverts back to text', async () => {
-    render(<EditableTitle value={value} onEdit={mockEdit} />);
+    render(editableTitleWithOpenFeatureProvider);
 
     const editButton = screen.getByRole('button', { name: 'Edit title' });
     await user.click(editButton);
@@ -89,7 +96,7 @@ describe('EditableTitle', () => {
   });
 
   it('clicking cancel does not call onEdit and restores the original title', async () => {
-    render(<EditableTitle value={value} onEdit={mockEdit} />);
+    render(editableTitleWithOpenFeatureProvider);
 
     await user.click(screen.getByRole('button', { name: 'Edit title' }));
 
@@ -105,7 +112,7 @@ describe('EditableTitle', () => {
   });
 
   it('displays an error message when attempting to save an empty value', async () => {
-    render(<EditableTitle value={value} onEdit={mockEdit} />);
+    render(editableTitleWithOpenFeatureProvider);
 
     const editButton = screen.getByRole('button', { name: 'Edit title' });
     await user.click(editButton);
@@ -121,7 +128,11 @@ describe('EditableTitle', () => {
     const mockEditError = jest.fn().mockImplementation(() => {
       throw new Error('Uh oh spaghettios');
     });
-    render(<EditableTitle value={value} onEdit={mockEditError} />);
+    render(
+      <OpenFeatureTestProvider>
+        <EditableTitle value={value} onEdit={mockEditError} />
+      </OpenFeatureTestProvider>
+    );
 
     const editButton = screen.getByRole('button', { name: 'Edit title' });
     await user.click(editButton);
@@ -147,7 +158,11 @@ describe('EditableTitle', () => {
       };
       throw fetchError;
     });
-    render(<EditableTitle value={value} onEdit={mockEditError} />);
+    render(
+      <OpenFeatureTestProvider>
+        <EditableTitle value={value} onEdit={mockEditError} />
+      </OpenFeatureTestProvider>
+    );
 
     const editButton = screen.getByRole('button', { name: 'Edit title' });
     await user.click(editButton);

--- a/public/app/core/components/Page/EditableTitle.test.tsx
+++ b/public/app/core/components/Page/EditableTitle.test.tsx
@@ -1,6 +1,5 @@
-import { OpenFeatureTestProvider } from '@openfeature/react-sdk';
-import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { act, render, screen, waitFor } from 'test/test-utils';
 
 import { type FetchError } from '@grafana/runtime';
 
@@ -22,24 +21,18 @@ describe('EditableTitle', () => {
 
   const mockEdit = jest.fn().mockImplementation((newValue: string) => Promise.resolve(newValue));
 
-  const editableTitleWithOpenFeatureProvider = (
-    <OpenFeatureTestProvider>
-      <EditableTitle value={value} onEdit={mockEdit} />
-    </OpenFeatureTestProvider>
-  );
-
   it('displays the provided text correctly', () => {
-    render(editableTitleWithOpenFeatureProvider);
+    render(<EditableTitle value={value} onEdit={mockEdit} />);
     expect(screen.getByRole('heading', { name: value })).toBeInTheDocument();
   });
 
   it('displays an edit button', () => {
-    render(editableTitleWithOpenFeatureProvider);
+    render(<EditableTitle value={value} onEdit={mockEdit} />);
     expect(screen.getByRole('button', { name: 'Edit title' })).toBeInTheDocument();
   });
 
   it('clicking the edit button changes the text to an input and autofocuses', async () => {
-    render(editableTitleWithOpenFeatureProvider);
+    render(<EditableTitle value={value} onEdit={mockEdit} />);
 
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
 
@@ -52,7 +45,7 @@ describe('EditableTitle', () => {
   });
 
   it('blurring the input calls the onEdit callback and reverts back to text', async () => {
-    render(editableTitleWithOpenFeatureProvider);
+    render(<EditableTitle value={value} onEdit={mockEdit} />);
 
     const editButton = screen.getByRole('button', { name: 'Edit title' });
     await user.click(editButton);
@@ -74,7 +67,7 @@ describe('EditableTitle', () => {
   });
 
   it('pressing enter calls the onEdit callback and reverts back to text', async () => {
-    render(editableTitleWithOpenFeatureProvider);
+    render(<EditableTitle value={value} onEdit={mockEdit} />);
 
     const editButton = screen.getByRole('button', { name: 'Edit title' });
     await user.click(editButton);
@@ -96,7 +89,7 @@ describe('EditableTitle', () => {
   });
 
   it('clicking cancel does not call onEdit and restores the original title', async () => {
-    render(editableTitleWithOpenFeatureProvider);
+    render(<EditableTitle value={value} onEdit={mockEdit} />);
 
     await user.click(screen.getByRole('button', { name: 'Edit title' }));
 
@@ -112,7 +105,7 @@ describe('EditableTitle', () => {
   });
 
   it('displays an error message when attempting to save an empty value', async () => {
-    render(editableTitleWithOpenFeatureProvider);
+    render(<EditableTitle value={value} onEdit={mockEdit} />);
 
     const editButton = screen.getByRole('button', { name: 'Edit title' });
     await user.click(editButton);
@@ -128,11 +121,7 @@ describe('EditableTitle', () => {
     const mockEditError = jest.fn().mockImplementation(() => {
       throw new Error('Uh oh spaghettios');
     });
-    render(
-      <OpenFeatureTestProvider>
-        <EditableTitle value={value} onEdit={mockEditError} />
-      </OpenFeatureTestProvider>
-    );
+    render(<EditableTitle value={value} onEdit={mockEditError} />);
 
     const editButton = screen.getByRole('button', { name: 'Edit title' });
     await user.click(editButton);
@@ -158,11 +147,7 @@ describe('EditableTitle', () => {
       };
       throw fetchError;
     });
-    render(
-      <OpenFeatureTestProvider>
-        <EditableTitle value={value} onEdit={mockEditError} />
-      </OpenFeatureTestProvider>
-    );
+    render(<EditableTitle value={value} onEdit={mockEditError} />);
 
     const editButton = screen.getByRole('button', { name: 'Edit title' });
     await user.click(editButton);

--- a/public/app/core/components/Page/EditableTitle.tsx
+++ b/public/app/core/components/Page/EditableTitle.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { Field, IconButton, Input, useStyles2, Text } from '@grafana/ui';
 
 export interface Props {
@@ -13,7 +14,8 @@ export interface Props {
 }
 
 export const EditableTitle = ({ value, onEdit }: Props) => {
-  const styles = useStyles2(getStyles);
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
+  const styles = useStyles2(getStyles, visualRefreshEnabled);
   const [localValue, setLocalValue] = useState(value);
   const [isEditing, setIsEditing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -81,7 +83,12 @@ export const EditableTitle = ({ value, onEdit }: Props) => {
           this is to prevent the title from flickering back to the old value after the user has edited
           caused by the delay between the save completing and the new value being refetched
         */}
-        <Text element="h1" truncate>
+        <Text
+          element="h1"
+          variant={visualRefreshEnabled ? 'h4' : 'h1'}
+          weight={visualRefreshEnabled ? 'bold' : 'regular'}
+          truncate
+        >
           {localValue}
         </Text>
         <IconButton
@@ -149,7 +156,7 @@ export const EditableTitle = ({ value, onEdit }: Props) => {
 
 EditableTitle.displayName = 'EditableTitle';
 
-const getStyles = (theme: GrafanaTheme2) => {
+const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled: boolean) => {
   return {
     textContainer: css({
       minWidth: 0,
@@ -162,11 +169,18 @@ const getStyles = (theme: GrafanaTheme2) => {
       position: 'relative',
       marginBottom: 0,
     }),
-    input: css({
-      input: {
-        ...theme.typography.h1,
+    input: css(
+      {
+        input: {
+          ...theme.typography.h1,
+        },
       },
-    }),
+      visualRefreshEnabled && {
+        input: {
+          ...theme.typography.h4,
+        },
+      }
+    ),
     inputContainer: css({
       display: 'flex',
       alignItems: 'baseline',

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -135,19 +135,26 @@ const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled: boolean) => {
       label: 'page-content',
       flexGrow: 1,
     }),
-    pageInner: css({
-      label: 'page-inner',
-      padding: theme.spacing(2),
-      borderBottom: 'none',
-      display: 'flex',
-      flexDirection: 'column',
-      flexGrow: 1,
-      margin: theme.spacing(0, 0, 0, 0),
+    pageInner: css(
+      {
+        label: 'page-inner',
+        padding: theme.spacing(2),
+        borderBottom: 'none',
+        display: 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+        margin: theme.spacing(0, 0, 0, 0),
 
-      [theme.breakpoints.up('md')]: {
-        padding: theme.spacing(4),
+        [theme.breakpoints.up('md')]: {
+          padding: theme.spacing(4),
+        },
       },
-    }),
+      visualRefreshEnabled && {
+        [theme.breakpoints.up('md')]: {
+          padding: theme.spacing(2, 4),
+        },
+      }
+    ),
     homeInner: css({
       label: 'home-inner',
       maxWidth: `${theme.breakpoints.values.xxl}px`,

--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -30,7 +30,7 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEd
         <div className={styles.titleInfoContainer}>
           <div className={styles.title}>
             {navItem.img && <img className={styles.img} src={navItem.img} alt={`logo for ${navItem.text}`} />}
-            <Stack gap={0.5} direction="column">
+            <Stack gap={0.5} direction="column" minWidth={0}>
               {onEditTitle ? (
                 <EditableTitle value={navItem.text} onEdit={onEditTitle} />
               ) : renderTitle ? (

--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -2,7 +2,8 @@ import { css } from '@emotion/css';
 import * as React from 'react';
 
 import { type NavModelItem, type GrafanaTheme2 } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
+import { Text, useStyles2 } from '@grafana/ui';
 
 import { PageInfo } from '../PageInfo/PageInfo';
 
@@ -19,8 +20,9 @@ export interface Props {
 }
 
 export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEditTitle }: Props) {
-  const styles = useStyles2(getStyles);
   const sub = subTitle ?? navItem.subTitle;
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
+  const styles = useStyles2(getStyles, visualRefreshEnabled);
 
   return (
     <div className={styles.pageHeader}>
@@ -33,7 +35,13 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEd
             ) : renderTitle ? (
               renderTitle(navItem.text)
             ) : (
-              <h1>{navItem.text}</h1>
+              <Text
+                element="h1"
+                variant={visualRefreshEnabled ? 'h4' : 'h1'}
+                weight={visualRefreshEnabled ? 'bold' : 'regular'}
+              >
+                {navItem.text}
+              </Text>
             )}
           </div>
           {info && <PageInfo info={info} />}
@@ -45,7 +53,7 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEd
   );
 }
 
-const getStyles = (theme: GrafanaTheme2) => {
+const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled: boolean) => {
   return {
     topRow: css({
       alignItems: 'flex-start',
@@ -85,10 +93,15 @@ const getStyles = (theme: GrafanaTheme2) => {
       gap: theme.spacing(1),
       marginBottom: theme.spacing(2),
     }),
-    subTitle: css({
-      position: 'relative',
-      color: theme.colors.text.secondary,
-    }),
+    subTitle: css(
+      {
+        position: 'relative',
+        color: theme.colors.text.secondary,
+      },
+      visualRefreshEnabled && {
+        ...theme.typography.bodySmall,
+      }
+    ),
     img: css({
       width: '32px',
       height: '32px',

--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { type NavModelItem, type GrafanaTheme2 } from '@grafana/data';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
-import { Text, useStyles2 } from '@grafana/ui';
+import { Stack, Text, useStyles2 } from '@grafana/ui';
 
 import { PageInfo } from '../PageInfo/PageInfo';
 
@@ -30,25 +30,28 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle, onEd
         <div className={styles.titleInfoContainer}>
           <div className={styles.title}>
             {navItem.img && <img className={styles.img} src={navItem.img} alt={`logo for ${navItem.text}`} />}
-            {onEditTitle ? (
-              <EditableTitle value={navItem.text} onEdit={onEditTitle} />
-            ) : renderTitle ? (
-              renderTitle(navItem.text)
-            ) : (
-              <Text
-                element="h1"
-                variant={visualRefreshEnabled ? 'h4' : 'h1'}
-                weight={visualRefreshEnabled ? 'bold' : 'regular'}
-              >
-                {navItem.text}
-              </Text>
-            )}
+            <Stack gap={0.5} direction="column">
+              {onEditTitle ? (
+                <EditableTitle value={navItem.text} onEdit={onEditTitle} />
+              ) : renderTitle ? (
+                renderTitle(navItem.text)
+              ) : (
+                <Text
+                  element="h1"
+                  variant={visualRefreshEnabled ? 'h4' : 'h1'}
+                  weight={visualRefreshEnabled ? 'bold' : 'regular'}
+                >
+                  {navItem.text}
+                </Text>
+              )}
+              {sub && visualRefreshEnabled && <div className={styles.subTitle}>{sub}</div>}
+            </Stack>
           </div>
           {info && <PageInfo info={info} />}
         </div>
         <div className={styles.actions}>{actions}</div>
       </div>
-      {sub && <div className={styles.subTitle}>{sub}</div>}
+      {sub && !visualRefreshEnabled && <div className={styles.subTitle}>{sub}</div>}
     </div>
   );
 }
@@ -60,16 +63,13 @@ const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled: boolean) => {
       display: 'flex',
       flexDirection: 'row',
       flexWrap: 'wrap',
-      gap: theme.spacing(1, 3),
+      gap: theme.spacing(visualRefreshEnabled ? 2 : 1, 3),
     }),
     title: css({
       display: 'flex',
       flexDirection: 'row',
       maxWidth: '100%',
       flex: 1,
-      h1: {
-        marginBottom: 0,
-      },
     }),
     actions: css({
       display: 'flex',

--- a/public/app/features/alerting/unified/components/common/Title.tsx
+++ b/public/app/features/alerting/unified/components/common/Title.tsx
@@ -1,10 +1,12 @@
 import { t } from '@grafana/i18n';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { LinkButton, Stack, Text } from '@grafana/ui';
 
 import { useReturnTo } from '../../hooks/useReturnTo';
 
 export const Title = ({ name, returnToFallback }: { name: string; returnToFallback: string }) => {
   const { returnTo } = useReturnTo(returnToFallback);
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
 
   return (
     <Stack direction="row" gap={1} minWidth={0} alignItems="center">
@@ -14,7 +16,12 @@ export const Title = ({ name, returnToFallback }: { name: string; returnToFallba
         icon="angle-left"
         href={returnTo}
       />
-      <Text element="h1" truncate>
+      <Text
+        element="h1"
+        variant={visualRefreshEnabled ? 'h4' : 'h1'}
+        weight={visualRefreshEnabled ? 'bold' : 'regular'}
+        truncate
+      >
         {name}
       </Text>
     </Stack>

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -350,7 +350,12 @@ export const Title = ({
         />
       )}
       {ruleOrigin && <PluginOriginBadge pluginId={ruleOrigin.pluginId} size="lg" />}
-      <Text variant={visualRefreshEnabled ? 'h4' : 'h1'} weight={visualRefreshEnabled ? 'bold' : 'regular'} truncate>
+      <Text
+        element="h1"
+        variant={visualRefreshEnabled ? 'h4' : 'h1'}
+        weight={visualRefreshEnabled ? 'bold' : 'regular'}
+        truncate
+      >
         {name}
       </Text>
       {isProvisioned && <ProvisioningBadge tooltip provenance={provenance} />}

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -7,6 +7,7 @@ import { AlertLabels, StateText } from '@grafana/alerting/unstable';
 import { type GrafanaTheme2, type NavModelItem, type UrlQueryValue } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import {
   Alert,
   LinkButton,
@@ -336,6 +337,7 @@ export const Title = ({
 
   const textHealth = normalizeHealth(health);
   const textState = isInhibited ? 'inhibited' : normalizeState(state);
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
 
   return (
     <Stack direction="row" gap={1} minWidth={0} alignItems="center">
@@ -348,7 +350,7 @@ export const Title = ({
         />
       )}
       {ruleOrigin && <PluginOriginBadge pluginId={ruleOrigin.pluginId} size="lg" />}
-      <Text element="h1" variant="h1" truncate>
+      <Text variant={visualRefreshEnabled ? 'h4' : 'h1'} weight={visualRefreshEnabled ? 'bold' : 'regular'} truncate>
         {name}
       </Text>
       {isProvisioned && <ProvisioningBadge tooltip provenance={provenance} />}

--- a/public/app/features/alerting/unified/components/silences/SilenceViewPage.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewPage.tsx
@@ -1,5 +1,6 @@
 import { t } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { Alert, LoadingPlaceholder, Stack, Text } from '@grafana/ui';
 import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound';
 
@@ -14,10 +15,13 @@ import { SilenceViewContent } from './SilenceViewContent';
 function Title({ title }: { title: string }) {
   const { silence } = useSilenceViewData();
   const silenceState = silence?.status.state;
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
 
   return (
     <Stack direction="row" gap={1} alignItems="center">
-      <Text variant="h1">{title}</Text>
+      <Text variant={visualRefreshEnabled ? 'h4' : 'h1'} weight={visualRefreshEnabled ? 'bold' : 'regular'}>
+        {title}
+      </Text>
       {silenceState && <SilenceStateTag state={silenceState} />}
     </Stack>
   );

--- a/public/app/features/alerting/unified/components/silences/SilenceViewPage.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceViewPage.tsx
@@ -19,7 +19,11 @@ function Title({ title }: { title: string }) {
 
   return (
     <Stack direction="row" gap={1} alignItems="center">
-      <Text variant={visualRefreshEnabled ? 'h4' : 'h1'} weight={visualRefreshEnabled ? 'bold' : 'regular'}>
+      <Text
+        element="h1"
+        variant={visualRefreshEnabled ? 'h4' : 'h1'}
+        weight={visualRefreshEnabled ? 'bold' : 'regular'}
+      >
         {title}
       </Text>
       {silenceState && <SilenceStateTag state={silenceState} />}

--- a/public/app/features/alerting/unified/group-details/Title.tsx
+++ b/public/app/features/alerting/unified/group-details/Title.tsx
@@ -1,10 +1,12 @@
 import { t } from '@grafana/i18n';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { LinkButton, Stack, Text } from '@grafana/ui';
 
 import { useReturnTo } from '../hooks/useReturnTo';
 
 export const Title = ({ name }: { name: string }) => {
   const { returnTo } = useReturnTo('/alerting/list');
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
 
   return (
     <Stack direction="row" gap={1} minWidth={0} alignItems="center">
@@ -14,7 +16,12 @@ export const Title = ({ name }: { name: string }) => {
         icon="angle-left"
         href={returnTo}
       />
-      <Text element="h1" truncate>
+      <Text
+        element="h1"
+        variant={visualRefreshEnabled ? 'h4' : 'h1'}
+        weight={visualRefreshEnabled ? 'bold' : 'regular'}
+        truncate
+      >
         {name}
       </Text>
     </Stack>

--- a/public/app/features/alerting/unified/notifications/NotificationDetailPage.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationDetailPage.tsx
@@ -11,7 +11,8 @@ import {
 } from '@grafana/api-clients/rtkq/historian.alerting/v0alpha1';
 import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, LoadingPlaceholder, TabContent, useStyles2 } from '@grafana/ui';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
+import { Alert, LoadingPlaceholder, TabContent, Text, useStyles2 } from '@grafana/ui';
 import { type PageInfoItem } from 'app/core/components/Page/types';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 
@@ -117,13 +118,22 @@ function NotificationDetailPage() {
   }
 
   const subTitle = headerData ? <NotificationHeader notification={headerData.notification} /> : undefined;
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
 
   return (
     <AlertingPageWrapper
       navId="alerts-history"
       pageNav={pageNav}
       isLoading={false}
-      renderTitle={() => <h1>{displayTitle}</h1>}
+      renderTitle={() => (
+        <Text
+          element={'h1'}
+          variant={visualRefreshEnabled ? 'h4' : 'h1'}
+          weight={visualRefreshEnabled ? 'bold' : 'regular'}
+        >
+          {displayTitle}
+        </Text>
+      )}
       info={info.length > 0 ? info : undefined}
       actions={notification ? <NotificationActionsMenu notification={notification} /> : undefined}
       subTitle={subTitle}

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
-import { Button, type ButtonProps, Stack } from '@grafana/ui';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
+import { Button, type ButtonProps, Stack, Text } from '@grafana/ui';
 
 import {
   type ViewExperienceToggleEventPayload,
@@ -123,10 +124,18 @@ export function RuleListPageTitle({ title }: { title: string }) {
         'data-testid': 'alerting-list-view-toggle-v2',
       };
 
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
+
   return (
     <>
       <Stack direction="row" alignItems="center" justifyContent="space-between" gap={2}>
-        <h1>{title}</h1>
+        <Text
+          element={'h1'}
+          variant={visualRefreshEnabled ? 'h4' : 'h1'}
+          weight={visualRefreshEnabled ? 'bold' : 'regular'}
+        >
+          {title}
+        </Text>
         {shouldShowV2Toggle && (
           <div>
             <Button size="sm" fill="outline" {...configToUse} onClick={handleToggleClick} className="fs-unmask" />

--- a/public/app/features/auth-config/ProviderConfigPage.tsx
+++ b/public/app/features/auth-config/ProviderConfigPage.tsx
@@ -64,7 +64,7 @@ export const ProviderConfigPage = () => {
       renderTitle={(title) => (
         <Stack gap={2} alignItems="center">
           <Text
-            element={'h1'}
+            element="h1"
             variant={visualRefreshEnabled ? 'h4' : 'h1'}
             weight={visualRefreshEnabled ? 'bold' : 'regular'}
           >

--- a/public/app/features/auth-config/ProviderConfigPage.tsx
+++ b/public/app/features/auth-config/ProviderConfigPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom-v5-compat';
 
 import { type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { Badge, Stack, Text } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { PageNotFound } from 'app/core/components/PageNotFound/PageNotFound';
@@ -44,6 +45,7 @@ export const ProviderConfigPage = () => {
   const { isLoading, providers } = useSelector((store) => store.authConfig);
   const { provider = '' } = useParams();
   const config = providers.find((config) => config.provider === provider);
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
 
   useEffect(() => {
     dispatch(loadProviders(provider));
@@ -61,7 +63,13 @@ export const ProviderConfigPage = () => {
       pageNav={pageNav}
       renderTitle={(title) => (
         <Stack gap={2} alignItems="center">
-          <Text variant={'h1'}>{title}</Text>
+          <Text
+            element={'h1'}
+            variant={visualRefreshEnabled ? 'h4' : 'h1'}
+            weight={visualRefreshEnabled ? 'bold' : 'regular'}
+          >
+            {title}
+          </Text>
           <Badge
             text={
               config.settings.enabled

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -7,6 +7,7 @@ import AutoSizer, { type Size } from 'react-virtualized-auto-sizer';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { Drawer, FilterInput, IconButton, useStyles2, Text, Stack } from '@grafana/ui';
 import { useGetFolderQueryFacade, useUpdateFolder } from 'app/api/clients/folder/v1beta1/hooks';
 import { Page } from 'app/core/components/Page/Page';
@@ -40,6 +41,7 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
   const { uid: folderUID } = useParams();
   const dispatch = useDispatch();
 
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
   const styles = useStyles2(getStyles);
   const [searchState, stateManager] = useSearchStateManager();
   const isSearching = stateManager.hasSearchFilters();
@@ -145,7 +147,13 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
   const renderTitle = (title: string) => {
     return (
       <Stack alignItems={'center'} gap={2}>
-        <Text element={'h1'}>{title}</Text>
+        <Text
+          element={'h1'}
+          variant={visualRefreshEnabled ? 'h4' : 'h1'}
+          weight={visualRefreshEnabled ? 'bold' : 'regular'}
+        >
+          {title}
+        </Text>
         {showEditTitle && isProvisionedFolder && !isRepoRootFolder && !isReadOnlyRepo && (
           <IconButton
             name="pen"

--- a/public/app/features/playlist/PlaylistEditPage.tsx
+++ b/public/app/features/playlist/PlaylistEditPage.tsx
@@ -4,7 +4,8 @@ import { useParams } from 'react-router-dom-v5-compat';
 import { type NavModelItem } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
-import { Stack } from '@grafana/ui';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
+import { Stack, Text } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { ManagedBadge } from 'app/features/provisioning/components/ManagedBadge';
 import { SaveProvisionedResourceDrawer } from 'app/features/provisioning/components/Shared/SaveProvisionedResourceDrawer';
@@ -34,6 +35,7 @@ export const PlaylistEditPage = () => {
   const { isAvailable, repositories } = useResourceRepositorySelection(resourceKindInfos.playlist);
   // Holds the edited playlist while the provisioning save drawer is open.
   const [provisionedPlaylist, setProvisionedPlaylist] = useState<Playlist | undefined>();
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
 
   const onSubmit = async (playlist: Playlist) => {
     // Repository-managed playlists are committed to git via the save drawer instead of
@@ -60,7 +62,13 @@ export const PlaylistEditPage = () => {
 
   const renderTitle = (title: string) => (
     <Stack direction="row" gap={1} alignItems="center" wrap>
-      <h1>{title}</h1>
+      <Text
+        element={'h1'}
+        variant={visualRefreshEnabled ? 'h4' : 'h1'}
+        weight={visualRefreshEnabled ? 'bold' : 'regular'}
+      >
+        {title}
+      </Text>
       {data && isManaged(data) && <ManagedBadge managerKind={getManagerKind(data)} name={getManagerIdentity(data)} />}
       {data && isManagedByRepository(data) && (
         <SourceLink repositoryName={getManagerIdentity(data)} sourcePath={getSourcePath(data)} />

--- a/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom-v5-compat';
 
 import { type SelectableValue, urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { Alert, EmptyState, Spinner, Stack, Tab, TabContent, TabsBar, Text, TextLink } from '@grafana/ui';
 import { getErrorMessage } from 'app/api/clients/provisioning/utils/httpUtils';
 import { useListRepositoryQuery } from 'app/api/clients/provisioning/v0alpha1';
@@ -54,6 +55,7 @@ export default function RepositoryStatusPage() {
     ],
     []
   );
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
 
   return (
     <Page
@@ -65,7 +67,13 @@ export default function RepositoryStatusPage() {
       renderTitle={(title) => (
         <Stack alignItems="center">
           <RepoIcon type={data?.spec?.type} autoHeight />
-          <Text element="h1">{title}</Text>
+          <Text
+            element={'h1'}
+            variant={visualRefreshEnabled ? 'h4' : 'h1'}
+            weight={visualRefreshEnabled ? 'bold' : 'regular'}
+          >
+            {title}
+          </Text>
         </Stack>
       )}
       actions={data && <RepositoryActions repository={data} />}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adapts `PageHeader` to match visual refresh designs behind a feature toggle

**Why do we need this feature?**
To accomplish the visual refresh of Grafana

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
Please check that: you have `grafana.visualDesignRefresh = true`

| Before | After |
|----------|----------|
| <img width="1315" height="442" alt="Screenshot 2026-07-10 at 12 08 25" src="https://github.com/user-attachments/assets/f6e834ba-e055-4706-816e-1011de752caf" /> | <img width="1311" height="459" alt="Screenshot 2026-07-10 at 13 39 18" src="https://github.com/user-attachments/assets/c14cec2b-69e6-4884-b129-1aac900e7ca2" /> |
| <img width="1315" height="590" alt="Screenshot 2026-07-10 at 12 09 46" src="https://github.com/user-attachments/assets/3ea9a71d-4cb0-4db6-9dab-2c9162840620" />|<img width="1313" height="495" alt="Screenshot 2026-07-10 at 13 51 05" src="https://github.com/user-attachments/assets/e87f7db4-8c1a-41c3-bc8e-d968a3dad3f9" />|
| <img width="1313" height="575" alt="Screenshot 2026-07-10 at 12 08 37" src="https://github.com/user-attachments/assets/88e18dfb-2ac5-4b71-bb07-9c5c7537ec4e" />|<img width="1311" height="410" alt="Screenshot 2026-07-10 at 13 42 28" src="https://github.com/user-attachments/assets/4d7426f1-3bb4-48a9-b743-25963f938adb" />|
| <img width="1313" height="534" alt="Screenshot 2026-07-10 at 12 10 06" src="https://github.com/user-attachments/assets/5a445b6b-047c-4102-b681-4b9f53979765" /> | <img width="1315" height="465" alt="Screenshot 2026-07-10 at 13 39 05" src="https://github.com/user-attachments/assets/db9ccf7d-faed-4a4d-b801-d2405fb83f75" />|
| <img width="1315" height="483" alt="Screenshot 2026-07-10 at 12 08 59" src="https://github.com/user-attachments/assets/b8d833b2-a43e-474f-8251-6262704c1117" />|<img width="1308" height="566" alt="Screenshot 2026-07-10 at 13 42 46" src="https://github.com/user-attachments/assets/b337107b-0fb1-4d98-8bb2-1dba24d62692" />|
| <img width="1315" height="490" alt="Screenshot 2026-07-10 at 12 09 19" src="https://github.com/user-attachments/assets/fb463680-ff16-4058-95d2-648777c6d0d8" />|<img width="1315" height="444" alt="Screenshot 2026-07-10 at 13 42 56" src="https://github.com/user-attachments/assets/313954c2-a2d1-4155-b229-40e976633e69" />|
| <img width="1316" height="563" alt="Screenshot 2026-07-10 at 12 09 32" src="https://github.com/user-attachments/assets/a9c17434-9c1a-4be4-92b6-d0f6490d68d5" />|<img width="1307" height="437" alt="Screenshot 2026-07-10 at 13 43 09" src="https://github.com/user-attachments/assets/3459a226-3541-4057-bbaa-2218387de596" />|
| <img width="1313" height="536" alt="Screenshot 2026-07-10 at 14 23 00" src="https://github.com/user-attachments/assets/bce267c6-3e5c-46fe-9c6e-7dbf3e72923f" />|<img width="1312" height="640" alt="Screenshot 2026-07-10 at 14 01 26" src="https://github.com/user-attachments/assets/25c4453c-e8f9-4b85-89e1-ff9bd53a95de" />|