### PR TITLE
Alerting: Fix environment variable substitution not applied to provisioned annotations

### DIFF
--- a/pkg/services/provisioning/alerting/rules_types.go
+++ b/pkg/services/provisioning/alerting/rules_types.go
@@ -150,7 +150,7 @@ func (rule *AlertRuleV1) mapToModel(orgID int64) (models.AlertRule, error) {
 		noDataState = models.NoData
 	}
 	alertRule.NoDataState = noDataState
-	alertRule.Annotations = rule.Annotations.Raw
+	alertRule.Annotations = rule.Annotations.Value()
 	alertRule.Labels = rule.Labels.Value()
 	for _, queryV1 := range rule.Data {
 		query, err := queryV1.mapToModel()

--- a/pkg/services/provisioning/alerting/rules_types_test.go
+++ b/pkg/services/provisioning/alerting/rules_types_test.go
@@ -199,6 +199,31 @@ func TestRules(t *testing.T) {
 		require.NotNil(t, ruleMapped.NotificationSettings)
 		require.Equal(t, models.NotificationSettingsFromContact(models.ContactPointRouting{Receiver: "test-receiver"}), *ruleMapped.NotificationSettings)
 	})
+	t.Run("a rule should interpolate environment variables in annotations the same way as in labels", func(t *testing.T) {
+		t.Setenv("TEST_ALERT_ANNOTATION_VALUE", "hello from env")
+		t.Setenv("TEST_ALERT_LABEL_VALUE", "hello from env")
+
+		rule := validRuleV1(t)
+
+		var annotations values.StringMapValue
+		err := yaml.Unmarshal([]byte("summary: ${TEST_ALERT_ANNOTATION_VALUE}"), &annotations)
+		require.NoError(t, err)
+		rule.Annotations = annotations
+
+		var labels values.StringMapValue
+		err = yaml.Unmarshal([]byte("severity: ${TEST_ALERT_LABEL_VALUE}"), &labels)
+		require.NoError(t, err)
+		rule.Labels = labels
+
+		ruleMapped, err := rule.mapToModel(1)
+		require.NoError(t, err)
+
+		// Before the fix, annotations used the un-interpolated Raw value while labels
+		// used the interpolated Value(), so this would fail with "${TEST_ALERT_ANNOTATION_VALUE}"
+		// instead of "hello from env".
+		require.Equal(t, "hello from env", ruleMapped.Annotations["summary"])
+		require.Equal(t, "hello from env", ruleMapped.Labels["severity"])
+	})
 }
 
 func TestRecordingRules(t *testing.T) {


### PR DESCRIPTION
What is this feature?

This is a bug fix, not a new feature. When alert rules are provisioned through YAML config files, environment variable substitution (for example ${MY_VAR}) is correctly applied to alert labels but was silently skipped for alert annotations, even though both fields are documented to support the same substitution behavior.

Why do we need this feature?

Users who provision alert rules as code (commonly through Helm charts or GitOps pipelines) rely on environment variable substitution to keep provisioning files reusable across environments. Annotations frequently carry runbook URLs, dashboard links, and contact information that need to differ per environment, so silently returning the literal ${VAR} string instead of the substituted value breaks alert routing and makes provisioned annotations look wrong in the UI with no error raised.

Root cause: in AlertRuleV1.mapToModel, Annotations and Labels are both parsed as values.StringMapValue, which exposes two accessors: .Value() (interpolated) and .Raw (not interpolated). Labels correctly used .Value(). Annotations was mapped from .Raw, bypassing interpolation entirely.

Who is this feature for?

Anyone provisioning Grafana alert rules via configuration files, particularly teams deploying through Helm/Kubernetes ConfigMaps or other infrastructure-as-code workflows that rely on environment variable substitution to parameterize provisioning across environments.

Which issue(s) does this PR fix?:

Fixes #84250

Special notes for your reviewer:


The fix is a single-line change: rule.Annotations.Raw to rule.Annotations.Value(). Both resolve to map[string]string, so there is no type or behavior change beyond correcting the interpolation.
Added a regression test (TestRules, subtest "a rule should interpolate environment variables in annotations the same way as in labels") that sets an environment variable, provisions a rule referencing it in both a label and an annotation, and asserts both are substituted. Prior to this fix, the annotation assertion fails with the literal ${VAR} string.
No documentation update needed since this restores documented behavior rather than introducing new behavior.
No feature toggle needed since this is a bug fix to existing, already-documented functionality.


Please check that:


 It works as expected from a user's perspective.
 If this is a pre-GA feature, it is behind a feature toggle. (N/A, bug fix)
 The docs are updated. (N/A, restores documented behavior)