### PR TITLE
Docs: Clarify that experimental feature toggles aren't listed

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -16,7 +16,7 @@ You use feature toggles, also known as feature flags, to enable or disable featu
 
 This page contains a list of available feature toggles. To learn how to turn on feature toggles, refer to our [Configure Grafana documentation](../#feature_toggles). Feature toggles are also available to Grafana Cloud Advanced customers. If you use Grafana Cloud Advanced, you can open a support ticket and specify the feature toggles and stack for which you want them enabled.
 
-This page doesn't list experimental feature toggles. To learn whether a feature uses an experimental feature toggle, refer to the documentation for that feature.
+Experimental feature toggles are listed in the respective feature's documentation only.
 
 For more information about feature release stages, refer to [Release life cycle for Grafana Labs](https://grafana.com/docs/release-life-cycle/) and [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/feature-toggles/#manage-feature-toggles).
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -16,6 +16,8 @@ You use feature toggles, also known as feature flags, to enable or disable featu
 
 This page contains a list of available feature toggles. To learn how to turn on feature toggles, refer to our [Configure Grafana documentation](../#feature_toggles). Feature toggles are also available to Grafana Cloud Advanced customers. If you use Grafana Cloud Advanced, you can open a support ticket and specify the feature toggles and stack for which you want them enabled.
 
+This page doesn't list experimental feature toggles. To learn whether a feature uses an experimental feature toggle, refer to the documentation for that feature.
+
 For more information about feature release stages, refer to [Release life cycle for Grafana Labs](https://grafana.com/docs/release-life-cycle/) and [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/feature-toggles/#manage-feature-toggles).
 
 ## General availability feature toggles

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -447,7 +447,7 @@ You use feature toggles, also known as feature flags, to enable or disable featu
 
 This page contains a list of available feature toggles. To learn how to turn on feature toggles, refer to our [Configure Grafana documentation](../#feature_toggles). Feature toggles are also available to Grafana Cloud Advanced customers. If you use Grafana Cloud Advanced, you can open a support ticket and specify the feature toggles and stack for which you want them enabled.
 
-This page doesn't list experimental feature toggles. To learn whether a feature uses an experimental feature toggle, refer to the documentation for that feature.
+Experimental feature toggles are listed in the respective feature's documentation only.
 
 For more information about feature release stages, refer to [Release life cycle for Grafana Labs](https://grafana.com/docs/release-life-cycle/) and [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/feature-toggles/#manage-feature-toggles).
 

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -447,6 +447,8 @@ You use feature toggles, also known as feature flags, to enable or disable featu
 
 This page contains a list of available feature toggles. To learn how to turn on feature toggles, refer to our [Configure Grafana documentation](../#feature_toggles). Feature toggles are also available to Grafana Cloud Advanced customers. If you use Grafana Cloud Advanced, you can open a support ticket and specify the feature toggles and stack for which you want them enabled.
 
+This page doesn't list experimental feature toggles. To learn whether a feature uses an experimental feature toggle, refer to the documentation for that feature.
+
 For more information about feature release stages, refer to [Release life cycle for Grafana Labs](https://grafana.com/docs/release-life-cycle/) and [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/feature-toggles/#manage-feature-toggles).
 
 ## General availability feature toggles


### PR DESCRIPTION
**What is this feature?**

The feature toggle reference page opens by saying that it "contains a list of available feature toggles", but experimental toggles are not on it. Readers who go looking for one find no entry and no explanation.

This PR adds a single sentence to the page noting that experimental toggles are not listed, and pointing readers to the documentation for the individual feature instead.

**Why do we need this feature?**

#126665 reports that `elasticsearchRawDSLQuery` and `elasticsearchESQLQuery` are missing from the page. They are `FeatureStageExperimental`, and `generateDocsMD()` only emits tables for general availability, public preview, deprecated, and dev mode toggles, so experimental toggles can never appear. That issue has since been closed as not planned, because both flags were removed from the datasource in 12.7.0. The gap it exposed on the reference page is generic though, and it is still present on main.

That is intentional. #103841 ("Feature Toggles: Stop documenting experimental toggles") removed the experimental section on purpose. Both toggles are already documented on the [Elasticsearch query editor page](https://grafana.com/docs/grafana/latest/datasources/elasticsearch/query-editor/) via the `docs/experimental` shortcode, which is where the What's New post links.

So the toggles are not missing from the docs. What is missing is any hint on the reference page that experimental toggles are excluded from it. This PR adds that hint rather than re-adding the section.

**Who is this feature for?**

Anyone reading the feature toggle reference and looking for a toggle that is still experimental.

**Which issue(s) does this PR fix?**

Originally opened for #126665, which has since been closed as not planned: the two Elasticsearch flags that prompted it were removed from the datasource in 12.7.0. This PR does not depend on that. `generateDocsMD()` still emits no experimental section, and the reference page still gives no hint that experimental toggles are excluded from it, so the change stands on its own. Not auto-closing any issue.

**Special notes for your reviewer:**

`docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md` is machine generated. The sentence was added to the raw string in `generateDocsMD()` and the page was regenerated with `go test ./pkg/services/featuremgmt/ -run TestFeatureToggleFiles`. The generated file was not hand edited.

Happy to reword the sentence if you prefer different phrasing.
