### PR TITLE
Plugins: Treat %VERSION% placeholder as unset in Meta API version

### DIFF
--- a/apps/plugins/pkg/app/meta/converter.go
+++ b/apps/plugins/pkg/app/meta/converter.go
@@ -42,8 +42,8 @@ func jsonDataToMetaJSONData(jsonData plugins.JSONData) pluginsv0alpha1.MetaJSOND
 			Small: jsonData.Info.Logos.Small,
 			Large: jsonData.Info.Logos.Large,
 		},
-		Updated: jsonData.Info.Updated,
-		Version: jsonData.Info.Version,
+		Updated: blankPluginPlaceholder(jsonData.Info.Updated, placeholderUpdated),
+		Version: blankPluginPlaceholder(jsonData.Info.Version, placeholderVersion),
 	}
 
 	if jsonData.Info.Description != "" {
@@ -787,12 +787,35 @@ func grafanaComChildPluginVersionToMetaSpec(logger logging.Logger, child grafana
 	return grafanaComPluginVersionMetaToMetaSpec(logger, childMeta, child.Path)
 }
 
+// placeholderVersion and placeholderUpdated are the unsubstituted plugin.json
+// placeholders that the build system leaves in place when it does not replace them.
+// They are treated as "unset", mirroring the loader's TemplateDecorateFunc, so that
+// downstream version handling (e.g. inheriting a nested plugin's version from its
+// parent) is not defeated by a literal "%VERSION%".
+const (
+	placeholderVersion = "%VERSION%"
+	placeholderUpdated = "%TODAY%"
+)
+
+// blankPluginPlaceholder returns "" when v is the given unsubstituted placeholder.
+func blankPluginPlaceholder(v, placeholder string) string {
+	if v == placeholder {
+		return ""
+	}
+	return v
+}
+
 // grafanaComPluginVersionMetaToMetaSpec converts a grafanaComPluginVersionMeta to a pluginsv0alpha1.MetaSpec.
 func grafanaComPluginVersionMetaToMetaSpec(logger logging.Logger, gcomMeta grafanaComPluginVersionMeta, pluginRelBasePath string) (pluginsv0alpha1.MetaSpec, error) {
 	metaSpec := pluginsv0alpha1.MetaSpec{
 		PluginJson: gcomMeta.JSON.MetaJSONData,
 		Class:      pluginsv0alpha1.MetaSpecClassExternal,
 	}
+
+	// This path uses the embedded plugin.json verbatim, so normalise the version/updated
+	// placeholders here (jsonDataToMetaJSONData handles the other provider paths).
+	metaSpec.PluginJson.Info.Version = blankPluginPlaceholder(metaSpec.PluginJson.Info.Version, placeholderVersion)
+	metaSpec.PluginJson.Info.Updated = blankPluginPlaceholder(metaSpec.PluginJson.Info.Updated, placeholderUpdated)
 
 	// The plugin.json embedded in the grafana.com response often omits the version
 	// (especially for nested/child plugins, which inherit it from the parent). Fall

--- a/apps/plugins/pkg/app/meta/converter.go
+++ b/apps/plugins/pkg/app/meta/converter.go
@@ -788,10 +788,9 @@ func grafanaComChildPluginVersionToMetaSpec(logger logging.Logger, child grafana
 }
 
 // placeholderVersion and placeholderUpdated are the unsubstituted plugin.json
-// placeholders that the build system leaves in place when it does not replace them.
-// They are treated as "unset", mirroring the loader's TemplateDecorateFunc, so that
-// downstream version handling (e.g. inheriting a nested plugin's version from its
-// parent) is not defeated by a literal "%VERSION%".
+// placeholders that the build system leaves in place for nested plugins.
+// We need to blank them out so that downstream version handling
+// is not defeated by a literal "%VERSION%".
 const (
 	placeholderVersion = "%VERSION%"
 	placeholderUpdated = "%TODAY%"

--- a/apps/plugins/pkg/app/meta/converter_test.go
+++ b/apps/plugins/pkg/app/meta/converter_test.go
@@ -38,6 +38,13 @@ func TestJsonDataToMetaJSONData(t *testing.T) {
 		}
 	})
 
+	t.Run("blanks unsubstituted version/updated placeholders", func(t *testing.T) {
+		jsonData := plugins.JSONData{ID: "test", Name: "Test", Info: plugins.Info{Version: "%VERSION%", Updated: "%TODAY%"}}
+		meta := jsonDataToMetaJSONData(jsonData)
+		assert.Empty(t, meta.Info.Version)
+		assert.Empty(t, meta.Info.Updated)
+	})
+
 	t.Run("converts categories", func(t *testing.T) {
 		testCases := []string{
 			"tsdb",
@@ -646,6 +653,22 @@ func TestGrafanaComPluginVersionMetaToMetaSpec(t *testing.T) {
 		meta, err := grafanaComPluginVersionMetaToMetaSpec(&logging.NoOpLogger{}, gcomMeta, "test-plugin")
 		require.NoError(t, err)
 		assert.Equal(t, "9.9.9", meta.PluginJson.Info.Version)
+	})
+
+	t.Run("treats a %VERSION% placeholder as empty and falls back to the gcom version", func(t *testing.T) {
+		gcomMeta := grafanaComPluginVersionMeta{
+			PluginSlug:          "test-plugin",
+			Version:             "2.3.4",
+			JSON:                grafanaComPluginVersionMetaJSON{MetaJSONData: pluginsv0alpha1.MetaJSONData{Id: "test-plugin", Info: pluginsv0alpha1.MetaInfo{Version: "%VERSION%", Updated: "%TODAY%"}}},
+			CDNURL:              "https://cdn.grafana.com",
+			CreatePluginVersion: "2023-01-01",
+			Manifest:            grafanaComPluginManifest{Files: map[string]string{}},
+		}
+
+		meta, err := grafanaComPluginVersionMetaToMetaSpec(&logging.NoOpLogger{}, gcomMeta, "test-plugin")
+		require.NoError(t, err)
+		assert.Equal(t, "2.3.4", meta.PluginJson.Info.Version)
+		assert.Empty(t, meta.PluginJson.Info.Updated)
 	})
 
 	t.Run("converts all signature types", func(t *testing.T) {


### PR DESCRIPTION
I found the following error when doing some tests in `dev`, for the helath check of `grafana-knowledgegraph-datasource`, which is a nested datasource:

```
[plugin.versionNotFound] grafana-asserts-app v%VERSION% was not returned by the Grafana.com catalog
```

## Changes

- `jsonDataToMetaJSONData` (local/core provider paths) — blank `%VERSION%`/`%TODAY%` when mapping `info.version`/`info.updated`.
- `grafanaComPluginVersionMetaToMetaSpec` (catalog path, which uses the embedded plugin.json verbatim) — normalize the placeholders before the parent/gcom version fallback.

This mirrors the loader's existing `TemplateDecorateFunc`, which blanks the same placeholders. Unit tests added for both paths.
