### PR TITLE
Command Palette: Add ask assistant shortcut and UI

### DIFF
--- a/public/app/features/commandPalette/AskAssistantPill.tsx
+++ b/public/app/features/commandPalette/AskAssistantPill.tsx
@@ -2,14 +2,14 @@ import { css } from '@emotion/css';
 import { useKBar } from 'kbar';
 import { useCallback, useEffect, useRef } from 'react';
 
-import { useAssistant } from '@grafana/assistant';
+import { OpenAssistantButton, useAssistant } from '@grafana/assistant';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Icon, useStyles2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
 
 /**
- * Pill in the command palette search row offering to ask the Grafana Assistant, together with its Shift+Enter
+ * Button in the command palette search row offering to ask the Grafana Assistant, together with its Shift+Enter
  * shortcut. Deep search almost always returns something, so the empty state (and its "ask the assistant" button)
  * rarely shows anymore — this keeps that escape hatch reachable while results exist. Renders nothing when
  * the assistant is unavailable or the search query is empty.
@@ -20,21 +20,19 @@ export function AskAssistantPill() {
   const { isAvailable: isAssistantAvailable, openAssistant } = useAssistant();
   const canAskAssistant = isAssistantAvailable && openAssistant !== undefined && searchQuery.length > 0;
 
-  const onAskAssistant = useCallback(
-    (trigger: 'shortcut' | 'input-pill') => {
-      // canAskAssistant already implies openAssistant is defined; the extra check only narrows the type
-      if (!canAskAssistant || !openAssistant) {
-        return;
-      }
-      reportInteraction('command_palette_ask_assistant', { trigger });
-      openAssistant({
-        origin: 'grafana/command-palette',
-        prompt: `Search for ${searchQuery}`,
-      });
-      query.toggle();
-    },
-    [canAskAssistant, openAssistant, searchQuery, query]
-  );
+  // Only used by the shortcut — clicks go through OpenAssistantButton, which opens the assistant itself
+  const onAskAssistant = useCallback(() => {
+    // canAskAssistant already implies openAssistant is defined; the extra check only narrows the type
+    if (!canAskAssistant || !openAssistant) {
+      return;
+    }
+    reportInteraction('command_palette_ask_assistant', { trigger: 'shortcut' });
+    openAssistant({
+      origin: 'grafana/command-palette',
+      prompt: `Search for ${searchQuery}`,
+    });
+    query.toggle();
+  }, [canAskAssistant, openAssistant, searchQuery, query]);
 
   // Shift+Enter asks the assistant from anywhere in the palette. Window capture for the same reason as the
   // navigation handler in RenderResults: global handlers (kbar's input focus guard, keybindingSrv) must not act
@@ -54,7 +52,7 @@ export function AskAssistantPill() {
       }
       event.preventDefault();
       event.stopImmediatePropagation();
-      onAskAssistantRef.current('shortcut');
+      onAskAssistantRef.current();
     };
     window.addEventListener('keydown', handler, { capture: true });
     return () => window.removeEventListener('keydown', handler, { capture: true });
@@ -65,36 +63,24 @@ export function AskAssistantPill() {
   }
 
   return (
-    <button type="button" className={styles.pill} onClick={() => onAskAssistant('input-pill')}>
-      <Icon name="ai-sparkle" size="sm" />
-      {t('command-palette.search-box.ask-assistant', 'Shift + Enter to ask Assistant')}
-    </button>
+    <div className={styles.wrapper}>
+      <OpenAssistantButton
+        origin="grafana/command-palette"
+        prompt={`Search for ${searchQuery}`}
+        title={t('command-palette.search-box.ask-assistant', 'Shift + Enter to ask Assistant')}
+        onClick={() => {
+          reportInteraction('command_palette_ask_assistant', { trigger: 'input-pill' });
+          query.toggle();
+        }}
+      />
+    </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  pill: css({
+  wrapper: css({
     label: 'ask-assistant-pill',
     flexShrink: 0,
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: theme.spacing(0.75),
     marginLeft: theme.spacing(1),
-    padding: theme.spacing(0.5, 1.5),
-    fontSize: theme.typography.bodySmall.fontSize,
-    color: theme.colors.text.secondary,
-    cursor: 'pointer',
-    whiteSpace: 'nowrap',
-    borderRadius: theme.shape.radius.pill,
-    // Gradient border: opaque inner background painted over the AI gradient,
-    // which stays visible only in the transparent 1px border ring. Same
-    // purple-to-orange gradient as the other assistant elements. The inner
-    // background matches the search row the pill sits on.
-    border: '1px solid transparent',
-    background: `linear-gradient(${theme.components.input.background}, ${theme.components.input.background}) padding-box, linear-gradient(90deg, rgb(168, 85, 247), rgb(249, 115, 22)) border-box`,
-    '&:hover, &:focus-visible': {
-      color: theme.colors.text.primary,
-      background: `linear-gradient(${theme.colors.emphasize(theme.components.input.background, 0.05)}, ${theme.colors.emphasize(theme.components.input.background, 0.05)}) padding-box, linear-gradient(90deg, rgb(168, 85, 247), rgb(249, 115, 22)) border-box`,
-    },
   }),
 });

--- a/public/app/features/commandPalette/AskAssistantPill.tsx
+++ b/public/app/features/commandPalette/AskAssistantPill.tsx
@@ -1,0 +1,100 @@
+import { css } from '@emotion/css';
+import { useKBar } from 'kbar';
+import { useCallback, useEffect, useRef } from 'react';
+
+import { useAssistant } from '@grafana/assistant';
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
+import { Icon, useStyles2 } from '@grafana/ui';
+
+/**
+ * Pill in the command palette search row offering to ask the Grafana Assistant, together with its Shift+Enter
+ * shortcut. Deep search almost always returns something, so the empty state (and its "ask the assistant" button)
+ * rarely shows anymore — this keeps that escape hatch reachable while results exist. Renders nothing when
+ * the assistant is unavailable or the search query is empty.
+ */
+export function AskAssistantPill() {
+  const styles = useStyles2(getStyles);
+  const { query, searchQuery } = useKBar((state) => ({ searchQuery: state.searchQuery }));
+  const { isAvailable: isAssistantAvailable, openAssistant } = useAssistant();
+  const canAskAssistant = isAssistantAvailable && openAssistant !== undefined && searchQuery.length > 0;
+
+  const onAskAssistant = useCallback(
+    (trigger: 'shortcut' | 'input-pill') => {
+      // canAskAssistant already implies openAssistant is defined; the extra check only narrows the type
+      if (!canAskAssistant || !openAssistant) {
+        return;
+      }
+      reportInteraction('command_palette_ask_assistant', { trigger });
+      openAssistant({
+        origin: 'grafana/command-palette',
+        prompt: `Search for ${searchQuery}`,
+      });
+      query.toggle();
+    },
+    [canAskAssistant, openAssistant, searchQuery, query]
+  );
+
+  // Shift+Enter asks the assistant from anywhere in the palette. Window capture for the same reason as the
+  // navigation handler in RenderResults: global handlers (kbar's input focus guard, keybindingSrv) must not act
+  // first. State is read through refs so the listener registers once — onAskAssistant depends on searchQuery and
+  // would re-register the listener on every input change.
+  const onAskAssistantRef = useRef(onAskAssistant);
+  onAskAssistantRef.current = onAskAssistant;
+  const canAskAssistantRef = useRef(canAskAssistant);
+  canAskAssistantRef.current = canAskAssistant;
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter' || !event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
+        return;
+      }
+      if (!canAskAssistantRef.current) {
+        return;
+      }
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      onAskAssistantRef.current('shortcut');
+    };
+    window.addEventListener('keydown', handler, { capture: true });
+    return () => window.removeEventListener('keydown', handler, { capture: true });
+  }, []);
+
+  if (!canAskAssistant) {
+    return null;
+  }
+
+  return (
+    <button type="button" className={styles.pill} onClick={() => onAskAssistant('input-pill')}>
+      <Icon name="ai-sparkle" size="sm" />
+      {t('command-palette.search-box.ask-assistant', 'Shift + Enter to ask Assistant')}
+    </button>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  pill: css({
+    label: 'ask-assistant-pill',
+    flexShrink: 0,
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+    marginLeft: theme.spacing(1),
+    padding: theme.spacing(0.5, 1.5),
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    borderRadius: theme.shape.radius.pill,
+    // Gradient border: opaque inner background painted over the AI gradient,
+    // which stays visible only in the transparent 1px border ring. Same
+    // purple-to-orange gradient as the other assistant elements. The inner
+    // background matches the search row the pill sits on.
+    border: '1px solid transparent',
+    background: `linear-gradient(${theme.components.input.background}, ${theme.components.input.background}) padding-box, linear-gradient(90deg, rgb(168, 85, 247), rgb(249, 115, 22)) border-box`,
+    '&:hover, &:focus-visible': {
+      color: theme.colors.text.primary,
+      background: `linear-gradient(${theme.colors.emphasize(theme.components.input.background, 0.05)}, ${theme.colors.emphasize(theme.components.input.background, 0.05)}) padding-box, linear-gradient(90deg, rgb(168, 85, 247), rgb(249, 115, 22)) border-box`,
+    },
+  }),
+});

