### PR TITLE
chore(analytics): remove unused RudderStack events — @grafana/sharing-squad

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
@@ -2,7 +2,7 @@ import { useCallback, useContext, useMemo } from 'react';
 
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { locationService, reportInteraction } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { type IconName, Menu, ModalsContext } from '@grafana/ui';
 import { getTrackingSource, shareDashboardType } from 'app/features/dashboard/components/ShareModal/utils';
 
@@ -79,9 +79,6 @@ export default function ExportMenu({ dashboard }: { dashboard: DashboardScene })
 
       continueAction();
 
-      reportInteraction('grafana_dashboards_export_dashboard_button_clicked', {
-        item: item.shareId,
-      });
     },
     [dashboard, hideModal, showModal]
   );


### PR DESCRIPTION
## Remove unused RudderStack events (monthly quota cleanup)

We are consuming our **monthly RudderStack event quota** on events nobody uses. The events below are **still being ingested** (they have volume in the last **30 days**) but have **not been referenced by any query, dbt model, or dashboard in the last 90 days** (downstream usage scanned over a 180-day window). Only events whose tables are at least **90 days old** were considered, so freshly instrumented events are excluded.

Combined, these events sent **33,026 events in the last 30 days** (~0.17 GB stored). Dropping the instrumentation stops the quota spend at the source.

Addresses https://github.com/grafana/grafana/issues/127679.
Tracking: https://github.com/grafana/product_analytics/issues/812.

Detected automatically by the `data_governance` unused-event detector. cc @grafana/sharing-squad

### Removed in this PR (1 events)

| Event | Events / 30d | Table size (GB) | Last consumed | Status |
| --- | ---: | ---: | --- | --- |
| `grafana_dashboards_export_dashboard_button_clicked` | 30,973 | 0.16 | 2026-03-21 | STALE |

For these, the bare `reportInteraction(...)` statements were removed automatically, along with the now-unused `reportInteraction` import where no other calls remained in the file.

### Also flagged — needs manual removal (1 events)

These are equally unused, but their call sites are not simple statements (JSX prop values, callback arguments, or test mocks), so they were left untouched to avoid breaking code. Please remove them in a follow-up:

- `sharing_publish_snapshot` (2,053 events/30d, 0.01 GB)
  - `public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/ShareSnapshot.tsx:176` — jsx_or_arg: `onClipboardCopy={() => reportInteraction('sharing_publish_snapshot')}`

### Notes for reviewers

- Events are instrumented via raw `reportInteraction(...)` calls; there is no analytics-events.md to regenerate.
- Automated removal can leave an empty line or unused local variable behind — please run `yarn lint --fix` and typecheck before merging.
- **Caveat**: consumption is measured at table/view-reference level. An event queried *only* via `stg_rudderstack__tracks WHERE event_name = ...` can appear unused. Please confirm none of these are consumed that way before merging.

_Opened as a draft for owning-team review._