### PR TITLE
chore: remove unused rudderstack tracking events

### DIFF
--- a/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState, type MouseEvent } from 'react';
 
 import type { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import {
   LoadingPlaceholder,
   EmptyState,
@@ -192,11 +192,6 @@ function AddNewConnectionWithSidebar() {
         e.preventDefault();
         e.stopPropagation();
         setSelectedItem(item);
-        reportInteraction('connections_plugin_card_clicked', {
-          plugin_id: item.id,
-          creator_team: 'grafana_plugins_catalog',
-          schema_version: '1.0.0',
-        });
       }
     },
     [canCreateDataSources]

--- a/public/app/features/connections/tabs/ConnectData/ConnectDataLegacy.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectDataLegacy.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom-v5-compat';
 
 import { PluginType, type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { locationSearchToObject, reportInteraction } from '@grafana/runtime';
+import { locationSearchToObject } from '@grafana/runtime';
 import { LoadingPlaceholder, EmptyState, Field, RadioButtonGroup, Tooltip, Combobox, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -92,11 +92,6 @@ export function AddNewConnectionLegacy() {
       e.preventDefault();
       e.stopPropagation();
       openModal(item);
-      reportInteraction('connections_plugin_card_clicked', {
-        plugin_id: item.id,
-        creator_team: 'grafana_plugins_catalog',
-        schema_version: '1.0.0',
-      });
     }
   };
 

--- a/public/app/features/datasources/components/DataSourceAddButton.tsx
+++ b/public/app/features/datasources/components/DataSourceAddButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type JSX } from 'react';
+import { type JSX } from 'react';
 
 import { Pages } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
@@ -8,19 +8,13 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { ROUTES } from 'app/features/connections/constants';
 import { AccessControlAction } from 'app/types/accessControl';
 
-import { trackAddNewDsClicked } from '../tracking';
-
 export function DataSourceAddButton(): JSX.Element | null {
   const canCreateDataSource = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
-  const handleClick = useCallback(() => {
-    trackAddNewDsClicked({ path: window.location.pathname });
-  }, []);
 
   return canCreateDataSource ? (
     <LinkButton
       icon="plus"
       href={config.appSubUrl + ROUTES.DataSourcesNew}
-      onClick={handleClick}
       data-testid={Pages.DataSources.dataSourceAddButton}
     >
       <Trans i18nKey="data-sources.datasource-add-button.label">Add new data source</Trans>

--- a/public/app/features/datasources/components/DataSourceCategories.tsx
+++ b/public/app/features/datasources/components/DataSourceCategories.tsx
@@ -1,9 +1,7 @@
 import { css } from '@emotion/css';
-import { useCallback } from 'react';
 
 import { type DataSourcePluginMeta, type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
 import { LinkButton, useStyles2 } from '@grafana/ui';
 import { type DataSourcePluginCategory } from 'app/types/datasources';
 
@@ -23,15 +21,6 @@ export function DataSourceCategories({ categories, onClickDataSourceType }: Prop
   const moreDataSourcesLink = `${ROUTES.AddNewConnection}?cat=data-source`;
   const styles = useStyles2(getStyles);
 
-  const handleClick = useCallback(() => {
-    reportInteraction('connections_add_datasource_find_more_ds_plugins_clicked', {
-      targetPath: moreDataSourcesLink,
-      path: window.location.pathname,
-      creator_team: 'grafana_plugins_catalog',
-      schema_version: '1.0.0',
-    });
-  }, [moreDataSourcesLink]);
-
   return (
     <>
       {/* Categories */}
@@ -46,7 +35,7 @@ export function DataSourceCategories({ categories, onClickDataSourceType }: Prop
 
       {/* Find more */}
       <div className={styles.more}>
-        <LinkButton variant="secondary" href={moreDataSourcesLink} onClick={handleClick} target="_self" rel="noopener">
+        <LinkButton variant="secondary" href={moreDataSourcesLink} target="_self" rel="noopener">
           <Trans i18nKey="datasources.data-source-categories.find-more-data-source-plugins">
             Find more data source plugins
           </Trans>

--- a/public/app/features/datasources/components/DataSourcesList.tsx
+++ b/public/app/features/datasources/components/DataSourcesList.tsx
@@ -1,11 +1,10 @@
 import { css } from '@emotion/css';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { type RefObject, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom-v5-compat';
 
 import { type DataSourceSettings, type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, useFavoriteDatasources, type FavoriteDatasources } from '@grafana/runtime';
+import { useFavoriteDatasources, type FavoriteDatasources } from '@grafana/runtime';
 import { EmptyState, LinkButton, TextLink, useStyles2, useTheme2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -19,7 +18,6 @@ import {
 } from '../../connections/hooks/useDatasourceAdvisorChecks';
 import { useLoadDataSources } from '../state/hooks';
 import { getDataSources, getDataSourcesCount } from '../state/selectors';
-import { trackDataSourcesListViewed } from '../tracking';
 
 import { DataSourcesListCard } from './DataSourcesListCard';
 import { DataSourcesListHeader } from './DataSourcesListHeader';
@@ -85,7 +83,6 @@ export function DataSourcesListView({
 }: ViewProps) {
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
-  const location = useLocation();
   const scrollRef = useRef<HTMLDivElement>(null);
   const isKeyboardNavigating = useIsKeyboardNavigating();
   const { datasourceFailureByUID } = useDatasourceFailureByUID();
@@ -105,13 +102,6 @@ export function DataSourcesListView({
     }
     return allDataSources.filter((dataSource) => favoriteDataSources?.isFavoriteDatasource(dataSource.uid));
   }, [allDataSources, showFavoritesOnly, favoriteDataSources]);
-
-  useEffect(() => {
-    trackDataSourcesListViewed({
-      grafana_version: config.buildInfo.version,
-      path: location.pathname,
-    });
-  }, [location]);
 
   const rowGap = Number.parseFloat(theme.spacing(1)) || 8;
   const rowVirtualizer = useVirtualizer({

--- a/public/app/features/datasources/components/DataSourcesListCard.tsx
+++ b/public/app/features/datasources/components/DataSourcesListCard.tsx
@@ -8,7 +8,6 @@ import { Card, LinkButton, Stack, Tag, useStyles2 } from '@grafana/ui';
 
 import { ROUTES } from '../../connections/constants';
 import { type DatasourceFailureDetails } from '../../connections/hooks/useDatasourceAdvisorChecks';
-import { trackExploreClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
 import { BuildDashboardButton } from './BuildDashboardButton';
@@ -53,14 +52,6 @@ export function DataSourcesListCard({ dataSource, hasWriteRights, hasExploreRigh
             variant="secondary"
             className={styles.button}
             href={constructDataSourceExploreUrl(dataSource)}
-            onClick={() => {
-              trackExploreClicked({
-                grafana_version: config.buildInfo.version,
-                datasource_uid: dataSource.uid,
-                plugin_name: dataSource.typeName,
-                path: window.location.pathname,
-              });
-            }}
           >
             <Trans i18nKey="datasources.data-sources-list-card.explore">Explore</Trans>
           </LinkButton>

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -1,13 +1,13 @@
 import { PluginExtensionPoints } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, usePluginLinks, useFavoriteDatasources, reportInteraction } from '@grafana/runtime';
+import { usePluginLinks, useFavoriteDatasources, reportInteraction } from '@grafana/runtime';
 import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { Button, Dropdown, LinkButton, Menu, Icon, IconButton } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { ALLOWED_DATASOURCE_EXTENSION_PLUGINS } from '../constants';
 import { useDataSource } from '../state/hooks';
-import { trackDsConfigClicked, trackExploreClicked } from '../tracking';
+import { trackDsConfigClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
 import { BuildDashboardButton } from './BuildDashboardButton';
@@ -77,12 +77,6 @@ export function EditDataSourceActions({ uid }: Props) {
 
   const handleExploreClick = () => {
     trackDsConfigClicked('explore');
-    trackExploreClicked({
-      grafana_version: config.buildInfo.version,
-      datasource_uid: dataSource.uid,
-      plugin_name: dataSource.typeName,
-      path: window.location.pathname,
-    });
   };
 
   const exploreMenu = (

--- a/public/app/features/datasources/tracking.ts
+++ b/public/app/features/datasources/tracking.ts
@@ -67,20 +67,12 @@ type DataSourceGeneralTrackingProps = {
   path?: string;
 };
 
-export const trackExploreClicked = (props: DataSourceGeneralTrackingProps) => {
-  reportInteraction('grafana_ds_explore_datasource_clicked', props);
-};
-
 export const trackBuildDashboardDropdownClicked = (props: DataSourceGeneralTrackingProps) => {
   reportInteraction('grafana_ds_build_dashboard_dropdown_clicked', props);
 };
 
 export const trackCreateDashboardClicked = (props: DataSourceGeneralTrackingProps) => {
   reportInteraction('grafana_ds_create_dashboard_clicked', props);
-};
-
-export const trackDataSourcesListViewed = (props: { grafana_version?: string; path?: string }) => {
-  reportInteraction('grafana_ds_datasources_list_viewed', props);
 };
 
 export const trackDsConfigClicked = (item: string) => {
@@ -93,14 +85,6 @@ export const trackDsConfigUpdated = (props: { item: string; error?: unknown }) =
 
 export const trackDsSearched = (props: { query: string }) => {
   reportInteraction('connections_datasource_list_searched', {
-    ...props,
-    creator_team: 'grafana_plugins_catalog',
-    schema_version: '1.0.0',
-  });
-};
-
-export const trackAddNewDsClicked = (props: { path: string }) => {
-  reportInteraction('connections_datasource_list_add_datasource_clicked', {
     ...props,
     creator_team: 'grafana_plugins_catalog',
     schema_version: '1.0.0',

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { type PluginMeta } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
 import { updateAppPluginSettings } from '@grafana/runtime/unstable';
 import { Button } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -29,12 +28,6 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
   const { enabled, autoEnabled, jsonData } = pluginConfig?.meta;
 
   const enable = () => {
-    reportInteraction('plugins_detail_enable_clicked', {
-      path: window.location.pathname,
-      plugin_id: plugin.id,
-      creator_team: 'grafana_plugins_catalog',
-      schema_version: '1.0.0',
-    });
     updatePluginSettingsAndReload(plugin.id, {
       enabled: true,
       pinned: true,
@@ -43,12 +36,6 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
   };
 
   const disable = () => {
-    reportInteraction('plugins_detail_disable_clicked', {
-      path: window.location.pathname,
-      plugin_id: plugin.id,
-      creator_team: 'grafana_plugins_catalog',
-      schema_version: '1.0.0',
-    });
     updatePluginSettingsAndReload(plugin.id, {
       enabled: false,
       pinned: false,

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -21,7 +21,7 @@ import {
   useUnsetInstall,
   useFetchDetailsLazy,
 } from '../../state/hooks';
-import { trackPluginInstalled, trackPluginUninstalled } from '../../tracking';
+import { trackPluginInstalled } from '../../tracking';
 import { type CatalogPlugin, PluginStatus, PluginTabIds, type Version } from '../../types';
 
 const PLUGIN_UPDATE_INTERACTION_EVENT_NAME = 'plugin_update_clicked';
@@ -92,7 +92,6 @@ export function InstallControlsButton({
 
   const onUninstall = async () => {
     hideConfirmModal();
-    trackPluginUninstalled(trackingProps);
     await uninstall(plugin.id);
     if (!errorUninstalling) {
       // If an app plugin is uninstalled we need to reset the active tab when the config / dashboards tabs are removed.

--- a/public/app/features/plugins/admin/components/PluginDetailsPanel.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPanel.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { type PageInfoItem } from '@grafana/runtime/internal';
 import {
   Stack,
@@ -53,9 +53,8 @@ export function PluginDetailsPanel(props: Props): React.ReactElement | null {
 
   const styles = useStyles2(getStyles);
 
-  const onClickReportConcern = (pluginId: string) => {
+  const onClickReportConcern = () => {
     setReportAbuseModalOpen(true);
-    reportInteraction('plugin_detail_report_concern', { plugin_id: pluginId });
   };
 
   function createTestId(text: string) {
@@ -239,7 +238,7 @@ export function PluginDetailsPanel(props: Props): React.ReactElement | null {
               }
             >
               <Stack direction="column">
-                <Button variant="secondary" fill="solid" icon="bell" onClick={() => onClickReportConcern(plugin.id)}>
+                <Button variant="secondary" fill="solid" icon="bell" onClick={onClickReportConcern}>
                   <Trans i18nKey="plugins.details.labels.contactGrafanaLabs">Contact Grafana Labs</Trans>
                 </Button>
               </Stack>

--- a/public/app/features/plugins/admin/components/RoadmapLinks.tsx
+++ b/public/app/features/plugins/admin/components/RoadmapLinks.tsx
@@ -1,5 +1,4 @@
 import { Trans } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
 import { Space, TextLink } from '@grafana/ui';
 
 export const RoadmapLinks = () => {
@@ -8,17 +7,12 @@ export const RoadmapLinks = () => {
       <Space v={2} />
       <TextLink
         href="https://github.com/grafana/grafana/issues/new?assignees=&labels=area%2Fdatasource%2Ctype%2Fnew-plugin-request&projects=&template=3-data_source_request.yaml&title=%5BNew+Data+Source%5D%3A+%3Cname-of-service%3E"
-        onClick={() => reportInteraction('connections_data_source_request_clicked')}
         external
       >
         <Trans i18nKey="connections.connect-data.request-data-source">Request a new data source</Trans>
       </TextLink>
       <br />
-      <TextLink
-        href="https://github.com/orgs/grafana/projects/619/views/1?pane=info"
-        onClick={() => reportInteraction('connections_data_source_roadmap_clicked')}
-        external
-      >
+      <TextLink href="https://github.com/orgs/grafana/projects/619/views/1?pane=info" external>
         <Trans i18nKey="connections.connect-data.roadmap">View roadmap</Trans>
       </TextLink>
     </div>

--- a/public/app/features/plugins/admin/tracking.ts
+++ b/public/app/features/plugins/admin/tracking.ts
@@ -12,7 +12,3 @@ type PluginTrackingProps = {
 export const trackPluginInstalled = (props: PluginTrackingProps) => {
   reportInteraction('grafana_plugin_install_clicked', props);
 };
-
-export const trackPluginUninstalled = (props: PluginTrackingProps) => {
-  reportInteraction('grafana_plugin_uninstall_clicked', props);
-};


### PR DESCRIPTION
**What is this feature?**

Removes the instrumentation for 11 RudderStack events that the data_governance unused-event detector flagged: they still ingest volume (46.5k events in the last 30 days) but nothing has queried them in 90+ days. Removal was approved on the issue.

**Why do we need this feature?**

These events consume monthly RudderStack quota and storage without any downstream consumer.

**Which issue(s) does this PR fix?**:

Fixes #127677

**Special notes for your reviewer:**

journey-tracking.md lists `connections_datasource_list_add_datasource_clicked` as one of three start triggers for the documented `datasource_configure` journey. That journey is not implemented yet, so the doc was left as is.