### PR TITLE
Provisioning: Refactor github webhooks to allow GithubEnterprise reuse

### DIFF
--- a/apps/provisioning/pkg/repository/github/extra.go
+++ b/apps/provisioning/pkg/repository/github/extra.go
@@ -76,9 +76,24 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 		return nil, fmt.Errorf("error creating github repository: %w", err)
 	}
 
-	if util.IsInterfaceNil(e.webhookBuilder) {
-		return ghRepo, nil
+	return MaybeWrapWithWebhook(ctx, r, ghRepo, secure, e.webhookBuilder)
+}
+
+// MaybeWrapWithWebhook wraps base as a webhook-capable repository when a webhook
+// URL is configured and enabled; otherwise it returns base unchanged. When the
+// webhook is disabled but a previously registered hook still exists, base is
+// wrapped with empty credentials so the reconciler can delete the stale hook.
+func MaybeWrapWithWebhook(
+	ctx context.Context,
+	r *provisioning.Repository,
+	base GithubRepository,
+	secure repository.SecureValues,
+	webhookBuilder WebhookURLBuilder,
+) (repository.Repository, error) {
+	if util.IsInterfaceNil(webhookBuilder) {
+		return base, nil
 	}
+	logger := logging.FromContext(ctx)
 
 	// Webhook integration is explicitly disabled for this repository, so polling will be
 	// used instead. Skip registration even if a webhook URL would otherwise be available.
@@ -87,15 +102,15 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 	if r.Spec.Webhook != nil && r.Spec.Webhook.Disabled {
 		if r.Status.Webhook == nil || r.Status.Webhook.ID == 0 {
 			logger.Debug("Skipping webhook setup: webhook is disabled")
-			return ghRepo, nil
+			return base, nil
 		}
-		return NewGithubWebhookRepository(ghRepo, "", ""), nil
+		return NewGithubWebhookRepository(base, "", ""), nil
 	}
 
-	webhookURL := e.webhookBuilder.WebhookURL(ctx, r)
+	webhookURL := webhookBuilder.WebhookURL(ctx, r)
 	if len(webhookURL) == 0 {
 		logger.Debug("Skipping webhook setup as no webhooks are not configured")
-		return ghRepo, nil
+		return base, nil
 	}
 
 	webhookSecret, err := secure.WebhookSecret(ctx)
@@ -103,7 +118,7 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 		return nil, fmt.Errorf("decrypt webhookSecret: %w", err)
 	}
 
-	return NewGithubWebhookRepository(ghRepo, webhookURL, webhookSecret), nil
+	return NewGithubWebhookRepository(base, webhookURL, webhookSecret), nil
 }
 
 func (e *extra) Mutate(ctx context.Context, obj runtime.Object) error {


### PR DESCRIPTION
**What is this feature?**
Refactoring some github webhook logic into 1 public function so Github Enterprise can call it.

Dependent Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/12573

**Who is this feature for?**
Enterprise

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1213

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
