### PR TITLE
Alerting: Remove alertingMultiplePolicies feature flag (frontend)

### DIFF
--- a/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.tsx
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.tsx
@@ -21,10 +21,6 @@ export type RoutingTreeSelectorProps = SingleSelectProps | MultiSelectProps;
 /**
  * Routing Tree Combobox which lists all available notification policy trees.
  *
- * When the `alertingMultiplePolicies` feature toggle is enabled on the backend,
- * this shows all available routing trees. Otherwise, it shows only the default
- * "user-defined" tree.
- *
  * The default routing tree (named "user-defined") is displayed as "Default policy"
  * and is always listed first.
  *

--- a/packages/grafana-alerting/src/grafana/notificationPolicies/hooks/useRoutingTrees.ts
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/hooks/useRoutingTrees.ts
@@ -25,8 +25,7 @@ type ListRoutingTreesQueryOptions = Parameters<
  *
  * This function wraps the notificationsAPIv0alpha1.useListRoutingTreeQuery with proper typing.
  *
- * When the `alertingMultiplePolicies` feature toggle is enabled on the backend, this returns all
- * available routing trees. Otherwise, it returns only the default "user-defined" tree.
+ * The backend returns all available routing trees.
  *
  * @param queryArgs - Optional query arguments for filtering, pagination, etc.
  * @param queryOptions - Optional query options (refetchOnFocus, skip, etc.)

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -99,14 +99,12 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
     {
       path: '/alerting/routes/policy/:name/edit',
       roles: evaluateAccess([AccessControlAction.AlertingNotificationsRead, ...PERMISSIONS_NOTIFICATION_POLICIES]),
-      component: config.featureToggles.alertingMultiplePolicies
-        ? importAlertingComponent(
-            () =>
-              import(
-                /* webpackChunkName: "PolicyPage" */ 'app/features/alerting/unified/components/notification-policies/PolicyPage'
-              )
+      component: importAlertingComponent(
+        () =>
+          import(
+            /* webpackChunkName: "PolicyPage" */ 'app/features/alerting/unified/components/notification-policies/PolicyPage'
           )
-        : () => <Navigate replace to="/alerting/routes" />,
+      ),
     },
     {
       path: '/alerting/silences',

--- a/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
@@ -4,7 +4,6 @@ import { clickSelectOption } from 'test/helpers/selectOptionInTest';
 import { render, screen, testWithFeatureToggles, userEvent, within } from 'test/test-utils';
 import { byLabelText, byRole, byTestId } from 'testing-library-selector';
 
-import { config } from '@grafana/runtime';
 import { mockComboboxRect } from '@grafana/test-utils';
 import { AppNotificationList } from 'app/core/components/AppNotifications/AppNotificationList';
 import { PERMISSIONS_NOTIFICATION_POLICIES } from 'app/features/alerting/unified/hooks/abilities/alertmanager/useNotificationPolicyAbility';
@@ -83,7 +82,7 @@ const openEditModal = async (
   await user.click(await ui.editButton.find());
 };
 
-// This is the page for the default policy when alertingMultiplePolicies is disabled.
+// This renders the notification policies tree/list page.
 const renderNotificationPolicies = (alertManagerSourceName: string = GRAFANA_RULES_SOURCE_NAME) =>
   render(
     <>
@@ -100,7 +99,7 @@ const renderNotificationPolicies = (alertManagerSourceName: string = GRAFANA_RUL
     }
   );
 
-// This is the page for the default policy when alertingMultiplePolicies is enabled.
+// This renders the dedicated policy editor page for a single named policy.
 const renderPolicyPage = (routeName: string) => () =>
   render(
     <Routes>
@@ -200,6 +199,13 @@ describe.each([
       ...PERMISSIONS_NOTIFICATION_POLICIES,
     ]);
     resetRoutingTreeMap();
+    // These tests exercise a single policy tree in isolation, so trim away the other
+    // fixture trees that resetRoutingTreeMap() registers by default (they're only relevant
+    // to multi-tree scenarios, covered separately in "Notification policy tree rendering").
+    deleteRoutingTree('Managed Policy - Empty Provisioned');
+    deleteRoutingTree('Managed Policy - Override + Inherit');
+    deleteRoutingTree('Managed Policy - Many Top-Level');
+    deleteRoutingTree('Managed Policy - Deeply Nested');
     // Copy default config to other policy name and clear the default, so we guarantee the tests are validating against
     // the custom route.
     const defaultRoute = getRoutingTree(ROOT_ROUTE_NAME)!;
@@ -349,7 +355,12 @@ describe.each([
     makeAllK8sGetEndpointsFail('alerting.config.notfound', errMessage);
 
     renderPage();
-    const alert = await screen.findByRole('alert', { name: /error loading alertmanager config/i });
+
+    // NotificationPoliciesPage lists all policy trees first, so a failing k8s request
+    // surfaces as a failure to fetch that list rather than the per-tree Alertmanager config error.
+    const alertName =
+      testName === 'NotificationPoliciesPage' ? /failed to fetch policies/i : /error loading alertmanager config/i;
+    const alert = await screen.findByRole('alert', { name: alertName });
     expect(await within(alert).findByText(new RegExp(errMessage))).toBeInTheDocument();
     expect(ui.rootRouteContainer.query()).not.toBeInTheDocument();
   });
@@ -592,13 +603,7 @@ const uiMultiRoute = {
   policyFilter: byRole('textbox', { name: /search routing trees/ }),
 };
 
-describe('alertingMultiplePolicies Feature Flag', () => {
-  const originalFeatureToggle = config.featureToggles.alertingMultiplePolicies;
-
-  afterAll(() => {
-    config.featureToggles.alertingMultiplePolicies = originalFeatureToggle;
-  });
-
+describe('Notification policy tree rendering', () => {
   afterEach(() => {
     resetRoutingTreeMap();
   });
@@ -611,27 +616,14 @@ describe('alertingMultiplePolicies Feature Flag', () => {
   // TODO: Re-enable this test once the am-root-route-container rendering issue is fixed.
   // Temporarily skipped due to failure in grafana-enterprise#11248
   // https://github.com/grafana/grafana-enterprise/actions/runs/23009165147/job/66815001544
-  it.skip('Should render MultiplePoliciesView when alertingMultiplePolicies feature flag is enabled', async () => {
-    config.featureToggles.alertingMultiplePolicies = true;
-
+  it.skip('Should render MultiplePoliciesView', async () => {
     renderNotificationPolicies();
     await screen.findByTestId('search-query-input');
 
     expect(screen.getAllByTestId('am-root-route-container').length).toBeGreaterThan(0);
   });
 
-  it('Should not render PoliciesList when alertingMultiplePolicies feature flag is disabled', async () => {
-    config.featureToggles.alertingMultiplePolicies = false;
-
-    renderNotificationPolicies();
-    await getRootRoute();
-
-    expect(uiMultiRoute.policyFilter.query()).not.toBeInTheDocument();
-  });
-
   it('Should not render PoliciesList when alertmanager is external', async () => {
-    config.featureToggles.alertingMultiplePolicies = true;
-
     setAlertmanagerStatus(dataSources.promAlertManager.uid, {
       ...someCloudAlertManagerStatus,
       config: someCloudAlertManagerConfig.alertmanager_config,
@@ -643,8 +635,6 @@ describe('alertingMultiplePolicies Feature Flag', () => {
   });
 
   it('Should render tree inline with create button when there is only one policy tree', async () => {
-    config.featureToggles.alertingMultiplePolicies = true;
-
     resetRoutingTreeMap();
     deleteRoutingTree('Managed Policy - Empty Provisioned');
     deleteRoutingTree('Managed Policy - Override + Inherit');
@@ -659,61 +649,37 @@ describe('alertingMultiplePolicies Feature Flag', () => {
   });
 });
 
-describe('alertingNavigationV2 respects alertingMultiplePolicies', () => {
+describe('alertingNavigationV2', () => {
   beforeAll(() => {
     setupDataSources(...Object.values(dataSources));
     grantUserPermissions([AccessControlAction.AlertingNotificationsExternalRead, ...PERMISSIONS_NOTIFICATION_POLICIES]);
   });
 
-  describe('when alertingMultiplePolicies is undefined', () => {
-    testWithFeatureToggles({ enable: ['alertingNavigationV2'] });
+  testWithFeatureToggles({ enable: ['alertingNavigationV2'] });
 
-    it('Should render PoliciesTree', async () => {
-      renderNotificationPolicies();
-      await getRootRoute();
-
-      expect(uiMultiRoute.policyFilter.query()).not.toBeInTheDocument();
-    });
-  });
-
-  describe('when alertingMultiplePolicies is disabled', () => {
-    testWithFeatureToggles({ enable: ['alertingNavigationV2'], disable: ['alertingMultiplePolicies'] });
-
-    it('Should render PoliciesTree', async () => {
-      renderNotificationPolicies();
-      await getRootRoute();
-
-      expect(uiMultiRoute.policyFilter.query()).not.toBeInTheDocument();
-    });
-  });
-
-  describe('when alertingMultiplePolicies is enabled', () => {
-    testWithFeatureToggles({ enable: ['alertingNavigationV2', 'alertingMultiplePolicies'] });
-
-    it('Should render MultiplePoliciesView', async () => {
-      render(
-        <>
-          <AppNotificationList />
-          <NotificationPolicies />
-        </>,
-        {
-          historyOptions: {
-            initialEntries: [`/alerting/routes?${ALERTMANAGER_NAME_QUERY_KEY}=${GRAFANA_RULES_SOURCE_NAME}`],
-          },
-          preloadedState: {
-            navIndex: {
-              'notification-config': {
-                id: 'notification-config',
-                text: 'Notification configuration',
-                url: '/alerting/notifications',
-              },
+  it('Should render MultiplePoliciesView', async () => {
+    render(
+      <>
+        <AppNotificationList />
+        <NotificationPolicies />
+      </>,
+      {
+        historyOptions: {
+          initialEntries: [`/alerting/routes?${ALERTMANAGER_NAME_QUERY_KEY}=${GRAFANA_RULES_SOURCE_NAME}`],
+        },
+        preloadedState: {
+          navIndex: {
+            'notification-config': {
+              id: 'notification-config',
+              text: 'Notification configuration',
+              url: '/alerting/notifications',
             },
           },
-        }
-      );
-      await screen.findByTestId('search-query-input');
+        },
+      }
+    );
+    await screen.findByTestId('search-query-input');
 
-      expect((await screen.findAllByTestId('am-root-route-container')).length).toBeGreaterThan(0);
-    });
+    expect((await screen.findAllByTestId('am-root-route-container')).length).toBeGreaterThan(0);
   });
 });

--- a/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
@@ -139,9 +139,8 @@ const NotificationPoliciesTabs = () => {
  * Unified policy tree view that handles both single and multiple policy trees.
  * Owns the single Web Worker instance and alert groups query shared by all PoliciesTree children.
  *
- * When the `alertingMultiplePolicies` feature toggle is enabled (Grafana AM only),
- * lists all policy trees with create/filter/expand controls.
- * Otherwise, renders a single default policy tree.
+ * For the Grafana Alertmanager, lists all policy trees with create/filter/expand controls.
+ * Otherwise (external Alertmanagers), renders a single default policy tree.
  */
 function PolicyTreeTab() {
   const { selectedAlertmanager = '', isGrafanaAlertmanager } = useAlertmanager();
@@ -154,7 +153,7 @@ function PolicyTreeTab() {
     { skip: !canSeeAlertGroups || !selectedAlertmanager }
   );
 
-  const useMultiplePolicies = isGrafanaAlertmanager && config.featureToggles.alertingMultiplePolicies;
+  const useMultiplePolicies = isGrafanaAlertmanager;
 
   const {
     currentData: allPolicies,

--- a/public/app/features/alerting/unified/components/RuleNotificationSection.tsx
+++ b/public/app/features/alerting/unified/components/RuleNotificationSection.tsx
@@ -5,7 +5,6 @@ import { useFormContext } from 'react-hook-form';
 import { notificationsAPIv0alpha1 } from '@grafana/alerting/unstable';
 import { type GrafanaTheme2, textUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import {
   Button,
   Combobox,
@@ -130,7 +129,6 @@ export function RuleNotificationSection() {
   // Validate runbook URL for form-level validation feedback
   const runbookUrlError = useMemo(() => validateRunbookUrl(runbookUrlValue), [runbookUrlValue]);
   const runbookUrlErrorId = useId();
-  const multiplePoliciesEnabled = config.featureToggles.alertingMultiplePolicies ?? false;
 
   return (
     <section className={styles.section} aria-labelledby="notification-section-heading">
@@ -195,7 +193,7 @@ export function RuleNotificationSection() {
             {useNotificationPolicy ? (
               <div className={styles.contentTopSpacer}>
                 <Stack direction="column" gap={2}>
-                  {multiplePoliciesEnabled && <PolicyTreeSelector />}
+                  <PolicyTreeSelector />
                   <NeedHelpInfoForNotificationPolicy />
                 </Stack>
               </div>

--- a/public/app/features/alerting/unified/components/notification-policies/Filters.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Filters.tsx
@@ -8,7 +8,6 @@ import {
 } from '@grafana/alerting/unstable';
 import { type RoutingTree } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Button, Field, Icon, Input, Label, Stack, Tooltip } from '@grafana/ui';
 import { ContactPointAction } from 'app/features/alerting/unified/hooks/abilities/types';
 import { type ObjectMatcher, type RouteWithID } from 'app/plugins/datasource/alertmanager/types';
@@ -153,7 +152,7 @@ const NotificationPoliciesFilter = ({ onChangeReceiver, onChangeMatchers }: Noti
           )}
         </Field>
       )}
-      {isGrafanaAlertmanager && config.featureToggles.alertingMultiplePolicies && (
+      {isGrafanaAlertmanager && (
         <Field label={t('alerting.multiple-policies-view.policy-tree-filter-label', 'Policy')} noMargin>
           <RoutingTreeSelector
             multi

--- a/public/app/features/alerting/unified/components/notification-policies/PoliciesList.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/PoliciesList.test.tsx
@@ -3,7 +3,6 @@ import { HttpResponse, http } from 'msw';
 import { render, screen, within } from 'test/test-utils';
 import { byTestId } from 'testing-library-selector';
 
-import { config } from '@grafana/runtime';
 import { AppNotificationList } from 'app/core/components/AppNotifications/AppNotificationList';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
@@ -109,13 +108,7 @@ const grantAlertmanagerAbilities = (allowed: readonly NotificationPolicyAction[]
 };
 
 describe('PoliciesList', () => {
-  const originalFeatureToggle = config.featureToggles.alertingMultiplePolicies;
-  afterAll(() => {
-    config.featureToggles.alertingMultiplePolicies = originalFeatureToggle;
-  });
-
   beforeEach(() => {
-    config.featureToggles.alertingMultiplePolicies = true;
     setupDataSources(...Object.values(dataSources));
     jest.clearAllMocks();
     jest.restoreAllMocks();

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -242,16 +242,14 @@ function AutomaticRooting({ alertUid }: AutomaticRootingProps) {
   ]);
   const selectedPolicy = watch('selectedPolicy');
 
-  const multiplePoliciesEnabled = config.featureToggles.alertingMultiplePolicies ?? false;
-
-  // Prefer the policy field (notification_settings.policy — canonical and honored by the backend
-  // in both toggle states), falling back to the legacy __grafana_managed_route__ label, so the
-  // notification preview fetches the correct routing tree instead of always defaulting to root.
+  // Prefer the policy field (notification_settings.policy — canonical and honored by the backend),
+  // falling back to the legacy __grafana_managed_route__ label, so the notification preview fetches
+  // the correct routing tree instead of always defaulting to root.
   const policyNameForPreview = selectedPolicy || labels.find((l) => l.key === NAMED_ROOT_LABEL_NAME)?.value;
 
   return (
     <Stack direction="column" gap={2}>
-      {multiplePoliciesEnabled && <PolicyTreeSelector />}
+      <PolicyTreeSelector />
       <NotificationPreview
         alertQueries={queries}
         customLabels={labels}

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
@@ -290,8 +290,8 @@ describe('PolicyTreeSelector', () => {
   });
 
   // Regression test for bug #1 from PR #124697:
-  // AutomaticRooting passed policyName={undefined} to NotificationPreview when only
-  // alertingMultiplePolicies was enabled (alertingPolicyRoutingSettings OFF).
+  // AutomaticRooting passed policyName={undefined} to NotificationPreview when a
+  // non-default policy tree was selected (alertingPolicyRoutingSettings OFF).
   // The selected tree (stored as __grafana_managed_route__ label) was never forwarded,
   // so routing was always evaluated against the default tree.
   describe('notification preview routing (alertingPolicyRoutingSettings OFF)', () => {
@@ -439,8 +439,8 @@ describe('PolicyTreeSelector', () => {
   });
 
   // Regression: a rule routed via notification_settings.policy (the canonical, backend-honored
-  // storage) was shown as "Default policy" and silently dropped on save when only
-  // alertingMultiplePolicies was enabled (alertingPolicyRoutingSettings OFF), because the
+  // storage) was shown as "Default policy" and silently dropped on save when a non-default
+  // policy tree was selected (alertingPolicyRoutingSettings OFF), because the
   // selector/save paths only looked at the legacy __grafana_managed_route__ label.
   describe('edit existing rule with notification_settings.policy (alertingPolicyRoutingSettings OFF)', () => {
     const CUSTOM_POLICY_NAME = 'Managed Policy - Empty Provisioned';

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
@@ -119,37 +119,8 @@ const grantAllPermissions = () => {
   ]);
 };
 
-describe('PolicyTreeSelector - feature toggle OFF', () => {
+describe('PolicyTreeSelector', () => {
   testWithFeatureToggles({ enable: ['alerting.rulesAPIV2'] });
-
-  beforeEach(() => {
-    localStorage.setItem(MANUAL_ROUTING_KEY, 'false');
-    contextSrv.isEditor = true;
-    contextSrv.hasEditPermissionInFolders = true;
-    setAlertmanagerChoices(AlertmanagerChoice.Internal, 1);
-    grantAllPermissions();
-  });
-
-  it('does not show policy tree selector when feature toggle is disabled', async () => {
-    const { user } = renderRuleEditor();
-
-    await user.type(await ui.inputs.name.find(), 'my great new rule');
-    await selectFolderAndGroup(user);
-
-    // Wait for the form to be fully loaded
-    await waitFor(() => {
-      expect(ui.buttons.save.get()).toBeEnabled();
-    });
-
-    // Should NOT show any policy selector elements
-    expect(policyTreeUi.policySelector.query()).not.toBeInTheDocument();
-    expect(policyTreeUi.changeButton.query()).not.toBeInTheDocument();
-    expect(policyTreeUi.defaultBadge.query()).not.toBeInTheDocument();
-  });
-});
-
-describe('PolicyTreeSelector - feature toggle ON', () => {
-  testWithFeatureToggles({ enable: ['alertingMultiplePolicies', 'alerting.rulesAPIV2'] });
 
   beforeEach(() => {
     localStorage.setItem(MANUAL_ROUTING_KEY, 'false');
@@ -543,7 +514,7 @@ describe('PolicyTreeSelector - feature toggle ON', () => {
 
 describe('PolicyTreeSelector - alertingPolicyRoutingSettings ON', () => {
   testWithFeatureToggles({
-    enable: ['alertingMultiplePolicies', 'alertingPolicyRoutingSettings', 'alerting.rulesAPIV2'],
+    enable: ['alertingPolicyRoutingSettings', 'alerting.rulesAPIV2'],
   });
 
   beforeEach(() => {

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/__snapshots__/PolicyTreeSelector.integration.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/__snapshots__/PolicyTreeSelector.integration.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PolicyTreeSelector - feature toggle ON new rule - collapsed default policy view adds __grafana_managed_route__ label when custom policy is selected 1`] = `
+exports[`PolicyTreeSelector new rule - collapsed default policy view adds __grafana_managed_route__ label when custom policy is selected 1`] = `
 [
   {
     "body": {
@@ -173,7 +173,7 @@ exports[`PolicyTreeSelector - feature toggle ON new rule - collapsed default pol
 ]
 `;
 
-exports[`PolicyTreeSelector - feature toggle ON new rule - collapsed default policy view does not add __grafana_managed_route__ label when saving with default policy 1`] = `
+exports[`PolicyTreeSelector new rule - collapsed default policy view does not add __grafana_managed_route__ label when saving with default policy 1`] = `
 [
   {
     "body": {

--- a/public/app/features/alerting/unified/hooks/abilities/alertmanager/useNotificationPolicyAbility.ts
+++ b/public/app/features/alerting/unified/hooks/abilities/alertmanager/useNotificationPolicyAbility.ts
@@ -128,8 +128,8 @@ export function useNotificationPolicyAbility(payload: NotificationPolicyAbilityP
 
       case NotificationPolicyAction.Export: {
         // Provisioning export (/api/v1/provisioning/policies/export) is Grafana AM only.
-        // Supports multiple routing trees via the routeName query param when alertingMultiplePolicies
-        // is enabled. Export is read-only — provisioned policies can be exported (same as mute timings).
+        // Supports multiple routing trees via the routeName query param.
+        // Export is read-only — provisioned policies can be exported (same as mute timings).
         if (!hasConfigurationAPI) {
           return NotSupported;
         }

--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilterSidebar.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilterSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, testWithFeatureToggles } from 'test/test-utils';
+import { render, screen } from 'test/test-utils';
 
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -94,44 +94,29 @@ beforeEach(() => {
 });
 
 describe('RulesFilterSidebar — policy filter', () => {
-  describe('when alertingMultiplePolicies is enabled', () => {
-    testWithFeatureToggles({ enable: ['alertingMultiplePolicies'] });
-
-    it('renders the notification policy selector', async () => {
-      render(<RulesFilterSidebar />);
-      expect(await screen.findByRole('combobox', { name: 'Notification policy' })).toBeInTheDocument();
-    });
-
-    it('calls updateFilters with the selected policy name', async () => {
-      const { user } = render(<RulesFilterSidebar />);
-      const select = await screen.findByRole('combobox', { name: 'Notification policy' });
-      await user.selectOptions(select, 'team-a-policy');
-      expect(mockUpdateFilters).toHaveBeenCalledWith(expect.objectContaining({ policy: 'team-a-policy' }));
-    });
-
-    it('does not include policy in the filter when the selection is cleared', async () => {
-      const { user } = render(<RulesFilterSidebar />);
-      const select = await screen.findByRole('combobox', { name: 'Notification policy' });
-      await user.selectOptions(select, 'team-a-policy');
-      await user.selectOptions(select, '');
-      const lastCall = mockUpdateFilters.mock.calls.at(-1)?.[0];
-      expect(lastCall?.policy).toBeUndefined();
-    });
+  it('renders the notification policy selector', async () => {
+    render(<RulesFilterSidebar />);
+    expect(await screen.findByRole('combobox', { name: 'Notification policy' })).toBeInTheDocument();
   });
 
-  describe('when alertingMultiplePolicies is disabled', () => {
-    testWithFeatureToggles({ disable: ['alertingMultiplePolicies'] });
+  it('calls updateFilters with the selected policy name', async () => {
+    const { user } = render(<RulesFilterSidebar />);
+    const select = await screen.findByRole('combobox', { name: 'Notification policy' });
+    await user.selectOptions(select, 'team-a-policy');
+    expect(mockUpdateFilters).toHaveBeenCalledWith(expect.objectContaining({ policy: 'team-a-policy' }));
+  });
 
-    it('does not render the notification policy selector', async () => {
-      render(<RulesFilterSidebar />);
-      expect(screen.queryByRole('combobox', { name: 'Notification policy' })).not.toBeInTheDocument();
-    });
+  it('does not include policy in the filter when the selection is cleared', async () => {
+    const { user } = render(<RulesFilterSidebar />);
+    const select = await screen.findByRole('combobox', { name: 'Notification policy' });
+    await user.selectOptions(select, 'team-a-policy');
+    await user.selectOptions(select, '');
+    const lastCall = mockUpdateFilters.mock.calls.at(-1)?.[0];
+    expect(lastCall?.policy).toBeUndefined();
   });
 });
 
 describe('RulesFilterSidebar — mutual exclusivity of contact point and policy filters', () => {
-  testWithFeatureToggles({ enable: ['alertingMultiplePolicies'] });
-
   beforeEach(() => {
     // canRenderContactPointSelector is evaluated per-render (not at module load),
     // so spyOn intercepts it correctly to grant the receivers permission.

--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilterSidebar.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilterSidebar.tsx
@@ -6,7 +6,6 @@ import { ContactPointSelector, RoutingTreeSelector } from '@grafana/alerting/uns
 import type { RoutingTree } from '@grafana/api-clients/rtkq/notifications.alerting/v1beta1';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Button, Combobox, Icon, Input, Label, MultiCombobox, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -327,127 +326,121 @@ function FilterSidebarForm({ filterState }: FilterSidebarFormProps) {
 
         <div className={styles.divider} />
 
-        {(canRenderContactPointSelector || config.featureToggles.alertingMultiplePolicies) && (
-          <>
-            <SidebarSection>
-              {canRenderContactPointSelector && (
-                <SidebarField
-                  label={
-                    <Stack gap={0.5} alignItems="center">
-                      <span>
-                        <Trans i18nKey="alerting.contactPointFilter.label">Contact point</Trans>
-                      </span>
+        <SidebarSection>
+          {canRenderContactPointSelector && (
+            <SidebarField
+              label={
+                <Stack gap={0.5} alignItems="center">
+                  <span>
+                    <Trans i18nKey="alerting.contactPointFilter.label">Contact point</Trans>
+                  </span>
+                  <Tooltip
+                    content={
+                      <Trans i18nKey="alerting.rules-filter.contact-point-tooltip">
+                        Filters alert rules which route directly to the selected contact point. Alert rules routed to
+                        notification policies will not be displayed.
+                      </Trans>
+                    }
+                  >
+                    <Icon
+                      name="info-circle"
+                      size="sm"
+                      title={t('alerting.rules-filter.contact-point-tooltip-title', 'Contact point filter help')}
+                    />
+                  </Tooltip>
+                </Stack>
+              }
+            >
+              <Controller
+                name="contactPoint"
+                control={control}
+                render={({ field }) => {
+                  const selector = (
+                    <ContactPointSelector
+                      placeholder={t('alerting.rules-filter.placeholder-contact-point', 'Select contact point')}
+                      value={field.value}
+                      isClearable
+                      disabled={isContactPointDisabled}
+                      onChange={handleContactPointChange}
+                    />
+                  );
+
+                  if (isContactPointDisabled) {
+                    return (
                       <Tooltip
-                        content={
-                          <Trans i18nKey="alerting.rules-filter.contact-point-tooltip">
-                            Filters alert rules which route directly to the selected contact point. Alert rules routed
-                            to notification policies will not be displayed.
-                          </Trans>
-                        }
+                        content={t(
+                          'alerting.rules-filter.contact-point-disabled-tooltip',
+                          'Contact point filtering is not available while a notification policy filter is active.'
+                        )}
+                        placement="top"
                       >
-                        <Icon
-                          name="info-circle"
-                          size="sm"
-                          title={t('alerting.rules-filter.contact-point-tooltip-title', 'Contact point filter help')}
-                        />
+                        <div>{selector}</div>
                       </Tooltip>
-                    </Stack>
+                    );
+                  }
+
+                  return selector;
+                }}
+              />
+            </SidebarField>
+          )}
+          <SidebarField
+            label={
+              <Stack gap={0.5} alignItems="center">
+                <span>
+                  <Trans i18nKey="alerting.policyFilter.label">Notification policy</Trans>
+                </span>
+                <Tooltip
+                  content={
+                    <Trans i18nKey="alerting.rules-filter.policy-tooltip">
+                      Filters alert rules which route to the selected notification policy tree. Alert rules using direct
+                      contact point routing will not be displayed.
+                    </Trans>
                   }
                 >
-                  <Controller
-                    name="contactPoint"
-                    control={control}
-                    render={({ field }) => {
-                      const selector = (
-                        <ContactPointSelector
-                          placeholder={t('alerting.rules-filter.placeholder-contact-point', 'Select contact point')}
-                          value={field.value}
-                          isClearable
-                          disabled={isContactPointDisabled}
-                          onChange={handleContactPointChange}
-                        />
-                      );
-
-                      if (isContactPointDisabled) {
-                        return (
-                          <Tooltip
-                            content={t(
-                              'alerting.rules-filter.contact-point-disabled-tooltip',
-                              'Contact point filtering is not available while a notification policy filter is active.'
-                            )}
-                            placement="top"
-                          >
-                            <div>{selector}</div>
-                          </Tooltip>
-                        );
-                      }
-
-                      return selector;
-                    }}
+                  <Icon
+                    name="info-circle"
+                    size="sm"
+                    title={t('alerting.rules-filter.policy-tooltip-title', 'Notification policy filter help')}
                   />
-                </SidebarField>
-              )}
-              {config.featureToggles.alertingMultiplePolicies && (
-                <SidebarField
-                  label={
-                    <Stack gap={0.5} alignItems="center">
-                      <span>
-                        <Trans i18nKey="alerting.policyFilter.label">Notification policy</Trans>
-                      </span>
-                      <Tooltip
-                        content={
-                          <Trans i18nKey="alerting.rules-filter.policy-tooltip">
-                            Filters alert rules which route to the selected notification policy tree. Alert rules using
-                            direct contact point routing will not be displayed.
-                          </Trans>
-                        }
-                      >
-                        <Icon
-                          name="info-circle"
-                          size="sm"
-                          title={t('alerting.rules-filter.policy-tooltip-title', 'Notification policy filter help')}
-                        />
-                      </Tooltip>
-                    </Stack>
-                  }
-                >
-                  <Controller
-                    name="policy"
-                    control={control}
-                    render={({ field }) => {
-                      const selector = (
-                        <RoutingTreeSelector
-                          placeholder={t('alerting.rules-filter.placeholder-policy', 'Select policy')}
-                          value={field.value ?? undefined}
-                          isClearable
-                          disabled={isPolicyDisabled}
-                          onChange={handlePolicyChange}
-                        />
-                      );
-
-                      if (isPolicyDisabled) {
-                        return (
-                          <Tooltip
-                            content={t(
-                              'alerting.rules-filter.policy-disabled-tooltip',
-                              'Notification policy filtering is not available while a contact point filter is active.'
-                            )}
-                            placement="top"
-                          >
-                            <div>{selector}</div>
-                          </Tooltip>
-                        );
-                      }
-
-                      return selector;
-                    }}
+                </Tooltip>
+              </Stack>
+            }
+          >
+            <Controller
+              name="policy"
+              control={control}
+              render={({ field }) => {
+                const selector = (
+                  <RoutingTreeSelector
+                    placeholder={t('alerting.rules-filter.placeholder-policy', 'Select policy')}
+                    value={field.value ?? undefined}
+                    isClearable
+                    disabled={isPolicyDisabled}
+                    onChange={handlePolicyChange}
                   />
-                </SidebarField>
-              )}
-            </SidebarSection>
-            <div className={styles.divider} />
-          </>
-        )}
+                );
+
+                if (isPolicyDisabled) {
+                  return (
+                    <Tooltip
+                      content={t(
+                        'alerting.rules-filter.policy-disabled-tooltip',
+                        'Notification policy filtering is not available while a contact point filter is active.'
+                      )}
+                      placement="top"
+                    >
+                      <div>{selector}</div>
+                    </Tooltip>
+                  );
+                }
+
+                return selector;
+              }}
+            />
+          </SidebarField>
+        </SidebarSection>
+        <div className={styles.divider} />
 
         <SidebarSection>
           <SidebarField


### PR DESCRIPTION
**What is this feature?**

Removes the last frontend references to the `alertingMultiplePolicies` feature toggle (multiple notification policies / "managed routes" support). The toggle has been GA and on by default for a while, so this keeps the enabled UI behavior (policy tree selector, notification policy filters, multi-tree list view) as the only behavior and deletes every flag-disabled branch and the tests that exercised it.

**Why do we need this feature?**

Cleans up a stale, always-on feature toggle and the conditional UI logic it required. This PR should merge **before** the companion backend PR (#128234), since the backend PR removes the toggle from the generated `featureToggles.gen.ts` type and CI on that PR fails while these frontend usages still reference it.

**Who is this feature for?**

N/A — internal cleanup, no user-facing behavior change (the toggle was already on by default).

**Which issue(s) does this PR fix?**:

Part of grafana/alerting-squad#1593 — the flag-cleanup step of the managed routes GA rollout epic (removing the `alertingMultiplePolicies` toggle).

**Special notes for your reviewer:**

- Companion PR: #128234 (backend removal, currently blocked on this PR merging first).
- `yarn typecheck`, `yarn lint`, and `yarn jest` on all touched test files pass.
- A few tests asserted "flag disabled" behavior (single-tree-only view, hidden policy filter) that's now impossible — those specific cases were deleted rather than adapted.
- `NotificationPoliciesPage.test.tsx` needed one non-mechanical fix: with multi-tree mode now unconditional, a `describe.each` block that renders a single named policy in isolation needed its mock fixture trees trimmed (same pattern already used elsewhere in the file), and one error-message assertion now varies by page variant since the policy list is always fetched first.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (N/A — flag was already GA, this PR removes it)
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New. (No user-facing behavior change, no docs/What's New needed; backend PR handles the doc-page wording updates)