### PR TITLE
Query: attribute backend frames to their result key in toDataQueryResponse

### DIFF
--- a/packages/grafana-runtime/src/utils/queryResponse.test.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.test.ts
@@ -172,6 +172,33 @@ describe('Query Response parser', () => {
     `);
   });
 
+  test('uses the result key as the frame refId even when the backend labels the frame with a different (source) refId', () => {
+    // e.g. a server-side expression `B = $A` whose passed-through frame is stamped with the source refId "A".
+    // Downstream logic (runRequest hiding results for hidden queries) keys off frame.refId, so a mislabeled
+    // frame must still be attributed to its result key ("B"), not the source ("A").
+    const expressionResp = {
+      data: {
+        results: {
+          B: {
+            frames: [
+              {
+                schema: {
+                  refId: 'A',
+                  fields: [{ name: 'Value', type: 'number', typeInfo: { frame: 'float64', nullable: true } }],
+                },
+                data: { values: [[1]] },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as FetchResponse<BackendDataSourceResponse>;
+
+    const frames = toDataQueryResponse(expressionResp, [{ refId: 'B' }]).data as DataFrame[];
+    expect(frames).toHaveLength(1);
+    expect(frames[0].refId).toEqual('B');
+  });
+
   test('should parse output with dataframe in order of queries', () => {
     const queries: DataQuery[] = [{ refId: 'B' }, { refId: 'A' }];
     const res = toDataQueryResponse(resp, queries);

--- a/packages/grafana-runtime/src/utils/queryResponse.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.ts
@@ -116,9 +116,12 @@ export function toDataQueryResponse(
             js = addCacheNotice(js);
           }
           const df = dataFrameFromJSON(js);
-          if (!df.refId) {
-            df.refId = dr.refId;
-          }
+          // The result key is authoritative for which query/refId a frame answers. Some backends
+          // (notably server-side expressions that pass an input through, e.g. `$A`) stamp the frame
+          // with the *source* query's refId rather than the expression's. Downstream logic keys off
+          // frame.refId — e.g. runRequest hides results whose refId matches a hidden query — so a
+          // mislabeled frame gets dropped. Always trust the result key.
+          df.refId = dr.refId;
           rsp.data.push(df);
         }
         continue; // the other tests are legacy


### PR DESCRIPTION
## What this PR does

`toDataQueryResponse` now labels each response frame with the refId of the **result it belongs to**, even when the backend stamps the frame with a different refId.

## Why

A server-side expression that passes an input through — e.g. a Math expression `B = $A` — returns a frame carrying the **source** query's refId (`A`) under the `B` result. Downstream logic keys off `frame.refId`; in particular `runRequest` drops frames whose refId matches a **hidden** query. So the expression's result was silently dropped whenever its source query was hidden.

In practice this showed up as panels intermittently rendering **"No data"** or missing series when a hidden query feeds an expression (a very common pattern: a hidden data query `A` + a visible `B = $A`). It's non-deterministic because the backend inconsistently tags frames with the source vs. the expression refId.

The result key is authoritative for which query a frame answers, so `toDataQueryResponse` now assigns it unconditionally instead of only when the frame has no refId.

## Testing

- Added a regression test in `queryResponse.test.ts` (a frame labeled with a source refId under a different result key is attributed to the result key).
- `queryResponse.test.ts`, `runRequest.test.ts`, `PanelQueryRunner.test.ts`, and `DataSourceWithBackend.test.ts` all pass.
- Verified end-to-end that a dashboard with hidden queries feeding expressions no longer intermittently drops results.

## Notes

Independent, pre-existing bug — surfaced while investigating multi-value datasource variables feeding expressions, but it affects any hidden-query→expression setup regardless of that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Repro Step of bug: 
1. checkout main and run grafana locally
2. create a prometheus datasource
3. import this dashboard [dashboard-1783706697820.json](https://github.com/user-attachments/files/29900402/dashboard-1783706697820.json)
4. make sure the dashboard connects to your prometheus datasource
5. in the panel on the left you'll see we render 4 responses
6. in the panel on the right we've "hidden" 2 of the responses, you'll notice when we refresh the page we get inconsistent behavior hiding the responses. Sometimes it hides 1 other times it hides the other, sometimes it shows no data, sometimes it shows the expected behavior. 
7. Checkout this branch, notice it fixes the issue

