### PR TITLE
Connections: Use latest advisor check by date for datasource badge

### DIFF
--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
@@ -88,6 +88,7 @@ function makeCheckType(
 
 function mockPluginFunctions(options: {
   completedCheck?: Check;
+  completedChecks?: Check[];
   completedChecksLoading?: boolean;
   retryCheckFn?: jest.Mock;
   createChecksFn?: jest.Mock;
@@ -97,6 +98,7 @@ function mockPluginFunctions(options: {
 }) {
   const {
     completedCheck,
+    completedChecks,
     completedChecksLoading = false,
     retryCheckFn,
     createChecksFn,
@@ -110,8 +112,9 @@ function mockPluginFunctions(options: {
   // the mock must do the same for useLayoutEffect deps to stabilize.
   const stableRetryCheck = retryCheckFn ?? jest.fn();
   const stableCreateChecks = createChecksFn ?? jest.fn();
-  const completedData: CheckList | undefined = completedCheck
-    ? { apiVersion: 'advisor.grafana.app/v0alpha1', kind: 'CheckList', items: [completedCheck], metadata: {} }
+  const items = completedChecks ?? (completedCheck ? [completedCheck] : undefined);
+  const completedData: CheckList | undefined = items
+    ? { apiVersion: 'advisor.grafana.app/v0alpha1', kind: 'CheckList', items, metadata: {} }
     : undefined;
   const completedResult = {
     isCompleted: !completedChecksLoading,
@@ -197,6 +200,20 @@ describe('useLatestDatasourceCheck', () => {
     const { result } = renderHook(() => useLatestDatasourceCheck(), { wrapper });
 
     expect(result.current.check?.metadata.name).toBe('latest');
+  });
+
+  it('returns the check with the newest creationTimestamp regardless of list order', () => {
+    // The advisor API returns every check for the type ordered by name, not by
+    // date, so the newest report must be picked by creationTimestamp.
+    const older = makeCheck({ name: 'check-aaa', creationTimestamp: '2026-07-07T10:32:05Z', failures: emptyReport });
+    const newest = makeCheck({ name: 'check-mmm', creationTimestamp: '2026-07-10T10:02:42Z', failures: emptyReport });
+    const middle = makeCheck({ name: 'check-zzz', creationTimestamp: '2026-07-08T14:01:57Z', failures: emptyReport });
+
+    mockPluginFunctions({ completedChecks: [older, newest, middle] });
+
+    const { result } = renderHook(() => useLatestDatasourceCheck(), { wrapper });
+
+    expect(result.current.check?.metadata.name).toBe('check-mmm');
   });
 
   it('returns isLoading true while plugin function is loading', () => {

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
@@ -125,7 +125,7 @@ function AdvisorCheckBridge({
   const retryCheckResult = retryCheckFn();
   const createChecksResult = createChecksFn?.();
 
-  const check = completedChecks?.data?.items?.[0]; // Given a type, the list of items will contain only the last one for that type
+  const check = getLatestCheck(completedChecks?.data?.items);
   const isLoading = completedChecks == null || completedChecks.isLoading || !completedChecks.isCompleted;
   const retryCheck = retryCheckResult?.retryCheck;
   const createChecks = createChecksResult?.createChecks;
@@ -192,6 +192,22 @@ export function useDatasourceFailureByUID(): DatasourceFailuresResult {
   }, [check, checkType]);
 
   return { datasourceFailureByUID, isLoading: isLoading || isCheckTypeLoading };
+}
+
+/**
+ * Returns the most recently created check. The advisor API returns every check for
+ * the type ordered by name (not by date), so the latest report must be selected by
+ * creationTimestamp rather than by list position.
+ */
+function getLatestCheck(checks: Check[] | undefined): Check | undefined {
+  if (!checks?.length) {
+    return undefined;
+  }
+  return checks.reduce((latest, current) => {
+    const latestTime = new Date(latest.metadata.creationTimestamp ?? 0).getTime();
+    const currentTime = new Date(current.metadata.creationTimestamp ?? 0).getTime();
+    return currentTime > latestTime ? current : latest;
+  });
 }
 
 function getStepMap(checkType: CheckType | undefined): Map<string, CheckType['spec']['steps'][number]> {


### PR DESCRIPTION
Use the latest `check` for the advisor badge based on its `creationTimestamp` not the possition in the returned array (which may not be the latest).