### PR TITLE
Table: Respect column filters when exporting CSV via Inspect

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/panel-inspector/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-inspector/index.md
@@ -13,6 +13,12 @@ labels:
 title: The panel inspect view
 description: Inspect the raw data of your panels to understand and troubleshoot them
 weight: 30
+refs:
+  table-column-filtering:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/table/#column-filtering
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/table/#column-filtering
 ---
 
 # The panel inspect view
@@ -38,6 +44,10 @@ The panel inspector consists of the following options:
 ## Download raw query results
 
 Grafana generates a CSV file that contains your data, including any transformations to that data. You can choose to view the data before or after the panel applies field options or field option overrides.
+
+{{< admonition type="note" >}}
+For table visualizations, if a [column filter](ref:table-column-filtering) is applied, the downloaded CSV file only includes the filtered rows.
+{{< /admonition >}}
 
 1. Edit the panel that contains the query data you want to download.
 1. In the query editor, click **Query Inspector**.

--- a/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
@@ -65,6 +65,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/time-series/#graph-styles-options
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/time-series/#graph-styles-options
+  panel-inspector:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/panel-inspector/#download-raw-query-results
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/panels-visualizations/panel-inspector/#download-raw-query-results
 ---
 
 # Table
@@ -133,6 +138,10 @@ If you need to hide columns, you can do so using [data transformations](ref:data
 
 You can temporarily change how column data is displayed using column filtering.
 For example, you can show or hide specific values.
+
+{{< admonition type="note" >}}
+When you [download the panel's data as a CSV file](ref:panel-inspector), the file only includes the rows that match your current column filters.
+{{< /admonition >}}
 
 ### Turn on column filtering
 

--- a/packages/grafana-ui/src/components/Table/TableNG/legacy/LegacyTableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/legacy/LegacyTableNG.tsx
@@ -138,6 +138,7 @@ export function LegacyTableNG(props: TableNGProps) {
     noValue,
     onCellFilterAdded,
     onColumnResize,
+    onFilteredRowsChange,
     onSortByChange,
     protoParserEnabled,
     showTypeIcons,
@@ -239,6 +240,19 @@ export function LegacyTableNG(props: TableNGProps) {
   } = useSortedRows(filteredRows, data.fields, nestedFields, { hasNestedFrames, initialSortBy: sortBy });
 
   useManagedSort({ sortByBehavior, setSortColumns, sortBy });
+
+  // Consumers (e.g. PanelContext.onInstanceStateChange) may hand back an unstable callback identity on every
+  // call, so this is read through a ref rather than being a dependency - otherwise the effect below could
+  // retrigger itself indefinitely without sortedRows ever actually changing.
+  const onFilteredRowsChangeRef = useRef(onFilteredRowsChange);
+  onFilteredRowsChangeRef.current = onFilteredRowsChange;
+
+  // sortedRows reflects the currently filtered/sorted set of top-level rows (pre-pagination), so this fires
+  // whenever a column filter or sort changes which rows are shown, not just when the underlying data changes.
+  // Nested child rows (__depth > 0) are excluded since CSV export only operates on the top-level DataFrame.
+  useEffect(() => {
+    onFilteredRowsChangeRef.current?.(sortedRows.filter((row) => row.__depth === 0).map((row) => row.__index));
+  }, [sortedRows]);
 
   const nestedRows = useNestedRows(
     rows,

--- a/packages/grafana-ui/src/components/Table/TableNG/refactored/TableFlat.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/refactored/TableFlat.tsx
@@ -1,5 +1,5 @@
 import memoize from 'micro-memoize';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { type Field } from '@grafana/data';
 import { type DataGridHandle, type DataGridProps } from '@grafana/react-data-grid';
@@ -68,6 +68,7 @@ export function TableFlat(props: TableNGProps) {
     noValue,
     onCellFilterAdded,
     onColumnResize,
+    onFilteredRowsChange,
     onSortByChange,
     protoParserEnabled,
     showTypeIcons,
@@ -121,6 +122,18 @@ export function TableFlat(props: TableNGProps) {
   } = useSortedRows(filteredRows, data.fields, [], { initialSortBy: sortBy });
 
   useManagedSort({ sortByBehavior, setSortColumns, sortBy });
+
+  // Consumers (e.g. PanelContext.onInstanceStateChange) may hand back an unstable callback identity on every
+  // call, so this is read through a ref rather than being a dependency - otherwise the effect below could
+  // retrigger itself indefinitely without sortedRows ever actually changing.
+  const onFilteredRowsChangeRef = useRef(onFilteredRowsChange);
+  onFilteredRowsChangeRef.current = onFilteredRowsChange;
+
+  // sortedRows reflects the currently filtered/sorted set of rows (pre-pagination), so this fires whenever a
+  // column filter or sort changes which rows are shown, not just when the underlying data changes.
+  useEffect(() => {
+    onFilteredRowsChangeRef.current?.(sortedRows.map((row) => row.__index));
+  }, [sortedRows]);
 
   const [inspectCell, setInspectCell] = useState<InspectCellProps | null>(null);
   const [tooltipState, setTooltipState] = useState<DataLinksActionsTooltipState>();

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -30,6 +30,9 @@ export type AdHocFilterItem = { key: string; value: string; operator: AdHocFilte
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
 type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number, fieldScope?: MatcherScope) => void;
 type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;
+/** Called whenever the set of top-level rows shown by the table changes, e.g. due to a column filter or sort
+ * being applied. `rowIndexes` are indexes into the original `DataFrame` passed to the table, in display order. */
+export type TableFilteredRowsChangeCallback = (rowIndexes: number[]) => void;
 type FooterItem = Array<KeyValue<string>> | string | undefined;
 
 type GetActionsFunction = (frame: DataFrame, field: Field, rowIndex: number) => ActionModel[];
@@ -123,6 +126,7 @@ interface BaseTableProps {
   onColumnResize?: TableColumnResizeActionCallback;
   onSortByChange?: TableSortByActionCallback;
   onCellFilterAdded?: TableFilterActionCallback;
+  onFilteredRowsChange?: TableFilteredRowsChangeCallback;
   footerValues?: FooterItem[];
   frozenColumns?: number;
   enablePagination?: boolean;

--- a/packages/grafana-ui/src/components/Table/TableRT/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/Table.tsx
@@ -53,6 +53,7 @@ export const Table = memo((props: Props) => {
     height,
     onCellFilterAdded,
     onColumnResize,
+    onFilteredRowsChange,
     width,
     columnMinWidth = COLUMN_MIN_WIDTH,
     noHeader,
@@ -204,6 +205,12 @@ export const Table = memo((props: Props) => {
 
   const extendedState = state as GrafanaTableState;
   toggleAllRowsExpandedRef.current = toggleAllRowsExpanded;
+
+  // rows reflects the currently filtered/sorted set of rows (pre-pagination), so this fires whenever a
+  // column filter or sort changes which rows are shown, not just when the underlying data changes.
+  useEffect(() => {
+    onFilteredRowsChange?.(rows.map((row) => row.index));
+  }, [rows, onFilteredRowsChange]);
 
   /*
     Footer value calculation is being moved in the Table component and the footerValues prop will be deprecated.

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -42,6 +42,9 @@ export type TableColumnResizeActionCallback = (
 ) => void;
 type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;
 export type TableInspectCellCallback = (state: InspectCell) => void;
+/** Called whenever the set of rows shown by the table changes, e.g. due to a column filter or sort being applied.
+ * `rowIndexes` are indexes into the original `DataFrame` passed to the table, in the order they are displayed. */
+export type TableFilteredRowsChangeCallback = (rowIndexes: number[]) => void;
 
 export interface TableSortByFieldState {
   displayName: string;
@@ -110,6 +113,7 @@ export interface TableRTProps {
   onColumnResize?: TableColumnResizeActionCallback;
   onSortByChange?: TableSortByActionCallback;
   onCellFilterAdded?: TableFilterActionCallback;
+  onFilteredRowsChange?: TableFilteredRowsChangeCallback;
   footerOptions?: TableFooterCalc;
   footerValues?: FooterItem[];
   enablePagination?: boolean;

--- a/public/app/features/dashboard-scene/inspect/InspectDataTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectDataTab.tsx
@@ -12,6 +12,7 @@ import {
 } from '@grafana/scenes';
 import { InspectTab } from 'app/features/inspector/types';
 import { type GetDataOptions } from 'app/features/query/state/PanelQueryRunner';
+import { type TablePanelInstanceState } from 'app/plugins/panel/table/TablePanel';
 
 import { InspectDataTab as InspectDataTabOld } from '../../inspector/InspectDataTab';
 
@@ -46,6 +47,7 @@ export class InspectDataTab extends SceneObjectBase<InspectDataTabState> {
   static Component = ({ model }: SceneComponentProps<InspectDataTab>) => {
     const { options } = model.useState();
     const panel = model.state.panelRef.resolve();
+    const { _pluginInstanceState } = panel.useState();
     const dataProvider = sceneGraph.getData(panel);
     const { data } = getDataProviderToSubscribeTo(dataProvider, options.withTransforms).useState();
     const timeRange = sceneGraph.getTimeRange(panel);
@@ -55,6 +57,11 @@ export class InspectDataTab extends SceneObjectBase<InspectDataTabState> {
         <Trans i18nKey="dashboard-scene.inspect-data-tab.no-data-found">No data found</Trans>
       </div>;
     }
+
+    // Only the built-in table panel populates instanceState with this shape; other panel types may use
+    // instanceState for unrelated purposes (see e.g. CanvasPanel), so this must stay gated on pluginId.
+    const tableInstanceState: TablePanelInstanceState | undefined =
+      panel.state.pluginId === 'table' ? _pluginInstanceState : undefined;
 
     return (
       <InspectDataTabOld
@@ -67,6 +74,8 @@ export class InspectDataTab extends SceneObjectBase<InspectDataTabState> {
         dataName={sceneGraph.interpolate(panel, panel.state.title)}
         fieldConfig={panel.state.fieldConfig}
         onOptionsChange={model.onOptionsChange}
+        panelFilteredRowIndexes={tableInstanceState?.filteredRowIndexes}
+        panelFilteredRowIndexesFrameIndex={tableInstanceState?.frameIndex}
       />
     );
   };

--- a/public/app/features/inspector/InspectDataTab.test.tsx
+++ b/public/app/features/inspector/InspectDataTab.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import saveAs from 'file-saver';
 import { type ComponentProps } from 'react';
 import { type Props } from 'react-virtualized-auto-sizer';
 
@@ -18,6 +19,8 @@ jest.mock('react-virtualized-auto-sizer', () => {
       width: 1,
     });
 });
+
+jest.mock('file-saver', () => jest.fn());
 
 const createProps = (propsOverride?: Partial<ComponentProps<typeof InspectDataTab>>) => {
   const defaultProps = {
@@ -213,6 +216,62 @@ describe('InspectDataTab', () => {
         />
       );
       expect(screen.getByText(/Download service graph/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('when a panel-driven column filter is present (dashboard table panel)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should export only the panel-filtered rows as CSV', async () => {
+      render(
+        <InspectDataTab
+          {...createProps({
+            panelFilteredRowIndexes: [2, 0],
+            panelFilteredRowIndexesFrameIndex: 0,
+          })}
+        />
+      );
+
+      await userEvent.click(screen.getByText(/Download CSV/i));
+
+      const call = jest.mocked(saveAs).mock.calls[0];
+      const blob = call[0];
+      const text = typeof blob === 'string' ? blob : await blob.text();
+
+      expect(text).toEqual('"time","name","value"\r\n300,c,3\r\n100,uniqueA,1');
+    });
+
+    it('should ignore the panel filter when it refers to a different frame than the one being exported', async () => {
+      render(
+        <InspectDataTab
+          {...createProps({
+            panelFilteredRowIndexes: [2, 0],
+            panelFilteredRowIndexesFrameIndex: 1, // exported frame (dataFrameIndex) defaults to 0
+          })}
+        />
+      );
+
+      await userEvent.click(screen.getByText(/Download CSV/i));
+
+      const call = jest.mocked(saveAs).mock.calls[0];
+      const blob = call[0];
+      const text = typeof blob === 'string' ? blob : await blob.text();
+
+      expect(text).toEqual('"time","name","value"\r\n100,uniqueA,1\r\n200,b,2\r\n300,c,3');
+    });
+
+    it('should not apply the panel filter when no panel filter is provided', async () => {
+      render(<InspectDataTab {...createProps()} />);
+
+      await userEvent.click(screen.getByText(/Download CSV/i));
+
+      const call = jest.mocked(saveAs).mock.calls[0];
+      const blob = call[0];
+      const text = typeof blob === 'string' ? blob : await blob.text();
+
+      expect(text).toEqual('"time","name","value"\r\n100,uniqueA,1\r\n200,b,2\r\n300,c,3');
     });
   });
 });

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -24,6 +24,7 @@ import { dataFrameToLogsModel } from '../logs/logsModel';
 import { InspectDataOptions } from './InspectDataOptions';
 import { getPanelInspectorStyles } from './styles';
 import { downloadAsJson, downloadDataFrameAsCsv, downloadLogsModelAsTxt, downloadTraceAsJson } from './utils/download';
+import { filterDataFrameByRowIndexes } from './utils/utils';
 
 interface Props {
   isLoading: boolean;
@@ -38,6 +39,11 @@ interface Props {
   hasTransformations?: boolean;
   formattedDataDescription?: string;
   onOptionsChange?: (options: GetDataOptions) => void;
+  /** Row indexes reflecting the column filter/sort currently applied on the panel's own visualization (not this
+   * tab's preview table), when the panel type supports reporting it (e.g. the table panel). Indexes are only
+   * meaningful for the frame at `panelFilteredRowIndexesFrameIndex`. */
+  panelFilteredRowIndexes?: number[];
+  panelFilteredRowIndexesFrameIndex?: number;
 }
 
 interface State {
@@ -51,6 +57,11 @@ interface State {
 }
 
 export class InspectDataTab extends PureComponent<Props, State> {
+  /** Row indexes into the currently previewed DataFrame, reflecting any column filter/sort applied in the preview
+   * table. Kept as an instance field rather than state since it updates on every keystroke in a filter popup and
+   * shouldn't trigger a re-render of this component. */
+  filteredRowIndexes?: number[];
+
   constructor(props: Props) {
     super(props);
 
@@ -96,10 +107,34 @@ export class InspectDataTab extends PureComponent<Props, State> {
     }
   }
 
+  /**
+   * Applies the panel's own live column filter (if any) to `dataFrame`, so the preview table - and CSV export
+   * derived from it - reflects the same rows the user filtered down to on the dashboard panel itself. It's only
+   * valid when it corresponds to the exact frame passed in and no transform has reshaped the data (which can
+   * add/remove/reorder rows).
+   */
+  getPanelFilteredFrame(dataFrame: DataFrame): DataFrame {
+    const { panelFilteredRowIndexes, panelFilteredRowIndexesFrameIndex } = this.props;
+    const { transformId, dataFrameIndex } = this.state;
+
+    const panelFilterApplies =
+      panelFilteredRowIndexes !== undefined &&
+      transformId === DataTransformerID.noop &&
+      panelFilteredRowIndexesFrameIndex === dataFrameIndex;
+
+    return panelFilterApplies ? filterDataFrameByRowIndexes(dataFrame, panelFilteredRowIndexes) : dataFrame;
+  }
+
   exportCsv(dataFrames: DataFrame[], hasLogs: boolean) {
     const { dataName } = this.props;
-    const { transformId } = this.state;
-    const dataFrame = dataFrames[this.state.dataFrameIndex];
+    const { transformId, dataFrameIndex } = this.state;
+
+    // this.filteredRowIndexes are indexes into whatever frame the preview table was actually showing, i.e.
+    // the panel-filtered frame below - applying it on top keeps both layers of filtering consistent.
+    const dataFrame = filterDataFrameByRowIndexes(
+      this.getPanelFilteredFrame(dataFrames[dataFrameIndex]),
+      this.filteredRowIndexes
+    );
 
     if (hasLogs) {
       reportInteraction('grafana_logs_download_clicked', { app: this.props.app, format: 'csv' });
@@ -162,6 +197,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
   };
 
   onDataFrameChange = (item: SelectableValue<DataTransformerID | number>) => {
+    this.filteredRowIndexes = undefined;
     this.setState({
       transformId:
         item.value === DataTransformerID.joinByField ? DataTransformerID.joinByField : DataTransformerID.noop,
@@ -174,6 +210,10 @@ export class InspectDataTab extends PureComponent<Props, State> {
     this.setState((prevState) => ({
       excelCompatibilityMode: !prevState.excelCompatibilityMode,
     }));
+  };
+
+  onFilteredRowsChange = (rowIndexes: number[]) => {
+    this.filteredRowIndexes = rowIndexes;
   };
 
   getProcessedData(): DataFrame[] {
@@ -300,7 +340,15 @@ export class InspectDataTab extends PureComponent<Props, State> {
                 return null;
               }
 
-              return <Table width={width} height={height} data={dataFrame} showTypeIcons={true} />;
+              return (
+                <Table
+                  width={width}
+                  height={height}
+                  data={this.getPanelFilteredFrame(dataFrame)}
+                  showTypeIcons={true}
+                  onFilteredRowsChange={this.onFilteredRowsChange}
+                />
+              );
             }}
           </AutoSizer>
         </div>

--- a/public/app/features/inspector/utils/utils.test.ts
+++ b/public/app/features/inspector/utils/utils.test.ts
@@ -1,0 +1,43 @@
+import { type DataFrame, FieldType } from '@grafana/data';
+
+import { filterDataFrameByRowIndexes } from './utils';
+
+describe('filterDataFrameByRowIndexes', () => {
+  const df: DataFrame = {
+    name: 'hello',
+    fields: [
+      {
+        name: 'fname',
+        labels: { a: 'AAA', b: 'BBB' },
+        config: {},
+        type: FieldType.number,
+        values: [1, 2, 3, 4],
+      },
+      {
+        name: 'time',
+        labels: { a: 'AAA', b: 'BBB' },
+        config: {},
+        type: FieldType.time,
+        values: [5, 6, 7, 8],
+      },
+    ],
+    length: 4,
+  };
+
+  it('filters the dataframe down to the given row indexes, in the given order', () => {
+    const rowIndexes = [3, 1];
+
+    expect(filterDataFrameByRowIndexes(df, rowIndexes)).toEqual({
+      ...df,
+      length: 2,
+      fields: [
+        { ...df.fields[0], values: [4, 2] },
+        { ...df.fields[1], values: [8, 6] },
+      ],
+    });
+  });
+
+  it('returns the dataframe unchanged when rowIndexes is undefined', () => {
+    expect(filterDataFrameByRowIndexes(df, undefined)).toBe(df);
+  });
+});

--- a/public/app/features/inspector/utils/utils.ts
+++ b/public/app/features/inspector/utils/utils.ts
@@ -1,5 +1,25 @@
-import { AppEvents } from '@grafana/data';
+import { AppEvents, type DataFrame } from '@grafana/data';
 import { appEvents } from 'app/core/app_events';
+
+/**
+ * Returns a copy of `dataFrame` containing only the rows at `rowIndexes`, in the given order.
+ * Used so CSV export from Inspect can reflect column filters/sorting currently applied in the data preview table.
+ * Returns `dataFrame` unchanged if `rowIndexes` is undefined.
+ */
+export function filterDataFrameByRowIndexes(dataFrame: DataFrame, rowIndexes: number[] | undefined): DataFrame {
+  if (!rowIndexes) {
+    return dataFrame;
+  }
+
+  return {
+    ...dataFrame,
+    length: rowIndexes.length,
+    fields: dataFrame.fields.map((field) => ({
+      ...field,
+      values: rowIndexes.map((rowIndex) => field.values[rowIndex]),
+    })),
+  };
+}
 
 export function getPrettyJSON(obj: unknown): string {
   let r = '';

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -30,6 +30,16 @@ interface Props extends PanelProps<Options> {
   sortByBehavior?: 'initial' | 'managed';
 }
 
+/**
+ * Shape of the table panel's `PanelContext.instanceState`, used to expose the currently filtered/sorted row
+ * indexes to Panel Inspect so CSV export can reflect column filters applied on the panel itself.
+ */
+export interface TablePanelInstanceState {
+  filteredRowIndexes?: number[];
+  /** Index (within `PanelData.series`) of the frame that `filteredRowIndexes` corresponds to. */
+  frameIndex?: number;
+}
+
 export function TablePanel(props: Props) {
   const {
     data,
@@ -67,6 +77,14 @@ export function TablePanel(props: Props) {
   const currentIndex = getCurrentFrameIndex(frames, options);
   const main = frames[currentIndex];
 
+  const onFilteredRowsChange = useCallback(
+    (filteredRowIndexes: number[]) => {
+      const instanceState: TablePanelInstanceState = { filteredRowIndexes, frameIndex: currentIndex };
+      panelContext.onInstanceStateChange?.(instanceState);
+    },
+    [panelContext, currentIndex]
+  );
+
   let tableHeight = height;
 
   if (!count || !hasFields) {
@@ -101,6 +119,7 @@ export function TablePanel(props: Props) {
         onColumnResize(displayName, resizedWidth, fieldScope, props)
       }
       onCellFilterAdded={panelContext.onAddAdHocFilter}
+      onFilteredRowsChange={onFilteredRowsChange}
       frozenColumns={options.frozenColumns?.left}
       enablePagination={options.enablePagination}
       cellHeight={options.cellHeight}


### PR DESCRIPTION
## What this does

  Panel Inspect's "Download CSV" always exported the full, unfiltered dataset,
  even when a column filter was applied on the table panel. This PR makes the
  export (and the Inspect Data preview) reflect the panel's current filter.

  Closes #29113

  This revisits #29767, which implemented the same idea in 2020 but was closed
  for lack of demand at the time. Since then Grafana replaced the table panel's
  renderer with `TableNG`, so the original approach (patching Inspect's own
  internal preview table) no longer touches what users actually filter on the
  dashboard. This PR re-implements it against the current architecture:

  - `TableNG` (both the legacy and refactored renderers) now reports its live
    filtered/sorted row indexes via a new `onFilteredRowsChange` prop.
  - The table panel relays that through `PanelContext.onInstanceStateChange`.
  - Panel Inspect's Data tab reads it back off the panel's Scene state and
    applies it to both the CSV export and its own preview table, layered
    under any additional filter applied directly within Inspect (still needed
    for Explore, where there's no panel to source a filter from).
  - The panel-driven filter is only applied when it corresponds to the exact
    frame being exported and no transform (e.g. "Series joined by time") has
    reshaped the data, since that can add/remove/reorder rows.

  ## Test plan

  - Added a unit test for the new `filterDataFrameByRowIndexes` helper.
  - Existing Table/TableNG/Inspector/TablePanel test suites all pass unmodified.
  - Manually verified: apply a column filter on a Table panel → Inspect → Data
    → preview reflects the filter → Download CSV → file contains only the
    filtered rows. Also verified the unfiltered case is unaffected.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When a column filter is applied on a Table panel visualization, Panel Inspect's "Download CSV" (and the Inspect Data preview) now exports only the filtered rows, instead of the full unfiltered dataset. The panel's live filter/sort state is threaded through to the Inspect drawer so both what you preview and what you download match what's actually shown on the dashboard.

**Why do we need this feature?**

Today, filtering a table panel's columns only changes what's rendered on screen — the underlying PanelData never changes, so Inspect's CSV export always pulls the complete, unfiltered dataset. Users who filter a table down to the rows they care about and then export for a report end up having to re-apply the same filter manually in Excel/Sheets, which defeats the point of filtering in Grafana in the first place. This was originally reported in #29113 (2020) and attempted in #29767, which was closed for insufficient demand at the time, but has seen renewed interest in the issue comments since — particularly from users doing report generation, where downloading the full, unfiltered CSV is impractical.

**Who is this feature for?**

 Anyone using a Table panel to explore or report on data who applies a column filter and then wants to export exactly what they're looking at — most concretely, users building reports or sharing data extracts from a dashboard, rather than downloading a full raw dump and re-filtering it elsewhere.

**Which issue(s) does this PR fix?**:

  Fixes #29113
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
