### PR TITLE
Provisioning: Read generateDashboardPreviews from pullRequest options

### DIFF
--- a/public/app/features/provisioning/utils/data.test.ts
+++ b/public/app/features/provisioning/utils/data.test.ts
@@ -166,6 +166,60 @@ describe('provisioning data mapping', () => {
       expect(data.url).toBe('https://github.com/owner/repo');
       expect(data.generateDashboardPreviews).toBe(true);
     });
+
+    it('honors github.generateDashboardPreviews for github specs, ignoring pullRequest', () => {
+      const spec: RepositorySpec = {
+        type: 'github',
+        title: 'repo',
+        description: '',
+        sync: baseSync,
+        workflows: [],
+        github: {
+          url: 'https://github.com/owner/repo',
+          branch: 'main',
+          path: '',
+          generateDashboardPreviews: false,
+        },
+        pullRequest: {
+          generateDashboardPreviews: true,
+        },
+      };
+
+      const data = specToData(spec);
+      expect(data.generateDashboardPreviews).toBe(false);
+    });
+  });
+
+  describe('githubEnterprise', () => {
+    it('writes generateDashboardPreviews onto pullRequest options, not the githubEnterprise config', () => {
+      const formData = makeFormData('githubEnterprise');
+      formData.generateDashboardPreviews = true;
+      const spec = dataToSpec(formData);
+
+      expect(spec.pullRequest?.generateDashboardPreviews).toBe(true);
+      expect(spec.githubEnterprise).not.toHaveProperty('generateDashboardPreviews');
+    });
+
+    it('reads generateDashboardPreviews from pullRequest options', () => {
+      const spec: RepositorySpec = {
+        type: 'githubEnterprise',
+        title: 'repo',
+        description: '',
+        sync: baseSync,
+        workflows: [],
+        githubEnterprise: {
+          url: 'https://ghes.example.com/owner/repo',
+          branch: 'main',
+          path: '',
+        },
+        pullRequest: {
+          generateDashboardPreviews: true,
+        },
+      };
+
+      const data = specToData(spec);
+      expect(data.generateDashboardPreviews).toBe(true);
+    });
   });
 
   describe('webhook', () => {

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -204,7 +204,8 @@ export const specToData = (spec: RepositorySpec): RepositoryFormData => {
     branchOptions: spec.branch,
     url: remoteConfig?.url || '',
     tokenUser: tokenUser || '',
-    generateDashboardPreviews: spec.github?.generateDashboardPreviews || false,
+    generateDashboardPreviews:
+      spec.github?.generateDashboardPreviews || spec.pullRequest?.generateDashboardPreviews || false,
     readOnly: !spec.workflows.length,
     prWorkflow: spec.workflows.includes('branch'),
     enablePushToConfiguredBranch: spec.workflows.includes('write'),

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -211,8 +211,8 @@ export const specToData = (spec: RepositorySpec): RepositoryFormData => {
     url: remoteConfig?.url || '',
     tokenUser: tokenUser || '',
     generateDashboardPreviews: spec.github
-      ? spec.github?.generateDashboardPreviews
-      : spec.pullRequest?.generateDashboardPreviews || false,
+      ? (spec.github?.generateDashboardPreviews ?? false)
+      : (spec.pullRequest?.generateDashboardPreviews ?? false),
     readOnly: !spec.workflows.length,
     prWorkflow: spec.workflows.includes('branch'),
     enablePushToConfiguredBranch: spec.workflows.includes('write'),

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -111,8 +111,14 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
     data.pullRequest?.titleTemplate,
     data.pullRequest?.enforceTemplate
   );
-  if (pullRequest) {
-    spec.pullRequest = pullRequest;
+  // GitHub keeps generateDashboardPreviews on its own config until existing repositories are
+  // backfilled; every other provider stores it on pullRequest options (matches the backend).
+  const generatePreviewsOnPullRequest = data.type !== 'github' && Boolean(data.generateDashboardPreviews);
+  if (pullRequest || generatePreviewsOnPullRequest) {
+    spec.pullRequest = {
+      ...pullRequest,
+      ...(generatePreviewsOnPullRequest ? { generateDashboardPreviews: data.generateDashboardPreviews } : {}),
+    };
   }
 
   if (data.webhook?.disabled) {
@@ -204,8 +210,9 @@ export const specToData = (spec: RepositorySpec): RepositoryFormData => {
     branchOptions: spec.branch,
     url: remoteConfig?.url || '',
     tokenUser: tokenUser || '',
-    generateDashboardPreviews:
-      spec.github?.generateDashboardPreviews || spec.pullRequest?.generateDashboardPreviews || false,
+    generateDashboardPreviews: spec.github
+      ? spec.github?.generateDashboardPreviews
+      : spec.pullRequest?.generateDashboardPreviews || false,
     readOnly: !spec.workflows.length,
     prWorkflow: spec.workflows.includes('branch'),
     enablePushToConfiguredBranch: spec.workflows.includes('write'),


### PR DESCRIPTION
Frontend: read `generateDashboardPreviews` from `spec.pullRequest`.

Mirrors the backend accessor added in the stacked PR below: `specToData` now falls back to `spec.pullRequest.generateDashboardPreviews` for non-GitHub providers, so previews toggled on GitHub Enterprise (and other providers) round-trip correctly.

Part of the GitHub Enterprise dashboard previews stack.

---
_Generated by Claude_