### PR TITLE
Provisioning: Drop redundant author ID from Git Sync jobs

### DIFF
--- a/apps/provisioning/pkg/apis/auth/author.go
+++ b/apps/provisioning/pkg/apis/auth/author.go
@@ -12,7 +12,6 @@ import (
 type Author struct {
 	Name  string
 	Email string
-	ID    string
 }
 
 // GetAuthorFromRequester returns the Author for the user in ctx. It returns
@@ -24,5 +23,5 @@ func GetAuthorFromRequester(ctx context.Context) (Author, bool) {
 	if err != nil || !id.IsIdentityType(authlib.TypeUser) {
 		return Author{}, false
 	}
-	return Author{Name: id.GetName(), Email: id.GetEmail(), ID: id.GetUID()}, true
+	return Author{Name: id.GetName(), Email: id.GetEmail()}, true
 }

--- a/apps/provisioning/pkg/apis/auth/author.go
+++ b/apps/provisioning/pkg/apis/auth/author.go
@@ -5,23 +5,18 @@ import (
 
 	authlib "github.com/grafana/authlib/types"
 
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
-// Author identifies the user behind a request.
-type Author struct {
-	Name  string
-	Email string
-}
-
-// GetAuthorFromRequester returns the Author for the user in ctx. It returns
-// false when there is no requester or the request is not made by a user (for
-// example a background service identity), in which case the caller should not
-// attribute anything to a user.
-func GetAuthorFromRequester(ctx context.Context) (Author, bool) {
+// GetAuthorFromRequester returns the commit signature for the user in ctx. It
+// returns false when there is no requester or the request is not made by a
+// user (for example a background service identity), in which case the caller
+// should not attribute anything to a user.
+func GetAuthorFromRequester(ctx context.Context) (repository.CommitSignature, bool) {
 	id, err := identity.GetRequester(ctx)
 	if err != nil || !id.IsIdentityType(authlib.TypeUser) {
-		return Author{}, false
+		return repository.CommitSignature{}, false
 	}
-	return Author{Name: id.GetName(), Email: id.GetEmail()}, true
+	return repository.CommitSignature{Name: id.GetName(), Email: id.GetEmail()}, true
 }

--- a/apps/provisioning/pkg/apis/auth/author_test.go
+++ b/apps/provisioning/pkg/apis/auth/author_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
@@ -14,7 +15,7 @@ func TestGetAuthorFromRequester(t *testing.T) {
 	tests := []struct {
 		name      string
 		requester identity.Requester
-		expected  *Author
+		expected  *repository.CommitSignature
 	}{
 		{
 			name: "user identity returns author",
@@ -24,7 +25,7 @@ func TestGetAuthorFromRequester(t *testing.T) {
 				Email:   "test@example.com",
 				UserUID: "abc123",
 			},
-			expected: &Author{Name: "Test User", Email: "test@example.com"},
+			expected: &repository.CommitSignature{Name: "Test User", Email: "test@example.com"},
 		},
 		{
 			name: "service identity returns nothing",

--- a/apps/provisioning/pkg/apis/auth/author_test.go
+++ b/apps/provisioning/pkg/apis/auth/author_test.go
@@ -24,7 +24,7 @@ func TestGetAuthorFromRequester(t *testing.T) {
 				Email:   "test@example.com",
 				UserUID: "abc123",
 			},
-			expected: &Author{Name: "Test User", Email: "test@example.com", ID: "user:abc123"},
+			expected: &Author{Name: "Test User", Email: "test@example.com"},
 		},
 		{
 			name: "service identity returns nothing",

--- a/apps/provisioning/pkg/jobs/mutator.go
+++ b/apps/provisioning/pkg/jobs/mutator.go
@@ -49,7 +49,6 @@ func (m *AdmissionMutator) Mutate(ctx context.Context, a admission.Attributes, o
 	// author always reflects who actually made the request.
 	delete(job.Annotations, AnnoAuthor)
 	delete(job.Annotations, AnnoAuthorEmail)
-	delete(job.Annotations, AnnoAuthorID)
 
 	if m.userAttributionEnabled == nil || !m.userAttributionEnabled(ctx) {
 		return nil
@@ -68,9 +67,6 @@ func (m *AdmissionMutator) Mutate(ctx context.Context, a admission.Attributes, o
 	}
 	if author.Email != "" {
 		job.Annotations[AnnoAuthorEmail] = author.Email
-	}
-	if author.ID != "" {
-		job.Annotations[AnnoAuthorID] = author.ID
 	}
 
 	return nil

--- a/apps/provisioning/pkg/jobs/mutator_test.go
+++ b/apps/provisioning/pkg/jobs/mutator_test.go
@@ -39,7 +39,6 @@ func TestAdmissionMutator_Mutate(t *testing.T) {
 			expected: map[string]string{
 				AnnoAuthor:      "Test User",
 				AnnoAuthorEmail: "test@example.com",
-				AnnoAuthorID:    "user:abc123",
 			},
 		},
 		{
@@ -51,7 +50,6 @@ func TestAdmissionMutator_Mutate(t *testing.T) {
 			expected: map[string]string{
 				AnnoAuthor:      "Test User",
 				AnnoAuthorEmail: "test@example.com",
-				AnnoAuthorID:    "user:abc123",
 			},
 		},
 		{
@@ -107,7 +105,7 @@ func TestAdmissionMutator_Mutate(t *testing.T) {
 			// The mutator only ever touches the author annotations; assert on
 			// exactly those to confirm none are left stray.
 			got := map[string]string{}
-			for _, k := range []string{AnnoAuthor, AnnoAuthorEmail, AnnoAuthorID} {
+			for _, k := range []string{AnnoAuthor, AnnoAuthorEmail} {
 				if v, ok := job.Annotations[k]; ok {
 					got[k] = v
 				}

--- a/apps/provisioning/pkg/jobs/validator.go
+++ b/apps/provisioning/pkg/jobs/validator.go
@@ -17,13 +17,12 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
-// AnnoAuthor, AnnoAuthorEmail and AnnoAuthorID carry the display name, email
-// and stable identity of the user that triggered the job. They are set by the
-// server at creation time and are immutable.
+// AnnoAuthor and AnnoAuthorEmail carry the display name and email of the user
+// that triggered the job. They are set by the server at creation time and are
+// immutable.
 const (
 	AnnoAuthor      = "provisioning.grafana.app/author"
 	AnnoAuthorEmail = "provisioning.grafana.app/authorEmail"
-	AnnoAuthorID    = "provisioning.grafana.app/authorID"
 )
 
 // ValidateJob performs validation on the Job specification and returns an error if validation fails.
@@ -336,11 +335,10 @@ func (v *AdmissionValidator) Validate(ctx context.Context, a admission.Attribute
 func validateAuthor(ctx context.Context, a admission.Attributes, job *provisioning.Job) error {
 	name := job.Annotations[AnnoAuthor]
 	email := job.Annotations[AnnoAuthorEmail]
-	authorID := job.Annotations[AnnoAuthorID]
 
 	switch a.GetOperation() {
 	case admission.Create:
-		if (name == "" && email == "" && authorID == "") || identity.IsServiceIdentity(ctx) {
+		if (name == "" && email == "") || identity.IsServiceIdentity(ctx) {
 			return nil
 		}
 		id, err := identity.GetRequester(ctx)
@@ -353,9 +351,6 @@ func validateAuthor(ctx context.Context, a admission.Attributes, job *provisioni
 		if email != "" && email != id.GetEmail() {
 			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s must match the requesting user", AnnoAuthorEmail))
 		}
-		if authorID != "" && authorID != id.GetUID() {
-			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s must match the requesting user", AnnoAuthorID))
-		}
 	case admission.Update:
 		old, ok := a.GetOldObject().(*provisioning.Job)
 		if !ok {
@@ -366,9 +361,6 @@ func validateAuthor(ctx context.Context, a admission.Attributes, job *provisioni
 		}
 		if old.Annotations[AnnoAuthorEmail] != email {
 			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s is immutable", AnnoAuthorEmail))
-		}
-		if old.Annotations[AnnoAuthorID] != authorID {
-			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s is immutable", AnnoAuthorID))
 		}
 	case admission.Delete, admission.Connect:
 	}

--- a/apps/provisioning/pkg/jobs/validator_test.go
+++ b/apps/provisioning/pkg/jobs/validator_test.go
@@ -1219,7 +1219,6 @@ func TestValidateAuthor(t *testing.T) {
 	annotations := map[string]string{
 		AnnoAuthor:      requester.GetName(),
 		AnnoAuthorEmail: requester.GetEmail(),
-		AnnoAuthorID:    requester.GetUID(),
 	}
 
 	tests := []struct {
@@ -1263,13 +1262,6 @@ func TestValidateAuthor(t *testing.T) {
 			wantErrContains: AnnoAuthorEmail + " must match",
 		},
 		{
-			name:            "create with mismatched author ID",
-			ctx:             userCtx,
-			operation:       admission.Create,
-			annotations:     map[string]string{AnnoAuthorID: "user:other"},
-			wantErrContains: AnnoAuthorID + " must match",
-		},
-		{
 			name:            "create without requester",
 			ctx:             t.Context(),
 			operation:       admission.Create,
@@ -1300,12 +1292,12 @@ func TestValidateAuthor(t *testing.T) {
 			wantErrContains: AnnoAuthorEmail + " is immutable",
 		},
 		{
-			name:            "update removing author ID",
+			name:            "update removing email",
 			ctx:             userCtx,
 			operation:       admission.Update,
-			annotations:     map[string]string{AnnoAuthor: requester.GetName(), AnnoAuthorEmail: requester.GetEmail()},
+			annotations:     map[string]string{AnnoAuthor: requester.GetName()},
 			oldAnnotations:  annotations,
-			wantErrContains: AnnoAuthorID + " is immutable",
+			wantErrContains: AnnoAuthorEmail + " is immutable",
 		},
 		{
 			name:        "delete is ignored",

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -633,10 +633,10 @@ export const useFlagProvisioningReadmes = (options?: ReactFlagEvaluationOptions)
  *
  * **Details:**
  * - flag key: `provisioning.userAttribution`
- * - default value: `true`
+ * - default value: `false`
  */
 export const useFlagProvisioningUserAttribution = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("provisioning.userAttribution", true, options).value;
+  return useFlag("provisioning.userAttribution", false, options).value;
 };
 
 /**

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -90,7 +90,7 @@ func (c *filesConnector) Connect(ctx context.Context, name string, opts runtime.
 func (c *filesConnector) handleRequest(ctx context.Context, name string, r *http.Request, responder rest.Responder, logger logging.Logger) {
 	if userAttributionEnabled(ctx) {
 		if author, ok := auth.GetAuthorFromRequester(ctx); ok {
-			ctx = repository.WithAuthorSignature(ctx, repository.CommitSignature{Name: author.Name, Email: author.Email})
+			ctx = repository.WithAuthorSignature(ctx, author)
 		}
 	}
 	repo, err := c.getRepo(ctx, r.Method, name)

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -284,7 +284,7 @@ var (
 			Description: "Author Git Sync commits as the acting Grafana user",
 			Stage:       FeatureStagePublicPreview,
 			Owner:       grafanaAppPlatformSquad,
-			Expression:  "true",
+			Expression:  "false",
 			Generate:    Generate{Go: true, React: true},
 		},
 		{

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4588,17 +4588,17 @@
     {
       "metadata": {
         "name": "provisioning.userAttribution",
-        "resourceVersion": "1783531000298",
+        "resourceVersion": "1783717809512",
         "creationTimestamp": "2026-07-08T13:32:58Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-07-08 17:16:40.298205 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-10 21:10:09.512157 +0000 UTC"
         }
       },
       "spec": {
         "description": "Author Git Sync commits as the acting Grafana user",
         "stage": "preview",
         "codeowner": "@grafana/grafana-app-platform-squad",
-        "expression": "true"
+        "expression": "false"
       }
     },
     {

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1541,6 +1541,7 @@ func defaultGrafanaOpts(provisioningPath string) testinfra.GrafanaOpts {
 		EnableFeatureToggles: []string{
 			featuremgmt.FlagProvisioning,
 			featuremgmt.FlagProvisioningExport,
+			featuremgmt.FlagProvisioningUserAttribution,
 			// Lets CleanupAllResources force-delete folders (gracePeriodSeconds=0),
 			// bypassing the eventually-consistent "folder is empty" admission check.
 			// Normal (non-force) deletes still enforce the check, so test behavior


### PR DESCRIPTION
**What is this feature?**

Follow-up to #128180. Jobs were stamped with a `provisioning.grafana.app/authorID` annotation carrying the acting user's uid, but the platform already records the same uid on every job in the `grafana.app/createdBy` annotation. This drops the redundant annotation, keeping only the author name and email ones used for commit attribution. The helper that reads the acting user now returns a commit signature directly. Also disables the user attribution feature toggle by default.

**Why do we need this feature?**

The author ID annotation duplicated what `grafana.app/createdBy` already tracks.

**Who is this feature for?**

Teams using Git Sync with user attribution enabled.

**Which issue(s) does this PR fix?**:

Part of grafana/git-ui-sync-project#1268

---
*Description generated by Claude Code.*