--- a/public/app/features/commandPalette/CommandPalette.test.tsx
+++ b/public/app/features/commandPalette/CommandPalette.test.tsx
@@ -1,7 +1,7 @@
 import { KBarProvider } from 'kbar';
 import { act, render, screen, userEvent } from 'test/test-utils';
 
-import { useAssistant } from '@grafana/assistant';
+import { OpenAssistantButton, useAssistant } from '@grafana/assistant';
 import { reportInteraction, setBackendSrv, setPluginLinksHook } from '@grafana/runtime';
 import {
   setGetObservablePluginLinks,
@@ -33,7 +33,7 @@ jest.mock('@grafana/runtime', () => ({
 jest.mock('@grafana/assistant', () => ({
   ...jest.requireActual('@grafana/assistant'),
   useAssistant: jest.fn(),
-  OpenAssistantButton: jest.fn().mockImplementation(({ title }) => <button>{title}</button>),
+  OpenAssistantButton: jest.fn().mockImplementation(({ title, onClick }) => <button onClick={onClick}>{title}</button>),
 }));
 
 jest.mock('@grafana/runtime/internal', () => ({
@@ -411,7 +411,8 @@ describe('CommandPalette', () => {
       await user.type(screen.getByPlaceholderText('Search or jump to...'), 'latency');
       await user.click(screen.getByRole('button', { name: /ask Assistant/ }));
 
-      expect(openAssistant).toHaveBeenCalledWith({
+      // The real OpenAssistantButton opens the assistant itself (mocked here), so assert it got the right props
+      expect((OpenAssistantButton as jest.Mock).mock.lastCall?.[0]).toMatchObject({
         origin: 'grafana/command-palette',
         prompt: 'Search for latency',
       });

--- a/public/app/features/commandPalette/CommandPalette.test.tsx
+++ b/public/app/features/commandPalette/CommandPalette.test.tsx
@@ -385,6 +385,81 @@ describe('CommandPalette', () => {
     });
   });
 
+  describe('ask assistant', () => {
+    it('opens the assistant with the search query on Shift+Enter', async () => {
+      const openAssistant = jest.fn();
+      (useAssistant as jest.Mock).mockReturnValue({ isLoading: false, isAvailable: true, openAssistant });
+
+      setup();
+      const user = userEvent.setup();
+      await user.type(screen.getByPlaceholderText('Search or jump to...'), 'latency');
+      await user.keyboard('{Shift>}{Enter}{/Shift}');
+
+      expect(openAssistant).toHaveBeenCalledWith({
+        origin: 'grafana/command-palette',
+        prompt: 'Search for latency',
+      });
+      expect(reportInteraction).toHaveBeenCalledWith('command_palette_ask_assistant', { trigger: 'shortcut' });
+    });
+
+    it('opens the assistant from the input pill', async () => {
+      const openAssistant = jest.fn();
+      (useAssistant as jest.Mock).mockReturnValue({ isLoading: false, isAvailable: true, openAssistant });
+
+      setup();
+      const user = userEvent.setup();
+      await user.type(screen.getByPlaceholderText('Search or jump to...'), 'latency');
+      await user.click(screen.getByRole('button', { name: /ask Assistant/ }));
+
+      expect(openAssistant).toHaveBeenCalledWith({
+        origin: 'grafana/command-palette',
+        prompt: 'Search for latency',
+      });
+      expect(reportInteraction).toHaveBeenCalledWith('command_palette_ask_assistant', { trigger: 'input-pill' });
+    });
+
+    it('does not show the pill or react to Shift+Enter when the assistant is not available', async () => {
+      (useAssistant as jest.Mock).mockReturnValue({ isLoading: false, isAvailable: false });
+
+      setup();
+      const user = userEvent.setup();
+      await user.type(screen.getByPlaceholderText('Search or jump to...'), 'latency');
+
+      expect(screen.queryByRole('button', { name: /ask Assistant/ })).not.toBeInTheDocument();
+      await user.keyboard('{Shift>}{Enter}{/Shift}');
+      expect(reportInteraction).not.toHaveBeenCalledWith('command_palette_ask_assistant', expect.anything());
+    });
+
+    it('does not show the pill or react to Shift+Enter when the search query is empty', async () => {
+      const openAssistant = jest.fn();
+      (useAssistant as jest.Mock).mockReturnValue({ isLoading: false, isAvailable: true, openAssistant });
+
+      setup();
+      const user = userEvent.setup();
+      // Focus the input without typing anything
+      screen.getByPlaceholderText('Search or jump to...').focus();
+
+      expect(screen.queryByRole('button', { name: /ask Assistant/ })).not.toBeInTheDocument();
+      await user.keyboard('{Shift>}{Enter}{/Shift}');
+      expect(openAssistant).not.toHaveBeenCalled();
+    });
+
+    it('does not show the pill or react to Shift+Enter when deep search is disabled', async () => {
+      // Either flag off → deepSearchEnabled is false → the pill and shortcut are gated off too
+      (useFlagGrafanaVectorSearchCmdk as jest.Mock).mockReturnValue(false);
+      const openAssistant = jest.fn();
+      (useAssistant as jest.Mock).mockReturnValue({ isLoading: false, isAvailable: true, openAssistant });
+
+      setup();
+      const user = userEvent.setup();
+      await user.type(screen.getByPlaceholderText('Search or jump to...'), 'latency');
+
+      expect(screen.queryByRole('button', { name: /ask Assistant/ })).not.toBeInTheDocument();
+      await user.keyboard('{Shift>}{Enter}{/Shift}');
+      expect(openAssistant).not.toHaveBeenCalled();
+    });
+  });
+
   describe('keyboard model', () => {
     it('uses the legacy model (auto-selects an item) when deep search is disabled', async () => {
       // Either flag off → deepSearchEnabled is false → legacy keyboard handling

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -13,6 +13,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { useFlagDashboardVectorSearch, useFlagGrafanaVectorSearchCmdk } from '@grafana/runtime/internal';
 import { EmptyState, Icon, LoadingBar, useStyles2 } from '@grafana/ui';
 
+import { AskAssistantPill } from './AskAssistantPill';
 import { type DeepSearchNavHandle, DeepSearchResults } from './DeepSearchResults';
 import { KBarResults } from './KBarResults';
 import { KBarSearch } from './KBarSearch';
@@ -139,6 +140,7 @@ function CommandPaletteContents() {
                 defaultPlaceholder={t('command-palette.search-box.placeholder', 'Search or jump to...')}
                 className={styles.search}
               />
+              {deepSearchEnabled && <AskAssistantPill />}
               <div className={styles.loadingBarContainer}>
                 {isFetchingSearchResults && <LoadingBar width={500} delay={0} />}
               </div>
@@ -393,7 +395,8 @@ const RenderResults = ({
             focusDeepSearch();
           }
           handled = true;
-        } else if (event.key === 'Enter') {
+        } else if (event.key === 'Enter' && !event.shiftKey) {
+          // Shift+Enter is the ask-assistant shortcut owned by CommandPaletteContents
           // The active row is always scrolled into view, so its element exists
           document.getElementById(getListboxItemId(current))?.click();
           handled = true;
@@ -421,8 +424,9 @@ const RenderResults = ({
             focusKeywordList();
           }
           handled = true;
-        } else if (event.key === 'Enter') {
-          // Keep global handlers away but let the anchor's native activation run
+        } else if (event.key === 'Enter' && !event.shiftKey) {
+          // Keep global handlers away but let the anchor's native activation run.
+          // Shift+Enter falls through to the ask-assistant shortcut instead.
           event.stopImmediatePropagation();
           return;
         } else if (event.key === 'Escape') {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4992,6 +4992,7 @@
       "selected-scopes-label": "Scopes: "
     },
     "search-box": {
+      "ask-assistant": "Shift + Enter to ask Assistant",
       "placeholder": "Search or jump to..."
     },
     "section": {


### PR DESCRIPTION
Needs `grafana.vectorSearchCmdk = true` feature toggle.

As the deep search portion of the palette (almost) always return some results, there is no empty state which means users won't see the "Ask assistant" button anymore.

This adds direct shortcut and pill/button to the input field, that is visible if there is any input, so that users can jump to assistant if needed anytime.


<img width="531" height="90" alt="Screenshot 2026-07-10 at 17 30 18" src="https://github.com/user-attachments/assets/162b83cc-17df-4b04-b336-83d892f20e81" />
