### PR TITLE
[release-13.1.1] Provisioning: make GitHub webhook creation idempotent (fix repos stuck unhealthy with HTTP 422)

### DIFF
--- a/apps/provisioning/pkg/repository/github/impl.go
+++ b/apps/provisioning/pkg/repository/github/impl.go
@@ -69,8 +69,48 @@ func translateGitHubError(err error) error {
 
 	default:
 		// Other errors - return with GitHub message context
+		if details := formatGitHubErrorDetails(ghErr.Errors); details != "" {
+			return fmt.Errorf("GitHub API error (HTTP %d: %s: %s)", statusCode, ghMessage, details)
+		}
 		return fmt.Errorf("GitHub API error (HTTP %d: %s)", statusCode, ghMessage)
 	}
+}
+
+// When receiving a 422 hook already exists error, we query
+// for all the repo's hooks and match against its payload URL.
+// If none match, we return this error
+var ErrWebhookAlreadyExists = errors.New("webhook already exists on repository but could not be queried based on payload url")
+
+func isWebhookAlreadyExists(ghErr *github.ErrorResponse) bool {
+	if ghErr.Response == nil || ghErr.Response.StatusCode != http.StatusUnprocessableEntity {
+		return false
+	}
+	if strings.Contains(strings.ToLower(ghErr.Message), "already exists") {
+		return true
+	}
+	for _, e := range ghErr.Errors {
+		if strings.Contains(strings.ToLower(e.Message), "already exists") {
+			return true
+		}
+	}
+	return false
+}
+
+// formatGitHubErrorDetails renders the per-field error details GitHub returns
+// alongside a validation error into a single readable string.
+func formatGitHubErrorDetails(errs []github.Error) string {
+	details := make([]string, 0, len(errs))
+	for _, e := range errs {
+		switch {
+		case e.Message != "":
+			details = append(details, e.Message)
+		case e.Field != "" && e.Code != "":
+			details = append(details, fmt.Sprintf("%s %s", e.Field, e.Code))
+		case e.Code != "":
+			details = append(details, e.Code)
+		}
+	}
+	return strings.Join(details, "; ")
 }
 
 const (
@@ -342,6 +382,15 @@ func (r *githubClient) CreateWebhook(ctx context.Context, cfg WebhookConfig) (We
 
 	createdHook, _, err := r.gh.Repositories.CreateHook(ctx, r.owner, r.repo, hook)
 	if err != nil {
+		// GitHub returns 422 when a hook with the same payload URL already exists
+		// (e.g. Status.Webhook was lost while the hook still lives on the repo).
+		// The 422 body carries no ID, so recover the existing hook by URL and
+		// take ownership of it instead of failing — this keeps CreateWebhook
+		// idempotent so the repository can self-heal rather than looping unhealthy.
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && isWebhookAlreadyExists(ghErr) {
+			return r.adoptExistingWebhook(ctx, cfg)
+		}
 		return WebhookConfig{}, translateGitHubError(err)
 	}
 
@@ -355,6 +404,64 @@ func (r *githubClient) CreateWebhook(ctx context.Context, cfg WebhookConfig) (We
 		// Secret is not returned by GitHub.
 		Secret: cfg.Secret,
 	}, nil
+}
+
+// adoptExistingWebhook recovers the hook already registered for cfg.URL after
+// CreateHook reported it exists. GitHub's 422 does not include the hook ID, so we
+// list the repo's hooks and match on the payload URL (GitHub's uniqueness key).
+// The stored secret is never returned by GitHub, so the matched hook is edited to
+// use cfg's secret and events, leaving a fully-owned webhook whose ID the caller
+// can persist to Status.Webhook.
+func (r *githubClient) adoptExistingWebhook(ctx context.Context, cfg WebhookConfig) (WebhookConfig, error) {
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		hooks, resp, err := r.gh.Repositories.ListHooks(ctx, r.owner, r.repo, opts)
+		if err != nil {
+			return WebhookConfig{}, fmt.Errorf("list webhooks to adopt existing: %w", translateGitHubError(err))
+		}
+
+		for _, h := range hooks {
+			if h.GetConfig().GetURL() != cfg.URL {
+				continue
+			}
+
+			edit := &github.Hook{
+				URL:    &cfg.URL,
+				Events: cfg.Events,
+				Active: &cfg.Active,
+				Config: &github.HookConfig{
+					ContentType: &cfg.ContentType,
+					Secret:      &cfg.Secret,
+					URL:         &cfg.URL,
+				},
+			}
+			if _, _, err := r.gh.Repositories.EditHook(ctx, r.owner, r.repo, h.GetID(), edit); err != nil {
+				return WebhookConfig{}, fmt.Errorf("adopt existing webhook %d: %w", h.GetID(), translateGitHubError(err))
+			}
+
+			logging.FromContext(ctx).Info("adopted existing webhook", "url", cfg.URL, "id", h.GetID())
+			return WebhookConfig{
+				ID:          h.GetID(),
+				Events:      cfg.Events,
+				Active:      true,
+				URL:         cfg.URL,
+				ContentType: cfg.ContentType,
+				Secret:      cfg.Secret,
+			}, nil
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	// GitHub said the hook exists but no hook matched our URL; surface it.
+	logging.FromContext(ctx).Error(
+		"GitHub said webhook exists but no hook with URL exists when queried",
+		slog.String("url", cfg.URL),
+	)
+	return WebhookConfig{}, ErrWebhookAlreadyExists
 }
 
 func (r *githubClient) GetWebhook(ctx context.Context, webhookID int64) (WebhookConfig, error) {

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -717,6 +717,108 @@ func TestGithubClient_CreateWebhook(t *testing.T) {
 			want:    WebhookConfig{},
 			wantErr: errors.New("GitHub API error (HTTP 500: Internal server error)"),
 		},
+		{
+			name: "hook already exists is adopted by URL",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.PostReposHooksByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusUnprocessableEntity)
+						require.NoError(t, json.NewEncoder(w).Encode(github.ErrorResponse{
+							Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+							Message:  "Validation Failed",
+							Errors:   []github.Error{{Resource: "Hook", Code: "custom", Message: "Hook already exists on this repository"}},
+						}))
+					}),
+				),
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetReposHooksByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						hooks := []*github.Hook{
+							{ID: github.Ptr(int64(111)), Config: &github.HookConfig{URL: github.Ptr("https://other.example.com/webhook")}},
+							{ID: github.Ptr(int64(456)), Config: &github.HookConfig{URL: github.Ptr("https://example.com/webhook")}},
+						}
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(hooks))
+					}),
+				),
+				mockhub.WithRequestMatchHandler(
+					mockhub.PatchReposHooksByOwnerByRepoByHookId,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						// The adopted hook must be reset to our secret and events.
+						body, err := io.ReadAll(r.Body)
+						require.NoError(t, err)
+						hook := &github.Hook{}
+						require.NoError(t, json.Unmarshal(body, hook))
+						assert.Equal(t, "secret123", hook.Config.GetSecret())
+						assert.Equal(t, []string{"push", "pull_request"}, hook.Events)
+
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(&github.Hook{
+							ID:     github.Ptr(int64(456)),
+							Events: []string{"push", "pull_request"},
+							Active: github.Ptr(true),
+							Config: &github.HookConfig{URL: github.Ptr("https://example.com/webhook"), ContentType: github.Ptr("json")},
+						}))
+					}),
+				),
+			),
+			owner:      "test-owner",
+			repository: "test-repo",
+			config: WebhookConfig{
+				Events:      []string{"push", "pull_request"},
+				Active:      true,
+				URL:         "https://example.com/webhook",
+				ContentType: "json",
+				Secret:      "secret123",
+			},
+			want: WebhookConfig{
+				ID:          456,
+				Events:      []string{"push", "pull_request"},
+				Active:      true,
+				URL:         "https://example.com/webhook",
+				ContentType: "json",
+				Secret:      "secret123",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "hook already exists but no url match returns sentinel",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.PostReposHooksByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusUnprocessableEntity)
+						require.NoError(t, json.NewEncoder(w).Encode(github.ErrorResponse{
+							Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+							Message:  "Validation Failed",
+							Errors:   []github.Error{{Resource: "Hook", Code: "custom", Message: "Hook already exists on this repository"}},
+						}))
+					}),
+				),
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetReposHooksByOwnerByRepo,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						hooks := []*github.Hook{
+							{ID: github.Ptr(int64(111)), Config: &github.HookConfig{URL: github.Ptr("https://other.example.com/webhook")}},
+						}
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(hooks))
+					}),
+				),
+			),
+			owner:      "test-owner",
+			repository: "test-repo",
+			config: WebhookConfig{
+				Events:      []string{"push", "pull_request"},
+				Active:      true,
+				URL:         "https://example.com/webhook",
+				ContentType: "json",
+				Secret:      "secret123",
+			},
+			want:    WebhookConfig{},
+			wantErr: ErrWebhookAlreadyExists,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Backport a84d7fac5a245e8cdac65d29dae58b45ce5de285 from #128068

