### PR TITLE
SqlStore: Fix migration deadlock on dialects without advisory locks

### DIFF
--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -85,6 +85,8 @@ type Dialect interface {
 	IsDeadlock(err error) bool
 	Lock(LockCfg) error
 	Unlock(LockCfg) error
+	// SupportsAdvisoryLocks returns whether Lock and Unlock actually lock anything.
+	SupportsAdvisoryLocks() bool
 
 	GetDBName(string) (string, error)
 
@@ -375,6 +377,10 @@ func (b *BaseDialect) Lock(_ LockCfg) error {
 
 func (b *BaseDialect) Unlock(_ LockCfg) error {
 	return nil
+}
+
+func (b *BaseDialect) SupportsAdvisoryLocks() bool {
+	return false
 }
 
 func (b *BaseDialect) OrderBy(order string) string {

--- a/pkg/services/sqlstore/migrator/locking_test.go
+++ b/pkg/services/sqlstore/migrator/locking_test.go
@@ -1,0 +1,62 @@
+package migrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/grafana/grafana/pkg/util/sqlite"
+	"github.com/grafana/grafana/pkg/util/xorm"
+)
+
+func TestSupportsAdvisoryLocks(t *testing.T) {
+	require.False(t, NewDialect(SQLite).SupportsAdvisoryLocks())
+	require.True(t, NewDialect(Postgres).SupportsAdvisoryLocks())
+	require.True(t, NewDialect(MySQL).SupportsAdvisoryLocks())
+}
+
+// TestRunMigrationsWithLockingSingleConnection is a regression test: on dialects
+// without advisory locks (SQLite), enabling database locking used to pin the
+// pool's only connection in an outer transaction while each migration waited
+// forever for a second one.
+func TestRunMigrationsWithLockingSingleConnection(t *testing.T) {
+	engine, err := xorm.NewEngine("sqlite3", "file::memory:?cache=shared")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+	engine.SetMaxOpenConns(1)
+
+	prev := connAcquireTimeout
+	connAcquireTimeout = 2 * time.Second // fail instead of hanging if this regresses
+	t.Cleanup(func() { connAcquireTimeout = prev })
+
+	mg := NewMigrator(engine, nil)
+	mg.AddCreateMigration()
+	mg.AddMigration("create locking test table", NewAddTableMigration(Table{
+		Name:    "migrator_locking_test",
+		Columns: []*Column{{Name: "id", Type: DB_Int}},
+	}))
+
+	require.NoError(t, mg.RunMigrations(context.Background(), true, 0))
+}
+
+func TestInTransactionFailsFastWhenPoolExhausted(t *testing.T) {
+	engine, err := xorm.NewEngine("sqlite3", "file::memory:?cache=shared")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+	engine.SetMaxOpenConns(1)
+
+	prev := connAcquireTimeout
+	connAcquireTimeout = 250 * time.Millisecond
+	t.Cleanup(func() { connAcquireTimeout = prev })
+
+	// Hold the pool's only connection in an open transaction.
+	holder := engine.NewSession()
+	require.NoError(t, holder.Begin())
+	t.Cleanup(holder.Close)
+
+	mg := NewMigrator(engine, nil)
+	err = mg.InTransaction(func(sess *xorm.Session) error { return nil })
+	require.ErrorContains(t, err, "waiting for a database connection")
+}

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -200,6 +200,25 @@ func (mg *Migrator) RunMigrations(ctx context.Context, isDatabaseLockingEnabled 
 		return mg.run(ctx)
 	}
 
+	logger := mg.Logger.FromContext(ctx)
+
+	if !mg.Dialect.SupportsAdvisoryLocks() {
+		// Without advisory locks (SQLite) the outer transaction below would only
+		// pin a pooled connection for the whole run while every migration begins
+		// its own transaction on a second connection — a deadlock once the rest
+		// of the pool is occupied. Keep the in-process guard and skip the rest.
+		if err := casRestoreOnErr(&mg.isLocked, false, true, ErrMigratorIsLocked, mg.Dialect.Lock, LockCfg{}); err != nil {
+			logger.Error("Failed to lock database", "error", err)
+			return err
+		}
+		defer func() {
+			if unlockErr := casRestoreOnErr(&mg.isLocked, true, false, ErrMigratorIsUnlocked, mg.Dialect.Unlock, LockCfg{}); unlockErr != nil {
+				logger.Error("Failed to unlock database", "error", unlockErr)
+			}
+		}()
+		return mg.run(ctx)
+	}
+
 	dbName, err := mg.Dialect.GetDBName(mg.DBEngine.DataSourceName())
 	if err != nil {
 		return err
@@ -208,8 +227,6 @@ func (mg *Migrator) RunMigrations(ctx context.Context, isDatabaseLockingEnabled 
 	if err != nil {
 		return err
 	}
-
-	logger := mg.Logger.FromContext(ctx)
 
 	return mg.InTransaction(func(sess *xorm.Session) error {
 		logger.Info("Locking database")
@@ -425,11 +442,35 @@ func (mg *Migrator) InTransaction(callback dbTransactionFunc) error {
 	return errors.Join(lastErr, b.Err())
 }
 
+// connAcquireTimeout bounds how long beginning a migration transaction may wait
+// for a pooled database connection. Waiting longer means the pool is exhausted
+// (e.g. every other connection is held while the migrator holds the database
+// lock); without a bound that wait is a silent deadlock. It is a variable so
+// tests can shorten it.
+var connAcquireTimeout = 30 * time.Second
+
 func (mg *Migrator) inTransaction(callback dbTransactionFunc) error {
 	sess := mg.DBEngine.NewSession()
 	defer sess.Close()
 
-	if err := sess.Begin(); err != nil {
+	// database/sql ties the context passed to BeginTx to the whole transaction
+	// lifetime (cancellation rolls the transaction back), so a plain WithTimeout
+	// would abort long-running migrations. Instead a watchdog cancels the context
+	// only if Begin is still waiting for a connection when the timer fires; on
+	// success the context stays alive until the deferred cancel after
+	// Commit/Rollback.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sess.Context(ctx)
+
+	watchdog := time.AfterFunc(connAcquireTimeout, cancel)
+	err := sess.Begin()
+	if !watchdog.Stop() {
+		// The watchdog fired: even if Begin won the race and succeeded, the
+		// canceled context has already doomed the transaction.
+		return fmt.Errorf("timed out after %s waiting for a database connection to begin a migration transaction (connection pool exhausted?)", connAcquireTimeout)
+	}
+	if err != nil {
 		return err
 	}
 

--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -274,6 +274,10 @@ func (db *MySQLDialect) UpsertMultipleSQL(tableName string, keyCols, updateCols 
 	return s, nil
 }
 
+func (db *MySQLDialect) SupportsAdvisoryLocks() bool {
+	return true
+}
+
 func (db *MySQLDialect) Lock(cfg LockCfg) error {
 	query := "SELECT GET_LOCK(?, ?)"
 	var success sql.NullBool

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -294,6 +294,10 @@ func (db *PostgresDialect) UpsertMultipleSQL(tableName string, keyCols, updateCo
 	return s, nil
 }
 
+func (db *PostgresDialect) SupportsAdvisoryLocks() bool {
+	return true
+}
+
 func (db *PostgresDialect) Lock(cfg LockCfg) error {
 	// trying to obtain the lock for a resource identified by a 64-bit or 32-bit key value
 	// the lock is exclusive: multiple lock requests stack, so that if the same resource is locked three times

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -1018,7 +1018,11 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 	require.NoError(t, err)
 	maxConns := opts.DBMaxConns
 	if maxConns <= 0 {
-		maxConns = 2
+		// Keep the pool small to surface connection leaks, but not so small that
+		// startup deadlocks: while migrating, the migrator can hold one connection
+		// on the database lock while each migration's transaction needs a second,
+		// and other startup components share the same pool.
+		maxConns = 5
 	}
 
 	_, err = dbSection.NewKey("max_open_conn", fmt.Sprintf("%d", maxConns))


### PR DESCRIPTION
- Fixes a deadlock during database migrations that hangs integration tests (example: run [28937491228](https://github.com/grafana/grafana/actions/runs/28937491228), where `pkg/tests/api/alerting` timed out after 16m with `TestIntegrationRulerAccess` blocked for 13m in `database/sql.(*DB).conn`).
- Added `Dialect.SupportsAdvisoryLocks()` (true for postgres / mysql, false otherwise). When false, the outer lock transaction is skipped.
- `inTransaction` now fails fast when beginning a transaction can't get a pooled connection. Before, it would silently hang and blame a random test when it eventually failed from timeout.
- Increased `testinfra`'s default `DBMaxConns` from 2 to 5.

**The deadlock:** `RunMigrations` with database locking enabled wraps the whole run in an outer transaction whose only purpose is to hold the advisory lock. On SQLite, `Dialect.Lock` is a no-op — so the transaction just pins a pooled connection for the entire run, while every individual migration opens a nested transaction that needs a *second* connection. testinfra caps the test server's pool at `max_open_conn=2`, so if any other startup component holds the second connection at that moment, the migrator waits forever.