### PR TITLE
Chore: Add unit tests for geomap and geo location utils

### DIFF
--- a/public/app/features/geo/utils/location.test.ts
+++ b/public/app/features/geo/utils/location.test.ts
@@ -4,7 +4,13 @@ import { toLonLat } from 'ol/proj';
 import { toDataFrame, FieldType } from '@grafana/data';
 import { FrameGeometrySourceMode } from '@grafana/schema';
 
-import { getGeometryField, getLocationFields, getLocationMatchers } from './location';
+import {
+  getDefaultLocationMatchers,
+  getGeometryField,
+  getLocationFields,
+  getLocationMatchers,
+  type LocationFieldMatchers,
+} from './location';
 
 const longitude = [0, -74.1];
 const latitude = [0, 40.7];
@@ -175,5 +181,160 @@ describe('handle location parsing', () => {
     });
     const geo = getGeometryField(frame, matchers).field!;
     expect(geo.values.map((p) => toLonLat((p as Point).getCoordinates()))).toEqual(EXPECTED_WGS84_FROM_GEOHASH_FIELDS);
+  });
+});
+
+describe('getDefaultLocationMatchers', () => {
+  it('runs synchronously with Auto mode and working field finders', () => {
+    const matchers = getDefaultLocationMatchers();
+    expect(matchers.mode).toBe(FrameGeometrySourceMode.Auto);
+
+    const frame = toDataFrame({
+      fields: [
+        { name: 'lat', type: FieldType.number, values: latitude },
+        { name: 'lng', type: FieldType.number, values: longitude },
+      ],
+    });
+    expect(matchers.latitude(frame)?.name).toBe('lat');
+    expect(matchers.longitude(frame)?.name).toBe('lng');
+    expect(matchers.gazetteer).toBeUndefined();
+  });
+});
+
+describe('getLocationMatchers manual modes', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue(geojsonObject),
+    } as unknown as Response);
+  });
+
+  const geohashFrame = toDataFrame({ fields: [{ name: 'gh', type: FieldType.string, values: ['9q94r'] }] });
+  const coordsFrame = toDataFrame({
+    fields: [
+      { name: 'myLat', type: FieldType.number, values: [1] },
+      { name: 'myLon', type: FieldType.number, values: [2] },
+    ],
+  });
+  const lookupFrame = toDataFrame({ fields: [{ name: 'country', type: FieldType.string, values: ['USA'] }] });
+
+  it('resolves gazetteer for every mode', async () => {
+    const matchers = await getLocationMatchers({ mode: FrameGeometrySourceMode.Lookup });
+    expect(matchers.gazetteer).toBeDefined();
+  });
+
+  it('Geohash mode uses the named field, or finds nothing when unset', async () => {
+    const named = await getLocationMatchers({ mode: FrameGeometrySourceMode.Geohash, geohash: 'gh' });
+    expect(named.geohash(geohashFrame)?.name).toBe('gh');
+
+    const unset = await getLocationMatchers({ mode: FrameGeometrySourceMode.Geohash });
+    expect(unset.geohash(geohashFrame)).toBeUndefined();
+  });
+
+  it('Coords mode uses the named fields, or finds nothing when unset', async () => {
+    const named = await getLocationMatchers({
+      mode: FrameGeometrySourceMode.Coords,
+      latitude: 'myLat',
+      longitude: 'myLon',
+    });
+    expect(named.latitude(coordsFrame)?.name).toBe('myLat');
+    expect(named.longitude(coordsFrame)?.name).toBe('myLon');
+
+    const unset = await getLocationMatchers({ mode: FrameGeometrySourceMode.Coords });
+    expect(unset.latitude(coordsFrame)).toBeUndefined();
+    expect(unset.longitude(coordsFrame)).toBeUndefined();
+  });
+
+  it('Lookup mode uses the named field, falling back to the first string field', async () => {
+    const named = await getLocationMatchers({ mode: FrameGeometrySourceMode.Lookup, lookup: 'country' });
+    expect(named.lookup(lookupFrame)?.name).toBe('country');
+
+    const byType = await getLocationMatchers({ mode: FrameGeometrySourceMode.Lookup });
+    expect(byType.lookup(lookupFrame)?.name).toBe('country');
+  });
+});
+
+describe('getLocationFields explicit modes', () => {
+  it('resolves fields for explicit Coords mode', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'lat', type: FieldType.number, values: latitude },
+        { name: 'lng', type: FieldType.number, values: longitude },
+      ],
+    });
+    const matchers: LocationFieldMatchers = { ...getDefaultLocationMatchers(), mode: FrameGeometrySourceMode.Coords };
+    const fields = getLocationFields(frame, matchers);
+    expect(fields.mode).toBe(FrameGeometrySourceMode.Coords);
+    expect(fields.latitude?.name).toBe('lat');
+    expect(fields.longitude?.name).toBe('lng');
+  });
+
+  it('returns empty mappings when Auto mode matches nothing', () => {
+    const frame = toDataFrame({ fields: [{ name: 'value', type: FieldType.number, values: [1] }] });
+    const fields = getLocationFields(frame, getDefaultLocationMatchers());
+    expect(fields.mode).toBe(FrameGeometrySourceMode.Auto);
+    expect(fields.geo).toBeUndefined();
+    expect(fields.latitude).toBeUndefined();
+    expect(fields.geohash).toBeUndefined();
+    expect(fields.lookup).toBeUndefined();
+  });
+});
+
+describe('getGeometryField warnings', () => {
+  const emptyFrame = toDataFrame({ fields: [{ name: 'value', type: FieldType.number, values: [1] }] });
+  const stringFrame = toDataFrame({ fields: [{ name: 'lookup', type: FieldType.string, values: ['USA'] }] });
+
+  it('warns when Auto mode cannot find any location fields', () => {
+    const result = getGeometryField(emptyFrame, getDefaultLocationMatchers());
+    expect(result.field).toBeUndefined();
+    expect(result.warning).toBe('Unable to find location fields');
+  });
+
+  it('warns when Coords mode is missing latitude/longitude', () => {
+    const matchers: LocationFieldMatchers = {
+      ...getDefaultLocationMatchers(),
+      mode: FrameGeometrySourceMode.Coords,
+      latitude: () => undefined,
+      longitude: () => undefined,
+    };
+    const result = getGeometryField(emptyFrame, matchers);
+    expect(result.field).toBeUndefined();
+    expect(result.warning).toBe('Select latitude/longitude fields');
+  });
+
+  it('warns when Geohash mode is missing a geohash field', () => {
+    const matchers: LocationFieldMatchers = {
+      ...getDefaultLocationMatchers(),
+      mode: FrameGeometrySourceMode.Geohash,
+      geohash: () => undefined,
+    };
+    const result = getGeometryField(emptyFrame, matchers);
+    expect(result.field).toBeUndefined();
+    expect(result.warning).toBe('Select geohash field');
+  });
+
+  it('warns when a lookup field is present but no gazetteer is configured', () => {
+    const matchers: LocationFieldMatchers = {
+      ...getDefaultLocationMatchers(),
+      mode: FrameGeometrySourceMode.Lookup,
+      lookup: (frame) => frame.fields[0],
+      gazetteer: undefined,
+    };
+    const result = getGeometryField(stringFrame, matchers);
+    expect(result.field).toBeUndefined();
+    expect(result.warning).toBe('Gazetteer not found');
+  });
+
+  it('warns when Lookup mode is missing a lookup field', () => {
+    const matchers: LocationFieldMatchers = {
+      ...getDefaultLocationMatchers(),
+      mode: FrameGeometrySourceMode.Lookup,
+      lookup: () => undefined,
+    };
+    const result = getGeometryField(emptyFrame, matchers);
+    expect(result.field).toBeUndefined();
+    expect(result.warning).toBe('Select lookup field');
   });
 });

