### PR TITLE
chore(analytics): remove unused RudderStack events — @grafana/grafana-frontend-navigation

### DIFF
--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -163,18 +163,11 @@ export class AppChromeService {
     const nextMode = this.getNextKioskMode();
     this.update({ kioskMode: nextMode });
     locationService.partial({ kiosk: this.getKioskUrlValue(nextMode) });
-    reportInteraction('grafana_kiosk_mode', {
-      action: 'toggle',
-      mode: nextMode,
-    });
   };
 
   public exitKioskMode() {
     this.update({ kioskMode: undefined });
     locationService.partial({ kiosk: null });
-    reportInteraction('grafana_kiosk_mode', {
-      action: 'exit',
-    });
   }
 
   public setKioskModeFromUrl(kiosk: UrlQueryValue) {

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -130,15 +130,10 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
         title: newValue,
       });
       if ('error' in result) {
-        reportInteraction('grafana_browse_dashboards_page_edit_folder_name', {
-          status: 'failed_with_error',
-        });
         throw result.error;
       } else {
-        reportInteraction('grafana_browse_dashboards_page_edit_folder_name', { status: 'success' });
       }
     } else {
-      reportInteraction('grafana_browse_dashboards_page_edit_folder_name', { status: 'failed_no_folderDTO' });
     }
   };
 

--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -76,10 +76,6 @@ export default function CreateNewButton({
       });
 
       const depth = parentFolder ? (parentFolder.parents?.length || 0) + 1 : 0;
