### PR TITLE
MSSQL: Add to default bundled and preinstalled plugins

### DIFF
--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -43,6 +43,7 @@ var (
 		"zipkin":                       {ID: "zipkin"},
 		"opentsdb":                     {ID: "opentsdb"},
 		"stackdriver":                  {ID: "stackdriver"},
+		"mssql":                        {ID: "mssql"},
 	}
 )
 

--- a/scripts/catalog-plugins-defaults
+++ b/scripts/catalog-plugins-defaults
@@ -5,3 +5,4 @@ tempo
 zipkin
 opentsdb
 stackdriver
+mssql


### PR DESCRIPTION
**What is this feature?**

Add MSSQL to the default plugin lists so on-prem and OSS users continue to have access to it after it is removed from core.
This is the on-prem preparation step before removing MSSQL from core. With both core and bundled versions present, nightly builds can validate that the external plugin works correctly as a drop-in replacement.

**Why do we need this feature?**

To be able to remove MSSQL from grafana/grafana 

**Who is this feature for?**

Grafana developers

Reference PR:
- https://github.com/grafana/grafana/pull/126842

Please check that:
- [ ] It works as expected from a user's perspective.