### PR TITLE
TimeComparison: Verify shift and compare together

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/panel-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-overview/index.md
@@ -103,12 +103,12 @@ By hovering over a panel with the mouse you can use some shortcuts that target t
 
 You can configure the following settings to control the time range for a panel:
 
-| Option                | Description                                                                                                                              |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Panel time range      | Overrides the dashboard time range. Use one of the preset values or enter a custom value like `5m` or `2h`.                              |
-| Time shift            | Adds a time shift relative to the dashboard or panel time range. Use one of the preset values or enter a custom value like `5m` or `2h`. |
-| Time comparison       | <p>Compare data between two time ranges.</p><p>To try out this feature, enable the `timeComparison` feature toggle.</p>                  |
-| Hide panel time range | Don't show the panel time range in the panel header.                                                                                     |
+| Option                | Description                                                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Panel time range      | Overrides the dashboard time range. Use one of the preset values or enter a custom value like `5m` or `2h`.                                                              |
+| Time shift            | Adds a time shift relative to the dashboard or panel time range. Use one of the preset values or enter a custom value like `5m` or `2h`.                                 |
+| Time comparison       | <p>Compare data between two time ranges. Applied after **Time shift** when used together.</p><p>To try out this feature, enable the `timeComparison` feature toggle.</p> |
+| Hide panel time range | Don't show the panel time range in the panel header.                                                                                                                     |
 
 ## Pan and zoom panel time range
 

--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.test.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.test.tsx
@@ -1,6 +1,6 @@
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { dateTime } from '@grafana/data';
+import { dateTime, type DataQueryRequest } from '@grafana/data';
 import {
   SceneCanvasText,
   SceneFlexItem,
@@ -77,6 +77,27 @@ describe('PanelTimeRange', () => {
     buildAndActivateSceneFor(panelTime);
 
     expect(panelTime.state.timeInfo).toBe('Last 1 hour + compared to day before');
+  });
+
+  it('should apply time comparison relative to the time-shifted panel range', () => {
+    // Composition order: time shift first, then compare offset from the shifted range.
+    // Dashboard now-6h→now at 19:00, shift 2h → primary 11:00–17:00; compare 1d → 11:00–17:00 previous day.
+    const panelTime = new PanelTimeRange({ timeShift: '2h', compareWith: '1d' });
+
+    buildAndActivateSceneFor(panelTime);
+
+    expect(panelTime.state.value.from.toISOString()).toBe('2019-02-11T11:00:00.000Z');
+    expect(panelTime.state.value.to.toISOString()).toBe('2019-02-11T17:00:00.000Z');
+    expect(panelTime.state.timeInfo).toBe('Timeshift -2h + compared to day before');
+
+    const extraQueries = panelTime.getExtraQueries({
+      targets: [{ refId: 'A' }],
+      range: panelTime.state.value,
+    } as DataQueryRequest);
+
+    expect(extraQueries).toHaveLength(1);
+    expect(extraQueries[0].req.range.from.toISOString()).toBe('2019-02-10T11:00:00.000Z');
+    expect(extraQueries[0].req.range.to.toISOString()).toBe('2019-02-10T17:00:00.000Z');
   });
 
   it('should update timeInfo when timeShift and timeFrom are variable expressions', async () => {


### PR DESCRIPTION
Adds test coverage to verify that time comparison is applied after time shift when both are used at the same time. Updates the docs to clarify that this is expected behavior.

Closes https://github.com/grafana/grafana/issues/126179