### PR TITLE
Suggestions: Fallback for no search result

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.test.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.test.tsx
@@ -549,7 +549,40 @@ describe('VisualizationSuggestions', () => {
     expect(screen.queryByTestId('suggestion-card-gauge-hash')).not.toBeInTheDocument();
   });
 
-  it('should show empty search result when no suggestions match the search query', async () => {
+  it('should fall back to all panel types when no suggestions match the search query', async () => {
+    mockGetAllSuggestions.mockResolvedValue({
+      suggestions: [
+        { pluginId: 'timeseries', name: 'Time series', hash: 'ts-hash', options: {} },
+        { pluginId: 'table', name: 'Table', hash: 'table-hash', options: {} },
+      ],
+      hasErrors: false,
+    });
+
+    const data: PanelData = {
+      series: [
+        toDataFrame({
+          fields: [
+            { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+            { name: 'value', type: FieldType.number, values: [10, 20, 30] },
+          ],
+        }),
+      ],
+      state: LoadingState.Done,
+      timeRange: getDefaultTimeRange(),
+      structureRev: 1,
+    };
+
+    render(<VisualizationSuggestions onChange={jest.fn()} data={data} panel={undefined} searchQuery="text" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Text')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('suggestion-card-ts-hash')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('suggestion-card-table-hash')).not.toBeInTheDocument();
+  });
+
+  it('should show empty search result when neither suggestions nor panel types match the search query', async () => {
     mockGetAllSuggestions.mockResolvedValue({
       suggestions: [
         { pluginId: 'timeseries', name: 'Time series', hash: 'ts-hash', options: {} },
@@ -743,6 +776,19 @@ describe('VisualizationSuggestions', () => {
 
       expect(screen.queryByText('Dashboard list')).not.toBeInTheDocument();
       expect(screen.queryByText('Alert list')).not.toBeInTheDocument();
+    });
+
+    it('should fall back to all panel types when no no-data panels match the search query', async () => {
+      render(<VisualizationSuggestions onChange={jest.fn()} data={emptyData} panel={undefined} searchQuery="time" />);
+
+      await waitForSuggestionsToLoad();
+
+      await waitFor(() => {
+        expect(screen.getByText('Time series')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Start without data')).not.toBeInTheDocument();
+      expect(screen.queryByText('Text')).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
@@ -12,7 +12,7 @@ import {
 import { Trans, t } from '@grafana/i18n';
 import { useListedPanelPluginMetas } from '@grafana/runtime/internal';
 import { type VizPanel } from '@grafana/scenes';
-import { Alert, Button, EmptySearchResult, Icon, Spinner, Text, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Icon, Spinner, Text, useStyles2 } from '@grafana/ui';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from 'app/features/dashboard-scene/scene/UnconfiguredPanel';
 
 import { useStructureRev } from '../../../explore/Graph/useStructureRev';
@@ -22,6 +22,7 @@ import { getAllSuggestions } from '../../suggestions/getAllSuggestions';
 import { hasData } from '../../suggestions/utils';
 
 import { VisualizationCardGrid, type VisualizationCardGridGroup } from './VisualizationCardGrid';
+import { VizTypePicker } from './VizTypePicker';
 import { VizTypePickerPlugin } from './VizTypePickerPlugin';
 import { VizSuggestionsInteractions, PANEL_STATES, type PanelState } from './interactions';
 import { type VizTypeChangeDetails } from './types';
@@ -189,14 +190,10 @@ export function VisualizationSuggestions({ onChange, data, panel, searchQuery, i
     return <NoDataPanelList searchQuery={searchQuery} panel={panel} onChange={onChange} />;
   }
 
+  // When the search matches no suggestions, fall back to the full panel list
+  // so users can still find and pick any visualization type.
   if (suggestions && suggestions.length === 0 && searchQuery) {
-    return (
-      <EmptySearchResult>
-        <Trans i18nKey="panel.viz-type-picker.could-anything-matching-query">
-          Could not find anything matching your query
-        </Trans>
-      </EmptySearchResult>
-    );
+    return <VizTypePicker pluginId={panel?.type ?? ''} searchQuery={searchQuery} onChange={onChange} />;
   }
 
   return (
@@ -240,6 +237,12 @@ function NoDataPanelList({ searchQuery, panel, onChange }: NoDataPanelListProps)
     const panels = meta.filter((p) => panelsWithoutData.has(p.id));
     return filterPluginList(panels, searchQuery ?? '', panel?.type);
   }, [searchQuery, panel?.type, meta]);
+
+  // When searching and no no-data panels match, fall back to the full panel list
+  // so users can still find and pick any visualization type.
+  if (searchQuery && noDataPanels.length === 0) {
+    return <VizTypePicker pluginId={panel?.type ?? ''} searchQuery={searchQuery} onChange={onChange} />;
+  }
 
   return (
     <>


### PR DESCRIPTION
Small quality of life improvement for suggestions: when searching through suggestions returns no results, falls back on searching all panels instead of returning an empty result.

Before:
<img width="1094" height="574" alt="Jul-10-2026 00-01-25" src="https://github.com/user-attachments/assets/de93a7e8-4b57-4a18-b451-7bcc2fff4947" />

After:
<img width="1094" height="574" alt="Jul-10-2026 00-00-23" src="https://github.com/user-attachments/assets/bed337b8-e3ad-4477-89bf-1b322a453e09" />