### PR TITLE
Provisioning: Test root folder creation for folder and folderless sync modes

### DIFF
--- a/pkg/tests/apis/provisioning/common/permissions.go
+++ b/pkg/tests/apis/provisioning/common/permissions.go
@@ -1,0 +1,129 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Folder permission levels as returned/accepted by the legacy folder
+// permissions API (/api/folders/{uid}/permissions).
+const (
+	FolderPermissionView  = 1
+	FolderPermissionEdit  = 2
+	FolderPermissionAdmin = 4
+)
+
+// FolderPermissions fetches the managed ACL entries for a folder via the legacy
+// folder permissions API using admin credentials. It fails the test if the
+// request does not return 200. The entries are returned as decoded JSON objects
+// (the endpoint returns more fields than the assertions here inspect).
+func FolderPermissions(t *testing.T, helper *ProvisioningTestHelper, folderUID string) []interface{} {
+	t.Helper()
+	perms, code, err := fetchFolderPermissions(folderAddr(helper), folderUID)
+	require.NoError(t, err, "GET folder permissions for %q", folderUID)
+	require.Equal(t, http.StatusOK, code, "unexpected status from permissions endpoint for %q", folderUID)
+	return perms
+}
+
+// RequirePermissionContainsRole asserts that perms contains at least one entry
+// matching the given built-in role and numeric permission level.
+func RequirePermissionContainsRole(t *testing.T, perms []interface{}, role string, permission int) {
+	t.Helper()
+	require.Truef(t, permissionsContainRole(perms, role, permission),
+		"expected role=%q permission=%d in ACL entries; got: %v", role, permission, perms)
+}
+
+// RequirePermissionLacksRole asserts that perms contains NO entry matching the
+// given built-in role and numeric permission level.
+func RequirePermissionLacksRole(t *testing.T, perms []interface{}, role string, permission int) {
+	t.Helper()
+	require.Falsef(t, permissionsContainRole(perms, role, permission),
+		"did not expect role=%q permission=%d in ACL entries; got: %v", role, permission, perms)
+}
+
+// RequireDefaultRootFolderPermissions asserts that a root folder carries the
+// default role-based permissions granted on creation: Editor → Edit and
+// Viewer → View. It waits because permissions are applied asynchronously after
+// the folder is created. The creator-admin grant depends on the caller identity
+// type and is intentionally not asserted here.
+func RequireDefaultRootFolderPermissions(t *testing.T, helper *ProvisioningTestHelper, folderUID string) {
+	t.Helper()
+	addr := folderAddr(helper)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		perms, code, err := fetchFolderPermissions(addr, folderUID)
+		if !assert.NoError(c, err, "GET folder permissions for %q", folderUID) {
+			return
+		}
+		if !assert.Equal(c, http.StatusOK, code, "unexpected status for %q", folderUID) {
+			return
+		}
+		assert.Truef(c, permissionsContainRole(perms, "Editor", FolderPermissionEdit),
+			"expected Editor→Edit in ACL for %q; got: %v", folderUID, perms)
+		assert.Truef(c, permissionsContainRole(perms, "Viewer", FolderPermissionView),
+			"expected Viewer→View in ACL for %q; got: %v", folderUID, perms)
+	}, 30*time.Second, 100*time.Millisecond,
+		"root folder %q should have default Editor/Viewer permissions", folderUID)
+}
+
+// RequireNoDefaultRootFolderPermissions asserts that a folder was NOT granted
+// the root-level default permissions. Default Editor/Viewer grants are applied
+// only to root folders (empty parent); nested folders inherit access from their
+// parent and carry no explicit default ACL. The GET endpoint returns a folder's
+// own managed ACL entries (not inherited ones), so the defaults must be absent.
+//
+// The caller must have already confirmed the folder exists (e.g. via a folder
+// wait helper): default permissions are never set on nested folders, so once the
+// folder is present a single read is authoritative.
+func RequireNoDefaultRootFolderPermissions(t *testing.T, helper *ProvisioningTestHelper, folderUID string) {
+	t.Helper()
+	perms := FolderPermissions(t, helper, folderUID)
+	RequirePermissionLacksRole(t, perms, "Editor", FolderPermissionEdit)
+	RequirePermissionLacksRole(t, perms, "Viewer", FolderPermissionView)
+}
+
+// folderAddr returns the host:port of the running test server.
+func folderAddr(helper *ProvisioningTestHelper) string {
+	return helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+}
+
+// fetchFolderPermissions performs the raw GET against the legacy folder
+// permissions API and decodes the ACL entries.
+func fetchFolderPermissions(addr, folderUID string) ([]interface{}, int, error) {
+	u := fmt.Sprintf("http://admin:admin@%s/api/folders/%s/permissions", addr, folderUID)
+	resp, err := http.Get(u) //nolint:gosec
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode, nil
+	}
+	var perms []interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&perms); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("decode permissions response for %q: %w", folderUID, err)
+	}
+	return perms, resp.StatusCode, nil
+}
+
+// permissionsContainRole reports whether perms has an entry matching the given
+// built-in role and numeric permission level. JSON numbers decode as float64.
+func permissionsContainRole(perms []interface{}, role string, permission int) bool {
+	for _, p := range perms {
+		entry, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		r, _ := entry["role"].(string)
+		level, _ := entry["permission"].(float64)
+		if r == role && int(level) == permission {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tests/apis/provisioning/root_folder_sync_modes_test.go
+++ b/pkg/tests/apis/provisioning/root_folder_sync_modes_test.go
@@ -56,27 +56,14 @@ func TestIntegrationProvisioning_RootFolder_FolderMode(t *testing.T) {
 		ExpectedFolders:    2,
 	})
 
-	// The root folder's k8s name is the repository name.
-	root, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
-	require.NoError(t, err, "folder mode should create a root folder named after the repository")
-
-	title, _, _ := unstructured.NestedString(root.Object, "spec", "title")
-	require.Equal(t, repoTitle, title, "root folder title should be the repository title")
-
-	annotations := root.GetAnnotations()
-	require.Equal(t, string(utils.ManagerKindRepo), annotations[utils.AnnoKeyManagerKind],
-		"root folder should be managed by a repository")
-	require.Equal(t, repo, annotations[utils.AnnoKeyManagerIdentity],
-		"root folder should be managed by this repository")
-	require.Empty(t, annotations[utils.AnnoKeySourcePath],
-		"folder-mode root folder maps to the repository root, so sourcePath is empty")
-	require.Empty(t, annotations[utils.AnnoKeyFolder],
-		"folder-mode root folder has no parent folder")
-
-	// The transient grant-permissions annotation must not survive on the stored
-	// object — it is consumed by the storage layer to trigger the default grant.
-	require.Empty(t, annotations[utils.AnnoKeyGrantPermissions],
-		"grant-permissions annotation should be cleared after the default grant")
+	// The root folder's k8s name is the repository name. Wait for it to be
+	// created and settled (title, empty sourcePath, empty parent) before reading
+	// it, so the assertions do not race the asynchronous sync.
+	common.RequireFolderState(t, helper.Folders, repo, repoTitle, "", "")
+	root := findManagedFolder(t, helper, repo, func(f *unstructured.Unstructured) bool {
+		return f.GetName() == repo
+	}, "root folder named after the repository")
+	requireRootFolderManagerAnnotations(t, root, repo)
 
 	// The default permissions must be granted on the root folder.
 	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
@@ -115,6 +102,8 @@ func TestIntegrationProvisioning_RootFolder_FolderlessMode(t *testing.T) {
 	})
 
 	// No wrapper folder named after the repository must exist in folderless mode.
+	// CreateLocalRepo already waited for exactly ExpectedFolders to settle, so a
+	// wrapper would have surfaced as an extra folder; this is a direct assertion.
 	_, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 	require.Error(t, err, "folderless mode must not create a repo-named wrapper folder")
 
@@ -128,16 +117,7 @@ func TestIntegrationProvisioning_RootFolder_FolderlessMode(t *testing.T) {
 		require.Equal(t, sourcePath, title,
 			"folderless root folder title should default to the directory name")
 
-		annotations := folder.GetAnnotations()
-		require.Equal(t, string(utils.ManagerKindRepo), annotations[utils.AnnoKeyManagerKind],
-			"folder %q should be managed by a repository", sourcePath)
-		require.Equal(t, repo, annotations[utils.AnnoKeyManagerIdentity],
-			"folder %q should be managed by this repository", sourcePath)
-		require.Empty(t, annotations[utils.AnnoKeyFolder],
-			"folderless top-level folder %q must have no parent folder", sourcePath)
-		require.Empty(t, annotations[utils.AnnoKeyGrantPermissions],
-			"grant-permissions annotation should be cleared after the default grant for %q", sourcePath)
-
+		requireRootFolderManagerAnnotations(t, folder, repo)
 		requireDefaultRootFolderPermissions(t, addr, folder.GetName())
 	}
 
@@ -155,6 +135,17 @@ func TestIntegrationProvisioning_RootFolder_FolderlessMode(t *testing.T) {
 // folder appears because sync populates the resource asynchronously.
 func findManagedFolderBySourcePath(t *testing.T, helper *common.ProvisioningTestHelper, repoName, sourcePath string) *unstructured.Unstructured {
 	t.Helper()
+	return findManagedFolder(t, helper, repoName, func(f *unstructured.Unstructured) bool {
+		return f.GetAnnotations()[utils.AnnoKeySourcePath] == sourcePath
+	}, fmt.Sprintf("sourcePath %q", sourcePath))
+}
+
+// findManagedFolder waits for and returns a folder managed by repoName that
+// satisfies match. It polls with EventuallyWithT because sync populates folders
+// asynchronously; the returned object is fully settled (annotations included),
+// so callers can assert on it without racing. desc labels the match in failures.
+func findManagedFolder(t *testing.T, helper *common.ProvisioningTestHelper, repoName string, match func(*unstructured.Unstructured) bool, desc string) *unstructured.Unstructured {
+	t.Helper()
 	var found *unstructured.Unstructured
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		list, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
@@ -162,16 +153,32 @@ func findManagedFolderBySourcePath(t *testing.T, helper *common.ProvisioningTest
 			return
 		}
 		for i := range list.Items {
-			ann := list.Items[i].GetAnnotations()
-			if ann[utils.AnnoKeyManagerIdentity] == repoName && ann[utils.AnnoKeySourcePath] == sourcePath {
+			if list.Items[i].GetAnnotations()[utils.AnnoKeyManagerIdentity] == repoName && match(&list.Items[i]) {
 				found = &list.Items[i]
 				return
 			}
 		}
-		c.Errorf("no folder managed by %q with sourcePath %q found", repoName, sourcePath)
+		c.Errorf("no folder managed by %q matching %s found", repoName, desc)
 	}, 30*time.Second, 100*time.Millisecond,
-		"expected a folder managed by %q at sourcePath %q", repoName, sourcePath)
+		"expected a folder managed by %q matching %s", repoName, desc)
 	return found
+}
+
+// requireRootFolderManagerAnnotations asserts the default annotations a root
+// folder receives on creation: repo manager ownership, no parent folder, and a
+// cleared grant-permissions annotation (the storage layer consumes it to trigger
+// the default permission grant). The folder must already be settled.
+func requireRootFolderManagerAnnotations(t *testing.T, folder *unstructured.Unstructured, repo string) {
+	t.Helper()
+	ann := folder.GetAnnotations()
+	require.Equal(t, string(utils.ManagerKindRepo), ann[utils.AnnoKeyManagerKind],
+		"folder %q should be managed by a repository", folder.GetName())
+	require.Equal(t, repo, ann[utils.AnnoKeyManagerIdentity],
+		"folder %q should be managed by this repository", folder.GetName())
+	require.Empty(t, ann[utils.AnnoKeyFolder],
+		"root folder %q must have no parent folder", folder.GetName())
+	require.Empty(t, ann[utils.AnnoKeyGrantPermissions],
+		"grant-permissions annotation should be cleared after the default grant for %q", folder.GetName())
 }
 
 // requireDefaultRootFolderPermissions asserts that a root folder carries the

