### PR TITLE
Export RadialGauge component from index.ts

### DIFF
--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -138,6 +138,7 @@ export {
 } from './components/BigValue/BigValueTypes';
 export { Sparkline } from './components/Sparkline/Sparkline';
 
+export { RadialGauge } from './components/RadialGauge/RadialGauge';
 export { BarGauge } from './components/BarGauge/BarGauge';
 export {
   VizTooltip,


### PR DESCRIPTION
**What is this feature?**

Add export for `RadialGauge` to `index.ts`

**Why do we need this feature?**

Bring the exports inline with the Docs

**Who is this feature for?**

everyone who needs a radial gauge for a custom panel plugin

**Which issue(s) does this PR fix?**:

Fixes #128283

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
