### PR TITLE
Table: remove default panel padding to eliminate gap below panel header

### DIFF
--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -135,4 +135,5 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
   .setPanelOptions((builder) => {
     addTableCustomPanelOptions(builder);
   })
-  .setSuggestionsSupplier(tableSuggestionsSupplier);
+  .setSuggestionsSupplier(tableSuggestionsSupplier)
+  .setNoPadding();


### PR DESCRIPTION
**What is this feature?**

Removes the unwanted gap between the panel title and the table header row by setting no-padding on the table panel plugin.

**Why do we need this feature?**

The default `md` panel padding is applied uniformly on all sides of the panel content area. Since the table panel renders its own header flush to the top of the content area, the top padding creates a visible gap between the panel title bar and the first table header row. Other full-area panels (stat, canvas, geomap) already use `.setNoPadding()` for the same reason.

**Who is this feature for?**

All users of the table panel — the gap is always visible and there is no workaround.

**Which issue(s) does this PR fix?**

Fixes #128058