### PR TITLE
add metrics for  authz in datasource apiservers

### DIFF
--- a/pkg/registry/apis/datasource/authorizer.go
+++ b/pkg/registry/apis/datasource/authorizer.go
@@ -32,9 +32,11 @@ func (b *DataSourceAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 				caller = svcIdentity[0]
 			}
 
+			verb := attr.GetVerb()
+
 			user, err := identity.GetRequester(ctx)
 			if err != nil {
-				recordAuthzDecision(sub, caller, "deny", "no_user")
+				recordAuthzDecision(sub, verb, caller, "deny", "no_user")
 				return authorizer.DecisionDeny, "valid user is required", err
 			}
 
@@ -43,7 +45,7 @@ func (b *DataSourceAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 				Resource:  "datasources",
 				Namespace: attr.GetNamespace(),
 				Name:      attr.GetName(),
-				Verb:      attr.GetVerb(),
+				Verb:      verb,
 			}
 
 			if sub != "" {
@@ -53,19 +55,19 @@ func (b *DataSourceAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 
 			rsp, err := b.accessClient.Check(ctx, user, req, "")
 			if err != nil {
-				recordAuthzDecision(sub, caller, "deny", "error")
+				recordAuthzDecision(sub, verb, caller, "deny", "error")
 				return authorizer.DecisionDeny, "failed to check permissions", err
 			}
 			if rsp.Allowed {
-				recordAuthzDecision(sub, caller, "allow", "")
+				recordAuthzDecision(sub, verb, caller, "allow", "")
 				return authorizer.DecisionAllow, "", nil
 			}
 			if req.Subresource != "" {
-				recordAuthzDecision(sub, caller, "deny", "missing_permissions")
+				recordAuthzDecision(sub, verb, caller, "deny", "missing_permissions")
 				return authorizer.DecisionDeny, "missing `query` subresource permission", nil
 			}
 
-			recordAuthzDecision(sub, caller, "deny", "access_denied")
+			recordAuthzDecision(sub, verb, caller, "deny", "access_denied")
 			return authorizer.DecisionDeny, "access denied", nil
 		})
 }

--- a/pkg/registry/apis/datasource/authorizer.go
+++ b/pkg/registry/apis/datasource/authorizer.go
@@ -36,7 +36,7 @@ func (b *DataSourceAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 
 			user, err := identity.GetRequester(ctx)
 			if err != nil {
-				recordAuthzDecision(sub, verb, caller, "deny", "no_user")
+				recordAuthzDecision(group, sub, verb, caller, "deny", "no_user")
 				return authorizer.DecisionDeny, "valid user is required", err
 			}
 
@@ -55,19 +55,19 @@ func (b *DataSourceAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 
 			rsp, err := b.accessClient.Check(ctx, user, req, "")
 			if err != nil {
-				recordAuthzDecision(sub, verb, caller, "deny", "error")
+				recordAuthzDecision(group, sub, verb, caller, "deny", "error")
 				return authorizer.DecisionDeny, "failed to check permissions", err
 			}
 			if rsp.Allowed {
-				recordAuthzDecision(sub, verb, caller, "allow", "")
+				recordAuthzDecision(group, sub, verb, caller, "allow", "")
 				return authorizer.DecisionAllow, "", nil
 			}
 			if req.Subresource != "" {
-				recordAuthzDecision(sub, verb, caller, "deny", "missing_permissions")
+				recordAuthzDecision(group, sub, verb, caller, "deny", "missing_permissions")
 				return authorizer.DecisionDeny, "missing `query` subresource permission", nil
 			}
 
-			recordAuthzDecision(sub, verb, caller, "deny", "access_denied")
+			recordAuthzDecision(group, sub, verb, caller, "deny", "access_denied")
 			return authorizer.DecisionDeny, "access denied", nil
 		})
 }

