### PR TITLE
Add on-demand datasource diagnostics panel action and drawer (behind feature toggle)

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -13,6 +13,7 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getObservablePluginLinks, locationService } from '@grafana/runtime';
+import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import { LocalValueVariable, sceneGraph, VizPanel, type VizPanelMenu } from '@grafana/scenes';
 import { type DataQuery, type OptionsWithLegend } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
@@ -265,6 +266,22 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
         onClick: (e: React.MouseEvent) => {
           e.preventDefault();
           dashboard.showModal(new PanelInspectDrawer({ panelRef: panel.getRef(), currentTab: InspectTab.Help }));
+        },
+      });
+    }
+
+    if (
+      contextSrv.isGrafanaAdmin &&
+      plugin &&
+      !plugin.meta.skipDataQuery &&
+      getFeatureFlagClient().getBooleanValue('grafana.onDemandDiagnostics', false)
+    ) {
+      moreSubMenu.push({
+        text: t('panel.header-menu.download-diagnostics', 'Download diagnostics'),
+        iconClassName: 'download-alt',
+        onClick: (e: React.MouseEvent) => {
+          e.preventDefault();
+          dashboard.showModal(new ShareDrawer({ shareView: 'download-diagnostics', panelRef: panel.getRef() }));
         },
       });
     }

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -21,6 +21,7 @@ import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getMessageFromError } from 'app/core/utils/errors';
+import { isOnPrem } from 'app/core/utils/isOnPrem';
 import { LogMessages, logInfo, trackCreateRuleFromPanelDrawerOpened } from 'app/features/alerting/unified/Analytics';
 import { type RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 import { getCreateAlertInMenuAvailability } from 'app/features/alerting/unified/utils/access-control';
@@ -271,6 +272,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
     }
 
     if (
+      isOnPrem() &&
       contextSrv.isGrafanaAdmin &&
       plugin &&
       !plugin.meta.skipDataQuery &&

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -13,7 +13,7 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getObservablePluginLinks, locationService } from '@grafana/runtime';
-import { getFeatureFlagClient } from '@grafana/runtime/internal';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { LocalValueVariable, sceneGraph, VizPanel, type VizPanelMenu } from '@grafana/scenes';
 import { type DataQuery, type OptionsWithLegend } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
@@ -274,14 +274,16 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       contextSrv.isGrafanaAdmin &&
       plugin &&
       !plugin.meta.skipDataQuery &&
-      getFeatureFlagClient().getBooleanValue('grafana.onDemandDiagnostics', false)
+      getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaOnDemandDiagnostics, false)
     ) {
       moreSubMenu.push({
         text: t('panel.header-menu.download-diagnostics', 'Download diagnostics'),
         iconClassName: 'download-alt',
         onClick: (e: React.MouseEvent) => {
           e.preventDefault();
-          dashboard.showModal(new ShareDrawer({ shareView: 'download-diagnostics', panelRef: panel.getRef() }));
+          dashboard.showModal(
+            new ShareDrawer({ shareView: shareDashboardType.downloadDiagnostics, panelRef: panel.getRef() })
+          );
         },
       });
     }

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -274,6 +274,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       contextSrv.isGrafanaAdmin &&
       plugin &&
       !plugin.meta.skipDataQuery &&
