### PR TITLE
Alerting: Return an empty contact point list for new organizations

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -116,6 +116,9 @@ func (ecp *ContactPointService) GetContactPoints(ctx context.Context, q ContactP
 	}
 
 	res, err := ecp.receiverService.GetReceivers(ctx, receiverQuery, u)
+	if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {
+		return []apimodels.EmbeddedContactPoint{}, nil
+	}
 	if err != nil {
 		return nil, convertRecSvcErr(err)
 	}

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -35,6 +35,7 @@ import (
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/routes"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
+	ngalertstore "github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/secrets/database"
@@ -82,6 +83,20 @@ func TestIntegrationContactPointService(t *testing.T) {
 		require.Len(t, cps, 2)
 		require.Equal(t, "grafana-default-email", cps[0].Name)
 		require.Equal(t, "slack receiver", cps[1].Name)
+	})
+
+	t.Run("service returns an empty list when the org has no AM config", func(t *testing.T) {
+		configStore := fakes.NewFakeAlertmanagerConfigStore("")
+		configStore.GetFn = func(_ context.Context, _ int64) (*models.AlertConfiguration, error) {
+			return nil, ngalertstore.ErrNoAlertmanagerConfiguration
+		}
+		sut := createContactPointServiceSutWithConfigStore(t, secretsService, configStore)
+
+		cps, err := sut.GetContactPoints(context.Background(), cpsQuery(1), redactedUser)
+
+		require.NoError(t, err)
+		require.NotNil(t, cps)
+		require.Empty(t, cps)
 	})
 
 	t.Run("service filters contact points by name", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Returns a non-nil empty contact point list when an organization does not have an Alertmanager configuration yet.

**Why do we need this feature?**

A new organization has no Alertmanager configuration. The contact-point provisioning GET endpoint currently propagates that state as `alerting.notification.configMissing` and returns HTTP 500. This also blocks reconcilers that list contact points before creating the first one.

**Who is this feature for?**

Grafana administrators and provisioning clients that initialize alerting resources in newly created organizations.

**Which issue(s) does this PR fix?**:

Fixes #128258

**Special notes for your reviewer:**

The test asserts that the returned slice is non-nil, so the API serializes the valid empty state as `[]` instead of `null`.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (Not applicable.)
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. (Bug fix; no user-facing docs change.)
