### PR TITLE
Alerting: add pure-k8s flat rule list view (FilterView.v3)

### DIFF
--- a/public/app/features/alerting/unified/rule-list/FilterView.v3.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/FilterView.v3.test.tsx
@@ -1,0 +1,186 @@
+import { HttpResponse, http } from 'msw';
+import { act, render, screen, waitFor, waitForElementToBeRemoved } from 'test/test-utils';
+import { byRole } from 'testing-library-selector';
+
+import { setPluginComponentsHook, setPluginLinksHook } from '@grafana/runtime';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { setupMswServer } from '../mockApi';
+import { grantUserPermissions } from '../mocks';
+import { alertRuleHitFactory, recordingRuleHitFactory } from '../mocks/server/entities/k8s/ruleSearchHits';
+import {
+  RULES_ALERTING_API_SERVER_BASE_URL,
+  rulesSearchHandlerFor,
+} from '../mocks/server/handlers/k8s/rulesSearch.k8s';
+import { type RulesFilter } from '../search/rulesSearchParser';
+
+import { FilterViewV3 } from './FilterView.v3';
+
+jest.mock('@grafana/assistant', () => ({
+  useAssistant: () => ({ isAvailable: false, openAssistant: jest.fn() }),
+}));
+
+setPluginLinksHook(() => ({ links: [], isLoading: false }));
+setPluginComponentsHook(() => ({ components: [], isLoading: false }));
+
+grantUserPermissions([AccessControlAction.AlertingRuleRead]);
+
+const server = setupMswServer();
+
+// The global IntersectionObserver mock in public/test/jest-setup.ts auto-fires isIntersecting on
+// observe(), which would cause runaway pagination here. Install a controllable mock that only fires
+// when enterNode()/leaveNode() is called.
+const io = installControllableIntersectionObserver();
+
+describe('RuleList - FilterView.v3', () => {
+  it('renders alert and recording rule rows from search hits', async () => {
+    server.use(
+      rulesSearchHandlerFor([
+        alertRuleHitFactory.build({
+          name: 'alert-uid',
+          title: 'My alert rule',
+          folder: 'NAMESPACE_UID',
+          group: 'my-group',
+          interval: '5m',
+        }),
+        recordingRuleHitFactory.build({ name: 'recording-uid', title: 'My recording rule', folder: 'NAMESPACE_UID' }),
+      ])
+    );
+
+    render(<FilterViewV3 filterState={getFilter()} />);
+
+    expect(await screen.findByText('My alert rule')).toBeInTheDocument();
+    expect(screen.getByText('My recording rule')).toBeInTheDocument();
+    expect(screen.getAllByRole('treeitem')).toHaveLength(2);
+
+    // folder title is resolved from the folder uid, not shown as the raw uid
+    expect(await screen.findByText('Some Folder')).toBeInTheDocument();
+    expect(screen.queryByText('NAMESPACE_UID')).not.toBeInTheDocument();
+  });
+
+  it('links each row to the rule view page by uid', async () => {
+    server.use(rulesSearchHandlerFor([alertRuleHitFactory.build({ name: 'the-uid', title: 'Linked rule' })]));
+
+    render(<FilterViewV3 filterState={getFilter()} />);
+
+    const link = await screen.findByRole('link', { name: 'Linked rule' });
+    expect(link).toHaveAttribute('href', expect.stringContaining('/alerting/grafana/the-uid/view'));
+  });
+
+  it('paginates via the load-more sentinel', async () => {
+    // page size is 24, so 30 hits require a second page
+    server.use(rulesSearchHandlerFor(alertRuleHitFactory.buildList(30)));
+
+    render(<FilterViewV3 filterState={getFilter()} />);
+
+    await waitFor(() => expect(screen.getAllByRole('treeitem')).toHaveLength(24));
+
+    await loadMoreResults();
+
+    expect(screen.getAllByRole('treeitem')).toHaveLength(30);
+    // no more pages -> sentinel gone
+    expect(screen.queryByTestId('load-more-helper')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when no rules match', async () => {
+    server.use(rulesSearchHandlerFor([]));
+
+    render(<FilterViewV3 filterState={getFilter()} />);
+
+    expect(await screen.findByText('No matching rules found')).toBeInTheDocument();
+    expect(screen.queryAllByRole('treeitem')).toHaveLength(0);
+  });
+
+  it('shows an error state when the search request fails', async () => {
+    server.use(
+      http.get(`${RULES_ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/search`, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 500 })
+      )
+    );
+
+    render(<FilterViewV3 filterState={getFilter()} />);
+
+    expect(await byRole('alert').find()).toHaveTextContent('Failed to load rules');
+    expect(screen.queryAllByRole('treeitem')).toHaveLength(0);
+  });
+});
+
+async function loadMoreResults() {
+  act(() => {
+    io.enterNode(screen.getByTestId('load-more-helper'));
+  });
+  await waitForElementToBeRemoved(screen.queryAllByTestId('alert-rule-list-item-loader'));
+}
+
+function getFilter(overrides: Partial<RulesFilter> = {}): RulesFilter {
+  return {
+    dataSourceNames: [],
+    freeFormWords: [],
+    labels: [],
+    ...overrides,
+  };
+}
+
+function installControllableIntersectionObserver() {
+  type Registration = {
+    callback: IntersectionObserverCallback;
+    observer: IntersectionObserver;
+    elements: Set<Element>;
+  };
+  const registrations: Registration[] = [];
+
+  global.IntersectionObserver = jest.fn().mockImplementation((callback: IntersectionObserverCallback) => {
+    const registration: Registration = {
+      callback,
+      observer: null as unknown as IntersectionObserver,
+      elements: new Set(),
+    };
+    const observer: IntersectionObserver = {
+      root: null,
+      rootMargin: '',
+      scrollMargin: '',
+      thresholds: [],
+      observe: (element: Element) => {
+        registration.elements.add(element);
+      },
+      unobserve: (element: Element) => {
+        registration.elements.delete(element);
+      },
+      disconnect: () => {
+        registration.elements.clear();
+        const idx = registrations.indexOf(registration);
+        if (idx >= 0) {
+          registrations.splice(idx, 1);
+        }
+      },
+      takeRecords: () => [],
+    };
+    registration.observer = observer;
+    registrations.push(registration);
+    return observer;
+  }) as unknown as typeof IntersectionObserver;
+
+  const fire = (element: Element, isIntersecting: boolean) => {
+    for (const reg of registrations) {
+      if (!reg.elements.has(element)) {
+        continue;
+      }
+      const rect = element.getBoundingClientRect();
+      const entry: IntersectionObserverEntry = {
+        target: element,
+        isIntersecting,
+        intersectionRatio: isIntersecting ? 1 : 0,
+        boundingClientRect: rect,
+        intersectionRect: rect,
+        rootBounds: null,
+        time: performance.now(),
+      };
+      reg.callback([entry], reg.observer);
+    }
+  };
+
+  return {
+    enterNode: (element: Element) => fire(element, true),
+    leaveNode: (element: Element) => fire(element, false),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/FilterView.v3.tsx
+++ b/public/app/features/alerting/unified/rule-list/FilterView.v3.tsx
@@ -1,0 +1,57 @@
+import { Trans, t } from '@grafana/i18n';
+import { Alert, EmptyState, Stack } from '@grafana/ui';
+
+import { type RulesFilter } from '../search/rulesSearchParser';
+
+import LoadMoreHelper from './LoadMoreHelper';
+import { AlertRuleListItemSkeleton } from './components/AlertRuleListItemLoader';
+import { K8sSearchRuleListItem } from './components/K8sSearchRuleListItem';
+import { useK8sRulesSearch } from './hooks/useK8sRulesSearch';
+
+interface FilterViewV3Props {
+  filterState: RulesFilter;
+}
+
+/**
+ * Pure-k8s flat rule list: renders definition-only search hits from `useK8sRulesSearch` with
+ * infinite-scroll pagination. No DMA merge, no Prometheus DTOs — the v3 replacement for `FilterView`.
+ */
+export function FilterViewV3({ filterState }: FilterViewV3Props) {
+  const { hits, isLoading, error, hasMore, loadMore } = useK8sRulesSearch(filterState);
+
+  if (error) {
+    return (
+      <Alert severity="error" title={t('alerting.rule-list.v3.search-error', 'Failed to load rules')}>
+        {String(error)}
+      </Alert>
+    );
+  }
+
+  const noRulesFound = hits.length === 0 && !isLoading;
+  if (noRulesFound) {
+    return (
+      <EmptyState variant="not-found" message={t('alerting.rule-list.v3.no-rules-found', 'No matching rules found')}>
+        <Trans i18nKey="alerting.rule-list.v3.no-rules-found-body">
+          No alert or recording rules matched your current set of filters.
+        </Trans>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <Stack direction="column" gap={0}>
+      <ul aria-label={t('alerting.rule-list.v3.aria-label-rule-list', 'rule list')}>
+        {hits.map((hit) => (
+          <K8sSearchRuleListItem key={hit.name} hit={hit} />
+        ))}
+        {isLoading && (
+          <>
+            <AlertRuleListItemSkeleton />
+            <AlertRuleListItemSkeleton />
+          </>
+        )}
+      </ul>
+      {hasMore && !isLoading && <LoadMoreHelper handleLoad={loadMore} />}
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/rule-list/RuleList.v3.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v3.tsx
@@ -1,8 +1,16 @@
 import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
+import { useRulesFilter } from '../hooks/useFilteredRules';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
+
+import { FilterViewV3 } from './FilterView.v3';
 
 export default function RuleListPage() {
   const { navId, pageNav } = useAlertRulesNav();
+  const { filterState } = useRulesFilter();
 
-  return <AlertingPageWrapper navId={navId} pageNav={pageNav} />;
+  return (
+    <AlertingPageWrapper navId={navId} pageNav={pageNav}>
+      <FilterViewV3 filterState={filterState} />
+    </AlertingPageWrapper>
+  );
 }

--- a/public/app/features/alerting/unified/rule-list/components/K8sRuleActions.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/K8sRuleActions.tsx
@@ -1,0 +1,39 @@
+import { Trans, t } from '@grafana/i18n';
+import { LinkButton, Stack } from '@grafana/ui';
+
+import { createRelativeUrl } from '../../utils/url';
+
+interface K8sRuleActionsProps {
+  /** The k8s rule uid (the `name` field on a search hit). */
+  uid: string;
+}
+
+/**
+ * Lightweight, definition-only row actions for v3 search hits: View + Edit links built from the rule
+ * uid. Stateful actions (pause, silence, delete, duplicate, export) need the full rule and land in a
+ * later PR — the definition-only search hit can't drive them.
+ */
+export function K8sRuleActions({ uid }: K8sRuleActionsProps) {
+  return (
+    <Stack gap={0} alignItems="center" wrap="nowrap">
+      <LinkButton
+        title={t('alerting.rule-list.v3.actions.view', 'View')}
+        size="sm"
+        variant="secondary"
+        fill="text"
+        href={createRelativeUrl(`/alerting/grafana/${uid}/view`)}
+      >
+        <Trans i18nKey="common.view">View</Trans>
+      </LinkButton>
+      <LinkButton
+        title={t('alerting.rule-list.v3.actions.edit', 'Edit')}
+        size="sm"
+        variant="secondary"
+        fill="text"
+        href={createRelativeUrl(`/alerting/${encodeURIComponent(uid)}/edit`)}
+      >
+        <Trans i18nKey="common.edit">Edit</Trans>
+      </LinkButton>
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/rule-list/components/K8sSearchRuleListItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/K8sSearchRuleListItem.tsx
@@ -1,0 +1,43 @@
+import { useFolder } from '../../hooks/useFolder';
+import { GRAFANA_RULES_SOURCE_NAME, GrafanaRulesSource } from '../../utils/datasource';
+import { groups } from '../../utils/navigation';
+import { parsePrometheusDuration } from '../../utils/time';
+import { createRelativeUrl } from '../../utils/url';
+import { GrafanaRuleType, type RuleSearchHit } from '../hooks/useK8sRulesSearch';
+
+import { AlertRuleListItem, RecordingRuleListItem, type RuleListItemCommonProps } from './AlertRuleListItem';
+import { K8sRuleActions } from './K8sRuleActions';
+
+interface K8sSearchRuleListItemProps {
+  hit: RuleSearchHit;
+}
+
+/**
+ * Maps a single pure-k8s search hit to the presentational rule list item. Definition-only: no
+ * state/health/instances (the `/search` endpoint doesn't return them). `hit.name` is the k8s uid,
+ * `hit.title` is the display name.
+ */
+export function K8sSearchRuleListItem({ hit }: K8sSearchRuleListItemProps) {
+  const { folder } = useFolder(hit.folder);
+
+  const commonProps: RuleListItemCommonProps = {
+    name: hit.title,
+    href: createRelativeUrl(`/alerting/grafana/${hit.name}/view`),
+    namespace: folder?.title,
+    group: hit.group,
+    groupUrl: hit.group ? groups.detailsPageLink(GRAFANA_RULES_SOURCE_NAME, hit.folder, hit.group) : undefined,
+    rulesSource: GrafanaRulesSource,
+    application: 'grafana',
+    isPaused: hit.paused,
+    labels: hit.labels,
+    querySourceUIDs: hit.datasourceUIDs,
+    evalIntervalSeconds: hit.interval ? parsePrometheusDuration(hit.interval) / 1000 : undefined,
+    actions: <K8sRuleActions uid={hit.name} />,
+  };
+
+  if (hit.type === GrafanaRuleType.Alerting) {
+    return <AlertRuleListItem {...commonProps} />;
+  }
+
+  return <RecordingRuleListItem {...commonProps} />;
+}


### PR DESCRIPTION
## Summary
PR 3 of the RuleList.v3 stack. Makes the `alerting.listViewV3` toggle show a **real flat list**:

- `FilterView.v3` renders definition-only search hits from `useK8sRulesSearch` (PR2) as a flat list with `LoadMoreHelper` infinite-scroll pagination, loading skeletons, and empty/error states.
- `K8sSearchRuleListItem` maps each k8s hit to the existing presentational row components (`AlertRuleListItem`/`RecordingRuleListItem`), resolving the folder title via `useFolder`.
- `K8sRuleActions` provides lightweight uid-only View/Edit links (stateful actions — pause/silence/delete/export — land in a later PR, since they need the full rule, not a definition-only hit).
- Wired into the v3 page shell; v1/v2 untouched, dark behind the toggle.

Stacked on top of #<PR2> (base branch `konrad/rulelist-v3-02-k8s-search-hook`).

## Test plan
- [x] `FilterView.v3.test.tsx` — integration tests via the realistic PR2 MSW mock: alert+recording rows render, folder title resolves (not the raw uid), row links resolve to `/alerting/grafana/{uid}/view`, pagination pages the next batch, empty + error states.
- [x] `yarn typecheck` clean
- [x] `yarn lint:fix` clean