### PR TITLE
chore(analytics): remove unused RudderStack events — @grafana/observability-logs

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -430,10 +430,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       };
       updatePanelState(payload);
 
-      reportInteraction('grafana_explore_logs_visualisation_changed', {
-        newVisualizationType: visualisation,
-        datasourceType: props.datasourceType ?? 'unknown',
-      });
     },
     [panelState?.logs, props.datasourceType, updatePanelState]
   );
@@ -441,10 +437,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
   const onToggleLogsVolumeCollapse = useCallback(
     (collapsed: boolean) => {
       props.onSetLogsVolumeEnabled(!collapsed);
-      reportInteraction('grafana_explore_logs_histogram_toggle_clicked', {
-        datasourceType: props.datasourceType,
-        type: !collapsed ? 'open' : 'close',
-      });
     },
     [props]
   );
@@ -454,10 +446,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       event.preventDefault();
       if (props.onStartScanning) {
         props.onStartScanning();
-        reportInteraction('grafana_explore_logs_scanning_button_clicked', {
-          type: 'start',
-          datasourceType: props.datasourceType,
-        });
       }
     },
     [props]
@@ -543,11 +531,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       const url = urlUtil.renderUrl(`${baseUrl}/explore`, { left: serializedState });
       await createAndCopyShortLink(url);
 
-      reportInteraction('grafana_explore_logs_permalink_clicked', {
-        datasourceType: row.datasourceType ?? 'unknown',
-        logRowUid: row.uid,
-        logRowLevel: row.logLevel,
-      });
     },
     [absoluteRange, displayedFields, exploreId, logRows, logsSortOrder, panelState, visualisationType]
   );

--- a/public/app/features/explore/Logs/LogsSamplePanel.tsx
+++ b/public/app/features/explore/Logs/LogsSamplePanel.tsx
@@ -15,7 +15,7 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+
 import { type DataQuery, LogsSortOrder, type TimeZone } from '@grafana/schema';
 import { Button, Collapse, Icon, Tooltip, useStyles2 } from '@grafana/ui';
 import { LogList } from 'app/features/logs/components/panel/LogList';
