### PR TITLE
chore(analytics): remove unused RudderStack events — @grafana/identity-squad

### DIFF
--- a/public/app/features/auth-config/AuthProvidersListPage.tsx
+++ b/public/app/features/auth-config/AuthProvidersListPage.tsx
@@ -3,7 +3,7 @@ import { connect, type ConnectedProps } from 'react-redux';
 
 import { GrafanaEdition } from '@grafana/data/internal';
 import { Trans } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { Grid, TextLink, ToolbarButton } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { type StoreState } from 'app/types/store';
@@ -50,7 +50,6 @@ export const AuthConfigPageUnconnected = ({
   const authProviders = getRegisteredAuthProviders();
   const availableProviders = authProviders.filter((p) => !providerStatuses[p.id]?.hide);
   const onProviderCardClick = (providerType: string, enabled: boolean) => {
-    reportInteraction('authentication_ui_provider_clicked', { provider: providerType, enabled });
   };
 
   // filter out saml from sso providers because it is already included in availableProviders

--- a/public/app/features/auth-config/ProviderConfigForm.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.tsx
@@ -145,10 +145,6 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
   const isEnabled = config?.settings.enabled;
 
   const onSaveAttempt = (toggleEnabled: boolean) => {
-    reportInteraction('grafana_authentication_ssosettings_save_attempt', {
-      provider,
-      enabled: toggleEnabled ? !isEnabled : isEnabled,
-    });
 
     if (toggleEnabled) {
       setValue('enabled', !isEnabled);
@@ -161,9 +157,6 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
         <FormPrompt
           confirmRedirect={!!Object.keys(dirtyFields).length && !dataSubmitted}
           onDiscard={() => {
-            reportInteraction('grafana_authentication_ssosettings_abandoned', {
-              provider,
-            });
             reset();
           }}
         />


### PR DESCRIPTION
## Remove unused RudderStack events (monthly quota cleanup)

We are consuming our **monthly RudderStack event quota** on events nobody uses. The events below are **still being ingested** (they have volume in the last **30 days**) but have **not been referenced by any query, dbt model, or dashboard in the last 90 days** (downstream usage scanned over a 180-day window). Only events whose tables are at least **90 days old** were considered, so freshly instrumented events are excluded.

Combined, these events sent **9,774 events in the last 30 days** (~0.18 GB stored). Dropping the instrumentation stops the quota spend at the source.

Addresses https://github.com/grafana/grafana/issues/127681.
Tracking: https://github.com/grafana/product_analytics/issues/812.

Detected automatically by the `data_governance` unused-event detector. cc @grafana/identity-squad

### Removed in this PR (4 events)

| Event | Events / 30d | Table size (GB) | Last consumed | Status |
| --- | ---: | ---: | --- | --- |
| `authentication_ui_provider_clicked` | 7,051 | 0.14 | 2026-01-27 | STALE |
| `grafana_authentication_ssosettings_save_attempt` | 1,792 | 0.04 | never (in lookback) | NEVER_QUERIED |
| `grafana_teams_list_delete_modal_confirm_clicked` | 849 | 0.0 | 2026-02-25 | STALE |
| `grafana_authentication_ssosettings_abandoned` | 82 | 0.0 | never (in lookback) | NEVER_QUERIED |

For these, the bare `reportInteraction(...)` statements were removed automatically, along with the now-unused `reportInteraction` import where no other calls remained in the file.

### Notes for reviewers

- Events are instrumented via raw `reportInteraction(...)` calls; there is no analytics-events.md to regenerate.
- Automated removal can leave an empty line or unused local variable behind — please run `yarn lint --fix` and typecheck before merging.
- **Caveat**: consumption is measured at table/view-reference level. An event queried *only* via `stg_rudderstack__tracks WHERE event_name = ...` can appear unused. Please confirm none of these are consumed that way before merging.

_Opened as a draft for owning-team review._