### PR TITLE
Dashboards: Fix bug related to templates, expressions, and mixed datasources

### DIFF
--- a/public/app/features/query/state/runRequest.test.ts
+++ b/public/app/features/query/state/runRequest.test.ts
@@ -18,6 +18,7 @@ import { type DataQuery } from '@grafana/schema';
 import { deepFreeze } from '../../../../test/core/redux/reducerTester';
 import { Echo } from '../../../core/services/echo/Echo';
 import { createDashboardModelFixture } from '../../dashboard/state/__fixtures__/dashboardFixtures';
+import { dataSource as expressionDataSource } from '../../expressions/ExpressionDatasource';
 
 import { getMockDataSource, type TestQuery } from './mocks/mockDataSource';
 import { callQueryMethodWithMigration, runRequest } from './runRequest';
@@ -426,12 +427,14 @@ describe('callQueryMethodWithMigration', () => {
     getDefaultQuery,
     queryFunction,
     migrateRequest,
+    mixed,
   }: {
     targets: TestQuery[];
     getDefaultQuery?: (app: CoreApp) => Partial<TestQuery>;
     filterQuery?: typeof ds.filterQuery;
     queryFunction?: typeof ds.query;
     migrateRequest?: jest.Mock;
+    mixed?: boolean;
   }) => {
     request = {
       range: {
@@ -450,6 +453,9 @@ describe('callQueryMethodWithMigration', () => {
     };
 
     const ds = getMockDataSource();
+    if (mixed) {
+      ds.meta = { ...ds.meta, mixed: true };
+    }
     if (filterQuery) {
       ds.filterQuery = filterQuery;
       filterQuerySpy = jest.spyOn(ds, 'filterQuery');
@@ -573,6 +579,29 @@ describe('callQueryMethodWithMigration', () => {
       filterQuery: (query: DataQuery) => query.refId !== 'A',
     });
     expect(filterQuerySpy).not.toHaveBeenCalled();
+  });
+
+  it('Should route to the expression datasource when a non-mixed datasource has an expression target', async () => {
+    setup({
+      targets: [
+        { refId: 'A', q: 'SUM(foo)' },
+        { datasource: ExpressionDatasourceRef, refId: 'B' },
+      ],
+    });
+    expect(expressionDataSource.query).toHaveBeenCalled();
+    expect(querySpy).not.toHaveBeenCalled();
+  });
+
+  it('Should delegate to the datasource query (not the expression datasource) when a mixed datasource has an expression target', async () => {
+    setup({
+      targets: [
+        { refId: 'A', q: 'SUM(foo)' },
+        { datasource: ExpressionDatasourceRef, refId: 'B' },
+      ],
+      mixed: true,
+    });
+    expect(expressionDataSource.query).not.toHaveBeenCalled();
+    expect(querySpy).toHaveBeenCalled();
   });
 
   it('Should get ds default query when query is empty', async () => {

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -216,9 +216,14 @@ function callQueryMethod(
     return from(datasource.query(request));
   }
 
-  for (const target of request.targets) {
-    if (isExpressionReference(target.datasource)) {
-      return expressionDatasource.query(request as DataQueryRequest<ExpressionQuery>);
+  // The Mixed datasource handles its own expression fan-out (so a multi-value datasource variable
+  // feeding an expression is expanded across every selected datasource). Only route directly to the
+  // expression datasource for non-mixed requests.
+  if (!datasource.meta?.mixed) {
+    for (const target of request.targets) {
+      if (isExpressionReference(target.datasource)) {
+        return expressionDatasource.query(request as DataQueryRequest<ExpressionQuery>);
+      }
     }
   }
 

--- a/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
@@ -281,6 +281,26 @@ describe('MixedDatasource', () => {
       });
     });
 
+    it('errors when a multi value datasource variable is mixed with other datasources in an expression', async () => {
+      const ds = new MixedDatasource({} as DataSourceInstanceSettings);
+      const request = {
+        targets: [
+          { refId: 'A', datasource: { uid: '$ds' }, hide: true },
+          { refId: 'C', datasource: { uid: 'A' }, hide: true },
+          { refId: 'B', datasource: ExpressionDatasourceRef, type: 'math', expression: '$C' },
+        ],
+        scopedVars: { __sceneObject: { value: multiScene } },
+      } as unknown as DataQueryRequest;
+
+      await expect(ds.query(request)).toEmitValuesWith((results) => {
+        expect(results).toHaveLength(1);
+        expect(results[0].state).toBe(LoadingState.Error);
+        expect(results[0].error?.message).toContain('not supported');
+      });
+      // no requests should have been dispatched
+      expect(expressionDS.requests).toHaveLength(0);
+    });
+
     it('sends a single expression request when no multi value datasource variable is used', async () => {
       const ds = new MixedDatasource({} as DataSourceInstanceSettings);
       const request = {

--- a/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
@@ -8,6 +8,7 @@ import {
   DataSourceApi,
   type DataSourceInstanceSettings,
   type DataSourceRef,
+  getDataSourceUID,
   LoadingState,
 } from '@grafana/data';
 import { type DataSourceSrv, setDataSourceSrv, setTemplateSrv } from '@grafana/runtime';
@@ -226,9 +227,8 @@ describe('MixedDatasource', () => {
       expressionDS = new RecordingExpressionDatasource();
       setDataSourceSrv({
         ...datasourceSrv,
-        get: (ref?: DataSourceRef | string) => {
-          const uid = typeof ref === 'string' ? ref : ref?.uid;
-          if (uid === ExpressionDatasourceRef.uid) {
+        get: (ref: DataSourceRef) => {
+          if (getDataSourceUID(ref) === ExpressionDatasourceRef.uid) {
             return Promise.resolve(expressionDS);
           }
           return datasourceSrv.get(ref);
@@ -237,7 +237,7 @@ describe('MixedDatasource', () => {
         getList: jest.fn(),
         reload: jest.fn(),
         registerRuntimeDataSource: jest.fn(),
-      } as unknown as DataSourceSrv);
+      } as DataSourceSrv);
       setTemplateSrv(new TemplateSrv());
     });
 

--- a/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
@@ -1,14 +1,17 @@
-import { lastValueFrom } from 'rxjs';
+import { lastValueFrom, type Observable, of } from 'rxjs';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
 import { DatasourceSrvMock, MockObservableDataSourceApi } from 'test/mocks/datasource_srv';
 
 import {
   type DataQueryRequest,
+  type DataQueryResponse,
+  DataSourceApi,
   type DataSourceInstanceSettings,
   type DataSourceRef,
   LoadingState,
 } from '@grafana/data';
 import { type DataSourceSrv, setDataSourceSrv, setTemplateSrv } from '@grafana/runtime';
+import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import { CustomVariable, SceneFlexLayout, SceneVariableSet } from '@grafana/scenes';
 
 import { TemplateSrv } from '../../../features/templating/template_srv';
@@ -28,6 +31,23 @@ const datasourceSrv = new DatasourceSrvMock(defaultDS, {
     { data: ['B'], key: 'B' },
   ]),
 });
+
+class RecordingExpressionDatasource extends DataSourceApi {
+  requests: DataQueryRequest[] = [];
+
+  constructor() {
+    super({ name: 'Expression' } as DataSourceInstanceSettings);
+  }
+
+  query(request: DataQueryRequest): Observable<DataQueryResponse> {
+    this.requests.push(request);
+    return of({ data: [] });
+  }
+
+  testDatasource() {
+    return Promise.resolve({ message: '', status: '' });
+  }
+}
 
 describe('MixedDatasource', () => {
   beforeEach(() => {
@@ -189,6 +209,93 @@ describe('MixedDatasource', () => {
         expect(results).toHaveLength(1);
         expect(results[0].data).toEqual(['BBBB']);
       });
+    });
+  });
+
+  describe('with expressions', () => {
+    const multiScene = new SceneFlexLayout({
+      children: [],
+      $variables: new SceneVariableSet({
+        variables: [new CustomVariable({ name: 'ds', value: ['B', 'C'] })],
+      }),
+    });
+
+    let expressionDS: RecordingExpressionDatasource;
+
+    beforeEach(() => {
+      expressionDS = new RecordingExpressionDatasource();
+      setDataSourceSrv({
+        ...datasourceSrv,
+        get: (ref?: DataSourceRef | string) => {
+          const uid = typeof ref === 'string' ? ref : ref?.uid;
+          if (uid === ExpressionDatasourceRef.uid) {
+            return Promise.resolve(expressionDS);
+          }
+          return datasourceSrv.get(ref);
+        },
+        getInstanceSettings: jest.fn().mockReturnValue({ meta: {} }),
+        getList: jest.fn(),
+        reload: jest.fn(),
+        registerRuntimeDataSource: jest.fn(),
+      } as unknown as DataSourceSrv);
+      setTemplateSrv(new TemplateSrv());
+    });
+
+    it('fans the whole query graph out to the expression datasource once per selected datasource', async () => {
+      const ds = new MixedDatasource({} as DataSourceInstanceSettings);
+      const request = {
+        targets: [
+          { refId: 'A', datasource: { uid: '$ds' }, hide: true },
+          { refId: 'B', datasource: ExpressionDatasourceRef, type: 'math', expression: '$A' },
+        ],
+        scopedVars: { __sceneObject: { value: multiScene } },
+      } as unknown as DataQueryRequest;
+
+      await lastValueFrom(ds.query(request));
+
+      // one expression request per selected datasource
+      expect(expressionDS.requests).toHaveLength(2);
+      // each carries the data query AND the expression query
+      for (const req of expressionDS.requests) {
+        expect(req.targets.map((t) => t.refId).sort()).toEqual(['A', 'B']);
+      }
+      // the multi value variable is pinned to a distinct datasource per request
+      expect(expressionDS.requests.map((r) => r.scopedVars?.ds?.value)).toEqual(['B', 'C']);
+    });
+
+    it('emits one namespaced result per selected datasource', async () => {
+      const ds = new MixedDatasource({} as DataSourceInstanceSettings);
+      const request = {
+        targets: [
+          { refId: 'A', datasource: { uid: '$ds' }, hide: true },
+          { refId: 'B', datasource: ExpressionDatasourceRef, type: 'math', expression: '$A' },
+        ],
+        scopedVars: { __sceneObject: { value: multiScene } },
+      } as unknown as DataQueryRequest;
+
+      await expect(ds.query(request)).toEmitValuesWith((results) => {
+        expect(results).toHaveLength(2);
+        expect(results[0].key).toBe('mixed-0-');
+        expect(results[1].key).toBe('mixed-1-');
+        expect(results[1].state).toBe(LoadingState.Done);
+      });
+    });
+
+    it('sends a single expression request when no multi value datasource variable is used', async () => {
+      const ds = new MixedDatasource({} as DataSourceInstanceSettings);
+      const request = {
+        targets: [
+          { refId: 'A', datasource: { uid: 'A' } },
+          { refId: 'C', datasource: { uid: 'C' } },
+          { refId: 'B', datasource: ExpressionDatasourceRef, type: 'math', expression: '$A + $C' },
+        ],
+      } as unknown as DataQueryRequest;
+
+      await lastValueFrom(ds.query(request));
+
+      // expression still gets all of its inputs in a single request (no per-uid split)
+      expect(expressionDS.requests).toHaveLength(1);
+      expect(expressionDS.requests[0].targets.map((t) => t.refId).sort()).toEqual(['A', 'B', 'C']);
     });
   });
 

--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -12,7 +12,8 @@ import {
   LoadingState,
   type ScopedVars,
 } from '@grafana/data';
-import { getDataSourceSrv, getTemplateSrv, toDataQueryError } from '@grafana/runtime';
+import { getDataSourceSrv, getTemplateSrv, isExpressionReference, toDataQueryError } from '@grafana/runtime';
+import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import { type CustomFormatterVariable } from '@grafana/scenes';
 
 import { SHARED_DASHBOARD_QUERY } from '../dashboard/constants';
@@ -42,6 +43,18 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
 
     if (!queries.length) {
       return of({ data: [] }); // nothing
+    }
+
+    // When a server-side expression is involved the whole query graph must stay in a single request
+    // (the expression references the other queries by refId). So instead of grouping by datasource we
+    // replicate the entire target set once per selected value of a multi-value datasource variable and
+    // route each replica through the expression datasource.
+    if (queries.some((t) => isExpressionReference(t.datasource))) {
+      const batches = this.getExpressionBatches(queries, request);
+      if (!batches.length) {
+        return of({ data: [] });
+      }
+      return this.batchQueries(batches, request);
     }
 
     // Build groups of queries to run in parallel
@@ -119,6 +132,76 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
     }
 
     return batches;
+  }
+
+  /**
+   * Builds the batches for a request that contains a server-side expression. Every batch keeps the
+   * complete target set (data queries + expressions) and is routed to the expression datasource.
+   * When a data query uses a multi-value datasource variable we produce one batch per selected value,
+   * pinning that value in scopedVars so each replica queries a single datasource — matching the
+   * fan-out behaviour of direct queries.
+   */
+  private getExpressionBatches(queries: DataQuery[], request: DataQueryRequest<DataQuery>): BatchedQueries[] {
+    const expressionDatasource = getDataSourceSrv().get(ExpressionDatasourceRef);
+    const multiValue = this.findMultiValueDatasourceVariable(queries, request);
+
+    if (!multiValue) {
+      return [
+        {
+          datasource: expressionDatasource,
+          queries: cloneDeep(queries),
+          scopedVars: { ...request.scopedVars },
+        },
+      ];
+    }
+
+    return multiValue.uids.map((uid) => ({
+      datasource: expressionDatasource,
+      queries: cloneDeep(queries),
+      scopedVars: {
+        ...request.scopedVars,
+        [multiValue.variableName]: { value: uid, text: getDataSourceSrv().getInstanceSettings(uid)?.name },
+      },
+    }));
+  }
+
+  /**
+   * Finds the first data query whose datasource is a multi-value template variable and returns the
+   * variable name together with the selected datasource UIDs. Reuses the templateSrv custom formatter
+   * trick to read the raw variable value. Returns undefined when no multi-value datasource variable is
+   * used (single value or a fixed datasource).
+   */
+  private findMultiValueDatasourceVariable(
+    queries: DataQuery[],
+    request: DataQueryRequest<DataQuery>
+  ): { variableName: string; uids: string[] } | undefined {
+    for (const query of queries) {
+      const dsUid = query.datasource?.uid;
+      if (!dsUid || isExpressionReference(query.datasource)) {
+        continue;
+      }
+
+      let found: { variableName: string; uids: string[] } | undefined;
+      getTemplateSrv().replace(
+        dsUid,
+        request.scopedVars,
+        (value: string | string[], variable: CustomFormatterVariable) => {
+          if (Array.isArray(value)) {
+            const uids = value.filter((uid) => uid !== 'default');
+            if (uids.length > 0) {
+              found = { variableName: variable.name, uids };
+            }
+          }
+          return '';
+        }
+      );
+
+      if (found) {
+        return found;
+      }
+    }
+
+    return undefined;
   }
 
   batchQueries(mixed: BatchedQueries[], request: DataQueryRequest<DataQuery>): Observable<DataQueryResponse> {

--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -50,7 +50,29 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
     // replicate the entire target set once per selected value of a multi-value datasource variable and
     // route each replica through the expression datasource.
     if (queries.some((t) => isExpressionReference(t.datasource))) {
-      const batches = this.getExpressionBatches(queries, request);
+      const multiValue = this.findMultiValueDatasourceVariable(queries, request);
+
+      // We can only correctly fan an expression out when every data query uses the same multi-value
+      // datasource variable. If the variable is mixed with other datasources we would replicate the
+      // unrelated queries/expressions once per selected datasource and emit duplicate results, so fail
+      // with a clear message instead. See the getExpressionBatches doc comment for the limitation.
+      if (multiValue) {
+        const dataSourceUids = new Set(
+          queries.filter((t) => !isExpressionReference(t.datasource)).map((t) => t.datasource?.uid)
+        );
+        if (dataSourceUids.size > 1) {
+          return of({
+            data: [],
+            state: LoadingState.Error,
+            error: {
+              message:
+                'Combining a multi-value datasource variable with other datasources in a server-side expression is not supported. Use the same datasource variable for every query, or split the queries into separate panels.',
+            },
+          });
+        }
+      }
+
+      const batches = this.getExpressionBatches(queries, request, multiValue);
       if (!batches.length) {
         return of({ data: [] });
       }
@@ -140,10 +162,17 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
    * When a data query uses a multi-value datasource variable we produce one batch per selected value,
    * pinning that value in scopedVars so each replica queries a single datasource — matching the
    * fan-out behaviour of direct queries.
+   *
+   * Limitation: because the whole target set is replicated, this only supports a single multi-value
+   * datasource variable shared by every data query. Mixing that variable with other datasources in the
+   * same expression graph would duplicate the unrelated targets, so the caller rejects that shape.
    */
-  private getExpressionBatches(queries: DataQuery[], request: DataQueryRequest<DataQuery>): BatchedQueries[] {
+  private getExpressionBatches(
+    queries: DataQuery[],
+    request: DataQueryRequest<DataQuery>,
+    multiValue: { variableName: string; uids: string[] } | undefined
+  ): BatchedQueries[] {
     const expressionDatasource = getDataSourceSrv().get(ExpressionDatasourceRef);
-    const multiValue = this.findMultiValueDatasourceVariable(queries, request);
 
     if (!multiValue) {
       return [


### PR DESCRIPTION
**What is this feature?**

When a dashboard query uses a multi-value datasource variable (e.g. 3 Prometheus datasources selected at once), Grafana normally "fans out" and runs that query once per selected datasource — but this fan-out only lives inside the Mixed datasource. The problem is that whenever a query feeds a server-side expression (Math, Reduce, etc.), Grafana short-circuits the entire request straight to the expression datasource, bypassing the Mixed datasource entirely. With the fan-out skipped, the multi-value variable collapses to just its first value, so only the first datasource ever gets queried. That's why the expression panel showed one result instead of three, and why reordering the selection changed the answer (and downstream math like "Cost per GB") by an order of magnitude. The fix routes expression requests through the Mixed datasource too, replicating the whole query-plus-expression graph once per selected datasource so all of them are queried.

See open issue for repo steps along with a sample dashboard to import to see this issue in action (just create 3 prometheus datasources in a local instance, then import dashboard, you'll see the bug)

**Why do we need this feature?**

Because server side expressions should work for "mixed datasource" templates 

**Who is this feature for?**

Grafana Dashboard users who rely on data source variables and server side expressions

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/127694

**Special notes for your reviewer:**

I believe that this is a bug and that this pr fixes it but this bug is long standing I believe and might cause breaking changes? I can't really imagine why you'd want the bug behavior but this isn't something I'm terribly familiar with so let me know if you think it's not a good idea. My only other thought is we could wrap this in some kind of feature flag or config setting that we enable by default and then remove assuming there are no other unforeseen issues here. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
