### PR TITLE
Folders: Fix move 500 from invalid OpenFGA batch-check correlation IDs

### DIFF
--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -284,10 +284,11 @@ func checkMoveAccess(
 
 	folderGVR := folders.FolderResourceInfo.GroupVersionResource()
 
+	// Separators must keep correlation IDs within OpenFGA's regex pattern ^[\w\d-]{1,36}$
 	const (
 		writeDestKey    = "writeDest"
-		newFolderPrefix = "newFolder|"
-		oldFolderPrefix = "oldFolder|"
+		newFolderPrefix = "newFolder-"
+		oldFolderPrefix = "oldFolder-"
 	)
 
 	checks := make([]authlib.BatchCheckItem, 0, 1+2*len(tierProbes))

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -3,6 +3,7 @@ package folders
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1546,6 +1547,7 @@ func TestCheckMoveAccess(t *testing.T) {
 			// All access checks must be batched into one BatchCheck round-trip.
 			if mock != nil {
 				require.Equal(t, 1, mock.batchCheckCall, "expected exactly one BatchCheck call")
+				require.Empty(t, mock.badCorrelationID, "correlation IDs must satisfy OpenFGA's regex")
 			}
 		})
 	}
@@ -1570,17 +1572,21 @@ func TestCheckMoveAccess(t *testing.T) {
 	t.Run("fails closed when BatchCheck omits an escalation verb result", func(t *testing.T) {
 		ctx := identity.WithRequester(context.Background(), &user.SignedInUser{UserID: 1, OrgID: orgID})
 		mock := newMockAccessClient([]allow{canCreateFolderInNew})
-		mock.dropResultFor = "newFolder|" + utils.VerbGet
+		mock.dropResultFor = "newFolder-" + utils.VerbGet
 		err := checkMoveAccess(ctx, namespace, sourceUID, oldParentUID, newParentUID, mock)
 		require.ErrorContains(t, err, "no result for verb")
 	})
 }
 
+// correlationIDPattern is the CorrelationId regex enforced by OpenFGA
+var correlationIDPattern = regexp.MustCompile(`^[\w\d-]{1,36}$`)
+
 type mockAccessClient struct {
-	allowed        map[allow]struct{}
-	batchCheckCall int
-	batchCheckErr  error
-	dropResultFor  string // CorrelationID to omit from BatchCheckResponse, simulating a bad server
+	allowed          map[allow]struct{}
+	batchCheckCall   int
+	batchCheckErr    error
+	dropResultFor    string // CorrelationID to omit from BatchCheckResponse, simulating a bad server
+	badCorrelationID string // first CorrelationID seen that OpenFGA would reject
 }
 
 func newMockAccessClient(allows []allow) *mockAccessClient {
@@ -1603,6 +1609,9 @@ func (m *mockAccessClient) BatchCheck(_ context.Context, _ authlib.AuthInfo, req
 	}
 	results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
 	for _, c := range req.Checks {
+		if m.badCorrelationID == "" && !correlationIDPattern.MatchString(c.CorrelationID) {
+			m.badCorrelationID = c.CorrelationID
+		}
 		if c.CorrelationID == m.dropResultFor {
 			continue
 		}

--- a/pkg/services/authz/zanzana/server/server_batch_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check_test.go
@@ -55,6 +55,23 @@ func TestIntegrationServerBatchCheck(t *testing.T) {
 		assert.True(t, res.GetResults()["check1"].GetAllowed())
 	})
 
+	t.Run("pipe in correlation id is rejected by OpenFGA", func(t *testing.T) {
+		// OpenFGA validates CorrelationId against ^[\w\d-]{1,36}$; '|' fails
+		items := []*authzv1.BatchCheckItem{
+			newItem("newFolder|get", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"),
+		}
+		_, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:1", items))
+		require.Error(t, err)
+
+		// '-' separator satisfies the regex; the request succeeds.
+		items = []*authzv1.BatchCheckItem{
+			newItem("newFolder-get", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:1", items))
+		require.NoError(t, err)
+		require.Contains(t, res.GetResults(), "newFolder-get")
+	})
+
 	t.Run("multiple items with mixed permissions", func(t *testing.T) {
 		items := []*authzv1.BatchCheckItem{
 			newItem("check1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"), // user:1 has access


### PR DESCRIPTION
**What is this feature?**

Fixes a 500 error when moving folders. The move-access batch check built authz correlation IDs with a `|` separator (`newFolder|get`); Zanzana forwards these to OpenFGA, which validates `CorrelationId` against `^[\w\d-]{1,36}$` and rejects `|` with `InvalidArgument`. This PR switches the separator to `-`.

See: https://github.com/openfga/dotnet-sdk/blob/v0.10.3/docs/OpenFgaApi.md#batchcheck

**Why do we need this feature?**

Every folder move that triggers the access-escalation check (moving into a non-root parent) failed with `failed to move folder: failed to perform batch check request` and a generic HTTP 500. The real cause was masked in the response and only visible in `zanzana.server` logs.

**Who is this feature for?**

All Grafana users organizing dashboards via nested folders when Zanzana/OpenFGA authorization is enabled.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Two tests added: an integration test in `server_batch_check_test.go` proving OpenFGA rejects a `|` correlation ID and accepts `-` (real embedded store), and a unit guard in `validate_test.go` that fails if `validate.go`'s separator regresses to a non-`[\w\d-]` character. Regression introduced by #125124.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New.