--- a/pkg/tests/apis/provisioning/root_folder_sync_modes_test.go
+++ b/pkg/tests/apis/provisioning/root_folder_sync_modes_test.go
@@ -1,0 +1,262 @@
+package provisioning
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// The two sync modes create root folders differently:
+//
+//   - folder mode (target: "folder"): a single wrapper folder is created whose
+//     k8s name equals the repository name. Everything the repository syncs lives
+//     under it. See resources.RootFolder / sync.FullSync.
+//   - folderless mode (target: "folderless"): no wrapper folder is created. Each
+//     top-level directory in the repository becomes a root folder on its own,
+//     with an empty parent. Ownership is tracked purely via manager annotations.
+//
+// In both cases the root folders (parent == "") are created with the default
+// manager annotations and are granted the default folder permissions. The
+// grafana.app/grant-permissions annotation that provisioning stamps on root
+// folders is consumed and cleared by the storage layer (it triggers the default
+// permission grant), so these tests assert the observable outcome — the manager
+// annotations on the stored folder and the default permissions readable via the
+// folder permissions API — rather than the transient annotation itself.
+
+// TestIntegrationProvisioning_RootFolder_FolderMode verifies that a repository
+// synced in "folder" mode creates exactly one root folder named after the
+// repository, with the default manager annotations and default permissions.
+func TestIntegrationProvisioning_RootFolder_FolderMode(t *testing.T) {
+	helper := sharedHelper(t)
+	const repo = "root-folder-mode"
+	const repoTitle = "Git Sync Folder Mode"
+
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:       repo,
+		Title:      repoTitle,
+		SyncTarget: "folder",
+		Copies: map[string]string{
+			// A dashboard at the repository root plus one inside a nested
+			// directory. Folders created: the repo-named wrapper root folder and
+			// the nested "team" child folder under it.
+			"testdata/all-panels.json":    "dashboard.json",
+			"testdata/timeline-demo.json": "team/dashboard.json",
+		},
+		ExpectedDashboards: 2,
+		ExpectedFolders:    2,
+	})
+
+	// The root folder's k8s name is the repository name.
+	root, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
+	require.NoError(t, err, "folder mode should create a root folder named after the repository")
+
+	title, _, _ := unstructured.NestedString(root.Object, "spec", "title")
+	require.Equal(t, repoTitle, title, "root folder title should be the repository title")
+
+	annotations := root.GetAnnotations()
+	require.Equal(t, string(utils.ManagerKindRepo), annotations[utils.AnnoKeyManagerKind],
+		"root folder should be managed by a repository")
+	require.Equal(t, repo, annotations[utils.AnnoKeyManagerIdentity],
+		"root folder should be managed by this repository")
+	require.Empty(t, annotations[utils.AnnoKeySourcePath],
+		"folder-mode root folder maps to the repository root, so sourcePath is empty")
+	require.Empty(t, annotations[utils.AnnoKeyFolder],
+		"folder-mode root folder has no parent folder")
+
+	// The transient grant-permissions annotation must not survive on the stored
+	// object — it is consumed by the storage layer to trigger the default grant.
+	require.Empty(t, annotations[utils.AnnoKeyGrantPermissions],
+		"grant-permissions annotation should be cleared after the default grant")
+
+	// The default permissions must be granted on the root folder.
+	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+	requireDefaultRootFolderPermissions(t, addr, repo)
+
+	// The nested child folder is parented under the root, so it must NOT receive
+	// the default permissions — those are granted on root-level folders only.
+	child := findManagedFolderBySourcePath(t, helper, repo, "team")
+	require.Equal(t, repo, child.GetAnnotations()[utils.AnnoKeyFolder],
+		"nested folder should be parented under the repository root folder")
+	requireNoDefaultRootFolderPermissions(t, addr, child.GetName())
+}
+
+// TestIntegrationProvisioning_RootFolder_FolderlessMode verifies that a repository
+// synced in "folderless" mode does NOT create a repo-named wrapper folder, and
+// instead promotes each top-level directory to a root folder with the default
+// manager annotations and default permissions.
+func TestIntegrationProvisioning_RootFolder_FolderlessMode(t *testing.T) {
+	helper := sharedHelper(t)
+	const repo = "root-folderless-mode"
+
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:       repo,
+		SyncTarget: "folderless",
+		Copies: map[string]string{
+			// Two top-level directories — each becomes a root folder. The nested
+			// "applications/nested" directory becomes a child folder under the
+			// "applications" root. A dashboard at the repository root would stay
+			// folderless (no folder annotation), but here every file is nested.
+			"testdata/all-panels.json":    "applications/dashboard.json",
+			"testdata/timeline-demo.json": "platform/dashboard.json",
+			"testdata/text-options.json":  "applications/nested/dashboard.json",
+		},
+		ExpectedDashboards: 3,
+		ExpectedFolders:    3,
+	})
+
+	// No wrapper folder named after the repository must exist in folderless mode.
+	_, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
+	require.Error(t, err, "folderless mode must not create a repo-named wrapper folder")
+
+	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+
+	// Each top-level directory becomes a root folder with default annotations and permissions.
+	for _, sourcePath := range []string{"applications", "platform"} {
+		folder := findManagedFolderBySourcePath(t, helper, repo, sourcePath)
+
+		title, _, _ := unstructured.NestedString(folder.Object, "spec", "title")
+		require.Equal(t, sourcePath, title,
+			"folderless root folder title should default to the directory name")
+
+		annotations := folder.GetAnnotations()
+		require.Equal(t, string(utils.ManagerKindRepo), annotations[utils.AnnoKeyManagerKind],
+			"folder %q should be managed by a repository", sourcePath)
+		require.Equal(t, repo, annotations[utils.AnnoKeyManagerIdentity],
+			"folder %q should be managed by this repository", sourcePath)
+		require.Empty(t, annotations[utils.AnnoKeyFolder],
+			"folderless top-level folder %q must have no parent folder", sourcePath)
+		require.Empty(t, annotations[utils.AnnoKeyGrantPermissions],
+			"grant-permissions annotation should be cleared after the default grant for %q", sourcePath)
+
+		requireDefaultRootFolderPermissions(t, addr, folder.GetName())
+	}
+
+	// The nested "applications/nested" folder is a child (parented under the
+	// "applications" root), so it must NOT receive the default permissions.
+	applications := findManagedFolderBySourcePath(t, helper, repo, "applications")
+	child := findManagedFolderBySourcePath(t, helper, repo, "applications/nested")
+	require.Equal(t, applications.GetName(), child.GetAnnotations()[utils.AnnoKeyFolder],
+		"nested folder should be parented under the applications root folder")
+	requireNoDefaultRootFolderPermissions(t, addr, child.GetName())
+}
+
+// findManagedFolderBySourcePath returns the folder managed by repoName whose
+// grafana.app/sourcePath annotation matches sourcePath. It waits until the
+// folder appears because sync populates the resource asynchronously.
+func findManagedFolderBySourcePath(t *testing.T, helper *common.ProvisioningTestHelper, repoName, sourcePath string) *unstructured.Unstructured {
+	t.Helper()
+	var found *unstructured.Unstructured
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		list, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list folders") {
+			return
+		}
+		for i := range list.Items {
+			ann := list.Items[i].GetAnnotations()
+			if ann[utils.AnnoKeyManagerIdentity] == repoName && ann[utils.AnnoKeySourcePath] == sourcePath {
+				found = &list.Items[i]
+				return
+			}
+		}
+		c.Errorf("no folder managed by %q with sourcePath %q found", repoName, sourcePath)
+	}, 30*time.Second, 100*time.Millisecond,
+		"expected a folder managed by %q at sourcePath %q", repoName, sourcePath)
+	return found
+}
+
+// requireDefaultRootFolderPermissions asserts that a root folder carries the
+// default role-based permissions granted on creation: Editor → Edit (2) and
+// Viewer → View (1). The creator-admin grant depends on the caller identity
+// type and is intentionally not asserted here.
+func requireDefaultRootFolderPermissions(t *testing.T, addr, folderUID string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		perms := getFolderPermissions(c, addr, folderUID)
+		assertPermissionContainsRole(c, perms, "Editor", 2)
+		assertPermissionContainsRole(c, perms, "Viewer", 1)
+	}, 30*time.Second, 100*time.Millisecond,
+		"root folder %q should have default Editor/Viewer permissions", folderUID)
+}
+
+// requireNoDefaultRootFolderPermissions asserts that a folder was NOT granted
+// the root-level default permissions. Default Editor/Viewer grants are applied
+// only to root folders (empty parent); nested folders inherit access from their
+// parent and carry no explicit default ACL. The GET endpoint returns a folder's
+// own managed ACL entries (not inherited ones), so the defaults must be absent.
+func requireNoDefaultRootFolderPermissions(t *testing.T, addr, folderUID string) {
+	t.Helper()
+	// A one-shot check is sufficient: the child folder was already confirmed to
+	// exist (so sync processed it), and default permissions are never set on
+	// nested folders — there is no later write that could add them.
+	var perms []interface{}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		perms = getFolderPermissions(c, addr, folderUID)
+	}, 30*time.Second, 100*time.Millisecond, "should be able to read permissions for %q", folderUID)
+
+	assertPermissionLacksRole(t, perms, "Editor", 2)
+	assertPermissionLacksRole(t, perms, "Viewer", 1)
+}
+
+// getFolderPermissions reads the ACL entries for a folder via the legacy
+// folder permissions API. It returns the decoded entries, or reports an error
+// on the CollectT (so it can be used inside EventuallyWithT).
+func getFolderPermissions(c *assert.CollectT, addr, folderUID string) []interface{} {
+	u := fmt.Sprintf("http://admin:admin@%s/api/folders/%s/permissions", addr, folderUID)
+	resp, err := http.Get(u) //nolint:gosec
+	if !assert.NoError(c, err, "GET folder permissions for %q", folderUID) {
+		return nil
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if !assert.Equal(c, http.StatusOK, resp.StatusCode, "unexpected status from permissions endpoint for %q", folderUID) {
+		return nil
+	}
+	var perms []interface{}
+	if !assert.NoError(c, json.NewDecoder(resp.Body).Decode(&perms), "decode permissions response for %q", folderUID) {
+		return nil
+	}
+	return perms
+}
+
+// assertPermissionContainsRole asserts that perms contains at least one entry
+// matching the given built-in role and numeric permission level. JSON numbers
+// decode as float64, so the comparison is done via float64.
+func assertPermissionContainsRole(c *assert.CollectT, perms []interface{}, expectedRole string, expectedPermission int) {
+	for _, p := range perms {
+		entry, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role, _ := entry["role"].(string)
+		level, _ := entry["permission"].(float64)
+		if role == expectedRole && int(level) == expectedPermission {
+			return
+		}
+	}
+	c.Errorf("expected role=%q permission=%d in ACL entries; got: %v", expectedRole, expectedPermission, perms)
+}
+
+// assertPermissionLacksRole asserts that perms contains NO entry matching the
+// given built-in role and numeric permission level.
+func assertPermissionLacksRole(t *testing.T, perms []interface{}, role string, permission int) {
+	t.Helper()
+	for _, p := range perms {
+		entry, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		r, _ := entry["role"].(string)
+		level, _ := entry["permission"].(float64)
+		require.Falsef(t, r == role && int(level) == permission,
+			"did not expect default role=%q permission=%d on non-root folder; got: %v", role, permission, perms)
+	}
+}

--- a/pkg/tests/apis/provisioning/root_folder_sync_modes_test.go
+++ b/pkg/tests/apis/provisioning/root_folder_sync_modes_test.go
@@ -1,9 +1,7 @@
 package provisioning
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -66,15 +64,14 @@ func TestIntegrationProvisioning_RootFolder_FolderMode(t *testing.T) {
 	requireRootFolderManagerAnnotations(t, root, repo)
 
 	// The default permissions must be granted on the root folder.
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
-	requireDefaultRootFolderPermissions(t, addr, repo)
+	common.RequireDefaultRootFolderPermissions(t, helper, repo)
 
 	// The nested child folder is parented under the root, so it must NOT receive
 	// the default permissions — those are granted on root-level folders only.
 	child := findManagedFolderBySourcePath(t, helper, repo, "team")
 	require.Equal(t, repo, child.GetAnnotations()[utils.AnnoKeyFolder],
 		"nested folder should be parented under the repository root folder")
-	requireNoDefaultRootFolderPermissions(t, addr, child.GetName())
+	common.RequireNoDefaultRootFolderPermissions(t, helper, child.GetName())
 }
 
 // TestIntegrationProvisioning_RootFolder_FolderlessMode verifies that a repository
@@ -107,8 +104,6 @@ func TestIntegrationProvisioning_RootFolder_FolderlessMode(t *testing.T) {
 	_, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 	require.Error(t, err, "folderless mode must not create a repo-named wrapper folder")
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
-
 	// Each top-level directory becomes a root folder with default annotations and permissions.
 	for _, sourcePath := range []string{"applications", "platform"} {
 		folder := findManagedFolderBySourcePath(t, helper, repo, sourcePath)
@@ -118,7 +113,7 @@ func TestIntegrationProvisioning_RootFolder_FolderlessMode(t *testing.T) {
 			"folderless root folder title should default to the directory name")
 
 		requireRootFolderManagerAnnotations(t, folder, repo)
-		requireDefaultRootFolderPermissions(t, addr, folder.GetName())
+		common.RequireDefaultRootFolderPermissions(t, helper, folder.GetName())
 	}
 
 	// The nested "applications/nested" folder is a child (parented under the
@@ -127,7 +122,7 @@ func TestIntegrationProvisioning_RootFolder_FolderlessMode(t *testing.T) {
 	child := findManagedFolderBySourcePath(t, helper, repo, "applications/nested")
 	require.Equal(t, applications.GetName(), child.GetAnnotations()[utils.AnnoKeyFolder],
 		"nested folder should be parented under the applications root folder")
-	requireNoDefaultRootFolderPermissions(t, addr, child.GetName())
+	common.RequireNoDefaultRootFolderPermissions(t, helper, child.GetName())
 }
 
 // findManagedFolderBySourcePath returns the folder managed by repoName whose
@@ -179,91 +174,4 @@ func requireRootFolderManagerAnnotations(t *testing.T, folder *unstructured.Unst
 		"root folder %q must have no parent folder", folder.GetName())
 	require.Empty(t, ann[utils.AnnoKeyGrantPermissions],
 		"grant-permissions annotation should be cleared after the default grant for %q", folder.GetName())
-}
-
-// requireDefaultRootFolderPermissions asserts that a root folder carries the
-// default role-based permissions granted on creation: Editor → Edit (2) and
-// Viewer → View (1). The creator-admin grant depends on the caller identity
-// type and is intentionally not asserted here.
-func requireDefaultRootFolderPermissions(t *testing.T, addr, folderUID string) {
-	t.Helper()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		perms := getFolderPermissions(c, addr, folderUID)
-		assertPermissionContainsRole(c, perms, "Editor", 2)
-		assertPermissionContainsRole(c, perms, "Viewer", 1)
-	}, 30*time.Second, 100*time.Millisecond,
-		"root folder %q should have default Editor/Viewer permissions", folderUID)
-}
-
-// requireNoDefaultRootFolderPermissions asserts that a folder was NOT granted
-// the root-level default permissions. Default Editor/Viewer grants are applied
-// only to root folders (empty parent); nested folders inherit access from their
-// parent and carry no explicit default ACL. The GET endpoint returns a folder's
-// own managed ACL entries (not inherited ones), so the defaults must be absent.
-func requireNoDefaultRootFolderPermissions(t *testing.T, addr, folderUID string) {
-	t.Helper()
-	// A one-shot check is sufficient: the child folder was already confirmed to
-	// exist (so sync processed it), and default permissions are never set on
-	// nested folders — there is no later write that could add them.
-	var perms []interface{}
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		perms = getFolderPermissions(c, addr, folderUID)
-	}, 30*time.Second, 100*time.Millisecond, "should be able to read permissions for %q", folderUID)
-
-	assertPermissionLacksRole(t, perms, "Editor", 2)
-	assertPermissionLacksRole(t, perms, "Viewer", 1)
-}
-
-// getFolderPermissions reads the ACL entries for a folder via the legacy
-// folder permissions API. It returns the decoded entries, or reports an error
-// on the CollectT (so it can be used inside EventuallyWithT).
-func getFolderPermissions(c *assert.CollectT, addr, folderUID string) []interface{} {
-	u := fmt.Sprintf("http://admin:admin@%s/api/folders/%s/permissions", addr, folderUID)
-	resp, err := http.Get(u) //nolint:gosec
-	if !assert.NoError(c, err, "GET folder permissions for %q", folderUID) {
-		return nil
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	if !assert.Equal(c, http.StatusOK, resp.StatusCode, "unexpected status from permissions endpoint for %q", folderUID) {
-		return nil
-	}
-	var perms []interface{}
-	if !assert.NoError(c, json.NewDecoder(resp.Body).Decode(&perms), "decode permissions response for %q", folderUID) {
-		return nil
-	}
-	return perms
-}
-
-// assertPermissionContainsRole asserts that perms contains at least one entry
-// matching the given built-in role and numeric permission level. JSON numbers
-// decode as float64, so the comparison is done via float64.
-func assertPermissionContainsRole(c *assert.CollectT, perms []interface{}, expectedRole string, expectedPermission int) {
-	for _, p := range perms {
-		entry, ok := p.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		role, _ := entry["role"].(string)
-		level, _ := entry["permission"].(float64)
-		if role == expectedRole && int(level) == expectedPermission {
-			return
-		}
-	}
-	c.Errorf("expected role=%q permission=%d in ACL entries; got: %v", expectedRole, expectedPermission, perms)
-}
-
-// assertPermissionLacksRole asserts that perms contains NO entry matching the
-// given built-in role and numeric permission level.
-func assertPermissionLacksRole(t *testing.T, perms []interface{}, role string, permission int) {
-	t.Helper()
-	for _, p := range perms {
-		entry, ok := p.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		r, _ := entry["role"].(string)
-		level, _ := entry["permission"].(float64)
-		require.Falsef(t, r == role && int(level) == permission,
-			"did not expect default role=%q permission=%d on non-root folder; got: %v", role, permission, perms)
-	}
 }


### PR DESCRIPTION
## What

Adds integration coverage for how the two provisioning sync modes materialize **root folders**, and the default annotations and permissions those folders receive. Also extracts the reusable folder-permission assertions into the shared `common` test package.

Two tests in `pkg/tests/apis/provisioning/root_folder_sync_modes_test.go`:
- `TestIntegrationProvisioning_RootFolder_FolderMode`
- `TestIntegrationProvisioning_RootFolder_FolderlessMode`

New helpers in `pkg/tests/apis/provisioning/common/permissions.go`:
- `FolderPermissions`, `RequirePermissionContainsRole`, `RequirePermissionLacksRole`
- `RequireDefaultRootFolderPermissions`, `RequireNoDefaultRootFolderPermissions`

Test-only change — no production code is touched.

## Why

The root-folder behavior differs meaningfully between sync modes and had **no direct integration coverage**, yet it governs where synced content lands and who can access it:

- **folder mode** (`target: "folder"`): a single wrapper folder is created whose k8s name equals the repository name; everything the repo syncs lives under it.
- **folderless mode** (`target: "folderless"`): no wrapper folder is created — each top-level directory becomes a root folder on its own, with an empty parent. Ownership is tracked purely via manager annotations.

Both modes create their root folders with default manager annotations **and** default folder permissions (Editor/Viewer), while nested child folders must *not* get those defaults (they inherit). This is exactly the kind of invariant that silently regresses, so it deserves an end-to-end test rather than only unit coverage of `resources.RootFolder` / `EnsureFolderExists`.

## How

Each test drives a real local repository sync via `CreateLocalRepo` (which blocks until the expected resource counts settle) and asserts, for the root folder(s):

- **Identity/shape**: repo-named folder in folder mode; one hash-UID folder per top-level dir in folderless mode; and crucially **no repo-named wrapper folder** exists in folderless mode.
- **Default manager annotations**: `grafana.app/managedBy=repo`, `grafana.app/managerId=<repo>`, `grafana.app/sourcePath`, and an empty parent (`grafana.app/folder`).
- **Transient annotation is consumed**: `grafana.app/grant-permissions` is cleared on the stored object — the storage layer reads it to trigger the default grant, then strips it, so the test asserts the *outcome*, not the annotation.
- **Default permissions** via `/api/folders/{uid}/permissions`: Editor→Edit(2) and Viewer→View(1) are present on roots.
- **Negative case**: nested child folders (`team` under the root; `applications/nested`) are parented under a root and do **not** carry the default Editor/Viewer grants.

Reliability and reuse:
- All folder-object reads go through polling helpers (`common.RequireFolderState`, a local `findManagedFolder` that returns a *settled* object) rather than a bare `Get` right after sync, avoiding races against the asynchronous reconcile. Permission checks poll with `EventuallyWithT` because default grants are applied asynchronously after folder creation.
- The permission assertions live in `common/permissions.go` (deriving the server address from the helper) so other provisioning suites can reuse them.

## Testing

- `go test -run 'TestIntegrationProvisioning_RootFolder_(FolderMode|FolderlessMode)' ./pkg/tests/apis/provisioning/ -count=3 -v` — all pass, no flakes.
- Both packages compile; `gofmt` clean.

## Follow-ups (not in this PR)

- The `foldermetadata` package still has near-duplicate permission helpers (`snapshotFolderPermissions`, `requirePermissionsContainRole`, `requireRolePermissionSetEqual`, `requireFolderAccessible`) that could migrate to `common/permissions.go`.

## Checklist

- [x] Tests added
- [x] No production code changed (test-only)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)