### PR TITLE
`TagsInput`: Add configurable maxLength prop

### DIFF
--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.test.tsx
@@ -24,7 +24,7 @@ describe('TagsInput', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('does NOT add a tag that exceeds the default max length of 50 characters', async () => {
+  it('caps typed input at the default max length of 50 characters', async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
     render(<TagsInput onChange={onChange} tags={[]} />);
@@ -32,8 +32,7 @@ describe('TagsInput', () => {
     await user.type(screen.getByRole('textbox'), 'a'.repeat(51));
     await user.keyboard('{Enter}');
 
-    expect(onChange).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: /Tag too long, max 50 characters/i })).toBeDisabled();
+    expect(onChange).toHaveBeenCalledWith(['a'.repeat(50)]);
   });
 
   it('adds a tag longer than 50 characters when a larger maxLength is provided', async () => {

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.test.tsx
@@ -23,4 +23,28 @@ describe('TagsInput', () => {
 
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('does NOT add a tag that exceeds the default max length of 50 characters', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<TagsInput onChange={onChange} tags={[]} />);
+
+    await user.type(screen.getByRole('textbox'), 'a'.repeat(51));
+    await user.keyboard('{Enter}');
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /Tag too long, max 50 characters/i })).toBeDisabled();
+  });
+
+  it('adds a tag longer than 50 characters when a larger maxLength is provided', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const longTag = 'a'.repeat(80);
+    render(<TagsInput onChange={onChange} tags={[]} maxLength={100} />);
+
+    await user.type(screen.getByRole('textbox'), longTag);
+    await user.keyboard('{Enter}');
+
+    expect(onChange).toHaveBeenCalledWith([longTag]);
+  });
 });

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -27,6 +27,8 @@ export interface Props {
   invalid?: boolean;
   /** Colours the tags 'randomly' based on the name. Defaults to true */
   autoColors?: boolean;
+  /** Maximum allowed length of a single tag. Defaults to 50 */
+  maxLength?: number;
 }
 
 /**
@@ -47,6 +49,7 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
       invalid,
       id,
       autoColors = true,
+      maxLength = 50,
     },
     ref
   ) => {
@@ -54,7 +57,7 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
     const [newTagName, setNewTagName] = useState('');
     const styles = useStyles2(getStyles);
     const theme = useTheme2();
-    const isTagTooLong = newTagName.length > 50;
+    const isTagTooLong = newTagName.length > maxLength;
 
     const onNameChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
       setNewTagName(event.target.value);
@@ -66,7 +69,7 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
 
     const onAdd = (event?: React.MouseEvent | React.KeyboardEvent) => {
       event?.preventDefault();
-      if (newTagName.length > 50) {
+      if (isTagTooLong) {
         return;
       }
       if (!tags.includes(newTagName)) {
@@ -107,7 +110,9 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
               size="md"
               disabled={newTagName.length <= 0 || isTagTooLong}
               title={
-                isTagTooLong ? t('grafana-ui.tags-input.tag-too-long', 'Tag too long, max 50 characters') : undefined
+                isTagTooLong
+                  ? t('grafana-ui.tags-input.tag-too-long', 'Tag too long, max {{maxLength}} characters', { maxLength })
+                  : undefined
               }
             >
               <Trans i18nKey="grafana-ui.tags-input.add">Add</Trans>

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -57,7 +57,6 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
     const [newTagName, setNewTagName] = useState('');
     const styles = useStyles2(getStyles);
     const theme = useTheme2();
-    const isTagTooLong = newTagName.length > maxLength;
 
     const onNameChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
       setNewTagName(event.target.value);
@@ -69,9 +68,6 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
 
     const onAdd = (event?: React.MouseEvent | React.KeyboardEvent) => {
       event?.preventDefault();
-      if (isTagTooLong) {
-        return;
-      }
       if (!tags.includes(newTagName)) {
         onChange(tags.concat(newTagName));
       }
@@ -101,19 +97,15 @@ export const TagsInput = forwardRef<HTMLInputElement, Props>(
           value={newTagName}
           onKeyDown={onKeyboardAdd}
           onBlur={onBlur}
-          invalid={invalid || isTagTooLong}
+          invalid={invalid}
+          maxLength={maxLength}
           suffix={
             <Button
               fill="text"
               className={styles.addButtonStyle}
               onClick={onAdd}
               size="md"
-              disabled={newTagName.length <= 0 || isTagTooLong}
-              title={
-                isTagTooLong
-                  ? t('grafana-ui.tags-input.tag-too-long', 'Tag too long, max {{maxLength}} characters', { maxLength })
-                  : undefined
-              }
+              disabled={newTagName.length <= 0}
             >
               <Trans i18nKey="grafana-ui.tags-input.add">Add</Trans>
             </Button>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10446,7 +10446,7 @@
       "add": "Add",
       "placeholder-new-tag": "New tag (enter key to add)",
       "remove": "Remove tag: {{name}}",
-      "tag-too-long": "Tag too long, max 50 characters"
+      "tag-too-long": "Tag too long, max {{maxLength}} characters"
     },
     "time-sync-button": {
       "aria-label-sync": "Sync times",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10445,8 +10445,7 @@
     "tags-input": {
       "add": "Add",
       "placeholder-new-tag": "New tag (enter key to add)",
-      "remove": "Remove tag: {{name}}",
-      "tag-too-long": "Tag too long, max {{maxLength}} characters"
+      "remove": "Remove tag: {{name}}"
     },
     "time-sync-button": {
       "aria-label-sync": "Sync times",


### PR DESCRIPTION
**What is this feature?**

Adds an optional `maxLength` prop to the `TagsInput` component that controls the maximum allowed length of a single tag. It defaults to `50`, preserving the current behavior for every existing consumer.

The limit is enforced natively via the `maxLength` attribute on the underlying `Input`, so the field simply stops accepting characters once the cap is reached — no separate validation state, disabled button, or tooltip.

**Why do we need this feature?**

The per-tag length limit was hardcoded to 50 characters, so consumers that legitimately need longer entries had no way to raise it. For example, the Adaptive Logs plugin uses `TagsInput` for "log line contains" substring filters, where 50 characters is too restrictive.

**Who is this feature for?**

Developers consuming `@grafana/ui`'s `TagsInput` who need a tag length limit other than the default 50.
