### PR TITLE
TimeComparison: Keep on query option change

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
@@ -622,6 +622,22 @@ describe('PanelDataQueriesTab', () => {
 
           expect(panel.state.$timeRange).toBeUndefined();
         });
+
+        it('should preserve compareWith when updating other query options', async () => {
+          const { queriesTab, panel } = await setupScene('panel-1');
+
+          panel.setState({ $timeRange: new PanelTimeRange({ compareWith: '1d' }) });
+
+          queriesTab.onQueryOptionsChange({
+            dataSource: { name: 'grafana-testdata', type: 'grafana-testdata-datasource', default: true },
+            queries: [],
+            maxDataPoints: 100,
+            timeRange: { from: undefined, shift: undefined },
+          });
+
+          expect(panel.state.$timeRange).toBeInstanceOf(PanelTimeRange);
+          expect((panel.state.$timeRange?.state as PanelTimeRangeState).compareWith).toBe('1d');
+        });
       });
 
       describe('max data points and interval', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -248,9 +248,11 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     const timeFrom = options.timeRange?.from ?? undefined;
     const timeShift = options.timeRange?.shift ?? undefined;
     const hideTimeOverride = options.timeRange?.hide;
+    const compareWith =
+      panel.state.$timeRange instanceof PanelTimeRange ? panel.state.$timeRange.state.compareWith : undefined;
 
-    if (timeFrom !== undefined || timeShift !== undefined) {
-      panelStateUpdate.$timeRange = new PanelTimeRange({ timeFrom, timeShift, hideTimeOverride });
+    if (timeFrom !== undefined || timeShift !== undefined || compareWith) {
+      panelStateUpdate.$timeRange = new PanelTimeRange({ timeFrom, timeShift, hideTimeOverride, compareWith });
       panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, panelStateUpdate.$timeRange?.state);
     } else {
       panelStateUpdate.$timeRange = undefined;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
@@ -238,6 +238,21 @@ describe('PanelDataPaneNext', () => {
         expect(lastCall.$timeRange).toBeUndefined();
       });
 
+      it('should preserve compareWith when updating other query options', () => {
+        mockPanel.setState({ $timeRange: new PanelTimeRange({ compareWith: '1d' }) });
+
+        dataPane.onQueryOptionsChange({
+          dataSource: { type: 'test', uid: 'test' },
+          queries: [],
+          maxDataPoints: 100,
+          timeRange: { from: undefined, shift: undefined },
+        });
+
+        const lastCall = (mockPanel.setState as jest.Mock).mock.calls.at(-1)[0];
+        expect(lastCall.$timeRange).toBeInstanceOf(PanelTimeRange);
+        expect((lastCall.$timeRange.state as PanelTimeRangeState).compareWith).toBe('1d');
+      });
+
       it('should set hideTimeOverride on PanelTimeRange', () => {
         dataPane.onQueryOptionsChange({
           dataSource: { type: 'test', uid: 'test' },

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -685,9 +685,11 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     const timeFrom = options.timeRange?.from ?? undefined;
     const timeShift = options.timeRange?.shift ?? undefined;
     const hideTimeOverride = options.timeRange?.hide;
+    const compareWith =
+      panel.state.$timeRange instanceof PanelTimeRange ? panel.state.$timeRange.state.compareWith : undefined;
 
-    if (timeFrom !== undefined || timeShift !== undefined) {
-      panelStateUpdate.$timeRange = new PanelTimeRange({ timeFrom, timeShift, hideTimeOverride });
+    if (timeFrom !== undefined || timeShift !== undefined || compareWith) {
+      panelStateUpdate.$timeRange = new PanelTimeRange({ timeFrom, timeShift, hideTimeOverride, compareWith });
       panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, panelStateUpdate.$timeRange?.state);
     } else {
       panelStateUpdate.$timeRange = undefined;


### PR DESCRIPTION
Ensure that time comparison is kept after changing query options.

Before:
<img width="1166" height="704" alt="Jul-09-2026 23-38-04" src="https://github.com/user-attachments/assets/ef91117e-46ea-4a02-9da3-5937979c3aa9" />

After:
<img width="1166" height="704" alt="Jul-09-2026 23-39-28" src="https://github.com/user-attachments/assets/9ae923fe-dcb4-47b3-97e2-553843eb696e" />

Fixes https://github.com/grafana/grafana/issues/126812