### PR TITLE
chore(analytics): remove unused RudderStack events — @grafana/grafana-catalog

### DIFF
--- a/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom-v5-compat';
 
 import { PluginType, type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { locationSearchToObject, reportInteraction } from '@grafana/runtime';
+import { locationSearchToObject } from '@grafana/runtime';
 import { LoadingPlaceholder, EmptyState, Field, RadioButtonGroup, Tooltip, Combobox, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -92,11 +92,6 @@ export function AddNewConnection() {
       e.preventDefault();
       e.stopPropagation();
       openModal(item);
-      reportInteraction('connections_plugin_card_clicked', {
-        plugin_id: item.id,
-        creator_team: 'grafana_plugins_catalog',
-        schema_version: '1.0.0',
-      });
     }
   };
 

--- a/public/app/features/datasources/components/DataSourceCategories.tsx
+++ b/public/app/features/datasources/components/DataSourceCategories.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 
 import { type DataSourcePluginMeta, type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+
 import { LinkButton, useStyles2 } from '@grafana/ui';
 import { type DataSourcePluginCategory } from 'app/types/datasources';
 
@@ -24,12 +24,6 @@ export function DataSourceCategories({ categories, onClickDataSourceType }: Prop
   const styles = useStyles2(getStyles);
 
   const handleClick = useCallback(() => {
-    reportInteraction('connections_add_datasource_find_more_ds_plugins_clicked', {
-      targetPath: moreDataSourcesLink,
-      path: window.location.pathname,
-      creator_team: 'grafana_plugins_catalog',
-      schema_version: '1.0.0',
-    });
   }, [moreDataSourcesLink]);
 
   return (

--- a/public/app/features/datasources/tracking.ts
+++ b/public/app/features/datasources/tracking.ts
@@ -68,7 +68,6 @@ type DataSourceGeneralTrackingProps = {
 };
 
 export const trackExploreClicked = (props: DataSourceGeneralTrackingProps) => {
-  reportInteraction('grafana_ds_explore_datasource_clicked', props);
 };
 
 export const trackBuildDashboardDropdownClicked = (props: DataSourceGeneralTrackingProps) => {
@@ -80,7 +79,6 @@ export const trackCreateDashboardClicked = (props: DataSourceGeneralTrackingProp
 };
 
 export const trackDataSourcesListViewed = (props: { grafana_version?: string; path?: string }) => {
-  reportInteraction('grafana_ds_datasources_list_viewed', props);
 };
 
 export const trackDsConfigClicked = (item: string) => {
@@ -100,9 +98,4 @@ export const trackDsSearched = (props: { query: string }) => {
 };
 
 export const trackAddNewDsClicked = (props: { path: string }) => {
-  reportInteraction('connections_datasource_list_add_datasource_clicked', {
-    ...props,
-    creator_team: 'grafana_plugins_catalog',
-    schema_version: '1.0.0',
-  });
 };

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { type PluginMeta } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+
 import { updateAppPluginSettings } from '@grafana/runtime/unstable';
 import { Button } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -29,12 +29,6 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
   const { enabled, autoEnabled, jsonData } = pluginConfig?.meta;
 
   const enable = () => {
-    reportInteraction('plugins_detail_enable_clicked', {
-      path: window.location.pathname,
-      plugin_id: plugin.id,
-      creator_team: 'grafana_plugins_catalog',
-      schema_version: '1.0.0',
-    });
     updatePluginSettingsAndReload(plugin.id, {
       enabled: true,
       pinned: true,
@@ -43,12 +37,6 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
   };
 
   const disable = () => {
-    reportInteraction('plugins_detail_disable_clicked', {
-      path: window.location.pathname,
-      plugin_id: plugin.id,
-      creator_team: 'grafana_plugins_catalog',
-      schema_version: '1.0.0',
-    });
     updatePluginSettingsAndReload(plugin.id, {
       enabled: false,
       pinned: false,

--- a/public/app/features/plugins/admin/components/PluginDetailsPanel.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPanel.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { type PageInfoItem } from '@grafana/runtime/internal';
 import {
   Stack,
@@ -55,7 +55,6 @@ export function PluginDetailsPanel(props: Props): React.ReactElement | null {
 
   const onClickReportConcern = (pluginId: string) => {
     setReportAbuseModalOpen(true);
-    reportInteraction('plugin_detail_report_concern', { plugin_id: pluginId });
   };
 
   function createTestId(text: string) {

--- a/public/app/features/plugins/admin/tracking.ts
+++ b/public/app/features/plugins/admin/tracking.ts
@@ -14,5 +14,4 @@ export const trackPluginInstalled = (props: PluginTrackingProps) => {
 };
 
 export const trackPluginUninstalled = (props: PluginTrackingProps) => {
-  reportInteraction('grafana_plugin_uninstall_clicked', props);
 };


### PR DESCRIPTION
## Remove unused RudderStack events (monthly quota cleanup)

We are consuming our **monthly RudderStack event quota** on events nobody uses. The events below are **still being ingested** (they have volume in the last **30 days**) but have **not been referenced by any query, dbt model, or dashboard in the last 90 days** (downstream usage scanned over a 180-day window). Only events whose tables are at least **90 days old** were considered, so freshly instrumented events are excluded.

Combined, these events sent **46,506 events in the last 30 days** (~4.21 GB stored). Dropping the instrumentation stops the quota spend at the source.

Addresses https://github.com/grafana/grafana/issues/127677.
Tracking: https://github.com/grafana/product_analytics/issues/812.

Detected automatically by the `data_governance` unused-event detector. cc @grafana/grafana-catalog

### Removed in this PR (9 events)

| Event | Events / 30d | Table size (GB) | Last consumed | Status |
| --- | ---: | ---: | --- | --- |
| `grafana_ds_datasources_list_viewed` | 23,831 | 3.54 | never (in lookback) | NEVER_QUERIED |
| `connections_datasource_list_add_datasource_clicked` | 13,784 | 0.25 | never (in lookback) | NEVER_QUERIED |
| `grafana_ds_explore_datasource_clicked` | 7,906 | 0.4 | 2026-03-27 | STALE |
| `connections_add_datasource_find_more_ds_plugins_clicked` | 473 | 0.01 | never (in lookback) | NEVER_QUERIED |
| `grafana_plugin_uninstall_clicked` | 127 | 0.01 | never (in lookback) | NEVER_QUERIED |
| `plugins_detail_enable_clicked` | 119 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `plugins_detail_disable_clicked` | 90 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `connections_plugin_card_clicked` | 82 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `plugin_detail_report_concern` | 14 | 0.0 | never (in lookback) | NEVER_QUERIED |

For these, the bare `reportInteraction(...)` statements were removed automatically, along with the now-unused `reportInteraction` import where no other calls remained in the file.

### Also flagged — needs manual removal (2 events)

These are equally unused, but their call sites are not simple statements (JSX prop values, callback arguments, or test mocks), so they were left untouched to avoid breaking code. Please remove them in a follow-up:

- `connections_data_source_request_clicked` (73 events/30d, 0.0 GB)
  - `public/app/features/plugins/admin/components/RoadmapLinks.tsx:11` — jsx_or_arg: `onClick={() => reportInteraction('connections_data_source_request_clicked')}`
- `connections_data_source_roadmap_clicked` (7 events/30d, 0.0 GB)
  - `public/app/features/plugins/admin/components/RoadmapLinks.tsx:19` — jsx_or_arg: `onClick={() => reportInteraction('connections_data_source_roadmap_clicked')}`

### Notes for reviewers

- Events are instrumented via raw `reportInteraction(...)` calls; there is no analytics-events.md to regenerate.
- Automated removal can leave an empty line or unused local variable behind — please run `yarn lint --fix` and typecheck before merging.
- **Caveat**: consumption is measured at table/view-reference level. An event queried *only* via `stg_rudderstack__tracks WHERE event_name = ...` can appear unused. Please confirm none of these are consumed that way before merging.

_Opened as a draft for owning-team review._