### PR TITLE
unified-storage: remove PermitWithoutStream from resource clients

### DIFF
--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -327,9 +327,8 @@ func (o *StorageOptions) buildGrpcDialOptions() []grpc.DialOption {
 
 	if o.GrpcClientKeepaliveTime > 0 {
 		opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                o.GrpcClientKeepaliveTime,
-			Timeout:             10 * time.Second,
-			PermitWithoutStream: true,
+			Time:    o.GrpcClientKeepaliveTime,
+			Timeout: 10 * time.Second,
 		}))
 	}
 

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -372,9 +372,8 @@ func grpcConn(address string, metrics *clientMetrics, clientKeepaliveTime time.D
 
 	if clientKeepaliveTime > 0 {
 		opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                clientKeepaliveTime,
-			Timeout:             10 * time.Second,
-			PermitWithoutStream: true,
+			Time:    clientKeepaliveTime,
+			Timeout: 10 * time.Second,
 		}))
 	}
 	// Create a connection to the gRPC server


### PR DESCRIPTION
follow up for https://github.com/grafana/grafana/pull/127684

Having `PermitWithoutStream: true` makes the client ping the grpc server on idle connections. But the grpc server must allow that, and we don't. So this config will be problematic (it's not in use right now). So I'm removing it.