-      reportInteraction('grafana_manage_dashboards_folder_created', {
-        is_subfolder: Boolean(parentFolder?.uid),
-        folder_depth: depth,
-      });
 
       if (!folder.error) {
         notifyApp.success('Folder created');

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -61,13 +61,6 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
 
   const onMove = async (destinationUID: string) => {
     await moveFolder({ folderUID: folder.uid, destinationUID: destinationUID });
-    reportInteraction('grafana_manage_dashboards_item_moved', {
-      item_counts: {
-        folder: 1,
-        dashboard: 0,
-      },
-      source: 'folder_actions',
-    });
   };
 
   const onDelete = async () => {

--- a/public/app/features/playlist/ShareModal.tsx
+++ b/public/app/features/playlist/ShareModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { type SelectableValue, type UrlQueryMap, urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+
 import { Checkbox, ClipboardButton, Field, FieldSet, Input, Modal, RadioButtonGroup } from '@grafana/ui';
 import { buildBaseUrl } from 'app/features/dashboard/components/ShareModal/utils';
 
@@ -59,10 +59,6 @@ export const ShareModal = ({ playlistUid, onDismiss }: Props) => {
                 variant="primary"
                 getText={() => shareUrl}
                 onClipboardCopy={() => {
-                  reportInteraction('grafana_kiosk_mode', {
-                    action: 'share_playlist',
-                    mode: mode,
-                  });
                 }}
               >
                 <Trans i18nKey="share-playlist.copy-link-button">Copy</Trans>

--- a/public/app/features/playlist/StartModal.tsx
+++ b/public/app/features/playlist/StartModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { type SelectableValue, type UrlQueryMap, urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, locationService, reportInteraction } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { Box, Button, Checkbox, Field, FieldSet, Modal, RadioButtonGroup, Stack } from '@grafana/ui';
 
 import { type Playlist } from '../../api/clients/playlist/v1';
@@ -54,10 +54,6 @@ export const StartModal = ({ playlist, onDismiss }: Props) => {
     }
 
     locationService.push(urlUtil.renderUrl(`/playlists/play/${playlist.metadata?.name}`, params));
-    reportInteraction('grafana_kiosk_mode', {
-      action: 'start_playlist',
-      mode: mode,
-    });
   };
 
   return (

--- a/public/app/plugins/panel/gettingstarted/components/TutorialCard.tsx
+++ b/public/app/plugins/panel/gettingstarted/components/TutorialCard.tsx
@@ -3,7 +3,7 @@ import { type MouseEvent } from 'react';
 
 import { type GrafanaTheme2, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+
 import { Text, useStyles2 } from '@grafana/ui';
 
 import { type TutorialCardType } from '../types';
@@ -46,7 +46,6 @@ const handleTutorialClick = (event: MouseEvent<HTMLAnchorElement>, card: Tutoria
   if (!isSet) {
     store.set(card.key, true);
   }
-  reportInteraction('grafana_getting_started_tutorial', { title: card.title });
 };
 
 const getStyles = (theme: GrafanaTheme2, complete: boolean) => {


### PR DESCRIPTION
## Remove unused RudderStack events (monthly quota cleanup)

We are consuming our **monthly RudderStack event quota** on events nobody uses. The events below are **still being ingested** (they have volume in the last **30 days**) but have **not been referenced by any query, dbt model, or dashboard in the last 90 days** (downstream usage scanned over a 180-day window). Only events whose tables are at least **90 days old** were considered, so freshly instrumented events are excluded.

Combined, these events sent **71,447 events in the last 30 days** (~4.17 GB stored). Dropping the instrumentation stops the quota spend at the source.

Addresses https://github.com/grafana/grafana/issues/127676.
Tracking: https://github.com/grafana/product_analytics/issues/812.

Detected automatically by the `data_governance` unused-event detector. cc @grafana/grafana-frontend-navigation

### Removed in this PR (7 events)

| Event | Events / 30d | Table size (GB) | Last consumed | Status |
| --- | ---: | ---: | --- | --- |
| `grafana_kiosk_mode` | 7,600 | 0.24 | 2026-03-02 | STALE |
| `grafana_manage_dashboards_folder_created` | 6,554 | 0.15 | 2026-02-23 | STALE |
| `grafana_manage_dashboards_item_moved` | 6,347 | 0.13 | never (in lookback) | NEVER_QUERIED |
| `grafana_browse_dashboards_page_edit_folder_name` | 1,367 | 0.04 | 2026-03-18 | STALE |
| `admin_manage_users_invite_form_action_clicked` | 5 | 0.0 | 2026-03-31 | STALE |
| `grafana_getting_started_remove_panel` | 4 | 0.0 | 2026-02-09 | STALE |
| `grafana_getting_started_tutorial` | 1 | 0.0 | 2026-02-03 | STALE |

For these, the bare `reportInteraction(...)` statements were removed automatically, along with the now-unused `reportInteraction` import where no other calls remained in the file.

### Also flagged — needs manual removal (2 events)

These are equally unused, but their call sites are not simple statements (JSX prop values, callback arguments, or test mocks), so they were left untouched to avoid breaking code. Please remove them in a follow-up:

- `grafana_empty_state_shown` (49,562 events/30d, 3.61 GB)
  - `public/app/features/commandPalette/CommandPalette.tsx:455` — jsx_or_arg: `showEmptyState && reportInteraction('grafana_empty_state_shown', { source: 'command_palette' });`
- `grafana_getting_started_docs` (7 events/30d, 0.0 GB)
  - `public/app/plugins/panel/gettingstarted/components/DocsCard.tsx:25` — jsx_or_arg: `onClick={() => reportInteraction('grafana_getting_started_docs', { title: card.title, link: card.hre`
  - `public/app/plugins/panel/gettingstarted/components/DocsCard.tsx:42` — jsx_or_arg: `onClick={() => reportInteraction('grafana_getting_started_docs', { title: card.title, link: card.lea`

### Notes for reviewers

- Events are instrumented via raw `reportInteraction(...)` calls; there is no analytics-events.md to regenerate.
- Automated removal can leave an empty line or unused local variable behind — please run `yarn lint --fix` and typecheck before merging.
- **Caveat**: consumption is measured at table/view-reference level. An event queried *only* via `stg_rudderstack__tracks WHERE event_name = ...` can appear unused. Please confirm none of these are consumed that way before merging.

_Opened as a draft for owning-team review._