### PR TITLE
Graphite: Bound /render and resource-call body sizes to prevent OOM

### DIFF
--- a/pkg/tsdb/graphite/caps.go
+++ b/pkg/tsdb/graphite/caps.go
@@ -1,0 +1,89 @@
+package graphite
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+// caps bounds the memory a single request can consume. The /render and
+// resource-call paths read upstream bodies into memory, and the resource
+// handler accepts inbound request bodies; without limits a large or
+// adversarial payload can force disproportionate heap allocation.
+type caps struct {
+	renderResponseMaxBytes   int64
+	resourceResponseMaxBytes int64
+	resourceRequestMaxBytes  int64
+}
+
+const (
+	defaultRenderResponseMaxBytes   int64 = 200 << 20 // 200 MiB, aligned with the plugin gRPC receive ceiling
+	defaultResourceResponseMaxBytes int64 = 32 << 20  // 32 MiB
+	defaultResourceRequestMaxBytes  int64 = 1 << 20   // 1 MiB
+
+	// Defence-in-depth bounds on operator-supplied overrides. The floor
+	// rejects values so small every legitimate response would fail (a typo);
+	// the ceiling rejects values large enough to re-introduce the OOM risk
+	// these caps exist to mitigate.
+	capMinBytes int64 = 1 << 10 // 1 KiB
+	capMaxBytes int64 = 1 << 30 // 1 GiB
+)
+
+// loadCaps reads operator-configurable overrides from GF_PLUGIN_* environment
+// variables. When this datasource runs as a standalone plugin process, Grafana
+// delivers the [plugin.graphite] configuration section as these variables;
+// when it runs in-process they can be set directly on the Grafana server
+// process. An unset, empty, unparseable, or non-positive value uses the
+// built-in default; an out-of-range positive value is clamped to [capMinBytes,
+// capMaxBytes] with a warning.
+func loadCaps() caps {
+	return caps{
+		renderResponseMaxBytes:   capFromEnv("GF_PLUGIN_RENDER_RESPONSE_MAX_BYTES", defaultRenderResponseMaxBytes),
+		resourceResponseMaxBytes: capFromEnv("GF_PLUGIN_RESOURCE_RESPONSE_MAX_BYTES", defaultResourceResponseMaxBytes),
+		resourceRequestMaxBytes:  capFromEnv("GF_PLUGIN_RESOURCE_REQUEST_MAX_BYTES", defaultResourceRequestMaxBytes),
+	}
+}
+
+// renderResponse, resourceResponse, and resourceRequest return the effective
+// cap, falling back to the built-in default when the field is unset (zero).
+// This keeps a zero-value caps{} safe: it enforces the defaults rather than a
+// 0-byte limit.
+func (c caps) renderResponse() int64 {
+	return orDefault(c.renderResponseMaxBytes, defaultRenderResponseMaxBytes)
+}
+func (c caps) resourceResponse() int64 {
+	return orDefault(c.resourceResponseMaxBytes, defaultResourceResponseMaxBytes)
+}
+func (c caps) resourceRequest() int64 {
+	return orDefault(c.resourceRequestMaxBytes, defaultResourceRequestMaxBytes)
+}
+
+func orDefault(v, def int64) int64 {
+	if v > 0 {
+		return v
+	}
+	return def
+}
+
+func capFromEnv(key string, def int64) int64 {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v <= 0 {
+		backend.Logger.Warn("Ignoring invalid graphite body-size cap; using default", "key", key, "value", raw, "default", def)
+		return def
+	}
+	if v < capMinBytes {
+		backend.Logger.Warn("Graphite body-size cap below safe minimum; clamping", "key", key, "configured", v, "min", capMinBytes)
+		return capMinBytes
+	}
+	if v > capMaxBytes {
+		backend.Logger.Warn("Graphite body-size cap above safe maximum; clamping", "key", key, "configured", v, "max", capMaxBytes)
+		return capMaxBytes
+	}
+	return v
+}

