### PR TITLE
Deps: Bump react-i18next to 17.0.9, i18next to 26.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -376,7 +376,7 @@
     "react-draggable": "4.5.0",
     "react-highlight-words": "0.21.0",
     "react-hook-form": "^7.49.2",
-    "react-i18next": "^16.6.6",
+    "react-i18next": "^17.0.9",
     "react-inlinesvg": "4.3.0",
     "react-loading-skeleton": "3.5.0",
     "react-moveable": "0.56.0",

--- a/package.json
+++ b/package.json
@@ -337,7 +337,7 @@
     "file-saver": "2.0.5",
     "history": "4.10.1",
     "html-to-image": "1.11.13",
-    "i18next": "^25.10.9",
+    "i18next": "^26.3.6",
     "idb": "^8.0.3",
     "immer": "10.2.0",
     "immutable": "5.1.5",

--- a/packages/grafana-i18n/package.json
+++ b/packages/grafana-i18n/package.json
@@ -55,7 +55,7 @@
     "@formatjs/intl-durationformat": "^0.7.0",
     "@typescript-eslint/utils": "^8.33.1",
     "fast-deep-equal": "^3.1.3",
-    "i18next": "^25.10.9",
+    "i18next": "^26.3.6",
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-pseudo": "^2.2.1",
     "micro-memoize": "^4.1.2",

--- a/packages/grafana-i18n/package.json
+++ b/packages/grafana-i18n/package.json
@@ -59,7 +59,7 @@
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-pseudo": "^2.2.1",
     "micro-memoize": "^4.1.2",
