### PR TITLE
DataPro (migration): Migrate `core/utils/explore.ts` (re-land)

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -1,19 +1,23 @@
 import {
-  type DataSourceApi,
+  type AdHocVariableFilter,
+  DataSourceApi,
+  type DataSourceInstanceSettings,
+  type DataSourcePluginMeta,
   dateTime,
   type ExploreUrlState,
   type GrafanaConfig,
   locationUtil,
   LogsSortOrder,
+  type ScopedVars,
   serializeStateToUrlParam,
 } from '@grafana/data';
+import { setDataSourceSrv, setTemplateSrv, type DataSourceSrv, type TemplateSrv } from '@grafana/runtime';
+import { initDataSourceInstanceSettings, setDataSourcePluginImporter } from '@grafana/runtime/internal';
 import { type DataQuery } from '@grafana/schema';
 import { RefreshPicker } from '@grafana/ui';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { DEFAULT_RANGE } from 'app/features/explore/state/constants';
 import { getVariablesUrlParams } from 'app/features/variables/getAllVariableValuesForUrl';
-
-import { DatasourceSrvMock, MockDataSourceApi } from '../../../test/mocks/datasource_srv';
 
 import {
   buildQueryTransaction,
@@ -31,45 +35,90 @@ const DEFAULT_EXPLORE_STATE: ExploreUrlState = {
   range: DEFAULT_RANGE,
 };
 
-const defaultDs = new MockDataSourceApi('default datasource', { data: ['default data'] });
-const interpolateMockLoki = jest
-  .fn()
-  .mockReturnValue([{ refId: 'a', expr: 'replaced testDs loki' }]) as unknown as DataQuery[];
-const interpolateMockProm = jest
-  .fn()
-  .mockReturnValue([{ refId: 'a', expr: 'replaced testDs2 prom' }]) as unknown as DataQuery[];
-const datasourceSrv = new DatasourceSrvMock(defaultDs, {
-  'generate empty query': new MockDataSourceApi('generateEmptyQuery'),
-  ds1: {
-    name: 'testDs',
-    type: 'loki',
-    meta: { mixed: false },
-    interpolateVariablesInQueries: interpolateMockLoki,
-    getRef: () => {
-      return 'ds1';
-    },
-  } as unknown as DataSourceApi,
-  ds2: {
-    name: 'testDs2',
-    type: 'prom',
-    meta: { mixed: false },
-    interpolateVariablesInQueries: interpolateMockProm,
-    getRef: () => {
-      return 'ds2';
-    },
-  } as unknown as DataSourceApi,
-  dsMixed: {
-    name: 'testDSMixed',
-    type: 'mixed',
-    meta: { mixed: true },
-  } as MockDataSourceApi,
-});
+// The migration under test swaps getDataSourceSrv().get() for getDataSourceInstance() from
+// @grafana/runtime/unstable. We deliberately seed the *real* new-API caches (instance settings +
+// plugin importer) rather than delegate getDataSourceInstance back to a legacy mock. A
+// delegate-to-legacy mock reasserts the old semantics by construction, so it can never fail on the
+// template-variable identity gap that got the original migration (#127578) reverted (#127870).
+const interpolateMockLoki = jest.fn().mockReturnValue([{ refId: 'a', expr: 'replaced testDs loki' }]);
+const interpolateMockProm = jest.fn().mockReturnValue([{ refId: 'a', expr: 'replaced testDs2 prom' }]);
+const interpolateByUid: Record<string, jest.Mock> = { ds1: interpolateMockLoki, ds2: interpolateMockProm };
 
-const getDataSourceSrvMock = jest.fn().mockReturnValue(datasourceSrv);
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => getDataSourceSrvMock(),
-}));
+function makeSettings(
+  uid: string,
+  name: string,
+  type: string,
+  opts: { isDefault?: boolean; mixed?: boolean } = {}
+): DataSourceInstanceSettings {
+  return {
+    id: 1,
+    uid,
+    name,
+    type,
+    access: 'direct',
+    jsonData: {},
+    readOnly: false,
+    isDefault: opts.isDefault ?? false,
+    meta: {
+      id: type,
+      name: type,
+      type: 'datasource',
+      module: '',
+      baseUrl: '',
+      mixed: opts.mixed ?? false,
+      metrics: true,
+      info: {
+        author: { name: '' },
+        description: '',
+        links: [],
+        logos: { small: '', large: '' },
+        screenshots: [],
+        updated: '',
+        version: '',
+      },
+    } as unknown as DataSourcePluginMeta,
+  } as DataSourceInstanceSettings;
+}
+
+const DEFAULT_DS_NAME = 'default datasource';
+const dsSettings: Record<string, DataSourceInstanceSettings> = {
+  default: makeSettings('default-uid', DEFAULT_DS_NAME, 'test-db', { isDefault: true }),
+  ds1: makeSettings('ds1', 'testDs', 'loki'),
+  ds2: makeSettings('ds2', 'testDs2', 'prom'),
+  dsMixed: makeSettings('dsMixed', 'testDSMixed', 'mixed', { mixed: true }),
+};
+
+// Unlike a preset-instance mock, this class derives its identity from the settings the loader
+// passes to its constructor — the identity a real plugin instance carries. A variable ref that
+// resolves to a concrete uid therefore yields an instance whose getRef()/uid is the concrete uid,
+// never the literal "${var}".
+class TestDataSource extends DataSourceApi<DataQuery> {
+  query() {
+    return Promise.resolve({ data: [] });
+  }
+  testDatasource() {
+    return Promise.resolve({ status: 'success', message: '' });
+  }
+  interpolateVariablesInQueries(queries: DataQuery[], scopedVars: ScopedVars, filters?: AdHocVariableFilter[]) {
+    const spy = interpolateByUid[this.uid];
+    return spy ? spy(queries, scopedVars, filters) : queries;
+  }
+}
+
+const pluginImporter = jest.fn().mockResolvedValue({ DataSourceClass: TestDataSource, components: {} });
+
+beforeEach(() => {
+  initDataSourceInstanceSettings(dsSettings, DEFAULT_DS_NAME);
+  setDataSourcePluginImporter(pluginImporter);
+  // Resolve the datasource template variable to a concrete uid, mirroring dashboard interpolation.
+  setTemplateSrv({
+    getVariables: () => [],
+    replace: (target?: string) => (target === '${datasource}' ? 'ds1' : (target ?? '')),
+  } as unknown as TemplateSrv);
+  // No legacy srv: the new-API fallback stays inert, so a resolution miss surfaces as a failure
+  // instead of silently delegating to legacy semantics (the shape that hid the reverted bug).
+  setDataSourceSrv(undefined as unknown as DataSourceSrv);
+});
 
 // Avoids errors caused by circular dependencies
 jest.mock('app/features/live/dashboard/dashboardWatcher', () => ({
@@ -181,6 +230,80 @@ describe('getExploreUrl', () => {
     it('should work with sub path', async () => {
       expect(await getExploreUrl(args)).toMatch(/subpath\/explore/g);
     });
+  });
+});
+
+describe('getExploreUrl datasource identity (DPRO-168 regression)', () => {
+  const timeRange = { from: dateTime(), to: dateTime(), raw: { from: 'now-1h', to: 'now' } };
+
+  // Reads the query datasource that getExploreUrl actually wrote into the URL. This is the field
+  // Explore consumes — the reverted migration wrote the literal "${datasource}" here, so Explore
+  // could not map it and fell back to the default datasource with an empty query.
+  function queryDatasourceFromUrl(url: string): unknown {
+    const panes = JSON.parse(new URLSearchParams(url.slice(url.indexOf('?') + 1)).get('panes')!);
+    const [pane] = Object.values(panes) as Array<{ queries: DataQuery[] }>;
+    return pane.queries[0].datasource;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves a concrete uid ref to that datasource', async () => {
+    const url = await getExploreUrl({
+      queries: [{ refId: 'A', expr: 'query1', datasource: { type: 'prom', uid: 'ds2' } }],
+      dsRef: { type: 'loki', uid: 'ds1' },
+      timeRange,
+      scopedVars: {},
+    } as unknown as GetExploreUrlArguments);
+
+    expect(queryDatasourceFromUrl(url!)).toEqual({ type: 'prom', uid: 'ds2' });
+  });
+
+  it('resolves to the default datasource when no ref is provided', async () => {
+    const url = await getExploreUrl({
+      queries: [{ refId: 'A', expr: 'query1' }],
+      dsRef: null,
+      timeRange,
+      scopedVars: {},
+    } as unknown as GetExploreUrlArguments);
+
+    expect(queryDatasourceFromUrl(url!)).toEqual({ type: 'test-db', uid: 'default-uid' });
+  });
+
+  it('carries the concrete resolved uid when the panel datasource is a ${var} ref object (v2 panel shape)', async () => {
+    const url = await getExploreUrl({
+      queries: [{ refId: 'A', expr: 'query1' }],
+      dsRef: { uid: '${datasource}', type: '' },
+      timeRange,
+      scopedVars: {},
+    } as unknown as GetExploreUrlArguments);
+
+    // Concrete uid, not the literal variable. On the old identity gap getRef() returned
+    // { type: 'loki', uid: '${datasource}' } and this assertion fails.
+    expect(queryDatasourceFromUrl(url!)).toEqual({ type: 'loki', uid: 'ds1' });
+  });
+
+  it('carries the concrete resolved uid when a query datasource is a ${var} ref object', async () => {
+    const url = await getExploreUrl({
+      queries: [{ refId: 'A', expr: 'query1', datasource: { uid: '${datasource}', type: '' } }],
+      dsRef: { type: 'prom', uid: 'ds2' },
+      timeRange,
+      scopedVars: {},
+    } as unknown as GetExploreUrlArguments);
+
+    expect(queryDatasourceFromUrl(url!)).toEqual({ type: 'loki', uid: 'ds1' });
+  });
+
+  it('carries the concrete resolved uid when a query datasource is a ${var} string', async () => {
+    const url = await getExploreUrl({
+      queries: [{ refId: 'A', expr: 'query1', datasource: '${datasource}' }],
+      dsRef: { type: 'prom', uid: 'ds2' },
+      timeRange,
+      scopedVars: {},
+    } as unknown as GetExploreUrlArguments);
+
+    expect(queryDatasourceFromUrl(url!)).toEqual({ type: 'loki', uid: 'ds1' });
   });
 });
 

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -24,7 +24,7 @@ import {
   urlUtil,
   generateUUID,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { RefreshPicker } from '@grafana/ui';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { type QueryOptions, type QueryTransaction } from 'app/types/explore';
@@ -74,7 +74,7 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
         .map(async (q) => {
           // if the query defines a datasource, use that one, otherwise use the one from the panel, which should always be defined.
           // this will rejects if the datasource is not found, or return the default one if dsRef is not provided.
-          const queryDs = await getDataSourceSrv().get(q.datasource || dsRef);
+          const queryDs = await getDataSourceInstance(q.datasource || dsRef);
 
           return {
             // interpolate the query using its datasource `interpolateVariablesInQueries` method if defined, othewise return the query as-is.
@@ -186,13 +186,13 @@ export async function generateEmptyQuery(
     // otherwise use last queries' datasource
     datasourceRef = queries[queries.length - 1].datasource;
   } else {
-    datasourceInstance = await getDataSourceSrv().get();
+    datasourceInstance = await getDataSourceInstance();
     defaultQuery = datasourceInstance.getDefaultQuery?.(CoreApp.Explore);
     datasourceRef = datasourceInstance.getRef();
   }
 
   if (!datasourceInstance) {
-    datasourceInstance = await getDataSourceSrv().get(datasourceRef);
+    datasourceInstance = await getDataSourceInstance(datasourceRef);
     defaultQuery = datasourceInstance.getDefaultQuery?.(CoreApp.Explore);
   }
 
@@ -230,7 +230,7 @@ export async function ensureQueries(
       let validDS = true;
       if (query.datasource) {
         try {
-          await getDataSourceSrv().get(query.datasource.uid);
+          await getDataSourceInstance(query.datasource.uid);
         } catch {
           console.error(`One of the queries has a datasource that is no longer available and was removed.`);
           validDS = false;
@@ -249,7 +249,7 @@ export async function ensureQueries(
   }
   try {
     // if a datasource override get its ref, otherwise get the default datasource
-    const emptyQueryRef = newQueryDataSourceOverride ?? (await getDataSourceSrv().get()).getRef();
+    const emptyQueryRef = newQueryDataSourceOverride ?? (await getDataSourceInstance()).getRef();
     const emptyQuery = await generateEmptyQuery(queries ?? [], undefined, emptyQueryRef);
     return [emptyQuery];
   } catch {

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -6,7 +6,8 @@ import { assertIsDefined } from 'test/helpers/asserts';
 import {
   type DataQueryRequest,
   type DataQueryResponse,
-  type DataSourceApi,
+  DataSourceApi,
+  type DataSourceInstanceSettings,
   type DataSourceJsonData,
   type DataSourcePluginMeta,
   type DataSourceWithSupplementaryQueriesSupport,
@@ -15,6 +16,7 @@ import {
   type RawTimeRange,
   SupplementaryQueryType,
 } from '@grafana/data';
+import { initDataSourceInstanceSettings, setDataSourcePluginImporter } from '@grafana/runtime/internal';
 import { type DataQuery, type DataSourceRef } from '@grafana/schema';
 import config from 'app/core/config';
 import { queryLogsSample, queryLogsVolume } from 'app/features/logs/logsModel';
@@ -108,6 +110,69 @@ jest.mock('@grafana/runtime', () => ({
     };
   },
 }));
+
+// explore.ts now resolves datasources via getDataSourceInstance() from @grafana/runtime/unstable.
+// This suite exercises that path through ensureQueries/generateEmptyQuery (via addQueryRow), so we
+// seed the real new-API caches (instance settings + a plugin importer) instead of delegating to the
+// legacy getDataSourceSrv mock above — seeding runs the real resolution path and does not reassert
+// legacy semantics.
+function makeSettings(uid: string, name: string, type: string, isDefault = false): DataSourceInstanceSettings {
+  return {
+    id: 1,
+    uid,
+    name,
+    type,
+    access: 'direct',
+    jsonData: {},
+    readOnly: false,
+    isDefault,
+    meta: {
+      id: type,
+      name: type,
+      type: 'datasource',
+      module: '',
+      baseUrl: '',
+      metrics: true,
+      info: {
+        author: { name: '' },
+        description: '',
+        links: [],
+        logos: { small: '', large: '' },
+        screenshots: [],
+        updated: '',
+        version: '',
+      },
+    } as unknown as DataSourcePluginMeta,
+  } as DataSourceInstanceSettings;
+}
+
+class TestDataSource extends DataSourceApi<DataQuery> {
+  query() {
+    return Promise.resolve({ data: [] });
+  }
+  testDatasource() {
+    return Promise.resolve({ status: 'success', message: '' });
+  }
+}
+
+beforeEach(() => {
+  // Seed every uid the suite's queries and root datasources reference so getDataSourceInstance
+  // resolves them via the new path. The legacy getDataSourceSrv mock silently returned the default
+  // for unknown uids; the new API throws, so an unseeded uid would drop or reject a query. The
+  // resolved instance's type is irrelevant here — generateEmptyQuery/ensureQueries only need the
+  // lookup to succeed and consume getRef()/the passed ref.
+  initDataSourceInstanceSettings(
+    {
+      testDs: makeSettings('ds1', 'testDs', 'postgres', true),
+      testDs2: makeSettings('ds2', 'testDs2', 'mysql'),
+      ds3: makeSettings('ds3', 'ds3', 'postgres'),
+      ds4: makeSettings('ds4', 'ds4', 'loki'),
+      'uid-loki': makeSettings('uid-loki', 'uid-loki', 'loki'),
+    },
+    'testDs'
+  );
+  setDataSourcePluginImporter(jest.fn().mockResolvedValue({ DataSourceClass: TestDataSource, components: {} }));
+});
 
 function setupQueryResponse(state: StoreState) {
   const leftDatasourceInstance = assertIsDefined(state.explore.panes.left!.datasourceInstance);


### PR DESCRIPTION
## Description
Re-land the migration of `core/utils/explore.ts` off the deprecated synchronous `getDataSourceSrv()` API to the new async `getDataSourceInstance()` from `@grafana/runtime/unstable`.

The original migration (#127578) was reverted (#127870) because `getDataSourceInstance` had an instance-identity parity gap for **template-variable datasource refs** (e.g. `$datasource` / `${datasource}`): it returned an instance whose `uid`/`getRef().uid` was the literal variable string instead of the resolved concrete uid. That broke "Open in Explore" from panels whose datasource is a template variable (Explore opened on the default datasource with an empty query) and poisoned the plugin cache session-wide.

That upstream gap is now fixed in #128035: `getDataSourceInstance` re-resolves variable refs through `rawRef` to the concrete settings and caches under the concrete uid, so instance identity matches legacy `getDataSourceSrv().get()`. With that in place the migration's behavioral parity holds, so this change re-applies the same source migration and hardens the tests so the gap can't silently regress.

Part of the async datasource-API migration effort (#125083). Fixes DPRO-168.

## Changes
* Replaced all five `getDataSourceSrv().get(...)` calls with `getDataSourceInstance(...)`:
  * `getExploreUrl` — resolves each query's datasource before interpolation.
  * `generateEmptyQuery` — resolves the default datasource and the datasource for a given ref.
  * `ensureQueries` — validates a query's datasource and resolves the default datasource ref.
* All call sites were already `await`ed, so these are 1:1 replacements. `getDataSourceInstance` returns the same `DataSourceApi`, returns the default datasource when no ref is given, and throws when a datasource cannot be resolved (the `ensureQueries` try/catch behaviour is unchanged).
* Reworked the tests instead of reusing the original delegate-to-legacy mock (`getDataSourceInstance: (ref) => datasourceSrv.get(ref)`), which reasserted legacy semantics by construction and could never fail on the parity gap that caused the revert:
  * `explore.test.ts` — seeds the real new-API caches (`initDataSourceInstanceSettings` + a plugin importer returning a capturing datasource class) so `getDataSourceInstance` runs its real resolution path, and adds a template-variable regression suite asserting the concrete resolved uid reaches the Explore URL (verified to fail on the pre-#128035 identity gap). Covers concrete uid, default/undefined, `DataSourceRef` object, and `${variable}` in both string and `{ uid: '${var}', type: '' }` object forms.
  * `query.test.ts` — seeds the real new-API caches for the refs this path resolves.

## Risks
* Low, and materially lower than the original: the revert's root cause is fixed upstream (#128035) and is now covered by a regression test in this PR that fails on that exact gap. Behavior matches the legacy API for every ref shape reaching this file, including template variables.

## Demo
Manually verified with `dashboardNewLayouts` enabled: a dashboard with a datasource template variable set to a non-default datasource, on a panel using `${datasource}`. Panel menu → Explore opens on the **resolved** datasource with the panel's query (not the default datasource with an empty query), and no `DataSource: cached a plugin instance whose uid does not match its cache key` warning appears in the console.

## Testing Instructions
* `yarn test public/app/core/utils/explore.test.ts public/app/features/explore/state/query.test.ts` — all tests pass.
* In a dashboard with a datasource template variable, on a panel whose datasource is that variable, use the panel's "Explore" action and confirm Explore opens with the resolved datasource and the panel's queries.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable