### PR TITLE
TimeComparison: Add tests for save and load

### DIFF
--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -1,3 +1,4 @@
+import { VizPanel } from '@grafana/scenes';
 import {
   defaultDataQueryKind,
   defaultPanelSpec,
@@ -9,6 +10,7 @@ import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constan
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
+import { vizPanelToSchemaV2 } from '../transformSceneToSaveModelSchemaV2';
 
 import { buildVizPanel, ensureUniqueRefIds, getPanelDataSource, getRuntimePanelDataSource } from './utils';
 
@@ -437,6 +439,24 @@ describe('buildVizPanel', () => {
       hideTimeOverride: true,
       compareWith: '1d',
     });
+  });
+
+  it('preserves timeCompare through v2 save and load', () => {
+    const panel = new VizPanel({
+      key: 'panel-1',
+      pluginId: 'timeseries',
+      title: 'Test',
+      $timeRange: new PanelTimeRange({ compareWith: '1w' }),
+    });
+
+    const saved = vizPanelToSchemaV2(panel, undefined, false);
+    expect(saved.kind).toBe('Panel');
+
+    const panelKind = saved as PanelKind;
+    expect(panelKind.spec.data.spec.queryOptions.timeCompare).toBe('1w');
+
+    const reloaded = getPanelTimeRange(panelKind);
+    expect(reloaded.state.compareWith).toBe('1w');
   });
 
   it('does not create $timeRange when only hideTimeOverride is set', () => {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -654,6 +654,7 @@ describe('transformSaveModelToScene', () => {
         type: 'test-plugin',
         timeFrom: '2h',
         timeShift: '1d',
+        timeCompare: '1d',
       };
 
       const { vizPanel } = buildGridItemForTest(panel);
@@ -662,6 +663,20 @@ describe('transformSaveModelToScene', () => {
       expect(timeRange).toBeInstanceOf(PanelTimeRange);
       expect(timeRange.state.timeFrom).toBe('2h');
       expect(timeRange.state.timeShift).toBe('1d');
+      expect(timeRange.state.compareWith).toBe('1d');
+    });
+
+    it('should set PanelTimeRange when only timeCompare is present', () => {
+      const panel = {
+        type: 'test-plugin',
+        timeCompare: '1w',
+      };
+
+      const { vizPanel } = buildGridItemForTest(panel);
+      const timeRange = vizPanel.state.$timeRange as PanelTimeRange;
+
+      expect(timeRange).toBeInstanceOf(PanelTimeRange);
+      expect(timeRange.state.compareWith).toBe('1w');
     });
 
     it('should handle a dashboard query data source', () => {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
@@ -38,6 +38,7 @@ import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLay
 import { type RowRepeaterBehavior } from '../scene/layout-default/RowRepeaterBehavior';
 import { RowItem } from '../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
+import { PanelTimeRange } from '../scene/panel-timerange/PanelTimeRange';
 import { NEW_LINK } from '../settings/links/utils';
 import { activateFullSceneTree, buildPanelRepeaterScene } from '../utils/test-utils';
 import { getVizPanelKeyForPanelId } from '../utils/utils';
@@ -374,12 +375,27 @@ describe('transformSceneToSaveModel', () => {
         timeFrom: '2h',
         timeShift: '1d',
         hideTimeOverride: true,
+        timeCompare: '1d',
       });
 
       const saveModel = gridItemToPanel(gridItem);
       expect(saveModel.timeFrom).toBe('2h');
       expect(saveModel.timeShift).toBe('1d');
       expect(saveModel.hideTimeOverride).toBe(true);
+      expect(saveModel.timeCompare).toBe('1d');
+    });
+
+    it('preserves timeCompare through v1 save and load', () => {
+      const gridItem = buildGridItemFromPanelSchema({ timeCompare: '1w' });
+      const saveModel = gridItemToPanel(gridItem);
+
+      expect(saveModel.timeCompare).toBe('1w');
+
+      const reloaded = buildGridItemFromPanelSchema(saveModel);
+      const timeRange = (reloaded.state.body as VizPanel).state.$timeRange as PanelTimeRange;
+
+      expect(timeRange).toBeInstanceOf(PanelTimeRange);
+      expect(timeRange.state.compareWith).toBe('1w');
     });
 
     it('transparent panel', () => {


### PR DESCRIPTION
Adds tests to ensure time comparison settings persist after you save and reload a dashboard in both v1 and v2.

Closes https://github.com/grafana/grafana/issues/126176