---

Fixes #127638

### What the fix is

When upgrading from 13.0.1 -> 13.1.0, some repos would get an ambiguous `error running OnUpdate: GitHub API error (HTTP 422: Validation Failed)`. Since 13.1.0, we now run the hooks if there is a spec change (existed previously) OR if a webhook is missing (PR: grafana/grafana#122725, grafana/grafana#122797). We didn't save the details of the github error but trying to create a webhook with the same URL returns a 422 which lines up with the issue:

```
{
  "message": "Validation Failed",
  "errors": [
    {
      "resource": "Hook",
      "code": "custom",
      "message": "Hook already exists on this repository"
    }
  ],
  "documentation_url": "https://docs.github.com/rest/repos/webhooks#create-a-repository-webhook",
  "status": "422"
}
```

`CreateWebhook` is now **idempotent**: on that 422 it adopts the existing hook instead of failing —
- the 422 body has no ID, so we `ListHooks` and match on the **payload URL** to recover the ID;
- we `EditHook` to reset the hook to our secret + events (GitHub never returns the stored secret);
- we return the recovered ID so a correct `status.webhook` is persisted, breaking the loop.

### How a repo gets into this state (`status.webhook == nil` while the hook still exists in GitHub)

1. A reconcile decides a webhook is needed (`OnCreate`, or `webhookMissing` on update) and calls into the webhook hook: [`OnCreate`](https://github.com/grafana/grafana/blob/v13.1.0/apps/provisioning/pkg/repository/github/webhook.go#L339) → [`createWebhook`](https://github.com/grafana/grafana/blob/v13.1.0/apps/provisioning/pkg/repository/github/webhook.go#L235).

2. `createWebhook` issues the GitHub `POST` — [the hook is live on GitHub the instant this returns](https://github.com/grafana/grafana/blob/v13.1.0/apps/provisioning/pkg/repository/github/impl.go#L343) (called via [webhook.go:249](https://github.com/grafana/grafana/blob/v13.1.0/apps/provisioning/pkg/repository/github/webhook.go#L249)). It returns patch ops `[set /status/webhook = Y]`.

3. Those ops are **appended to a batch, not applied yet** — [repository.go:732](https://github.com/grafana/grafana/blob/v13.1.0/pkg/registry/apis/provisioning/controller/repository.go#L732) (returned from [`processHooks` at repository.go:724](https://github.com/grafana/grafana/blob/v13.1.0/pkg/registry/apis/provisioning/controller/repository.go#L724)).

4. The reconcile keeps going and hits a step that **returns an error** before the batch is saved — e.g. [`GetDefaultBranch` at repository.go:751](https://github.com/grafana/grafana/blob/v13.1.0/pkg/registry/apis/provisioning/controller/repository.go#L751) → [`return` at repository.go:753](https://github.com/grafana/grafana/blob/v13.1.0/pkg/registry/apis/provisioning/controller/repository.go#L753).

5. Because it returned, the final [`statusPatcher.Patch(...)` at repository.go:817](https://github.com/grafana/grafana/blob/v13.1.0/pkg/registry/apis/provisioning/controller/repository.go#L817) is **never reached** → the `set /status/webhook = Y` op is **discarded**.

6. Result: **hook Y is live on GitHub, but `status.webhook` is still nil.** ← the entry state.

7. Next reconcile: `webhookMissing` (nil) → [`createWebhook`](https://github.com/grafana/grafana/blob/v13.1.0/apps/provisioning/pkg/repository/github/webhook.go#L235) → `POST` → GitHub `422 "Hook already exists"` → repeats every reconcile. **Stuck in the loop.**

**Once status.webhook == nil, we're in a stuck state.** You can't delete your way out: `webhookOnDelete` short-circuits when `status.webhook == nil` (it needs the ID to call GitHub), so deleting the repo leaves the hook **orphaned**, and recreating collides with that orphan → `OnCreate` 422.

## Why 13.1 and not 13.0.1
13.0.1 only attempted a create at initial repo creation (rare, one-time), and once status persisted it never touched the webhook again — so the "created-but-not-persisted" window was tiny and, if hit, mostly self-healed.
13.1's webhookMissing re-attempts the create on every reconcile while status is nil, so (a) the window gets hit far more often, and (b) once you're in the state it's retried forever (422 loop) instead of ignored. Rotation adds another way to null it plus a synchronized post-upgrade burst.

### Testing
`go test ./apps/provisioning/pkg/repository/github/` — all passing.
