### PR TITLE
chore(analytics): remove unused RudderStack events — @grafana/grafana-frontend-platform

### DIFF
--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
@@ -158,10 +158,6 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
         preferenceType: props.preferenceType,
       });
     } else {
-      reportInteraction('grafana_preferences_language_changed', {
-        toLanguage: language,
-        preferenceType: props.preferenceType,
-      });
     }
   };
 

--- a/public/app/core/components/SharedPreferences/SharedPreferencesOld.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesOld.tsx
@@ -152,10 +152,6 @@ class SharedPreferences extends PureComponent<Props, State> {
   onLanguageChanged = (language: string) => {
     this.setState({ language });
 
-    reportInteraction('grafana_preferences_language_changed', {
-      toLanguage: language,
-      preferenceType: this.props.preferenceType,
-    });
   };
 
   render() {

--- a/public/app/core/services/NewFrontendAssetsChecker.ts
+++ b/public/app/core/services/NewFrontendAssetsChecker.ts
@@ -53,10 +53,6 @@ export class NewFrontendAssetsChecker {
     }
     // Track potential page change
     else if (this.hasUpdates) {
-      reportInteraction('new_frontend_assets_reload_ignored', {
-        newLocation: location.pathname,
-        prevLocation: this.prevLocationPath,
-      });
     }
 
     this.prevLocationPath = location.pathname;
@@ -96,7 +92,6 @@ export class NewFrontendAssetsChecker {
   public reloadIfUpdateDetected() {
     if (this.hasUpdates) {
       // Report that we detected new assets
-      reportInteraction('new_frontend_assets_reload', {});
       window.location.reload();
     }
 


### PR DESCRIPTION
## Remove unused RudderStack events (monthly quota cleanup)

We are consuming our **monthly RudderStack event quota** on events nobody uses. The events below are **still being ingested** (they have volume in the last **30 days**) but have **not been referenced by any query, dbt model, or dashboard in the last 90 days** (downstream usage scanned over a 180-day window). Only events whose tables are at least **90 days old** were considered, so freshly instrumented events are excluded.

Combined, these events sent **757,685 events in the last 30 days** (~17.69 GB stored). Dropping the instrumentation stops the quota spend at the source.

Addresses https://github.com/grafana/grafana/issues/127671.
Tracking: https://github.com/grafana/product_analytics/issues/812.

Detected automatically by the `data_governance` unused-event detector. cc @grafana/grafana-frontend-platform

### Removed in this PR (3 events)

| Event | Events / 30d | Table size (GB) | Last consumed | Status |
| --- | ---: | ---: | --- | --- |
| `new_frontend_assets_reload_ignored` | 729,075 | 15.24 | never (in lookback) | NEVER_QUERIED |
| `new_frontend_assets_reload` | 27,556 | 2.42 | never (in lookback) | NEVER_QUERIED |
| `grafana_preferences_language_changed` | 1,054 | 0.03 | never (in lookback) | NEVER_QUERIED |

For these, the bare `reportInteraction(...)` statements were removed automatically, along with the now-unused `reportInteraction` import where no other calls remained in the file.

### Notes for reviewers

- Events are instrumented via raw `reportInteraction(...)` calls; there is no analytics-events.md to regenerate.
- Automated removal can leave an empty line or unused local variable behind — please run `yarn lint --fix` and typecheck before merging.
- **Caveat**: consumption is measured at table/view-reference level. An event queried *only* via `stg_rudderstack__tracks WHERE event_name = ...` can appear unused. Please confirm none of these are consumed that way before merging.

_Opened as a draft for owning-team review._