### PR TITLE
TraceView: default trace-to-logs span/trace ID filtering to on

### DIFF
--- a/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.test.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { type DataSourceInstanceSettings, type DataSourceSettings } from '@grafana/data';
 import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
 
-import { type TraceToLogsData, TraceToLogsSettings } from './TraceToLogsSettings';
+import { getTraceToLogsOptions, type TraceToLogsData, TraceToLogsSettings } from './TraceToLogsSettings';
 
 const defaultOptionsOldFormat: DataSourceSettings<TraceToLogsData> = {
   jsonData: {
@@ -118,5 +118,63 @@ describe('TraceToLogsSettings', () => {
         },
       },
     ]);
+  });
+
+  it('renders unset ID filters as enabled by default', () => {
+    const options = {
+      jsonData: {
+        tracesToLogsV2: {
+          datasourceUid: 'loki1_uid',
+          customQuery: false,
+        },
+      },
+    } as unknown as DataSourceSettings<TraceToLogsData>;
+    render(<TraceToLogsSettings options={options} onOptionsChange={() => {}} />);
+    expect((screen.getByLabelText('Filter by trace ID') as HTMLInputElement).checked).toBeTruthy();
+    expect((screen.getByLabelText('Filter by span ID') as HTMLInputElement).checked).toBeTruthy();
+  });
+});
+
+describe('getTraceToLogsOptions', () => {
+  it('defaults span and trace ID filtering to on when unset (v2)', () => {
+    const result = getTraceToLogsOptions({
+      tracesToLogsV2: { datasourceUid: 'loki1_uid', customQuery: false },
+    });
+    expect(result?.filterByTraceID).toBe(true);
+    expect(result?.filterBySpanID).toBe(true);
+  });
+
+  it('preserves an explicit false opt-out (v2)', () => {
+    const result = getTraceToLogsOptions({
+      tracesToLogsV2: {
+        datasourceUid: 'loki1_uid',
+        customQuery: false,
+        filterByTraceID: false,
+        filterBySpanID: false,
+      },
+    });
+    expect(result?.filterByTraceID).toBe(false);
+    expect(result?.filterBySpanID).toBe(false);
+  });
+
+  it('defaults span and trace ID filtering to on when unset (v1 -> v2 transform)', () => {
+    const result = getTraceToLogsOptions({
+      tracesToLogs: { datasourceUid: 'loki1_uid' },
+    });
+    expect(result?.filterByTraceID).toBe(true);
+    expect(result?.filterBySpanID).toBe(true);
+  });
+
+  it('preserves an explicit false opt-out through the v1 -> v2 transform', () => {
+    const result = getTraceToLogsOptions({
+      tracesToLogs: { datasourceUid: 'loki1_uid', filterByTraceID: false, filterBySpanID: false },
+    });
+    expect(result?.filterByTraceID).toBe(false);
+    expect(result?.filterBySpanID).toBe(false);
+  });
+
+  it('returns undefined when no trace-to-logs config is present', () => {
+    expect(getTraceToLogsOptions({})).toBeUndefined();
+    expect(getTraceToLogsOptions(undefined)).toBeUndefined();
   });
 });