--- a/pkg/tsdb/graphite/caps_enforcement_test.go
+++ b/pkg/tsdb/graphite/caps_enforcement_test.go
@@ -1,0 +1,102 @@
+package graphite
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseResponseRejectsOversizedRenderBody(t *testing.T) {
+	svc := &Service{
+		logger: log.NewNullLogger(),
+		caps:   caps{renderResponseMaxBytes: 16},
+	}
+	res := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("x"), 100))),
+		Header:     make(http.Header),
+	}
+
+	_, err := svc.parseResponse(res)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeded")
+}
+
+func TestParseResponseAcceptsBodyAtCap(t *testing.T) {
+	payload := "[]"
+	svc := &Service{
+		logger: log.NewNullLogger(),
+		caps:   caps{renderResponseMaxBytes: int64(len(payload))},
+	}
+	res := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(payload)),
+		Header:     make(http.Header),
+	}
+
+	out, err := svc.parseResponse(res)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestDecodeRejectsOversizedResponse(t *testing.T) {
+	body := io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("y"), 100)))
+
+	_, err := decode("", body, 16)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeded")
+}
+
+func TestDecodeAcceptsResponseAtCap(t *testing.T) {
+	out, err := decode("", io.NopCloser(strings.NewReader("hello")), 5)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(out))
+}
+
+func TestHandleResourceReqRejectsOversizedRequestBody(t *testing.T) {
+	svc := &Service{
+		logger: log.NewNullLogger(),
+		im:     &mockInstanceManager{instance: datasourceInfo{Id: 1}},
+		caps:   caps{resourceRequestMaxBytes: 16},
+	}
+	handlerReached := false
+	handler := handleResourceReq(func(context.Context, *datasourceInfo, *map[string]any) ([]byte, int, error) {
+		handlerReached = true
+		return []byte("{}"), http.StatusOK, nil
+	}, svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/metrics/find", bytes.NewReader(bytes.Repeat([]byte("z"), 100)))
+	rw := httptest.NewRecorder()
+
+	handler(rw, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rw.Code)
+	assert.False(t, handlerReached, "handler should not run when the request body is over the cap")
+}
+
+func TestHandleResourceReqAcceptsRequestBodyAtCap(t *testing.T) {
+	body := `{"q":"x"}`
+	svc := &Service{
+		logger: log.NewNullLogger(),
+		im:     &mockInstanceManager{instance: datasourceInfo{Id: 1}},
+		caps:   caps{resourceRequestMaxBytes: int64(len(body))},
+	}
+	handler := handleResourceReq(func(context.Context, *datasourceInfo, *map[string]any) ([]byte, int, error) {
+		return []byte(`{"ok":true}`), http.StatusOK, nil
+	}, svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/metrics/find", strings.NewReader(body))
+	rw := httptest.NewRecorder()
+
+	handler(rw, req)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+}

--- a/pkg/tsdb/graphite/caps_test.go
+++ b/pkg/tsdb/graphite/caps_test.go
@@ -1,0 +1,65 @@
+package graphite
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCapsEffectiveValues(t *testing.T) {
+	t.Run("zero field falls back to default", func(t *testing.T) {
+		var c caps
+		assert.Equal(t, defaultRenderResponseMaxBytes, c.renderResponse())
+		assert.Equal(t, defaultResourceResponseMaxBytes, c.resourceResponse())
+		assert.Equal(t, defaultResourceRequestMaxBytes, c.resourceRequest())
+	})
+
+	t.Run("positive field is used as-is", func(t *testing.T) {
+		c := caps{renderResponseMaxBytes: 5, resourceResponseMaxBytes: 6, resourceRequestMaxBytes: 7}
+		assert.Equal(t, int64(5), c.renderResponse())
+		assert.Equal(t, int64(6), c.resourceResponse())
+		assert.Equal(t, int64(7), c.resourceRequest())
+	})
+}
+
+func TestProvideServiceLoadsCaps(t *testing.T) {
+	s := ProvideService(httpclient.NewProvider(), tracing.DefaultTracer())
+
+	assert.Equal(t, defaultRenderResponseMaxBytes, s.caps.renderResponseMaxBytes)
+	assert.Equal(t, defaultResourceResponseMaxBytes, s.caps.resourceResponseMaxBytes)
+	assert.Equal(t, defaultResourceRequestMaxBytes, s.caps.resourceRequestMaxBytes)
+}
+
+func TestLoadCaps(t *testing.T) {
+	t.Run("defaults when env unset", func(t *testing.T) {
+		c := loadCaps()
+		assert.Equal(t, defaultRenderResponseMaxBytes, c.renderResponseMaxBytes)
+		assert.Equal(t, defaultResourceResponseMaxBytes, c.resourceResponseMaxBytes)
+		assert.Equal(t, defaultResourceRequestMaxBytes, c.resourceRequestMaxBytes)
+	})
+
+	t.Run("valid override is applied", func(t *testing.T) {
+		t.Setenv("GF_PLUGIN_RENDER_RESPONSE_MAX_BYTES", "104857600") // 100 MiB
+		assert.Equal(t, int64(104857600), loadCaps().renderResponseMaxBytes)
+	})
+
+	t.Run("value below the 1 KiB floor is clamped up", func(t *testing.T) {
+		t.Setenv("GF_PLUGIN_RESOURCE_REQUEST_MAX_BYTES", "100")
+		assert.Equal(t, capMinBytes, loadCaps().resourceRequestMaxBytes)
+	})
+
+	t.Run("value above the 1 GiB ceiling is clamped down", func(t *testing.T) {
+		t.Setenv("GF_PLUGIN_RENDER_RESPONSE_MAX_BYTES", "9999999999") // ~9.3 GiB
+		assert.Equal(t, capMaxBytes, loadCaps().renderResponseMaxBytes)
+	})
+
+	t.Run("junk, zero, or negative falls back to the default", func(t *testing.T) {
+		for _, raw := range []string{"not-a-number", "0", "-5"} {
+			t.Setenv("GF_PLUGIN_RESOURCE_RESPONSE_MAX_BYTES", raw)
+			assert.Equal(t, defaultResourceResponseMaxBytes, loadCaps().resourceResponseMaxBytes,
+				"input %q should fall back to default", raw)
+		}
+	})
+}

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -22,6 +22,7 @@ type Service struct {
 	logger          log.Logger
 	resourceHandler backend.CallResourceHandler
 	HTTPClient      *http.Client
+	caps            caps
 }
 
 const (
@@ -35,6 +36,7 @@ func ProvideService(httpClientProvider *httpclient.Provider, tracer trace.Tracer
 		im:     datasource.NewInstanceManager(newInstanceSettings(httpClientProvider)),
 		tracer: tracer,
 		logger: logger,
+		caps:   loadCaps(),
 	}
 
 	s.resourceHandler = httpadapter.New(s.newResourceMux())

--- a/pkg/tsdb/graphite/query.go
+++ b/pkg/tsdb/graphite/query.go
@@ -250,15 +250,24 @@ func (s *Service) toDataFrames(response *http.Response, refId string) (frames da
 }
 
 func (s *Service) parseResponse(res *http.Response) ([]TargetResponseDTO, error) {
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, backend.DownstreamError(err)
-	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {
 			s.logger.Warn("Failed to close response body", "err", err)
 		}
 	}()
+
+	// Bound the /render response so a large or adversarial upstream body cannot
+	// force unbounded heap allocation. Read one extra byte to distinguish a
+	// body that exactly fills the cap from one that overflows it.
+	maxBytes := s.caps.renderResponse()
+	body, err := io.ReadAll(io.LimitReader(res.Body, maxBytes+1))
+	if err != nil {
+		return nil, backend.DownstreamError(err)
+	}
+	if int64(len(body)) > maxBytes {
+		s.logger.Error("Graphite /render response exceeded the configured cap", "max_bytes", maxBytes)
+		return nil, backend.DownstreamError(fmt.Errorf("response from Graphite /render exceeded %d bytes", maxBytes))
+	}
 
 	if res.StatusCode/100 != 2 {
 		graphiteError := parseGraphiteError(res.StatusCode, string(body))

--- a/pkg/tsdb/graphite/resource_handler.go
+++ b/pkg/tsdb/graphite/resource_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,8 +56,17 @@ func handleResourceReq[T any](handlerFn resourceHandler[T], s *Service) func(rw 
 
 		var parsedBody *T
 		if req.Body != nil {
+			// Bound the inbound request body so an oversized payload cannot force
+			// unbounded heap allocation; an overflow surfaces as HTTP 413.
+			maxBytes := s.caps.resourceRequest()
+			req.Body = http.MaxBytesReader(rw, req.Body, maxBytes)
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
+				if maxErr, ok := errors.AsType[*http.MaxBytesError](err); ok {
+					s.logger.Warn("Graphite resource request body exceeded the configured cap", "max_bytes", maxBytes)
+					writeErrorResponse(rw, http.StatusRequestEntityTooLarge, fmt.Sprintf("request body exceeded %d bytes", maxErr.Limit))
+					return
+				}
 				s.logger.Error("Failed to read request body", "error", err)
 				writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
 				return
@@ -105,7 +115,7 @@ func (s *Service) handleEvents(ctx context.Context, dsInfo *datasourceInfo, even
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to create events request %v", err)
 	}
 
-	events, _, statusCode, err := doGraphiteRequest[[]GraphiteEventsResponse](ctx, dsInfo, s.logger, req, false)
+	events, _, statusCode, err := doGraphiteRequest[[]GraphiteEventsResponse](ctx, dsInfo, s.logger, req, false, s.caps.resourceResponse())
 	if err != nil {
 		return nil, statusCode, fmt.Errorf("events request failed: %v", err)
 	}
@@ -148,7 +158,7 @@ func (s *Service) handleMetricsFind(ctx context.Context, dsInfo *datasourceInfo,
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to create metrics find request %v", err)
 	}
 
-	metrics, _, statusCode, err := doGraphiteRequest[[]GraphiteMetricsFindResponse](ctx, dsInfo, s.logger, req, false)
+	metrics, _, statusCode, err := doGraphiteRequest[[]GraphiteMetricsFindResponse](ctx, dsInfo, s.logger, req, false, s.caps.resourceResponse())
 	if err != nil {
 		return nil, statusCode, fmt.Errorf("metrics find request failed: %v", err)
 	}
@@ -184,7 +194,7 @@ func (s *Service) handleMetricsExpand(ctx context.Context, dsInfo *datasourceInf
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to create metrics expand request %v", err)
 	}
 
-	metrics, _, statusCode, err := doGraphiteRequest[GraphiteMetricsExpandResponse](ctx, dsInfo, s.logger, req, false)
+	metrics, _, statusCode, err := doGraphiteRequest[GraphiteMetricsExpandResponse](ctx, dsInfo, s.logger, req, false, s.caps.resourceResponse())
 	if err != nil {
 		return nil, statusCode, fmt.Errorf("metrics expand request failed: %v", err)
 	}
@@ -219,7 +229,7 @@ func (s *Service) handleTagsAutocomplete(ctx context.Context, dsInfo *datasource
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to create tags autocomplete request %v", err)
 	}
 
-	tags, _, statusCode, err := doGraphiteRequest[[]string](ctx, dsInfo, s.logger, req, false)
+	tags, _, statusCode, err := doGraphiteRequest[[]string](ctx, dsInfo, s.logger, req, false, s.caps.resourceResponse())
 	if err != nil {
 		return nil, statusCode, fmt.Errorf("tags autocomplete request failed: %v", err)
 	}
@@ -250,7 +260,7 @@ func (s *Service) handleTagValuesAutocomplete(ctx context.Context, dsInfo *datas
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to create tag values autocomplete request %v", err)
 	}
 
-	tagValues, _, statusCode, err := doGraphiteRequest[[]string](ctx, dsInfo, s.logger, req, false)
+	tagValues, _, statusCode, err := doGraphiteRequest[[]string](ctx, dsInfo, s.logger, req, false, s.caps.resourceResponse())
 	if err != nil {
 		return nil, statusCode, fmt.Errorf("tag values autocomplete request failed: %v", err)
 	}
@@ -271,7 +281,7 @@ func (s *Service) handleVersion(ctx context.Context, dsInfo *datasourceInfo, _ *
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to create version request %v", err)
 	}
 
-	version, _, statusCode, err := doGraphiteRequest[string](ctx, dsInfo, s.logger, req, false)
+	version, _, statusCode, err := doGraphiteRequest[string](ctx, dsInfo, s.logger, req, false, s.caps.resourceResponse())
 	if err != nil {
 		return nil, statusCode, fmt.Errorf("version request failed: %v", err)
 	}
@@ -292,7 +302,7 @@ func (s *Service) handleFunctions(ctx context.Context, dsInfo *datasourceInfo, _
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to create functions request %v", err)
 	}
 
-	_, rawBody, statusCode, err := doGraphiteRequest[map[string]any](ctx, dsInfo, s.logger, req, true)
+	_, rawBody, statusCode, err := doGraphiteRequest[map[string]any](ctx, dsInfo, s.logger, req, true, s.caps.resourceResponse())
 	if err != nil {
 		return nil, statusCode, fmt.Errorf("functions request failed: %v", err)
 	}
@@ -311,7 +321,7 @@ func (s *Service) handleFunctions(ctx context.Context, dsInfo *datasourceInfo, _
 	return rawBodyReplaced, statusCode, nil
 }
 
-func doGraphiteRequest[T any](ctx context.Context, dsInfo *datasourceInfo, logger log.Logger, req *http.Request, isRaw bool) (*T, *[]byte, int, error) {
+func doGraphiteRequest[T any](ctx context.Context, dsInfo *datasourceInfo, logger log.Logger, req *http.Request, isRaw bool, maxResponseBytes int64) (*T, *[]byte, int, error) {
 	_, span := tracing.DefaultTracer().Start(ctx, "graphite request")
 	defer span.End()
 	span.SetAttributes(
@@ -333,7 +343,7 @@ func doGraphiteRequest[T any](ctx context.Context, dsInfo *datasourceInfo, logge
 		}
 	}()
 
-	parsedResponse, rawBody, err := parseResponse[T](res, isRaw, logger)
+	parsedResponse, rawBody, err := parseResponse[T](res, isRaw, logger, maxResponseBytes)
 	if err != nil {
 		return nil, nil, http.StatusInternalServerError, fmt.Errorf("failed to parse response: %v", err)
 	}
@@ -351,9 +361,9 @@ func parseRequestBody[V any](requestBody []byte, logger log.Logger) (*V, error) 
 	return requestJson, nil
 }
 
-func parseResponse[V any](res *http.Response, isRaw bool, logger log.Logger) (*V, *[]byte, error) {
+func parseResponse[V any](res *http.Response, isRaw bool, logger log.Logger, maxBytes int64) (*V, *[]byte, error) {
 	encoding := res.Header.Get("Content-Encoding")
-	body, err := decode(encoding, res.Body)
+	body, err := decode(encoding, res.Body, maxBytes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read response: %v", err)
 	}

--- a/pkg/tsdb/graphite/resource_handler_test.go
+++ b/pkg/tsdb/graphite/resource_handler_test.go
@@ -1021,7 +1021,7 @@ func TestDoGraphiteRequest(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			result, _, status, err := doGraphiteRequest[[]GraphiteEventsResponse](ctx, tt.dsInfo, svc.logger, req, false)
+			result, _, status, err := doGraphiteRequest[[]GraphiteEventsResponse](ctx, tt.dsInfo, svc.logger, req, false, defaultResourceResponseMaxBytes)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -1080,7 +1080,7 @@ func TestDoGraphiteRequestGenericTypes(t *testing.T) {
 				})
 				assert.NoError(t, err)
 
-				result, _, status, err := doGraphiteRequest[[]GraphiteMetricsFindResponse](ctx, dsInfo, svc.logger, req, false)
+				result, _, status, err := doGraphiteRequest[[]GraphiteMetricsFindResponse](ctx, dsInfo, svc.logger, req, false, defaultResourceResponseMaxBytes)
 
 				assert.NoError(t, err)
 				assert.NotNil(t, result)
@@ -1108,7 +1108,7 @@ func TestDoGraphiteRequestGenericTypes(t *testing.T) {
 				})
 				assert.NoError(t, err)
 
-				result, _, status, err := doGraphiteRequest[GraphiteMetricsExpandResponse](ctx, dsInfo, svc.logger, req, false)
+				result, _, status, err := doGraphiteRequest[GraphiteMetricsExpandResponse](ctx, dsInfo, svc.logger, req, false, defaultResourceResponseMaxBytes)
 
 				assert.NoError(t, err)
 				assert.NotNil(t, result)
@@ -1252,7 +1252,7 @@ func TestParseResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, _, err := parseResponse[[]GraphiteEventsResponse](tt.response, false, log.NewNullLogger())
+			result, _, err := parseResponse[[]GraphiteEventsResponse](tt.response, false, log.NewNullLogger(), defaultResourceResponseMaxBytes)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/tsdb/graphite/utils.go
+++ b/pkg/tsdb/graphite/utils.go
@@ -10,7 +10,11 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func decode(encoding string, original io.ReadCloser) ([]byte, error) {
+// decode reads and decompresses a resource-call response body, bounded by
+// maxBytes so a large or adversarial upstream body cannot force unbounded heap
+// allocation. The cap is applied after decompression, so it is also a defence
+// against compression bombs. A non-positive maxBytes falls back to the default.
+func decode(encoding string, original io.ReadCloser, maxBytes int64) ([]byte, error) {
 	var reader io.Reader
 	var err error
 	switch encoding {
@@ -39,9 +43,17 @@ func decode(encoding string, original io.ReadCloser) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected encoding type %v", err)
 	}
 
-	body, err := io.ReadAll(reader)
+	if maxBytes <= 0 {
+		maxBytes = defaultResourceResponseMaxBytes
+	}
+	// Read one extra byte so a body that exactly fills the cap is distinguishable
+	// from one that overflows it.
+	body, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
 	if err != nil {
 		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("resource response from Graphite exceeded %d bytes", maxBytes)
 	}
 	return body, nil
 }


### PR DESCRIPTION
**What is this feature?**

Backports grafana/grafana-graphite-datasource#80 onto the core Graphite datasource. It bounds the memory a single Graphite request can consume:

| Cap | Default | Override env var |
|---|---|---|
| `/render` response body | 200 MiB | `GF_PLUGIN_RENDER_RESPONSE_MAX_BYTES` |
| resource-call response body | 32 MiB | `GF_PLUGIN_RESOURCE_RESPONSE_MAX_BYTES` |
| inbound resource request body | 1 MiB | `GF_PLUGIN_RESOURCE_REQUEST_MAX_BYTES` |

Overrides are clamped to `[1 KiB, 1 GiB]` (out-of-range values are clamped with a startup warning, unset/invalid/non-positive values fall back to the default). Resource-response caps are applied **after** decompression, so they also defend against compression bombs. An oversized inbound request body is rejected with HTTP 413.

When the datasource runs as a standalone plugin process, Grafana delivers the `[plugin.graphite]` configuration section as these `GF_PLUGIN_*` variables. When it runs in-process, the variables can be set directly on the Grafana server process. The safe defaults apply everywhere with no configuration.

**Why do we need this feature?**

The `/render` and resource-call paths previously read upstream bodies via unbounded `io.ReadAll`, and the resource handler accepted unbounded inbound request bodies. A large or adversarial payload could force disproportionate heap allocation and OOM the process. The externalised Graphite datasource gained these caps in grafana/grafana-graphite-datasource#80; core keeps shipping the built-in plugin and needs the same protection.

**Who is this feature for?**

Operators running Grafana instances with Graphite datasources, particularly against Graphite backends that can return very large responses.

**User-facing impact:** a `/render` response larger than 200 MiB, a resource-call response larger than 32 MiB, or a resource request body larger than 1 MiB now fails with a clear error instead of being read unbounded. Operators can raise the caps via the environment variables above.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

This is a near-verbatim port of the merged external-datasource PR, adapted to core's Wire-provided `Service` (caps load once in `ProvideService`, which both the in-process and standalone builds use). Two deliberate deviations: core's linter requires Go 1.26's `errors.AsType` instead of `errors.As`, and the `loadCaps` doc comment is reworded because in-process core does not receive `[plugin.graphite]` as `GF_PLUGIN_*` env vars.

`go test ./pkg/tsdb/graphite/...`, `go vet`, and `golangci-lint` all pass.