### PR TITLE
TimeComparison: Ensure header visibility

### DIFF
--- a/public/app/features/dashboard-scene/scene/panel-timerange/utils.ts
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/utils.ts
@@ -39,7 +39,7 @@ export function getUpdatedHoverHeader(title: string, timeOverride?: Partial<Pane
   }
 
   if (timeOverride && !timeOverride.hideTimeOverride) {
-    if (timeOverride.timeFrom || timeOverride.timeShift) {
+    if (timeOverride.timeFrom || timeOverride.timeShift || timeOverride.compareWith) {
       return false;
     }
   }

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -454,7 +454,7 @@ describe('buildVizPanel', () => {
 
   describe('hoverHeader interaction with time range', () => {
     // hoverHeader is shown only when there's no title AND no visible time override.
-    // timeOverrideShown = (timeFrom || timeShift) && !hideTimeOverride — note timeCompare is NOT included.
+    // timeOverrideShown = (timeFrom || timeShift || timeCompare) && !hideTimeOverride.
 
     it('shows hoverHeader when there is no title and no time fields', () => {
       const viz = buildVizPanel(buildPanelWithQueryOptions({}, ''));
@@ -480,10 +480,10 @@ describe('buildVizPanel', () => {
       expect(viz.state.hoverHeader).toBe(true);
     });
 
-    it('shows hoverHeader when only timeCompare is set (timeCompare is not a visible time override)', () => {
+    it('hides hoverHeader when only timeCompare is set', () => {
       const viz = buildVizPanel(buildPanelWithQueryOptions({ timeCompare: '1d' }, ''));
 
-      expect(viz.state.hoverHeader).toBe(true);
+      expect(viz.state.hoverHeader).toBe(false);
     });
 
     it('hides hoverHeader when the panel has a title, regardless of time fields', () => {

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -65,7 +65,8 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
   }
 
   const queryOptions = panel.spec.data.spec.queryOptions;
-  const timeOverrideShown = (queryOptions.timeFrom || queryOptions.timeShift) && !queryOptions.hideTimeOverride;
+  const timeOverrideShown =
+    (queryOptions.timeFrom || queryOptions.timeShift || queryOptions.timeCompare) && !queryOptions.hideTimeOverride;
 
   // Extract __angularMigration data if present
   // This data is used to run Angular panel migrations in v2 (e.g., singlestat -> stat)

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -473,7 +473,7 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
     titleItems.push(new PanelNotices());
   }
 
-  const timeOverrideShown = (panel.timeFrom || panel.timeShift) && !panel.hideTimeOverride;
+  const timeOverrideShown = (panel.timeFrom || panel.timeShift || panel.timeCompare) && !panel.hideTimeOverride;
 
   const vizPanelState: VizPanelState = {
     key: getVizPanelKeyForPanelId(panel.id),


### PR DESCRIPTION
Treats time comparison like other time settings and ensures it will stay visible in the header without the need to hover.

Fixes https://github.com/grafana/grafana/issues/126177