### PR TITLE
feat: add word wrap to table legend label

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.test.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.test.tsx
@@ -10,7 +10,7 @@ function makeItem(overrides: Partial<VizLegendItem> = {}): VizLegendItem {
 
 function renderInTable(overrides: Partial<Props> = {}) {
   return render(
-    <table>
+    <table style={{ width: '100px' }}>
       <tbody>
         <LegendTableItem item={makeItem()} {...overrides} />
       </tbody>
@@ -84,6 +84,12 @@ describe('LegendTableItem', () => {
     it('allows the label to wrap (normal) when overflow is "wrap"', () => {
       renderInTable({ overflow: 'wrap' });
       expect(screen.getByRole('button')).toHaveStyle({ whiteSpace: 'normal' });
+    });
+
+    it('allows the label to wrap without word breaks', () => {
+      renderInTable();
+      expect(screen.getByRole('button')).toHaveStyle({ wordWrap: 'break-word' });
+      expect(screen.getByRole('button')).toHaveStyle({ textOverflow: 'ellipsis' });
     });
   });
 });

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.test.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.test.tsx
@@ -84,12 +84,7 @@ describe('LegendTableItem', () => {
     it('allows the label to wrap (normal) when overflow is "wrap"', () => {
       renderInTable({ overflow: 'wrap' });
       expect(screen.getByRole('button')).toHaveStyle({ whiteSpace: 'normal' });
-    });
-
-    it('allows the label to wrap without word breaks', () => {
-      renderInTable();
-      expect(screen.getByRole('button')).toHaveStyle({ wordWrap: 'break-word' });
-      expect(screen.getByRole('button')).toHaveStyle({ textOverflow: 'ellipsis' });
+      expect(screen.getByRole('button')).toHaveStyle({ overflowWrap: 'break-word' });
     });
   });
 });

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.test.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.test.tsx
@@ -10,7 +10,7 @@ function makeItem(overrides: Partial<VizLegendItem> = {}): VizLegendItem {
 
 function renderInTable(overrides: Partial<Props> = {}) {
   return render(
-    <table style={{ width: '100px' }}>
+    <table>
       <tbody>
         <LegendTableItem item={makeItem()} {...overrides} />
       </tbody>

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
@@ -137,7 +137,7 @@ const getStyles = (theme: GrafanaTheme2, overflow?: LegendOverflow) => {
       overflow: 'hidden',
       userSelect: 'text',
       textAlign: 'left',
-      wordWrap: 'break-word',
+      overflowWrap: 'break-word',
     }),
     labelDisabled: css({
       label: 'LegendLabelDisabled',

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
@@ -137,6 +137,7 @@ const getStyles = (theme: GrafanaTheme2, overflow?: LegendOverflow) => {
       overflow: 'hidden',
       userSelect: 'text',
       textAlign: 'left',
+      wordWrap: 'break-word',
     }),
     labelDisabled: css({
       label: 'LegendLabelDisabled',


### PR DESCRIPTION
**What is this feature?**

Legend label wrapping currently only wraps at word boundaries

Before:
<img width="905" height="340" alt="image" src="https://github.com/user-attachments/assets/06db1826-e7c8-4f3c-8569-c65bfebc9453" />

After this PR is applied:
<img width="905" height="342" alt="image" src="https://github.com/user-attachments/assets/d79b4bea-40e5-4a02-ae42-1019318045b6" />

**Why do we need this feature?**

Since scroll is disabled with panel option `Legend > Overflow` set to `Wrap`, there isn't a way for users to render the entire legend label without `Legend > Mode` set to `List`, or by hovering over each legend label individually.

**Special notes for your reviewer:**
The label css is always applied because it doesn't have any impact when ellipsis option is set (which sets `white-space` to `nowrap`).

Test coverage is explicitly testing implementation for this PR since JSDom doesn't apply CSS, but going through the effort of adding e2e coverage for this seems like too much investment for the priority of the issue.


Reproduction dashboard:

<details>
<summary>Legend_table_right_not_word_wrapping.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 3,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "showValues": false,
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 9,
        "w": 11,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "table",
          "placement": "right",
          "showLegend": true,
          "width": 200,
          "overflow": "wrap"
        },
        "tooltip": {
          "hideZeros": false,
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "12.2.0",
      "targets": [
        {
          "alias": "Really_really_really_really_really_really long name",
          "datasource": {
            "type": "grafana-testdata-datasource"
          },
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 1
        },
        {
          "alias": "Really_really_really_really_really_really_REALLY long name",
          "datasource": {
            "type": "grafana-testdata-datasource"
          },
          "hide": false,
          "refId": "B",
          "scenarioId": "random_walk",
          "seriesCount": 1
        }
      ],
      "title": "",
      "type": "timeseries"
    }
  ],
  "preload": false,
  "schemaVersion": 42,
  "tags": [],
  "templating": {
    "list": []
  },
  "timepicker": {},
  "timezone": "",
  "title": "Legend - table right - word wrap",
  "uid": "3cc6f5cd-f427-43a6-9e5f-a32c8d768c84",
  "version": 4
}

```

</details>

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
