### PR TITLE
Datasources: Add on-demand diagnostics logic with HTTP capture (behind feature toggle)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -409,6 +409,7 @@
 /pkg/plugins/ @grafana/grafana-catalog
 /pkg/services/datasourceproxy/ @grafana/grafana-catalog
 /pkg/services/datasources/ @grafana/grafana-catalog
+/pkg/services/diagnostics/ @grafana/data-sources
 /pkg/services/pluginsintegration/ @grafana/grafana-catalog
 /pkg/plugins/codegen/pfs/ @grafana/grafana-catalog @grafana/grafana-as-code
 /pkg/tsdb/grafana-testdata-datasource/ @grafana/grafana-catalog

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0 // @grafana/grafana-app-platform-squad
 	github.com/charmbracelet/bubbletea v1.3.10 // @grafana/grafana-app-platform-squad
 	github.com/charmbracelet/lipgloss v1.1.0 // @grafana/grafana-app-platform-squad
+	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d // @grafana/data-sources
 	github.com/crewjam/saml v0.4.14 // @grafana/identity-access-team
 	github.com/dgraph-io/badger/v4 v4.9.2 // @grafana/grafana-search-and-storage
 	github.com/dlmiddlecote/sqlstats v1.0.2 // @grafana/grafana-backend-group
@@ -404,7 +405,6 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/cheekybits/genny v1.0.0 // indirect
-	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -502,12 +502,12 @@ func (hs *HTTPServer) registerRoutes() {
 		// DataSource w/ expressions
 		apiRoute.Post("/ds/query", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.getDSQueryEndpoint())
 
-		// On-demand datasource diagnostics. Admin-only, experimental.
-		// Two deliberate, independent gates: this registration is
-		// on-prem only (empty StackID => never on Grafana Cloud), and the handler additionally gates
-		// on the grafana.onDemandDiagnostics feature flag at request time. Admin-only, experimental.
+		// On-demand datasource diagnostics. Admin-only, on-prem-only, experimental.
+		// Two deliberate, independent gates:
+		// 1. on-prem only (empty StackID => never on Grafana Cloud)
+		// 2. grafana.onDemandDiagnostics flag at request time
 		if hs.Cfg.StackID == "" {
-			apiRoute.Post("/ds/diagnostics", reqGrafanaAdmin, routing.Wrap(hs.QueryDiagnostics))
+			apiRoute.Post("/ds/diagnostics", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), reqGrafanaAdmin, routing.Wrap(hs.QueryDiagnostics))
 		}
 
 		// Unified Alerting

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -76,8 +76,13 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	resp, queryErr := queryData(captureCtx, c.SignedInUser, c.SkipDSCache, reqDTO.MetricRequest)
 
 	// A datasource query usually fails per-refId (DataResponse.Error) with no top-level error, the
-	// same way QueryMetricsV2 surfaces failures. Capture that too so it's recorded in the bundle.
+	// same way QueryMetricsV2 surfaces failures. Capture that too so it's recorded in the bundle. An
+	// externalized plugin whose top-level QueryData error was swallowed to survive the gRPC boundary
+	// carries it in the __har__ frame instead; fold that in as well.
 	respErr := diagnostics.ResponseError(resp)
+	if respErr == nil {
+		respErr = diagnostics.PluginCaptureError(resp)
+	}
 
 	// If the query failed before any traffic was captured (e.g. pre-flight access-denied or
 	// datasource-not-found, which never reach the datasource), there's nothing to diagnose, so

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -65,7 +65,15 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	// context, so mutating it here takes effect for this request.
 	c.SkipQueryCache = true
 
-	resp, queryErr := hs.queryDataService.QueryData(captureCtx, c.SignedInUser, c.SkipDSCache, reqDTO.MetricRequest)
+	// Mirror QueryMetricsV2's dispatch (see ds_query.go) so diagnostics run the queries exactly as
+	// the panel did: with per-query time ranges when the client asks for Query V2 semantics, else
+	// the top-level from/to. Otherwise captured traffic wouldn't match a panel that uses per-query
+	// ranges, defeating the "reproduce offline" goal.
+	queryData := hs.queryDataService.QueryData
+	if c.Req.Header.Get("X-Query-V2") == "true" {
+		queryData = hs.queryDataService.QueryDataNew
+	}
+	resp, queryErr := queryData(captureCtx, c.SignedInUser, c.SkipDSCache, reqDTO.MetricRequest)
 
 	// If the query failed before any traffic was captured (e.g. pre-flight access-denied or
 	// datasource-not-found, which never reach the datasource), there's nothing to diagnose, so

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -1,38 +1,87 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
 
+	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/diagnostics"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/web"
 )
 
-// diagnosticsFeatureClient is a shared OpenFeature client reused across requests (its evaluations
-// resolve against the current global provider), so we don't allocate one per request.
+// diagnosticsRequest is the body posted by the "Download diagnostics" panel action. It carries
+// the datasource queries to run with HAR capture active, plus the optional panel and dashboard
+// definitions the client already holds (so we avoid a dashboard-service lookup).
+type diagnosticsRequest struct {
+	dtos.MetricRequest
+	Dashboard json.RawMessage `json:"dashboard"`
+	Panel     json.RawMessage `json:"panel"`
+}
+
+// diagnosticsFeatureClient is a shared OpenFeature client reused across requests. Flags are
+// evaluated via OpenFeature rather than featuremgmt.FeatureToggles.IsEnabled, which is deprecated
+// (staticcheck SA1019) and slated for removal.
 var diagnosticsFeatureClient = openfeature.NewDefaultClient()
 
-// QueryDiagnostics is the entry point for on-demand datasource diagnostics: it will run the
-// supplied datasource queries with HTTP capture active and return a diagnostic bundle (captured
-// traffic, scoped logs, and the panel/dashboard JSON). Bundle generation is added in a follow-up;
-// for now the endpoint only establishes the route.
+// QueryDiagnostics executes the supplied datasource queries with HAR capture active and returns a
+// .tar.gz diagnostic bundle (captured traffic and the panel/dashboard JSON). Bundle assembly lives
+// in the diagnostics service; this handler owns the HTTP concerns: gating, request binding, running
+// the queries, and writing the response.
 //
-// Two independent gates apply by design (see registerRoutes):
-//   - Deployment: the route is registered only on on-prem/self-managed instances (empty StackID),
-//     so it is never exposed on Grafana Cloud (where the async/HA and multi-tenant story is not
-//     ready). This handler therefore never runs on Cloud.
-//   - Feature availability: within on-prem, it is gated at request time on the
-//     grafana.onDemandDiagnostics feature flag, so it can be toggled without re-registering routes.
-//
-// Access is further restricted to Grafana server admins via reqGrafanaAdmin.
+// Two independent gates apply by design (see registerRoutes): the route is registered only on
+// on-prem/self-managed instances (empty StackID) so it never runs on Grafana Cloud, and within
+// on-prem it is gated at request time on the grafana.onDemandDiagnostics feature flag. Access is
+// further restricted to Grafana server admins via reqGrafanaAdmin.
 func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Response {
 	ctx := c.Req.Context()
 	if !diagnosticsFeatureClient.Boolean(ctx, featuremgmt.FlagGrafanaOnDemandDiagnostics, false, openfeature.TransactionContext(ctx)) {
 		return response.Error(http.StatusNotFound, "on-demand diagnostics is not enabled", nil)
 	}
 
-	// Bundle generation is not implemented in this scaffold; a follow-up backend PR adds it.
-	return response.Error(http.StatusNotImplemented, "on-demand diagnostics is not implemented yet", nil)
+	reqDTO := diagnosticsRequest{}
+	if err := web.Bind(c.Req, &reqDTO); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	if len(reqDTO.Queries) == 0 {
+		return response.Error(http.StatusBadRequest, "at least one query is required", nil)
+	}
+
+	captureCtx, harBuffer := harcapture.WithCapture(ctx)
+
+	// Force a live query: a query-result cache hit returns without a datasource round trip, so HTTP
+	// capture would run on nothing and traffic.har would be silently empty. Diagnostics must capture
+	// what actually happens on the wire, so bypass the query cache (the caching service reads this
+	// off the request's ReqContext).
+	c.SkipQueryCache = true
+
+	resp, queryErr := hs.queryDataService.QueryData(captureCtx, c.SignedInUser, c.SkipDSCache, reqDTO.MetricRequest)
+
+	// If the query failed before any traffic was captured (e.g. pre-flight access-denied or
+	// datasource-not-found, which never reach the datasource), there's nothing to diagnose, so
+	// surface the real HTTP error (403/404/…) instead of a 200 bundle. A runtime failure that did
+	// hit the wire leaves captured traffic (in-process buffer or an external __har__ frame) and
+	// falls through — the captured failure is exactly what the bundle is for, recorded alongside
+	// query-error.txt.
+	if queryErr != nil && !diagnostics.HasCapturedHAR(resp, harBuffer) {
+		return hs.handleQueryMetricsError(queryErr)
+	}
+
+	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryErr)
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
+	}
+
+	filename := fmt.Sprintf("diagnostics-%s.tar.gz", time.Now().UTC().Format("20060102-150405"))
+	header := http.Header{}
+	header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	header.Set("Content-Type", "application/tar+gzip")
+	return response.CreateNormalResponse(header, bundle, http.StatusOK)
 }

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -125,7 +126,9 @@ func (hs *HTTPServer) diagnosticsNoCaptureError(queryErr, respErr error) respons
 		return hs.handleQueryMetricsError(queryErr)
 	}
 	if respErr != nil {
-		return response.Error(http.StatusBadRequest, "query failed", respErr)
+		// Redact any URL (with secret query params) the error text may embed before it reaches the
+		// response, mirroring the bundle's query-error.txt handling.
+		return response.Error(http.StatusBadRequest, "query failed", errors.New(harcapture.RedactErrorText(respErr.Error())))
 	}
 	return nil
 }

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -76,24 +76,28 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	resp, queryErr := queryData(captureCtx, c.SignedInUser, c.SkipDSCache, reqDTO.MetricRequest)
 
 	// A datasource query usually fails per-refId (DataResponse.Error) with no top-level error, the
-	// same way QueryMetricsV2 surfaces failures. Fold those into queryErr so they are both recorded
-	// in the bundle (query-error.txt) and — when nothing was captured — surfaced as an error rather
-	// than a 200 with a sparse bundle that never explains the failure.
-	if queryErr == nil {
-		queryErr = diagnostics.ResponseError(resp)
-	}
+	// same way QueryMetricsV2 surfaces failures. Capture that too so it's recorded in the bundle.
+	respErr := diagnostics.ResponseError(resp)
 
 	// If the query failed before any traffic was captured (e.g. pre-flight access-denied or
 	// datasource-not-found, which never reach the datasource), there's nothing to diagnose, so
-	// surface the real HTTP error (403/404/…) instead of a 200 bundle. A runtime failure that did
-	// hit the wire leaves captured traffic (in-process buffer or an external __har__ frame) and
-	// falls through — the captured failure is exactly what the bundle is for, recorded alongside
+	// surface the failure with the same status QueryMetricsV2 would return instead of a 200 bundle:
+	// a top-level error keeps its typed status (403/404, else 500), while a per-refId (bad-query)
+	// failure is a client error (400). A failure that did hit the wire leaves captured traffic and
+	// falls through — that captured failure is exactly what the bundle is for, recorded alongside
 	// query-error.txt.
-	if queryErr != nil && !diagnostics.HasCapturedHAR(resp, harBuffer) {
-		return hs.handleQueryMetricsError(queryErr)
+	if !diagnostics.HasCapturedHAR(resp, harBuffer) {
+		if r := hs.diagnosticsNoCaptureError(queryErr, respErr); r != nil {
+			return r
+		}
 	}
 
-	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryErr)
+	// Record whatever failure occurred in the bundle, preferring the top-level error.
+	bundleErr := queryErr
+	if bundleErr == nil {
+		bundleErr = respErr
+	}
+	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, bundleErr)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
 	}
@@ -103,4 +107,20 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	header.Set("Content-Type", "application/tar+gzip")
 	return response.CreateNormalResponse(header, bundle, http.StatusOK)
+}
+
+// diagnosticsNoCaptureError returns the response to send when a query failed and nothing was
+// captured — there is no traffic to diagnose, so surface the failure with the same status
+// QueryMetricsV2 would return instead of a 200 bundle. A top-level error keeps its typed status
+// (403/404, else 500) via handleQueryMetricsError; a per-refId failure is a bad query, so a client
+// error (400), matching QueryMetricsV2's per-refId handling. Returns nil when nothing failed, so
+// the caller proceeds to assemble the bundle.
+func (hs *HTTPServer) diagnosticsNoCaptureError(queryErr, respErr error) response.Response {
+	if queryErr != nil {
+		return hs.handleQueryMetricsError(queryErr)
+	}
+	if respErr != nil {
+		return response.Error(http.StatusBadRequest, "query failed", respErr)
+	}
+	return nil
 }

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -75,6 +75,14 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	}
 	resp, queryErr := queryData(captureCtx, c.SignedInUser, c.SkipDSCache, reqDTO.MetricRequest)
 
+	// A datasource query usually fails per-refId (DataResponse.Error) with no top-level error, the
+	// same way QueryMetricsV2 surfaces failures. Fold those into queryErr so they are both recorded
+	// in the bundle (query-error.txt) and — when nothing was captured — surfaced as an error rather
+	// than a 200 with a sparse bundle that never explains the failure.
+	if queryErr == nil {
+		queryErr = diagnostics.ResponseError(resp)
+	}
+
 	// If the query failed before any traffic was captured (e.g. pre-flight access-denied or
 	// datasource-not-found, which never reach the datasource), there's nothing to diagnose, so
 	// surface the real HTTP error (403/404/…) instead of a 200 bundle. A runtime failure that did

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -58,8 +58,11 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 
 	// Force a live query: a query-result cache hit returns without a datasource round trip, so HTTP
 	// capture would run on nothing and traffic.har would be silently empty. Diagnostics must capture
