### PR TITLE
Dashboards: fix race condition in row item repeater. 

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.test.tsx
@@ -8,6 +8,7 @@ import {
   CustomVariable,
   LocalValueVariable,
   type MultiValueVariable,
+  sceneGraph,
   SceneTimeRange,
   SceneVariableSet,
   TestVariable,
@@ -81,16 +82,24 @@ describe('RowItemRepeater', () => {
       const { repeatByVariable, rowToRepeat } = renderScene({ variableQueryTime: 0 });
       let stateUpdates = 0;
 
-      rowToRepeat.subscribeToState((s) => stateUpdates++);
+      rowToRepeat.subscribeToState(() => stateUpdates++);
 
       await waitFor(() => {
         expect(screen.queryByText('Row C')).toBeInTheDocument();
       });
 
+      // Flush deferred initial performRowRepeats before measuring the no-op path.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      stateUpdates = 0;
+
       act(() => {
         repeatByVariable.changeValueTo(['A1', 'B1', 'C1']);
       });
 
+      // performRowRepeats skips re-cloning (same values), but the variable change
+      // still yields a single row state notification — same as pre-setTimeout behavior.
       expect(stateUpdates).toBe(1);
     });
 
@@ -172,6 +181,95 @@ describe('RowItemRepeater', () => {
         expect(variables![0].state.name).toBe('server');
         expect(variables![0].getValue()).toBe('row-scope');
       }
+    });
+  });
+
+  describe('render-before-activation race', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.useRealTimers();
+    });
+
+    it('does not initialize repeats when deps are loading, and stays stuck if the repeat variable never notifies again', () => {
+      const row = new RowItem({
+        key: 'row-1',
+        title: 'Row $item',
+        repeatByVariable: 'item',
+        layout: AutoGridLayoutManager.createEmpty(),
+      });
+      const item = new CustomVariable({
+        name: 'item',
+        query: 'alpha',
+        value: 'alpha',
+        text: 'alpha',
+      });
+      // Attach a parent so performRowRepeats can publish NewSceneObjectAddedEvent safely.
+      new RowsLayoutManager({ rows: [row] });
+
+      const hasLoading = jest.spyOn(sceneGraph, 'hasVariableDependencyInLoadingState').mockReturnValue(true);
+
+      performRowRepeats(item as unknown as MultiValueVariable, row, false);
+      expect(row.state.repeatedRows).toBeUndefined();
+
+      // Deps clear without an item state change — mirrors a URL-preselected var finishing
+      // (or set becoming active) without notifying subscribeToState.
+      hasLoading.mockReturnValue(false);
+      expect(row.state.repeatedRows).toBeUndefined();
+
+      performRowRepeats(item as unknown as MultiValueVariable, row, false);
+      expect(row.state.repeatedRows).toBeDefined();
+      expect(row.state.repeatedRows).toHaveLength(0);
+    });
+
+    it('Should initialize repeats via deferred mount after dependency loading clears without a variable state change', async () => {
+      jest.useFakeTimers();
+
+      let depsLoading = true;
+      jest.spyOn(sceneGraph, 'hasVariableDependencyInLoadingState').mockImplementation(() => depsLoading);
+
+      const row = new RowItem({
+        key: 'row-1',
+        title: 'Row $item',
+        repeatByVariable: 'item',
+        layout: new AutoGridLayoutManager({
+          layout: new AutoGridLayout({
+            children: [
+              new AutoGridItem({
+                body: buildTextPanel('text-1', 'Panel inside repeated row, item = $item'),
+              }),
+            ],
+          }),
+        }),
+      });
+      // Pre-resolved single value (URL-selected) — no further state updates.
+      const item = new CustomVariable({
+        name: 'item',
+        query: 'alpha',
+        value: 'alpha',
+        text: 'alpha',
+      });
+      const scene = new DashboardScene({
+        $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+        $variables: new SceneVariableSet({ variables: [item] }),
+        body: new RowsLayoutManager({ rows: [row] }),
+      });
+
+      render(<scene.Component model={scene} />);
+
+      // Mount effect scheduled setTimeout(0); deps still "loading" so a sync perform would skip.
+      expect(row.state.repeatedRows).toBeUndefined();
+
+      // Set / deps become ready before the deferred perform runs (RENDER_BEFORE_ACTIVATION).
+      depsLoading = false;
+
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+
+      await waitFor(() => {
+        expect(row.state.repeatedRows).toBeDefined();
+        expect(screen.queryByText('Row alpha')).toBeInTheDocument();
+      });
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.tsx
@@ -28,9 +28,14 @@ interface Props {
 export function RowItemRepeater({ row, variable }: Props) {
   const { repeatedRows } = row.useState();
 
-  // Subscribe to variable state changes and perform repeats when the variable changes
+  // Subscribe to variable state changes and perform repeats when the variable changes.
+  // Defer the initial performRowRepeats to the next macrotask so the parent SceneVariableSet
+  // can activate first under RENDER_BEFORE_ACTIVATION (same fix as TabItemRepeater / #118567).
+  // A sync call here can early-return while the set is inactive; if the later options update
+  // does not notify subscribeToState (URL value already set), repeatedRows stays undefined
+  // and the row spinner never clears.
   useEffect(() => {
-    performRowRepeats(variable, row, false);
+    const timeoutId = setTimeout(() => performRowRepeats(variable, row, false), 0);
 
     const variableChangeSub = variable.subscribeToState((state) => performRowRepeats(variable, row, false));
     const editEventSub = row.subscribeToEvent(DashboardStateChangedEvent, (e) =>
@@ -38,6 +43,7 @@ export function RowItemRepeater({ row, variable }: Props) {
     );
 
     return () => {
+      clearTimeout(timeoutId);
       editEventSub.unsubscribe();
       variableChangeSub.unsubscribe();
     };

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.tsx
@@ -30,7 +30,7 @@ export function RowItemRepeater({ row, variable }: Props) {
 
   // Subscribe to variable state changes and perform repeats when the variable changes.
   // Defer the initial performRowRepeats to the next macrotask so the parent SceneVariableSet
-  // can activate first under RENDER_BEFORE_ACTIVATION (same fix as TabItemRepeater / #118567).
+  // can activate first under RENDER_BEFORE_ACTIVATION).
   // A sync call here can early-return while the set is inactive; if the later options update
   // does not notify subscribeToState (URL value already set), repeatedRows stays undefined
   // and the row spinner never clears.


### PR DESCRIPTION
- Fixes an intermittent infinite loading spinner on **RowsLayout** rows that repeat by a variable (`RowItemRepeater`).
- Same race as repeated tabs: under `RENDER_BEFORE_ACTIVATION` (`grafana.scenesFlickeringFix`), the first `performRowRepeats` can run while the parent `SceneVariableSet` is still inactive, early-return, and never retry if the repeat variable does not emit another state change (common when the value is already set from the URL).
- Ports the tab fix from #118567: defer the initial `performRowRepeats` with `setTimeout(0)` and `clearTimeout` on unmount.
- Adds regression tests for the skip-without-retry race and deferred-mount recovery.

### What was happening

On cold load (especially after clearing browser cache), a repeating row could show a spinner forever. Soft refresh often recovered. Sibling non-repeating rows on the same dashboard loaded normally.

#### HAR findings (stuck load)

Captured while the repeating row was spinning indefinitely:

| Observation | Detail |
| --- | --- |
| Variable queries | All completed **200 OK** (dependency chain + repeat variable), ~0.2–1s |
| Non-repeating rows | Panel queries ran and completed successfully |
| Repeating row panels | **Zero** panel queries — the row never left the spinner / never mounted panel query runners |
| Errors / hung requests | None relevant (no failed variable or query calls for the stuck row) |

Conclusion: not a datasource hang. `RowItemRepeater` kept `repeatedRows === undefined` after variables finished, so it stayed on `<Spinner />`.

Fixes: https://github.com/grafana/support-escalations/issues/23247