### PR TITLE
Dashboard: Fall back when collection deletion is unsupported

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1872,7 +1872,36 @@ func (dr *DashboardServiceImpl) saveDashboardThroughK8s(ctx context.Context, cmd
 }
 
 func (dr *DashboardServiceImpl) deleteAllDashboardThroughK8s(ctx context.Context, orgID int64) error {
-	return dr.k8sclient.DeleteCollection(ctx, orgID, v1.ListOptions{})
+	err := dr.k8sclient.DeleteCollection(ctx, orgID, v1.ListOptions{})
+	if err == nil || !apierrors.IsMethodNotSupported(err) {
+		return err
+	}
+
+	// Unified storage does not implement DeleteCollection. Fall back to
+	// forced individual deletes so organization deletion also removes provisioned dashboards.
+	zeroGracePeriod := int64(0)
+	deleteOptions := v1.DeleteOptions{GracePeriodSeconds: &zeroGracePeriod}
+	for continueToken := ""; ; {
+		list, err := dr.k8sclient.List(ctx, orgID, v1.ListOptions{
+			Limit:    listAllDashboardsLimit,
+			Continue: continueToken,
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, item := range list.Items {
+			err := dr.k8sclient.Delete(ctx, item.GetName(), orgID, deleteOptions)
+			if err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+
+		continueToken = list.GetContinue()
+		if continueToken == "" {
+			return nil
+		}
+	}
 }
 
 func (dr *DashboardServiceImpl) deleteDashboardThroughK8s(ctx context.Context, cmd *dashboards.DeleteDashboardCommand, validateProvisionedDashboard bool) error {

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -13,8 +14,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	dashboardv0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
@@ -967,16 +970,85 @@ func TestDeleteDashboard(t *testing.T) {
 }
 
 func TestDeleteAllDashboards(t *testing.T) {
-	service := &DashboardServiceImpl{
-		cfg: setting.NewCfg(),
-	}
+	t.Run("deletes the collection when supported", func(t *testing.T) {
+		service := &DashboardServiceImpl{cfg: setting.NewCfg()}
+		ctx, k8sCliMock := setupK8sDashboardTests(service)
+		k8sCliMock.On("DeleteCollection", mock.Anything, int64(1), metav1.ListOptions{}).Return(nil).Once()
 
-	ctx, k8sCliMock := setupK8sDashboardTests(service)
-	k8sCliMock.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		err := service.DeleteAllDashboards(ctx, 1)
 
-	err := service.DeleteAllDashboards(ctx, 1)
-	require.NoError(t, err)
-	k8sCliMock.AssertExpectations(t)
+		require.NoError(t, err)
+		k8sCliMock.AssertExpectations(t)
+	})
+
+	t.Run("falls back to individual deletes when collection deletion is unsupported", func(t *testing.T) {
+		service := &DashboardServiceImpl{cfg: setting.NewCfg()}
+		ctx, k8sCliMock := setupK8sDashboardTests(service)
+		methodNotSupported := apierrors.NewMethodNotSupported(
+			schema.GroupResource{Resource: "dashboards"},
+			"deletecollection",
+		)
+		k8sCliMock.On("DeleteCollection", mock.Anything, int64(1), metav1.ListOptions{}).Return(methodNotSupported).Once()
+		k8sCliMock.On("List", mock.Anything, int64(1), mock.MatchedBy(func(opts metav1.ListOptions) bool {
+			return opts.Limit == listAllDashboardsLimit && opts.Continue == ""
+		})).Return(&unstructured.UnstructuredList{
+			Object: map[string]any{
+				"metadata": map[string]any{"continue": "next-page"},
+			},
+			Items: []unstructured.Unstructured{
+				{Object: map[string]any{"metadata": map[string]any{"name": "dashboard-1"}}},
+			},
+		}, nil).Once()
+		forceDelete := mock.MatchedBy(func(opts metav1.DeleteOptions) bool {
+			return opts.GracePeriodSeconds != nil && *opts.GracePeriodSeconds == 0
+		})
+		k8sCliMock.On("Delete", mock.Anything, "dashboard-1", int64(1), forceDelete).Return(nil).Once()
+		k8sCliMock.On("List", mock.Anything, int64(1), mock.MatchedBy(func(opts metav1.ListOptions) bool {
+			return opts.Limit == listAllDashboardsLimit && opts.Continue == "next-page"
+		})).Return(&unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{
+				{Object: map[string]any{"metadata": map[string]any{"name": "dashboard-2"}}},
+			},
+		}, nil).Once()
+		notFound := apierrors.NewNotFound(schema.GroupResource{Resource: "dashboards"}, "dashboard-2")
+		k8sCliMock.On("Delete", mock.Anything, "dashboard-2", int64(1), forceDelete).Return(notFound).Once()
+
+		err := service.DeleteAllDashboards(ctx, 1)
+
+		require.NoError(t, err)
+		k8sCliMock.AssertExpectations(t)
+	})
+
+	t.Run("deletes an empty organization when collection deletion is unsupported", func(t *testing.T) {
+		service := &DashboardServiceImpl{cfg: setting.NewCfg()}
+		ctx, k8sCliMock := setupK8sDashboardTests(service)
+		methodNotSupported := apierrors.NewMethodNotSupported(
+			schema.GroupResource{Resource: "dashboards"},
+			"deletecollection",
+		)
+		k8sCliMock.On("DeleteCollection", mock.Anything, int64(1), metav1.ListOptions{}).Return(methodNotSupported).Once()
+		k8sCliMock.On("List", mock.Anything, int64(1), mock.MatchedBy(func(opts metav1.ListOptions) bool {
+			return opts.Limit == listAllDashboardsLimit && opts.Continue == ""
+		})).Return(&unstructured.UnstructuredList{}, nil).Once()
+
+		err := service.DeleteAllDashboards(ctx, 1)
+
+		require.NoError(t, err)
+		k8sCliMock.AssertNotCalled(t, "Delete")
+		k8sCliMock.AssertExpectations(t)
+	})
+
+	t.Run("returns errors other than method not supported", func(t *testing.T) {
+		service := &DashboardServiceImpl{cfg: setting.NewCfg()}
+		ctx, k8sCliMock := setupK8sDashboardTests(service)
+		expectedErr := apierrors.NewInternalError(errors.New("storage failure"))
+		k8sCliMock.On("DeleteCollection", mock.Anything, int64(1), metav1.ListOptions{}).Return(expectedErr).Once()
+
+		err := service.DeleteAllDashboards(ctx, 1)
+
+		require.ErrorIs(t, err, expectedErr)
+		k8sCliMock.AssertExpectations(t)
+	})
 }
 
 func TestSearchDashboards(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Falls back to listing and individually deleting dashboards when the dashboard Kubernetes API returns `405 Method Not Allowed` for `DeleteCollection` during organization deletion.

The fallback:

- follows pagination until every dashboard is removed;
- force-deletes each dashboard with `gracePeriodSeconds: 0`, including file-provisioned dashboards;
- tolerates a dashboard disappearing between list and delete;
- preserves errors other than the unsupported collection verb.

**Why do we need this feature?**

The dashboard resource does not currently support the `deletecollection` verb. As a result, deleting any organization returns HTTP 500, including an empty organization.

**Who is this feature for?**

Grafana server administrators who manage multiple organizations through the UI or Admin API.

**Which issue(s) does this PR fix?**:

Fixes #127386

**Special notes for your reviewer:**

This is a focused alternative to #127404. It keeps the change in the dashboard service and explicitly force-deletes dashboards in the fallback, matching the existing SQL deletion semantics for provisioned dashboards.

Tests cover collection deletion support, paginated fallback, an empty organization, a concurrent `NotFound`, force-delete options, and propagation of non-405 errors.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (Not applicable.)
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. (Bug fix; no user-facing docs change.)
