### PR TITLE
Docs: Document deprecated feature toggles

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -104,6 +104,15 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `flameGraphWithCallTree`          | Enables the new Flame Graph UI containing the Call Tree view                                   |
 | `splashScreen`                    | Enables the splash screen modal for introducing new Grafana features on first session          |
 
+## Deprecated feature toggles
+
+When features are slated for removal, they will be marked as Deprecated first.
+
+| Feature toggle name               | Description                                                                                                                                                                 |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prometheusAzureOverrideAudience` | Deprecated. Allow override default AAD audience for Azure Prometheus endpoint. Enabled by default. This feature should no longer be used and will be removed in the future. |
+| `prometheusTypeMigration`         | Checks for deprecated Prometheus authentication methods (SigV4 and Azure), installs the relevant data source, and migrates the Prometheus data sources                      |
+
 ## Development feature toggles
 
 The following toggles require explicitly setting Grafana's [app mode](../#app_mode) to 'development' before you can enable this feature toggle. These features tend to be experimental.

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -428,6 +428,12 @@ func generateCSV(lookup map[string]featuretoggleapi.Feature) string {
 
 func generateDocsMD() string {
 	hasDeprecatedFlags := false
+	for _, flag := range standardFeatureFlags {
+		if flag.Stage == FeatureStageDeprecated && !flag.HideFromDocs {
+			hasDeprecatedFlags = true
+			break
+		}
+	}
 
 	buf := `---
 aliases:
@@ -472,7 +478,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 
 When features are slated for removal, they will be marked as Deprecated first.
 
-	` + writeToggleDocsTable(func(flag FeatureFlag) bool {
+` + writeToggleDocsTable(func(flag FeatureFlag) bool {
 			return flag.Stage == FeatureStageDeprecated
 		}, false)
 	}


### PR DESCRIPTION
**What is this feature?**

The "Deprecated feature toggles" section has never been rendered on the feature toggles reference page.

In `generateDocsMD()`, `hasDeprecatedFlags` is initialized to `false` and never assigned, so the `if hasDeprecatedFlags { ... }` block is unreachable. `git log -S hasDeprecatedFlags` returns a single commit (240c77bb42, #59483), so the variable has been dead since it was introduced.

This PR sets the flag by checking the registry for deprecated toggles that are not hidden from the docs. Guarding on `!flag.HideFromDocs` matches the filter already applied inside `writeToggleDocsTable`, so an empty section is never emitted if every deprecated toggle is hidden.

It also removes a stray tab. The section's raw string began with a tab immediately before the generated table:

```
When features are slated for removal, they will be marked as Deprecated first.

	` + writeToggleDocsTable(func(flag FeatureFlag) bool {
```

A tab indented line opens a code block in Markdown, so the table would not have rendered even if the section had been reachable. The general availability, public preview, and development sections all place the backtick at column 0, and the deprecated block now matches them. That the tab survived at all is further evidence the block never executed.

**Why do we need this feature?**

Two deprecated toggles are currently invisible on the reference page. Both are enabled by default:

* `prometheusAzureOverrideAudience`
* `prometheusTypeMigration`

`grafana.logLevelInference` is also deprecated but sets `HideFromDocs: true`, and remains excluded. The regenerated table therefore has two rows.

**Who is this feature for?**

Operators reading the feature toggle reference who need to know which toggles are deprecated and slated for removal.

**Which issue(s) does this PR fix?**

Closes #128188

**Special notes for your reviewer:**

This is deliberately not related to #103841, which intentionally stopped documenting *experimental* toggles. That change deleted the experimental block outright but kept the deprecated block, so the deprecated section reads as an unfinished code path rather than a suppression. If you would rather deprecated toggles also stay off this page, say so and I will change this PR to delete the dead block instead.

`docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md` is machine generated and was regenerated with `go test ./pkg/services/featuremgmt/ -run TestFeatureToggleFiles`, not edited by hand.
