### PR TITLE
Provisioning: Use neutral fallback in the jobs Triggered by column

### DIFF
--- a/public/app/features/provisioning/Job/RecentJobs.test.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.test.tsx
@@ -67,10 +67,10 @@ describe('RecentJobs', () => {
       expect(await screen.findByText('ada@example.com')).toBeInTheDocument();
     });
 
-    it('shows Webhook when no user triggered the job', async () => {
+    it('shows System when no user triggered the job', async () => {
       setup([createJob()]);
 
-      expect(await screen.findByText('Webhook')).toBeInTheDocument();
+      expect(await screen.findByText('System')).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -74,7 +74,7 @@ const getJobColumns = (showAuthor: boolean) => [
           cell: ({ row: { original: job } }: JobCell) => {
             const annotations = job.metadata?.annotations;
             const author = annotations?.[AnnoAuthor] || annotations?.[AnnoAuthorEmail];
-            return author || t('provisioning.recent-jobs.triggered-by-webhook', 'Webhook');
+            return author || t('provisioning.recent-jobs.triggered-by-system', 'System');
           },
         },
       ]

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13642,7 +13642,7 @@
       "error-loading-active-jobs": "Error loading active jobs",
       "error-loading-historic-jobs": "Error loading historic jobs",
       "jobs": "Jobs",
-      "triggered-by-webhook": "Webhook"
+      "triggered-by-system": "System"
     },
     "repository-actions": {
       "connection": "Connection",


### PR DESCRIPTION
**What is this feature?**

Follow-up to #127984. The jobs list on a Git Sync repository page labeled every job without a triggering user as "Webhook". Those jobs can also come from background syncs, so the column now falls back to "System".

**Why do we need this feature?**

The previous label was inaccurate for jobs not started through a webhook.

**Who is this feature for?**

Anyone reviewing repository activity in Grafana.

**Which issue(s) does this PR fix?**:

Part of grafana/git-ui-sync-project#1268

---
*Description generated by Claude Code.*