### PR TITLE
chore(analytics): remove unused RudderStack events — @grafana/dashboards-squad

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { useUpdateEffect } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
+
 import { ReactUtils, useStyles2 } from '@grafana/ui';
 
 import { QueryOperationRowHeader, type ExpanderMessages } from './QueryOperationRowHeader';
@@ -73,12 +73,6 @@ export function QueryOperationRow({
       const y = e.clientY - rect.top;
 
       // report relative mouse position within the header element
-      reportInteraction('query_row_reorder_drag_position', {
-        x: x / rect.width,
-        y: y / rect.height,
-        width: rect.width,
-        height: rect.height,
-      });
     }
   }, []);
 

--- a/public/app/features/dashboard-scene/assistant/ViewModePanelPromptCard.tsx
+++ b/public/app/features/dashboard-scene/assistant/ViewModePanelPromptCard.tsx
@@ -135,7 +135,6 @@ export function ViewModePanelPromptCard({ targets, onClose }: ViewModePanelPromp
 
       return () => {
         if (!closedExplicitlyRef.current) {
-          reportInteraction('dashboards_assistant_popover_closed', { action: 'click_outside' });
         }
       };
     }
@@ -145,7 +144,6 @@ export function ViewModePanelPromptCard({ targets, onClose }: ViewModePanelPromp
 
   const handleClose = useCallback(() => {
     closedExplicitlyRef.current = true;
-    reportInteraction('dashboards_assistant_popover_closed', { action: 'escape' });
     onClose();
   }, [onClose]);
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx
@@ -103,9 +103,6 @@ function NewEmptyTransformationsMessage(props: EmptyTransformationsProps) {
   };
 
   const handleShowMoreClick = () => {
-    reportInteraction('grafana_panel_transformations_show_more_clicked', {
-      context: 'empty_transformations_placeholder',
-    });
     props.onShowPicker();
   };
 

--- a/public/app/features/dashboard-scene/settings/variables/VariablesUnknownTable.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariablesUnknownTable.tsx
@@ -32,7 +32,6 @@ export function VariablesUnknownTable({ variables, dashboard }: VariablesUnknown
     const stop = Date.now();
     const elapsed = stop - start;
     if (elapsed >= SLOW_VARIABLES_EXPANSION_THRESHOLD) {
-      reportInteraction('Slow unknown variables expansion', { elapsed });
     }
     setChanged(0);
 

--- a/public/app/features/dashboard/services/DashboardProfiler.ts
+++ b/public/app/features/dashboard/services/DashboardProfiler.ts
@@ -1,4 +1,4 @@
-import { logMeasurement, reportInteraction, config } from '@grafana/runtime';
+import { logMeasurement, config } from '@grafana/runtime';
 import { performanceUtils, type SceneObject } from '@grafana/scenes';
 
 interface SceneInteractionProfileEvent {
@@ -32,12 +32,6 @@ export function getDashboardComponentInteractionCallback(uid: string, title: str
       endTs: e.endTs,
       timeSinceBoot: performance.measure('time_since_boot', 'frontend_boot_js_done_time_seconds').duration,
     };
-
-    reportInteraction('dashboard_interaction', {
-      interactionType: e.origin,
-      uid,
-      ...payload,
-    });
 
     logMeasurement(`dashboard_interaction`, payload, { interactionType: e.origin, dashboard: uid, title: title });
   };

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -102,7 +102,6 @@ export class InspectDataTab extends PureComponent<Props, State> {
     const dataFrame = dataFrames[this.state.dataFrameIndex];
 
     if (hasLogs) {
-      reportInteraction('grafana_logs_download_clicked', { app: this.props.app, format: 'csv' });
     }
 
     downloadDataFrameAsCsv(dataFrame, dataName, {}, transformId, this.state.excelCompatibilityMode);

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -291,9 +291,6 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
       onQueryToggled(query.hide);
     }
 
-    reportInteraction('query_editor_row_hide_query_clicked', {
-      hide: !query.hide,
-    });
   };
 
   onToggleHelp = () => {

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -13,7 +13,7 @@ import {
   getNextRefId,
   isSystemOverrideWithRef,
 } from '@grafana/data';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { getDataSourceSrv } from '@grafana/runtime';
 import { SafeSerializableSceneObject, type SceneObjectRef, type VizPanel } from '@grafana/scenes';
 import { type DataSourceRef } from '@grafana/schema';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
@@ -191,11 +191,6 @@ export class QueryEditorRows extends PureComponent<Props> {
   onDragStart = (result: DragStart) => {
     const { queries, dsSettings } = this.props;
 
-    reportInteraction('query_row_reorder_started', {
-      startIndex: result.source.index,
-      numberOfQueries: queries.length,
-      datasourceType: dsSettings.type,
-    });
   };
 
   onDragEnd = (result: DropResult) => {
@@ -208,12 +203,6 @@ export class QueryEditorRows extends PureComponent<Props> {
     const startIndex = result.source.index;
     const endIndex = result.destination.index;
     if (startIndex === endIndex) {
-      reportInteraction('query_row_reorder_canceled', {
-        startIndex,
-        endIndex,
-        numberOfQueries: queries.length,
-        datasourceType: dsSettings.type,
-      });
       return;
     }
 
@@ -222,12 +211,6 @@ export class QueryEditorRows extends PureComponent<Props> {
     update.splice(endIndex, 0, removed);
     onQueriesChange(update);
 
-    reportInteraction('query_row_reorder_ended', {
-      startIndex,
-      endIndex,
-      numberOfQueries: queries.length,
-      datasourceType: dsSettings.type,
-    });
   };
 
   render() {

--- a/public/app/features/variables/inspect/VariablesUnknownTable.tsx
+++ b/public/app/features/variables/inspect/VariablesUnknownTable.tsx
@@ -34,7 +34,6 @@ export function VariablesUnknownTable({ variables, dashboard }: VariablesUnknown
       const stop = Date.now();
       const elapsed = stop - start;
       if (elapsed >= SLOW_VARIABLES_EXPANSION_THRESHOLD) {
-        reportInteraction('Slow unknown variables expansion', { elapsed });
       }
       setChanged(0);
       setUsages(unknownsNetwork);


### PR DESCRIPTION
## Remove unused RudderStack events (monthly quota cleanup)

We are consuming our **monthly RudderStack event quota** on events nobody uses. The events below are **still being ingested** (they have volume in the last **30 days**) but have **not been referenced by any query, dbt model, or dashboard in the last 90 days** (downstream usage scanned over a 180-day window). Only events whose tables are at least **90 days old** were considered, so freshly instrumented events are excluded.

Combined, these events sent **193,383 events in the last 30 days** (~20.41 GB stored). Dropping the instrumentation stops the quota spend at the source.

Addresses https://github.com/grafana/grafana/issues/127674.
Tracking: https://github.com/grafana/product_analytics/issues/812.

Detected automatically by the `data_governance` unused-event detector. cc @grafana/dashboards-squad

### Removed in this PR (10 events)

| Event | Events / 30d | Table size (GB) | Last consumed | Status |
| --- | ---: | ---: | --- | --- |
| `query_editor_row_hide_query_clicked` | 157,336 | 18.17 | never (in lookback) | NEVER_QUERIED |
| `grafana_panel_transformations_show_more_clicked` | 13,138 | 0.2 | never (in lookback) | NEVER_QUERIED |
| `query_row_reorder_drag_position` | 8,656 | 0.91 | never (in lookback) | NEVER_QUERIED |
| `query_row_reorder_started` | 4,342 | 0.49 | never (in lookback) | NEVER_QUERIED |
| `query_row_reorder_ended` | 3,545 | 0.4 | never (in lookback) | NEVER_QUERIED |
| `dashboard_interaction` | 3,000 | 0.04 | never (in lookback) | NEVER_QUERIED |
| `grafana_logs_download_clicked` | 2,572 | 0.1 | never (in lookback) | NEVER_QUERIED |
| `query_row_reorder_canceled` | 656 | 0.08 | never (in lookback) | NEVER_QUERIED |
| `dashboards_assistant_popover_closed` | 137 | 0.02 | 2026-04-01 | STALE |
| `Slow unknown variables expansion` | 1 | 0.0 | never (in lookback) | NEVER_QUERIED |

For these, the bare `reportInteraction(...)` statements were removed automatically, along with the now-unused `reportInteraction` import where no other calls remained in the file.

### Notes for reviewers

- Events are instrumented via raw `reportInteraction(...)` calls; there is no analytics-events.md to regenerate.
- Automated removal can leave an empty line or unused local variable behind — please run `yarn lint --fix` and typecheck before merging.
- **Caveat**: consumption is measured at table/view-reference level. An event queried *only* via `stg_rudderstack__tracks WHERE event_name = ...` can appear unused. Please confirm none of these are consumed that way before merging.

_Opened as a draft for owning-team review._