--- a/public/app/plugins/panel/geomap/utils/actions.test.ts
+++ b/public/app/plugins/panel/geomap/utils/actions.test.ts
@@ -22,8 +22,8 @@ jest.mock('./utils', () => ({
   getNextLayerName: jest.fn(() => 'Layer 1'),
 }));
 
-const getIfExists = geomapLayerRegistry.getIfExists as jest.Mock;
-const initLayerMock = initLayer as jest.Mock;
+const getIfExists = jest.mocked(geomapLayerRegistry.getIfExists);
+const initLayerMock = jest.mocked(initLayer);
 
 const flush = () => new Promise((resolve) => setTimeout(resolve));
 
@@ -118,6 +118,8 @@ describe('getActions', () => {
       const newLayer = layerState('Layer 1');
       getIfExists.mockReturnValue({
         id: 'markers',
+        name: 'Markers',
+        create: jest.fn(),
         defaultOptions: { foo: 'bar' },
         showLocation: true,
         hideOpacity: false,
@@ -151,6 +153,8 @@ describe('getActions', () => {
       const { panel } = createPanel();
       getIfExists.mockReturnValue({
         id: 'basemap',
+        name: 'Basemap',
+        create: jest.fn(),
         defaultOptions: {},
         showLocation: false,
         hideOpacity: true,

--- a/public/app/plugins/panel/geomap/utils/actions.test.ts
+++ b/public/app/plugins/panel/geomap/utils/actions.test.ts
@@ -1,0 +1,181 @@
+import { FrameGeometrySourceMode } from '@grafana/schema';
+
+import { type GeomapPanel } from '../GeomapPanel';
+import { geomapLayerRegistry } from '../layers/registry';
+import { defaultStyleConfig } from '../style/types';
+import { type MapLayerState } from '../types';
+
+import { getActions } from './actions';
+import { initLayer } from './layers';
+
+jest.mock('../layers/registry', () => ({
+  geomapLayerRegistry: {
+    getIfExists: jest.fn(),
+  },
+}));
+
+jest.mock('./layers', () => ({
+  initLayer: jest.fn(),
+}));
+
+jest.mock('./utils', () => ({
+  getNextLayerName: jest.fn(() => 'Layer 1'),
+}));
+
+const getIfExists = geomapLayerRegistry.getIfExists as jest.Mock;
+const initLayerMock = initLayer as jest.Mock;
+
+const flush = () => new Promise((resolve) => setTimeout(resolve));
+
+function layerState(name: string): MapLayerState {
+  return {
+    options: { name, type: 'markers' } as MapLayerState['options'],
+    layer: { name } as unknown as MapLayerState['layer'],
+    handler: {} as MapLayerState['handler'],
+    onChange: jest.fn(),
+    mouseEvents: {} as MapLayerState['mouseEvents'],
+    getName: () => name,
+  };
+}
+
+function createPanel(overrides: Partial<GeomapPanel> = {}) {
+  const group = {
+    clear: jest.fn(),
+    push: jest.fn(),
+  };
+  const map = {
+    removeLayer: jest.fn(),
+    addLayer: jest.fn(),
+    getLayers: jest.fn(() => group),
+  };
+  const panel = {
+    layers: [layerState('a'), layerState('b')],
+    byName: new Map<string, MapLayerState>(),
+    map,
+    doOptionsUpdate: jest.fn(),
+    panelContext: { onInstanceStateChange: jest.fn() },
+    actions: {},
+    ...overrides,
+  } as unknown as GeomapPanel;
+  return { panel, map, group };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getActions', () => {
+  describe('selectLayer', () => {
+    it('reports the selected index through the panel context', () => {
+      const { panel } = createPanel();
+      getActions(panel).selectLayer('b');
+      expect(panel.panelContext!.onInstanceStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({ selected: 1, map: panel.map, layers: panel.layers })
+      );
+    });
+
+    it('does nothing when there is no panel context', () => {
+      const { panel } = createPanel({ panelContext: undefined });
+      expect(() => getActions(panel).selectLayer('b')).not.toThrow();
+    });
+  });
+
+  describe('canRename', () => {
+    it('is false when the name is already taken', () => {
+      const { panel } = createPanel();
+      panel.byName.set('taken', layerState('taken'));
+      const actions = getActions(panel);
+      expect(actions.canRename('taken')).toBe(false);
+      expect(actions.canRename('free')).toBe(true);
+    });
+  });
+
+  describe('deleteLayer', () => {
+    it('removes the matching layer from the map and state', () => {
+      const { panel, map } = createPanel();
+      const removed = panel.layers[0];
+      getActions(panel).deleteLayer('a');
+
+      expect(map.removeLayer).toHaveBeenCalledWith(removed.layer);
+      expect(panel.layers).toHaveLength(1);
+      expect(panel.layers[0].getName()).toBe('b');
+      expect(panel.doOptionsUpdate).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('addlayer', () => {
+    it('ignores unknown layer types', () => {
+      const { panel } = createPanel();
+      getIfExists.mockReturnValue(undefined);
+
+      getActions(panel).addlayer('does-not-exist');
+
+      expect(initLayerMock).not.toHaveBeenCalled();
+    });
+
+    it('initializes and appends a known layer type', async () => {
+      const { panel, map } = createPanel();
+      const newLayer = layerState('Layer 1');
+      getIfExists.mockReturnValue({
+        id: 'markers',
+        defaultOptions: { foo: 'bar' },
+        showLocation: true,
+        hideOpacity: false,
+      });
+      initLayerMock.mockResolvedValue(newLayer);
+
+      getActions(panel).addlayer('markers');
+
+      expect(initLayerMock).toHaveBeenCalledWith(
+        panel,
+        panel.map,
+        expect.objectContaining({
+          type: 'markers',
+          name: 'Layer 1',
+          config: { foo: 'bar' },
+          location: { mode: FrameGeometrySourceMode.Auto },
+          tooltip: true,
+          opacity: defaultStyleConfig.opacity,
+        }),
+        false
+      );
+
+      await flush();
+
+      expect(panel.layers).toContain(newLayer);
+      expect(map.addLayer).toHaveBeenCalledWith(newLayer.layer);
+      expect(panel.doOptionsUpdate).toHaveBeenLastCalledWith(panel.layers.length - 1);
+    });
+
+    it('omits opacity and location when the layer type opts out', async () => {
+      const { panel } = createPanel();
+      getIfExists.mockReturnValue({
+        id: 'basemap',
+        defaultOptions: {},
+        showLocation: false,
+        hideOpacity: true,
+      });
+      initLayerMock.mockResolvedValue(layerState('Layer 1'));
+
+      getActions(panel).addlayer('basemap');
+
+      const options = initLayerMock.mock.calls[0][2];
+      expect(options.location).toBeUndefined();
+      expect(options.opacity).toBeUndefined();
+    });
+  });
+
+  describe('reorder', () => {
+    it('moves a layer and rebuilds the map layer group in order', () => {
+      const { panel, group } = createPanel();
+      getActions(panel).reorder(0, 1);
+
+      expect(panel.layers.map((l) => l.getName())).toEqual(['b', 'a']);
+      expect(group.clear).toHaveBeenCalled();
+      expect(group.push).toHaveBeenCalledTimes(2);
+      expect(group.push).toHaveBeenNthCalledWith(1, panel.layers[0].layer);
+      expect(group.push).toHaveBeenNthCalledWith(2, panel.layers[1].layer);
+      expect(panel.doOptionsUpdate).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/public/app/plugins/panel/geomap/utils/layers.test.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.test.ts
@@ -1,6 +1,13 @@
 jest.mock('ol-mapbox-style', () => ({}));
 jest.mock('geotiff', () => ({}));
 
+jest.mock('../layers/registry', () => ({
+  DEFAULT_BASEMAP_CONFIG: { type: 'default-basemap', name: 'default' },
+  geomapLayerRegistry: { getIfExists: jest.fn() },
+}));
+jest.mock('../layers/data/markersLayer', () => ({ MARKERS_LAYER_ID: 'markers' }));
+jest.mock('./utils', () => ({ getNextLayerName: jest.fn(() => 'Layer 1') }));
+
 import type BaseLayer from 'ol/layer/Base';
 
 import {
@@ -11,10 +18,18 @@ import {
   type MapLayerHandler,
   type MapLayerOptions,
   type PanelData,
+  textUtil,
   type TimeRange,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
-import { applyLayerFilter } from './layers';
+import { type GeomapPanel } from '../GeomapPanel';
+import { geomapLayerRegistry } from '../layers/registry';
+import { type MapLayerState } from '../types';
+
+import { applyLayerFilter, getMapLayerState, initLayer } from './layers';
+
+const getIfExists = geomapLayerRegistry.getIfExists as jest.Mock;
 
 describe('applyLayerFilter', () => {
   const createDataFrame = (refId: string): DataFrame => ({
@@ -119,5 +134,113 @@ describe('applyLayerFilter', () => {
     applyLayerFilter(handler, options, panelData);
 
     expect(update).toHaveBeenCalledWith(panelData);
+  });
+});
+
+describe('initLayer', () => {
+  const makeLayer = () => ({ setOpacity: jest.fn() }) as unknown as BaseLayer;
+
+  const makeHandler = (layer: BaseLayer) =>
+    ({
+      init: () => layer,
+      update: jest.fn(),
+      dispose: jest.fn(),
+    }) as unknown as MapLayerHandler;
+
+  const createPanel = () =>
+    ({
+      map: {},
+      byName: new Map<string, MapLayerState>(),
+      props: { eventBus: {}, data: {} },
+    }) as unknown as GeomapPanel;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects unknown layer types', async () => {
+    getIfExists.mockReturnValue(undefined);
+    await expect(initLayer(createPanel(), {} as never, { type: 'bogus' } as MapLayerOptions, false)).rejects.toBe(
+      'unknown layer: bogus'
+    );
+  });
+
+  it('builds and registers the layer state, and applies opacity', async () => {
+    const panel = createPanel();
+    const layer = makeLayer();
+    const create = jest.fn().mockResolvedValue(makeHandler(layer));
+    getIfExists.mockReturnValue({ id: 'markers', create });
+
+    const state = await initLayer(panel, {} as never, { type: 'markers', name: 'My layer', opacity: 0.5 }, false);
+
+    expect(state.options.name).toBe('My layer');
+    expect(state.getName()).toBe('My layer');
+    expect(state.isBasemap).toBe(false);
+    expect(layer.setOpacity).toHaveBeenCalledWith(0.5);
+    expect(panel.byName.get('My layer')).toBe(state);
+    expect(getMapLayerState(layer)).toBe(state);
+  });
+
+  it('names the layer via getNextLayerName when unnamed', async () => {
+    const panel = createPanel();
+    getIfExists.mockReturnValue({ id: 'markers', create: jest.fn().mockResolvedValue(makeHandler(makeLayer())) });
+
+    const state = await initLayer(panel, {} as never, { type: 'markers' } as MapLayerOptions, false);
+
+    expect(state.options.name).toBe('Layer 1');
+  });
+
+  it('sanitizes the attribution config', async () => {
+    const spy = jest.spyOn(textUtil, 'sanitizeTextPanelContent').mockReturnValue('SANITIZED');
+    const panel = createPanel();
+    getIfExists.mockReturnValue({ id: 'markers', create: jest.fn().mockResolvedValue(makeHandler(makeLayer())) });
+
+    const state = await initLayer(
+      panel,
+      {} as never,
+      {
+        type: 'markers',
+        name: 'x',
+        config: { attribution: '<script>alert(1)</script>' },
+      } as MapLayerOptions
+    );
+
+    expect(spy).toHaveBeenCalledWith('<script>alert(1)</script>');
+    expect((state.options.config as { attribution?: string })?.attribution).toBe('SANITIZED');
+    spy.mockRestore();
+  });
+
+  it('falls back to the markers layer when no type is provided', async () => {
+    const panel = createPanel();
+    getIfExists.mockReturnValue({ id: 'markers', create: jest.fn().mockResolvedValue(makeHandler(makeLayer())) });
+
+    await initLayer(panel, {} as never, {} as MapLayerOptions, false);
+
+    expect(getIfExists).toHaveBeenCalledWith('markers');
+  });
+
+  it('forces the default basemap config when custom base layers are disabled', async () => {
+    const original = config.geomapDisableCustomBaseLayer;
+    config.geomapDisableCustomBaseLayer = true;
+    const panel = createPanel();
+    getIfExists.mockReturnValue({
+      id: 'default-basemap',
+      create: jest.fn().mockResolvedValue(makeHandler(makeLayer())),
+    });
+
+    await initLayer(panel, {} as never, { type: 'markers', name: 'x' }, true);
+
+    expect(getIfExists).toHaveBeenCalledWith('default-basemap');
+    config.geomapDisableCustomBaseLayer = original;
+  });
+});
+
+describe('getMapLayerState', () => {
+  it('returns undefined for an undefined layer', () => {
+    expect(getMapLayerState(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for a layer that was never registered', () => {
+    expect(getMapLayerState({} as BaseLayer)).toBeUndefined();
   });
 });

--- a/public/app/plugins/panel/geomap/utils/layers.test.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.test.ts
@@ -1,12 +1,7 @@
+// ol-mapbox-style and geotiff fail to parse under jest; stub them so the real
+// layer registry (and everything it transitively imports) can still load.
 jest.mock('ol-mapbox-style', () => ({}));
 jest.mock('geotiff', () => ({}));
-
-jest.mock('../layers/registry', () => ({
-  DEFAULT_BASEMAP_CONFIG: { type: 'default', name: '', config: {} },
-  geomapLayerRegistry: { getIfExists: jest.fn() },
-}));
-jest.mock('../layers/data/markersLayer', () => ({ MARKERS_LAYER_ID: 'markers' }));
-jest.mock('./utils', () => ({ getNextLayerName: jest.fn(() => 'Layer 1') }));
 
 import type BaseLayer from 'ol/layer/Base';
 
@@ -24,12 +19,13 @@ import {
 import { config } from '@grafana/runtime';
 
 import { type GeomapPanel } from '../GeomapPanel';
-import { geomapLayerRegistry } from '../layers/registry';
+import { MARKERS_LAYER_ID } from '../layers/data/markersLayer';
+import { DEFAULT_BASEMAP_CONFIG, geomapLayerRegistry } from '../layers/registry';
 import { type MapLayerState } from '../types';
 
 import { applyLayerFilter, getMapLayerState, initLayer } from './layers';
 
-const getIfExists = jest.mocked(geomapLayerRegistry.getIfExists);
+const getIfExists = jest.spyOn(geomapLayerRegistry, 'getIfExists');
 
 describe('applyLayerFilter', () => {
   const createDataFrame = (refId: string): DataFrame => ({
@@ -150,6 +146,7 @@ describe('initLayer', () => {
   const createPanel = () =>
     ({
       map: {},
+      layers: [],
       byName: new Map<string, MapLayerState>(),
       props: { eventBus: {}, data: {} },
     }) as unknown as GeomapPanel;
@@ -191,7 +188,8 @@ describe('initLayer', () => {
 
     const state = await initLayer(panel, {} as never, { type: 'markers' } as MapLayerOptions, false);
 
-    expect(state.options.name).toBe('Layer 1');
+    // Real getNextLayerName derives the name from the (empty) layer list.
+    expect(state.options.name).toMatch(/^Layer/);
   });
 
   it('sanitizes the attribution config', async () => {
@@ -221,14 +219,14 @@ describe('initLayer', () => {
   it('falls back to the markers layer when no type is provided', async () => {
     const panel = createPanel();
     getIfExists.mockReturnValue({
-      id: 'markers',
+      id: MARKERS_LAYER_ID,
       name: 'Markers',
       create: jest.fn().mockResolvedValue(makeHandler(makeLayer())),
     });
 
     await initLayer(panel, {} as never, {} as MapLayerOptions, false);
 
-    expect(getIfExists).toHaveBeenCalledWith('markers');
+    expect(getIfExists).toHaveBeenCalledWith(MARKERS_LAYER_ID);
   });
 
   it('forces the default basemap config when custom base layers are disabled', async () => {
@@ -236,14 +234,14 @@ describe('initLayer', () => {
     config.geomapDisableCustomBaseLayer = true;
     const panel = createPanel();
     getIfExists.mockReturnValue({
-      id: 'default',
+      id: DEFAULT_BASEMAP_CONFIG.type,
       name: 'Default base layer',
       create: jest.fn().mockResolvedValue(makeHandler(makeLayer())),
     });
 
     await initLayer(panel, {} as never, { type: 'markers', name: 'x' }, true);
 
-    expect(getIfExists).toHaveBeenCalledWith('default');
+    expect(getIfExists).toHaveBeenCalledWith(DEFAULT_BASEMAP_CONFIG.type);
     config.geomapDisableCustomBaseLayer = original;
   });
 });

--- a/public/app/plugins/panel/geomap/utils/layers.test.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.test.ts
@@ -29,7 +29,7 @@ import { type MapLayerState } from '../types';
 
 import { applyLayerFilter, getMapLayerState, initLayer } from './layers';
 
-const getIfExists = geomapLayerRegistry.getIfExists as jest.Mock;
+const getIfExists = jest.mocked(geomapLayerRegistry.getIfExists);
 
 describe('applyLayerFilter', () => {
   const createDataFrame = (refId: string): DataFrame => ({
@@ -169,7 +169,7 @@ describe('initLayer', () => {
     const panel = createPanel();
     const layer = makeLayer();
     const create = jest.fn().mockResolvedValue(makeHandler(layer));
-    getIfExists.mockReturnValue({ id: 'markers', create });
+    getIfExists.mockReturnValue({ id: 'markers', name: 'Markers', create });
 
     const state = await initLayer(panel, {} as never, { type: 'markers', name: 'My layer', opacity: 0.5 }, false);
 
@@ -183,7 +183,11 @@ describe('initLayer', () => {
 
   it('names the layer via getNextLayerName when unnamed', async () => {
     const panel = createPanel();
-    getIfExists.mockReturnValue({ id: 'markers', create: jest.fn().mockResolvedValue(makeHandler(makeLayer())) });
+    getIfExists.mockReturnValue({
+      id: 'markers',
+      name: 'Markers',
+      create: jest.fn().mockResolvedValue(makeHandler(makeLayer())),
+    });
 
     const state = await initLayer(panel, {} as never, { type: 'markers' } as MapLayerOptions, false);
 
@@ -193,7 +197,11 @@ describe('initLayer', () => {
   it('sanitizes the attribution config', async () => {
     const spy = jest.spyOn(textUtil, 'sanitizeTextPanelContent').mockReturnValue('SANITIZED');
     const panel = createPanel();
-    getIfExists.mockReturnValue({ id: 'markers', create: jest.fn().mockResolvedValue(makeHandler(makeLayer())) });
+    getIfExists.mockReturnValue({
+      id: 'markers',
+      name: 'Markers',
+      create: jest.fn().mockResolvedValue(makeHandler(makeLayer())),
+    });
 
     const state = await initLayer(
       panel,
@@ -212,7 +220,11 @@ describe('initLayer', () => {
 
   it('falls back to the markers layer when no type is provided', async () => {
     const panel = createPanel();
-    getIfExists.mockReturnValue({ id: 'markers', create: jest.fn().mockResolvedValue(makeHandler(makeLayer())) });
+    getIfExists.mockReturnValue({
+      id: 'markers',
+      name: 'Markers',
+      create: jest.fn().mockResolvedValue(makeHandler(makeLayer())),
+    });
 
     await initLayer(panel, {} as never, {} as MapLayerOptions, false);
 
@@ -225,6 +237,7 @@ describe('initLayer', () => {
     const panel = createPanel();
     getIfExists.mockReturnValue({
       id: 'default',
+      name: 'Default base layer',
       create: jest.fn().mockResolvedValue(makeHandler(makeLayer())),
     });
 

--- a/public/app/plugins/panel/geomap/utils/layers.test.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.test.ts
@@ -2,7 +2,7 @@ jest.mock('ol-mapbox-style', () => ({}));
 jest.mock('geotiff', () => ({}));
 
 jest.mock('../layers/registry', () => ({
-  DEFAULT_BASEMAP_CONFIG: { type: 'default-basemap', name: 'default' },
+  DEFAULT_BASEMAP_CONFIG: { type: 'default', name: '', config: {} },
   geomapLayerRegistry: { getIfExists: jest.fn() },
 }));
 jest.mock('../layers/data/markersLayer', () => ({ MARKERS_LAYER_ID: 'markers' }));
@@ -224,13 +224,13 @@ describe('initLayer', () => {
     config.geomapDisableCustomBaseLayer = true;
     const panel = createPanel();
     getIfExists.mockReturnValue({
-      id: 'default-basemap',
+      id: 'default',
       create: jest.fn().mockResolvedValue(makeHandler(makeLayer())),
     });
 
     await initLayer(panel, {} as never, { type: 'markers', name: 'x' }, true);
 
-    expect(getIfExists).toHaveBeenCalledWith('default-basemap');
+    expect(getIfExists).toHaveBeenCalledWith('default');
     config.geomapDisableCustomBaseLayer = original;
   });
 });


### PR DESCRIPTION
## What

Adds unit test coverage for three previously under-tested `@grafana/dataviz-squad` utility modules. Test-only change — no production code modified.

| Module | Statements before | after |
| --- | --- | --- |
| `public/app/plugins/panel/geomap/utils/actions.ts` | 0% | **100%** |
| `public/app/features/geo/utils/location.ts` | ~56% | **~93%** |
| `public/app/plugins/panel/geomap/utils/layers.ts` | ~27% | **~55%** |

## Why

Raising `@grafana/dataviz-squad` statement coverage toward the 80% target. These modules were flagged as high-ROI, pure-logic gaps (no map/DOM rendering required to exercise them).

## Details

- **`actions.test.ts`** (new): covers `getActions` — `selectLayer`, `canRename`, `deleteLayer`, `addlayer` (known/unknown type + opacity/location opt-out), and `reorder`.
- **`location.test.ts`** (extended): adds `getDefaultLocationMatchers`, the manual-mode branches of `getLocationMatchers` (Geohash/Coords/Lookup with and without named fields), explicit-mode `getLocationFields`, and every `getGeometryField` warning path.
- **`layers.test.ts`** (extended): adds `initLayer` (unknown-type rejection, state construction, opacity, auto-naming, attribution sanitization, default-markers fallback, basemap-disable) and `getMapLayerState`. The unexported `updateLayer` remains uncovered — it is only reachable via a layer's `onChange` callback and needs a much heavier `GeomapPanel` mock, so it was intentionally left.

## Testing

`yarn jest` — 38 tests pass across the three files. ESLint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)