### PR TITLE
Docs: Refine Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,10 +150,12 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 
 ### Prerequisites
 
-- **Node.js v24.x** (see `.nvmrc` for exact version). Use `nvm install` / `nvm use` to match.
-- **Go 1.26.4** (see `go.mod`). Pre-installed in the VM.
-- **Yarn 4.11.0** via corepack (bundled in `.yarn/releases/`). Run `corepack enable` if `yarn` is not found.
+- **Node.js v24.x** (see `.nvmrc` for exact version), installed via `nvm`.
+- **Go 1.26.x** (see `go.mod` for exact version), installed to `/usr/local/go`.
+- **Yarn** via corepack — the version is pinned by the `packageManager` field in `package.json` (bundled in `.yarn/releases/`). Run `corepack enable` if `yarn` is not found.
 - **GCC** required for CGo/SQLite compilation of the backend.
+
+> PATH gotcha: the base image ships a `node` in `/exec-daemon` that is earlier on `PATH` and shadows the nvm-managed Node. `~/.bashrc` prepends the correct Node 24 bin dir and `/usr/local/go/bin` so login shells get the right toolchains — verify with `node --version` / `go version` if a build complains about the wrong version.
 
 ### Running services
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Small documentation-only update to the `## Cursor Cloud specific instructions` section of `AGENTS.md`:

- Correct the Go toolchain reference to `1.26.x` (matching `go.mod`, previously said `1.26.4` and "pre-installed").
- Clarify that Node is installed via `nvm` and Go is installed to `/usr/local/go`.
- Reference the `packageManager` field in `package.json` for the pinned Yarn version instead of a stale hard-coded version.
- Document the `/exec-daemon` PATH shadowing gotcha, since it otherwise causes the wrong Node/Go to be used, and note that `~/.bashrc` prepends the correct toolchain bin dirs.

**Why do we need this feature?**

While setting up the development environment on a fresh Cursor Cloud VM, the existing notes had a couple of inaccurate statements and were missing a non-obvious PATH gotcha. These changes help future agents get the correct toolchains without debugging.

**Who is this feature for?**

AI agents and developers setting up the Grafana dev environment in Cursor Cloud.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Documentation-only change; no code paths affected. Verified the full dev environment end-to-end in this environment: backend (`make run`), frontend (`yarn start`), lint (`make golangci-lint`, `yarn eslint`), and tests (`go test ./pkg/util/...`, `yarn jest`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b616236-752d-42b1-93ab-91ccd4826161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b616236-752d-42b1-93ab-91ccd4826161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

