### PR TITLE
Alerting: add useGlobalSilenceAbility and migrate silence permission checks

### DIFF
--- a/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.ts
+++ b/public/app/features/alerting/unified/hooks/abilities/alertmanager/useSilenceAbility.ts
@@ -1,18 +1,25 @@
 import { useMemo } from 'react';
 
 import { type Silence } from 'app/plugins/datasource/alertmanager/types';
-import { type AccessControlAction } from 'app/types/accessControl';
+import { AccessControlAction } from 'app/types/accessControl';
 
+import { useFolder } from '../../../hooks/useFolder';
 import { useAlertmanager } from '../../../state/AlertmanagerContext';
 import { instancesPermissions, silencesPermissions } from '../../../utils/access-control';
 import { makeAbility } from '../abilityUtils';
-import { type AsyncAbility, InsufficientPermissions, Loading, SilenceAction } from '../types';
+import { type Ability, type AsyncAbility, Granted, InsufficientPermissions, Loading, SilenceAction } from '../types';
 
 export type SilenceAbilityParam =
   | { action: SilenceAction.View }
   | { action: SilenceAction.Create }
   | { action: SilenceAction.Preview }
   | { action: SilenceAction.Update; context?: Silence };
+
+export type GlobalSilenceAbilityParam =
+  | { action: SilenceAction.View }
+  | { action: SilenceAction.Create; folderUID?: string }
+  | { action: SilenceAction.Preview }
+  | { action: SilenceAction.Update };
 
 // Backend HTTP gates accept either alert.instances:* or alert.silences:* for Grafana AM.
 // Frontend mirrors that by listing both in the accepted set.
@@ -29,6 +36,35 @@ const EXTERNAL_PERMISSIONS: Record<SilenceAction, AccessControlAction[]> = {
   [SilenceAction.Create]: [instancesPermissions.create.external],
   [SilenceAction.Update]: [instancesPermissions.update.external],
 };
