### PR TITLE
Explore: add contentOutline URL param to hide the outline for a view

### DIFF
--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -19,6 +19,7 @@ import { usePluginLinks } from '@grafana/runtime';
 import { getTestFeatureFlagClient, setTestFlags } from '@grafana/test-utils/unstable';
 import { configureStore } from 'app/store/configureStore';
 
+import { CONTENT_OUTLINE_LOCAL_STORAGE_KEYS } from './ContentOutline/ContentOutline';
 import { ContentOutlineContextProvider } from './ContentOutline/ContentOutlineContext';
 import { Explore, type Props } from './Explore';
 import { QueryLibraryContextProviderMock } from './QueryLibrary/mocks';
@@ -251,10 +252,20 @@ describe('Explore', () => {
   });
 
   describe('Content Outline', () => {
+    const originalLocation = window.location;
+
+    const setLocationSearch = (search: string) => {
+      Object.defineProperty(window, 'location', {
+        value: { ...originalLocation, search },
+        writable: true,
+      });
+    };
+
     afterEach(() => {
       act(() => {
         setTestFlags({});
       });
+      Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
     });
 
     it('should retrieve the last visible state from local storage', async () => {
@@ -266,6 +277,39 @@ describe('Explore', () => {
       const showContentOutlineButton = screen.queryByRole('button', { name: 'Collapse outline' });
       expect(showContentOutlineButton).not.toBeInTheDocument();
       getBoolMock.mockRestore();
+    });
+
+    it('renders the outline by default when no contentOutline URL param is present', async () => {
+      setup();
+      await screen.findByTestId(selectors.components.DataSourcePicker.container);
+
+      expect(screen.queryByRole('button', { name: 'Collapse outline' })).toBeInTheDocument();
+    });
+
+    it('hides the outline when contentOutline=false is set in the URL, without touching the saved preference', async () => {
+      setLocationSearch('?contentOutline=false');
+      const setMock = jest.spyOn(store, 'set');
+      setup();
+      await screen.findByTestId(selectors.components.DataSourcePicker.container);
+
+      expect(screen.queryByRole('button', { name: 'Collapse outline' })).not.toBeInTheDocument();
+      expect(setMock).not.toHaveBeenCalledWith(CONTENT_OUTLINE_LOCAL_STORAGE_KEYS.visible, expect.anything());
+      setMock.mockRestore();
+    });
+
+    it('reveals the outline and persists the choice when the toolbar toggle is clicked while contentOutline=false is set', async () => {
+      setLocationSearch('?contentOutline=false');
+      const setMock = jest.spyOn(store, 'set');
+      setup();
+      await screen.findByTestId(selectors.components.DataSourcePicker.container);
+
+      expect(screen.queryByRole('button', { name: 'Collapse outline' })).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByTestId(selectors.pages.Explore.toolbar.contentOutline));
+
+      expect(await screen.findByRole('button', { name: 'Collapse outline' })).toBeInTheDocument();
+      expect(setMock).toHaveBeenCalledWith(CONTENT_OUTLINE_LOCAL_STORAGE_KEYS.visible, true);
+      setMock.mockRestore();
     });
 
     it('shows an expandable query card when a Mixed datasource contains a managed Prometheus flavor query', async () => {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -185,9 +185,13 @@ export class Explore extends PureComponent<Props, ExploreState> {
   };
 
   onContentOutlineToogle = () => {
-    store.set(CONTENT_OUTLINE_LOCAL_STORAGE_KEYS.visible, !this.state.contentOutlineVisible);
-    this.setState((state) => {
-      const newContentOutlineVisible = this.props.compact ? true : !state.contentOutlineVisible;
+    // Base the flip on what's actually visible right now, not just the raw persisted state,
+    // since `outlineHiddenFromUrl` can be hiding the panel despite `contentOutlineVisible` being true.
+    const isVisible = this.state.contentOutlineVisible && !this.outlineHiddenFromUrl;
+    this.outlineHiddenFromUrl = false;
+    store.set(CONTENT_OUTLINE_LOCAL_STORAGE_KEYS.visible, !isVisible);
+    this.setState(() => {
+      const newContentOutlineVisible = this.props.compact ? true : !isVisible;
       reportInteraction('explore_toolbar_contentoutline_clicked', {
         item: 'outline',
         type: newContentOutlineVisible ? 'open' : 'close',
@@ -688,7 +692,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
           exploreId={exploreId}
           onChangeTime={this.onChangeTime}
           onContentOutlineToogle={this.onContentOutlineToogle}
-          isContentOutlineOpen={contentOutlineVisible}
+          isContentOutlineOpen={contentOutlineVisible && !this.outlineHiddenFromUrl}
         />
         <div
           style={{

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -159,7 +159,8 @@ export class Explore extends PureComponent<Props, ExploreState> {
     };
     this.graphEventBus = props.eventBus.newScopedBus('graph', { onlyLocal: false });
     this.logsEventBus = props.eventBus.newScopedBus('logs', { onlyLocal: false });
-    this.outlineHiddenFromUrl = urlUtil.getUrlSearchParams().contentOutline === 'false';
+    const { contentOutline } = urlUtil.getUrlSearchParams();
+    this.outlineHiddenFromUrl = (Array.isArray(contentOutline) ? contentOutline[0] : contentOutline) === 'false';
   }
 
   onChangeTime = (rawRange: RawTimeRange) => {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -18,6 +18,7 @@ import {
   type SplitOpenOptions,
   store,
   SupplementaryQueryType,
+  urlUtil,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
@@ -149,6 +150,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
   scrollElement: HTMLDivElement | undefined;
   graphEventBus: EventBus;
   logsEventBus: EventBus;
+  outlineHiddenFromUrl: boolean;
 
   constructor(props: Props) {
     super(props);
@@ -157,6 +159,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
     };
     this.graphEventBus = props.eventBus.newScopedBus('graph', { onlyLocal: false });
     this.logsEventBus = props.eventBus.newScopedBus('logs', { onlyLocal: false });
+    this.outlineHiddenFromUrl = urlUtil.getUrlSearchParams().contentOutline === 'false';
   }
 
   onChangeTime = (rawRange: RawTimeRange) => {
@@ -694,7 +697,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
           }}
         >
           <div className={styles.wrapper}>
-            {contentOutlineVisible && !compact && (
+            {contentOutlineVisible && !compact && !this.outlineHiddenFromUrl && (
               <ContentOutline
                 scroller={this.scrollElement}
                 panelId={`content-outline-container-${exploreId}`}


### PR DESCRIPTION
**What is this feature?**

Adds a `contentOutline` URL query param to Explore. `?contentOutline=false` hides the Content Outline panel for that page load.

**Why do we need this feature?**

There's currently no way to hide the outline for a single view (e.g. an embedded/shared Explore link) without flipping the user's saved outline preference in localStorage.

**Who is this feature for?**

Anyone linking to or embedding Explore who wants a cleaner view without the outline panel. For example, Grafana Assistant takes screenshots of the Explore view to share pictures of the graphs: content outline is not useful in that case.