### PR TITLE
fix(annotations): prevent deleted annotations from resurfacing in legacy

### DIFF
--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
-	annotationpkg "github.com/grafana/grafana/pkg/registry/apps/annotation"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -113,19 +112,35 @@ func (s *annotationAPIClient) Delete(ctx context.Context, orgID int64, name stri
 	return s.k8sClient.Delete(ctx, name, orgID, v1.DeleteOptions{})
 }
 
+// GetByLegacyID fetches an annotation by its legacy ID, including the tombstone if it has
+// been soft-deleted, so callers can tell a deleted record from a missing one.
+//
 // TODO: expensive — the legacyID index does not cover the time partition, so this scans
 // every partition. Carrying the annotation time to the call sites would let us prune them.
 func (s *annotationAPIClient) GetByLegacyID(ctx context.Context, orgID int64, annotationID int64) (*annotationV0.Annotation, error) {
-	list, err := s.k8sClient.List(ctx, orgID, v1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%d", annotationpkg.LabelKeyLegacyID, annotationID),
-	})
+	rc, err := s.getRESTClient()
 	if err != nil {
 		return nil, err
+	}
+
+	namespace := s.k8sClient.GetNamespace(orgID)
+	raw, err := rc.Get().
+		AbsPath("apis", annotationV0.APIGroup, annotationV0.APIVersion, "namespaces", namespace, "search").
+		Param("legacyID", strconv.FormatInt(annotationID, 10)).
+		Param("deleted", "include"). // include the tombstone so we can distinguish between deleted and missing
+		DoRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var list annotationV0.AnnotationList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
 	}
 	if len(list.Items) == 0 {
 		return nil, ErrNotFound
 	}