-	// what actually happens on the wire, so bypass the query cache (the caching service reads this
-	// off the request's ReqContext).
+	// what actually happens on the wire, so bypass the query cache. This is the same signal the
+	// X-Cache-Skip request header feeds (see middleware.go); the Enterprise caching service reads it
+	// back off the ReqContext via contexthandler.FromContext in the plugin caching middleware
+	// (clientmiddleware.CachingMiddleware), and c is the same ReqContext pointer stored in the query
+	// context, so mutating it here takes effect for this request.
 	c.SkipQueryCache = true
 
 	resp, queryErr := hs.queryDataService.QueryData(captureCtx, c.SignedInUser, c.SkipDSCache, reqDTO.MetricRequest)

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/datasources"
+)
+
+// TestDiagnosticsNoCaptureError guards the status mapping used when a query fails and no HAR was
+// captured: a per-refId (bad-query) failure must surface as 400 like QueryMetricsV2, NOT 500, while
+// top-level errors keep their typed status.
+func TestDiagnosticsNoCaptureError(t *testing.T) {
+	hs := &HTTPServer{}
+
+	t.Run("per-refId failure is a client error (400), not 500", func(t *testing.T) {
+		r := hs.diagnosticsNoCaptureError(nil, errors.New("bad promql"))
+		require.NotNil(t, r)
+		require.Equal(t, http.StatusBadRequest, r.Status())
+	})
+
+	t.Run("generic top-level error is 500", func(t *testing.T) {
+		r := hs.diagnosticsNoCaptureError(errors.New("boom"), nil)
+		require.Equal(t, http.StatusInternalServerError, r.Status())
+	})
+
+	t.Run("typed top-level errors keep their status", func(t *testing.T) {
+		require.Equal(t, http.StatusForbidden,
+			hs.diagnosticsNoCaptureError(datasources.ErrDataSourceAccessDenied, nil).Status())
+		require.Equal(t, http.StatusNotFound,
+			hs.diagnosticsNoCaptureError(datasources.ErrDataSourceNotFound, nil).Status())
+	})
+
+	t.Run("top-level error takes precedence over per-refId", func(t *testing.T) {
+		r := hs.diagnosticsNoCaptureError(errors.New("boom"), errors.New("bad promql"))
+		require.Equal(t, http.StatusInternalServerError, r.Status())
+	})
+
+	t.Run("no failure proceeds to bundle assembly (nil)", func(t *testing.T) {
+		require.Nil(t, hs.diagnosticsNoCaptureError(nil, nil))
+	})
+}

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -259,9 +259,11 @@ func FromContext(ctx context.Context) *Buffer {
 	return v
 }
 
