### PR TITLE
Fix token matching for Hugo shortcodes missing post-argument whitespace

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,4 +2,5 @@ MinAlertLevel = warning
 
 [*.md]
 BasedOnStyles = Grafana
-TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*
+TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*, \
+({{<[^\n]+?>}}|{{%[^\n]+?%}})


### PR DESCRIPTION
Extends TokenIgnores to also ignore Hugo shortcodes like `{{< figure src="..." alt="...">}}` that omit the space before the closing delimiter.