### PR TITLE
Alerting: Track import method analytics in import to gma

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -8,6 +8,7 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { type RuleNamespace } from '../../../types/unified-alerting';
 import { type RulerRulesConfigDTO } from '../../../types/unified-alerting-dto';
 
+import { type ImportMethod } from './components/import-to-gma/Wizard/types';
 import { type Origin } from './components/rule-viewer/tabs/version-history/ConfirmVersionRestoreModal';
 import { type FilterType } from './components/rules/central-state-history/EventListSceneObject';
 import { type RulesFilter } from './search/rulesSearchParser';
@@ -250,18 +251,20 @@ export const trackDeletedRuleRestoreFail = async () => {
 };
 
 export const trackImportToGMASuccess = async (payload: {
+  importMethod?: ImportMethod;
   notificationsSource?: 'yaml' | 'datasource';
   rulesSource?: 'yaml' | 'datasource';
-  isRootFolder: boolean;
+  isRootFolder?: boolean;
   namespace?: string;
   ruleGroup?: string;
-  pauseRecordingRules: boolean;
-  pauseAlertingRules: boolean;
+  pauseRecordingRules?: boolean;
+  pauseAlertingRules?: boolean;
 }) => {
   reportInteraction('grafana_alerting_import_to_gma_success', { ...payload });
 };
 
 export const trackImportToGMAError = async (payload: {
+  importMethod?: ImportMethod;
   notificationsSource?: 'yaml' | 'datasource';
   rulesSource?: 'yaml' | 'datasource';
 }) => {

--- a/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
@@ -169,6 +169,7 @@ export const ConfirmConversionModal = ({ importPayload, isOpen, onDismiss }: Mod
       const isRootFolder = isEmpty(targetFolder?.uid);
 
       trackImportToGMASuccess({
+        importMethod: 'legacy-datasource-rules',
         rulesSource: importSource,
         isRootFolder,
         namespace,
@@ -184,7 +185,7 @@ export const ConfirmConversionModal = ({ importPayload, isOpen, onDismiss }: Mod
       );
       locationService.push(ruleListUrl);
     } catch (error) {
-      trackImportToGMAError({ rulesSource: importSource });
+      trackImportToGMAError({ importMethod: 'legacy-datasource-rules', rulesSource: importSource });
       notifyApp.error(
         t('alerting.import-to-gma.error', 'Failed to import alert rules: {{error}}', {
           error: stringifyErrorLike(error),

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.test.tsx
@@ -1,0 +1,117 @@
+import { HttpResponse, http } from 'msw';
+import { render, screen, waitFor, within } from 'test/test-utils';
+
+import { locationService, reportInteraction } from '@grafana/runtime';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { setupMswServer } from '../../mockApi';
+import { grantUserPermissions } from '../../mocks';
+
+import { ImportWizardGate } from './ImportToGMA';
+
+// Spread requireActual so config/locationService/feature-toggle reads stay real; only stub the
+// analytics sink so we can assert the reported payload.
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+// Seed a valid YAML notifications source so the real useImportNotifications resolves and posts to
+// the convert endpoint (mocked with MSW below). The real step body pulls in network-backed pickers
+// we don't need — the assertion target is handleConfirmImport's tracking payload, not the step UI.
+jest.mock('./steps/Step1AlertmanagerResources', () => {
+  const { useEffect } = require('react');
+  const { useFormContext } = require('react-hook-form');
+  return {
+    Step1Content: function Step1Content() {
+      const { setValue } = useFormContext();
+      useEffect(() => {
+        setValue('notificationsSource', 'yaml');
+        setValue(
+          'notificationsYamlFile',
+          new File(['route:\n  receiver: default\nreceivers:\n  - name: default\n'], 'alertmanager.yaml', {
+            type: 'application/yaml',
+          })
+        );
+      }, [setValue]);
+      return null;
+    },
+    useStep1Validation: () => true,
+  };
+});
+// Rules step is skipped in these flows, so its body never renders a network call.
+jest.mock('./steps/Step2AlertRules', () => ({
+  Step2Content: () => null,
+  useStep2Validation: () => true,
+}));
+
+const CONVERT_URL = '/api/convert/api/v1/alerts';
+
+const server = setupMswServer();
+
+const mockReportInteraction = jest.mocked(reportInteraction);
+
+beforeEach(() => {
+  mockReportInteraction.mockClear();
+  // Default: the notifications import succeeds. Individual tests override this to force a failure.
+  server.use(http.post(CONVERT_URL, () => HttpResponse.json({ status: 'success' })));
+  grantUserPermissions([
+    AccessControlAction.AlertingNotificationsWrite,
+    AccessControlAction.AlertingRuleCreate,
+    AccessControlAction.AlertingProvisioningSetStatus,
+  ]);
+  locationService.push('/');
+});
+
+/**
+ * Drives the wizard: pick the method, complete the notifications step, skip the rules step, then
+ * open and accept the confirm modal. Leaves the rest to the caller's assertions.
+ */
+async function importWith(method: 'stage' | 'promote', user: ReturnType<typeof render>['user']) {
+  if (method === 'promote') {
+    await user.click(await screen.findByRole('radio', { name: /promote/i }));
+  }
+  // Method -> Notifications
+  await user.click(await screen.findByTestId('wizard-next-button'));
+  // Notifications -> Rules (Step1Content is stubbed; it seeds a YAML source and validation is forced true)
+  await user.click(await screen.findByTestId('wizard-next-button'));
+  // Skip Rules -> Review
+  await user.click(await screen.findByTestId('wizard-skip-button'));
+  // Review -> open confirm modal
+  await user.click(await screen.findByRole('button', { name: /start import/i }));
+  // Confirm inside the modal
+  const dialog = await screen.findByRole('dialog');
+  await user.click(within(dialog).getByRole('button', { name: /start import/i }));
+}
+
+describe('ImportToGMA wizard — stage/promote analytics', () => {
+  it.each(['stage', 'promote'] as const)('tracks success with importMethod=%s', async (method) => {
+    const { user } = render(<ImportWizardGate />);
+
+    await importWith(method, user);
+
+    await waitFor(() =>
+      expect(mockReportInteraction).toHaveBeenCalledWith(
+        'grafana_alerting_import_to_gma_success',
+        expect.objectContaining({ importMethod: method })
+      )
+    );
+    await waitFor(() => expect(locationService.getLocation().pathname).toContain('/alerting/list'), { timeout: 3000 });
+  });
+
+  it('tracks an error with importMethod when the import fails', async () => {
+    server.use(http.post(CONVERT_URL, () => new HttpResponse(null, { status: 500 })));
+    const { user } = render(<ImportWizardGate />);
+
+    await importWith('stage', user);
+
+    await waitFor(() =>
+      expect(mockReportInteraction).toHaveBeenCalledWith(
+        'grafana_alerting_import_to_gma_error',
+        expect.objectContaining({ importMethod: 'stage' })
+      )
+    );
+    expect(mockReportInteraction).not.toHaveBeenCalledWith('grafana_alerting_import_to_gma_success', expect.anything());
+    expect(locationService.getLocation().pathname).not.toContain('/alerting/list');
+  });
+});

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -394,6 +394,7 @@ function ImportWizardContent() {
       const isRootFolder = isEmpty(targetFolder?.uid);
 
       trackImportToGMASuccess({
+        importMethod: values.importMethod,
         notificationsSource: willImportNotifications ? values.notificationsSource : undefined,
         rulesSource: willImportRules ? values.rulesSource : undefined,
         isRootFolder,
@@ -418,6 +419,7 @@ function ImportWizardContent() {
     } catch (err) {
       setImportStatus('error');
       trackImportToGMAError({
+        importMethod: values.importMethod,
         notificationsSource: willImportNotifications ? values.notificationsSource : undefined,
         rulesSource: willImportRules ? values.rulesSource : undefined,
       });

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/types.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/types.ts
@@ -10,7 +10,7 @@ export enum StepKey {
   ReviewEnable = 'review-enable',
 }
 
-export type ImportMethod = 'stage' | 'promote' | 'autosync';
+export type ImportMethod = 'stage' | 'promote' | 'autosync' | 'legacy-datasource-rules';
 export interface WizardFormValues {
   importMethod: ImportMethod;
 }

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/StepReviewEnableAutoSync.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/StepReviewEnableAutoSync.test.tsx
@@ -2,11 +2,12 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { render, screen, waitFor } from 'test/test-utils';
 import { byRole, byText } from 'testing-library-selector';
 
-import { locationService } from '@grafana/runtime';
+import { locationService, reportInteraction } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { grantUserRole } from 'app/features/alerting/unified/mocks';
 import {
   type AdminConfigPostState,
+  setupAdminConfigPost,
   setupAlertmanagersStatus,
   setupStatefulAdminConfig,
 } from 'app/features/alerting/unified/mocks/server/configure/admin_config';
@@ -21,6 +22,12 @@ import { StepKey } from '../Wizard/types';
 
 import { StepReviewEnableAutoSync } from './StepReviewEnableAutoSync';
 
+// Spread requireActual so locationService and config stay real; only stub the analytics sink.
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
 const server = setupMswServer();
 
 const MIMIR_DS_UID = 'mimir-uid';
@@ -28,8 +35,13 @@ const MIMIR_DS_NAME = 'Test Mimir Alertmanager';
 
 const postState: AdminConfigPostState = { lastPayload: null };
 
+const mockReportInteraction = jest.mocked(reportInteraction);
+
 beforeEach(() => {
   postState.lastPayload = null;
+  mockReportInteraction.mockClear();
+  // Known baseline so the "did not navigate" assertion is meaningful across tests.
+  locationService.push('/');
   grantUserRole('Admin');
   setupAlertmanagersStatus(server);
   setupStatefulAdminConfig(server, postState);
@@ -72,7 +84,7 @@ describe('StepReviewEnableAutoSync', () => {
     expect(await screen.findByText(MIMIR_DS_NAME)).toBeInTheDocument();
   });
 
-  it('enables auto-sync by posting the selected source and navigates to the alert rules list', async () => {
+  it('enables auto-sync by posting the selected source, tracks success and navigates to the alert rules list', async () => {
     const { user } = renderStep();
 
     await waitFor(() => expect(ui.enableButton.get()).toBeEnabled());
@@ -80,6 +92,27 @@ describe('StepReviewEnableAutoSync', () => {
 
     await waitFor(() => expect(postState.lastPayload).toEqual({ external_alertmanager_uid: MIMIR_DS_UID }));
     await waitFor(() => expect(locationService.getLocation().pathname).toContain('/alerting/list'), { timeout: 3000 });
+
+    expect(mockReportInteraction).toHaveBeenCalledWith('grafana_alerting_import_to_gma_success', {
+      importMethod: 'autosync',
+    });
+  });
+
+  it('tracks an import error and stays on the step when enabling fails', async () => {
+    // Genuine failure — save() rejects, the shared hook shows its own error toast and resolves false.
+    setupAdminConfigPost(server, postState, 500);
+    const { user } = renderStep();
+
+    await waitFor(() => expect(ui.enableButton.get()).toBeEnabled());
+    await user.click(ui.enableButton.get());
+
+    await waitFor(() =>
+      expect(mockReportInteraction).toHaveBeenCalledWith('grafana_alerting_import_to_gma_error', {
+        importMethod: 'autosync',
+      })
+    );
+    expect(mockReportInteraction).not.toHaveBeenCalledWith('grafana_alerting_import_to_gma_success', expect.anything());
+    expect(locationService.getLocation().pathname).not.toContain('/alerting/list');
   });
 
   it('returns to the method step when Back is clicked', async () => {

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/StepReviewEnableAutoSync.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/StepReviewEnableAutoSync.tsx
@@ -4,6 +4,7 @@ import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import { Badge, Box, Button, Stack, Text } from '@grafana/ui';
 
+import { trackImportToGMAError, trackImportToGMASuccess } from '../../../Analytics';
 import { alertListPageLink } from '../../../utils/navigation';
 import { useAutoSyncConfiguration } from '../../settings/useAutoSyncConfiguration';
 import { type ImportFormValues } from '../ImportToGMA';
@@ -33,8 +34,11 @@ export function StepReviewEnableAutoSync({ onCancel }: StepReviewEnableAutoSyncP
   const handleEnable = async () => {
     const enabled = await save(selectedUid);
     if (enabled) {
+      trackImportToGMASuccess({ importMethod: 'autosync' });
       // No list filters are applied for auto-sync.
       locationService.push(alertListPageLink({}, { skipSubPath: true }));
+    } else {
+      trackImportToGMAError({ importMethod: 'autosync' });
     }
   };
 


### PR DESCRIPTION
**What is this feature?**

This PR adds tracking of the import method used in the import to GMA wizard when it is successful or throws an error.
Also added a new import type to track legacy rules only import.

**Why do we need this feature?**

To better track the usage of the import to GMA wizard

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1845

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