+      !isReadOnlyRepeat &&
       getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaOnDemandDiagnostics, false)
     ) {
       moreSubMenu.push({

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
@@ -83,6 +83,17 @@ describe('DownloadDiagnostics', () => {
     expect(await screen.findByText('404 Not Found')).toBeInTheDocument();
   });
 
+  it('shows a message and does not POST when the panel has no active queries', async () => {
+    const runner = new SceneQueryRunner({ queries: [{ refId: 'A', hide: true }] });
+    const { tab } = setupScenario(undefined, runner);
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    expect(await screen.findByText('This panel has no active queries to capture.')).toBeInTheDocument();
+    expect(downloadDiagnosticsForQueries).not.toHaveBeenCalled();
+  });
+
   it('calls onDismiss when cancelled', async () => {
     const onDismiss = jest.fn();
     const { tab } = setupScenario(onDismiss);

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
@@ -51,6 +51,24 @@ describe('DownloadDiagnostics', () => {
     expect(typeof to).toBe('string');
   });
 
+  it('fills the runner-level datasource onto queries that lack one', async () => {
+    const runner = new SceneQueryRunner({
+      datasource: { uid: 'runner-ds', type: 'prometheus' },
+      queries: [{ refId: 'A' }, { refId: 'B', datasource: { uid: 'own-ds', type: 'loki' } }],
+    });
+    const { tab } = setupScenario(undefined, runner);
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    const [queries] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    expect(queries).toEqual([
+      // A had no datasource -> filled from the runner; B keeps its own.
+      { refId: 'A', datasource: { uid: 'runner-ds', type: 'prometheus' } },
+      { refId: 'B', datasource: { uid: 'own-ds', type: 'loki' } },
+    ]);
+  });
+
   it('calls onDismiss when cancelled', async () => {
     const onDismiss = jest.fn();
     const { tab } = setupScenario(onDismiss);
@@ -62,14 +80,12 @@ describe('DownloadDiagnostics', () => {
   });
 });
 
-function setupScenario(onDismiss?: () => void) {
+function setupScenario(onDismiss?: () => void, runner?: SceneQueryRunner) {
   const vizPanel = new VizPanel({
     key: 'panel-1',
     pluginId: 'table',
     title: 'Panel',
-    $data: new SceneQueryRunner({
-      queries: [{ refId: 'A' }, { refId: 'B', hide: true }],
-    }),
+    $data: runner ?? new SceneQueryRunner({ queries: [{ refId: 'A' }, { refId: 'B', hide: true }] }),
   });
 
   const gridItem = new DashboardGridItem({ key: 'grid-item-1', body: vizPanel });

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
@@ -88,8 +88,8 @@ function setupScenario(onDismiss?: () => void) {
     overlay: tab,
   });
 
-  // Constructing the scene wires up parent pointers, which is all getDashboardSceneFor /
-  // getTimeRange / getQueryRunnerFor need here. We deliberately skip activation so the
-  // SceneQueryRunner does not try to execute (and fail) its queries against a real datasource.
+  // Constructing the scene wires up parent pointers, which is all sceneGraph.getTimeRange and the
+  // query-runner lookup need here. We deliberately skip activation so the SceneQueryRunner does not
+  // try to execute (and fail) its queries against a real datasource.
   return { tab, dashboard };
 }

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
@@ -69,6 +69,20 @@ describe('DownloadDiagnostics', () => {
     ]);
   });
 
+  it('shows the request status in the alert when the download fails', async () => {
+    // getBackendSrv fetch (responseType blob) rejects with a FetchError whose detail is in
+    // status/statusText, not message — the alert must still show something useful.
+    jest
+      .mocked(downloadDiagnosticsForQueries)
+      .mockRejectedValueOnce({ status: 404, statusText: 'Not Found', data: new Blob() });
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    expect(await screen.findByText('404 Not Found')).toBeInTheDocument();
+  });
+
   it('calls onDismiss when cancelled', async () => {
     const onDismiss = jest.fn();
     const { tab } = setupScenario(onDismiss);

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
@@ -1,0 +1,95 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
+import { getPanelPlugin } from '@grafana/data/test';
+import { setPluginImportUtils } from '@grafana/runtime';
+import { SceneGridLayout, SceneQueryRunner, SceneTimeRange, VizPanel } from '@grafana/scenes';
+import { downloadDiagnosticsForQueries } from 'app/features/query/diagnostics/downloadDiagnostics';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+
+import { DownloadDiagnostics } from './DownloadDiagnostics';
+
+jest.mock('app/features/query/diagnostics/downloadDiagnostics', () => ({
+  downloadDiagnosticsForQueries: jest.fn(),
+}));
+
+setPluginImportUtils({
+  importPanelPlugin: () => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: () => undefined,
+});
+
+describe('DownloadDiagnostics', () => {
+  beforeEach(() => {
+    jest.mocked(downloadDiagnosticsForQueries).mockClear();
+  });
+
+  it('renders the sensitive-data warning and download action', () => {
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+
+    expect(screen.getByText('May contain sensitive data')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download diagnostics' })).toBeInTheDocument();
+  });
+
+  it('passes the panel visible queries and time range when downloading', async () => {
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    expect(downloadDiagnosticsForQueries).toHaveBeenCalledTimes(1);
+    const [queries, from, to] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    // The component forwards the panel's queries verbatim; hidden-query filtering happens
+    // downstream in downloadDiagnosticsForQueries (mocked here).
+    expect(queries).toEqual([{ refId: 'A' }, { refId: 'B', hide: true }]);
+    expect(typeof from).toBe('string');
+    expect(typeof to).toBe('string');
+  });
+
+  it('calls onDismiss when cancelled', async () => {
+    const onDismiss = jest.fn();
+    const { tab } = setupScenario(onDismiss);
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+function setupScenario(onDismiss?: () => void) {
+  const vizPanel = new VizPanel({
+    key: 'panel-1',
+    pluginId: 'table',
+    title: 'Panel',
+    $data: new SceneQueryRunner({
+      queries: [{ refId: 'A' }, { refId: 'B', hide: true }],
+    }),
+  });
+
+  const gridItem = new DashboardGridItem({ key: 'grid-item-1', body: vizPanel });
+
+  const tab = new DownloadDiagnostics({
+    panelRef: vizPanel.getRef(),
+    onDismiss,
+  });
+
+  const dashboard = new DashboardScene({
+    title: 'Dash',
+    uid: 'dash-1',
+    meta: { canEdit: true },
+    $timeRange: new SceneTimeRange({}),
+    body: new DefaultGridLayoutManager({ grid: new SceneGridLayout({ children: [gridItem] }) }),
+    overlay: tab,
+  });
+
+  // Constructing the scene wires up parent pointers, which is all getDashboardSceneFor /
+  // getTimeRange / getQueryRunnerFor need here. We deliberately skip activation so the
+  // SceneQueryRunner does not try to execute (and fail) its queries against a real datasource.
+  return { tab, dashboard };
+}

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -57,10 +57,14 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
     let dashboardJSON: unknown;
     try {
       panelJSON = vizPanelToPanel(panel);
-    } catch {}
+    } catch (err) {
+      console.warn('Diagnostics: failed to serialize panel JSON', err);
+    }
     try {
       dashboardJSON = transformSceneToSaveModel(dashboard);
-    } catch {}
+    } catch (err) {
+      console.warn('Diagnostics: failed to serialize dashboard JSON', err);
+    }
 
     await downloadDiagnosticsForQueries(
       queries,

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -49,8 +49,7 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
       return;
     }
     const queryRunner = getQueryRunnerFor(panel);
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const queries = (queryRunner?.state.queries ?? []) as Array<Record<string, unknown>>;
+    const queries = queryRunner?.state.queries ?? [];
     const timeRange = sceneGraph.getTimeRange(panel).state.value;
 
     // Panel/dashboard serialization is best-effort; on failure we still capture HAR + logs.

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { useEffect, useRef } from 'react';
 import { useAsyncFn } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -62,14 +63,18 @@ function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQueryRunn
 function diagnosticsErrorMessage(error: Error): string {
   if (isFetchError(error)) {
     const parts = [error.status, error.statusText].filter(Boolean);
-    return parts.length ? parts.join(' ') : 'Request failed';
+    return parts.length ? parts.join(' ') : t('dashboard.diagnostics.request-failed', 'Request failed');
   }
-  return error.message || 'Failed to generate diagnostics';
+  return error.message || t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics');
 }
 
 function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiagnostics>) {
   const { onDismiss, panelRef } = model.useState();
   const styles = useStyles2(getStyles);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Abort any in-flight request if the drawer unmounts.
+  useEffect(() => () => abortRef.current?.abort(), []);
 
   const [{ loading: isGenerating, error }, onDownload] = useAsyncFn(async () => {
     const panel = panelRef?.resolve();
@@ -86,13 +91,28 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
     );
     // Known limitation (follow-up): template variables are sent un-interpolated, so captured
     // traffic won't match a panel that uses $vars until per-datasource interpolation is applied.
+    if (queries.filter((query) => !query.hide).length === 0) {
+      throw new Error(t('dashboard.diagnostics.no-queries', 'This panel has no active queries to capture.'));
+    }
     const timeRange = sceneGraph.getTimeRange(panel).state.value;
 
-    await downloadDiagnosticsForQueries(queries, String(timeRange.from.valueOf()), String(timeRange.to.valueOf()));
+    const controller = new AbortController();
+    abortRef.current = controller;
+    await downloadDiagnosticsForQueries(
+      queries,
+      String(timeRange.from.valueOf()),
+      String(timeRange.to.valueOf()),
+      controller.signal
+    );
   }, [panelRef]);
 
+  const handleDismiss = () => {
+    abortRef.current?.abort();
+    onDismiss?.();
+  };
+
   return (
-    <main>
+    <div>
       <p className={styles.info}>
         <Trans i18nKey="dashboard.diagnostics.info-text-panel">
           Generates a diagnostic bundle for this panel by re-running its queries with HTTP capture active. The download
@@ -131,11 +151,11 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
             <Trans i18nKey="dashboard.diagnostics.download-button">Download diagnostics</Trans>
           )}
         </Button>
-        <Button variant="secondary" onClick={onDismiss} fill="outline">
+        <Button variant="secondary" onClick={handleDismiss} fill="outline">
           <Trans i18nKey="dashboard.diagnostics.cancel-button">Cancel</Trans>
         </Button>
       </div>
-    </main>
+    </div>
   );
 }
 

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -1,0 +1,125 @@
+import { css } from '@emotion/css';
+import { useAsyncFn } from 'react-use';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import {
+  sceneGraph,
+  type SceneComponentProps,
+  SceneObjectBase,
+  type SceneObjectRef,
+  type VizPanel,
+} from '@grafana/scenes';
+import { Alert, Button, useStyles2 } from '@grafana/ui';
+import { downloadDiagnosticsForQueries } from 'app/features/query/diagnostics/downloadDiagnostics';
+
+import { transformSceneToSaveModel, vizPanelToPanel } from '../serialization/transformSceneToSaveModel';
+import { getDashboardSceneFor, getQueryRunnerFor } from '../utils/utils';
+
+import { type SceneShareTabState, type ShareView } from './types';
+
+export interface DownloadDiagnosticsState extends SceneShareTabState {
+  // The panel this diagnostics bundle is scoped to.
+  panelRef?: SceneObjectRef<VizPanel>;
+}
+
+export class DownloadDiagnostics extends SceneObjectBase<DownloadDiagnosticsState> implements ShareView {
+  static Component = DownloadDiagnosticsRenderer;
+
+  public getTabLabel() {
+    return t('dashboard.diagnostics.title', 'Download diagnostics');
+  }
+
+  public getSubtitle() {
+    return t(
+      'dashboard.diagnostics.subtitle-panel',
+      'Bundle HTTP traffic (HAR), logs, and panel JSON to help troubleshoot this panel.'
+    );
+  }
+}
+
+function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiagnostics>) {
+  const { onDismiss, panelRef } = model.useState();
+  const dashboard = getDashboardSceneFor(model);
+  const styles = useStyles2(getStyles);
+
+  const [{ loading: isGenerating }, onDownload] = useAsyncFn(async () => {
+    const panel = panelRef?.resolve();
+    if (!panel) {
+      return;
+    }
+    const queryRunner = getQueryRunnerFor(panel);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const queries = (queryRunner?.state.queries ?? []) as Array<Record<string, unknown>>;
+    const timeRange = sceneGraph.getTimeRange(panel).state.value;
+
+    // Panel/dashboard serialization is best-effort; on failure we still capture HAR + logs.
+    let panelJSON: unknown;
+    let dashboardJSON: unknown;
+    try {
+      panelJSON = vizPanelToPanel(panel);
+    } catch {}
+    try {
+      dashboardJSON = transformSceneToSaveModel(dashboard);
+    } catch {}
+
+    await downloadDiagnosticsForQueries(
+      queries,
+      String(timeRange.from.valueOf()),
+      String(timeRange.to.valueOf()),
+      panelJSON,
+      dashboardJSON
+    );
+  }, [dashboard, panelRef]);
+
+  return (
+    <main>
+      <p className={styles.info}>
+        <Trans i18nKey="dashboard.diagnostics.info-text-panel">
+          Generates a diagnostic bundle for this panel by re-running its queries with HTTP capture active. The download
+          may take a moment while the bundle is generated.
+        </Trans>
+      </p>
+
+      {/* Seed warning. Additional warnings (e.g. sensitive-data redaction, large bundles) are added here later. */}
+      <Alert
+        severity="warning"
+        title={t('dashboard.diagnostics.sensitive-warning-title', 'May contain sensitive data')}
+      >
+        <Trans i18nKey="dashboard.diagnostics.sensitive-warning-body">
+          The bundle can include request headers, query parameters, and server log lines. Review it before sharing
+          outside your organization.
+        </Trans>
+      </Alert>
+
+      {/* Diagnostic options (artifact selection, time range, redaction toggles) will be added here. */}
+      <div
+        className={styles.buttonRow}
+        role="group"
+        aria-label={t('dashboard.diagnostics.actions', 'Diagnostics actions')}
+      >
+        <Button variant="primary" onClick={onDownload} disabled={isGenerating} icon="download-alt">
+          {isGenerating ? (
+            <Trans i18nKey="dashboard.diagnostics.generating-button">Generating…</Trans>
+          ) : (
+            <Trans i18nKey="dashboard.diagnostics.download-button">Download diagnostics</Trans>
+          )}
+        </Button>
+        <Button variant="secondary" onClick={onDismiss} fill="outline">
+          <Trans i18nKey="dashboard.diagnostics.cancel-button">Cancel</Trans>
+        </Button>
+      </div>
+    </main>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  info: css({
+    marginBottom: theme.spacing(2),
+  }),
+  buttonRow: css({
+    display: 'flex',
+    gap: theme.spacing(2),
+    marginTop: theme.spacing(2),
+  }),
+});

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -6,15 +6,16 @@ import { Trans, t } from '@grafana/i18n';
 import {
   sceneGraph,
   type SceneComponentProps,
+  SceneDataTransformer,
+  type SceneObject,
   SceneObjectBase,
   type SceneObjectRef,
+  SceneQueryRunner,
   type VizPanel,
 } from '@grafana/scenes';
+import { type DataQuery } from '@grafana/schema';
 import { Alert, Button, useStyles2 } from '@grafana/ui';
 import { downloadDiagnosticsForQueries } from 'app/features/query/diagnostics/downloadDiagnostics';
-
-import { transformSceneToSaveModel, vizPanelToPanel } from '../serialization/transformSceneToSaveModel';
-import { getDashboardSceneFor, getQueryRunnerFor } from '../utils/utils';
 
 import { type SceneShareTabState, type ShareView } from './types';
 
@@ -38,42 +39,36 @@ export class DownloadDiagnostics extends SceneObjectBase<DownloadDiagnosticsStat
   }
 }
 
+// Inlined rather than imported from dashboard-scene/utils/utils: that module transitively reaches
+// DashboardScene, which imports ShareDrawer (which imports this view), creating an import cycle.
+function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQueryRunner | undefined {
+  if (!sceneObject) {
+    return undefined;
+  }
+  const dataProvider = sceneObject.state.$data ?? sceneObject.parent?.state.$data;
+  if (dataProvider instanceof SceneQueryRunner) {
+    return dataProvider;
+  }
+  if (dataProvider instanceof SceneDataTransformer) {
+    return getQueryRunnerFor(dataProvider);
+  }
+  return undefined;
+}
+
 function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiagnostics>) {
   const { onDismiss, panelRef } = model.useState();
-  const dashboard = getDashboardSceneFor(model);
   const styles = useStyles2(getStyles);
 
-  const [{ loading: isGenerating }, onDownload] = useAsyncFn(async () => {
+  const [{ loading: isGenerating, error }, onDownload] = useAsyncFn(async () => {
     const panel = panelRef?.resolve();
     if (!panel) {
       return;
     }
-    const queryRunner = getQueryRunnerFor(panel);
-    const queries = queryRunner?.state.queries ?? [];
+    const queries: DataQuery[] = getQueryRunnerFor(panel)?.state.queries ?? [];
     const timeRange = sceneGraph.getTimeRange(panel).state.value;
 
-    // Panel/dashboard serialization is best-effort; on failure we still capture HAR + logs.
-    let panelJSON: unknown;
-    let dashboardJSON: unknown;
-    try {
-      panelJSON = vizPanelToPanel(panel);
-    } catch (err) {
-      console.warn('Diagnostics: failed to serialize panel JSON', err);
-    }
-    try {
-      dashboardJSON = transformSceneToSaveModel(dashboard);
-    } catch (err) {
-      console.warn('Diagnostics: failed to serialize dashboard JSON', err);
-    }
-
-    await downloadDiagnosticsForQueries(
-      queries,
-      String(timeRange.from.valueOf()),
-      String(timeRange.to.valueOf()),
-      panelJSON,
-      dashboardJSON
-    );
-  }, [dashboard, panelRef]);
+    await downloadDiagnosticsForQueries(queries, String(timeRange.from.valueOf()), String(timeRange.to.valueOf()));
+  }, [panelRef]);
 
   return (
     <main>
@@ -96,6 +91,13 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
       </Alert>
 
       {/* Diagnostic options (artifact selection, time range, redaction toggles) will be added here. */}
+
+      {error && (
+        <Alert severity="error" title={t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics')}>
+          {error.message}
+        </Alert>
+      )}
+
       <div
         className={styles.buttonRow}
         role="group"

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -3,6 +3,7 @@ import { useAsyncFn } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { isFetchError } from '@grafana/runtime';
 import {
   sceneGraph,
   type SceneComponentProps,
@@ -55,6 +56,17 @@ function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQueryRunn
   return undefined;
 }
 
+// The download uses a blob-response fetch, whose FetchError carries the detail in status/statusText
+// (its data is a Blob and message is unset), so build a message from those rather than error.message
+// which would leave the alert body empty.
+function diagnosticsErrorMessage(error: Error): string {
+  if (isFetchError(error)) {
+    const parts = [error.status, error.statusText].filter(Boolean);
+    return parts.length ? parts.join(' ') : 'Request failed';
+  }
+  return error.message || 'Failed to generate diagnostics';
+}
+
 function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiagnostics>) {
   const { onDismiss, panelRef } = model.useState();
   const styles = useStyles2(getStyles);
@@ -103,7 +115,7 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
 
       {error && (
         <Alert severity="error" title={t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics')}>
-          {error.message}
+          {diagnosticsErrorMessage(error)}
         </Alert>
       )}
 

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -64,7 +64,16 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
     if (!panel) {
       return;
     }
-    const queries: DataQuery[] = getQueryRunnerFor(panel)?.state.queries ?? [];
+    const runner = getQueryRunnerFor(panel);
+    // Classic panels keep the datasource on the query runner rather than on each target, and unlike
+    // the normal /api/ds/query path nothing fills that in here. Copy the runner-level datasource
+    // onto any query that lacks one so the diagnostics endpoint can still route them.
+    const runnerDatasource = runner?.state.datasource;
+    const queries: DataQuery[] = (runner?.state.queries ?? []).map((query) =>
+      query.datasource ? query : { ...query, datasource: runnerDatasource }
+    );
+    // Known limitation (follow-up): template variables are sent un-interpolated, so captured
+    // traffic won't match a panel that uses $vars until per-datasource interpolation is applied.
     const timeRange = sceneGraph.getTimeRange(panel).state.value;
 
     await downloadDiagnosticsForQueries(queries, String(timeRange.from.valueOf()), String(timeRange.to.valueOf()));

--- a/public/app/features/dashboard-scene/sharing/ShareDrawer/ShareDrawer.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareDrawer/ShareDrawer.tsx
@@ -128,7 +128,7 @@ function getPanelShareView(
       return new SharePanelEmbedTab({ panelRef, onDismiss });
     case shareDashboardType.libraryPanel:
       return new ShareLibraryPanelTab({ panelRef, onDismiss });
-    case 'download-diagnostics':
+    case shareDashboardType.downloadDiagnostics:
       return new DownloadDiagnostics({ panelRef, onDismiss });
     default:
       return new SharePanelInternally({ panelRef, onDismiss });

--- a/public/app/features/dashboard-scene/sharing/ShareDrawer/ShareDrawer.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareDrawer/ShareDrawer.tsx
@@ -11,6 +11,7 @@ import { Drawer } from '@grafana/ui';
 import { shareDashboardType } from '../../../dashboard/components/ShareModal/utils';
 import { type DashboardScene } from '../../scene/DashboardScene';
 import { getDashboardSceneFor } from '../../utils/utils';
+import { DownloadDiagnostics } from '../DownloadDiagnostics';
 import { ExportAsCode } from '../ExportButton/ExportAsCode';
 import { ExportAsImage } from '../ExportButton/ExportAsImage';
 import { ShareExternally } from '../ShareButton/share-externally/ShareExternally';
@@ -127,6 +128,8 @@ function getPanelShareView(
       return new SharePanelEmbedTab({ panelRef, onDismiss });
     case shareDashboardType.libraryPanel:
       return new ShareLibraryPanelTab({ panelRef, onDismiss });
+    case 'download-diagnostics':
+      return new DownloadDiagnostics({ panelRef, onDismiss });
     default:
       return new SharePanelInternally({ panelRef, onDismiss });
   }

--- a/public/app/features/dashboard/components/ShareModal/utils.ts
+++ b/public/app/features/dashboard/components/ShareModal/utils.ts
@@ -201,4 +201,5 @@ export const shareDashboardType: {
   publicDashboard: 'public_dashboard',
   inviteUser: 'invite_user',
   image: 'image',
+  downloadDiagnostics: 'download_diagnostics',
 };

--- a/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
@@ -1,0 +1,35 @@
+import { saveAs } from 'file-saver';
+
+import { type DataQuery } from '@grafana/schema';
+
+import { downloadDiagnosticsForQueries } from './downloadDiagnostics';
+
+jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
+
+// NOTE: this covers the temporary client-side placeholder. When bundle generation moves to
+// POST /api/ds/diagnostics, this test is replaced by one asserting the request/response handling.
+describe('downloadDiagnosticsForQueries (placeholder)', () => {
+  beforeEach(() => jest.mocked(saveAs).mockClear());
+
+  it('does nothing when there are no visible queries', async () => {
+    await downloadDiagnosticsForQueries([{ refId: 'A', hide: true }], '1', '2');
+
+    expect(saveAs).not.toHaveBeenCalled();
+  });
+
+  it('saves a PLACEHOLDER bundle containing only the visible queries', async () => {
+    const queries: DataQuery[] = [{ refId: 'A' }, { refId: 'B', hide: true }];
+
+    await downloadDiagnosticsForQueries(queries, '100', '200');
+
+    expect(saveAs).toHaveBeenCalledTimes(1);
+    const [blob, filename] = jest.mocked(saveAs).mock.calls[0];
+    expect(filename).toMatch(/^diagnostics-\d{8}-\d{6}-PLACEHOLDER\.json$/);
+
+    const parsed = JSON.parse(await (blob as Blob).text());
+    expect(parsed.queries).toEqual([{ refId: 'A' }]);
+    expect(parsed.from).toBe('100');
+    expect(parsed.to).toBe('200');
+    expect(parsed._placeholder).toEqual(expect.any(String));
+  });
+});

--- a/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
@@ -1,35 +1,64 @@
 import { saveAs } from 'file-saver';
+import { of } from 'rxjs';
 
+import { getBackendSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
 import { downloadDiagnosticsForQueries } from './downloadDiagnostics';
 
 jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
+jest.mock('@grafana/runtime', () => ({ getBackendSrv: jest.fn() }));
 
-// NOTE: this covers the temporary client-side placeholder. When bundle generation moves to
-// POST /api/ds/diagnostics, this test is replaced by one asserting the request/response handling.
-describe('downloadDiagnosticsForQueries (placeholder)', () => {
-  beforeEach(() => jest.mocked(saveAs).mockClear());
+function setupBackendSrv(response: unknown) {
+  const fetch = jest.fn().mockReturnValue(of(response));
+  jest.mocked(getBackendSrv).mockReturnValue({ fetch } as unknown as ReturnType<typeof getBackendSrv>);
+  return fetch;
+}
+
+describe('downloadDiagnosticsForQueries', () => {
+  beforeEach(() => {
+    jest.mocked(saveAs).mockClear();
+  });
 
   it('does nothing when there are no visible queries', async () => {
+    const fetch = setupBackendSrv({});
+
     await downloadDiagnosticsForQueries([{ refId: 'A', hide: true }], '1', '2');
 
+    expect(fetch).not.toHaveBeenCalled();
     expect(saveAs).not.toHaveBeenCalled();
   });
 
-  it('saves a PLACEHOLDER bundle containing only the visible queries', async () => {
+  it('POSTs the visible queries and saves the returned bundle', async () => {
+    const blob = new Blob(['bundle'], { type: 'application/gzip' });
+    const fetch = setupBackendSrv({
+      data: blob,
+      headers: new Headers({ 'Content-Disposition': 'attachment; filename="diagnostics-20260101-000000.tar.gz"' }),
+    });
     const queries: DataQuery[] = [{ refId: 'A' }, { refId: 'B', hide: true }];
 
     await downloadDiagnosticsForQueries(queries, '100', '200');
 
-    expect(saveAs).toHaveBeenCalledTimes(1);
-    const [blob, filename] = jest.mocked(saveAs).mock.calls[0];
-    expect(filename).toMatch(/^diagnostics-\d{8}-\d{6}-PLACEHOLDER\.json$/);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/api/ds/diagnostics',
+        method: 'POST',
+        responseType: 'blob',
+        // Only the visible query is forwarded.
+        data: { from: '100', to: '200', queries: [{ refId: 'A' }] },
+      })
+    );
+    expect(saveAs).toHaveBeenCalledWith(blob, 'diagnostics-20260101-000000.tar.gz');
+  });
 
-    const parsed = JSON.parse(await (blob as Blob).text());
-    expect(parsed.queries).toEqual([{ refId: 'A' }]);
-    expect(parsed.from).toBe('100');
-    expect(parsed.to).toBe('200');
-    expect(parsed._placeholder).toEqual(expect.any(String));
+  it('falls back to a generated filename when no Content-Disposition is returned', async () => {
+    const blob = new Blob(['bundle'], { type: 'application/gzip' });
+    setupBackendSrv({ data: blob, headers: new Headers() });
+
+    await downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2');
+
+    expect(saveAs).toHaveBeenCalledTimes(1);
+    const [, filename] = jest.mocked(saveAs).mock.calls[0];
+    expect(filename).toMatch(/^diagnostics-\d{8}-\d{6}\.tar\.gz$/);
   });
 });

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -1,0 +1,44 @@
+import { saveAs } from 'file-saver';
+
+/** Builds a human-readable bundle filename stem, e.g. `diagnostics-20260623-172901` (local time). */
+function diagnosticsFileName(): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  return `diagnostics-${stamp}`;
+}
+
+/**
+ * Downloads a diagnostic artifact for the given panel queries.
+ *
+ * TEMPORARY / PLACEHOLDER: real bundle generation (HAR + logs + panel/dashboard JSON) is produced
+ * by the backend endpoint `POST /api/ds/diagnostics`, which lands in a separate backend PR. Until
+ * then, this generates a small dummy JSON artifact client-side so the panel action + drawer flow is
+ * reviewable end-to-end. Replace this body with a POST to the endpoint once the backend is merged.
+ */
+export async function downloadDiagnosticsForQueries(
+  queries: Array<Record<string, unknown>>,
+  from: string,
+  to: string,
+  panel?: unknown,
+  dashboard?: unknown
+): Promise<void> {
+  const visibleQueries = queries.filter((query) => !query.hide);
+
+  if (visibleQueries.length === 0) {
+    return;
+  }
+
+  const placeholder = {
+    _placeholder: 'Dummy diagnostics artifact — backend generation is not wired up yet (see PR).',
+    generatedAt: new Date().toISOString(),
+    from,
+    to,
+    queries: visibleQueries,
+    panel,
+    dashboard,
+  };
+
+  const blob = new Blob([JSON.stringify(placeholder, null, 2)], { type: 'application/json' });
+  saveAs(blob, `${diagnosticsFileName()}-PLACEHOLDER.json`);
+}

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -29,7 +29,12 @@ function fileNameFromContentDisposition(header: string | null): string | undefin
  * yet (it lands in a separate backend PR); until then this call fails and the drawer surfaces the
  * error. The request/response contract and this download flow are final.
  */
-export async function downloadDiagnosticsForQueries(queries: DataQuery[], from: string, to: string): Promise<void> {
+export async function downloadDiagnosticsForQueries(
+  queries: DataQuery[],
+  from: string,
+  to: string,
+  signal?: AbortSignal
+): Promise<void> {
   const visibleQueries = queries.filter((query) => !query.hide);
 
   if (visibleQueries.length === 0) {
@@ -44,6 +49,8 @@ export async function downloadDiagnosticsForQueries(queries: DataQuery[], from: 
       data: { from, to, queries: visibleQueries },
       // Surface failures in the drawer instead of a global toast.
       showErrorAlert: false,
+      // Cancelling the drawer aborts the in-flight request.
+      abortSignal: signal,
     })
   );
 

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -1,46 +1,50 @@
 import { saveAs } from 'file-saver';
+import { lastValueFrom } from 'rxjs';
 
+import { getBackendSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
-/** Builds a human-readable bundle filename stem, e.g. `diagnostics-20260623-172901` (local time). */
-function diagnosticsFileName(): string {
+const DIAGNOSTICS_ENDPOINT = '/api/ds/diagnostics';
+
+/** Fallback bundle filename, e.g. `diagnostics-20260623-172901.tar.gz` (local time), used when the
+ * response carries no Content-Disposition filename. */
+function fallbackFileName(): string {
   const now = new Date();
   const pad = (n: number) => String(n).padStart(2, '0');
   const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-  return `diagnostics-${stamp}`;
+  return `diagnostics-${stamp}.tar.gz`;
+}
+
+/** Extracts the filename from a Content-Disposition header, if present. */
+function fileNameFromContentDisposition(header: string | null): string | undefined {
+  return header?.match(/filename="?([^"]+)"?/i)?.[1];
 }
 
 /**
- * Downloads a diagnostic artifact for the given panel queries.
+ * Requests a diagnostic bundle for the given panel queries from the backend and downloads it.
  *
- * TEMPORARY / PLACEHOLDER: real bundle generation (HAR + logs + panel/dashboard JSON) is produced
- * by the backend endpoint `POST /api/ds/diagnostics`, which lands in a separate backend PR. Until
- * then, this generates a small dummy JSON artifact client-side so the panel action + drawer flow is
- * reviewable end-to-end. Replace this body with a POST to the endpoint once the backend is merged.
+ * The bundle is generated server-side by `POST /api/ds/diagnostics`. That endpoint is not available
+ * yet (it lands in a separate backend PR); until then this call fails and the drawer surfaces the
+ * error. The request/response contract and this download flow are final.
  */
-export async function downloadDiagnosticsForQueries(
-  queries: DataQuery[],
-  from: string,
-  to: string,
-  panel?: unknown,
-  dashboard?: unknown
-): Promise<void> {
+export async function downloadDiagnosticsForQueries(queries: DataQuery[], from: string, to: string): Promise<void> {
   const visibleQueries = queries.filter((query) => !query.hide);
 
   if (visibleQueries.length === 0) {
     return;
   }
 
-  const placeholder = {
-    _placeholder: 'Dummy diagnostics artifact — backend generation is not wired up yet (see PR).',
-    generatedAt: new Date().toISOString(),
-    from,
-    to,
-    queries: visibleQueries,
-    panel,
-    dashboard,
-  };
+  const response = await lastValueFrom(
+    getBackendSrv().fetch<Blob>({
+      url: DIAGNOSTICS_ENDPOINT,
+      method: 'POST',
+      responseType: 'blob',
+      data: { from, to, queries: visibleQueries },
+      // Surface failures in the drawer instead of a global toast.
+      showErrorAlert: false,
+    })
+  );
 
-  const blob = new Blob([JSON.stringify(placeholder, null, 2)], { type: 'application/json' });
-  saveAs(blob, `${diagnosticsFileName()}-PLACEHOLDER.json`);
+  const filename = fileNameFromContentDisposition(response.headers.get('Content-Disposition')) ?? fallbackFileName();
+  saveAs(response.data, filename);
 }

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -17,7 +17,9 @@ function fallbackFileName(): string {
 
 /** Extracts the filename from a Content-Disposition header, if present. */
 function fileNameFromContentDisposition(header: string | null): string | undefined {
-  return header?.match(/filename="?([^"]+)"?/i)?.[1];
+  // Stop at a closing quote or the next parameter (;), so an unquoted filename followed by other
+  // Content-Disposition params (e.g. filename*=) doesn't get captured into the name.
+  return header?.match(/filename="?([^";]+)"?/i)?.[1];
 }
 
 /**

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -1,5 +1,7 @@
 import { saveAs } from 'file-saver';
 
+import { type DataQuery } from '@grafana/schema';
+
 /** Builds a human-readable bundle filename stem, e.g. `diagnostics-20260623-172901` (local time). */
 function diagnosticsFileName(): string {
   const now = new Date();
@@ -17,7 +19,7 @@ function diagnosticsFileName(): string {
  * reviewable end-to-end. Replace this body with a POST to the endpoint once the backend is merged.
  */
 export async function downloadDiagnosticsForQueries(
-  queries: Array<Record<string, unknown>>,
+  queries: DataQuery[],
   from: string,
   to: string,
   panel?: unknown,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5556,6 +5556,17 @@
     "description": {
       "action": "Change dashboard description"
     },
+    "diagnostics": {
+      "actions": "Diagnostics actions",
+      "cancel-button": "Cancel",
+      "download-button": "Download diagnostics",
+      "generating-button": "Generating…",
+      "info-text-panel": "Generates a diagnostic bundle for this panel by re-running its queries with HTTP capture active. The download may take a moment while the bundle is generated.",
+      "sensitive-warning-body": "The bundle can include request headers, query parameters, and server log lines. Review it before sharing outside your organization.",
+      "sensitive-warning-title": "May contain sensitive data",
+      "subtitle-panel": "Bundle HTTP traffic (HAR), logs, and panel JSON to help troubleshoot this panel.",
+      "title": "Download diagnostics"
+    },
     "dynamic-config-value-editor": {
       "render-label": {
         "tooltip-remove-property": "Remove property"
@@ -12458,6 +12469,7 @@
     "header-menu": {
       "copy": "Copy",
       "copy-styles": "Copy styles",
+      "download-diagnostics": "Download diagnostics",
       "duplicate": "Duplicate",
       "edit": "Edit",
       "explore": "Explore",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5563,6 +5563,8 @@
       "error-title": "Failed to generate diagnostics",
       "generating-button": "Generating…",
       "info-text-panel": "Generates a diagnostic bundle for this panel by re-running its queries with HTTP capture active. The download may take a moment while the bundle is generated.",
+      "no-queries": "This panel has no active queries to capture.",
+      "request-failed": "Request failed",
       "sensitive-warning-body": "The bundle can include request headers, query parameters, and server log lines. Review it before sharing outside your organization.",
       "sensitive-warning-title": "May contain sensitive data",
       "subtitle-panel": "Bundle HTTP traffic (HAR), logs, and panel JSON to help troubleshoot this panel.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5560,6 +5560,7 @@
       "actions": "Diagnostics actions",
       "cancel-button": "Cancel",
       "download-button": "Download diagnostics",
+      "error-title": "Failed to generate diagnostics",
       "generating-button": "Generating…",
       "info-text-panel": "Generates a diagnostic bundle for this panel by re-running its queries with HTTP capture active. The download may take a moment while the bundle is generated.",
       "sensitive-warning-body": "The bundle can include request headers, query parameters, and server log lines. Review it before sharing outside your organization.",


### PR DESCRIPTION
**What is this feature?**

Adds a "Download diagnostics" action to the panel menu (under "More…") that opens a drawer for generating an on-demand diagnostic bundle scoped to a single panel. The bundle is intended to help troubleshoot on-prem datasource issues by capturing the panel's HTTP traffic (HAR), a tail of the server log, and the panel/dashboard JSON — so an issue can be reproduced and replayed offline.

This PR is *frontend-only*: the panel action, the `DownloadDiagnostics` share-drawer view, its registration in `ShareDrawer`, and the download entry point. The artifact generation logic in the backend will follow in dedicated PRs.

The export button and drawer are gated behind feature flag, as this effort is experimental.

Screenshots from dummy dashboard:

<img width="1512" height="982" alt="button" src="https://github.com/user-attachments/assets/ebb6b220-88f4-431c-a880-6e274bff0bc4" />
<img width="1512" height="982" alt="drawer" src="https://github.com/user-attachments/assets/dfa3aa34-46ab-49ae-aa47-8294413bbf58" />

____

**Why do we need this feature?**

Part of the ongoing effort to improve on-prem troubleshooting.

**Who is this feature for?**

Grafana server admins on on-prem (self-managed) instances, working with Grafana support to diagnose datasource issues.

**Known limitations**

These functionalities are intentionally out of scope and will potentially be tackled separately:

- Template variables are not interpolated
- Sensitive-data redaction of captured headers/params before download.
- Handle the empty/all-hidden-queries case with a user-facing notice instead of a silent no-op

