### PR TITLE
Secret: Return cipher error from Encrypt instead of discarding it

### DIFF
--- a/pkg/registry/apis/secret/encryption/cipher/service/service.go
+++ b/pkg/registry/apis/secret/encryption/cipher/service/service.go
@@ -130,6 +130,9 @@ func (s *cipherService) Encrypt(ctx context.Context, payload []byte, secret stri
 
 	var encrypted []byte
 	encrypted, err = s.cipher.Encrypt(ctx, payload, secret)
+	if err != nil {
+		return nil, err
+	}
 
 	prefix := make([]byte, base64.RawStdEncoding.EncodedLen(len([]byte(s.algorithm)))+2)
 	base64.RawStdEncoding.Encode(prefix[1:], []byte(s.algorithm))

--- a/pkg/registry/apis/secret/encryption/cipher/service/service_test.go
+++ b/pkg/registry/apis/secret/encryption/cipher/service/service_test.go
@@ -1,14 +1,18 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption/cipher"
+	"github.com/grafana/grafana/pkg/registry/apis/secret/encryption/cipher/provider"
 )
 
 func newGcmService(t *testing.T) cipher.Cipher {
@@ -18,6 +22,12 @@ func newGcmService(t *testing.T) cipher.Cipher {
 	svc, err := ProvideAESGCMCipherService(noop.NewTracerProvider().Tracer("test"), usageStats)
 	require.NoError(t, err, "failed to set up encryption service")
 	return svc
+}
+
+type erroringEncrypter struct{ err error }
+
+func (e erroringEncrypter) Encrypt(context.Context, []byte, string) ([]byte, error) {
+	return nil, e.err
 }
 
 func TestService(t *testing.T) {
@@ -68,5 +78,22 @@ func TestService(t *testing.T) {
 		_, err := svc.Decrypt(t.Context(), []byte("x"), "1234")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing algorithm delimiter")
+	})
+
+	t.Run("encrypt should propagate cipher error instead of returning a bogus ciphertext", func(t *testing.T) {
+		t.Parallel()
+
+		// Regression: Encrypt used to discard this error and return a bogus payload as success.
+		wantErr := errors.New("cipher failure")
+		svc := &cipherService{
+			tracer:    noop.NewTracerProvider().Tracer("test"),
+			log:       log.New("test"),
+			cipher:    erroringEncrypter{err: wantErr},
+			algorithm: provider.AesGcm,
+		}
+
+		out, err := svc.Encrypt(t.Context(), []byte("grafana"), "1234")
+		require.ErrorIs(t, err, wantErr)
+		require.Nil(t, out)
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Bug fix: `cipherService.Encrypt` now returns the error from the underlying cipher instead of discarding it.

**Why do we need this feature?**

`Encrypt` captured the cipher error but returned `(ciphertext, nil)`, so a cipher failure produced a prefix-only payload reported as success, and callers persisted an unrecoverable value believing encryption had succeeded.

**Who is this feature for?**

Anyone relying on the secrets encryption path; it surfaces encryption failures instead of masking them.

**Which issue(s) does this PR fix?**:

None filed.

**Special notes for your reviewer:**

Added a regression subtest (stub cipher that fails): it fails before this change and passes after. `gofmt`, `go vet`, and `golangci-lint` clean.

Please check that:
- [x] It works as expected from a user's perspective. (Regression test added.)
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A — bug fix.)
- [ ] The docs are updated. (N/A — no user-facing change.)