-// AddEntry appends a captured request/response pair. Thread-safe.
-func (b *Buffer) AddEntry(req *http.Request, resp *http.Response, started time.Time, elapsed time.Duration) {
-	e := buildEntry(req, resp, started, elapsed, b.snapshotSensitive())
+// AddEntry appends a captured request/response pair. rtErr is the RoundTrip error (nil on success);
+// a transport-level failure (connection refused, DNS/TLS error, timeout) leaves resp nil and is
+// recorded in the entry's comment. Thread-safe.
+func (b *Buffer) AddEntry(req *http.Request, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration) {
+	e := buildEntry(req, resp, rtErr, started, elapsed, b.snapshotSensitive())
 	b.mu.Lock()
 	b.entries = append(b.entries, e)
 	b.mu.Unlock()
@@ -293,7 +295,7 @@ func (b *Buffer) ToHAR() ([]byte, error) {
 	return json.Marshal(doc)
 }
 
-func buildEntry(req *http.Request, resp *http.Response, started time.Time, elapsed time.Duration, extra map[string]struct{}) *har.Entry {
+func buildEntry(req *http.Request, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration, extra map[string]struct{}) *har.Entry {
 	reqHeaders := toNameValues(req.Header, extra)
 
 	query := req.URL.Query()
@@ -369,6 +371,11 @@ func buildEntry(req *http.Request, resp *http.Response, started time.Time, elaps
 		}
 	}
 
+	var comment string
+	if rtErr != nil {
+		comment = "transport error: " + rtErr.Error()
+	}
+
 	waitMs := float64(elapsed.Milliseconds())
 	return &har.Entry{
 		StartedDateTime: started.UTC().Format(time.RFC3339Nano),
@@ -387,6 +394,7 @@ func buildEntry(req *http.Request, resp *http.Response, started time.Time, elaps
 		Response: harResp,
 		Cache:    &har.Cache{},
 		Timings:  &har.Timings{Send: 0, Wait: waitMs, Receive: 0},
+		Comment:  comment,
 	}
 }
 

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -1,0 +1,373 @@
+package harcapture
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/chromedp/cdproto/har"
+)
+
+// redactedValue replaces sensitive header/cookie/query values in captured traffic. Diagnostic
+// bundles are meant to be shared (often externally), and the capture sits after the middlewares
+// that inject auth headers, so credentials must never reach the archive.
+const redactedValue = "[REDACTED]"
+
+// sensitiveHeaders (canonical form) have their value redacted in captured HAR entries.
+var sensitiveHeaders = map[string]struct{}{
+	"Authorization":        {},
+	"Proxy-Authorization":  {},
+	"Www-Authenticate":     {},
+	"Cookie":               {},
+	"Set-Cookie":           {},
+	"X-Api-Key":            {},
+	"Api-Key":              {},
+	"X-Auth-Token":         {},
+	"X-Grafana-Id":         {},
+	"X-Id-Token":           {},
+	"X-Amz-Security-Token": {}, // AWS SigV4 header-based auth (IRSA / temporary credentials)
+}
+
+// sensitiveQueryParams (lower-case) have their value redacted in captured request URLs.
+var sensitiveQueryParams = map[string]struct{}{
+	"api_key":       {},
+	"apikey":        {},
+	"access_token":  {},
+	"auth_token":    {},
+	"token":         {},
+	"private_token": {},
+	"password":      {},
+	"passwd":        {},
+	"pwd":           {},
+	"secret":        {},
+	"client_secret": {},
+	"signature":     {},
+	"sig":           {}, // Azure SAS
+	// AWS SigV4 presigned URLs
+	"x-amz-signature":      {},
+	"x-amz-credential":     {},
+	"x-amz-security-token": {},
+	// GCS signed URLs
+	"x-goog-signature":  {},
+	"x-goog-credential": {},
+}
+
+// urlValuedHeaders (canonical form) carry a URL whose query string may hold secrets; their value is
+// query-redacted (rather than dropped) so the redirect/referrer target stays visible.
+var urlValuedHeaders = map[string]struct{}{
+	"Location":         {},
+	"Content-Location": {},
+	"Referer":          {},
+}
+
+func redactHeader(name, value string) string {
+	canonical := http.CanonicalHeaderKey(name)
+	if _, ok := sensitiveHeaders[canonical]; ok {
+		return redactedValue
+	}
+	if _, ok := urlValuedHeaders[canonical]; ok {
+		if u, err := url.Parse(value); err == nil {
+			return redactedURLString(u)
+		}
+	}
+	return value
+}
+
+func redactQueryParam(name, value string) string {
+	if _, ok := sensitiveQueryParams[strings.ToLower(name)]; ok {
+		return redactedValue
+	}
+	return value
+}
+
+// redactedURLString renders u with inline credentials stripped and sensitive query params redacted.
+// The query is only rewritten when a param was actually redacted, so an otherwise-untouched URL is
+// preserved verbatim (parameter order and encoding unchanged).
+func redactedURLString(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	redacted := *u
+	redacted.User = nil // drop any inline user:password@ credentials
+	if redacted.RawQuery != "" {
+		changed := false
+		out := url.Values{}
+		for k, vals := range redacted.Query() {
+			for _, v := range vals {
+				rv := redactQueryParam(k, v)
+				if rv != v {
+					changed = true
+				}
+				out.Add(k, rv)
+			}
+		}
+		if changed {
+			redacted.RawQuery = out.Encode()
+		}
+	}
+	return redacted.String()
+}
+
+// RedactHARDocument applies the same header/cookie/query/URL redaction used for in-process capture
+// to a HAR 1.2 document produced elsewhere (e.g. an external plugin's __har__ frame), so
+// externally-sourced entries don't leak secrets into a shared bundle. It returns nil if the document
+// can't be parsed — failing closed (drop the frame) rather than merging a document we couldn't
+// redact. (Request/response body payload redaction is out of scope, same as for in-process capture.)
+func RedactHARDocument(doc []byte) []byte {
+	var h har.HAR
+	if err := json.Unmarshal(doc, &h); err != nil || h.Log == nil {
+		return nil
+	}
+	for _, e := range h.Log.Entries {
+		if e == nil {
+			continue
+		}
+		if e.Request != nil {
+			redactPairs(e.Request.Headers, redactHeader)
+			redactPairs(e.Request.QueryString, redactQueryParam)
+			redactCookieValues(e.Request.Cookies)
+			if u, err := url.Parse(e.Request.URL); err == nil {
+				e.Request.URL = redactedURLString(u)
+			}
+		}
+		if e.Response != nil {
+			redactPairs(e.Response.Headers, redactHeader)
+			redactCookieValues(e.Response.Cookies)
+			if e.Response.RedirectURL != "" {
+				if u, err := url.Parse(e.Response.RedirectURL); err == nil {
+					e.Response.RedirectURL = redactedURLString(u)
+				}
+			}
+		}
+	}
+	out, err := json.Marshal(h)
+	if err != nil {
+		return doc
+	}
+	return out
+}
+
+func redactPairs(pairs []*har.NameValuePair, redact func(name, value string) string) {
+	for _, p := range pairs {
+		if p != nil {
+			p.Value = redact(p.Name, p.Value)
+		}
+	}
+}
+
+func redactCookieValues(cookies []*har.Cookie) {
+	for _, c := range cookies {
+		if c != nil {
+			c.Value = redactedValue
+		}
+	}
+}
+
+// encodeBody returns the HAR text representation of a body plus its encoding. Valid UTF-8 is stored
+// as-is; binary payloads are base64-encoded (with encoding "base64") so they survive JSON marshaling
+// intact instead of being corrupted by string() replacing invalid bytes with U+FFFD.
+func encodeBody(body []byte) (text, encoding string) {
+	if utf8.Valid(body) {
+		return string(body), ""
+	}
+	return base64.StdEncoding.EncodeToString(body), "base64"
+}
+
+type contextKey struct{}
+
+// Buffer collects HTTP request/response pairs as HAR 1.2 entries in memory.
+type Buffer struct {
+	mu      sync.Mutex
+	entries []*har.Entry
+}
+
+// WithCapture returns a child context carrying a new Buffer and the buffer itself.
+func WithCapture(ctx context.Context) (context.Context, *Buffer) {
+	buf := &Buffer{}
+	return context.WithValue(ctx, contextKey{}, buf), buf
+}
+
+// FromContext returns the Buffer stored in ctx, or nil if absent.
+func FromContext(ctx context.Context) *Buffer {
+	v, _ := ctx.Value(contextKey{}).(*Buffer)
+	return v
+}
+
+// AddEntry appends a captured request/response pair. Thread-safe.
+func (b *Buffer) AddEntry(req *http.Request, resp *http.Response, started time.Time, elapsed time.Duration) {
+	e := buildEntry(req, resp, started, elapsed)
+	b.mu.Lock()
+	b.entries = append(b.entries, e)
+	b.mu.Unlock()
+}
+
+// Len returns the number of captured entries. Thread-safe.
+func (b *Buffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.entries)
+}
+
+// ToHAR serializes the captured entries to HAR 1.2 JSON. The entry types come from
+// github.com/chromedp/cdproto/har -- the same library the plugin SDK's e2e HAR storage uses -- so
+// the output stays replay-compatible with that fixture format.
+func (b *Buffer) ToHAR() ([]byte, error) {
+	b.mu.Lock()
+	entries := make([]*har.Entry, len(b.entries))
+	copy(entries, b.entries)
+	b.mu.Unlock()
+
+	doc := har.HAR{
+		Log: &har.Log{
+			Version: "1.2",
+			Creator: &har.Creator{Name: "Grafana", Version: "1.0"},
+			Entries: entries,
+		},
+	}
+	return json.Marshal(doc)
+}
+
+func buildEntry(req *http.Request, resp *http.Response, started time.Time, elapsed time.Duration) *har.Entry {
+	reqHeaders := toNameValues(req.Header)
+
+	query := req.URL.Query()
+	queryKeys := make([]string, 0, len(query))
+	for k := range query {
+		queryKeys = append(queryKeys, k)
+	}
+	sort.Strings(queryKeys)
+	queryString := make([]*har.NameValuePair, 0, len(query))
+	for _, k := range queryKeys {
+		for _, v := range query[k] {
+			queryString = append(queryString, &har.NameValuePair{Name: k, Value: redactQueryParam(k, v)})
+		}
+	}
+
+	var pd *har.PostData
+	var reqBodySize int64
+	if req.Body != nil {
+		body, readErr := io.ReadAll(req.Body)
+		if readErr != nil {
+			// Mirror the response-body path: restore the captured (partial) bytes followed by the
+			// error rather than leaving req.Body consumed, so a caller of this shared helper can
+			// still read the body and observe the failure.
+			req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), &errorReader{err: readErr}))
+		} else {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+			reqBodySize = int64(len(body))
+			if len(body) > 0 {
+				// HAR PostData has no encoding field, so a binary request body is base64-encoded to
+				// avoid corruption on marshal (datasource request bodies are text in practice).
+				text, _ := encodeBody(body)
+				pd = &har.PostData{
+					MimeType: req.Header.Get("Content-Type"),
+					Text:     text,
+				}
+			}
+		}
+	}
+
+	// Content is required by the HAR spec and dereferenced unconditionally by the SDK's replay, so
+	// always attach a (possibly empty) Content, even for transport failures with no response body.
+	harResp := &har.Response{HeadersSize: -1, Content: &har.Content{}}
+	if resp != nil {
+		harResp.Status = int64(resp.StatusCode)
+		harResp.StatusText = resp.Status
+		harResp.HTTPVersion = resp.Proto
+		harResp.Headers = toNameValues(resp.Header)
+		harResp.Cookies = toCookies(resp.Cookies())
+		if loc := resp.Header.Get("Location"); loc != "" {
+			if u, err := url.Parse(loc); err == nil {
+				harResp.RedirectURL = redactedURLString(u)
+			} else {
+				harResp.RedirectURL = loc
+			}
+		}
+		if resp.Body != nil {
+			// Drain then Close the original transport body so its connection is returned to the
+			// idle pool (per the net/http contract), then hand the caller a fresh reader over the
+			// captured bytes.
+			body, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				// Preserve the original read failure for the caller: replay the captured bytes,
+				// then surface the same error rather than silently substituting a truncated body.
+				resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), &errorReader{err: readErr}))
+			} else {
+				resp.Body = io.NopCloser(bytes.NewReader(body))
+			}
+			harResp.BodySize = int64(len(body))
+			text, encoding := encodeBody(body)
+			harResp.Content = &har.Content{
+				Size:     int64(len(body)),
+				MimeType: resp.Header.Get("Content-Type"),
+				Text:     text,
+				Encoding: encoding,
+			}
+		}
+	}
+
+	waitMs := float64(elapsed.Milliseconds())
+	return &har.Entry{
+		StartedDateTime: started.UTC().Format(time.RFC3339Nano),
+		Time:            waitMs,
+		Request: &har.Request{
+			Method:      req.Method,
+			URL:         redactedURLString(req.URL),
+			HTTPVersion: req.Proto,
+			Headers:     reqHeaders,
+			QueryString: queryString,
+			Cookies:     toCookies(req.Cookies()),
+			PostData:    pd,
+			BodySize:    reqBodySize,
+			HeadersSize: -1,
+		},
+		Response: harResp,
+		Cache:    &har.Cache{},
+		Timings:  &har.Timings{Send: 0, Wait: waitMs, Receive: 0},
+	}
+}
+
+// toNameValues flattens an http.Header into HAR name/value pairs, emitting one pair per value so
+// repeated headers (e.g. multiple Set-Cookie) are preserved, in sorted order for deterministic output.
+func toNameValues(h http.Header) []*har.NameValuePair {
+	names := make([]string, 0, len(h))
+	for name := range h {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	result := make([]*har.NameValuePair, 0, len(h))
+	for _, name := range names {
+		for _, v := range h[name] {
+			result = append(result, &har.NameValuePair{Name: name, Value: redactHeader(name, v)})
+		}
+	}
+	return result
+}
+
+// toCookies converts parsed HTTP cookies into HAR cookie entries (name/value), matching the SDK
+// e2e HAR storage output so captured traffic stays replayable by the E2E fixture proxy.
+func toCookies(cookies []*http.Cookie) []*har.Cookie {
+	// Cookie values are session/auth tokens; keep the name for context but always redact the value.
+	result := make([]*har.Cookie, 0, len(cookies))
+	for _, c := range cookies {
+		result = append(result, &har.Cookie{Name: c.Name, Value: redactedValue})
+	}
+	return result
+}
+
+// errorReader yields the wrapped error on Read. Used to re-surface a response-body read failure to
+// the caller after the captured (partial) bytes have been replayed.
+type errorReader struct{ err error }
+
+func (r *errorReader) Read([]byte) (int, error) { return 0, r.err }

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -143,20 +143,30 @@ func redactedURLString(u *url.URL) string {
 		// sensitive value in RawQuery unredacted -- a fail-open. Splitting the raw string never drops
 		// a pair, and preserves parameter order/encoding for the untouched ones.
 		changed := false
-		parts := strings.Split(redacted.RawQuery, "&")
-		for i, p := range parts {
-			key, _, hasValue := strings.Cut(p, "=")
-			name := key
-			if unescaped, err := url.QueryUnescape(key); err == nil {
-				name = unescaped
+		// Split on both "&" and ";": ";" is a historically-valid query separator, so a secret after
+		// one (?foo=bar;token=SECRET) would otherwise ride along inside a non-sensitive segment
+		// unredacted. Both separators round-trip through Split/Join, so untouched params keep their
+		// exact bytes (and the changed gate leaves the query verbatim when nothing was redacted). We
+		// deliberately do NOT split on "," or "|" — those are ordinary characters in real query
+		// values (e.g. region=us,eu), not separators.
+		amp := strings.Split(redacted.RawQuery, "&")
+		for i, seg := range amp {
+			subs := strings.Split(seg, ";")
+			for j, sub := range subs {
+				key, _, hasValue := strings.Cut(sub, "=")
+				name := key
+				if unescaped, err := url.QueryUnescape(key); err == nil {
+					name = unescaped
+				}
+				if _, sensitive := sensitiveQueryParams[strings.ToLower(name)]; sensitive && hasValue {
+					subs[j] = key + "=" + redactedValue
+					changed = true
+				}
 			}
-			if _, sensitive := sensitiveQueryParams[strings.ToLower(name)]; sensitive && hasValue {
-				parts[i] = key + "=" + redactedValue
-				changed = true
-			}
+			amp[i] = strings.Join(subs, ";")
 		}
 		if changed {
-			redacted.RawQuery = strings.Join(parts, "&")
+			redacted.RawQuery = strings.Join(amp, "&")
 		}
 	}
 	return redacted.String()

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -96,6 +96,10 @@ func redactedURLString(u *url.URL) string {
 	}
 	redacted := *u
 	redacted.User = nil // drop any inline user:password@ credentials
+	// Drop any #fragment: it can carry secrets (e.g. an OAuth implicit-flow #access_token=...) and
+	// is query-shaped but not covered by the query-param redaction below, so fail closed.
+	redacted.Fragment = ""
+	redacted.RawFragment = ""
 	if redacted.RawQuery != "" {
 		changed := false
 		out := url.Values{}

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -151,7 +151,9 @@ func RedactHARDocument(doc []byte) []byte {
 	}
 	out, err := json.Marshal(h)
 	if err != nil {
-		return doc
+		// Fail closed: returning the original bytes here would leak the unredacted frame we just
+		// failed to re-serialize into a bundle meant for external sharing.
+		return nil
 	}
 	return out
 }

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -69,15 +69,27 @@ var urlValuedHeaders = map[string]struct{}{
 	"Referer":          {},
 }
 
-func redactHeader(name, value string) string {
+// redactHeader redacts a header value if its name is in the static denylist or in extra -- the
+// per-request set of datasource "Custom HTTP Headers" names, which carry secrets under arbitrary
+// names the static denylist can't enumerate. extra may be nil.
+func redactHeader(name, value string, extra map[string]struct{}) string {
 	canonical := http.CanonicalHeaderKey(name)
 	if _, ok := sensitiveHeaders[canonical]; ok {
+		return redactedValue
+	}
+	if _, ok := extra[canonical]; ok {
 		return redactedValue
 	}
 	if _, ok := urlValuedHeaders[canonical]; ok {
 		return redactURLValue(value)
 	}
 	return value
+}
+
+// redactHeaderStatic redacts using only the static denylist. Used for externally-sourced HAR frames,
+// where the per-request custom-header names are not known to this process.
+func redactHeaderStatic(name, value string) string {
+	return redactHeader(name, value, nil)
 }
 
 func redactQueryParam(name, value string) string {
@@ -146,7 +158,7 @@ func RedactHARDocument(doc []byte) []byte {
 			continue
 		}
 		if e.Request != nil {
-			redactPairs(e.Request.Headers, redactHeader)
+			redactPairs(e.Request.Headers, redactHeaderStatic)
 			redactPairs(e.Request.QueryString, redactQueryParam)
 			redactCookieValues(e.Request.Cookies)
 			if e.Request.URL != "" {
@@ -154,7 +166,7 @@ func RedactHARDocument(doc []byte) []byte {
 			}
 		}
 		if e.Response != nil {
-			redactPairs(e.Response.Headers, redactHeader)
+			redactPairs(e.Response.Headers, redactHeaderStatic)
 			redactCookieValues(e.Response.Cookies)
 			if e.Response.RedirectURL != "" {
 				e.Response.RedirectURL = redactURLValue(e.Response.RedirectURL)
@@ -202,6 +214,37 @@ type contextKey struct{}
 type Buffer struct {
 	mu      sync.Mutex
 	entries []*har.Entry
+	// extraSensitive holds per-request header names (canonical form) to redact in addition to the
+	// static denylist -- e.g. a datasource's "Custom HTTP Headers", which carry secrets under
+	// arbitrary names. Populated via MarkSensitiveHeaders as the client middleware chain is built.
+	extraSensitive map[string]struct{}
+}
+
+// MarkSensitiveHeaders registers header names whose values must be redacted from captured entries,
+// in addition to the static denylist. Names are canonicalized. Thread-safe.
+func (b *Buffer) MarkSensitiveHeaders(names ...string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.extraSensitive == nil {
+		b.extraSensitive = make(map[string]struct{}, len(names))
+	}
+	for _, n := range names {
+		b.extraSensitive[http.CanonicalHeaderKey(n)] = struct{}{}
+	}
+}
+
+// snapshotSensitive returns a copy of the extra sensitive-header set, safe to read without the lock.
+func (b *Buffer) snapshotSensitive() map[string]struct{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.extraSensitive) == 0 {
+		return nil
+	}
+	cp := make(map[string]struct{}, len(b.extraSensitive))
+	for k := range b.extraSensitive {
+		cp[k] = struct{}{}
+	}
+	return cp
 }
 
 // WithCapture returns a child context carrying a new Buffer and the buffer itself.
@@ -218,7 +261,7 @@ func FromContext(ctx context.Context) *Buffer {
 
 // AddEntry appends a captured request/response pair. Thread-safe.
 func (b *Buffer) AddEntry(req *http.Request, resp *http.Response, started time.Time, elapsed time.Duration) {
-	e := buildEntry(req, resp, started, elapsed)
+	e := buildEntry(req, resp, started, elapsed, b.snapshotSensitive())
 	b.mu.Lock()
 	b.entries = append(b.entries, e)
 	b.mu.Unlock()
@@ -250,8 +293,8 @@ func (b *Buffer) ToHAR() ([]byte, error) {
 	return json.Marshal(doc)
 }
 
-func buildEntry(req *http.Request, resp *http.Response, started time.Time, elapsed time.Duration) *har.Entry {
-	reqHeaders := toNameValues(req.Header)
+func buildEntry(req *http.Request, resp *http.Response, started time.Time, elapsed time.Duration, extra map[string]struct{}) *har.Entry {
+	reqHeaders := toNameValues(req.Header, extra)
 
 	query := req.URL.Query()
 	queryKeys := make([]string, 0, len(query))
@@ -297,7 +340,7 @@ func buildEntry(req *http.Request, resp *http.Response, started time.Time, elaps
 		harResp.Status = int64(resp.StatusCode)
 		harResp.StatusText = resp.Status
 		harResp.HTTPVersion = resp.Proto
-		harResp.Headers = toNameValues(resp.Header)
+		harResp.Headers = toNameValues(resp.Header, extra)
 		harResp.Cookies = toCookies(resp.Cookies())
 		if loc := resp.Header.Get("Location"); loc != "" {
 			harResp.RedirectURL = redactURLValue(loc)
@@ -349,7 +392,7 @@ func buildEntry(req *http.Request, resp *http.Response, started time.Time, elaps
 
 // toNameValues flattens an http.Header into HAR name/value pairs, emitting one pair per value so
 // repeated headers (e.g. multiple Set-Cookie) are preserved, in sorted order for deterministic output.
-func toNameValues(h http.Header) []*har.NameValuePair {
+func toNameValues(h http.Header, extra map[string]struct{}) []*har.NameValuePair {
 	names := make([]string, 0, len(h))
 	for name := range h {
 		names = append(names, name)
@@ -359,7 +402,7 @@ func toNameValues(h http.Header) []*har.NameValuePair {
 	result := make([]*har.NameValuePair, 0, len(h))
 	for _, name := range names {
 		for _, v := range h[name] {
-			result = append(result, &har.NameValuePair{Name: name, Value: redactHeader(name, v)})
+			result = append(result, &har.NameValuePair{Name: name, Value: redactHeader(name, v, extra)})
 		}
 	}
 	return result

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -18,9 +18,11 @@ import (
 	"github.com/chromedp/cdproto/har"
 )
 
-// urlInText matches http(s) URL substrings in freeform text, e.g. a Go net/url.Error message, which
-// renders the full request URL including its query string.
-var urlInText = regexp.MustCompile(`https?://[^\s"'<>]+`)
+// urlInText matches URL substrings in freeform text, e.g. a Go net/url.Error message, which renders
+// the full request URL including its query string. Case-insensitive (URL schemes are case-insensitive
+// per RFC 3986 and net/url preserves the original case) and scheme-agnostic (so credentials in a
+// non-HTTP DSN such as redis://user:pass@host or postgres://... are redacted too, not just http(s)).
+var urlInText = regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^\s"'<>]+`)
 
 // RedactErrorText redacts inline credentials, fragments, and sensitive query params from any URL
 // substrings in a freeform error message. Transport errors (net/url.Error) embed the full request
@@ -136,19 +138,25 @@ func redactedURLString(u *url.URL) string {
 	redacted.Fragment = ""
 	redacted.RawFragment = ""
 	if redacted.RawQuery != "" {
+		// Parse RawQuery manually rather than via url.Query(): url.Query() silently drops any pair
+		// whose value has a malformed percent-escape (e.g. sig=abc%ZZ), which would leave that
+		// sensitive value in RawQuery unredacted -- a fail-open. Splitting the raw string never drops
+		// a pair, and preserves parameter order/encoding for the untouched ones.
 		changed := false
-		out := url.Values{}
-		for k, vals := range redacted.Query() {
-			for _, v := range vals {
-				rv := redactQueryParam(k, v)
-				if rv != v {
-					changed = true
-				}
-				out.Add(k, rv)
+		parts := strings.Split(redacted.RawQuery, "&")
+		for i, p := range parts {
+			key, _, hasValue := strings.Cut(p, "=")
+			name := key
+			if unescaped, err := url.QueryUnescape(key); err == nil {
+				name = unescaped
+			}
+			if _, sensitive := sensitiveQueryParams[strings.ToLower(name)]; sensitive && hasValue {
+				parts[i] = key + "=" + redactedValue
+				changed = true
 			}
 		}
 		if changed {
-			redacted.RawQuery = out.Encode()
+			redacted.RawQuery = strings.Join(parts, "&")
 		}
 	}
 	return redacted.String()

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -16,6 +17,28 @@ import (
 
 	"github.com/chromedp/cdproto/har"
 )
+
+// urlInText matches http(s) URL substrings in freeform text, e.g. a Go net/url.Error message, which
+// renders the full request URL including its query string.
+var urlInText = regexp.MustCompile(`https?://[^\s"'<>]+`)
+
+// RedactErrorText redacts inline credentials, fragments, and sensitive query params from any URL
+// substrings in a freeform error message. Transport errors (net/url.Error) embed the full request
+// URL -- query string included -- and Go only masks userinfo passwords, not query params, so an
+// unredacted error would leak a datasource credential carried in a query param (e.g. ?api_key=,
+// Azure ?sig=) into a bundle meant for external sharing. Non-URL text is returned unchanged.
+func RedactErrorText(msg string) string {
+	return urlInText.ReplaceAllStringFunc(msg, func(u string) string {
+		// Strip trailing punctuation the error format appends after the URL (": ", ".", ")", ...)
+		// so it is not fed to url.Parse and then re-appended verbatim.
+		trailing := ""
+		for len(u) > 0 && strings.IndexByte(":.,;)]}", u[len(u)-1]) >= 0 {
+			trailing = string(u[len(u)-1]) + trailing
+			u = u[:len(u)-1]
+		}
+		return redactURLValue(u) + trailing
+	})
+}
 
 // redactedValue replaces sensitive header/cookie/query values in captured traffic. Diagnostic
 // bundles are meant to be shared (often externally), and the capture sits after the middlewares

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -75,9 +75,7 @@ func redactHeader(name, value string) string {
 		return redactedValue
 	}
 	if _, ok := urlValuedHeaders[canonical]; ok {
-		if u, err := url.Parse(value); err == nil {
-			return redactedURLString(u)
-		}
+		return redactURLValue(value)
 	}
 	return value
 }
@@ -117,6 +115,18 @@ func redactedURLString(u *url.URL) string {
 	return redacted.String()
 }
 
+// redactURLValue query-redacts a URL-valued string, failing closed: a value that can't be parsed
+// can't be safely query-redacted, so it is dropped (redactedValue) rather than passed through. This
+// matters because net/url.Parse rejects some inputs (e.g. a raw control character a misbehaving
+// datasource might emit), and this bundle is meant for external sharing.
+func redactURLValue(value string) string {
+	u, err := url.Parse(value)
+	if err != nil {
+		return redactedValue
+	}
+	return redactedURLString(u)
+}
+
 // RedactHARDocument applies the same header/cookie/query/URL redaction used for in-process capture
 // to a HAR 1.2 document produced elsewhere (e.g. an external plugin's __har__ frame), so
 // externally-sourced entries don't leak secrets into a shared bundle. It returns nil if the document
@@ -135,17 +145,15 @@ func RedactHARDocument(doc []byte) []byte {
 			redactPairs(e.Request.Headers, redactHeader)
 			redactPairs(e.Request.QueryString, redactQueryParam)
 			redactCookieValues(e.Request.Cookies)
-			if u, err := url.Parse(e.Request.URL); err == nil {
-				e.Request.URL = redactedURLString(u)
+			if e.Request.URL != "" {
+				e.Request.URL = redactURLValue(e.Request.URL)
 			}
 		}
 		if e.Response != nil {
 			redactPairs(e.Response.Headers, redactHeader)
 			redactCookieValues(e.Response.Cookies)
 			if e.Response.RedirectURL != "" {
-				if u, err := url.Parse(e.Response.RedirectURL); err == nil {
-					e.Response.RedirectURL = redactedURLString(u)
-				}
+				e.Response.RedirectURL = redactURLValue(e.Response.RedirectURL)
 			}
 		}
 	}
@@ -288,11 +296,7 @@ func buildEntry(req *http.Request, resp *http.Response, started time.Time, elaps
 		harResp.Headers = toNameValues(resp.Header)
 		harResp.Cookies = toCookies(resp.Cookies())
 		if loc := resp.Header.Get("Location"); loc != "" {
-			if u, err := url.Parse(loc); err == nil {
-				harResp.RedirectURL = redactedURLString(u)
-			} else {
-				harResp.RedirectURL = loc
-			}
+			harResp.RedirectURL = redactURLValue(loc)
 		}
 		if resp.Body != nil {
 			// Drain then Close the original transport body so its connection is returned to the

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -1,0 +1,325 @@
+package harcapture
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/har"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithCapture(t *testing.T) {
+	ctx := context.Background()
+	child, buf := WithCapture(ctx)
+
+	require.NotNil(t, buf)
+	assert.Same(t, buf, FromContext(child))
+	assert.Nil(t, FromContext(ctx), "parent context must not carry the buffer")
+}
+
+func TestFromContext_absent(t *testing.T) {
+	assert.Nil(t, FromContext(context.Background()))
+}
+
+func TestBuffer_Len(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	assert.Equal(t, 0, buf.Len())
+
+	buf.AddEntry(newGetReq(t, "http://example.com"), okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+	assert.Equal(t, 1, buf.Len())
+}
+
+func TestBuffer_ToHAR_structure(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	req := newPostReq(t, "http://ds.example.com/query", `{"q":"test"}`)
+	resp := okResp(200) //nolint:bodyclose
+	resp.Body = io.NopCloser(bytes.NewBufferString(`{"data":"result"}`))
+	resp.Header.Set("Content-Type", "application/json")
+
+	buf.AddEntry(req, resp, time.Now(), 42*time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+
+	assert.Equal(t, "1.2", doc.Log.Version)
+	require.Len(t, doc.Log.Entries, 1)
+
+	e := doc.Log.Entries[0]
+	assert.Equal(t, "POST", e.Request.Method)
+	assert.Equal(t, "http://ds.example.com/query", e.Request.URL)
+	assert.Equal(t, `{"q":"test"}`, e.Request.PostData.Text)
+	assert.Equal(t, int64(200), e.Response.Status)
+	assert.Equal(t, `{"data":"result"}`, e.Response.Content.Text)
+	assert.InDelta(t, 42.0, e.Time, 1.0)
+}
+
+func TestBuffer_ToHAR_requestBodyRestored(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	req := newPostReq(t, "http://example.com", `body`)
+	buf.AddEntry(req, okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+
+	// body must still be readable after AddEntry
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "body", string(body))
+}
+
+func TestBuffer_ToHAR_responseBodyRestored(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	resp := okResp(200) //nolint:bodyclose
+	resp.Body = io.NopCloser(bytes.NewBufferString("response"))
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, time.Now(), time.Millisecond)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "response", string(body))
+}
+
+func TestBuffer_ToHAR_responseBodyReadError_surfacedToCaller(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	wantErr := errors.New("read boom")
+	resp := okResp(200) //nolint:bodyclose
+	resp.Body = io.NopCloser(&partialThenErrorReader{data: []byte("partial"), err: wantErr})
+
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, time.Now(), time.Millisecond)
+
+	// The caller reads the captured bytes, then the original read error is re-surfaced rather
+	// than being silently swallowed and replaced with a truncated-but-successful body.
+	got, err := io.ReadAll(resp.Body)
+	assert.Equal(t, "partial", string(got))
+	assert.ErrorIs(t, err, wantErr)
+
+	raw, e := buf.ToHAR()
+	require.NoError(t, e)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+	assert.Equal(t, "partial", doc.Log.Entries[0].Response.Content.Text)
+}
+
+func TestBuffer_ToHAR_requestBodyReadError_restored(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	wantErr := errors.New("req read boom")
+	req := newGetReq(t, "http://example.com")
+	req.Body = io.NopCloser(&partialThenErrorReader{data: []byte("partial-req"), err: wantErr})
+
+	buf.AddEntry(req, okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+
+	// Symmetric with the response path: req.Body is restored (captured bytes then the error),
+	// not left consumed.
+	got, err := io.ReadAll(req.Body)
+	assert.Equal(t, "partial-req", string(got))
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestBuffer_ToHAR_redactsSensitiveData(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	req := newGetReq(t, "http://ds.example.com/query?api_key=QUERYSECRET&X-Amz-Signature=AWSSIG&region=us-east-1")
+	req.Header.Set("Authorization", "Bearer super-secret-token")
+	req.Header.Set("X-Grafana-Id", "id-token-value")
+	req.Header.Set("X-Amz-Security-Token", "AWSSESSION")
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(&http.Cookie{Name: "grafana_session", Value: "req-cookie-secret"})
+
+	resp := okResp(200) //nolint:bodyclose
+	resp.Header.Set("Set-Cookie", "grafana_session=resp-cookie-secret; Path=/")
+
+	buf.AddEntry(req, resp, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	s := string(raw)
+
+	// Secrets must not appear anywhere in the serialized HAR (headers, cookies, query, or URL).
+	for _, secret := range []string{"super-secret-token", "id-token-value", "AWSSESSION", "QUERYSECRET", "AWSSIG", "req-cookie-secret", "resp-cookie-secret"} {
+		assert.NotContains(t, s, secret, "secret leaked into HAR")
+	}
+	assert.Contains(t, s, redactedValue)
+	// Non-sensitive values are preserved.
+	assert.Contains(t, s, "us-east-1")
+	assert.Contains(t, s, "application/json")
+}
+
+func TestBuffer_ToHAR_binaryResponseBody_base64(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	binary := []byte{0xff, 0xfe, 0x00, 0x01, 0x80, 0x02} // invalid UTF-8
+	resp := okResp(200)                                  //nolint:bodyclose
+	resp.Body = io.NopCloser(bytes.NewReader(binary))
+	resp.Header.Set("Content-Type", "application/octet-stream")
+
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+
+	c := doc.Log.Entries[0].Response.Content
+	assert.Equal(t, "base64", c.Encoding, "binary body flagged as base64")
+	assert.Equal(t, int64(len(binary)), c.Size, "size reflects the raw byte length")
+
+	decoded, err := base64.StdEncoding.DecodeString(c.Text)
+	require.NoError(t, err)
+	assert.Equal(t, binary, decoded, "binary body round-trips losslessly")
+}
+
+func TestBuffer_ToHAR_redactsURLsAndCredentials(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	// Inline credentials + a non-sensitive query on the request URL.
+	req := newGetReq(t, "https://user:pass@ds.example.com/api?b=2&a=1")
+	resp := okResp(302) //nolint:bodyclose
+	// A redirect whose Location carries a secret in its query string.
+	resp.Header.Set("Location", "https://idp.example.com/cb?access_token=SECRET&state=ok")
+
+	buf.AddEntry(req, resp, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	s := string(raw)
+
+	assert.NotContains(t, s, "user:pass", "inline URL credentials are dropped")
+	assert.NotContains(t, s, "SECRET", "sensitive param in the redirect Location is redacted")
+	assert.Contains(t, s, "state=ok", "non-sensitive redirect param is kept")
+
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	// No sensitive request params -> the query is preserved verbatim (order not rewritten).
+	assert.Equal(t, "https://ds.example.com/api?b=2&a=1", doc.Log.Entries[0].Request.URL)
+	assert.NotContains(t, doc.Log.Entries[0].Response.RedirectURL, "SECRET")
+}
+
+func TestRedactHARDocument(t *testing.T) {
+	doc := []byte(`{"log":{"entries":[{` +
+		`"request":{"headers":[{"name":"Authorization","value":"Bearer SECRET"},{"name":"Accept","value":"application/json"}],` +
+		`"queryString":[{"name":"api_key","value":"QSECRET"},{"name":"region","value":"eu"}],` +
+		`"cookies":[{"name":"sess","value":"COOKIESECRET"}],"url":"https://u:p@h/x?api_key=QSECRET"},` +
+		`"response":{"headers":[{"name":"Location","value":"https://idp/cb?access_token=RSECRET"}],"cookies":[]}` +
+		`}]}}`)
+
+	out := string(RedactHARDocument(doc))
+
+	for _, secret := range []string{"Bearer SECRET", "QSECRET", "COOKIESECRET", "RSECRET", "u:p@"} {
+		assert.NotContains(t, out, secret, "secret leaked through frame redaction")
+	}
+	assert.Contains(t, out, "application/json", "non-sensitive header preserved")
+	assert.Contains(t, out, "region", "non-sensitive query preserved")
+
+	// Unparseable input is dropped (fail closed), not returned unredacted.
+	assert.Nil(t, RedactHARDocument([]byte("not har")))
+	assert.Nil(t, RedactHARDocument([]byte(`{"notalog":1}`)))
+}
+
+func TestToNameValues_sortedAndMultiValue(t *testing.T) {
+	h := http.Header{
+		"X-Zeta":  {"z"},
+		"X-Alpha": {"a1", "a2"}, // repeated header values must all be preserved
+	}
+
+	assert.Equal(t, []*har.NameValuePair{
+		{Name: "X-Alpha", Value: "a1"},
+		{Name: "X-Alpha", Value: "a2"},
+		{Name: "X-Zeta", Value: "z"},
+	}, toNameValues(h), "names sorted, one pair per value")
+}
+
+func TestBuffer_ToHAR_emptyHeaderValues_noPanic(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	req := newGetReq(t, "http://example.com")
+	req.Header["X-Empty"] = []string{}                           // empty value slice — must not panic
+	buf.AddEntry(req, okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+	_, err := buf.ToHAR()
+	require.NoError(t, err)
+}
+
+func TestBuffer_ToHAR_nilResponse(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	// A transport-level failure yields a nil response; the entry must still serialize.
+	buf.AddEntry(newGetReq(t, "http://example.com"), nil, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+	assert.Equal(t, int64(0), doc.Log.Entries[0].Response.Status)
+}
+
+func TestBuffer_concurrentAddEntry(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	var wg sync.WaitGroup
+	const n = 100
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			buf.AddEntry(newGetReq(t, "http://example.com"), okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, n, buf.Len())
+}
+
+// --- helpers ---
+
+func newGetReq(t *testing.T, url string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	return req
+}
+
+func newPostReq(t *testing.T, url, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func okResp(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Proto:      "HTTP/1.1",
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+	}
+}
+
+// partialThenErrorReader yields data, then fails with err -- simulating a body read that breaks
+// mid-stream (e.g. a dropped connection).
+type partialThenErrorReader struct {
+	data []byte
+	err  error
+	off  int
+}
+
+func (r *partialThenErrorReader) Read(p []byte) (int, error) {
+	if r.off < len(r.data) {
+		n := copy(p, r.data[r.off:])
+		r.off += n
+		return n, nil
+	}
+	return 0, r.err
+}

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -230,6 +230,23 @@ func TestRedactHARDocument(t *testing.T) {
 	assert.Nil(t, RedactHARDocument([]byte(`{"notalog":1}`)))
 }
 
+func TestRedactErrorText(t *testing.T) {
+	// A Go *url.Error renders the full request URL (query string included); the secret query param
+	// must be redacted while the surrounding message and non-sensitive params survive.
+	in := `Get "https://ds.example.com/api?api_key=SECRET&region=eu": dial tcp: connection refused`
+	out := RedactErrorText(in)
+	assert.NotContains(t, out, "SECRET", "secret query param must be redacted from error text")
+	assert.Contains(t, out, "region=eu", "non-sensitive param preserved")
+	assert.Contains(t, out, "connection refused", "surrounding error message preserved")
+
+	// Unquoted URL form followed by ": " — trailing colon must not defeat parsing/redaction.
+	in2 := `Get https://ds.example.com/q?token=SECRET: EOF`
+	assert.NotContains(t, RedactErrorText(in2), "SECRET")
+
+	// Non-URL text is returned unchanged.
+	assert.Equal(t, "context deadline exceeded", RedactErrorText("context deadline exceeded"))
+}
+
 func TestRedactedURLString_dropsFragment(t *testing.T) {
 	// A #fragment can carry a token (OAuth implicit flow); it must be dropped, not passed through.
 	u, err := url.Parse("https://idp.example.com/cb?state=ok#access_token=SECRET")

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -35,7 +35,7 @@ func TestBuffer_Len(t *testing.T) {
 	_, buf := WithCapture(context.Background())
 	assert.Equal(t, 0, buf.Len())
 
-	buf.AddEntry(newGetReq(t, "http://example.com"), okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+	buf.AddEntry(newGetReq(t, "http://example.com"), okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
 	assert.Equal(t, 1, buf.Len())
 }
 
@@ -47,7 +47,7 @@ func TestBuffer_ToHAR_structure(t *testing.T) {
 	resp.Body = io.NopCloser(bytes.NewBufferString(`{"data":"result"}`))
 	resp.Header.Set("Content-Type", "application/json")
 
-	buf.AddEntry(req, resp, time.Now(), 42*time.Millisecond)
+	buf.AddEntry(req, resp, nil, time.Now(), 42*time.Millisecond)
 
 	raw, err := buf.ToHAR()
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestBuffer_ToHAR_requestBodyRestored(t *testing.T) {
 	_, buf := WithCapture(context.Background())
 
 	req := newPostReq(t, "http://example.com", `body`)
-	buf.AddEntry(req, okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
 
 	// body must still be readable after AddEntry
 	body, err := io.ReadAll(req.Body)
@@ -84,7 +84,7 @@ func TestBuffer_ToHAR_responseBodyRestored(t *testing.T) {
 
 	resp := okResp(200) //nolint:bodyclose
 	resp.Body = io.NopCloser(bytes.NewBufferString("response"))
-	buf.AddEntry(newGetReq(t, "http://example.com"), resp, time.Now(), time.Millisecond)
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestBuffer_ToHAR_responseBodyReadError_surfacedToCaller(t *testing.T) {
 	resp := okResp(200) //nolint:bodyclose
 	resp.Body = io.NopCloser(&partialThenErrorReader{data: []byte("partial"), err: wantErr})
 
-	buf.AddEntry(newGetReq(t, "http://example.com"), resp, time.Now(), time.Millisecond)
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
 
 	// The caller reads the captured bytes, then the original read error is re-surfaced rather
 	// than being silently swallowed and replaced with a truncated-but-successful body.
@@ -121,7 +121,7 @@ func TestBuffer_ToHAR_requestBodyReadError_restored(t *testing.T) {
 	req := newGetReq(t, "http://example.com")
 	req.Body = io.NopCloser(&partialThenErrorReader{data: []byte("partial-req"), err: wantErr})
 
-	buf.AddEntry(req, okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
 
 	// Symmetric with the response path: req.Body is restored (captured bytes then the error),
 	// not left consumed.
@@ -143,7 +143,7 @@ func TestBuffer_ToHAR_redactsSensitiveData(t *testing.T) {
 	resp := okResp(200) //nolint:bodyclose
 	resp.Header.Set("Set-Cookie", "grafana_session=resp-cookie-secret; Path=/")
 
-	buf.AddEntry(req, resp, time.Now(), time.Millisecond)
+	buf.AddEntry(req, resp, nil, time.Now(), time.Millisecond)
 
 	raw, err := buf.ToHAR()
 	require.NoError(t, err)
@@ -167,7 +167,7 @@ func TestBuffer_ToHAR_binaryResponseBody_base64(t *testing.T) {
 	resp.Body = io.NopCloser(bytes.NewReader(binary))
 	resp.Header.Set("Content-Type", "application/octet-stream")
 
-	buf.AddEntry(newGetReq(t, "http://example.com"), resp, time.Now(), time.Millisecond)
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
 
 	raw, err := buf.ToHAR()
 	require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestBuffer_ToHAR_redactsURLsAndCredentials(t *testing.T) {
 	// A redirect whose Location carries a secret in its query string.
 	resp.Header.Set("Location", "https://idp.example.com/cb?access_token=SECRET&state=ok")
 
-	buf.AddEntry(req, resp, time.Now(), time.Millisecond)
+	buf.AddEntry(req, resp, nil, time.Now(), time.Millisecond)
 
 	raw, err := buf.ToHAR()
 	require.NoError(t, err)
@@ -270,6 +270,20 @@ func TestToNameValues_sortedAndMultiValue(t *testing.T) {
 	}, toNameValues(h, nil), "names sorted, one pair per value")
 }
 
+func TestBuffer_ToHAR_transportError_recordedInComment(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	// A failed dial has no HTTP response; the attempt (and why it failed) must still be captured.
+	buf.AddEntry(newGetReq(t, "http://ds.example.com/q"), nil, errors.New("dial tcp: connection refused"), time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+	assert.Equal(t, int64(0), doc.Log.Entries[0].Response.Status, "no-response entry has zero status")
+	assert.Contains(t, doc.Log.Entries[0].Comment, "connection refused", "transport error recorded in entry comment")
+}
+
 func TestBuffer_ToHAR_redactsCustomHeaders(t *testing.T) {
 	_, buf := WithCapture(context.Background())
 	// A datasource's custom HTTP headers carry secrets under arbitrary names not in the denylist.
@@ -280,7 +294,7 @@ func TestBuffer_ToHAR_redactsCustomHeaders(t *testing.T) {
 	req.Header.Set("X-Vault-Token", "vault-SECRET") // canonicalization must still match
 	req.Header.Set("Accept", "application/json")    // untouched header stays for fidelity
 
-	buf.AddEntry(req, okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
 	raw, err := buf.ToHAR()
 	require.NoError(t, err)
 	s := string(raw)
@@ -293,8 +307,8 @@ func TestBuffer_ToHAR_redactsCustomHeaders(t *testing.T) {
 func TestBuffer_ToHAR_emptyHeaderValues_noPanic(t *testing.T) {
 	_, buf := WithCapture(context.Background())
 	req := newGetReq(t, "http://example.com")
-	req.Header["X-Empty"] = []string{}                           // empty value slice — must not panic
-	buf.AddEntry(req, okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+	req.Header["X-Empty"] = []string{}                                // empty value slice — must not panic
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
 	_, err := buf.ToHAR()
 	require.NoError(t, err)
 }
@@ -302,7 +316,7 @@ func TestBuffer_ToHAR_emptyHeaderValues_noPanic(t *testing.T) {
 func TestBuffer_ToHAR_nilResponse(t *testing.T) {
 	_, buf := WithCapture(context.Background())
 	// A transport-level failure yields a nil response; the entry must still serialize.
-	buf.AddEntry(newGetReq(t, "http://example.com"), nil, time.Now(), time.Millisecond)
+	buf.AddEntry(newGetReq(t, "http://example.com"), nil, nil, time.Now(), time.Millisecond)
 
 	raw, err := buf.ToHAR()
 	require.NoError(t, err)
@@ -321,7 +335,7 @@ func TestBuffer_concurrentAddEntry(t *testing.T) {
 	for range n {
 		go func() {
 			defer wg.Done()
-			buf.AddEntry(newGetReq(t, "http://example.com"), okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+			buf.AddEntry(newGetReq(t, "http://example.com"), okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
 		}()
 	}
 	wg.Wait()

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -243,6 +243,15 @@ func TestRedactErrorText(t *testing.T) {
 	in2 := `Get https://ds.example.com/q?token=SECRET: EOF`
 	assert.NotContains(t, RedactErrorText(in2), "SECRET")
 
+	// Uppercase/mixed-case scheme must still be redacted (URL schemes are case-insensitive).
+	assert.NotContains(t, RedactErrorText(`Get "HTTPS://host/db?api_key=SUPERSECRET": refused`), "SUPERSECRET")
+
+	// Non-HTTP scheme DSNs carrying inline credentials must have the userinfo dropped.
+	assert.NotContains(t, RedactErrorText(`dial redis://default:hunter2@host:6379: timeout`), "hunter2")
+
+	// A malformed percent-escape in a sensitive param must not fail open (url.Query drops it).
+	assert.NotContains(t, RedactErrorText(`Get "https://host/p?sig=abc%ZZ": bad`), "abc%ZZ")
+
 	// Non-URL text is returned unchanged.
 	assert.Equal(t, "context deadline exceeded", RedactErrorText("context deadline exceeded"))
 }

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -248,11 +248,11 @@ func TestRedactURLValue_failsClosedOnUnparseable(t *testing.T) {
 
 	assert.Equal(t, redactedValue, redactURLValue(bad))
 	// The same must hold when the value arrives via a URL-valued header (Location/Referer/...).
-	assert.Equal(t, redactedValue, redactHeader("Location", bad))
-	assert.NotContains(t, redactHeader("Referer", bad), "SECRET")
+	assert.Equal(t, redactedValue, redactHeader("Location", bad, nil))
+	assert.NotContains(t, redactHeader("Referer", bad, nil), "SECRET")
 
 	// A parseable URL is still query-redacted in place (not dropped wholesale).
-	ok := redactHeader("Location", "https://idp.example.com/cb?access_token=SECRET&state=ok")
+	ok := redactHeader("Location", "https://idp.example.com/cb?access_token=SECRET&state=ok", nil)
 	assert.NotContains(t, ok, "SECRET")
 	assert.Contains(t, ok, "state=ok")
 }
@@ -267,7 +267,27 @@ func TestToNameValues_sortedAndMultiValue(t *testing.T) {
 		{Name: "X-Alpha", Value: "a1"},
 		{Name: "X-Alpha", Value: "a2"},
 		{Name: "X-Zeta", Value: "z"},
-	}, toNameValues(h), "names sorted, one pair per value")
+	}, toNameValues(h, nil), "names sorted, one pair per value")
+}
+
+func TestBuffer_ToHAR_redactsCustomHeaders(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	// A datasource's custom HTTP headers carry secrets under arbitrary names not in the denylist.
+	buf.MarkSensitiveHeaders("PRIVATE-TOKEN", "x-vault-token")
+
+	req := newGetReq(t, "http://ds.example.com")
+	req.Header.Set("PRIVATE-TOKEN", "glpat-SECRET")
+	req.Header.Set("X-Vault-Token", "vault-SECRET") // canonicalization must still match
+	req.Header.Set("Accept", "application/json")     // untouched header stays for fidelity
+
+	buf.AddEntry(req, okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	s := string(raw)
+
+	assert.NotContains(t, s, "glpat-SECRET", "custom header value must be redacted")
+	assert.NotContains(t, s, "vault-SECRET", "custom header value must be redacted (case-insensitive name)")
+	assert.Contains(t, s, "application/json", "non-custom headers stay for diagnostic fidelity")
 }
 
 func TestBuffer_ToHAR_emptyHeaderValues_noPanic(t *testing.T) {

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -278,7 +278,7 @@ func TestBuffer_ToHAR_redactsCustomHeaders(t *testing.T) {
 	req := newGetReq(t, "http://ds.example.com")
 	req.Header.Set("PRIVATE-TOKEN", "glpat-SECRET")
 	req.Header.Set("X-Vault-Token", "vault-SECRET") // canonicalization must still match
-	req.Header.Set("Accept", "application/json")     // untouched header stays for fidelity
+	req.Header.Set("Accept", "application/json")    // untouched header stays for fidelity
 
 	buf.AddEntry(req, okResp(200), time.Now(), time.Millisecond) //nolint:bodyclose
 	raw, err := buf.ToHAR()

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -230,6 +230,16 @@ func TestRedactHARDocument(t *testing.T) {
 	assert.Nil(t, RedactHARDocument([]byte(`{"notalog":1}`)))
 }
 
+func TestRedactedURLString_dropsFragment(t *testing.T) {
+	// A #fragment can carry a token (OAuth implicit flow); it must be dropped, not passed through.
+	u, err := url.Parse("https://idp.example.com/cb?state=ok#access_token=SECRET")
+	require.NoError(t, err)
+	out := redactedURLString(u)
+	assert.NotContains(t, out, "SECRET")
+	assert.NotContains(t, out, "access_token")
+	assert.Equal(t, "https://idp.example.com/cb?state=ok", out)
+}
+
 func TestRedactURLValue_failsClosedOnUnparseable(t *testing.T) {
 	// net/url.Parse rejects raw control characters; such a value can't be query-redacted, so it
 	// must be dropped rather than passed through into a bundle meant for external sharing.

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -252,6 +252,13 @@ func TestRedactErrorText(t *testing.T) {
 	// A malformed percent-escape in a sensitive param must not fail open (url.Query drops it).
 	assert.NotContains(t, RedactErrorText(`Get "https://host/p?sig=abc%ZZ": bad`), "abc%ZZ")
 
+	// A secret after a ";" separator must be redacted (";" is a valid query separator)...
+	assert.NotContains(t, RedactErrorText(`Get "https://host/p?foo=bar;token=SECRET": bad`), "SECRET")
+	// ...but "," is an ordinary value char and must NOT be treated as a separator.
+	out2 := RedactErrorText(`Get "https://host/p?region=us,eu&token=SECRET": bad`)
+	assert.NotContains(t, out2, "SECRET")
+	assert.Contains(t, out2, "region=us,eu", "comma-containing values are preserved, not split")
+
 	// Non-URL text is returned unchanged.
 	assert.Equal(t, "context deadline exceeded", RedactErrorText("context deadline exceeded"))
 }

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -227,6 +228,23 @@ func TestRedactHARDocument(t *testing.T) {
 	// Unparseable input is dropped (fail closed), not returned unredacted.
 	assert.Nil(t, RedactHARDocument([]byte("not har")))
 	assert.Nil(t, RedactHARDocument([]byte(`{"notalog":1}`)))
+}
+
+func TestRedactURLValue_failsClosedOnUnparseable(t *testing.T) {
+	// net/url.Parse rejects raw control characters; such a value can't be query-redacted, so it
+	// must be dropped rather than passed through into a bundle meant for external sharing.
+	bad := "https://idp.example.com/cb?access_token=SECRET\x7f"
+	require.Error(t, func() error { _, err := url.Parse(bad); return err }(), "guard: value must be unparseable")
+
+	assert.Equal(t, redactedValue, redactURLValue(bad))
+	// The same must hold when the value arrives via a URL-valued header (Location/Referer/...).
+	assert.Equal(t, redactedValue, redactHeader("Location", bad))
+	assert.NotContains(t, redactHeader("Referer", bad), "SECRET")
+
+	// A parseable URL is still query-redacted in place (not dropped wholesale).
+	ok := redactHeader("Location", "https://idp.example.com/cb?access_token=SECRET&state=ok")
+	assert.NotContains(t, ok, "SECRET")
+	assert.Contains(t, ok, "state=ok")
 }
 
 func TestToNameValues_sortedAndMultiValue(t *testing.T) {

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -1,0 +1,226 @@
+// Package diagnostics assembles on-demand datasource diagnostic bundles: captured HTTP traffic
+// (HAR) and the panel/dashboard JSON. The HTTP handler in pkg/api runs the queries with capture
+// active and delegates bundle assembly here.
+package diagnostics
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"sort"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+)
+
+// Bundler assembles diagnostic bundles.
+type Bundler struct{}
+
+// NewBundler returns a Bundler.
+func NewBundler() *Bundler {
+	return &Bundler{}
+}
+
+// Build assembles a .tar.gz bundle from the query response, the captured HAR buffer, and the
+// optional panel/dashboard JSON the client supplied. traffic.har is omitted when nothing was
+// captured.
+//
+// TODO: re-add a request-scoped server log. The previous whole-file tail was dropped because it is
+// not scoped to this request and would leak unrelated activity into a bundle meant for external
+// sharing; log inclusion returns (behind a drawer option) once it can be scoped to the request.
+// queryErr is the error (if any) from running the queries. A failed query is itself diagnostic
+// signal — the captured HAR already holds the failed attempt(s) — so it is recorded in the bundle
+// rather than causing the capture to be discarded.
+func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON json.RawMessage, queryErr error) ([]byte, error) {
+	files := map[string][]byte{}
+
+	if har := collectHAR(resp, harBuffer); len(har) > 0 {
+		files["traffic.har"] = har
+	}
+
+	if len(panelJSON) > 0 {
+		files["panel.json"] = indentJSON(panelJSON)
+	}
+	if len(dashboardJSON) > 0 {
+		files["dashboard.json"] = indentJSON(dashboardJSON)
+	}
+
+	if queryErr != nil {
+		files["query-error.txt"] = []byte(queryErr.Error() + "\n")
+	}
+
+	return buildTarGz(files)
+}
+
+// harResponseKey is the reserved synthetic refId under which externalized (gRPC) plugins return
+// captured traffic as a __har__ response frame.
+const harResponseKey = "__har__"
+
+// HasCapturedHAR reports whether any HAR traffic was captured for this request — either the
+// in-process buffer has entries (core plugins) or an external plugin returned a __har__ frame. The
+// handler uses it to decide whether a failed query still has something worth bundling.
+func HasCapturedHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) bool {
+	if harBuffer != nil && harBuffer.Len() > 0 {
+		return true
+	}
+	if resp != nil {
+		if r, ok := resp.Responses[harResponseKey]; ok && len(r.Frames) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// collectHAR returns the captured HTTP traffic as HAR 1.2 JSON. It merges two sources: the
+// in-process buffer (core plugins) and the __har__ response frame(s) returned by externalized GRPC
+// plugins. Returns nil when nothing was captured.
+//
+// NOTE: the __har__ frame path is inert until the SDK-side HTTP capture middleware that emits those
+// frames ships and Grafana is bumped to that SDK version (#1270) — until then external
+// (out-of-process) plugin traffic is NOT captured. Externally-sourced frames are run through
+// harcapture.RedactHARDocument before merging, so their headers/cookies/query/URLs are redacted the
+// same way in-process capture is (don't rely on the plugin/SDK to redact).
+func collectHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) []byte {
+	var bufferDoc []byte
+	if harBuffer.Len() > 0 {
+		if b, err := harBuffer.ToHAR(); err == nil {
+			bufferDoc = b
+		}
+	}
+
+	// __har__ frames carry capture from externalized gRPC plugins (out-of-process). "__har__" is a
+	// reserved synthetic refId; a client query using it would be consumed here, but that's harmless
+	// as query results are not part of the bundle (only captured traffic + panel/dashboard JSON).
+	var frameDocs [][]byte
+	if resp != nil {
+		if harResp, ok := resp.Responses[harResponseKey]; ok {
+			delete(resp.Responses, harResponseKey)
+			// A plugin may split its capture across multiple frames; collect every frame's HAR
+			// payload rather than only the first, so no entries are lost.
+			for _, frame := range harResp.Frames {
+				if frame == nil || frame.Meta == nil {
+					continue
+				}
+				custom, ok := frame.Meta.Custom.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if harStr, ok := custom["har"].(string); ok && harStr != "" {
+					// Redact externally-sourced entries just like in-process capture. A frame that
+					// can't be redacted (nil) is dropped rather than merged unredacted.
+					if redacted := harcapture.RedactHARDocument([]byte(harStr)); redacted != nil {
+						frameDocs = append(frameDocs, redacted)
+					}
+				}
+			}
+		}
+	}
+
+	// Common case: only the in-process buffer captured traffic (core plugins). Its ToHAR output is
+	// already a complete HAR 1.2 document, so return it directly rather than re-parsing and
+	// re-marshaling every captured request/response through mergeHAR.
+	if len(frameDocs) == 0 {
+		return bufferDoc
+	}
+
+	docs := frameDocs
+	if bufferDoc != nil {
+		docs = append([][]byte{bufferDoc}, frameDocs...)
+	}
+	return mergeHAR(docs)
+}
+
+// mergeHAR combines multiple HAR 1.2 documents into a single one by concatenating their
+// log.entries. Documents that fail to parse are skipped. Returns nil when there are no entries.
+func mergeHAR(docs [][]byte) []byte {
+	type harEnvelope struct {
+		Log struct {
+			Creator json.RawMessage   `json:"creator"`
+			Entries []json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+
+	entries := make([]json.RawMessage, 0)
+	var creator json.RawMessage
+	for _, d := range docs {
+		var env harEnvelope
+		if err := json.Unmarshal(d, &env); err != nil {
+			continue
+		}
+		entries = append(entries, env.Log.Entries...)
+		if creator == nil && len(env.Log.Creator) > 0 {
+			creator = env.Log.Creator
+		}
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	if creator == nil {
+		creator = json.RawMessage(`{"name":"Grafana","version":"1.0"}`)
+	}
+
+	out := map[string]any{
+		"log": map[string]any{
+			"version": "1.2",
+			"creator": creator,
+			"entries": entries,
+		},
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// buildTarGz packs the named files into a gzipped tar archive. Files are written in deterministic
+// (sorted) name order.
+func buildTarGz(files map[string][]byte) ([]byte, error) {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	now := time.Now()
+	for _, name := range names {
+		data := files[name]
+		hdr := &tar.Header{
+			Name:    name,
+			Mode:    0o600,
+			Size:    int64(len(data)),
+			ModTime: now,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write(data); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// indentJSON pretty-prints raw JSON for readability in the bundle, falling back to the raw bytes
+// if it cannot be parsed.
+func indentJSON(raw []byte) []byte {
+	var out bytes.Buffer
+	if err := json.Indent(&out, raw, "", "  "); err != nil {
+		return raw
+	}
+	return out.Bytes()
+}

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -118,7 +118,7 @@ func HasCapturedHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffe
 // same way in-process capture is (don't rely on the plugin/SDK to redact).
 func collectHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) ([]byte, error) {
 	var bufferDoc []byte
-	if harBuffer.Len() > 0 {
+	if harBuffer != nil && harBuffer.Len() > 0 {
 		b, err := harBuffer.ToHAR()
 		if err != nil {
 			// The in-process buffer captured traffic but couldn't be serialized. Surface the error

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -91,6 +91,34 @@ func ResponseError(resp *backend.QueryDataResponse) error {
 	return errors.Join(errs...)
 }
 
+// PluginCaptureError returns the error an externalized (gRPC) plugin stashed alongside its captured
+// __har__ frame (Custom["queryError"]), or nil if absent. The SDK capture middleware records a
+// top-level QueryData error there rather than returning it, because a gRPC error would discard the
+// whole response — and the captured traffic with it — before it crossed the wire. Reading it back
+// here lets the failure still be recorded in the bundle.
+func PluginCaptureError(resp *backend.QueryDataResponse) error {
+	if resp == nil {
+		return nil
+	}
+	r, ok := resp.Responses[harResponseKey]
+	if !ok {
+		return nil
+	}
+	for _, frame := range r.Frames {
+		if frame == nil || frame.Meta == nil {
+			continue
+		}
+		custom, ok := frame.Meta.Custom.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if msg, ok := custom["queryError"].(string); ok && msg != "" {
+			return errors.New(msg)
+		}
+	}
+	return nil
+}
+
 // HasCapturedHAR reports whether any HAR traffic was captured for this request — either the
 // in-process buffer has entries (core plugins) or an external plugin returned a __har__ frame. The
 // handler uses it to decide whether a failed query still has something worth bundling.

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"sort"
 	"time"
 
@@ -62,6 +64,32 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 // harResponseKey is the reserved synthetic refId under which externalized (gRPC) plugins return
 // captured traffic as a __har__ response frame.
 const harResponseKey = "__har__"
+
+// ResponseError returns a combined error describing any per-refId query failures in resp
+// (backend.DataResponse.Error), or nil if there are none. Datasource queries usually fail this way
+// — QueryData returns no top-level error while individual responses carry the failure — so a caller
+// that only checks the top-level error would miss them. Errors are wrapped per refId (preserving
+// errors.Is/As for typed classification) and ordered deterministically by refId.
+func ResponseError(resp *backend.QueryDataResponse) error {
+	if resp == nil {
+		return nil
+	}
+	refIDs := make([]string, 0, len(resp.Responses))
+	for refID, r := range resp.Responses {
+		if r.Error != nil {
+			refIDs = append(refIDs, refID)
+		}
+	}
+	if len(refIDs) == 0 {
+		return nil
+	}
+	sort.Strings(refIDs)
+	errs := make([]error, 0, len(refIDs))
+	for _, refID := range refIDs {
+		errs = append(errs, fmt.Errorf("%s: %w", refID, resp.Responses[refID].Error))
+	}
+	return errors.Join(errs...)
+}
 
 // HasCapturedHAR reports whether any HAR traffic was captured for this request — either the
 // in-process buffer has entries (core plugins) or an external plugin returned a __har__ frame. The

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -55,7 +55,10 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 	}
 
 	if queryErr != nil {
-		files["query-error.txt"] = []byte(queryErr.Error() + "\n")
+		// Redact URL query params from the error text: a transport error (net/url.Error) embeds the
+		// full request URL, and Go masks only userinfo passwords, so a credential in a query param
+		// would otherwise leak into this externally-shared file despite the HAR-level redaction.
+		files["query-error.txt"] = []byte(harcapture.RedactErrorText(queryErr.Error()) + "\n")
 	}
 
 	return buildTarGz(files)

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -37,7 +37,11 @@ func NewBundler() *Bundler {
 func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON json.RawMessage, queryErr error) ([]byte, error) {
 	files := map[string][]byte{}
 
-	if har := collectHAR(resp, harBuffer); len(har) > 0 {
+	har, err := collectHAR(resp, harBuffer)
+	if err != nil {
+		return nil, err
+	}
+	if len(har) > 0 {
 		files["traffic.har"] = har
 	}
 
@@ -76,19 +80,25 @@ func HasCapturedHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffe
 
 // collectHAR returns the captured HTTP traffic as HAR 1.2 JSON. It merges two sources: the
 // in-process buffer (core plugins) and the __har__ response frame(s) returned by externalized GRPC
-// plugins. Returns nil when nothing was captured.
+// plugins. Returns (nil, nil) when nothing was captured, and a non-nil error if traffic was
+// captured but could not be serialized (so the caller can fail rather than return an empty bundle).
 //
 // NOTE: the __har__ frame path is inert until the SDK-side HTTP capture middleware that emits those
 // frames ships and Grafana is bumped to that SDK version (#1270) — until then external
 // (out-of-process) plugin traffic is NOT captured. Externally-sourced frames are run through
 // harcapture.RedactHARDocument before merging, so their headers/cookies/query/URLs are redacted the
 // same way in-process capture is (don't rely on the plugin/SDK to redact).
-func collectHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) []byte {
+func collectHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) ([]byte, error) {
 	var bufferDoc []byte
 	if harBuffer.Len() > 0 {
-		if b, err := harBuffer.ToHAR(); err == nil {
-			bufferDoc = b
+		b, err := harBuffer.ToHAR()
+		if err != nil {
+			// The in-process buffer captured traffic but couldn't be serialized. Surface the error
+			// instead of silently dropping traffic.har and returning a success bundle with no
+			// captured traffic.
+			return nil, err
 		}
+		bufferDoc = b
 	}
 
 	// __har__ frames carry capture from externalized gRPC plugins (out-of-process). "__har__" is a
@@ -123,14 +133,14 @@ func collectHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) [
 	// already a complete HAR 1.2 document, so return it directly rather than re-parsing and
 	// re-marshaling every captured request/response through mergeHAR.
 	if len(frameDocs) == 0 {
-		return bufferDoc
+		return bufferDoc, nil
 	}
 
 	docs := frameDocs
 	if bufferDoc != nil {
 		docs = append([][]byte{bufferDoc}, frameDocs...)
 	}
-	return mergeHAR(docs)
+	return mergeHAR(docs), nil
 }
 
 // mergeHAR combines multiple HAR 1.2 documents into a single one by concatenating their

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -79,6 +79,12 @@ func ResponseError(resp *backend.QueryDataResponse) error {
 	}
 	refIDs := make([]string, 0, len(resp.Responses))
 	for refID, r := range resp.Responses {
+		// Skip the synthetic capture frame: an externalized plugin sets an error on it (so the SDK's
+		// own middlewares see the failure), but its clean error text is read via PluginCaptureError,
+		// not surfaced here under the reserved refID.
+		if refID == harResponseKey {
+			continue
+		}
 		if r.Error != nil {
 			refIDs = append(refIDs, refID)
 		}

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -1,0 +1,191 @@
+package diagnostics
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+)
+
+func TestBundler_Build(t *testing.T) {
+	// No HAR captured (empty buffer, nil response) -> traffic.har omitted; only panel.json present.
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "panel.json")
+	require.NotContains(t, files, "traffic.har", "no HAR was captured")
+	require.NotContains(t, files, "dashboard.json", "no dashboard JSON supplied")
+	require.NotContains(t, files, "server.log", "server log is intentionally omitted until it can be request-scoped")
+	require.NotContains(t, files, "query-error.txt", "no query error")
+	require.JSONEq(t, `{"id":1}`, string(files["panel.json"]))
+}
+
+func TestBundler_Build_recordsQueryError(t *testing.T) {
+	// A failed query must still produce a bundle, with the error recorded (capture is not discarded).
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, errors.New("datasource timeout"))
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "query-error.txt")
+	require.Contains(t, string(files["query-error.txt"]), "datasource timeout")
+}
+
+func TestMergeHAR(t *testing.T) {
+	d1 := []byte(`{"log":{"creator":{"name":"A","version":"1"},"entries":[{"n":1}]}}`)
+	d2 := []byte(`{"log":{"entries":[{"n":2},{"n":3}]}}`)
+	malformed := []byte(`not json`)
+
+	out := mergeHAR([][]byte{d1, malformed, d2})
+	require.NotNil(t, out)
+
+	var env struct {
+		Log struct {
+			Version string            `json:"version"`
+			Creator json.RawMessage   `json:"creator"`
+			Entries []json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+	require.NoError(t, json.Unmarshal(out, &env))
+	require.Equal(t, "1.2", env.Log.Version)
+	require.Len(t, env.Log.Entries, 3, "entries from all valid docs are concatenated; malformed skipped")
+	require.JSONEq(t, `{"name":"A","version":"1"}`, string(env.Log.Creator), "first creator is kept")
+
+	require.Nil(t, mergeHAR([][]byte{malformed}), "no parseable entries -> nil")
+	require.Nil(t, mergeHAR(nil))
+}
+
+func TestHasCapturedHAR(t *testing.T) {
+	require.False(t, HasCapturedHAR(nil, &harcapture.Buffer{}), "no buffer entries, no response")
+	require.False(t, HasCapturedHAR(&backend.QueryDataResponse{Responses: backend.Responses{}}, &harcapture.Buffer{}))
+
+	// An external __har__ frame counts as captured even when the in-process buffer is empty — the
+	// handler must not short-circuit a failed query away in that case.
+	f := data.NewFrame("")
+	f.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": `{"log":{"entries":[]}}`}}
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"__har__": backend.DataResponse{Frames: data.Frames{f}}}}
+	require.True(t, HasCapturedHAR(resp, &harcapture.Buffer{}))
+}
+
+func TestCollectHAR_ExternalFramesAndNilFrame(t *testing.T) {
+	// A frame with a secret in a request header — it must be redacted when merged, not passed verbatim.
+	frameHAR := `{"log":{"entries":[{"request":{"headers":[{"name":"Authorization","value":"Bearer FRAMESECRET"}],"queryString":[],"cookies":[],"url":"http://x/y"},"response":{"headers":[],"cookies":[]}}]}}`
+	withHAR := data.NewFrame("")
+	withHAR.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": frameHAR}}
+
+	resp := &backend.QueryDataResponse{
+		Responses: backend.Responses{
+			// A nil frame must not panic (regression guard), and the HAR frame must be collected.
+			"__har__": backend.DataResponse{Frames: data.Frames{nil, withHAR}},
+		},
+	}
+
+	out := collectHAR(resp, &harcapture.Buffer{})
+	require.NotNil(t, out)
+
+	var env struct {
+		Log struct {
+			Entries []json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+	require.NoError(t, json.Unmarshal(out, &env))
+	require.Len(t, env.Log.Entries, 1)
+	require.NotContains(t, string(out), "FRAMESECRET", "external-plugin frame headers must be redacted before merge")
+
+	_, ok := resp.Responses["__har__"]
+	require.False(t, ok, "__har__ synthetic response is consumed, not returned to the client")
+}
+
+func TestCollectHAR_Empty(t *testing.T) {
+	require.Nil(t, collectHAR(nil, &harcapture.Buffer{}))
+	require.Nil(t, collectHAR(&backend.QueryDataResponse{Responses: backend.Responses{}}, &harcapture.Buffer{}))
+}
+
+func TestCollectHAR_BufferOnly_returnedVerbatim(t *testing.T) {
+	buf := &harcapture.Buffer{}
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	buf.AddEntry(req, nil, time.Now(), time.Millisecond)
+
+	out := collectHAR(nil, buf)
+	require.NotNil(t, out)
+
+	// With no external frames, the buffer's own HAR document is returned as-is (no mergeHAR
+	// re-marshal round-trip), so it must be byte-identical to Buffer.ToHAR().
+	want, err := buf.ToHAR()
+	require.NoError(t, err)
+	require.Equal(t, want, out)
+
+	var doc struct {
+		Log struct {
+			Entries []json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+	require.NoError(t, json.Unmarshal(out, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+}
+
+func TestBuildTarGz(t *testing.T) {
+	blob, err := buildTarGz(map[string][]byte{"b.txt": []byte("bbb"), "a.txt": []byte("aaa")})
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Equal(t, "aaa", string(files["a.txt"]))
+	require.Equal(t, "bbb", string(files["b.txt"]))
+}
+
+func TestBuildTarGz_deterministicOrder(t *testing.T) {
+	blob, err := buildTarGz(map[string][]byte{"b.txt": []byte("b"), "a.txt": []byte("a"), "c.txt": []byte("c")})
+	require.NoError(t, err)
+
+	gz, err := gzip.NewReader(bytes.NewReader(blob))
+	require.NoError(t, err)
+	tr := tar.NewReader(gz)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	require.Equal(t, []string{"a.txt", "b.txt", "c.txt"}, names, "files written in sorted order")
+}
+
+func TestIndentJSON(t *testing.T) {
+	require.Equal(t, "{\n  \"a\": 1\n}", string(indentJSON([]byte(`{"a":1}`))))
+	require.Equal(t, "not json", string(indentJSON([]byte("not json"))), "falls back to raw bytes when unparseable")
+}
+
+func readTarGz(t *testing.T, data []byte) map[string][]byte {
+	t.Helper()
+
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	tr := tar.NewReader(gz)
+	out := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		b, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		out[hdr.Name] = b
+	}
+	return out
+}

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -220,6 +220,18 @@ func TestPluginCaptureError(t *testing.T) {
 	require.EqualError(t, err, "datasource boom")
 }
 
+func TestResponseError_skipsSyntheticHARFrame(t *testing.T) {
+	// The SDK sets an error on the synthetic __har__ response so its own middlewares see the failure;
+	// ResponseError must not surface it under the reserved refID (PluginCaptureError handles it).
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{
+		"__har__": {Error: errors.New("swallowed boom")},
+	}}
+	require.NoError(t, ResponseError(resp), "__har__ synthetic error must be skipped")
+	// A real per-refId error alongside it is still reported.
+	resp.Responses["A"] = backend.DataResponse{Error: errors.New("real boom")}
+	require.EqualError(t, ResponseError(resp), "A: real boom")
+}
+
 func TestResponseError(t *testing.T) {
 	require.NoError(t, ResponseError(nil))
 	require.NoError(t, ResponseError(&backend.QueryDataResponse{Responses: backend.Responses{"A": {}}}))

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -91,7 +91,8 @@ func TestCollectHAR_ExternalFramesAndNilFrame(t *testing.T) {
 		},
 	}
 
-	out := collectHAR(resp, &harcapture.Buffer{})
+	out, err := collectHAR(resp, &harcapture.Buffer{})
+	require.NoError(t, err)
 	require.NotNil(t, out)
 
 	var env struct {
@@ -108,8 +109,13 @@ func TestCollectHAR_ExternalFramesAndNilFrame(t *testing.T) {
 }
 
 func TestCollectHAR_Empty(t *testing.T) {
-	require.Nil(t, collectHAR(nil, &harcapture.Buffer{}))
-	require.Nil(t, collectHAR(&backend.QueryDataResponse{Responses: backend.Responses{}}, &harcapture.Buffer{}))
+	out, err := collectHAR(nil, &harcapture.Buffer{})
+	require.NoError(t, err)
+	require.Nil(t, out)
+
+	out, err = collectHAR(&backend.QueryDataResponse{Responses: backend.Responses{}}, &harcapture.Buffer{})
+	require.NoError(t, err)
+	require.Nil(t, out)
 }
 
 func TestCollectHAR_BufferOnly_returnedVerbatim(t *testing.T) {
@@ -118,7 +124,8 @@ func TestCollectHAR_BufferOnly_returnedVerbatim(t *testing.T) {
 	require.NoError(t, err)
 	buf.AddEntry(req, nil, time.Now(), time.Millisecond)
 
-	out := collectHAR(nil, buf)
+	out, err := collectHAR(nil, buf)
+	require.NoError(t, err)
 	require.NotNil(t, out)
 
 	// With no external frames, the buffer's own HAR document is returned as-is (no mergeHAR

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -187,6 +187,26 @@ func TestIndentJSON(t *testing.T) {
 	require.Equal(t, "not json", string(indentJSON([]byte("not json"))), "falls back to raw bytes when unparseable")
 }
 
+func TestPluginCaptureError(t *testing.T) {
+	require.NoError(t, PluginCaptureError(nil))
+	require.NoError(t, PluginCaptureError(&backend.QueryDataResponse{Responses: backend.Responses{"A": {}}}))
+
+	// No queryError in the frame -> nil.
+	noErr := data.NewFrame("__har__")
+	noErr.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": "{}"}}
+	require.NoError(t, PluginCaptureError(&backend.QueryDataResponse{Responses: backend.Responses{
+		"__har__": {Frames: data.Frames{noErr}},
+	}}))
+
+	// queryError present -> surfaced.
+	withErr := data.NewFrame("__har__")
+	withErr.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": "{}", "queryError": "datasource boom"}}
+	err := PluginCaptureError(&backend.QueryDataResponse{Responses: backend.Responses{
+		"__har__": {Frames: data.Frames{withErr}},
+	}})
+	require.EqualError(t, err, "datasource boom")
+}
+
 func TestResponseError(t *testing.T) {
 	require.NoError(t, ResponseError(nil))
 	require.NoError(t, ResponseError(&backend.QueryDataResponse{Responses: backend.Responses{"A": {}}}))

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -42,6 +42,19 @@ func TestBundler_Build_recordsQueryError(t *testing.T) {
 	require.Contains(t, string(files["query-error.txt"]), "datasource timeout")
 }
 
+func TestBundler_Build_redactsQueryErrorURL(t *testing.T) {
+	// A transport error embedding a URL with a secret query param must not leak into query-error.txt.
+	err := errors.New(`Get "https://ds.example.com/api?api_key=SECRET": dial tcp: connection refused`)
+	blob, buildErr := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, err)
+	require.NoError(t, buildErr)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "query-error.txt")
+	got := string(files["query-error.txt"])
+	require.NotContains(t, got, "SECRET", "secret query param must be redacted from query-error.txt")
+	require.Contains(t, got, "connection refused", "error message otherwise preserved")
+}
+
 func TestMergeHAR(t *testing.T) {
 	d1 := []byte(`{"log":{"creator":{"name":"A","version":"1"},"entries":[{"n":1}]}}`)
 	d2 := []byte(`{"log":{"entries":[{"n":2},{"n":3}]}}`)

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -133,7 +133,7 @@ func TestCollectHAR_BufferOnly_returnedVerbatim(t *testing.T) {
 	buf := &harcapture.Buffer{}
 	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	require.NoError(t, err)
-	buf.AddEntry(req, nil, time.Now(), time.Millisecond)
+	buf.AddEntry(req, nil, nil, time.Now(), time.Millisecond)
 
 	out, err := collectHAR(nil, buf)
 	require.NoError(t, err)

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -176,6 +176,22 @@ func TestIndentJSON(t *testing.T) {
 	require.Equal(t, "not json", string(indentJSON([]byte("not json"))), "falls back to raw bytes when unparseable")
 }
 
+func TestResponseError(t *testing.T) {
+	require.NoError(t, ResponseError(nil))
+	require.NoError(t, ResponseError(&backend.QueryDataResponse{Responses: backend.Responses{"A": {}}}))
+
+	sentinel := errors.New("boom")
+	err := ResponseError(&backend.QueryDataResponse{Responses: backend.Responses{
+		"B": {Error: sentinel},
+		"A": {Error: errors.New("bad query")},
+	}})
+	require.Error(t, err)
+	// Typed classification survives (handleQueryMetricsError relies on errors.Is).
+	require.ErrorIs(t, err, sentinel)
+	// Combined, wrapped per refId, and ordered deterministically by refId.
+	require.Equal(t, "A: bad query\nB: boom", err.Error())
+}
+
 func readTarGz(t *testing.T, data []byte) map[string][]byte {
 	t.Helper()
 

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -108,6 +108,17 @@ func TestCollectHAR_ExternalFramesAndNilFrame(t *testing.T) {
 	require.False(t, ok, "__har__ synthetic response is consumed, not returned to the client")
 }
 
+func TestCollectHAR_nilBuffer_noPanic(t *testing.T) {
+	out, err := collectHAR(nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, out)
+
+	// A nil buffer must also flow through Build without panicking.
+	bundle, err := NewBundler().Build(nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+}
+
 func TestCollectHAR_Empty(t *testing.T) {
 	out, err := collectHAR(nil, &harcapture.Buffer{})
 	require.NoError(t, err)

--- a/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
@@ -49,7 +49,19 @@ func (m *HTTPCaptureMiddleware) QueryData(ctx context.Context, req *backend.Quer
 	req.Headers[harCaptureHeader] = "true"
 
 	// Inject capturing RoundTripper for core (in-process) plugins.
-	captureMW := sdkhttpclient.NamedMiddlewareFunc("http-capture", func(_ sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
+	captureMW := sdkhttpclient.NamedMiddlewareFunc("http-capture", func(opts sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
+		// A datasource's "Custom HTTP Headers" (opts.Header, applied by CustomHeadersMiddleware)
+		// carry secrets under arbitrary names the static denylist can't enumerate. Capture runs
+		// after that middleware, so those headers are on the wire; mark their names sensitive so
+		// they're redacted from the bundle. opts.Header is this datasource's config, so this is
+		// scoped correctly even when multiple datasources are queried in one request.
+		if len(opts.Header) > 0 {
+			names := make([]string, 0, len(opts.Header))
+			for name := range opts.Header {
+				names = append(names, name)
+			}
+			buf.MarkSensitiveHeaders(names...)
+		}
 		return sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			// Buffer the request body before it is consumed by the transport.
 			var bodyBytes []byte

--- a/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
@@ -86,7 +86,7 @@ func (m *HTTPCaptureMiddleware) QueryData(ctx context.Context, req *backend.Quer
 			// requests worth seeing in a diagnostics bundle. Restore the request body first so
 			// buildEntry can read it.
 			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-			buf.AddEntry(r, resp, started, elapsed)
+			buf.AddEntry(r, resp, err, started, elapsed)
 
 			return resp, err
 		})

--- a/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
@@ -1,0 +1,85 @@
+package clientmiddleware
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+)
+
+const harCaptureHeader = "X-Grafana-HAR-Capture"
+
+// NewHTTPCaptureMiddleware creates a backend.HandlerMiddleware that captures HTTP traffic
+// for QueryData calls when a harcapture.Buffer is present in the context.
+//
+// For core (in-process) plugins: injects a capturing RoundTripper as contextual middleware
+// so the existing ContextualMiddleware in the HTTP client chain picks it up.
+//
+// For external GRPC plugins: sets X-Grafana-HAR-Capture on the request headers. NOTE: this is
+// currently inert — the SDK-side middleware that reads this header and emits __har__ response frames
+// is not released yet, so out-of-process plugin traffic is NOT captured until Grafana is bumped to
+// an SDK version that includes it (#1270). The header is set now only for forward compatibility.
+func NewHTTPCaptureMiddleware() backend.HandlerMiddleware {
+	return backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
+		return &HTTPCaptureMiddleware{BaseHandler: backend.NewBaseHandler(next)}
+	})
+}
+
+type HTTPCaptureMiddleware struct {
+	backend.BaseHandler
+}
+
+func (m *HTTPCaptureMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	buf := harcapture.FromContext(ctx)
+	if buf == nil {
+		return m.BaseHandler.QueryData(ctx, req)
+	}
+
+	// Signal external GRPC plugins via request header.
+	if req.Headers == nil {
+		req.Headers = map[string]string{}
+	}
+	req.Headers[harCaptureHeader] = "true"
+
+	// Inject capturing RoundTripper for core (in-process) plugins.
+	captureMW := sdkhttpclient.NamedMiddlewareFunc("http-capture", func(_ sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
+		return sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			// Buffer the request body before it is consumed by the transport.
+			var bodyBytes []byte
+			if r.Body != nil {
+				var readErr error
+				bodyBytes, readErr = io.ReadAll(r.Body)
+				_ = r.Body.Close()
+				if readErr != nil {
+					// Fail the request rather than silently forwarding a truncated body to the
+					// datasource; the diagnostics run surfaces the error.
+					return nil, fmt.Errorf("har capture: reading request body: %w", readErr)
+				}
+				r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			}
+
+			started := time.Now()
+			resp, err := next.RoundTrip(r)
+			elapsed := time.Since(started)
+
+			// Capture every attempt, including transport-level failures (connection refused,
+			// timeouts, etc.) where err is non-nil and resp is nil -- those are exactly the
+			// requests worth seeing in a diagnostics bundle. Restore the request body first so
+			// buildEntry can read it.
+			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			buf.AddEntry(r, resp, started, elapsed)
+
+			return resp, err
+		})
+	})
+	ctx = sdkhttpclient.WithContextualMiddleware(ctx, captureMW)
+
+	return m.BaseHandler.QueryData(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware_test.go
@@ -1,0 +1,183 @@
+package clientmiddleware
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/handlertest"
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+)
+
+func TestHTTPCaptureMiddleware_noBuffer_doesNotSetHeader(t *testing.T) {
+	var gotHeader string
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(_ context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		gotHeader = req.Headers[harCaptureHeader]
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	_, err := cdt.MiddlewareHandler.QueryData(context.Background(), &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, gotHeader)
+}
+
+func TestHTTPCaptureMiddleware_withBuffer_setsGRPCHeader(t *testing.T) {
+	var gotHeader string
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(_ context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		gotHeader = req.Headers[harCaptureHeader]
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, _ := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", gotHeader)
+}
+
+func TestHTTPCaptureMiddleware_withBuffer_injectsContextualMiddleware(t *testing.T) {
+	var contextualMWs []sdkhttpclient.Middleware
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		contextualMWs = sdkhttpclient.ContextualMiddlewareFromContext(ctx)
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, _ := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, contextualMWs)
+}
+
+func TestHTTPCaptureMiddleware_withBuffer_capturesHTTPEntry(t *testing.T) {
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		makeGrafanaHTTPCall(ctx, t, "http://example.com", nil)
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, buf := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, buf.Len())
+}
+
+func TestHTTPCaptureMiddleware_withBuffer_capturesFailedRequest(t *testing.T) {
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		// Transport-level failure: RoundTrip returns an error and a nil response.
+		makeGrafanaHTTPCall(ctx, t, "http://example.com", errors.New("connection refused"))
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, buf := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, buf.Len(), "failed requests must still be captured in the HAR")
+}
+
+func TestHTTPCaptureMiddleware_capturesAndRestoresRequestBody(t *testing.T) {
+	var transportSawBody string
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		rt := buildContextualRT(ctx, sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			b, _ := io.ReadAll(r.Body) // the transport must still see the full body
+			transportSawBody = string(b)
+			return okHTTPResp(), nil
+		}))
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", bytes.NewBufferString("payload"))
+		_, err := rt.RoundTrip(req) //nolint:bodyclose
+		require.NoError(t, err)
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, buf := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, "payload", transportSawBody, "transport receives the full (restored) request body")
+	require.Equal(t, 1, buf.Len())
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "payload", "captured request body appears in the HAR")
+}
+
+func TestHTTPCaptureMiddleware_requestBodyReadError_failsRequest(t *testing.T) {
+	transportCalled := false
+	var rtErr error
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		rt := buildContextualRT(ctx, sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			transportCalled = true
+			return okHTTPResp(), nil
+		}))
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+		req.Body = io.NopCloser(&failingReader{err: errors.New("body boom")})
+		_, rtErr = rt.RoundTrip(req) //nolint:bodyclose
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, buf := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	require.Error(t, rtErr)
+	assert.Contains(t, rtErr.Error(), "reading request body")
+	assert.False(t, transportCalled, "transport must not be called when the request body cannot be read")
+	assert.Equal(t, 0, buf.Len(), "no entry is recorded when the request body read fails")
+}
+
+// buildContextualRT wraps base with every contextual middleware registered in ctx (outermost last),
+// mirroring how the in-process HTTP client applies them.
+func buildContextualRT(ctx context.Context, base http.RoundTripper) http.RoundTripper {
+	rt := base
+	for _, mw := range sdkhttpclient.ContextualMiddlewareFromContext(ctx) {
+		rt = mw.CreateMiddleware(sdkhttpclient.Options{}, rt)
+	}
+	return rt
+}
+
+func okHTTPResp() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		Proto:      "HTTP/1.1",
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewBufferString("ok")),
+	}
+}
+
+type failingReader struct{ err error }
+
+func (f *failingReader) Read([]byte) (int, error) { return 0, f.err }
+
+// makeGrafanaHTTPCall simulates an in-process plugin making an HTTP call through the contextual
+// middleware chain. When rtErr is non-nil, the simulated transport returns it with a nil response.
+func makeGrafanaHTTPCall(ctx context.Context, t *testing.T, url string, rtErr error) {
+	t.Helper()
+	mws := sdkhttpclient.ContextualMiddlewareFromContext(ctx)
+	var rt http.RoundTripper = sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if rtErr != nil {
+			return nil, rtErr
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewBufferString("ok")),
+		}, nil
+	})
+	for _, mw := range mws {
+		rt = mw.CreateMiddleware(sdkhttpclient.Options{}, rt)
+	}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	_, _ = rt.RoundTrip(req) //nolint:bodyclose
+}

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -213,6 +213,7 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 		middlewares = append(middlewares, clientmiddleware.NewHostedGrafanaACHeaderMiddleware(cfg))
 	}
 
+	middlewares = append(middlewares, clientmiddleware.NewHTTPCaptureMiddleware())
 	middlewares = append(middlewares, clientmiddleware.NewHTTPClientMiddleware())
 
 	// ErrorSourceMiddleware should be at the very bottom, or any middlewares below it won't see the


### PR DESCRIPTION
**What is this feature?**

Adds the backend endpoint that powers on-demand datasource diagnostics: **`POST /api/ds/diagnostics`**. It runs the supplied datasource queries with **HTTP capture active** and returns a `.tar.gz` diagnostic bundle containing:

- `traffic.har` — the captured datasource HTTP traffic in HAR 1.2 format
- `panel.json` / `dashboard.json` — the panel/dashboard definitions the client supplied (optional)

A **server log** is intentionally *not* included in this PR. The straightforward whole-file tail is not scoped to the request, so it would leak unrelated concurrent activity into a bundle meant for external sharing. Follow up PRs to tentatively tackle this part will follow.

The panel "Download diagnostics" action (frontend PR #128212) POSTs to this endpoint and downloads the bundle.

**Why do we need this feature?**

Reproducing on-prem customer datasource problems means a lot of manual back-and-forth (config, queries, captured traffic). This gives support/engineering a one-shot, replayable snapshot of what a datasource query actually did on the wire — the HAR is compatible with the plugin SDK's e2e replay fixtures.

**Who is this feature for?**

Grafana server admins on self-managed / on-prem instances, working with support to diagnose datasource issues.


