### PR TITLE
docs: fix for support escalation #23249

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -159,7 +159,6 @@ Return to Grafana and fill in the following fields:
 1. Paste the **Repository URL** for your Bitbucket repository into the text box.
 
    Use the Git clone URL for the repository, not the URL that appears in your browser's address bar when you view the repository. To find it, select **Clone** in Bitbucket and copy the HTTPS URL. The clone URL ends in `.git`, and its format depends on your Bitbucket deployment:
-
    - Bitbucket Cloud: `https://bitbucket.org/<workspace>/<repository>.git`
    - Bitbucket Data Center and Server: `https://<bitbucket-host>/scm/<PROJECT>/<repository>.git`
 

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -158,6 +158,17 @@ Return to Grafana and fill in the following fields:
 1. Paste the token into the **API Token** text box.
 1. Paste the **Repository URL** for your Bitbucket repository into the text box.
 
+   Use the Git clone URL for the repository, not the URL that appears in your browser's address bar when you view the repository. To find it, select **Clone** in Bitbucket and copy the HTTPS URL. The clone URL ends in `.git`, and its format depends on your Bitbucket deployment:
+
+   - Bitbucket Cloud: `https://bitbucket.org/<workspace>/<repository>.git`
+   - Bitbucket Data Center and Server: `https://<bitbucket-host>/scm/<PROJECT>/<repository>.git`
+
+   {{< admonition type="tip" >}}
+
+   If Grafana returns an `ls-refs` error when it connects to the repository, check that you entered the clone URL and not the browser URL.
+
+   {{< /admonition >}}
+
 Select **Configure repository** to set up your provisioning folder.
 
 ### Configure with Pure Git


### PR DESCRIPTION
## Draft doc fix

Drafted from a P5 documentation escalation: https://github.com/grafana/support-escalations/issues/23249
Document: https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/#configure-with-bitbucket

### What changed

The Git Sync **Configure with Bitbucket** section instructed users to paste the **Repository URL** with no guidance on which URL to use. Users who pasted the browser address-bar URL hit `ls-refs` errors, because Git Sync clones over Smart HTTP protocol v2 and needs the Git clone URL.

This change clarifies that the field needs the clone URL (not the browser URL), provides Bitbucket Cloud and Data Center/Server templates, and adds a tip naming the `ls-refs` symptom and its fix.

Closes grafana/support-escalations#23249

> [!IMPORTANT]
> Machine-assisted draft — verify accuracy, tone, and style before merging.