### PR TITLE
Elasticsearch: Drop 7.x from supported versions in docs

### DIFF
--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -40,7 +40,7 @@ The Elasticsearch data source supports:
 
 Before you configure the Elasticsearch data source, you need:
 
-- An Elasticsearch instance (v7.17+, v8.x, or v9.x)
+- An Elasticsearch instance (v8.x or v9.x)
 - Network access from Grafana to your Elasticsearch server
 - Appropriate user credentials or API keys with read access
 
@@ -48,7 +48,6 @@ Before you configure the Elasticsearch data source, you need:
 
 This data source supports these versions of Elasticsearch:
 
-- ≥ v7.17
 - v8.x
 - v9.x
 - Elastic Cloud Serverless

--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -42,7 +42,7 @@ The Elasticsearch data source supports:
 
 Before you configure the Elasticsearch data source, you need:
 
-- An Elasticsearch instance (v7.17+, v8.x, or v9.x)
+- An Elasticsearch instance (v8.x or v9.x)
 - Network access from Grafana to your Elasticsearch server
 - Appropriate user credentials or API keys with read access
 
@@ -50,7 +50,6 @@ Before you configure the Elasticsearch data source, you need:
 
 This data source supports these versions of Elasticsearch:
 
-- ≥ v7.17
 - v8.x
 - v9.x
 - Elastic Cloud Serverless

--- a/docs/sources/datasources/elasticsearch/configure/index.md
+++ b/docs/sources/datasources/elasticsearch/configure/index.md
@@ -30,7 +30,7 @@ Administrators can also [configure the data source via YAML](#provision-the-data
 To configure the Elasticsearch data source, you need:
 
 - **Grafana administrator permissions:** Only users with the organization `administrator` role can add data sources.
-- **A supported Elasticsearch version:** v7.17 or later, v8.x, v9.x or Elastic Cloud Serverless.
+- **A supported Elasticsearch version:** v8.x, v9.x or Elastic Cloud Serverless.
 - **Elasticsearch server URL:** The HTTP or HTTPS endpoint for your Elasticsearch instance, including the port (default: `9200`).
 - **Authentication credentials:** Depending on your Elasticsearch security configuration, you need one of the following:
   - Username and password for basic authentication

--- a/docs/sources/datasources/elasticsearch/troubleshooting/index.md
+++ b/docs/sources/datasources/elasticsearch/troubleshooting/index.md
@@ -206,7 +206,7 @@ The following errors occur when there are Elasticsearch version compatibility is
 
 **Solution:**
 
-1. Upgrade Elasticsearch to a supported version (7.17+, 8.x, or 9.x).
+1. Upgrade Elasticsearch to a supported version (8.x or 9.x).
 1. Refer to [Elastic Product End of Life Dates](https://www.elastic.co/support/eol) for version support information.
 1. Note that queries may still work, but Grafana does not guarantee functionality for unsupported versions.
 

--- a/docs/sources/datasources/elasticsearch/troubleshooting/index.md
+++ b/docs/sources/datasources/elasticsearch/troubleshooting/index.md
@@ -208,7 +208,7 @@ The following errors occur when there are Elasticsearch version compatibility is
 
 **Solution:**
 
-1. Upgrade Elasticsearch to a supported version (7.17+, 8.x, or 9.x).
+1. Upgrade Elasticsearch to a supported version (8.x or 9.x).
 1. Refer to [Elastic Product End of Life Dates](https://www.elastic.co/support/eol) for version support information.
 1. Note that queries may still work, but Grafana does not guarantee functionality for unsupported versions.
 


### PR DESCRIPTION
## What

Removes Elasticsearch 7.x from the supported-versions statements in the Elasticsearch data source docs (`_index.md`, `configure/index.md`, `troubleshooting/index.md`). Supported versions are now 8.x, 9.x, and Elastic Cloud Serverless.

## Why

Elasticsearch 7.x is past its [end of life](https://www.elastic.co/support/eol). The plugin drops 7.x support in grafana/grafana-elasticsearch-datasource#362 (breaking change, major version bump): the query editor warns for versions below 8.0 and the `moving_avg` aggregation is removed. This docs change should land alongside that plugin release.

Companion plugin PR: https://github.com/grafana/grafana-elasticsearch-datasource/pull/362