### PR TITLE
Type CodeMirror SQL dialect loading in language loader

### DIFF
--- a/packages/grafana-ui/src/components/CodeMirror/languageLoader.test.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/languageLoader.test.ts
@@ -9,6 +9,10 @@ jest.mock('@codemirror/lang-sql', () => {
 // The language loader memoizes extensions in a module-level cache, so each test
 // runs with an isolated module registry to exercise loading fresh.
 describe('loadLanguageExtension', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns null when no language is provided', async () => {
     await jest.isolateModulesAsync(async () => {
       const { loadLanguageExtension } = await import('./languageLoader');

--- a/packages/grafana-ui/src/components/CodeMirror/languageLoader.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/languageLoader.ts
@@ -1,3 +1,5 @@
+import { type SQLDialect } from '@codemirror/lang-sql';
+
 import { type CodeMirrorEditorLanguage, type CodeMirrorExtension, type CodeMirrorSqlDialect } from './types';
 
 const DEFAULT_SQL_DIALECT: CodeMirrorSqlDialect = 'standardSql';
@@ -9,7 +11,7 @@ const loadSql = async (dialect: CodeMirrorSqlDialect): Promise<CodeMirrorExtensi
   const { sql, StandardSQL, MySQL } = await import(
     /* webpackChunkName: "codemirror-lang-sql" */ '@codemirror/lang-sql'
   );
-  const dialects = {
+  const dialects: Record<CodeMirrorSqlDialect, SQLDialect> = {
     standardSql: StandardSQL,
     mySql: MySQL,
   };


### PR DESCRIPTION
## Description
Addresses follow-up feedback from #126966 after merge. This tightens the SQL dialect loader typing and makes the language loader tests independent of mock call order.

## Changes
* Type the CodeMirror SQL dialect lookup as `Record<CodeMirrorSqlDialect, SQLDialect>`.
* Clear mocked CodeMirror SQL calls before each `languageLoader` test.

## Risks
Low risk. This is a TypeScript typing and test hygiene follow-up and does not change runtime behavior.

## Demo
Not applicable; no UI behavior changes.

## Testing Instructions
* Review the code

## Reviewer Checklist
- [x] Tests are updated where applicable
- [x] Issue or PR context is linked to PR
- [ ] Code pulled and tested