### PR TITLE
chore(analytics): remove unused RudderStack events — @grafana/datapro

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1563,11 +1563,6 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx": {
-    "react-hooks/exhaustive-deps": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx": {
     "react-hooks/exhaustive-deps": {
       "count": 1

--- a/public/app/features/explore/PrometheusListView/RawListContainer.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListContainer.tsx
@@ -6,7 +6,6 @@ import { VariableSizeList as List } from 'react-window';
 
 import { type DataFrame, type Field as DataFrameField } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-
 import { Field, Switch } from '@grafana/ui';
 
 import { ItemLabels } from './ItemLabels';
@@ -78,9 +77,6 @@ const RawListContainer = (props: RawListContainerProps) => {
 
   const onContentClick = () => {
     setIsExpandedView(!isExpandedView);
-    const props = {
-      isExpanded: !isExpandedView,
-    };
   };
 
   useEffect(() => {

--- a/public/app/features/explore/PrometheusListView/RawListContainer.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListContainer.tsx
@@ -6,7 +6,7 @@ import { VariableSizeList as List } from 'react-window';
 
 import { type DataFrame, type Field as DataFrameField } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+
 import { Field, Switch } from '@grafana/ui';
 
 import { ItemLabels } from './ItemLabels';
@@ -81,7 +81,6 @@ const RawListContainer = (props: RawListContainerProps) => {
     const props = {
       isExpanded: !isExpandedView,
     };
-    reportInteraction('grafana_explore_prometheus_instant_query_ui_raw_toggle_expand', props);
   };
 
   useEffect(() => {

--- a/public/app/features/explore/QueryRows.tsx
+++ b/public/app/features/explore/QueryRows.tsx
@@ -95,7 +95,6 @@ export const QueryRows = ({ exploreId, isOpen, changeCompactMode }: Props) => {
   };
 
   const onQueryToggled = (queryStatus?: boolean) => {
-    reportInteraction('grafana_query_row_toggle', queryStatus === undefined ? {} : { queryEnabled: queryStatus });
   };
 
   const onCancelQueryLibraryEdit = () => {

--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -148,8 +148,6 @@ export function RichHistoryCard(props: Props) {
     : undefined;
 
   const onCopyQuery = async () => {
-    const datasources = [...queryHistoryItem.queries.map((query) => query.datasource?.type || 'unknown')];
-
     const queriesText = queryHistoryItem.queries
       .map((query) => {
         let queryDS = datasourceInstances?.find((di) => di.uid === queryHistoryItem.datasourceUid);

--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -149,10 +149,6 @@ export function RichHistoryCard(props: Props) {
 
   const onCopyQuery = async () => {
     const datasources = [...queryHistoryItem.queries.map((query) => query.datasource?.type || 'unknown')];
-    reportInteraction('grafana_explore_query_history_copy_query', {
-      datasources,
-      mixed: Boolean(cardRootDatasource?.meta.mixed),
-    });
 
     const queriesText = queryHistoryItem.queries
       .map((query) => {

--- a/public/app/features/explore/state/correlations.ts
+++ b/public/app/features/explore/state/correlations.ts
@@ -5,7 +5,7 @@ import {
   generatedAPI as correlationsAPIv0alpha1,
 } from '@grafana/api-clients/rtkq/correlations/v0alpha1';
 import { type DataLinkTransformationConfig } from '@grafana/data';
-import { type CorrelationData, reportInteraction, config } from '@grafana/runtime';
+import { type CorrelationData, config } from '@grafana/runtime';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -109,10 +109,6 @@ export function saveCurrentCorrelation(
           dispatch(splitClose(keys[1]));
           await dispatch(reloadCorrelations(keys[0]));
           await dispatch(runQueries({ exploreId: keys[0] }));
-          reportInteraction('grafana_explore_correlation_editor_saved', {
-            sourceDatasourceType: sourceDatasource.type,
-            targetDataSourceType: targetDatasource.type,
-          });
         } else {
           dispatch(
             notifyApp(createErrorNotification('Error creating correlation', getMessageFromError(response.error)))
@@ -138,10 +134,6 @@ export function saveCurrentCorrelation(
             dispatch(splitClose(keys[1]));
             await dispatch(reloadCorrelations(keys[0]));
             await dispatch(runQueries({ exploreId: keys[0] }));
-            reportInteraction('grafana_explore_correlation_editor_saved', {
-              sourceDatasourceType: sourceDatasource.type,
-              targetDataSourceType: targetDatasource.type,
-            });
           })
           .catch((err) => {
             dispatch(notifyApp(createErrorNotification('Error creating correlation', err)));


### PR DESCRIPTION
## Remove unused RudderStack events (monthly quota cleanup)

We are consuming our **monthly RudderStack event quota** on events nobody uses. The events below are **still being ingested** (they have volume in the last **30 days**) but have **not been referenced by any query, dbt model, or dashboard in the last 90 days** (downstream usage scanned over a 180-day window). Only events whose tables are at least **90 days old** were considered, so freshly instrumented events are excluded.

Combined, these events sent **197,076 events in the last 30 days** (\~32.8 GB stored). Dropping the instrumentation stops the quota spend at the source.

Addresses [https://github.com/grafana/grafana/issues/127673](<https://github.com/grafana/grafana/issues/127673>).<br>Tracking: [https://github.com/grafana/product_analytics/issues/812](<https://github.com/grafana/product_analytics/issues/812>).

Detected automatically by the `data_governance` unused-event detector. cc @grafana/datapro

### Removed in this PR (13 events)

<!-- linear:table-colwidths:160,160,160,160,160 -->
| Event | Events / 30d | Table size (GB) | Last consumed | Status |
| -- | -- | -- | -- | -- |
| `grafana_query_row_toggle` | 89,180 | 18.38 | never (in lookback) | NEVER_QUERIED |
| `grafana_explore_query_row_remove` | 39,705 | 6.54 | never (in lookback) | NEVER_QUERIED |
| `grafana_explore_split_view_closed` | 33,974 | 4.62 | never (in lookback) | NEVER_QUERIED |
| `grafana_explore_prometheus_instant_query_ui_raw_toggle_expand` | 20,435 | 1.77 | never (in lookback) | NEVER_QUERIED |
| `grafana_explore_query_row_copy` | 9,456 | 1.36 | never (in lookback) | NEVER_QUERIED |
| `grafana_explore_query_replaced_from_library` | 3,333 | 0.09 | never (in lookback) | NEVER_QUERIED |
| `grafana_correlations_adding_started` | 238 | 0.01 | 2026-03-25 | STALE |
| `grafana_correlations_edited` | 224 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `grafana_explore_query_history_copy_query` | 145 | 0.01 | never (in lookback) | NEVER_QUERIED |
| `grafana_correlations_added` | 71 | 0.0 | 2026-03-25 | STALE |
| `grafana_explore_correlation_editor_exit_pressed` | 48 | 0.01 | never (in lookback) | NEVER_QUERIED |
| `grafana_correlations_deleted` | 31 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `grafana_explore_correlation_editor_saved` | 6 | 0.0 | never (in lookback) | NEVER_QUERIED |

For these, the bare `reportInteraction(...)` statements were removed automatically, along with the now-unused `reportInteraction` import where no other calls remained in the file.

### Also flagged — needs manual removal (1 events)

These are equally unused, but their call sites are not simple statements (JSX prop values, callback arguments, or test mocks), so they were left untouched to avoid breaking code. Please remove them in a follow-up:

* `grafana_correlations_details_expanded` (230 events/30d, 0.01 GB)
  * `public/app/features/correlations/CorrelationsPage.tsx:271` — jsx_or_arg: `() => reportInteraction('grafana_correlations_details_expanded'),`

### Notes for reviewers

* Events are instrumented via raw `reportInteraction(...)` calls; there is no analytics-events.md to regenerate.
* Automated removal can leave an empty line or unused local variable behind — please run `yarn lint --fix` and typecheck before merging.
* **Caveat**: consumption is measured at table/view-reference level. An event queried *only* via `stg_rudderstack__tracks WHERE event_name = ...` can appear unused. Please confirm none of these are consumed that way before merging.

*Opened as a draft for owning-team review.*