### PR TITLE
Provisioning: Stop using generateDashboardPreviews on githubEnterprise spec

### DIFF
--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -137,7 +137,6 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
     case 'githubEnterprise':
       spec.githubEnterprise = {
         ...baseConfig,
-        generateDashboardPreviews: data.generateDashboardPreviews,
       };
       break;
     case 'gitlab':
@@ -205,8 +204,7 @@ export const specToData = (spec: RepositorySpec): RepositoryFormData => {
     branchOptions: spec.branch,
     url: remoteConfig?.url || '',
     tokenUser: tokenUser || '',
-    generateDashboardPreviews:
-      spec.github?.generateDashboardPreviews || spec.githubEnterprise?.generateDashboardPreviews || false,
+    generateDashboardPreviews: spec.github?.generateDashboardPreviews || false,
     readOnly: !spec.workflows.length,
     prWorkflow: spec.workflows.includes('branch'),
     enablePushToConfiguredBranch: spec.workflows.includes('write'),


### PR DESCRIPTION
Frontend: stop reading and writing `generateDashboardPreviews` under `spec.githubEnterprise`.

The backend moves this flag off `GitHubEnterpriseRepositoryConfig` onto `PullRequestOptions` (stacked PR above). This lands first so the frontend never serializes a field the API is about to remove.

- `dataToSpec`: no longer writes `generateDashboardPreviews` to the `githubEnterprise` config
- `specToData`: no longer reads it from `spec.githubEnterprise`

Part of the GitHub Enterprise dashboard previews stack.

---
_Generated by Claude_