### PR TITLE
Scopes: return apply promise so the default-scope .catch() actually catches

### DIFF
--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -1191,6 +1191,24 @@ describe('ScopesService', () => {
         expect(selectorService.changeScopes).not.toHaveBeenCalled();
       });
 
+      it('logs and does not throw when the apply promise rejects', async () => {
+        turnOnScopesFirstMode();
+        selectorService.state.appliedScopes = [];
+        selectorService.state.selectedScopes = [];
+        apiClient.fetchDefaultScope = jest.fn().mockResolvedValue('gdev-shoe-org');
+        selectorService.changeScopes = jest.fn().mockRejectedValue(new Error('apply failed'));
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        service.setEnabled(true);
+        // Wait long enough for the fetch to resolve, then the changeScopes
+        // rejection to propagate through the .catch() handler.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(errorSpy).toHaveBeenCalledWith('Failed to apply default scope:', expect.any(Error));
+        errorSpy.mockRestore();
+      });
+
       it('does not fetch twice when setEnabled(true) is called twice in a row', async () => {
         turnOnScopesFirstMode();
         selectorService.state.appliedScopes = [];

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -287,13 +287,17 @@ export class ScopesService implements ScopesContextValue {
               // the scope manually. The scope metadata is already in the
               // getScope RTK Query cache (seeded by fetchDefaultScope), so
               // applyScopes' downstream fetch is a cache hit.
-              this.selectorService.changeScopes([name], undefined, undefined, true);
+              // Return the promise so the outer .catch below actually catches
+              // a rejection from changeScopes → applyScopes → fetch chains.
+              // Without the return, the inner promise floats free and any
+              // rejection surfaces as unhandled.
+              return this.selectorService.changeScopes([name], undefined, undefined, true);
             })
             .catch((err) => {
-              // fetchDefaultScope handles its own errors, but changeScopes above
-              // returns an un-awaited promise; a rejection there would otherwise
-              // surface as an unhandled rejection. Match the pattern used by the
-              // resolvePathToRoot(...).catch(...) calls elsewhere in this file.
+              // Match the .catch(...) pattern used by the resolvePathToRoot(...)
+              // calls elsewhere in this file so a rejection from either
+              // fetchDefaultScope or the changeScopes chain above is logged
+              // instead of surfacing as an unhandled rejection.
               console.error('Failed to apply default scope:', err);
             });
         }


### PR DESCRIPTION
## Summary

Follow-up to #126740. The `.catch()` added to the default-scope apply chain in `ScopesService.setEnabled` never fires because the `.then` callback doesn't `return` the `changeScopes` promise — so a rejection from the apply chain floats free as an unhandled rejection instead of hitting the handler.

## Changes

- `ScopesService.ts` — return `this.selectorService.changeScopes(...)` from the `.then` callback so the outer `.catch` catches rejections from the apply chain.
- `ScopesService.test.ts` — new test that mocks `changeScopes` to reject and asserts `console.error` is emitted, covering the `.catch` branch that CI coverage previously flagged as uncovered.

## Test plan

- [x] `yarn jest public/app/features/scopes/ScopesService.test.ts` — 60 tests pass.
- [x] Coverage on `ScopesService.ts` now includes the `.catch` handler (uncovered lines don't include the catch block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)