### PR TITLE
Team folders: Test multiple team ownerReferences persist on a folder

### DIFF
--- a/pkg/tests/apis/provisioning/folderownerrefs_test.go
+++ b/pkg/tests/apis/provisioning/folderownerrefs_test.go
@@ -24,6 +24,22 @@ var ownerRefsPatch = []byte(`[{
 	}]
 }]`)
 
+var multiOwnerRefsPatch = []byte(`[{
+	"op": "add",
+	"path": "/metadata/ownerReferences",
+	"value": [{
+		"apiVersion": "iam.grafana.app/v0alpha1",
+		"kind": "Team",
+		"name": "test-team",
+		"uid": "00000000-0000-0000-0000-000000000001"
+	}, {
+		"apiVersion": "iam.grafana.app/v0alpha1",
+		"kind": "Team",
+		"name": "test-team-2",
+		"uid": "00000000-0000-0000-0000-000000000002"
+	}]
+}]`)
+
 func TestIntegrationFolderOwnerRefs_ProvisionedFolders(t *testing.T) {
 	helper := sharedHelper(t)
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -132,5 +148,36 @@ func TestIntegrationFolderOwnerRefs_UnprovisionedFolders(t *testing.T) {
 		require.Len(t, updated.GetOwnerReferences(), 1, "ownerReferences should be persisted")
 		require.Equal(t, "Team", updated.GetOwnerReferences()[0].Kind)
 		require.Equal(t, "test-team", updated.GetOwnerReferences()[0].Name)
+	})
+
+	t.Run("should set multiple team ownerReferences on unmanaged folder", func(t *testing.T) {
+		unmanagedFolder := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"metadata": map[string]interface{}{
+					"generateName": "test-folder-",
+				},
+				"spec": map[string]interface{}{
+					"title": "Multi-owner Folder",
+				},
+			},
+		}
+		createdFolder, err := helper.Folders.Resource.Create(t.Context(), unmanagedFolder, metav1.CreateOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, createdFolder)
+
+		_, err = helper.Folders.Resource.Patch(t.Context(), createdFolder.GetName(), types.JSONPatchType, multiOwnerRefsPatch, metav1.PatchOptions{})
+		require.NoError(t, err, "should set multiple ownerReferences on unmanaged folder")
+
+		updated, err := helper.Folders.Resource.Get(t.Context(), createdFolder.GetName(), metav1.GetOptions{})
+		require.NoError(t, err)
+		ownerRefs := updated.GetOwnerReferences()
+		require.Len(t, ownerRefs, 2, "all ownerReferences should be persisted")
+		for _, ref := range ownerRefs {
+			require.Equal(t, "Team", ref.Kind)
+		}
+		names := []string{ownerRefs[0].Name, ownerRefs[1].Name}
+		require.ElementsMatch(t, []string{"test-team", "test-team-2"}, names)
 	})
 }


### PR DESCRIPTION
## What this PR does

Adds a backend integration test asserting that a folder can carry **multiple team `ownerReferences`** (the association behind team folders) and that they persist and round-trip on an unmanaged folder. Repo-managed folders still reject owner-reference changes.

This is the **backend counterpart** to the frontend PR that lifts the single-team-owner cap in the UI (#128248). There are no production backend changes — the folder apiserver already supports a list of `ownerReferences`; this locks that behavior in with a test.

Split from #128248 to satisfy `check-separation` (frontend and backend deploy at different cadences).

## Testing

`TestIntegrationFolderOwnerRefs_*` — 5/5 pass locally (including the new `should set multiple team ownerReferences on unmanaged folder`).