### PR TITLE
IAM: Return an empty array instead of null from the display endpoint

### DIFF
--- a/pkg/registry/apis/iam/display/handler.go
+++ b/pkg/registry/apis/iam/display/handler.go
@@ -154,6 +154,12 @@ func (r *DisplayHandler) handleDisplay(w http.ResponseWriter, req *http.Request)
 		pending = unresolvedKeys(keys, rsp.Items, rsp.InvalidKeys)
 	}
 
+	// Display must serialize as an empty array ([]) rather than null when no
+	// identities resolve, so clients can always iterate over it. (#128232)
+	if rsp.Items == nil {
+		rsp.Items = []iam.Display{}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(rsp)
 }

--- a/pkg/registry/apis/iam/display/handler_test.go
+++ b/pkg/registry/apis/iam/display/handler_test.go
@@ -1,0 +1,48 @@
+package display
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	iam "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+)
+
+type stubResolver struct {
+	result *iam.DisplayList
+}
+
+func (s stubResolver) GetDisplayList(_ context.Context, _ authlib.NamespaceInfo, _ []string) (*iam.DisplayList, error) {
+	return s.result, nil
+}
+
+func TestHandleDisplay_emptyResultSerializesAsArray(t *testing.T) {
+	// Regression test for #128232: when no identity resolves, the "display"
+	// field must serialize as an empty array ([]) rather than null, so clients
+	// can always iterate over it.
+	handler := NewDisplayHandler(stubResolver{
+		result: &iam.DisplayList{Keys: []string{"access-policy:provisioning"}},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/display?key=access-policy:provisioning", nil)
+	req = req.WithContext(identity.WithRequester(req.Context(), &identity.StaticRequester{
+		Type:      authlib.TypeUser,
+		UserUID:   "u1",
+		Namespace: "default",
+	}))
+	rec := httptest.NewRecorder()
+
+	handler.handleDisplay(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	require.JSONEq(t, "[]", string(raw["display"]))
+}


### PR DESCRIPTION
**What this PR does / why we need it**

The IAM display endpoint assembles its response with a nil `Items` slice (`DisplayList.display`). Because that field has no `omitempty` and the slice is only ever grown via `append`, it serializes as `"display": null` whenever no identities resolve — e.g. when every requested key is a non-user identity type such as `access-policy:provisioning` (as happens for a Git Sync / provisioned dashboard whose version history was authored only by the provisioning identity).

Clients that iterate over `display` then fail on the null value. The reported symptom (#128232) is the dashboard **Settings → Versions** tab throwing `Uncaught TypeError: displayData.display is not iterable` and rendering the full-page error boundary.

This normalizes `Items` to an empty non-nil slice before encoding, so `display` always serializes as `[]` (iterable) — resolving the crash at the source for every client, not just the one call site.

**Which issue(s) this PR fixes**

Fixes #128232

**Special notes for your reviewer**

- Added `handler_test.go` with a regression test: an all-unresolvable key set now yields `"display": []`. It fails before the change (`null`) and passes after.
- `go test ./pkg/registry/apis/iam/display/...`, `go vet`, and `gofmt` are clean.
- The frontend guard mentioned in the issue (`VersionsEditView.tsx`) is a reasonable complementary defensive measure, but this backend change alone fixes the crash. Happy to follow up on the frontend guard separately if you'd like.