@@ -46,10 +46,6 @@ export function LogsSamplePanel(props: Props) {
 
   const onToggleLogsSampleCollapse = (isOpen: boolean) => {
     setLogsSampleEnabled(isOpen);
-    reportInteraction('grafana_explore_logs_sample_toggle_clicked', {
-      datasourceType: datasourceInstance?.type ?? 'unknown',
-      type: isOpen ? 'open' : 'close',
-    });
   };
 
   const OpenInSplitViewButton = () => {
@@ -70,10 +66,6 @@ export function LogsSamplePanel(props: Props) {
 
     const onSplitOpen = () => {
       splitOpen({ queries: logSampleQueries, datasourceUid: datasourceInstance.uid });
-      reportInteraction('grafana_explore_logs_sample_split_button_clicked', {
-        datasourceType: datasourceInstance?.type ?? 'unknown',
-        queriesCount: logSampleQueries.length,
-      });
     };
 
     return (

--- a/public/app/features/explore/Logs/PopoverMenu.tsx
+++ b/public/app/features/explore/Logs/PopoverMenu.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { type GrafanaTheme2, type LogRowModel } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+
 import { Menu, useStyles2 } from '@grafana/ui';
 
 import { copyText } from '../../logs/utils';
@@ -110,11 +110,6 @@ export const PopoverMenu = ({
 };
 
 function track(action: string, selectionLength: number, dataSourceType: string | undefined) {
-  reportInteraction(`grafana_explore_logs_popover_menu`, {
-    action,
-    selectionLength: selectionLength,
-    datasourceType: dataSourceType || 'unknown',
-  });
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -143,10 +143,6 @@ export const LogLineContext = memo(
     useEffect(() => {
       if (open) {
         updateContextQuery();
-        reportInteraction('logs_log_line_context_open', {
-          datasourceType: log.datasourceType,
-          uid: log.uid,
-        });
       }
     }, [updateContextQuery, open, log]);
 
@@ -255,9 +251,6 @@ export const LogLineContext = memo(
         })
       );
       onClose();
-      reportInteraction('logs_log_line_context_open_in_split_clicked', {
-        datasourceType: log.datasourceType,
-      });
     }, [contextQuery, dispatch, log.dataFrame.refId, log.datasourceType, log.uid, onClose, timeRange]);
 
     const handleTimeWindowChange = useCallback(
@@ -277,10 +270,6 @@ export const LogLineContext = memo(
     );
 
     const handleClose = useCallback(() => {
-      reportInteraction('logs_log_line_context_closed', {
-        datasourceType: log.datasourceType,
-        uid: log.uid,
-      });
       onClose();
     }, [log.datasourceType, log.uid, onClose]);
 

--- a/public/app/features/logs/components/panel/LogListControls.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.tsx
@@ -110,9 +110,6 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
 
   const onFilterLevelClick = useCallback(
     (level?: LogLevel) => {
-      reportInteraction('logs_log_list_controls_level_clicked', {
-        level,
-      });
       if (level === undefined) {
         setFilterLevels([]);
       } else if (!filterLevels.includes(level)) {
@@ -133,9 +130,6 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
   }, [fontSize, setFontSize]);
 
   const onShowUniqueLabelsClick = useCallback(() => {
-    reportInteraction('logs_log_list_controls_show_unique_labels_clicked', {
-      show_unique_labels: showUniqueLabels,
-    });
     setShowUniqueLabels(!showUniqueLabels);
   }, [setShowUniqueLabels, showUniqueLabels]);
 
@@ -156,9 +150,6 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
   const onSetUnwrappedColumnsClick = useCallback(
     (e: MouseEvent) => {
       e.preventDefault();
-      reportInteraction('logs_log_list_controls_unwrapped_columns_clicked', {
-        state: !unwrappedColumns,
-      });
       setUnwrappedColumns(!unwrappedColumns);
     },
     [setUnwrappedColumns, unwrappedColumns]
@@ -175,9 +166,6 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
             label={capitalize(option)}
             onClick={() => {
               setDedupStrategy(option);
-              reportInteraction('logs_log_list_controls_deduplication_clicked', {
-                option,
-              });
             }}
           />
         ))}
@@ -215,27 +203,18 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
           label={t('logs.logs-controls.download-logs.txt', 'txt')}
           onClick={() => {
             downloadLogs(DownloadFormat.Text);
-            reportInteraction('logs_log_list_controls_downloaded_logs', {
-              format: DownloadFormat.Text,
-            });
           }}
         />
         <Menu.Item
           label={t('logs.logs-controls.download-logs.json', 'json')}
           onClick={() => {
             downloadLogs(DownloadFormat.Json);
-            reportInteraction('logs_log_list_controls_downloaded_logs', {
-              format: DownloadFormat.Json,
-            });
           }}
         />
         <Menu.Item
           label={t('logs.logs-controls.download-logs.csv', 'csv')}
           onClick={() => {
             downloadLogs(DownloadFormat.CSV);
-            reportInteraction('logs_log_list_controls_downloaded_logs', {
-              format: DownloadFormat.CSV,
-            });
           }}
         />
       </Menu>

--- a/public/app/features/logs/components/panel/LogTableControls.tsx
+++ b/public/app/features/logs/components/panel/LogTableControls.tsx
@@ -58,27 +58,18 @@ export const LogTableControls = ({
           label={t('logs.logs-controls.download-logs.txt', 'txt')}
           onClick={() => {
             downloadLogs(DownloadFormat.Text);
-            reportInteraction('logs_log_list_controls_downloaded_logs', {
-              format: DownloadFormat.Text,
-            });
           }}
         />
         <Menu.Item
           label={t('logs.logs-controls.download-logs.json', 'json')}
           onClick={() => {
             downloadLogs(DownloadFormat.Json);
-            reportInteraction('logs_log_list_controls_downloaded_logs', {
-              format: DownloadFormat.Json,
-            });
           }}
         />
         <Menu.Item
           label={t('logs.logs-controls.download-logs.csv', 'csv')}
           onClick={() => {
             downloadLogs(DownloadFormat.CSV);
-            reportInteraction('logs_log_list_controls_downloaded_logs', {
-              format: DownloadFormat.CSV,
-            });
           }}
         />
       </Menu>


### PR DESCRIPTION
## Remove unused RudderStack events (monthly quota cleanup)

We are consuming our **monthly RudderStack event quota** on events nobody uses. The events below are **still being ingested** (they have volume in the last **30 days**) but have **not been referenced by any query, dbt model, or dashboard in the last 90 days** (downstream usage scanned over a 180-day window). Only events whose tables are at least **90 days old** were considered, so freshly instrumented events are excluded.

Combined, these events sent **517,824 events in the last 30 days** (~25.53 GB stored). Dropping the instrumentation stops the quota spend at the source.

Addresses https://github.com/grafana/grafana/issues/127672.
Tracking: https://github.com/grafana/product_analytics/issues/812.

Detected automatically by the `data_governance` unused-event detector. cc @grafana/observability-logs

### Removed in this PR (16 events)

| Event | Events / 30d | Table size (GB) | Last consumed | Status |
| --- | ---: | ---: | --- | --- |
| `grafana_explore_logs_popover_menu` | 218,268 | 14.05 | 2026-02-19 | STALE |
| `logs_log_line_context_open` | 75,662 | 1.08 | never (in lookback) | NEVER_QUERIED |
| `logs_log_line_context_closed` | 56,978 | 0.91 | never (in lookback) | NEVER_QUERIED |
| `logs_log_list_controls_downloaded_logs` | 42,356 | 0.91 | never (in lookback) | NEVER_QUERIED |
| `grafana_explore_logs_visualisation_changed` | 34,975 | 2.6 | 2026-03-27 | STALE |
| `grafana_explore_logs_sample_toggle_clicked` | 24,305 | 2.28 | never (in lookback) | NEVER_QUERIED |
| `logs_log_list_controls_expand_controls_clicked` | 21,526 | 0.55 | never (in lookback) | NEVER_QUERIED |
| `grafana_explore_logs_histogram_toggle_clicked` | 17,217 | 1.54 | never (in lookback) | NEVER_QUERIED |
| `logs_log_list_controls_level_clicked` | 9,295 | 0.31 | 2026-03-11 | STALE |
| `grafana_explore_logs_scanning_button_clicked` | 5,923 | 0.39 | never (in lookback) | NEVER_QUERIED |
| `grafana_explore_logs_permalink_clicked` | 5,590 | 0.63 | never (in lookback) | NEVER_QUERIED |
| `logs_log_list_controls_deduplication_clicked` | 2,789 | 0.09 | never (in lookback) | NEVER_QUERIED |
| `logs_log_list_controls_unwrapped_columns_clicked` | 1,619 | 0.02 | 2026-02-11 | STALE |
| `grafana_explore_logs_sample_split_button_clicked` | 975 | 0.12 | never (in lookback) | NEVER_QUERIED |
| `logs_log_line_context_open_in_split_clicked` | 336 | 0.01 | never (in lookback) | NEVER_QUERIED |
| `logs_log_list_controls_show_unique_labels_clicked` | 10 | 0.04 | never (in lookback) | NEVER_QUERIED |

For these, the bare `reportInteraction(...)` statements were removed automatically, along with the now-unused `reportInteraction` import where no other calls remained in the file.

### Notes for reviewers

- Events are instrumented via raw `reportInteraction(...)` calls; there is no analytics-events.md to regenerate.
- Automated removal can leave an empty line or unused local variable behind — please run `yarn lint --fix` and typecheck before merging.
- **Caveat**: consumption is measured at table/view-reference level. An event queried *only* via `stg_rudderstack__tracks WHERE event_name = ...` can appear unused. Please confirm none of these are consumed that way before merging.

_Opened as a draft for owning-team review._