-	return fromUnstructured(&list.Items[0])
+	return &list.Items[0], nil
 }
 
 func (s *annotationAPIClient) GetUsersFromMeta(ctx context.Context, usersMeta []string) (map[string]*user.User, error) {

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -22,6 +22,11 @@ import (
 // ErrNotFound is returned by proxy methods when the annotation is not in the new storage
 var ErrNotFound = errors.New("annotation not found in new store")
 
+// ErrGone is returned when the annotation was soft-deleted (tombstoned) in the new store.
+// Unlike ErrNotFound, callers must NOT fall back to legacy as the new store is authoritative
+// and the record is deleted.
+var ErrGone = errors.New("annotation has been deleted in new store")
+
 // partialDecodeError signals that one or more optional fields could not be decoded
 // from an annotation. The annotation is still usable without those fields, so callers
 // can return the DTO (minus the affected fields) rather than dropping it.
@@ -164,6 +169,9 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	if err != nil {
 		return err
 	}
+	if existing.GetDeletionTimestamp() != nil {
+		return ErrGone
+	}
 	anno, err := itemToAnnotation(item)
 	if err != nil {
 		return err
@@ -182,20 +190,29 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	return err
 }
 
-// Delete removes from new store. Returns ErrNotFound if the record is not there yet — caller falls back to legacy.
+// Delete soft-deletes in the new store. Returns ErrNotFound if the record is not
+// there yet (caller falls back to legacy) or ErrGone if it was already deleted.
 func (h *MigrationProxy) Delete(ctx context.Context, orgID int64, annotationID int64) error {
 	existing, err := h.client.GetByLegacyID(ctx, orgID, annotationID)
 	if err != nil {
 		return err
 	}
+	if existing.GetDeletionTimestamp() != nil {
+		return ErrGone
+	}
 	return h.client.Delete(ctx, orgID, existing.GetName())
 }
 
-// TODO: soft-delete not yet implemented
+// Get reads a single annotation from the new store. Returns ErrNotFound if the
+// record is not there yet (caller falls back to legacy) or ErrGone if it was
+// soft-deleted (caller must not fall back).
 func (h *MigrationProxy) Get(ctx context.Context, orgID int64, annotationID int64) (*annotations.ItemDTO, error) {
 	anno, err := h.client.GetByLegacyID(ctx, orgID, annotationID)
 	if err != nil {
 		return nil, err
+	}
+	if anno.GetDeletionTimestamp() != nil {
+		return nil, ErrGone
 	}
 
 	dto, err := annoToItemDTO(anno)

--- a/pkg/services/annotations/annotationsapi/migration_repository.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository.go
@@ -110,12 +110,16 @@ func (r *migrationRepository) legacyToMerge(ctx context.Context, query *annotati
 }
 
 // findByID reads a single annotation from the new store, falling back to legacy when the
-// record is not there yet (pre-migration record or an alert annotation).
+// record is not there yet (pre-migration record or an alert annotation). A record deleted
+// in the new store (ErrGone) is authoritatively gone and must not fall back to legacy.
 func (r *migrationRepository) findByID(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
 	dto, err := r.proxy.Get(ctx, query.OrgID, query.AnnotationID)
 	switch {
 	case err == nil:
 		return []*annotations.ItemDTO{dto}, nil
+	case errors.Is(err, ErrGone):
+		// deleted in new store, don't fall back to legacy
+		return nil, nil
 	case errors.Is(err, ErrNotFound):
 		return r.legacy.Find(ctx, query)
 	default:
@@ -157,7 +161,8 @@ func (r *migrationRepository) SaveMany(ctx context.Context, items []annotations.
 }
 
 // Update writes to the new store. On ErrNotFound (older record) it falls back to legacy,
-// which preserves any Data the caller omits.
+// which preserves any Data the caller omits. On ErrGone (deleted in the new store) it
+// returns the error without falling back, so an update can't resurrect a deleted record.
 func (r *migrationRepository) Update(ctx context.Context, item *annotations.Item) error {
 	err := r.proxy.Update(ctx, item.OrgID, item.ID, item)
 	if err == nil || !errors.Is(err, ErrNotFound) {
@@ -166,24 +171,30 @@ func (r *migrationRepository) Update(ctx context.Context, item *annotations.Item
 	return r.legacy.Update(ctx, item)
 }
 
-// Delete removes one annotation from the new store, falling back to legacy on ErrNotFound
-// (older record).
-// TODO: this only removes the new-store copy. If the same annotation still exists in
-// legacy (e.g. migrated but not purged), the legacy row survives and reappears in the
-// merged Find results. Needs a dual-delete or a tombstone once soft-delete lands.
+// Delete removes one annotation from both stores.
+// When a record is not in the new store yet (ErrNotFound), legacy still owns it so we delete it there.
+// When a record is already deleted in the new store (ErrGone), we still best-effort delete the
+// legacy record to ensure consistency.
 func (r *migrationRepository) Delete(ctx context.Context, params *annotations.DeleteParams) error {
 	// No ID means a mass delete by dashboard/panel, which the proxy can't express.
 	if params.ID == 0 {
 		return r.legacy.Delete(ctx, params)
 	}
 	err := r.proxy.Delete(ctx, params.OrgID, params.ID)
-	if err == nil {
+	switch {
+	case err == nil, errors.Is(err, ErrGone):
+		// Best-effort delete the legacy copy. A failure means the annotation could
+		// briefly resurface in a merged read until legacy is retired for the instance.
+		// A re-delete would land here again and retry the cleanup.
+		if err := r.legacy.Delete(ctx, params); err != nil {
+			r.logger.Warn("failed to delete legacy copy after new-store delete", "id", params.ID, "err", err)
+		}
 		return nil
-	}
-	if !errors.Is(err, ErrNotFound) {
+	case errors.Is(err, ErrNotFound):
+		return r.legacy.Delete(ctx, params)
+	default:
 		return err
 	}
-	return r.legacy.Delete(ctx, params)
 }
 
 // TODO: FindTags reads from legacy only. Follow up to proxy tag searches to the new store.

--- a/pkg/services/annotations/annotationsapi/migration_repository_test.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository_test.go
@@ -23,6 +23,7 @@ type fakeLegacy struct {
 	findCalls    []*annotations.ItemQuery
 	updateItems  []*annotations.Item
 	deleteParams []*annotations.DeleteParams
+	deleteErr    error
 }
 
 func (f *fakeLegacy) Find(_ context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
@@ -37,7 +38,7 @@ func (f *fakeLegacy) Update(_ context.Context, item *annotations.Item) error {
 }
 func (f *fakeLegacy) Delete(_ context.Context, params *annotations.DeleteParams) error {
 	f.deleteParams = append(f.deleteParams, params)
-	return nil
+	return f.deleteErr
 }
 func (f *fakeLegacy) FindTags(context.Context, *annotations.TagsQuery) (annotations.FindTagsResult, error) {
 	return annotations.FindTagsResult{}, nil
@@ -200,6 +201,18 @@ func TestMigrationRepository_Find(t *testing.T) {
 		assert.Equal(t, []*annotations.ItemDTO{item(5, 10)}, got)
 		assert.Equal(t, 1, proxy.getCalls)
 		assert.Len(t, legacy.findCalls, 1)
+	})
+
+	t.Run("by-id returns empty on ErrGone and does not fall back to legacy", func(t *testing.T) {
+		legacy := &fakeLegacy{findResult: []*annotations.ItemDTO{item(5, 10)}}
+		proxy := &fakeProxy{getErr: ErrGone}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		got, err := repo.Find(context.Background(), &annotations.ItemQuery{AnnotationID: 5})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+		assert.Equal(t, 1, proxy.getCalls)
+		assert.Empty(t, legacy.findCalls)
 	})
 
 	t.Run("by-id propagates other proxy errors", func(t *testing.T) {
@@ -414,19 +427,38 @@ func TestMigrationRepository_Update(t *testing.T) {
 		require.Len(t, legacy.updateItems, 1)
 		assert.Same(t, item, legacy.updateItems[0])
 	})
+
+	t.Run("ErrGone does not fall back to legacy", func(t *testing.T) {
+		legacy := &fakeLegacy{}
+		proxy := &fakeProxy{updateErr: ErrGone}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		require.ErrorIs(t, repo.Update(context.Background(), &annotations.Item{OrgID: 1, ID: 5}), ErrGone)
+		assert.Empty(t, legacy.updateItems)
+	})
 }
 
 // --- Delete ----------------------------------------------------------------
 
 func TestMigrationRepository_Delete(t *testing.T) {
-	t.Run("single delete hits new store and skips legacy", func(t *testing.T) {
+	t.Run("single delete removes from new store then dual-deletes the legacy copy", func(t *testing.T) {
 		legacy := &fakeLegacy{}
 		proxy := &fakeProxy{}
 		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
 
 		require.NoError(t, repo.Delete(context.Background(), &annotations.DeleteParams{OrgID: 1, ID: 5}))
 		assert.Equal(t, 1, proxy.deleteCalls)
-		assert.Empty(t, legacy.deleteParams)
+		require.Len(t, legacy.deleteParams, 1)
+	})
+
+	t.Run("single delete succeeds even when the best-effort legacy delete fails", func(t *testing.T) {
+		legacy := &fakeLegacy{deleteErr: assert.AnError}
+		proxy := &fakeProxy{}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		require.NoError(t, repo.Delete(context.Background(), &annotations.DeleteParams{OrgID: 1, ID: 5}))
+		assert.Equal(t, 1, proxy.deleteCalls)
+		require.Len(t, legacy.deleteParams, 1)
 	})
 
 	t.Run("single delete propagates non-NotFound proxy errors", func(t *testing.T) {
@@ -441,6 +473,16 @@ func TestMigrationRepository_Delete(t *testing.T) {
 	t.Run("single delete falls back to legacy on ErrNotFound", func(t *testing.T) {
 		legacy := &fakeLegacy{}
 		proxy := &fakeProxy{deleteErr: ErrNotFound}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		require.NoError(t, repo.Delete(context.Background(), &annotations.DeleteParams{OrgID: 1, ID: 5}))
+		assert.Equal(t, 1, proxy.deleteCalls)
+		require.Len(t, legacy.deleteParams, 1)
+	})
+
+	t.Run("single delete treats ErrGone as idempotent success and retries the legacy cleanup", func(t *testing.T) {
+		legacy := &fakeLegacy{}
+		proxy := &fakeProxy{deleteErr: ErrGone}
 		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
 
 		require.NoError(t, repo.Delete(context.Background(), &annotations.DeleteParams{OrgID: 1, ID: 5}))


### PR DESCRIPTION
During the annotations API migration, deleting a record that exists in both stores currently leaves the legacy copy behind and resurfaces it in merged reads (this is a TODO from the first iteration of the proxy work).

This PR makes the new store authoritative for deletes. A proxied delete soft-deletes the annotation in the new store and best-effort cleans up any legacy record so it doesn't resurface when listing. Single-record reads/updates/deletes now also honor the new store's tombstone instead of falling back to legacy.

Closes: https://github.com/grafana/grafana-org/issues/961