### PR TITLE
Docs: Clarify that Max data points can change calculated values, not just visuals

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -400,7 +400,7 @@ For example, if you set it to `100`, Grafana requests no more than 100 points, r
 This means the query resolution remains more consistent whether the panel is in the dashboard grid or in view mode.
 
 {{< admonition type="note" >}}
-Because **Max data points** defaults to the panel’s pixel width, resizing a panel changes how many points the data source returns. This affects not only the visual resolution but also any values calculated from that data, such as transformations, Stat reducer calculations, and expressions. If a panel’s computed value shifts with its size, set **Max data points** to a fixed value, or set **Min interval** to stabilize the resolution.
+**Max data points** defaults to the panel’s pixel width, so resizing a panel changes how many points the data source returns. This affects not only the visual resolution, but also any values calculated from that data, such as transformations, Stat reducer calculations, and expressions. If a panel’s computed value shifts with its size, set **Max data points** to a fixed value, or set **Min interval** to stabilize the resolution.
 {{< /admonition >}}
 
 With streaming data, Grafana uses the max data points value for the rolling buffer.

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -400,7 +400,7 @@ For example, if you set it to `100`, Grafana requests no more than 100 points, r
 This means the query resolution remains more consistent whether the panel is in the dashboard grid or in view mode.
 
 {{< admonition type="note" >}}
-**Max data points** defaults to the panel’s pixel width, so resizing a panel changes how many points the data source returns. This affects not only the visual resolution, but also any values calculated from that data, such as transformations, Stat reducer calculations, and expressions. If a panel’s computed value shifts with its size, set **Max data points** to a fixed value, or set **Min interval** to stabilize the resolution.
+**Max data points** defaults to the panel’s pixel width, so resizing a panel changes how many points the data source returns. This affects not only the visual resolution, but also any values calculated from that data, such as transformations, reducer calculations (the **Calculation** option in visualizations like Stat, Gauge, and Bar gauge), and expressions. If a panel’s computed value shifts with its size, set **Max data points** to a fixed value, or set **Min interval** to stabilize the resolution.
 {{< /admonition >}}
 
 With streaming data, Grafana uses the max data points value for the rolling buffer.

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -399,6 +399,10 @@ To get a consistent visual representation in both views, set **Max data points**
 For example, if you set it to `100`, Grafana requests no more than 100 points, regardless of the panel’s pixel width.
 This means the query resolution remains more consistent whether the panel is in the dashboard grid or in view mode.
 
+{{< admonition type="note" >}}
+Because **Max data points** defaults to the panel’s pixel width, resizing a panel changes how many points the data source returns. This affects not only the visual resolution but also any values calculated from that data, such as transformations, Stat reducer calculations, and expressions. If a panel’s computed value shifts with its size, set **Max data points** to a fixed value, or set **Min interval** to stabilize the resolution.
+{{< /admonition >}}
+
 With streaming data, Grafana uses the max data points value for the rolling buffer.
 Streaming is a continuous flow of data, and buffering divides the stream into chunks.
 For example, Loki streams data in its live tailing mode.


### PR DESCRIPTION
Adds a note to the Max data points section of the Query options docs clarifying that panel size doesn't only affect visual resolution — it can also change calculated/aggregated results (transformations, Stat reducer calculations, expressions). Because Max data points defaults to the panel's pixel width, resizing a panel changes how many data points the data source returns, which surprised users seeing different computed numbers at different panel sizes (see #123904). Closes #127693