### PR TITLE
GaugePanel: Format scale labels using field units

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.story.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.story.tsx
@@ -349,6 +349,7 @@ interface ExampleProps {
   colorScheme?: FieldColorModeId;
   endpointMarker?: RadialGaugeProps['endpointMarker'];
   decimals?: number;
+  unit?: string;
   showScaleLabels?: boolean;
   neutral?: number;
 }
@@ -387,6 +388,7 @@ export function RadialGaugeExample({
   colorScheme = FieldColorModeId.Thresholds,
   endpointMarker = 'glow',
   decimals = 0,
+  unit = 'percent',
   showScaleLabels,
   neutral,
 }: ExampleProps) {
@@ -416,7 +418,7 @@ export function RadialGaugeExample({
         config: {
           min: min,
           max: max,
-          unit: 'percent',
+          unit,
           decimals: decimals,
           color: { mode: colorScheme, fixedColor: color ? theme.visualization.getColorByName(color) : undefined },
           thresholds,

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.test.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.test.tsx
@@ -88,6 +88,30 @@ describe('RadialGauge', () => {
       expect(screen.getByLabelText('Threshold 85')).toBeInTheDocument();
     });
 
+    it('should format absolute threshold labels without units by default', () => {
+      const yearInMs = 365 * 24 * 60 * 60 * 1000;
+      const threeYearsInMs = 3 * yearInMs;
+
+      render(
+        <RadialGaugeExample
+          showScaleLabels
+          unit="ms"
+          value={2 * yearInMs}
+          max={threeYearsInMs}
+          thresholds={{
+            mode: ThresholdsMode.Absolute,
+            steps: [
+              { value: 0, color: 'green' },
+              { value: threeYearsInMs, color: 'red' },
+            ],
+          }}
+        />
+      );
+
+      expect(screen.getByLabelText('Threshold 3')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
     it('should render labels for a circle gauge', () => {
       render(<RadialGaugeExample showScaleLabels shape="circle" />);
 

--- a/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
@@ -6,7 +6,7 @@ import { t } from '@grafana/i18n';
 import { measureText } from '../../utils/measureText';
 
 import { type RadialGaugeDimensions } from './types';
-import { getFieldConfigMinMax, drawRadialArcPath } from './utils';
+import { getFieldConfigMinMax, drawRadialArcPath, getFieldDisplayProcessor } from './utils';
 
 interface RadialScaleLabelsProps {
   fieldDisplay: FieldDisplay;
@@ -20,8 +20,7 @@ interface RadialScaleLabelsProps {
 }
 
 interface RadialScaleLabel {
-  value: number;
-  labelValue?: string;
+  labelValue: string;
   startOffset: number;
   label: string;
 }
@@ -47,6 +46,7 @@ export const RadialScaleLabels = memo(
 
     const { centerX, centerY, scaleLabelsFontSize, scaleLabelsRadius, barWidth } = dimensions;
     const [min, max] = getFieldConfigMinMax(fieldDisplay);
+    const displayProcessor = getFieldDisplayProcessor(fieldDisplay);
     const thresholds = rawThresholds.filter(
       (threshold) =>
         resolvedThresholdValue(threshold.value, thresholdsMode, min, max) >= min &&
@@ -112,9 +112,9 @@ export const RadialScaleLabels = memo(
 
     const labels: RadialScaleLabel[] = thresholds.map((threshold) => {
       const resolvedValue = resolvedThresholdValue(threshold.value, thresholdsMode, min, max);
-      const labelText = thresholdsMode === ThresholdsMode.Percentage ? `${threshold.value}%` : String(threshold.value);
+      const labelText =
+        thresholdsMode === ThresholdsMode.Percentage ? `${threshold.value}%` : displayProcessor(resolvedValue).text;
       return {
-        value: resolvedValue,
         labelValue: labelText,
         startOffset: getStartOffset(labelText, resolvedValue),
         label: t(`gauge.threshold`, 'Threshold {{value}}', { value: labelText }),
@@ -122,10 +122,11 @@ export const RadialScaleLabels = memo(
     });
 
     if (neutral !== undefined) {
+      const labelText = displayProcessor(neutral).text;
       labels.push({
-        value: neutral,
-        startOffset: getStartOffset(String(neutral), neutral),
-        label: t(`gauge.neutral`, 'Neutral {{value}}', { value: neutral }),
+        labelValue: labelText,
+        startOffset: getStartOffset(labelText, neutral),
+        label: t(`gauge.neutral`, 'Neutral {{value}}', { value: labelText }),
       });
     }
 
@@ -143,7 +144,7 @@ export const RadialScaleLabels = memo(
             aria-label={label.label}
           >
             <textPath href={`#${pathId}`} startOffset={label.startOffset}>
-              {label.labelValue ?? label.value}
+              {label.labelValue}
             </textPath>
           </text>
         ))}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Formats radial gauge scale labels using the field display processor. Absolute threshold and neutral labels now respect the selected field unit, while percentage thresholds continue to display as percentages.

**Why do we need this feature?**

Gauge values already use the selected field unit, but scale labels display raw values. For example, a duration could display as years in the gauge while its threshold label remained in milliseconds.

**Who is this feature for?**

Users displaying gauge threshold labels with configured field units.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #106242 

**Special notes for your reviewer:**

Adds regression coverage for both the visible formatted threshold label and its accessibility label.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
