### PR TITLE
Move DashboardPreview option to PullRequestOption

### DIFF
--- a/apps/provisioning/kinds/repository.cue
+++ b/apps/provisioning/kinds/repository.cue
@@ -47,8 +47,6 @@ repository: {
 					token?: string
 					// Token for accessing the repository, but encrypted. This is not possible to read back to a user decrypted.
 					encryptedToken?: [...string]
-					// Whether we should show dashboard previews for pull requests.
-					generateDashboardPreviews?: bool
 					// Path is the subdirectory for the Grafana data inside the repository.
 					path?: string
 				}

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -77,6 +77,7 @@ type GitHubRepositoryConfig struct {
 
 	// Whether we should show dashboard previews for pull requests.
 	// By default, this is false (i.e. we will not create previews).
+	// TODO: deprecate this field in favor of PullRequestOptions.GenerateDashboardPreviews once all Github repositories have been backfilled.
 	GenerateDashboardPreviews bool `json:"generateDashboardPreviews,omitempty"`
 
 	// Path is the subdirectory for the Grafana data. If specified, Grafana will ignore anything that is outside this directory in the repository.
@@ -102,9 +103,6 @@ type GitHubEnterpriseRepositoryConfig struct {
 
 	// The branch to use in the repository.
 	Branch string `json:"branch"`
-
-	// Whether we should show dashboard previews for pull requests.
-	GenerateDashboardPreviews bool `json:"generateDashboardPreviews,omitempty"`
 
 	// Path is the subdirectory for the Grafana data inside the repository.
 	Path string `json:"path,omitempty"`
@@ -334,20 +332,12 @@ func (r *Repository) Path() string {
 }
 
 func (r *Repository) ShouldGenerateDashboardPreviews() bool {
-	switch r.Spec.Type {
-	case GitHubRepositoryType:
-		if r.Spec.GitHub != nil {
-			return r.Spec.GitHub.GenerateDashboardPreviews
-		}
-	case GitHubEnterpriseRepositoryType:
-		if r.Spec.GitHubEnterprise != nil {
-			return r.Spec.GitHubEnterprise.GenerateDashboardPreviews
-		}
-	default:
-		return false
+	// GitHub keeps this on its own config until existing repositories are backfilled
+	// onto PullRequest options. Every other provider reads it from PullRequest.
+	if r.Spec.Type == GitHubRepositoryType {
+		return r.Spec.GitHub != nil && r.Spec.GitHub.GenerateDashboardPreviews
 	}
-
-	return false
+	return r.Spec.PullRequest != nil && r.Spec.PullRequest.GenerateDashboardPreviews
 }
 
 // ConnectionName returns the name of the connection referenced by this repository,
@@ -444,6 +434,10 @@ type PullRequestOptions struct {
 
 	// When true, the PR title field in Save drawers is read-only.
 	EnforceTemplate bool `json:"enforceTemplate,omitempty"`
+
+	// Whether we should show dashboard previews for pull requests.
+	// By default, this is false (i.e. we will not create previews).
+	GenerateDashboardPreviews bool `json:"generateDashboardPreviews,omitempty"`
 }
 
 func (PullRequestOptions) OpenAPIModelName() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types_test.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types_test.go
@@ -266,27 +266,27 @@ func TestRepository_ShouldGenerateDashboardPreviews(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "githubEnterprise with previews enabled",
+			name: "githubEnterprise with previews enabled via pull request options",
 			repo: v0alpha1.Repository{
 				Spec: v0alpha1.RepositorySpec{
-					Type:             v0alpha1.GitHubEnterpriseRepositoryType,
-					GitHubEnterprise: &v0alpha1.GitHubEnterpriseRepositoryConfig{GenerateDashboardPreviews: true},
+					Type:        v0alpha1.GitHubEnterpriseRepositoryType,
+					PullRequest: &v0alpha1.PullRequestOptions{GenerateDashboardPreviews: true},
 				},
 			},
 			want: true,
 		},
 		{
-			name: "githubEnterprise with previews disabled",
+			name: "githubEnterprise with previews disabled via pull request options",
 			repo: v0alpha1.Repository{
 				Spec: v0alpha1.RepositorySpec{
-					Type:             v0alpha1.GitHubEnterpriseRepositoryType,
-					GitHubEnterprise: &v0alpha1.GitHubEnterpriseRepositoryConfig{GenerateDashboardPreviews: false},
+					Type:        v0alpha1.GitHubEnterpriseRepositoryType,
+					PullRequest: &v0alpha1.PullRequestOptions{GenerateDashboardPreviews: false},
 				},
 			},
 			want: false,
 		},
 		{
-			name: "githubEnterprise type with nil config",
+			name: "githubEnterprise type with nil pull request options",
 			repo: v0alpha1.Repository{
 				Spec: v0alpha1.RepositorySpec{
 					Type: v0alpha1.GitHubEnterpriseRepositoryType,
@@ -295,7 +295,17 @@ func TestRepository_ShouldGenerateDashboardPreviews(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "non-github type returns false",
+			name: "gitlab with previews enabled via pull request options",
+			repo: v0alpha1.Repository{
+				Spec: v0alpha1.RepositorySpec{
+					Type:        v0alpha1.GitLabRepositoryType,
+					PullRequest: &v0alpha1.PullRequestOptions{GenerateDashboardPreviews: true},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "non-github type with nil pull request options returns false",
 			repo: v0alpha1.Repository{
 				Spec: v0alpha1.RepositorySpec{
 					Type: v0alpha1.GitLabRepositoryType,

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -1075,13 +1075,6 @@ func schema_pkg_apis_provisioning_v0alpha1_GitHubEnterpriseRepositoryConfig(ref 
 							Format:      "",
 						},
 					},
-					"generateDashboardPreviews": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Whether we should show dashboard previews for pull requests.",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Path is the subdirectory for the Grafana data inside the repository.",
@@ -2084,6 +2077,13 @@ func schema_pkg_apis_provisioning_v0alpha1_PullRequestOptions(ref common.Referen
 					"enforceTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "When true, the PR title field in Save drawers is read-only.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"generateDashboardPreviews": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether we should show dashboard previews for pull requests. By default, this is false (i.e. we will not create previews).",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/githubenterpriserepositoryconfig.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/githubenterpriserepositoryconfig.go
@@ -16,8 +16,6 @@ type GitHubEnterpriseRepositoryConfigApplyConfiguration struct {
 	URL *string `json:"url,omitempty"`
 	// The branch to use in the repository.
 	Branch *string `json:"branch,omitempty"`
-	// Whether we should show dashboard previews for pull requests.
-	GenerateDashboardPreviews *bool `json:"generateDashboardPreviews,omitempty"`
 	// Path is the subdirectory for the Grafana data inside the repository.
 	Path *string `json:"path,omitempty"`
 }
@@ -49,14 +47,6 @@ func (b *GitHubEnterpriseRepositoryConfigApplyConfiguration) WithURL(value strin
 // If called multiple times, the Branch field is set to the value of the last call.
 func (b *GitHubEnterpriseRepositoryConfigApplyConfiguration) WithBranch(value string) *GitHubEnterpriseRepositoryConfigApplyConfiguration {
 	b.Branch = &value
-	return b
-}
-
-// WithGenerateDashboardPreviews sets the GenerateDashboardPreviews field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the GenerateDashboardPreviews field is set to the value of the last call.
-func (b *GitHubEnterpriseRepositoryConfigApplyConfiguration) WithGenerateDashboardPreviews(value bool) *GitHubEnterpriseRepositoryConfigApplyConfiguration {
-	b.GenerateDashboardPreviews = &value
 	return b
 }
 

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/githubrepositoryconfig.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/githubrepositoryconfig.go
@@ -13,6 +13,7 @@ type GitHubRepositoryConfigApplyConfiguration struct {
 	Branch *string `json:"branch,omitempty"`
 	// Whether we should show dashboard previews for pull requests.
 	// By default, this is false (i.e. we will not create previews).
+	// TODO: deprecate this field in favor of PullRequestOptions.GenerateDashboardPreviews once all Github repositories have been backfilled.
 	GenerateDashboardPreviews *bool `json:"generateDashboardPreviews,omitempty"`
 	// Path is the subdirectory for the Grafana data. If specified, Grafana will ignore anything that is outside this directory in the repository.
 	// This is usually something like `grafana/`. Trailing and leading slash are not required. They are always added when needed.

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/pullrequestoptions.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/pullrequestoptions.go
@@ -14,6 +14,9 @@ type PullRequestOptionsApplyConfiguration struct {
 	TitleTemplate *string `json:"titleTemplate,omitempty"`
 	// When true, the PR title field in Save drawers is read-only.
 	EnforceTemplate *bool `json:"enforceTemplate,omitempty"`
+	// Whether we should show dashboard previews for pull requests.
+	// By default, this is false (i.e. we will not create previews).
+	GenerateDashboardPreviews *bool `json:"generateDashboardPreviews,omitempty"`
 }
 
 // PullRequestOptionsApplyConfiguration constructs a declarative configuration of the PullRequestOptions type for use with
@@ -35,5 +38,13 @@ func (b *PullRequestOptionsApplyConfiguration) WithTitleTemplate(value string) *
 // If called multiple times, the EnforceTemplate field is set to the value of the last call.
 func (b *PullRequestOptionsApplyConfiguration) WithEnforceTemplate(value bool) *PullRequestOptionsApplyConfiguration {
 	b.EnforceTemplate = &value
+	return b
+}
+
+// WithGenerateDashboardPreviews sets the GenerateDashboardPreviews field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the GenerateDashboardPreviews field is set to the value of the last call.
+func (b *PullRequestOptionsApplyConfiguration) WithGenerateDashboardPreviews(value bool) *PullRequestOptionsApplyConfiguration {
+	b.GenerateDashboardPreviews = &value
 	return b
 }

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -184,14 +184,13 @@ func (v *RepositoryValidator) validateDashboardPreviews(cfg *provisioning.Reposi
 	if v.allowImageRendering {
 		return nil
 	}
-	if cfg.Spec.GitHub != nil && cfg.Spec.GitHub.GenerateDashboardPreviews {
+	// Mirror the runtime accessor so validation covers every provider (GitHub reads
+	// its own config; others read PullRequest) and can never drift from it.
+	if cfg.ShouldGenerateDashboardPreviews() {
 		return field.ErrorList{field.Invalid(field.NewPath("spec", "generateDashboardPreviews"),
-			cfg.Spec.GitHub.GenerateDashboardPreviews, "image rendering is not enabled")}
+			true, "image rendering is not enabled")}
 	}
-	if cfg.Spec.GitHubEnterprise != nil && cfg.Spec.GitHubEnterprise.GenerateDashboardPreviews {
-		return field.ErrorList{field.Invalid(field.NewPath("spec", "generateDashboardPreviews"),
-			cfg.Spec.GitHubEnterprise.GenerateDashboardPreviews, "image rendering is not enabled")}
-	}
+
 	return nil
 }
 

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -155,7 +155,7 @@ func TestValidator_Validate(t *testing.T) {
 			},
 		},
 		{
-			name: "githubEnterprise enabled when image rendering is not allowed",
+			name: "githubEnterprise previews enabled via pull request options when image rendering is not allowed",
 			repository: func() *provisioning.Repository {
 				return &provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
@@ -164,7 +164,8 @@ func TestValidator_Validate(t *testing.T) {
 					Spec: provisioning.RepositorySpec{
 						Title:            "Test Repo",
 						Type:             provisioning.GitHubEnterpriseRepositoryType,
-						GitHubEnterprise: &provisioning.GitHubEnterpriseRepositoryConfig{GenerateDashboardPreviews: true},
+						GitHubEnterprise: &provisioning.GitHubEnterpriseRepositoryConfig{},
+						PullRequest:      &provisioning.PullRequestOptions{GenerateDashboardPreviews: true},
 					},
 				}
 			}(),

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1883,8 +1883,6 @@ export type GitHubRepositoryConfig = {
 export type GitHubEnterpriseRepositoryConfig = {
   /** The branch to use in the repository. */
   branch: string;
-  /** Whether we should show dashboard previews for pull requests. */
-  generateDashboardPreviews?: boolean;
   /** Path is the subdirectory for the Grafana data inside the repository. */
   path?: string;
   /** The GitHub Enterprise Server URL (e.g. `https://ghes.example.com`). */
@@ -1908,6 +1906,8 @@ export type LocalRepositoryConfig = {
 export type PullRequestOptions = {
   /** When true, the PR title field in Save drawers is read-only. */
   enforceTemplate?: boolean;
+  /** Whether we should show dashboard previews for pull requests. By default, this is false (i.e. we will not create previews). */
+  generateDashboardPreviews?: boolean;
   /** Template for pull request titles. Supports the same variables as BranchOptions.NameTemplate ({{random}} is available but rarely useful here). When empty, the first line of the commit message is used. */
   titleTemplate?: string;
 };

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -4313,10 +4313,6 @@
             "type": "string",
             "default": ""
           },
-          "generateDashboardPreviews": {
-            "description": "Whether we should show dashboard previews for pull requests.",
-            "type": "boolean"
-          },
           "path": {
             "description": "Path is the subdirectory for the Grafana data inside the repository.",
             "type": "string"
@@ -4978,6 +4974,10 @@
         "properties": {
           "enforceTemplate": {
             "description": "When true, the PR title field in Save drawers is read-only.",
+            "type": "boolean"
+          },
+          "generateDashboardPreviews": {
+            "description": "Whether we should show dashboard previews for pull requests. By default, this is false (i.e. we will not create previews).",
             "type": "boolean"
           },
           "titleTemplate": {

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -4189,10 +4189,6 @@
             "type": "string",
             "default": ""
           },
-          "generateDashboardPreviews": {
-            "description": "Whether we should show dashboard previews for pull requests.",
-            "type": "boolean"
-          },
           "path": {
             "description": "Path is the subdirectory for the Grafana data inside the repository.",
             "type": "string"
@@ -4738,6 +4734,10 @@
         "properties": {
           "enforceTemplate": {
             "description": "When true, the PR title field in Save drawers is read-only.",
+            "type": "boolean"
+          },
+          "generateDashboardPreviews": {
+            "description": "Whether we should show dashboard previews for pull requests. By default, this is false (i.e. we will not create previews).",
             "type": "boolean"
           },
           "titleTemplate": {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -1603,8 +1603,10 @@ func TestEvaluate_GitHubEnterpriseDoesNotPanic(t *testing.T) {
 	reader.On("Config").Return(&provisioning.Repository{
 		ObjectMeta: metav1.ObjectMeta{Name: "ghes-repo", Namespace: "x"},
 		Spec: provisioning.RepositorySpec{
-			Type:             provisioning.GitHubEnterpriseRepositoryType,
-			GitHubEnterprise: &provisioning.GitHubEnterpriseRepositoryConfig{GenerateDashboardPreviews: true},
+			Type: provisioning.GitHubEnterpriseRepositoryType,
+			PullRequest: &provisioning.PullRequestOptions{
+				GenerateDashboardPreviews: true,
+			},
 		},
 	})
 	reader.On("Read", mock.Anything, "playlist.json", "ref").Return(finfo, nil)

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4683,10 +4683,6 @@
             "type": "string",
             "default": ""
           },
-          "generateDashboardPreviews": {
-            "description": "Whether we should show dashboard previews for pull requests.",
-            "type": "boolean"
-          },
           "path": {
             "description": "Path is the subdirectory for the Grafana data inside the repository.",
             "type": "string"
@@ -5380,6 +5376,10 @@
         "properties": {
           "enforceTemplate": {
             "description": "When true, the PR title field in Save drawers is read-only.",
+            "type": "boolean"
+          },
+          "generateDashboardPreviews": {
+            "description": "Whether we should show dashboard previews for pull requests. By default, this is false (i.e. we will not create previews).",
             "type": "boolean"
           },
           "titleTemplate": {

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -4559,10 +4559,6 @@
             "type": "string",
             "default": ""
           },
-          "generateDashboardPreviews": {
-            "description": "Whether we should show dashboard previews for pull requests.",
-            "type": "boolean"
-          },
           "path": {
             "description": "Path is the subdirectory for the Grafana data inside the repository.",
             "type": "string"
@@ -5140,6 +5136,10 @@
         "properties": {
           "enforceTemplate": {
             "description": "When true, the PR title field in Save drawers is read-only.",
+            "type": "boolean"
+          },
+          "generateDashboardPreviews": {
+            "description": "Whether we should show dashboard previews for pull requests. By default, this is false (i.e. we will not create previews).",
             "type": "boolean"
           },
           "titleTemplate": {


### PR DESCRIPTION
Backend: move `GenerateDashboardPreviews` off `GitHubEnterpriseRepositoryConfig` onto `PullRequestOptions`.

Every provider except GitHub now reads the flag from `spec.pullRequest`; GitHub keeps its own field until existing repositories are backfilled.

- `ShouldGenerateDashboardPreviews()`: GitHub reads `spec.github`, all other providers read `spec.pullRequest` (nil-safe)
- `validateDashboardPreviews` reuses the accessor, so the image-rendering guard now covers GitHub Enterprise/GitLab/Bitbucket too
- regenerated OpenAPI specs and API clients

Part of the GitHub Enterprise dashboard previews stack.

---
_Generated by Claude_