### PR TITLE
fix(settings): Register [dashboard_cleanup] in default config so env overrides apply

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -609,6 +609,15 @@ dashboard_performance_metrics =
 # Maximum number of series that will be showed in a single panel. Users can opt in to rendering all series. Default is 0 (unlimited).
 panel_series_limit =
 
+################################### Dashboard cleanup ####################
+[dashboard_cleanup]
+# How often to run the job that cleans up resources associated with dashboards deleted through /apis. Default: 30s, Minimum: 10s.
+# The interval string must include a unit suffix (ms, s, m, h), e.g. 30s or 1m.
+interval = 30s
+
+# Number of deleted dashboards to process in each batch during cleanup. Default: 10, Minimum: 5, Maximum: 200.
+batch_size = 10
+
 ################################### Data sources #########################
 [datasources]
 # Upper limit of data sources that Grafana will return. This limit is a temporary configuration and it will be deprecated when pagination will be introduced on the list data sources API.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -512,6 +512,15 @@
 # Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json"
 ;default_home_dashboard_path =
 
+################################### Dashboard cleanup ####################
+[dashboard_cleanup]
+# How often to run the job that cleans up resources associated with dashboards deleted through /apis. Default: 30s, Minimum: 10s.
+# The interval string must include a unit suffix (ms, s, m, h), e.g. 30s or 1m.
+;interval = 30s
+
+# Number of deleted dashboards to process in each batch during cleanup. Default: 10, Minimum: 5, Maximum: 200.
+;batch_size = 10
+
 ################################### Data sources #########################
 [datasources]
 # Upper limit of data sources that Grafana will return. This limit is a temporary configuration and it will be deprecated when pagination will be introduced on the list data sources API.


### PR DESCRIPTION
**What is this feature?**

Registers the `[dashboard_cleanup]` section (`interval`, `batch_size`) in `conf/defaults.ini` and `conf/sample.ini`, using the existing defaults from the code (`interval = 30s`, `batch_size = 10`).

**Why do we need this feature?**

`GF_DASHBOARD_CLEANUP_INTERVAL` and `GF_DASHBOARD_CLEANUP_BATCH_SIZE` had no effect. The `dashboard_cleanup` section existed only in Go (`pkg/setting/setting_k8s_dashboard_cleanup.go`) and the docs, never in an ini file. `applyEnvVariableOverrides` (`pkg/setting/setting.go`) only applies an env override when the section/key already exists in the parsed ini file: its first pass overrides existing keys, and its second pass attaches unknown `GF_*` vars only to sections that already exist. With `dashboard_cleanup` absent from `defaults.ini`, both passes skipped it, and `readK8sDashboardCleanupSettings` always fell back to the compiled defaults. Declaring the section (uncommented in `defaults.ini`, commented in `sample.ini`) makes the documented env vars take effect. Values remain subject to the existing clamps (`interval >= 10s`, `batch_size` in `[5, 200]`).

**Who is this feature for?**

Operators who configure Grafana via environment variables (for example Kubernetes/Helm deployments) and want to tune the dashboard cleanup job.

**Which issue(s) does this PR fix?**:

Related to:
- https://github.com/grafana/grafana/issues/126369


**Special notes for your reviewer:**

Config-only change; no change to default behaviour. The section is already documented under `[dashboard_cleanup]` in `docs/sources/setup-grafana/configure-grafana/_index.md`.
