### PR TITLE
[release-13.0.4] Provisioning: Improve form errors for github connections

### DIFF
--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -144,14 +144,15 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 				Errors: []provisioning.ErrorDetails{
 					{
 						Type:     metav1.CauseTypeFieldValueInvalid,
-						Field:    field.NewPath("spec", "github", "appID").String(),
-						Detail:   "verify appID is correct",
+						Field:    field.NewPath("spec", string(c.obj.Spec.Type), "appID").String(),
+						Detail:   "authentication failed. The appID exists but could not be accessed with the privateKey. Verify appID is correct",
 						BadValue: c.obj.Spec.GitHub.AppID,
 					},
 					{
-						Type:   metav1.CauseTypeFieldValueInvalid,
-						Field:  field.NewPath("secure", "privateKey").String(),
-						Detail: "verify privateKey is correct",
+						Type:     metav1.CauseTypeFieldValueInvalid,
+						Field:    field.NewPath("secure", "privateKey").String(),
+						Detail:   "authentication failed. Verify privateKey is the generated private key for the appID",
+						BadValue: "****",
 					},
 				},
 			}, nil
@@ -188,7 +189,7 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 				},
 			}, nil
 		default:
-			// Generic error - invalid spec
+			// Generic error
 			return &provisioning.TestResults{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: provisioning.APIVERSION,
@@ -198,15 +199,8 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 				Success: false,
 				Errors: []provisioning.ErrorDetails{
 					{
-						Type:     metav1.CauseTypeFieldValueInvalid,
-						Field:    field.NewPath("spec", "github", "appID").String(),
-						Detail:   "verify appID is correct",
-						BadValue: c.obj.Spec.GitHub.AppID,
-					},
-					{
 						Type:   metav1.CauseTypeFieldValueInvalid,
-						Field:  field.NewPath("secure", "privateKey").String(),
-						Detail: "verify privateKey is correct",
+						Detail: fmt.Errorf("failed to GET app: %w", err).Error(),
 					},
 				},
 			}, nil
@@ -305,7 +299,7 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 				},
 			}, nil
 		default:
-			// Generic error - invalid spec
+			// Generic error
 			return &provisioning.TestResults{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: provisioning.APIVERSION,
@@ -315,10 +309,8 @@ func (c *Connection) Test(ctx context.Context) (*provisioning.TestResults, error
 				Success: false,
 				Errors: []provisioning.ErrorDetails{
 					{
-						Type:     metav1.CauseTypeFieldValueInvalid,
-						Field:    field.NewPath("spec", "github", "installationID").String(),
-						Detail:   "invalid installation ID",
-						BadValue: c.obj.Spec.GitHub.InstallationID,
+						Type:   metav1.CauseTypeFieldValueInvalid,
+						Detail: fmt.Errorf("failed to GET app installation: %w", err).Error(),
 					},
 				},
 			}, nil

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -436,15 +436,8 @@ func TestConnection_Test(t *testing.T) {
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
-					Type:     metav1.CauseTypeFieldValueInvalid,
-					Field:    "spec.github.appID",
-					Detail:   "verify appID is correct",
-					BadValue: appID,
-				},
-				{
 					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  "secure.privateKey",
-					Detail: "verify privateKey is correct",
+					Detail: "failed to GET app: unauthorized",
 				},
 			},
 		},
@@ -505,13 +498,14 @@ func TestConnection_Test(t *testing.T) {
 				{
 					Type:     metav1.CauseTypeFieldValueInvalid,
 					Field:    "spec.github.appID",
-					Detail:   "verify appID is correct",
+					Detail:   "authentication failed. The appID exists but could not be accessed with the privateKey. Verify appID is correct",
 					BadValue: appID,
 				},
 				{
-					Type:   metav1.CauseTypeFieldValueInvalid,
-					Field:  "secure.privateKey",
-					Detail: "verify privateKey is correct",
+					Type:     metav1.CauseTypeFieldValueInvalid,
+					Field:    "secure.privateKey",
+					Detail:   "authentication failed. Verify privateKey is the generated private key for the appID",
+					BadValue: "****",
 				},
 			},
 		},
@@ -935,10 +929,8 @@ func TestConnection_Test(t *testing.T) {
 			expectSuccess: false,
 			expectedErrors: []provisioning.ErrorDetails{
 				{
-					Type:     metav1.CauseTypeFieldValueInvalid,
-					Field:    "spec.github.installationID",
-					Detail:   "invalid installation ID",
-					BadValue: "456",
+					Type:   metav1.CauseTypeFieldValueInvalid,
+					Detail: "failed to GET app installation: unexpected error",
 				},
 			},
 		},


### PR DESCRIPTION
Backport 48f5f030adddeebdfcdaa0a50b771f8343f193db from #128133

---

**What is this feature?**

GitHub returns 2 different errors if the `privateKey + appID` do not match. 
1. **AuthenticationError** 
  They found the appID but the privateKey does not belong to the app. This does not mean the appID is necessarily correct (could be a private app) - it simply means that it exists in GitHub to some account. Can test this with a valid private key + appID: `10000` (high number that likely exists as an appID)
2. **NotFoundError** 
  They did not find the appID. The privateKey could still be incorrect, but they don't know. Can test this with a valid private key + appID: `1` (github must only start their IDs after some int) 
 
 For case 1, we get errors on the form like: 
 <img width="1472" height="1558" alt="image" src="https://github.com/user-attachments/assets/efde3d09-c14d-400d-87b1-a25fa96102e7" />
 
The user believes we didn't parse their privateKey because `invalid value: ""` and they're unsure what is wrong. 

Updated to add more details of 
<img width="693" height="851" alt="Screenshot 2026-07-09 at 10 53 15 PM" src="https://github.com/user-attachments/assets/4e1e95a2-c2ac-4099-9786-fde4fd8207fa" />


**Why do we need this feature?**
Display actual github error instead of swallowing it. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/127746

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
