### PR TITLE
Alerting: Migrate rule-viewer components to focused ability hooks (7/N)

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.test.tsx
@@ -24,7 +24,7 @@ import { fromCombinedRule } from 'app/features/alerting/unified/utils/rule-id';
 import { AccessControlAction } from 'app/types/accessControl';
 import { PromAlertingRuleState, PromRuleType } from 'app/types/unified-alerting-dto';
 
-import { AlertRuleAction } from '../../hooks/useAbilities';
+import { RuleAction } from '../../hooks/abilities/types';
 
 const mockOpenAssistant = jest.fn();
 jest.mock('@grafana/assistant', () => ({
@@ -253,7 +253,7 @@ describe('AlertRuleMenu', () => {
     // Generalized test to reduce repetition for menu item visibility
     type MenuItemTestCase = {
       description: string;
-      action: AlertRuleAction;
+      action: RuleAction;
       menuItem: keyof typeof ui.menuItems;
       granted: boolean;
       shouldShow: boolean;
@@ -269,8 +269,8 @@ describe('AlertRuleMenu', () => {
 
         if (granted) {
           switch (action) {
-            case AlertRuleAction.Pause:
-            case AlertRuleAction.Update:
+            case RuleAction.Pause:
+            case RuleAction.Update:
               permissions.push(
                 AccessControlAction.AlertingRuleRead,
                 AccessControlAction.AlertingRuleUpdate,
@@ -280,7 +280,7 @@ describe('AlertRuleMenu', () => {
               folderAccessControl[AccessControlAction.AlertingRuleUpdate] = true;
               folderAccessControl[AccessControlAction.FoldersRead] = true;
               break;
-            case AlertRuleAction.Delete:
+            case RuleAction.Delete:
               permissions.push(
                 AccessControlAction.AlertingRuleRead,
                 AccessControlAction.AlertingRuleDelete,
@@ -290,13 +290,13 @@ describe('AlertRuleMenu', () => {
               folderAccessControl[AccessControlAction.AlertingRuleDelete] = true;
               folderAccessControl[AccessControlAction.FoldersRead] = true;
               break;
-            case AlertRuleAction.Duplicate:
+            case RuleAction.Duplicate:
               permissions.push(AccessControlAction.AlertingRuleCreate);
               break;
-            case AlertRuleAction.Silence:
+            case RuleAction.Silence:
               permissions.push(AccessControlAction.AlertingInstanceCreate, AccessControlAction.AlertingSilenceCreate);
               break;
-            case AlertRuleAction.ModifyExport:
+            case RuleAction.ModifyExport:
               permissions.push(AccessControlAction.AlertingRuleRead);
               break;
           }
@@ -339,7 +339,7 @@ describe('AlertRuleMenu', () => {
     describe('Pause/Resume visibility', () => {
       testMenuItemVisibility({
         description: 'shows Pause when pause permission is granted',
-        action: AlertRuleAction.Pause,
+        action: RuleAction.Pause,
         menuItem: 'pause',
         granted: true,
         shouldShow: true,
@@ -347,7 +347,7 @@ describe('AlertRuleMenu', () => {
 
       testMenuItemVisibility({
         description: 'hides Pause when pause permission is denied',
-        action: AlertRuleAction.Pause,
+        action: RuleAction.Pause,
         menuItem: 'pause',
         granted: false,
         shouldShow: false,
@@ -357,7 +357,7 @@ describe('AlertRuleMenu', () => {
     describe('Delete visibility', () => {
       testMenuItemVisibility({
         description: 'shows Delete when delete permission is granted',
-        action: AlertRuleAction.Delete,
+        action: RuleAction.Delete,
         menuItem: 'delete',
         granted: true,
         shouldShow: true,
@@ -365,7 +365,7 @@ describe('AlertRuleMenu', () => {
 
       testMenuItemVisibility({
         description: 'hides Delete when delete permission is denied',
-        action: AlertRuleAction.Delete,
+        action: RuleAction.Delete,
         menuItem: 'delete',
         granted: false,
         shouldShow: false,
@@ -375,7 +375,7 @@ describe('AlertRuleMenu', () => {
     describe('Duplicate visibility', () => {
       testMenuItemVisibility({
         description: 'shows Duplicate when duplicate permission is granted',
-        action: AlertRuleAction.Duplicate,
+        action: RuleAction.Duplicate,
         menuItem: 'duplicate',
         granted: true,
         shouldShow: true,
@@ -383,7 +383,7 @@ describe('AlertRuleMenu', () => {
 
       testMenuItemVisibility({
         description: 'hides Duplicate when duplicate permission is denied',
-        action: AlertRuleAction.Duplicate,
+        action: RuleAction.Duplicate,
         menuItem: 'duplicate',
         granted: false,
         shouldShow: false,
@@ -393,7 +393,7 @@ describe('AlertRuleMenu', () => {
     describe('Silence visibility', () => {
       testMenuItemVisibility({
         description: 'shows Silence when silence permission is granted',
-        action: AlertRuleAction.Silence,
+        action: RuleAction.Silence,
         menuItem: 'silence',
         granted: true,
         shouldShow: true,
@@ -401,7 +401,7 @@ describe('AlertRuleMenu', () => {
 
       testMenuItemVisibility({
         description: 'hides Silence when silence permission is denied',
-        action: AlertRuleAction.Silence,
+        action: RuleAction.Silence,
         menuItem: 'silence',
         granted: false,
         shouldShow: false,
@@ -411,7 +411,7 @@ describe('AlertRuleMenu', () => {
     describe('Export visibility', () => {
       testMenuItemVisibility({
         description: 'shows Export when export permission is granted',
-        action: AlertRuleAction.ModifyExport,
+        action: RuleAction.ModifyExport,
         menuItem: 'export',
         granted: true,
         shouldShow: true,
@@ -419,7 +419,7 @@ describe('AlertRuleMenu', () => {
 
       testMenuItemVisibility({
         description: 'hides Export when export permission is denied',
-        action: AlertRuleAction.ModifyExport,
+        action: RuleAction.ModifyExport,
         menuItem: 'export',
         granted: false,
         shouldShow: false,

--- a/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx
@@ -17,14 +17,20 @@ import {
 } from 'app/types/unified-alerting';
 import { PromAlertingRuleState, type RulerRuleDTO } from 'app/types/unified-alerting-dto';
 
+import { isGranted } from '../../hooks/abilities/abilityUtils';
+import { useEnrichmentAbility } from '../../hooks/abilities/otherAbilities';
 import {
-  AlertRuleAction,
-  EnrichmentAction,
-  skipToken,
-  useEnrichmentAbility,
-  useGrafanaPromRuleAbilities,
-  useRulerRuleAbilities,
-} from '../../hooks/useAbilities';
+  usePromRuleAdministrationAbility,
+  usePromRuleExportAbility,
+  usePromRuleSilenceAbility,
+} from '../../hooks/abilities/rules/promRuleAbilities';
+import { skipToken } from '../../hooks/abilities/rules/ruleAbilities.utils';
+import {
+  useRuleAdministrationAbility,
+  useRuleExportAbility,
+  useRuleSilenceAbility,
+} from '../../hooks/abilities/rules/rulerRuleAbilities';
+import { EnrichmentAction } from '../../hooks/abilities/types';
 import { createShareLink, isLocalDevEnv, isOpenSourceEdition } from '../../utils/misc';
 import * as ruleId from '../../utils/rule-id';
 import {
@@ -72,56 +78,27 @@ const AlertRuleMenu = ({
   fill,
 }: Props) => {
   // check all abilities and permissions using rulerRule
-  const [rulerPauseAbility, rulerDeleteAbility, rulerDuplicateAbility, rulerSilenceAbility, rulerExportAbility] =
-    useRulerRuleAbilities(rulerRule, groupIdentifier, [
-      AlertRuleAction.Pause,
-      AlertRuleAction.Delete,
-      AlertRuleAction.Duplicate,
-      AlertRuleAction.Silence,
-      AlertRuleAction.ModifyExport,
-    ]);
+  const rulerAbilities = useRuleAdministrationAbility(rulerRule, groupIdentifier);
+  const rulerSilenceAbility = useRuleSilenceAbility(rulerRule);
+  const rulerExportAbility = useRuleExportAbility(rulerRule);
 
-  // check all abilities and permissions using promRule
-  const [
-    grafanaPauseAbility,
-    grafanaDeleteAbility,
-    grafanaDuplicateAbility,
-    grafanaSilenceAbility,
-    grafanaExportAbility,
-  ] = useGrafanaPromRuleAbilities(prometheusRuleType.grafana.rule(promRule) ? promRule : skipToken, [
-    AlertRuleAction.Pause,
-    AlertRuleAction.Delete,
-    AlertRuleAction.Duplicate,
-    AlertRuleAction.Silence,
-    AlertRuleAction.ModifyExport,
-  ]);
+  // check all abilities and permissions using promRule (for list view without ruler)
+  const grafanaPromRule = prometheusRuleType.grafana.rule(promRule) ? promRule : skipToken;
+  const grafanaAbilities = usePromRuleAdministrationAbility(grafanaPromRule);
+  const grafanaSilenceAbility = usePromRuleSilenceAbility(grafanaPromRule);
+  const grafanaExportAbility = usePromRuleExportAbility(grafanaPromRule);
 
-  const [pauseSupported, pauseAllowed] = rulerPauseAbility;
-  const [grafanaPauseSupported, grafanaPauseAllowed] = grafanaPauseAbility;
-  const canPause = (pauseSupported && pauseAllowed) || (grafanaPauseSupported && grafanaPauseAllowed);
-
-  const [deleteSupported, deleteAllowed] = rulerDeleteAbility;
-  const [grafanaDeleteSupported, grafanaDeleteAllowed] = grafanaDeleteAbility;
-  const canDelete = (deleteSupported && deleteAllowed) || (grafanaDeleteSupported && grafanaDeleteAllowed);
-
-  const [duplicateSupported, duplicateAllowed] = rulerDuplicateAbility;
-  const [grafanaDuplicateSupported, grafanaDuplicateAllowed] = grafanaDuplicateAbility;
-  const canDuplicate =
-    (duplicateSupported && duplicateAllowed) || (grafanaDuplicateSupported && grafanaDuplicateAllowed);
-
-  const [silenceSupported, silenceAllowed] = rulerSilenceAbility;
-  const [grafanaSilenceSupported, grafanaSilenceAllowed] = grafanaSilenceAbility;
-  const canSilence = (silenceSupported && silenceAllowed) || (grafanaSilenceSupported && grafanaSilenceAllowed);
-
-  const [exportSupported, exportAllowed] = rulerExportAbility;
-  const [grafanaExportSupported, grafanaExportAllowed] = grafanaExportAbility;
-  const canExport = (exportSupported && exportAllowed) || (grafanaExportSupported && grafanaExportAllowed);
+  const canPause = isGranted(rulerAbilities.pause) || isGranted(grafanaAbilities.pause);
+  const canDelete = isGranted(rulerAbilities.delete) || isGranted(grafanaAbilities.delete);
+  const canDuplicate = isGranted(rulerAbilities.duplicate) || isGranted(grafanaAbilities.duplicate);
+  const canSilence = isGranted(rulerSilenceAbility) || isGranted(grafanaSilenceAbility);
+  const canExport = isGranted(rulerExportAbility) || isGranted(grafanaExportAbility);
 
   const ruleExtensionLinks = useRulePluginLinkExtension(promRule, groupIdentifier);
 
   const extensionsAvailable = ruleExtensionLinks.length > 0;
 
-  const [enrichmentReadSupported, enrichmentReadAllowed] = useEnrichmentAbility(EnrichmentAction.Read);
+  const enrichmentReadAbility = useEnrichmentAbility(EnrichmentAction.Read);
 
   /**
    * Since Incident isn't available as an open-source product we shouldn't show it for Open-Source licenced editions of Grafana.
@@ -153,8 +130,7 @@ const AlertRuleMenu = ({
     ruleUid &&
     handleManageEnrichments &&
     config.featureToggles.alertingEnrichmentPerRule &&
-    enrichmentReadSupported &&
-    enrichmentReadAllowed;
+    isGranted(enrichmentReadAbility);
 
   const menuItems = (
     <>

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/AlertVersionHistory.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/AlertVersionHistory.tsx
@@ -14,7 +14,8 @@ import {
   trackRuleVersionsRestoreSuccess,
 } from '../../../Analytics';
 import { alertRuleApi } from '../../../api/alertRuleApi';
-import { AlertRuleAction, useRulerRuleAbility } from '../../../hooks/useAbilities';
+import { isGranted } from '../../../hooks/abilities/abilityUtils';
+import { useRuleAdministrationAbility } from '../../../hooks/abilities/rules/rulerRuleAbilities';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
 import { stringifyErrorLike } from '../../../utils/misc';
 
@@ -63,9 +64,8 @@ export function AlertVersionHistory({ rule }: AlertVersionHistoryProps) {
     groupName: rule.grafana_alert.rule_group,
     groupOrigin: 'grafana',
   };
-  const [restoreSupported, restoreAllowed] = useRulerRuleAbility(rule, groupIdentifier, AlertRuleAction.Restore);
-  const canRestore =
-    restoreAllowed && restoreSupported && Boolean(config.featureToggles.alertingRuleVersionHistoryRestore);
+  const { restore: restoreAbility } = useRuleAdministrationAbility(rule, groupIdentifier);
+  const canRestore = isGranted(restoreAbility) && Boolean(config.featureToggles.alertingRuleVersionHistoryRestore);
 
   //tracking functions for restore action
   const onRestoreSuccess = useCallback(

--- a/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
@@ -4,6 +4,19 @@ import { byRole } from 'testing-library-selector';
 import { setPluginLinksHook } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 
+import { useEnrichmentAbility as useEnrichmentAbilityNew } from '../../hooks/abilities/otherAbilities';
+import {
+  usePromRuleAdministrationAbility,
+  usePromRuleExportAbility,
+  usePromRuleSilenceAbility,
+} from '../../hooks/abilities/rules/promRuleAbilities';
+import { type RuleEditAbilityResult } from '../../hooks/abilities/rules/ruleAbilities.utils';
+import {
+  useRuleAdministrationAbility,
+  useRuleExportAbility,
+  useRuleSilenceAbility,
+} from '../../hooks/abilities/rules/rulerRuleAbilities';
+import { Granted, NotSupported } from '../../hooks/abilities/types';
 import {
   AlertRuleAction,
   useAlertRuleAbility,
@@ -22,19 +35,40 @@ jest.mock('@grafana/assistant', () => ({
   useAssistant: () => ({ isAvailable: false, openAssistant: jest.fn() }),
 }));
 
+// Legacy hooks — still used by RuleActionsButtons (not yet migrated)
 jest.mock('../../hooks/useAbilities');
 
+// New focused ability hooks — used by AlertRuleMenu after migration
+jest.mock('../../hooks/abilities/rules/rulerRuleAbilities');
+jest.mock('../../hooks/abilities/rules/promRuleAbilities');
+jest.mock('../../hooks/abilities/otherAbilities');
+
+const deniedAdminAbilities: RuleEditAbilityResult = {
+  update: NotSupported,
+  delete: NotSupported,
+  pause: NotSupported,
+  restore: NotSupported,
+  duplicate: NotSupported,
+  deletePermanently: NotSupported,
+  loading: false,
+};
+
 const mocks = {
-  // Mock the hooks that are actually used by the components:
-  // RuleActionsButtons uses: useAlertRuleAbility (singular)
-  // AlertRuleMenu uses: useRulerRuleAbilities and useGrafanaPromRuleAbilities (plural)
-  // We can also use useGrafanaPromRuleAbility (singular) for simpler mocking
+  // Legacy hooks used by RuleActionsButtons
   useRulerRuleAbility: jest.mocked(useRulerRuleAbility),
   useAlertRuleAbility: jest.mocked(useAlertRuleAbility),
   useGrafanaPromRuleAbility: jest.mocked(useGrafanaPromRuleAbility),
   useRulerRuleAbilities: jest.mocked(useRulerRuleAbilities),
   useGrafanaPromRuleAbilities: jest.mocked(useGrafanaPromRuleAbilities),
   useEnrichmentAbility: jest.mocked(useEnrichmentAbility),
+  // New focused hooks used by AlertRuleMenu
+  useRuleAdministrationAbility: jest.mocked(useRuleAdministrationAbility),
+  useRuleSilenceAbility: jest.mocked(useRuleSilenceAbility),
+  useRuleExportAbility: jest.mocked(useRuleExportAbility),
+  usePromRuleAdministrationAbility: jest.mocked(usePromRuleAdministrationAbility),
+  usePromRuleSilenceAbility: jest.mocked(usePromRuleSilenceAbility),
+  usePromRuleExportAbility: jest.mocked(usePromRuleExportAbility),
+  useEnrichmentAbilityNew: jest.mocked(useEnrichmentAbilityNew),
 };
 
 setPluginLinksHook(() => ({
@@ -71,13 +105,22 @@ describe('RulesTable RBAC', () => {
     mocks.useGrafanaPromRuleAbility.mockReturnValue([false, false]);
     mocks.useEnrichmentAbility.mockReturnValue([false, false]);
 
-    // Plural hooks (used by AlertRuleMenu) - need to return arrays based on input actions
+    // Plural hooks (legacy, used by components not yet migrated)
     mocks.useRulerRuleAbilities.mockImplementation((_rule, _groupIdentifier, actions) => {
       return actions.map(() => [false, false]);
     });
     mocks.useGrafanaPromRuleAbilities.mockImplementation((_rule, actions) => {
       return actions.map(() => [false, false]);
     });
+
+    // New focused ability hooks (used by AlertRuleMenu after migration) — default: all denied
+    mocks.useRuleAdministrationAbility.mockReturnValue(deniedAdminAbilities);
+    mocks.useRuleSilenceAbility.mockReturnValue(NotSupported);
+    mocks.useRuleExportAbility.mockReturnValue(NotSupported);
+    mocks.usePromRuleAdministrationAbility.mockReturnValue(deniedAdminAbilities);
+    mocks.usePromRuleSilenceAbility.mockReturnValue(NotSupported);
+    mocks.usePromRuleExportAbility.mockReturnValue(NotSupported);
+    mocks.useEnrichmentAbilityNew.mockReturnValue(NotSupported);
   });
 
   describe('Grafana rules action buttons', () => {
@@ -139,14 +182,13 @@ describe('RulesTable RBAC', () => {
     });
 
     it('Should render Delete button for users with the delete permission', async () => {
-      // Mock the specific hooks needed for Grafana rules
       mocks.useAlertRuleAbility.mockImplementation((rule, action) => {
         return action === AlertRuleAction.Delete ? [true, true] : [false, false];
       });
-      mocks.useGrafanaPromRuleAbilities.mockImplementation((rule, actions) => {
-        return actions.map((action) => {
-          return action === AlertRuleAction.Delete ? [true, true] : [false, false];
-        });
+      // AlertRuleMenu now uses the focused ability hooks — grant delete via the prom path
+      mocks.usePromRuleAdministrationAbility.mockReturnValue({
+        ...deniedAdminAbilities,
+        delete: Granted,
       });
 
       render(<RulesTable rules={[grafanaRule]} />);
@@ -269,17 +311,13 @@ describe('RulesTable RBAC', () => {
     });
 
     it('Should render Delete button for users with the delete permission', async () => {
-      mocks.useRulerRuleAbility.mockImplementation((_rule, _groupIdentifier, action) => {
-        return action === AlertRuleAction.Delete ? [true, true] : [false, false];
-      });
       mocks.useAlertRuleAbility.mockImplementation((_rule, action) => {
         return action === AlertRuleAction.Delete ? [true, true] : [false, false];
       });
-      // Cloud rules only need useRulerRuleAbilities mock (useGrafanaPromRuleAbilities gets skipToken)
-      mocks.useRulerRuleAbilities.mockImplementation((_rule, _groupIdentifier, actions) => {
-        return actions.map((action) => {
-          return action === AlertRuleAction.Delete ? [true, true] : [false, false];
-        });
+      // AlertRuleMenu now uses the focused ability hooks — grant delete via the ruler path
+      mocks.useRuleAdministrationAbility.mockReturnValue({
+        ...deniedAdminAbilities,
+        delete: Granted,
       });
 
       render(<RulesTable rules={[cloudRule]} />);


### PR DESCRIPTION
**What is this feature?**

Migrates the rule viewer UI away from the monolithic `useAbilities` / `contextSrv` pattern to the focused ability hooks introduced in PR #123338 (7 of N in the series).

**Why do we need this feature?**

Following up on #123338 which introduced the new modular ability system. This PR updates rule viewer components to use the new rule ability hooks directly, replacing the old `[supported, allowed]` tuple pattern with the richer discriminated-union `Ability` type and `isGranted()`.

Components migrated:
- `AlertRuleMenu.tsx` — replaces `useRulerRuleAbilities` / `useGrafanaPromRuleAbilities` with `useRuleAdministrationAbility`, `useRuleSilenceAbility`, `useRuleExportAbility` (ruler path) and their prom counterparts; replaces `useEnrichmentAbility` tuple destructuring with `isGranted()`
- `AlertVersionHistory.tsx` — replaces `useRulerRuleAbility(…, AlertRuleAction.Restore)` with `useRuleAdministrationAbility(…).restore`

Supersedes #126094.

**Who is this feature for?**

Internal: alerting squad engineers.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- No behaviour changes — the dual-path check (ruler || grafana prom) is preserved; if either path grants an action the menu item is shown.
- All 92 tests in `components/rule-viewer/` pass.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.