### PR TITLE
Expr: don't mutate a shared frame's RefID in AsDataFrames

### DIFF
--- a/pkg/expr/mathexp/types.go
+++ b/pkg/expr/mathexp/types.go
@@ -25,8 +25,18 @@ type Values []Value
 func (vals Values) AsDataFrames(refID string) []*data.Frame {
 	frames := make([]*data.Frame, len(vals))
 	for i, v := range vals {
-		frames[i] = v.AsDataFrame()
-		frames[i].RefID = refID
+		frame := v.AsDataFrame()
+		// A passthrough expression (e.g. `$A`) returns its input's Values verbatim, so the
+		// underlying frame is shared with the input result. Because the results map is iterated in
+		// a non-deterministic order, mutating RefID in place would let one result overwrite the
+		// other's RefID on the shared frame. Copy the frame header (fields are still shared) so each
+		// result owns its RefID.
+		if frame.RefID != refID {
+			frameCopy := *frame
+			frameCopy.RefID = refID
+			frame = &frameCopy
+		}
+		frames[i] = frame
 	}
 	return frames
 }

--- a/pkg/expr/mathexp/types_test.go
+++ b/pkg/expr/mathexp/types_test.go
@@ -323,3 +323,23 @@ func TestSeriesName(t *testing.T) {
 		})
 	}
 }
+
+func TestAsDataFramesDoesNotMutateSharedFrame(t *testing.T) {
+	// A passthrough expression (e.g. `$A`) returns its input's Values verbatim, so the "B" result
+	// shares the same underlying *data.Frame as the "A" result. Labeling one result's frames must
+	// not change the RefID of the other's (which previously happened because AsDataFrames mutated
+	// the shared frame in place and the results map is iterated in a non-deterministic order).
+	shared := data.NewFrame("", data.NewField("value", nil, []float64{1}))
+	shared.RefID = "A"
+
+	aValues := Values{Number{Frame: shared}}
+	bValues := Values{Number{Frame: shared}}
+
+	aFrames := aValues.AsDataFrames("A")
+	bFrames := bValues.AsDataFrames("B")
+
+	require.Equal(t, "A", aFrames[0].RefID)
+	require.Equal(t, "B", bFrames[0].RefID)
+	// Relabeling "B" must not have mutated the frame shared with (and returned for) "A".
+	require.Equal(t, "A", shared.RefID)
+}

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -78,6 +78,9 @@ func TestService(t *testing.T) {
 		TypeVersion: data.FrameTypeVersion{0, 1},
 	})
 
+	// The service labels each result's frames with its refID, so A's frame is returned as "A".
+	dsDF.RefID = "A"
+
 	expect := &backend.QueryDataResponse{
 		Responses: backend.Responses{
 			"A": {


### PR DESCRIPTION
## What this PR does

Server-side expressions no longer mislabel their result frames. `Values.AsDataFrames` now copies the frame header when setting `RefID`, instead of mutating a frame that may be shared with another result.

Repro Step of bug: 
1. checkout main and run grafana locally
2. create a prometheus datasource
3. import this dashboard [dashboard-1783706697820.json](https://github.com/user-attachments/files/29900402/dashboard-1783706697820.json)
4. make sure the queries in the dashboard connect properly to your prometheus datasource
5. in the panel on the left you'll see we render 4 responses
6. in the panel on the right we've "hidden" 2 of those responses, you'll notice when we refresh the page we get inconsistent behavior hiding the responses. Sometimes it hides 1 other times it hides the other, sometimes it shows no data, sometimes it shows the expected behavior. 
7. Checkout this branch, notice it fixes the issue

## Why

A passthrough expression (e.g. a Math expression `B = $A`) returns its input's `Values` verbatim (`walk` returns `e.Vars["A"]` for a variable node), so result `B` shares the exact same `*data.Frame` as result `A`. `AsDataFrames` set `RefID` on that frame **in place**, and `ExecutePipeline` iterates the results map in a **non-deterministic order** — so `A` and `B` raced to stamp the shared frame, and the loser was left labeled with the wrong `RefID` (typically the source query's).

Downstream this surfaced as expression results **intermittently rendering "No data"** / dropping series: `runRequest` on the frontend removes frames whose `refId` matches a hidden query, so when the shared frame ended up labeled with the (hidden) source query's refId, the expression's own result got dropped. The non-determinism came from the results-map iteration order.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
