### PR TITLE
Plugins: Send grafana.com token in plugin update checks when configured

### DIFF
--- a/pkg/services/updatemanager/plugins.go
+++ b/pkg/services/updatemanager/plugins.go
@@ -34,17 +34,18 @@ type availableUpdate struct {
 type PluginsService struct {
 	availableUpdates map[string]availableUpdate
 
-	enabled         bool
-	grafanaVersion  string
-	pluginStore     pluginstore.Store
-	httpClient      httpClient
-	mutex           sync.RWMutex
-	log             log.Logger
-	tracer          tracing.Tracer
-	updateCheckURL  *url.URL
-	pluginInstaller plugins.Installer
-	updateChecker   *pluginchecker.Service
-	updateStrategy  string
+	enabled          bool
+	grafanaVersion   string
+	pluginStore      pluginstore.Store
+	httpClient       httpClient
+	mutex            sync.RWMutex
+	log              log.Logger
+	tracer           tracing.Tracer
+	updateCheckURL   *url.URL
+	updateCheckToken string
+	pluginInstaller  plugins.Installer
+	updateChecker    *pluginchecker.Service
+	updateStrategy   string
 
 	features featuremgmt.FeatureToggles
 	cfg      *setting.Cfg
@@ -86,6 +87,7 @@ func ProvidePluginsService(cfg *setting.Cfg,
 		pluginStore:      pluginStore,
 		availableUpdates: make(map[string]availableUpdate),
 		updateCheckURL:   parsedUpdateCheckURL,
+		updateCheckToken: cfg.GrafanaComProxyAPIToken,
 		pluginInstaller:  pluginInstaller,
 		features:         features,
 		updateChecker:    updateChecker,
@@ -171,6 +173,12 @@ func (s *PluginsService) checkForUpdates(ctx context.Context) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
 	if err != nil {
 		return err
+	}
+	// authenticate when a grafana.com token is configured (e.g. in Grafana Cloud)
+	// so the response reflects the plugin scopes visible to this instance instead
+	// of the anonymous catalog
+	if s.updateCheckToken != "" {
+		req.Header.Set("Authorization", "Bearer "+s.updateCheckToken)
 	}
 	resp, err := s.httpClient.Do(req)
 	if err != nil {

--- a/pkg/services/updatemanager/plugins_test.go
+++ b/pkg/services/updatemanager/plugins_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginchecker"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/provisionedplugins"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type mockPluginPreinstall struct {
@@ -277,6 +278,26 @@ func TestPluginUpdateChecker_checkForUpdates(t *testing.T) {
 		err := svc.checkForUpdates(context.Background())
 		require.NoError(t, err)
 		require.Empty(t, client.authHeader)
+	})
+}
+
+func TestProvidePluginsService(t *testing.T) {
+	t.Run("wires the grafana.com token and update check URL from the config", func(t *testing.T) {
+		cfg := &setting.Cfg{
+			GrafanaComAPIURL:        "https://grafana.com/api",
+			GrafanaComProxyAPIToken: "token",
+		}
+
+		svc, err := ProvidePluginsService(cfg,
+			&pluginstore.FakePluginStore{},
+			&pluginfakes.FakePluginInstaller{},
+			tracing.InitializeTracerForTest(),
+			&featuremgmt.FeatureManager{},
+			pluginchecker.ProvideService(managedplugins.NewNoop(), provisionedplugins.NewNoop(), &mockPluginPreinstall{}),
+		)
+		require.NoError(t, err)
+		require.Equal(t, "token", svc.updateCheckToken)
+		require.Equal(t, "https://grafana.com/api/plugins/versioncheck", svc.updateCheckURL.String())
 	})
 }
 

--- a/pkg/services/updatemanager/plugins_test.go
+++ b/pkg/services/updatemanager/plugins_test.go
@@ -243,6 +243,41 @@ func TestPluginUpdateChecker_checkForUpdates(t *testing.T) {
 
 		require.Empty(t, svc.availableUpdates["test-core-panel"])
 	})
+
+	t.Run("sends the grafana.com token when configured", func(t *testing.T) {
+		updateCheckURL, _ := url.Parse("https://grafana.com/api/plugins/versioncheck")
+		client := &fakeHTTPClient{fakeResp: "[]"}
+		svc := PluginsService{
+			availableUpdates: map[string]availableUpdate{},
+			pluginStore:      &pluginstore.FakePluginStore{},
+			httpClient:       client,
+			log:              log.NewNopLogger(),
+			tracer:           tracing.InitializeTracerForTest(),
+			updateCheckURL:   updateCheckURL,
+			updateCheckToken: "token",
+		}
+
+		err := svc.checkForUpdates(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "Bearer token", client.authHeader)
+	})
+
+	t.Run("does not send an authorization header without a token", func(t *testing.T) {
+		updateCheckURL, _ := url.Parse("https://grafana.com/api/plugins/versioncheck")
+		client := &fakeHTTPClient{fakeResp: "[]"}
+		svc := PluginsService{
+			availableUpdates: map[string]availableUpdate{},
+			pluginStore:      &pluginstore.FakePluginStore{},
+			httpClient:       client,
+			log:              log.NewNopLogger(),
+			tracer:           tracing.InitializeTracerForTest(),
+			updateCheckURL:   updateCheckURL,
+		}
+
+		err := svc.checkForUpdates(context.Background())
+		require.NoError(t, err)
+		require.Empty(t, client.authHeader)
+	})
 }
 
 func TestPluginUpdateChecker_updateAll(t *testing.T) {
@@ -294,10 +329,12 @@ type fakeHTTPClient struct {
 	fakeResp string
 
 	requestURL string
+	authHeader string
 }
 
 func (c *fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	c.requestURL = req.URL.String()
+	c.authHeader = req.Header.Get("Authorization")
 
 	resp := &http.Response{
 		Body: io.NopCloser(strings.NewReader(c.fakeResp)),


### PR DESCRIPTION
**What is this feature?**

The plugin update checker (`check_for_plugin_updates`) now sends `Authorization: Bearer <token>` on its `GET /api/plugins/versioncheck` requests to grafana.com when `GrafanaComProxyAPIToken` is configured, the same token and pattern the `/api/gnet` proxy already uses. When no token is configured (stock on-prem installs) nothing changes.

**Why do we need this feature?**

Plugin versions on grafana.com can be scoped (e.g. `grafana_cloud`). The catalog browsing and install paths already authenticate with the instance's grafana.com token, but the update checker always called anonymously, so instances with scoped visibility got update results for the anonymous catalog instead of their own: a Grafana Cloud instance never saw an update whose newest version is cloud-scoped. Found during the discovery for grafana/grafana-com#19295, together with a server-side fix for scope handling on the versioncheck endpoint (grafana/grafana-com#19583).

**Who is this feature for?**

Grafana Cloud instances (hosted-grafana injects the token), and any install that configures `[grafana_com] proxy_token` / `sso_api_token`.

**Special notes for your reviewer:**

The token is copied onto the service at provide time like `grafanaVersion`, after `ResolveGrafanaComProxyAPIToken()` has run at startup. Tests cover the header being set with a token and absent without one.