--- a/pkg/registry/apis/datasource/authorizer.go
+++ b/pkg/registry/apis/datasource/authorizer.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
+	authn "github.com/grafana/authlib/authn"
 	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -17,8 +18,23 @@ func (b *DataSourceAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 			if !attr.IsResourceRequest() {
 				return authorizer.DecisionNoOpinion, "", nil
 			}
+
+			sub := attr.GetSubresource()
+
+			var svcIdentity []string
+			if authInfo, ok := authlib.AuthInfoFrom(ctx); ok {
+				svcIdentity = authInfo.GetExtra()[authn.ServiceIdentityKey]
+			}
+
+			// Observe svc_identity state for future enforcement.
+			caller := "empty"
+			if len(svcIdentity) > 0 {
+				caller = svcIdentity[0]
+			}
+
 			user, err := identity.GetRequester(ctx)
 			if err != nil {
+				recordAuthzDecision(sub, caller, "deny", "no_user")
 				return authorizer.DecisionDeny, "valid user is required", err
 			}
 
@@ -30,22 +46,26 @@ func (b *DataSourceAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 				Verb:      attr.GetVerb(),
 			}
 
-			// Must have query permission to access any subresource
-			if attr.GetSubresource() != "" {
+			if sub != "" {
 				req.Verb = utils.VerbCreate
 				req.Subresource = "query"
 			}
 
 			rsp, err := b.accessClient.Check(ctx, user, req, "")
 			if err != nil {
+				recordAuthzDecision(sub, caller, "deny", "error")
 				return authorizer.DecisionDeny, "failed to check permissions", err
 			}
 			if rsp.Allowed {
+				recordAuthzDecision(sub, caller, "allow", "")
 				return authorizer.DecisionAllow, "", nil
 			}
 			if req.Subresource != "" {
+				recordAuthzDecision(sub, caller, "deny", "missing_permissions")
 				return authorizer.DecisionDeny, "missing `query` subresource permission", nil
 			}
+
+			recordAuthzDecision(sub, caller, "deny", "access_denied")
 			return authorizer.DecisionDeny, "access denied", nil
 		})
 }

--- a/pkg/registry/apis/datasource/metrics.go
+++ b/pkg/registry/apis/datasource/metrics.go
@@ -15,7 +15,7 @@ var (
 			Name:      "authz_decisions_total",
 			Help:      "Total datasource authorizer decisions by subresource, outcome, and reason.",
 		},
-		[]string{"subresource", "svcIdentity", "decision", "reason"},
+		[]string{"group", "subresource", "verb", "svcIdentity", "decision", "reason"},
 	)
 
 	dsSubresourceRequests = prometheus.NewCounterVec(
@@ -50,8 +50,8 @@ func registerSubresourceMetrics(reg prometheus.Registerer) {
 
 // recordAuthzDecision increments the authz counter. subresource is the raw
 // k8s subresource from the request (empty string for CRUD operations).
-func recordAuthzDecision(subresource, svcIdentity, decision, reason string) {
-	dsAuthzDecisions.WithLabelValues(subresource, svcIdentity, decision, reason).Inc()
+func recordAuthzDecision(group, subresource, verb, svcIdentity, decision, reason string) {
+	dsAuthzDecisions.WithLabelValues(group, subresource, verb, svcIdentity, decision, reason).Inc()
 }
 
 // connectMetric tracks a single request across the Connect (setup) and

--- a/pkg/registry/apis/datasource/metrics.go
+++ b/pkg/registry/apis/datasource/metrics.go
@@ -8,6 +8,16 @@ import (
 )
 
 var (
+	dsAuthzDecisions = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "grafana",
+			Subsystem: "ds_apiserver",
+			Name:      "authz_decisions_total",
+			Help:      "Total datasource authorizer decisions by subresource, outcome, and reason.",
+		},
+		[]string{"subresource", "svcIdentity", "decision", "reason"},
+	)
+
 	dsSubresourceRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "grafana",
@@ -34,8 +44,14 @@ var (
 
 func registerSubresourceMetrics(reg prometheus.Registerer) {
 	registerSubresourceMetricsOnce.Do(func() {
-		reg.MustRegister(dsSubresourceRequests, dsSubresourceRequestDuration)
+		reg.MustRegister(dsAuthzDecisions, dsSubresourceRequests, dsSubresourceRequestDuration)
 	})
+}
+
+// recordAuthzDecision increments the authz counter. subresource is the raw
+// k8s subresource from the request (empty string for CRUD operations).
+func recordAuthzDecision(subresource, svcIdentity, decision, reason string) {
+	dsAuthzDecisions.WithLabelValues(subresource, svcIdentity, decision, reason).Inc()
 }
 
 // connectMetric tracks a single request across the Connect (setup) and


### PR DESCRIPTION
Adds some metrics so we can track the state of authz against the datasource api service http requests. Will also give us insight into who is calling us to help determine how we want to hande things in the future