### PR TITLE
fix(pyroscope): use regex formatting for label selector variables

### DIFF
--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.test.ts
@@ -78,6 +78,16 @@ describe('Pyroscope data source', () => {
       );
       expect(query).toMatchObject({ labelSelector: `{interpolated="interpolated"}`, profileTypeId: 'interpolated' });
     });
+
+    it('should request regex format for labelSelector so multi-value variables produce valid alternation', () => {
+      const templateSrv = {
+        replace: (query: string, _scopedVars: unknown, format?: string): string =>
+          format === 'regex' ? query.replace(/\$pod/g, '(pod-1|pod-2)') : query,
+      } as unknown as TemplateSrv;
+      const ds = new PyroscopeDataSource(defaultSettings, templateSrv);
+      const result = ds.applyTemplateVariables(defaultQuery({ labelSelector: '{pod=~"$pod"}', profileTypeId: '' }), {});
+      expect(result.labelSelector).toBe('{pod=~"(pod-1|pod-2)"}');
+    });
   });
 
   it('implements ad hoc variable support for keys', async () => {

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
@@ -107,7 +107,7 @@ export class PyroscopeDataSource extends DataSourceWithBackend<Query, PyroscopeD
   }
 
   applyTemplateVariables(query: Query, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): Query {
-    let labelSelector = this.templateSrv.replace(query.labelSelector ?? '', scopedVars);
+    let labelSelector = this.templateSrv.replace(query.labelSelector ?? '', scopedVars, 'regex');
     if (filters && labelSelector) {
       for (const filter of filters) {
         labelSelector = addLabelToQuery(labelSelector, filter.key, filter.value, filter.operator);


### PR DESCRIPTION
## Summary

When template variables expand inside a Pyroscope label selector, multi-value variables are currently interpolated using the default formatter, producing invalid regex expressions.

This changes the interpolation to use Grafana`s canonical `regex` formatter, matching existing behavior used elsewhere in Grafana.

Fixes #68092.

## Changes

- use TemplateSrv.replace(..., scopedVars, 'regex')
- add regression test covering multi-value variable interpolation

## Validation

- formatter
- plugin tests
- all existing tests pass

## Notes

This follows the same interpolation convention already used by other Grafana components and uses the built-in regex formatter, which already performs regex escaping.