+
+/**
+ * Global (unscoped) silence ability check, outside of AlertmanagerContext.
+ *
+ * Performs a pure RBAC check with no alertmanager-type gate.
+ *
+ * For `SilenceAction.Create`, an optional `folderUID` can be provided to also check
+ * folder-level RBAC (`AlertingSilenceCreate` on that folder). When `folderUID` is
+ * omitted the folder check is skipped and only global permissions are evaluated.
+ */
+export function useGlobalSilenceAbility(payload: GlobalSilenceAbilityParam): Ability {
+  const folderUID = payload.action === SilenceAction.Create ? payload.folderUID : undefined;
+  const { folder } = useFolder(folderUID);
+
+  return useMemo(() => {
+    switch (payload.action) {
+      case SilenceAction.Create: {
+        const globalAbility = makeAbility(true, GRAFANA_PERMISSIONS[SilenceAction.Create]);
+        const hasFolderPermission = folder?.accessControl?.[AccessControlAction.AlertingSilenceCreate] ?? false;
+        return globalAbility.granted || hasFolderPermission ? Granted : globalAbility;
+      }
+
+      case SilenceAction.View:
+      case SilenceAction.Preview:
+      case SilenceAction.Update:
+        return makeAbility(true, GRAFANA_PERMISSIONS[payload.action]);
+    }
+  }, [payload.action, folder]);
+}
 
 export function useSilenceAbility(payload: SilenceAbilityParam): AsyncAbility {
   const { selectedAlertmanager, isGrafanaAlertmanager } = useAlertmanager();

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -218,18 +218,6 @@ export function useCanViewContactPoints(): boolean {
 }
 
 /**
- * UI-only permission helper for actions that create silences.
- */
-export function useCanCreateSilences(): boolean {
-  return useMemo(
-    () =>
-      ctx.hasPermission(AccessControlAction.AlertingInstanceCreate) ||
-      ctx.hasPermission(AccessControlAction.AlertingSilenceCreate),
-    []
-  );
-}
-
-/**
  * This one will check for enrichment abilities
  */
 export const useEnrichmentAbilities = (): Abilities<EnrichmentAction> => {

--- a/public/app/features/alerting/unified/notifications/NotificationDetailActions.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationDetailActions.tsx
@@ -7,7 +7,10 @@ import { appEvents } from 'app/core/app_events';
 
 import MoreButton from '../components/MoreButton';
 import { DeclareIncidentMenuItem } from '../components/bridges/DeclareIncidentButton';
-import { useCanCreateSilences, useCanViewContactPoints } from '../hooks/useAbilities';
+import { isGranted } from '../hooks/abilities/abilityUtils';
+import { useGlobalSilenceAbility } from '../hooks/abilities/alertmanager/useSilenceAbility';
+import { SilenceAction } from '../hooks/abilities/types';
+import { useCanViewContactPoints } from '../hooks/useAbilities';
 import { isLocalDevEnv, isOpenSourceEdition, makeLabelBasedSilenceLink } from '../utils/misc';
 import { createRelativeUrl } from '../utils/url';
 
@@ -20,7 +23,7 @@ interface NotificationActionsMenuProps {
 export function NotificationActionsMenu({ notification }: NotificationActionsMenuProps) {
   const { isAvailable: isAssistantAvailable, openAssistant } = useAssistant();
   const canViewContactPoint = useCanViewContactPoints();
-  const canSilence = useCanCreateSilences();
+  const canSilence = isGranted(useGlobalSilenceAbility({ action: SilenceAction.Create }));
 
   const shouldShowDeclareIncident = !isOpenSourceEdition() || isLocalDevEnv();
 

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -89,7 +89,6 @@ export function InstanceDetailsDrawerTitle({
   const canAccessIncident = settings
     ? canAccessPluginPage(settings, createBridgeURL(pluginId, '/incidents/declare'))
     : false;
-  const canSilence = canCreateSilence;
 
   return (
     <Stack direction="column" gap={2}>
@@ -124,12 +123,12 @@ export function InstanceDetailsDrawerTitle({
             <Stack direction="row" gap={1} alignItems="center">
               {silenceLink && (
                 <>
-                  {canSilence && onOpenSilence && (
+                  {canCreateSilence && onOpenSilence && (
                     <Button icon="bell-slash" variant="secondary" size="sm" onClick={onOpenSilence}>
                       <Trans i18nKey="alerting.triage.instance-details-drawer.silence-button">Silence</Trans>
                     </Button>
                   )}
-                  {canSilence && !onOpenSilence && (
+                  {canCreateSilence && !onOpenSilence && (
                     <LinkButton
                       href={silenceLink}
                       icon="bell-slash"
@@ -141,7 +140,7 @@ export function InstanceDetailsDrawerTitle({
                       <Trans i18nKey="alerting.triage.instance-details-drawer.silence-button">Silence</Trans>
                     </LinkButton>
                   )}
-                  {!canSilence && (
+                  {!canCreateSilence && (
                     <Tooltip
                       content={t(
                         'alerting.triage.instance-details-drawer.silence-no-permission',

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -4,11 +4,12 @@ import { AlertLabels, StateText } from '@grafana/alerting/unstable';
 import { type Labels } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Box, Button, LinkButton, Stack, Text, Tooltip } from '@grafana/ui';
-import { AccessControlAction } from 'app/types/accessControl';
 import { GrafanaAlertState, type GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
 
 import { createBridgeURL } from '../../components/PluginBridge';
-import { useCanCreateSilences } from '../../hooks/useAbilities';
+import { isGranted } from '../../hooks/abilities/abilityUtils';
+import { useGlobalSilenceAbility } from '../../hooks/abilities/alertmanager/useSilenceAbility';
+import { SilenceAction } from '../../hooks/abilities/types';
 import { stringifyFolder, useFolder } from '../../hooks/useFolder';
 import { canAccessPluginPage, useIrmPlugin } from '../../hooks/usePluginBridge';
 import { SupportedPlugin } from '../../types/pluginBridges';
@@ -70,7 +71,9 @@ export function InstanceDetailsDrawerTitle({
 }: InstanceDetailsDrawerTitleProps) {
   const { folder } = useFolder(rule?.namespace_uid);
   const { pluginId, installed, settings } = useIrmPlugin(SupportedPlugin.Incident);
-  const canCreateSilence = useCanCreateSilences();
+  const canCreateSilence = isGranted(
+    useGlobalSilenceAbility({ action: SilenceAction.Create, folderUID: rule?.namespace_uid })
+  );
 
   const silenceLink = useMemo(() => {
     if (!rule) {
@@ -86,8 +89,7 @@ export function InstanceDetailsDrawerTitle({
   const canAccessIncident = settings
     ? canAccessPluginPage(settings, createBridgeURL(pluginId, '/incidents/declare'))
     : false;
-  const hasFolderSilencePermission = folder?.accessControl?.[AccessControlAction.AlertingSilenceCreate] ?? false;
-  const canSilence = canCreateSilence || hasFolderSilencePermission;
+  const canSilence = canCreateSilence;
 
   return (
     <Stack direction="column" gap={2}>


### PR DESCRIPTION
**What is this feature?**

Fills the missing `useGlobalSilenceAbility` hook — every other alertmanager-domain hook (`useTimeIntervalAbility`, `useContactPointAbility`, etc.) already has a `useGlobal*` companion for use outside `AlertmanagerContext`. Silences were the only exception.

**Why do we need this feature?**

Part of the ongoing migration away from the monolithic `useAbilities` / `contextSrv` pattern introduced in PR #123338.

**Changes:**

New hooks added to `useSilenceAbility.ts`:
- `GlobalSilenceAbilityParam` — discriminated union mirroring `SilenceAbilityParam`; the `Create` action carries an optional `folderUID` context
- `useGlobalSilenceAbility(payload)` — pure RBAC check, no `AlertmanagerContext` required; when `folderUID` is provided for `Create`, also checks folder-level `AlertingSilenceCreate` as a fallback
- `useCanCreateSilences(folderUID?)` — thin boolean wrapper over `useGlobalSilenceAbility`; co-located with the other silence hooks

Callers migrated:
- `NotificationDetailActions` — `useCanCreateSilences()` → `isGranted(useGlobalSilenceAbility({ action: SilenceAction.Create }))`
- `InstanceDetailsDrawerTitle` — monolithic `useCanCreateSilences()` + manual `folder.accessControl` read → `useCanCreateSilences(rule?.namespace_uid)`

Removed:
- Monolithic `useCanCreateSilences` from `hooks/useAbilities.ts` (no remaining callers)

**Who is this feature for?**

Internal: alerting squad engineers.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.