-    "react-i18next": "^16.6.6"
+    "react-i18next": "^17.0.9"
   },
   "devDependencies": {
     "@types/react": "18.3.18",

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -8,13 +8,6 @@ import { DEFAULT_LANGUAGE, PSEUDO_LOCALE } from './constants';
 import { LANGUAGES } from './languages';
 import { type ResourceLoader, type Resources, type TFunction, type TransProps, type TransType } from './types';
 
-// FIXME: No longer needed in i18next@26: https://www.locize.com/docs/general-questions/why-was-there-a-support-notice-for-i18next
-// Set __i18next_supportNoticeShown to true to avoid the console.info message promoting Locize.
-if (typeof globalThis !== 'undefined') {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  (globalThis as Record<string, unknown>).__i18next_supportNoticeShown = true;
-}
-
 let tFunc: I18NextTFunction<string[], undefined> | undefined;
 let transComponent: TransType;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,7 +2560,7 @@ __metadata:
     i18next-browser-languagedetector: "npm:^8.0.0"
     i18next-pseudo: "npm:^2.2.1"
     micro-memoize: "npm:^4.1.2"
-    react-i18next: "npm:^16.6.6"
+    react-i18next: "npm:^17.0.9"
     rollup: "npm:^4.60.1"
     typescript: "npm:6.0.2"
   peerDependencies:
@@ -18863,7 +18863,7 @@ __metadata:
     react-draggable: "npm:4.5.0"
     react-highlight-words: "npm:0.21.0"
     react-hook-form: "npm:^7.49.2"
-    react-i18next: "npm:^16.6.6"
+    react-i18next: "npm:^17.0.9"
     react-inlinesvg: "npm:4.3.0"
     react-loading-skeleton: "npm:3.5.0"
     react-moveable: "npm:0.56.0"
@@ -27791,31 +27791,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-i18next@npm:^16.6.6":
-  version: 16.6.6
-  resolution: "react-i18next@npm:16.6.6"
-  dependencies:
-    "@babel/runtime": "npm:^7.29.2"
-    html-parse-stringify: "npm:^3.0.1"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    i18next: ">= 25.10.9"
-    react: ">= 16.8.0"
-    typescript: ^5 || ^6
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-    typescript:
-      optional: true
-  checksum: 10/5916b8eb0bf2e8d6aef06077640c2ac81603b47aca82c1314c73be3604f0a64337964049d6efc07607f296209f02ffe2ba7a0fa6fbed570f3d5e1b83ee8a4059
-  languageName: node
-  linkType: hard
-
-"react-i18next@npm:^17.0.7":
-  version: 17.0.8
-  resolution: "react-i18next@npm:17.0.8"
+"react-i18next@npm:^17.0.7, react-i18next@npm:^17.0.9":
+  version: 17.0.9
+  resolution: "react-i18next@npm:17.0.9"
   dependencies:
     "@babel/runtime": "npm:^7.29.2"
     html-parse-stringify: "npm:^3.0.1"
@@ -27823,7 +27801,7 @@ __metadata:
   peerDependencies:
     i18next: ">= 26.2.0"
     react: ">= 16.8.0"
-    typescript: ^5 || ^6
+    typescript: ^5 || ^6 || ^7
   peerDependenciesMeta:
     react-dom:
       optional: true
@@ -27831,7 +27809,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10/7ac39b9b38ae2e572b6ffcf1e2e3ef9479daef9cd4c51e2e16464b5e0e641a55d16b2a5988fc99da8f749a63c8bb21a6ebf810182c22fb63cc7a18fbbd6334dd
+  checksum: 10/9849d2681f5a045a825137a09822a304a16bed0cee697b92a797a539b3fb2a4ed87ee1360a1f303e308e6f0469c27c2bbdaad6cc4363b9ba2923a99117fa3701
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,7 +2556,7 @@ __metadata:
     "@types/react": "npm:18.3.18"
     "@typescript-eslint/utils": "npm:^8.33.1"
     fast-deep-equal: "npm:^3.1.3"
-    i18next: "npm:^25.10.9"
+    i18next: "npm:^26.3.6"
     i18next-browser-languagedetector: "npm:^8.0.0"
     i18next-pseudo: "npm:^2.2.1"
     micro-memoize: "npm:^4.1.2"
@@ -18793,7 +18793,7 @@ __metadata:
     history: "npm:4.10.1"
     html-to-image: "npm:1.11.13"
     http-server: "npm:14.1.1"
-    i18next: "npm:^25.10.9"
+    i18next: "npm:^26.3.6"
     i18next-cli: "npm:^1.48.0"
     idb: "npm:^8.0.3"
     immer: "npm:10.2.0"
@@ -19601,17 +19601,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"i18next@npm:^25.10.9":
-  version: 25.10.10
-  resolution: "i18next@npm:25.10.10"
-  dependencies:
-    "@babel/runtime": "npm:^7.29.2"
+"i18next@npm:^26.3.6":
+  version: 26.3.6
+  resolution: "i18next@npm:26.3.6"
   peerDependencies:
-    typescript: ^5 || ^6
+    typescript: ^5 || ^6 || ^7
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/ee4f6ba360902a2f0550cfeef234c9e68a67487b575d204e89bdf2f2db647934aa3900a39c64174b9201a8979e455d0bf8f56b57934c34fc8f9aa3b430cb152d
+  checksum: 10/529f1dbfae6b0fe98d997af98af5d6d0a0e27ddf5b91b81c5dfccad94e3a66dceeba2d1b7327f0045085bc4d552abbf4a1efbfadd4bbb98d13a54e3310eae428
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Follow-up to #128063, bumps `react-i18next` to its latest version, from 16.6.6 to 17.0.9. The only [documented breaking change](https://github.com/i18next/react-i18next/blob/master/CHANGELOG.md#1700) is a fix for translations generated when `transKeepBasicHtmlNodesFor` is set. We do not override this setting, though it does appear to be enabled by default -- `make i18n-extract` does not appear to generate a diff, and I already see `<strong>` in translation files, so I don't think we're affected 🤔.

This also bumps the `i18next` version from 25.10.9 to 26.3.6, as `react-i18next@17` has a minimum peer dependency of `i18next@26`. The only [documented breaking changes](https://github.com/i18next/i18next/blob/master/CHANGELOG.md#2600) are removals of three deprecated options (`initImmediate`, `simplifyPluralSuffix`, and `interpolation.format`) that Grafana does not use, as well as the removal of the `console.info` promotional message (which we can clean up our suppression of).

**Why do we need this feature?**

Gets these dependencies both updated to their latest major versions, and also, quite nicely, introduces support for TypeScript 7 for both!

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
