### PR TITLE
unified-storage: use the same KV when running shared tests

### DIFF
--- a/pkg/storage/unified/resource/lease/lease_test.go
+++ b/pkg/storage/unified/resource/lease/lease_test.go
@@ -19,9 +19,7 @@ import (
 )
 
 func TestLease(t *testing.T) {
-	test.RunLeaseTest(t, func(ctx context.Context) kv.KV {
-		return newMapKV()
-	})
+	test.RunLeaseTest(t, newMapKV())
 }
 
 func TestAcquireNameValidation(t *testing.T) {

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -627,7 +627,8 @@ func runTestKVConcurrent(t *testing.T, kv resource.KV, nsPrefix string) {
 
 						// List to verify it exists
 						found := false
-						for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{}) {
+						start, end := nsRange(nsPrefix)
+						for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{StartKey: start, EndKey: end}) {
 							if err != nil {
 								return
 							}

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -39,9 +39,6 @@ const (
 	testSection = "unified/events"
 )
 
-// NewKVFunc is a function that creates a new KV instance for testing
-type NewKVFunc func(ctx context.Context) resource.KV
-
 // KVTestOptions configures which tests to run
 type KVTestOptions struct {
 	SkipTests map[string]bool
@@ -53,8 +50,15 @@ func GenerateRandomKVPrefix() string {
 	return fmt.Sprintf("kvtest-%d", time.Now().UnixNano())
 }
 
-// RunKVTest runs the KV test suite
-func RunKVTest(t *testing.T, newKV NewKVFunc, opts *KVTestOptions) {
+func nsRange(nsPrefix string) (start, end string) {
+	p := nsPrefix + "/"
+	return p, resource.PrefixRangeEnd(p)
+}
+
+// RunKVTest runs the KV test suite against a single shared KV instance. Cases
+// isolate themselves using key prefixes (see nsPrefix). The passed store is
+// expected to be empty.
+func RunKVTest(t *testing.T, kv resource.KV, opts *KVTestOptions) {
 	if opts == nil {
 		opts = &KVTestOptions{}
 	}
@@ -89,7 +93,7 @@ func RunKVTest(t *testing.T, newKV NewKVFunc, opts *KVTestOptions) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			tc.fn(t, newKV(context.Background()), opts.NSPrefix)
+			tc.fn(t, kv, opts.NSPrefix)
 		})
 	}
 }
@@ -305,8 +309,9 @@ func runTestKVKeys(t *testing.T, kv resource.KV, nsPrefix string) {
 	}
 
 	t.Run("list all keys", func(t *testing.T) {
+		start, end := nsRange(nsPrefix)
 		var keys []string //nolint:prealloc
-		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{}) {
+		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{StartKey: start, EndKey: end}) {
 			require.NoError(t, err)
 			keys = append(keys, k)
 		}
@@ -329,10 +334,13 @@ func runTestKVKeys(t *testing.T, kv resource.KV, nsPrefix string) {
 	})
 
 	t.Run("invalid sort option, defaults to asc", func(t *testing.T) {
+		start, end := nsRange(nsPrefix)
 		var keys []string
 		var errors []error
 		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{
-			Sort: resource.SortOrder(100),
+			StartKey: start,
+			EndKey:   end,
+			Sort:     resource.SortOrder(100),
 		}) {
 			if err != nil {
 				errors = append(errors, err)
@@ -364,7 +372,7 @@ func runTestKVKeys(t *testing.T, kv resource.KV, nsPrefix string) {
 
 	t.Run("list keys returns 0 keys", func(t *testing.T) {
 		// Use a key range with no keys.
-		startKey, endKey := "aaaaa", "aaaaz"
+		startKey, endKey := namespacedKey(nsPrefix, "aaaaa"), namespacedKey(nsPrefix, "aaaaz")
 
 		var keys []string //nolint:prealloc
 		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{
@@ -379,8 +387,9 @@ func runTestKVKeys(t *testing.T, kv resource.KV, nsPrefix string) {
 	})
 
 	t.Run("interrupting the iterator", func(t *testing.T) {
+		start, end := nsRange(nsPrefix)
 		var keys []string //nolint:prealloc
-		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{}) {
+		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{StartKey: start, EndKey: end}) {
 			require.NoError(t, err)
 			keys = append(keys, k)
 
@@ -404,8 +413,9 @@ func runTestKVKeysWithLimits(t *testing.T, kv resource.KV, nsPrefix string) {
 	}
 
 	t.Run("keys with limit", func(t *testing.T) {
+		start, end := nsRange(nsPrefix)
 		var keys []string //nolint:prealloc
-		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{Limit: 3}) {
+		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{StartKey: start, EndKey: end, Limit: 3}) {
 			require.NoError(t, err)
 			keys = append(keys, k)
 		}
@@ -461,8 +471,9 @@ func runTestKVKeysWithSort(t *testing.T, kv resource.KV, nsPrefix string) {
 	}
 
 	t.Run("keys in ascending order (default)", func(t *testing.T) {
+		start, end := nsRange(nsPrefix)
 		var keys []string //nolint:prealloc
-		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{Sort: resource.SortOrderAsc}) {
+		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{StartKey: start, EndKey: end, Sort: resource.SortOrderAsc}) {
 			require.NoError(t, err)
 			keys = append(keys, k)
 		}
@@ -470,8 +481,9 @@ func runTestKVKeysWithSort(t *testing.T, kv resource.KV, nsPrefix string) {
 	})
 
 	t.Run("keys in descending order", func(t *testing.T) {
+		start, end := nsRange(nsPrefix)
 		var keys []string //nolint:prealloc
-		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{Sort: resource.SortOrderDesc}) {
+		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{StartKey: start, EndKey: end, Sort: resource.SortOrderDesc}) {
 			require.NoError(t, err)
 			keys = append(keys, k)
 		}
@@ -505,10 +517,13 @@ func runTestKVKeysWithSort(t *testing.T, kv resource.KV, nsPrefix string) {
 	})
 
 	t.Run("keys descending with limit", func(t *testing.T) {
+		start, end := nsRange(nsPrefix)
 		var keys []string //nolint:prealloc
 		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{
-			Sort:  resource.SortOrderDesc,
-			Limit: 3,
+			StartKey: start,
+			EndKey:   end,
+			Sort:     resource.SortOrderDesc,
+			Limit:    3,
 		}) {
 			require.NoError(t, err)
 			keys = append(keys, k)

--- a/pkg/storage/unified/testing/kv_test.go
+++ b/pkg/storage/unified/testing/kv_test.go
@@ -16,20 +16,12 @@ import (
 )
 
 func TestBadgerKV(t *testing.T) {
-	RunKVTest(t, func(ctx context.Context) resource.KV {
-		opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
-		db, err := badger.Open(opts)
-		require.NoError(t, err)
+	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
+	bdb, err := badger.Open(opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bdb.Close()) })
 
-		t.Cleanup(func() {
-			err := db.Close()
-			require.NoError(t, err)
-		})
-
-		return resource.NewBadgerKV(db)
-	}, &KVTestOptions{
-		NSPrefix: "badger-kv-test",
-	})
+	RunKVTest(t, resource.NewBadgerKV(bdb), &KVTestOptions{NSPrefix: "badger-kv-test"})
 }
 
 func TestMain(m *testing.M) {
@@ -37,16 +29,13 @@ func TestMain(m *testing.M) {
 }
 
 func TestSQLKV(t *testing.T) {
-	RunKVTest(t, func(ctx context.Context) resource.KV {
-		dbstore := db.InitTestDB(t)
-		eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
-		require.NoError(t, err)
-		dbConn, err := eDB.Init(ctx)
-		require.NoError(t, err)
-		kv, err := kv.NewSQLKV(dbConn.SqlDB(), dbConn.DriverName())
-		require.NoError(t, err)
-		return kv
-	}, &KVTestOptions{
-		NSPrefix: "sql-kv-test",
-	})
+	dbstore := db.InitTestDB(t)
+	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
+	require.NoError(t, err)
+	dbConn, err := eDB.Init(context.Background())
+	require.NoError(t, err)
+	sqlKV, err := kv.NewSQLKV(dbConn.SqlDB(), dbConn.DriverName())
+	require.NoError(t, err)
+
+	RunKVTest(t, sqlKV, &KVTestOptions{NSPrefix: "sql-kv-test"})
 }

--- a/pkg/storage/unified/testing/lease.go
+++ b/pkg/storage/unified/testing/lease.go
@@ -23,13 +23,12 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource/lease"
 )
 
-// RunLeaseTest runs the lease contract suite against any kv.KV produced by
-// newKV. The suite is shared between unit tests (using an in-memory map KV)
-// and integration tests (Badger and sqlkv).
-func RunLeaseTest(t *testing.T, newKV NewKVFunc) {
+// RunLeaseTest runs the lease contract suite against a single shared kv.KV. The
+// suite is shared between unit tests (using an in-memory map KV) and integration
+// tests (Badger and sqlkv), and isolates cases from one another via lease names.
+func RunLeaseTest(t *testing.T, store kv.KV) {
 	t.Helper()
 
-	store := newKV(t.Context())
 	t.Cleanup(func() { validateLeaseStore(t, store) })
 
 	t.Run("happy path", func(t *testing.T) { runLeaseHappyPath(t, store) })

--- a/pkg/storage/unified/testing/lease_test.go
+++ b/pkg/storage/unified/testing/lease_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 	"github.com/grafana/grafana/pkg/util/testutil"
@@ -18,31 +17,25 @@ import (
 func TestIntegrationLeaseBadger(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	RunLeaseTest(t, func(ctx context.Context) resource.KV {
-		opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
-		db, err := badger.Open(opts)
-		require.NoError(t, err)
+	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
+	bdb, err := badger.Open(opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bdb.Close()) })
 
-		t.Cleanup(func() {
-			require.NoError(t, db.Close())
-		})
-
-		return kv.NewBadgerKV(db)
-	})
+	RunLeaseTest(t, kv.NewBadgerKV(bdb))
 }
 
 func TestIntegrationLeaseSQLKV(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 	t.Cleanup(db.CleanupTestDB)
 
-	RunLeaseTest(t, func(ctx context.Context) resource.KV {
-		dbstore := db.InitTestDB(t)
-		eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
-		require.NoError(t, err)
-		dbConn, err := eDB.Init(ctx)
-		require.NoError(t, err)
-		store, err := kv.NewSQLKV(dbConn.SqlDB(), dbConn.DriverName())
-		require.NoError(t, err)
-		return store
-	})
+	dbstore := db.InitTestDB(t)
+	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
+	require.NoError(t, err)
+	dbConn, err := eDB.Init(context.Background())
+	require.NoError(t, err)
+	store, err := kv.NewSQLKV(dbConn.SqlDB(), dbConn.DriverName())
+	require.NoError(t, err)
+
+	RunLeaseTest(t, store)
 }


### PR DESCRIPTION
No need to create an entire new database for each test case. Rely on key prefixes to ensure each test is isolated.

Part of: https://github.com/grafana/search-and-storage-team/issues/854