### PR TITLE
Explore: Fix graph series past the first 19 being permanently hidden when a query returns more than 20 series

### DIFF
--- a/public/app/features/explore/Table/TableContainer.test.tsx
+++ b/public/app/features/explore/Table/TableContainer.test.tsx
@@ -1,11 +1,24 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { type DataFrame, FieldType, getDefaultTimeRange, InternalTimeZones, toDataFrame } from '@grafana/data';
+import { setPanelRenderer } from '@grafana/runtime/internal';
 
 import { TableContainer } from './TableContainer';
 
+const mockRenderedSeries: DataFrame[][] = [];
+
+setPanelRenderer((props) => {
+  mockRenderedSeries.push(props.data?.series ?? []);
+  return <div>PanelRenderer</div>;
+});
+
 function getPanels(): HTMLElement[] {
   return screen.getAllByText(/PanelRenderer/);
+}
+
+function getLastRenderedFrame(): DataFrame {
+  return mockRenderedSeries[mockRenderedSeries.length - 1][0];
 }
 
 const dataFrame = toDataFrame({
@@ -47,6 +60,10 @@ const defaultProps = {
 };
 
 describe('TableContainer', () => {
+  beforeEach(() => {
+    mockRenderedSeries.length = 0;
+  });
+
   describe('With one main frame', () => {
     it('should render component', () => {
       render(<TableContainer {...defaultProps} />);
@@ -99,8 +116,61 @@ describe('TableContainer', () => {
       });
 
       render(<TableContainer {...defaultProps} tableResult={[df]} />);
-      expect(df.fields[0].config.custom?.hideFrom?.viz).toBe(true);
-      expect(df.fields[1].config.custom?.hideFrom?.viz).toBe(false);
+
+      const rendered = getLastRenderedFrame();
+      expect(rendered.fields[0].config.custom?.hideFrom?.viz).toBe(true);
+      expect(rendered.fields[1].config.custom?.hideFrom?.viz).toBe(false);
+    });
+
+    it('does not mutate the frames from state when limiting columns', () => {
+      const df = toDataFrame({
+        name: 'A',
+        fields: Array.from({ length: 25 }, (_, i) => ({
+          name: `field${i}`,
+          type: FieldType.number,
+          values: [i],
+          config: {},
+        })),
+      });
+      const configsBefore = df.fields.map((field) => field.config);
+
+      render(<TableContainer {...defaultProps} tableResult={[df]} />);
+
+      // limiting is applied to the rendered copy...
+      const rendered = getLastRenderedFrame();
+      expect(rendered.fields[19].config.custom?.hideFrom?.viz).toBe(false);
+      expect(rendered.fields[20].config.custom?.hideFrom?.viz).toBe(true);
+      expect(rendered.fields[24].config.custom?.hideFrom?.viz).toBe(true);
+
+      // ...but the frame from state is untouched, as its field configs can be shared
+      // by reference with other visualizations (e.g. the Explore graph)
+      df.fields.forEach((field, i) => {
+        expect(field.config).toBe(configsBefore[i]);
+        expect(field.config.custom?.hideFrom).toBeUndefined();
+        expect(field.config.custom?.hidden).toBeUndefined();
+      });
+    });
+
+    it('shows all columns after clicking "Show all columns"', async () => {
+      const df = toDataFrame({
+        name: 'A',
+        fields: Array.from({ length: 25 }, (_, i) => ({
+          name: `field${i}`,
+          type: FieldType.number,
+          values: [i],
+          config: {},
+        })),
+      });
+
+      render(<TableContainer {...defaultProps} tableResult={[df]} />);
+      expect(getLastRenderedFrame().fields[24].config.custom?.hideFrom?.viz).toBe(true);
+
+      await userEvent.click(screen.getByText('Show all columns'));
+
+      const rendered = getLastRenderedFrame();
+      rendered.fields.forEach((field) => {
+        expect(field.config.custom?.hideFrom?.viz).toBe(false);
+      });
     });
   });
 

--- a/public/app/features/explore/Table/TableContainer.tsx
+++ b/public/app/features/explore/Table/TableContainer.tsx
@@ -111,8 +111,11 @@ export const TableContainer = memo(function TableContainer({
   let dataLimited = false;
 
   if (dataFrames?.length) {
-    dataFrames = dataFrames.map((frame) => {
-      frame.fields.forEach((field, index) => {
+    // Fields (and their configs) can be shared by reference with other Explore visualizations, e.g. the
+    // graph frames a joined table frame was built from, so hiding columns must not mutate them in place.
+    dataFrames = dataFrames.map((frame) => ({
+      ...frame,
+      fields: frame.fields.map((field, index) => {
         const custom = field.config.custom ?? {};
 
         const hiddenByColumnLimit = showAll ? false : index >= MAX_NUMBER_OF_COLUMNS;
@@ -121,17 +124,22 @@ export const TableContainer = memo(function TableContainer({
         const hiddenByDatasource = custom.hideFrom?.viz === true || custom.hidden === true;
         const hidden = hiddenByDatasource || hiddenByColumnLimit;
 
-        field.config.custom = {
-          ...custom,
-          hidden,
-          hideFrom: {
-            ...custom.hideFrom,
-            viz: hidden,
+        return {
+          ...field,
+          config: {
+            ...field.config,
+            custom: {
+              ...custom,
+              hidden,
+              hideFrom: {
+                ...custom.hideFrom,
+                viz: hidden,
+              },
+            },
           },
         };
-      });
-      return frame;
-    });
+      }),
+    }));
 
     dataFrames = applyFieldOverrides({
       data: dataFrames,
@@ -166,6 +174,7 @@ export const TableContainer = memo(function TableContainer({
               titleItems={[
                 !showAll && dataLimited && (
                   <LimitedDataDisclaimer
+                    key="disclaimer"
                     toggleShowAllSeries={() => setShowAll(true)}
                     info={
                       <Trans i18nKey={'table.container.show-only-series'}>


### PR DESCRIPTION
**What is this feature?**

Fixes a 13.0 regression where an Explore query returning more than 20 series would permanently hide series in the Graph panel, grey them out in the legend, and break both the graph's "Show all N" and the table's "Show all columns" buttons.

`TableContainer` applies the 20-column table limit by mutating `field.config.custom` in place on the frames held in Explore state. For metrics queries the table frame is built by the `joinByField` transformer, which reuses the graph frames' `field.config` objects by reference, so writing `hideFrom.viz = true` for columns past the limit also hides those series in the timeseries panel (series index 19 onwards, since the time column occupies the first slot). The written value is then read back as `hiddenByDatasource` on the next render, making the hidden state self-perpetuating.

This PR makes the column limiting derive new field objects with copied configs instead of mutating the frames from state, which fixes the graph contamination and the show-all feedback loop at once. It also adds a missing `key` on the disclaimer element in `titleItems`.

The mutation has existed since #98726 (12.0) but only wrote `custom.hidden`, which the graph ignores. #116601 (13.0) changed it to also write `custom.hideFrom.viz`, which the timeseries panel honours, turning it user-visible.

**Which issue(s) does this PR fix?**

Fixes #128255