--- a/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx
@@ -52,10 +52,17 @@ export interface TraceToLogsData extends DataSourceJsonData {
 /**
  * Gets new version of the traceToLogs config from the json data either returning directly or transforming the old
  * version to new and returning that.
+ *
+ * Span and trace ID filtering default to on when unset so the trace-to-logs link scopes logs to the span/trace
+ * instead of returning every log for the service. An explicit `false` means the user opted out and is preserved.
  */
 export function getTraceToLogsOptions(data?: TraceToLogsData): TraceToLogsOptionsV2 | undefined {
   if (data?.tracesToLogsV2) {
-    return data.tracesToLogsV2;
+    return {
+      ...data.tracesToLogsV2,
+      filterByTraceID: data.tracesToLogsV2.filterByTraceID ?? true,
+      filterBySpanID: data.tracesToLogsV2.filterBySpanID ?? true,
+    };
   }
   if (!data?.tracesToLogs) {
     return undefined;
@@ -67,8 +74,8 @@ export function getTraceToLogsOptions(data?: TraceToLogsData): TraceToLogsOption
   traceToLogs.tags = data.tracesToLogs.mapTagNamesEnabled
     ? data.tracesToLogs.mappedTags
     : data.tracesToLogs.tags?.map((tag) => ({ key: tag }));
-  traceToLogs.filterByTraceID = data.tracesToLogs.filterByTraceID;
-  traceToLogs.filterBySpanID = data.tracesToLogs.filterBySpanID;
+  traceToLogs.filterByTraceID = data.tracesToLogs.filterByTraceID ?? true;
+  traceToLogs.filterBySpanID = data.tracesToLogs.filterBySpanID ?? true;
   traceToLogs.spanStartTimeShift = data.tracesToLogs.spanStartTimeShift;
   traceToLogs.spanEndTimeShift = data.tracesToLogs.spanEndTimeShift;
   return traceToLogs;

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -152,7 +152,12 @@ export function TraceView(props: Props) {
   );
 
   const instanceSettings = getDatasourceSrv().getInstanceSettings(datasource?.name);
-  const traceToLogsOptions = getTraceToLogsOptions(instanceSettings?.jsonData);
+  // getTraceToLogsOptions applies defaults and returns a fresh object, so memoize to keep the
+  // createSpanLink useMemo below stable across renders.
+  const traceToLogsOptions = useMemo(
+    () => getTraceToLogsOptions(instanceSettings?.jsonData),
+    [instanceSettings?.jsonData]
+  );
   const traceToMetrics: TraceToMetricsData | undefined = instanceSettings?.jsonData;
   const traceToMetricsOptions = traceToMetrics?.tracesToMetrics;
   const traceToProfilesData: TraceToProfilesData | undefined = instanceSettings?.jsonData;


### PR DESCRIPTION
## What this PR does / why we need it

The "Logs for this span" link in the trace view returned **service-scoped** logs by default. `filterByTraceID` and `filterBySpanID` were off unless a user explicitly enabled them, so the generated query filtered on tags only (`{service=…, namespace=…, pod=…}`). The label promised span/trace scoping the query never delivered.

This defaults both filters to on when they are unset, so the link scopes to the span/trace out of the box. The change is applied in `getTraceToLogsOptions`, which normalizes both the current (`tracesToLogsV2`) and legacy (`tracesToLogs`) config formats, so coverage is uniform regardless of which format a datasource is stored in. An explicit `false` is preserved as an opt-out, and custom queries are unaffected.

`traceToLogsOptions` in `TraceView` is now memoized because `getTraceToLogsOptions` returns a fresh object; this keeps the `createSpanLink` memo stable across renders.

## Which issue(s) this PR fixes

Fixes #126968

## Special notes for your reviewer

This is a **behavior change** applied at read time — no stored migration. It affects existing *and* new Tempo/Jaeger datasources whose flags are unset: on upgrade, clicking the link returns span/trace-scoped logs instead of all service logs. For logs that do not carry the trace/span ID this can yield empty results, which is the intended, more-honest outcome over silently returning unrelated logs. Users can opt back out by turning the toggle off.

Runtime behavior updates with core immediately for both Tempo and Jaeger (the trace view and `createSpanLink` are in core). Tempo's config-editor toggle *display* reflects the new default once the externalized plugin bumps its `@grafana/o11y-ds-frontend` dependency; the actual query behavior is already correct via core.

Affected datasources: Tempo and Jaeger (the only two exposing a trace-to-logs config section). Zipkin has none and is untouched.

## Test plan

- `yarn jest TraceToLogsSettings createSpanLink TraceView` — 70 + 13 pass, including new `getTraceToLogsOptions` unit tests (unset → true for v1/v2, explicit `false` preserved, no-config → undefined) and a component test asserting unset flags render both toggles checked.
- `yarn typecheck`, `yarn prettier --check` — clean.

Generated with [Claude Code](https://claude.com/claude-code)
